### PR TITLE
Fix man page ipa-replica-manage: remove duplicate -c option from --no-lookup

### DIFF
--- a/install/tools/man/ipa-replica-manage.1
+++ b/install/tools/man/ipa-replica-manage.1
@@ -109,11 +109,11 @@ Provide additional information
 \fB\-f\fR, \fB\-\-force\fR
 Ignore some types of errors, don't prompt when deleting a master
 .TP
-\fB\-c\fR, \fB\-\-no\-lookup\fR
-Do not perform DNS lookup checks.
-.TP
 \fB\-c\fR, \fB\-\-cleanup\fR
 When deleting a master with the \-\-force flag, remove leftover references to an already deleted master.
+.TP
+\fB\-\-no\-lookup\fR
+Do not perform DNS lookup checks.
 .TP
 \fB\-\-binddn\fR=\fIADMIN_DN\fR
 Bind DN to use with remote server (default is cn=Directory Manager) \- Be careful to quote this value on the command line


### PR DESCRIPTION
https://fedorahosted.org/freeipa/ticket/6233