### PR TITLE
adtrust-install: Mention AD GC port 3286 in list of required ports

### DIFF
--- a/install/tools/ipa-adtrust-install
+++ b/install/tools/ipa-adtrust-install
@@ -488,6 +488,7 @@ You must make sure these network ports are open:
 \t  * 139: netbios-ssn
 \t  * 445: microsoft-ds
 \t  * 1024..1300: epmap listener range
+\t  * 3268: msft-gc
 \tUDP Ports:
 \t  * 138: netbios-dgm
 \t  * 139: netbios-ssn

--- a/install/tools/man/ipa-adtrust-install.1
+++ b/install/tools/man/ipa-adtrust-install.1
@@ -52,6 +52,8 @@ the following ports to be open to allow IPA and Active Directory to communicate 
 .IP
 \(bu 1024/tcp through 1300/tcp to allow EPMAP on port 135/tcp to create a TCP listener based
 on an incoming request.
+.IP
+\(bu 3268/tcp Microsoft-GC
 .TP
 \fBUDP Ports\fR
 .IP


### PR DESCRIPTION
Port name "msft-gc" is taken form /etc/services file provided by package
setup-2.10.1-1.fc24.noarch.

https://fedorahosted.org/freeipa/ticket/6235