### PR TITLE
add python-libsss_nss_idmap and python-sss to BuildRequires

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -105,6 +105,8 @@ BuildRequires:  custodia
 BuildRequires:  libini_config-devel >= 1.2.0
 BuildRequires:  dbus-python
 BuildRequires:  python-netifaces >= 0.10.4
+BuildRequires:  python-libsss_nss_idmap
+BuildRequires:  python-sss
 
 # Build dependencies for unit tests
 BuildRequires:  libcmocka-devel


### PR DESCRIPTION
This fixes pylint failing on import errors during 'lint' phase of build.

https://fedorahosted.org/freeipa/ticket/6244