### PR TITLE
Tests: Duplicate declaration on variables in ID views tests

### DIFF
--- a/ipatests/test_xmlrpc/test_idviews_plugin.py
+++ b/ipatests/test_xmlrpc/test_idviews_plugin.py
@@ -42,11 +42,6 @@ if six.PY3:
 idview1 = u'idview1'
 idview2 = u'idview2'
 
-host1 = u'host1.test'
-host2 = u'host2.test'
-host3 = u'host3.test'
-host4 = u'host4.test'
-
 hostgroup1 = u'hostgroup1'
 hostgroup2 = u'hostgroup2'
 


### PR DESCRIPTION
In ipatests/test_xmlrpc/test_idviews_plugin several variables are declared
twice, while never using the first declaration. The duplicate declaration is
hereby removed.

https://fedorahosted.org/freeipa/ticket/6246