### PR TITLE
Tests: Failing intree tests

### DIFF
--- a/ipatests/test_ipalib/test_plugable.py
+++ b/ipatests/test_ipalib/test_plugable.py
@@ -118,7 +118,7 @@ def test_Registry():
     # a class:
     p = plugin1()
     e = raises(TypeError, r(), p)
-    assert str(e) == 'plugin must be a class; got %r' % p
+    assert str(e) == 'plugin must be callable; got %r' % p
 
     # Check that registration works
     r()(plugin1)
@@ -229,7 +229,7 @@ class test_API(ClassChecker):
             base_name = get_base_name(b)
             base = locals()[base_name]
             ns = getattr(api, base_name)
-            assert isinstance(ns, plugable.NameSpace)
+            assert isinstance(ns, plugable.APINameSpace)
             assert read_only(api, base_name) is ns
             assert len(ns) == 3
             for p in range(3):
@@ -239,7 +239,6 @@ class test_API(ClassChecker):
                 assert isinstance(inst, base)
                 assert isinstance(inst, plugin)
                 assert inst.name == plugin_name
-                assert read_only(ns, plugin_name) is inst
                 assert inst.method(7) == 7 + b
 
         # Test that calling finilize again raises AssertionError:

--- a/ipatests/test_ipalib/test_rpc.py
+++ b/ipatests/test_ipalib/test_rpc.py
@@ -209,14 +209,6 @@ class test_xmlclient(PluginTester):
         class user_add(Command):
             pass
 
-        # Test that ValueError is raised when forwarding a command that is not
-        # in api.Command:
-        (o, api, home) = self.instance('Backend', in_server=False)
-        e = raises(ValueError, o.forward, 'user_add')
-        assert str(e) == '%s.forward(): %r not in api.Command' % (
-            'xmlclient', 'user_add'
-        )
-
         (o, api, home) = self.instance('Backend', user_add, in_server=False)
         args = (binary_bytes, utf8_bytes, unicode_str)
         kw = dict(one=binary_bytes, two=utf8_bytes, three=unicode_str)

--- a/ipatests/test_ipaserver/test_ldap.py
+++ b/ipatests/test_ipaserver/test_ldap.py
@@ -35,8 +35,6 @@ import nss.nss as nss
 import six
 
 from ipaserver.plugins.ldap2 import ldap2
-from ipaserver.plugins.service import service, service_show
-from ipaserver.plugins.host import host
 from ipalib import api, x509, create_api, errors
 from ipapython import ipautil
 from ipaplatform.paths import paths
@@ -118,10 +116,6 @@ class test_ldap(object):
         # we need for the test.
         myapi = create_api(mode=None)
         myapi.bootstrap(context='cli', in_server=True, in_tree=True)
-        myapi.add_plugin(ldap2)
-        myapi.add_plugin(host)
-        myapi.add_plugin(service)
-        myapi.add_plugin(service_show)
         myapi.finalize()
 
         pwfile = api.env.dot_ipa + os.sep + ".dmpw"


### PR DESCRIPTION
Fixing failing tests in:
test_ipalib/test_plugable
test_ipalib/test_rpc
test_ipaserver/test_ldap
All issues were discussed with Jan Cholasta and are results of thin client implementation.