### PR TITLE
Secure permissions of Custodia server.keys

### DIFF
--- a/ipapython/secrets/kem.py
+++ b/ipapython/secrets/kem.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2015  IPA Project Contributors, see COPYING for license
 
 from __future__ import print_function
+import os
 from ipaplatform.paths import paths
 from six.moves.configparser import ConfigParser
 from ipapython.dn import DN
@@ -143,7 +144,9 @@ class KEMLdap(iSecLdap):
 def newServerKeys(path, keyid):
     skey = JWK(generate='RSA', use='sig', kid=keyid)
     ekey = JWK(generate='RSA', use='enc', kid=keyid)
-    with open(path, 'w+') as f:
+    with open(path, 'w') as f:
+        os.fchmod(f.fileno(), 0o600)
+        os.fchown(f.fileno(), 0, 0)
         f.write('[%s,%s]' % (skey.export(), ekey.export()))
     return [skey.get_op_key('verify'), ekey.get_op_key('encrypt')]
 

--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -15,6 +15,7 @@ from jwcrypto.common import json_decode
 import functools
 import shutil
 import os
+import stat
 import tempfile
 import pwd
 
@@ -73,6 +74,10 @@ class CustodiaInstance(SimpleServiceInstance):
         if not sysupgrade.get_upgrade_state("custodia", "installed"):
             root_logger.info("Custodia service is being configured")
             self.create_instance()
+        mode = os.stat(self.server_keys).st_mode
+        if stat.S_IMODE(mode) != 0o600:
+            root_logger.info("Secure server.keys mode")
+            os.chmod(self.server_keys, 0o600)
 
     def create_replica(self, master_host_name):
         suffix = ipautil.realm_to_suffix(self.realm)


### PR DESCRIPTION
Custodia's server.keys file contain the private RSA keys for encrypting
and signing Custodia messages. The file was created with permission 644
and is only secured by permission 700 of the directory
/etc/ipa/custodia. The installer and upgrader ensure that the file
has 600.

https://bugzilla.redhat.com/show_bug.cgi?id=1353936
https://fedorahosted.org/freeipa/ticket/6056