### PR TITLE
Require httpd 2.4.6-31 with mod_proxy Unix socket support

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -139,7 +139,7 @@ Requires(post): krb5-server >= %{krb5_base_version}, krb5-server < %{krb5_base_v
 Requires: krb5-pkinit-openssl
 Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: ntp
-Requires: httpd >= 2.4.6-6
+Requires: httpd >= 2.4.6-31
 Requires: mod_wsgi
 Requires: mod_auth_gssapi >= 1.4.0
 Requires: mod_nss >= 1.0.8-26
@@ -229,7 +229,7 @@ Summary: Common files used by IPA server
 Group: System Environment/Base
 BuildArch: noarch
 Requires: %{name}-client-common = %{version}-%{release}
-Requires: httpd >= 2.4.6-6
+Requires: httpd >= 2.4.6-31
 Requires: systemd-units >= 38
 Requires: custodia
 


### PR DESCRIPTION
httpd 2.4.6-6 does not support mod_proxy ProxyPass for Unix sockets. The
feature is provided by 2.4.7 upstream was backported to 2.4.6-31
(bz1168081). It's required to proxy Custodia.

https://bugzilla.redhat.com/show_bug.cgi?id=1168081
https://httpd.apache.org/docs/trunk/mod/mod_proxy.html#proxypass

https://fedorahosted.org/freeipa/ticket/6251

Signed-off-by: Christian Heimes <cheimes@redhat.com>