### PR TITLE
otptoken: Convert ipatokenotpkey on server

### DIFF
--- a/ipaserver/plugins/otptoken.py
+++ b/ipaserver/plugins/otptoken.py
@@ -214,6 +214,8 @@ class otptoken(LDAPObject):
             doc=_('Token secret (Base32; default: random)'),
             default_from=lambda: os.urandom(KEY_LENGTH),
             autofill=True,
+            # force server-side conversion
+            normalizer=lambda x: x,
             flags=('no_display', 'no_update', 'no_search'),
         ),
         StrEnum('ipatokenotpalgorithm?',

--- a/ipaserver/plugins/permission.py
+++ b/ipaserver/plugins/permission.py
@@ -283,6 +283,8 @@ class permission(baseldap.LDAPObject):
             cli_name='subtree',
             label=_('Subtree'),
             doc=_('Subtree to apply permissions to'),
+            # force server-side conversion
+            normalizer=lambda x: x,
             flags={'ask_create'},
         ),
         Str(


### PR DESCRIPTION
Force client to send the value of ipatokenotpkey as entered by user.
Otherwise client encodes the value with base64 before sending to server
resulting in using base32(base64(value)) instead of base32(value).

https://fedorahosted.org/freeipa/ticket/6247