### PR TITLE
[master, ipa-4-3] Raise error when running ipa-adtrust-install with empty netbios--name

### DIFF
--- a/install/tools/ipa-adtrust-install
+++ b/install/tools/ipa-adtrust-install
@@ -93,7 +93,7 @@ def parse_options():
 def netbios_name_error(name):
     print("\nIllegal NetBIOS name [%s].\n" % name)
     print("Up to 15 characters and only uppercase ASCII letters, digits "
-          "and dashes are allowed.")
+          "and dashes are allowed. Empty string is not allowed.")
 
 def read_netbios_name(netbios_default):
     netbios_name = ""
@@ -193,8 +193,11 @@ def set_and_check_netbios_name(netbios_name, unattended):
         # all possible cases should be covered above
         raise Exception('Unexpected state while checking NetBIOS domain name')
 
+    if unattended and netbios_name is None and gen_netbios_name:
+        netbios_name = gen_netbios_name
+
     if not adtrustinstance.check_netbios_name(netbios_name):
-        if unattended and not gen_netbios_name:
+        if unattended:
             netbios_name_error(netbios_name)
             sys.exit("Aborting installation.")
         else:
@@ -204,9 +207,6 @@ def set_and_check_netbios_name(netbios_name, unattended):
 
     if not unattended and not netbios_name:
         netbios_name = read_netbios_name(gen_netbios_name)
-
-    if unattended and not netbios_name and gen_netbios_name:
-        netbios_name = gen_netbios_name
 
     return (netbios_name, reset_netbios_name)
 

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -94,7 +94,7 @@ def ipa_smb_conf_exists():
 
 def check_netbios_name(name):
     # Empty NetBIOS name is not allowed
-    if name is None:
+    if not name:
         return False
 
     # NetBIOS names may not be longer than 15 allowed characters


### PR DESCRIPTION
When running ipa-adtrust-install, a netbios-name option must be specified.
Currently if an invalid netbios name in form of empty string is specified, the
installation proceeds, but changes the invalid value to a netbios name
determined from domain name without any notification.

Fixing this so that any attempt to supply empty string as netbios name fails
with error in case of unattended installation, or to request input of valid
netbios name from command line during normal installation.

https://fedorahosted.org/freeipa/ticket/6120

**Note - newly intended behaviour of ipa-adtrust-install:**
- unattended installation with --netbios-name="" fails
- unattended installation without --netbios-name specification proceeds and uses default value derived from domain name
- normal installation in both cases requests inserting of valid netbios name