### PR TITLE
Don't ignore --ignore-last-of-role for last CA

### DIFF
--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -499,9 +499,10 @@ class server_del(LDAPDelete):
                 'ca_renewal_master_server', [])
 
             if ca_servers == [hostname]:
-                raise errors.ServerRemovalError(
-                    reason=_("Deleting this server is not allowed as it would "
-                             "leave your installation without a CA."))
+                handler(
+                    _("Deleting this server is not allowed as it would "
+                      "leave your installation without a CA."),
+                    ignore_last_of_role)
 
             if ca_renewal_master == hostname:
                 other_cas = [ca for ca in ca_servers if ca != hostname]


### PR DESCRIPTION
Use a handler created for the purpose of deciding whether
to raise exception or not.

https://fedorahosted.org/freeipa/ticket/6259