### PR TITLE
Enable LDAPS in replica promotion

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -395,6 +395,7 @@ class DsInstance(service.Service):
             self.step("creating DS keytab", self.__get_ds_keytab)
             if self.ca_is_configured:
                 self.step("retrieving DS Certificate", self.__get_ds_cert)
+            self.step("configuring ssl for ds instance", self.__enable_ssl)
             self.step("restarting directory server", self.__restart_instance)
 
         self.step("setting up initial replication", self.__setup_replica)


### PR DESCRIPTION
With CA-less master and CA-less replica, attempting to install CA on replica
would fail. LDAPS has to be enabled during replica promotion, because it is
required by Dogtag.

https://fedorahosted.org/freeipa/ticket/6226