### PR TITLE
cert: add missing param values to cert-find output

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1207,7 +1207,8 @@ class cert_find(Search, CertMethod):
                 obj = ra_obj
                 obj['issuer'] = issuer
                 obj['subject'] = DN(ra_obj['subject'])
-                del obj['serial_number_hex']
+                obj['revoked'] = (
+                    ra_obj['status'] in (u'REVOKED', u'REVOKED_EXPIRED'))
 
                 if all:
                     ra_obj = ra.get_certificate(str(serial_number))


### PR DESCRIPTION
Add back `serial_number_hex` and `revoked` param values to cert-find output
accidentally removed in commit c718ef058847bb39e78236e8af0ad69ac961bbcf.

https://fedorahosted.org/freeipa/ticket/6269