### PR TITLE
Removed incorrect check for returncode

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -187,7 +187,9 @@ class TestReplicaPromotionLevel1(ReplicaPromotionBase):
         self.replicas[0].run_command(['ipa-replica-install', '-w',
                                      self.master.config.admin_password,
                                      '-n', self.master.domain.name,
-                                     '-r', self.master.domain.realm])
+                                     '-r', self.master.domain.realm,
+                                     '--server', self.master.hostname,
+                                     '-U'])
 
 
 class TestReplicaManageCommands(IntegrationTest):
@@ -308,6 +310,7 @@ class TestUnprivilegedUserPermissions(IntegrationTest):
                                        '-w', self.new_password,
                                        '--domain', replica.domain.name,
                                        '--realm', replica.domain.realm, '-U'],
+                                       '--server', self.master.hostname],
                                       raiseonerr=False)
         assert_error(result1, "No permission to join this host", 1)
 
@@ -332,6 +335,7 @@ class TestUnprivilegedUserPermissions(IntegrationTest):
                                       '-p', self.new_password,
                                       '-n', self.master.domain.name,
                                       '-r', self.master.domain.realm])
+                                      '-U'])
 
 
 class TestProhibitReplicaUninstallation(IntegrationTest):

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -114,6 +114,7 @@ class TestKRAInstall(IntegrationTest):
         tasks.install_kra(replica2)
 
 
+@pytest.mark.xfail(reason="Ticket N 6274", strict=True)
 class TestCAInstall(IntegrationTest):
     topology = 'star'
     domain_level = DOMAIN_LEVEL_0
@@ -192,6 +193,7 @@ class TestReplicaPromotionLevel1(ReplicaPromotionBase):
                                      '-U'])
 
 
+@pytest.mark.xfail(reason="Ticket N 6274", strict=True)
 class TestReplicaManageCommands(IntegrationTest):
     topology = "star"
     num_replicas = 2
@@ -357,6 +359,7 @@ class TestProhibitReplicaUninstallation(IntegrationTest):
                                       '-U', '--ignore-topology-disconnect'])
 
 
+@pytest.mark.xfail(reason="Ticket N 6274", strict=True)
 class TestOldReplicaWorksAfterDomainUpgrade(IntegrationTest):
     topology = 'star'
     num_replicas = 1

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -348,10 +348,7 @@ class TestProhibitReplicaUninstallation(IntegrationTest):
         result = self.replicas[0].run_command(['ipa-server-install',
                                                '--uninstall', '-U'],
                                               raiseonerr=False)
-        assert(result.returncode > 0), ("The replica was removed without "
-                                         "'--ignore-topology-disconnect' option")
-        assert("Uninstallation leads to disconnected topology"
-               in result.stdout_text), ("Expected error message was not found")
+        assert_error(result, "Uninstallation leads to disconnected topology", 0)
         self.replicas[0].run_command(['ipa-server-install', '--uninstall',
                                       '-U', '--ignore-topology-disconnect'])
 


### PR DESCRIPTION
The server installation in most cases returns response code 0 no matter what
happens except for really severe errors. In this case when we try to uninstall
the middle replica of a line topology, it fails, notifies us that we should use
'--ignore-topology-disconnect', but returns 0

https://fedorahosted.org/freeipa/ticket/3230