### PR TITLE
do not use trusted forest name to construct domain admin principal

### DIFF
--- a/ipaserver/plugins/trust.py
+++ b/ipaserver/plugins/trust.py
@@ -319,7 +319,7 @@ def generate_creds(trustinstance, style, **options):
             else:
                sp = admin_name.split(sep)
             if len(sp) == 1:
-                sp.append(trustinstance.remote_domain.info['dns_forest'].upper())
+                sp.append(trustinstance.remote_domain.info['dns_domain'].upper())
         creds = u"{name}%{password}".format(name=sep.join(sp),
                                             password=password)
     return creds


### PR DESCRIPTION
When `trust-add` is supplied AD domain admin name without realm component, the
code appends the uppercased AD forest root domain name to construct the full
principal. This can cause authentication error, however, when external trust
with non-root domain is requested.

We should instead use the supplied DNS domain name (if valid) as a realm
component.

https://fedorahosted.org/freeipa/ticket/6277