### PR TITLE
Postpone enabling LDAPS in replica promotion

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -395,7 +395,6 @@ class DsInstance(service.Service):
             self.step("creating DS keytab", self.__get_ds_keytab)
             if self.ca_is_configured:
                 self.step("retrieving DS Certificate", self.__get_ds_cert)
-            self.step("configuring ssl for ds instance", self.__enable_ssl)
             self.step("restarting directory server", self.__restart_instance)
 
         self.step("setting up initial replication", self.__setup_replica)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1476,6 +1476,9 @@ def promote(installer):
         cainstance.export_kra_agent_pem()
         CA.fix_ra_perms()
 
+    # we now need to enable ssl on the ds
+    ds.enable_ssl()
+
     krb = install_krb(config,
                       setup_pkinit=not options.no_pkinit,
                       promote=True)


### PR DESCRIPTION
Fixes a bug that prevented ipa-replica-install with CA, because
LDAPS was configured before the SSL cerificate was assigned.

https://fedorahosted.org/freeipa/ticket/6226