### PR TITLE
custodia: force reconnect before retrieving CA certs from LDAP

### DIFF
--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -158,6 +158,8 @@ class CustodiaInstance(SimpleServiceInstance):
             # Add CA certificates
             tmpdb = CertDB(self.realm, nssdir=tmpnssdir)
             self.suffix = ipautil.realm_to_suffix(self.realm)
+            if self.admin_conn is not None:
+                self.ldap_disconnect()
             self.import_ca_certs(tmpdb, True)
 
             # Now that we gathered all certs, re-export


### PR DESCRIPTION
Force reconnect to LDAP as DS might have been restarted after the
connection was opened, rendering the connection invalid.

This fixes a crash in ipa-replica-install with --setup-ca.

https://fedorahosted.org/freeipa/ticket/6207