### PR TITLE
Don't show error messages in bash completion

### DIFF
--- a/contrib/completion/ipa.bash_completion
+++ b/contrib/completion/ipa.bash_completion
@@ -11,7 +11,7 @@
 
 _ipa_commands()
 {
-    ipa help commands | sed -r 's/^([-[:alnum:]]*).*/\1/' | grep '^[[:alnum:]]'
+    ipa help commands 2>/dev/null | sed -r 's/^([-[:alnum:]]*).*/\1/' | grep '^[[:alnum:]]'
 }
 
 _ipa()


### PR DESCRIPTION
Redirect bash error output to prevent displaying error
messages in bash completion for ipa command.

https://fedorahosted.org/freeipa/ticket/6273