### PR TITLE
cli: use full name when executing a command

### DIFF
--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -1101,7 +1101,7 @@ class cli(backend.Executioner):
         cmd = self.get_command(argv)
         if cmd is None:
             return
-        name = cmd.name
+        name = cmd.full_name
         kw = self.parse(cmd, argv[1:])
         if not isinstance(cmd, frontend.Local):
             self.create_context()


### PR DESCRIPTION
Fixes the CLI not to always call the default version of a command even when
the version was explicitly specified.

https://fedorahosted.org/freeipa/ticket/6279