### PR TITLE
Fix parse errors with link-local addresses

### DIFF
--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -173,8 +173,13 @@ class CheckedIPAddress(UnsafeIPAddress):
             iface = None
             for interface in netifaces.interfaces():
                 for ifdata in netifaces.ifaddresses(interface).get(family, []):
+
+                    # link-local addresses contain '%suffix' that causes parse
+                    # errors in IPNetwork
+                    ifaddr = ifdata['addr'].split(u'%', 1)[0]
+
                     ifnet = netaddr.IPNetwork('{addr}/{netmask}'.format(
-                        addr=ifdata['addr'],
+                        addr=ifaddr,
                         netmask=ifdata['netmask']
                     ))
                     if ifnet == self._net or (


### PR DESCRIPTION
Link-local addresses received from netifaces contains '%suffix' that
causes parse error in IPNetwork class. We must remove %suffix before
it us used in IPNetwork objects.

https://fedorahosted.org/freeipa/ticket/6296