### PR TITLE
Use RSA-OAEP instead of RSA PKCS#1 v1.5

### DIFF
--- a/ipapython/secrets/client.py
+++ b/ipapython/secrets/client.py
@@ -86,7 +86,7 @@ class CustodiaClient(object):
         url = 'https://%s/ipa/keys/%s' % (self.server, keyname)
 
         # Prepare signed/encrypted request
-        encalg = ('RSA1_5', 'A256CBC-HS512')
+        encalg = ('RSA-OAEP', 'A256CBC-HS512')
         request = self.kemcli.make_request(keyname, encalg=encalg)
 
         # Prepare Authentication header


### PR DESCRIPTION
jwcrypto's RSA1-5 (PKCS#1 v1.5) is vulnerable to padding oracle
side-channel attacks. OAEP (PKCS#1 v2.0) is a safe, more modern
alternative.

https://fedorahosted.org/freeipa/ticket/6278

Signed-off-by: Christian Heimes <cheimes@redhat.com>