### PR TITLE
Fix BadSyntax exception in ldapupdate.py

### DIFF
--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -83,8 +83,8 @@ def connect(ldapi=False, realm=None, fqdn=None, dm_password=None, pw_name=None):
 class BadSyntax(installutils.ScriptError):
     def __init__(self, value):
         self.value = value
-        self.msg = "LDAPUpdate: syntax error: \n  %s" % value
-        self.rval = 1
+        super(BadSyntax, self).__init__(
+            msg="LDAPUpdate: syntax error: \n  %s" % value, rval=1)
 
     def __str__(self):
         return repr(self.value)


### PR DESCRIPTION
This complements commit 00d43095da211f542189c95c88fc2e2c32e75565 and fixes two
failing testcases in `ipatests/test_install/test_updates.py`

https://fedorahosted.org/freeipa/ticket/6294