### PR TITLE
Use Travis-CI for basic sanity checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+services:
+    - docker
+
+before_install:
+    - pip install pep8
+
+script:
+    - >
+        if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]];
+        then
+            git diff origin/${TRAVIS_BRANCH} -U0 | pep8 --diff;
+        fi
+    - >
+        docker run -v $PWD:/freeipa -w /freeipa
+        martbab/freeipa-fedora-builder:${TRAVIS_BRANCH}-latest
+        /bin/bash -c 'dnf builddep -y --spec freeipa.spec.in && make rpms'


### PR DESCRIPTION
This patch adds the config file for Travis CI. The config file instructs the
CI to:
* check pep8 errors in PR
* pull in a freeipa builder container image from
  docker.io/martbab/freeipa-fedora-builder
* build RPMs in pulled container

These basic checks should eliminate basic errors that can break the build
itself, it does not run any of our integration/unit tests.