### PR TITLE
cert: fix cert-find --certificate when the cert is not in LDAP

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1266,17 +1266,15 @@ class cert_find(Search, CertMethod):
                     rule)
                 filters.append(filter)
 
-        cert = options.get('certificate')
-        if cert is not None:
-            filter = ldap.make_filter_from_attr('usercertificate', cert)
-            filters.append(filter)
-
         result = collections.OrderedDict()
         complete = bool(filters)
 
-        if cert is None:
+        cert = options.get('certificate')
+        if cert is not None:
+            filter = ldap.make_filter_from_attr('usercertificate', cert)
+        else:
             filter = '(usercertificate=*)'
-            filters.append(filter)
+        filters.append(filter)
 
         filter = ldap.combine_filters(filters, ldap.MATCH_ALL)
         try:


### PR DESCRIPTION
Always return the cert specified in --certificate in cert-find result, even
when the cert is not found in LDAP.

https://fedorahosted.org/freeipa/ticket/6304