### PR TITLE
[master, ipa-4-4] Tests: Add cleanup to integration trust tests

### DIFF
--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -687,6 +687,11 @@ def uninstall_master(host, ignore_topology_disconnect=True,
                       paths.PKI_TOMCAT,
                       paths.REPLICA_INFO_GPG_TEMPLATE % host.hostname],
                      raiseonerr=False)
+    host.run_command("find /var/lib/sss/keytabs -name '*.keytab' | "
+                     "xargs rm -fv", raiseonerr=False)
+    host.run_command("find /run/ipa -name 'krb5*' | xargs rm -fv",
+                     raiseonerr=False)
+    host.run_command(['systemctl', 'restart', 'sssd'])
     unapply_fixes(host)
 
 


### PR DESCRIPTION
Trust tests fail if they are executed after external trust tests. This is
caused my missing cleanup. Providing cleanup that would enable correct
execution of the tests regardless of their order.

https://fedorahosted.org/freeipa/ticket/6306