### PR TITLE
netgroup: avoid extraneous LDAP search when retrieving primary key from DN

### DIFF
--- a/ipaserver/plugins/netgroup.py
+++ b/ipaserver/plugins/netgroup.py
@@ -237,6 +237,26 @@ class netgroup(LDAPObject):
         external_host_param,
     )
 
+    def get_primary_key_from_dn(self, dn):
+        assert isinstance(dn, DN)
+        if not dn.rdns:
+            return u''
+
+        first_ava = dn.rdns[0][0]
+        if first_ava[0] == self.primary_key.name:
+            return unicode(first_ava[1])
+
+        try:
+            entry_attrs = self.backend.get_entry(
+                dn, [self.primary_key.name]
+            )
+            try:
+                return entry_attrs[self.primary_key.name][0]
+            except (KeyError, IndexError):
+                return u''
+        except errors.NotFound:
+            return unicode(dn)
+
 
 @register()
 class netgroup_add(LDAPCreate):


### PR DESCRIPTION
Fixes https://fedorahosted.org/freeipa/ticket/5855

Please note that the parent method does not correctly handle cases when the
attribute considered as primary ked is contained in multiple RDNs: 
```python
>>> api.Object.netgroup.get_primary_key_from_dn(
...     DN('ipauniqueid=yadda-yadda,cn=ng,cn=alt,dc=ipa,dc=test'))
u'ng'
```
That's why I had to completely override parent method.