### PR TITLE
[master, ipa-4-4] Tests: Fix failing ldap.backend test

### DIFF
--- a/ipatests/test_ipaserver/test_ldap.py
+++ b/ipatests/test_ipaserver/test_ldap.py
@@ -115,7 +115,7 @@ class test_ldap(object):
         # a client-only api. Then we register in the commands and objects
         # we need for the test.
         myapi = create_api(mode=None)
-        myapi.bootstrap(context='cli', in_server=True, in_tree=True)
+        myapi.bootstrap(context='cli', in_server=True)
         myapi.finalize()
 
         pwfile = api.env.dot_ipa + os.sep + ".dmpw"


### PR DESCRIPTION
Test ipatests/test_ipaserver/test_ldap::test_Backend fails claiming service
cannot be found. Fixing this by not using api with in_tree parameter.

https://fedorahosted.org/freeipa/ticket/6312