### PR TITLE
[master, ipa-4-4] Tests: Add krb5kdc.service restart to integration trust tests

### DIFF
--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -490,6 +490,8 @@ def establish_trust_with_ad(master, ad_domain, extra_args=()):
                         stdin_text=master.config.ad_admin_password)
     master.run_command(['smbcontrol', 'all', 'debug', '1'])
     clear_sssd_cache(master)
+    master.run_command(['systemctl', 'restart', 'krb5kdc.service'])
+    time.sleep(60)
 
 
 def remove_trust_with_ad(master, ad_domain):

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -24,7 +24,6 @@ from ipatests.test_integration.base import IntegrationTest
 from ipatests.test_integration import tasks
 from ipatests.test_integration import util
 from ipaplatform.paths import paths
-import time
 
 
 class ADTrustBase(IntegrationTest):
@@ -400,8 +399,6 @@ class TestTrustWithUPN(ADTrustBase):
 
     def test_upn_user_authentication(self):
         """ Check that AD user with UPN can authenticate in IPA """
-        self.master.run_command(['systemctl', 'restart', 'krb5kdc'])
-        time.sleep(60)
         self.master.run_command(['kinit', '-C', '-E', self.upn_principal],
                                 stdin_text=self.upn_password)
 


### PR DESCRIPTION
krb5kdc.service restart is necessary for proper running of integration trust
related tests.

https://fedorahosted.org/freeipa/ticket/6322