### PR TITLE
Tests: Update host test with ipa-join

### DIFF
--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -42,6 +42,7 @@ from ipatests.test_xmlrpc import objectclasses
 from ipatests.test_xmlrpc.tracker.host_plugin import HostTracker
 from ipatests.test_xmlrpc.testcert import get_testcert
 from ipatests.util import assert_deepequal
+from ipaplatform.paths import paths
 
 # Constants DNS integration tests
 # TODO: Use tracker fixtures for zones/records/users/groups
@@ -520,14 +521,18 @@ class TestHostFalsePwdChange(XMLRPC_test):
     def test_join_host(self, host, keytabname):
         """
         Create a test host and join it into IPA.
+
+        This test must not run remotely.
         """
 
-        join_command = 'ipa-client/ipa-join'
-        if not os.path.isfile(join_command):
-            pytest.skip("Command '%s' not found" % join_command)
+        if not os.path.isfile(paths.SBIN_IPA_JOIN):
+            pytest.skip("Command '%s' not found. "
+                        "The test must not run remotely."
+                        % paths.SBIN_IPA_JOIN)
 
         # create a test host with bulk enrollment password
         host.track_create()
+
         del host.attrs['krbprincipalname']
         host.attrs['has_password'] = True
         objclass = list(set(
@@ -545,7 +550,7 @@ class TestHostFalsePwdChange(XMLRPC_test):
 
         # joint the host with the bulk password
         new_args = [
-            join_command,
+            paths.SBIN_IPA_JOIN,
             "-s", host.api.env.host,
             "-h", host.fqdn,
             "-k", keytabname,

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -533,7 +533,10 @@ class TestHostFalsePwdChange(XMLRPC_test):
         # create a test host with bulk enrollment password
         host.track_create()
 
+        # manipulate host.attrs to correspond with real attributes of host
+        # after creating it with random password
         del host.attrs['krbprincipalname']
+        del host.attrs['krbcanonicalname']
         host.attrs['has_password'] = True
         objclass = list(set(
             host.attrs['objectclass']) - {u'krbprincipal', u'krbprincipalaux'})
@@ -565,9 +568,12 @@ class TestHostFalsePwdChange(XMLRPC_test):
             # the keytab is not necessary for further tests
             print(e)
 
+        # fix host.attrs again to correspond with current state
         host.attrs['has_keytab'] = True
         host.attrs['has_password'] = False
         host.attrs['krbprincipalname'] = [u'host/%s@%s' % (host.fqdn,
+                                                           host.api.env.realm)]
+        host.attrs['krbcanonicalname'] = [u'host/%s@%s' % (host.fqdn,
                                                            host.api.env.realm)]
         host.retrieve()
 


### PR DESCRIPTION
Updating path to ipa-join command to allow execution of
test_xmlrpc/test_host::TestHostFalsePwdChange::test_join_host. Fixing
discrepancies in returned and checked attributes.

https://fedorahosted.org/freeipa/ticket/6326