### PR TITLE
Fix regexp in user/group name

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -276,3 +276,6 @@ IPA_CA_CN = u'ipa'
 IPA_CA_RECORD = "ipa-ca"
 IPA_CA_NICKNAME = 'caSigningCert cert-pki-ca'
 RENEWAL_CA_NAME = 'dogtag-ipa-ca-renew-agent'
+
+# regexp definitions
+PATTERN_GROUPUSER_NAME = '^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$'

--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -33,6 +33,7 @@ from ipaserver.plugins.service import (
    validate_certificate, validate_realm, normalize_principal)
 from ipalib.request import context
 from ipalib import _
+from ipalib.constants import PATTERN_GROUPUSER_NAME
 from ipapython import kerberos
 from ipapython.ipautil import ipa_generate_password, GEN_TMP_PWD_LEN
 from ipapython.ipavalidate import Email
@@ -172,7 +173,7 @@ class baseuser(LDAPObject):
 
     takes_params = (
         Str('uid',
-            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$',
+            pattern=PATTERN_GROUPUSER_NAME,
             pattern_errmsg='may only include letters, numbers, _, -, . and $',
             maxlength=255,
             cli_name='login',

--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -172,7 +172,7 @@ class baseuser(LDAPObject):
 
     takes_params = (
         Str('uid',
-            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_.-]{0,252}[a-zA-Z0-9_.$-]?$',
+            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$',
             pattern_errmsg='may only include letters, numbers, _, -, . and $',
             maxlength=255,
             cli_name='login',

--- a/ipaserver/plugins/group.py
+++ b/ipaserver/plugins/group.py
@@ -22,6 +22,7 @@ import six
 
 from ipalib import api
 from ipalib import Int, Str, Flag
+from ipalib.constants import PATTERN_GROUPUSER_NAME
 from ipalib.plugable import Registry
 from .baseldap import (
     add_external_post_callback,
@@ -260,7 +261,7 @@ class group(LDAPObject):
 
     takes_params = (
         Str('cn',
-            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$',
+            pattern=PATTERN_GROUPUSER_NAME,
             pattern_errmsg='may only include letters, numbers, _, -, . and $',
             maxlength=255,
             cli_name='group_name',

--- a/ipaserver/plugins/group.py
+++ b/ipaserver/plugins/group.py
@@ -260,7 +260,7 @@ class group(LDAPObject):
 
     takes_params = (
         Str('cn',
-            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_.-]{0,252}[a-zA-Z0-9_.$-]?$',
+            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$',
             pattern_errmsg='may only include letters, numbers, _, -, . and $',
             maxlength=255,
             cli_name='group_name',

--- a/ipaserver/plugins/idviews.py
+++ b/ipaserver/plugins/idviews.py
@@ -29,7 +29,11 @@ from .baseldap import (LDAPQuery, LDAPObject, LDAPCreate,
 from .hostgroup import get_complete_hostgroup_member_list
 from .service import validate_certificate
 from ipalib import api, Str, Int, Bytes, Flag, _, ngettext, errors, output
-from ipalib.constants import IPA_ANCHOR_PREFIX, SID_ANCHOR_PREFIX
+from ipalib.constants import (
+    IPA_ANCHOR_PREFIX,
+    SID_ANCHOR_PREFIX,
+    PATTERN_GROUPUSER_NAME,
+)
 from ipalib.plugable import Registry
 from ipalib.util import (normalize_sshpubkey, validate_sshpubkey,
     convert_sshpubkey_post)
@@ -841,7 +845,7 @@ class idoverrideuser(baseidoverride):
 
     takes_params = baseidoverride.takes_params + (
         Str('uid?',
-            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$',
+            pattern=PATTERN_GROUPUSER_NAME,
             pattern_errmsg='may only include letters, numbers, _, -, . and $',
             maxlength=255,
             cli_name='login',
@@ -944,7 +948,7 @@ class idoverridegroup(baseidoverride):
 
     takes_params = baseidoverride.takes_params + (
         Str('cn?',
-            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$',
+            pattern=PATTERN_GROUPUSER_NAME,
             pattern_errmsg='may only include letters, numbers, _, -, . and $',
             maxlength=255,
             cli_name='group_name',

--- a/ipaserver/plugins/idviews.py
+++ b/ipaserver/plugins/idviews.py
@@ -841,7 +841,7 @@ class idoverrideuser(baseidoverride):
 
     takes_params = baseidoverride.takes_params + (
         Str('uid?',
-            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_.-]{0,252}[a-zA-Z0-9_.$-]?$',
+            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$',
             pattern_errmsg='may only include letters, numbers, _, -, . and $',
             maxlength=255,
             cli_name='login',
@@ -944,7 +944,7 @@ class idoverridegroup(baseidoverride):
 
     takes_params = baseidoverride.takes_params + (
         Str('cn?',
-            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_.-]{0,252}[a-zA-Z0-9_.$-]?$',
+            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$',
             pattern_errmsg='may only include letters, numbers, _, -, . and $',
             maxlength=255,
             cli_name='group_name',

--- a/ipaserver/plugins/servicedelegation.py
+++ b/ipaserver/plugins/servicedelegation.py
@@ -143,7 +143,7 @@ class servicedelegation(LDAPObject):
     takes_params = (
         Str(
             'cn',
-            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_ .-]{0,253}[a-zA-Z0-9_.-]?$',
+            pattern='^[a-zA-Z0-9_.][a-zA-Z0-9_ .-]*[a-zA-Z0-9_.-]?$',
             pattern_errmsg='may only include letters, numbers, _, -, ., '
                            'and a space inside',
             maxlength=255,

--- a/ipaserver/plugins/topology.py
+++ b/ipaserver/plugins/topology.py
@@ -129,7 +129,7 @@ class topologysegment(LDAPObject):
         ),
         Str(
             'iparepltoposegmentleftnode',
-            pattern='^[a-zA-Z0-9.][a-zA-Z0-9.-]{0,252}[a-zA-Z0-9.$-]?$',
+            pattern='^[a-zA-Z0-9.][a-zA-Z0-9.-]*[a-zA-Z0-9.$-]?$',
             pattern_errmsg='may only include letters, numbers, -, . and $',
             maxlength=255,
             cli_name='leftnode',
@@ -140,7 +140,7 @@ class topologysegment(LDAPObject):
         ),
         Str(
             'iparepltoposegmentrightnode',
-            pattern='^[a-zA-Z0-9.][a-zA-Z0-9.-]{0,252}[a-zA-Z0-9.$-]?$',
+            pattern='^[a-zA-Z0-9.][a-zA-Z0-9.-]*[a-zA-Z0-9.$-]?$',
             pattern_errmsg='may only include letters, numbers, -, . and $',
             maxlength=255,
             cli_name='rightnode',


### PR DESCRIPTION
Regexp should not enforce lenght of string, we have different checks for
that. Secondly regexp with length specified produces an incorrect error
message.

https://fedorahosted.org/freeipa/ticket/5822