### PR TITLE
Made sssd restart a non-raising opration

### DIFF
--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -691,7 +691,7 @@ def uninstall_master(host, ignore_topology_disconnect=True,
                      "xargs rm -fv", raiseonerr=False)
     host.run_command("find /run/ipa -name 'krb5*' | xargs rm -fv",
                      raiseonerr=False)
-    host.run_command(['systemctl', 'restart', 'sssd'])
+    host.run_command(['systemctl', 'restart', 'sssd'], raiseonerr=False)
     unapply_fixes(host)
 
 


### PR DESCRIPTION
Uninstallation of ipa-server usually removes sssd configuration file,
/etc/sssd/sssd.conf
If we then issue syustemctl restart sssd.service, the command fails because is
unable to find the config file. We need to make this call not raise an
exception