### PR TITLE
dns: re-introduce --raw in dnsrecord-del

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -1340,7 +1340,7 @@ output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
 command: dnsrecord_del/1
-args: 2,34,3
+args: 2,35,3
 arg: DNSNameParam('dnszoneidnsname', cli_name='dnszone')
 arg: DNSNameParam('idnsname', cli_name='name')
 option: A6Record('a6record*', autofill=False, cli_name='a6_rec')
@@ -1367,6 +1367,7 @@ option: NAPTRRecord('naptrrecord*', autofill=False, cli_name='naptr_rec')
 option: NSECRecord('nsecrecord*', autofill=False, cli_name='nsec_rec')
 option: NSRecord('nsrecord*', autofill=False, cli_name='ns_rec')
 option: PTRRecord('ptrrecord*', autofill=False, cli_name='ptr_rec')
+option: Flag('raw', autofill=True, default=False)
 option: RPRecord('rprecord*', autofill=False, cli_name='rp_rec')
 option: RRSIGRecord('rrsigrecord*', autofill=False, cli_name='rrsig_rec')
 option: SIGRecord('sigrecord*', autofill=False, cli_name='sig_rec')

--- a/VERSION
+++ b/VERSION
@@ -90,5 +90,5 @@ IPA_DATA_VERSION=20100614120000
 #                                                      #
 ########################################################
 IPA_API_VERSION_MAJOR=2
-IPA_API_VERSION_MINOR=214
-# Last change: ftweedal: add ca-disable and ca-enable commands
+IPA_API_VERSION_MINOR=215
+# Last change: dns: re-introduce --raw in dnsrecord-del

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -3800,6 +3800,10 @@ class dnsrecord_del(LDAPUpdate):
                 label=_('Delete all associated records'),
             ),
             dnsrecord.structured_flag,
+            Flag(
+                'raw',
+                exclude=('cli', 'webui'),
+            ),
     )
 
     def get_options(self):


### PR DESCRIPTION
The flag was removed in commit ff52c25ae299abba8bed653fe324951979a41293
because it is unused. Add it back for compatibility with old clients.

https://fedorahosted.org/freeipa/ticket/5644