### PR TITLE
Update ipa-server-install man page for hostname

### DIFF
--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -43,7 +43,7 @@ The password for the IPA admin user
 Create home directories for users on their first login
 .TP
 \fB\-\-hostname\fR=\fIHOST_NAME\fR
-The fully\-qualified DNS name of this server. If the hostname does not match system hostname, the system hostname will be updated accordingly to prevent service failures.
+The fully\-qualified DNS name of this server.
 .TP
 \fB\-\-ip\-address\fR=\fIIP_ADDRESS\fR
 The IP address of this server. If this address does not match the address the host resolves to and \-\-setup\-dns is not selected the installation will fail. If the server hostname is not resolvable, a record for the hostname and IP_ADDRESS is added to /etc/hosts.


### PR DESCRIPTION
Hostname is always set, remove the text that says
hostname is set only if it does not match the current
hostname.

https://fedorahosted.org/freeipa/ticket/6330