### PR TITLE
Add help info about certificate revocation reasons

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -826,7 +826,8 @@ class cert(BaseCertObject):
         Int(
             'revocation_reason',
             label=_('Revocation reason'),
-            doc=_('Reason for revoking the certificate (0-10)'),
+            doc=_('Reason for revoking the certificate (0-10). Type '
+                  '"ipa help cert" for revocation reason details. '),
             minvalue=0,
             maxvalue=10,
             flags={'no_create', 'no_update'},


### PR DESCRIPTION
Inform the user where to find additional information
about certificate revocation reasons.

https://fedorahosted.org/freeipa/ticket/6327