### PR TITLE
Tests: Remove SSSD restart from integration tests

### DIFF
--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -691,7 +691,6 @@ def uninstall_master(host, ignore_topology_disconnect=True,
                      "xargs rm -fv", raiseonerr=False)
     host.run_command("find /run/ipa -name 'krb5*' | xargs rm -fv",
                      raiseonerr=False)
-    host.run_command(['systemctl', 'restart', 'sssd'])
     unapply_fixes(host)
 
 


### PR DESCRIPTION
SSSD restart has been mistakenly added to integration tests
(test_integration/tasks.py::uninstall_master). When system setup is correct,
this restart has no significance, moreover it makes tests fail, hence its
removal is necessary.

https://fedorahosted.org/freeipa/ticket/6338