### PR TITLE
[ipa-4-2] Keep NSS trust flags of existing certificates

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1015,6 +1015,10 @@ class CAInstance(DogtagInstance):
             os.remove(pwd_name)
 
     def __import_ca_chain(self):
+        # Backup NSS trust flags of all already existing certificates
+        certdb = certs.CertDB(self.realm)
+        cert_backup_list = certdb.list_certs()
+
         chain = self.__get_ca_chain()
 
         # If this chain contains multiple certs then certutil will only import
@@ -1063,6 +1067,10 @@ class CAInstance(DogtagInstance):
                 finally:
                     os.remove(chain_name)
                     subid += 1
+
+        # Restore NSS trust flags of all previously existing certificates
+        for nick, trust_flags in cert_backup_list:
+            certdb.trust_root_cert(nick, trust_flags)
 
     def __request_ra_certificate(self):
         # Create a noise file for generating our private key


### PR DESCRIPTION
Backup and restore trust flags of existing certificates during CA
installation. This prevents marking a previously trusted certificate
as untrusted, as was the case when CA-less was converted to CA-full
with external CA when using the same certificate.

https://fedorahosted.org/freeipa/ticket/5791