### PR TITLE
Show error message for invalid IPs in client install

### DIFF
--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -133,8 +133,11 @@ class CheckedIPAddress(UnsafeIPAddress):
     """
     def __init__(self, addr, match_local=False, parse_netmask=True,
                  allow_loopback=False, allow_multicast=False):
+        try:
+            super(CheckedIPAddress, self).__init__(addr)
+        except netaddr.core.AddrFormatError as e:
+            raise ValueError(e)
 
-        super(CheckedIPAddress, self).__init__(addr)
         if isinstance(addr, CheckedIPAddress):
             self.prefixlen = addr.prefixlen
             return


### PR DESCRIPTION
Re-raise the thrown exception to get an error message
instead of a traceback during ipa-client-install with
invalid IP address.

https://fedorahosted.org/freeipa/ticket/6340