### PR TITLE
Tests: Remove --force options from tracker base class

### DIFF
--- a/ipatests/test_xmlrpc/test_certprofile_plugin.py
+++ b/ipatests/test_xmlrpc/test_certprofile_plugin.py
@@ -128,7 +128,7 @@ class TestProfileCRUD(XMLRPC_test):
     def test_create_duplicate(self, user_profile):
         msg = u'Certificate Profile with name "{}" already exists'
         user_profile.ensure_exists()
-        command = user_profile.make_create_command(force=True)
+        command = user_profile.make_create_command()
         with raises_exact(errors.DuplicateEntry(
                 message=msg.format(user_profile.name))):
             command()

--- a/ipatests/test_xmlrpc/tracker/automember_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/automember_plugin.py
@@ -38,8 +38,7 @@ class AutomemberTracker(Tracker):
         self.dn = DN(('cn', self.cn), ('cn', self.membertype.title()),
                      ('cn', 'automember'), ('cn', 'etc'), api.env.basedn)
 
-    def make_create_command(self,
-                            force=True, *args, **kwargs):
+    def make_create_command(self, *args, **kwargs):
         """ Make function that creates an automember using 'automember-add' """
         return self.make_command('automember_add', self.cn,
                                  description=self.description,

--- a/ipatests/test_xmlrpc/tracker/base.py
+++ b/ipatests/test_xmlrpc/tracker/base.py
@@ -167,7 +167,7 @@ class Tracker(object):
         """If the entry does not exist (according to tracker state), create it
         """
         if not self.exists:
-            self.create(force=True)
+            self.create()
 
     def ensure_missing(self):
         """If the entry exists (according to tracker state), delete it
@@ -175,7 +175,7 @@ class Tracker(object):
         if self.exists:
             self.delete()
 
-    def make_create_command(self, force=True):
+    def make_create_command(self):
         """Make function that creates the plugin entry object."""
         raise NotImplementedError(self._override_me_msg)
 
@@ -199,11 +199,11 @@ class Tracker(object):
         """Make function that modifies the entry using ${CMD}_mod"""
         raise NotImplementedError(self._override_me_msg)
 
-    def create(self, force=True):
+    def create(self):
         """Helper function to create an entry and check the result"""
         self.ensure_missing()
         self.track_create()
-        command = self.make_create_command(force=force)
+        command = self.make_create_command()
         result = command()
         self.check_create(result)
 

--- a/ipatests/test_xmlrpc/tracker/ca_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/ca_plugin.py
@@ -37,7 +37,7 @@ class CATracker(Tracker):
                      self.api.env.container_ca,
                      self.api.env.basedn)
 
-    def make_create_command(self, force=True):
+    def make_create_command(self):
         """Make function that creates the plugin entry object."""
         return self.make_command(
             'ca_add', self.name, ipacasubjectdn=self.ipasubjectdn,

--- a/ipatests/test_xmlrpc/tracker/caacl_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/caacl_plugin.py
@@ -87,7 +87,7 @@ class CAACLTracker(Tracker):
         """
         return {cat: [v] for cat, v in self.categories.items() if v}
 
-    def make_create_command(self, force=True):
+    def make_create_command(self):
         return self.make_command(u'caacl_add', self.name,
                                  description=self.description,
                                  **self.categories)

--- a/ipatests/test_xmlrpc/tracker/certprofile_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/certprofile_plugin.py
@@ -57,7 +57,7 @@ class CertprofileTracker(Tracker):
             content = f.read()
         return unicode(content)
 
-    def make_create_command(self, force=True):
+    def make_create_command(self):
         if not self.profile:
             raise RuntimeError('Tracker object without path to profile '
                                'cannot be used to create profile entry.')

--- a/ipatests/test_xmlrpc/tracker/group_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/group_plugin.py
@@ -30,7 +30,7 @@ class GroupTracker(Tracker):
         self.dn = get_group_dn(self.cn)
 
     def make_create_command(self, nonposix=False, external=False,
-                            force=True, *args, **kwargs):
+                            *args, **kwargs):
         """ Make function that creates a group using 'group-add' """
         return self.make_command('group_add', self.cn,
                                  description=self.description,

--- a/ipatests/test_xmlrpc/tracker/host_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/host_plugin.py
@@ -93,6 +93,14 @@ class HostTracker(KerberosAliasMixin, Tracker):
         """Make function that modifies the host using host_mod"""
         return self.make_command('host_mod', self.fqdn, **updates)
 
+    def create(self, force=True):
+        """Helper function to create an entry and check the result"""
+        self.ensure_missing()
+        self.track_create()
+        command = self.make_create_command(force=force)
+        result = command()
+        self.check_create(result)
+
     def track_create(self):
         """Update expected state for host creation"""
         self.attrs = dict(

--- a/ipatests/test_xmlrpc/tracker/location_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/location_plugin.py
@@ -43,13 +43,13 @@ class LocationTracker(Tracker):
 
         self.servers = {}
 
-    def make_create_command(self, force=None):
+    def make_create_command(self):
         """Make function that creates this location using location-add"""
         return self.make_command(
             'location_add', self.idnsname, description=self.description,
         )
 
-    def make_delete_command(self, force=None):
+    def make_delete_command(self):
         """Make function that removes this location using location-del"""
         return self.make_command('location_del', self.idnsname)
 

--- a/ipatests/test_xmlrpc/tracker/service_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/service_plugin.py
@@ -85,6 +85,14 @@ class ServiceTracker(KerberosAliasMixin, Tracker):
 
         return self.make_command('service_mod', self.name, **updates)
 
+    def create(self, force=True):
+        """Helper function to create an entry and check the result"""
+        self.ensure_missing()
+        self.track_create()
+        command = self.make_create_command(force=force)
+        result = command()
+        self.check_create(result)
+
     def track_create(self, **options):
         """ Update expected state for service creation """
         self.attrs = {

--- a/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
@@ -71,7 +71,7 @@ class StageUserTracker(Tracker):
 
         self.kwargs = kwargs
 
-    def make_create_command(self, options=None, force=None):
+    def make_create_command(self, options=None):
         """ Make function that creates a staged user using stageuser-add """
         if options is not None:
             self.kwargs = options

--- a/ipatests/test_xmlrpc/tracker/sudocmd_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/sudocmd_plugin.py
@@ -32,7 +32,7 @@ class SudoCmdTracker(Tracker):
         """ Property holding the name of the entry in LDAP """
         return self.cmd
 
-    def make_create_command(self, force=True):
+    def make_create_command(self):
         """ Make function that creates a sudocmd using 'sudocmd-add' """
         return self.make_command('sudocmd_add', self.cmd,
                                  description=self.description)

--- a/ipatests/test_xmlrpc/tracker/sudocmdgroup_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/sudocmdgroup_plugin.py
@@ -36,8 +36,7 @@ class SudoCmdGroupTracker(Tracker):
         self.dn = DN(('cn', self.cn), ('cn', 'sudocmdgroups'),
                      ('cn', 'sudo'), api.env.basedn)
 
-    def make_create_command(self,
-                            force=True, *args, **kwargs):
+    def make_create_command(self, *args, **kwargs):
         """ Make function that creates a sudocmdgroup
             using 'sudocmdgroup-add' """
         return self.make_command('sudocmdgroup_add', self.cn,

--- a/ipatests/test_xmlrpc/tracker/user_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/user_plugin.py
@@ -71,7 +71,7 @@ class UserTracker(KerberosAliasMixin, Tracker):
 
         self.kwargs = kwargs
 
-    def make_create_command(self, force=None):
+    def make_create_command(self):
         """ Make function that crates a user using user-add """
         return self.make_command(
             'user_add', self.uid,


### PR DESCRIPTION
Removing --force option from tracker base class so it would not be required to
be implemented in every specific tracker, even though it's not necessary.
Modifying existing trackers to reflect this change.

https://fedorahosted.org/freeipa/ticket/6124