### PR TITLE
Updated ipa-client-install info about hostname

### DIFF
--- a/client/ipa-client-install
+++ b/client/ipa-client-install
@@ -136,7 +136,8 @@ def parse_options():
     basic_group.add_option("", "--hostname", dest="hostname",
                       help="The hostname of this machine (FQDN). If specified, the hostname will be set and "
                            "the system configuration will be updated to persist over reboot. "
-                           "By default a nodename result from uname(2) is used.")
+                           "By default the result of getfqdn() call from "
+                           "Python's socket module is used.")
     basic_group.add_option("", "--force-join", dest="force_join",
                       action="store_true", default=False,
                       help="Force client enrollment even if already enrolled")

--- a/client/man/ipa-client-install.1
+++ b/client/man/ipa-client-install.1
@@ -111,7 +111,7 @@ Path to backed up host keytab from previous enrollment. Joins the host even if i
 Configure PAM to create a users home directory if it does not exist.
 .TP
 \fB\-\-hostname\fR
-The hostname of this machine (FQDN). If specified, the hostname will be set and the system configuration will be updated to persist over reboot. By default a nodename result from uname(2) is used.
+The hostname of this machine (FQDN). If specified, the hostname will be set and the system configuration will be updated to persist over reboot. By default the result of getfqdn() call from Python's socket module is used.
 .TP
 \fB\-\-force\-join\fR
 Join the host even if it is already enrolled.

--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -172,7 +172,8 @@ def parse_options():
 
     common_group.add_option("", "--hostname", dest="hostname",
                       help="The hostname of this server (FQDN). "
-                           "By default a nodename from uname(2) is used.")
+                           "By default the result of getfqdn() call from "
+                           "Python's socket module is used.")
     parser.add_option_group(common_group)
 
     parser.add_option("-d", "--debug", dest="debug",

--- a/install/tools/man/ipa-replica-conncheck.1
+++ b/install/tools/man/ipa-replica-conncheck.1
@@ -60,7 +60,7 @@ Remote replica machine address
 Include in a check also a set of dogtag connection requirements. Only needed when the master was installed with Dogtag 9 or lower.
 .TP
 \fB\-h\fR \fIHOSTNAME\fR, \fB\-\-hostname\fR=\fIHOSTNAME\fR
-The hostname of this server (FQDN). By default a nodename from uname(2) is used
+The hostname of this server (FQDN). By default the result of getfqdn() call from Python's socket module is used.
 .TP
 \fB\-d\fR, \fB\-\-debug\fR
 Print debugging information


### PR DESCRIPTION
The man page and help of ipa-client-install had an outdated
information about what is used as a hostname.

https://fedorahosted.org/freeipa/ticket/5754