### PR TITLE
Pylint: enable additional checks

### DIFF
--- a/daemons/dnssec/ipa-dnskeysyncd
+++ b/daemons/dnssec/ipa-dnskeysyncd
@@ -38,7 +38,9 @@ KEYTAB_FB = paths.IPA_DNSKEYSYNCD_KEYTAB
 # Shutdown handler
 def commenceShutdown(signum, stack):
     # Declare the needed global variables
-    global watcher_running, ldap_connection, log
+    global watcher_running
+    global ldap_connection  # pylint: disable=global-variable-not-assigned
+
     log.info('Signal %s received: Shutting down!', signum)
 
     # We are no longer running

--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -385,7 +385,6 @@ def main():
         print_info("\nConnection from replica to master is OK.")
 
         # create listeners
-        global RESPONDERS
         print_info("Start listening on required ports for remote master check")
 
         for port in required_ports:

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -314,9 +314,6 @@ def install_check(standalone, api, replica, options, hostname):
 
 
 def install(standalone, replica, options, api=api):
-    global ip_addresses
-    global reverse_zones
-
     local_dnskeysyncd_dn = DN(('cn', 'DNSKeySync'), ('cn', api.env.host),
                               ('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
                               api.env.basedn)

--- a/ipaserver/install/sysupgrade.py
+++ b/ipaserver/install/sysupgrade.py
@@ -35,17 +35,14 @@ def _load_sstore():
 
 def get_upgrade_state(module, state):
     _load_sstore()
-    global _sstore
     return _sstore.get_state(module, state)
 
 def set_upgrade_state(module, state, value):
     _load_sstore()
-    global _sstore
     _sstore.backup_state(module, state, value)
 
 def remove_upgrade_state(module, state):
     _load_sstore()
-    global _sstore
     _sstore.delete_state(module, state)
 
 def remove_upgrade_file():

--- a/ipatests/test_xmlrpc/test_cert_plugin.py
+++ b/ipatests/test_xmlrpc/test_cert_plugin.py
@@ -166,8 +166,6 @@ class test_cert(XMLRPC_test):
         """
         Verify that service-show has the right certificate using service-show.
         """
-        global cert
-
         res = api.Command['service_show'](self.service_princ)['result']
         assert base64.b64encode(res['usercertificate'][0]) == cert
 
@@ -175,8 +173,6 @@ class test_cert(XMLRPC_test):
         """
         Verify that service-find has the right certificate using service-find.
         """
-        global cert
-
         # Assume there is only one service
         res = api.Command['service_find'](self.service_princ)['result']
         assert base64.b64encode(res[0]['usercertificate'][0]) == cert
@@ -210,8 +206,6 @@ class test_cert(XMLRPC_test):
         """
         Verify the new certificate with service-show.
         """
-        global cert, newcert
-
         res = api.Command['service_show'](self.service_princ)['result']
 
         # Both the old and the new certs should be listed as certificates now

--- a/pylintrc
+++ b/pylintrc
@@ -17,7 +17,6 @@ enable=
 
 disable=
     I,
-    cyclic-import,
     duplicate-code,
     import-error,
     interface-not-implemented,

--- a/pylintrc
+++ b/pylintrc
@@ -46,7 +46,6 @@ disable=
     exec-used,
     fixme,
     global-statement,
-    global-variable-not-assigned,
     no-init,
     pointless-string-statement,
     protected-access,


### PR DESCRIPTION
Enabling:
* cyclic-imports
* global-variable-not-assigned