### PR TITLE
Update man/help for --server option

### DIFF
--- a/client/ipa-client-automount
+++ b/client/ipa-client-automount
@@ -49,7 +49,7 @@ from ipaplatform.paths import paths
 def parse_options():
     usage = "%prog [options]\n"
     parser = OptionParser(usage=usage)
-    parser.add_option("--server", dest="server", help="IPA server")
+    parser.add_option("--server", dest="server", help="FQDN of IPA server")
     parser.add_option("--location", dest="location", help="Automount location",
         default="default")
     parser.add_option("-S", "--no-sssd", dest="sssd",

--- a/client/ipa-client-install
+++ b/client/ipa-client-install
@@ -116,7 +116,7 @@ def parse_options():
 
     basic_group = OptionGroup(parser, "basic options")
     basic_group.add_option("--domain", dest="domain", help="domain name")
-    basic_group.add_option("--server", dest="server", help="IPA server", action="append")
+    basic_group.add_option("--server", dest="server", help="FQDN of IPA server", action="append")
     basic_group.add_option("--realm", dest="realm_name", help="realm name")
     basic_group.add_option("--fixed-primary", dest="primary", action="store_true",
                       default=False, help="Configure sssd to use fixed server as primary IPA server")

--- a/client/man/ipa-client-automount.1
+++ b/client/man/ipa-client-automount.1
@@ -49,7 +49,7 @@ The nsswitch automount service is configured to use either sss or ldap and files
 NFSv4 is also configured. The rpc.gssd and rpc.idmapd are started on clients to support Kerberos\-secured mounts.
 .SH "OPTIONS"
 \fB\-\-server\fR=\fISERVER\fR
-Set the IPA server to connect to
+Set the FQDN of the IPA server to connect to
 .TP
 \fB\-\-location\fR=\fILOCATION\fR
 Automount location

--- a/client/man/ipa-client-install.1
+++ b/client/man/ipa-client-install.1
@@ -87,7 +87,7 @@ Consequences of the re\-enrollment on the host entry:
 Set the domain name to DOMAIN. When no \-\-server option is specified, the installer will try to discover all available servers via DNS SRV record autodiscovery (see DNS Autodiscovery section for details).
 .TP
 \fB\-\-server\fR=\fISERVER\fR
-Set the IPA server to connect to. May be specified multiple times to add multiple servers to ipa_server value in sssd.conf or krb5.conf. Only the first value is considered when used with \-\-no\-sssd. When this option is used, DNS autodiscovery for Kerberos is disabled and a fixed list of KDC and Admin servers is configured.
+Set the FQDN of the IPA server to connect to. May be specified multiple times to add multiple servers to ipa_server value in sssd.conf or krb5.conf. Only the first value is considered when used with \-\-no\-sssd. When this option is used, DNS autodiscovery for Kerberos is disabled and a fixed list of KDC and Admin servers is configured.
 .TP
 \fB\-\-realm\fR=\fIREALM_NAME\fR
 Set the IPA realm name to REALM_NAME. Under normal circumstances, this option is not needed as the realm name is retrieved from the IPA server.

--- a/ipapython/config.py
+++ b/ipapython/config.py
@@ -223,7 +223,8 @@ def __discover_config(discover_server = True):
 
 def add_standard_options(parser):
     parser.add_option("--realm", dest="realm", help="Override default IPA realm")
-    parser.add_option("--server", dest="server", help="Override default IPA server")
+    parser.add_option("--server", dest="server",
+                      help="Override default FQDN of IPA server")
     parser.add_option("--domain", dest="domain", help="Override default IPA DNS domain")
 
 def init_config(options=None):


### PR DESCRIPTION
The --server option now specifically mentions that
it expects the FQDN of the IPA server.

https://fedorahosted.org/freeipa/ticket/6202