### PR TITLE
sudorule: add SELinux transition examples to plugin doc

### DIFF
--- a/ipaserver/plugins/sudorule.py
+++ b/ipaserver/plugins/sudorule.py
@@ -88,6 +88,10 @@ EXAMPLES:
 """) + _("""
  Set a default Sudo option:
    ipa sudorule-add-option defaults --sudooption '!authenticate'
+""") + _("""
+ Set SELinux type and role transitions on a rule:
+   ipa sudorule-add-option sysadmin_sudo --sudooption type=unconfined_t
+   ipa sudorule-add-option sysadmin_sudo --sudooption role=unconfined_r
 """)
 
 register = Registry()


### PR DESCRIPTION
It is not obvious how to add SELinux type and role transitions to a
Sudo rule.  Update the 'sudorule' plugin documentation with examples
of how to do this.

Fixes: https://fedorahosted.org/freeipa/ticket/3461