### PR TITLE
test_text: add test ipa.pot file for tests

### DIFF
--- a/ipatests/setup.py.in
+++ b/ipatests/setup.py.in
@@ -82,6 +82,7 @@ def setup_package():
                 'ipatests': ['pytest.ini'],
                 'ipatests.test_install': ['*.update'],
                 'ipatests.test_integration': ['scripts/*'],
+                'ipatests.test_ipalib': ['data/*'],
                 'ipatests.test_pkcs10': ['*.csr'],
                 "ipatests.test_ipaserver": ['data/*'],
                 'ipatests.test_xmlrpc': ['data/*'],

--- a/ipatests/test_ipalib/data/ipa.pot
+++ b/ipatests/test_ipalib/data/ipa.pot
@@ -1,0 +1,47 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Red Hat
+# This file is distributed under the same license as the ipa package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: ipa\n"
+"Report-Msgid-Bugs-To: https://fedorahosted.org/freeipa/newticket\n"
+"POT-Creation-Date: 2016-08-29 10:39+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: ipaclient/frontend.py:28 ipaclient/frontend.py:85
+#: ipaserver/plugins/baseldap.py:52
+msgid "Failed members"
+msgstr ""
+
+#: ipaclient/frontend.py:32 ipaserver/plugins/baseldap.py:169
+msgid "Failed source hosts/hostgroups"
+msgstr ""
+
+#: ipaclient/frontend.py:36 ipaserver/plugins/baseldap.py:172
+msgid "Failed hosts/hostgroups"
+msgstr ""
+
+#: ipaclient/frontend.py:40 ipaserver/plugins/baseldap.py:175
+msgid "Failed users/groups"
+msgstr ""
+
+#: ipaclient/plugins/dns.py:249
+#, python-format
+msgid ""
+"%(count)d %(type)s record skipped. Only one value per DNS record type can be "
+"modified at one time."
+msgid_plural ""
+"%(count)d %(type)s records skipped. Only one value per DNS record type can "
+"be modified at one time."
+msgstr[0] ""
+msgstr[1] ""

--- a/ipatests/test_ipalib/test_text.py
+++ b/ipatests/test_ipalib/test_text.py
@@ -59,8 +59,6 @@ class test_TestLang(object):
         self.lang = 'xh_ZA'
         self.domain = 'ipa'
 
-        self.ipa_i18n_dir = os.path.join(os.path.dirname(__file__), '../../install/po')
-
         self.pot_basename = '%s.pot' % self.domain
         self.po_basename = '%s.po' % self.lang
         self.mo_basename = '%s.mo' % self.domain
@@ -74,7 +72,8 @@ class test_TestLang(object):
         if not os.path.exists(self.msg_dir):
             os.makedirs(self.msg_dir)
 
-        self.pot_file = os.path.join(self.ipa_i18n_dir, self.pot_basename)
+        self.pot_file = os.path.join(
+            os.path.dirname(__file__), 'data', self.pot_basename)
         self.mo_file = os.path.join(self.msg_dir, self.mo_basename)
         self.po_file = os.path.join(self.tmp_dir, self.po_basename)
 
@@ -84,10 +83,12 @@ class test_TestLang(object):
                                 (self.po_file, self.mo_file, self.pot_file))
 
         if not file_exists(self.po_file):
-            raise nose.SkipTest('Test po file unavailable, run "make test" in install/po')
+            raise nose.SkipTest(
+                'Test po file unavailable: {}'.format(self.po_file))
 
         if not file_exists(self.mo_file):
-            raise nose.SkipTest('Test mo file unavailable, run "make test" in install/po')
+            raise nose.SkipTest(
+                'Test mo file unavailable: {}'.format(self.mo_file))
 
         self.po_file_iterate = po_file_iterate
 


### PR DESCRIPTION
Input data should be packaged into freeipa-test module to be able run
test from RPM (outoftree)

https://fedorahosted.org/freeipa/ticket/6333