### PR TITLE
Prompt for forwarder in dnsforwardzone-add

### DIFF
--- a/ipaclient/plugins/dns.py
+++ b/ipaclient/plugins/dns.py
@@ -389,6 +389,11 @@ class dnsconfig_mod(MethodOverride):
 @register(override=True, no_fail=True)
 class dnsforwardzone_add(MethodOverride):
     def interactive_prompt_callback(self, kw):
+        if ('idnsforwarders' not in kw and
+                kw.get('idnsforwardpolicy') != u'none'):
+            kw['idnsforwarders'] = self.Backend.textui.prompt(
+                _(u'DNS forwarder'))
+
         # show informative message on client side
         # server cannot send messages asynchronous
         if kw.get('idnsforwarders', False):


### PR DESCRIPTION
When the command ipa dnsforwardzone-add is invoked without
specifying the forwarder as an argument and the forward
policy is not set to none, prompt for DNS forwarder.

https://fedorahosted.org/freeipa/ticket/6169