### PR TITLE
The first jab at fixing https://fedorahosted.org/freeipa/ticket/5809

### DIFF
--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -1484,3 +1484,30 @@ def is_fips_enabled():
         # Consider that the host is not fips-enabled if the file does not exist
         pass
     return False
+
+
+def unescape_seq(seq, *args):
+    """
+    unescape (remove '\\') all occurences of sequence in input strings.
+
+    :param seq: sequence to unescape
+    :param args: input string to process
+
+    :returns: tuple of strings with unescaped sequences
+    """
+    unescape_re = re.compile(r'\\{}'.format(seq))
+
+    return tuple(re.sub(unescape_re, seq, a) for a in args)
+
+
+def escape_seq(seq, *args):
+    """
+    escape (prepend '\\') all occurences of sequence in input strings
+
+    :param seq: sequence to escape
+    :param args: input string to process
+
+    :returns: tuple of strings with escaped sequences
+    """
+
+    return tuple(a.replace(seq, u'\\{}'.format(seq)) for a in args)

--- a/ipapython/kerberos.py
+++ b/ipapython/kerberos.py
@@ -8,6 +8,8 @@ classes/utils for Kerberos principal name validation/manipulation
 import re
 import six
 
+from ipapython.ipautil import escape_seq, unescape_seq
+
 if six.PY3:
     unicode = str
 
@@ -56,33 +58,6 @@ def split_principal_name(principal_name):
     NT-PRINCIPAL and NT-ENTERPRISE, primary name and instance for others)
     """
     return tuple(COMPONENT_SPLIT_RE.split(principal_name))
-
-
-def unescape_seq(seq, *args):
-    """
-    unescape (remove '\\') all occurences of sequence in input strings.
-
-    :param seq: sequence to unescape
-    :param args: input string to process
-
-    :returns: tuple of strings with unescaped sequences
-    """
-    unescape_re = re.compile(r'\\{}'.format(seq))
-
-    return tuple(re.sub(unescape_re, seq, a) for a in args)
-
-
-def escape_seq(seq, *args):
-    """
-    escape (prepend '\\') all occurences of sequence in input strings
-
-    :param seq: sequence to escape
-    :param args: input string to process
-
-    :returns: tuple of strings with escaped sequences
-    """
-
-    return tuple(a.replace(seq, u'\\{}'.format(seq)) for a in args)
 
 
 @six.python_2_unicode_compatible

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -263,7 +263,8 @@ class HTTPInstance(service.Service):
             print("Updating port in %s failed." % paths.HTTPD_NSS_CONF)
 
     def __set_mod_nss_nickname(self, nickname):
-        installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSNickname', nickname)
+        installutils.set_directive(
+            paths.HTTPD_NSS_CONF, 'NSSNickname', nickname, quote_char="'")
 
     def set_mod_nss_protocol(self):
         installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSProtocol', 'TLSv1.0,TLSv1.1,TLSv1.2', False)


### PR DESCRIPTION
There are two ways to fix the issue reported in the ticket:

1.) Make certificate handling code to generate nicknames that do not break
existing implementation of `installutils.set_directive`

2.) Extend the quoting abilities of the function so that it is less fragile
when encoding more funky values such as quoted RDNs

This PR opts for option 2.