### PR TITLE
ipalib.constants: Remove default domain, realm, basedn, xmlrpc_uri, ldap_uri

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -71,9 +71,12 @@ DEFAULT_CONFIG = (
     ('version', VERSION),
 
     # Domain, realm, basedn:
-    ('domain', 'example.com'),
-    ('realm', 'EXAMPLE.COM'),
-    ('basedn', DN(('dc', 'example'), ('dc', 'com'))),
+    # Following values do not have any reasonable default.
+    # Do not initialize them so the code which depends on them blows up early
+    # and does not do crazy stuff with default values instead of real ones.
+    # ('domain', 'example.com'),
+    # ('realm', 'EXAMPLE.COM'),
+    # ('basedn', DN(('dc', 'example'), ('dc', 'com'))),
 
     # LDAP containers:
     ('container_accounts', DN(('cn', 'accounts'))),
@@ -127,9 +130,12 @@ DEFAULT_CONFIG = (
     ('container_custodia', DN(('cn', 'custodia'), ('cn', 'ipa'), ('cn', 'etc'))),
 
     # Ports, hosts, and URIs:
-    ('xmlrpc_uri', 'http://localhost:8888/ipa/xml'),
+    # Following values do not have any reasonable default.
+    # Do not initialize them so the code which depends on them blows up early
+    # and does not do crazy stuff with default values instead of real ones.
+    # ('xmlrpc_uri', 'http://localhost:8888/ipa/xml'),
     # jsonrpc_uri is set in Env._finalize_core()
-    ('ldap_uri', 'ldap://localhost:389'),
+    # ('ldap_uri', 'ldap://localhost:389'),
 
     ('rpc_protocol', 'jsonrpc'),
 

--- a/makeaci
+++ b/makeaci
@@ -96,6 +96,9 @@ def main(options):
         plugins_on_demand=False,
         basedn=DN('dc=ipa,dc=example'),
         realm='IPA.EXAMPLE',
+        domain="example.com",
+        xmlrpc_uri="http://localhost:8888/ipa/xml",
+        ldap_uri="ldap://localhost:389",
     )
 
     from ipaserver.install.plugins import update_managed_permissions

--- a/makeapi
+++ b/makeapi
@@ -37,6 +37,7 @@ from ipalib.parameters import Param
 from ipalib.output import Output
 from ipalib.text import Gettext, NGettext, ConcatenatedLazyText
 from ipalib.capabilities import capabilities
+from ipapython.dn import DN
 
 API_FILE='API.txt'
 
@@ -510,6 +511,11 @@ def main():
         enable_ra=True,
         mode='developer',
         plugins_on_demand=False,
+        basedn=DN(('dc', 'example'), ('dc', 'com')),
+        realm="EXAMPLE.COM",
+        domain="example.com",
+        xmlrpc_uri="http://localhost:8888/ipa/xml",
+        ldap_uri="ldap://localhost:389",
     )
 
     api.bootstrap(**cfg)


### PR DESCRIPTION
Domain, realm, basedn, xmlrpc_uri, ldap_uri do not have any reasonable default.
This patch removes hardcoded default so the so the code which depends
on these values blows up early and does not do crazy stuff
with default values instead of real ones.

This should help to uncover issues caused by improper ipalib
initialization.

It will surely break something but right now, at the beginning of devel cycle, is IMHO the right time to do change like this and to remove some old cruft.
