### PR TITLE
Raise errors from service.py:_ldap_mod() by default

### DIFF
--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -185,7 +185,7 @@ class Service(object):
         self.admin_conn.unbind()
         self.admin_conn = None
 
-    def _ldap_mod(self, ldif, sub_dict=None, raise_on_err=False):
+    def _ldap_mod(self, ldif, sub_dict=None, raise_on_err=True):
         pw_name = None
         fd = None
         path = ipautil.SHARE_DIR + ldif
@@ -229,9 +229,9 @@ class Service(object):
             try:
                 ipautil.run(args, nolog=nologlist)
             except ipautil.CalledProcessError as e:
+                root_logger.critical("Failed to load %s: %s" % (ldif, str(e)))
                 if raise_on_err:
                     raise
-                root_logger.critical("Failed to load %s: %s" % (ldif, str(e)))
         finally:
             if pw_name:
                 os.remove(pw_name)


### PR DESCRIPTION
This is to prevent situations when installer prints
CRITICAL Failed to load ....ldif
and continues just to crash later on because of non-existing LDAP container
or so on.

Beginning of devel cycle is the right time to fix this so we have time to uncover potential regressions and fix long hidden bugs.