### PR TITLE
Add fix for no-hbac-allow option in server install

### DIFF
--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -58,7 +58,7 @@ The starting user and group id number (default random)
 \fB\-\-idmax\fR=\fIIDMAX\fR
 The maximum user and group id number (default: idstart+199999). If set to zero, the default value will be used.
 .TP
-\fB\-\-no_hbac_allow\fR
+\fB\-\-no-hbac-allow\fR
 Don't install allow_all HBAC rule. This rule lets any user from any host access any service on any other host. It is expected that users will remove this rule before moving to production.
 .TP
 \fB\-\-ignore-topology-disconnect\fR

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1288,7 +1288,8 @@ class Server(BaseServer):
     no_hbac_allow = Knob(
         bool, False,
         description="Don't install allow_all HBAC rule",
-        cli_name='no_hbac_allow',
+        cli_name='no-hbac-allow',
+        cli_aliases=['no_hbac_allow'],
     )
 
     ignore_topology_disconnect = Knob(


### PR DESCRIPTION
Fixes: https://fedorahosted.org/freeipa/ticket/6357

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>