### PR TITLE
WebUI: hide buttons in certificate widget according to acl

### DIFF
--- a/install/ui/src/freeipa/user.js
+++ b/install/ui/src/freeipa/user.js
@@ -208,6 +208,8 @@ return {
                         },
                         {
                             $type: 'certs',
+                            acl_param: 'usercertificate',
+                            acl_result_index: 0,
                             adapter: {
                                 $type: 'object_adapter',
                                 result_index: 3


### PR DESCRIPTION
When user is logged in and opens details page of another user there should not
be visible button for adding new certificate and also the option in action menu
for deleting certificate should be grayed out.

This is achieved by adding custom field for certificates widget, which is able to
read ACLs from result of user-show and not from cert-find result.

https://fedorahosted.org/freeipa/ticket/6341