### PR TITLE
Pretty-print structures in assert_deepequal

### DIFF
--- a/ipatests/pytest.ini
+++ b/ipatests/pytest.ini
@@ -12,6 +12,7 @@ addopts = --doctest-modules
           -p ipatests.pytest_plugins.declarative
           -p ipatests.pytest_plugins.integration
           -p ipatests.pytest_plugins.beakerlib
+          -p ipatests.pytest_plugins.additional_config
             # Ignore files for doc tests.
             # TODO: ideally, these should all use __name__=='__main__' guards
           --ignore=setup.py

--- a/ipatests/pytest_plugins/additional_config.py
+++ b/ipatests/pytest_plugins/additional_config.py
@@ -1,0 +1,8 @@
+#
+# Copyright (C) 2016  FreeIPA Contributors see COPYING for license
+#
+
+
+def pytest_addoption(parser):
+    parser.addoption("--no-pretty-print", action="store_false",
+                     dest="pretty_print", help="Don't pretty-print structures")


### PR DESCRIPTION
By default, ipa-run-tests will now pretty-print structures
compared in the assert_deepequal function. This behaviour
can be turned off by the --no-pretty-print option.

https://fedorahosted.org/freeipa/ticket/6212