### PR TITLE
Pylint: enable unused-variable check

### DIFF
--- a/client/ipa-client-automount
+++ b/client/ipa-client-automount
@@ -45,6 +45,7 @@ from ipaplatform.tasks import tasks
 from ipaplatform import services
 from ipaplatform.paths import paths
 
+# pylint: disable=unused-variable
 
 def parse_options():
     usage = "%prog [options]\n"

--- a/client/ipa-client-install
+++ b/client/ipa-client-install
@@ -72,6 +72,8 @@ error was:
 """ % e, file=sys.stderr)
     sys.exit(1)
 
+# pylint: disable=unused-variable
+
 SUCCESS = 0
 CLIENT_INSTALL_ERROR = 1
 CLIENT_NOT_CONFIGURED = 2

--- a/daemons/dnssec/ipa-dnskeysync-replica
+++ b/daemons/dnssec/ipa-dnskeysync-replica
@@ -49,7 +49,7 @@ def update_metadata_set(log, source_set, target_set):
 def find_unwrapping_key(log, localhsm, wrapping_key_uri):
     wrap_keys = localhsm.find_keys(uri=wrapping_key_uri)
     # find usable unwrapping key with matching ID
-    for key_id, key in wrap_keys.items():
+    for key_id in wrap_keys.keys():
         unwrap_keys = localhsm.find_keys(id=key_id, cka_unwrap=True)
         if len(unwrap_keys) > 0:
             return unwrap_keys.popitem()[1]

--- a/daemons/dnssec/ipa-ods-exporter
+++ b/daemons/dnssec/ipa-ods-exporter
@@ -41,6 +41,8 @@ from ipapython.dnssec.abshsm import sync_pkcs11_metadata, wrappingmech_name2id
 from ipapython.dnssec.ldapkeydb import LdapKeyDB
 from ipapython.dnssec.localhsm import LocalHSM
 
+# pylint: disable=unused-variable
+
 DAEMONNAME = 'ipa-ods-exporter'
 PRINCIPAL = None  # not initialized yet
 WORKDIR = os.path.join(paths.VAR_OPENDNSSEC_DIR ,'tmp')

--- a/doc/examples/examples.py
+++ b/doc/examples/examples.py
@@ -415,7 +415,7 @@ class exuser_find(Method):
         # patter expects them in one dict. We need to arrange that.
         for e in entries:
             e[1]['dn'] = e[0]
-        entries = [e for (dn, e) in entries]
+        entries = [e for (_dn, e) in entries]
 
         return dict(result=entries, count=len(entries), truncated=truncated)
 

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -44,6 +44,8 @@ from ipaplatform.paths import paths
 from ipaserver.plugins.ldap2 import ldap2
 from ipaserver.install import cainstance, certs
 
+# pylint: disable=unused-variable
+
 # This is a certmonger CA helper script for IPA CA subsystem cert renewal. See
 # https://git.fedorahosted.org/cgit/certmonger.git/tree/doc/submit.txt for more
 # info on certmonger CA helper scripts.

--- a/install/oddjob/com.redhat.idm.trust-fetch-domains
+++ b/install/oddjob/com.redhat.idm.trust-fetch-domains
@@ -34,7 +34,7 @@ def retrieve_keytab(api, ccache_name, oneway_keytab_name, oneway_principal):
     try:
         sssd = pwd.getpwnam(constants.SSSD_USER)
         os.chown(oneway_keytab_name, sssd[2], sssd[3])
-    except KeyError as e:
+    except KeyError:
         # If user 'sssd' does not exist, we don't need to chown from root to sssd
         # because it means SSSD does not run as sssd user
         pass

--- a/install/share/copy-schema-to-ca.py
+++ b/install/share/copy-schema-to-ca.py
@@ -113,7 +113,7 @@ def main():
     standard_logging_setup(verbose=True)
 
     # In 3.0, restarting needs access to api.env
-    (options, argv) = api.bootstrap_with_global_options(context='server')
+    api.bootstrap_with_global_options(context='server')
 
     add_ca_schema()
     restart_pki_ds()

--- a/install/tools/ipa-adtrust-install
+++ b/install/tools/ipa-adtrust-install
@@ -45,6 +45,8 @@ from ipaplatform.paths import paths
 from ipapython.ipa_log_manager import root_logger, standard_logging_setup
 from ipapython.dn import DN
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/install/tools/ipa-csreplica-manage
+++ b/install/tools/ipa-csreplica-manage
@@ -232,9 +232,6 @@ def del_link(realm, replica1, replica2, dirman_passwd, force=False):
     print("Deleted replication agreement from '%s' to '%s'" % (replica1, replica2))
 
 def del_master(realm, hostname, options):
-
-    force_del = False
-
     delrepl = None
 
     # 1. Connect to the local dogtag DS server
@@ -258,7 +255,6 @@ def del_master(realm, hostname, options):
             sys.exit(1)
         else:
             print("Unable to connect to replica %s, forcing removal" % hostname)
-            force_del = True
 
     # 4. Get list of agreements.
     if delrepl is None:

--- a/install/tools/ipa-dns-install
+++ b/install/tools/ipa-dns-install
@@ -89,7 +89,7 @@ def parse_options():
     parser.add_option("--force", dest="force", action="store_true",
                       help="Force install")
 
-    options, args = parser.parse_args()
+    options, _args = parser.parse_args()
     safe_options = parser.get_safe_opts(options)
 
     if options.dnssec_master and options.disable_dnssec_master:

--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -185,7 +185,7 @@ def parse_options():
     parser.add_option("--no-log", dest="log_to_file", action="store_false",
                       default=True, help="Do not log into file")
 
-    options, args = parser.parse_args()
+    options, _args = parser.parse_args()
     safe_options = parser.get_safe_opts(options)
 
     if options.master and options.replica:

--- a/install/tools/ipa-replica-manage
+++ b/install/tools/ipa-replica-manage
@@ -45,6 +45,8 @@ from ipaclient import ipadiscovery
 from six.moves.xmlrpc_client import MAXINT
 from ipaplatform.paths import paths
 
+# pylint: disable=unused-variable
+
 # dict of command name and tuples of min/max num of args needed
 commands = {
     "list":(0, 1, "[master fqdn]", ""),

--- a/install/tools/ipactl
+++ b/install/tools/ipactl
@@ -39,6 +39,8 @@ from ipapython.dn import DN
 from ipaplatform import services
 from ipaplatform.paths import paths
 
+# pylint: disable=unused-variable
+
 
 MSG_HINT_IGNORE_SERVICE_FAILURE = (
     "Hint: You can use --ignore-service-failure option for forced start in "

--- a/ipaclient/ipa_certupdate.py
+++ b/ipaclient/ipa_certupdate.py
@@ -99,7 +99,7 @@ class CertUpdate(admintool.AdminTool):
                 from ipaserver.install import cainstance
                 cainstance.add_lightweight_ca_tracking_requests(
                     self.log, lwcas)
-            except Exception as e:
+            except Exception:
                 self.log.exception(
                     "Failed to add lightweight CA tracking requests")
 

--- a/ipaclient/ipachangeconf.py
+++ b/ipaclient/ipachangeconf.py
@@ -24,6 +24,8 @@ import shutil
 
 import six
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaclient/ipadiscovery.py
+++ b/ipaclient/ipadiscovery.py
@@ -30,6 +30,8 @@ from ipaplatform.paths import paths
 from ipapython.ipautil import valid_ip, realm_to_suffix
 from ipapython.dn import DN
 
+# pylint: disable=unused-variable
+
 NOT_FQDN = -1
 NO_LDAP_SERVER = -2
 REALM_NOT_FOUND = -3

--- a/ipaclient/plugins/automount.py
+++ b/ipaclient/plugins/automount.py
@@ -152,7 +152,7 @@ class automountlocation_import(Command):
         The basic idea is to read the master file and create all the maps
         we need, then read each map file and add all the keys for the map.
         """
-        location = self.api.Command['automountlocation_show'](args[0])
+        self.api.Command['automountlocation_show'](args[0])
 
         result = {'maps':[], 'keys':[], 'skipped':[], 'duplicatekeys':[], 'duplicatemaps':[]}
         maps = {}
@@ -183,7 +183,7 @@ class automountlocation_import(Command):
                             automountkey=unicode(am[0]),
                             automountinformation=unicode(' '.join(am[1:])))
                 result['keys'].append([am[0], u'auto.master'])
-            except errors.DuplicateEntry as e:
+            except errors.DuplicateEntry:
                 if unicode(am[0]) in DEFAULT_KEYS:
                     # ignore conflict when the key was pre-created by the framework
                     pass
@@ -198,7 +198,7 @@ class automountlocation_import(Command):
                 try:
                     api.Command['automountmap_add'](args[0], unicode(am[1]))
                     result['maps'].append(am[1])
-                except errors.DuplicateEntry as e:
+                except errors.DuplicateEntry:
                     if unicode(am[1]) in DEFAULT_MAPS:
                         # ignore conflict when the map was pre-created by the framework
                         pass

--- a/ipaclient/plugins/cert.py
+++ b/ipaclient/plugins/cert.py
@@ -27,6 +27,8 @@ from ipalib.parameters import File, Flag, Str
 from ipalib.plugable import Registry
 from ipalib.text import _
 
+# pylint: disable=unused-variable
+
 register = Registry()
 
 

--- a/ipaclient/plugins/location.py
+++ b/ipaclient/plugins/location.py
@@ -18,7 +18,7 @@ class location_show(MethodOverride):
 
         servers = output.get('servers', {})
         first = True
-        for hostname, details in servers.items():
+        for details in servers.values():
             if first:
                 textui.print_indented(_("Servers details:"), indent=1)
                 first = False

--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -629,9 +629,6 @@ class vault_archive(Local):
         return self.api.Command.vault_archive_internal.output()
 
     def forward(self, *args, **options):
-
-        name = args[-1]
-
         data = options.get('data')
         input_file = options.get('in')
 
@@ -883,9 +880,6 @@ class vault_retrieve(Local):
         return self.api.Command.vault_retrieve_internal.output()
 
     def forward(self, *args, **options):
-
-        name = args[-1]
-
         output_file = options.get('out')
 
         password = options.get('password')

--- a/ipalib/aci.py
+++ b/ipalib/aci.py
@@ -103,8 +103,6 @@ class ACI(object):
         lexer = shlex.shlex(aci)
         lexer.wordchars = lexer.wordchars + "."
 
-        l = []
-
         var = False
         op = "="
         for token in lexer:

--- a/ipalib/certstore.py
+++ b/ipalib/certstore.py
@@ -29,6 +29,7 @@ from ipapython.dn import DN
 from ipapython.certdb import get_ca_nickname
 from ipalib import errors, x509
 
+# pylint: disable=unused-variable
 
 def _parse_cert(dercert):
     try:

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -1342,7 +1342,7 @@ cli_plugins = (
 def run(api):
     error = None
     try:
-        (options, argv) = api.bootstrap_with_global_options(context='cli')
+        (_options, argv) = api.bootstrap_with_global_options(context='cli')
         for klass in cli_plugins:
             api.add_plugin(klass)
         api.finalize()

--- a/ipalib/frontend.py
+++ b/ipalib/frontend.py
@@ -40,6 +40,8 @@ from ipalib import errors, messages
 from ipalib.request import context, context_frame
 from ipalib.util import classproperty, json_serialize
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -119,6 +119,7 @@ from ipapython import kerberos
 from ipapython.dn import DN
 from ipapython.dnsutil import DNSName
 
+# pylint: disable=unused-variable
 
 def _is_null(value):
     return not value and value != 0 # NOTE: False == 0

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -70,6 +70,8 @@ from ipapython.kerberos import Principal
 from ipalib.capabilities import VERSION_WITHOUT_CAPABILITIES
 from ipalib import api
 
+# pylint: disable=unused-variable
+
 # The XMLRPC client is in  "six.moves.xmlrpc_client", but pylint
 # cannot handle that
 try:

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -51,6 +51,8 @@ from ipapython.dnsutil import DNSName
 from ipapython.dnsutil import resolve_ip_addresses
 from ipapython.ipa_log_manager import root_logger
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -30,6 +30,8 @@ from ipapython.ipa_log_manager import root_logger
 from ipapython import ipautil
 from ipalib import x509
 
+# pylint: disable=unused-variable
+
 CA_NICKNAME_FMT = "%s IPA CA"
 
 

--- a/ipapython/certmonger.py
+++ b/ipapython/certmonger.py
@@ -34,6 +34,8 @@ from ipapython.ipa_log_manager import root_logger
 from ipaplatform.paths import paths
 from ipaplatform import services
 
+# pylint: disable=unused-variable
+
 DBUS_CM_PATH = '/org/fedorahosted/certmonger'
 DBUS_CM_IF = 'org.fedorahosted.certmonger'
 DBUS_CM_NAME = 'org.fedorahosted.certmonger'

--- a/ipapython/cookie.py
+++ b/ipapython/cookie.py
@@ -27,6 +27,8 @@ from six.moves.urllib.parse import urlparse
 
 from ipapython.ipa_log_manager import log_mgr
 
+# pylint: disable=unused-variable
+
 '''
 Core Python has two cookie libraries, Cookie.py targeted to server
 side and cookielib.py targeted to client side. So why this module and

--- a/ipapython/dn.py
+++ b/ipapython/dn.py
@@ -1186,9 +1186,10 @@ class DN(object):
         # differ in case must yield the same hash value.
 
         str_dn = ';,'.join([
-            '++'.join(
-                ['=='.join((atype, avalue or '')) for atype,avalue,dummy in rdn]
-            ) for rdn in self.rdns
+            '++'.join([
+                '=='.join((atype, avalue or ''))
+                for atype, avalue, _dummy in rdn
+            ]) for rdn in self.rdns
         ])
         return hash(str_dn.lower())
 
@@ -1225,9 +1226,7 @@ class DN(object):
 
     def _cmp_sequence(self, pattern, self_start, pat_len):
         self_idx = self_start
-        self_len = len(self)
         pat_idx = 0
-        #  and self_idx < self_len
         while pat_idx < pat_len:
             r = cmp_rdns(self.rdns[self_idx], pattern.rdns[pat_idx])
             if r != 0:

--- a/ipapython/dnssec/localhsm.py
+++ b/ipapython/dnssec/localhsm.py
@@ -18,6 +18,8 @@ from ipapython.dnssec.abshsm import (attrs_name2id, attrs_id2name, AbstractHSM,
                                      keytype_id2name, keytype_name2id,
                                      ldap2p11helper_api_params)
 
+# pylint: disable=unused-variable
+
 private_key_api_params = set(["label", "id", "data", "unwrapping_key",
     "wrapping_mech", "key_type", "cka_always_authenticate", "cka_copyable",
     "cka_decrypt", "cka_derive", "cka_extractable", "cka_modifiable",

--- a/ipapython/dogtag.py
+++ b/ipapython/dogtag.py
@@ -113,7 +113,7 @@ def ca_status(ca_host=None):
     """
     if ca_host is None:
         ca_host = api.env.ca_host
-    status, headers, body = http_request(
+    status, _headers, body = http_request(
         ca_host, 8080, '/ca/admin/ca/getStatus')
     if status == 503:
         # Service temporarily unavailable

--- a/ipapython/graph.py
+++ b/ipapython/graph.py
@@ -44,8 +44,8 @@ class Graph(object):
 
         # delete _adjacencies
         del self._adj[vertex]
-        for key, _adj in self._adj.items():
-            _adj[:] = [v for v in _adj if v != vertex]
+        for adj in self._adj.values():
+            adj[:] = [v for v in adj if v != vertex]
 
         # delete edges
         edges = [e for e in self.edges if e[0] != vertex and e[1] != vertex]

--- a/ipapython/install/cli.py
+++ b/ipapython/install/cli.py
@@ -152,7 +152,7 @@ class ConfigureTool(admintool.AdminTool):
                     **kwargs
                 )
 
-        for group, opt_group in groups.items():
+        for opt_group in groups.values():
             parser.add_option_group(opt_group)
 
         super(ConfigureTool, cls).add_options(parser,

--- a/ipapython/install/common.py
+++ b/ipapython/install/common.py
@@ -60,7 +60,7 @@ class Step(Installable):
         raise AttributeError('parent')
 
     def _install(self):
-        for nothing in self._installer(self.parent):
+        for _nothing in self._installer(self.parent):
             yield from_(super(Step, self)._install())
 
     @staticmethod
@@ -68,7 +68,7 @@ class Step(Installable):
         yield
 
     def _uninstall(self):
-        for nothing in self._uninstaller(self.parent):
+        for _nothing in self._uninstaller(self.parent):
             yield from_(super(Step, self)._uninstall())
 
     @staticmethod

--- a/ipapython/install/core.py
+++ b/ipapython/install/core.py
@@ -19,6 +19,8 @@ from ipapython.ipa_log_manager import root_logger
 from . import util
 from .util import from_
 
+# pylint: disable=unused-variable
+
 __all__ = ['InvalidStateError', 'KnobValueError', 'Property', 'Knob',
            'Configurable', 'Group', 'Component', 'Composite']
 

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -44,6 +44,8 @@ from ipapython.dn import DN
 from ipapython.dnsutil import DNSName
 from ipapython.kerberos import Principal
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -54,6 +54,8 @@ from ipapython import config
 from ipaplatform.paths import paths
 from ipapython.dn import DN
 
+# pylint: disable=unused-variable
+
 SHARE_DIR = paths.USR_SHARE_IPA_DIR
 PLUGINS_SHARE_DIR = paths.IPA_PLUGINS
 

--- a/ipapython/nsslib.py
+++ b/ipapython/nsslib.py
@@ -234,7 +234,7 @@ class NSSConnection(httplib.HTTPConnection, NSSAddressFamilyFallback):
         self.sock.set_ssl_option(ssl.SSL_HANDSHAKE_AS_CLIENT, True)
         try:
             self.sock.set_ssl_version_range(self.tls_version_min, self.tls_version_max)
-        except NSPRError as e:
+        except NSPRError:
             root_logger.error('Failed to set TLS range to %s, %s' % (self.tls_version_min, self.tls_version_max))
             raise
         self.sock.set_ssl_option(ssl_require_safe_negotiation, False)

--- a/ipapython/p11helper.py
+++ b/ipapython/p11helper.py
@@ -12,6 +12,8 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 from cffi import FFI
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipapython/sysrestore.py
+++ b/ipapython/sysrestore.py
@@ -35,6 +35,8 @@ from six.moves.configparser import SafeConfigParser
 from ipaplatform.tasks import tasks
 from ipaplatform.paths import paths
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -63,6 +63,8 @@ from ipaplatform.paths import paths
 from ldap.filter import escape_filter_chars
 from time import sleep
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
     long = int

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -742,13 +742,13 @@ class ADTRUSTInstance(service.Service):
         try:
             self.ldap_enable('ADTRUST', self.fqdn, self.dm_password, \
                              self.suffix)
-        except (ldap.ALREADY_EXISTS, errors.DuplicateEntry) as e:
+        except (ldap.ALREADY_EXISTS, errors.DuplicateEntry):
             root_logger.info("ADTRUST Service startup entry already exists.")
 
         try:
             self.ldap_enable('EXTID', self.fqdn, self.dm_password, \
                              self.suffix)
-        except (ldap.ALREADY_EXISTS, errors.DuplicateEntry) as e:
+        except (ldap.ALREADY_EXISTS, errors.DuplicateEntry):
             root_logger.info("EXTID Service startup entry already exists.")
 
     def __setup_sub_dict(self):

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -60,6 +60,8 @@ from ipalib.util import (validate_zonemgr_str, normalize_zonemgr,
                          UnresolvableRecordError)
 from ipalib.constants import CACERT
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -15,6 +15,8 @@ from ipalib import api, certstore, x509
 from ipapython.dn import DN
 from ipapython.ipa_log_manager import root_logger
 
+# pylint: disable=unused-variable
+
 external_cert_file = None
 external_ca_file = None
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -81,6 +81,7 @@ try:
 except ImportError:
     import http.client as httplib
 
+# pylint: disable=unused-variable
 
 # We need to reset the template because the CA uses the regular boot
 # information

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -45,6 +45,8 @@ from ipalib.text import _
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 
+# pylint: disable=unused-variable
+
 # Apache needs access to this database so we need to create it
 # where apache can reach
 NSS_DIR = paths.HTTPD_ALIAS_DIR

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -34,6 +34,8 @@ from ipaserver.install import ntpinstance
 from ipaserver.install import odsexporterinstance
 from ipaserver.install import opendnssecinstance
 
+# pylint: disable=unused-variable
+
 ip_addresses = []
 reverse_zones = []
 

--- a/ipaserver/install/dnskeysyncinstance.py
+++ b/ipaserver/install/dnskeysyncinstance.py
@@ -28,6 +28,8 @@ from ipalib import errors, api
 from ipalib.constants import CACERT
 from ipaserver.install.bindinstance import dns_container_exists
 
+# pylint: disable=unused-variable
+
 softhsm_token_label = u'ipaDNSSEC'
 softhsm_slot = 0
 replica_keylabel_template = u"dnssec-replica:%s"

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -45,6 +45,8 @@ from ipaserver.install import replication
 from ipaserver.install.installutils import stopped_service
 from ipapython.ipa_log_manager import log_mgr
 
+# pylint: disable=unused-variable
+
 HTTPD_USER = constants.HTTPD_USER
 
 

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -52,6 +52,8 @@ from ipapython.admintool import ScriptError
 from ipaplatform import services
 from ipaplatform.paths import paths
 
+# pylint: disable=unused-variable
+
 DS_USER = platformconstants.DS_USER
 DS_GROUP = platformconstants.DS_GROUP
 

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1021,7 +1021,7 @@ def load_external_cert(files, subject_base):
         ca_subject = DN(('CN', 'Certificate Authority'), subject_base)
         ca_nickname = None
         cache = {}
-        for nickname, trust_flags in nssdb.list_certs():
+        for nickname, _trust_flags in nssdb.list_certs():
             cert = nssdb.get_cert(nickname, pem=True)
 
             nss_cert = x509.load_certificate(cert)

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -40,6 +40,8 @@ from ipalib.constants import CACERT
 from ipaplatform.constants import constants
 from ipaplatform.tasks import tasks
 
+# pylint: disable=unused-variable
+
 """
 A test gpg can be generated like this:
 

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -31,6 +31,8 @@ from ipaplatform.paths import paths
 from ipalib import api, errors, x509, certstore
 from ipaserver.install import certs, cainstance, installutils
 
+# pylint: disable=unused-variable
+
 
 class CACertManage(admintool.AdminTool):
     command_name = 'ipa-cacert-manage'

--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -200,7 +200,7 @@ class PBKDF2KeyDerivation(XMLKeyDerivation):
             hash = [0] * mac.digest_size
 
             # Perform n iterations.
-            for j in xrange(self.iter):
+            for _j in xrange(self.iter):
                 tmp = mac.copy()
                 tmp.update(last)
                 last = tmp.digest()

--- a/ipaserver/install/ipa_replica_prepare.py
+++ b/ipaserver/install/ipa_replica_prepare.py
@@ -43,6 +43,7 @@ from ipalib import errors
 from ipaplatform.paths import paths
 from ipalib.constants import CACERT, DOMAIN_LEVEL_0
 
+# pylint: disable=unused-variable
 
 UNSUPPORTED_DOMAIN_LEVEL_TEMPLATE = """
 Replica creation using '{command_name}' to generate replica file

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -51,6 +51,7 @@ try:
 except ImportError:
     adtrustinstance = None
 
+# pylint: disable=unused-variable
 
 def recursive_chown(path, uid, gid):
     '''

--- a/ipaserver/install/ipa_winsync_migrate.py
+++ b/ipaserver/install/ipa_winsync_migrate.py
@@ -29,6 +29,8 @@ from ipapython.dn import DN
 from ipapython.ipautil import realm_to_suffix, posixify
 from ipaserver.install import replication, installutils
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -286,7 +286,7 @@ class KrbInstance(service.Service):
         )
         try:
             ipautil.run(args, nolog=(self.master_password,), stdin=''.join(dialogue))
-        except ipautil.CalledProcessError as e:
+        except ipautil.CalledProcessError:
             print("Failed to initialize the realm container")
 
     def __configure_instance(self):

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -848,7 +848,7 @@ class LDAPUpdate(object):
     def get_all_files(self, root, recursive=False):
         """Get all update files"""
         f = []
-        for path, subdirs, files in os.walk(root):
+        for path, _subdirs, files in os.walk(root):
             for name in files:
                 if fnmatch.fnmatch(name, "*.update"):
                     f.append(os.path.join(path, name))

--- a/ipaserver/install/ntpinstance.py
+++ b/ipaserver/install/ntpinstance.py
@@ -152,7 +152,7 @@ class NTPInstance(service.Service):
                         fd.write(line)
                         continue
                     sline = sline.replace(NTPD_OPTS_QUOTE, '')
-                    (variable, opts) = sline.split('=', 1)
+                    (_variable, opts) = sline.split('=', 1)
                     fd.write(NTPD_OPTS_VAR + '="%s %s"\n' % (opts, ' '.join(newopts)))
                     done = True
                 else:

--- a/ipaserver/install/odsexporterinstance.py
+++ b/ipaserver/install/odsexporterinstance.py
@@ -66,8 +66,6 @@ class ODSExporterInstance(service.Service):
         self.start_creation()
 
     def __check_dnssec_status(self):
-        ods_enforcerd = services.knownservices.ods_enforcerd
-
         try:
             self.ods_uid = pwd.getpwnam(constants.ODS_USER).pw_uid
         except KeyError:

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -20,6 +20,8 @@ from ipaplatform.paths import paths
 from ipalib import errors, api
 from ipaserver.install import dnskeysyncinstance
 
+# pylint: disable=unused-variable
+
 KEYMASTER = u'dnssecKeyMaster'
 softhsm_slot = 0
 

--- a/ipaserver/install/plugins/adtrust.py
+++ b/ipaserver/install/plugins/adtrust.py
@@ -40,7 +40,7 @@ class update_default_range(Updater):
         dn = DN(self.api.env.container_ranges, self.api.env.basedn)
         search_filter = "objectclass=ipaDomainIDRange"
         try:
-            (entries, truncated) = ldap.find_entries(search_filter, [], dn)
+            ldap.find_entries(search_filter, [], dn)
         except errors.NotFound:
             pass
         else:
@@ -85,7 +85,7 @@ class update_default_range(Updater):
         search_filter = "objectclass=dnaSharedConfig"
         attrs = ['dnaHostname', 'dnaRemainingValues']
         try:
-            (entries, truncated) = ldap.find_entries(search_filter, attrs, dn)
+            (entries, _truncated) = ldap.find_entries(search_filter, attrs, dn)
         except errors.NotFound:
             root_logger.warning("default_range: no dnaSharedConfig object found. "
                                 "Cannot check default range size.")

--- a/ipaserver/install/plugins/dns.py
+++ b/ipaserver/install/plugins/dns.py
@@ -278,7 +278,6 @@ class update_master_to_dnsforwardzones(DNSUpdater):
     backup_filename = u'dns-master-to-forward-zones-%Y-%m-%d-%H-%M-%S.ldif'
 
     def execute(self, **options):
-        ldap = self.api.Backend.ldap2
         # check LDAP if forwardzones already uses new semantics
         if not self.version_update_needed(target_version=1):
             # forwardzones already uses new semantics,

--- a/ipaserver/install/plugins/rename_managed.py
+++ b/ipaserver/install/plugins/rename_managed.py
@@ -24,6 +24,8 @@ from ipalib import Updater
 from ipapython import ipautil
 from ipapython.dn import DN
 
+# pylint: disable=unused-variable
+
 register = Registry()
 
 if six.PY3:

--- a/ipaserver/install/plugins/update_idranges.py
+++ b/ipaserver/install/plugins/update_idranges.py
@@ -132,7 +132,7 @@ class update_idrange_baserid(Updater):
         )
 
         try:
-            (entries, truncated) = ldap.find_entries(
+            (entries, _truncated) = ldap.find_entries(
                 search_filter, ['ipabaserid'], base_dn,
                 paged_search=True, time_limit=0, size_limit=0)
 

--- a/ipaserver/install/plugins/update_managed_permissions.py
+++ b/ipaserver/install/plugins/update_managed_permissions.py
@@ -433,7 +433,7 @@ class update_managed_permissions(Updater):
             else:
                 if 'ipapermissiontype' not in legacy_entry:
                     if is_new:
-                        acientry, acistr = (
+                        _acientry, acistr = (
                             permission_plugin._get_aci_entry_and_string(
                                 legacy_entry, notfound_ok=True))
                         try:

--- a/ipaserver/install/plugins/update_passsync.py
+++ b/ipaserver/install/plugins/update_passsync.py
@@ -60,7 +60,7 @@ class update_passync_privilege_update(Updater):
                 self.api.env.basedn)
 
         try:
-            entry = ldap.get_entry(passsync_dn, [''])
+            ldap.get_entry(passsync_dn, [''])
         except errors.NotFound:
             root_logger.debug("PassSync user not found, no update needed")
             sysupgrade.set_upgrade_state('winsync', 'passsync_privilege_updated', True)

--- a/ipaserver/install/plugins/update_uniqueness.py
+++ b/ipaserver/install/plugins/update_uniqueness.py
@@ -177,7 +177,7 @@ class update_uniqueness_plugins_to_new_syntax(Updater):
         )
 
         try:
-            entries, truncated = ldap.find_entries(
+            entries, _truncated = ldap.find_entries(
                 filter=old_style_plugin_search_filter,
                 base_dn=self.plugins_dn,
             )

--- a/ipaserver/install/plugins/upload_cacrt.py
+++ b/ipaserver/install/plugins/upload_cacrt.py
@@ -55,7 +55,7 @@ class update_upload_cacrt(Updater):
             if nickname == ca_nickname and ca_enabled:
                 trust_flags = 'CT,C,C'
             cert = db.get_cert_from_db(nickname, pem=False)
-            trust, ca, eku = certstore.trust_flags_to_key_policy(trust_flags)
+            trust, _ca, eku = certstore.trust_flags_to_key_policy(trust_flags)
 
             dn = DN(('cn', nickname), ('cn', 'certificates'), ('cn', 'ipa'),
                     ('cn','etc'), self.api.env.basedn)

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -38,6 +38,8 @@ from ipapython.dn import DN
 from ipaplatform import services
 from ipaplatform.paths import paths
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/install/schemaupdate.py
+++ b/ipaserver/install/schemaupdate.py
@@ -125,7 +125,7 @@ def update_schema(schema_files, ldapi=False, dm_password=None,):
 
     for filename in schema_files:
         log.debug('Processing schema LDIF file %s', filename)
-        dn, new_schema = ldap.schema.subentry.urlfetch(filename)
+        _dn, new_schema = ldap.schema.subentry.urlfetch(filename)
 
         for attrname, cls in SCHEMA_ELEMENT_CLASSES:
             for oids_set in _get_oid_dependency_order(new_schema, cls):

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -59,6 +59,8 @@ except ImportError:
 
 from .common import BaseServer, BaseServerCA
 
+# pylint: disable=unused-variable
+
 SYSRESTORE_DIR_PATH = paths.SYSRESTORE
 
 

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -47,6 +47,8 @@ from binascii import hexlify
 
 from .common import BaseServer
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -49,6 +49,8 @@ from ipaserver.install import dogtaginstance
 from ipaserver.install.upgradeinstance import IPAUpgrade
 from ipaserver.install.ldapupdate import BadSyntax
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -116,7 +116,7 @@ def find_providing_server(svcname, conn, host_name=None, api=api):
                                      'ipaConfigString': 'enabledService',
                                      'cn': svcname}, rules='&')
     try:
-        entries, trunc = conn.find_entries(filter=query_filter, base_dn=dn)
+        entries, _trunc = conn.find_entries(filter=query_filter, base_dn=dn)
     except errors.NotFound:
         return None
     if len(entries):
@@ -523,7 +523,7 @@ class Service(object):
         search_kw = {'ipaConfigString': u'enabledService'}
         filter = self.admin_conn.make_filter(search_kw)
         try:
-            entries, truncated = self.admin_conn.find_entries(
+            entries, _truncated = self.admin_conn.find_entries(
                 filter=filter,
                 attrs_list=['ipaConfigString'],
                 base_dn=entry_dn,

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -30,6 +30,8 @@ from ipaserver.install import schemaupdate
 from ipaserver.install import ldapupdate
 from ipaserver.install import service
 
+# pylint: disable=unused-variable
+
 DSE = 'dse.ldif'
 
 

--- a/ipaserver/plugins/aci.py
+++ b/ipaserver/plugins/aci.py
@@ -132,6 +132,8 @@ from .baseldap import gen_pkey_only_option, pkey_to_value
 from ipapython.ipa_log_manager import root_logger
 from ipapython.dn import DN
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -39,6 +39,8 @@ from ipalib.messages import add_message, SearchResultTruncated
 from ipapython.dn import DN
 from ipapython.version import API_VERSION
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -53,6 +53,8 @@ from ipapython.dn import DN
 from ipapython.ipa_log_manager import root_logger
 from ipaserver.plugins.service import normalize_principal, validate_realm
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -293,7 +293,7 @@ class config_mod(LDAPUpdate):
                               for field in entry_attrs[k].split(',')]
                 # test if all base types (without sub-types) are allowed
                 for a in attributes:
-                    a, tomato, olive = a.partition(';')
+                    a, _dummy, _dummy = a.partition(';')
                     if a not in allowed_attrs:
                         raise errors.ValidationError(
                             name=k, error=_('attribute "%s" not allowed') % a
@@ -325,7 +325,7 @@ class config_mod(LDAPUpdate):
                 if self.api.Object[obj].uuid_attribute:
                     checked_attrs = checked_attrs + [self.api.Object[obj].uuid_attribute]
                 for obj_attr in checked_attrs:
-                    obj_attr, tomato, olive = obj_attr.partition(';')
+                    obj_attr, _dummy, _dummy = obj_attr.partition(';')
                     if obj_attr in OPERATIONAL_ATTRIBUTES:
                         continue
                     if obj_attr in self.api.Object[obj].params and \

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -85,6 +85,8 @@ from ipaserver.dns_data_management import (
     IPADomainIsNotManagedByIPAError,
 )
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -259,6 +259,8 @@ if api.env.in_server:
     import pki.crypto as cryptoutil
     from pki.kra import KRAClient
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/plugins/domainlevel.py
+++ b/ipaserver/plugins/domainlevel.py
@@ -60,7 +60,7 @@ def get_master_entries(ldap, api):
         api.env.basedn
     )
 
-    masters, _ = ldap.find_entries(
+    masters, _dummy = ldap.find_entries(
         filter="(cn=*)",
         base_dn=container_masters,
         scope=ldap.SCOPE_ONELEVEL,

--- a/ipaserver/plugins/group.py
+++ b/ipaserver/plugins/group.py
@@ -329,7 +329,7 @@ class group_del(LDAPDelete):
         assert isinstance(dn, DN)
         config = ldap.get_ipa_config()
         def_primary_group = config.get('ipadefaultprimarygroup', '')
-        def_primary_group_dn = group_dn = self.obj.get_dn(def_primary_group)
+        def_primary_group_dn = self.obj.get_dn(def_primary_group)
         if dn == def_primary_group_dn:
             raise errors.DefaultGroupError()
         group_attrs = self.obj.methods.show(

--- a/ipaserver/plugins/hbactest.py
+++ b/ipaserver/plugins/hbactest.py
@@ -411,7 +411,8 @@ class hbactest(Command):
                 ldap = self.api.Backend.ldap2
                 group_container = DN(api.env.container_group, api.env.basedn)
                 try:
-                    entries, truncated = ldap.find_entries(filter_sids, ['memberof'], group_container)
+                    entries, _truncated = ldap.find_entries(
+                        filter_sids, ['memberof'], group_container)
                 except errors.NotFound:
                     request.user.groups = []
                 else:

--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -601,7 +601,7 @@ class host(LDAPObject):
         managed_hosts = []
 
         try:
-            (hosts, truncated) = ldap.find_entries(
+            (hosts, _truncated) = ldap.find_entries(
                 base_dn=DN(self.container_dn, api.env.basedn),
                 filter=host_filter, attrs_list=host_attrs)
 

--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -26,6 +26,8 @@ from ipalib import api, Int, Str, StrEnum, _, ngettext
 from ipalib import errors
 from ipapython.dn import DN
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/plugins/idviews.py
+++ b/ipaserver/plugins/idviews.py
@@ -40,6 +40,8 @@ from ipalib.util import (normalize_sshpubkey, validate_sshpubkey,
 
 from ipapython.dn import DN
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/plugins/migration.py
+++ b/ipaserver/plugins/migration.py
@@ -40,6 +40,8 @@ from ipapython.kerberos import Principal
 import datetime
 from ipaplatform.paths import paths
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/plugins/permission.py
+++ b/ipaserver/plugins/permission.py
@@ -33,6 +33,8 @@ from ipalib.aci import ACI
 from ipapython.dn import DN
 from ipalib.request import context
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/plugins/privilege.py
+++ b/ipaserver/plugins/privilege.py
@@ -64,7 +64,7 @@ def validate_permission_to_privilege(api, permission):
         '(objectClass=ipaPermissionV2)', '(!(ipaPermBindRuleType=permission))',
         ldap.make_filter_from_attr('cn', permission, rules='|')])
     try:
-        entries, truncated = ldap.find_entries(
+        entries, _truncated = ldap.find_entries(
             filter=ldapfilter,
             attrs_list=['cn', 'ipapermbindruletype'],
             base_dn=DN(api.env.container_permission, api.env.basedn),

--- a/ipaserver/plugins/selinuxusermap.py
+++ b/ipaserver/plugins/selinuxusermap.py
@@ -109,7 +109,7 @@ def validate_selinuxuser(ugettext, user):
 
     # If we add in ::: we don't have to check to see if some values are
     # empty
-    (name, mls, mcs, ignore) = (user + ':::').split(':', 3)
+    (name, mls, mcs, _ignore) = (user + ':::').split(':', 3)
 
     if not regex_name.match(name):
         return _('Invalid SELinux user name, only a-Z and _ are allowed')

--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -889,7 +889,7 @@ class server_conncheck(crud.PKQuery):
                              follow_name_owner_changes=True)
         server = dbus.Interface(obj, 'org.freeipa.server')
 
-        ret, stdout, stderr = server.conncheck(keys[-1])
+        ret, stdout, _stderr = server.conncheck(keys[-1])
 
         result = dict(
             result=(ret == 0),

--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -284,7 +284,7 @@ def check_required_principal(ldap, principal):
     """
     try:
         host_is_master(ldap, principal.hostname)
-    except errors.ValidationError as e:
+    except errors.ValidationError:
         service_types = ['HTTP', 'ldap', 'DNS', 'dogtagldap']
         if principal.service_name in service_types:
             raise errors.ValidationError(name='principal', error=_('This principal is required by the IPA master'))

--- a/ipaserver/plugins/stageuser.py
+++ b/ipaserver/plugins/stageuser.py
@@ -50,6 +50,8 @@ from ipaplatform.paths import paths
 from ipapython.ipautil import ipa_generate_password, GEN_TMP_PWD_LEN
 from ipalib.capabilities import client_has_capability
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/plugins/sudocmd.py
+++ b/ipaserver/plugins/sudocmd.py
@@ -164,7 +164,7 @@ class sudocmd_del(LDAPDelete):
             ldap.MATCH_ALL)
         dependent_sudorules = []
         try:
-            entries, truncated = ldap.find_entries(
+            entries, _truncated = ldap.find_entries(
                 filter, ['cn'],
                 base_dn=DN(api.env.container_sudorule, api.env.basedn))
         except errors.NotFound:

--- a/ipaserver/plugins/trust.py
+++ b/ipaserver/plugins/trust.py
@@ -45,6 +45,8 @@ from ipalib import output
 from ldap import SCOPE_SUBTREE
 from time import sleep
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -69,6 +69,8 @@ from ipalib.capabilities import client_has_capability
 if api.env.in_server:
     from ipaserver.plugins.ldap2 import ldap2
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -64,6 +64,8 @@ from ipaplatform.paths import paths
 from ipapython.version import VERSION
 from ipalib.text import _
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipaserver/session.py
+++ b/ipaserver/session.py
@@ -961,7 +961,7 @@ class MemcacheSessionManager(SessionManager):
 
         try:
             session_cookie = Cookie.get_named_cookie_from_string(cookie_header, self.session_cookie_name)
-        except Exception as e:
+        except Exception:
             session_cookie = None
         if session_cookie:
             session_id = session_cookie.value

--- a/ipatests/i18n.py
+++ b/ipatests/i18n.py
@@ -345,7 +345,7 @@ def validate_positional_substitutions(s, prog_langs, s_name='string'):
 
     errors = []
     if n_fmts > 1:
-        for i, fmt_parts in enumerate(fmts):
+        for fmt_parts in fmts:
             fmt        = fmt_parts['fmt']
             fmt_arg    = fmt_parts['fmt_arg']
             width      = fmt_parts['width']
@@ -543,7 +543,7 @@ def create_po(pot_file, po_file, mo_file):
     #
     # It is demanding the rhs of plural= only contains the identifer 'n'
 
-    for k,v in po.metadata.items():
+    for k in po.metadata:
         if k.lower() == 'plural-forms':
             po.metadata[k] = 'nplurals=2; plural=(n != 1)'
             break

--- a/ipatests/pytest_plugins/declarative.py
+++ b/ipatests/pytest_plugins/declarative.py
@@ -23,7 +23,6 @@
 def pytest_generate_tests(metafunc):
     """Generates Declarative tests"""
     if 'declarative_test_definition' in metafunc.fixturenames:
-        name = metafunc.cls.__name__
         tests = []
         descriptions = []
         for i, test in enumerate(metafunc.cls.tests):

--- a/ipatests/pytest_plugins/integration.py
+++ b/ipatests/pytest_plugins/integration.py
@@ -34,6 +34,7 @@ from ipatests.test_integration import tasks
 from ipatests.test_integration.config import Config
 from ipatests.test_integration.env_config import get_global_config
 
+# pylint: disable=unused-variable
 
 log = log_mgr.get_logger(__name__)
 

--- a/ipatests/test_cmdline/test_help.py
+++ b/ipatests/test_cmdline/test_help.py
@@ -141,6 +141,6 @@ def test_multiline_description():
     assert '\n\n' in unicode(api.Command.trust_add.doc).strip()
 
     with CLITestContext(exception=SystemExit) as help_ctx:
-        return_value = api.Backend.cli.run(['trust-add', '-h'])
+        api.Backend.cli.run(['trust-add', '-h'])
 
     assert unicode(api.Command.trust_add.doc).strip() in help_ctx.stdout

--- a/ipatests/test_cmdline/test_ipagetkeytab.py
+++ b/ipatests/test_cmdline/test_ipagetkeytab.py
@@ -114,7 +114,7 @@ class test_ipagetkeytab(cmdline_test):
                 self.keytabname)
             assert expected in result.error_output, (
                 'Success message not in output:\n%s' % result.error_output)
-        except ipautil.CalledProcessError as e:
+        except ipautil.CalledProcessError:
             assert (False)
 
     def test_3_use(self):

--- a/ipatests/test_install/test_updates.py
+++ b/ipatests/test_install/test_updates.py
@@ -34,6 +34,8 @@ from ipapython import ipautil, ipaldap
 from ipaplatform.paths import paths
 from ipapython.dn import DN
 
+# pylint: disable=unused-variable
+
 """
 The updater works through files only so this is just a thin-wrapper controlling
 which file we test at any given point.

--- a/ipatests/test_integration/env_config.py
+++ b/ipatests/test_integration/env_config.py
@@ -279,7 +279,7 @@ def domain_from_env(env, config, index, domain_type):
     env_suffix = '_env%s' % index
 
     master_env = '%s%s' % (master_role, env_suffix)
-    hostname, dot, domain_name = env[master_env].partition('.')
+    hostname, _dot, domain_name = env[master_env].partition('.')
     domain = Domain(config, domain_name, domain_type)
 
     for role in _roles_from_env(domain, env, env_suffix):

--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -44,6 +44,8 @@ from ipalib.util import get_reverse_zone_default, verify_host_resolvable
 from ipalib.constants import DOMAIN_SUFFIX_NAME
 from ipalib.constants import DOMAIN_LEVEL_0
 
+# pylint: disable=unused-variable
+
 log = log_mgr.get_logger(__name__)
 
 

--- a/ipatests/test_integration/test_testconfig.py
+++ b/ipatests/test_integration/test_testconfig.py
@@ -420,7 +420,7 @@ class TestComplexConfig(CheckConfig):
     def check_config(self, conf):
         assert len(conf.domains) == 3
         main_dom = conf.domains[0]
-        (client1, client2, extra, extram1, extram2, master,
+        (client1, client2, extra, extram1, extram2, _master,
          replica1, replica2) = sorted(main_dom.hosts, key=lambda h: h.role)
         assert main_dom.name == 'ipadomain.test'
         assert main_dom.type == 'IPA'

--- a/ipatests/test_integration/test_topology.py
+++ b/ipatests/test_integration/test_topology.py
@@ -188,9 +188,8 @@ class TestTopologyOptions(IntegrationTest):
         returncode, error = tasks.destroy_segment(self.master, "%s-to-%s" % replicas)
         assert returncode != 0, error1
         assert error.count(text) == 1, error2 % error
-        newseg, err = tasks.create_segment(self.master,
-                                           self.master,
-                                           self.replicas[1])
+        _newseg, err = tasks.create_segment(
+            self.master, self.master, self.replicas[1])
         assert err == "", err
         returncode, error = tasks.destroy_segment(self.master, "%s-to-%s" % replicas)
         assert returncode == 0, error

--- a/ipatests/test_ipalib/test_backend.py
+++ b/ipatests/test_ipalib/test_backend.py
@@ -189,7 +189,7 @@ class test_Executioner(ClassChecker):
         """
         Test the `ipalib.backend.Executioner.execute` method.
         """
-        (api, home) = create_test_api(in_server=True)
+        api, _home = create_test_api(in_server=True)
 
         class echo(Command):
             takes_args = ('arg1', 'arg2+')

--- a/ipatests/test_ipalib/test_base.py
+++ b/ipatests/test_ipalib/test_base.py
@@ -263,9 +263,9 @@ class test_NameSpace(ClassChecker):
         Test the `ipalib.base.NameSpace.__len__` method.
         """
         for count in (5, 18, 127):
-            (o, members) = self.new(count)
+            o, _members = self.new(count)
             assert len(o) == count
-            (o, members) = self.new(count, sort=False)
+            o, _members = self.new(count, sort=False)
             assert len(o) == count
 
     def test_iter(self):
@@ -353,7 +353,7 @@ class test_NameSpace(ClassChecker):
         """
         for cnt in (0, 1, 2):
             for sort in (True, False):
-                (o, members) = self.new(cnt, sort=sort)
+                o, _members = self.new(cnt, sort=sort)
                 if cnt == 1:
                     assert repr(o) == \
                         'NameSpace(<%d member>, sort=%r)' % (cnt, sort)

--- a/ipatests/test_ipalib/test_config.py
+++ b/ipatests/test_ipalib/test_config.py
@@ -577,7 +577,7 @@ class test_Env(ClassChecker):
         Test the `ipalib.config.Env._finalize` method.
         """
         # Check that calls cascade up the chain:
-        (o, home) = self.new(in_tree=True)
+        o, _home = self.new(in_tree=True)
         assert o._isdone('_bootstrap') is False
         assert o._isdone('_finalize_core') is False
         assert o._isdone('_finalize') is False
@@ -591,7 +591,7 @@ class test_Env(ClassChecker):
         assert str(e) == 'Env._finalize() already called'
 
         # Check that _finalize() calls __lock__()
-        (o, home) = self.new(in_tree=True)
+        o, _home = self.new(in_tree=True)
         assert o.__islocked__() is False
         o._finalize()
         assert o.__islocked__() is True
@@ -599,7 +599,7 @@ class test_Env(ClassChecker):
         assert str(e) == 'Env.__lock__() already called'
 
         # Check that **lastchance works
-        (o, home) = self.finalize_core(None)
+        o, _home = self.finalize_core(None)
         key = 'just_one_more_key'
         value = u'with one more value'
         lastchance = {key: value}

--- a/ipatests/test_ipalib/test_crud.py
+++ b/ipatests/test_ipalib/test_crud.py
@@ -38,7 +38,7 @@ class CrudChecker(ClassChecker):
         """
         Return a finalized `ipalib.plugable.API` instance.
         """
-        (api, home) = get_api()
+        api, _home = get_api()
         class user(frontend.Object):
             takes_params = (
                 'givenname',

--- a/ipatests/test_ipalib/test_errors.py
+++ b/ipatests/test_ipalib/test_errors.py
@@ -243,7 +243,6 @@ class test_PublicError(PublicExceptionTester):
     def test_init(self):
         message = u'The translated, interpolated message'
         format = 'key=%(key1)r and key2=%(key2)r'
-        uformat = u'Translated key=%(key1)r and key2=%(key2)r'
         val1 = u'Value 1'
         val2 = u'Value 2'
         kw = dict(key1=val1, key2=val2)
@@ -303,7 +302,6 @@ class test_PublicError(PublicExceptionTester):
         class subclass(self.klass):
             format = '%(true)r %(text)r %(number)r'
 
-        uformat = u'Translated %(true)r %(text)r %(number)r'
         kw = dict(true=True, text=u'Hello!', number=18)
 
         # Test with format=str, message=None

--- a/ipatests/test_ipalib/test_frontend.py
+++ b/ipatests/test_ipalib/test_frontend.py
@@ -36,6 +36,8 @@ from ipalib import output, messages
 from ipalib.parameters import Str
 from ipapython.version import API_VERSION
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipatests/test_ipalib/test_parameters.py
+++ b/ipatests/test_ipalib/test_parameters.py
@@ -43,6 +43,8 @@ from ipalib.constants import TYPE_ERROR, CALLABLE_ERROR
 from ipalib.errors import ValidationError, ConversionError
 from ipalib import _
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
     long = int

--- a/ipatests/test_ipalib/test_plugable.py
+++ b/ipatests/test_ipalib/test_plugable.py
@@ -103,13 +103,11 @@ def test_Registry():
         pass
     class Base2(object):
         pass
-    class Base3(object):
-        pass
+
+
     class plugin1(Base1):
         pass
     class plugin2(Base2):
-        pass
-    class plugin3(Base3):
         pass
 
     # Test creation of Registry:
@@ -250,7 +248,7 @@ class test_API(ClassChecker):
         """
         Test the `ipalib.plugable.API.bootstrap` method.
         """
-        (o, home) = create_test_api()
+        o, _home = create_test_api()
         assert o.env._isdone('_bootstrap') is False
         assert o.env._isdone('_finalize_core') is False
         assert o.isdone('bootstrap') is False
@@ -266,7 +264,7 @@ class test_API(ClassChecker):
         """
         Test the `ipalib.plugable.API.load_plugins` method.
         """
-        (o, home) = create_test_api()
+        o, _home = create_test_api()
         assert o.isdone('bootstrap') is False
         assert o.isdone('load_plugins') is False
         o.load_plugins()

--- a/ipatests/test_ipalib/test_rpc.py
+++ b/ipatests/test_ipalib/test_rpc.py
@@ -34,6 +34,8 @@ from ipalib.request import context, Connection
 from ipalib import rpc, errors, api, request
 from ipapython.version import API_VERSION
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipatests/test_ipalib/test_x509.py
+++ b/ipatests/test_ipalib/test_x509.py
@@ -55,20 +55,20 @@ class test_x509(object):
         """
 
         # Load a good cert
-        cert = x509.load_certificate(goodcert)
+        x509.load_certificate(goodcert)
 
         # Load a good cert with headers
         newcert = '-----BEGIN CERTIFICATE-----' + goodcert + '-----END CERTIFICATE-----'
-        cert = x509.load_certificate(newcert)
+        x509.load_certificate(newcert)
 
         # Load a good cert with bad headers
         newcert = '-----BEGIN CERTIFICATE-----' + goodcert
         with pytest.raises((TypeError, ValueError)):
-            cert = x509.load_certificate(newcert)
+            x509.load_certificate(newcert)
 
         # Load a bad cert
         with pytest.raises(NSPRError):
-            cert = x509.load_certificate(badcert)
+            x509.load_certificate(badcert)
 
     def test_1_load_der_cert(self):
         """
@@ -78,7 +78,7 @@ class test_x509(object):
         der = base64.b64decode(goodcert)
 
         # Load a good cert
-        cert = x509.load_certificate(der, x509.DER)
+        x509.load_certificate(der, x509.DER)
 
     def test_2_get_subject(self):
         """

--- a/ipatests/test_ipapython/test_cookie.py
+++ b/ipatests/test_ipapython/test_cookie.py
@@ -279,7 +279,7 @@ class TestInvalidAttributes(unittest.TestCase):
         # Invalid Max-Age
         s = 'color=blue; Max-Age=over-the-hill'
         with self.assertRaises(ValueError):
-            cookies = Cookie.parse(s)
+            Cookie.parse(s)
 
         cookie = Cookie('color', 'blue')
         with self.assertRaises(ValueError):
@@ -288,7 +288,7 @@ class TestInvalidAttributes(unittest.TestCase):
         # Invalid Expires
         s = 'color=blue; Expires=Sun, 06 Xxx 1994 08:49:37 GMT'
         with self.assertRaises(ValueError):
-            cookies = Cookie.parse(s)
+            Cookie.parse(s)
 
         cookie = Cookie('color', 'blue')
         with self.assertRaises(ValueError):

--- a/ipatests/test_ipapython/test_dn.py
+++ b/ipatests/test_ipapython/test_dn.py
@@ -933,7 +933,7 @@ class TestDN(unittest.TestCase):
             dn3[1.0]  # pylint: disable=pointless-statement
 
     def test_assignments(self):
-        dn = dn2 = DN('t=0,t=1,t=2,t=3,t=4,t=5,t=6,t=7,t=8,t=9')
+        dn = DN('t=0,t=1,t=2,t=3,t=4,t=5,t=6,t=7,t=8,t=9')
         with self.assertRaises(TypeError):
             dn[0] = RDN('t=a')
         with self.assertRaises(TypeError):

--- a/ipatests/test_ipapython/test_ipautil.py
+++ b/ipatests/test_ipapython/test_ipautil.py
@@ -183,7 +183,6 @@ class TestCIDict(object):
             self.cidict.keys(), self.cidict.values()))
 
     def test_iter(self):
-        items = []
         assert list(self.cidict) == list(self.cidict.keys())
         assert sorted(self.cidict) == sorted(['Key1', 'key2', 'KEY3'])
 

--- a/ipatests/test_ipapython/test_keyring.py
+++ b/ipatests/test_ipapython/test_keyring.py
@@ -111,7 +111,7 @@ class test_keyring(object):
         """
         Read a non-existent key
         """
-        result = kernel_keyring.read_key(TEST_KEY)
+        kernel_keyring.read_key(TEST_KEY)
 
     def test_06(self):
         """

--- a/ipatests/test_ipaserver/test_otptoken_import.py
+++ b/ipatests/test_ipaserver/test_otptoken_import.py
@@ -102,7 +102,7 @@ class test_otptoken_import(object):
     def test_figure8(self):
         nss.nss_init_nodb()
         try:
-            doc = PSKCDocument(os.path.join(basename, "pskc-figure8.xml"))
+            PSKCDocument(os.path.join(basename, "pskc-figure8.xml"))
         except NotImplementedError: # X.509 is not supported.
             pass
         else:
@@ -113,7 +113,7 @@ class test_otptoken_import(object):
     def test_invalid(self):
         nss.nss_init_nodb()
         try:
-            doc = PSKCDocument(os.path.join(basename, "pskc-invalid.xml"))
+            PSKCDocument(os.path.join(basename, "pskc-invalid.xml"))
         except ValueError: # File is invalid.
             pass
         else:

--- a/ipatests/test_ipaserver/test_rpcserver.py
+++ b/ipatests/test_ipaserver/test_rpcserver.py
@@ -30,6 +30,8 @@ from ipatests.util import assert_equal, raises, PluginTester
 from ipalib import errors
 from ipaserver import rpcserver
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipatests/test_ipaserver/test_serverroles.py
+++ b/ipatests/test_ipaserver/test_serverroles.py
@@ -15,6 +15,7 @@ from ipalib import api, create_api, errors
 from ipapython.dn import DN
 from ipatests.util import MockLDAP
 
+# pylint: disable=unused-variable
 
 def _make_service_entry_mods(enabled=True, other_config=None):
     mods = {

--- a/ipatests/test_pkcs10/test_pkcs10.py
+++ b/ipatests/test_pkcs10/test_pkcs10.py
@@ -111,7 +111,7 @@ class test_update(object):
         csr = self.read_file("test3.csr")
 
         try:
-            request = pkcs10.load_certificate_request(csr)
+            pkcs10.load_certificate_request(csr)
         except NSPRError as nsprerr:
             # (SEC_ERROR_BAD_DER) security library: improperly formatted DER-encoded message.
             assert(nsprerr. errno== -8183)
@@ -122,6 +122,6 @@ class test_update(object):
         """
         csr = self.read_file("test4.csr")
         try:
-            request = pkcs10.load_certificate_request(csr)
+            pkcs10.load_certificate_request(csr)
         except (TypeError, binascii.Error) as typeerr:
             assert(str(typeerr) == 'Incorrect padding')

--- a/ipatests/test_webui/test_host.py
+++ b/ipatests/test_webui/test_host.py
@@ -134,7 +134,6 @@ class test_host(host_tasks):
         self.init_app()
         # ENHANCEMENT: generate csr dynamically
         csr = self.load_file(csr_path)
-        realm = self.config.get('ipa_realm')
         cert_widget_sel = "div.certificate-widget"
 
         self.add_record(ENTITY, self.data)
@@ -229,7 +228,6 @@ class test_host(host_tasks):
 
         self.init_app()
         cert = self.load_file(cert_path)
-        realm = self.config.get('ipa_realm')
         self.add_record(ENTITY, self.data)
 
         self.navigate_to_record(self.pkey)

--- a/ipatests/test_webui/test_idviews.py
+++ b/ipatests/test_webui/test_idviews.py
@@ -106,7 +106,6 @@ class test_idviews(UI_driver):
 
         self.navigate_to_record(idview.PKEY)
         self.switch_to_facet(idview.HOST_FACET)
-        parent_entity = 'idview'
 
         # apply to host
         self.add_associations(

--- a/ipatests/test_webui/test_range.py
+++ b/ipatests/test_webui/test_range.py
@@ -59,9 +59,6 @@ class test_range(range_tasks):
 
         pkey_local = 'itest-local'
         pkey_ad = 'itest-ad'
-        pkey_posix = 'itest-ad-posix'
-        pkey_winsync = 'itest-ad-winsync'
-        pkey_trust = 'itest-ipa-trust'
         column = 'iparangetype'
 
         add = self.get_add_data(pkey_local)

--- a/ipatests/test_webui/test_service.py
+++ b/ipatests/test_webui/test_service.py
@@ -93,8 +93,6 @@ class test_service(sevice_tasks):
         data = self.prep_data()
         pkey = data.get('pkey')
         csr = self.load_file(csr_path)
-        host = self.config.get('ipa_server')
-        realm = self.config.get('ipa_realm')
         cert_widget_sel = "div.certificate-widget"
 
         self.add_record(ENTITY, data)
@@ -190,7 +188,6 @@ class test_service(sevice_tasks):
         data = self.prep_data()
         pkey = data.get('pkey')
         cert = self.load_file(cert_path)
-        realm = self.config.get('ipa_realm')
         cert_widget_sel = "div.certificate-widget"
 
         self.add_record(ENTITY, data)

--- a/ipatests/test_webui/test_user.py
+++ b/ipatests/test_webui/test_user.py
@@ -190,7 +190,6 @@ class test_user(user_tasks):
         self.init_app()
         # ENHANCEMENT: generate csr dynamically
         csr = self.load_file(csr_path)
-        realm = self.config.get('ipa_realm')
         cert_widget_sel = "div.certificate-widget"
 
         self.add_record(user.ENTITY, user.DATA)

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -306,7 +306,7 @@ class UI_driver(object):
         """
         runner = self
 
-        for i in range(n):
+        for _i in range(n):
             self.wait(implicit)
             WebDriverWait(self.driver, self.request_timeout).until_not(lambda d: runner.has_active_request())
             self.wait()
@@ -1499,7 +1499,7 @@ class UI_driver(object):
 
         # add values
         for t in tables:
-            table, keys, exts = get_t_vals(t)
+            table, keys, _exts = get_t_vals(t)
             # add one by one to test for #3711
             for key in keys:
                 self.add_table_associations(table, [key])
@@ -1517,7 +1517,7 @@ class UI_driver(object):
         p = self.get_form()
         # now tables in categories should be empty, check it
         for t in tables:
-            table, keys, exts = get_t_vals(t)
+            table, keys, _exts = get_t_vals(t)
             if table in no_categories:
                 # clear the rest
                 self.delete_record(keys, None, p, table)
@@ -1534,7 +1534,7 @@ class UI_driver(object):
         self.assert_rule_tables_enabled(t_list, True)
 
         for t in tables:
-            table, keys, exts = get_t_vals(t)
+            table, keys, _exts = get_t_vals(t)
             # add multiple at once and test table delete button
             self.add_table_associations(table, keys, delete=True)
 
@@ -1678,7 +1678,7 @@ class UI_driver(object):
         """
         if not parent:
             parent = self.get_form()
-        el = self.find(selector, By.CSS_SELECTOR, parent, strict=True)
+        self.find(selector, By.CSS_SELECTOR, parent, strict=True)
         dis = self.find(selector+"[disabled]", By.CSS_SELECTOR, parent)
         if negative:
             assert dis is None, "Element is disabled: %s" % selector

--- a/ipatests/test_xmlrpc/test_add_remove_cert_cmd.py
+++ b/ipatests/test_xmlrpc/test_add_remove_cert_cmd.py
@@ -90,13 +90,13 @@ class CertManipCmdTestBase(XMLRPC_test):
         # list of certificates to add to entry
         cls.certs = [
             get_testcert(DN(('CN', cls.entity_subject)), cls.entity_principal)
-            for i in range(3)
+            for _i in range(3)
         ]
 
         # list of certificates for testing of removal of non-existent certs
         cls.nonexistent_certs = [
             get_testcert(DN(('CN', cls.entity_subject)), cls.entity_principal)
-            for j in range(2)
+            for _j in range(2)
             ]
 
         # cert subset to remove from entry

--- a/ipatests/test_xmlrpc/test_automount_plugin.py
+++ b/ipatests/test_xmlrpc/test_automount_plugin.py
@@ -184,7 +184,8 @@ class test_automount(AutomountTest):
         """
         Test adding a duplicate key using `xmlrpc.automountkey_add` method.
         """
-        res = api.Command['automountkey_add'](self.locname, self.mapname, **self.key_kw)
+        api.Command['automountkey_add'](
+            self.locname, self.mapname, **self.key_kw)
 
     def test_5_automountmap_show(self):
         """
@@ -368,7 +369,8 @@ class test_automount_direct(AutomountTest):
         """
         Test adding a duplicate direct map.
         """
-        res = api.Command['automountmap_add_indirect'](self.locname, self.mapname, **self.direct_kw)['result']
+        api.Command['automountmap_add_indirect'](
+            self.locname, self.mapname, **self.direct_kw)
 
     def test_2a_automountmap_tofiles(self):
         """Test the `automountmap_tofiles` command"""

--- a/ipatests/test_xmlrpc/test_baseldap_plugin.py
+++ b/ipatests/test_xmlrpc/test_baseldap_plugin.py
@@ -53,7 +53,8 @@ def test_exc_wrapper():
     # Test with one callback first
 
     @test_callback.register_exc_callback
-    def handle_exception(self, keys, options, e, call_func, *args, **kwargs):
+    def handle_exception(  # pylint: disable=unused-variable
+            self, keys, options, e, call_func, *args, **kwargs):
         assert args == (1, 2)
         assert kwargs == dict(a=1, b=2)
         handled_exceptions.append(type(e))
@@ -150,7 +151,8 @@ def test_exc_callback_registration():
         pass
 
     @callbacktest_subclass.register_exc_callback
-    def exc_callback(self, keys, options, exc, call_func, *args, **kwargs):
+    def exc_callback(  # pylint: disable=unused-variable
+            self, keys, options, exc, call_func, *args, **kwargs):
         """Subclass's private exception callback"""
         messages.append('Subclass registered callback')
         raise exc
@@ -163,7 +165,8 @@ def test_exc_callback_registration():
 
 
     @callbacktest_base.register_exc_callback
-    def exc_callback_2(self, keys, options, exc, call_func, *args, **kwargs):
+    def exc_callback_2(  # pylint: disable=unused-variable
+            self, keys, options, exc, call_func, *args, **kwargs):
         """Callback on super class; doesn't affect the subclass"""
         messages.append('Superclass registered callback')
         raise exc

--- a/ipatests/test_xmlrpc/test_cert_plugin.py
+++ b/ipatests/test_xmlrpc/test_cert_plugin.py
@@ -141,11 +141,11 @@ class test_cert(XMLRPC_test):
         This should fail because the service principal doesn't exist
         """
         # First create the host that will use this policy
-        res = api.Command['host_add'](self.host_fqdn, force= True)['result']
+        assert 'result' in api.Command['host_add'](self.host_fqdn, force=True)
 
         csr = unicode(self.generateCSR(str(self.subject)))
         with assert_raises(errors.NotFound):
-            res = api.Command['cert_request'](csr, principal=self.service_princ)
+            api.Command['cert_request'](csr, principal=self.service_princ)
 
     def test_0002_cert_add(self):
         """
@@ -267,7 +267,7 @@ class test_cert_find(XMLRPC_test):
         """
         Search for the OCSP certificate.
         """
-        res = api.Command['cert_find'](subject=u'OCSP Subsystem')
+        api.Command['cert_find'](subject=u'OCSP Subsystem')
 
     def test_0004_find_this_host(self):
         """
@@ -458,7 +458,7 @@ class test_cert_find(XMLRPC_test):
         """
         Search with a negative sizelimit
         """
-        res = api.Command['cert_find'](sizelimit=-100)
+        api.Command['cert_find'](sizelimit=-100)
 
     def test_0029_search_for_notfound(self):
         """
@@ -479,4 +479,4 @@ class test_cert_find(XMLRPC_test):
         """
         Search using invalid date format
         """
-        res = api.Command['cert_find'](issuedon_from=u'xyz')
+        api.Command['cert_find'](issuedon_from=u'xyz')

--- a/ipatests/test_xmlrpc/test_hbac_plugin.py
+++ b/ipatests/test_xmlrpc/test_hbac_plugin.py
@@ -268,7 +268,7 @@ class test_hbac(XMLRPC_test):
         """
         Test deprecated command hbacrule_add_sourcehost.
         """
-        ret = api.Command['hbacrule_add_sourcehost'](
+        api.Command['hbacrule_add_sourcehost'](
             self.rule_name, host=self.test_host, hostgroup=self.test_hostgroup
         )
 
@@ -307,7 +307,7 @@ class test_hbac(XMLRPC_test):
         """
         Test deprecated command hbacrule_remove_sourcehost.
         """
-        ret = api.Command['hbacrule_remove_sourcehost'](
+        api.Command['hbacrule_remove_sourcehost'](
             self.rule_name, host=self.test_host, hostgroup=self.test_hostgroup
         )
 
@@ -316,7 +316,7 @@ class test_hbac(XMLRPC_test):
         """
         Test adding the same external host using `xmlrpc.hbacrule_add_host`.
         """
-        ret = api.Command['hbacrule_mod'](
+        api.Command['hbacrule_mod'](
             self.rule_name, setattr=self.test_invalid_sourcehost
         )
 

--- a/ipatests/test_xmlrpc/test_hbactest_plugin.py
+++ b/ipatests/test_xmlrpc/test_hbactest_plugin.py
@@ -91,20 +91,20 @@ class test_hbactest(XMLRPC_test):
                 self.rule_names[i], accessruletype=self.rule_type, description=self.rule_descs[i],
             )
 
-            ret = api.Command['hbacrule_add_user'](
+            api.Command['hbacrule_add_user'](
                 self.rule_names[i], user=self.test_user, group=self.test_group
             )
 
-            ret = api.Command['hbacrule_add_host'](
+            api.Command['hbacrule_add_host'](
                 self.rule_names[i], host=self.test_host, hostgroup=self.test_hostgroup
             )
 
-            ret = api.Command['hbacrule_add_service'](
+            api.Command['hbacrule_add_service'](
                 self.rule_names[i], hbacsvc=self.test_service
             )
 
             if i & 1:
-                ret = api.Command['hbacrule_disable'](self.rule_names[i])
+                api.Command['hbacrule_disable'](self.rule_names[i])
 
     def test_a_hbactest_check_rules_detail(self):
         """

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -619,9 +619,9 @@ class TestHostDNS(XMLRPC_test):
         try:
             ipv6only_host.create(force=False)
         finally:
-            command = ipv6only_host.run_command('dnsrecord_del', dnszone,
-                                                ipv6only_host.shortname,
-                                                aaaarecord=aaaarec)
+            ipv6only_host.run_command(
+                'dnsrecord_del', dnszone, ipv6only_host.shortname,
+                aaaarecord=aaaarec)
 
     def test_add_ipv4only_host(self, dns_setup, ipv4only_host):
         ipv4only_host.run_command('dnsrecord_add', dnszone,
@@ -629,9 +629,9 @@ class TestHostDNS(XMLRPC_test):
         try:
             ipv4only_host.create(force=False)
         finally:
-            command = ipv4only_host.run_command('dnsrecord_del', dnszone,
-                                                ipv4only_host.shortname,
-                                                arecord=arec)
+            ipv4only_host.run_command(
+                'dnsrecord_del', dnszone, ipv4only_host.shortname,
+                arecord=arec)
 
     def test_add_ipv46both_host(self, dns_setup, ipv46both_host):
         ipv46both_host.run_command('dnsrecord_add', dnszone,
@@ -640,10 +640,9 @@ class TestHostDNS(XMLRPC_test):
         try:
             ipv46both_host.create(force=False)
         finally:
-            command = ipv46both_host.run_command('dnsrecord_del', dnszone,
-                                                 ipv46both_host.shortname,
-                                                 arecord=arec2,
-                                                 aaaarecord=aaaarec2)
+            ipv46both_host.run_command(
+                'dnsrecord_del', dnszone, ipv46both_host.shortname,
+                arecord=arec2, aaaarecord=aaaarec2)
 
     def test_add_ipv4_host_from_ip(self, dns_setup, ipv4_fromip_host):
         ipv4_fromip_host.ensure_missing()

--- a/ipatests/test_xmlrpc/test_permission_plugin.py
+++ b/ipatests/test_xmlrpc/test_permission_plugin.py
@@ -138,7 +138,7 @@ def lineinfo(level):
     # Including this info in the test name makes it possible
     # to locate failing tests.
     frame = inspect.currentframe()
-    for i in range(level):
+    for _i in range(level):
         frame = frame.f_back
     lineno = frame.f_lineno
     filename = os.path.basename(frame.f_code.co_filename)
@@ -3455,9 +3455,8 @@ class test_managed_permissions(Declarative):
         ldap = ldap2(api)
         ldap.connect()
 
-        result = api.Command.permission_add(permission1, type=u'user',
-                                            ipapermright=u'write',
-                                            attrs=[u'cn'])
+        api.Command.permission_add(
+            permission1, type=u'user', ipapermright=u'write', attrs=[u'cn'])
 
         # TODO: This hack relies on the permission internals.
         # Change as necessary.
@@ -3468,8 +3467,7 @@ class test_managed_permissions(Declarative):
         ldap.update_entry(entry)
 
         # Update the ACI via the API
-        result = api.Command.permission_mod(permission1,
-                                            attrs=[u'l', u'o', u'cn'])
+        api.Command.permission_mod(permission1, attrs=[u'l', u'o', u'cn'])
 
         # Set the permission type to MANAGED
         entry = ldap.get_entry(permission1_dn)

--- a/ipatests/test_xmlrpc/test_pwpolicy_plugin.py
+++ b/ipatests/test_xmlrpc/test_pwpolicy_plugin.py
@@ -163,7 +163,8 @@ class test_pwpolicy(XMLRPC_test):
         Test adding password policy to a managed group.
         """
         try:
-            entry = api.Command['pwpolicy_add'](self.user, krbminpwdlife=50, cospriority=2)['result']
+            api.Command['pwpolicy_add'](
+                self.user, krbminpwdlife=50, cospriority=2)
         except errors.ManagedPolicyError:
             pass
         else:

--- a/ipatests/test_xmlrpc/test_sudorule_plugin.py
+++ b/ipatests/test_xmlrpc/test_sudorule_plugin.py
@@ -29,6 +29,8 @@ from ipalib import api
 from ipalib import errors
 import pytest
 
+# pylint: disable=unused-variable
+
 if six.PY3:
     unicode = str
 

--- a/ipatests/test_xmlrpc/testcert.py
+++ b/ipatests/test_xmlrpc/testcert.py
@@ -93,10 +93,6 @@ def makecert(reqdir, subject, principal):
     # Generate NSS cert database to store the private key for our CSR
     run_certutil(reqdir, ["-N", "-f", pwname])
 
-    res = api.Command['config_show']()
-    subject_base = res['result']['ipacertificatesubjectbase'][0]
-
-    cert = None
     csr = unicode(generate_csr(reqdir, pwname, str(subject)))
 
     res = api.Command['cert_request'](csr, principal=principal, add=True)

--- a/ipatests/test_xmlrpc/tracker/automember_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/automember_plugin.py
@@ -110,7 +110,7 @@ class AutomemberTracker(Tracker):
             try:
                 self.attrs[u'group'] =\
                     self.attrs[u'group'] + [options[u'group']]
-            except KeyError as ex:
+            except KeyError:
                 self.attrs[u'group'] = [options[u'group']]
             # search for hosts in the target automember and
             # add them as memberindirect hosts
@@ -118,7 +118,7 @@ class AutomemberTracker(Tracker):
             try:
                 self.attrs[u'hostgroup'] =\
                     self.attrs[u'hostgroup'] + [options[u'hostgroup']]
-            except KeyError as ex:
+            except KeyError:
                 self.attrs[u'hostgroup'] = [options[u'hostgroup']]
 
         command = self.make_add_member_command(options)
@@ -135,12 +135,12 @@ class AutomemberTracker(Tracker):
         try:
             if not self.attrs[u'member_host']:
                 del self.attrs[u'member_host']
-        except KeyError as ex:
+        except KeyError:
             pass
         try:
             if not self.attrs[u'member_automember']:
                 del self.attrs[u'member_automember']
-        except KeyError as ex:
+        except KeyError:
             pass
 
         command = self.make_remove_member_command(options)

--- a/ipatests/test_xmlrpc/tracker/group_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/group_plugin.py
@@ -117,13 +117,13 @@ class GroupTracker(Tracker):
             try:
                 self.attrs[u'member_user'] =\
                     self.attrs[u'member_user'] + [options[u'user']]
-            except KeyError as ex:
+            except KeyError:
                 self.attrs[u'member_user'] = [options[u'user']]
         elif u'group' in options:
             try:
                 self.attrs[u'member_group'] =\
                     self.attrs[u'member_group'] + [options[u'group']]
-            except KeyError as ex:
+            except KeyError:
                 self.attrs[u'member_group'] = [options[u'group']]
 
         command = self.make_add_member_command(options)
@@ -140,12 +140,12 @@ class GroupTracker(Tracker):
         try:
             if not self.attrs[u'member_user']:
                 del self.attrs[u'member_user']
-        except KeyError as ex:
+        except KeyError:
             pass
         try:
             if not self.attrs[u'member_group']:
                 del self.attrs[u'member_group']
-        except KeyError as ex:
+        except KeyError:
             pass
 
         command = self.make_remove_member_command(options)

--- a/ipatests/test_xmlrpc/tracker/hostgroup_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/hostgroup_plugin.py
@@ -91,7 +91,7 @@ class HostGroupTracker(Tracker):
             try:
                 self.attrs[u'member_host'] =\
                     self.attrs[u'member_host'] + [options[u'host']]
-            except KeyError as ex:
+            except KeyError:
                 self.attrs[u'member_host'] = [options[u'host']]
             # search for hosts in the target hostgroup and
             # add them as memberindirect hosts
@@ -99,7 +99,7 @@ class HostGroupTracker(Tracker):
             try:
                 self.attrs[u'member_hostgroup'] =\
                     self.attrs[u'member_hostgroup'] + [options[u'hostgroup']]
-            except KeyError as ex:
+            except KeyError:
                 self.attrs[u'member_hostgroup'] = [options[u'hostgroup']]
 
         command = self.make_add_member_command(options)
@@ -116,12 +116,12 @@ class HostGroupTracker(Tracker):
         try:
             if not self.attrs[u'member_host']:
                 del self.attrs[u'member_host']
-        except KeyError as ex:
+        except KeyError:
             pass
         try:
             if not self.attrs[u'member_hostgroup']:
                 del self.attrs[u'member_hostgroup']
-        except KeyError as ex:
+        except KeyError:
             pass
 
         command = self.make_remove_member_command(options)

--- a/ipatests/test_xmlrpc/tracker/sudocmdgroup_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/sudocmdgroup_plugin.py
@@ -88,7 +88,7 @@ class SudoCmdGroupTracker(Tracker):
         try:
             self.attrs[u'member_sudocmd'] =\
                 self.attrs[u'member_sudocmd'] + [options[u'sudocmd']]
-        except KeyError as ex:
+        except KeyError:
             self.attrs[u'member_sudocmd'] = [options[u'sudocmd']]
 
         command = self.make_add_member_command(options)
@@ -102,7 +102,7 @@ class SudoCmdGroupTracker(Tracker):
         try:
             if not self.attrs[u'member_sudocmd']:
                 del self.attrs[u'member_sudocmd']
-        except KeyError as ex:
+        except KeyError:
             pass
 
         command = self.make_remove_member_command(options)

--- a/ipatests/test_xmlrpc/tracker/user_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/user_plugin.py
@@ -165,7 +165,7 @@ class UserTracker(KerberosAliasMixin, Tracker):
                         (self.kwargs[key].split('@'))[0].lower(),
                         (self.kwargs[key].split('@'))[1]
                     )]
-                except IndexError as ex:
+                except IndexError:
                     # we can provide just principal part
                     self.attrs[key] = [u'%s@%s' % (
                         (self.kwargs[key].lower(),

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -604,7 +604,7 @@ class DummyClass(object):
     def __init__(self, *calls):
         self.__calls = calls
         self.__i = 0
-        for (name, args, kw, result) in calls:
+        for (name, _args, _kw, _result) in calls:
             method = DummyMethod(self.__process, name)
             setattr(self, name, method)
 

--- a/makeapi
+++ b/makeapi
@@ -499,7 +499,7 @@ def validate_api():
 
 def main():
     rval = 0
-    options, args = parse_options()
+    options, _args = parse_options()
 
     cfg = dict(
         in_server=True,

--- a/pylintrc
+++ b/pylintrc
@@ -55,7 +55,6 @@ disable=
     undefined-loop-variable,
     unnecessary-lambda,
     unused-argument,
-    unused-variable,
     useless-else-on-loop,
     bad-continuation,
     bad-whitespace,
@@ -93,3 +92,7 @@ reports=no
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
 msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg})'
+
+
+[VARIABLES]
+dummy-variables-rgx=_.+


### PR DESCRIPTION
Modules with too many unused variables have check locally disabled