### PR TITLE
Fix: find OSCP certificate test

### DIFF
--- a/ipatests/test_xmlrpc/test_cert_plugin.py
+++ b/ipatests/test_xmlrpc/test_cert_plugin.py
@@ -267,7 +267,9 @@ class test_cert_find(XMLRPC_test):
         """
         Search for the OCSP certificate.
         """
-        api.Command['cert_find'](subject=u'OCSP Subsystem')
+        res = api.Command['cert_find'](subject=u'OCSP Subsystem')
+        assert 'count' in res
+        assert res['count'], "No OSCP certificate found"
 
     def test_0004_find_this_host(self):
         """


### PR DESCRIPTION
Test should check if any OSCP certificate has been returned

https://fedorahosted.org/freeipa/ticket/6359