### PR TITLE
Add iSecStore.span

### DIFF
--- a/ipapython/secrets/store.py
+++ b/ipapython/secrets/store.py
@@ -252,3 +252,6 @@ class iSecStore(CSStore):
 
     def cut(self, key):
         raise NotImplementedError
+
+    def span(self, key):
+        raise NotImplementedError


### PR DESCRIPTION
In the future Custodia is going to make CSStore.span an abstract method.

Closes: https://fedorahosted.org/freeipa/ticket/6365
Signed-off-by: Christian Heimes <cheimes@redhat.com>