### PR TITLE
Fix ipa migrate-ds when it finds a search reference

### DIFF
--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -1309,7 +1309,7 @@ class LDAPClient(object):
 
     def find_entries(self, filter=None, attrs_list=None, base_dn=None,
                      scope=ldap.SCOPE_SUBTREE, time_limit=None,
-                     size_limit=None, search_refs=False, paged_search=False):
+                     size_limit=None, paged_search=False):
         """
         Return a list of entries and indication of whether the results were
         truncated ([(dn, entry_attrs)], truncated) matching specified search
@@ -1323,8 +1323,6 @@ class LDAPClient(object):
         time_limit -- time limit in seconds (default unlimited)
         size_limit -- size (number of entries returned) limit
             (default unlimited)
-        search_refs -- allow search references to be returned
-            (default skips these entries)
         paged_search -- search using paged results control
 
         :raises: errors.NotFound if result set is empty
@@ -1379,12 +1377,10 @@ class LDAPClient(object):
                     while True:
                         result = self.conn.result3(id, 0)
                         objtype, res_list, _res_id, res_ctrls = result
-                        res_list = self._convert_result(res_list)
-                        if not res_list:
+                        if objtype == ldap.RES_SEARCH_RESULT:
                             break
-                        if (objtype == ldap.RES_SEARCH_ENTRY or
-                                (search_refs and
-                                    objtype == ldap.RES_SEARCH_REFERENCE)):
+                        res_list = self._convert_result(res_list)
+                        if res_list:
                             res.append(res_list[0])
 
                     if paged_search:

--- a/ipaserver/plugins/migration.py
+++ b/ipaserver/plugins/migration.py
@@ -746,8 +746,7 @@ migration process might be incomplete\n''')
                 entries, truncated = ds_ldap.find_entries(
                     search_filter, ['*'], search_bases[ldap_obj_name],
                     scope,
-                    time_limit=0, size_limit=-1,
-                    search_refs=True    # migrated DS may contain search references
+                    time_limit=0, size_limit=-1
                 )
             except errors.NotFound:
                 if not options.get('continue',False):


### PR DESCRIPTION
When ipa migrate-ds finds user entries and a search reference, it complains
that the LDAP search did not return any result and does not migrate the
entries or the groups.

The issue comes from LDAPClient._convert_result which returns an empty result
list when the input is a search reference. In turn LDAPClient.find_entries
assumes that the empty result list corresponds to a Search Result Done and
returns without any entry.

The fix is to return a LDAPUrl inside _convert_result and properly process
LDAPUrl in find_entries.

https://fedorahosted.org/freeipa/ticket/6358
