### PR TITLE
Properly handle LDAP socket closures in ipa-otpd

### DIFF
--- a/daemons/ipa-otpd/bind.c
+++ b/daemons/ipa-otpd/bind.c
@@ -85,6 +85,9 @@ static void on_bind_readable(verto_ctx *vctx, verto_ev *ev)
         if (rslt <= 0)
             results = NULL;
         ldap_msgfree(results);
+        otpd_log_err(EIO, "IO error received on bind socket");
+        verto_break(ctx.vctx);
+        ctx.exitstatus = 1;
         return;
     }
 
@@ -137,11 +140,6 @@ void otpd_on_bind_io(verto_ctx *vctx, verto_ev *ev)
     flags = verto_get_fd_state(ev);
     if (flags & VERTO_EV_FLAG_IO_WRITE)
         on_bind_writable(vctx, ev);
-    if (flags & VERTO_EV_FLAG_IO_READ)
+    if (flags & (VERTO_EV_FLAG_IO_READ | VERTO_EV_FLAG_IO_ERROR))
         on_bind_readable(vctx, ev);
-    if (flags & VERTO_EV_FLAG_IO_ERROR) {
-        otpd_log_err(EIO, "IO error received on bind socket");
-        verto_break(ctx.vctx);
-        ctx.exitstatus = 1;
-    }
 }


### PR DESCRIPTION
In at least one case, when an LDAP socket closes, a read event is fired
rather than an error event. Without this patch, ipa-otpd silently
ignores this event and enters a state where all bind auths fail.

To remedy this problem, we pass error events along the same path as read
events. Should the actual read fail, we exit.

https://bugzilla.redhat.com/show_bug.cgi?id=1377858
https://fedorahosted.org/freeipa/ticket/6368