### PR TITLE
Added --ip-address paramenter to client installation

### DIFF
--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -421,6 +421,7 @@ def install_client(master, client, extra_args=()):
                         '--realm', client.domain.realm,
                         '-p', client.config.admin_name,
                         '-w', client.config.admin_password,
+                        '--ip-address', client.ip,
                         '--server', master.hostname]
                        + list(extra_args))
 


### PR DESCRIPTION
A record for client machine is only created during client installation if the
'--ip-address' parameter is provided. Without A record in some cases
replica connection check fails making it impossible to promote the client to
replica without '--skip-conncheck' option