### PR TITLE
Fix KRA install tests

### DIFF
--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -359,6 +359,9 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
         args.append('-U')
     if setup_ca:
         args.append('--setup-ca')
+    if setup_kra:
+        assert setup_ca, "CA must be installed on replica with KRA"
+        args.append('--setup-kra')
     if setup_dns:
         args.extend([
             '--setup-dns',
@@ -388,17 +391,6 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
     if result.returncode == 0:
         enable_replication_debugging(replica)
         setup_sssd_debugging(replica)
-        if setup_kra:
-            assert setup_ca, "CA must be installed on replica with KRA"
-            args = [
-                "ipa-kra-install",
-                "-p", replica.config.dirman_password,
-                "-U",
-            ]
-            if domainlevel(master) == DOMAIN_LEVEL_0:
-                args.append(replica_filename)
-            replica.run_command(args)
-
         kinit_admin(replica)
     return result
 

--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -994,12 +994,20 @@ def double_circle_topo(master, replicas, site_size=6):
 
 
 def install_topo(topo, master, replicas, clients, domain_level=None,
-                 skip_master=False, setup_replica_cas=True):
+                 skip_master=False, setup_replica_cas=True,
+                 setup_replica_kras=False):
     """Install IPA servers and clients in the given topology"""
+    if setup_replica_kras and not setup_replica_cas:
+        raise ValueError("Option 'setup_replica_kras' requires "
+                         "'setup_replica_cas' set to True")
     replicas = list(replicas)
     installed = {master}
     if not skip_master:
-        install_master(master, domain_level=domain_level)
+        install_master(
+            master,
+            domain_level=domain_level,
+            setup_kra=setup_replica_kras
+        )
 
     add_a_records_for_hosts_in_master_domain(master)
 
@@ -1009,7 +1017,11 @@ def install_topo(topo, master, replicas, clients, domain_level=None,
             connect_replica(parent, child)
         else:
             log.info('Installing replica %s from %s' % (parent, child))
-            install_replica(parent, child, setup_ca=setup_replica_cas)
+            install_replica(
+                parent, child,
+                setup_ca=setup_replica_cas,
+                setup_kra=setup_replica_kras
+            )
         installed.add(child)
     install_clients([master] + replicas, clients)
 

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -7,9 +7,13 @@ Module provides tests which testing ability of various subsystems to be
 installed.
 """
 
+import pytest
+from ipalib.constants import DOMAIN_LEVEL_0
+from ipatests.test_integration.env_config import get_global_config
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.test_integration import tasks
 
+config = get_global_config()
 
 class InstallTestBase1(IntegrationTest):
 
@@ -90,12 +94,42 @@ class TestInstallWithCA1(InstallTestBase1):
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=False)
 
+    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
+                        reason='does not work on DOMAIN_LEVEL_0 by design')
+    def test_replica1_ipa_kra_install(self):
+        super(TestInstallWithCA1, self).test_replica1_ipa_kra_install()
+
+    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
+                        reason='does not work on DOMAIN_LEVEL_0 by design')
+    def test_replica2_with_ca_kra_install(self):
+        super(TestInstallWithCA1, self).test_replica2_with_ca_kra_install()
+
+    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
+                        reason='does not work on DOMAIN_LEVEL_0 by design')
+    def test_replica2_ipa_dns_install(self):
+        super(TestInstallWithCA1, self).test_replica2_ipa_dns_install()
+
 
 class TestInstallWithCA2(InstallTestBase2):
 
     @classmethod
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=False)
+
+    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
+                        reason='does not work on DOMAIN_LEVEL_0 by design')
+    def test_replica0_with_ca_kra_dns_install(self):
+        super(TestInstallWithCA2, self).test_replica0_with_ca_kra_dns_install()
+
+    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
+                        reason='does not work on DOMAIN_LEVEL_0 by design')
+    def test_replica1_ipa_kra_install(self):
+        super(TestInstallWithCA2, self).test_replica1_ipa_kra_install()
+
+    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
+                        reason='does not work on DOMAIN_LEVEL_0 by design')
+    def test_replica2_ipa_kra_install(self):
+        super(TestInstallWithCA2, self).test_replica2_ipa_kra_install()
 
 
 class TestInstallWithCA_KRA1(InstallTestBase1):
@@ -121,12 +155,44 @@ class TestInstallWithCA_DNS1(InstallTestBase1):
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=True)
 
+    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
+                        reason='does not work on DOMAIN_LEVEL_0 by design')
+    def test_replica1_ipa_kra_install(self):
+        super(TestInstallWithCA_DNS1, self).test_replica1_ipa_kra_install()
+
+    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
+                        reason='does not work on DOMAIN_LEVEL_0 by design')
+    def test_replica2_with_ca_kra_install(self):
+        super(TestInstallWithCA_DNS1, self).test_replica2_with_ca_kra_install()
+
+    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
+                        reason='does not work on DOMAIN_LEVEL_0 by design')
+    def test_replica2_ipa_dns_install(self):
+        super(TestInstallWithCA_DNS1, self).test_replica2_ipa_dns_install()
+
 
 class TestInstallWithCA_DNS2(InstallTestBase2):
 
     @classmethod
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=True)
+
+    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
+                        reason='does not work on DOMAIN_LEVEL_0 by design')
+    def test_replica0_with_ca_kra_dns_install(self):
+        super(
+            TestInstallWithCA_DNS2, self
+        ).test_replica0_with_ca_kra_dns_install()
+
+    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
+                        reason='does not work on DOMAIN_LEVEL_0 by design')
+    def test_replica1_ipa_kra_install(self):
+        super(TestInstallWithCA_DNS2, self).test_replica1_ipa_kra_install()
+
+    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
+                        reason='does not work on DOMAIN_LEVEL_0 by design')
+    def test_replica2_ipa_kra_install(self):
+        super(TestInstallWithCA_DNS2, self).test_replica2_ipa_kra_install()
 
 
 class TestInstallWithCA_KRA_DNS1(InstallTestBase1):

--- a/ipatests/test_integration/test_replication_layouts.py
+++ b/ipatests/test_integration/test_replication_layouts.py
@@ -52,6 +52,16 @@ class TestLineTopologyWithCA(LayoutsBaseTest):
         self.replication_is_working()
 
 
+class TestLineTopologyWithCAKRA(LayoutsBaseTest):
+
+    num_replicas = 3
+
+    def test_line_topology_with_ca_kra(self):
+        tasks.install_topo('line', self.master, self.replicas, [],
+                           setup_replica_cas=True, setup_replica_kras=True)
+        self.replication_is_working()
+
+
 class TestStarTopologyWithoutCA(LayoutsBaseTest):
 
     num_replicas = 3
@@ -69,6 +79,16 @@ class TestStarTopologyWithCA(LayoutsBaseTest):
     def test_star_topology_with_ca(self):
         tasks.install_topo('star', self.master, self.replicas, [],
                            setup_replica_cas=True)
+        self.replication_is_working()
+
+
+class TestStarTopologyWithCAKRA(LayoutsBaseTest):
+
+    num_replicas = 3
+
+    def test_star_topology_with_ca_kra(self):
+        tasks.install_topo('star', self.master, self.replicas, [],
+                           setup_replica_cas=True, setup_replica_kras=True)
         self.replication_is_working()
 
 
@@ -92,6 +112,16 @@ class TestCompleteTopologyWithCA(LayoutsBaseTest):
         self.replication_is_working()
 
 
+class TestCompleteTopologyWithCAKRA(LayoutsBaseTest):
+
+    num_replicas = 3
+
+    def test_complete_topology_with_ca_kra(self):
+        tasks.install_topo('complete', self.master, self.replicas, [],
+                           setup_replica_cas=True, setup_replica_kras=True)
+        self.replication_is_working()
+
+
 @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                     reason='does not work on DOMAIN_LEVEL_0 by design')
 class Test2ConnectedTopologyWithoutCA(LayoutsBaseTest):
@@ -112,6 +142,15 @@ class Test2ConnectedTopologyWithCA(LayoutsBaseTest):
         self.replication_is_working()
 
 
+class Test2ConnectedTopologyWithCAKRA(LayoutsBaseTest):
+    num_replicas = 33
+
+    def test_2_connected_topology_with_ca_kra(self):
+        tasks.install_topo('2-connected', self.master, self.replicas, [],
+                           setup_replica_cas=True, setup_replica_kras=True)
+        self.replication_is_working()
+
+
 @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                     reason='does not work on DOMAIN_LEVEL_0 by design')
 class TestDoubleCircleTopologyWithoutCA(LayoutsBaseTest):
@@ -129,4 +168,13 @@ class TestDoubleCircleTopologyWithCA(LayoutsBaseTest):
     def test_2_connected_topology_with_ca(self):
         tasks.install_topo('double-circle', self.master, self.replicas, [],
                            setup_replica_cas=True)
+        self.replication_is_working()
+
+
+class TestDoubleCircleTopologyWithCAKRA(LayoutsBaseTest):
+    num_replicas = 29
+
+    def test_2_connected_topology_with_ca_kra(self):
+        tasks.install_topo('double-circle', self.master, self.replicas, [],
+                           setup_replica_cas=True, setup_replica_kras=True)
         self.replication_is_working()


### PR DESCRIPTION
- fix replica installation of kra as single step in tests
- in test_installation test suite with domain level 0, some KRA tests must be skipped because does not work under domain level 0 by design
- I added KRA tests into replication_layout test suite to test how KRA install works with more replicas and various layouts (needed mainly for domain level 0)

https://fedorahosted.org/freeipa/ticket/6088