### PR TITLE
Test: disabled wrong client domain tests for domlevel 0

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -398,6 +398,7 @@ class TestWrongClientDomain(IntegrationTest):
     topology = "star"
     num_replicas = 1
     domain_name = 'exxample.test'
+    domain_level = DOMAIN_LEVEL_1
 
     @classmethod
     def install(cls, mh):


### PR DESCRIPTION
These tests are only relevant for domain level 1

https://fedorahosted.org/freeipa/ticket/6382