### PR TITLE
Tests: Fix failing test_ipalib/test_parameters

### DIFF
--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -473,7 +473,7 @@ class Param(ReadOnly):
                         CALLABLE_ERROR % (key, value, type(value))
                     )
                 kw[key] = value
-            else:
+            elif key not in ('required', 'multivalue'):
                 kw.pop(key, None)
 
         # We keep these values to use in __repr__():


### PR DESCRIPTION
Parameters test fails because of KeyError caused by improper manipulation with
kwargs in Param.__init__ method. During initialization, if kwargs['required']
or kwargs['multivalue'] is None, it is delete from dictionary and hence the
missing key. Small change of the condition prevents this from happening.

Partially fixes https://fedorahosted.org/freeipa/ticket/6292