### PR TITLE
CheckedIPAddress: Implement __(g|s)etstate__ and to ensure proper (un)pickling

### DIFF
--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -127,6 +127,17 @@ class UnsafeIPAddress(netaddr.IPAddress):
         super(UnsafeIPAddress, self).__init__(addr,
                                               flags=self.netaddr_ip_flags)
 
+    def __getstate__(self):
+        state = {
+            '_net': self._net,
+            'super_state': super(UnsafeIPAddress, self).__getstate__(),
+        }
+        return state
+
+    def __setstate__(self, state):
+        super(UnsafeIPAddress, self).__setstate__(state['super_state'])
+        self._net = state['_net']
+
 
 class CheckedIPAddress(UnsafeIPAddress):
     """IPv4 or IPv6 address with additional constraints.
@@ -204,6 +215,17 @@ class CheckedIPAddress(UnsafeIPAddress):
                 self._net = netaddr.IPNetwork(str(self) + '/64')
 
         self.prefixlen = self._net.prefixlen
+
+    def __getstate__(self):
+        state = {
+            'prefixlen': self.prefixlen,
+            'super_state': super(CheckedIPAddress, self).__getstate__(),
+        }
+        return state
+
+    def __setstate__(self, state):
+        super(CheckedIPAddress, self).__setstate__(state['super_state'])
+        self.prefixlen = state['prefixlen']
 
     def is_network_addr(self):
         return self == self._net.network


### PR DESCRIPTION
Missing attributes in instance created by pickle.load cause AttributeError in
second part of ipa-server-install --external-ca.

https://fedorahosted.org/freeipa/ticket/6385