### PR TITLE
Issue6386 nss dir

### DIFF
--- a/ipaclient/ipa_certupdate.py
+++ b/ipaclient/ipa_certupdate.py
@@ -111,7 +111,7 @@ class CertUpdate(admintool.AdminTool):
     def update_client(self, certs):
         self.update_file(paths.IPA_CA_CRT, certs)
 
-        ipa_db = certdb.NSSDatabase(paths.IPA_NSSDB_DIR)
+        ipa_db = certdb.NSSDatabase(api.env.nss_dir)
 
         # Remove old IPA certs from /etc/ipa/nssdb
         for nickname in ('IPA CA', 'External CA cert'):

--- a/ipaclient/plugins/otptoken.py
+++ b/ipaclient/plugins/otptoken.py
@@ -25,7 +25,6 @@ from ipalib import api, Str, Password, _
 from ipalib.messages import add_message, ResultFormattingError
 from ipalib.plugable import Registry
 from ipalib.frontend import Local
-from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipapython.nsslib import NSSConnection
 from ipapython.version import API_VERSION
@@ -174,7 +173,7 @@ class otptoken_sync(Local):
 
         # Sync the token.
         # pylint: disable=E1101
-        handler = HTTPSHandler(dbdir=paths.IPA_NSSDB_DIR,
+        handler = HTTPSHandler(dbdir=api.env.nss_dir,
                                tls_version_min=api.env.tls_version_min,
                                tls_version_max=api.env.tls_version_max)
         rsp = urllib.request.build_opener(handler).open(sync_uri, query)

--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -43,7 +43,6 @@ from ipalib import api, errors
 from ipalib import Bytes, Flag, Str
 from ipalib.plugable import Registry
 from ipalib import _
-from ipaplatform.paths import paths
 
 
 def validated_read(argname, filename, mode='r', encoding=None):
@@ -752,8 +751,7 @@ class vault_archive(Local):
                 error=_('Invalid vault type'))
 
         # initialize NSS database
-        current_dbdir = paths.IPA_NSSDB_DIR
-        nss.nss_init(current_dbdir)
+        nss.nss_init(api.env.nss_dir)
 
         # retrieve transport certificate
         config = self.api.Command.vaultconfig_show()['result']
@@ -912,8 +910,7 @@ class vault_retrieve(Local):
         vault_type = vault['ipavaulttype'][0]
 
         # initialize NSS database
-        current_dbdir = paths.IPA_NSSDB_DIR
-        nss.nss_init(current_dbdir)
+        nss.nss_init(api.env.nss_dir)
 
         # retrieve transport certificate
         config = self.api.Command.vaultconfig_show()['result']


### PR DESCRIPTION
See https://fedorahosted.org/freeipa/ticket/6386
- use api.env.nss_dir in all ipaclient plugins
- set api.env.nss_dir to confdir/nssdb
