### PR TITLE
WebUI: fix API Browser menu label

### DIFF
--- a/install/ui/src/freeipa/navigation/menu_spec.js
+++ b/install/ui/src/freeipa/navigation/menu_spec.js
@@ -249,7 +249,7 @@ var nav = {};
                 },
                 {
                     name: 'apibrowser',
-                    label: 'API browser',
+                    label: '@i18n:widget.api_browser',
                     facet: 'apibrowser',
                     args: { 'type': 'command' }
                 },

--- a/install/ui/test/data/ipa_init.json
+++ b/install/ui/test/data/ipa_init.json
@@ -734,6 +734,7 @@
                     },
                     "true": "True",
                     "widget": {
+                        "api_browser": "API Browser",
                         "first": "First",
                         "last": "Last",
                         "next": "Next",

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -887,6 +887,7 @@ class i18n_messages(Command):
         },
         "true": _("True"),
         "widget": {
+            "api_browser": _("API Browser"),
             "first": _("First"),
             "last": _("Last"),
             "next": _("Next"),


### PR DESCRIPTION
The label of API Browser is now in translatable strings and it has
uppercase B at the beginnig of second word.

https://fedorahosted.org/freeipa/ticket/6384