### PR TITLE
Unaccessible variable self.attrs in Tracker

### DIFF
--- a/ipatests/test_xmlrpc/tracker/base.py
+++ b/ipatests/test_xmlrpc/tracker/base.py
@@ -76,6 +76,7 @@ class Tracker(object):
         self.api = api
         self.default_version = default_version or API_VERSION
         self._dn = None
+        self.attrs = {}
 
         self.exists = False
 


### PR DESCRIPTION
In tracker, 'self.attrs' variable is created and filled in track_create method.
Some objects are not created but still require access to this variable.
Created 'self.attrs' variable in init

https://fedorahosted.org/freeipa/ticket/6125