### PR TITLE
[ipa-4-4 only] disable warnings reported by pylint-1.6.4-1

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -87,7 +87,9 @@ disable=
     misplaced-comparison-constant,
     unneeded-not,
     not-a-mapping,
-    singleton-comparison
+    singleton-comparison,
+    trailing-newlines,
+    consider-iterating-dictionary
 
 
 [REPORTS]


### PR DESCRIPTION
Pylint shipped in Fedora 25 reports 'trailing-newlines' and
'consider-iterating-dictionary' warnings which break FreeIPA builds.

On ipa-4-4 branch it is safer to just disable these warnings so as to not mess
with code considered stable

https://fedorahosted.org/freeipa/ticket/6391