### PR TITLE
cert: add revocation reason back to cert-find output

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1231,16 +1231,17 @@ class cert_find(Search, CertMethod):
                 obj = {'serial_number': serial_number}
             else:
                 obj = ra_obj
-                obj['issuer'] = issuer
-                obj['subject'] = DN(ra_obj['subject'])
-                obj['revoked'] = (
-                    ra_obj['status'] in (u'REVOKED', u'REVOKED_EXPIRED'))
-
                 if all:
-                    ra_obj = ra.get_certificate(str(serial_number))
-                    if not raw:
+                    obj.update(ra.get_certificate(str(serial_number)))
+
+                if not raw:
+                    obj['issuer'] = issuer
+                    obj['subject'] = DN(ra_obj['subject'])
+                    obj['revoked'] = (
+                        ra_obj['status'] in (u'REVOKED', u'REVOKED_EXPIRED'))
+                    if all:
                         obj['certificate'] = (
-                            ra_obj['certificate'].replace('\r\n', ''))
+                            obj['certificate'].replace('\r\n', ''))
                         self.obj._parse(obj)
 
             obj['cacn'] = ca_obj['cn'][0]


### PR DESCRIPTION
In commit c718ef058847bb39e78236e8af0ad69ac961bbcf some param values were
accidentally removed from cert-find output.

In commit 22d5f579bbd8bb452cf1bf620294ab6ade6e7c47 `serial_number_hex` and
`revoked` were added back.

Add back `revocation_reason` as well.

https://fedorahosted.org/freeipa/ticket/6269