### PR TITLE
git: Add commit template

### DIFF
--- a/.git-commit-template
+++ b/.git-commit-template
@@ -1,0 +1,5 @@
+component: Subject
+
+Explanation
+
+https://fedorahosted.org/freeipa/ticket/XXXX


### PR DESCRIPTION
In order to use the commit template, run the
following command:
git config commit.template .git-commit-template
