### PR TITLE
Reverted the assertion for replica uninstall returncode

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -357,12 +357,8 @@ class TestProhibitReplicaUninstallation(IntegrationTest):
         result = self.replicas[0].run_command(['ipa-server-install',
                                                '--uninstall', '-U'],
                                               raiseonerr=False)
-        # Due to ticket 3230 server installation/uninstallation always returns
-        # 0 unless an uncaught exception occurs. Once this issue is properly
-        # addressed, please care to change expected return code in the
-        # following assert from 0 to something else.
         assert_error(result, "Removal of '%s' leads to disconnected"
-                             " topology" % self.replicas[0].hostname, 0)
+                             " topology" % self.replicas[0].hostname, 1)
         self.replicas[0].run_command(['ipa-server-install', '--uninstall',
                                       '-U', '--ignore-topology-disconnect'])
 


### PR DESCRIPTION
As the issue with ipa installer always returning 0 returncode is apparently
addressed, the test needs to be made aware of this change.

https://fedorahosted.org/freeipa/ticket/3230