### PR TITLE
CI: workaround: wait for dogtag before replica-prepare

### DIFF
--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -370,6 +370,9 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
     args.extend(extra_args)
 
     if domain_level == DOMAIN_LEVEL_0:
+        # workaround #6274 - remove when fixed
+        time.sleep(30)  # wait until dogtag wakes up
+
         # prepare the replica file on master and put it to replica, AKA "old way"
         replica_prepare(master, replica)
         replica_filename = get_replica_filename(replica)


### PR DESCRIPTION
In domain level 0 ipa-replica-prepare fails because dogtag is not ready
so soon after final restart during installation (tests are too fast).
Wait 30 seconds before ipa-replica-prepare is executed, to make sure
that dogtag is ready. Remove this workaround when ticket is fixed.

https://fedorahosted.org/freeipa/ticket/6274