### PR TITLE
Certificate processing refactoring

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -37,9 +37,9 @@ import json
 
 import six
 
-from ipapython import ipautil
+from ipapython import certmonger, ipautil
 from ipapython.dn import DN
-from ipalib import api, errors, pkcs10, x509
+from ipalib import api, errors, x509
 from ipaplatform.paths import paths
 from ipaserver.plugins.ldap2 import ldap2
 from ipaserver.install import cainstance, certs
@@ -65,8 +65,14 @@ if six.PY3:
 IPA_CA_NICKNAME = 'caSigningCert cert-pki-ca'
 
 def get_nickname():
-    csr = os.environ.get('CERTMONGER_CSR')
-    return pkcs10.get_friendlyname(csr) if csr else None
+    subject = os.environ.get('CERTMONGER_REQ_SUBJECT')
+    if not subject:
+        return None
+    request_id = certmonger.get_request_id({'template-subject': subject})
+    if not request_id:
+        return None
+    return certmonger.get_request_value(request_id, 'cert-nickname')
+
 
 def is_lightweight_ca():
     nickname = get_nickname() or ''
@@ -216,13 +222,9 @@ def store_cert():
     else:
         return (OPERATION_NOT_SUPPORTED_BY_HELPER,)
 
-    csr = os.environ.get('CERTMONGER_CSR')
-    if not csr:
-        return (UNCONFIGURED, "Certificate request not provided")
-
-    nickname = pkcs10.get_friendlyname(csr)
+    nickname = get_nickname()
     if not nickname:
-        return (REJECTED, "No friendly name in the certificate request")
+        return (REJECTED, "Nickname could not be determined")
 
     cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if not cert:
@@ -325,13 +327,9 @@ def retrieve_or_reuse_cert():
     Retrieve certificate from LDAP. If the certificate is not available, reuse
     the old certificate.
     """
-    csr = os.environ.get('CERTMONGER_CSR')
-    if not csr:
-        return (UNCONFIGURED, "Certificate request not provided")
-
-    nickname = pkcs10.get_friendlyname(csr)
+    nickname = get_nickname()
     if not nickname:
-        return (REJECTED, "No friendly name in the certificate request")
+        return (REJECTED, "Nickname could not be determined")
 
     cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if not cert:

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -45,6 +45,7 @@ import nss.nss as nss
 from nss.error import NSPRError
 from pyasn1.type import univ, char, namedtype, tag
 from pyasn1.codec.der import decoder, encoder
+from pyasn1_modules import rfc2459
 import six
 
 from ipalib import api
@@ -200,49 +201,11 @@ def is_self_signed(certificate, datatype=PEM, dbdir=None):
     del nsscert
     return self_signed
 
-class _Name(univ.Choice):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('rdnSequence',
-            univ.SequenceOf()),
-    )
-
-class _TBSCertificate(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType(
-            'version',
-            univ.Integer().subtype(explicitTag=tag.Tag(
-                tag.tagClassContext, tag.tagFormatSimple, 0))),
-        namedtype.NamedType('serialNumber', univ.Integer()),
-        namedtype.NamedType('signature', univ.Sequence()),
-        namedtype.NamedType('issuer', _Name()),
-        namedtype.NamedType('validity', univ.Sequence()),
-        namedtype.NamedType('subject', _Name()),
-        namedtype.NamedType('subjectPublicKeyInfo', univ.Sequence()),
-        namedtype.OptionalNamedType(
-            'issuerUniquedID',
-            univ.BitString().subtype(implicitTag=tag.Tag(
-                tag.tagClassContext, tag.tagFormatSimple, 1))),
-        namedtype.OptionalNamedType(
-            'subjectUniquedID',
-            univ.BitString().subtype(implicitTag=tag.Tag(
-                tag.tagClassContext, tag.tagFormatSimple, 2))),
-        namedtype.OptionalNamedType(
-            'extensions',
-            univ.Sequence().subtype(explicitTag=tag.Tag(
-                tag.tagClassContext, tag.tagFormatSimple, 3))),
-        )
-
-class _Certificate(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('tbsCertificate', _TBSCertificate()),
-        namedtype.NamedType('signatureAlgorithm', univ.Sequence()),
-        namedtype.NamedType('signature', univ.BitString()),
-        )
 
 def _get_der_field(cert, datatype, dbdir, field):
     cert = load_certificate(cert, datatype, dbdir)
     cert = cert.der_data
-    cert = decoder.decode(cert, _Certificate())[0]
+    cert = decoder.decode(cert, rfc2459.Certificate())[0]
     field = cert['tbsCertificate'][field]
     field = encoder.encode(field)
     return field
@@ -364,75 +327,22 @@ def write_certificate_list(rawcerts, filename):
     except (IOError, OSError) as e:
         raise errors.FileError(reason=str(e))
 
-class _Extension(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('extnID', univ.ObjectIdentifier()),
-        namedtype.NamedType('critical', univ.Boolean()),
-        namedtype.NamedType('extnValue', univ.OctetString()),
-    )
 
 def _encode_extension(oid, critical, value):
-    ext = _Extension()
+    ext = rfc2459.Extension()
     ext['extnID'] = univ.ObjectIdentifier(oid)
     ext['critical'] = univ.Boolean(critical)
     ext['extnValue'] = univ.OctetString(value)
     ext = encoder.encode(ext)
     return ext
 
-class _ExtKeyUsageSyntax(univ.SequenceOf):
-    componentType = univ.ObjectIdentifier()
 
 def encode_ext_key_usage(ext_key_usage):
-    eku = _ExtKeyUsageSyntax()
+    eku = rfc2459.ExtKeyUsageSyntax()
     for i, oid in enumerate(ext_key_usage):
         eku[i] = univ.ObjectIdentifier(oid)
     eku = encoder.encode(eku)
     return _encode_extension('2.5.29.37', EKU_ANY not in ext_key_usage, eku)
-
-
-class _AnotherName(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('type-id', univ.ObjectIdentifier()),
-        namedtype.NamedType('value', univ.Any().subtype(
-            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))
-        ),
-    )
-
-
-class _GeneralName(univ.Choice):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('otherName', _AnotherName().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))
-        ),
-        namedtype.NamedType('rfc822Name', char.IA5String().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))
-        ),
-        namedtype.NamedType('dNSName', char.IA5String().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2))
-        ),
-        namedtype.NamedType('x400Address', univ.Sequence().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 3))
-        ),
-        namedtype.NamedType('directoryName', _Name().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 4))
-        ),
-        namedtype.NamedType('ediPartyName', univ.Sequence().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 5))
-        ),
-        namedtype.NamedType('uniformResourceIdentifier', char.IA5String().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 6))
-        ),
-        namedtype.NamedType('iPAddress', univ.OctetString().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 7))
-        ),
-        namedtype.NamedType('registeredID', univ.ObjectIdentifier().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 8))
-        ),
-    )
-
-
-class _SubjectAltName(univ.SequenceOf):
-    componentType = _GeneralName()
 
 
 class _PrincipalName(univ.Sequence):
@@ -488,7 +398,8 @@ def decode_generalnames(secitem):
 
     """
     nss_names = nss.x509_alt_name(secitem, repr_kind=nss.AsObject)
-    asn1_names = decoder.decode(secitem.data, asn1Spec=_SubjectAltName())[0]
+    asn1_names = decoder.decode(
+            secitem.data, asn1Spec=rfc2459.SubjectAltName())[0]
     names = []
     for nss_name, asn1_name in zip(nss_names, asn1_names):
         # NOTE: we use the NSS enum to identify the name type.

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -33,6 +33,7 @@
 
 from __future__ import print_function
 
+import binascii
 import collections
 import os
 import sys
@@ -550,6 +551,28 @@ def process_othernames(gns):
             yield cls(gn.type_id, gn.value)
         else:
             yield gn
+
+
+def chunk(size, s):
+    """Yield chunks of the specified size from the given string.
+
+    The input must be a multiple of the chunk size (otherwise
+    trailing characters are dropped).
+
+    Works on character strings only.
+
+    """
+    return (u''.join(span) for span in six.moves.zip(*[iter(s)] * size))
+
+
+def add_colons(s):
+    """Add colons between each nibble pair in a hex string."""
+    return u':'.join(chunk(2, s))
+
+
+def to_hex_with_colons(bs):
+    """Convert bytes to a hex string with colons."""
+    return add_colons(binascii.hexlify(bs).decode('utf-8'))
 
 
 if __name__ == '__main__':

--- a/ipapython/dn.py
+++ b/ipapython/dn.py
@@ -422,6 +422,7 @@ from __future__ import print_function
 import sys
 import functools
 
+import cryptography.x509
 from ldap.dn import str2dn, dn2str
 from ldap import DECODING_ERROR
 import six
@@ -976,6 +977,8 @@ class DN(object):
       to yield one or more RDN's which will be appended in order to
       the DN. The parsing recognizes the DN syntax escaping rules.
 
+    * A single ``cryptography.x509.name.Name`` object.
+
     * A RDN object, the RDN will copied respecting the constructors
       keyword configuration parameters and appended in order.
 
@@ -1125,9 +1128,17 @@ class DN(object):
             rdns = [[ava]]
         elif isinstance(value, RDN):
             rdns = [value.to_openldap()]
+        elif isinstance(value, cryptography.x509.name.Name):
+            rdns = list(reversed([
+                [get_ava(
+                    _ATTR_NAME_BY_OID.get(ava.oid, ava.oid.dotted_string),
+                    ava.value)]
+                for ava in value
+            ]))
         else:
-            raise TypeError("must be str, unicode, tuple, or RDN or DN, got %s instead" %
-                            type(value))
+            raise TypeError(
+                "must be str, unicode, tuple, Name, RDN or DN, got %s instead"
+                % type(value))
         return rdns
 
     def _rdns_from_sequence(self, seq):
@@ -1407,3 +1418,31 @@ class DN(object):
         if i == -1:
             raise ValueError("pattern not found")
         return i
+
+
+_ATTR_NAME_BY_OID = {
+    cryptography.x509.oid.NameOID.COMMON_NAME: 'CN',
+    cryptography.x509.oid.NameOID.COUNTRY_NAME: 'C',
+    cryptography.x509.oid.NameOID.LOCALITY_NAME: 'L',
+    cryptography.x509.oid.NameOID.STATE_OR_PROVINCE_NAME: 'ST',
+    cryptography.x509.oid.NameOID.ORGANIZATION_NAME: 'O',
+    cryptography.x509.oid.NameOID.ORGANIZATIONAL_UNIT_NAME: 'OU',
+    cryptography.x509.oid.NameOID.SERIAL_NUMBER: 'serialNumber',
+    cryptography.x509.oid.NameOID.SURNAME: 'SN',
+    cryptography.x509.oid.NameOID.GIVEN_NAME: 'givenName',
+    cryptography.x509.oid.NameOID.TITLE: 'title',
+    cryptography.x509.oid.NameOID.GENERATION_QUALIFIER: 'generationQualifier',
+    cryptography.x509.oid.NameOID.DN_QUALIFIER: 'dnQualifier',
+    cryptography.x509.oid.NameOID.PSEUDONYM: 'pseudonym',
+    cryptography.x509.oid.NameOID.DOMAIN_COMPONENT: 'DC',
+    cryptography.x509.oid.NameOID.EMAIL_ADDRESS: 'E',
+    cryptography.x509.oid.NameOID.JURISDICTION_COUNTRY_NAME:
+        'incorporationCountry',
+    cryptography.x509.oid.NameOID.JURISDICTION_LOCALITY_NAME:
+        'incorporationLocality',
+    cryptography.x509.oid.NameOID.JURISDICTION_STATE_OR_PROVINCE_NAME:
+        'incorporationState',
+    cryptography.x509.oid.NameOID.BUSINESS_CATEGORY: 'businessCategory',
+    cryptography.x509.ObjectIdentifier('2.5.4.9'): 'STREET',
+    cryptography.x509.ObjectIdentifier('0.9.2342.19200300.100.1.1'): 'UID',
+}

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -399,10 +399,10 @@ class BaseCertObject(Object):
             if full:
                 obj['valid_not_before'] = unicode(cert.valid_not_before_str)
                 obj['valid_not_after'] = unicode(cert.valid_not_after_str)
-                obj['md5_fingerprint'] = unicode(
-                    nss.data_to_hex(nss.md5_digest(cert.der_data), 64)[0])
-                obj['sha1_fingerprint'] = unicode(
-                    nss.data_to_hex(nss.sha1_digest(cert.der_data), 64)[0])
+                obj['md5_fingerprint'] = x509.to_hex_with_colons(
+                    nss.md5_digest(cert.der_data))
+                obj['sha1_fingerprint'] = x509.to_hex_with_colons(
+                    nss.sha1_digest(cert.der_data))
 
             try:
                 ext_san = cert.get_extension(nss.SEC_OID_X509_SUBJECT_ALT_NAME)

--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -274,8 +274,10 @@ def set_certificate_attrs(entry_attrs):
     entry_attrs['issuer'] = unicode(cert.issuer)
     entry_attrs['valid_not_before'] = unicode(cert.valid_not_before_str)
     entry_attrs['valid_not_after'] = unicode(cert.valid_not_after_str)
-    entry_attrs['md5_fingerprint'] = unicode(nss.data_to_hex(nss.md5_digest(cert.der_data), 64)[0])
-    entry_attrs['sha1_fingerprint'] = unicode(nss.data_to_hex(nss.sha1_digest(cert.der_data), 64)[0])
+    entry_attrs['md5_fingerprint'] = x509.to_hex_with_colons(
+        nss.md5_digest(cert.der_data))
+    entry_attrs['sha1_fingerprint'] = x509.to_hex_with_colons(
+        nss.sha1_digest(cert.der_data))
 
 def check_required_principal(ldap, principal):
     """


### PR DESCRIPTION
This PR contains ready-for-review/test commits that:

- support converting python-cryptography Name type to DN

- avoid the need to parse friendlyName from CSR and remove
  the code that does that

- convert `ipalib.pkcs10` to use python-cryptography instead of NSS
  for processing CSRs.

- eliminate our use of the nss.data_to_hex function

- switch `ipalib.x509` to use ASN.1 specifications provided by
  *pyasn1-modules* library, and remove our hand-rolled definitions.


It was discussed to target subteam staging branches for the ongoing
refactoring work but it does not seem that these were created yet.
I can retarget the PR after the cert refactoring branch gets
created.