### PR TITLE
Do not create Object Signing certificate

### DIFF
--- a/install/ui/test/data/cert_find.json
+++ b/install/ui/test/data/cert_find.json
@@ -57,12 +57,6 @@
                 "serial_number_hex": "0x9",
                 "status": "VALID",
                 "subject": "CN=dev.example.com,O=EXAMPLE.COM"
-            },
-            {
-                "serial_number": 10,
-                "serial_number_hex": "0xA",
-                "status": "VALID",
-                "subject": "CN=Object Signing Cert,O=EXAMPLE.COM"
             }
         ],
         "summary": "10 certificates matched",

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -94,8 +94,7 @@ def install_check(standalone, replica_config, options):
         for db in (cadb, dsdb):
             for nickname, _trust_flags in db.list_certs():
                 if nickname in (certdb.get_ca_nickname(realm_name),
-                                'ipaCert',
-                                'Signing-Cert'):
+                                'ipaCert'):
                     raise ScriptError(
                         "Certificate with nickname %s is present in %s, "
                         "cannot continue." % (nickname, db.secdir))
@@ -105,8 +104,7 @@ def install_check(standalone, replica_config, options):
                     continue
                 subject = DN(str(x509.get_subject(cert)))
                 if subject in (DN('CN=Certificate Authority', subject_base),
-                               DN('CN=IPA RA', subject_base),
-                               DN('CN=Object Signing Cert', subject_base)):
+                               DN('CN=IPA RA', subject_base)):
                     raise ScriptError(
                         "Certificate with subject %s is present in %s, "
                         "cannot continue." % (subject, db.secdir))

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -347,7 +347,6 @@ class HTTPInstance(service.Service):
                                                  ca_db)
             db.track_server_cert(self.cert_nickname, self.principal,
                                  db.passwd_fname, 'restart_httpd')
-            db.create_signing_cert("Signing-Cert", "Object Signing Cert", ca_db)
             self.add_cert_to_service()
 
         # Fix the database permissions

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -96,7 +96,6 @@ def install_http_certs(config, fstore, remote_api):
     subject = DN(('O', config.realm_name))
     db = certs.CertDB(config.realm_name, nssdir=nssdir, subject_base=subject)
     db.request_service_cert('Server-Cert', principal, config.host_name, True)
-    # FIXME: need Signing-Cert too ?
 
 
 def install_replica_ds(config, options, ca_is_configured, remote_api,


### PR DESCRIPTION
The Object Signing certificate created during server installation
was used only for signing the (recently removed) Firefox extension,
so there's no need to create that certificate any more.

Fixes: https://fedorahosted.org/freeipa/ticket/6399