### PR TITLE
Trust AD cleanup

### DIFF
--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -517,6 +517,17 @@ def remove_trust_with_ad(master, ad_domain):
     range_name = ad_domain.upper() + '_id_range'
     master.run_command(['ipa', 'idrange-del', range_name])
 
+    remove_trust_info_from_ad(master, ad_domain)
+
+
+def remove_trust_info_from_ad(master, ad_domain):
+    # Remove record about trust from AD
+    master.run_command(['rpcclient', ad_domain,
+                        '-U\\Administrator%{}'.format(
+                            master.config.ad_admin_password),
+                        '-c', 'deletetrustdom {}'.format(master.domain.name)],
+                       raiseonerr=False)
+
 
 def configure_auth_to_local_rule(master, ad):
     """

--- a/ipatests/test_integration/test_legacy_clients.py
+++ b/ipatests/test_integration/test_legacy_clients.py
@@ -368,6 +368,10 @@ class BaseTestLegacyClient(object):
         cls.master.run_command(['ipa', 'user-del', 'disabledipauser'],
                                 raiseonerr=False)
 
+        # Remove information about trust from AD, if domain was defined
+        if hasattr(cls, 'ad_domain'):
+            tasks.remove_trust_info_from_ad(cls.master, cls.ad_domain)
+
         # Also unapply fixes on the legacy client, if defined
         if hasattr(cls, 'legacy_client'):
             tasks.unapply_fixes(cls.legacy_client)

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -35,6 +35,9 @@ class ADTrustBase(IntegrationTest):
 
     @classmethod
     def install(cls, mh):
+        if not cls.master.transport.file_exists('/usr/bin/rpcclient'):
+            raise nose.SkipTest("Package samba-client not available "
+                                "on {}".format(cls.master.hostname))
         super(ADTrustBase, cls).install(mh)
         cls.ad = cls.ad_domains[0].ads[0]
         cls.ad_domain = cls.ad.domain.name

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -237,7 +237,7 @@ ipa_class_members = {
                 'stderr_text',
                 'returncode',
             ]},
-            {'transport': ['put_file']},
+            {'transport': ['put_file', 'file_exists']},
             'put_file_contents',
             'get_file_contents',
             'ldap_connect',


### PR DESCRIPTION
Adding operations that remove test related trust information from AD machines.
Package samba-client is necessary for this operation, hence tests are skipped if the package is not installed.
