### PR TITLE
Update cli.py

### DIFF
--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -248,7 +248,7 @@ class textui(backend.Backend):
         >>> ui.print_indented('No indentation.', indent=0)
         No indentation.
         """
-        print((CLI_TAB * indent + text))
+        print((CLI_TAB * indent + text.encode("utf-8")))
 
     def print_keyval(self, rows, indent=1):
         """


### PR DESCRIPTION
fix for ipa host-find

ipa: ERROR: UnicodeEncodeError: 'ascii' codec can't encode characters in position 15-26: ordinal not in range(128)
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/ipalib/cli.py", line 1339, in run
    sys.exit(api.Backend.cli.run(argv))
  File "/usr/lib/python2.7/site-packages/ipalib/cli.py", line 1104, in run
    rv = cmd.output_for_cli(self.api.Backend.textui, result, _args, *_options)
  File "/usr/lib/python2.7/site-packages/ipalib/frontend.py", line 1029, in output_for_cli
    textui.print_entries(result, order, labels, flags, print_all)
  File "/usr/lib/python2.7/site-packages/ipalib/cli.py", line 354, in print_entries
    self.print_entry(entry, order, labels, flags, print_all, format, indent)
  File "/usr/lib/python2.7/site-packages/ipalib/cli.py", line 394, in print_entry
    label, value, format, indent, one_value_per_line
  File "/usr/lib/python2.7/site-packages/ipalib/cli.py", line 317, in print_attribute
    self.print_indented(format % (attr, text[0]), indent)
  File "/usr/lib/python2.7/site-packages/ipalib/cli.py", line 240, in print_indented
    print (CLI_TAB \* indent + text)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 15-26: ordinal not in range(128)
ipa: ERROR: an internal error has occurred
