### PR TITLE
fix pki-tomcat error after uninstall

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -585,6 +585,11 @@ class CAInstance(DogtagInstance):
         with open(cfg_file, "wb") as f:
             config.write(f)
 
+        # Create parent directory for pki-tomcatd service file
+        PKI_SERVICE_LOCATION="/etc/systemd/system/pki-tomcatd.target.wants"
+        if not os.path.exists(PKI_SERVICE_LOCATION):
+            os.mkdir(PKI_SERVICE_LOCATION)
+
         self.backup_state('installed', True)
         try:
             DogtagInstance.spawn_instance(self, cfg_file)


### PR DESCRIPTION
I set up the freeipa(version 4.3.1) environment in Ubuntu 16.04, there is a reconfigure error found after uninstall. The error message is ERROR CA configuration failed. The pki log message shows that pkispawn : ERROR ....... OSError: [Errno 2] No such file or directory! The reason is that there is no pki-tomcatd.target.wants directory in /etc/systemd/system/ directory. Creating the directory can solve the problem.
