### PR TITLE
Ensure correct IPA CA nickname in DS and HTTP NSSDBs

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -1265,7 +1265,7 @@ class DsInstance(service.Service):
         os.chown(paths.DS_KEYTAB, pent.pw_uid, pent.pw_gid)
 
     def __get_ds_cert(self):
-        subject = DN(('O', self.realm))
+        subject = self.subject_base or DN(('O', self.realm))
         nssdb_dir = config_dirname(self.serverid)
         db = certs.CertDB(self.realm, nssdir=nssdb_dir, subject_base=subject)
         db.request_service_cert(self.nickname, self.principal, self.fqdn)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -93,7 +93,7 @@ def install_http_certs(config, fstore, remote_api):
 
     # Obtain certificate for the HTTP service
     nssdir = certs.NSS_DIR
-    subject = DN(('O', config.realm_name))
+    subject = config.subject_base or DN(('O', config.realm_name))
     db = certs.CertDB(config.realm_name, nssdir=nssdir, subject_base=subject)
     db.request_service_cert('Server-Cert', principal, config.host_name, True)
 


### PR DESCRIPTION
During replica installation, if the IPA deployment has a custom
subject_base, the routines that create the DS and HTTP NSSDBs
erroneously compare the subject of CA certs to the _default_ subject
base. This causes the IPA CA cert to be added to the NSSDBs with a
nickname derived from the subject name, instead of "{REALM} IPA CA".

At a later stage of installation, the `upload_cacrt` plugin reads
certs from the HTTP NSSDB in order to update the cn=certificates
LDAP certstore.  The NSSDB nickname of the cert is used as the CN
for the entry.  Because the IPA CA cert was not installed in the
HTTP NSSDB with the "{REALM} IPA CA", this causes a spurious entry
for the IPA CA to be added to the certstore.

To avoid this scenario, use the deployment's actual subject base
when deciding if a cert is the IPA CA cert.

Fixes: https://fedorahosted.org/freeipa/ticket/6415
