### PR TITLE
Remove ipapython/ipa.conf

### DIFF
--- a/ipapython/MANIFEST.in
+++ b/ipapython/MANIFEST.in
@@ -1,2 +1,0 @@
-include *.conf
-

--- a/ipapython/ipa.conf
+++ b/ipapython/ipa.conf
@@ -1,3 +1,0 @@
-[defaults]
-# realm = EXAMPLE.COM
-# server = ipa.example.com


### PR DESCRIPTION
The file ipapython/ipa.conf is no longer used and not installed.

Signed-off-by: Christian Heimes <cheimes@redhat.com>