### PR TITLE
Fix for handling CalledProcessError in authconfig

### DIFF
--- a/ipaplatform/redhat/authconfig.py
+++ b/ipaplatform/redhat/authconfig.py
@@ -18,10 +18,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from ipaplatform.paths import paths
 from ipapython import ipautil
+from ipapython.admintool import ScriptError
 import os
 
 FILES_TO_NOT_BACKUP = ['passwd', 'group', 'shadow', 'gshadow']
+
 
 class RedHatAuthConfig(object):
     """
@@ -85,10 +88,16 @@ class RedHatAuthConfig(object):
             self.add_option("update")
 
         args = self.build_args()
-        ipautil.run(["/usr/sbin/authconfig"] + args)
+        try:
+            ipautil.run([paths.AUTHCONFIG] + args)
+        except ipautil.CalledProcessError:
+            raise ScriptError("Failed to execute authconfig command")
 
     def backup(self, path):
-        ipautil.run(["/usr/sbin/authconfig", "--savebackup", path])
+        try:
+            ipautil.run([paths.AUTHCONFIG, "--savebackup", path])
+        except ipautil.CalledProcessError:
+            raise ScriptError("Failed to execute authconfig command")
 
         # do not backup these files since we don't want to mess with
         # users/groups during restore. Authconfig doesn't seem to mind about
@@ -101,4 +110,7 @@ class RedHatAuthConfig(object):
                 pass
 
     def restore(self, path):
-        ipautil.run(["/usr/sbin/authconfig", "--restorebackup", path])
+        try:
+            ipautil.run([paths.AUTHCONFIG, "--restorebackup", path])
+        except ipautil.CalledProcessError:
+            raise ScriptError("Failed to execute authconfig command")

--- a/ipaplatform/redhat/paths.py
+++ b/ipaplatform/redhat/paths.py
@@ -33,6 +33,7 @@ class RedHatPathNamespace(BasePathNamespace):
     if sys.maxsize > 2**32:
         LIBSOFTHSM2_SO = BasePathNamespace.LIBSOFTHSM2_SO_64
         PAM_KRB5_SO = BasePathNamespace.PAM_KRB5_SO_64
+    AUTHCONFIG = '/usr/sbin/authconfig'
 
 
 paths = RedHatPathNamespace()


### PR DESCRIPTION
NIS configuration error should be hidden from user
while running ipa-client-install

Fixes https://fedorahosted.org/freeipa/ticket/5244

Signed-off-by: Abhijeet Kasurde akasurde@redhat.com
