### PR TITLE
Make api.env.nss_dir relative to api.env.confdir

### DIFF
--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -474,6 +474,9 @@ class Env(object):
         if 'conf_default' not in self:
             self.conf_default = self._join('confdir', 'default.conf')
 
+        if 'nss_dir' not in self:
+            self.nss_dir = self._join('confdir', 'nssdb')
+
         # Set plugins_on_demand:
         if 'plugins_on_demand' not in self:
             self.plugins_on_demand = (self.context == 'cli')

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -133,8 +133,6 @@ DEFAULT_CONFIG = (
 
     ('rpc_protocol', 'jsonrpc'),
 
-    ('nss_dir', paths.IPA_NSSDB_DIR),
-
     # Define an inclusive range of SSL/TLS version support
     ('tls_version_min', 'tls1.0'),
     ('tls_version_max', 'tls1.2'),
@@ -229,6 +227,7 @@ DEFAULT_CONFIG = (
     ('conf', object),  # File containing context specific config
     ('conf_default', object),  # File containing context independent config
     ('plugins_on_demand', object),  # Whether to finalize plugins on-demand (bool)
+    ('nss_dir', object),  # Path to nssdb, default {confdir}/nssdb
 
     # Set in Env._finalize_core():
     ('in_server', object),  # Whether or not running in-server (bool)


### PR DESCRIPTION
api.env.nss_dir is no longer hard-coded to paths.IPA_NSSDB_DIR. Instead
the path is calculated relatively to api.env.confdir. The default value
is still /etc/ipa/nssdb. The change makes it a bit easier to run
FreeIPA's API with a custom configuration directory.

See https://fedorahosted.org/freeipa/ticket/6386

Signed-off-by: Christian Heimes cheimes@redhat.com
