### PR TITLE
Use env var IPA_CONFDIR to get confdir for 'cli' context

### DIFF
--- a/client/man/ipa.1
+++ b/client/man/ipa.1
@@ -190,6 +190,10 @@ The ipa client will determine which server to connect to in this order:
 
 .TP
 If a kerberos error is raised by any of the requests then it will stop processing and display the error message.
+.SH "ENVIRONMENT VARIABLES"
+.TP
+\fBIPA_CONFDIR\fR
+Override path to confdir (default: \fB/etc/ipa\fR).
 .SH "FILES"
 .TP
 \fB/etc/ipa/default.conf\fR

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -43,6 +43,7 @@ from ipapython.dn import DN
 from ipalib.base import check_name
 from ipalib.constants import CONFIG_SECTION
 from ipalib.constants import OVERRIDE_ERROR, SET_ERROR, DEL_ERROR
+from ipapython.admintool import ScriptError
 
 if six.PY3:
     unicode = str
@@ -460,8 +461,17 @@ class Env(object):
             self.context = 'default'
 
         # Set confdir:
+        self.env_confdir = os.environ.get('IPA_CONFDIR')
         if 'confdir' not in self:
-            if self.in_tree:
+            if self.env_confdir is not None:
+                if (not path.isabs(self.env_confdir)
+                        or not path.isdir(self.env_confdir)):
+                    raise ScriptError(
+                        "IPA_CONFDIR env var must be an absolute path to an "
+                        "existing directory, got '{}'.".format(
+                            self.env_confdir))
+                self.confdir = self.env_confdir
+            elif self.in_tree:
                 self.confdir = self.dot_ipa
             else:
                 self.confdir = path.join('/', 'etc', 'ipa')

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -713,6 +713,15 @@ class API(ReadOnly):
         self.__doing('finalize')
         self.__do_if_not_done('load_plugins')
 
+        if self.env.env_confdir is not None:
+            if self.env.env_confdir == self.env.confdir:
+                self.log.info(
+                    "IPA_CONFDIR env sets confdir to '%s'.", self.env.confdir)
+            else:
+                self.log.warn(
+                    "IPA_CONFDIR env is overridden by an explicit confdir "
+                    "argument.")
+
         for plugin in self.__plugins:
             if not self.env.validate_api:
                 if plugin.full_name not in DEFAULT_PLUGINS:

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -96,6 +96,12 @@ class TempDir(object):
     def __del__(self):
         self.rmtree()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.rmtree()
+
 
 class TempHome(TempDir):
     def __init__(self):


### PR DESCRIPTION
For 'cli' contexts, the environment variable IPA_CONFDIR overrides the
default confdir path. The value of the environment variable must be an
absolute path to an existing directory. The new variable simplifies
local configuration. Server and installer contexts do not use it.

Signed-off-by: Christian Heimes cheimes@redhat.com
