### PR TITLE
Minor install script fixes

### DIFF
--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -603,7 +603,8 @@ class KerbTransport(SSLTransport):
                     except (TypeError, UnicodeError):
                         pass
             if not token:
-                raise KerberosError(message="No valid Negotiate header in server response")
+                raise KerberosError(
+                    message=u"No valid Negotiate header in server response")
             token = self._sec_context.step(token=token)
             if self._sec_context.complete:
                 self._sec_context = None

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -896,6 +896,8 @@ def install(installer):
             args.append("--no-sshd")
         if options.mkhomedir:
             args.append("--mkhomedir")
+        if options.debug:
+            args.append("--debug")
         run(args, redirect_output=True)
         print()
     except Exception:


### PR DESCRIPTION
- Use the correct unicode string for an error message, otherwise an
exception will generate another exception about incorrect type,
masking the original error.

- Make sure to pass down the debug flag to ipa-client-install when
the server install is run in debug mode
