### PR TITLE
TESTS: Update group type name

### DIFF
--- a/ipatests/test_webui/data_group.py
+++ b/ipatests/test_webui/data_group.py
@@ -26,7 +26,7 @@ DATA = {
     'add': [
         ('textbox', 'cn', PKEY),
         ('textarea', 'description', 'test-group desc'),
-        ('radio', 'type', 'normal'),
+        ('radio', 'type', 'nonposix'),
     ],
     'mod': [
         ('textarea', 'description', 'test-group desc modified'),


### PR DESCRIPTION
As the group type has been changed from 'normal' to 'nonposix' we need to update
this information also in tests.

https://fedorahosted.org/freeipa/ticket/6334
