### PR TITLE
Register entry points of Custodia plugins

### DIFF
--- a/ipapython/secrets/store.py
+++ b/ipapython/secrets/store.py
@@ -217,7 +217,7 @@ NAME_DB_MAP = {
 }
 
 
-class iSecStore(CSStore):
+class IPASecStore(CSStore):
 
     def __init__(self, config=None):
         self.config = config
@@ -255,3 +255,7 @@ class iSecStore(CSStore):
 
     def span(self, key):
         raise NotImplementedError
+
+
+# backwards compatibility with FreeIPA 4.3 and 4.4.
+iSecStore = IPASecStore

--- a/ipapython/setup.py
+++ b/ipapython/setup.py
@@ -38,4 +38,12 @@ if __name__ == '__main__':
             "ipapython.secrets",
             "ipapython.install"
         ],
+        entry_points={
+            'custodia.authorizers': [
+                'IPAKEMKeys = ipapython.secrets.kem:IPAKEMKeys',
+            ],
+            'custodia.stores': [
+                'IPASecStore = ipapython.secrets.store:IPASecStore',
+            ],
+        },
     )


### PR DESCRIPTION
With setuptools in place FreeIPA is able to register its Custodia
plugins. Custodia 0.1 ignores the plugins directives. Custodia 0.2 uses
the entry points to discover plugins.

https://fedorahosted.org/freeipa/ticket/6492

Signed-off-by: Christian Heimes cheimes@redhat.com
