### PR TITLE
Move Python egg-info to top level directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,12 +39,11 @@ freeipa2-dev-doc
 /freeipa.spec
 !/Makefile
 /dist/
-/*/dist/
 /RELEASE
 /rpmbuild/
 # Build
 /ipasetup.py
-*.egg-info
+/*.egg-info
 
 # Subdirectories
 /daemons/ipa-otpd/ipa-otpd

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ pylint: bootstrap-autogen
 	FILES=`find . \
 		-type d -exec test -e '{}/__init__.py' \; -print -prune -o \
 		-path '*/.*' -o \
+		-path '*/build/*' -o \
 		-path './dist/*' -o \
 		-path './lextab.py' -o \
 		-path './yacctab.py' -o \
@@ -166,7 +167,7 @@ ipasetup.py: ipasetup.py.in FORCE
 	sed -e s/__VERSION__/$(IPA_VERSION)/ $< > $@
 
 .PHONY: egg_info
-egg_info: ipapython/version.py ipaplatform/__init__.py ipasetup.py
+egg_info: ipapython/version.py ipasetup.py
 	for directory in $(PYPKGDIRS); do \
 	    pushd $${directory} ; \
 	    $(PYTHON) setup.py egg_info $(EXTRA_SETUP); \

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1127,7 +1127,7 @@ fi
 %defattr(-,root,root,-)
 %doc README Contributors.txt
 %license COPYING
-%{python_sitelib}/freeipa-*.egg-info
+%{python_sitelib}/ipaserver-*.egg-info
 %dir %{python_sitelib}/ipaserver
 %dir %{python_sitelib}/ipaserver/install
 %dir %{python_sitelib}/ipaserver/install/plugins

--- a/ipaclient/setup.py
+++ b/ipaclient/setup.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
         name="ipaclient",
         doc=__doc__,
         scripts=['../ipa'],
-        package_dir={'ipaclient': ''},
+        setupfile=__file__,
         packages=[
             "ipaclient",
             "ipaclient.plugins",

--- a/ipalib/setup.py
+++ b/ipalib/setup.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     ipasetup(
         name="ipalib",
         doc=__doc__,
-        package_dir={'ipalib': ''},
+        setupfile=__file__,
         packages=[
             "ipalib",
         ],

--- a/ipaplatform/setup.py
+++ b/ipaplatform/setup.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     ipasetup(
         name="ipaplatform",
         doc=__doc__,
-        package_dir={'ipaplatform': ''},
+        setupfile=__file__,
         packages=[
             "ipaplatform",
             "ipaplatform.base",

--- a/ipapython/setup.py
+++ b/ipapython/setup.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     ipasetup(
         name="ipapython",
         doc=__doc__,
-        package_dir={'ipapython': ''},
+        setupfile=__file__,
         packages=[
             "ipapython",
             "ipapython.dnssec",

--- a/ipaserver/setup.py
+++ b/ipaserver/setup.py
@@ -31,9 +31,9 @@ if __name__ == '__main__':
     from ipasetup import ipasetup  # noqa: E402
 
     ipasetup(
-        name='freeipa',
+        name='ipaserver',
         doc=__doc__,
-        package_dir={'ipaserver': ''},
+        setupfile=__file__,
         packages=[
             'ipaserver',
             'ipaserver.advise',

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -15,8 +15,32 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function
+
 import os
 import sys
+
+from setuptools.command.egg_info import egg_info as setuptools_egg_info
+
+
+class egg_info(setuptools_egg_info):
+    def initialize_options(self):
+        setuptools_egg_info.initialize_options(self)
+        self.build_base = None
+
+    def finalize_options(self):
+        setuptools_egg_info.finalize_options(self)
+        # set self.build_base from build.build_base
+        self.set_undefined_options(
+            'build',
+            ('build_base', 'build_base'))
+        # egg-info directories are stored in project root
+        # /ipaplatform/build/../.. == /
+        toplevel = os.path.join(self.build_base, os.pardir, os.pardir)
+        self.egg_base = os.path.relpath(toplevel)
+        self.egg_info = os.path.join(self.egg_base,
+                                     os.path.basename(self.egg_info))
+
 
 common_args = dict(
     version="__VERSION__",
@@ -27,6 +51,9 @@ common_args = dict(
     maintainer_email="freeipa-devel@redhat.com",
     url="http://www.freeipa.org/",
     download_url="http://www.freeipa.org/page/Downloads",
+    cmdclass={
+        "egg_info": egg_info,
+    },
     platforms=["Linux", "Solaris", "Unix"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -45,14 +72,16 @@ local_path = os.path.dirname(os.path.abspath(sys.argv[0]))
 old_path = os.path.abspath(os.getcwd())
 
 
-def ipasetup(name, doc, **kwargs):
+def ipasetup(name, doc, setupfile, **kwargs):
     doclines = doc.split("\n")
+    package_root = os.path.abspath(os.path.dirname(setupfile))
 
     setup_kwargs = common_args.copy()
     setup_kwargs.update(
         name=name,
         description=doclines[0],
         long_description="\n".join(doclines[:2]),
+        package_dir={name: package_root},
         **kwargs
     )
     # exclude setup helpers from getting installed

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     ipasetup(
         name="ipatests",
         doc=__doc__,
-        package_dir={'ipatests': ''},
+        setupfile=__file__,
         packages=[
             "ipatests",
             "ipatests.pytest_plugins",


### PR DESCRIPTION
All setup.py use the same build, dist and *.egg-info directory on top
level. Build artefacts are no longer placed in local build directories.

Signed-off-by: Christian Heimes cheimes@redhat.com
