### PR TITLE
server-del: fix incorrect check for one IPA master

### DIFF
--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -473,7 +473,7 @@ class server_del(LDAPDelete):
         ipa_masters = ipa_config['ipa_master_server']
 
         # skip these checks if the last master is being removed
-        if ipa_masters == [hostname]:
+        if len(ipa_masters) <= 1:
             return
 
         if self.api.Command.dns_is_enabled()['result']:


### PR DESCRIPTION
make the check more robust against returned container types for multivalued
attributes (lists vs. tuples).

https://fedorahosted.org/freeipa/ticket/6417
