### PR TITLE
[ipa-4-4] Make httpd publish its CA certificate on DL1

### DIFF
--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -175,8 +175,7 @@ class HTTPInstance(service.Service):
         self.step("importing CA certificates from LDAP", self.__import_ca_certs)
         if autoconfig:
             self.step("setting up browser autoconfig", self.__setup_autoconfig)
-        if not self.promote:
-            self.step("publish CA cert", self.__publish_ca_cert)
+        self.step("publish CA cert", self.__publish_ca_cert)
         self.step("clean up any existing httpd ccache", self.remove_httpd_ccache)
         self.step("configuring SELinux for httpd", self.configure_selinux_for_httpd)
         if not self.is_kdcproxy_configured():


### PR DESCRIPTION
httpd did not publish its certificate on DL1 which could
cause issues during client installation in a rare corner
case where there would be no way of getting the certificate
but from a HTTP instance.

https://fedorahosted.org/freeipa/ticket/6393