### PR TITLE
spec file: bump minimal required version of 389-ds-base

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -137,7 +137,7 @@ Requires: %{name}-server-common = %{version}-%{release}
 Requires: %{name}-client = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 Requires: python2-ipaserver = %{version}-%{release}
-Requires: 389-ds-base >= 1.3.5.6
+Requires: 389-ds-base >= 1.3.5.14
 Requires: openldap-clients > 2.4.35-4
 Requires: nss >= 3.14.3-12.0
 Requires: nss-tools >= 3.14.3-12.0
@@ -169,7 +169,7 @@ Requires: zip
 Requires: policycoreutils >= 2.1.12-5
 Requires: tar
 Requires(pre): certmonger >= 0.78
-Requires(pre): 389-ds-base >= 1.3.5.6
+Requires(pre): 389-ds-base >= 1.3.5.14
 Requires: fontawesome-fonts
 Requires: open-sans-fonts
 Requires: openssl


### PR DESCRIPTION
Require 389-ds-base >= 1.3.5.14 for:
https://fedorahosted.org/389/ticket/48992

https://fedorahosted.org/freeipa/ticket/6369