### PR TITLE
ipa-getkeytab enhancements

### DIFF
--- a/client/man/ipa-getkeytab.1
+++ b/client/man/ipa-getkeytab.1
@@ -21,7 +21,7 @@
 .SH "NAME"
 ipa\-getkeytab \- Get a keytab for a Kerberos principal
 .SH "SYNOPSIS"
-ipa\-getkeytab \fB\-p\fR \fIprincipal\-name\fR \fB\-k\fR \fIkeytab\-file\fR [ \fB\-e\fR \fIencryption\-types\fR ] [ \fB\-s\fR \fIipaserver\fR ] [ \fB\-q\fR ] [ \fB\-D\fR|\fB\-\-binddn\fR \fIBINDDN\fR ] [ \fB\-w|\-\-bindpw\fR ] [ \fB\-P\fR|\fB\-\-password\fR \fIPASSWORD\fR ] [ \fB\-\-cacert \fICACERT\fR ] [ \fB\-r\fR ]
+ipa\-getkeytab \fB\-p\fR \fIprincipal\-name\fR \fB\-k\fR \fIkeytab\-file\fR [ \fB\-e\fR \fIencryption\-types\fR ] [ \fB\-s\fR \fIipaserver\fR ] [ \fB\-q\fR ] [ \fB\-D\fR|\fB\-\-binddn\fR \fIBINDDN\fR ] [ \fB\-w|\-\-bindpw\fR ] [ \fB\-P\fR|\fB\-\-password\fR \fIPASSWORD\fR ] [ \fB\-\-cacert \fICACERT\fR ] [ \fB\-H|\-\-ldapuri \fIURI\fR ] [ \fB\-Y|\-\-mech \fIGSSAPI|EXTERNAL\fR ] [ \fB\-r\fR ]
 
 .SH "DESCRIPTION"
 Retrieves a Kerberos \fIkeytab\fR.
@@ -73,7 +73,7 @@ des\-cbc\-crc
 \fB\-s ipaserver\fR
 The IPA server to retrieve the keytab from (FQDN). If this option is not
 provided the server name is read from the IPA configuration file
-(/etc/ipa/default.conf)
+(/etc/ipa/default.conf). Cannot be used together with \fB\-H\fR.
 .TP
 \fB\-q\fR
 Quiet mode. Only errors are displayed.
@@ -96,11 +96,18 @@ Use this password for the key instead of one randomly generated.
 The LDAP DN to bind as when retrieving a keytab without Kerberos credentials. Generally used with the \fB\-w\fR option.
 .TP
 \fB\-w, \-\-bindpw\fR
-The LDAP password to use when not binding with Kerberos.
+The LDAP password to use when not binding with Kerberos. \fB\-D\fR and \fB\-w\fR can not be used together with \fB\-Y\fR.
 .TP
 \fB\-\-cacert\fR
-The path to the IPA CA certificate used to validate LDAPS connections. Defaults to
-/etc/ipa/ca.crt
+The path to the IPA CA certificate used to validate LDAPS/STARTTLS connections.
+Defaults to /etc/ipa/ca.crt
+.TP
+\fB\-H, \-\-ldapuri\fR
+LDAP URI. If ldap:// is specified, STARTTLS is initiated by default. Can not be used with \fB\-s\fR.
+.TP
+\fB\-Y, \-\-mech\fR
+SASL mechanism to use if \fB\-D\fR and \fB\-w\fR are not specified. Use either
+GSSAPI or EXTERNAL.
 .TP
 \fB\-r\fR
 Retrieve mode. Retrieve an existing key from the server instead of generating a

--- a/client/man/ipa-getkeytab.1
+++ b/client/man/ipa-getkeytab.1
@@ -21,7 +21,7 @@
 .SH "NAME"
 ipa\-getkeytab \- Get a keytab for a Kerberos principal
 .SH "SYNOPSIS"
-ipa\-getkeytab \fB\-p\fR \fIprincipal\-name\fR \fB\-k\fR \fIkeytab\-file\fR [ \fB\-e\fR \fIencryption\-types\fR ] [ \fB\-s\fR \fIipaserver\fR ] [ \fB\-q\fR ] [ \fB\-D\fR|\fB\-\-binddn\fR \fIBINDDN\fR ] [ \fB\-w|\-\-bindpw\fR ] [ \fB\-P\fR|\fB\-\-password\fR \fIPASSWORD\fR ] [ \fB\-r\fR ]
+ipa\-getkeytab \fB\-p\fR \fIprincipal\-name\fR \fB\-k\fR \fIkeytab\-file\fR [ \fB\-e\fR \fIencryption\-types\fR ] [ \fB\-s\fR \fIipaserver\fR ] [ \fB\-q\fR ] [ \fB\-D\fR|\fB\-\-binddn\fR \fIBINDDN\fR ] [ \fB\-w|\-\-bindpw\fR ] [ \fB\-P\fR|\fB\-\-password\fR \fIPASSWORD\fR ] [ \fB\-\-cacert \fICACERT\fR ] [ \fB\-r\fR ]
 
 .SH "DESCRIPTION"
 Retrieves a Kerberos \fIkeytab\fR.
@@ -97,6 +97,10 @@ The LDAP DN to bind as when retrieving a keytab without Kerberos credentials. Ge
 .TP
 \fB\-w, \-\-bindpw\fR
 The LDAP password to use when not binding with Kerberos.
+.TP
+\fB\-\-cacert\fR
+The path to the IPA CA certificate used to validate LDAPS connections. Defaults to
+/etc/ipa/ca.crt
 .TP
 \fB\-r\fR
 Retrieve mode. Retrieve an existing key from the server instead of generating a

--- a/ipatests/test_cmdline/test_ipagetkeytab.py
+++ b/ipatests/test_cmdline/test_ipagetkeytab.py
@@ -28,10 +28,10 @@ import gssapi
 import pytest
 
 from ipalib import api
-from ipalib import errors
 from ipapython import ipautil, ipaldap
 from ipaserver.plugins.ldap2 import ldap2
 from ipatests.test_cmdline.cmdline import cmdline_test
+from ipatests.test_xmlrpc.tracker import host_plugin, service_plugin
 
 def use_keytab(principal, keytab):
     try:
@@ -53,104 +53,110 @@ def use_keytab(principal, keytab):
             shutil.rmtree(tmpdir)
 
 
+@pytest.fixture(scope='class')
+def test_host(request):
+    host_tracker = host_plugin.HostTracker(u'test-host')
+    return host_tracker.make_fixture(request)
+
+
+@pytest.fixture(scope='class')
+def test_service(request, test_host):
+    service_tracker = service_plugin.ServiceTracker(u'srv', test_host.name)
+    test_host.ensure_exists()
+    return service_tracker.make_fixture(request)
+
+
 @pytest.mark.tier0
 class test_ipagetkeytab(cmdline_test):
     """
     Test `ipa-getkeytab`.
     """
     command = "ipa-getkeytab"
-    host_fqdn = u'ipatest.%s' % api.env.domain
-    service_princ = u'test/%s@%s' % (host_fqdn, api.env.realm)
-    [keytabfd, keytabname] = tempfile.mkstemp()
-    os.close(keytabfd)
+    keytabname = None
 
-    def test_0_setup(self):
-        """
-        Create a host to test against.
-        """
-        # Create the service
+    @classmethod
+    def setup_class(cls):
+        super(test_ipagetkeytab, cls).setup_class()
+
+        keytabfd, keytabname = tempfile.mkstemp()
+
+        os.close(keytabfd)
+        os.unlink(keytabname)
+
+        cls.keytabname = keytabname
+
+    @classmethod
+    def teardown_class(cls):
+        super(test_ipagetkeytab, cls).teardown_class()
+
         try:
-            api.Command['host_add'](self.host_fqdn, force=True)
-        except errors.DuplicateEntry:
-            # it already exists, no problem
+            os.unlink(cls.keytabname)
+        except OSError:
             pass
 
-    def test_1_run(self):
+    def run_ipagetkeytab(self, service_principal, raiseonerr=False):
+        new_args = [self.command,
+                    "-s", api.env.host,
+                    "-p", service_principal,
+                    "-k", self.keytabname]
+        return ipautil.run(
+            new_args,
+            stdin=None,
+            raiseonerr=raiseonerr,
+            capture_error=True)
+
+    def test_1_run(self, test_service):
         """
         Create a keytab with `ipa-getkeytab` for a non-existent service.
         """
-        new_args = [self.command,
-                    "-s", api.env.host,
-                    "-p", "test/notfound.example.com",
-                    "-k", self.keytabname,
-                   ]
-        result = ipautil.run(new_args, stdin=None, raiseonerr=False,
-                             capture_error=True)
+        test_service.ensure_missing()
+        result = self.run_ipagetkeytab(test_service.name)
         err = result.error_output
+
         assert 'Failed to parse result: PrincipalName not found.\n' in err, err
         rc = result.returncode
         assert rc > 0, rc
 
-    def test_2_run(self):
+    def test_2_run(self, test_service):
         """
         Create a keytab with `ipa-getkeytab` for an existing service.
         """
-        # Create the service
-        try:
-            api.Command['service_add'](self.service_princ, force=True)
-        except errors.DuplicateEntry:
-            # it already exists, no problem
-            pass
+        test_service.ensure_exists()
 
-        os.unlink(self.keytabname)
-        new_args = [self.command,
-                    "-s", api.env.host,
-                    "-p", self.service_princ,
-                    "-k", self.keytabname,
-                   ]
-        try:
-            result = ipautil.run(new_args, None, capture_error=True)
-            expected = 'Keytab successfully retrieved and stored in: %s\n' % (
-                self.keytabname)
-            assert expected in result.error_output, (
-                'Success message not in output:\n%s' % result.error_output)
-        except ipautil.CalledProcessError:
-            assert (False)
+        result = self.run_ipagetkeytab(test_service.name, raiseonerr=True)
+        expected = 'Keytab successfully retrieved and stored in: %s\n' % (
+            self.keytabname)
+        assert expected in result.error_output, (
+            'Success message not in output:\n%s' % result.error_output)
 
-    def test_3_use(self):
+    def test_3_use(self, test_service):
         """
         Try to use the service keytab.
         """
-        use_keytab(self.service_princ, self.keytabname)
+        use_keytab(test_service.name, self.keytabname)
 
-    def test_4_disable(self):
+    def test_4_disable(self, test_service):
         """
         Disable a kerberos principal
         """
+        retrieve_cmd = test_service.make_retrieve_command()
+        result = retrieve_cmd()
         # Verify that it has a principal key
-        entry = api.Command['service_show'](self.service_princ)['result']
-        assert(entry['has_keytab'] == True)
+        assert result[u'result'][u'has_keytab']
 
         # Disable it
-        api.Command['service_disable'](self.service_princ)
+        disable_cmd = test_service.make_disable_command()
+        disable_cmd()
 
         # Verify that it looks disabled
-        entry = api.Command['service_show'](self.service_princ)['result']
-        assert(entry['has_keytab'] == False)
+        result = retrieve_cmd()
+        assert not result[u'result'][u'has_keytab']
 
-    def test_5_use_disabled(self):
+    def test_5_use_disabled(self, test_service):
         """
         Try to use the disabled keytab
         """
         try:
-            use_keytab(self.service_princ, self.keytabname)
+            use_keytab(test_service.name, self.keytabname)
         except Exception as errmsg:
             assert('Unable to bind to LDAP. Error initializing principal' in str(errmsg))
-
-    def test_9_cleanup(self):
-        """
-        Clean up test data
-        """
-        # First create the host that will use this policy
-        os.unlink(self.keytabname)
-        api.Command['host_del'](self.host_fqdn)

--- a/ipatests/test_xmlrpc/tracker/service_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/service_plugin.py
@@ -85,6 +85,10 @@ class ServiceTracker(KerberosAliasMixin, Tracker):
 
         return self.make_command('service_mod', self.name, **updates)
 
+    def make_disable_command(self):
+        """ make command  that disables the service principal """
+        return self.make_command('service_disable', self.name)
+
     def create(self, force=True):
         """Helper function to create an entry and check the result"""
         self.ensure_missing()


### PR DESCRIPTION
This PR implements '-H' and '-Y' options mentioned in
https://fedorahosted.org/freeipa/ticket/6409 along with the ability to specify
CA cert on the command line (which proved useful during the work on installer
refactoring).

Since my C skills are not at the level I would like them to be it would be nice
if you point out even the tiniest mistakes, risky code or non-idiomatic usage.

Also the test case `test_retrieval_using_plain_ldap` fails due to unsuccesful
simple bind. I wanted to implement StartTLS for simple binds over ldap://, but
I get the following errors in dirsrv error log:

        [01/Nov/2016:10:44:52.395126000 +0000] connection - conn=883 fd=135
        Incoming BER Element was 3 bytes, max allowable is 209715200 bytes.
        Change the nsslapd-maxbersize attribute in cn=config to increase.

I guess there is something fishy with the way I initialize the StartTLS
session. I would appreciate your help with it.