### PR TITLE
Provide user hint about IP address in IPA install

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -267,9 +267,11 @@ def add_record_to_hosts(ip, host_name, conf_file=paths.HOSTS):
 
 def read_ip_addresses():
     ips = []
-    print("Enter the IP address to use, or press Enter to finish.")
+    msg_first = "Please provide the IP address to be used for this host name"
+    msg_other = "Enter an additional IP address, or press Enter to skip"
     while True:
-        ip = ipautil.user_input("Please provide the IP address to be used for this host name", allow_empty = True)
+        msg = msg_other if ips else msg_first
+        ip = ipautil.user_input(msg, allow_empty=True)
         if not ip:
             break
         try:


### PR DESCRIPTION
With this fix, user will be notified about pressing enter
to proceed with IPA installation procedure, if user has
provided valid IP address previously.

Fixes https://fedorahosted.org/freeipa/ticket/5949

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>