### PR TITLE
Tests: Fix integration sudo test

### DIFF
--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -530,7 +530,7 @@ class TestSudo(IntegrationTest):
 
     def test_sudo_rule_restricted_to_running_as_single_group(self):
         result1 = self.list_sudo_commands("testuser1", verbose=True)
-        assert "RunAsUsers: root" in result1.stdout_text
+        assert "RunAsUsers: testuser1" in result1.stdout_text
         assert "RunAsGroups: testgroup2" in result1.stdout_text
 
     def test_setting_category_to_all_with_valid_entries_runasgroup(self):
@@ -551,7 +551,7 @@ class TestSudo(IntegrationTest):
 
     def test_sudo_rule_restricted_to_running_as_single_local_group(self):
         result1 = self.list_sudo_commands("testuser1", verbose=True)
-        assert "RunAsUsers: root" in result1.stdout_text
+        assert "RunAsUsers: testuser1" in result1.stdout_text
         assert "RunAsGroups: localgroup" in result1.stdout_text
 
     def test_setting_category_to_all_with_valid_entries_runasgroup_local(self):


### PR DESCRIPTION
Tests with sudorules using only RunAsGroups attributes with empty RunAsUsers
attribute fail due to different expected value than is really returned. This is
caused by improper behaviour of sudo in versions before 1.8.18 (see [1]), to
which the tests were originally fitted. Changing the expected value to proper
one.

[1] - https://www.sudo.ws/pipermail/sudo-workers/2016-November/001025.html

https://fedorahosted.org/freeipa/ticket/6378