### PR TITLE
ipaldap: remove do_bind from LDAPClient

### DIFF
--- a/install/tools/ipa-csreplica-manage
+++ b/install/tools/ipa-csreplica-manage
@@ -281,8 +281,7 @@ def del_master(realm, hostname, options):
 
     # 7. And clean up the removed replica DNS entries if any.
     try:
-        if bindinstance.dns_container_exists(options.host, api.env.basedn,
-                                             dm_password=options.dirman_passwd):
+        if bindinstance.dns_container_exists(api.env.basedn):
             bind = bindinstance.BindInstance()
             bind.update_system_records()
     except Exception as e:

--- a/install/tools/ipa-replica-manage
+++ b/install/tools/ipa-replica-manage
@@ -903,8 +903,7 @@ def ensure_last_services(conn, hostname, masters, options):
 
 def cleanup_server_dns_entries(realm, hostname, suffix, options):
     try:
-        if bindinstance.dns_container_exists(options.host, suffix,
-                                             dm_password=options.dirman_passwd):
+        if bindinstance.dns_container_exists(suffix):
             bindinstance.remove_master_dns_records(hostname, realm)
             dnskeysyncinstance.remove_replica_public_keys(hostname)
     except Exception as e:

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -223,7 +223,6 @@ def install_step_1(standalone, replica_config, options):
         return
 
     realm_name = options.realm_name
-    dm_password = options.dm_password
     host_name = options.host_name
     subject_base = options.subject
 
@@ -285,7 +284,7 @@ def install_step_1(standalone, replica_config, options):
 
     if standalone:
         # Install CA DNS records
-        if bindinstance.dns_container_exists(host_name, basedn, dm_password):
+        if bindinstance.dns_container_exists(basedn):
             bind = bindinstance.BindInstance()
             bind.update_system_records()
 

--- a/ipaserver/install/ipa_replica_prepare.py
+++ b/ipaserver/install/ipa_replica_prepare.py
@@ -253,10 +253,7 @@ class ReplicaPrepare(admintool.AdminTool):
         except installutils.BadHostError as e:
             if isinstance(e, installutils.HostLookupError):
                 if not options.ip_addresses:
-                    if dns_container_exists(
-                            api.env.host, api.env.basedn,
-                            dm_password=self.dirman_password,
-                            ldapi=True, realm=api.env.realm):
+                    if dns_container_exists(api.env.basedn):
                         self.log.info('You might use the --ip-address option '
                                       'to create a DNS entry if the DNS zone '
                                       'is managed by IPA.')
@@ -268,9 +265,7 @@ class ReplicaPrepare(admintool.AdminTool):
                 raise
 
         if options.ip_addresses:
-            if not dns_container_exists(api.env.host, api.env.basedn,
-                                        dm_password=self.dirman_password,
-                                        ldapi=True, realm=api.env.realm):
+            if not dns_container_exists(api.env.basedn):
                 self.log.error(
                     "It is not possible to add a DNS record automatically "
                     "because DNS is not managed by IPA. Please create DNS "

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -171,9 +171,7 @@ def install_http(config, auto_redirect, ca_is_configured, ca_file,
 def install_dns_records(config, options, remote_api):
 
     if not bindinstance.dns_container_exists(
-            config.host_name,
-            ipautil.realm_to_suffix(config.realm_name),
-            realm=config.realm_name, ldapi=True):
+            ipautil.realm_to_suffix(config.realm_name)):
         return
 
     try:


### PR DESCRIPTION
Remove do_bind() method that was a relict used in IPAdmin. Replace
its uses with simple / external binds.

https://fedorahosted.org/freeipa/ticket/6461