### PR TITLE
libexec scripts: ldap conn management

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -476,6 +476,7 @@ def main():
 
     api.bootstrap(in_server=True, context='renew')
     api.finalize()
+    api.Backend.ldap2.connect()
 
     operation = os.environ.get('CERTMONGER_OPERATION')
     if operation not in ('SUBMIT', 'POLL'):
@@ -506,6 +507,8 @@ def main():
     finally:
         certs.renewal_lock.release()
         shutil.rmtree(tmpdir)
+        api.Backend.ldap2.disconnect()
+
 
 try:
     sys.exit(main())

--- a/install/restart_scripts/renew_ca_cert
+++ b/install/restart_scripts/renew_ca_cert
@@ -40,6 +40,7 @@ def _main():
 
     api.bootstrap(in_server=True, context='restart')
     api.finalize()
+    api.Backend.ldap2.connect()
 
     dogtag_service = services.knownservices['pki_tomcatd']
 
@@ -182,6 +183,7 @@ def _main():
                     conn.disconnect()
     finally:
         shutil.rmtree(tmpdir)
+        api.Backend.ldap2.disconnect()
 
     # Now we can start the CA. Using the services start should fire
     # off the servlet to verify that the CA is actually up and responding so

--- a/install/restart_scripts/renew_ra_cert
+++ b/install/restart_scripts/renew_ra_cert
@@ -39,6 +39,7 @@ def _main():
 
     api.bootstrap(in_server=True, context='restart')
     api.finalize()
+    api.Backend.ldap2.connect()
 
     tmpdir = tempfile.mkdtemp(prefix="tmp-")
     try:
@@ -65,6 +66,7 @@ def _main():
             krainstance.export_kra_agent_pem()
     finally:
         shutil.rmtree(tmpdir)
+        api.Backend.ldap2.disconnect()
 
     # Now restart Apache so the new certificate is available
     syslog.syslog(syslog.LOG_NOTICE, "Restarting httpd")


### PR DESCRIPTION
Certificate renewal scripts require connection to LDAP. Properly
handle connects and disconnects from LDAP.

https://fedorahosted.org/freeipa/ticket/6461