### PR TITLE
change certificate processing code to use python-cryptography

### DIFF
--- a/client/ipa-client-install
+++ b/client/ipa-client-install
@@ -35,9 +35,9 @@ try:
     import gssapi
     import netifaces
 
-    import nss.nss as nss
     import SSSDConfig
     from six.moves.urllib.parse import urlparse, urlunparse
+    from cryptography.hazmat.primitives import serialization
 
     from ipapython.ipa_log_manager import standard_logging_setup, root_logger
     from ipaclient import ipadiscovery
@@ -92,15 +92,10 @@ def parse_options():
         if not os.path.isabs(value):
             raise OptionValueError("%s option '%s' is not an absolute file path" % (opt, value))
 
-        initialized = nss.nss_is_initialized()
         try:
-            cert = x509.load_certificate_from_file(value)
+            x509.load_certificate_from_file(value)
         except Exception:
             raise OptionValueError("%s option '%s' is not a valid certificate file" % (opt, value))
-        else:
-            del(cert)
-            if not initialized:
-                nss.nss_shutdown()
 
         parser.values.ca_cert_file = value
 
@@ -300,10 +295,10 @@ def cert_summary(msg, certs, indent='    '):
     else:
         s = ''
     for cert in certs:
-        s += '%sSubject:     %s\n' % (indent, cert.subject)
-        s += '%sIssuer:      %s\n' % (indent, cert.issuer)
-        s += '%sValid From:  %s\n' % (indent, cert.valid_not_before_str)
-        s += '%sValid Until: %s\n' % (indent, cert.valid_not_after_str)
+        s += '%sSubject:     %s\n' % (indent, DN(cert.subject))
+        s += '%sIssuer:      %s\n' % (indent, DN(cert.issuer))
+        s += '%sValid From:  %s\n' % (indent, cert.not_valid_before)
+        s += '%sValid Until: %s\n' % (indent, cert.not_valid_after)
         s += '\n'
     s = s[:-1]
 
@@ -2148,7 +2143,10 @@ def get_ca_certs(fstore, options, server, basedn, realm):
 
     if ca_certs is not None:
         try:
-            ca_certs = [cert.der_data for cert in ca_certs]
+            ca_certs = [
+                cert.public_bytes(serialization.Encoding.DER)
+                for cert in ca_certs
+            ]
             x509.write_certificate_list(ca_certs, ca_file)
         except Exception as e:
             if os.path.exists(ca_file):
@@ -2815,7 +2813,10 @@ def install(options, env, fstore, statestore):
 
         # Add CA certs to a temporary NSS database
         ca_certs = x509.load_certificate_list_from_file(CACERT)
-        ca_certs = [cert.der_data for cert in ca_certs]
+        ca_certs = [
+            cert.public_bytes(serialization.Encoding.DER)
+            for cert in ca_certs
+        ]
         try:
             pwd_file = ipautil.write_tmp_file(ipautil.ipa_generate_password())
             tmp_db.create_db(pwd_file.name)

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -39,10 +39,10 @@ import six
 
 from ipapython import ipautil
 from ipapython.dn import DN
-from ipalib import api, errors, pkcs10, x509
+from ipalib import api, errors, x509
 from ipaplatform.paths import paths
 from ipaserver.plugins.ldap2 import ldap2
-from ipaserver.install import cainstance, certs
+from ipaserver.install import cainstance, dsinstance, certs
 
 # This is a certmonger CA helper script for IPA CA subsystem cert renewal. See
 # https://git.fedorahosted.org/cgit/certmonger.git/tree/doc/submit.txt for more
@@ -65,8 +65,36 @@ if six.PY3:
 IPA_CA_NICKNAME = 'caSigningCert cert-pki-ca'
 
 def get_nickname():
-    csr = os.environ.get('CERTMONGER_CSR')
-    return pkcs10.get_friendlyname(csr) if csr else None
+    subject = os.environ.get('CERTMONGER_REQ_SUBJECT')
+    if not subject:
+        return None
+
+    subject_base = dsinstance.DsInstance().find_subject_base()
+    if not subject_base:
+        return None
+
+    nickname_by_subject_dn = {
+        DN('CN=Certificate Authority', subject_base):
+            'caSigningCert cert-pki-ca',
+        DN('CN=CA Audit', subject_base): 'auditSigningCert cert-pki-ca',
+        DN('CN=OCSP Subsystem', subject_base): 'ocspSigningCert cert-pki-ca',
+        DN('CN=CA Subsystem', subject_base): 'subsystemCert cert-pki-ca',
+        DN('CN=KRA Audit', subject_base): 'auditSigningCert cert-pki-kra',
+        DN('CN=KRA Transport Certificate', subject_base):
+            'transportCert cert-pki-kra',
+        DN('CN=KRA Storage Certificate', subject_base):
+            'storageCert cert-pki-kra',
+        DN('CN=IPA RA', subject_base): 'ipaCert',
+    }
+
+    try:
+        return nickname_by_subject_dn[DN(subject)]
+    except KeyError:
+        cas = api.Command.ca_find(ipacasubjectdn=DN(subject))['result']
+        if len(cas) == 0:
+            return None
+        return 'caSigningCert cert-pki-ca {}'.format(cas[0]['ipacaid'][0])
+
 
 def is_lightweight_ca():
     nickname = get_nickname() or ''
@@ -216,13 +244,9 @@ def store_cert():
     else:
         return (OPERATION_NOT_SUPPORTED_BY_HELPER,)
 
-    csr = os.environ.get('CERTMONGER_CSR')
-    if not csr:
-        return (UNCONFIGURED, "Certificate request not provided")
-
-    nickname = pkcs10.get_friendlyname(csr)
+    nickname = get_nickname()
     if not nickname:
-        return (REJECTED, "No friendly name in the certificate request")
+        return (REJECTED, "Nickname could not be determined")
 
     cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if not cert:
@@ -325,13 +349,9 @@ def retrieve_or_reuse_cert():
     Retrieve certificate from LDAP. If the certificate is not available, reuse
     the old certificate.
     """
-    csr = os.environ.get('CERTMONGER_CSR')
-    if not csr:
-        return (UNCONFIGURED, "Certificate request not provided")
-
-    nickname = pkcs10.get_friendlyname(csr)
+    nickname = get_nickname()
     if not nickname:
-        return (REJECTED, "No friendly name in the certificate request")
+        return (REJECTED, "Nickname could not be determined")
 
     cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if not cert:

--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -21,6 +21,7 @@
 from __future__ import print_function
 
 from ipapython.config import IPAOptionParser
+from ipapython.dn import DN
 from ipapython import version
 from ipapython import ipautil, certdb
 from ipalib import api, errors, x509
@@ -40,7 +41,7 @@ from socket import SOCK_STREAM, SOCK_DGRAM
 import distutils.spawn
 from ipaplatform.paths import paths
 import gssapi
-from nss import nss
+from cryptography.hazmat.primitives import serialization
 
 CONNECT_TIMEOUT = 5
 RESPONDERS = [ ]
@@ -121,16 +122,12 @@ def parse_options():
             raise OptionValueError(
                 "%s option '%s' is not an absolute file path" % (opt, value))
 
-        initialized = nss.nss_is_initialized()
         try:
             x509.load_certificate_list_from_file(value)
         except Exception:
             raise OptionValueError(
                 "%s option '%s' is not a valid certificate file" %
                 (opt, value))
-        finally:
-            if not initialized:
-                nss.nss_shutdown()
 
         parser.values.ca_cert_file = value
 
@@ -472,12 +469,12 @@ def main():
                         nss_db.create_db(password_file.name)
 
                         ca_certs = x509.load_certificate_list_from_file(
-                            options.ca_cert_file, dbdir=nss_db.secdir)
+                            options.ca_cert_file)
                         for ca_cert in ca_certs:
+                            data = ca_cert.public_bytes(
+                                serialization.Encoding.DER)
                             nss_db.add_cert(
-                                ca_cert.der_data, str(ca_cert.subject), 'C,,')
-                            del ca_cert
-                        del ca_certs
+                                data, str(DN(ca_cert.subject)), 'C,,')
                     else:
                         nss_dir = None
 

--- a/ipalib/pkcs10.py
+++ b/ipalib/pkcs10.py
@@ -20,7 +20,6 @@
 from __future__ import print_function
 
 import binascii
-import sys
 from cryptography.hazmat.backends import default_backend
 import cryptography.x509
 
@@ -55,12 +54,3 @@ def load_certificate_request(data):
     except binascii.Error as e:
         raise ValueError(e)
     return cryptography.x509.load_der_x509_csr(data, default_backend())
-
-
-if __name__ == '__main__':
-    # Read PEM request from stdin and print out its components
-
-    csrlines = sys.stdin.readlines()
-    csr = ''.join(csrlines)
-
-    print(load_certificate_request(csr))

--- a/ipalib/pkcs10.py
+++ b/ipalib/pkcs10.py
@@ -23,56 +23,7 @@ import binascii
 import sys
 from cryptography.hazmat.backends import default_backend
 import cryptography.x509
-from pyasn1.type import univ, namedtype, tag
-from pyasn1.codec.der import decoder
 
-
-# Unfortunately, NSS can only parse the extension request attribute, so
-# we have to parse friendly name ourselves (see RFC 2986)
-class _Attribute(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('type', univ.ObjectIdentifier()),
-        namedtype.NamedType('values', univ.Set()),
-        )
-
-class _Attributes(univ.SetOf):
-    componentType = _Attribute()
-
-class _CertificationRequestInfo(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('version', univ.Integer()),
-        namedtype.NamedType('subject', univ.Sequence()),
-        namedtype.NamedType('subjectPublicKeyInfo', univ.Sequence()),
-        namedtype.OptionalNamedType('attributes', _Attributes().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)))
-        )
-
-class _CertificationRequest(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('certificationRequestInfo',
-                            _CertificationRequestInfo()),
-        namedtype.NamedType('signatureAlgorithm', univ.Sequence()),
-        namedtype.NamedType('signatureValue', univ.BitString()),
-        )
-
-_FRIENDLYNAME = univ.ObjectIdentifier('1.2.840.113549.1.9.20')
-
-def get_friendlyname(csr, datatype=PEM):
-    """
-    Given a CSR return the value of the friendlyname attribute, if any.
-
-    The return value is a string.
-    """
-    if datatype == PEM:
-        csr = strip_header(csr)
-        csr = base64.b64decode(csr)
-
-    csr = decoder.decode(csr, asn1Spec=_CertificationRequest())[0]
-    for attribute in csr['certificationRequestInfo']['attributes']:
-        if attribute['type'] == _FRIENDLYNAME:
-            return unicode(attribute['values'][0])
-
-    return None
 
 def strip_header(csr):
     """
@@ -113,4 +64,3 @@ if __name__ == '__main__':
     csr = ''.join(csrlines)
 
     print(load_certificate_request(csr))
-    print(get_friendlyname(csr))

--- a/ipalib/pkcs10.py
+++ b/ipalib/pkcs10.py
@@ -19,71 +19,12 @@
 
 from __future__ import print_function
 
+import binascii
 import sys
-import base64
-import nss.nss as nss
+from cryptography.hazmat.backends import default_backend
+import cryptography.x509
 from pyasn1.type import univ, namedtype, tag
 from pyasn1.codec.der import decoder
-import six
-from ipalib import x509
-
-if six.PY3:
-    unicode = str
-
-PEM = 0
-DER = 1
-
-def get_subject(csr, datatype=PEM):
-    """
-    Given a CSR return the subject value.
-
-    This returns an nss.DN object.
-    """
-    request = load_certificate_request(csr, datatype)
-    try:
-        return request.subject
-    finally:
-        del request
-
-def get_extensions(csr, datatype=PEM):
-    """
-    Given a CSR return OIDs of certificate extensions.
-
-    The return value is a tuple of strings
-    """
-    request = load_certificate_request(csr, datatype)
-
-    # Work around a bug in python-nss where nss.oid_dotted_decimal
-    # errors on unrecognised OIDs
-    #
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1246729
-    #
-    def get_prefixed_oid_str(ext):
-        """Returns a string like 'OID.1.2...'."""
-        if ext.oid_tag == 0:
-            return repr(ext)
-        else:
-            return nss.oid_dotted_decimal(ext.oid)
-
-    return tuple(get_prefixed_oid_str(ext)[4:]
-                 for ext in request.extensions)
-
-
-def get_subjectaltname(csr, datatype=PEM):
-    """
-    Given a CSR return the subjectaltname value, if any.
-
-    The return value is a tuple of strings or None
-    """
-    request = load_certificate_request(csr, datatype)
-    for extension in request.extensions:
-        if extension.oid_tag == nss.SEC_OID_X509_SUBJECT_ALT_NAME:
-            break
-    else:
-        return None
-    del request
-
-    return x509.decode_generalnames(extension.value)
 
 
 # Unfortunately, NSS can only parse the extension request attribute, so
@@ -148,31 +89,28 @@ def strip_header(csr):
 
     return csr
 
-def load_certificate_request(csr, datatype=PEM):
-    """
-    Given a base64-encoded certificate request, with or without the
-    header/footer, return a request object.
-    """
-    if datatype == PEM:
-        csr = strip_header(csr)
-        csr = base64.b64decode(csr)
 
-    # A fail-safe so we can always read a CSR. python-nss/NSS will segfault
-    # otherwise
-    if not nss.nss_is_initialized():
-        nss.nss_init_nodb()
+def load_certificate_request(data):
+    """
+    Load a PEM or base64-encoded PKCS #10 certificate request.
 
-    return nss.CertificateRequest(csr)
+    :return: a python-cryptography ``Certificate`` object.
+    :raises: ``ValueError`` if unable to load the request
+
+    """
+    data = strip_header(data)
+    try:
+        data = binascii.a2b_base64(data)
+    except binascii.Error as e:
+        raise ValueError(e)
+    return cryptography.x509.load_der_x509_csr(data, default_backend())
+
 
 if __name__ == '__main__':
-    nss.nss_init_nodb()
-
     # Read PEM request from stdin and print out its components
 
     csrlines = sys.stdin.readlines()
     csr = ''.join(csrlines)
 
     print(load_certificate_request(csr))
-    print(get_subject(csr))
-    print(get_subjectaltname(csr))
     print(get_friendlyname(csr))

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -45,6 +45,7 @@ import nss.nss as nss
 from nss.error import NSPRError
 from pyasn1.type import univ, char, namedtype, tag
 from pyasn1.codec.der import decoder, encoder
+from pyasn1_modules import rfc2459
 import six
 
 from ipalib import api
@@ -200,49 +201,11 @@ def is_self_signed(certificate, datatype=PEM, dbdir=None):
     del nsscert
     return self_signed
 
-class _Name(univ.Choice):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('rdnSequence',
-            univ.SequenceOf()),
-    )
-
-class _TBSCertificate(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType(
-            'version',
-            univ.Integer().subtype(explicitTag=tag.Tag(
-                tag.tagClassContext, tag.tagFormatSimple, 0))),
-        namedtype.NamedType('serialNumber', univ.Integer()),
-        namedtype.NamedType('signature', univ.Sequence()),
-        namedtype.NamedType('issuer', _Name()),
-        namedtype.NamedType('validity', univ.Sequence()),
-        namedtype.NamedType('subject', _Name()),
-        namedtype.NamedType('subjectPublicKeyInfo', univ.Sequence()),
-        namedtype.OptionalNamedType(
-            'issuerUniquedID',
-            univ.BitString().subtype(implicitTag=tag.Tag(
-                tag.tagClassContext, tag.tagFormatSimple, 1))),
-        namedtype.OptionalNamedType(
-            'subjectUniquedID',
-            univ.BitString().subtype(implicitTag=tag.Tag(
-                tag.tagClassContext, tag.tagFormatSimple, 2))),
-        namedtype.OptionalNamedType(
-            'extensions',
-            univ.Sequence().subtype(explicitTag=tag.Tag(
-                tag.tagClassContext, tag.tagFormatSimple, 3))),
-        )
-
-class _Certificate(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('tbsCertificate', _TBSCertificate()),
-        namedtype.NamedType('signatureAlgorithm', univ.Sequence()),
-        namedtype.NamedType('signature', univ.BitString()),
-        )
 
 def _get_der_field(cert, datatype, dbdir, field):
     cert = load_certificate(cert, datatype, dbdir)
     cert = cert.der_data
-    cert = decoder.decode(cert, _Certificate())[0]
+    cert = decoder.decode(cert, rfc2459.Certificate())[0]
     field = cert['tbsCertificate'][field]
     field = encoder.encode(field)
     return field
@@ -364,75 +327,22 @@ def write_certificate_list(rawcerts, filename):
     except (IOError, OSError) as e:
         raise errors.FileError(reason=str(e))
 
-class _Extension(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('extnID', univ.ObjectIdentifier()),
-        namedtype.NamedType('critical', univ.Boolean()),
-        namedtype.NamedType('extnValue', univ.OctetString()),
-    )
 
 def _encode_extension(oid, critical, value):
-    ext = _Extension()
+    ext = rfc2459.Extension()
     ext['extnID'] = univ.ObjectIdentifier(oid)
     ext['critical'] = univ.Boolean(critical)
-    ext['extnValue'] = univ.OctetString(value)
+    ext['extnValue'] = univ.Any(encoder.encode(univ.OctetString(value)))
     ext = encoder.encode(ext)
     return ext
 
-class _ExtKeyUsageSyntax(univ.SequenceOf):
-    componentType = univ.ObjectIdentifier()
 
 def encode_ext_key_usage(ext_key_usage):
-    eku = _ExtKeyUsageSyntax()
+    eku = rfc2459.ExtKeyUsageSyntax()
     for i, oid in enumerate(ext_key_usage):
         eku[i] = univ.ObjectIdentifier(oid)
     eku = encoder.encode(eku)
     return _encode_extension('2.5.29.37', EKU_ANY not in ext_key_usage, eku)
-
-
-class _AnotherName(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('type-id', univ.ObjectIdentifier()),
-        namedtype.NamedType('value', univ.Any().subtype(
-            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))
-        ),
-    )
-
-
-class _GeneralName(univ.Choice):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('otherName', _AnotherName().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))
-        ),
-        namedtype.NamedType('rfc822Name', char.IA5String().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))
-        ),
-        namedtype.NamedType('dNSName', char.IA5String().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2))
-        ),
-        namedtype.NamedType('x400Address', univ.Sequence().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 3))
-        ),
-        namedtype.NamedType('directoryName', _Name().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 4))
-        ),
-        namedtype.NamedType('ediPartyName', univ.Sequence().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 5))
-        ),
-        namedtype.NamedType('uniformResourceIdentifier', char.IA5String().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 6))
-        ),
-        namedtype.NamedType('iPAddress', univ.OctetString().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 7))
-        ),
-        namedtype.NamedType('registeredID', univ.ObjectIdentifier().subtype(
-            implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 8))
-        ),
-    )
-
-
-class _SubjectAltName(univ.SequenceOf):
-    componentType = _GeneralName()
 
 
 class _PrincipalName(univ.Sequence):
@@ -488,7 +398,8 @@ def decode_generalnames(secitem):
 
     """
     nss_names = nss.x509_alt_name(secitem, repr_kind=nss.AsObject)
-    asn1_names = decoder.decode(secitem.data, asn1Spec=_SubjectAltName())[0]
+    asn1_names = decoder.decode(
+            secitem.data, asn1Spec=rfc2459.SubjectAltName())[0]
     names = []
     for nss_name, asn1_name in zip(nss_names, asn1_names):
         # NOTE: we use the NSS enum to identify the name type.

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -35,7 +35,6 @@ from __future__ import print_function
 import binascii
 import datetime
 import ipaddress
-import sys
 import base64
 import re
 
@@ -486,17 +485,3 @@ def format_datetime(t):
     if t.tzinfo is None:
         t = t.replace(tzinfo=UTC())
     return unicode(t.strftime("%a %b %d %H:%M:%S %Y %Z"))
-
-
-if __name__ == '__main__':
-    # this can be run with:
-    # python ipalib/x509.py < /etc/ipa/ca.crt
-
-    # Read PEM cert from stdin and print out its components
-
-    certlines = sys.stdin.readlines()
-    cert = ''.join(certlines)
-
-    cert = load_certificate(cert)
-
-    print(cert)

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -33,6 +33,7 @@
 
 from __future__ import print_function
 
+import binascii
 import collections
 import os
 import sys
@@ -550,6 +551,28 @@ def process_othernames(gns):
             yield cls(gn.type_id, gn.value)
         else:
             yield gn
+
+
+def chunk(size, s):
+    """Yield chunks of the specified size from the given string.
+
+    The input must be a multiple of the chunk size (otherwise
+    trailing characters are dropped).
+
+    Works on character strings only.
+
+    """
+    return (u''.join(span) for span in six.moves.zip(*[iter(s)] * size))
+
+
+def add_colons(s):
+    """Add colons between each nibble pair in a hex string."""
+    return u':'.join(chunk(2, s))
+
+
+def to_hex_with_colons(bs):
+    """Convert bytes to a hex string with colons."""
+    return add_colons(binascii.hexlify(bs).decode('utf-8'))
 
 
 if __name__ == '__main__':

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -102,7 +102,7 @@ def install_check(standalone, replica_config, options):
                 cert = db.get_cert_from_db(nickname)
                 if not cert:
                     continue
-                subject = DN(str(x509.get_subject(cert)))
+                subject = DN(x509.load_certificate(cert).subject)
                 if subject in (DN('CN=Certificate Authority', subject_base),
                                DN('CN=IPA RA', subject_base)):
                     raise ScriptError(

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -60,9 +60,8 @@ def get_cert_nickname(cert):
     representation of the first RDN in the subject and subject_dn
     is a DN object.
     """
-    nsscert = x509.load_certificate(cert)
-    subject = str(nsscert.subject)
-    dn = DN(subject)
+    cert_obj = x509.load_certificate(cert)
+    dn = DN(cert_obj.subject)
 
     return (str(dn[0]), dn)
 
@@ -304,8 +303,8 @@ class CertDB(object):
             return
 
         cert = self.get_cert_from_db(nickname)
-        nsscert = x509.load_certificate(cert, dbdir=self.secdir)
-        subject = str(nsscert.subject)
+        cert_obj = x509.load_certificate(cert)
+        subject = str(DN(cert_obj.subject))
         certmonger.add_principal(request_id, principal)
         certmonger.add_subject(request_id, subject)
 

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -921,10 +921,9 @@ def load_pkcs12(cert_files, key_password, key_nickname, ca_cert_files,
             if ca_cert is None:
                 ca_cert = cert
 
-            nss_cert = x509.load_certificate(cert, x509.DER)
-            subject = DN(str(nss_cert.subject))
-            issuer = DN(str(nss_cert.issuer))
-            del nss_cert
+            cert_obj = x509.load_certificate(cert, x509.DER)
+            subject = DN(cert_obj.subject)
+            issuer = DN(cert_obj.issuer)
 
             if subject == issuer:
                 break
@@ -1046,10 +1045,9 @@ def load_external_cert(files, subject_base):
         for nickname, _trust_flags in nssdb.list_certs():
             cert = nssdb.get_cert(nickname, pem=True)
 
-            nss_cert = x509.load_certificate(cert)
-            subject = DN(str(nss_cert.subject))
-            issuer = DN(str(nss_cert.issuer))
-            del nss_cert
+            cert_obj = x509.load_certificate(cert)
+            subject = DN(cert_obj.subject)
+            issuer = DN(cert_obj.issuer)
 
             cache[nickname] = (cert, subject, issuer)
             if subject == ca_subject:

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -297,7 +297,7 @@ class KRAInstance(DogtagInstance):
             usertype=["undefined"],
             userCertificate=[cert_data],
             description=['2;%s;%s;%s' % (
-                cert.serial_number,
+                cert.serial,
                 DN(('CN', 'Certificate Authority'), self.subject_base),
                 DN(('CN', 'IPA RA'), self.subject_base))])
         conn.add_entry(entry)

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -379,10 +379,10 @@ class BaseCertObject(Object):
             obj['valid_not_before'] = unicode(cert.valid_not_before_str)
             obj['valid_not_after'] = unicode(cert.valid_not_after_str)
             if full:
-                obj['md5_fingerprint'] = unicode(
-                    nss.data_to_hex(nss.md5_digest(cert.der_data), 64)[0])
-                obj['sha1_fingerprint'] = unicode(
-                    nss.data_to_hex(nss.sha1_digest(cert.der_data), 64)[0])
+                obj['md5_fingerprint'] = x509.to_hex_with_colons(
+                    nss.md5_digest(cert.der_data))
+                obj['sha1_fingerprint'] = x509.to_hex_with_colons(
+                    nss.sha1_digest(cert.der_data))
 
             try:
                 ext_san = cert.get_extension(nss.SEC_OID_X509_SUBJECT_ALT_NAME)

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -20,14 +20,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import base64
-import binascii
 import collections
 import datetime
 import os
 
+import cryptography.x509
 from nss import nss
 from nss.error import NSPRError
-from pyasn1.error import PyAsn1Error
 import six
 
 from ipalib import Command, Str, Int, Flag
@@ -174,30 +173,8 @@ def validate_csr(ugettext, csr):
             return
     try:
         pkcs10.load_certificate_request(csr)
-    except (TypeError, binascii.Error) as e:
-        raise errors.Base64DecodeError(reason=str(e))
-    except Exception as e:
+    except (TypeError, ValueError) as e:
         raise errors.CertificateOperationError(error=_('Failure decoding Certificate Signing Request: %s') % e)
-
-def normalize_csr(csr):
-    """
-    Strip any leading and trailing cruft around the BEGIN/END block
-    """
-    end_len = 37
-    s = csr.find('-----BEGIN NEW CERTIFICATE REQUEST-----')
-    if s == -1:
-        s = csr.find('-----BEGIN CERTIFICATE REQUEST-----')
-    e = csr.find('-----END NEW CERTIFICATE REQUEST-----')
-    if e == -1:
-        e = csr.find('-----END CERTIFICATE REQUEST-----')
-        if e != -1:
-            end_len = 33
-
-    if s > -1 and e > -1:
-        # We're normalizing here, not validating
-        csr = csr[s:e+end_len]
-
-    return csr
 
 
 def normalize_serial_number(num):
@@ -515,7 +492,6 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
             'csr', validate_csr,
             label=_('CSR'),
             cli_name='csr_file',
-            normalizer=normalize_csr,
             noextrawhitespace=False,
         ),
     )
@@ -607,17 +583,21 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
             caacl_check(principal_type, principal, ca, profile_id)
 
         try:
-            subject = pkcs10.get_subject(csr)
-            extensions = pkcs10.get_extensions(csr)
-            subjectaltname = pkcs10.get_subjectaltname(csr) or ()
-        except (NSPRError, PyAsn1Error, ValueError) as e:
+            csr_obj = pkcs10.load_certificate_request(csr)
+        except ValueError as e:
             raise errors.CertificateOperationError(
                 error=_("Failure decoding Certificate Signing Request: %s") % e)
+
+        try:
+            ext_san = csr_obj.extensions.get_extension_for_oid(
+                cryptography.x509.oid.ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
+        except cryptography.x509.extensions.ExtensionNotFound:
+            ext_san = None
 
         # self-service and host principals may bypass SAN permission check
         if (bind_principal_string != principal_string
                 and bind_principal_type != HOST):
-            if '2.5.29.17' in extensions:
+            if ext_san is not None:
                 self.check_access('request certificate with subjectaltname')
 
         dn = None
@@ -650,10 +630,14 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
         dn = principal_obj['dn']
 
         # Ensure that the DN in the CSR matches the principal
-        cn = subject.common_name  #pylint: disable=E1101
-        if not cn:
+        #
+        # We only look at the "most specific" CN value
+        cns = csr_obj.subject.get_attributes_for_oid(
+                cryptography.x509.oid.NameOID.COMMON_NAME)
+        if len(cns) == 0:
             raise errors.ValidationError(name='csr',
                 error=_("No Common Name was found in subject of request."))
+        cn = cns[-1].value  # "most specific" is end of list
 
         if principal_type in (SERVICE, HOST):
             if cn.lower() != principal.hostname.lower():
@@ -670,8 +654,11 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
                 )
 
             # check email address
-            mail = subject.email_address  #pylint: disable=E1101
-            if mail is not None and mail not in principal_obj.get('mail', []):
+            #
+            # fail if any email addr from DN does not appear in ldap entry
+            email_addrs = csr_obj.subject.get_attributes_for_oid(
+                    cryptography.x509.oid.NameOID.EMAIL_ADDRESS)
+            if len(set(email_addrs) - set(principal_obj.get('mail', []))) > 0:
                 raise errors.ValidationError(
                     name='csr',
                     error=_(
@@ -685,9 +672,12 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
                 "to the 'userCertificate' attribute of entry '%s'.") % dn)
 
         # Validate the subject alt name, if any
-        for name_type, desc, name, _der_name in subjectaltname:
-            if name_type == nss.certDNSName:
-                name = unicode(name)
+        generalnames = []
+        if ext_san is not None:
+            generalnames = x509.process_othernames(ext_san.value)
+        for gn in generalnames:
+            if isinstance(gn, cryptography.x509.general_name.DNSName):
+                name = gn.value
                 alt_principal = None
                 alt_principal_obj = None
                 try:
@@ -703,8 +693,9 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
                     elif principal_type == USER:
                         raise errors.ValidationError(
                             name='csr',
-                            error=_("subject alt name type %s is forbidden "
-                                "for user principals") % desc
+                            error=_(
+                                "subject alt name type %s is forbidden "
+                                "for user principals") % "DNSName"
                         )
                 except errors.NotFound:
                     # We don't want to issue any certificates referencing
@@ -721,17 +712,15 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
                             "with subject alt name '%s'.") % name)
                 if alt_principal is not None and not bypass_caacl:
                     caacl_check(principal_type, alt_principal, ca, profile_id)
-            elif name_type in [
-                (nss.certOtherName, x509.SAN_UPN),
-                (nss.certOtherName, x509.SAN_KRB5PRINCIPALNAME),
-            ]:
-                if name != principal_string:
+            elif isinstance(gn, (x509.KRB5PrincipalName, x509.UPN)):
+                if gn.name != principal_string:
                     raise errors.ACIError(
-                        info=_("Principal '%s' in subject alt name does not "
-                               "match requested principal") % name)
-            elif name_type == nss.certRFC822Name:
+                        info=_(
+                            "Principal '%s' in subject alt name does not "
+                            "match requested principal") % gn.name)
+            elif isinstance(gn, cryptography.x509.general_name.RFC822Name):
                 if principal_type == USER:
-                    if name not in principal_obj.get('mail', []):
+                    if gn.value not in principal_obj.get('mail', []):
                         raise errors.ValidationError(
                             name='csr',
                             error=_(
@@ -741,12 +730,14 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
                 else:
                     raise errors.ValidationError(
                         name='csr',
-                        error=_("subject alt name type %s is forbidden "
-                            "for non-user principals") % desc
+                        error=_(
+                            "subject alt name type %s is forbidden "
+                            "for non-user principals") % "RFC822Name"
                     )
             else:
                 raise errors.ACIError(
-                    info=_("Subject alt name type %s is forbidden") % desc)
+                    info=_("Subject alt name type %s is forbidden")
+                    % type(gn).__name__)
 
         # Request the certificate
         try:

--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -274,8 +274,10 @@ def set_certificate_attrs(entry_attrs):
     entry_attrs['issuer'] = unicode(cert.issuer)
     entry_attrs['valid_not_before'] = unicode(cert.valid_not_before_str)
     entry_attrs['valid_not_after'] = unicode(cert.valid_not_after_str)
-    entry_attrs['md5_fingerprint'] = unicode(nss.data_to_hex(nss.md5_digest(cert.der_data), 64)[0])
-    entry_attrs['sha1_fingerprint'] = unicode(nss.data_to_hex(nss.sha1_digest(cert.der_data), 64)[0])
+    entry_attrs['md5_fingerprint'] = x509.to_hex_with_colons(
+        nss.md5_digest(cert.der_data))
+    entry_attrs['sha1_fingerprint'] = x509.to_hex_with_colons(
+        nss.sha1_digest(cert.der_data))
 
 def check_required_principal(ldap, principal):
     """

--- a/ipatests/test_ipaserver/test_ldap.py
+++ b/ipatests/test_ipaserver/test_ldap.py
@@ -80,7 +80,7 @@ class test_ldap(object):
         entry_attrs = self.conn.get_entry(self.dn, ['usercertificate'])
         cert = entry_attrs.get('usercertificate')
         cert = cert[0]
-        serial = unicode(x509.get_serial_number(cert, x509.DER))
+        serial = x509.load_certificate(cert, x509.DER).serial
         assert serial is not None
 
     def test_simple(self):
@@ -99,7 +99,7 @@ class test_ldap(object):
         entry_attrs = self.conn.get_entry(self.dn, ['usercertificate'])
         cert = entry_attrs.get('usercertificate')
         cert = cert[0]
-        serial = unicode(x509.get_serial_number(cert, x509.DER))
+        serial = x509.load_certificate(cert, x509.DER).serial
         assert serial is not None
 
     def test_Backend(self):
@@ -127,7 +127,7 @@ class test_ldap(object):
         entry_attrs = result['result']
         cert = entry_attrs.get('usercertificate')
         cert = cert[0]
-        serial = unicode(x509.get_serial_number(cert, x509.DER))
+        serial = x509.load_certificate(cert, x509.DER).serial
         assert serial is not None
 
     def test_autobind(self):
@@ -143,7 +143,7 @@ class test_ldap(object):
         entry_attrs = self.conn.get_entry(self.dn, ['usercertificate'])
         cert = entry_attrs.get('usercertificate')
         cert = cert[0]
-        serial = unicode(x509.get_serial_number(cert, x509.DER))
+        serial = x509.load_certificate(cert, x509.DER).serial
         assert serial is not None
 
 

--- a/ipatests/test_ipaserver/test_otptoken_import.py
+++ b/ipatests/test_ipaserver/test_otptoken_import.py
@@ -20,7 +20,6 @@
 import os
 import pytest
 from nss import nss
-from ipalib.x509 import initialize_nss_database
 
 from ipaserver.install.ipa_otptoken_import import PSKCDocument, ValidationError
 
@@ -29,9 +28,6 @@ basename = os.path.join(os.path.dirname(__file__), "data")
 @pytest.mark.skipif(True, reason="Causes NSS errors. Ticket 5192")
 @pytest.mark.tier1
 class test_otptoken_import(object):
-
-    def teardown(self):
-        initialize_nss_database()
 
     def test_figure3(self):
         doc = PSKCDocument(os.path.join(basename, "pskc-figure3.xml"))


### PR DESCRIPTION
This commit changes certificate processing code to use python-cryptography
instead of NSS.

Part of the refactoring effort, certificates sub-effort.

Reviewed at dkupka/freeipa:pull/1