### PR TITLE
gitignore: ignore tar ball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ libtool
 build/
 compile
 test-driver
+freeipa-*.tar.gz
 
 # Python compilation
 *.pyc


### PR DESCRIPTION
Add tar ball generated by build to gitignore.

https://fedorahosted.org/freeipa/ticket/6418