### PR TITLE
LDAP refactoring: remove admin_conn

### DIFF
--- a/install/tools/ipa-adtrust-install
+++ b/install/tools/ipa-adtrust-install
@@ -411,7 +411,7 @@ def main():
         try:
             # Search only masters which have support for domain levels
             # because only these masters will have SSSD recent enough to support AD trust agents
-            entries_m, _truncated = smb.admin_conn.find_entries(
+            entries_m, _truncated = api.Backend.ldap2.find_entries(
                 filter="(&(objectclass=ipaSupportedDomainLevelConfig)(ipaMaxDomainLevel=*)(ipaMinDomainLevel=*))",
                 base_dn=masters_dn, attrs_list=['cn'], scope=ldap.SCOPE_ONELEVEL)
         except errors.NotFound:
@@ -421,7 +421,7 @@ def main():
            print(unicode(e))
 
         try:
-           entries_a, _truncated = smb.admin_conn.find_entries(
+           entries_a, _truncated = api.Backend.ldap2.find_entries(
                filter="", base_dn=agents_dn, attrs_list=['member'],
                scope=ldap.SCOPE_BASE)
         except errors.NotFound:
@@ -470,7 +470,7 @@ def main():
                 # Add the CIFS and host principals to the 'adtrust agents' group
                 # as 389-ds only operates with GroupOfNames, we have to use
                 # the principal's proper dn as defined in self.cifs_agent
-                service.add_principals_to_group(smb.admin_conn, agents_dn, "member",
+                service.add_principals_to_group(api.Backend.ldap2, agents_dn, "member",
                                                 [x[1] for x in new_agents])
                 print("""
 WARNING: you MUST restart (e.g. ipactl restart) the following IPA masters in order

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -846,10 +846,10 @@ class BindInstance(service.Service):
         self.__add_master_records(self.fqdn, self.ip_addresses)
 
     def __add_others(self):
-        entries = self.admin_conn.get_entries(
+        entries = api.Backend.ldap2.get_entries(
             DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
                self.suffix),
-            self.admin_conn.SCOPE_ONELEVEL, None, ['dn'])
+            api.Backend.ldap2.SCOPE_ONELEVEL, None, ['dn'])
 
         for entry in entries:
             fqdn = entry.dn[0]['cn']
@@ -888,7 +888,7 @@ class BindInstance(service.Service):
         mod = [(ldap.MOD_ADD, 'member', dns_principal)]
 
         try:
-            self.admin_conn.modify_s(dns_group, mod)
+            api.Backend.ldap2.modify_s(dns_group, mod)
         except ldap.TYPE_OR_VALUE_EXISTS:
             pass
         except Exception as e:
@@ -903,7 +903,7 @@ class BindInstance(service.Service):
                (ldap.MOD_REPLACE, 'nsIdleTimeout', '-1'),
                (ldap.MOD_REPLACE, 'nsLookThroughLimit', '-1')]
         try:
-            self.admin_conn.modify_s(dns_principal, mod)
+            api.Backend.ldap2.modify_s(dns_principal, mod)
         except Exception as e:
             root_logger.critical("Could not set principal's %s LDAP limits: %s" \
                     % (dns_principal, str(e)))
@@ -933,7 +933,7 @@ class BindInstance(service.Service):
         )
 
     def __setup_server_configuration(self):
-        ensure_dnsserver_container_exists(self.admin_conn, self.api)
+        ensure_dnsserver_container_exists(api.Backend.ldap2, self.api)
         try:
             self.api.Command.dnsserver_add(
                 self.fqdn, idnssoamname=DNSName(self.fqdn).make_absolute(),

--- a/ipaserver/install/dnskeysyncinstance.py
+++ b/ipaserver/install/dnskeysyncinstance.py
@@ -266,7 +266,7 @@ class DNSKeySyncInstance(service.Service):
         keylabel = replica_keylabel_template % DNSName(self.fqdn).\
             make_absolute().canonicalize().ToASCII()
 
-        ldap = self.admin_conn
+        ldap = api.Backend.ldap2
         dn_base = DN(('cn', 'keys'), ('cn', 'sec'), ('cn', 'dns'), api.env.basedn)
 
         with open(paths.DNSSEC_SOFTHSM_PIN, "r") as f:
@@ -413,7 +413,7 @@ class DNSKeySyncInstance(service.Service):
         mod = [(ldap.MOD_ADD, 'member', dnssynckey_principal_dn)]
 
         try:
-            self.admin_conn.modify_s(dns_group, mod)
+            api.Backend.ldap2.modify_s(dns_group, mod)
         except ldap.TYPE_OR_VALUE_EXISTS:
             pass
         except Exception as e:
@@ -429,7 +429,7 @@ class DNSKeySyncInstance(service.Service):
                (ldap.MOD_REPLACE, 'nsIdleTimeout', '-1'),
                (ldap.MOD_REPLACE, 'nsLookThroughLimit', '-1')]
         try:
-            self.admin_conn.modify_s(dnssynckey_principal_dn, mod)
+            api.Backend.ldap2.modify_s(dnssynckey_principal_dn, mod)
         except Exception as e:
             self.logger.critical("Could not set principal's %s LDAP limits: %s"
                                  % (dnssynckey_principal_dn, str(e)))

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -434,13 +434,13 @@ class DsInstance(service.Service):
         # they may conflict.
 
         try:
-            res = self.admin_conn.get_entries(
+            res = api.Backend.ldap2.get_entries(
                 DN(('cn', 'mapping'), ('cn', 'sasl'), ('cn', 'config')),
-                self.admin_conn.SCOPE_ONELEVEL,
+                api.Backend.ldap2.SCOPE_ONELEVEL,
                 "(objectclass=nsSaslMapping)")
             for r in res:
                 try:
-                    self.admin_conn.delete_entry(r)
+                    api.Backend.ldap2.delete_entry(r)
                 except Exception as e:
                     root_logger.critical(
                         "Error during SASL mapping removal: %s", e)
@@ -449,7 +449,7 @@ class DsInstance(service.Service):
             root_logger.critical("Error while enumerating SASL mappings %s", e)
             raise
 
-        entry = self.admin_conn.make_entry(
+        entry = api.Backend.ldap2.make_entry(
             DN(
                 ('cn', 'Full Principal'), ('cn', 'mapping'), ('cn', 'sasl'),
                 ('cn', 'config')),
@@ -460,9 +460,9 @@ class DsInstance(service.Service):
             nsSaslMapFilterTemplate=['(krbPrincipalName=\\1@\\2)'],
             nsSaslMapPriority=['10'],
         )
-        self.admin_conn.add_entry(entry)
+        api.Backend.ldap2.add_entry(entry)
 
-        entry = self.admin_conn.make_entry(
+        entry = api.Backend.ldap2.make_entry(
             DN(
                 ('cn', 'Name Only'), ('cn', 'mapping'), ('cn', 'sasl'),
                 ('cn', 'config')),
@@ -473,7 +473,7 @@ class DsInstance(service.Service):
             nsSaslMapFilterTemplate=['(krbPrincipalName=&@%s)' % self.realm],
             nsSaslMapPriority=['10'],
         )
-        self.admin_conn.add_entry(entry)
+        api.Backend.ldap2.add_entry(entry)
 
     def __update_schema(self):
         # FIXME: https://fedorahosted.org/389/ticket/47490
@@ -1119,7 +1119,7 @@ class DsInstance(service.Service):
         """
         dn = DN('cn=IPA SIDGEN,cn=plugins,cn=config')
         try:
-            self.admin_conn.get_entry(dn)
+            api.Backend.ldap2.get_entry(dn)
         except errors.NotFound:
             self._ldap_mod('ipa-sidgen-conf.ldif', dict(SUFFIX=suffix))
         else:
@@ -1137,7 +1137,7 @@ class DsInstance(service.Service):
         """
         dn = DN('cn=ipa_extdom_extop,cn=plugins,cn=config')
         try:
-            self.admin_conn.get_entry(dn)
+            api.Backend.ldap2.get_entry(dn)
         except errors.NotFound:
             self._ldap_mod('ipa-extdom-extop-conf.ldif', dict(SUFFIX=suffix))
         else:

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -416,7 +416,8 @@ class HTTPInstance(service.Service):
         attr_name = 'kdcProxyEnabled'
 
         try:
-            entry = self.admin_conn.get_entry(entry_name, ['ipaConfigString'])
+            entry = api.Backend.ldap2.get_entry(
+                entry_name, ['ipaConfigString'])
         except errors.NotFound:
             pass
         else:
@@ -427,7 +428,7 @@ class HTTPInstance(service.Service):
 
             entry.setdefault('ipaConfigString', []).append(attr_name)
             try:
-                self.admin_conn.update_entry(entry)
+                api.Backend.ldap2.update_entry(entry)
             except errors.EmptyModlist:
                 root_logger.debug("service KDCPROXY already enabled")
                 return
@@ -438,7 +439,7 @@ class HTTPInstance(service.Service):
             root_logger.debug("service KDCPROXY enabled")
             return
 
-        entry = self.admin_conn.make_entry(
+        entry = api.Backend.ldap2.make_entry(
             entry_name,
             objectclass=["nsContainer", "ipaConfigObject"],
             cn=['KDC'],
@@ -446,7 +447,7 @@ class HTTPInstance(service.Service):
         )
 
         try:
-            self.admin_conn.add_entry(entry)
+            api.Backend.ldap2.add_entry(entry)
         except errors.DuplicateEntry:
             root_logger.debug("failed to add service KDCPROXY entry")
             raise

--- a/ipaserver/install/ipa_server_upgrade.py
+++ b/ipaserver/install/ipa_server_upgrade.py
@@ -40,15 +40,12 @@ class ServerUpgrade(admintool.AdminTool):
 
         api.bootstrap(in_server=True, context='updates')
         api.finalize()
-        api.Backend.ldap2.connect()
 
         try:
             server.upgrade_check(self.options)
             server.upgrade()
         except RuntimeError as e:
             raise admintool.ScriptError(str(e))
-
-        api.Backend.ldap2.disconnect()
 
     def handle_error(self, exception):
         if not isinstance(exception, SystemExit):

--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -131,9 +131,10 @@ def uninstall(standalone):
 
     if standalone:
         try:
-            kra.admin_conn.delete_entry(DN(('cn', 'KRA'), ('cn', api.env.host),
-                                           ('cn', 'masters'), ('cn', 'ipa'),
-                                           ('cn', 'etc'), api.env.basedn))
+            api.Backend.ldap2.delete_entry(
+                DN(('cn', 'KRA'), ('cn', api.env.host),
+                   ('cn', 'masters'), ('cn', 'ipa'),
+                   ('cn', 'etc'), api.env.basedn))
         except errors.NotFound:
             pass
 

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -30,6 +30,7 @@ from ipaserver.install import service
 from ipaserver.install import installutils
 from ipapython import ipautil
 from ipapython import kernel_keyring
+from ipalib import api
 from ipalib.constants import CACERT
 from ipapython.ipa_log_manager import root_logger
 from ipapython.dn import DN
@@ -79,14 +80,14 @@ class KrbInstance(service.Service):
         """
 
         service_dn = DN(('krbprincipalname', principal), self.get_realm_suffix())
-        service_entry = self.admin_conn.get_entry(service_dn)
-        self.admin_conn.delete_entry(service_entry)
+        service_entry = api.Backend.ldap2.get_entry(service_dn)
+        api.Backend.ldap2.delete_entry(service_entry)
 
         # Create a host entry for this master
         host_dn = DN(
             ('fqdn', self.fqdn), ('cn', 'computers'), ('cn', 'accounts'),
             self.suffix)
-        host_entry = self.admin_conn.make_entry(
+        host_entry = api.Backend.ldap2.make_entry(
             host_dn,
             objectclass=[
                'top', 'ipaobject', 'nshost', 'ipahost', 'ipaservice',
@@ -108,7 +109,7 @@ class KrbInstance(service.Service):
                 'krbpasswordexpiration']
         if 'krbticketflags' in service_entry:
             host_entry['krbticketflags'] = service_entry['krbticketflags']
-        self.admin_conn.add_entry(host_entry)
+        api.Backend.ldap2.add_entry(host_entry)
 
         # Add the host to the ipaserver host group
         ld = ldapupdate.LDAPUpdate(ldapi=True)
@@ -362,9 +363,9 @@ class KrbInstance(service.Service):
         # Create the special anonymous principal
         installutils.kadmin_addprinc(princ_realm)
         dn = DN(('krbprincipalname', princ_realm), self.get_realm_suffix())
-        entry = self.admin_conn.get_entry(dn)
+        entry = api.Backend.ldap2.get_entry(dn)
         entry['nsAccountlock'] = ['TRUE']
-        self.admin_conn.update_entry(entry)
+        api.Backend.ldap2.update_entry(entry)
 
     def __convert_to_gssapi_replication(self):
         repl = replication.ReplicationManager(self.realm,

--- a/ipaserver/install/odsexporterinstance.py
+++ b/ipaserver/install/odsexporterinstance.py
@@ -112,7 +112,7 @@ class ODSExporterInstance(service.Service):
         mod = [(ldap.MOD_ADD, 'member', dns_exporter_principal_dn)]
 
         try:
-            self.admin_conn.modify_s(dns_group, mod)
+            api.Backend.ldap2.modify_s(dns_group, mod)
         except ldap.TYPE_OR_VALUE_EXISTS:
             pass
         except Exception as e:
@@ -127,7 +127,7 @@ class ODSExporterInstance(service.Service):
                (ldap.MOD_REPLACE, 'nsIdleTimeout', '-1'),
                (ldap.MOD_REPLACE, 'nsLookThroughLimit', '-1')]
         try:
-            self.admin_conn.modify_s(dns_exporter_principal_dn, mod)
+            api.Backend.ldap2.modify_s(dns_exporter_principal_dn, mod)
         except Exception as e:
             root_logger.critical("Could not set principal's %s LDAP limits: %s"
                                  % (dns_exporter_principal_dn, str(e)))

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -82,7 +82,7 @@ class OpenDNSSECInstance(service.Service):
     suffix = ipautil.dn_attribute_property('_suffix')
 
     def get_masters(self):
-        return get_dnssec_key_masters(self.admin_conn)
+        return get_dnssec_key_masters(api.Backend.ldap2)
 
     def create_instance(self, fqdn, realm_name, generate_master_key=True,
                         kasp_db_file=None):
@@ -145,7 +145,7 @@ class OpenDNSSECInstance(service.Service):
         dn = DN(('cn', 'DNSSEC'), ('cn', self.fqdn), api.env.container_masters,
                 api.env.basedn)
         try:
-            entry = self.admin_conn.get_entry(dn, ['ipaConfigString'])
+            entry = api.Backend.ldap2.get_entry(dn, ['ipaConfigString'])
         except errors.NotFound as e:
             root_logger.error(
                 "DNSSEC service entry not found in the LDAP (%s)", e)
@@ -153,7 +153,7 @@ class OpenDNSSECInstance(service.Service):
             config = entry.setdefault('ipaConfigString', [])
             if KEYMASTER not in config:
                 config.append(KEYMASTER)
-                self.admin_conn.update_entry(entry)
+                api.Backend.ldap2.update_entry(entry)
 
     def __setup_conf_files(self):
         if not self.fstore.has_file(paths.OPENDNSSEC_CONF_FILE):

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -96,8 +96,9 @@ class IPAUpgrade(service.Service):
 
     def __stop_instance(self):
         """Stop only the main DS instance"""
+        if api.Backend.ldap2.isconnected():
+            api.Backend.ldap2.disconnect()
         super(IPAUpgrade, self).stop(self.serverid)
-        api.Backend.ldap2.disconnect()
 
     def create_instance(self):
         ds_running = super(IPAUpgrade, self).is_running()


### PR DESCRIPTION
This first commit removes the admin_conn alias for api.Backend.ldap2 that was previously used in services.

When trying to get rid of it, I found some legacy code in ipa-server-upgrade. The second commit improves ldap connection management in upgrade and removes useless start and stops of directory server at random places.