### PR TITLE
Build refactoring phase 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ build/
 compile
 test-driver
 freeipa-*.tar.gz
+.tarball_name
+.version
 
 # Python compilation
 *.pyc

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,8 +4,7 @@ MOSTLYCLEANFILES = ipasetup.pyc ipasetup.pyo \
 		   ignore_import_errors.pyc ignore_import_errors.pyo \
 		   ipasetup.pyc ipasetup.pyo \
 		   lite-server.pyc lite-server.pyo \
-		   pylint_plugins.pyc pylint_plugins.pyo \
-		   $(TARBALL)
+		   pylint_plugins.pyc pylint_plugins.pyo
 
 # user-facing scripts
 dist_bin_SCRIPTS = ipa
@@ -34,8 +33,12 @@ clean-local:
 	rm -rf "$(RPMBUILD)"
 	rm -rf "$(top_builddir)/dist"
 	rm -rf "$(top_srcdir)/__pycache__"
+	rm -f "$(top_builddir)"/$(PACKAGE)-*.tar.gz
+
 
 # convenience targets for RPM build
+.PHONY: rpmroot rpmdistdir version-update _dist-version-bakein _rpms-prep \
+	rpms _rpms-body
 RPMBUILD ?= $(abs_builddir)/rpmbuild
 TARBALL = $(PACKAGE)-$(VERSION).tar.gz
 rpmroot:
@@ -49,11 +52,47 @@ rpmdistdir:
 	mkdir -p $(top_builddir)/dist/rpms
 	mkdir -p $(top_builddir)/dist/srpms
 
-rpms: dist-gzip rpmroot rpmdistdir
-	cp $(top_builddir)/$(TARBALL) $(RPMBUILD)/SOURCES/
+# force IPA version re-generation (useful for build from Git)
+version-update:
+	touch $(srcdir)/VERSION.m4
+
+# convert Git snapshot version to static value usable from inside of tarball
+_dist-version-bakein:
+if !IS_GIT_SNAPSHOT
+	@echo "version-bakein target requires IPA_VERSION_IS_GIT_SNAPSHOT=yes"
+	exit 1
+endif !IS_GIT_SNAPSHOT
+	chmod u+w $(top_distdir)/VERSION.m4
+	$(SED) -e 's/^define(IPA_VERSION_IS_GIT_SNAPSHOT,.*)/define(IPA_VERSION_IS_GIT_SNAPSHOT, no)/' -i $(top_distdir)/VERSION.m4
+	$(SED) -e 's/^define(IPA_VERSION_PRE_RELEASE,\(.*\))/define(IPA_VERSION_PRE_RELEASE,\1.$(GIT_VERSION))/' -i $(top_distdir)/VERSION.m4
+	cd $(top_distdir) && autoconf  # re-generate configure from VERSION.m4
+
+if IS_GIT_SNAPSHOT
+VERSION_UPDATE_TARGET = version-update
+VERSION_BAKEIN_TARGET = _dist-version-bakein
+endif IS_GIT_SNAPSHOT
+
+# HACK to support IPA_VERSION_IS_GIT_SNAPSHOT:
+# touch VERSION.m4 will reexecute configure and change $(VERSION) used by dist
+# but it will not change $(VERSION) in already running target rpms.
+# We need to record new $(TARBALL) value used by dist for furher use
+# in rpms target.
+dist-hook: $(VERSION_BAKEIN_TARGET)
+	echo "$(TARBALL)" > $(top_builddir)/.tarball_name
+	echo "$(VERSION)" > $(top_builddir)/.version
+
+_rpms-prep: dist-gzip rpmroot rpmdistdir
+	cp $(top_builddir)/$$(cat $(top_builddir)/.tarball_name) $(RPMBUILD)/SOURCES/
+	rm -f $(top_builddir)/.tarball_name
+
+rpms: $(VERSION_UPDATE_TARGET)
+	$(MAKE) _rpms-body
+
+_rpms-body: _rpms-prep
 	rpmbuild --define "_topdir $(RPMBUILD)" -ba $(top_builddir)/$(PACKAGE).spec
-	cp $(RPMBUILD)/RPMS/*/*.rpm $(top_builddir)/dist/rpms/
-	cp $(RPMBUILD)/SRPMS/*.src.rpm $(top_builddir)/dist/srpms/
+	cp $(RPMBUILD)/RPMS/*/*$$(cat $(top_builddir)/.version)*.rpm $(top_builddir)/dist/rpms/
+	cp $(RPMBUILD)/SRPMS/*$$(cat $(top_builddir)/.version)*.src.rpm $(top_builddir)/dist/srpms/
+	rm -f rm -f $(top_builddir)/.version
 
 .PHONY: lint
 if WITH_POLINT

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,7 @@ clean-local:
 
 # convenience targets for RPM build
 .PHONY: rpmroot rpmdistdir version-update _dist-version-bakein _rpms-prep \
-	rpms _rpms-body
+	rpms _rpms-body srpms _srpms-body
 RPMBUILD ?= $(abs_builddir)/rpmbuild
 TARBALL = $(PACKAGE)-$(VERSION).tar.gz
 rpmroot:
@@ -91,6 +91,14 @@ rpms: $(VERSION_UPDATE_TARGET)
 _rpms-body: _rpms-prep
 	rpmbuild --define "_topdir $(RPMBUILD)" -ba $(top_builddir)/$(PACKAGE).spec
 	cp $(RPMBUILD)/RPMS/*/*$$(cat $(top_builddir)/.version)*.rpm $(top_builddir)/dist/rpms/
+	cp $(RPMBUILD)/SRPMS/*$$(cat $(top_builddir)/.version)*.src.rpm $(top_builddir)/dist/srpms/
+	rm -f rm -f $(top_builddir)/.version
+
+srpms: $(VERSION_UPDATE_TARGET)
+	$(MAKE) _srpms-body
+
+_srpms-body: _rpms-prep
+	rpmbuild --define "_topdir $(RPMBUILD)" -bs $(top_builddir)/$(PACKAGE).spec
 	cp $(RPMBUILD)/SRPMS/*$$(cat $(top_builddir)/.version)*.src.rpm $(top_builddir)/dist/srpms/
 	rm -f rm -f $(top_builddir)/.version
 

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -46,7 +46,7 @@ define(IPA_VERSION_PRE_RELEASE, )
 # This option works only with GNU m4:                  #
 # it requires esyscmd m4 macro.                        #
 ########################################################
-define(IPA_VERSION_IS_GIT_SNAPSHOT, no)
+define(IPA_VERSION_IS_GIT_SNAPSHOT, yes)
 
 ########################################################
 # The version of IPA data. This is used to identify    #
@@ -105,24 +105,28 @@ dnl helper for translit in IPA_VERSION
 define(NEWLINE,`
 ')
 
-define(IPA_VERSION, translit(dnl remove new lines from version (from esyscmd)
+dnl Git snapshot: 20170102030405.GITabcdefg
+define(IPA_GIT_VERSION, translit(dnl remove new lines from version (from esyscmd)
 ifelse(IPA_VERSION_IS_GIT_SNAPSHOT, yes,dnl
-dnl Git snapshot: 1.0.0.20170102030405.GITabcdefg
-IPA_VERSION_MAJOR.IPA_VERSION_MINOR.IPA_VERSION_RELEASE.dnl 1.0.0
 esyscmd(date -u +'%Y%m%d%H%M')dnl 20170102030405
 .GIT
 esyscmd(git log -1 --format="%h" HEAD),dnl abcdefg
-dnl Git end
-ifelse(IPA_VERSION_PRE_RELEASE, ,
-dnl Release version: 1.0.0
-IPA_VERSION_MAJOR.IPA_VERSION_MINOR.IPA_VERSION_RELEASE,
-dnl Pre-release: 1.0.0rc1; newline separates m4 tokens
+), NEWLINE))
+dnl IPA_GIT_VERSION end
+
+define(IPA_VERSION, translit(dnl remove new lines from version (from esyscmd)
+dnl 1.0.0
 IPA_VERSION_MAJOR.IPA_VERSION_MINOR.IPA_VERSION_RELEASE
-IPA_VERSION_PRE_RELEASE)),
+IPA_VERSION_PRE_RELEASE
+dnl version with Git snapshot: 1.0.0.20170102030405.GITabcdefg
+ifelse(IPA_VERSION_IS_GIT_SNAPSHOT, yes,
+.
+IPA_GIT_VERSION),
 NEWLINE)) dnl IPA_VERSION end
 
 dnl DEBUG: uncomment following lines and run command m4 VERSION.m4
 dnl `IPA_VERSION: ''IPA_VERSION'
+dnl `IPA_GIT_VERSION: ''IPA_GIT_VERSION'
 dnl `IPA_API_VERSION: ''IPA_API_VERSION'
 dnl `IPA_DATA_VERSION: ''IPA_DATA_VERSION'
 dnl `IPA_NUM_VERSION: ''IPA_NUM_VERSION'

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -5,7 +5,7 @@
 # 1.0.x                  New production series         #
 # 1.0.x{alpha,beta,rc}y  Alpha/Preview/Testing, Beta,  #
 #                           Release Candidate          #
-# 1.0.0.20170102030405.GITabcdefg  Build from GIT      #
+# 1.0.0.dev20170102030405+gitabcdefg  Build from GIT   #
 #                                                      #
 ########################################################
 
@@ -38,10 +38,10 @@ define(IPA_VERSION_PRE_RELEASE, )
 # in the development BRANCH, and set to 'no' only in   #
 # the IPA_X_X_RELEASE BRANCH                           #
 #                                                      #
-# <MAJOR>.<MINOR>.<RELEASE>.<TIMESTAMP>.GIT<hash>      #
+# <MAJOR>.<MINOR>.<RELEASE>.dev<TIMESTAMP>+git<hash>   #
 #                                                      #
 # e.g. define(IPA_VERSION_IS_GIT_SNAPSHOT, yes)        #
-#  ->  "1.0.0.20170102030405.GITabcdefg"               #
+#  ->  "1.0.0.dev20170102030405+gitabcdefg"            #
 #                                                      #
 # This option works only with GNU m4:                  #
 # it requires esyscmd m4 macro.                        #
@@ -105,11 +105,12 @@ dnl helper for translit in IPA_VERSION
 define(NEWLINE,`
 ')
 
-dnl Git snapshot: 20170102030405.GITabcdefg
+dnl Git snapshot: dev20170102030405+gitabcdefg
 define(IPA_GIT_VERSION, translit(dnl remove new lines from version (from esyscmd)
 ifelse(IPA_VERSION_IS_GIT_SNAPSHOT, yes,dnl
+dev
 esyscmd(date -u +'%Y%m%d%H%M')dnl 20170102030405
-.GIT
++git
 esyscmd(git log -1 --format="%h" HEAD),dnl abcdefg
 ), NEWLINE))
 dnl IPA_GIT_VERSION end
@@ -118,7 +119,7 @@ define(IPA_VERSION, translit(dnl remove new lines from version (from esyscmd)
 dnl 1.0.0
 IPA_VERSION_MAJOR.IPA_VERSION_MINOR.IPA_VERSION_RELEASE
 IPA_VERSION_PRE_RELEASE
-dnl version with Git snapshot: 1.0.0.20170102030405.GITabcdefg
+dnl version with Git snapshot: 1.0.0.dev20170102030405+gitabcdefg
 ifelse(IPA_VERSION_IS_GIT_SNAPSHOT, yes,
 .
 IPA_GIT_VERSION),

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_INIT([freeipa],
 
 AC_CONFIG_HEADERS([config.h])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([foreign 1.9 tar-ustar])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES])
 
 AC_PROG_CC_C99

--- a/configure.ac
+++ b/configure.ac
@@ -372,6 +372,7 @@ AC_SUBST([DATA_VERSION], [IPA_DATA_VERSION])
 AC_SUBST([NUM_VERSION], [IPA_NUM_VERSION])
 AC_SUBST(VENDOR_SUFFIX)
 AC_SUBST([VERSION], [IPA_VERSION])
+AC_SUBST([GIT_VERSION], [IPA_GIT_VERSION])
 
 dnl ---------------------------------------------------------------------------
 dnl Finish

--- a/configure.ac
+++ b/configure.ac
@@ -350,6 +350,17 @@ AC_MSG_RESULT([${IPAPLATFORM}])
 dnl ---------------------------------------------------------------------------
 dnl Version information from VERSION.m4 and command line
 dnl ---------------------------------------------------------------------------
+dnl Are we in source tree?
+AM_CONDITIONAL([IS_GIT_SNAPSHOT], [test "IPA_VERSION_IS_GIT_SNAPSHOT" == "yes"])
+AM_COND_IF([IS_GIT_SNAPSHOT], [
+	AC_MSG_CHECKING([if source directory is a Git reposistory])
+	if test ! -d "${srcdir}/.git"; then
+		AC_MSG_ERROR([Git reposistory is required by VERSION.m4 IPA_VERSION_IS_GIT_SNAPSHOT but not found])
+	else
+		AC_MSG_RESULT([yes])
+	fi
+])
+
 AC_ARG_WITH([vendor-suffix],
             AS_HELP_STRING([--with-vendor-suffix=STRING],
 			   [Vendor string used by package system, e.g. "-1.fc24"]),

--- a/configure.ac
+++ b/configure.ac
@@ -17,9 +17,6 @@ AC_HEADER_STDC
 
 AM_CONDITIONAL([HAVE_GCC], [test "$ac_cv_prog_gcc" = yes])
 
-AC_SUBST(VERSION)
-AC_SUBST([INSTALL_DATA], ['$(INSTALL) -m 644 -p'])
-
 dnl ---------------------------------------------------------------------------
 dnl - Check for NSPR/NSS
 dnl ---------------------------------------------------------------------------
@@ -359,7 +356,6 @@ AC_ARG_WITH([vendor-suffix],
             [VENDOR_SUFFIX=${withval}],
 	    [VENDOR_SUFFIX=""])
 
-dnl TODO: IPA_VENDOR_RELEASE
 AC_SUBST([API_VERSION], [IPA_API_VERSION])
 AC_SUBST([DATA_VERSION], [IPA_DATA_VERSION])
 AC_SUBST([NUM_VERSION], [IPA_NUM_VERSION])

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -687,7 +687,7 @@ This package contains tests that verify IPA functionality under Python 3.
 %build
 # UI compilation segfaulted on some arches when the stack was lower (#1040576)
 export JAVA_STACK_SIZE="8m"
-%configure
+%configure --with-vendor-suffix=-%{release}
 %make_build
 
 

--- a/po/Makefile.in
+++ b/po/Makefile.in
@@ -5,7 +5,6 @@ datadir = ${datarootdir}
 localedir = ${datarootdir}/locale
 
 INSTALL = @INSTALL@
-INSTALL_DATA = @INSTALL@ -m 644
 AWK = @AWK@
 SED = @SED@
 MKDIR_P = @MKDIR_P@


### PR DESCRIPTION
This PR fixes IPA_VERSION_IS_GIT_SNAPSHOT option and vendor version passing from SPEC to configure. At also contains minor cleanup and srpm target which is used by Coverity.