### PR TITLE
cert-request: allow directoryName in SAN extension

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -427,6 +427,7 @@ class BaseCertObject(Object):
         }
         default_attrs = {
             'san_rfc822name', 'san_dnsname', 'san_other_upn', 'san_other_kpn',
+            'san_directoryname',
         }
 
         if type(gn) not in name_type_map:
@@ -742,6 +743,12 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
                         error=_(
                             "subject alt name type %s is forbidden "
                             "for non-user principals") % "RFC822Name"
+                    )
+            elif isinstance(gn, cryptography.x509.general_name.DirectoryName):
+                if DN(gn.value) != principal_obj['dn']:
+                    raise errors.ValidationError(
+                        name='csr',
+                        error=_("Directory Name does not match principal's DN")
                     )
             else:
                 raise errors.ACIError(


### PR DESCRIPTION
Allow directoryName in SAN extension if the value matches the
subject principal's DN in the IPA directory.

Fixes: https://fedorahosted.org/freeipa/ticket/6112

---

A bit of commentary about this feature: it was just a drive-by case
of "hey I could implement this in a way that I think makes sense".
Noone actually asked for it (yet).

Also, there is not agreement that using directoryName to carry the
DN of the subject is valid.  On my part, I think it is obviously
valid, but see the original review thread for discussion:
https://www.redhat.com/archives/freeipa-devel/2016-August/msg00714.html

I had to rebase this commit and resolve conflicts, so now it is a PR
and it can age in oak on GitHub instead of the mailing list :)