### PR TITLE
Remove the renewal lock file upon uninstall

### DIFF
--- a/install/restart_scripts/renew_ra_cert
+++ b/install/restart_scripts/renew_ra_cert
@@ -30,7 +30,6 @@ import traceback
 from ipapython import ipautil
 from ipalib import api
 from ipaserver.install import certs, cainstance, krainstance
-from ipaplatform import services
 from ipaplatform.paths import paths
 
 
@@ -67,15 +66,6 @@ def _main():
     finally:
         shutil.rmtree(tmpdir)
         api.Backend.ldap2.disconnect()
-
-    # Now restart Apache so the new certificate is available
-    syslog.syslog(syslog.LOG_NOTICE, "Restarting httpd")
-    try:
-        services.knownservices.httpd.restart()
-    except Exception as e:
-        syslog.syslog(syslog.LOG_ERR, "Cannot restart httpd: %s" % e)
-    else:
-        syslog.syslog(syslog.LOG_NOTICE, "Restarted httpd")
 
 
 def main():

--- a/install/restart_scripts/restart_dirsrv
+++ b/install/restart_scripts/restart_dirsrv
@@ -39,7 +39,8 @@ def _main():
     syslog.syslog(syslog.LOG_NOTICE, "certmonger restarted dirsrv instance '%s'" % instance)
 
     try:
-        services.knownservices.dirsrv.restart(instance)
+        if services.knownservices.dirsrv.is_running():
+            services.knownservices.dirsrv.restart(instance)
     except Exception as e:
         syslog.syslog(syslog.LOG_ERR, "Cannot restart dirsrv (instance: '%s'): %s" % (instance, str(e)))
 

--- a/install/restart_scripts/restart_httpd
+++ b/install/restart_scripts/restart_httpd
@@ -29,7 +29,8 @@ def _main():
     syslog.syslog(syslog.LOG_NOTICE, 'certmonger restarted httpd')
 
     try:
-        services.knownservices.httpd.restart()
+        if services.knownservices.httpd.is_running():
+            services.knownservices.httpd.restart()
     except Exception as e:
         syslog.syslog(syslog.LOG_ERR, "Cannot restart httpd: %s" % str(e))
 

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -166,11 +166,11 @@ class HTTPInstance(service.Service):
         self.step("enabling mod_nss renegotiate", self.enable_mod_nss_renegotiate)
         self.step("adding URL rewriting rules", self.__add_include)
         self.step("configuring httpd", self.__configure_http)
+        self.step("setting up httpd keytab", self._request_service_keytab)
+        self.step("setting up ssl", self.__setup_ssl)
         if self.ca_is_configured:
             self.step("configure certmonger for renewals",
                       self.configure_certmonger_renewal_guard)
-        self.step("setting up httpd keytab", self._request_service_keytab)
-        self.step("setting up ssl", self.__setup_ssl)
         self.step("importing CA certificates from LDAP", self.__import_ca_certs)
         self.step("publish CA cert", self.__publish_ca_cert)
         self.step("clean up any existing httpd ccache", self.remove_httpd_ccache)

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -4,6 +4,7 @@
 
 from __future__ import print_function
 
+import errno
 import os
 import pickle
 import shutil
@@ -1117,6 +1118,14 @@ def uninstall(installer):
                           'These may be untracked by executing\n'
                           ' # getcert stop-tracking -i <request_id>\n'
                           'for each id in: %s' % ', '.join(ids))
+
+    # Remove the cert renewal lock file
+    try:
+        os.remove(paths.IPA_RENEWAL_LOCK)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            root_logger.warning("Failed to remove file %s: %s",
+                                paths.IPA_RENEWAL_LOCK, e)
 
     print("Removing IPA client configuration")
     try:


### PR DESCRIPTION
Make sure that the file /var/run/ipa/renewal.lock is deleted upon
uninstallation, in order to avoid subsequent installation issues.

Part of the refactoring effort, certificates sub-effort.

https://fedorahosted.org/freeipa/ticket/6433