### PR TITLE
cert-request: accept CSRs with extraneous data

### DIFF
--- a/ipalib/pkcs10.py
+++ b/ipalib/pkcs10.py
@@ -26,7 +26,7 @@ import cryptography.x509
 
 def strip_header(csr):
     """
-    Remove the header and footer from a CSR.
+    Remove the header and footer (and surrounding material) from a CSR.
     """
     headerlen = 40
     s = csr.find("-----BEGIN NEW CERTIFICATE REQUEST-----")


### PR DESCRIPTION
The cert-request command used to accept CSRs that had extra data
surrounding the PEM data, e.g. commentary about the contents of the
CSR.  Recent commits that switch to using python-cryptography for
cert and CSR handling broke this.  Our acceptance tests use such
CSRs, hence the tests are now failing.

To avoid the issue, freshly encode the python-cryptography
CertificateSigningRequest object as PEM.  This avoids re-using the
user-supplied data, in case it has extraneous data.

Fixes: https://fedorahosted.org/freeipa/ticket/6472