### PR TITLE
Do not log DM password in ca/kra installation logs

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -576,7 +576,10 @@ class CAInstance(DogtagInstance):
 
         self.backup_state('installed', True)
         try:
-            DogtagInstance.spawn_instance(self, cfg_file)
+            DogtagInstance.spawn_instance(
+                self, cfg_file,
+                nolog_list=(self.dm_password, self.admin_password)
+            )
         finally:
             os.remove(cfg_file)
 

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -150,19 +150,13 @@ class DogtagInstance(service.Service):
         return os.path.exists(os.path.join(
             paths.VAR_LIB_PKI_TOMCAT_DIR, self.subsystem.lower()))
 
-    def spawn_instance(self, cfg_file, nolog_list=None):
+    def spawn_instance(self, cfg_file, nolog_list=()):
         """
         Create and configure a new Dogtag instance using pkispawn.
         Passes in a configuration file with IPA-specific
         parameters.
         """
         subsystem = self.subsystem
-
-        # Define the things we don't want logged
-        if nolog_list is None:
-            nolog_list = []
-        nolog = tuple(nolog_list) + (self.admin_password,)
-
         args = [paths.PKISPAWN,
                 "-s", subsystem,
                 "-f", cfg_file]
@@ -170,10 +164,10 @@ class DogtagInstance(service.Service):
         with open(cfg_file) as f:
             self.log.debug(
                 'Contents of pkispawn configuration file (%s):\n%s',
-                cfg_file, ipautil.nolog_replace(f.read(), nolog))
+                cfg_file, ipautil.nolog_replace(f.read(), nolog_list))
 
         try:
-            ipautil.run(args, nolog=nolog)
+            ipautil.run(args, nolog=nolog_list)
         except ipautil.CalledProcessError as e:
             self.handle_setup_error(e)
 

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -257,7 +257,10 @@ class KRAInstance(DogtagInstance):
             config.write(f)
 
         try:
-            DogtagInstance.spawn_instance(self, cfg_file)
+            DogtagInstance.spawn_instance(
+                self, cfg_file,
+                nolog_list=(self.dm_password, self.admin_password)
+            )
         finally:
             os.remove(p12_tmpfile_name)
             os.remove(cfg_file)


### PR DESCRIPTION
We can merge this after refactoring merges not to mess the rebases.

https://fedorahosted.org/freeipa/ticket/6461