### PR TITLE
Build phase 6: %install cleanup

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -122,3 +122,6 @@ MAINTAINERCLEANFILES =		\
 	version.m4		\
 	$(NULL)
 
+install-data-hook:
+	$(INSTALL) -d -m 755 $(DESTDIR)$(IPA_SYSCONF_DIR)/nssdb
+	$(INSTALL) -d -m 755 $(DESTDIR)$(localstatedir)/lib/ipa-client/sysrestore

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -763,37 +763,18 @@ rm %{buildroot}/%{plugin_dir}/libtopology.la
 rm %{buildroot}/%{_libdir}/krb5/plugins/kdb/ipadb.la
 rm %{buildroot}/%{_libdir}/samba/pdb/ipasam.la
 
-# Some user-modifiable HTML files are provided. Move these to /etc
-# and link back.
-mkdir -p %{buildroot}/%{_sysconfdir}/ipa/html
-mkdir %{buildroot}%{_usr}/share/ipa/html/
-ln -s ../../../..%{_sysconfdir}/ipa/html/ffconfig.js \
-    %{buildroot}%{_usr}/share/ipa/html/ffconfig.js
-ln -s ../../../..%{_sysconfdir}/ipa/html/ffconfig_page.js \
-    %{buildroot}%{_usr}/share/ipa/html/ffconfig_page.js
-ln -s ../../../..%{_sysconfdir}/ipa/html/ssbrowser.html \
-    %{buildroot}%{_usr}/share/ipa/html/ssbrowser.html
-ln -s ../../../..%{_sysconfdir}/ipa/html/unauthorized.html \
-    %{buildroot}%{_usr}/share/ipa/html/unauthorized.html
-ln -s ../../../..%{_sysconfdir}/ipa/html/browserconfig.html \
-    %{buildroot}%{_usr}/share/ipa/html/browserconfig.html
-
 # So we can own our Apache configuration
 mkdir -p %{buildroot}%{_sysconfdir}/httpd/conf.d/
 /bin/touch %{buildroot}%{_sysconfdir}/httpd/conf.d/ipa.conf
 /bin/touch %{buildroot}%{_sysconfdir}/httpd/conf.d/ipa-kdc-proxy.conf
 /bin/touch %{buildroot}%{_sysconfdir}/httpd/conf.d/ipa-pki-proxy.conf
 /bin/touch %{buildroot}%{_sysconfdir}/httpd/conf.d/ipa-rewrite.conf
-mkdir -p %{buildroot}%{_usr}/share/ipa/html/
 /bin/touch %{buildroot}%{_usr}/share/ipa/html/ca.crt
 /bin/touch %{buildroot}%{_usr}/share/ipa/html/kerberosauth.xpi
 /bin/touch %{buildroot}%{_usr}/share/ipa/html/krb.con
 /bin/touch %{buildroot}%{_usr}/share/ipa/html/krb.js
 /bin/touch %{buildroot}%{_usr}/share/ipa/html/krb5.ini
 /bin/touch %{buildroot}%{_usr}/share/ipa/html/krbrealm.con
-
-# Web UI plugin dir
-mkdir -p %{buildroot}%{_usr}/share/ipa/ui/js/plugins
 
 mkdir -p %{buildroot}%{_libdir}/krb5/plugins/libkrb5
 touch %{buildroot}%{_libdir}/krb5/plugins/libkrb5/winbind_krb5_locator.so

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -804,11 +804,8 @@ touch %{buildroot}%{_libdir}/krb5/plugins/libkrb5/winbind_krb5_locator.so
 mkdir -p %{buildroot}/%{_localstatedir}/lib/ipa/backup
 %endif # ONLY_CLIENT
 
-mkdir -p %{buildroot}%{_sysconfdir}/ipa/
 /bin/touch %{buildroot}%{_sysconfdir}/ipa/default.conf
 /bin/touch %{buildroot}%{_sysconfdir}/ipa/ca.crt
-mkdir -p %{buildroot}%{_sysconfdir}/ipa/nssdb
-mkdir -p %{buildroot}/%{_localstatedir}/lib/ipa-client/sysrestore
 
 %if ! %{ONLY_CLIENT}
 mkdir -p %{buildroot}%{_sysconfdir}/cron.d

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -741,8 +741,6 @@ sed -i -e'1s/python\(3\|$\)/python2/' %{buildroot}%{_bindir}/ipa
 
 %find_lang %{gettext_domain}
 
-mkdir -p %{buildroot}%{_usr}/share/ipa
-
 %if ! %{ONLY_CLIENT}
 # Remove .la files from libtool - we don't want to package
 # these files
@@ -793,7 +791,6 @@ mkdir -p %{buildroot}%{_usr}/share/ipa/html/
 /bin/touch %{buildroot}%{_usr}/share/ipa/html/krb.js
 /bin/touch %{buildroot}%{_usr}/share/ipa/html/krb5.ini
 /bin/touch %{buildroot}%{_usr}/share/ipa/html/krbrealm.con
-mkdir -p %{buildroot}%{_initrddir}
 
 # Web UI plugin dir
 mkdir -p %{buildroot}%{_usr}/share/ipa/ui/js/plugins
@@ -801,7 +798,6 @@ mkdir -p %{buildroot}%{_usr}/share/ipa/ui/js/plugins
 mkdir -p %{buildroot}%{_libdir}/krb5/plugins/libkrb5
 touch %{buildroot}%{_libdir}/krb5/plugins/libkrb5/winbind_krb5_locator.so
 
-mkdir -p %{buildroot}/%{_localstatedir}/lib/ipa/backup
 %endif # ONLY_CLIENT
 
 /bin/touch %{buildroot}%{_sysconfdir}/ipa/default.conf
@@ -817,10 +813,6 @@ mkdir -p %{buildroot}%{_sysconfdir}/cron.d
 (cd %{buildroot}/%{python_sitelib}/ipatests && find . -type f  | \
     sed -e 's,\.py.*$,.*,g' | sort -u | \
     sed -e 's,\./,%%{python_sitelib}/ipatests/,g' ) >tests-python.list
-
-mkdir -p %{buildroot}%{_sysconfdir}/ipa/custodia
-
-mkdir -p %{buildroot}%{_usr}/share/ipa/schema.d
 
 %endif # ONLY_CLIENT
 

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -702,6 +702,14 @@ make %{?_smp_mflags} client-check VERBOSE=yes LIBDIR=%{_libdir}
 
 
 %install
+# Please put as much logic as possible into make install. It allows:
+# - easier porting to other distributions
+# - rapid devel & install cycle using make install
+#   (instead of full RPM build and installation each time)
+#
+# All files and directories created by spec install should be marked as ghost.
+# (These are typically configuration files created by IPA installer.)
+# All other artifacts should be created by make install.
 %make_install
 # remove files which are useful only for make uninstall
 find %{buildroot} -wholename '*/site-packages/*/install_files.txt' -exec rm {} \;

--- a/install/Makefile.am
+++ b/install/Makefile.am
@@ -19,12 +19,11 @@ SUBDIRS =			\
 	$(NULL)
 
 install-exec-local:
-	mkdir -p $(DESTDIR)$(localstatedir)/lib/ipa/sysrestore
-	chmod 700 $(DESTDIR)$(localstatedir)/lib/ipa/sysrestore
-	mkdir -p $(DESTDIR)$(localstatedir)/lib/ipa/sysupgrade
-	chmod 700 $(DESTDIR)$(localstatedir)/lib/ipa/sysupgrade
-	mkdir -p $(DESTDIR)$(localstatedir)/lib/ipa/pki-ca
-	chmod 755 $(DESTDIR)$(localstatedir)/lib/ipa/pki-ca
+	$(INSTALL) -d -m 700 $(DESTDIR)$(IPA_SYSCONF_DIR)/custodia
+	$(INSTALL) -d -m 700 $(DESTDIR)$(localstatedir)/lib/ipa/backup
+	$(INSTALL) -d -m 700 $(DESTDIR)$(localstatedir)/lib/ipa/sysrestore
+	$(INSTALL) -d -m 700 $(DESTDIR)$(localstatedir)/lib/ipa/sysupgrade
+	$(INSTALL) -d -m 755 $(DESTDIR)$(localstatedir)/lib/ipa/pki-ca
 
 uninstall-local:
 	-rmdir $(DESTDIR)$(localstatedir)/lib/ipa/sysrestore

--- a/install/html/Makefile.am
+++ b/install/html/Makefile.am
@@ -16,3 +16,17 @@ EXTRA_DIST =                            \
 MAINTAINERCLEANFILES =                  \
         *~                              \
         Makefile.in
+
+# Default user-modifiable HTML files are installed into /etc.
+# /usr points to these modifiable files in /etc
+# This is ugly but we do not have time to change it right now.
+# Relative paths must be used to ensure that symlinks created in buildroot
+# work after installation.
+htmldatadir = $(datarootdir)/ipa/html
+install-data-hook:
+	$(INSTALL) -d -m 755 $(DESTDIR)$(htmldatadir)
+	for FILE in $(app_DATA); do				\
+		$(LN_S) --force --relative			\
+			$(DESTDIR)$(appdir)/$${FILE}		\
+			$(DESTDIR)$(htmldatadir)/$${FILE};	\
+	done

--- a/install/ui/Makefile.am
+++ b/install/ui/Makefile.am
@@ -34,3 +34,6 @@ MAINTAINERCLEANFILES =                  \
         *~                              \
         Makefile.in
 	$(NULL)
+
+install-data-hook:
+	$(INSTALL) -d -m 755 $(DESTDIR)$(appdir)/js/plugins


### PR DESCRIPTION
This patch set is based on phase 5 - PR #226.

Now all the installation steps (except Python2/3) are handled by make install.

Python 2/3 support will deserve separate PR.