### PR TITLE
Always use GSSAPI to set up initial replication

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -125,6 +125,7 @@ DEFAULT_CONFIG = (
     ('container_ca', DN(('cn', 'cas'), ('cn', 'ca'))),
     ('container_dnsservers', DN(('cn', 'servers'), ('cn', 'dns'))),
     ('container_custodia', DN(('cn', 'custodia'), ('cn', 'ipa'), ('cn', 'etc'))),
+    ('container_sysaccounts', DN(('cn', 'sysaccounts'), ('cn', 'etc'))),
 
     # Ports, hosts, and URIs:
     ('xmlrpc_uri', 'http://localhost:8888/ipa/xml'),

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -180,9 +180,6 @@ class KrbInstance(service.Service):
         self.step("adding the password extension to the directory", self.__add_pwd_extop_module)
         if setup_pkinit:
             self.step("installing X509 Certificate for PKINIT", self.__setup_pkinit)
-        if not promote:
-            self.step("enable GSSAPI for replication",
-                      self.__convert_to_gssapi_replication)
 
         self.__common_post_setup()
 

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1602,12 +1602,16 @@ class ReplicationManager(object):
             entry['nsDS5ReplicaBindDN'].remove(replica_binddn)
         conn.update_entry(entry)
 
-    def setup_promote_replication(self, r_hostname):
+    def setup_promote_replication(self, r_hostname, r_binddn=None,
+                                  r_bindpw=None, cacert=CACERT):
         # note - there appears to be a bug in python-ldap - it does not
         # allow connections using two different CA certs
         ldap_uri = ipaldap.get_ldap_uri(r_hostname)
-        r_conn = ipaldap.LDAPClient(ldap_uri)
-        r_conn.gssapi_bind()
+        r_conn = ipaldap.LDAPClient(ldap_uri, cacert=cacert)
+        if r_bindpw:
+            r_conn.simple_bind(r_binddn, r_bindpw)
+        else:
+            r_conn.gssapi_bind()
 
         # Setup the first half
         l_id = self._get_replica_id(self.conn, r_conn)


### PR DESCRIPTION
This PR makes DS replica use common method to set up initial replication in both domain levels, namely GSSAPI. Since the workflow was introduced during replica promotion work, I have take a special care to make it work also against old (think ipa 3.0.0) masters that may still be in production.

https://fedorahosted.org/freeipa/ticket/6406