### PR TITLE
Port ipapython.dnssec.odsmgr to xml.etree

### DIFF
--- a/client/ipa-client-automount
+++ b/client/ipa-client-automount
@@ -29,6 +29,11 @@ import time
 import tempfile
 import gssapi
 
+try:
+    from xml.etree import cElementTree as etree
+except ImportError:
+    from xml.etree import ElementTree as etree
+
 import SSSDConfig
 # pylint: disable=import-error
 from six.moves.urllib.parse import urlsplit
@@ -94,40 +99,34 @@ def wait_for_sssd():
         print("This may mean that sssd didn't re-start properly after the configuration changes.")
 
 def configure_xml(fstore):
-    from lxml import etree
-
-    fstore.backup_file(paths.AUTOFS_LDAP_AUTH_CONF)
+    authconf = paths.AUTOFS_LDAP_AUTH_CONF
+    fstore.backup_file(authconf)
 
     try:
-        f = open(paths.AUTOFS_LDAP_AUTH_CONF, 'r')
-        lines = f.read()
-        f.close()
-
-        saslconf = etree.fromstring(lines)
-        element = saslconf.xpath('//autofs_ldap_sasl_conf')
-        root = saslconf.getroottree()
+        tree = etree.parse(authconf)
     except IOError as e:
         root_logger.debug('Unable to open file %s' % e)
         root_logger.debug('Creating new from template')
-        element = [etree.Element('autofs_ldap_sasl_conf')]
-        root = element[0].getroottree()
+        tree = etree.ElementTree(
+            element=etree.Element('autofs_ldap_sasl_conf')
+        )
 
-    if len(element) != 1:
-        raise RuntimeError('Unable to parse %s' % paths.AUTOFS_LDAP_AUTH_CONF)
+    element = tree.getroot()
+    if element.tag != 'autofs_ldap_sasl_conf':
+        raise RuntimeError('Invalid XML root in file %s' % authconf)
 
-    element[0].set('usetls', 'no')
-    element[0].set('tlsrequired', 'no')
-    element[0].set('authrequired', 'yes')
-    element[0].set('authtype', 'GSSAPI')
-    element[0].set('clientprinc', 'host/%s@%s' % (api.env.host, api.env.realm))
+    element.set('usetls', 'no')
+    element.set('tlsrequired', 'no')
+    element.set('authrequired', 'yes')
+    element.set('authtype', 'GSSAPI')
+    element.set('clientprinc', 'host/%s@%s' % (api.env.host, api.env.realm))
 
-    newconf = open(paths.AUTOFS_LDAP_AUTH_CONF, 'w')
     try:
-        root.write(newconf, pretty_print=True, xml_declaration=True, encoding='UTF-8')
-        newconf.close()
+        tree.write(authconf, xml_declaration=True, encoding='UTF-8')
     except IOError as e:
-        print("Unable to write %s: %s" % (paths.AUTOFS_LDAP_AUTH_CONF, e))
-    print("Configured %s" % paths.AUTOFS_LDAP_AUTH_CONF)
+        print("Unable to write %s: %s" % (authconf, e))
+    else:
+        print("Configured %s" % authconf)
 
 def configure_nsswitch(fstore, options):
     """

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -248,6 +248,7 @@ Requires: %{name}-server-common = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 Requires: python2-ipaclient = %{version}-%{release}
 Requires: python-ldap >= 2.4.15
+Requires: python-lxml
 Requires: python-gssapi >= 1.1.2
 Requires: python-sssdconfig
 Requires: python-pyasn1
@@ -509,7 +510,6 @@ Requires: keyutils
 Requires: pyOpenSSL
 Requires: python-nss >= 0.16
 Requires: python-cryptography >= 0.9
-Requires: python-lxml
 Requires: python-netaddr
 Requires: python-libipa_hbac
 Requires: python-qrcode-core >= 5.0.0
@@ -559,7 +559,6 @@ Requires: keyutils
 Requires: python3-pyOpenSSL
 Requires: python3-nss >= 0.16
 Requires: python3-cryptography
-Requires: python3-lxml
 Requires: python3-netaddr
 Requires: python3-libipa_hbac
 Requires: python3-qrcode-core >= 5.0.0

--- a/ipatests/test_ipapython/test_dnssec.py
+++ b/ipatests/test_ipapython/test_dnssec.py
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2016  FreeIPA Contributors see COPYING for license
+#
+"""
+Test the `ipapython/dnssec` package.
+"""
+import dns.name
+
+from ipapython.dnssec.odsmgr import ODSZoneListReader
+
+
+ZONELIST_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<ZoneList>
+  <Zone name="ipa.example">
+    <Policy>default</Policy>
+    <Adapters>
+      <Input>
+        <Adapter type="File">/var/lib/ipa/dns/zone/entryUUID/12345</Adapter>
+      </Input>
+      <Output>
+        <Adapter type="File">/var/lib/ipa/dns/zone/entryUUID/12345</Adapter>
+      </Output>
+    </Adapters>
+  </Zone>
+</ZoneList>
+"""
+
+
+def test_ods_zonelist_reader():
+    uuid = '12345'
+    name = dns.name.from_text('ipa.example.')
+
+    reader = ODSZoneListReader("<ZoneList/>")
+    assert reader.mapping == {}
+    assert reader.names == set()
+    assert reader.uuids == set()
+
+    reader = ODSZoneListReader(ZONELIST_XML)
+    assert reader.mapping == {uuid: name}
+    assert reader.names == {name}
+    assert reader.uuids == {uuid}


### PR DESCRIPTION
The module ipapython.dnssec.odsmgr is the only module in ipalib,
ipaclient, ipapython and ipaplatform that uses lxml.etree.

The only dependency on lxml left in [free]ipa-client package is in the
ipa-client-automount script.

https://fedorahosted.org/freeipa/ticket/6469
https://fedorahosted.org/freeipa/ticket/6491

Signed-off-by: Christian Heimes <cheimes@redhat.com>