### PR TITLE
Don't modify redhat_system_units

### DIFF
--- a/ipaplatform/fedora/services.py
+++ b/ipaplatform/fedora/services.py
@@ -26,7 +26,7 @@ from ipaplatform.redhat import services as redhat_services
 
 # Mappings from service names as FreeIPA code references to these services
 # to their actual systemd service names
-fedora_system_units = redhat_services.redhat_system_units
+fedora_system_units = redhat_services.redhat_system_units.copy()
 
 # Service that sets domainname on Fedora is called fedora-domainname.service
 fedora_system_units['domainname'] = 'fedora-domainname.service'


### PR DESCRIPTION
ipaplatform.fedora.services used to modify the redhat_system_units dict.
It now creates a proper shallow copy.

Signed-off-by: Christian Heimes <cheimes@redhat.com>