### PR TITLE
Add templating to ipaplatform path [RFC]

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1882,14 +1882,10 @@ def configure_firefox(options, statestore, domain):
         else:
             # test if firefox is installed
             if file_exists(paths.FIREFOX):
-
-                # find valid preferences path
-                for path in [paths.LIB_FIREFOX, paths.LIB64_FIREFOX]:
-                    pref_path = os.path.join(path,
-                                             FIREFOX_PREFERENCES_REL_PATH)
-                    if dir_exists(pref_path):
-                        preferences_dir = pref_path
-                        break
+                pref_path = os.path.join(paths.LIB_FIREFOX,
+                                         FIREFOX_PREFERENCES_REL_PATH)
+                if dir_exists(pref_path):
+                    preferences_dir = pref_path
             else:
                 root_logger.error(
                     "Firefox configuration skipped (Firefox not found).")

--- a/ipaplatform/fedora/paths.py
+++ b/ipaplatform/fedora/paths.py
@@ -31,3 +31,6 @@ class FedoraPathNamespace(RedHatPathNamespace):
 
 
 paths = FedoraPathNamespace()
+
+if __name__ == '__main__':
+    paths._dump()

--- a/ipaplatform/redhat/paths.py
+++ b/ipaplatform/redhat/paths.py
@@ -22,17 +22,16 @@ This Red Hat OS family base platform module exports default filesystem paths as
 common in Red Hat OS family-based systems.
 '''
 
-import sys
-
 # Fallback to default path definitions
 from ipaplatform.base.paths import BasePathNamespace
 
 
 class RedHatPathNamespace(BasePathNamespace):
-    # https://docs.python.org/2/library/platform.html#cross-platform
-    if sys.maxsize > 2**32:
-        LIBSOFTHSM2_SO = BasePathNamespace.LIBSOFTHSM2_SO_64
-        PAM_KRB5_SO = BasePathNamespace.PAM_KRB5_SO_64
+    pass
 
 
 paths = RedHatPathNamespace()
+
+
+if __name__ == '__main__':
+    paths._dump()

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -79,12 +79,6 @@ ALL_SCHEMA_FILES = IPA_SCHEMA_FILES + ("05rfc2247.ldif", )
 DS_INSTANCE_PREFIX = 'slapd-'
 
 
-def find_server_root():
-    if ipautil.dir_exists(paths.USR_LIB_DIRSRV_64):
-        return paths.USR_LIB_DIRSRV_64
-    else:
-        return paths.USR_LIB_DIRSRV
-
 def config_dirname(serverid):
     return (paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % serverid) + "/"
 
@@ -486,7 +480,7 @@ class DsInstance(service.Service):
         self.disable()
 
     def __setup_sub_dict(self):
-        server_root = find_server_root()
+        server_root = paths.USR_LIB_DIRSRV
         try:
             idrange_size = self.idmax - self.idstart + 1
         except TypeError:


### PR DESCRIPTION
Please comment

The ipaplatform.base.paths module contains a lot of repetitions. The
path class now uses recursive format calls for common prefixes. The
SO/SO_64 hack is replaced by platform detection.

Signed-off-by: Christian Heimes <cheimes@redhat.com>