### PR TITLE
Allow full customisability of IPA CA subject DN

### DIFF
--- a/install/share/certmap.conf.template
+++ b/install/share/certmap.conf.template
@@ -41,6 +41,6 @@ certmap default         default
 #default:InitFn         <Init function's name>
 default:DNComps
 default:FilterComps     uid
-certmap ipaca           CN=Certificate Authority,$SUBJECT_BASE
+certmap ipaca           $ISSUER_DN
 ipaca:CmapLdapAttr      seeAlso
 ipaca:verifycert        on

--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -80,12 +80,14 @@ def parse_options():
                       default=None,
                       help=(
                           "The certificate subject base "
-                          "(default O=<realm-name>)"))
+                          "(default O=<realm-name>).  "
+                          "RDNs are in LDAP order (most specific RDN first)."))
     parser.add_option("--ca-subject", dest="ca_subject",
                       default=None,
                       help=(
                           "The CA certificate subject DN "
-                          "(default CN=Certificate Authority,O=<realm-name>)"))
+                          "(default CN=Certificate Authority,O=<realm-name>). "
+                          "RDNs are in LDAP order (most specific RDN first)."))
 
     options, args = parser.parse_args()
     safe_options = parser.get_safe_opts(options)

--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -122,6 +122,11 @@ def get_dirman_password():
 
 
 def install_replica(safe_options, options, filename):
+    if options.ca_subject:
+        sys.exit("--ca-subject cannot be used when installing a CA replica")
+    if options.subject_base:
+        sys.exit("--subject-base cannot be used when installing a CA replica")
+
     if options.promote:
         if filename is not None:
             sys.exit("Too many parameters provided. "

--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -81,6 +81,11 @@ def parse_options():
                       help=(
                           "The certificate subject base "
                           "(default O=<realm-name>)"))
+    parser.add_option("--ca-subject", dest="ca_subject",
+                      default=None,
+                      help=(
+                          "The CA certificate subject DN "
+                          "(default CN=Certificate Authority,O=<realm-name>)"))
 
     options, args = parser.parse_args()
     safe_options = parser.get_safe_opts(options)
@@ -177,7 +182,6 @@ def install_replica(safe_options, options, filename):
     options.domain_name = config.domain_name
     options.dm_password = config.dirman_password
     options.host_name = config.host_name
-    options.subject_base = config.subject_base
     if os.path.exists(cafile):
         options.ca_cert_file = cafile
     else:
@@ -206,6 +210,18 @@ def install_master(safe_options, options):
 
     if not options.subject_base:
         options.subject_base = installutils.default_subject_base(api.env.realm)
+    if not options.ca_subject:
+        options.ca_subject = installutils.default_ca_subject_dn(
+            options.subject_base)
+
+    try:
+        ca.subject_validator(ca.VALID_SUBJECT_BASE_ATTRS, options.subject_base)
+    except ValueError as e:
+        sys.exit("Subject base: {}".format(e.message))
+    try:
+        ca.subject_validator(ca.VALID_SUBJECT_ATTRS, options.ca_subject)
+    except ValueError as e:
+        sys.exit("CA subject: {}".format(e.message))
 
     ca.install_check(True, None, options)
     ca.install(True, None, options)

--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -172,7 +172,7 @@ def install_replica(safe_options, options, filename):
     options.domain_name = config.domain_name
     options.dm_password = config.dirman_password
     options.host_name = config.host_name
-    options.subject = config.subject_base
+    options.subject_base = config.subject_base
     if os.path.exists(cafile):
         options.ca_cert_file = cafile
     else:
@@ -201,7 +201,7 @@ def install_master(safe_options, options):
     options.domain_name = api.env.domain
     options.dm_password = dm_password
     options.host_name = api.env.host
-    options.subject = subject_base
+    options.subject_base = subject_base
 
     ca.install_check(True, None, options)
     ca.install(True, None, options)

--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -76,6 +76,11 @@ def parse_options():
                       help="Signing algorithm of the IPA CA certificate")
     parser.add_option("-P", "--principal", dest="principal", sensitive=True,
                       default=None, help="User allowed to manage replicas")
+    parser.add_option("--subject-base", dest="subject_base",
+                      default=None,
+                      help=(
+                          "The certificate subject base "
+                          "(default O=<realm-name>)"))
 
     options, args = parser.parse_args()
     safe_options = parser.get_safe_opts(options)
@@ -194,14 +199,13 @@ def install_master(safe_options, options):
         if dm_password is None:
             sys.exit("Directory Manager password required")
 
-    config = api.Command['config_show']()['result']
-    subject_base = config['ipacertificatesubjectbase'][0]
-
     options.realm_name = api.env.realm
     options.domain_name = api.env.domain
     options.dm_password = dm_password
     options.host_name = api.env.host
-    options.subject_base = subject_base
+
+    if not options.subject_base:
+        options.subject_base = installutils.default_subject_base(api.env.realm)
 
     ca.install_check(True, None, options)
     ca.install(True, None, options)

--- a/install/tools/man/ipa-ca-install.1
+++ b/install/tools/man/ipa-ca-install.1
@@ -46,6 +46,12 @@ Type of the external CA. Possible values are "generic", "ms-cs". Default value i
 \fB\-\-external\-cert\-file\fR=\fIFILE\fR
 File containing the IPA CA certificate and the external CA certificate chain. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times.
 .TP
+\fB\-\-ca\-subject\fR=\fISUBJECT\fR
+The CA certificate subject DN (default CN=Certificate Authority,O=REALM.NAME)
+.TP
+\fB\-\-subject\-base\fR=\fISUBJECT\fR
+The subject base for certificates issued by IPA (default O=REALM.NAME)
+.TP
 \fB\-\-ca\-signing\-algorithm\fR=\fIALGORITHM\fR
 Signing algorithm of the IPA CA certificate. Possible values are SHA1withRSA, SHA256withRSA, SHA512withRSA. Default value is SHA256withRSA. Use this option with --external-ca if the external CA does not support the default signing algorithm.
 .TP

--- a/install/tools/man/ipa-ca-install.1
+++ b/install/tools/man/ipa-ca-install.1
@@ -47,10 +47,10 @@ Type of the external CA. Possible values are "generic", "ms-cs". Default value i
 File containing the IPA CA certificate and the external CA certificate chain. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times.
 .TP
 \fB\-\-ca\-subject\fR=\fISUBJECT\fR
-The CA certificate subject DN (default CN=Certificate Authority,O=REALM.NAME)
+The CA certificate subject DN (default CN=Certificate Authority,O=REALM.NAME).  RDNs are in LDAP order (most specific RDN first).
 .TP
 \fB\-\-subject\-base\fR=\fISUBJECT\fR
-The subject base for certificates issued by IPA (default O=REALM.NAME)
+The subject base for certificates issued by IPA (default O=REALM.NAME).  RDNs are in LDAP order (most specific RDN first).
 .TP
 \fB\-\-ca\-signing\-algorithm\fR=\fIALGORITHM\fR
 Signing algorithm of the IPA CA certificate. Possible values are SHA1withRSA, SHA256withRSA, SHA512withRSA. Default value is SHA256withRSA. Use this option with --external-ca if the external CA does not support the default signing algorithm.

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -123,10 +123,10 @@ Name of the Kerberos KDC SSL certificate to install
 File containing the CA certificate of the CA which issued the Directory Server, Apache Server and Kerberos KDC certificates. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times. Use this option if the CA certificate is not present in the certificate files.
 .TP
 \fB\-\-ca\-subject\fR=\fISUBJECT\fR
-The CA certificate subject DN (default CN=Certificate Authority,O=REALM.NAME)
+The CA certificate subject DN (default CN=Certificate Authority,O=REALM.NAME).  RDNs are in LDAP order (most specific RDN first).
 .TP
 \fB\-\-subject\-base\fR=\fISUBJECT\fR
-The subject base for certificates issued by IPA (default O=REALM.NAME)
+The subject base for certificates issued by IPA (default O=REALM.NAME).  RDNs are in LDAP order (most specific RDN first).
 .TP
 \fB\-\-ca\-signing\-algorithm\fR=\fIALGORITHM\fR
 Signing algorithm of the IPA CA certificate. Possible values are SHA1withRSA, SHA256withRSA, SHA512withRSA. Default value is SHA256withRSA. Use this option with --external-ca if the external CA does not support the default signing algorithm.

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -122,6 +122,9 @@ Name of the Kerberos KDC SSL certificate to install
 \fB\-\-ca\-cert\-file\fR=\fIFILE\fR
 File containing the CA certificate of the CA which issued the Directory Server, Apache Server and Kerberos KDC certificates. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times. Use this option if the CA certificate is not present in the certificate files.
 .TP
+\fB\-\-ca\-subject\fR=\fISUBJECT\fR
+The CA certificate subject DN (default CN=Certificate Authority,O=REALM.NAME)
+.TP
 \fB\-\-subject\-base\fR=\fISUBJECT\fR
 The subject base for certificates issued by IPA (default O=REALM.NAME)
 .TP

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -122,8 +122,8 @@ Name of the Kerberos KDC SSL certificate to install
 \fB\-\-ca\-cert\-file\fR=\fIFILE\fR
 File containing the CA certificate of the CA which issued the Directory Server, Apache Server and Kerberos KDC certificates. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times. Use this option if the CA certificate is not present in the certificate files.
 .TP
-\fB\-\-subject\fR=\fISUBJECT\fR
-The certificate subject base (default O=REALM.NAME)
+\fB\-\-subject\-base\fR=\fISUBJECT\fR
+The subject base for certificates issued by IPA (default O=REALM.NAME)
 .TP
 \fB\-\-ca\-signing\-algorithm\fR=\fIALGORITHM\fR
 Signing algorithm of the IPA CA certificate. Possible values are SHA1withRSA, SHA256withRSA, SHA512withRSA. Default value is SHA256withRSA. Use this option with --external-ca if the external CA does not support the default signing algorithm.

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -15,6 +15,7 @@ import six
 
 from ipalib.install import certstore
 from ipalib.install.service import enroll_only, master_install_only, replica_install_only
+from ipaserver.install import sysupgrade
 from ipapython.install import typing
 from ipapython.install.core import knob
 from ipaserver.install import (cainstance,
@@ -211,6 +212,13 @@ def install_step_0(standalone, replica_config, options):
         ra_p12 = os.path.join(replica_config.dir, 'ra.p12')
         ra_only = not replica_config.setup_ca
         promote = options.promote
+
+    # if upgrading from CA-less to CA-ful, need to rewrite
+    # subject_base configuration
+    #
+    set_subject_base_in_config(subject_base)
+    sysupgrade.set_upgrade_state(
+        'certmap.conf', 'subject_base', str(subject_base))
 
     ca = cainstance.CAInstance(realm_name, certs.NSS_DIR,
                                host_name=host_name)

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -109,7 +109,9 @@ def install_check(standalone, replica_config, options):
                   "--external-ca.")
 
         external_cert_file, external_ca_file = installutils.load_external_cert(
-            options.external_cert_files, options.subject)
+            options.external_cert_files,
+            DN(('CN', 'Certificate Authority'), options.subject)
+        )
     elif options.external_ca:
         if cainstance.is_step_one_done():
             raise ScriptError(

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -66,7 +66,7 @@ def install_check(standalone, replica_config, options):
 
     realm_name = options.realm_name
     host_name = options.host_name
-    subject_base = options.subject
+    subject_base = options.subject_base
 
     if replica_config is not None:
         if standalone and api.env.ra_plugin == 'selfsign':
@@ -110,7 +110,7 @@ def install_check(standalone, replica_config, options):
 
         external_cert_file, external_ca_file = installutils.load_external_cert(
             options.external_cert_files,
-            DN(('CN', 'Certificate Authority'), options.subject)
+            DN(('CN', 'Certificate Authority'), options.subject_base)
         )
     elif options.external_ca:
         if cainstance.is_step_one_done():
@@ -164,7 +164,7 @@ def install_step_0(standalone, replica_config, options):
     host_name = options.host_name
 
     if replica_config is None:
-        subject_base = options.subject
+        subject_base = options.subject_base
 
         ca_signing_algorithm = options.ca_signing_algorithm
         if options.external_ca:
@@ -236,7 +236,7 @@ def install_step_1(standalone, replica_config, options):
 
     realm_name = options.realm_name
     host_name = options.host_name
-    subject_base = options.subject
+    subject_base = options.subject_base
 
     basedn = ipautil.realm_to_suffix(realm_name)
 
@@ -379,14 +379,15 @@ class CAInstallInterface(dogtag.DogtagInstallInterface,
         if any(not os.path.isabs(path) for path in value):
             raise ValueError("must use an absolute path")
 
-    subject = knob(
+    subject_base = knob(
         str, None,
         description="The certificate subject base (default O=<realm-name>)",
+        cli_deprecated_names=['--subject'],
     )
-    subject = master_install_only(subject)
+    subject_base = master_install_only(subject_base)
 
-    @subject.validator
-    def subject(self, value):
+    @subject_base.validator
+    def subject_base(self, value):
         v = unicode(value, 'utf-8')
         if any(ord(c) < 0x20 for c in v):
             raise ValueError("must not contain control characters")

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -434,7 +434,10 @@ class CAInstallInterface(dogtag.DogtagInstallInterface,
 
     subject_base = knob(
         str, None,
-        description="The certificate subject base (default O=<realm-name>)",
+        description=(
+            "The certificate subject base (default O=<realm-name>). "
+            "RDNs are in LDAP order (most specific RDN first)."
+        ),
         cli_deprecated_names=['--subject'],
     )
     subject_base = master_install_only(subject_base)
@@ -447,7 +450,8 @@ class CAInstallInterface(dogtag.DogtagInstallInterface,
         str, None,
         description=(
             "The CA certificate subject DN "
-            "(default CN=Certificate Authority,O=<realm-name>)"
+            "(default CN=Certificate Authority,O=<realm-name>). "
+            "RDNs are in LDAP order (most specific RDN first)."
         ),
     )
     ca_subject = master_install_only(ca_subject)

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -48,6 +48,15 @@ external_cert_file = None
 external_ca_file = None
 
 
+def set_subject_base_in_config(subject_base):
+    entry_attrs = api.Backend.ldap2.get_ipa_config()
+    entry_attrs['ipacertificatesubjectbase'] = [str(subject_base)]
+    try:
+        api.Backend.ldap2.update_entry(entry_attrs)
+    except errors.EmptyModlist:
+        pass
+
+
 def install_check(standalone, replica_config, options):
     global external_cert_file
     global external_ca_file

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -352,10 +352,10 @@ class CAInstance(DogtagInstance):
             self.clone = True
         self.master_host = master_host
         self.master_replication_port = master_replication_port
-        if subject_base is None:
-            self.subject_base = DN(('O', self.realm))
-        else:
-            self.subject_base = subject_base
+
+        self.subject_base = \
+            subject_base or installutils.default_subject_base(self.realm)
+
         if ca_signing_algorithm is None:
             self.ca_signing_algorithm = 'SHA256withRSA'
         else:

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -1251,7 +1251,8 @@ class DsInstance(service.Service):
                                          replacevars=vardict)
 
     def __get_ds_cert(self):
-        subject = self.subject_base or DN(('O', self.realm))
+        subject = self.subject_base \
+                or installutils.default_subject_base(self.realm)
         nssdb_dir = config_dirname(self.serverid)
         db = certs.CertDB(self.realm, nssdir=nssdb_dir, subject_base=subject)
         db.create_from_cacert(paths.IPA_CA_CRT)

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1476,3 +1476,7 @@ def restart_dirsrv(instance_name="", capture_output=True):
                                           capture_output=capture_output,
                                           wait=True, ldapi=True)
     api.Backend.ldap2.connect()
+
+
+def default_subject_base(realm_name):
+    return DN(('O', realm_name))

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1095,7 +1095,8 @@ def check_entropy():
     except ValueError as e:
         root_logger.debug("Invalid value in %s %s", paths.ENTROPY_AVAIL, e)
 
-def load_external_cert(files, subject_base):
+
+def load_external_cert(files, ca_subject):
     """
     Load and verify external CA certificate chain from multiple files.
 
@@ -1103,7 +1104,7 @@ def load_external_cert(files, subject_base):
     chain formats.
 
     :param files: Names of files to import
-    :param subject_base: Subject name base for IPA certificates
+    :param ca_subject: IPA CA subject DN
     :returns: Temporary file with the IPA CA certificate and temporary file
         with the external CA certificate chain
     """
@@ -1117,7 +1118,7 @@ def load_external_cert(files, subject_base):
         except RuntimeError as e:
             raise ScriptError(str(e))
 
-        ca_subject = DN(('CN', 'Certificate Authority'), subject_base)
+        ca_subject = DN(ca_subject)
         ca_nickname = None
         cache = {}
         for nickname, _trust_flags in nssdb.list_certs():

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1480,3 +1480,7 @@ def restart_dirsrv(instance_name="", capture_output=True):
 
 def default_subject_base(realm_name):
     return DN(('O', realm_name))
+
+
+def default_ca_subject_dn(subject_base):
+    return DN(('CN', 'Certificate Authority'), subject_base)

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -192,14 +192,17 @@ class CACertManage(admintool.AdminTool):
 
         options = self.options
         conn = api.Backend.ldap2
-        cert_file, ca_file = installutils.load_external_cert(
-            options.external_cert_files, x509.subject_base())
 
         old_cert_obj = x509.load_certificate(old_cert_der, x509.DER)
         old_der_subject = x509.get_der_subject(old_cert_der, x509.DER)
         old_spki = old_cert_obj.public_key().public_bytes(
             serialization.Encoding.DER,
             serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+
+        cert_file, ca_file = installutils.load_external_cert(
+            options.external_cert_files,
+            DN(('CN', 'Certificate Authority'), x509.subject_base())
         )
 
         with open(cert_file.name) as f:

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -201,9 +201,7 @@ class CACertManage(admintool.AdminTool):
         )
 
         cert_file, ca_file = installutils.load_external_cert(
-            options.external_cert_files,
-            DN(('CN', 'Certificate Authority'), x509.subject_base())
-        )
+            options.external_cert_files, DN(old_cert_obj.subject))
 
         with open(cert_file.name) as f:
             new_cert_data = f.read()

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -90,10 +90,10 @@ class KRAInstance(DogtagInstance):
         if self.pkcs12_info is not None or promote:
             self.clone = True
         self.master_host = master_host
-        if subject_base is None:
-            self.subject_base = DN(('O', self.realm))
-        else:
-            self.subject_base = subject_base
+
+        self.subject_base = \
+            subject_base or installutils.default_subject_base(realm_name)
+
         self.realm = realm_name
         self.suffix = ipautil.realm_to_suffix(realm_name)
 

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -77,7 +77,8 @@ class KRAInstance(DogtagInstance):
 
     def configure_instance(self, realm_name, host_name, dm_password,
                            admin_password, pkcs12_info=None, master_host=None,
-                           subject_base=None, ra_only=False, promote=False):
+                           subject_base=None, subject=None,
+                           ra_only=False, promote=False):
         """Create a KRA instance.
 
            To create a clone, pass in pkcs12_info.
@@ -93,6 +94,8 @@ class KRAInstance(DogtagInstance):
 
         self.subject_base = \
             subject_base or installutils.default_subject_base(realm_name)
+        self.subject = \
+            subject or installutils.default_ca_subject_dn(self.subject_base)
 
         self.realm = realm_name
         self.suffix = ipautil.realm_to_suffix(realm_name)
@@ -307,7 +310,7 @@ class KRAInstance(DogtagInstance):
             userCertificate=[cert_data],
             description=['2;%s;%s;%s' % (
                 cert.serial,
-                DN(('CN', 'Certificate Authority'), self.subject_base),
+                DN(self.subject),
                 DN(('CN', 'IPA RA'), self.subject_base))])
         conn.add_entry(entry)
 

--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -573,7 +573,8 @@ class ServerReplicaInstall(ServerReplicaInstallInterface):
     Server replica installer
     """
 
-    subject = None
+    subject_base = None
+    ca_subject = None
 
     admin_password = knob(
         bases=ServerReplicaInstallInterface.admin_password,

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -464,8 +464,8 @@ def install_check(installer):
     else:
         realm_name = options.realm_name.upper()
 
-    if not options.subject:
-        options.subject = DN(('O', realm_name))
+    if not options.subject_base:
+        options.subject_base = DN(('O', realm_name))
 
     if options.http_cert_files:
         if options.http_pin is None:
@@ -725,7 +725,7 @@ def install(installer):
             ds.create_instance(realm_name, host_name, domain_name,
                                dm_password, dirsrv_pkcs12_info,
                                idstart=options.idstart, idmax=options.idmax,
-                               subject_base=options.subject,
+                               subject_base=options.subject_base,
                                hbac_allow=not options.no_hbac_allow)
         else:
             ds = dsinstance.DsInstance(fstore=fstore,
@@ -735,7 +735,7 @@ def install(installer):
             ds.create_instance(realm_name, host_name, domain_name,
                                dm_password,
                                idstart=options.idstart, idmax=options.idmax,
-                               subject_base=options.subject,
+                               subject_base=options.subject_base,
                                hbac_allow=not options.no_hbac_allow)
 
         ntpinstance.ntp_ldap_enable(host_name, ds.suffix, realm_name)
@@ -747,7 +747,7 @@ def install(installer):
         installer._ds = ds
         ds.init_info(
             realm_name, host_name, domain_name, dm_password,
-            options.subject, 1101, 1100, None)
+            options.subject_base, 1101, 1100, None)
 
     if setup_ca:
         if not options.external_cert_files and options.external_ca:
@@ -781,7 +781,7 @@ def install(installer):
                         dm_password, master_password,
                         setup_pkinit=not options.no_pkinit,
                         pkcs12_info=pkinit_pkcs12_info,
-                        subject_base=options.subject)
+                        subject_base=options.subject_base)
 
     # restart DS to enable ipa-pwd-extop plugin
     print("Restarting directory server to enable password extension plugin")
@@ -811,13 +811,13 @@ def install(installer):
     if options.http_cert_files:
         http.create_instance(
             realm_name, host_name, domain_name,
-            pkcs12_info=http_pkcs12_info, subject_base=options.subject,
+            pkcs12_info=http_pkcs12_info, subject_base=options.subject_base,
             auto_redirect=not options.no_ui_redirect,
             ca_is_configured=setup_ca)
     else:
         http.create_instance(
             realm_name, host_name, domain_name,
-            subject_base=options.subject,
+            subject_base=options.subject_base,
             auto_redirect=not options.no_ui_redirect,
             ca_is_configured=setup_ca)
     tasks.restore_context(paths.CACHE_IPA_SESSIONS)

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -467,6 +467,10 @@ def install_check(installer):
     if not options.subject_base:
         options.subject_base = installutils.default_subject_base(realm_name)
 
+    if not options.ca_subject:
+        options.ca_subject = \
+            installutils.default_ca_subject_dn(options.subject_base)
+
     if options.http_cert_files:
         if options.http_pin is None:
             options.http_pin = installutils.read_password(
@@ -726,6 +730,7 @@ def install(installer):
                                dm_password, dirsrv_pkcs12_info,
                                idstart=options.idstart, idmax=options.idmax,
                                subject_base=options.subject_base,
+                               ca_subject=options.ca_subject,
                                hbac_allow=not options.no_hbac_allow)
         else:
             ds = dsinstance.DsInstance(fstore=fstore,
@@ -736,6 +741,7 @@ def install(installer):
                                dm_password,
                                idstart=options.idstart, idmax=options.idmax,
                                subject_base=options.subject_base,
+                               ca_subject=options.ca_subject,
                                hbac_allow=not options.no_hbac_allow)
 
         ntpinstance.ntp_ldap_enable(host_name, ds.suffix, realm_name)
@@ -747,7 +753,7 @@ def install(installer):
         installer._ds = ds
         ds.init_info(
             realm_name, host_name, domain_name, dm_password,
-            options.subject_base, 1101, 1100, None)
+            options.subject_base, options.ca_subject, 1101, 1100, None)
 
     if setup_ca:
         if not options.external_cert_files and options.external_ca:

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -465,7 +465,7 @@ def install_check(installer):
         realm_name = options.realm_name.upper()
 
     if not options.subject_base:
-        options.subject_base = DN(('O', realm_name))
+        options.subject_base = installutils.default_subject_base(realm_name)
 
     if options.http_cert_files:
         if options.http_pin is None:

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -364,6 +364,13 @@ def install_check(installer):
         setup_ca = True
     options.setup_ca = setup_ca
 
+    if not setup_ca and options.ca_subject:
+        raise ScriptError(
+            "--ca-subject cannot be used with CA-less installation")
+    if not setup_ca and options.subject_base:
+        raise ScriptError(
+            "--subject-base cannot be used with CA-less installation")
+
     # first instance of KRA must be installed by ipa-kra-install
     options.setup_kra = False
 

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -78,7 +78,7 @@ def install_http_certs(host_name, realm_name, subject_base):
     principal = 'HTTP/%s@%s' % (host_name, realm_name)
     # Obtain certificate for the HTTP service
     nssdir = certs.NSS_DIR
-    subject = subject_base or DN(('O', realm_name))
+    subject = subject_base or installutils.default_subject_base(realm_name)
     db = certs.CertDB(realm_name, nssdir=nssdir, subject_base=subject)
     db.request_service_cert('Server-Cert', principal, host_name, True)
 

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -796,7 +796,7 @@ def install_check(installer):
         if ca_enabled:
             options.realm_name = config.realm_name
             options.host_name = config.host_name
-            options.subject = config.subject_base
+            options.subject_base = config.subject_base
             ca.install_check(False, config, options)
 
         if kra_enabled:
@@ -1203,7 +1203,7 @@ def promote_check(installer):
         if ca_enabled:
             options.realm_name = config.realm_name
             options.host_name = config.host_name
-            options.subject = config.subject_base
+            options.subject_base = config.subject_base
             ca.install_check(False, config, options)
 
         if kra_enabled:

--- a/ipaserver/plugins/ca.py
+++ b/ipaserver/plugins/ca.py
@@ -193,7 +193,7 @@ class ca_find(LDAPSearch):
     )
 
     def execute(self, *keys, **options):
-        ca_enabled_check()
+        ca_enabled_check(self.api)
         result = super(ca_find, self).execute(*keys, **options)
         if not options.get('pkey_only', False):
             for entry in result['result']:
@@ -217,7 +217,7 @@ class ca_show(LDAPRetrieve):
     )
 
     def execute(self, *keys, **options):
-        ca_enabled_check()
+        ca_enabled_check(self.api)
         result = super(ca_show, self).execute(*keys, **options)
         set_certificate_attrs(result['result'], options)
         return result
@@ -233,7 +233,7 @@ class ca_add(LDAPCreate):
     )
 
     def pre_callback(self, ldap, dn, entry, entry_attrs, *keys, **options):
-        ca_enabled_check()
+        ca_enabled_check(self.api)
         if not ldap.can_add(dn[1:]):
             raise errors.ACIError(
                 info=_("Insufficient 'add' privilege for entry '%s'.") % dn)
@@ -276,7 +276,7 @@ class ca_del(LDAPDelete):
     msg_summary = _('Deleted CA "%(value)s"')
 
     def pre_callback(self, ldap, dn, *keys, **options):
-        ca_enabled_check()
+        ca_enabled_check(self.api)
 
         if keys[0] == IPA_CA_CN:
             raise errors.ProtectedEntryError(
@@ -298,7 +298,7 @@ class ca_mod(LDAPUpdate):
     msg_summary = _('Modified CA "%(value)s"')
 
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys, **options):
-        ca_enabled_check()
+        ca_enabled_check(self.api)
 
         if 'rename' in options or 'cn' in entry_attrs:
             if keys[0] == IPA_CA_CN:
@@ -314,7 +314,7 @@ class CAQuery(LDAPQuery):
     has_output = output.standard_value
 
     def execute(self, cn, **options):
-        ca_enabled_check()
+        ca_enabled_check(self.api)
 
         ca_id = self.api.Command.ca_show(cn)['result']['ipacaid'][0]
         with self.api.Backend.ra_lightweight_ca as ca_api:

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -196,8 +196,8 @@ def normalize_serial_number(num):
     return unicode(num)
 
 
-def ca_enabled_check():
-    if not api.Command.ca_is_enabled()['result']:
+def ca_enabled_check(_api):
+    if not _api.Command.ca_is_enabled()['result']:
         raise errors.NotFound(reason=_('CA is not configured'))
 
 def caacl_check(principal_type, principal, ca, profile_id):
@@ -538,7 +538,7 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
             yield arg
 
     def execute(self, csr, all=False, raw=False, **kw):
-        ca_enabled_check()
+        ca_enabled_check(self.api)
 
         ldap = self.api.Backend.ldap2
         realm = unicode(self.api.env.realm)
@@ -898,7 +898,7 @@ class cert_status(Retrieve, BaseCertMethod, VirtualCommand):
     operation = "certificate status"
 
     def execute(self, request_id, **kw):
-        ca_enabled_check()
+        ca_enabled_check(self.api)
         self.check_access()
 
         # Dogtag requests are uniquely identified by their number;
@@ -1006,7 +1006,7 @@ class cert_show(Retrieve, CertMethod, VirtualCommand):
 
     def execute(self, serial_number, all=False, raw=False, no_members=False,
                 **options):
-        ca_enabled_check()
+        ca_enabled_check(self.api)
 
         # Dogtag lightweight CAs have shared serial number domain, so
         # we don't tell Dogtag the issuer (but we check the cert after).
@@ -1069,7 +1069,7 @@ class cert_revoke(PKQuery, CertMethod, VirtualCommand):
             yield option
 
     def execute(self, serial_number, **kw):
-        ca_enabled_check()
+        ca_enabled_check(self.api)
 
         # Make sure that the cert specified by issuer+serial exists.
         # Will raise NotFound if it does not.
@@ -1105,7 +1105,7 @@ class cert_remove_hold(PKQuery, CertMethod, VirtualCommand):
     operation = "certificate remove hold"
 
     def execute(self, serial_number, **kw):
-        ca_enabled_check()
+        ca_enabled_check(self.api)
 
         # Make sure that the cert specified by issuer+serial exists.
         # Will raise NotFound if it does not.
@@ -1312,7 +1312,7 @@ class cert_find(Search, CertMethod):
         complete = bool(ra_options)
 
         try:
-            ca_enabled_check()
+            ca_enabled_check(self.api)
         except errors.NotFound:
             if ra_options:
                 raise


### PR DESCRIPTION
This patchset adds full customisability of CA subject DN apart from
subject base, via the ipa-server-install `--ca-subject` option.  It
also renames ipa-server-install `--subject` option to
`--subject-base`, and adds `--ca-subject` and `--subject-base`
options to ipa-ca-install.

Earlier version of this patchset was previously reviewed by
@jcholast on freeipa-devel:
https://www.redhat.com/archives/freeipa-devel/2016-August/msg00570.html

All review items have been addressed, except for item 9.  The
suggestion will not work because a fair bit of code besides
what's in `ipaserver.install.ca` requires knowing the CA Subject DN
and/or subject base.  So the defaults must be applied close to the
"entry points".

I also carved a few smaller commits out of the main patch (but it is
still pretty big and hairy to review).

https://fedorahosted.org/freeipa/ticket/2614