### PR TITLE
Add 'ipa local-env' subcommand

### DIFF
--- a/client/man/ipa.1
+++ b/client/man/ipa.1
@@ -65,13 +65,17 @@ The principal function of the CLI is to execute administrative commands specifie
 
 From the implementation perspective, the CLI distinguishes two types of commands \- built\-ins and plugin provided.
 
-Built\-in commands are static and are all available in all installations of IPA. There are two of them:
+Built\-in commands are static and are all available in all installations of IPA. There are three of them:
 .TP
 \fBconsole\fR
 Start the IPA interactive Python console.
 .TP
 \fBhelp\fR [\fITOPIC\fR | \fICOMMAND\fR | \fBtopics\fR | \fBcommands\fR]
 Display help for a command or topic.
+\fBlocal-env\fR
+Show local IPA api.env values.
+.TP
+
 
 The \fBhelp\fR command invokes the built\-in documentation system. Without parameters a list of built\-in commands and help topics is displayed. Help topics are generated from loaded IPA plugin modules. Executing \fBhelp\fR with the name of an available topic displays a help message provided by the corresponding plugin module and list of commands it contains.
 .LP

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -54,6 +54,7 @@ from ipalib.constants import CLI_TAB, LDAP_GENERALIZED_TIME_FORMAT
 from ipalib.parameters import File, Str, Enum, Any, Flag
 from ipalib.text import _
 from ipalib import api  # pylint: disable=unused-import
+from ipapython.dn import DN
 from ipapython.dnsutil import DNSName
 
 import datetime
@@ -859,6 +860,28 @@ class help(frontend.Local):
                 writer(_('  ipa <command> --help'))
             writer()
 
+
+class local_env(frontend.Local):
+    """Dump local api.env vars
+    """
+
+    takes_args = ()
+    takes_options = ()
+    has_output = ()
+    topic = None
+
+    def run(self, *args, **options):
+        for key in sorted(self.api.env):
+            value = getattr(api.env, key)
+            if isinstance(value, DN):
+                value = unicode(value)
+            if isinstance(value, (str, unicode)):
+                # shell escape
+                value = value.replace(r'"', r'\"')
+                value = value.replace('$', r'$$')
+            print('{}="{}"'.format(key, value))
+
+
 class show_mappings(frontend.Command):
     """
     Show mapping of LDAP attributes to command-line option.
@@ -1336,6 +1359,7 @@ cli_plugins = (
     console,
     help,
     show_mappings,
+    local_env,
 )
 
 


### PR DESCRIPTION
ipa local-env simply dumps all values from api.env as sorted key="value"
pairs. It's a convenient helper for debugging and to write tests for
e.g. PR #182.

https://fedorahosted.org/freeipa/ticket/6490

Signed-off-by: Christian Heimes <cheimes@redhat.com>