### PR TITLE
Remove references to ds_newinst.pl

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -157,7 +157,6 @@ class BasePathNamespace(object):
     PKCS12EXPORT = "/usr/bin/PKCS12Export"
     CERTUTIL = "/usr/bin/certutil"
     CHROMIUM_BROWSER = "/usr/bin/chromium-browser"
-    DS_NEWINST_PL = "/usr/bin/ds_newinst.pl"
     FIREFOX = "/usr/bin/firefox"
     GETCERT = "/usr/bin/getcert"
     GPG = "/usr/bin/gpg"

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -536,12 +536,12 @@ class DsInstance(service.Service):
         inf_fd = ipautil.write_tmp_file(inf_txt)
         inf_txt = re.sub(r"RootDNPwd=.*\n", "", inf_txt)
         root_logger.debug(inf_txt)
-        if ipautil.file_exists(paths.SETUP_DS_PL):
-            args = [paths.SETUP_DS_PL, "--silent", "--logfile", "-", "-f", inf_fd.name]
-            root_logger.debug("calling setup-ds.pl")
-        else:
-            args = [paths.DS_NEWINST_PL, inf_fd.name]
-            root_logger.debug("calling ds_newinst.pl")
+        args = [
+            paths.SETUP_DS_PL, "--silent",
+            "--logfile", "-",
+            "-f", inf_fd.name,
+        ]
+        root_logger.debug("calling setup-ds.pl")
         try:
             ipautil.run(args)
             root_logger.debug("completed creating ds instance")


### PR DESCRIPTION
ds_newinst.pl was removed from 389 DS over 9 years ago. Remove
references to it.

Fixes: https://fedorahosted.org/freeipa/ticket/6496