### PR TITLE
ipapython and ipatest no longer require lxml

### DIFF
--- a/ipapython/setup.py
+++ b/ipapython/setup.py
@@ -48,7 +48,6 @@ if __name__ == '__main__':
             "ipaplatform",
             # "ipalib",  # circular dependency
             "pyldap",
-            "lxml",
             "netaddr",
             "netifaces",
             "python-nss",

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -67,7 +67,6 @@ if __name__ == '__main__':
             "ipaplatform",
             "ipapython",
             "ipaserver",
-            "lxml",
             "nose",
             "pyldap",
             "pytest",


### PR DESCRIPTION
Commits 64af88fe and 9fbd29cc have removed dependency on lxml.

Signed-off-by: Christian Heimes <cheimes@redhat.com>