### PR TITLE
Add rebuild rule for template files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,13 @@ EXTRA_DIST = .mailmap \
 	     pylintrc \
 	     pytest.ini
 
+# re-run configure after templates have been altered
+CONFIG_STATUS_DEPENDENCIES = \
+	     daemons/ipa-version.h.in \
+	     freeipa.spec.in \
+	     ipapython/version.py.in \
+	     ipasetup.py.in
+
 clean-local:
 	rm -rf "$(RPMBUILD)"
 	rm -rf "$(top_builddir)/dist"


### PR DESCRIPTION
CONFIG_STATUS_DEPENDENCIES ensure that 'make' will re-run configure
after any of the template files (freeipa.spec.in, ipasetup.py.in...)
have been altered.

Signed-off-by: Christian Heimes <cheimes@redhat.com>