### PR TITLE
Adjustments for setup requirements

### DIFF
--- a/ipaclient/setup.py
+++ b/ipaclient/setup.py
@@ -48,13 +48,12 @@ if __name__ == '__main__':
             "ipalib",
             "ipapython",
             "python-nss",
+            "python-yubico",
+            "pyusb",
             "qrcode",
             "six",
         ],
-        setup_requires=[
-            "wheel",
-        ],
-        extra_requires={
+        extras_require={
             "ipaclient.install": ["ipaplatform"],
             "otptoken_yubikey": ["yubico", "usb"]
         }

--- a/ipalib/setup.py
+++ b/ipalib/setup.py
@@ -40,6 +40,7 @@ if __name__ == '__main__':
             "ipapython",
             "netaddr",
             "pyasn1",
+            "pyasn1-modules",
             "python-nss",
             "six",
         ],

--- a/ipaplatform/setup.py
+++ b/ipaplatform/setup.py
@@ -47,7 +47,4 @@ if __name__ == '__main__':
             "python-nss",
             "six",
         ],
-        setup_requires=[
-            "wheel",
-        ],
     )

--- a/ipapython/setup.py
+++ b/ipapython/setup.py
@@ -51,10 +51,8 @@ if __name__ == '__main__':
             "requests",
             "six",
         ],
-        setup_requires=[
-            "wheel",
-        ],
         extras_require={
             ":python_version<'3'": ["enum34"],
+            "install": ["dbus-python"],  # for certmonger
         },
     )

--- a/ipaserver/setup.py
+++ b/ipaserver/setup.py
@@ -56,9 +56,9 @@ if __name__ == '__main__':
             "ipapython",
             "lxml",
             "netaddr",
-            "memcache",
             "pyasn1",
             "pyldap",
+            "python-memcached",
             "python-nss",
             "six",
             # not available on PyPI

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -62,10 +62,10 @@ PACKAGE_VERSION = {
     'ipaserver': 'ipaserver == @VERSION@',
     'kdcproxy': 'kdcproxy >= 0.3',
     'netifaces': 'netifaces >= 0.10.4',
-    'python-nss': 'python-nss >= 0.16',
     'pyldap': 'pyldap >= 2.4.15',
+    'python-nss': 'python-nss >= 0.16',
+    'python-yubico': 'python-yubico >= 1.2.3',
     'qrcode': 'qrcode >= 5.0',
-    # 'yubico': 'yubico >= 1.2.3',
 }
 
 

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -59,24 +59,24 @@ if __name__ == '__main__':
         },
         install_requires=[
             "cryptography",
-            "dbus-python",
             "dnspython",
-            "dogtag-pki",
+            "gssapi",
             "ipaclient",
             "ipalib",
             "ipaplatform",
             "ipapython",
-            "ipaserver",
             "nose",
+            "polib",
             "pyldap",
             "pytest",
-            "python-gssapi",
+            "pytest_multihost",
             "python-nss",
-            "selenium",
             "six",
-            "yaml",
         ],
-        setup_requires=[
-            "wheel",
-        ],
+        extras_require={
+            "integration": ["dbus-python", "pyyaml", "ipaserver"],
+            "ipaserver": ["ipaserver"],
+            "webui": ["selenium", "pyyaml", "ipaserver"],
+            "xmlrpc": ["ipaserver"],
+        }
     )


### PR DESCRIPTION
Fix some typos, missing or surplus dependencies. ipatests is now
installable. Tests need further changes to be runable.

https://fedorahosted.org/freeipa/ticket/6468

Signed-off-by: Christian Heimes <cheimes@redhat.com>