### PR TITLE
Pylint: whitelist packages with extension modules

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -9,6 +9,15 @@ load-plugins=pylint_plugins
 # Use multiple processes to speed up Pylint.
 jobs=0
 
+# A list of packages with safe C extensions to load
+extension-pkg-whitelist=
+    _ldap,
+    cryptography,
+    gssapi,
+    netifaces,
+    nss
+
+
 [MESSAGES CONTROL]
 
 enable=


### PR DESCRIPTION
Pylint refuses to load extension modules from unsafe places. This
triggers import-error failures for pylint runs inside a tox virtualenv.
Any module or package in extension-pkg-whitelist is whitelisted and
pylint imports extension modules.

https://fedorahosted.org/freeipa/ticket/6468

Signed-off-by: Christian Heimes <cheimes@redhat.com>