### PR TITLE
Don't ship install subpackages with wheels

### DIFF
--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -14,8 +14,41 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from distutils import log
 import os
 import sys
+from setuptools.command.build_py import build_py as setuptools_build_py
+
+
+class build_py(setuptools_build_py):
+    """Exclude NAME.install subpackage from wheels
+    """
+    def initialize_options(self):
+        setuptools_build_py.initialize_options(self)
+        self.skip_package = None
+
+    def finalize_options(self):
+        setuptools_build_py.finalize_options(self)
+        if 'bdist_wheel' in self.distribution.commands:
+            distname = self.distribution.metadata.name
+            self.skip_package = '{}.install'.format(distname)
+            log.warn("bdist_wheel: Ignore package: %s",
+                     self.skip_package)
+
+    def build_module(self, module, module_file, package):
+        if isinstance(package, str):
+            package = package.split('.')
+        name = '.'.join(list(package) + [module])
+        if self.skip_package and name.startswith(self.skip_package):
+            # remove file in case it has been copied to build/lib before
+            outfile = self.get_module_outfile(self.build_lib, package, module)
+            try:
+                os.unlink(outfile)
+            except OSError:
+                pass
+        else:
+            return setuptools_build_py.build_module(self, module,
+                                                    module_file, package)
 
 
 PACKAGE_VERSION = {
@@ -89,6 +122,9 @@ def ipasetup(name, doc, **kwargs):
     # exclude setup helpers from getting installed
     epd = setup_kwargs.setdefault('exclude_package_data', {})
     epd.setdefault('', []).extend(['*/setup.py', '*/ipasetup.py'])
+    # exclude NAME.install from wheels
+    cmdclass = setup_kwargs.setdefault('cmdclass', {})
+    cmdclass['build_py'] = build_py
 
     os.chdir(local_path)
     try:


### PR DESCRIPTION
The install subpackages of ipaclient, ipalib and ipapython contain
helper code for installers such as ipa-client-install. They also depend
on external modules that are not available on PyPI, e.g. SSSDConfig.
Since PyPI wheel packages do not support client installation, the
install subpackages contain dead and unsupported code.

The custom build_py plugin removes the subpackages from bdist_wheel
builds. It's not enough to just remove 'ipaclient.install' from the
'packages' list. Surplus files have to be removed from build/lib, too.

https://fedorahosted.org/freeipa/ticket/6468

Signed-off-by: Christian Heimes <cheimes@redhat.com>