### PR TITLE
Break ipaplatform / ipalib import cycle of hell

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2822,7 +2822,7 @@ def _install(options):
         root_logger.info("%s enabled", "SSSD" if options.sssd else "LDAP")
 
         if options.sssd:
-            sssd = services.service('sssd')
+            sssd = services.service('sssd', api)
             try:
                 sssd.restart()
             except CalledProcessError:
@@ -3139,7 +3139,7 @@ def uninstall(options):
 
         root_logger.info(
             "IPA domain removed from current one, restarting SSSD service")
-        sssd = services.service('sssd')
+        sssd = services.service('sssd', api)
         try:
             sssd.restart()
         except CalledProcessError:
@@ -3153,7 +3153,7 @@ def uninstall(options):
             "Other domains than IPA domain found, IPA domain was removed "
             "from /etc/sssd/sssd.conf.")
 
-        sssd = services.service('sssd')
+        sssd = services.service('sssd', api)
         try:
             sssd.restart()
         except CalledProcessError:
@@ -3172,7 +3172,7 @@ def uninstall(options):
             "Redundant SSSD configuration file "
             "/etc/sssd/sssd.conf was moved to /etc/sssd/sssd.conf.deleted")
 
-        sssd = services.service('sssd')
+        sssd = services.service('sssd', api)
         try:
             sssd.stop()
         except CalledProcessError:

--- a/ipaclient/ntpconf.py
+++ b/ipaclient/ntpconf.py
@@ -16,11 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import os
+import shutil
 
+from ipalib import api
 from ipapython import ipautil
 from ipapython.ipa_log_manager import root_logger
-import shutil
-import os
 from ipaplatform.tasks import tasks
 from ipaplatform import services
 from ipaplatform.paths import paths
@@ -189,7 +190,7 @@ def check_timedate_services():
         if service == 'ntpd':
             continue
         # Make sure that the service is not enabled
-        instance = services.service(service)
+        instance = services.service(service, api)
         if instance.is_enabled() or instance.is_running():
             raise NTPConflictingService(conflicting_service=instance.service_name)
 
@@ -201,7 +202,7 @@ def force_ntpd(statestore):
     for service in services.timedate_services:
         if service == 'ntpd':
             continue
-        instance = services.service(service)
+        instance = services.service(service, api)
         enabled = instance.is_enabled()
         running = instance.is_running()
 
@@ -224,7 +225,7 @@ def restore_forced_ntpd(statestore):
         if service == 'ntpd':
             continue
         if statestore.has_state(service):
-            instance = services.service(service)
+            instance = services.service(service, api)
             enabled = statestore.restore_state(instance.service_name, 'enabled')
             running = statestore.restore_state(instance.service_name, 'running')
             if enabled:

--- a/ipaplatform/fedora/services.py
+++ b/ipaplatform/fedora/services.py
@@ -41,17 +41,17 @@ class FedoraService(redhat_services.RedHatService):
 # Function that constructs proper Fedora-specific server classes for services
 # of specified name
 
-def fedora_service_class_factory(name):
+def fedora_service_class_factory(name, api=None):
     if name == 'domainname':
-        return FedoraService(name)
-    return redhat_services.redhat_service_class_factory(name)
+        return FedoraService(name, api)
+    return redhat_services.redhat_service_class_factory(name, api)
 
 
 # Magicdict containing FedoraService instances.
 
 class FedoraServices(redhat_services.RedHatServices):
-    def service_class_factory(self, name):
-        return fedora_service_class_factory(name)
+    def service_class_factory(self, name, api=None):
+        return fedora_service_class_factory(name, api)
 
 
 # Objects below are expected to be exported by platform module

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -44,8 +44,6 @@ from ipapython.ipa_log_manager import root_logger, log_mgr
 from ipapython import ipautil
 import ipapython.errors
 
-from ipalib import x509 # FIXME: do not import from ipalib
-
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipaplatform.redhat.authconfig import RedHatAuthConfig
@@ -214,6 +212,8 @@ class RedHatTaskNamespace(BaseTaskNamespace):
             return True
 
     def insert_ca_certs_into_systemwide_ca_store(self, ca_certs):
+        from ipalib import x509  # FixMe: break import cycle
+
         new_cacert_path = paths.SYSTEMWIDE_IPA_CA_CRT
 
         if os.path.exists(new_cacert_path):

--- a/ipaplatform/rhel/services.py
+++ b/ipaplatform/rhel/services.py
@@ -41,17 +41,17 @@ class RHELService(redhat_services.RedHatService):
 # Function that constructs proper RHEL-specific server classes for services
 # of specified name
 
-def rhel_service_class_factory(name):
+def rhel_service_class_factory(name, api=None):
     if name == 'domainname':
-        return RHELService(name)
-    return redhat_services.redhat_service_class_factory(name)
+        return RHELService(name, api)
+    return redhat_services.redhat_service_class_factory(name, api)
 
 
 # Magicdict containing RHELService instances.
 
 class RHELServices(redhat_services.RedHatServices):
-    def service_class_factory(self, name):
-        return rhel_service_class_factory(name)
+    def service_class_factory(self, name, api=None):
+        return rhel_service_class_factory(name, api)
 
 
 # Objects below are expected to be exported by platform module

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -697,14 +697,14 @@ class ADTRUSTInstance(service.Service):
     def __start(self):
         try:
             self.start()
-            services.service('winbind').start()
+            services.service('winbind', api).start()
         except Exception:
             root_logger.critical("CIFS services failed to start")
 
     def __stop(self):
         self.backup_state("running", self.is_running())
         try:
-            services.service('winbind').stop()
+            services.service('winbind', api).stop()
             self.stop()
         except Exception:
             pass
@@ -856,7 +856,7 @@ class ADTRUSTInstance(service.Service):
         self.restore_state("running")
         self.restore_state("enabled")
 
-        winbind = services.service("winbind")
+        winbind = services.service("winbind", api)
         # Always try to stop and disable smb service, since we do not leave
         # working configuration after uninstall
         try:

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -617,7 +617,7 @@ class BindInstance(service.Service):
         self.forwarders = None
         self.sub_dict = None
         self.reverse_zones = []
-        self.named_regular = services.service('named-regular')
+        self.named_regular = services.service('named-regular', api)
 
     suffix = ipautil.dn_attribute_property('_suffix')
 

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -219,7 +219,7 @@ def install_check(standalone, api, replica, options, hostname):
                 "Only one DNSSEC key master is supported in current version.")
 
         if options.kasp_db_file:
-            dnskeysyncd = services.service('ipa-dnskeysyncd')
+            dnskeysyncd = services.service('ipa-dnskeysyncd', api)
 
             if not dnskeysyncd.is_installed():
                 raise RuntimeError("ipa-dnskeysyncd is not configured on this "

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -463,7 +463,7 @@ class HTTPInstance(service.Service):
         os.chmod(target_fname, 0o644)
 
     def enable_and_start_oddjobd(self):
-        oddjobd = services.service('oddjobd')
+        oddjobd = services.service('oddjobd', api)
         self.sstore.backup_state('oddjobd', 'running', oddjobd.is_running())
         self.sstore.backup_state('oddjobd', 'enabled', oddjobd.is_enabled())
 
@@ -484,7 +484,7 @@ class HTTPInstance(service.Service):
         enabled = self.restore_state("enabled")
 
         # Restore oddjobd to its original state
-        oddjobd = services.service('oddjobd')
+        oddjobd = services.service('oddjobd', api)
 
         if not self.sstore.restore_state('oddjobd', 'running'):
             try:

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -984,7 +984,7 @@ def stopped_service(service, instance_name=""):
                       'the next set of commands is being executed.', service,
                       log_instance_name)
 
-    service_obj = services.service(service)
+    service_obj = services.service(service, api)
 
     # Figure out if the service is running, if not, yield
     if not service_obj.is_running(instance_name):

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -410,7 +410,7 @@ class Restore(admintool.AdminTool):
                 self.log.info('Starting IPA services')
                 run(['ipactl', 'start'])
                 self.log.info('Restarting SSSD')
-                sssd = services.service('sssd')
+                sssd = services.service('sssd', api)
                 sssd.restart()
                 http.remove_httpd_ccache()
         finally:

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -317,7 +317,7 @@ class OpenDNSSECInstance(service.Service):
         except Exception:
             pass
 
-        ods_exporter = services.service('ipa-ods-exporter')
+        ods_exporter = services.service('ipa-ods-exporter', api)
         try:
             ods_exporter.stop()
         except Exception:

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -451,7 +451,7 @@ def promote_sssd(host_name):
         sssdconfig.save_domain(domain)
         sssdconfig.write()
 
-        sssd = services.service('sssd')
+        sssd = services.service('sssd', api)
         try:
             sssd.restart()
         except CalledProcessError:

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1230,21 +1230,21 @@ def uninstall_dogtag_9(ds, http):
         dsdb.untrack_server_cert("Server-Cert")
 
     try:
-        services.service('pki-cad').disable('pki-ca')
+        services.service('pki-cad', api).disable('pki-ca')
     except Exception as e:
         root_logger.warning("Failed to disable pki-cad: %s", e)
     try:
-        services.service('pki-cad').stop('pki-ca')
+        services.service('pki-cad', api).stop('pki-ca')
     except Exception as e:
         root_logger.warning("Failed to stop pki-cad: %s", e)
 
     if serverid is not None:
         try:
-            services.service('dirsrv').disable(serverid)
+            services.service('dirsrv', api).disable(serverid)
         except Exception as e:
             root_logger.warning("Failed to disable dirsrv: %s", e)
         try:
-            services.service('dirsrv').stop(serverid)
+            services.service('dirsrv', api).stop(serverid)
         except Exception as e:
             root_logger.warning("Failed to stop dirsrv: %s", e)
 
@@ -1261,7 +1261,7 @@ def mask_named_regular():
 
     if bindinstance.named_conf_exists():
         root_logger.info('[Masking named]')
-        named = services.service('named-regular')
+        named = services.service('named-regular', api)
         try:
             named.stop()
         except Exception as e:

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -143,7 +143,7 @@ class Service(object):
                  keytab=None):
         self.service_name = service_name
         self.service_desc = service_desc
-        self.service = services.service(service_name)
+        self.service = services.service(service_name, api)
         self.steps = []
         self.output_fd = sys.stdout
 

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -91,7 +91,8 @@ class IPAUpgrade(service.Service):
         self.schema_files = schema_files
 
     def __start(self):
-        services.service(self.service_name).start(self.serverid, ldapi=True)
+        srv = services.service(self.service_name, api)
+        srv.start(self.serverid, ldapi=True)
         api.Backend.ldap2.connect()
 
     def __stop_instance(self):

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -2710,7 +2710,7 @@ class dnszone(DNSZoneBase):
                 options['version'],
                 result,
                 messages.ServiceRestartRequired(
-                    service=services.service('named').systemd_name,
+                    service=services.service('named', api).systemd_name,
                     server=_('<all IPA DNS servers>'), )
                 )
 

--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -262,7 +262,7 @@ class server_mod(LDAPUpdate):
 
         if 'ipalocation_location' or 'ipaserviceweight' in options:
             self.add_message(messages.ServiceRestartRequired(
-                service=services.service('named').systemd_name,
+                service=services.service('named', api).systemd_name,
                 server=keys[0], ))
 
             result = self.api.Command.dns_update_system_records()


### PR DESCRIPTION
Here is an attempt to break the import cycle of hell between ipaplatform
and ipalib. All services now pass an ipalib.api object to
services.service(). RedHatServices.__init__() still needs to do a local
import because it initializes its wellknown service dict with service
instances.

Signed-off-by: Christian Heimes <cheimes@redhat.com>