### PR TITLE
Minor fixes for IPAVersion class

### DIFF
--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -83,19 +83,25 @@ def selinux_enabled():
 class IPAVersion(object):
 
     def __init__(self, version):
-        self.version = version
+        self._version = version
+        self._bytes = version.encode('utf-8')
 
     @property
-    def _bytes(self):
-        return self.version.encode('utf-8')
+    def version(self):
+        return self._version
 
     def __eq__(self, other):
-        assert isinstance(other, IPAVersion)
+        if not isinstance(other, IPAVersion):
+            return NotImplemented
         return _librpm.rpmvercmp(self._bytes, other._bytes) == 0
 
     def __lt__(self, other):
-        assert isinstance(other, IPAVersion)
+        if not isinstance(other, IPAVersion):
+            return NotImplemented
         return _librpm.rpmvercmp(self._bytes, other._bytes) < 0
+
+    def __hash__(self):
+        return hash(self._version)
 
 
 class RedHatTaskNamespace(BaseTaskNamespace):


### PR DESCRIPTION
Py3: classes with __eq__ must provide __hash__ function or set __hash__
to None.
Comparison function like __eq__ must signal unsupported types by
returning NotImplemented. Python turns this in a proper TypeError.
Make the version member read-only and cache _bytes represention.

https://fedorahosted.org/freeipa/ticket/6473

Signed-off-by: Christian Heimes <cheimes@redhat.com>