### PR TITLE
upgrade: do not set HTTP and DS principals explicitly

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1589,7 +1589,6 @@ def upgrade_configuration():
     http = httpinstance.HTTPInstance(fstore)
     http.fqdn = fqdn
     http.realm = api.env.realm
-    http.principal = "HTTP/%s@%s" % (http.fqdn, http.realm)
     http.configure_selinux_for_httpd()
     http.change_mod_nss_port_from_http()
 
@@ -1612,7 +1611,6 @@ def upgrade_configuration():
     ds.fqdn = fqdn
     ds.realm = api.env.realm
     ds.suffix = ipautil.realm_to_suffix(api.env.realm)
-    ds.principal = "ldap/%s@%s" % (ds.fqdn, ds.realm)
 
     ds_enable_sidgen_extdom_plugins(ds)
 


### PR DESCRIPTION
In ipa-server-upgrade, HTTP and DS principals are explicitly constructed from
realm, fqdn, and service prefix. This is no neither required nor desirable,
since the principal is now a read-only property which constructs the principal
name in the same way.

https://fedorahosted.org/freeipa/ticket/6500