### PR TITLE
upgrade: do not explicitly set principal for services

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1589,7 +1589,6 @@ def upgrade_configuration():
     http = httpinstance.HTTPInstance(fstore)
     http.fqdn = fqdn
     http.realm = api.env.realm
-    http.principal = "HTTP/%s@%s" % (http.fqdn, http.realm)
     http.configure_selinux_for_httpd()
     http.change_mod_nss_port_from_http()
 
@@ -1612,7 +1611,6 @@ def upgrade_configuration():
     ds.fqdn = fqdn
     ds.realm = api.env.realm
     ds.suffix = ipautil.realm_to_suffix(api.env.realm)
-    ds.principal = "ldap/%s@%s" % (ds.fqdn, ds.realm)
 
     ds_enable_sidgen_extdom_plugins(ds)
 


### PR DESCRIPTION
After installer refactoring, principal is a property of service.

https://fedorahosted.org/freeipa/ticket/6500