### PR TITLE
Python3 pylint fixes

### DIFF
--- a/client/ipa-client-automount
+++ b/client/ipa-client-automount
@@ -39,7 +39,7 @@ import SSSDConfig
 from six.moves.urllib.parse import urlsplit
 # pylint: enable=import-error
 
-from optparse import OptionParser
+from optparse import OptionParser  # pylint: disable=deprecated-module
 from ipalib import api, errors
 from ipapython import sysrestore
 from ipapython import ipautil

--- a/install/tools/ipa-adtrust-install
+++ b/install/tools/ipa-adtrust-install
@@ -29,7 +29,7 @@ import ldap
 
 import six
 
-from optparse import SUPPRESS_HELP
+from optparse import SUPPRESS_HELP  # pylint: disable=deprecated-module
 
 from ipaserver.install import adtrustinstance
 from ipaserver.install.installutils import (

--- a/install/tools/ipa-compat-manage
+++ b/install/tools/ipa-compat-manage
@@ -24,7 +24,7 @@ from __future__ import print_function
 import sys
 from ipaplatform.paths import paths
 try:
-    from optparse import OptionParser
+    from optparse import OptionParser  # pylint: disable=deprecated-module
     from ipapython import ipautil, config
     from ipaserver.install import installutils
     from ipaserver.install.ldapupdate import LDAPUpdate

--- a/install/tools/ipa-csreplica-manage
+++ b/install/tools/ipa-csreplica-manage
@@ -50,7 +50,7 @@ commands = {
 
 
 def parse_options():
-    from optparse import OptionParser
+    from optparse import OptionParser  # pylint: disable=deprecated-module
 
     parser = OptionParser(version=version.VERSION)
     parser.add_option("-H", "--host", dest="host", help="starting host")

--- a/install/tools/ipa-dns-install
+++ b/install/tools/ipa-dns-install
@@ -24,7 +24,7 @@ from __future__ import print_function
 import os
 import sys
 
-from optparse import SUPPRESS_HELP
+from optparse import SUPPRESS_HELP  # pylint: disable=deprecated-module
 
 from ipaserver.install import bindinstance
 from ipaserver.install import installutils

--- a/install/tools/ipa-managed-entries
+++ b/install/tools/ipa-managed-entries
@@ -22,7 +22,7 @@ from __future__ import print_function
 
 import re
 import sys
-from optparse import OptionParser
+from optparse import OptionParser  # pylint: disable=deprecated-module
 
 from ipapython import config
 from ipaserver.install import installutils

--- a/install/tools/ipa-nis-manage
+++ b/install/tools/ipa-nis-manage
@@ -25,7 +25,7 @@ import sys
 import os
 from ipaplatform.paths import paths
 try:
-    from optparse import OptionParser
+    from optparse import OptionParser  # pylint: disable=deprecated-module
     from ipapython import ipautil, config
     from ipaserver.install import installutils
     from ipaserver.install.ldapupdate import LDAPUpdate

--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -27,7 +27,9 @@ from ipapython import ipautil, certdb
 from ipalib import api, errors, x509
 from ipaserver.install import installutils
 import ipaclient.ipachangeconf
+# pylint: disable=deprecated-module
 from optparse import OptionGroup, OptionValueError
+# pylint: enable=deprecated-module
 from ipapython.ipa_log_manager import root_logger, standard_logging_setup
 import sys
 import os

--- a/ipaclient/ipa_certupdate.py
+++ b/ipaclient/ipa_certupdate.py
@@ -99,7 +99,9 @@ class CertUpdate(admintool.AdminTool):
         if server_fstore.has_files():
             self.update_server(certs)
             try:
+                # pylint: disable=import-error
                 from ipaserver.install import cainstance
+                # pylint: enable=import-error
                 cainstance.add_lightweight_ca_tracking_requests(
                     self.log, lwcas)
             except Exception:

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -27,7 +27,7 @@ import textwrap
 import sys
 import getpass
 import code
-import optparse
+import optparse  # pylint: disable=deprecated-module
 import fcntl
 import termios
 import struct
@@ -41,8 +41,8 @@ if six.PY3:
     unicode = str
 
 if six.PY2:
-    reload(sys)                         # pylint: disable=reload-builtin
-    sys.setdefaultencoding('utf-8')     # pylint: disable=no-member
+    reload(sys)  # pylint: disable=reload-builtin, undefined-variable
+    sys.setdefaultencoding('utf-8')  # pylint: disable=no-member
 
 from ipalib import frontend
 from ipalib import backend

--- a/ipalib/krb_utils.py
+++ b/ipalib/krb_utils.py
@@ -161,7 +161,7 @@ def get_credentials(name=None, ccache_name=None):
         return gssapi.Credentials(usage='initiate', name=name, store=store)
     except gssapi.exceptions.GSSError as e:
         if e.min_code == KRB5_FCC_NOFILE:  # pylint: disable=no-member
-            raise ValueError('"%s", ccache="%s"' % (e.message, ccache_name))
+            raise ValueError('"%s", ccache="%s"' % (e, ccache_name))
         raise
 
 def get_principal(ccache_name=None):

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -29,7 +29,7 @@ import sys
 import threading
 import os
 from os import path
-import optparse
+import optparse  # pylint: disable=deprecated-module
 import textwrap
 import collections
 import importlib

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -623,7 +623,9 @@ class KerbTransport(SSLTransport):
 
             while True:
                 if six.PY2:
+                    # pylint: disable=no-value-for-parameter
                     self.send_request(h, handler, request_body)
+                    # pylint: enable=no-value-for-parameter
                     self.send_host(h, host)
                     self.send_user_agent(h)
                     self.send_content(h, request_body)

--- a/ipalib/text.py
+++ b/ipalib/text.py
@@ -254,7 +254,7 @@ class Gettext(LazyText):
         else:
             t = create_translation(self.key)
         if six.PY2:
-            return t.ugettext(self.msg)
+            return t.ugettext(self.msg)  # pylint: disable=no-member
         else:
             return t.gettext(self.msg)
 
@@ -409,7 +409,9 @@ class NGettext(LazyText):
         else:
             t = create_translation(self.key)
         if six.PY2:
+            # pylint: disable=no-member
             return t.ungettext(self.singular, self.plural, count)
+            # pylint: enable=no-member
         else:
             return t.ngettext(self.singular, self.plural, count)
 

--- a/ipapython/admintool.py
+++ b/ipapython/admintool.py
@@ -25,7 +25,7 @@ Handles common operations like option parsing and logging
 import sys
 import os
 import traceback
-from optparse import OptionGroup
+from optparse import OptionGroup  # pylint: disable=deprecated-module
 
 from ipapython import version
 from ipapython import config

--- a/ipapython/config.py
+++ b/ipapython/config.py
@@ -17,7 +17,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from optparse import Option, Values, OptionParser, IndentedHelpFormatter, OptionValueError
+# pylint: disable=deprecated-module
+from optparse import (
+    Option, Values, OptionParser, IndentedHelpFormatter, OptionValueError)
+# pylint: enable=deprecated-module
 from copy import copy
 
 from dns import resolver, rdatatype

--- a/ipapython/install/cli.py
+++ b/ipapython/install/cli.py
@@ -9,7 +9,7 @@ Command line support.
 import collections
 import enum
 import functools
-import optparse
+import optparse  # pylint: disable=deprecated-module
 import signal
 
 import six

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -27,7 +27,10 @@ import contextlib
 import collections
 import os
 import pwd
-from urlparse import urlparse
+
+# pylint: disable=import-error
+from six.moves.urllib.parse import urlparse
+# pylint: enable=import-error
 
 import ldap
 import ldap.sasl

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -690,7 +690,9 @@ class CIDict(dict):
 
     if six.PY2:
         def has_key(self, key):
+            # pylint: disable=no-member
             return super(CIDict, self).has_key(key.lower())
+            # pylint: enable=no-member
 
     def get(self, key, failobj=None):
         try:

--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -35,13 +35,18 @@ from ipalib.util import normalize_name
 
 import os
 import struct
+import random
+
+# TODO: Remove pylint disable when Python 3 bindings are available.
+# pylint: disable=import-error
 from samba import param
 from samba import credentials
 from samba.dcerpc import security, lsa, drsblobs, nbt, netlogon
 from samba.ndr import ndr_pack, ndr_print
 from samba import net
 import samba
-import random
+# pylint: enable=import-error
+
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
 from cryptography.hazmat.backends import default_backend
 import ldap as _ldap

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -30,6 +30,7 @@ import fcntl
 import time
 import datetime
 
+import six
 from six.moves import configparser
 
 from ipapython.ipa_log_manager import root_logger
@@ -720,7 +721,10 @@ class _CrossProcessLock(object):
 
     def _read(self, fileobj):
         p = configparser.RawConfigParser()
-        p.readfp(fileobj)
+        if six.PY2:
+            p.readfp(fileobj)  # pylint: disable=deprecated-method
+        else:
+            p.read_file(fileobj)  # pylint: disable=no-member
 
         try:
             self._locked = p.getboolean('lock', 'locked')

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -132,7 +132,7 @@ def install_check(standalone, api, replica, options, hostname):
             if options.force or options.allow_zone_overlap:
                 root_logger.warning("%s Please make sure that the domain is "
                                     "properly delegated to this IPA server.",
-                                    e.message)
+                                    e)
             else:
                 raise e
 
@@ -141,7 +141,7 @@ def install_check(standalone, api, replica, options, hostname):
             dnsutil.check_zone_overlap(reverse_zone)
         except ValueError as e:
             if options.force or options.allow_zone_overlap:
-                root_logger.warning(e.message)
+                root_logger.warning(six.text_type(e))
             else:
                 raise e
 

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -20,7 +20,7 @@
 from __future__ import print_function
 
 import os
-from optparse import OptionGroup
+from optparse import OptionGroup  # pylint: disable=deprecated-module
 from cryptography.hazmat.primitives import serialization
 import gssapi
 

--- a/ipaserver/install/ipa_replica_prepare.py
+++ b/ipaserver/install/ipa_replica_prepare.py
@@ -25,7 +25,9 @@ import os
 import shutil
 import tempfile
 import time
+# pylint: disable=deprecated-module
 from optparse import OptionGroup, SUPPRESS_HELP
+# pylint: enable=deprecated-module
 
 import dns.resolver
 # pylint: disable=import-error

--- a/ipaserver/install/ipa_server_certinstall.py
+++ b/ipaserver/install/ipa_server_certinstall.py
@@ -21,7 +21,7 @@
 import os
 import os.path
 import pwd
-import optparse
+import optparse  # pylint: disable=deprecated-module
 
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths

--- a/ipaserver/plugins/aci.py
+++ b/ipaserver/plugins/aci.py
@@ -354,7 +354,7 @@ def _aci_to_kw(ldap, a, test=False, pkey_only=False):
                 try:
                     targetdn = DN(target.replace('ldap:///',''))
                 except ValueError as e:
-                    raise errors.ValidationError(name='subtree', error=_("invalid DN (%s)") % e.message)
+                    raise errors.ValidationError(name='subtree', error=_("invalid DN (%s)") % e)
                 if targetdn.endswith(DN(api.env.container_group, api.env.basedn)):
                     kw['targetgroup'] = targetdn[0]['cn']
                 else:

--- a/ipaserver/plugins/aci.py
+++ b/ipaserver/plugins/aci.py
@@ -354,7 +354,8 @@ def _aci_to_kw(ldap, a, test=False, pkey_only=False):
                 try:
                     targetdn = DN(target.replace('ldap:///',''))
                 except ValueError as e:
-                    raise errors.ValidationError(name='subtree', error=_("invalid DN (%s)") % e)
+                    raise errors.ValidationError(
+                        name='subtree', error=_("invalid DN (%s)") % e)
                 if targetdn.endswith(DN(api.env.container_group, api.env.basedn)):
                     kw['targetgroup'] = targetdn[0]['cn']
                 else:

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -2149,7 +2149,7 @@ class DNSZoneBase_add(LDAPCreate):
             try:
                 check_zone_overlap(keys[-1], raise_on_error=False)
             except ValueError as e:
-                raise errors.InvocationError(e.message)
+                raise errors.InvocationError(six.text_type(e))
 
         return dn
 

--- a/ipatests/i18n.py
+++ b/ipatests/i18n.py
@@ -32,6 +32,8 @@ import traceback
 import polib
 from collections import namedtuple
 
+import six
+
 '''
 We test our translations by taking the original untranslated string
 (e.g. msgid) and prepend a prefix character and then append a suffix
@@ -610,8 +612,14 @@ def test_translations(po_file, lang, domain, locale_dir):
 
     t = gettext.translation(domain, locale_dir)
 
-    get_msgstr = t.ugettext
-    get_msgstr_plural = t.ungettext
+    if six.PY2:
+        # pylint: disable=no-member
+        get_msgstr = t.ugettext
+        get_msgstr_plural = t.ungettext
+        # pylint: enable=no-member
+    else:
+        get_msgstr = t.gettext
+        get_msgstr_plural = t.ngettext
 
     return po_file_iterate(po_file, get_msgstr, get_msgstr_plural)
 

--- a/ipatests/i18n.py
+++ b/ipatests/i18n.py
@@ -23,7 +23,7 @@ from __future__ import print_function
 
 # WARNING: Do not import ipa modules, this is also used as a
 # stand-alone script (invoked from po Makefile).
-import optparse
+import optparse  # pylint: disable=deprecated-module
 import sys
 import gettext
 import re

--- a/ipatests/test_integration/env_config.py
+++ b/ipatests/test_integration/env_config.py
@@ -114,8 +114,8 @@ def config_from_env(env):
         try:
             import yaml
         except ImportError as e:
-            raise ImportError("%s, please install PyYAML package to fix it" %
-                              e.message)
+            raise ImportError(
+                "%s, please install PyYAML package to fix it" % e)
         with open(env['IPATEST_YAML_CONFIG']) as file:
             confdict = yaml.safe_load(file)
             return Config.from_dict(confdict)

--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -1032,7 +1032,8 @@ def install_topo(topo, master, replicas, clients, domain_level=None,
 
 def install_clients(servers, clients):
     """Install IPA clients, distributing them among the given servers"""
-    for server, client in itertools.izip(itertools.cycle(servers), clients):
+    izip = getattr(itertools, 'izip', zip)
+    for server, client in izip(itertools.cycle(servers), clients):
         log.info('Installing client %s on %s' % (server, client))
         install_client(server, client)
 

--- a/ipatests/test_integration/test_idviews.py
+++ b/ipatests/test_integration/test_idviews.py
@@ -68,7 +68,7 @@ class TestCertsInIDOverrides(IntegrationTest):
         # Initialize NSS database
         tasks.run_certutil(master, ["-N", "-f", cls.pwname], cls.reqdir)
         # Now generate self-signed certs for a windows user
-        stdin_text = string.digits+string.letters[2:] + '\n'
+        stdin_text = string.digits+string.ascii_letters[2:] + '\n'
         tasks.run_certutil(master, ['-S', '-s',
                                     "cn=%s,dc=ad,dc=test" % cls.adcert1, '-n',
                                     cls.adcert1, '-x', '-t', 'CT,C,C', '-v',

--- a/ipatests/test_xmlrpc/test_automount_plugin.py
+++ b/ipatests/test_xmlrpc/test_automount_plugin.py
@@ -106,7 +106,7 @@ class AutomountTest(XMLRPC_test):
                     skipped=(),
                     duplicatemaps=(),
                     duplicatekeys=(),
-                )), res)
+                )), res)  # pylint: disable=used-before-assignment
             self.check_tofiles()
         finally:
             res = api.Command['automountlocation_del'](self.locname)['result']

--- a/lite-server.py
+++ b/lite-server.py
@@ -32,7 +32,7 @@ Unfortunately, SSL support is broken under Python 2.6 with paste 1.7.2, see:
 """
 
 from os import path, getcwd
-import optparse
+import optparse  # pylint: disable=deprecated-module
 from paste import httpserver
 import paste.gzipper
 from paste.urlmap import URLMap

--- a/makeapi
+++ b/makeapi
@@ -86,7 +86,7 @@ OUTPUT_IGNORED_ATTRIBUTES = (
 )
 
 def parse_options():
-    from optparse import OptionParser
+    from optparse import OptionParser  # pylint: disable=deprecated-module
 
     parser = OptionParser()
     parser.add_option("--validate", dest="validate", action="store_true",


### PR DESCRIPTION
Sprinkle 'pylint disable' comments over the code base to silence a bunch
of pylint warnings on Python 3. All silenced warnings are harmless and
not bugs.

https://fedorahosted.org/freeipa/ticket/4985

Signed-off-by: Christian Heimes <cheimes@redhat.com>