### PR TITLE
Prevent denial of replication updates during CA replica install

### DIFF
--- a/install/share/ca-topology.uldif
+++ b/install/share/ca-topology.uldif
@@ -12,3 +12,4 @@ default: cn: ca
 
 dn: cn=replica,cn=o\3Dipaca,cn=mapping tree,cn=config
 onlyifexist: nsds5replicabinddngroup: cn=replication managers,cn=sysaccounts,cn=etc,$SUFFIX
+add: nsds5replicabinddngroupcheckinterval: 60

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -457,6 +457,12 @@ class ReplicationManager(object):
             if self.repl_man_group_dn not in binddn_groups:
                 mod.append((ldap.MOD_ADD, 'nsds5replicabinddngroup',
                             self.repl_man_group_dn))
+
+            if 'nsds5replicabinddngroupcheckinterval' not in entry:
+                mod.append(
+                    (ldap.MOD_ADD,
+                     'nsds5replicabinddngroupcheckinterval',
+                     '60'))
             if mod:
                 conn.modify_s(dn, mod)
 


### PR DESCRIPTION
This PR fixes a case when CA replica install against upgraded topology hangs
due to incorrectly configured ipaca replica entry.

https://fedorahosted.org/freeipa/ticket/6508