### PR TITLE
Improve the robustness FreeIPA's i18n module and its tests

### DIFF
--- a/ipatests/i18n.py
+++ b/ipatests/i18n.py
@@ -600,8 +600,11 @@ def test_translations(po_file, lang, domain, locale_dir):
     # use a dummy language not associated with any real language,
     # but the setlocale function demands the locale be a valid
     # known locale, Zambia Xhosa is a reasonable choice :)
+    locale_envs = ('LANGUAGE', 'LC_ALL', 'LC_MESSAGES', 'LANG')
 
-    os.environ['LANG'] = lang
+    os.environ.update(
+        {locale_env: lang for locale_env in locale_envs}
+    )
 
     # Create a gettext translation object specifying our domain as
     # 'ipa' and the locale_dir as 'test_locale' (i.e. where to


### PR DESCRIPTION
Prevent false positive errors reported by `ipatests/i18n.py` and
`ipatests/test_ipalib/test_text.py` when LANGUAGE env variable is set in the
environment.

Additionally, also set LC_ALL and LC_MESSAGES during checks to further improve
the robustness.

https://fedorahosted.org/freeipa/ticket/6512