### PR TITLE
Enhance __repr__ method of Principal

### DIFF
--- a/ipapython/kerberos.py
+++ b/ipapython/kerberos.py
@@ -181,3 +181,7 @@ class Principal(object):
             principal_string = u'@'.join([principal_string, realm])
 
         return principal_string
+
+    def __repr__(self):
+        return "{0.__module__}.{0.__name__}('{1}')".format(
+            self.__class__, self)

--- a/ipatests/test_ipapython/test_kerberos.py
+++ b/ipatests/test_ipapython/test_kerberos.py
@@ -82,6 +82,8 @@ def test_principals(valid_principal):
         assert getattr(princ, name) == value
 
     assert unicode(princ) == principal_name
+    assert repr(princ) == "ipapython.kerberos.Principal('{}')".format(
+        principal_name)
 
 
 def test_multiple_unescaped_ats_raise_error():


### PR DESCRIPTION
`__repr__` now returns more descriptive string containing the actual principal
name while keeping the ability to reconstruct the object from it.

This makes principal names visible in debug logs, easing troubleshooting a
bit.

https://fedorahosted.org/freeipa/ticket/6505