### PR TITLE
Set explicit confdir option for global contexts

### DIFF
--- a/client/ipa-client-automount
+++ b/client/ipa-client-automount
@@ -384,6 +384,7 @@ def main():
 
     cfg = dict(
         context='cli_installer',
+        confdir=paths.ETC_IPA,
         in_server=False,
         debug=options.debug,
         verbose=0,

--- a/daemons/dnssec/ipa-dnskeysync-replica
+++ b/daemons/dnssec/ipa-dnskeysync-replica
@@ -122,7 +122,10 @@ def ldap2replica_zone_keys_sync(log, ldapkeydb, localhsm):
 
 
 # IPA framework initialization
-ipalib.api.bootstrap(in_server=True, log=None)  # no logging to file
+ipalib.api.bootstrap(
+    context='dns', confdir=paths.ETC_IPA,
+    in_server=True, log=None,  # no logging to file
+)
 ipalib.api.finalize()
 standard_logging_setup(verbose=True, debug = True)  # debug=ipalib.api.env.debug)
 log = root_logger

--- a/daemons/dnssec/ipa-dnskeysyncd
+++ b/daemons/dnssec/ipa-dnskeysyncd
@@ -19,7 +19,10 @@ from ipaplatform.paths import paths
 from ipaserver.dnssec.keysyncer import KeySyncer
 
 # IPA framework initialization
-api.bootstrap(in_server=True, log=None)  # no logging to file
+api.bootstrap(
+    context='dns', confdir=paths.ETC_IPA,
+    in_server=True, log=None,  # no logging to file
+)
 api.finalize()
 standard_logging_setup(verbose=True, debug=api.env.debug)
 log = root_logger

--- a/daemons/dnssec/ipa-ods-exporter
+++ b/daemons/dnssec/ipa-ods-exporter
@@ -614,7 +614,10 @@ elif len(sys.argv) == 2:
     log.addHandler(console)
 
 # IPA framework initialization
-ipalib.api.bootstrap(in_server=True, log=None)  # no logging to file
+ipalib.api.bootstrap(
+    context='dns', confdir=paths.ETC_IPA,
+    in_server=True, log=None,  # no logging to file
+)
 ipalib.api.finalize()
 
 # Kerberos initialization

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -494,7 +494,7 @@ def main():
         'ipaCACertRenewal':     renew_ca_cert,
     }
 
-    api.bootstrap(in_server=True, context='renew')
+    api.bootstrap(in_server=True, context='renew', confdir=paths.ETC_IPA)
     api.finalize()
     api.Backend.ldap2.connect()
 

--- a/install/migration/migration.py
+++ b/install/migration/migration.py
@@ -24,6 +24,7 @@ import cgi
 import errno
 from wsgiref.util import request_uri
 
+from ipaplatform.paths import paths
 from ipapython.ipa_log_manager import root_logger
 from ipapython.dn import DN
 from ipapython import ipaldap
@@ -72,7 +73,7 @@ def application(environ, start_response):
 
     # API object only for configuration, finalize() not needed
     api = create_api(mode=None)
-    api.bootstrap(context='server', in_server=True)
+    api.bootstrap(context='server', confdir=paths.ETC_IPA, in_server=True)
     try:
         bind(api.env.ldap_uri, api.env.basedn,
              form_data['username'].value, form_data['password'].value)

--- a/install/oddjob/com.redhat.idm.trust-fetch-domains
+++ b/install/oddjob/com.redhat.idm.trust-fetch-domains
@@ -8,6 +8,7 @@ from ipapython.dn import DN
 from ipalib.config import Env
 from ipalib.constants import DEFAULT_CONFIG
 from ipaplatform.constants import constants
+from ipaplatform.paths import paths
 import sys
 import os
 import pwd
@@ -95,7 +96,8 @@ env._bootstrap(debug=options.debug, log=None)
 env._finalize_core(**dict(DEFAULT_CONFIG))
 
 # Initialize the API with the proper debug level
-api.bootstrap(in_server=True, debug=env.debug, log=None, context='server')
+api.bootstrap(in_server=True, debug=env.debug, log=None,
+              context='server', confdir=paths.ETC_IPA)
 api.finalize()
 
 # Only import trust plugin after api is initialized or internal imports

--- a/install/restart_scripts/renew_ca_cert
+++ b/install/restart_scripts/renew_ca_cert
@@ -40,7 +40,7 @@ from ipaplatform.paths import paths
 def _main():
     nickname = sys.argv[1]
 
-    api.bootstrap(in_server=True, context='restart')
+    api.bootstrap(in_server=True, context='restart', confdir=paths.ETC_IPA)
     api.finalize()
     api.Backend.ldap2.connect()
 

--- a/install/restart_scripts/renew_ra_cert
+++ b/install/restart_scripts/renew_ra_cert
@@ -36,7 +36,7 @@ from ipaplatform.paths import paths
 def _main():
     nickname = 'ipaCert'
 
-    api.bootstrap(in_server=True, context='restart')
+    api.bootstrap(in_server=True, context='restart', confdir=paths.ETC_IPA)
     api.finalize()
     api.Backend.ldap2.connect()
 

--- a/install/restart_scripts/restart_dirsrv
+++ b/install/restart_scripts/restart_dirsrv
@@ -24,6 +24,7 @@ import syslog
 import traceback
 from ipalib import api
 from ipaplatform import services
+from ipaplatform.paths import paths
 from ipaserver.install import certs
 
 
@@ -33,7 +34,7 @@ def _main():
     except IndexError:
         instance = ""
 
-    api.bootstrap(in_server=True, context='restart')
+    api.bootstrap(in_server=True, context='restart', confdir=paths.ETC_IPA)
     api.finalize()
 
     syslog.syslog(syslog.LOG_NOTICE, "certmonger restarted dirsrv instance '%s'" % instance)

--- a/install/restart_scripts/stop_pkicad
+++ b/install/restart_scripts/stop_pkicad
@@ -23,11 +23,12 @@ import syslog
 import traceback
 from ipalib import api
 from ipaplatform import services
+from ipaplatform.paths import paths
 from ipaserver.install import certs
 
 
 def main():
-    api.bootstrap(in_server=True, context='restart')
+    api.bootstrap(in_server=True, context='restart', confdir=paths.ETC_IPA)
     api.finalize()
 
     dogtag_service = services.knownservices['pki_tomcatd']

--- a/install/share/copy-schema-to-ca.py
+++ b/install/share/copy-schema-to-ca.py
@@ -114,7 +114,7 @@ def main():
     standard_logging_setup(verbose=True)
 
     # In 3.0, restarting needs access to api.env
-    api.bootstrap_with_global_options(context='server')
+    api.bootstrap_with_global_options(context='server', confdir=paths.ETC_IPA)
 
     add_ca_schema()
     restart_pki_ds()

--- a/install/share/wsgi.py
+++ b/install/share/wsgi.py
@@ -23,6 +23,7 @@
 """
 WSGI appliction for IPA server.
 """
+from ipaplatform.paths import paths
 from ipalib import api
 from ipalib.config import Env
 from ipalib.constants import DEFAULT_CONFIG
@@ -31,11 +32,12 @@ from ipalib.constants import DEFAULT_CONFIG
 # by reading in the configuration file(s). The server always reads
 # default.conf and will also read in `context'.conf.
 env = Env()
-env._bootstrap(context='server', log=None)
+env._bootstrap(context='server', log=None, confdir=paths.ETC_IPA)
 env._finalize_core(**dict(DEFAULT_CONFIG))
 
 # Initialize the API with the proper debug level
-api.bootstrap(context='server', debug=env.debug, log=None)
+api.bootstrap(context='server', confdir=paths.ETC_IPA,
+              debug=env.debug, log=None)
 try:
     api.finalize()
 except Exception as e:

--- a/install/tools/ipa-adtrust-install
+++ b/install/tools/ipa-adtrust-install
@@ -263,11 +263,12 @@ def main():
         sys.exit("Aborting installation.")
 
     # Initialize the ipalib api
-    cfg = dict(
+    api.bootstrap(
         in_server=True,
         debug=options.debug,
+        context='install',
+        confdir=paths.ETC_IPA
     )
-    api.bootstrap(**cfg)
     api.finalize()
 
     # If domain name and realm does not match, IPA server will not be able

--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -261,7 +261,10 @@ def main():
 
     # override ra_plugin setting read from default.conf so that we have
     # functional dogtag backend plugins during CA install
-    api.bootstrap(in_server=True, ra_plugin='dogtag')
+    api.bootstrap(
+        context='install', confdir=paths.ETC_IPA,
+        in_server=True, ra_plugin='dogtag'
+    )
     api.finalize()
     api.Backend.ldap2.connect()
 

--- a/install/tools/ipa-csreplica-manage
+++ b/install/tools/ipa-csreplica-manage
@@ -408,14 +408,13 @@ def main():
 
     # Just initialize the environment. This is so the installer can have
     # access to the plugin environment
-    api_env = {'in_server' : True,
-               'verbose'   : options.verbose,
-              }
-
+    api_env = {}
     if os.getegid() != 0:
         api_env['log'] = None # turn off logging for non-root
 
-    api.bootstrap(**api_env)
+    api.bootstrap(
+        context='cli', in_server=True, verbose=options.verbose, **api_env
+    )
     api.finalize()
 
     dirman_passwd = None

--- a/install/tools/ipa-dns-install
+++ b/install/tools/ipa-dns-install
@@ -132,11 +132,10 @@ def main():
     installutils.check_server_configuration()
 
     # Initialize the ipalib api
-    cfg = dict(
-        in_server=True,
-        debug=options.debug,
+    api.bootstrap(
+        context='install', confdir=paths.ETC_IPA,
+        in_server=True, debug=options.debug,
     )
-    api.bootstrap(**cfg)
     api.finalize()
     api.Backend.ldap2.connect()
 

--- a/install/tools/ipa-httpd-kdcproxy
+++ b/install/tools/ipa-httpd-kdcproxy
@@ -184,7 +184,8 @@ class KDCProxyConfig(object):
 def main(debug=DEBUG, time_limit=TIME_LIMIT):
     # initialize API without file logging
     if not api.isdone('bootstrap'):
-        api.bootstrap(context='ipa-httpd-kdcproxy', log=None, debug=debug)
+        api.bootstrap(context='server', confdir=paths.ETC_IPA,
+                      log=None, debug=debug)
         standard_logging_setup(verbose=True, debug=debug)
 
     try:

--- a/install/tools/ipa-nis-manage
+++ b/install/tools/ipa-nis-manage
@@ -113,7 +113,9 @@ def main():
     if not dirman_password:
         sys.exit("No password supplied")
 
-    api.bootstrap(context='cli', debug=options.debug, in_server=True)
+    api.bootstrap(
+        context='cli', confdir=paths.ETC_IPA,
+        debug=options.debug, in_server=True)
     api.finalize()
     api.Backend.ldap2.connect(bind_pw=dirman_password)
 

--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -480,7 +480,9 @@ def main():
                     else:
                         nss_dir = None
 
-                    api.bootstrap(context='client', xmlrpc_uri=xmlrpc_uri,
+                    api.bootstrap(context='client',
+                                  confdir=paths.ETC_IPA,
+                                  xmlrpc_uri=xmlrpc_uri,
                                   nss_dir=nss_db.secdir)
                     api.finalize()
                     try:

--- a/install/tools/ipa-replica-manage
+++ b/install/tools/ipa-replica-manage
@@ -1508,7 +1508,10 @@ def main(options, args):
     if os.getegid() != 0:
         api_env['log'] = None # turn off logging for non-root
 
-    api.bootstrap(**api_env)
+    api.bootstrap(
+        context='cli', confdir=paths.ETC_IPA,
+        in_server=True, verbose=options.verbose
+    )
     api.finalize()
 
     dirman_passwd = None

--- a/install/tools/ipactl
+++ b/install/tools/ipactl
@@ -560,7 +560,10 @@ def main():
         else:
             raise e
 
-    api.bootstrap(in_server=True, context='ipactl', debug=options.debug)
+    api.bootstrap(in_server=True,
+                  context='ipactl',
+                  confdir=paths.ETC_IPA,
+                  debug=options.debug)
     api.finalize()
 
     if '.' not in api.env.host:

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2620,6 +2620,7 @@ def _install(options):
 
     with certdb.NSSDatabase() as tmp_db:
         api.bootstrap(context='cli_installer',
+                      confdir=paths.ETC_IPA,
                       debug=options.debug,
                       delegate=False,
                       nss_dir=tmp_db.secdir)

--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -53,7 +53,7 @@ class CertUpdate(admintool.AdminTool):
             raise admintool.ScriptError(
                 "IPA client is not configured on this system.")
 
-        api.bootstrap(context='cli_installer')
+        api.bootstrap(context='cli_installer', confdir=paths.ETC_IPA)
         api.finalize()
 
         server = urlsplit(api.env.jsonrpc_uri).hostname

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -256,7 +256,7 @@ class Backup(admintool.AdminTool):
         options = self.options
         super(Backup, self).run()
 
-        api.bootstrap(in_server=True, context='backup')
+        api.bootstrap(in_server=True, context='backup', confdir=paths.ETC_IPA)
         api.finalize()
 
         self.log.info("Preparing backup on %s", api.env.host)

--- a/ipaserver/install/ipa_ldap_updater.py
+++ b/ipaserver/install/ipa_ldap_updater.py
@@ -89,7 +89,7 @@ class LDAPUpdater(admintool.AdminTool):
     def run(self):
         super(LDAPUpdater, self).run()
 
-        api.bootstrap(in_server=True, context='updates')
+        api.bootstrap(in_server=True, context='updates', confdir=paths.ETC_IPA)
         api.finalize()
 
     def handle_error(self, exception):

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -841,6 +841,7 @@ class Restore(admintool.AdminTool):
         services.knownservices.certmonger.restart()
 
     def init_api(self, **overrides):
+        overrides.setdefault('confdir', paths.ETC_IPA)
         api.bootstrap(in_server=True, context='restore', **overrides)
         api.finalize()
 

--- a/ipaserver/install/ipa_server_upgrade.py
+++ b/ipaserver/install/ipa_server_upgrade.py
@@ -38,7 +38,7 @@ class ServerUpgrade(admintool.AdminTool):
     def run(self):
         super(ServerUpgrade, self).run()
 
-        api.bootstrap(in_server=True, context='updates')
+        api.bootstrap(in_server=True, context='updates', confdir=paths.ETC_IPA)
         api.finalize()
 
         try:

--- a/ipaserver/install/ipa_winsync_migrate.py
+++ b/ipaserver/install/ipa_winsync_migrate.py
@@ -24,6 +24,7 @@ import six
 
 from ipalib import api
 from ipalib import errors
+from ipaplatform.paths import paths
 from ipapython import admintool
 from ipapython.dn import DN
 from ipapython.ipautil import realm_to_suffix, posixify
@@ -346,7 +347,7 @@ class WinsyncMigrate(admintool.AdminTool):
             sys.exit(e)
 
         # Finalize API
-        api.bootstrap(in_server=True, context='server')
+        api.bootstrap(in_server=True, context='server', confdir=paths.ETC_IPA)
         api.finalize()
 
         # Setup LDAP connection

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -308,7 +308,9 @@ class LDAPUpdate(object):
             self.sub_dict["TOTAL_EXCLUDES"] = "(objectclass=*) $ EXCLUDE " + \
                 " ".join(constants.REPL_AGMT_TOTAL_EXCLUDES)
         self.api = create_api(mode=None)
-        self.api.bootstrap(in_server=True, context='updates',
+        self.api.bootstrap(in_server=True,
+                           context='updates',
+                           confdir=paths.ETC_IPA,
                            ldap_uri=self.ldapuri)
         self.api.finalize()
         if online:

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -566,6 +566,7 @@ def install_check(installer):
     # we are sure we have the configuration file ready.
     cfg = dict(
         context='installer',
+        confdir=paths.ETC_IPA,
         in_server=True,
         # make sure host name specified by user is used instead of default
         host=host_name,
@@ -962,6 +963,7 @@ def uninstall_check(installer):
     # we are sure we have the configuration file ready.
     cfg = dict(
         context='installer',
+        confdir=paths.ETC_IPA,
         in_server=True,
     )
 

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -692,7 +692,7 @@ def install_check(installer):
     # Note: We must do this before bootstraping and finalizing ipalib.api
     create_ipa_conf(fstore, config, ca_enabled)
 
-    api.bootstrap(in_server=True, context='installer')
+    api.bootstrap(in_server=True, context='installer', confdir=paths.ETC_IPA)
     api.finalize()
 
     installutils.verify_fqdn(config.master_host_name, options.no_host_dns)
@@ -731,7 +731,9 @@ def install_check(installer):
 
     ldapuri = 'ldaps://%s' % ipautil.format_netloc(config.master_host_name)
     remote_api = create_api(mode=None)
-    remote_api.bootstrap(in_server=True, context='installer',
+    remote_api.bootstrap(in_server=True,
+                         context='installer',
+                         confdir=paths.ETC_IPA,
                          ldap_uri=ldapuri)
     remote_api.finalize()
     conn = remote_api.Backend.ldap2
@@ -954,12 +956,14 @@ def promote_check(installer):
     fstore = sysrestore.FileStore(paths.SYSRESTORE)
 
     env = Env()
-    env._bootstrap(context='installer', log=None)
+    env._bootstrap(context='installer', confdir=paths.ETC_IPA, log=None)
     env._finalize_core(**dict(constants.DEFAULT_CONFIG))
 
     # pylint: disable=no-member
     xmlrpc_uri = 'https://{}/ipa/xml'.format(ipautil.format_netloc(env.host))
-    api.bootstrap(in_server=True, context='installer',
+    api.bootstrap(in_server=True,
+                  context='installer',
+                  confdir=paths.ETC_IPA,
                   ldap_uri=installutils.realm_to_ldapi_uri(env.realm),
                   xmlrpc_uri=xmlrpc_uri)
     # pylint: enable=no-member
@@ -1056,8 +1060,11 @@ def promote_check(installer):
     xmlrpc_uri = 'https://{}/ipa/xml'.format(
         ipautil.format_netloc(config.master_host_name))
     remote_api = create_api(mode=None)
-    remote_api.bootstrap(in_server=True, context='installer',
-                         ldap_uri=ldapuri, xmlrpc_uri=xmlrpc_uri)
+    remote_api.bootstrap(in_server=True,
+                         context='installer',
+                         confdir=paths.ETC_IPA,
+                         ldap_uri=ldapuri,
+                         xmlrpc_uri=xmlrpc_uri)
     remote_api.finalize()
 
     check_remote_version(remote_api)


### PR DESCRIPTION
Some API contexts are used to modify global state (e.g. files in /etc
and /var). These contexts do not support confdir overrides. Initialize
the API with an explicit confdir argument to paths.ETC_IPA.

The special contexts are:

* backup
* cli_installer
* installer
* ipctl
* renew
* restore
* server
* updates

The patch also corrects the context of the ipa-httpd-kdcproxy script to
'server'.

https://fedorahosted.org/freeipa/ticket/6389

Signed-off-by: Christian Heimes <cheimes@redhat.com>