### PR TITLE
Accept server host names resolvable only using /etc/hosts

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -57,7 +57,6 @@ from ipaserver.install import certs, service, sysupgrade
 from ipaplatform import services
 from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks
-from ipapython import dnsutil
 
 if six.PY3:
     unicode = str
@@ -474,9 +473,9 @@ def resolve_ip_addresses_nss(fqdn):
     :returns:
         list of IP addresses as UnsafeIPAddress objects
     """
-    # make sure the name is fully qualified
-    # so search path from resolv.conf does not apply
-    fqdn = str(dnsutil.DNSName(fqdn).make_absolute())
+    # it would be good disable search list processing from resolv.conf
+    # to avoid cases where we get IP address for an totally different name
+    # but there is no way to do this using getaddrinfo parameters
     try:
         addrinfos = socket.getaddrinfo(fqdn, None,
                                        socket.AF_UNSPEC, socket.SOCK_STREAM)


### PR DESCRIPTION
Apparently "files" implementation of hosts NSS database cannot deal with
trailing period in host names.

Previously name server.example.com which is was resolvable neither using
dns nor myhostname NSS modules were rejected by installer
(despite having matching line in /etc/hosts).

These names which are resolvable purely using "files" database are now
accepted.

The problem is that I had to remove trailing period from names passed
to getaddrinfo() function. This effectivelly enables search list processing.
This means that items from the search list might be silently appended to
the query and we might get an IP address for totally different names
than we asked for.

Unfortunatelly I see no way around this while keeping ability
to use names from NSS hosts database.

https://fedorahosted.org/freeipa/ticket/6518