### PR TITLE
ipautil: check for open ports on all resolved IPs

### DIFF
--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -381,8 +381,9 @@ def port_check(host, port_list):
     ports_udp_warning = []  # conncheck could not verify that port is open
     for port in port_list:
         try:
-            port_open = ipautil.host_port_open(host, port.port,
-                    port.port_type, socket_timeout=CONNECT_TIMEOUT)
+            port_open = ipautil.host_port_open(
+                host, port.port, port.port_type,
+                socket_timeout=CONNECT_TIMEOUT, log_errors=True)
         except socket.gaierror:
             raise RuntimeError("Port check failed! Unable to resolve host name '%s'" % host)
         if port_open:


### PR DESCRIPTION
When a hostname is provided to host_port_open, it should check if
ports are open for ALL IPs that are resolved from the hostname, instead
of checking whether the port is reachable on at least one of the IPs.

https://fedorahosted.org/freeipa/ticket/6522