### PR TITLE
Check the result of cert request in replica installer

### DIFF
--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -312,8 +312,9 @@ def request_and_wait_for_cert(
     state = wait_for_request(reqId, timeout=60)
     ca_error = get_request_value(reqId, 'ca-error')
     if state != 'MONITORING' or ca_error:
-        raise RuntimeError("Certificate issuance failed")
+        raise RuntimeError("Certificate issuance failed ({})".format(state))
     return reqId
+
 
 def request_cert(
         nssdb, nickname, subject, principal, passwd_fname=None,

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -647,13 +647,11 @@ class CertDB(object):
     def request_service_cert(self, nickname, principal, host, pwdconf=False):
         if pwdconf:
             self.create_password_conf()
-        reqid = certmonger.request_cert(nssdb=self.secdir,
-                                        nickname=nickname,
-                                        principal=principal,
-                                        subject=host,
-                                        passwd_fname=self.passwd_fname)
-        # Now wait for the cert to appear. Check three times then abort
-        certmonger.wait_for_request(reqid, timeout=60)
+        certmonger.request_and_wait_for_cert(nssdb=self.secdir,
+                                             nickname=nickname,
+                                             principal=principal,
+                                             subject=host,
+                                             passwd_fname=self.passwd_fname)
 
 
 class _CrossProcessLock(object):


### PR DESCRIPTION
When running ipa-replica-install in domain-level 1, the installer
requests the LDAP and HTTP certificates using certmonger but does
not check the return code. The installer goes on and fails when
restarting dirsrv.

Fix: when certmonger was not able to request the certificate, raise an
exception and exit from the installer:

  [28/45]: retrieving DS Certificate
  [error] RuntimeError: Certificate issuance failed
Your system may be partly configured.
Run /usr/sbin/ipa-server-install --uninstall to clean up.

ipa.ipapython.install.cli.install_tool(CompatServerReplicaInstall): ERROR    Certificate issuance failed
ipa.ipapython.install.cli.install_tool(CompatServerReplicaInstall): ERROR    The ipa-replica-install command failed. See /var/log/ipareplica-install.log for more information

https://fedorahosted.org/freeipa/ticket/6514