### PR TITLE
Wheel bundles fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4
 
-IPACLIENT_SUBDIRS = ipaclient ipalib ipaplatform ipapython
-SUBDIRS = asn1 util client contrib daemons init install $(IPACLIENT_SUBDIRS) ipaserver ipatests po
+IPACLIENT_SUBDIRS = ipaclient ipalib ipapython
+SUBDIRS = asn1 util client contrib daemons init install $(IPACLIENT_SUBDIRS) ipaplatform ipaserver ipatests po
 
 MOSTLYCLEANFILES = ipasetup.pyc ipasetup.pyo \
 		   ignore_import_errors.pyc ignore_import_errors.pyo \

--- a/ipaclient/setup.py
+++ b/ipaclient/setup.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
             "six",
         ],
         extras_require={
-            "ipaclient.install": ["ipaplatform"],
+            "install": ["ipaplatform"],
             "otptoken_yubikey": ["yubico", "usb"]
         }
     )

--- a/ipalib/setup.py
+++ b/ipalib/setup.py
@@ -48,6 +48,6 @@ if __name__ == '__main__':
             "wheel",
         ],
         extras_require={
-            "ipalib.install": ["ipaplatform"],
+            "install": ["ipaplatform"],
         },
     )


### PR DESCRIPTION
* make wheel_bundle no longer bundles ipaplatform
* ipaclient and ipalib use a consistent extra tag for the install
  subpackage. `pip install ipalib[ipalib.install]` looks a bit silly.

https://fedorahosted.org/freeipa/ticket/6474

Signed-off-by: Christian Heimes <cheimes@redhat.com>