### PR TITLE
Require python-gssapi >= 1.2.0

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -115,7 +115,7 @@ BuildRequires:  samba-python
 BuildRequires:  python-setuptools
 # 0.6: serialization.load_pem_private_key, load_pem_public_key
 BuildRequires:  python-cryptography >= 0.6
-BuildRequires:  python-gssapi
+BuildRequires:  python-gssapi >= 1.2.0
 BuildRequires:  pylint >= 1.0
 # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1096506
 BuildRequires:  python2-polib
@@ -187,7 +187,7 @@ Requires: mod_wsgi
 Requires: mod_auth_gssapi >= 1.4.0
 Requires: mod_nss >= 1.0.8-26
 Requires: python-ldap >= 2.4.15
-Requires: python-gssapi >= 1.1.2
+Requires: python-gssapi >= 1.2.0
 Requires: acl
 Requires: memcached
 Requires: python-memcached
@@ -250,7 +250,7 @@ Requires: %{name}-common = %{version}-%{release}
 Requires: python2-ipaclient = %{version}-%{release}
 Requires: python-ldap >= 2.4.15
 Requires: python-lxml
-Requires: python-gssapi >= 1.1.2
+Requires: python-gssapi >= 1.2.0
 Requires: python-sssdconfig
 Requires: python-pyasn1
 Requires: dbus-python
@@ -374,7 +374,7 @@ Requires: certmonger >= 0.78
 Requires: nss-tools
 Requires: bind-utils
 Requires: oddjob-mkhomedir
-Requires: python-gssapi >= 1.1.2
+Requires: python-gssapi >= 1.2.0
 Requires: libsss_autofs
 Requires: autofs
 Requires: libnfsidmap
@@ -505,7 +505,7 @@ Provides: python2-ipapython = %{version}-%{release}
 Provides: python2-ipaplatform = %{version}-%{release}
 %{?python_provide:%python_provide python2-ipaplatform}
 Requires: %{name}-common = %{version}-%{release}
-Requires: python-gssapi >= 1.1.2
+Requires: python-gssapi >= 1.2.0
 Requires: gnupg
 Requires: keyutils
 Requires: pyOpenSSL
@@ -554,7 +554,7 @@ Provides: python3-ipapython = %{version}-%{release}
 Provides: python3-ipaplatform = %{version}-%{release}
 %{?python_provide:%python_provide python3-ipaplatform}
 Requires: %{name}-common = %{version}-%{release}
-Requires: python3-gssapi >= 1.1.2
+Requires: python3-gssapi >= 1.2.0
 Requires: gnupg
 Requires: keyutils
 Requires: python3-pyOpenSSL

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -54,7 +54,7 @@ class build_py(setuptools_build_py):
 PACKAGE_VERSION = {
     'cryptography': 'cryptography >= 0.9',
     'dnspython': 'dnspython >= 1.13',
-    'gssapi': 'gssapi > 1.1.2',
+    'gssapi': 'gssapi > 1.2.0',
     'ipaclient': 'ipaclient == @VERSION@',
     'ipalib': 'ipalib == @VERSION@',
     'ipaplatform': 'ipaplatform == @VERSION@',


### PR DESCRIPTION
The PyPI package for python-gssapi 1.1.x has a packaging bug. It depends on
enum34 for Python 3 although it is only required for 2.7. 1.2.0 is the
oldest version that has been tested at length by QE. It's know to work.

Bump up in freeipa.spec is not required for technical reasons. The
packaging bug only affects PyPI packages. It's policy to keep
requirements in sync.

https://fedorahosted.org/freeipa/ticket/6468

Signed-off-by: Christian Heimes <cheimes@redhat.com>