### PR TITLE
Require python-cryptography >= 1.3.1

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -113,8 +113,8 @@ BuildRequires:  python-cffi
 %if 0%{?with_lint}
 BuildRequires:  samba-python
 BuildRequires:  python-setuptools
-# 0.6: serialization.load_pem_private_key, load_pem_public_key
-BuildRequires:  python-cryptography >= 0.6
+# 1.3: oldest PyPI version that still compiles with recent OpenSSL
+BuildRequires:  python-cryptography >= 1.3.1
 BuildRequires:  python-gssapi >= 1.2.0
 BuildRequires:  pylint >= 1.0
 # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1096506
@@ -510,7 +510,7 @@ Requires: gnupg
 Requires: keyutils
 Requires: pyOpenSSL
 Requires: python-nss >= 0.16
-Requires: python-cryptography >= 0.9
+Requires: python-cryptography >= 1.3.1
 Requires: python-netaddr
 Requires: python-libipa_hbac
 Requires: python-qrcode-core >= 5.0.0
@@ -559,7 +559,7 @@ Requires: gnupg
 Requires: keyutils
 Requires: python3-pyOpenSSL
 Requires: python3-nss >= 0.16
-Requires: python3-cryptography
+Requires: python3-cryptography >= 1.3.1
 Requires: python3-netaddr
 Requires: python3-libipa_hbac
 Requires: python3-qrcode-core >= 5.0.0
@@ -633,7 +633,7 @@ Requires: python-pytest-multihost >= 0.5
 Requires: python-pytest-sourceorder
 Requires: ldns-utils
 Requires: python-sssdconfig
-Requires: python2-cryptography
+Requires: python2-cryptography >= 1.3.1
 
 Provides: %{alt_name}-tests = %{version}
 Conflicts: %{alt_name}-tests
@@ -667,7 +667,7 @@ Requires: python3-pytest-multihost >= 0.5
 Requires: python3-pytest-sourceorder
 Requires: ldns-utils
 Requires: python3-sssdconfig
-Requires: python3-cryptography
+Requires: python3-cryptography >= 1.3.1
 
 %description -n python3-ipatests
 IPA is an integrated solution to provide centrally managed Identity (users,

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -52,7 +52,7 @@ class build_py(setuptools_build_py):
 
 
 PACKAGE_VERSION = {
-    'cryptography': 'cryptography >= 0.9',
+    'cryptography': 'cryptography >= 1.3.1',
     'dnspython': 'dnspython >= 1.13',
     'gssapi': 'gssapi > 1.2.0',
     'ipaclient': 'ipaclient == @VERSION@',


### PR DESCRIPTION
python-cryptography versions < 1.3 no longer compile with recent OpenSSL
1.0.2 versions. In order to build wheels, a more recent version of
cryptography is required. 1.3.1 is the oldest well tested version (RHEL
7.3) that is known to work with FreeIPA.

Bump up in freeipa.spec is not required for technical reasons. The
problem only affects PyPI packages. It's policy to keep
requirements in sync.

https://fedorahosted.org/freeipa/ticket/6468

Signed-off-by: Christian Heimes <cheimes@redhat.com>