### PR TITLE
replica install: track the RA agent certificate again

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -647,7 +647,7 @@ class CAInstance(DogtagInstance):
                                    'NSS_ENABLE_PKIX_VERIFY', '1',
                                    quotes=False, separator='=')
 
-    def import_ra_cert(self, rafile, configure_renewal=True):
+    def import_ra_cert(self, rafile):
         """
         Cloned RAs will use the same RA agent cert as the master so we
         need to import from a PKCS#12 file.
@@ -663,10 +663,14 @@ class CAInstance(DogtagInstance):
         finally:
             os.remove(agent_name)
 
+        self.configure_agent_renewal()
+
     def __import_ra_key(self):
         custodia = custodiainstance.CustodiaInstance(host_name=self.fqdn,
                                                      realm=self.realm)
         custodia.import_ra_key(self.master_host)
+
+        self.configure_agent_renewal()
 
     def __create_ca_agent(self):
         """


### PR DESCRIPTION
During the rebase of commit 822e1bc82af3a6c1556546c4fbe96eeafad45762 on top
of commit 808b1436b4158cb6f926ac2b5bd0979df6ea7e9f, the call to track the
RA agent certificate with certmonger was accidentally removed from
ipa-replica-install.

Put the call back so that the certificate is tracked after replica install.

https://fedorahosted.org/freeipa/ticket/6392