### PR TITLE
Run out-of-tree tests in Travis CI

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -1,0 +1,50 @@
+container:
+  detach: true
+  hostname: master.ipa.test
+  working_dir: /freeipa
+host:
+  binds:
+  - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - /dev/urandom:/dev/random:ro
+  privileged: true
+  security_opt:
+  - label:disable
+  tmpfs:
+  - /tmp
+  - /run
+server:
+  domain: ipa.test
+  password: Secret123
+  realm: IPA.TEST
+steps:
+  build:
+  - make V=0 ${make_target}
+  builddep:
+  - rm -rf /var/cache/dnf/*
+  - "dnf makecache fast || :"
+  - dnf builddep -y ${builddep_opts} --spec freeipa.spec.in --best --allowerasing
+  cleanup:
+  - chown -R ${uid}:${gid} ${container_working_dir}
+  configure:
+  - ./autogen.sh
+  install_packages:
+  - dnf install -y ${container_working_dir}/dist/rpms/*.rpm --best --allowerasing
+  install_server:
+  - ipa-server-install -U --domain ${server_domain} --realm ${server_realm} -p ${server_password}
+    -a ${server_password} --setup-dns --auto-forwarders
+  - ipa-kra-install -p ${server_password}
+  lint:
+  - make V=0 lint
+  prepare_tests:
+  - echo ${server_password} | kinit admin && ipa ping
+  - cp -r /etc/ipa/* ~/.ipa/
+  - echo ${server_password} > ~/.ipa/.dmpw
+  - echo 'wait_for_dns=5' >> ~/.ipa/default.conf
+  run_tests:
+  - ipa-run-tests ${tests_ignore} -k-test_dns_soa ${tests_verbose} ${path}
+tests:
+  ignore:
+  - test_integration
+  - test_webui
+  - test_ipapython/test_keyring.py
+  verbose: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,44 @@
 services:
     - docker
 
+env:
+    global:
+        - TEST_RUNNER_IMAGE="martbab/freeipa-fedora-test-runner:master-latest"
+    matrix:
+        - TESTS_TO_RUN="test_xmlrpc/test_[a-k]*.py"
+        - >
+            TESTS_TO_RUN="test_cmdline
+            test_install
+            test_ipalib
+            test_ipapython
+            test_ipaserver
+            test_pkcs10
+            test_xmlrpc/test_[l-z]*.py"
 before_install:
     - pip install pep8
+    - >
+      pip3 install
+      git+https://github.com/freeipa/ipa-docker-test-runner@release-0-2-0
 
 script:
     - >
         if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]];
         then
-            git diff origin/${TRAVIS_BRANCH} -U0 | pep8 --diff;
+            git diff origin/${TRAVIS_BRANCH} -U0 | pep8 --diff &> pep8_errors.log;
         fi
+    - "pushd ipatests; test_set=`ls -d -1 $TESTS_TO_RUN 2> /dev/null`; popd"
+    # use travis_wait so that long running tasks (tests) which produce no
+    # output do not cause premature termination of the build
+    - "docker pull ${TEST_RUNNER_IMAGE}"
     - >
-        docker run -v $PWD:/freeipa -w /freeipa
-        martbab/freeipa-fedora-builder:${TRAVIS_BRANCH}-latest
-        /bin/bash -c 'dnf builddep -y -D "with_lint 1" --spec freeipa.spec.in && autoreconf -i && ./configure && make lint && make rpms'
+        travis_wait 50
+        ipa-docker-test-runner -l ci_results_${TRAVIS_BRANCH}.log
+        -c .test_runner_config.yaml
+        --container-image ${TEST_RUNNER_IMAGE}
+        --git-repo ${TRAVIS_BUILD_DIR}
+        run-tests $test_set
+after_failure:
+  - echo "Test runner output:"
+  - tail -n 5000 ci_results_${TRAVIS_BRANCH}.log
+  - echo "PEP-8 errors:"
+  - cat pep8_errors.log


### PR DESCRIPTION
This PR implements out-of-tree tests in Travis CI using
https://github.com/martbab/ipa-docker-test-runner

There is couple of issues with this PR we may discuss:

* Currently ipa-docker-test-runner is pulled and installed directly from git
  master branch.
  It will probably be better if I release some stable version to PyPI so that
  changes in master do not break CI. This would also allow us to cache the
  package and its dependencies between builds, saving some time

* We have currently two concurrent jobs that run most tests split evenly
  between them. This cuts the time from 42 or so minutes to around half an
  hour. Any ideas to further speed the tests are welcome.

* DNS tests are flaky in Travis CI. Some of them are ignored because they tend
  to fail non-deterministically. I will try to determin the root causes and
  work around them.