### PR TITLE
Issue6474 fixups

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -24,13 +24,11 @@ This base platform module exports default filesystem paths.
 
 class BasePathNamespace(object):
     BASH = "/bin/bash"
-    BIN_FALSE = "/bin/false"
     BIN_HOSTNAMECTL = "/bin/hostnamectl"
     LS = "/bin/ls"
     SH = "/bin/sh"
     SYSTEMCTL = "/bin/systemctl"
     TAR = "/bin/tar"
-    BIN_TRUE = "/bin/true"
     AUTOFS_LDAP_AUTH_CONF = "/etc/autofs_ldap_auth.conf"
     ETC_DIRSRV = "/etc/dirsrv"
     DS_KEYTAB = "/etc/dirsrv/ds.keytab"

--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -32,14 +32,16 @@ from ipapython import ipautil
 from ipalib import x509
 
 try:
-    from ipaplatform.paths import paths
-    CERTUTIL = paths.CERTUTIL
-    PK12UTIL = paths.PK12UTIL
-    OPENSSL = paths.OPENSSL
+    from ipaplatform.paths import paths  # pylint: disable=import-error
 except ImportError:
     CERTUTIL = '/usr/bin/certutil'
     PK12UTIL = '/usr/bin/pk12util'
     OPENSSL = '/usr/bin/openssl'
+else:
+    CERTUTIL = paths.CERTUTIL
+    PK12UTIL = paths.PK12UTIL
+    OPENSSL = paths.OPENSSL
+
 
 CA_NICKNAME_FMT = "%s IPA CA"
 

--- a/ipatests/test_ipalib/test_config.py
+++ b/ipatests/test_ipalib/test_config.py
@@ -30,7 +30,6 @@ from ipatests.util import TempDir, TempHome
 from ipalib.constants import OVERRIDE_ERROR, SET_ERROR, DEL_ERROR
 from ipalib.constants import NAME_REGEX, NAME_ERROR
 from ipalib import config, constants, base
-from ipaplatform.paths import paths
 
 import pytest
 
@@ -450,8 +449,8 @@ class test_Env(ClassChecker):
         assert o.dot_ipa == home.join('.ipa')
         assert o.in_tree is False
         assert o.context == 'default'
-        assert o.confdir == paths.ETC_IPA
-        assert o.conf == paths.IPA_DEFAULT_CONF
+        assert o.confdir == '/etc/ipa'
+        assert o.conf == '/etc/ipa/default.conf'
         assert o.conf_default == o.conf
 
         # Test overriding values created by _bootstrap()
@@ -463,11 +462,11 @@ class test_Env(ClassChecker):
         assert o.in_tree is False
         assert o.context == 'default'
         assert o.conf == '/my/wacky/whatever.conf'
-        assert o.conf_default == paths.IPA_DEFAULT_CONF
+        assert o.conf_default == '/etc/ipa/default.conf'
         (o, home) = self.bootstrap(conf_default='/my/wacky/default.conf')
         assert o.in_tree is False
         assert o.context == 'default'
-        assert o.conf == paths.IPA_DEFAULT_CONF
+        assert o.conf == '/etc/ipa/default.conf'
         assert o.conf_default == '/my/wacky/default.conf'
 
         # Test various overrides and types conversion

--- a/ipatests/test_ipalib/test_errors.py
+++ b/ipatests/test_ipalib/test_errors.py
@@ -32,7 +32,6 @@ import six
 
 from ipatests.util import assert_equal, raises
 from ipalib import errors
-from ipaplatform.paths import paths
 from ipalib.constants import TYPE_ERROR
 
 if six.PY3:
@@ -115,10 +114,11 @@ class test_SubprocessError(PrivateExceptionTester):
         """
         Test the `ipalib.errors.SubprocessError.__init__` method.
         """
-        inst = self.new(returncode=1, argv=(paths.BIN_FALSE,))
+        bin_false = '/bin/false'
+        inst = self.new(returncode=1, argv=(bin_false,))
         assert inst.returncode == 1
-        assert inst.argv == (paths.BIN_FALSE,)
-        assert str(inst) == "return code 1 from ('/bin/false',)"
+        assert inst.argv == (bin_false,)
+        assert str(inst) == "return code 1 from ('{}',)".format(bin_false)
         assert inst.message == str(inst)
 
 


### PR DESCRIPTION
Three small fixes that slipped through the review of #271.

* ipatests for ipalib and ipapython no longer depend on ipaplatform
* pylint fix for ipapython.certdb for client-only installations