### PR TITLE
Require python-gssapi >= 1.2.0, take 2

### DIFF
--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -65,7 +65,7 @@ if SETUPTOOLS_VERSION < (8, 0, 0):
 PACKAGE_VERSION = {
     'cryptography': 'cryptography >= 1.3.1',
     'dnspython': 'dnspython >= 1.13',
-    'gssapi': 'gssapi > 1.2.0',
+    'gssapi': 'gssapi >= 1.2.0',
     'ipaclient': 'ipaclient == {}'.format(VERSION),
     'ipalib': 'ipalib == {}'.format(VERSION),
     'ipaplatform': 'ipaplatform == {}'.format(VERSION),


### PR DESCRIPTION
Fix version range typo in ipasetup.py.in.

Sorry, the bug slipped through my internal tests. The version pinning is
only relevant for make wheel_bundle. The wheel bundle target has been
failing from the start because python-nss has a build bug for wheels,
https://bugzilla.redhat.com/show_bug.cgi?id=1389739

https://fedorahosted.org/freeipa/ticket/6468

Signed-off-by: Christian Heimes <cheimes@redhat.com>