### PR TITLE
ipaldap: handle binary encoding option transparently

### DIFF
--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -632,6 +632,22 @@ class LDAPClient(object):
     SCOPE_ONELEVEL = ldap.SCOPE_ONELEVEL
     SCOPE_SUBTREE = ldap.SCOPE_SUBTREE
 
+    _ENCODING_OPTION_BINARY = 'binary'
+
+    # although per RFC 4523 it is the /syntax/ that defines whether
+    # ;binary is required, 389DS punted on implementing the RFC 4523
+    # syntaxes, and uses 1.3.6.1.4.1.1466.115.121.1.40 Octet String
+    # instead.  So we must map by attribute name.
+    _ENCODING_OPTIONS = CIDict({
+        'userCertificate':              _ENCODING_OPTION_BINARY,
+        'cACertificate':                _ENCODING_OPTION_BINARY,
+        'crossCertificatePair':         _ENCODING_OPTION_BINARY,
+        'certificateRevocationList':    _ENCODING_OPTION_BINARY,
+        'authorityRevocationList':      _ENCODING_OPTION_BINARY,
+        'deltaRevocationList':          _ENCODING_OPTION_BINARY,
+        'supportedAlgorithms':          _ENCODING_OPTION_BINARY,
+    })
+
     _SYNTAX_MAPPING = {
         '1.3.6.1.4.1.1466.115.121.1.1'   : bytes, # ACI item
         '1.3.6.1.4.1.1466.115.121.1.4'   : bytes, # Audio
@@ -756,8 +772,14 @@ class LDAPClient(object):
         # FIXME: for backwards compatibility only
         assert isinstance(dn, DN)
         dn = str(dn)
-        modlist = [(a, self.encode(b), self.encode(c)) for a, b, c in modlist]
-        return self.conn.modify_s(dn, modlist)
+        modlist_encoded = []
+        for modtype, attr, vals in modlist:
+            modlist_encoded.append((
+                modtype,
+                self.add_encoding_options(self.encode(attr)),
+                self.encode(vals)
+            ))
+        return self.conn.modify_s(dn, modlist_encoded)
 
     @property
     def conn(self):
@@ -831,6 +853,23 @@ class LDAPClient(object):
 
         return unicode
 
+    def add_encoding_options(self, name_or_oid):
+        """Add required encoding options, if any."""
+        option = self._ENCODING_OPTIONS.get(name_or_oid)
+        if option is not None:
+            name_or_oid = b';'.join([name_or_oid, option])
+        return name_or_oid
+
+    def strip_encoding_options(self, name):
+        """Remove non-subtyping encoding options from attribute description."""
+        parts = name.split(';')
+        parts[1:] = [
+            option for option in parts[1:]
+            if option != self._ENCODING_OPTIONS.get(parts[0])
+        ]
+        name = ';'.join(parts)
+        return name
+
     def has_dn_syntax(self, name_or_oid):
         """
         Check the schema to see if the attribute uses DN syntax.
@@ -886,7 +925,10 @@ class LDAPClient(object):
         elif isinstance(val, tuple):
             return tuple(self.encode(m) for m in val)
         elif isinstance(val, dict):
-            dct = dict((self.encode(k), self.encode(v)) for k, v in val.items())
+            dct = dict(
+                (self.add_encoding_options(self.encode(k)), self.encode(v))
+                for k, v in val.items()
+            )
             return dct
         elif isinstance(val, datetime.datetime):
             return val.strftime(LDAP_GENERALIZED_TIME_FORMAT)
@@ -956,6 +998,7 @@ class LDAPClient(object):
             ipa_entry = LDAPEntry(self, DN(original_dn))
 
             for attr, original_values in original_attrs.items():
+                attr = self.strip_encoding_options(attr)
                 ipa_entry.raw[attr] = original_values
             ipa_entry.reset_modlist()
 
@@ -1559,9 +1602,7 @@ class LDAPClient(object):
 
         # pass arguments to python-ldap
         with self.error_handler():
-            modlist = [(a, str(b), self.encode(c))
-                       for a, b, c in modlist]
-            self.conn.modify_s(str(entry.dn), modlist)
+            self.modify_s(entry.dn, modlist)
 
         entry.reset_modlist()
 

--- a/ipaserver/install/plugins/upload_cacrt.py
+++ b/ipaserver/install/plugins/upload_cacrt.py
@@ -89,11 +89,11 @@ class update_upload_cacrt(Updater):
                 entry = ldap.make_entry(dn)
                 entry['objectclass'] = ['nsContainer', 'pkiCA']
                 entry.single_value['cn'] = 'CAcert'
-                entry.single_value['cACertificate;binary'] = ca_cert
+                entry.single_value['cACertificate'] = ca_cert
                 ldap.add_entry(entry)
             else:
-                if b'' in entry['cACertificate;binary']:
-                    entry.single_value['cACertificate;binary'] = ca_cert
+                if b'' in entry['cACertificate']:
+                    entry.single_value['cACertificate'] = ca_cert
                     ldap.update_entry(entry)
 
         return False, []

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1310,24 +1310,23 @@ class cert_find(Search, CertMethod):
             truncated = bool(truncated)
 
         for entry in entries:
-            for attr in ('usercertificate', 'usercertificate;binary'):
-                for cert in entry.get(attr, []):
-                    try:
-                        key = self._get_cert_key(cert)
-                    except ValueError:
-                        truncated = True
-                        continue
+            for cert in entry.get('usercertificate', []):
+                try:
+                    key = self._get_cert_key(cert)
+                except ValueError:
+                    truncated = True
+                    continue
 
-                    try:
-                        obj = result[key]
-                    except KeyError:
-                        obj = self._get_cert_obj(cert, all, raw, pkey_only)
-                        result[key] = obj
+                try:
+                    obj = result[key]
+                except KeyError:
+                    obj = self._get_cert_obj(cert, all, raw, pkey_only)
+                    result[key] = obj
 
-                    if not pkey_only and (all or not no_members):
-                        owners = obj.setdefault('owner', [])
-                        if entry.dn not in owners:
-                            owners.append(entry.dn)
+                if not pkey_only and (all or not no_members):
+                    owners = obj.setdefault('owner', [])
+                    if entry.dn not in owners:
+                        owners.append(entry.dn)
 
         if not raw:
             for obj in six.itervalues(result):

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -1163,42 +1163,12 @@ class user_add_cert(LDAPAddAttributeViaOption):
     msg_summary = _('Added certificates to user "%(value)s"')
     attribute = 'usercertificate'
 
-    def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys,
-                     **options):
-        dn = self.obj.get_either_dn(*keys, **options)
-
-        self.obj.convert_usercertificate_pre(entry_attrs)
-
-        return dn
-
-    def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
-        assert isinstance(dn, DN)
-
-        self.obj.convert_usercertificate_post(entry_attrs, **options)
-
-        return dn
-
 
 @register()
 class user_remove_cert(LDAPRemoveAttributeViaOption):
     __doc__ = _('Remove one or more certificates to the user entry')
     msg_summary = _('Removed certificates from user "%(value)s"')
     attribute = 'usercertificate'
-
-    def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys,
-                     **options):
-        dn = self.obj.get_either_dn(*keys, **options)
-
-        self.obj.convert_usercertificate_pre(entry_attrs)
-
-        return dn
-
-    def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
-        assert isinstance(dn, DN)
-
-        self.obj.convert_usercertificate_post(entry_attrs, **options)
-
-        return dn
 
 
 @register()

--- a/ipatests/test_xmlrpc/tracker/user_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/user_plugin.py
@@ -27,7 +27,7 @@ class UserTracker(KerberosAliasMixin, Tracker):
         u'telephonenumber', u'title', u'memberof', u'nsaccountlock',
         u'memberofindirect', u'ipauserauthtype', u'userclass',
         u'ipatokenradiusconfiglink', u'ipatokenradiususername',
-        u'krbprincipalexpiration', u'usercertificate;binary',
+        u'krbprincipalexpiration', u'usercertificate',
         u'has_keytab', u'has_password', u'memberof_group', u'sshpubkeyfp',
         u'krbcanonicalname', 'krbprincipalname'
     }


### PR DESCRIPTION
This patchset addresses
  https://fedorahosted.org/freeipa/ticket/6529.  I'm publishing it for
  discussion and review but it should not be hastily merged because
  there are compatibility implications for older server versions
  (discussed in https://fedorahosted.org/freeipa/ticket/6530).

Per RFC 4523, particular attribute syntaxes require use of the
';binary' attribute option.  Attributes using these syntaxes include
'userCertificate' and 'cACertificate'.  Our handling of this requirement is
inconsistent with no library support (i.e. it was up to individual plugin
authors to "do the right thing".

Also, because 389 DS currently does not always use this encoding option
(which is a defect), whether you need to read the
'userCertificate' or 'userCertificate;binary' attribute - or both - is
often unclear.  But technically, these both refer to the same attribute,
because the 'binary' option does not specify an attribute subtype.

This commit implements proper handling of the binary encoding option within
ipaldap.  Plugin code should now always use an attribute description
*without* the binary encoding option, and allow ipaldap to automatically
add it when sending attribute to the server, and strip it when reading
attributes in search results.