### PR TITLE
Remove "Request Certificate with SubjectAltName" permission

### DIFF
--- a/install/updates/40-delegation.update
+++ b/install/updates/40-delegation.update
@@ -133,21 +133,6 @@ default:objectClass: top
 default:objectClass: nsContainer
 default:cn: certificate remove hold
 
-dn: cn=request certificate with subjectaltname,cn=virtual operations,cn=etc,$SUFFIX
-default:objectClass: top
-default:objectClass: nsContainer
-default:cn: request certificate with subjectaltname
-
-dn: cn=Request Certificate with SubjectAltName,cn=permissions,cn=pbac,$SUFFIX
-default:objectClass: top
-default:objectClass: groupofnames
-default:objectClass: ipapermission
-default:cn: Request Certificate with SubjectAltName
-default:member: cn=Certificate Administrators,cn=privileges,cn=pbac,$SUFFIX
-
-dn: $SUFFIX
-add:aci:(targetattr = "objectclass")(target = "ldap:///cn=request certificate with subjectaltname,cn=virtual operations,cn=etc,$SUFFIX" )(version 3.0; acl "permission:Request Certificate with SubjectAltName"; allow (write) groupdn = "ldap:///cn=Request Certificate with SubjectAltName,cn=permissions,cn=pbac,$SUFFIX";)
-
 dn: cn=request certificate ignore caacl,cn=virtual operations,cn=etc,$SUFFIX
 default:objectClass: top
 default:objectClass: nsContainer

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -620,12 +620,6 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
         except cryptography.x509.extensions.ExtensionNotFound:
             ext_san = None
 
-        # self-service and host principals may bypass SAN permission check
-        if (bind_principal_string != principal_string
-                and bind_principal_type != HOST):
-            if ext_san is not None:
-                self.check_access('request certificate with subjectaltname')
-
         dn = None
         principal_obj = None
         # See if the service exists and punt if it doesn't and we aren't

--- a/ipatests/test_xmlrpc/test_permission_plugin.py
+++ b/ipatests/test_xmlrpc/test_permission_plugin.py
@@ -3125,7 +3125,7 @@ def check_legacy_results(results):
     legacy_permissions = [p for p in results
                           if not p.get('ipapermissiontype')]
     print(legacy_permissions)
-    assert len(legacy_permissions) == 9, len(legacy_permissions)
+    assert len(legacy_permissions) == 8, len(legacy_permissions)
     return True
 
 


### PR DESCRIPTION
Fixes: https://fedorahosted.org/freeipa/ticket/6526

*Note: the ticket hasn't been triaged or even agreed to.  But here is the code
^_^*

subjectAltName is required or relevant in most certificate use cases
(esp. TLS, where carrying DNS name in Subject DN CN attribute is
deprecated).  Therefore it does not really make sense to have a
special permission for this, over and above "request certificate"
permission.

Furthermore, we already do rigorously validate SAN contents again
the subject principal, and the permission is waived for self-service
requests or if the operator is a host principal.

So remove the permission, the associated virtual operation, and the
associated code in cert_request.