### PR TITLE
WebUI: Add support for custom table pagination size

### DIFF
--- a/install/ui/src/freeipa/config.js
+++ b/install/ui/src/freeipa/config.js
@@ -20,14 +20,18 @@
 
 
 
-define([], function() {
+define([
+    'dojo/_base/declare',
+    'dojo/topic'
+    ],
+    function(declare, topic) {
 
     /**
      * Application configuration
      * @class config
      * @singleton
      */
-    var config = {
+    var config = declare([], {
 
         /**
          * Selector for application container node
@@ -82,8 +86,43 @@ define([], function() {
          * Hide sections without any visible widget
          * @property {boolean}
          */
-        hide_empty_sections: true
-    };
+        hide_empty_sections: true,
 
-    return config;
+        /**
+         * Number of lines in table on table_facets
+         * @property {Integer}
+         */
+        table_page_size: 20,
+
+        /**
+         * Genereal setter for config values.
+         * @param item_name {string}
+         * @param value
+         * @param store {Boolean} sets whether the value will be stored into
+         *                  local storage
+         */
+        set: function(item_name, value, store) {
+            if (!item_name) return;
+            this[item_name] = value;
+
+            if (store) {
+                window.localStorage.setItem(item_name, value);
+            }
+        },
+
+        /**
+         * Genereal setter for config values.
+         * @param item_name {string}
+         */
+        get: function(item_name) {
+            return this[item_name];
+        },
+
+        constructor: function() {
+            var user_limit = window.localStorage.getItem('table_page_size');
+            if (user_limit) this.table_page_size = user_limit;
+        }
+    });
+
+    return new config();
 });

--- a/install/ui/src/freeipa/facet.js
+++ b/install/ui/src/freeipa/facet.js
@@ -25,12 +25,14 @@ define([
         'dojo/_base/declare',
         'dojo/_base/lang',
         'dojo/dom-construct',
+        'dojo/topic',
         'dojo/on',
         'dojo/Stateful',
         'dojo/Evented',
         './_base/Singleton_registry',
         './_base/construct',
         './builder',
+        './config',
         './ipa',
         './jquery',
         './navigation',
@@ -43,8 +45,8 @@ define([
         './dialog',
         './field',
         './widget'
-       ], function(declare, lang, construct, on, Stateful, Evented,
-                   Singleton_registry, construct_utils, builder, IPA, $,
+    ], function(declare, lang, construct, topic, on, Stateful, Evented,
+                   Singleton_registry, construct_utils, builder, config, IPA, $,
                    navigation, phases, reg, rpc, su, text, ActionDropdownWidget) {
 
 /**
@@ -2357,6 +2359,14 @@ exp.table_facet = IPA.table_facet = function(spec, no_init) {
             pagination: true,
             scrollable: false,
             selectable: that.selectable && !that.read_only
+        });
+
+        topic.subscribe("change-pagination", function() {
+            that.table.page_length = config.get('table_page_size');
+
+            that.set_expired_flag();
+
+            if (that.is_shown) that.refresh();
         });
 
         var columns = that.columns.values;

--- a/install/ui/src/freeipa/field.js
+++ b/install/ui/src/freeipa/field.js
@@ -971,6 +971,39 @@ field.validator = IPA.validator = function(spec) {
 };
 
 /**
+ * Javascript integer validator
+ *
+ * It allows to insert only integer numbers which can be safely represented by
+ * Javascript.
+ *
+ * @class
+ * @alternateClassName IPA.integer_validator
+ * @extends IPA.validator
+ */
+ field.integer_validator = IPA.integer_validator = function(spec) {
+
+     var that = IPA.validator(spec);
+
+     /**
+      * @inheritDoc
+      */
+     that.validate = function(value) {
+
+         if (!value.match(/^-?\d+$/)) {
+             return that.false_result(text.get('@i18n:widget.validation.integer'));
+         }
+
+         if (!Number.isSafeInteger(parseInt(value, 10))) {
+             return that.false_result(text.get('@i18n:widget.validation.unsupported'));
+         }
+
+         return that.true_result();
+     };
+
+     return that;
+ };
+
+/**
  * Metadata validator
  *
  * Validates value according to supplied metadata
@@ -1710,6 +1743,7 @@ field.register = function() {
     v.register('metadata', field.metadata_validator);
     v.register('unsupported', field.unsupported_validator);
     v.register('same_password', field.same_password_validator);
+    v.register('integer', field.integer_validator);
 
     l.register('adapter', field.Adapter);
     l.register('object_adapter', field.ObjectAdapter);

--- a/install/ui/src/freeipa/widget.js
+++ b/install/ui/src/freeipa/widget.js
@@ -3584,7 +3584,7 @@ IPA.column = function (spec) {
  * @param {boolean} [spec.save_values=true]
  * @param {string} [spec.class] css class
  * @param {boolean} [spec.pagination] render pagination
- * @param {number} [spec.page_length=20]
+ * @param {number} [spec.page_length=config.table_page_size]
  * @param {boolean} [spec.multivalued=true]
  * @param {Array} columns columns or columns specs
  * @param {string} [value_attr_name=name]
@@ -3609,7 +3609,7 @@ IPA.table_widget = function (spec) {
     that.pagination = spec.pagination;
     that.current_page = 1;
     that.total_pages = 1;
-    that.page_length = spec.page_length || 20;
+    that.page_length = spec.page_length || config.get('table_page_size');
 
     that.multivalued = spec.multivalued === undefined ? true : spec.multivalued;
 

--- a/install/ui/src/freeipa/widgets/App.js
+++ b/install/ui/src/freeipa/widgets/App.js
@@ -234,6 +234,8 @@ define(['dojo/_base/declare',
                 this.emit('logout-click');
             } else if (item.name == 'password_reset') {
                 this.emit('password-reset-click');
+            } else if (item.name == 'configuration') {
+                this.emit('configuration-click');
             } else if (item.name == 'about') {
                 this.emit('about-click');
             }
@@ -263,6 +265,11 @@ define(['dojo/_base/declare',
                     },
                     {
                         'class': 'divider'
+                    },
+                    {
+                        name: 'configuration',
+                        label: 'Customization',
+                        icon: 'fa-gear'
                     },
                     {
                         name: 'about',

--- a/install/ui/test/data/ipa_init.json
+++ b/install/ui/test/data/ipa_init.json
@@ -101,6 +101,10 @@
                         "update": "Update",
                         "view": "View"
                     },
+                    "customization": {
+                        "customization": "Customization",
+                        "table_pagination": "Table Pagination Size",
+                    },
                     "details": {
                         "collapse_all": "Collapse All",
                         "expand_all": "Expand All",

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -250,6 +250,10 @@ class i18n_messages(Command):
             "update": _("Update"),
             "view": _("View"),
         },
+        "customization": {
+            "customization": _("Customization"),
+            "table_pagination": _("Pagination Size"),
+        },
         "details": {
             "collapse_all": _("Collapse All"),
             "expand_all": _("Expand All"),


### PR DESCRIPTION
New customization button opens dialog with field for setting the number of lines
in tables. After saving the new value there is new topic which starts refreshing
current table facet (if shown) and set all other facets expired. Therefore all
tables are immediately regenerated.

https://fedorahosted.org/freeipa/ticket/5742