### PR TITLE
scripts, tests: explicitly set confdir in the rest of server code

### DIFF
--- a/doc/guide/wsgi.py.txt
+++ b/doc/guide/wsgi.py.txt
@@ -1,3 +1,4 @@
+from ipaplatform.paths import paths
 from ipalib import api
 from ipalib.config import Env
 from ipalib.constants import DEFAULT_CONFIG
@@ -6,11 +7,12 @@ from ipalib.constants import DEFAULT_CONFIG
 # by reading in the configuration file(s). The server always reads
 # default.conf and will also read in `context'.conf.
 env = Env()
-env._bootstrap(context='server', log=None)
+env._bootstrap(context='server', log=None, confdir=paths.ETC_IPA)
 env._finalize_core(**dict(DEFAULT_CONFIG))
 
 # Initialize the API with the proper debug level
-api.bootstrap(context='server', debug=env.debug, log=None) (ref:wsgi-app-bootstrap)
+api.bootstrap(context='server', confdir=paths.ETC_IPA,
+              debug=env.debug, log=None) (ref:wsgi-app-bootstrap)
 try:
     api.finalize() (ref:wsgi-app-finalize)
 except Exception as e:

--- a/install/tools/ipa-compat-manage
+++ b/install/tools/ipa-compat-manage
@@ -100,7 +100,10 @@ def main():
         if dirman_password is None:
             sys.exit("Directory Manager password required")
 
-    api.bootstrap(context='cli', in_server=True, debug=options.debug)
+    api.bootstrap(context='cli',
+                  in_server=True,
+                  debug=options.debug,
+                  confdir=paths.ETC_IPA)
     api.finalize()
     api.Backend.ldap2.connect()
 

--- a/install/tools/ipa-csreplica-manage
+++ b/install/tools/ipa-csreplica-manage
@@ -413,7 +413,11 @@ def main():
         api_env['log'] = None # turn off logging for non-root
 
     api.bootstrap(
-        context='cli', in_server=True, verbose=options.verbose, **api_env
+        context='cli',
+        in_server=True,
+        verbose=options.verbose,
+        confdir=paths.ETC_IPA,
+        **api_env
     )
     api.finalize()
 

--- a/install/tools/ipa-managed-entries
+++ b/install/tools/ipa-managed-entries
@@ -24,6 +24,7 @@ import re
 import sys
 from optparse import OptionParser  # pylint: disable=deprecated-module
 
+from ipaplatform.paths import paths
 from ipapython import config
 from ipaserver.install import installutils
 from ipalib import api, errors
@@ -72,7 +73,7 @@ def main():
         sys.exit("Unrecognized action [" + args[0] + "]")
     standard_logging_setup(None, debug=options.debug)
 
-    api.bootstrap(context='cli', debug=options.debug)
+    api.bootstrap(context='cli', debug=options.debug, confdir=paths.ETC_IPA)
     api.finalize()
     api.Backend.ldap2.connect(bind_pw=options.dirman_password)
 

--- a/ipaserver/advise/base.py
+++ b/ipaserver/advise/base.py
@@ -25,6 +25,7 @@ from textwrap import wrap
 from ipalib import api
 from ipalib.plugable import Plugin, API
 from ipalib.errors import ValidationError
+from ipaplatform.paths import paths
 from ipapython import admintool
 from ipapython.ipa_log_manager import log_mgr
 
@@ -235,9 +236,13 @@ class IpaAdvise(admintool.AdminTool):
     def run(self):
         super(IpaAdvise, self).run()
 
-        api.bootstrap(in_server=False, context='cli')
+        api.bootstrap(in_server=False,
+                      context='cli',
+                      confdir=paths.ETC_IPA)
         api.finalize()
-        advise_api.bootstrap(in_server=False, context='cli')
+        advise_api.bootstrap(in_server=False,
+                             context='cli',
+                             confdir=paths.ETC_IPA)
         advise_api.finalize()
         if not self.options.verbose:
             # Do not print connection information by default

--- a/ipaserver/dnssec/ldapkeydb.py
+++ b/ipaserver/dnssec/ldapkeydb.py
@@ -9,6 +9,7 @@ import collections
 from pprint import pprint
 
 import ipalib
+from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipapython import ipaldap
 from ipapython import ipa_log_manager
@@ -414,7 +415,8 @@ if __name__ == '__main__':
     log = ipa_log_manager.root_logger
 
     # IPA framework initialization
-    ipalib.api.bootstrap(in_server=True, log=None)  # no logging to file
+    # no logging to file
+    ipalib.api.bootstrap(in_server=True, log=None, confdir=paths.ETC_IPA)
     ipalib.api.finalize()
 
     # LDAP initialization

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -97,7 +97,7 @@ class CACertManage(admintool.AdminTool):
     def run(self):
         command = self.command
 
-        api.bootstrap(in_server=True)
+        api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
         api.finalize()
 
         self.ldap_connect()

--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -77,7 +77,7 @@ class KRAInstall(admintool.AdminTool):
 
         installutils.check_server_configuration()
 
-        api.bootstrap(in_server=True)
+        api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
         api.finalize()
 
     @classmethod

--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -34,6 +34,7 @@ import gssapi
 import six
 from six.moves import xrange
 
+from ipaplatform.paths import paths
 from ipapython import admintool
 from ipalib import api, errors
 from ipaserver.plugins.ldap2 import AUTOBIND_DISABLED
@@ -509,7 +510,7 @@ class OTPTokenImport(admintool.AdminTool):
                 self.doc.setKey(f.read())
 
     def run(self):
-        api.bootstrap(in_server=True)
+        api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
         api.finalize()
 
         try:

--- a/ipaserver/install/ipa_replica_prepare.py
+++ b/ipaserver/install/ipa_replica_prepare.py
@@ -180,7 +180,7 @@ class ReplicaPrepare(admintool.AdminTool):
         else:
             [self.replica_fqdn] = self.args
 
-        api.bootstrap(in_server=True)
+        api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
         api.finalize()
         # Connect to LDAP, connection is closed at the end of run()
         api.Backend.ldap2.connect()

--- a/ipaserver/install/ipa_server_certinstall.py
+++ b/ipaserver/install/ipa_server_certinstall.py
@@ -98,7 +98,7 @@ class ServerCertInstall(admintool.AdminTool):
                     "Private key unlock password required")
 
     def run(self):
-        api.bootstrap(in_server=True)
+        api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
         api.finalize()
         api.Backend.ldap2.connect(bind_pw=self.options.dirman_password)
 

--- a/ipatests/test_ipaserver/test_ldap.py
+++ b/ipatests/test_ipaserver/test_ldap.py
@@ -34,6 +34,7 @@ from nose.tools import assert_raises  # pylint: disable=E0611
 import nss.nss as nss
 import six
 
+from ipaplatform.paths import paths
 from ipaserver.plugins.ldap2 import ldap2
 from ipalib import api, x509, create_api, errors
 from ipapython import ipautil
@@ -111,7 +112,7 @@ class test_ldap(object):
         # a client-only api. Then we register in the commands and objects
         # we need for the test.
         myapi = create_api(mode=None)
-        myapi.bootstrap(context='cli', in_server=True)
+        myapi.bootstrap(context='cli', in_server=True, confdir=paths.ETC_IPA)
         myapi.finalize()
 
         pwfile = api.env.dot_ipa + os.sep + ".dmpw"

--- a/ipatests/test_ipaserver/test_serverroles.py
+++ b/ipatests/test_ipaserver/test_serverroles.py
@@ -11,6 +11,7 @@ from collections import namedtuple
 import ldap
 import pytest
 
+from ipaplatform.paths import paths
 from ipalib import api, create_api, errors
 from ipapython.dn import DN
 from ipatests.util import MockLDAP
@@ -469,7 +470,9 @@ class MockMasterTopology(object):
 @pytest.fixture(scope='module')
 def mock_api(request):
     test_api = create_api(mode=None)
-    test_api.bootstrap(in_server=True, ldap_uri=api.env.ldap_uri)
+    test_api.bootstrap(in_server=True,
+                       ldap_uri=api.env.ldap_uri,
+                       confdir=paths.ETC_IPA)
     test_api.finalize()
 
     if not test_api.Backend.ldap2.isconnected():


### PR DESCRIPTION
Commit 1e6a204b4372bbbfb722a00370a5ce4e34406b9f added explicit confdir
setting to api.bootstrap() calls of a randomly selected portion of
server-side scripts and tests. This commit adds it to the rest of
server-side code for consistency.

https://fedorahosted.org/freeipa/ticket/6389