### PR TITLE
Relax check for .git to support freeipa in submodules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -353,7 +353,7 @@ dnl Are we in source tree?
 AM_CONDITIONAL([IS_GIT_SNAPSHOT], [test "IPA_VERSION_IS_GIT_SNAPSHOT" == "yes"])
 AM_COND_IF([IS_GIT_SNAPSHOT], [
 	AC_MSG_CHECKING([if source directory is a Git reposistory])
-	if test ! -d "${srcdir}/.git"; then
+	if test ! -e "${srcdir}/.git"; then
 		AC_MSG_ERROR([Git reposistory is required by VERSION.m4 IPA_VERSION_IS_GIT_SNAPSHOT but not found])
 	else
 		AC_MSG_RESULT([yes])


### PR DESCRIPTION
Let's relax the check for .git from directory to exists in order to
support freeipa in a git submodule. Submodules have a .git file with
content like

    gitdir: ../.git/modules/freeipa

Signed-off-by: Christian Heimes <cheimes@redhat.com>