### PR TITLE
Add 'env_confdir' to constants

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -221,6 +221,7 @@ DEFAULT_CONFIG = (
     ('dot_ipa', object),  # ~/.ipa directory
     ('context', object),  # Name of context, default is 'default'
     ('confdir', object),  # Directory containing config files
+    ('env_confdir', None),  # conf dir specified by IPA_CONFDIR env variable
     ('conf', object),  # File containing context specific config
     ('conf_default', object),  # File containing context independent config
     ('plugins_on_demand', object),  # Whether to finalize plugins on-demand (bool)


### PR DESCRIPTION
Env confdir is always populated so it should be listed among variables
set during a call to `Env._bootstrap()`.

https://fedorahosted.org/freeipa/ticket/6389