### PR TITLE
Unify password generation across FreeIPA

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2296,7 +2296,7 @@ def create_ipa_nssdb():
     ipautil.backup_file(os.path.join(db.secdir, 'secmod.db'))
 
     with open(pwdfile, 'w') as f:
-        f.write(ipautil.ipa_generate_password(pwd_len=40))
+        f.write(ipautil.ipa_generate_password())
     os.chmod(pwdfile, 0o600)
 
     db.create_db(pwdfile)

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -25,7 +25,6 @@ import shutil
 import xml.dom.minidom
 import pwd
 import base64
-from hashlib import sha1
 import fcntl
 import time
 import datetime
@@ -159,9 +158,6 @@ class CertDB(object):
             perms |= stat.S_IWUSR
         os.chmod(fname, perms)
 
-    def gen_password(self):
-        return sha1(ipautil.ipa_generate_password()).hexdigest()
-
     def run_certutil(self, args, stdin=None, **kwargs):
         return self.nssdb.run_certutil(args, stdin, **kwargs)
 
@@ -177,7 +173,7 @@ class CertDB(object):
         if ipautil.file_exists(self.noise_fname):
             os.remove(self.noise_fname)
         f = open(self.noise_fname, "w")
-        f.write(self.gen_password())
+        f.write(ipautil.ipa_generate_password(pwd_len=25))
         self.set_perms(self.noise_fname)
 
     def create_passwd_file(self, passwd=None):
@@ -186,7 +182,7 @@ class CertDB(object):
         if passwd is not None:
             f.write("%s\n" % passwd)
         else:
-            f.write(self.gen_password())
+            f.write(ipautil.ipa_generate_password(pwd_len=25))
         f.close()
         self.set_perms(self.passwd_fname)
 

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -173,7 +173,7 @@ class CertDB(object):
         if ipautil.file_exists(self.noise_fname):
             os.remove(self.noise_fname)
         f = open(self.noise_fname, "w")
-        f.write(ipautil.ipa_generate_password(pwd_len=25))
+        f.write(ipautil.ipa_generate_password())
         self.set_perms(self.noise_fname)
 
     def create_passwd_file(self, passwd=None):
@@ -182,7 +182,7 @@ class CertDB(object):
         if passwd is not None:
             f.write("%s\n" % passwd)
         else:
-            f.write(ipautil.ipa_generate_password(pwd_len=25))
+            f.write(ipautil.ipa_generate_password())
         f.close()
         self.set_perms(self.passwd_fname)
 

--- a/ipaserver/install/dnskeysyncinstance.py
+++ b/ipaserver/install/dnskeysyncinstance.py
@@ -224,10 +224,11 @@ class DNSKeySyncInstance(service.Service):
         os.chown(paths.DNSSEC_TOKENS_DIR, self.ods_uid, self.named_gid)
 
         # generate PINs for softhsm
-        allowed_chars = u'123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
         pin_length = 30  # Bind allows max 32 bytes including ending '\0'
-        pin = ipautil.ipa_generate_password(allowed_chars, pin_length)
-        pin_so = ipautil.ipa_generate_password(allowed_chars, pin_length)
+        pin = ipautil.ipa_generate_password(
+            entropy_bits=0, special=None, min_len=pin_length)
+        pin_so = ipautil.ipa_generate_password(
+            entropy_bits=0, special=None, min_len=pin_length)
 
         self.logger.debug("Saving user PIN to %s", paths.DNSSEC_SOFTHSM_PIN)
         named_fd = open(paths.DNSSEC_SOFTHSM_PIN, 'w')

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -18,7 +18,6 @@
 #
 
 import base64
-import binascii
 import ldap
 import os
 import shutil
@@ -428,7 +427,7 @@ class DogtagInstance(service.Service):
 
     def setup_admin(self):
         self.admin_user = "admin-%s" % self.fqdn
-        self.admin_password = binascii.hexlify(os.urandom(16))
+        self.admin_password = ipautil.ipa_generate_password(pwd_len=20)
         self.admin_dn = DN(('uid', self.admin_user),
                            ('ou', 'people'), ('o', 'ipaca'))
 

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -427,7 +427,7 @@ class DogtagInstance(service.Service):
 
     def setup_admin(self):
         self.admin_user = "admin-%s" % self.fqdn
-        self.admin_password = ipautil.ipa_generate_password(pwd_len=20)
+        self.admin_password = ipautil.ipa_generate_password()
         self.admin_dn = DN(('uid', self.admin_user),
                            ('ou', 'people'), ('o', 'ipaca'))
 

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -508,7 +508,7 @@ class DsInstance(service.Service):
             idrange_size = None
         self.sub_dict = dict(FQDN=self.fqdn, SERVERID=self.serverid,
                              PASSWORD=self.dm_password,
-                             RANDOM_PASSWORD=self.generate_random(),
+                             RANDOM_PASSWORD=ipautil.ipa_generate_password(),
                              SUFFIX=self.suffix,
                              REALM=self.realm, USER=DS_USER,
                              SERVER_ROOT=server_root, DOMAIN=self.domain,
@@ -774,9 +774,6 @@ class DsInstance(service.Service):
 
     def __add_enrollment_module(self):
         self._ldap_mod("enrollment-conf.ldif", self.sub_dict)
-
-    def generate_random(self):
-        return ipautil.ipa_generate_password()
 
     def __enable_ssl(self):
         dirname = config_dirname(self.serverid)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -313,7 +313,7 @@ class HTTPInstance(service.Service):
             ipautil.backup_file(nss_path)
 
         # Create the password file for this db
-        password = ipautil.ipa_generate_password(pwd_len=15)
+        password = ipautil.ipa_generate_password()
         f = os.open(pwd_file, os.O_CREAT | os.O_RDWR)
         os.write(f, password)
         os.close(f)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -19,7 +19,6 @@
 
 from __future__ import print_function
 
-import binascii
 import os
 import os.path
 import pwd
@@ -314,9 +313,9 @@ class HTTPInstance(service.Service):
             ipautil.backup_file(nss_path)
 
         # Create the password file for this db
-        hex_str = binascii.hexlify(os.urandom(10))
+        password = ipautil.ipa_generate_password(pwd_len=15)
         f = os.open(pwd_file, os.O_CREAT | os.O_RDWR)
-        os.write(f, hex_str)
+        os.write(f, password)
         os.close(f)
 
         ipautil.run([paths.CERTUTIL, "-d", database, "-f", pwd_file, "-N"])

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -45,7 +45,6 @@ from ipaserver.install.replication import (
     ReplicationManager, replica_conn_check)
 import SSSDConfig
 from subprocess import CalledProcessError
-from binascii import hexlify
 
 if six.PY3:
     unicode = str
@@ -1303,7 +1302,7 @@ def install(installer):
                 if conn.isconnected():
                     conn.disconnect()
                 os.environ['KRB5CCNAME'] = ccache
-        config.dirman_password = hexlify(ipautil.ipa_generate_password())
+        config.dirman_password = ipautil.ipa_generate_password()
 
         # FIXME: allow to use passed in certs instead
         if ca_enabled:

--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import string
-
 import six
 
 from ipalib import api, errors
@@ -35,7 +33,7 @@ from ipalib.request import context
 from ipalib import _
 from ipalib.constants import PATTERN_GROUPUSER_NAME
 from ipapython import kerberos
-from ipapython.ipautil import ipa_generate_password, GEN_TMP_PWD_LEN
+from ipapython.ipautil import ipa_generate_password, TMP_PWD_ENTROPY_BITS
 from ipapython.ipavalidate import Email
 from ipalib.util import (
     normalize_sshpubkey,
@@ -75,8 +73,6 @@ UPG_DEFINITION_DN = DN(('cn', 'UPG Definition'),
                        ('cn', 'etc'),
                        api.env.basedn)
 
-# characters to be used for generating random user passwords
-baseuser_pwdchars = string.digits + string.ascii_letters + '_,.@+-='
 
 def validate_nsaccountlock(entry_attrs):
     if 'nsaccountlock' in entry_attrs:
@@ -554,7 +550,7 @@ class baseuser_mod(LDAPUpdate):
     def check_userpassword(self, entry_attrs, **options):
         if 'userpassword' not in entry_attrs and options.get('random'):
             entry_attrs['userpassword'] = ipa_generate_password(
-                baseuser_pwdchars, pwd_len=GEN_TMP_PWD_LEN)
+                entropy_bits=TMP_PWD_ENTROPY_BITS)
             # save the password so it can be displayed in post_callback
             setattr(context, 'randompassword', entry_attrs['userpassword'])
 

--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -21,7 +21,6 @@
 from __future__ import absolute_import
 
 import dns.resolver
-import string
 
 import six
 
@@ -62,7 +61,7 @@ from ipalib.util import (normalize_sshpubkey, validate_sshpubkey_no_options,
 from ipapython.ipautil import (
     ipa_generate_password,
     CheckedIPAddress,
-    GEN_TMP_PWD_LEN
+    TMP_PWD_ENTROPY_BITS
 )
 from ipapython.dnsutil import DNSName
 from ipapython.ssh import SSHPublicKey
@@ -135,10 +134,6 @@ EXAMPLES:
 """)
 
 register = Registry()
-
-# Characters to be used by random password generator
-# The set was chosen to avoid the need for escaping the characters by user
-host_pwd_chars = string.digits + string.ascii_letters + '_,.@+-='
 
 
 def remove_ptr_rec(ipaddr, fqdn):
@@ -688,7 +683,7 @@ class host_add(LDAPCreate):
                 entry_attrs['objectclass'].remove('krbprincipal')
         if options.get('random'):
             entry_attrs['userpassword'] = ipa_generate_password(
-                characters=host_pwd_chars, pwd_len=GEN_TMP_PWD_LEN)
+                entropy_bits=TMP_PWD_ENTROPY_BITS)
             # save the password so it can be displayed in post_callback
             setattr(context, 'randompassword', entry_attrs['userpassword'])
         certs = options.get('usercertificate', [])
@@ -915,7 +910,8 @@ class host_mod(LDAPUpdate):
             entry_attrs['usercertificate'] = certs_der
 
         if options.get('random'):
-            entry_attrs['userpassword'] = ipa_generate_password(characters=host_pwd_chars)
+            entry_attrs['userpassword'] = ipa_generate_password(
+                entropy_bits=TMP_PWD_ENTROPY_BITS)
             setattr(context, 'randompassword', entry_attrs['userpassword'])
 
         if 'macaddress' in entry_attrs:

--- a/ipaserver/plugins/stageuser.py
+++ b/ipaserver/plugins/stageuser.py
@@ -38,7 +38,6 @@ from .baseuser import (
     baseuser_find,
     baseuser_show,
     NO_UPG_MAGIC,
-    baseuser_pwdchars,
     baseuser_output_params,
     baseuser_add_manager,
     baseuser_remove_manager)
@@ -47,7 +46,7 @@ from ipalib.util import set_krbcanonicalname
 from ipalib import _, ngettext
 from ipalib import output
 from ipaplatform.paths import paths
-from ipapython.ipautil import ipa_generate_password, GEN_TMP_PWD_LEN
+from ipapython.ipautil import ipa_generate_password, TMP_PWD_ENTROPY_BITS
 from ipalib.capabilities import client_has_capability
 
 if six.PY3:
@@ -340,7 +339,7 @@ class stageuser_add(baseuser_add):
         # If requested, generate a userpassword
         if 'userpassword' not in entry_attrs and options.get('random'):
             entry_attrs['userpassword'] = ipa_generate_password(
-                baseuser_pwdchars, pwd_len=GEN_TMP_PWD_LEN)
+                entropy_bits=TMP_PWD_ENTROPY_BITS)
             # save the password so it can be displayed in post_callback
             setattr(context, 'randompassword', entry_attrs['userpassword'])
 

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -38,7 +38,6 @@ from .baseuser import (
     NO_UPG_MAGIC,
     UPG_DEFINITION_DN,
     baseuser_output_params,
-    baseuser_pwdchars,
     validate_nsaccountlock,
     convert_nsaccountlock,
     fix_addressbook_permission_bindrule,
@@ -63,7 +62,7 @@ from ipalib import _, ngettext
 from ipalib import output
 from ipaplatform.paths import paths
 from ipapython.dn import DN
-from ipapython.ipautil import ipa_generate_password, GEN_TMP_PWD_LEN
+from ipapython.ipautil import ipa_generate_password, TMP_PWD_ENTROPY_BITS
 from ipalib.capabilities import client_has_capability
 
 if api.env.in_server:
@@ -529,7 +528,7 @@ class user_add(baseuser_add):
 
         if 'userpassword' not in entry_attrs and options.get('random'):
             entry_attrs['userpassword'] = ipa_generate_password(
-                baseuser_pwdchars, pwd_len=GEN_TMP_PWD_LEN)
+                entropy_bits=TMP_PWD_ENTROPY_BITS)
             # save the password so it can be displayed in post_callback
             setattr(context, 'randompassword', entry_attrs['userpassword'])
 

--- a/ipaserver/secrets/store.py
+++ b/ipaserver/secrets/store.py
@@ -122,7 +122,7 @@ class NSSCertDB(DBMAPHandler):
             with open(nsspwfile, 'w+') as f:
                 f.write(self.nssdb_password)
             pk12pwfile = os.path.join(tdir, 'pk12pwfile')
-            password = ipautil.ipa_generate_password(pwd_len=20)
+            password = ipautil.ipa_generate_password()
             with open(pk12pwfile, 'w+') as f:
                 f.write(password)
             pk12file = os.path.join(tdir, 'pk12file')

--- a/ipaserver/secrets/store.py
+++ b/ipaserver/secrets/store.py
@@ -122,7 +122,7 @@ class NSSCertDB(DBMAPHandler):
             with open(nsspwfile, 'w+') as f:
                 f.write(self.nssdb_password)
             pk12pwfile = os.path.join(tdir, 'pk12pwfile')
-            password = b64encode(os.urandom(16))
+            password = ipautil.ipa_generate_password(pwd_len=20)
             with open(pk12pwfile, 'w+') as f:
                 f.write(password)
             pk12file = os.path.join(tdir, 'pk12file')


### PR DESCRIPTION
When installing FreeIPA in FIPS mode I noticed that there were often different ways of generating passwords in different spots raising the same issue with password requirements. Handling password generation at one centralized spot should allow us handle any password requirements issues at this very spot.