### PR TITLE
add missing attribute to ipaca replica during CA topology update

### DIFF
--- a/install/share/ca-topology.uldif
+++ b/install/share/ca-topology.uldif
@@ -12,4 +12,3 @@ default: cn: ca
 
 dn: cn=replica,cn=o\3Dipaca,cn=mapping tree,cn=config
 onlyifexist: nsds5replicabinddngroup: cn=replication managers,cn=sysaccounts,cn=etc,$SUFFIX
-add: nsds5replicabinddngroupcheckinterval: 60


### PR DESCRIPTION
The previous fix for missing 'nsds5replicabinddngroupcheckinterval' fails when
the first CA master is being set up. The attribute addition from update file
has to be moved to the update plugin with a proper logic that determines the
presence of o=ipaca replica entry.

https://fedorahosted.org/freeipa/ticket/6508