### PR TITLE
certdb: fix PKCS#12 import with empty password

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -168,7 +168,7 @@ class NSSDatabase(object):
                 "-k", db_password_filename, '-v']
         pkcs12_password_file = None
         if pkcs12_passwd is not None:
-            pkcs12_password_file = ipautil.write_tmp_file(pkcs12_passwd)
+            pkcs12_password_file = ipautil.write_tmp_file(pkcs12_passwd + '\n')
             args = args + ["-w", pkcs12_password_file.name]
         try:
             ipautil.run(args)


### PR DESCRIPTION
Since commit f919ab4ee0ec26d77ee6978e75de5daba4073402, a temporary file is
used to give passwords to pk12util. When a password is empty, the temporary
will be empty as well, which pk12util does not like.

Add new line after the password in the temporary file to please pk12util.

https://fedorahosted.org/freeipa/ticket/6541