### PR TITLE
Check for conflict entries before raising domain level

### DIFF
--- a/ipaserver/plugins/domainlevel.py
+++ b/ipaserver/plugins/domainlevel.py
@@ -48,6 +48,30 @@ def get_domainlevel_range(master_entry):
         return DomainLevelRange(0, 0)
 
 
+def check_conflict_entries(ldap, api, desired_value):
+    """
+    Check if conflict entries exist in topology subtree
+    """
+
+    container_dn = DN(
+        ('cn', 'ipa'),
+        ('cn', 'etc'),
+        api.env.basedn
+    )
+    conflict="(nsds5replconflict=*)"
+    subentry="(|(objectclass=ldapsubentry)(objectclass=*))"
+    try:
+        ldap.get_entries(
+            filter="(& %s %s)" % (conflict, subentry),
+            base_dn=container_dn,
+            scope=ldap.SCOPE_SUBTREE)
+        message = _("Domain Level cannot be raised to {0}, "
+                    "existing replication conflicts have to be resolved."
+                    .format(desired_value))
+        raise errors.InvalidDomainLevelError(reason=message)
+    except errors.NotFound:
+        pass
+
 def get_master_entries(ldap, api):
     """
     Returns list of LDAPEntries representing IPA masters.
@@ -130,6 +154,10 @@ class domainlevel_set(Command):
                             "does not support it."
                             .format(desired_value, master['cn'][0]))
                 raise errors.InvalidDomainLevelError(reason=message)
+
+        # Check if conflict entries exist in topology subtree
+        # should be resolved first
+        check_conflict_entries(ldap, self.api, desired_value)
 
         current_entry.single_value['ipaDomainLevel'] = desired_value
         ldap.update_entry(current_entry)


### PR DESCRIPTION
Checking of conflicts is not only done in topology container as
tests showed it can occurs elsewhere

https://fedorahosted.org/freeipa/ticket/6534