### PR TITLE
WebUI: Hide incorrectly shown buttons on hosts tab in ID Views

### DIFF
--- a/install/ui/src/freeipa/details.js
+++ b/install/ui/src/freeipa/details.js
@@ -1647,6 +1647,7 @@ exp.value_state_evaluator = IPA.value_state_evaluator = function(spec) {
 
     spec.name = spec.name || 'value_state_evaluator';
     spec.event = spec.event || 'post_load';
+    spec.adapter = spec.adapter || {};
 
     var that = IPA.state_evaluator(spec);
 


### PR DESCRIPTION
There was missing default value for evaluator adapter.
In that case the adapter variable could be undefined and
it crashes on building adapter. Therefore it did not
evaluate all evaluators. That is the reason why 'Delete'
and 'Add' buttons were incorrectly shown.
Default value is now set to empty object.

https://fedorahosted.org/freeipa/ticket/6546