### PR TITLE
fix: regression in API version comparison

### DIFF
--- a/ipalib/frontend.py
+++ b/ipalib/frontend.py
@@ -776,8 +776,7 @@ class Command(HasParam):
                                sver=self.api_version,
                                server=self.env.xmlrpc_uri)
 
-        if (client_apiver.major != server_apiver.major
-                or client_apiver > server_apiver):
+        if client_apiver.major != server_apiver.major:
             raise VersionError(cver=client_version,
                                sver=self.api_version,
                                server=self.env.xmlrpc_uri)


### PR DESCRIPTION
Commint 2cbaf156045769b54150e4d4c3c1071f164a16fb introduced a regression
in API version comparison. In case that newer client is trying to call
older server an error is returned, but it should work. This commit fixes
it.

https://fedorahosted.org/freeipa/ticket/6468