### PR TITLE
WebUI: don't change casing of Auth Indicators values

### DIFF
--- a/install/ui/src/freeipa/aci.js
+++ b/install/ui/src/freeipa/aci.js
@@ -546,6 +546,9 @@ aci.attributes_widget = function(spec) {
     spec.add_field_label = spec.add_field_label ||
                             '@i18n:objects.permission.attribute';
 
+    spec.set_value_to_lowercase = spec.set_value_to_lowercase === undefined ?
+                    true : spec.set_value_to_lowercase;
+
     var that = IPA.custom_checkboxes_widget(spec);
 
     that.object_type = spec.object_type;

--- a/install/ui/src/freeipa/host.js
+++ b/install/ui/src/freeipa/host.js
@@ -124,11 +124,11 @@ return {
                             add_field_label: '@i18n:authtype.auth_indicator',
                             options: [
                                 {
-                                    label: '@i18n:authtype.otp',
+                                    label: 'otp',
                                     value: 'otp'
                                 },
                                 {
-                                    label: '@i18n:authtype.type_radius',
+                                    label: 'radius',
                                     value: 'radius'
                                 }
                             ],

--- a/install/ui/src/freeipa/service.js
+++ b/install/ui/src/freeipa/service.js
@@ -134,11 +134,11 @@ return {
                             add_field_label: '@i18n:authtype.auth_indicator',
                             options: [
                                 {
-                                    label: '@i18n:authtype.otp',
+                                    label: 'otp',
                                     value: 'otp'
                                 },
                                 {
-                                    label: '@i18n:authtype.type_radius',
+                                    label: 'radius',
                                     value: 'radius'
                                 }
                             ],

--- a/install/ui/src/freeipa/widget.js
+++ b/install/ui/src/freeipa/widget.js
@@ -2502,6 +2502,8 @@ IPA.custom_checkboxes_widget = function(spec) {
 
     var that = IPA.checkboxes_widget(spec);
 
+    that.set_value_to_lowercase = spec.set_value_to_lowercase || false;
+
     that.add_dialog_title = spec.add_dialog_title ||
                             "@i18n:dialogs.add_custom_value";
     that.add_field_label = spec.add_field_label ||
@@ -2619,7 +2621,7 @@ IPA.custom_checkboxes_widget = function(spec) {
 
             if (!value || value === '') continue;
 
-            value = value.toLowerCase();
+            if (that.set_value_to_lowercase) value = value.toLowerCase();
             that.values.push(value);
         }
 


### PR DESCRIPTION
All values were previously converted to lowercase which was not
coresponding with CLI behaviour. Now they stay as they are
inserted. I also have to change the strings to lowercase because
the otp and radius should be inserted as lowercase words.

https://fedorahosted.org/freeipa/ticket/6308
