### PR TITLE
Py3: Fix ToASCII method

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -126,8 +126,8 @@ BuildRequires:  python-memcached
 BuildRequires:  python-lxml
 # 5.0.0: QRCode.print_ascii
 BuildRequires:  python-qrcode-core >= 5.0.0
-# 1.13: python-dns URI record support
-BuildRequires:  python-dns >= 1.13
+# 1.15: python-dns changed return type in to_text() method in PY3
+BuildRequires:  python-dns >= 1.15
 BuildRequires:  jsl
 BuildRequires:  python-yubico
 # pki Python package
@@ -163,8 +163,8 @@ BuildRequires:  python3-memcached
 BuildRequires:  python3-lxml
 # 5.0.0: QRCode.print_ascii
 BuildRequires:  python3-qrcode-core >= 5.0.0
-# 1.13: python-dns URI record support
-BuildRequires:  python3-dns >= 1.13
+# 1.15: python-dns changed return type in to_text() method in PY3
+BuildRequires:  python3-dns >= 1.15
 BuildRequires:  python3-yubico
 # pki Python package
 # 10.2.1: crypto.NSSCryptoProvider(password_file)
@@ -294,7 +294,7 @@ Requires: python-gssapi >= 1.2.0
 Requires: python-sssdconfig
 Requires: python-pyasn1
 Requires: dbus-python
-Requires: python-dns >= 1.13
+Requires: python-dns >= 1.15
 Requires: python-kdcproxy >= 0.3
 Requires: rpm-libs
 
@@ -323,7 +323,7 @@ Requires: python3-gssapi >= 1.2.0
 Requires: python3-sssdconfig
 Requires: python3-pyasn1
 Requires: python3-dbus
-Requires: python3-dns >= 1.11.1
+Requires: python3-dns >= 1.15
 Requires: python3-kdcproxy >= 0.3
 Requires: rpm-libs
 
@@ -482,7 +482,7 @@ BuildArch: noarch
 Requires: %{name}-client-common = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 Requires: python2-ipalib = %{version}-%{release}
-Requires: python-dns >= 1.13
+Requires: python-dns >= 1.15
 
 %description -n python2-ipaclient
 IPA is an integrated solution to provide centrally managed Identity (users,
@@ -504,7 +504,7 @@ BuildArch: noarch
 Requires: %{name}-client-common = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 Requires: python3-ipalib = %{version}-%{release}
-Requires: python3-dns >= 1.11.1
+Requires: python3-dns >= 1.15
 
 %description -n python3-ipaclient
 IPA is an integrated solution to provide centrally managed Identity (users,
@@ -598,7 +598,7 @@ Requires: python-cffi
 Requires: python-ldap >= 2.4.15
 Requires: python-requests
 Requires: python-custodia
-Requires: python-dns >= 1.13
+Requires: python-dns >= 1.15
 Requires: python-enum34
 Requires: python-netifaces >= 0.10.4
 Requires: pyusb
@@ -648,7 +648,7 @@ Requires: python3-cffi
 Requires: python3-pyldap >= 2.4.15
 Requires: python3-custodia
 Requires: python3-requests
-Requires: python3-dns >= 1.11.1
+Requires: python3-dns >= 1.15
 Requires: python3-netifaces >= 0.10.4
 Requires: python3-pyusb
 

--- a/ipapython/dnsutil.py
+++ b/ipapython/dnsutil.py
@@ -69,9 +69,14 @@ class DNSName(dns.name.Name):
     def __str__(self):
         return self.to_unicode()
 
-    def ToASCII(self):
-        #method named by RFC 3490 and python standard library
-        return self.to_text().decode('ascii')  # must be unicode string
+    # method ToASCII named by RFC 3490 and python standard library
+    if six.PY2:
+        def ToASCII(self):
+            # must be unicode string in Py2
+            return self.to_text().decode('ascii')
+    else:
+        def ToASCII(self):
+            return self.to_text()
 
     def canonicalize(self):
         return DNSName(super(DNSName, self).canonicalize())

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -64,7 +64,7 @@ if SETUPTOOLS_VERSION < (8, 0, 0):
 
 PACKAGE_VERSION = {
     'cryptography': 'cryptography >= 1.3.1',
-    'dnspython': 'dnspython >= 1.13',
+    'dnspython': 'dnspython >= 1.15',
     'gssapi': 'gssapi >= 1.2.0',
     'ipaclient': 'ipaclient == {}'.format(VERSION),
     'ipalib': 'ipalib == {}'.format(VERSION),


### PR DESCRIPTION
in Py2 to_text method returns Py2 non-unicode string, but in Py3 to_text method
returns Py3 default (unicode) string. So only in Py2 we have to decode
str to unicode.

https://fedorahosted.org/freeipa/ticket/5935

Edit: ticket number