### PR TITLE
[4.3] password policy: Add explicit default password policy for hosts and services

### DIFF
--- a/install/updates/20-default_password_policy.update
+++ b/install/updates/20-default_password_policy.update
@@ -1,0 +1,133 @@
+# Default password policies for hosts, services and Kerberos services
+# Setting all attributes to zero effectively disables any password policy
+# We can do this because hosts and services uses keytabs instead of passwords
+
+# hosts
+dn: cn=Default Host Password Policy,cn=computers,cn=accounts,$SUFFIX
+default:objectClass: krbPwdPolicy
+default:objectClass: nsContainer
+default:objectClass: top
+default:cn: Default Host Password Policy
+default:krbMinPwdLife: 0
+default:krbPwdMinDiffChars: 0
+default:krbPwdMinLength: 0
+default:krbPwdHistoryLength: 0
+default:krbMaxPwdLife: 0
+default:krbPwdMaxFailure: 0
+default:krbPwdFailureCountInterval: 0
+default:krbPwdLockoutDuration: 0
+
+# services
+dn: cn=Default Service Password Policy,cn=services,cn=accounts,$SUFFIX
+default:objectClass: krbPwdPolicy
+default:objectClass: nsContainer
+default:objectClass: top
+default:cn: Default Service Password Policy
+default:krbMinPwdLife: 0
+default:krbPwdMinDiffChars: 0
+default:krbPwdMinLength: 0
+default:krbPwdHistoryLength: 0
+default:krbMaxPwdLife: 0
+default:krbPwdMaxFailure: 0
+default:krbPwdFailureCountInterval: 0
+default:krbPwdLockoutDuration: 0
+
+# kerberos policy container
+# this is necessary to avoid mixing the Kerberos sevice password policy
+# with group-membership based user password policies
+dn: cn=Kerberos Service Password Policy,cn=$REALM,cn=kerberos,$SUFFIX
+default:objectClass: nsContainer
+default:objectClass: top
+default:cn: Kerberos Service Password Policy
+
+# kerberos services
+dn: cn=Default Kerberos Service Password Policy,cn=Kerberos Service Password Policy,cn=$REALM,cn=kerberos,$SUFFIX
+default:objectClass: krbPwdPolicy
+default:objectClass: nsContainer
+default:objectClass: top
+default:cn: Default Kerberos Service Password Policy
+default:krbMinPwdLife: 0
+default:krbPwdMinDiffChars: 0
+default:krbPwdMinLength: 0
+default:krbPwdHistoryLength: 0
+default:krbMaxPwdLife: 0
+default:krbPwdMaxFailure: 0
+default:krbPwdFailureCountInterval: 0
+default:krbPwdLockoutDuration: 0
+
+# default password policies for hosts, services and kerberos services
+# cosPriority is set intentionally to higher number than FreeIPA API allows
+# to set to ensure that these password policies have always lower priority
+# than any defined by user.
+
+# hosts
+dn: cn=cosTemplates,cn=computers,cn=accounts,$SUFFIX
+default:objectclass: top
+default:objectclass: nsContainer
+default:cn: cosTemplates
+
+dn: cn=Default Password Policy,cn=cosTemplates,cn=computers,cn=accounts,$SUFFIX
+default:objectclass: top
+default:objectclass: cosTemplate
+default:objectclass: extensibleObject
+default:objectclass: krbContainer
+default:cn: Default Password Policy
+default:cosPriority: 10000000000
+default:krbPwdPolicyReference: cn=Default Host Password Policy,cn=computers,cn=accounts,$SUFFIX
+
+dn: cn=Default Password Policy,cn=computers,cn=accounts,$SUFFIX
+default:description: Default Password Policy for Hosts
+default:objectClass: top
+default:objectClass: ldapsubentry
+default:objectClass: cosSuperDefinition
+default:objectClass: cosPointerDefinition
+default:cosTemplateDn: cn=Default Password Policy,cn=cosTemplates,cn=computers,cn=accounts,$SUFFIX
+default:cosAttribute: krbPwdPolicyReference default
+
+# services
+dn: cn=cosTemplates,cn=services,cn=accounts,$SUFFIX
+default:objectclass: top
+default:objectclass: nsContainer
+default:cn: cosTemplates
+
+dn: cn=Default Password Policy,cn=cosTemplates,cn=services,cn=accounts,$SUFFIX
+default:objectclass: top
+default:objectclass: cosTemplate
+default:objectclass: extensibleObject
+default:objectclass: krbContainer
+default:cn: Default Password Policy
+default:cosPriority: 10000000000
+default:krbPwdPolicyReference: cn=Default Service Password Policy,cn=services,cn=accounts,$SUFFIX
+
+dn: cn=Default Password Policy,cn=services,cn=accounts,$SUFFIX
+default:description: Default Password Policy for Services
+default:objectClass: top
+default:objectClass: ldapsubentry
+default:objectClass: cosSuperDefinition
+default:objectClass: cosPointerDefinition
+default:cosTemplateDn: cn=Default Password Policy,cn=cosTemplates,cn=services,cn=accounts,$SUFFIX
+default:cosAttribute: krbPwdPolicyReference default
+
+# kerberos services
+dn: cn=cosTemplates,cn=$REALM,cn=kerberos,$SUFFIX
+default:objectclass: top
+default:objectclass: nsContainer
+default:cn: cosTemplates
+
+dn: cn=Default Password Policy,cn=cosTemplates,cn=$REALM,cn=kerberos,$SUFFIX
+default:objectclass: top
+default:objectclass: cosTemplate
+default:objectclass: extensibleObject
+default:objectclass: krbContainer
+default:cn: Default Password Policy
+default:cosPriority: 10000000000
+default:krbPwdPolicyReference: cn=Default Kerberos Service Password Policy,cn=Kerberos Service Password Policy,cn=$REALM,cn=kerberos,$SUFFIX
+
+dn: cn=Default Password Policy,cn=$REALM,cn=kerberos,$SUFFIX
+default:description: Default Password Policy for Kerberos Services
+default:objectClass: top
+default:objectClass: ldapsubentry
+default:objectClass: cosSuperDefinition
+default:objectClass: cosPointerDefinition
+default:cosTemplateDn: cn=Default Password Policy,cn=cosTemplates,cn=$REALM,cn=kerberos,$SUFFIX
+default:cosAttribute: krbPwdPolicyReference default

--- a/install/updates/Makefile.am
+++ b/install/updates/Makefile.am
@@ -22,6 +22,7 @@ app_DATA =				\
 	20-user_private_groups.update	\
 	20-winsync_index.update		\
 	20-uuid.update  \
+	20-default_password_policy.update \
 	21-replicas_container.update	\
 	21-ca_renewal_container.update	\
 	21-certstore_container.update	\

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -251,6 +251,7 @@ class Service(object):
             # There is no service in the wrong location, nothing to do.
             # This can happen when installing a replica
             return None
+        entry.pop('krbpwdpolicyreference', None)  # don't copy virtual attr
         newdn = DN(('krbprincipalname', principal), ('cn', 'services'), ('cn', 'accounts'), self.suffix)
         hostdn = DN(('fqdn', self.fqdn), ('cn', 'computers'), ('cn', 'accounts'), self.suffix)
         self.admin_conn.delete_entry(entry)


### PR DESCRIPTION
Set explicitly krbPwdPolicyReference attribute to all hosts (entries in
cn=computers,cn=accounts), services (entries in cn=services,cn=accounts) and
Kerberos services (entries in cn=$REALM,cn=kerberos). This is done using DS's
CoS so no attributes are really added.

The default policies effectively disable any enforcement or lockout for hosts
and services. Since hosts and services use keytabs passwords enforcements
doesn't make much sense. Also the lockout policy could be used for easy and
cheap DoS.