### PR TITLE
[4.3] certprofile-mod: correctly authorise config update

### DIFF
--- a/ipalib/plugins/certprofile.py
+++ b/ipalib/plugins/certprofile.py
@@ -326,6 +326,11 @@ class certprofile_mod(LDAPUpdate):
             raise errors.ProtectedEntryError(label='certprofile', key=keys[0],
                 reason=_('Certificate profiles cannot be renamed'))
         if 'file' in options:
+            # ensure operator has permission to update a certprofile
+            if not ldap.can_write(dn, 'ipacertprofilestoreissued'):
+                raise errors.ACIError(info=_(
+                    "Insufficient privilege to modify a certificate profile."))
+
             with self.api.Backend.ra_certprofile as profile_api:
                 profile_api.disable_profile(keys[0])
                 try:


### PR DESCRIPTION
Certificate profiles consist of an FreeIPA object, and a
corresponding Dogtag configuration object.  When updating profile
configuration, changes to the Dogtag configuration are not properly
authorised, allowing unprivileged operators to modify (but not
create or delete) profiles.  This could result in issuance of
certificates with fraudulent subject naming information, improper
key usage, or other badness.

Update certprofile-mod to ensure that the operator has permission to
modify FreeIPA certprofile objects before modifying the Dogtag
configuration.

https://fedorahosted.org/freeipa/ticket/6560