### PR TITLE
ipa-kdb: search for password policies globally

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_pwdpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_pwdpolicy.c
@@ -163,7 +163,7 @@ krb5_error_code ipadb_get_pwd_policy(krb5_context kcontext, char *name,
     }
 
     kerr = ipadb_simple_search(ipactx,
-                               ipactx->realm_base, LDAP_SCOPE_SUBTREE,
+                               ipactx->base, LDAP_SCOPE_SUBTREE,
                                src_filter, std_pwdpolicy_attrs, &res);
     if (kerr) {
         goto done;


### PR DESCRIPTION
With the CoS templates now used to create additional password policies
per object type that are placed under the object subtrees, DAL driver
needs to search for the policies in the whole tree.

Individual policies referenced by the krbPwdPolicyReference attribute
are always searched by their full DN and with the base scope. However,
when KDC asks a DAL driver to return a password policy by name, we don't
have any specific base to search. The original code did search by the
realm subtree.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1404910