### PR TITLE
ca: fix ca-find with --pkey-only

### DIFF
--- a/ipaserver/plugins/ca.py
+++ b/ipaserver/plugins/ca.py
@@ -162,7 +162,10 @@ class ca(LDAPObject):
 
 
 def set_certificate_attrs(entry, options, want_cert=True):
-    ca_id = entry['ipacaid'][0]
+    try:
+        ca_id = entry['ipacaid'][0]
+    except KeyError:
+        return
     full = options.get('all', False)
     want_chain = options.get('chain', False)
 
@@ -192,8 +195,9 @@ class ca_find(LDAPSearch):
     def execute(self, *keys, **options):
         ca_enabled_check()
         result = super(ca_find, self).execute(*keys, **options)
-        for entry in result['result']:
-            set_certificate_attrs(entry, options, want_cert=False)
+        if not options.get('pkey_only', False):
+            for entry in result['result']:
+                set_certificate_attrs(entry, options, want_cert=False)
         return result
 
 


### PR DESCRIPTION
Since commit 32b1743e5fb318b226a602ec8d9a4b6ef2a25c9d, ca-find will fail
with internal error if --pkey-only is specified, because the code to
look up the CA certificate and certificate chain assumes that the ipaCAId
attribute is always present in the result.

Fix this by not attempting to lookup the certificate / chain at all when
--pkey-only is specified.

https://fedorahosted.org/freeipa/ticket/6178