### PR TITLE
spec file: do not define with_lint inside a comment

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -9,7 +9,7 @@
 %endif
 
 # lint is not executed during rpmbuild
-# %global with_lint 1
+# %%global with_lint 1
 
 %global alt_name ipa
 %if 0%{?rhel}


### PR DESCRIPTION
RPM expands macros even inside comments in spec files, so the with_lint
macro is unintentionally always defined.

Escape the percent sign in '%global' in the comment to prevent this.

https://fedorahosted.org/freeipa/ticket/6418