### PR TITLE
spec file: revert to the previous Release tag

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -41,7 +41,7 @@
 
 Name:           freeipa
 Version:        %{IPA_VERSION}
-Release:        upstream
+Release:        0%{?dist}
 Summary:        The Identity, Policy and Audit system
 
 Group:          System Environment/Base


### PR DESCRIPTION
Revert from the current Release tag value `upstream` to the previously used
`0%{?dist}`, because:

* `0` sorts before `1`, which is usually used as the initial release number
  in downstream packages,

* the information provided by `%{?dist}` is useful, as packages built on
  one OS are not always installable on another OS.

https://fedorahosted.org/freeipa/ticket/6418