### PR TITLE
[fedora-26] named.conf template: update API for bind 9.11

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -371,18 +371,11 @@ Summary: IPA integrated DNS server with support for automatic DNSSEC signing
 Group: System Environment/Base
 BuildArch: noarch
 Requires: %{name}-server = %{version}-%{release}
-Requires: bind-dyndb-ldap >= 10.0
-%if 0%{?fedora} >= 21
-Requires: bind >= 9.9.6-3
-Requires: bind-utils >= 9.9.6-3
-Requires: bind-pkcs11 >= 9.9.6-3
-Requires: bind-pkcs11-utils >= 9.9.6-3
-%else
-Requires: bind >= 9.9.4-21
-Requires: bind-utils >= 9.9.4-21
-Requires: bind-pkcs11 >= 9.9.4-21
-Requires: bind-pkcs11-utils >= 9.9.4-21
-%endif
+Requires: bind-dyndb-ldap >= 11.0
+Requires: bind >= 9.11.0-6.P2
+Requires: bind-utils >= 9.11.0-6.P2
+Requires: bind-pkcs11 >= 9.11.0-6.P2
+Requires: bind-pkcs11-utils >= 9.11.0-6.P2
 Requires: opendnssec >= 1.4.6-4
 
 Provides: %{alt_name}-server-dns = %{version}

--- a/install/share/bind.named.conf.template
+++ b/install/share/bind.named.conf.template
@@ -43,13 +43,11 @@ zone "." IN {
 include "$RFC1912_ZONES";
 include "$ROOT_KEY";
 
-dynamic-db "ipa" {
-	library "ldap.so";
-	arg "uri ldapi://%2fvar%2frun%2fslapd-$SERVER_ID.socket";
-	arg "base cn=dns, $SUFFIX";
-	arg "server_id $FQDN";
-	arg "auth_method sasl";
-	arg "sasl_mech GSSAPI";
-	arg "sasl_user DNS/$FQDN";
-	arg "serial_autoincrement yes";
+dyndb "ipa" "$BIND_LDAP_SO" {
+	uri "ldapi://%2fvar%2frun%2fslapd-$SERVER_ID.socket";
+	base "cn=dns, $SUFFIX";
+	server_id "$FQDN";
+	auth_method "sasl";
+	sasl_mech "GSSAPI";
+	sasl_user "DNS/$FQDN";
 };

--- a/ipaplatform/redhat/paths.py
+++ b/ipaplatform/redhat/paths.py
@@ -33,6 +33,7 @@ class RedHatPathNamespace(BasePathNamespace):
     if sys.maxsize > 2**32:
         LIBSOFTHSM2_SO = BasePathNamespace.LIBSOFTHSM2_SO_64
         PAM_KRB5_SO = BasePathNamespace.PAM_KRB5_SO_64
+        BIND_LDAP_SO = BasePathNamespace.BIND_LDAP_SO_64
     AUTHCONFIG = '/usr/sbin/authconfig'
 
 

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -769,6 +769,7 @@ class BindInstance(service.Service):
             RFC1912_ZONES=paths.NAMED_RFC1912_ZONES,
             NAMED_PID=paths.NAMED_PID,
             NAMED_VAR_DIR=paths.NAMED_VAR_DIR,
+            BIND_LDAP_SO=paths.BIND_LDAP_SO,
             )
 
     def __setup_dns_container(self):


### PR DESCRIPTION
Please **do not merge** this patch upstream, we need to have BIND 9.11 available before we do, otherwise it will break DNS installation. This patch is intended for Fedora 26 downstream and I'm only posting it for review.

This patch only fixes DNS for new IPA installations. Another patch for fixing existing named configs is necessary. This will most likely be fixed in bind-dyndb-ldap upstream.

---

Use the new API for bind 9.11. Removed deprecated "serial_autoincrement"
and updated the rest of configuration to conform to the new format.

https://fedorahosted.org/freeipa/ticket/6565