### PR TITLE
Fix DL1 replica installation in CA-less topology

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1338,7 +1338,7 @@ def install(installer):
         # Always try to install DNS records
         install_dns_records(config, options, remote_api)
 
-        if promote:
+        if promote and ca_enabled:
             # we need to install http certs to setup ssl for httpd
             install_http_certs(config.host_name,
                                config.realm_name,


### PR DESCRIPTION
Commit dbb98765d73519289ee22f3de1a5ccde140f6f5d changed certmonger
requests for DS and HTTP certificates during installation to raise
on error (https://fedorahosted.org/freeipa/ticket/6514).
This introduced a regression in DL1 replica installation in CA-less
topology.  A certificate was requested, but prior to the
aforementioned commit this would fail silently and installation
continued, whereas now installation fails.

Guard the certificate request with a check that the topology is
CA-ful.

Fixes: https://fedorahosted.org/freeipa/ticket/6573