### PR TITLE
server install: fix KRA agent PEM file not being created

### DIFF
--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -181,6 +181,7 @@ class KRAInstaller(KRAInstall):
 
         self.options.dm_password = self.options.password
         self.options.setup_ca = False
+        self.options.setup_kra = True
 
         api.Backend.ldap2.connect()
 

--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -77,7 +77,7 @@ def install(api, replica_config, options):
 
         pkcs12_info = None
         master_host = None
-        ra_only = False
+        ra_only = not options.setup_kra
         promote = False
     else:
         krafile = os.path.join(replica_config.dir, 'kracert.p12')

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -609,6 +609,7 @@ def install_check(installer):
 
     if setup_ca:
         ca.install_check(False, None, options)
+        kra.install_check(api, None, options)
 
     if options.setup_dns:
         dns.install_check(False, api, False, options, host_name)
@@ -809,6 +810,7 @@ def install(installer):
 
     if setup_ca:
         ca.install_step_1(False, None, options)
+        kra.install(api, None, options)
 
     # The DS instance is created before the keytab, add the SSL cert we
     # generated


### PR DESCRIPTION
In commit 822e1bc82af3a6c1556546c4fbe96eeafad45762 the call to create the
KRA agent PEM file was accidentally removed from the server installer.

Call into the KRA installer from the server installer to create the file
again.

https://fedorahosted.org/freeipa/ticket/6392