### PR TITLE
Use the tar Posix option for tarballs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ esac
 
 AC_CONFIG_HEADERS([config.h])
 
-AM_INIT_AUTOMAKE([foreign 1.9 tar-ustar])
+AM_INIT_AUTOMAKE([foreign 1.9 tar-pax])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES])
 
 AC_PROG_CC_C99


### PR DESCRIPTION
This is necessary to be able to successfully build archives in
environments controlled by an IPA domain which may have large uidNumbers
for user accounts.

https://fedorahosted.org/freeipa/ticket/6418

Signed-off-by: Simo Sorce <simo@redhat.com>