### PR TITLE
dogtag: search past the first 100 certificates

### DIFF
--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1914,7 +1914,7 @@ class ra(rabase.rabase, RestClient):
 
         url = 'http://%s/ca/rest/certs/search?size=%d' % (
             ipautil.format_netloc(self.ca_host, 8080),
-            options.get('sizelimit', 100))
+            options.get('sizelimit', 0x7fffffff))
 
         opener = urllib.request.build_opener()
         opener.addheaders = [('Accept-Encoding', 'gzip, deflate'),


### PR DESCRIPTION
Dogtag requires a size limit to be specified when searching for
certificates. When no limit is specified in the dogtag plugin, a limit of
100 entries is assumed. As a result, an unlimited certificate search
returns data only for a maximum of 100 certificates.

Raise the "unlimited" limit to the maximum value Dogtag accepts.

https://fedorahosted.org/freeipa/ticket/6564