### PR TITLE
This PR implements a number of improvements for our Travis CI:

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -1,3 +1,9 @@
+#
+# Copyright (C) 2017 FreeIPA Contributors see COPYING for license
+#
+
+# Configuration file for the test runner used in Travis CI
+
 container:
   detach: true
   hostname: master.ipa.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,5 @@ script:
         --git-repo ${TRAVIS_BUILD_DIR}
         run-tests $test_set
 after_failure:
-  - echo "Test runner output:"
-  - tail -n 5000 ci_results_${TRAVIS_BRANCH}.log
-  - echo "PEP-8 errors:"
-  - cat pep8_errors.log
+    - echo "Test runner output:"; tail -n 5000 ci_results_${TRAVIS_BRANCH}.log
+    - echo "PEP-8 errors:"; cat pep8_errors.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,22 +22,7 @@ before_install:
       git+https://github.com/freeipa/ipa-docker-test-runner@release-0-2-1
 
 script:
-    - >
-        if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]];
-        then
-            git diff origin/${TRAVIS_BRANCH} -U0 | pep8 --diff &> pep8_errors.log;
-        fi
-    - "pushd ipatests; test_set=`ls -d -1 $TESTS_TO_RUN 2> /dev/null`; popd"
-    # use travis_wait so that long running tasks (tests) which produce no
-    # output do not cause premature termination of the build
-    - "docker pull ${TEST_RUNNER_IMAGE}"
-    - >
-        travis_wait 50
-        ipa-docker-test-runner -l ci_results_${TRAVIS_BRANCH}.log
-        -c .test_runner_config.yaml
-        --container-image ${TEST_RUNNER_IMAGE}
-        --git-repo ${TRAVIS_BUILD_DIR}
-        run-tests $test_set
+    - travis_wait 50 ./.travis_run_task.sh
 after_failure:
     - echo "Test runner output:"; tail -n 5000 ci_results_${TRAVIS_BRANCH}.log
     - echo "PEP-8 errors:"; cat pep8_errors.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,15 @@ services:
 env:
     global:
         - TEST_RUNNER_IMAGE="martbab/freeipa-fedora-test-runner:master-latest"
+          TEST_RUNNER_CONFIG=".test_runner_config.yaml"
+          PEP8_ERROR_LOG="pep8_errors.log"
+          CI_RESULTS_LOG="ci_results_${TRAVIS_BRANCH}.log"
     matrix:
-        - TESTS_TO_RUN="test_xmlrpc/test_[a-k]*.py"
-        - >
-            TESTS_TO_RUN="test_cmdline
+        - TASK_TO_RUN="lint"
+        - TASK_TO_RUN="run-tests"
+          TESTS_TO_RUN="test_xmlrpc/test_[a-k]*.py"
+        - TASK_TO_RUN="run-tests"
+          TESTS_TO_RUN="test_cmdline
             test_install
             test_ipalib
             test_ipapython
@@ -24,5 +29,5 @@ before_install:
 script:
     - travis_wait 50 ./.travis_run_task.sh
 after_failure:
-    - echo "Test runner output:"; tail -n 5000 ci_results_${TRAVIS_BRANCH}.log
-    - echo "PEP-8 errors:"; cat pep8_errors.log
+    - echo "Test runner output:"; tail -n 5000 $CI_RESULTS_LOG
+    - echo "PEP-8 errors:"; cat $PEP8_ERROR_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 services:
     - docker
 
+cache: pip
 env:
     global:
         - TEST_RUNNER_IMAGE="martbab/freeipa-fedora-test-runner:master-latest"
@@ -20,7 +21,7 @@ env:
             test_ipaserver
             test_pkcs10
             test_xmlrpc/test_[l-z]*.py"
-before_install:
+install:
     - pip install pep8
     - >
       pip3 install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 services:
     - docker
 
+python:
+    - "2.7"
 cache: pip
 env:
     global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
     - pip install pep8
     - >
       pip3 install
-      git+https://github.com/freeipa/ipa-docker-test-runner@release-0-2-0
+      git+https://github.com/freeipa/ipa-docker-test-runner@release-0-2-1
 
 script:
     - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: python
 services:
     - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
           TEST_RUNNER_CONFIG=".test_runner_config.yaml"
           PEP8_ERROR_LOG="pep8_errors.log"
           CI_RESULTS_LOG="ci_results_${TRAVIS_BRANCH}.log"
+          CI_BACKLOG_SIZE=5000
     matrix:
         - TASK_TO_RUN="lint"
         - TASK_TO_RUN="run-tests"
@@ -32,5 +33,5 @@ install:
 script:
     - travis_wait 50 ./.travis_run_task.sh
 after_failure:
-    - echo "Test runner output:"; tail -n 5000 $CI_RESULTS_LOG
+    - echo "Test runner output:"; tail -n $CI_BACKLOG_SIZE $CI_RESULTS_LOG
     - echo "PEP-8 errors:"; cat $PEP8_ERROR_LOG

--- a/.travis_run_task.sh
+++ b/.travis_run_task.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-
+#
+# Copyright (C) 2017 FreeIPA Contributors see COPYING for license
+#
 # NOTE: this script is intended to run in Travis CI only
 
 PYTHON="/usr/bin/python${TRAVIS_PYTHON_VERSION}"

--- a/.travis_run_task.sh
+++ b/.travis_run_task.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # NOTE: this script is intended to run in Travis CI only
-set -ev
 
+PYTHON="/usr/bin/python${TRAVIS_PYTHON_VERSION}"
 test_set=""
 developer_mode_opt="--developer-mode"
 
@@ -29,6 +29,7 @@ docker pull $TEST_RUNNER_IMAGE
 ipa-docker-test-runner -l $CI_RESULTS_LOG \
     -c $TEST_RUNNER_CONFIG \
     $developer_mode_opt \
+    --container-environment "PYTHON=$PYTHON" \
     --container-image $TEST_RUNNER_IMAGE \
     --git-repo $TRAVIS_BUILD_DIR \
     $TASK_TO_RUN $test_set

--- a/.travis_run_task.sh
+++ b/.travis_run_task.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# NOTE: this script is intended to run in Travis CI only
+set -ev
+
+test_set=""
+developer_mode_opt="--developer-mode"
+
+if [[ "$TASK_TO_RUN" == "lint" ]]
+then
+    if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]
+    then
+        git diff origin/$TRAVIS_BRANCH -U0 | pep8 --diff &> $PEP8_ERROR_LOG ||:
+    fi 
+
+    # disable developer mode for lint task, otherwise we get an error
+    developer_mode_opt=""
+fi
+
+if [[ -n "$TESTS_TO_RUN" ]]
+then
+    pushd ipatests
+    test_set=`ls -d -1 $TESTS_TO_RUN 2> /dev/null | tr '\n' ' '`
+    popd
+fi
+
+docker pull $TEST_RUNNER_IMAGE
+
+ipa-docker-test-runner -l $CI_RESULTS_LOG \
+    -c $TEST_RUNNER_CONFIG \
+    $developer_mode_opt \
+    --container-image $TEST_RUNNER_IMAGE \
+    --git-repo $TRAVIS_BUILD_DIR \
+    $TASK_TO_RUN $test_set

--- a/.travis_run_task.sh
+++ b/.travis_run_task.sh
@@ -8,6 +8,17 @@ PYTHON="/usr/bin/python${TRAVIS_PYTHON_VERSION}"
 test_set=""
 developer_mode_opt="--developer-mode"
 
+function truncate_log_to_test_failures() {
+    # chop off everything in the CI_RESULTS_LOG preceding pytest error output
+    # if there are pytest errors in the log
+    error_fail_regexp='\(=== ERRORS ===\)\|\(=== FAILURES ===\)'
+
+    if grep -e "$error_fail_regexp" $CI_RESULTS_LOG > /dev/null
+    then
+        sed -i "/$error_fail_regexp/,\$!d" $CI_RESULTS_LOG
+    fi
+}
+
 if [[ "$TASK_TO_RUN" == "lint" ]]
 then
     if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]
@@ -35,3 +46,8 @@ ipa-docker-test-runner -l $CI_RESULTS_LOG \
     --container-image $TEST_RUNNER_IMAGE \
     --git-repo $TRAVIS_BUILD_DIR \
     $TASK_TO_RUN $test_set
+
+if $?
+then
+    truncate_log_to_test_failures
+fi


### PR DESCRIPTION
* split out the test runner part into a standalone script, .travis.yml should
  now only define test matrix, set environment variables and process output 
  after failure

* mark the project as Python one, implement support for running builds using
  different python version (future-proofing against incoming Python2/3 CI) and
  cache job dependencies

* use separate job for pep8/linters. This shaves off ca 6-8 minutes from
  overall build time. You should get CI results in 26 min compared to previous
  33 min