### PR TITLE
ipaclient: schema cache: Handle malformed server info data gracefully

### DIFF
--- a/ipaclient/remote_plugins/__init__.py
+++ b/ipaclient/remote_plugins/__init__.py
@@ -41,8 +41,14 @@ class ServerInfo(collections.MutableMapping):
         try:
             with open(self._path, 'r') as sc:
                 self._dict = json.load(sc)
-        except EnvironmentError as e:
-            if e.errno != errno.ENOENT:
+        except Exception as e:
+            if (isinstance(e, EnvironmentError) and
+                    e.errno == errno.ENOENT):  # pylint: disable=no-member
+                # ignore non-existent file, this happens when the cache was
+                # erased or the server is contacted for the first time
+                pass
+            else:
+                # warn that the file is unreadable, probably corrupted
                 logger.warning('Failed to read server info: {}'.format(e))
 
     def _write(self):


### PR DESCRIPTION
As a part of CLI schema cache some data about each previously contacted server
are stored in simple JSON file. The file may get corrupted and became
undecodable for various reasons (parallel access, file system error,
tampering). Since the data are not necessary we should just warn an continue.

https://fedorahosted.org/freeipa/ticket/6578