### PR TITLE
Catch ValueError raised by pytest.config.getoption()

### DIFF
--- a/ipatests/test_util.py
+++ b/ipatests/test_util.py
@@ -140,8 +140,10 @@ class test_Fuzzy(object):
 
 def test_assert_deepequal():
     f = util.assert_deepequal
-    # pylint: disable=no-member
-    pretty = pytest.config.getoption("pretty_print")
+    try:  # pylint: disable=no-member
+        pretty = pytest.config.getoption("pretty_print")
+    except (AttributeError, ValueError):
+        pretty = False
 
     # LEN and KEYS formats use special function to pretty print structures
     # depending on a pytest environment settings

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -337,7 +337,7 @@ def assert_deepequal(expected, got, doc='', stack=tuple()):
     """
     try:
         pretty_print = pytest.config.getoption("pretty_print")  # pylint: disable=no-member
-    except AttributeError:
+    except (AttributeError, ValueError):
         pretty_print = False
 
     if pretty_print:


### PR DESCRIPTION
pytest.config.getoption() can raise ValueError for unknown options, too.

I ran into the issue while I was working on PR #366 