### PR TITLE
Restore IPA 3.0 compatibility of copy-schema-to-ca.py

### DIFF
--- a/install/share/copy-schema-to-ca.py
+++ b/install/share/copy-schema-to-ca.py
@@ -17,7 +17,6 @@ import shutil
 
 from hashlib import sha1
 
-from ipaplatform.paths import paths
 from ipapython import ipautil
 from ipapython.ipa_log_manager import root_logger, standard_logging_setup
 from ipaserver.install.dsinstance import schema_dirname
@@ -33,6 +32,14 @@ except ImportError:
     # oh dear, this is an old IPA (3.0+)
     from ipaserver.install.dsinstance import DS_USER   #pylint: disable=E0611
     from ipaserver.install.cainstance import PKI_USER  #pylint: disable=E0611
+
+try:
+    from ipaplatform.paths import paths
+    USR_SHARE_IPA_DIR = paths.USR_SHARE_IPA_DIR
+    ETC_IPA = paths.ETC_IPA
+except (ImportError, AttributeError):
+    USR_SHARE_IPA_DIR = "/usr/share/ipa/"
+    ETC_IPA = "/etc/ipa"
 
 try:
     from ipaplatform import services
@@ -66,7 +73,7 @@ def add_ca_schema():
     pki_pent = pwd.getpwnam(PKI_USER)
     ds_pent = pwd.getpwnam(DS_USER)
     for schema_fname in SCHEMA_FILENAMES:
-        source_fname = os.path.join(paths.USR_SHARE_IPA_DIR, schema_fname)
+        source_fname = os.path.join(USR_SHARE_IPA_DIR, schema_fname)
         target_fname = os.path.join(schema_dirname(SERVERID), schema_fname)
         if not os.path.exists(source_fname):
             root_logger.debug('File does not exist: %s', source_fname)
@@ -114,7 +121,7 @@ def main():
     standard_logging_setup(verbose=True)
 
     # In 3.0, restarting needs access to api.env
-    api.bootstrap_with_global_options(context='server', confdir=paths.ETC_IPA)
+    api.bootstrap_with_global_options(context='server', confdir=ETC_IPA)
 
     add_ca_schema()
     restart_pki_ds()


### PR DESCRIPTION
Apparently ipaplatform.paths is not available on IPA 3.x.

https://fedorahosted.org/freeipa/ticket/6540

Signed-off-by: Christian Heimes <cheimes@redhat.com>