### PR TITLE
pytest: set rules to find test files and functions

### DIFF
--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -42,6 +42,12 @@ NO_RECURSE_DIRS = [
     'install/share'
 ]
 
+INIVALUES = {
+    'python_classes': ['test_', 'Test'],
+    'python_files': ['test_*.py'],
+    'python_functions': ['test_*'],
+}
+
 
 def pytest_configure(config):
     # add pytest markers
@@ -52,12 +58,10 @@ def pytest_configure(config):
     for norecursedir in NO_RECURSE_DIRS:
         config.addinivalue_line('norecursedirs', norecursedir)
 
-    # load test classes with these prefixes.
-    # addinivalue_line() adds duplicated entries.
-    python_classes = config.getini('python_classes')
-    for value in ['test_', 'Test']:
-        if value not in python_classes:
-            python_classes.append(value)
+    # addinivalue_line() adds duplicated entries and does not remove existing.
+    for name, values in INIVALUES.items():
+        current = config.getini(name)
+        current[:] = values
 
     # set default JUnit prefix
     if config.option.junitprefix is None:


### PR DESCRIPTION
1e06a5195bafe0224d77371987f2509f5508ca2f removed pytest.ini. Without the
ini file, pytest 3.x has suboptimal settings and no longer picks up all
test functions and test files.

Signed-off-by: Christian Heimes <cheimes@redhat.com>