### PR TITLE
dogtaginstance: track server certificate with our renew agent

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -108,6 +108,15 @@ def is_renewable():
         return x509.is_self_signed(cert) or is_lightweight_ca()
 
 
+def is_replicated():
+    return not get_nickname()
+
+
+def is_renewal_master():
+    ca = cainstance.CAInstance(host_name=api.env.host)
+    return ca.is_renewal_master()
+
+
 @contextlib.contextmanager
 def ldap_connect():
     conn = None
@@ -447,10 +456,8 @@ def renew_ca_cert():
     if operation == 'SUBMIT':
         state = 'retrieve'
 
-        if is_renewable():
-            ca = cainstance.CAInstance(host_name=api.env.host)
-            if ca.is_renewal_master():
-                state = 'request'
+        if is_renewable() and is_renewal_master():
+            state = 'request'
     elif operation == 'POLL':
         cookie = os.environ.get('CERTMONGER_CA_COOKIE')
         if not cookie:
@@ -506,14 +513,14 @@ def main():
     certs.renewal_lock.acquire()
     try:
         profile = os.environ.get('CERTMONGER_CA_PROFILE')
-        if profile:
-            handler = handlers.get(profile, request_and_store_cert)
-        else:
-            ca = cainstance.CAInstance(host_name=api.env.host)
-            if ca.is_renewal_master():
+        if is_replicated():
+            if profile or is_renewal_master():
                 handler = request_and_store_cert
             else:
                 handler = retrieve_cert_continuous
+        else:
+            handler = request_cert
+        handler = handlers.get(profile, handler)
 
         res = call_handler(handler)
         for item in res[1:]:

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -32,8 +32,6 @@ import sys
 import syslog
 import time
 import tempfile
-import shlex
-import pipes
 
 # pylint: disable=import-error
 from six.moves.configparser import ConfigParser, RawConfigParser
@@ -946,16 +944,6 @@ class CAInstance(DogtagInstance):
         if path:
             iface.remove_known_ca(path)
 
-        helper = self.restore_state('certmonger_dogtag_helper')
-        if helper:
-            path = iface.find_ca_by_nickname('dogtag-ipa-renew-agent')
-            if path:
-                ca_obj = bus.get_object('org.fedorahosted.certmonger', path)
-                ca_iface = dbus.Interface(ca_obj,
-                                          'org.freedesktop.DBus.Properties')
-                ca_iface.Set('org.fedorahosted.certmonger.ca',
-                             'external-helper', helper)
-
         cmonger.stop()
 
         # remove CRL files
@@ -986,35 +974,23 @@ class CAInstance(DogtagInstance):
         fd.close()
         os.chmod(location, 0o444)
 
-
-    def configure_certmonger_renewal(self):
-        super(CAInstance, self).configure_certmonger_renewal()
-
-        self.configure_certmonger_renewal_guard()
-
-    def configure_certmonger_renewal_guard(self):
+    def unconfigure_certmonger_renewal_guard(self):
         if not self.is_configured():
             return
 
-        bus = dbus.SystemBus()
-        obj = bus.get_object('org.fedorahosted.certmonger',
-                             '/org/fedorahosted/certmonger')
-        iface = dbus.Interface(obj, 'org.fedorahosted.certmonger')
-        path = iface.find_ca_by_nickname('dogtag-ipa-renew-agent')
-        if path:
-            ca_obj = bus.get_object('org.fedorahosted.certmonger', path)
-            ca_iface = dbus.Interface(ca_obj,
-                                      'org.freedesktop.DBus.Properties')
-            helper = ca_iface.Get('org.fedorahosted.certmonger.ca',
-                                  'external-helper')
-            if helper:
-                args = shlex.split(helper)
-                if args[0] != paths.IPA_SERVER_GUARD:
-                    self.backup_state('certmonger_dogtag_helper', helper)
-                    args = [paths.IPA_SERVER_GUARD] + args
-                    helper = ' '.join(pipes.quote(a) for a in args)
-                    ca_iface.Set('org.fedorahosted.certmonger.ca',
-                                 'external-helper', helper)
+        helper = self.restore_state('certmonger_dogtag_helper')
+        if helper:
+            bus = dbus.SystemBus()
+            obj = bus.get_object('org.fedorahosted.certmonger',
+                                 '/org/fedorahosted/certmonger')
+            iface = dbus.Interface(obj, 'org.fedorahosted.certmonger')
+            path = iface.find_ca_by_nickname('dogtag-ipa-renew-agent')
+            if path:
+                ca_obj = bus.get_object('org.fedorahosted.certmonger', path)
+                ca_iface = dbus.Interface(ca_obj,
+                                          'org.freedesktop.DBus.Properties')
+                ca_iface.Set('org.fedorahosted.certmonger.ca',
+                             'external-helper', helper)
 
     def configure_agent_renewal(self):
         try:

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -325,7 +325,7 @@ class DogtagInstance(service.Service):
         pin = self.__get_pin()
         try:
             certmonger.dogtag_start_tracking(
-                ca='dogtag-ipa-renew-agent',
+                ca='dogtag-ipa-ca-renew-agent',
                 nickname=self.server_cert_name,
                 pin=pin,
                 pinfile=None,

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -917,7 +917,7 @@ def certificate_renewal_update(ca, ds, http):
     dirsrv_dir = dsinstance.config_dirname(serverid)
 
     # bump version when requests is changed
-    version = 5
+    version = 6
     requests = (
         (
             paths.PKI_TOMCAT_ALIAS_DIR,
@@ -962,7 +962,7 @@ def certificate_renewal_update(ca, ds, http):
         (
             paths.PKI_TOMCAT_ALIAS_DIR,
             'Server-Cert cert-pki-ca',
-            'dogtag-ipa-renew-agent',
+            'dogtag-ipa-ca-renew-agent',
             template % 'stop_pkicad',
             '%s "Server-Cert cert-pki-ca"' % (template % 'renew_ca_cert'),
             None,

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1613,7 +1613,7 @@ def upgrade_configuration():
     if ca.is_configured() and not certmonger_service.is_running():
         certmonger_service.start()
 
-    ca.configure_certmonger_renewal_guard()
+    ca.unconfigure_certmonger_renewal_guard()
 
     update_dbmodules(api.env.realm)
     uninstall_ipa_kpasswd()


### PR DESCRIPTION
This patchset is intended to make @simo5's life easier when changing the RA agent certificate location in #314.

**renew agent: handle non-replicated certificates**

In addition to replicated certificates (Dogtag certificates, RA
certificate), handle non-replicated certificates in
dogtag-ipa-ca-renew-agent as well.

**dogtaginstance: track server certificate with our renew agent**

Track Dogtag's server certificate with dogtag-ipa-ca-renew-agent instead of
dogtag-ipa-renew-agent.

**cainstance: do not configure renewal guard**

Do not configure renewal guard for dogtag-ipa-renew-agent, as it is not
used in IPA anymore.

https://fedorahosted.org/freeipa/ticket/5959