### PR TITLE
Travis CI: actually return non-zero exit status when the test job fails

### DIFF
--- a/.travis_run_task.sh
+++ b/.travis_run_task.sh
@@ -47,7 +47,11 @@ ipa-docker-test-runner -l $CI_RESULTS_LOG \
     --git-repo $TRAVIS_BUILD_DIR \
     $TASK_TO_RUN $test_set
 
-if $?
+exit_status="$?"
+
+if [[ "$exit_status" -ne 0 ]]
 then
     truncate_log_to_test_failures
 fi
+
+exit $exit_status


### PR DESCRIPTION
Thanks to @stlaz for catching this.