### PR TITLE
disable hostname canonicalization by Kerberos library

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -676,6 +676,7 @@ def configure_krb5_conf(
         ])
     libopts.extend([
         krbconf.setOption('rdns', 'false'),
+        krbconf.setOption('dns_canonicalize_hostname', 'false'),
         krbconf.setOption('ticket_lifetime', '24h'),
         krbconf.setOption('forwardable', 'true'),
         krbconf.setOption('udp_preference_limit', '0')


### PR DESCRIPTION
By default, Kerberos client library attempts to canonicalize service
hostname in TGS requests. This can fail e.g. if hosts file on the client
machine references short names before FQDNs. In this case the short name
is used in TGS_REQ which KDC fails to resolve.

Since we do not (yet) support referencing hosts by their short names it
is safe to just disable this behavior in krb5.conf and use supplied
FQDNs.

https://fedorahosted.org/freeipa/ticket/6584