### PR TITLE
[Py3] ipa-server-install fixes (working NTP, DS, CA install steps)

### DIFF
--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -969,7 +969,7 @@ class vault_retrieve(Local):
         json_vault_data = decoding_ctx.cipher_op(wrapped_vault_data)\
             + decoding_ctx.digest_final()
 
-        vault_data = json.loads(json_vault_data)
+        vault_data = json.loads(json_vault_data.decode('utf-8'))
         data = base64.b64decode(vault_data[u'data'].encode('utf-8'))
 
         encrypted_key = None

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -1101,7 +1101,8 @@ class JSONServerProxy(object):
         )
 
         try:
-            response = json_decode_binary(json.loads(response.decode('ascii')))
+            response = json_decode_binary(
+                json.loads(response.decode('utf-8')))
         except ValueError as e:
             raise JSONError(error=str(e))
 

--- a/ipapython/dogtag.py
+++ b/ipapython/dogtag.py
@@ -209,6 +209,7 @@ def _httplib_request(
         http_body = res.read()
         conn.close()
     except Exception as e:
+        root_logger.exception("httplib request failed:")
         raise NetworkError(uri=uri, error=str(e))
 
     root_logger.debug('response status %d',    http_status)

--- a/ipapython/dogtag.py
+++ b/ipapython/dogtag.py
@@ -205,7 +205,7 @@ def _httplib_request(
         res = conn.getresponse()
 
         http_status = res.status
-        http_headers = res.msg.dict
+        http_headers = res.msg
         http_body = res.read()
         conn.close()
     except Exception as e:

--- a/ipapython/dogtag.py
+++ b/ipapython/dogtag.py
@@ -188,9 +188,7 @@ def _httplib_request(
 
     Perform a HTTP(s) request.
     """
-    if isinstance(host, unicode):
-        host = host.encode('utf-8')
-    uri = '%s://%s%s' % (protocol, ipautil.format_netloc(host, port), path)
+    uri = u'%s://%s%s' % (protocol, ipautil.format_netloc(host, port), path)
     root_logger.debug('request %s %s', method, uri)
     root_logger.debug('request body %r', request_body)
 

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -1252,8 +1252,9 @@ class LDAPClient(object):
                 value = u'\\'.join(
                     value[i:i+2] for i in six.moves.range(-2, len(value), 2))
             else:
-                value = value_to_utf8(value)
+                value = six.text_type(value)
                 value = ldap.filter.escape_filter_chars(value)
+
             if not exact:
                 template = '%s'
                 if leading_wildcard:

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -887,7 +887,8 @@ class LDAPClient(object):
         elif isinstance(val, tuple):
             return tuple(self.encode(m) for m in val)
         elif isinstance(val, dict):
-            dct = dict((self.encode(k), self.encode(v)) for k, v in val.items())
+            # key in dict must be str not bytes
+            dct = dict((k, self.encode(v)) for k, v in val.items())
             return dct
         elif isinstance(val, datetime.datetime):
             return val.strftime(LDAP_GENERALIZED_TIME_FORMAT)

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -852,7 +852,7 @@ def ipa_generate_password(entropy_bits=256, uppercase=1, lowercase=1, digits=1,
     rnd = random.SystemRandom()
 
     todo_entropy = entropy_bits
-    password = ''
+    password = u''
     # Generate required character classes:
     # The order of generated characters is fixed to comply with check in
     # NSS function sftk_newPinCheck() in nss/lib/softoken/fipstokn.c.

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -1020,7 +1020,7 @@ $)''', re.VERBOSE)
     orig_stat = os.stat(filepath)
     old_values = dict()
     temp_filename = None
-    with tempfile.NamedTemporaryFile(delete=False) as new_config:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as new_config:
         temp_filename = new_config.name
         with open(filepath, 'r') as f:
             for line in f:
@@ -1106,7 +1106,7 @@ $)''', re.VERBOSE)
     orig_stat = os.stat(filepath)
     old_values = dict()
     temp_filename = None
-    with tempfile.NamedTemporaryFile(delete=False) as new_config:
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as new_config:
         temp_filename = new_config.name
         with open(filepath, 'r') as f:
             in_section = False

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -19,6 +19,7 @@
 
 from __future__ import print_function
 
+import codecs
 import string
 import tempfile
 import subprocess
@@ -1359,6 +1360,55 @@ def escape_seq(seq, *args):
     """
 
     return tuple(a.replace(seq, u'\\{}'.format(seq)) for a in args)
+
+
+def decode_json(data):
+    """Decode JSON bytes to string with proper encoding
+
+    Only for supporting Py 3.5
+
+    Py 3.6 supports bytes as parameter for json.load, we can drop this when
+    there is no need for python 3.5 anymore
+
+    Code from:
+        https://bugs.python.org/file43513/json_detect_encoding_3.patch
+
+    :param data: JSON bytes
+    :return: return JSON string
+    """
+
+    def detect_encoding(b):
+        bstartswith = b.startswith
+        if bstartswith((codecs.BOM_UTF32_BE, codecs.BOM_UTF32_LE)):
+            return 'utf-32'
+        if bstartswith((codecs.BOM_UTF16_BE, codecs.BOM_UTF16_LE)):
+            return 'utf-16'
+        if bstartswith(codecs.BOM_UTF8):
+            return 'utf-8-sig'
+
+        if len(b) >= 4:
+            if not b[0]:
+                # 00 00 -- -- - utf-32-be
+                # 00 XX -- -- - utf-16-be
+                return 'utf-16-be' if b[1] else 'utf-32-be'
+            if not b[1]:
+                # XX 00 00 00 - utf-32-le
+                # XX 00 XX XX - utf-16-le
+                return 'utf-16-le' if b[2] or b[3] else 'utf-32-le'
+        elif len(b) == 2:
+            if not b[0]:
+                # 00 XX - utf-16-be
+                return 'utf-16-be'
+            if not b[1]:
+                # XX 00 - utf-16-le
+                return 'utf-16-le'
+        # default
+        return 'utf-8'
+
+    if isinstance(data, six.text_type):
+        return data
+
+    return data.decode(detect_encoding(data), 'surrogatepass')
 
 
 class APIVersion(tuple):

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -33,6 +33,7 @@ import syslog
 import time
 import tempfile
 
+import six
 # pylint: disable=import-error
 from six.moves.configparser import ConfigParser, RawConfigParser
 # pylint: enable=import-error
@@ -500,7 +501,7 @@ class CAInstance(DogtagInstance):
         # Directory server
         config.set("CA", "pki_ds_ldap_port", "389")
         config.set("CA", "pki_ds_password", self.dm_password)
-        config.set("CA", "pki_ds_base_dn", self.basedn)
+        config.set("CA", "pki_ds_base_dn", six.text_type(self.basedn))
         config.set("CA", "pki_ds_database", "ipaca")
 
         if self.use_ldaps:

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -599,7 +599,7 @@ class CAInstance(DogtagInstance):
         config.set("Tomcat", "pki_ajp_host", "::1")
 
         # Generate configuration file
-        with open(cfg_file, "wb") as f:
+        with open(cfg_file, "w") as f:
             config.write(f)
 
         self.backup_state('installed', True)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1528,22 +1528,19 @@ def __add_acls(new_rules):
     Return ``True`` if any ACLs were added otherwise ``False``.
 
     """
-    server_id = installutils.realm_to_serverid(api.env.realm)
-    dogtag_uri = 'ldapi://%%2fvar%%2frun%%2fslapd-%s.socket' % server_id
     updated = False
 
     dn = DN(('cn', 'aclResources'), ('o', 'ipaca'))
 
-    conn = ldap2.ldap2(api, ldap_uri=dogtag_uri)
-    if not conn.isconnected():
-        conn.connect(autobind=True)
-    cur_rules = conn.get_entry(dn).get('resourceACLS', [])
+    conn = api.Backend.ldap2
+    entry = conn.get_entry(dn)
+    cur_rules = entry.get('resourceACLS', [])
     add_rules = [rule for rule in new_rules if rule not in cur_rules]
     if add_rules:
-        conn.conn.modify_s(str(dn), [(ldap.MOD_ADD, 'resourceACLS', add_rules)])
+        cur_rules.extend(add_rules)
+        conn.update_entry(entry)
         updated = True
 
-    conn.disconnect()
     return updated
 
 

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -587,14 +587,15 @@ class DsInstance(service.Service):
             'dse.ldif'
         )
 
-        with tempfile.NamedTemporaryFile(delete=False) as new_dse_ldif:
+        with tempfile.NamedTemporaryFile(
+                mode='w', delete=False) as new_dse_ldif:
             temp_filename = new_dse_ldif.name
             with open(dse_filename, "r") as input_file:
                 parser = installutils.ModifyLDIF(input_file, new_dse_ldif)
                 parser.replace_value(
                         'cn=config,cn=ldbm database,cn=plugins,cn=config',
                         'nsslapd-db-locks',
-                        ['50000']
+                        [b'50000']
                         )
                 if self.config_ldif:
                     # parse modifications from ldif file supplied by the admin

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -19,6 +19,7 @@
 
 from __future__ import print_function
 
+import io
 import os
 import os.path
 import pwd
@@ -314,9 +315,8 @@ class HTTPInstance(service.Service):
 
         # Create the password file for this db
         password = ipautil.ipa_generate_password()
-        f = os.open(pwd_file, os.O_CREAT | os.O_RDWR)
-        os.write(f, password)
-        os.close(f)
+        with io.open(pwd_file, 'w') as f:
+            f.write(password)
 
         ipautil.run([paths.CERTUTIL, "-d", database, "-f", pwd_file, "-N"])
 

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -22,6 +22,7 @@ import pwd
 import shutil
 import tempfile
 
+import six
 # pylint: disable=import-error
 from six.moves.configparser import ConfigParser
 # pylint: enable=import-error
@@ -190,7 +191,7 @@ class KRAInstance(DogtagInstance):
         # Directory server
         config.set("KRA", "pki_ds_ldap_port", "389")
         config.set("KRA", "pki_ds_password", self.dm_password)
-        config.set("KRA", "pki_ds_base_dn", self.basedn)
+        config.set("KRA", "pki_ds_base_dn", six.text_type(self.basedn))
         config.set("KRA", "pki_ds_database", "ipaca")
         config.set("KRA", "pki_ds_create_new_db", "False")
 

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -263,7 +263,7 @@ class KRAInstance(DogtagInstance):
                 admin_path.write(cert)
 
         # Generate configuration file
-        with open(cfg_file, "wb") as f:
+        with open(cfg_file, "w") as f:
             config.write(f)
 
         try:

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -208,9 +208,10 @@ class Service(object):
         args += ["-H", ldap_uri]
 
         if dm_password:
-            [pw_fd, pw_name] = tempfile.mkstemp()
-            os.write(pw_fd, dm_password)
-            os.close(pw_fd)
+            with tempfile.NamedTemporaryFile(
+                    mode='w', delete=False) as pw_file:
+                pw_file.write(dm_password)
+                pw_name = pw_file.name
             auth_parms = ["-x", "-D", "cn=Directory Manager", "-y", pw_name]
         # Use GSSAPI auth when not using DM password or not being root
         elif os.getegid() != 0:

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -654,7 +654,7 @@ class LDAPObject(Object):
             del entry_attrs[attr]
 
             for member in value:
-                memberdn = DN(member)
+                memberdn = DN(member.decode('utf-8'))
                 for ldap_obj_name in self.attribute_members[attr]:
                     ldap_obj = self.api.Object[ldap_obj_name]
                     try:

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1232,7 +1232,8 @@ class RestClient(Backend):
     @staticmethod
     def _parse_dogtag_error(body):
         try:
-            return pki.PKIException.from_json(json.loads(body))
+            return pki.PKIException.from_json(
+                json.loads(ipautil.decode_json(body)))
         except Exception:
             return None
 
@@ -1667,7 +1668,7 @@ class ra(rabase.rabase, RestClient):
         )
 
         try:
-            resp_obj = json.loads(http_body)
+            resp_obj = json.loads(ipautil.decode_json(http_body))
         except ValueError:
             raise errors.RemoteRetrieveError(reason=_("Response from CA was not valid JSON"))
 
@@ -2115,7 +2116,7 @@ class ra_lightweight_ca(RestClient):
             body=json.dumps({"parentID": "host-authority", "dn": unicode(dn)}),
         )
         try:
-            return json.loads(resp_body)
+            return json.loads(ipautil.decode_json(resp_body))
         except Exception as e:
             self.log.debug(e, exc_info=True)
             raise errors.RemoteRetrieveError(
@@ -2125,7 +2126,7 @@ class ra_lightweight_ca(RestClient):
         _status, _resp_headers, resp_body = self._ssldo(
             'GET', ca_id, headers={'Accept': 'application/json'})
         try:
-            return json.loads(resp_body)
+            return json.loads(ipautil.decode_json(resp_body))
         except Exception as e:
             self.log.debug(e, exc_info=True)
             raise errors.RemoteRetrieveError(

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -2116,16 +2116,20 @@ class ra_lightweight_ca(RestClient):
         )
         try:
             return json.loads(resp_body)
-        except:
-            raise errors.RemoteRetrieveError(reason=_("Response from CA was not valid JSON"))
+        except Exception as e:
+            self.log.debug(e, exc_info=True)
+            raise errors.RemoteRetrieveError(
+                reason=_("Response from CA was not valid JSON"))
 
     def read_ca(self, ca_id):
         _status, _resp_headers, resp_body = self._ssldo(
             'GET', ca_id, headers={'Accept': 'application/json'})
         try:
             return json.loads(resp_body)
-        except:
-            raise errors.RemoteRetrieveError(reason=_("Response from CA was not valid JSON"))
+        except Exception as e:
+            self.log.debug(e, exc_info=True)
+            raise errors.RemoteRetrieveError(
+                reason=_("Response from CA was not valid JSON"))
 
     def read_ca_cert(self, ca_id):
         _status, _resp_headers, resp_body = self._ssldo(

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -417,7 +417,7 @@ class ldap2(CrudBackend, LDAPClient):
         # update group entry
         try:
             with self.error_handler():
-                modlist = [(a, self.encode(b), self.encode(c))
+                modlist = [(a, b, self.encode(c))
                            for a, b, c in modlist]
                 self.conn.modify_s(str(group_dn), modlist)
         except errors.DatabaseError:


### PR DESCRIPTION
This PR should allow to install server with py3

Up to "Done configuring certificate server (pki-tomcatd)."

I decided to split this effort as it looke that there will be too many patches