### PR TITLE
Remove duplicated step from DS install

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -340,8 +340,6 @@ class DsInstance(service.Service):
         self.step("adding range check plugin", self.__add_range_check_plugin)
         if hbac_allow:
             self.step("creating default HBAC rule allow_all", self.add_hbac)
-        self.step("adding sasl mappings to the directory",
-                  self.__configure_sasl_mappings)
         self.step("adding entries for topology management", self.__add_topology_entries)
 
         self.__common_post_setup()


### PR DESCRIPTION
"Adding SASL mappings.." is duplicated step in __common_setup in DS
instance and should be removed.