### PR TITLE
Add fix for user prompt in dnsrecord-add

### DIFF
--- a/ipaclient/plugins/dns.py
+++ b/ipaclient/plugins/dns.py
@@ -254,7 +254,7 @@ class dnsrecord_add(MethodOverride):
                 continue
             ok = True
 
-        user_options = prompt_parts(rrtype, self)
+        user_options = prompt_missing_parts(rrtype, self, kw)
         kw.update(user_options)
 
 


### PR DESCRIPTION
Fix added to skip optional parameter in dnsrecord-add
interactive prompts

Fixes https://fedorahosted.org/freeipa/ticket/6457

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>