### PR TITLE
py3: enable py3 pylint

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -40,7 +40,8 @@ steps:
     -a ${server_password} --setup-dns --auto-forwarders
   - ipa-kra-install -p ${server_password}
   lint:
-  - make V=0 lint
+  - PYTHON=/usr/bin/python2 make V=0 lint
+  - PYTHON=/usr/bin/python3 make V=0 pylint
   prepare_tests:
   - echo ${server_password} | kinit admin && ipa ping
   - cp -r /etc/ipa/* ~/.ipa/


### PR DESCRIPTION
We should run pylint in both python2 and python3 versions