### PR TITLE
ipapython: Add dependencies on version.py

### DIFF
--- a/ipapython/Makefile.am
+++ b/ipapython/Makefile.am
@@ -4,6 +4,8 @@ EXTRA_DIST = version.py.in
 
 all-local: version.py
 dist-hook: version.py
+install-exec-local: version.py
+bdist_wheel: version.py
 
 version.py: version.py.in $(top_builddir)/$(CONFIG_STATUS)
 	$(AM_V_GEN)sed						\


### PR DESCRIPTION
install-exec and bdist_wheel also depend on version.py. Let's ensure
that version.py is correctly generated when installing or building
packages.

Yes, make is clever and correctly merges dependencies with rules from
included make files.

Signed-off-by: Christian Heimes <cheimes@redhat.com>