### PR TITLE
[Py3] allow to run wsgi - part1

### DIFF
--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -251,13 +251,22 @@ def normalize_certificate(rawcert):
 
     rawcert = strip_header(rawcert)
 
-    if util.isvalid_base64(rawcert):
-        try:
-            dercert = base64.b64decode(rawcert)
-        except Exception as e:
-            raise errors.Base64DecodeError(reason=str(e))
-    else:
+    try:
+        if isinstance(rawcert, bytes):
+            # base64 must work with utf-8, otherwise it is raw bin certificate
+            decoded_cert = rawcert.decode('utf-8')
+        else:
+            decoded_cert = rawcert
+    except UnicodeDecodeError:
         dercert = rawcert
+    else:
+        if util.isvalid_base64(decoded_cert):
+            try:
+                dercert = base64.b64decode(decoded_cert)
+            except Exception as e:
+                raise errors.Base64DecodeError(reason=str(e))
+        else:
+            dercert = rawcert
 
     # At this point we should have a DER certificate.
     # Attempt to decode it.

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -85,12 +85,16 @@ def strip_header(pem):
     """
     Remove the header and footer from a certificate.
     """
-    s = pem.find("-----BEGIN CERTIFICATE-----")
-    if s >= 0:
-        e = pem.find("-----END CERTIFICATE-----")
-        pem = pem[s+27:e]
-
-    return pem
+    regexp = (
+        u"^-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----"
+    )
+    if isinstance(pem, bytes):
+        regexp = regexp.encode('ascii')
+    s = re.search(regexp, pem, re.MULTILINE | re.DOTALL)
+    if s is not None:
+        return s.group(1)
+    else:
+        return pem
 
 
 def load_certificate(data, datatype=PEM):

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -896,7 +896,9 @@ class LDAPClient(object):
         elif isinstance(val, tuple):
             return tuple(self.decode(m, attr) for m in val)
         elif isinstance(val, dict):
-            dct = dict((k.decode('utf-8'), self.decode(v, k)) for k, v in val.items())
+            dct = {
+                k.decode('utf-8'): self.decode(v, k) for k, v in val.items()
+            }
             return dct
         elif val is None:
             return None

--- a/ipapython/kerberos.py
+++ b/ipapython/kerberos.py
@@ -66,7 +66,12 @@ class Principal(object):
     Container for the principal name and realm according to RFC 1510
     """
     def __init__(self, components, realm=None):
-        if isinstance(components, six.string_types):
+        if isinstance(components, six.binary_type):
+            raise TypeError(
+                "Cannot create a principal object from bytes: {!r}".format(
+                    components)
+            )
+        elif isinstance(components, six.string_types):
             # parse principal components from realm
             self.components, self.realm = self._parse_from_text(
                 components, realm)

--- a/ipapython/ssh.py
+++ b/ipapython/ssh.py
@@ -192,9 +192,8 @@ class SSHPublicKey(object):
 
     def fingerprint_hex_sha256(self):
         # OpenSSH trims the trailing '=' of base64 sha256 FP representation
-        # Using unicode argument converts the result to unicode object
-        fp = base64.b64encode(sha256(self._key).digest()).rstrip(u'=')
-        return 'SHA256:{fp}'.format(fp=fp)
+        fp = base64.b64encode(sha256(self._key).digest()).rstrip(b'=')
+        return u'SHA256:{fp}'.format(fp=fp.decode('utf-8'))
 
     def _fingerprint_dns(self, fpfunc, fptype):
         if self._keytype == 'ssh-rsa':

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -804,7 +804,9 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
         try:
             # re-serialise to PEM, in case the user-supplied data has
             # extraneous material that will cause Dogtag to freak out
-            csr_pem = csr_obj.public_bytes(serialization.Encoding.PEM)
+            # keep it as string not bytes, it is required later
+            csr_pem = csr_obj.public_bytes(
+                serialization.Encoding.PEM).decode('utf-8')
             result = self.Backend.ra.request_certificate(
                 csr_pem, profile_id, ca_id, request_type=request_type)
         except errors.HTTPRequestError as e:

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1634,7 +1634,7 @@ class ra(rabase.rabase, RestClient):
         self.debug('%s.request_certificate()', type(self).__name__)
 
         # Call CMS
-        template = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        template = u'''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
             <CertEnrollmentRequest>
                 <ProfileID>{profile}</ProfileID>
                 <Input id="i1">

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -289,7 +289,10 @@ class ldap2(CrudBackend, LDAPClient):
         principal = getattr(context, 'principal')
         entry = self.find_entry_by_attr("krbprincipalname", principal,
             "krbPrincipalAux", base_dn=self.api.env.basedn)
-        sctrl = [GetEffectiveRightsControl(True, "dn: " + str(entry.dn))]
+        sctrl = [
+            GetEffectiveRightsControl(
+                True, "dn: {0}".format(entry.dn).encode('utf-8'))
+        ]
         self.conn.set_option(_ldap.OPT_SERVER_CONTROLS, sctrl)
         try:
             entry = self.get_entry(dn, attrs_list)

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -310,7 +310,7 @@ class ldap2(CrudBackend, LDAPClient):
 
         attrs = self.get_effective_rights(dn, [attr])
         if 'attributelevelrights' in attrs:
-            attr_rights = attrs.get('attributelevelrights')[0].decode('UTF-8')
+            attr_rights = attrs.get('attributelevelrights')[0]
             (attr, rights) = attr_rights.split(':')
             if 'w' in rights:
                 return True

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -389,8 +389,9 @@ class WSGIExecutioner(Executioner):
                 )
                 # get at least some context of what is going on
                 params = options
+                error = e
             if error:
-                result_string = type(e).__name__
+                result_string = type(error).__name__
             else:
                 result_string = 'SUCCESS'
             self.info('[%s] %s: %s(%s): %s',

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -404,7 +404,7 @@ class WSGIExecutioner(Executioner):
                       type(self).__name__,
                       principal,
                       name,
-                      type(e).__name__)
+                      type(error).__name__)
 
         version = options.get('version', VERSION_WITHOUT_CAPABILITIES)
         return self.marshal(result, error, _id, version)

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -144,7 +144,7 @@ class HTTP_Status(plugable.Plugin):
         self.info('%s: URL="%s", %s', status, url, message)
         start_response(status, response_headers)
         output = _not_found_template % dict(url=escape(url))
-        return [output]
+        return [output.encode('utf-8')]
 
     def bad_request(self, environ, start_response, message):
         """
@@ -157,7 +157,7 @@ class HTTP_Status(plugable.Plugin):
 
         start_response(status, response_headers)
         output = _bad_request_template % dict(message=escape(message))
-        return [output]
+        return [output.encode('utf-8')]
 
     def internal_error(self, environ, start_response, message):
         """
@@ -170,7 +170,7 @@ class HTTP_Status(plugable.Plugin):
 
         start_response(status, response_headers)
         output = _internal_error_template % dict(message=escape(message))
-        return [output]
+        return [output.encode('utf-8')]
 
     def unauthorized(self, environ, start_response, message, reason):
         """
@@ -185,7 +185,7 @@ class HTTP_Status(plugable.Plugin):
 
         start_response(status, response_headers)
         output = _unauthorized_template % dict(message=escape(message))
-        return [output]
+        return [output.encode('utf-8')]
 
 def read_input(environ):
     """
@@ -427,7 +427,7 @@ class WSGIExecutioner(Executioner):
         except Exception:
             self.exception('WSGI %s.__call__():', self.name)
             status = HTTP_STATUS_SERVER_ERROR
-            response = status
+            response = status.encode('utf-8')
             headers = [('Content-Type', 'text/plain; charset=utf-8')]
 
         session_data = getattr(context, 'session_data', None)
@@ -489,7 +489,8 @@ class jsonserver(WSGIExecutioner, HTTP_Status):
             version=unicode(VERSION),
         )
         response = json_encode_binary(response, version)
-        return json.dumps(response, sort_keys=True, indent=4)
+        dump = json.dumps(response, sort_keys=True, indent=4)
+        return dump.encode('utf-8')
 
     def unmarshal(self, data):
         try:
@@ -672,7 +673,7 @@ class KerberosWSGIExecutioner(WSGIExecutioner, HTTP_Status, KerberosSession):
                     'xmlserver', user_ccache, environ, start_response, headers)
         except PublicError as e:
             status = HTTP_STATUS_SUCCESS
-            response = status
+            response = status.encode('utf-8')
             start_response(status, headers)
             return self.marshal(None, e)
         finally:
@@ -758,7 +759,8 @@ class xmlserver(KerberosWSGIExecutioner):
             if isinstance(result, dict):
                 self.debug('response: entries returned %d', result.get('count', 1))
             response = (result,)
-        return xml_dumps(response, version, methodresponse=True)
+        dump = xml_dumps(response, version, methodresponse=True)
+        return dump.encode('utf-8')
 
 
 class jsonserver_session(jsonserver, KerberosSession):
@@ -782,7 +784,7 @@ class jsonserver_session(jsonserver, KerberosSession):
     def need_login(self, start_response):
         status = '401 Unauthorized'
         headers = []
-        response = ''
+        response = b''
 
         self.debug('jsonserver_session: %s need login', status)
 
@@ -1252,7 +1254,7 @@ class xmlserver_session(xmlserver, KerberosSession):
     def need_login(self, start_response):
         status = '401 Unauthorized'
         headers = []
-        response = ''
+        response = b''
 
         self.debug('xmlserver_session: %s need login', status)
 

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -195,7 +195,7 @@ def read_input(environ):
         length = int(environ.get('CONTENT_LENGTH'))
     except (ValueError, TypeError):
         return
-    return environ['wsgi.input'].read(length)
+    return environ['wsgi.input'].read(length).decode('utf-8')
 
 
 def params_2_args_options(params):

--- a/ipaserver/session.py
+++ b/ipaserver/session.py
@@ -21,6 +21,7 @@ import random
 import os
 import re
 import time
+import io
 
 # pylint: disable=import-error
 from six.moves.urllib.parse import urlparse
@@ -1228,9 +1229,8 @@ def load_ccache_data(ccache_name):
     scheme, name = krb5_parse_ccache(ccache_name)
     if scheme == 'FILE':
         root_logger.debug('reading ccache data from file "%s"', name)
-        src = open(name)
-        ccache_data = src.read()
-        src.close()
+        with io.open(name, "rb") as src:
+            ccache_data = src.read()
         return ccache_data
     else:
         raise ValueError('ccache scheme "%s" unsupported (%s)', scheme, ccache_name)
@@ -1239,9 +1239,8 @@ def bind_ipa_ccache(ccache_data, scheme='FILE'):
     if scheme == 'FILE':
         name = _get_krbccache_pathname()
         root_logger.debug('storing ccache data into file "%s"', name)
-        dst = open(name, 'w')
-        dst.write(ccache_data)
-        dst.close()
+        with io.open(name, 'wb') as dst:
+            dst.write(ccache_data)
     else:
         raise ValueError('ccache scheme "%s" unsupported', scheme)
 

--- a/ipaserver/session.py
+++ b/ipaserver/session.py
@@ -828,7 +828,7 @@ class MemcacheSessionManager(SessionManager):
         result = {}
         stats = self.mc.get_stats()
         for server in stats:
-            match = self.mc_server_stat_name_re.search(server[0])
+            match = self.mc_server_stat_name_re.search(server[0].decode())
             if match:
                 name = match.group(1)
                 result[name] = server[1]


### PR DESCRIPTION
With these patches we can run commands with server running on py3

Note: to use py3 install module `python3-mod_wsgi` that enables py3 wsgi automatically

Note: this may or may not depend (I haven't tested) on my PR #382 so it contains all patches, will be rebased when PR #382 merged

first WSGI related commit is 
- py3: session.py decode server name to str ￼…			7ff4b83

