### PR TITLE
Configure PKI ajp redirection to use "localhost" instead of "::1"

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -246,8 +246,8 @@ Requires(post): systemd-units
 Requires: selinux-policy >= %{selinux_policy_version}
 Requires(post): selinux-policy-base >= %{selinux_policy_version}
 Requires: slapi-nis >= %{slapi_nis_version}
-Requires: pki-ca >= 10.3.5-6
-Requires: pki-kra >= 10.3.5-6
+Requires: pki-ca >= 10.3.5-11
+Requires: pki-kra >= 10.3.5-11
 Requires(preun): python systemd-units
 Requires(postun): python systemd-units
 Requires: policycoreutils >= 2.1.12-5

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -594,10 +594,6 @@ class CAInstance(DogtagInstance):
             config.set("CA", "pki_external_ca_cert_chain_path", cert_chain_file.name)
             config.set("CA", "pki_external_step_two", "True")
 
-        # PKI IPv6 Configuration
-        config.add_section("Tomcat")
-        config.set("Tomcat", "pki_ajp_host", "::1")
-
         # Generate configuration file
         with open(cfg_file, "w") as f:
             config.write(f)


### PR DESCRIPTION
When ipa-server-install configures PKI, it provides a configuration file
with the parameter pki_ajp_host set to ::1. This parameter is used to configure
Tomcat redirection in /etc/pki/pki-tomcat/server.xml:
    <Connector port="8009"
            protocol="AJP/1.3"
            redirectPort="8443"
            address="::1" />
ie all requests to port 8009 are redirected to port 8443 on address ::1.

If the /etc/hosts config file does not define ::1 for localhost, then AJP
redirection fails and replica install is not able to request a certificate
for the replica. Using "localhost" instead works with IPv4 or IPv6.

https://fedorahosted.org/freeipa/ticket/6575