### PR TITLE
Explicitly remove support of SSLv2

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -283,3 +283,13 @@ ANON_USER = 'WELLKNOWN/ANONYMOUS'
 # IPA API Framework user
 IPAAPI_USER = 'ipaapi'
 IPAAPI_GROUP = 'ipaapi'
+
+# TLS related constants
+TLS_VERSIONS = [
+    "ssl2",
+    "ssl3",
+    "tls1.0",
+    "tls1.1",
+    "tls1.2"
+]
+TLS_VERSION_MINIMAL = "tls1.0"


### PR DESCRIPTION
It was possible to set tls_version_min/max to 'ssl2', even though
newer versions of NSS will fail to set this as a valid TLS version.
This patch explicitly checks for deprecated TLS versions prior to
creating a TLS connection.

https://fedorahosted.org/freeipa/ticket/6607