### PR TITLE
Improve wheel building and provide ipaserver wheel for local testing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -256,6 +256,17 @@ endif  # WITH_JSLINT
 WHEELDISTDIR = $(top_builddir)/dist/wheels
 WHEELBUNDLEDIR = $(top_builddir)/dist/bundle
 
+@MK_IFEQ@ ($(IPA_SERVER_WHEELS),1)
+    IPA_WHEEL_PACKAGES @MK_ASSIGN@ $(IPACLIENT_SUBDIRS) ipaplatform ipaserver
+    IPA_OMIT_INSTALL @MK_ASSIGN@ 0
+@MK_ELSE@
+    IPA_WHEEL_PACKAGES @MK_ASSIGN@ $(IPACLIENT_SUBDIRS)
+    IPA_OMIT_INSTALL @MK_ASSIGN@ 1
+@MK_ENDIF@
+
+# additional wheels for bundle, e.g. IPA_EXTRA_WHEELS="ipatests[webui] pylint"
+IPA_EXTRA_WHEELS=
+
 $(WHEELDISTDIR):
 	mkdir -p $(WHEELDISTDIR)
 
@@ -263,19 +274,22 @@ $(WHEELBUNDLEDIR):
 	mkdir -p $(WHEELBUNDLEDIR)
 
 bdist_wheel: $(WHEELDISTDIR)
-	for dir in $(IPACLIENT_SUBDIRS); do \
+	rm -f $(foreach item,$(IPA_WHEEL_PACKAGES) ipatests,$(WHEELDISTDIR)/$(item)-*.whl)
+	export IPA_OMIT_INSTALL=$(IPA_OMIT_INSTALL); \
+	for dir in $(IPA_WHEEL_PACKAGES) ipatests; do \
 	    $(MAKE) $(AM_MAKEFLAGS) -C $${dir} $@ || exit 1; \
 	done
 
 wheel_bundle: $(WHEELBUNDLEDIR) bdist_wheel .wheelconstraints
-	rm -f $(foreach item,$(IPACLIENT_SUBDIRS),$(WHEELBUNDLEDIR)/$(item)-*.whl)
-	$(PYTHON) -m pip wheel \
+	rm -f $(foreach item,$(IPA_WHEEL_PACKAGES) ipatests,$(WHEELBUNDLEDIR)/$(item)-*.whl)
+	@# dbus-python sometimes fails when MAKEFLAGS is set to -j2 or higher
+	MAKEFLAGS= $(PYTHON) -m pip wheel \
 	    --disable-pip-version-check \
 	    --constraint .wheelconstraints \
 	    --find-links $(WHEELDISTDIR) \
 	    --find-links $(WHEELBUNDLEDIR) \
 	    --wheel-dir $(WHEELBUNDLEDIR) \
-	    $(IPACLIENT_SUBDIRS)
+	    $(IPA_WHEEL_PACKAGES) $(IPA_EXTRA_WHEELS)
 
 wheel_placeholder: $(WHEELDISTDIR)
 	for dir in $(IPA_PLACEHOLDERS); do \

--- a/configure.ac
+++ b/configure.ac
@@ -385,6 +385,12 @@ AC_SUBST([GIT_VERSION], [IPA_GIT_VERSION])
 # used by Makefile.am for files depending on templates
 AC_SUBST([CONFIG_STATUS])
 
+# workaround for syntax clash between make and automake
+AC_SUBST([MK_IFEQ], [ifeq])
+AC_SUBST([MK_ELSE], [else])
+AC_SUBST([MK_ENDIF], [endif])
+AC_SUBST([MK_ASSIGN], [=])
+
 dnl ---------------------------------------------------------------------------
 dnl Finish
 dnl ---------------------------------------------------------------------------

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -146,6 +146,7 @@ BuildRequires:  python-cffi
 # Build dependencies for wheel packaging and PyPI upload
 #
 %if 0%{with_wheels}
+BuildRequires:  dbus-glib-devel
 BuildRequires:  python2-twine
 BuildRequires:  python2-wheel
 %if 0%{?with_python3}

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -31,9 +31,6 @@
     %global linter_options --disable-pylint --without-jslint
 %endif
 
-# Python wheel support and PyPI packages
-%global with_wheels 0
-
 %global alt_name ipa
 %if 0%{?rhel}
 # Require 4.6.0-4 which brings RC4 for FIPS + trust fixes to priv. separation
@@ -145,7 +142,7 @@ BuildRequires:  python-cffi
 #
 # Build dependencies for wheel packaging and PyPI upload
 #
-%if 0%{with_wheels}
+%if 0%{?with_wheels}
 BuildRequires:  dbus-glib-devel
 BuildRequires:  python2-twine
 BuildRequires:  python2-wheel

--- a/ipaserver/plugins/hbactest.py
+++ b/ipaserver/plugins/hbactest.py
@@ -34,7 +34,7 @@ import six
 try:
     import pyhbac
 except ImportError:
-    pyhbac = None
+    raise errors.SkipPluginModule(reason=_('pyhbac is not installed.'))
 
 
 if six.PY3:
@@ -314,14 +314,6 @@ class hbactest(Command):
         return host
 
     def execute(self, *args, **options):
-        if pyhbac is None:
-            raise errors.ValidationError(
-                name=_('missing pyhbac'),
-                error=_(
-                    'pyhbac is not available on the server.'
-                )
-            )
-
         # First receive all needed information:
         # 1. HBAC rules (whether enabled or disabled)
         # 2. Required options are (user, target host, service)

--- a/ipaserver/setup.py
+++ b/ipaserver/setup.py
@@ -60,12 +60,6 @@ if __name__ == '__main__':
             "pyasn1",
             "pyldap",
             "six",
-            # not available on PyPI
-            # "python-libipa_hbac",
-            # "python-sss",
-            # "python-sss-murmur",
-            # "python-SSSDConfig",
-            # "samba-python",
         ],
         entry_points={
             'custodia.authorizers': [
@@ -75,4 +69,12 @@ if __name__ == '__main__':
                 'IPASecStore = ipaserver.secrets.store:IPASecStore',
             ],
         },
+        extras_require={
+            # These packages are currently not available on PyPI.
+            "caacl": ["pyhbac"],
+            "dcerpc": ["samba", "pysss", "pysss_nss_idmap"],
+            "hbactest": ["pyhbac"],
+            "install": ["SSSDConfig"],
+            "trust": ["pysss_murmur", "pysss_nss_idmap"],
+        }
     )

--- a/ipaserver/setup.py
+++ b/ipaserver/setup.py
@@ -71,7 +71,6 @@ if __name__ == '__main__':
         },
         extras_require={
             # These packages are currently not available on PyPI.
-            "caacl": ["pyhbac"],
             "dcerpc": ["samba", "pysss", "pysss_nss_idmap"],
             "hbactest": ["pyhbac"],
             "install": ["SSSDConfig"],

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -29,7 +29,8 @@ class build_py(setuptools_build_py):
 
     def finalize_options(self):
         setuptools_build_py.finalize_options(self)
-        if 'bdist_wheel' in self.distribution.commands:
+        omit = os.environ.get('IPA_OMIT_INSTALL', '0')
+        if omit == '1':
             distname = self.distribution.metadata.name
             self.skip_package = '{}.install'.format(distname)
             log.warn("bdist_wheel: Ignore package: %s",


### PR DESCRIPTION
The PR improve wheel bundle building and allows ipaserver bundles for local testing
with instrumented build of Python. Debug builds and instrumented builds can have a different binary interface (ABI). For example it is useful for dtrace or test installations in a virtual env. ipaplatform and ipaserver will not be uploaded to PyPI, though.