### PR TITLE
ipa-kdb: support KDB DAL version 6.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,27 @@ krb5rundir="${localstatedir}/run/krb5kdc"
 AC_SUBST(KRAD_LIBS)
 AC_SUBST(krb5rundir)
 
+AC_CHECK_HEADER(kdb.h, [], [AC_MSG_ERROR([kdb.h not found])])
+AC_CHECK_MEMBER(
+	[kdb_vftabl.free_principal],
+	[AC_DEFINE([HAVE_KDB_FREEPRINCIPAL], [1],
+		   [KDB driver API has free_principal callback])],
+	[AC_MSG_NOTICE([KDB driver API has no free_principal callback])],
+	[[#include <kdb.h>]])
+AC_CHECK_MEMBER(
+	[kdb_vftabl.free_principal_e_data],
+	[AC_DEFINE([HAVE_KDB_FREEPRINCIPAL_EDATA], [1],
+		   [KDB driver API has free_principal_e_data callback])],
+	[AC_MSG_NOTICE([KDB driver API has no free_principal_e_data callback])],
+	[[#include <kdb.h>]])
+
+if test "x$ac_cv_member_kdb_vftabl_free_principal" = "xno" \
+	-a "x$ac_cv_member_kdb_vftable_free_principal_e_data" = "xno" ; then
+    AC_MSG_WARN([KDB driver API does not allow to free Kerberos principal data.])
+    AC_MSG_WARN([KDB driver will leak memory on Kerberos principal use])
+    AC_MSG_WARN([See https://github.com/krb5/krb5/pull/596 for details])
+fi
+
 dnl ---------------------------------------------------------------------------
 dnl - Check for OpenLDAP SDK
 dnl ---------------------------------------------------------------------------

--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -625,6 +625,9 @@ static void ipadb_free(krb5_context context, void *ptr)
 
 /* KDB Virtual Table */
 
+/* We explicitly want to keep different ABI tables below separate. */
+/* Do not merge them together. Older ABI does not need to be updated */
+
 #if KRB5_KDB_DAL_MAJOR_VERSION == 5
 kdb_vftabl kdb_function_table = {
     .maj_ver = KRB5_KDB_DAL_MAJOR_VERSION,
@@ -657,8 +660,9 @@ kdb_vftabl kdb_function_table = {
     .audit_as_req = ipadb_audit_as_req,
     .check_allowed_to_delegate = ipadb_check_allowed_to_delegate
 };
+#endif
 
-#elif KRB5_KDB_DAL_MAJOR_VERSION == 6
+#if (KRB5_KDB_DAL_MAJOR_VERSION == 6) && !defined(HAVE_KDB_FREEPRINCIPAL_EDATA)
 kdb_vftabl kdb_function_table = {
     .maj_ver = KRB5_KDB_DAL_MAJOR_VERSION,
     .min_ver = 0,
@@ -686,8 +690,42 @@ kdb_vftabl kdb_function_table = {
     .audit_as_req = ipadb_audit_as_req,
     .check_allowed_to_delegate = ipadb_check_allowed_to_delegate
 };
+#endif
 
-#else
+#if (KRB5_KDB_DAL_MAJOR_VERSION == 6) && defined(HAVE_KDB_FREEPRINCIPAL_EDATA)
+kdb_vftabl kdb_function_table = {
+    .maj_ver = KRB5_KDB_DAL_MAJOR_VERSION,
+    .min_ver = 1,
+    .init_library = ipadb_init_library,
+    .fini_library = ipadb_fini_library,
+    .init_module = ipadb_init_module,
+    .fini_module = ipadb_fini_module,
+    .create = ipadb_create,
+    .get_age = ipadb_get_age,
+    .get_principal = ipadb_get_principal,
+    .put_principal = ipadb_put_principal,
+    .delete_principal = ipadb_delete_principal,
+    .iterate = ipadb_iterate,
+    .create_policy = ipadb_create_pwd_policy,
+    .get_policy = ipadb_get_pwd_policy,
+    .put_policy = ipadb_put_pwd_policy,
+    .iter_policy = ipadb_iterate_pwd_policy,
+    .delete_policy = ipadb_delete_pwd_policy,
+    .fetch_master_key = ipadb_fetch_master_key,
+    .store_master_key_list = ipadb_store_master_key_list,
+    .change_pwd = ipadb_change_pwd,
+    .sign_authdata = ipadb_sign_authdata,
+    .check_transited_realms = ipadb_check_transited_realms,
+    .check_policy_as = ipadb_check_policy_as,
+    .audit_as_req = ipadb_audit_as_req,
+    .check_allowed_to_delegate = ipadb_check_allowed_to_delegate,
+    /* The order is important, DAL version 6.1 added
+     * the free_principal_e_data callback */
+    .free_principal_e_data = ipadb_free_principal_e_data,
+};
+#endif
+
+#if (KRB5_KDB_DAL_MAJOR_VERSION != 5) && (KRB5_KDB_DAL_MAJOR_VERSION != 6)
 #error unsupported DAL major version
 #endif
 

--- a/daemons/ipa-kdb/ipa_kdb.h
+++ b/daemons/ipa-kdb/ipa_kdb.h
@@ -180,6 +180,8 @@ krb5_error_code ipadb_get_principal(krb5_context kcontext,
                                     unsigned int flags,
                                     krb5_db_entry **entry);
 void ipadb_free_principal(krb5_context kcontext, krb5_db_entry *entry);
+/* Helper function for DAL API 6.1 or later */
+void ipadb_free_principal_e_data(krb5_context kcontext, krb5_octet *e_data);
 krb5_error_code ipadb_put_principal(krb5_context kcontext,
                                     krb5_db_entry *entry,
                                     char **db_args);

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -57,8 +57,16 @@ Source0:        freeipa-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:  openldap-devel
+# For KDB DAL version, make explicit dependency so that increase of version
+# will cause the build to fail due to unsatisfied dependencies.
+# DAL version change may cause code crash or memory leaks, it is better to fail early.
+%if 0%{?fedora} > 25
+BuildRequires: krb5-devel >= 1.15-5
+BuildRequires: krb5-kdb-version = 6.1
+%else
 # 1.12: libkrad (http://krbdev.mit.edu/rt/Ticket/Display.html?id=7678)
 BuildRequires:  krb5-devel >= 1.12
+%endif
 # 1.27.4: xmlrpc_curl_xportparms.gssapi_delegation
 BuildRequires:  xmlrpc-c-devel >= 1.27.4
 BuildRequires:  popt-devel


### PR DESCRIPTION
DAL version 6.0 removed support for a callback to free principal.
This broke KDB drivers which had complex e_data structure within
the principal structure. As result, FreeIPA KDB driver was leaking
memory with DAL version 6.0 (krb5 1.15).

DAL version 6.1 added a special callback for freeing e_data structure.
See details at https://github.com/krb5/krb5/pull/596

Restructure KDB driver code to provide this callback in case
we are built against DAL version that supports it. For DAL version
prior to 6.0 use this callback in the free_principal callback to
tidy the code.

https://fedorahosted.org/freeipa/ticket/6619

On Fedora the required interface is available in krb5-1.15-5.fc26 package.