### PR TITLE
Define template version in certmap.conf

### DIFF
--- a/install/share/certmap.conf.template
+++ b/install/share/certmap.conf.template
@@ -1,3 +1,7 @@
+# VERSION 3 - DO NOT REMOVE THIS LINE
+#
+# This file is managed by IPA and will be overwritten on upgrades.
+#
 #
 # This file configures how a certificate is mapped to an LDAP entry.  See the
 # documentation for more information on this file.

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -169,6 +169,9 @@ def upgrade_file(sub_dict, filename, template, add=False):
     if new < 0:
         root_logger.error("%s not found." % template)
 
+    if new == 0:
+        root_logger.error("Template %s is not versioned." % template)
+
     if old == 0:
         # The original file does not have a VERSION entry. This means it's now
         # managed by IPA, but previously was not.
@@ -1558,7 +1561,7 @@ def upgrade_configuration():
 
     subject_base = find_subject_base()
     if subject_base:
-        sub_dict['SUBJECT_BASE'] = subject_base
+        sub_dict['ISSUER_DN'] = 'CN=Certificate Authority,' + subject_base
 
     ca = cainstance.CAInstance(
             api.env.realm, host_name=api.env.host)


### PR DESCRIPTION
A previous commit (ffb9a09a0d63f7edae2b647b5c1d503d1d4d7a6e) removed the
definition of VERSION 2 in certmap.conf.template.

ipa-server-upgrade tool compares the template version with the version in
certmap.conf. As VERSION is not defined in either file, it concludes that
version = 0 for both and does not make a backup of certmap.conf even though
it prints that it will.

The fix re-defines VERSION in the template and adapts the code because the
template has changed (it is using $ISSUER_DN instead of
CN=Certificate Authority,$SUBJECT_BASE).

The fix also logs an error when a template file is not versioned.

https://fedorahosted.org/freeipa/ticket/6354