### PR TITLE
ca-del: require CA to already be disabled

### DIFF
--- a/ipaserver/plugins/ca.py
+++ b/ipaserver/plugins/ca.py
@@ -286,7 +286,12 @@ class ca_del(LDAPDelete):
 
         ca_id = self.api.Command.ca_show(keys[0])['result']['ipacaid'][0]
         with self.api.Backend.ra_lightweight_ca as ca_api:
-            ca_api.disable_ca(ca_id)
+            data = ca_api.read_ca(ca_id)
+            if data['enabled']:
+                raise errors.ProtectedEntryError(
+                    label=_("CA"),
+                    key=keys[0],
+                    reason=_("Must be disabled first"))
             ca_api.delete_ca(ca_id)
 
         return dn

--- a/ipatests/test_xmlrpc/test_ca_plugin.py
+++ b/ipatests/test_xmlrpc/test_ca_plugin.py
@@ -87,6 +87,10 @@ class TestCAbasicCRUD(XMLRPC_test):
     def test_retrieve_all(self, crud_subca):
         crud_subca.retrieve(all=True)
 
+    def test_delete_while_not_disabled(self, crud_subca):
+        with pytest.raises(errors.ProtectedEntryError):
+            crud_subca.make_command('ca_del', crud_subca.name)()
+
     def test_delete(self, crud_subca):
         crud_subca.delete()
 

--- a/ipatests/test_xmlrpc/tracker/ca_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/ca_plugin.py
@@ -82,7 +82,11 @@ class CATracker(Tracker):
 
     def make_delete_command(self):
         """Make function that deletes the plugin entry object."""
-        return self.make_command('ca_del', self.name)
+        def disable_then_delete():
+            self.make_command('ca_disable', self.name)()
+            return self.make_command('ca_del', self.name)()
+
+        return disable_then_delete
 
     def check_delete(self, result):
         assert_deepequal(dict(


### PR DESCRIPTION
Currently ca-del disables the target CA before deleting it.
Conceptually, this involves two separate permissions: modify and
delete.  A user with delete permission does not necessarily have
modify permission.

As we move toward enforcing IPA permissions in Dogtag, it is
necessary to decouple disablement from deletion, otherwise the
disable operation would fail if the user does not have modify
permission.  Although it introduces an additional step for
administrators, the process is consistent, required permissions are
clear, and errors are human-friendly.

Part of: https://fedorahosted.org/freeipa/ticket/5011

freeipa-devel discussion: https://www.redhat.com/archives/freeipa-devel/2017-January/msg00435.html