### PR TITLE
private_ccache: yield ccache name

### DIFF
--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -1300,7 +1300,7 @@ def private_ccache(path=None):
     os.environ['KRB5CCNAME'] = path
 
     try:
-        yield
+        yield path
     finally:
         if original_value is not None:
             os.environ['KRB5CCNAME'] = original_value


### PR DESCRIPTION
When using private_ccache, yield 'path' from the context manager.
This is cleaner than inspecting 'os.environ['KRB5CCNAME']' within
the context.

Part of: https://fedorahosted.org/freeipa/ticket/5011