### PR TITLE
replica install: do not log host OTP

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -876,6 +876,7 @@ def ensure_enrolled(installer):
 
         args = [paths.IPA_CLIENT_INSTALL, "--unattended", "--no-ntp"]
         stdin = None
+        nolog = []
 
         if installer.domain_name:
             args.extend(["--domain", installer.domain_name])
@@ -888,6 +889,7 @@ def ensure_enrolled(installer):
 
         if installer.password:
             args.extend(["--password", installer.password])
+            nolog.append(installer.password)
         else:
             if installer.admin_password:
                 # Always set principal if password was set explicitly,
@@ -908,7 +910,7 @@ def ensure_enrolled(installer):
         if installer.mkhomedir:
             args.append("--mkhomedir")
 
-        ipautil.run(args, stdin=stdin, redirect_output=True)
+        ipautil.run(args, stdin=stdin, nolog=nolog, redirect_output=True)
         print()
     except Exception:
         raise ScriptError("Configuration of client side components failed!")


### PR DESCRIPTION
Do not log the value of the --password option of ipa-client-install when it
is run from ipa-replica-install before replica promotion.

https://fedorahosted.org/freeipa/ticket/6633