### PR TITLE
ipa-ca-install: do not fail without --subject-base and --ca-subject

### DIFF
--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -216,10 +216,11 @@ def install_master(safe_options, options):
     options.host_name = api.env.host
 
     if not options.subject_base:
-        options.subject_base = installutils.default_subject_base(api.env.realm)
+        options.subject_base = str(
+            installutils.default_subject_base(api.env.realm))
     if not options.ca_subject:
-        options.ca_subject = installutils.default_ca_subject_dn(
-            options.subject_base)
+        options.ca_subject = str(
+            installutils.default_ca_subject_dn(options.subject_base))
 
     try:
         ca.subject_validator(ca.VALID_SUBJECT_BASE_ATTRS, options.subject_base)


### PR DESCRIPTION
When --subject-base and --ca-subject are not specified in ipa-ca-install,
default values are used. DN objects are used as the default values in
ipa-ca-install, but the CA installer expects the values to be strings. This
causes ipa-ca-install to fail unless both --subject-base and --ca-subject
are specified.

Convert the DN objects to strings to fix the issue.

https://fedorahosted.org/freeipa/ticket/2614