### PR TITLE
Allow login to WebUI using Kerberos aliases/enterprise principals

### DIFF
--- a/ipalib/krb_utils.py
+++ b/ipalib/krb_utils.py
@@ -79,20 +79,6 @@ def krb5_parse_ccache(ccache_name):
 def krb5_unparse_ccache(scheme, name):
     return '%s:%s' % (scheme.upper(), name)
 
-def krb5_format_principal_name(user, realm):
-    '''
-    Given a Kerberos user principal name and a Kerberos realm
-    return the Kerberos V5 user principal name.
-
-    :parameters:
-      user
-        User principal name.
-      realm
-        The Kerberos realm the user exists in.
-    :returns:
-      Kerberos V5 user principal name.
-    '''
-    return '%s@%s' % (user, realm)
 
 def krb5_format_service_principal_name(service, host, realm):
     '''


### PR DESCRIPTION
The logic of the extraction/validation of principal from the request and
subsequent authentication was simplified and most of the guesswork will be done
by KDC during kinit. This allows for using principal aliases/enterprise
principals to log into WebUI and also lays foundation for enabling logons from
users from trusted domains.

https://fedorahosted.org/freeipa/ticket/6343