### PR TITLE
Fix reference before assignment

### DIFF
--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -706,6 +706,7 @@ class KerbTransport(SSLTransport):
             cookie_header = [cookie_header]
 
         # Search for the session cookie
+        session_cookie = None
         try:
             for cookie in cookie_header:
                 session_cookie = \


### PR DESCRIPTION
In 'store_session_cookie', if the server does not set the session
cookie for some reason, the 'session_cookie' variable does not get
assigned, resulting in UnboundLocalError.  Set an initial value of
'None'.

Fixes: https://fedorahosted.org/freeipa/ticket/6636