### PR TITLE
Tests: fix wait_for_replication task

### DIFF
--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -1067,8 +1067,15 @@ def wait_for_replication(ldap, timeout=30):
             filter='(objectclass=nsds5replicationagreement)',
             attrs_list=[status_attr, progress_attr])
         log.debug('Replication agreements: \n%s', _entries_to_ldif(entries))
-        if any(not e.single_value[status_attr].startswith('0 ')
-               for e in entries):
+        if any(
+                not (
+                    # older DS format
+                    e.single_value[status_attr].startswith('0 ') or
+                    # newer DS format
+                    e.single_value[status_attr].startswith('Error (0) ')
+                )
+            for e in entries
+        ):
             log.error('Replication error')
             continue
         if any(e.single_value[progress_attr] == 'TRUE' for e in entries):


### PR DESCRIPTION
DS changed a format of replication status attribute. Now it is with
prefix "Error (x)" where x is the error code.

Both formats were kept to allow tests run on older and new
versions of DS.