### PR TITLE
ipa-kra-install must create directory if it does not exist

### DIFF
--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -259,6 +259,10 @@ class KRAInstance(DogtagInstance):
         else:
             # the admin cert file is needed for the first instance of KRA
             cert = DogtagInstance.get_admin_cert(self)
+            # First make sure that the directory exists
+            parentdir = os.path.dirname(paths.ADMIN_CERT_PATH)
+            if not os.path.exists(parentdir):
+                os.makedirs(parentdir)
             with open(paths.ADMIN_CERT_PATH, "w") as admin_path:
                 admin_path.write(cert)
 


### PR DESCRIPTION
ipa-kra-install creates an admin cert file in
/root/.dogtag/pki-tomcat/ca_admin.cert but does not check that the
parent directory exists. This situation can happen when uninstall + restore
has been run.

The fix creates the directory if not present.

https://fedorahosted.org/freeipa/ticket/6606