### PR TITLE
DNSSEC: forwarders validation improvement

### DIFF
--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -670,8 +670,7 @@ def validate_dnssec_global_forwarder(ip_addr, log=None, timeout=10):
                               timeout=timeout)
     except DNSException as e:
         _log_response(log, e)
-        raise UnresolvableRecordError(owner=owner, rtype=rtype, ip=ip_addr,
-                                      error=e)
+        raise DNSSECSignatureMissingError(owner=owner, rtype=rtype, ip=ip_addr)
 
     try:
         ans.response.find_rrset(


### PR DESCRIPTION
Some DNS servers behaves oddly and instead sending result without RRSIG records
don't reply at all when DNSSEC flag is enabled (timeout). Instead of
hard error IPA should this handle as DNSSEC error and continue with
installation/adding forwarders.