### PR TITLE
[Py3] ipa-server-install

### DIFF
--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -727,7 +727,7 @@ class LDAPClient(object):
         # FIXME: for backwards compatibility only
         assert isinstance(dn, DN)
         dn = str(dn)
-        modlist = [(a, self.encode(b), self.encode(c)) for a, b, c in modlist]
+        modlist = [(a, b, self.encode(c)) for a, b, c in modlist]
         return self.conn.modify_s(dn, modlist)
 
     @property

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -860,6 +860,8 @@ def ipa_generate_password(entropy_bits=256, uppercase=1, lowercase=1, digits=1,
     for charclass_name in ['digits', 'uppercase', 'lowercase', 'special']:
         charclass = pwd_charsets[charclass_name]
         todo_characters = req_classes[charclass_name]
+        if todo_characters is None:
+            continue
         while todo_characters > 0:
             password += rnd.choice(charclass['chars'])
             todo_entropy -= charclass['entropy']

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -668,10 +668,13 @@ class BindInstance(service.Service):
                 system_records.get_base_records()
             )
         )
-        [fd, name] = tempfile.mkstemp(".db","ipa.system.records.")
-        os.write(fd, text)
-        os.close(fd)
-        print("Please add records in this file to your DNS system:", name)
+        with tempfile.NamedTemporaryFile(
+                mode="w", prefix="ipa.system.records.",
+                suffix=".db", delete=False
+        ) as f:
+            f.write(text)
+            print("Please add records in this file to your DNS system:",
+                  f.name)
 
     def create_instance(self):
 

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -124,7 +124,7 @@ class IPAUpgrade(service.Service):
 
     def __save_config(self):
         shutil.copy2(self.filename, self.savefilename)
-        with open(self.filename, "rb") as in_file:
+        with open(self.filename, "r") as in_file:
             parser = GetEntryFromLDIF(in_file, entries_dn=["cn=config"])
             parser.parse()
             try:
@@ -156,8 +156,8 @@ class IPAUpgrade(service.Service):
 
     def __enable_ds_global_write_lock(self):
         ldif_outfile = "%s.modified.out" % self.filename
-        with open(ldif_outfile, "wb") as out_file:
-            with open(self.filename, "rb") as in_file:
+        with open(ldif_outfile, "w") as out_file:
+            with open(self.filename, "r") as in_file:
                 parser = installutils.ModifyLDIF(in_file, out_file)
 
                 parser.replace_value(
@@ -172,8 +172,8 @@ class IPAUpgrade(service.Service):
         global_lock = self.restore_state('nsslapd-global-backend-lock')
 
         ldif_outfile = "%s.modified.out" % self.filename
-        with open(ldif_outfile, "wb") as out_file:
-            with open(self.filename, "rb") as in_file:
+        with open(ldif_outfile, "w") as out_file:
+            with open(self.filename, "r") as in_file:
                 parser = installutils.ModifyLDIF(in_file, out_file)
 
                 if port is not None:
@@ -194,8 +194,8 @@ class IPAUpgrade(service.Service):
 
     def __disable_listeners(self):
         ldif_outfile = "%s.modified.out" % self.filename
-        with open(ldif_outfile, "wb") as out_file:
-            with open(self.filename, "rb") as in_file:
+        with open(ldif_outfile, "w") as out_file:
+            with open(self.filename, "r") as in_file:
                 parser = installutils.ModifyLDIF(in_file, out_file)
                 parser.replace_value("cn=config", "nsslapd-port", ["0"])
                 parser.replace_value("cn=config", "nsslapd-security", ["off"])

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -162,7 +162,7 @@ class IPAUpgrade(service.Service):
                 parser = installutils.ModifyLDIF(in_file, out_file)
 
                 parser.replace_value(
-                    "cn=config", "nsslapd-global-backend-lock", ["on"])
+                    "cn=config", "nsslapd-global-backend-lock", [b"on"])
                 parser.parse()
 
         shutil.copy2(ldif_outfile, self.filename)
@@ -199,8 +199,8 @@ class IPAUpgrade(service.Service):
         with open(ldif_outfile, "w") as out_file:
             with open(self.filename, "r") as in_file:
                 parser = installutils.ModifyLDIF(in_file, out_file)
-                parser.replace_value("cn=config", "nsslapd-port", ["0"])
-                parser.replace_value("cn=config", "nsslapd-security", ["off"])
+                parser.replace_value("cn=config", "nsslapd-port", [b"0"])
+                parser.replace_value("cn=config", "nsslapd-security", [b"off"])
                 parser.remove_value("cn=config", "nsslapd-ldapientrysearchbase")
                 parser.parse()
 

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -134,21 +134,22 @@ class IPAUpgrade(service.Service):
                                    self.filename)
 
             try:
-                port = config_entry['nsslapd-port'][0]
+                port = config_entry['nsslapd-port'][0].decode('utf-8')
             except KeyError:
                 pass
             else:
                 self.backup_state('nsslapd-port', port)
 
             try:
-                security = config_entry['nsslapd-security'][0]
+                security = config_entry['nsslapd-security'][0].decode('utf-8')
             except KeyError:
                 pass
             else:
                 self.backup_state('nsslapd-security', security)
 
             try:
-                global_lock = config_entry['nsslapd-global-backend-lock'][0]
+                global_lock = config_entry[
+                    'nsslapd-global-backend-lock'][0].decode('utf-8')
             except KeyError:
                 pass
             else:
@@ -177,16 +178,17 @@ class IPAUpgrade(service.Service):
                 parser = installutils.ModifyLDIF(in_file, out_file)
 
                 if port is not None:
-                    parser.replace_value("cn=config", "nsslapd-port", [port])
+                    parser.replace_value(
+                        "cn=config", "nsslapd-port", [port.encode('utf-8')])
                 if security is not None:
                     parser.replace_value("cn=config", "nsslapd-security",
-                                         [security])
+                                         [security.encode('utf-8')])
 
                 # disable global lock by default
                 parser.remove_value("cn=config", "nsslapd-global-backend-lock")
                 if global_lock is not None:
                     parser.add_value("cn=config", "nsslapd-global-backend-lock",
-                                     [global_lock])
+                                     [global_lock.encode('utf-8')])
 
                 parser.parse()
 

--- a/ipaserver/secrets/common.py
+++ b/ipaserver/secrets/common.py
@@ -23,7 +23,7 @@ class iSecLdap(object):
         if self._basedn is None:
             conn = self.connect()
             r = conn.search_s('', ldap.SCOPE_BASE)
-            self._basedn = r[0][1]['defaultnamingcontext'][0]
+            self._basedn = r[0][1]['defaultnamingcontext'][0].decode('utf-8')
         return self._basedn
 
     def connect(self):

--- a/ipaserver/secrets/kem.py
+++ b/ipaserver/secrets/kem.py
@@ -181,7 +181,7 @@ class IPAKEMKeys(KEMKeysStore):
         self.realm = conf.get('global', 'realm')
         self.ldap_uri = config.get('ldap_uri', None)
         if self.ldap_uri is None:
-            self.ldap_uri = conf.get('global', 'ldap_uri', None)
+            self.ldap_uri = conf.get('global', 'ldap_uri', raw=True)
         self._server_keys = None
 
     def find_key(self, kid, usage):

--- a/ipaserver/secrets/kem.py
+++ b/ipaserver/secrets/kem.py
@@ -139,8 +139,7 @@ class KEMLdap(iSecLdap):
                     ('memberPrincipal', principal.encode('utf-8')),
                     ('ipaPublicKey', public_key)]
             conn.add_s(dn, mods)
-        except Exception:  # pylint: disable=broad-except
-            # This may fail if the entry already exists
+        except ldap.ALREADY_EXISTS:
             mods = [(ldap.MOD_REPLACE, 'ipaPublicKey', public_key)]
             conn.modify_s(dn, mods)
 

--- a/ipaserver/secrets/kem.py
+++ b/ipaserver/secrets/kem.py
@@ -130,13 +130,13 @@ class KEMLdap(iSecLdap):
         service_rdn = ('cn', servicename) if servicename != 'host' else DN()
         dn = str(DN(('cn', name), service_rdn, self.keysbase))
         try:
-            mods = [('objectClass', ['nsContainer',
-                                     'ipaKeyPolicy',
-                                     'ipaPublicKeyObject',
-                                     'groupOfPrincipals']),
-                    ('cn', name),
-                    ('ipaKeyUsage', RFC5280_USAGE_MAP[usage]),
-                    ('memberPrincipal', principal),
+            mods = [('objectClass', [b'nsContainer',
+                                     b'ipaKeyPolicy',
+                                     b'ipaPublicKeyObject',
+                                     b'groupOfPrincipals']),
+                    ('cn', name.encode('utf-8')),
+                    ('ipaKeyUsage', RFC5280_USAGE_MAP[usage].encode('utf-8')),
+                    ('memberPrincipal', principal.encode('utf-8')),
                     ('ipaPublicKey', public_key)]
             conn.add_s(dn, mods)
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
This PR allows to install ipa server using PY3 (CA, no DNS, no KRA, no CA-less, no external CA) and uninstall it (ipa-server-install --uninstall)

Functionality depends on #427