### PR TITLE
[py3] ipactl restart: log httplib failues as debug

### DIFF
--- a/ipapython/dogtag.py
+++ b/ipapython/dogtag.py
@@ -209,7 +209,7 @@ def _httplib_request(
         http_body = res.read()
         conn.close()
     except Exception as e:
-        root_logger.exception("httplib request failed:")
+        root_logger.debug("httplib request failed:", exc_info=True)
         raise NetworkError(uri=uri, error=str(e))
 
     root_logger.debug('response status %d',    http_status)


### PR DESCRIPTION
With python3 there are several excerptions ConnectionRefusedError raised
before ipactl is able to connect to dogtag after restart. These
exception should be logged on debug level until timeout is reached.

https://fedorahosted.org/freeipa/ticket/4985