### PR TITLE
[py3] tests_xmlrpc: do not call str() on bytes

### DIFF
--- a/ipatests/test_xmlrpc/test_caacl_profile_enforcement.py
+++ b/ipatests/test_xmlrpc/test_caacl_profile_enforcement.py
@@ -434,7 +434,7 @@ def santest_csr(request, santest_host_1, santest_host_2):
         pkey, hashes.SHA256(), backend
     ).public_bytes(serialization.Encoding.PEM)
 
-    return unicode(csr)
+    return csr.decode('ascii')
 
 
 class SubjectAltNameOneServiceBase(XMLRPC_test):

--- a/ipatests/test_xmlrpc/test_kerberos_principal_aliases.py
+++ b/ipatests/test_xmlrpc/test_kerberos_principal_aliases.py
@@ -260,7 +260,7 @@ class TestKerberosAliasExceptions(XMLRPC_test):
         # Add an alias overlapping the UPN of a trusted domain
         upn_suffix = (
             trusted_domain_with_suffix['ldif']['ipaNTAdditionalSuffixes']
-        )
+        ).decode('utf-8')
 
         with pytest.raises(errors.ValidationError):
             krbalias_user.add_principal(
@@ -278,7 +278,7 @@ class TestKerberosAliasExceptions(XMLRPC_test):
         # Add an alias overlapping the NETBIOS name of a trusted domain
         netbios_name = (
             trusted_domain_with_suffix['ldif']['ipaNTFlatName']
-        )
+        ).decode('utf-8')
 
         with pytest.raises(errors.ValidationError):
             krbalias_user.add_principal(


### PR DESCRIPTION
Calling str() on bytes causes undesired side effect: it adds prefix "b"
to the result of conversion. The method decode() should be used instead.

https://fedorahosted.org/freeipa/ticket/4985