### PR TITLE
build: Add missing dependency on libxmlrpc{,_util}

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -224,7 +224,7 @@ PKG_CHECK_MODULES([SASL], [libsasl2])
 dnl ---------------------------------------------------------------------------
 dnl - Check for XMLRPC-C
 dnl ---------------------------------------------------------------------------
-PKG_CHECK_MODULES([XMLRPC], [xmlrpc_client])
+PKG_CHECK_MODULES([XMLRPC], [xmlrpc xmlrpc_client xmlrpc_util])
 
 dnl ---------------------------------------------------------------------------
 dnl - Check for libintl


### PR DESCRIPTION
Change in libxmlrpc packaging uncovered missing linking  dependency in our
build system.

https://fedorahosted.org/freeipa/ticket/6637