### PR TITLE
csrgen: Allow some certificate fields to be specified by the user

### DIFF
--- a/ipaclient/csrgen.py
+++ b/ipaclient/csrgen.py
@@ -414,7 +414,7 @@ class CSRGenerator(object):
                                 ' use a variable "userdata.<var_name>"') %
                             {'rule': rule.name})
 
-                    prompts[var_parts[1]] = rule.options['prompt']
+                    prompts[var_parts[1]] = _(rule.options['prompt'])
 
         return prompts
 

--- a/ipaclient/csrgen/rules/dataEmailUserSpecified.json
+++ b/ipaclient/csrgen/rules/dataEmailUserSpecified.json
@@ -1,0 +1,16 @@
+{
+  "rules": [
+    {
+      "helper": "openssl",
+      "template": "email = {{userdata.email}}"
+    },
+    {
+      "helper": "certutil",
+      "template": "email:{{userdata.email|quote}}"
+    }
+  ],
+  "options": {
+    "data_source": "userdata.email",
+    "prompt": "Email address"
+  }
+}

--- a/ipatests/test_ipaclient/test_csrgen.py
+++ b/ipatests/test_ipaclient/test_csrgen.py
@@ -176,7 +176,8 @@ class test_CSRGenerator(object):
             ],
         }
 
-        script = generator.csr_config(principal, config, 'userCert')
+        script = generator.csr_config(
+            principal, config, {}, 'userCert')
         with open(os.path.join(
                 CSR_DATA_DIR, 'configs', 'userCert.conf')) as f:
             expected_script = f.read()
@@ -195,7 +196,7 @@ class test_CSRGenerator(object):
         }
 
         script = generator.csr_config(
-            principal, config, 'caIPAserviceCert')
+            principal, config, {}, 'caIPAserviceCert')
         with open(os.path.join(
                 CSR_DATA_DIR, 'configs', 'caIPAserviceCert.conf')) as f:
             expected_script = f.read()
@@ -212,7 +213,7 @@ class test_rule_handling(object):
             rule_provider, formatter_class=IdentityFormatter)
 
         script = generator.csr_config(
-            principal, {}, 'example')
+            principal, {}, {}, 'example')
         assert script == '\n'
 
     def test_twoDataRulesOneMissing(self, generator):
@@ -225,7 +226,7 @@ class test_rule_handling(object):
         generator = csrgen.CSRGenerator(
             rule_provider, formatter_class=IdentityFormatter)
 
-        script = generator.csr_config(principal, {}, 'example')
+        script = generator.csr_config(principal, {}, {}, 'example')
         assert script == ',testuser\n'
 
     def test_requiredAttributeMissing(self):
@@ -239,4 +240,4 @@ class test_rule_handling(object):
 
         with pytest.raises(errors.CSRTemplateError):
             _script = generator.csr_config(
-                principal, {}, 'example')
+                principal, {}, {}, 'example')


### PR DESCRIPTION
These patches allow CSR generation rules to contain a "prompt," which will cause data to be requested from the user and interpolated into the CSR.

The second commit runs the prompt through gettext. As I asked about [here](https://www.redhat.com/archives/freeipa-devel/2016-August/msg00823.html), I'm not sure if this is useful because the prompt strings in the rule files won't be recognized as translatable. But I decided to include the commit for discussion.