### PR TITLE
csrgen: Automate full cert request flow

### DIFF
--- a/install/share/csrgen/templates/openssl_base.tmpl
+++ b/install/share/csrgen/templates/openssl_base.tmpl
@@ -3,15 +3,16 @@
 {%- endraw %}
 #!/bin/bash -e
 
-if [[ $# -ne 2 ]]; then
-echo "Usage: $0 <outfile> <keyfile>"
+if [[ $# -lt 2 ]]; then
+echo "Usage: $0 <outfile> <keyfile> <other openssl arguments>"
 echo "Called as: $0 $@"
 exit 1
 fi
 
 CONFIG="$(mktemp)"
 CSR="$1"
-shift
+KEYFILE="$2"
+shift; shift
 
 echo \
 {% raw %}{% filter quote %}{% endraw -%}
@@ -30,5 +31,5 @@ req_extensions = {% call openssl.section() %}{{ rendered_extensions }}{% endcall
 {{ openssl.openssl_sections|join('\n\n') }}
 {% endfilter %}{%- endraw %} > "$CONFIG"
 
-openssl req -new -config "$CONFIG" -out "$CSR" -key $1
+openssl req -new -config "$CONFIG" -out "$CSR" -key "$KEYFILE" "$@"
 rm "$CONFIG"

--- a/ipaclient/plugins/cert.py
+++ b/ipaclient/plugins/cert.py
@@ -52,6 +52,11 @@ class cert_request(MethodOverride):
             doc=_('Path to PEM file containing a private key'),
         ),
         Str(
+            'password_file?',
+            label=_(
+                'File containing a password for the private key or database'),
+        ),
+        Str(
             'csr_profile_id?',
             label=_('Name of CSR generation profile (if not the same as'
                     ' profile_id)'),
@@ -68,14 +73,19 @@ class cert_request(MethodOverride):
         database = options.pop('database', None)
         private_key = options.pop('private_key', None)
         csr_profile_id = options.pop('csr_profile_id', None)
+        password_file = options.pop('password_file', None)
 
         if csr is None:
             if database:
                 helper = u'certutil'
                 helper_args = ['-d', database]
+                if password_file:
+                    helper_args += ['-f', password_file]
             elif private_key:
                 helper = u'openssl'
                 helper_args = [private_key]
+                if password_file:
+                    helper_args += ['-passin', 'file:%s' % password_file]
             else:
                 raise errors.InvocationError(
                     message=u"One of 'database' or 'private_key' is required")

--- a/ipaclient/plugins/csrgen.py
+++ b/ipaclient/plugins/csrgen.py
@@ -13,6 +13,7 @@ from ipalib.frontend import Local, Str
 from ipalib.parameters import Principal
 from ipalib.plugable import Registry
 from ipalib.text import _
+from ipapython import dogtag
 
 if six.PY3:
     unicode = str
@@ -36,7 +37,7 @@ class cert_get_requestdata(Local):
                   ' HTTP/test.example.com)'),
         ),
         Str(
-            'profile_id',
+            'profile_id?',
             label=_('Profile ID'),
             doc=_('CSR Generation Profile to use'),
         ),
@@ -73,6 +74,8 @@ class cert_get_requestdata(Local):
 
         principal = options.get('principal')
         profile_id = options.get('profile_id')
+        if profile_id is None:
+            profile_id = dogtag.DEFAULT_PROFILE
         helper = options.get('helper')
 
         if self.api.env.in_server:


### PR DESCRIPTION
Adds `--autogenerate` flag to `ipa cert-request` command. It no longer
requires a CSR passed on the command line, instead it creates a config
(bash script) with `cert-get-requestdata`, then runs it to build a CSR,
and submits that CSR.

Example usage (NSS database):
$ ipa cert-request --autogenerate --principal blipton --profile-id userCert --database /tmp/certs

Example usage (PEM private key file):
$ ipa cert-request --autogenerate --principal blipton --profile-id userCert --private-key /tmp/key.pem