### PR TITLE
x509: allow leading text in PEM files

### DIFF
--- a/ipatests/test_ipalib/test_x509.py
+++ b/ipatests/test_ipalib/test_x509.py
@@ -69,6 +69,17 @@ class test_x509(object):
         x509.load_certificate((newcert,))
         x509.load_certificate([newcert])
 
+        # Load a good cert with headers and leading text
+        newcert = (
+            'leading text\n-----BEGIN CERTIFICATE-----' +
+            goodcert +
+            '-----END CERTIFICATE-----')
+        x509.load_certificate(newcert)
+
+        # Should handle list/tuple
+        x509.load_certificate((newcert,))
+        x509.load_certificate([newcert])
+
         # Load a good cert with bad headers
         newcert = '-----BEGIN CERTIFICATE-----' + goodcert
         with pytest.raises((TypeError, ValueError)):


### PR DESCRIPTION
This fixes a regression introduced in commit
b8d6524d43dd0667184aebc79fb77a9b8a46939a.

https://fedorahosted.org/freeipa/ticket/4985