### PR TITLE
Add password file to certutil calls in ipapython.certdb module

### DIFF
--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -542,12 +542,7 @@ def main():
 
                 with certdb.NSSDatabase(nss_dir) as nss_db:
                     if options.ca_cert_file:
-                        nss_dir = nss_db.secdir
-
-                        password = ipautil.ipa_generate_password()
-                        password_file = ipautil.write_tmp_file(password)
-                        nss_db.create_db(password_file.name)
-
+                        nss_db.create_db()
                         ca_certs = x509.load_certificate_list_from_file(
                             options.ca_cert_file)
                         for ca_cert in ca_certs:
@@ -555,8 +550,6 @@ def main():
                                 serialization.Encoding.DER)
                             nss_db.add_cert(
                                 data, str(DN(ca_cert.subject)), 'C,,')
-                    else:
-                        nss_dir = None
 
                     api.bootstrap(context='client',
                                   confdir=paths.ETC_IPA,

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2284,18 +2284,8 @@ def install_check(options):
 
 def create_ipa_nssdb():
     db = certdb.NSSDatabase(paths.IPA_NSSDB_DIR)
-    pwdfile = os.path.join(db.secdir, 'pwdfile.txt')
-
-    ipautil.backup_file(pwdfile)
-    ipautil.backup_file(os.path.join(db.secdir, 'cert8.db'))
-    ipautil.backup_file(os.path.join(db.secdir, 'key3.db'))
-    ipautil.backup_file(os.path.join(db.secdir, 'secmod.db'))
-
-    with open(pwdfile, 'w') as f:
-        f.write(ipautil.ipa_generate_password())
-    os.chmod(pwdfile, 0o600)
-
-    db.create_db(pwdfile)
+    db.create_db(backup=True)
+    os.chmod(db.pwd_file, 0o600)
     os.chmod(os.path.join(db.secdir, 'cert8.db'), 0o644)
     os.chmod(os.path.join(db.secdir, 'key3.db'), 0o644)
     os.chmod(os.path.join(db.secdir, 'secmod.db'), 0o644)
@@ -2667,8 +2657,7 @@ def _install(options):
             for cert in ca_certs
         ]
         try:
-            pwd_file = ipautil.write_tmp_file(ipautil.ipa_generate_password())
-            tmp_db.create_db(pwd_file.name)
+            tmp_db.create_db()
 
             for i, cert in enumerate(ca_certs):
                 tmp_db.add_cert(cert, 'CA certificate %d' % (i + 1), 'C,,')

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -230,8 +230,7 @@ class CACertManage(admintool.AdminTool):
                 "troubleshooting guide)")
 
         with certs.NSSDatabase() as tmpdb:
-            pw = ipautil.write_tmp_file(ipautil.ipa_generate_password())
-            tmpdb.create_db(pw.name)
+            tmpdb.create_db()
             tmpdb.add_cert(old_cert_der, 'IPA CA', 'C,,')
 
             try:
@@ -330,8 +329,7 @@ class CACertManage(admintool.AdminTool):
                                               False)
 
         with certs.NSSDatabase() as tmpdb:
-            pw = ipautil.write_tmp_file(ipautil.ipa_generate_password())
-            tmpdb.create_db(pw.name)
+            tmpdb.create_db()
             tmpdb.add_cert(cert, nickname, 'C,,')
             for ca_cert, ca_nickname, ca_trust_flags in ca_certs:
                 tmpdb.add_cert(ca_cert, ca_nickname, ca_trust_flags)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1543,6 +1543,12 @@ def upgrade_configuration():
             api.env.realm, paths.IPA_RADB_DIR, host_name=api.env.host)
     ca_running = ca.is_running()
 
+    # create passswd.txt file in PKI_TOMCAT_ALIAS_DIR if it does not exist
+    # this file will be required on most actions over this NSS DB in FIPS
+    if not os.path.exists(os.path.join(
+            paths.PKI_TOMCAT_ALIAS_DIR, 'pwdfile.txt')):
+        ca.create_certstore_passwdfile()
+
     with installutils.stopped_service('pki-tomcatd', 'pki-tomcat'):
         # Dogtag must be stopped to be able to backup CS.cfg config
         ca.backup_config()


### PR DESCRIPTION
With this patchset, ipa-client-install should not ask for NSS database password.

Prerequisite for it to work in FIPS:
https://github.com/freeipa/freeipa/pull/367

**edit:** This was a part of a bigger branch and might be missing some parts.