### PR TITLE
certdb: remove unused keysize property

### DIFF
--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -109,7 +109,6 @@ class CertDB(object):
             raise RuntimeError("Unable to determine the current directory: %s" % str(e))
 
         self.cacert_name = get_ca_nickname(self.realm)
-        self.valid_months = "120"
 
         # We are going to set the owner of all of the cert
         # files to the owner of the containing directory

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -110,7 +110,6 @@ class CertDB(object):
 
         self.cacert_name = get_ca_nickname(self.realm)
         self.valid_months = "120"
-        self.keysize = "1024"
 
         # We are going to set the owner of all of the cert
         # files to the owner of the containing directory


### PR DESCRIPTION
Keysize property is no longer used anywhere in the code. It was
originally introduced for the request_cert function, which was later
refactored to use a function argument instead.

---

The value of this property caught my eye, because I don't think we should be using 1024bit keys. Fortunately, I discovered this bit of code is obsolete and we actually use 2048bit key length by default.

Commit that originally introduced the property: 158b4e8ff4704b967d4049e2a16f9b32fbb33b80
Commit that removed the usage of the property: 9182c10b03a7841c9318ad64ae6c5deda77d93d1