### PR TITLE
[ WIP] ipa-run-tests: allow to run tests with server-api

### DIFF
--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -71,9 +71,31 @@ def pytest_configure(config):
     config.option.doctestmodules = True
 
 
+def pytest_addoption(parser):
+    def truefalse(arg):
+        if arg.lower() == 'true':
+            return True
+        if arg.lower() == 'false':
+            return False
+        return arg  # triggers an error later
+
+    group = parser.getgroup("IPA integration tests")
+    group.addoption(
+        '--in-server',
+        dest="ipa_in_server",
+        type=truefalse,
+        choices=(True, False),
+        default=False,
+        help="Run IPA tests with in-server API (talk directly to LDAP, avoid "
+             "http communications). Requires to run test on "
+             "installed server (default: False)"
+    )
+
+
 def pytest_cmdline_main(config):
     api.bootstrap(
-        context=u'cli', in_server=False, in_tree=True, fallback=False
+        context=u'cli', in_server=config.option.ipa_in_server,
+        in_tree=True, fallback=False
     )
     for klass in cli_plugins:
         api.add_plugin(klass)

--- a/ipatests/test_xmlrpc/xmlrpc_test.py
+++ b/ipatests/test_xmlrpc/xmlrpc_test.py
@@ -131,8 +131,12 @@ def fuzzy_set_ci(s):
     return Fuzzy(test=lambda other: set(x.lower() for x in other) == set(y.lower() for y in s))
 
 try:
-    if not api.Backend.rpcclient.isconnected():
-        api.Backend.rpcclient.connect()
+    if api.env.in_server:
+        if not api.Backend.ldap2.isconnected():
+            api.Backend.ldap2.connect()
+    else:
+        if not api.Backend.rpcclient.isconnected():
+            api.Backend.rpcclient.connect()
     res = api.Command['user_show'](u'notfound')
 except errors.NetworkError:
     server_available = False
@@ -206,8 +210,12 @@ class XMLRPC_test(object):
         if not server_available:
             raise nose.SkipTest('%r: Server not available: %r' %
                                 (cls.__module__, api.env.xmlrpc_uri))
-        if not api.Backend.rpcclient.isconnected():
-            api.Backend.rpcclient.connect()
+        if api.env.in_server:
+            if not api.Backend.ldap2.isconnected():
+                api.Backend.ldap2.connect()
+        else:
+            if not api.Backend.rpcclient.isconnected():
+                api.Backend.rpcclient.connect()
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
This allow to test server-api with ipa-run-tests. It is useful because
internal error tracebacks are printed to test output and it is handy to
use it with python -bb option to check BytesWarnings

- I havent tested option parsing in pytest yet, only the code around that allows to run server_api
- This can be useful with Travis to see tracebacks directly in test output
- tests may be faster
- we should really rename test_xmlrpc to something like test_api
- I will use this for python -bb testing