### PR TITLE
Backup /root/kracert.p12

### DIFF
--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -157,6 +157,7 @@ class Backup(admintool.AdminTool):
         paths.DOGTAG_ADMIN_P12,
         paths.KRA_AGENT_PEM,
         paths.CACERT_P12,
+        paths.KRACERT_P12,
         paths.KRB5KDC_KDC_CONF,
         paths.SYSTEMD_IPA_SERVICE,
         paths.SYSTEMD_SSSD_SERVICE,


### PR DESCRIPTION
ipa-backup now backs up /root/kracert.p12. The file contains the
certs and encrypted private keys for KRA transport, storage and audit.

Closes: https://fedorahosted.org/freeipa/ticket/6659
Signed-off-by: Christian Heimes <cheimes@redhat.com>