### PR TITLE
adtrustinstance: use LDAPI/EXTERNAL to retrieve CIFS keytab

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -393,7 +393,7 @@ class DsInstance(service.Service):
         self.__common_setup(enable_ssl=(not self.promote))
         self.step("restarting directory server", self.__restart_instance)
 
-        self.step("creating DS keytab", self._request_service_keytab)
+        self.step("creating DS keytab", self.request_service_keytab)
         if self.promote:
             if self.pkcs12_info:
                 self.step("configuring TLS for DS instance", self.__enable_ssl)
@@ -1221,8 +1221,8 @@ class DsInstance(service.Service):
         if self.domainlevel is not None:
             self._ldap_mod("domainlevel.ldif", self.sub_dict)
 
-    def _request_service_keytab(self):
-        super(DsInstance, self)._request_service_keytab()
+    def request_service_keytab(self):
+        super(DsInstance, self).request_service_keytab()
 
         # Configure DS to use the keytab
         vardict = {"KRB5_KTNAME": self.keytab}

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -166,7 +166,7 @@ class HTTPInstance(service.Service):
         self.step("enabling mod_nss renegotiate", self.enable_mod_nss_renegotiate)
         self.step("adding URL rewriting rules", self.__add_include)
         self.step("configuring httpd", self.__configure_http)
-        self.step("setting up httpd keytab", self._request_service_keytab)
+        self.step("setting up httpd keytab", self.request_service_keytab)
         self.step("retrieving anonymous keytab", self.request_anon_keytab)
         self.step("configuring Gssproxy", self.configure_gssproxy)
         self.step("setting up ssl", self.__setup_ssl)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -317,12 +317,15 @@ class HTTPInstance(service.Service):
         parent = os.path.dirname(paths.ANON_KEYTAB)
         if not os.path.exists(parent):
             os.makedirs(parent, 0o755)
+
+        self.clean_previous_keytab(keytab=paths.ANON_KEYTAB)
         self.run_getkeytab(self.api.env.ldap_uri, paths.ANON_KEYTAB, ANON_USER)
 
         pent = pwd.getpwnam(IPAAPI_USER)
         os.chmod(parent, 0o700)
         os.chown(parent, pent.pw_uid, pent.pw_gid)
-        os.chown(paths.ANON_KEYTAB, pent.pw_uid, pent.pw_gid)
+
+        self.set_keytab_owner(keytab=paths.ANON_KEYTAB, owner=IPAAPI_USER)
 
     def create_password_conf(self):
         """

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -588,7 +588,7 @@ class Service(object):
 
         ipautil.run(args, nolog=nolog)
 
-    def _request_service_keytab(self):
+    def request_service_keytab(self):
         if any(attr is None for attr in (self.principal, self.keytab)):
             raise NotImplementedError(
                 "service must have defined principal "


### PR DESCRIPTION
In order to be able to function as a part of composite installer, samba
configuration code must be able to work without admin credentials. This
requires changes in the CIFS principal key retrieval method so that it is not
bound to the presence of privileged user ccache. This is achieved by slightly
altering and re-using the recently developed code for service keytab retrieval.

https://fedorahosted.org/freeipa/ticket/6638