### PR TITLE
Faster JSON encoder/decoder

### DIFF
--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -388,7 +388,7 @@ def json_encode_binary(val, version):
     return json.dumps(result)
 
 
-def _ipa_obj_hook(dct):
+def _ipa_obj_hook(dct, _iteritems=six.iteritems, _list=list):
     if '__base64__' in dct:
         return base64.b64decode(dct['__base64__'])
     elif '__datetime__' in dct:
@@ -397,6 +397,10 @@ def _ipa_obj_hook(dct):
     elif '__dns_name__' in dct:
         return DNSName(dct['__dns_name__'])
     else:
+        # XXX tests assume tuples. Is this really necessary?
+        for k, v in _iteritems(dct):
+            if v.__class__ is _list:
+                dct[k] = tuple(v)
         return dct
 
 

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -285,9 +285,12 @@ class _JSONPrimer(dict):
 
     * O(1) type look instead of O(n) chain of costly isinstance() calls
     * __missing__ and __mro__ with caching to handle subclasses
-    * inlined code with minor code duplication
+    * inline code with minor code duplication (func lookup in enc_list/dict)
+    * avoid surplus function calls (e.g. func is _identity, obj.__class__
+      instead if type(obj))
     * function default arguments to turn global into local lookups
-    * on-demand lookup of client capabilities with cache
+    * avoid re-creation of bound method objects (e.g. result.append)
+    * on-demand lookup of client capabilities with cached values
 
     Depending on the client version number, the primer converts:
 

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -483,7 +483,9 @@ class jsonserver(WSGIExecutioner, HTTP_Status):
             principal=unicode(principal),
             version=unicode(VERSION),
         )
-        dump = json_encode_binary(response, version)
+        dump = json_encode_binary(
+            response, version, pretty_print=self.api.env.debug >= 2
+        )
         return dump.encode('utf-8')
 
     def unmarshal(self, data):

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -25,8 +25,8 @@ Also see the `ipalib.rpc` module.
 
 from xml.sax.saxutils import escape
 import os
-import json
 import traceback
+
 import gssapi
 import requests
 
@@ -483,13 +483,12 @@ class jsonserver(WSGIExecutioner, HTTP_Status):
             principal=unicode(principal),
             version=unicode(VERSION),
         )
-        response = json_encode_binary(response, version)
-        dump = json.dumps(response, sort_keys=True, indent=4)
+        dump = json_encode_binary(response, version)
         return dump.encode('utf-8')
 
     def unmarshal(self, data):
         try:
-            d = json.loads(data)
+            d = json_decode_binary(data)
         except ValueError as e:
             raise JSONError(error=e)
         if not isinstance(d, dict):
@@ -498,7 +497,6 @@ class jsonserver(WSGIExecutioner, HTTP_Status):
             raise JSONError(error=_('Request is missing "method"'))
         if 'params' not in d:
             raise JSONError(error=_('Request is missing "params"'))
-        d = json_decode_binary(d)
         method = d['method']
         params = d['params']
         _id = d.get('id')

--- a/ipatests/test_ipaserver/test_rpcserver.py
+++ b/ipatests/test_ipaserver/test_rpcserver.py
@@ -257,7 +257,7 @@ class test_jsonserver(PluginTester):
         assert unicode(e.error) == 'params[1] (aka options) must be a dict'
 
         # Test with valid values:
-        args = (u'jdoe', )
+        args = [u'jdoe']
         options = dict(givenname=u'John', sn='Doe')
         d = dict(method=u'user_add', params=(args, options), id=18)
         assert o.unmarshal(json.dumps(d)) == (u'user_add', args, options, 18)


### PR DESCRIPTION
Improve performance of FreeIPA's JSON serializer and deserializer.

* Don't indent and sort keys. Both options trigger a slow path in
  Python's json package. Without indention and sorting, encoding
  mostly happens in optimized C code.
* Replace O(n) type checks with O(1) type lookup and eliminate
  the use of isinstance().
* Check each client capability only once for every conversion.
* Use decoder's obj_hook feature to traverse the object tree once and
  to eliminate calls to isinstance().

Closes: https://fedorahosted.org/freeipa/ticket/6655
Signed-off-by: Christian Heimes <cheimes@redhat.com>