### PR TITLE
ipa-server-install, ipa-server-upgrade fixes

### DIFF
--- a/ipalib/install/sysrestore.py
+++ b/ipalib/install/sysrestore.py
@@ -31,7 +31,11 @@ import random
 
 import six
 # pylint: disable=import-error
-from six.moves.configparser import SafeConfigParser
+if six.PY3:
+    # The SafeConfigParser class has been renamed to ConfigParser in Py3
+    from configparser import ConfigParser as SafeConfigParser
+else:
+    from ConfigParser import SafeConfigParser
 # pylint: enable=import-error
 
 from ipaplatform.tasks import tasks

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -847,9 +847,9 @@ class LDAPClient(object):
         # entered for a boolean value instead of the boolean clause.
         if isinstance(val, bool):
             if val:
-                return 'TRUE'
+                return b'TRUE'
             else:
-                return 'FALSE'
+                return b'FALSE'
         elif isinstance(val, (unicode, six.integer_types, Decimal, DN,
                               Principal)):
             return six.text_type(val).encode('utf-8')

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1638,11 +1638,16 @@ def repair_profile_caIPAserviceCert():
             return
 
     indicators = [
-        "policyset.serverCertSet.1.default.params.name="
-            "CN=$request.req_subject_name.cn$, OU=pki-ipa, O=IPA ",
-        "policyset.serverCertSet.9.default.params.crlDistPointsPointName_0="
-            "https://ipa.example.com/ipa/crl/MasterCRL.bin",
-        ]
+        (
+            b"policyset.serverCertSet.1.default.params.name="
+            b"CN=$request.req_subject_name.cn$, OU=pki-ipa, O=IPA "
+        ),
+        (
+            b"policyset.serverCertSet.9.default.params."
+            b"crlDistPointsPointName_0="
+            b"https://ipa.example.com/ipa/crl/MasterCRL.bin"
+        ),
+    ]
     need_repair = all(l in cur_config for l in indicators)
 
     if need_repair:

--- a/ipaserver/install/dnskeysyncinstance.py
+++ b/ipaserver/install/dnskeysyncinstance.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 import os
 import pwd
 import grp
-import random
 import shutil
 import stat
 
@@ -282,9 +281,7 @@ class DNSKeySyncInstance(service.Service):
             key_id = None
             while True:
                 # check if key with this ID exist in softHSM
-                # id is 16 Bytes long
-                key_id = "".join(chr(random.randint(0, 255))
-                                 for _ in range(0, 16))
+                key_id = _ipap11helper.gen_key_id()
                 replica_pubkey_dn = DN(('ipk11UniqueId', 'autogenerate'), dn_base)
 
 

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -41,7 +41,12 @@ import ldap
 import ldapurl
 import six
 # pylint: disable=import-error
-from six.moves.configparser import SafeConfigParser, NoOptionError
+if six.PY3:
+    # The SafeConfigParser class has been renamed to ConfigParser in Py3
+    from configparser import ConfigParser as SafeConfigParser
+else:
+    from ConfigParser import SafeConfigParser
+from six.moves.configparser import NoOptionError
 # pylint: enable=import-error
 
 from ipalib.install import sysrestore

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -749,10 +749,9 @@ def read_replica_info(dir_path, rconfig):
 
     rconfig is a ReplicaConfig object
     """
-    filename = dir_path + "/realm_info"
-    fd = open(filename)
+    filename = os.path.join(dir_path, "realm_info")
     config = SafeConfigParser()
-    config.readfp(fd)
+    config.read(filename)
 
     rconfig.realm_name = config.get("realm", "realm_name")
     rconfig.master_host_name = config.get("realm", "master_host_name")

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -23,8 +23,13 @@ import tempfile
 import time
 import pwd
 
+import six
 # pylint: disable=import-error
-from six.moves.configparser import SafeConfigParser
+if six.PY3:
+    # The SafeConfigParser class has been renamed to ConfigParser in Py3
+    from configparser import ConfigParser as SafeConfigParser
+else:
+    from ConfigParser import SafeConfigParser
 # pylint: enable=import-error
 
 from ipaplatform.paths import paths

--- a/ipaserver/install/ipa_replica_prepare.py
+++ b/ipaserver/install/ipa_replica_prepare.py
@@ -30,8 +30,13 @@ from optparse import OptionGroup, SUPPRESS_HELP
 # pylint: enable=deprecated-module
 
 import dns.resolver
+import six
 # pylint: disable=import-error
-from six.moves.configparser import SafeConfigParser
+if six.PY3:
+    # The SafeConfigParser class has been renamed to ConfigParser in Py3
+    from configparser import ConfigParser as SafeConfigParser
+else:
+    from ConfigParser import SafeConfigParser
 # pylint: enable=import-error
 
 from ipaserver.install import certs, installutils, bindinstance, dsinstance, ca

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -25,8 +25,13 @@ import pwd
 import ldif
 import itertools
 
+import six
 # pylint: disable=import-error
-from six.moves.configparser import SafeConfigParser
+if six.PY3:
+    # The SafeConfigParser class has been renamed to ConfigParser in Py3
+    from configparser import ConfigParser as SafeConfigParser
+else:
+    from ConfigParser import SafeConfigParser
 # pylint: enable=import-error
 
 from ipaclient.install.client import update_ipa_nssdb
@@ -715,7 +720,11 @@ class Restore(admintool.AdminTool):
         self.backup_host = config.get('ipa', 'host')
         self.backup_ipa_version = config.get('ipa', 'ipa_version')
         self.backup_version = config.get('ipa', 'version')
+        # pylint: disable=no-member
+        # we can assume that returned object is string and it has .split()
+        # method
         self.backup_services = config.get('ipa', 'services').split(',')
+        # pylint: enable=no-member
 
 
     def extract_backup(self, keyring=None):

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -711,9 +711,8 @@ class Restore(admintool.AdminTool):
         Read the backup file header that contains the meta data about
         this particular backup.
         '''
-        with open(self.header) as fd:
-            config = SafeConfigParser()
-            config.readfp(fd)
+        config = SafeConfigParser()
+        config.read(self.header)
 
         self.backup_type = config.get('ipa', 'type')
         self.backup_time = config.get('ipa', 'time')

--- a/ipaserver/install/schemaupdate.py
+++ b/ipaserver/install/schemaupdate.py
@@ -119,7 +119,7 @@ def update_schema(schema_files, ldapi=False, dm_password=None,):
 
     # The exact representation the DS gives us for each OID
     # (for debug logging)
-    old_entries_by_oid = {cls(str(attr)).oid: str(attr)
+    old_entries_by_oid = {cls(attr.decode('utf-8')).oid: attr.decode('utf-8')
                           for (attrname, cls) in SCHEMA_ELEMENT_CLASSES
                           for attr in schema_entry[attrname]}
 

--- a/ipaserver/install/schemaupdate.py
+++ b/ipaserver/install/schemaupdate.py
@@ -143,7 +143,6 @@ def update_schema(schema_files, ldapi=False, dm_password=None,):
                         # Note: An add will automatically replace any existing
                         # schema with the same OID. So, we only add.
                         value = add_x_origin(new_obj)
-                        new_elements.append(value)
 
                         if old_obj:
                             old_attr = old_entries_by_oid.get(oid)
@@ -151,6 +150,8 @@ def update_schema(schema_files, ldapi=False, dm_password=None,):
                             log.debug('   with: %s', value)
                         else:
                             log.debug('Add: %s', value)
+
+                        new_elements.append(value.encode('utf-8'))
 
                 modified = modified or new_elements
                 schema_entry[attrname].extend(new_elements)

--- a/ipaserver/install/schemaupdate.py
+++ b/ipaserver/install/schemaupdate.py
@@ -125,7 +125,8 @@ def update_schema(schema_files, ldapi=False, dm_password=None,):
 
     for filename in schema_files:
         log.debug('Processing schema LDIF file %s', filename)
-        _dn, new_schema = ldap.schema.subentry.urlfetch(filename)
+        url = "file://{}".format(filename)
+        _dn, new_schema = ldap.schema.subentry.urlfetch(url)
 
         for attrname, cls in SCHEMA_ELEMENT_CLASSES:
             for oids_set in _get_oid_dependency_order(new_schema, cls):

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1438,7 +1438,7 @@ def update_mod_nss_cipher_suite(http):
     root_logger.info('[Updating mod_nss cipher suite]')
 
     revision = sysupgrade.get_upgrade_state('nss.conf', 'cipher_suite_updated')
-    if revision >= httpinstance.NSS_CIPHER_REVISION:
+    if revision and revision >= httpinstance.NSS_CIPHER_REVISION:
         root_logger.debug("Cipher suite already updated")
         return
 

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -16,7 +16,11 @@ import dns.exception
 
 import six
 # pylint: disable=import-error
-from six.moves.configparser import SafeConfigParser
+if six.PY3:
+    # The SafeConfigParser class has been renamed to ConfigParser in Py3
+    from configparser import ConfigParser as SafeConfigParser
+else:
+    from ConfigParser import SafeConfigParser
 # pylint: enable=import-error
 
 from ipalib import api

--- a/ipaserver/p11helper.py
+++ b/ipaserver/p11helper.py
@@ -5,6 +5,7 @@
 import random
 import ctypes.util
 import binascii
+import struct
 
 import six
 from cryptography.hazmat.backends import default_backend
@@ -1824,6 +1825,18 @@ MECH_AES_KEY_WRAP = CKM_AES_KEY_WRAP
 MECH_AES_KEY_WRAP_PAD = CKM_AES_KEY_WRAP_PAD
 
 
+def gen_key_id(key_id_len=16):
+    """
+    Generate random softhsm KEY_ID
+    :param key_id_len: this should be 16
+    :return: random softhsm KEY_ID in bytes representation
+    """
+    return struct.pack(
+        "B" * key_id_len,  # key_id must be bytes
+        *(random.randint(0, 255) for _ in range(key_id_len))
+    )
+
+
 def generate_master_key(p11, keylabel=u"dnssec-master", key_length=16,
                         disable_old_keys=True):
     assert isinstance(p11, P11_Helper)
@@ -1832,7 +1845,7 @@ def generate_master_key(p11, keylabel=u"dnssec-master", key_length=16,
     while True:
         # check if key with this ID exist in LDAP or softHSM
         # id is 16 Bytes long
-        key_id = "".join(chr(random.randint(0, 255)) for _ in range(0, 16))
+        key_id = gen_key_id()
         keys = p11.find_keys(KEY_CLASS_SECRET_KEY,
                              label=keylabel,
                              id=key_id)


### PR DESCRIPTION
ipa-server-install --setup-dns now work without BytesWarnings under python3, ipa-server-upgrade should work on IPA side but there are issues on pyldap side.
