### PR TITLE
Bump required python-cryptography version

### DIFF
--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -63,7 +63,7 @@ if SETUPTOOLS_VERSION < (8, 0, 0):
 
 
 PACKAGE_VERSION = {
-    'cryptography': 'cryptography >= 1.3.1',
+    'cryptography': 'cryptography >= 1.4',
     'dnspython': 'dnspython >= 1.15',
     'gssapi': 'gssapi >= 1.2.0',
     'ipaclient': 'ipaclient == {}'.format(VERSION),


### PR DESCRIPTION
Since we started using `Certificate.serial_number` instead of `.serial` from python-cryptography (https://github.com/freeipa/freeipa/commit/3d9bec2e879d60e6bb7b2602084d3314765a6283), bump the required version to the one where the above mentioned transition happened (https://github.com/pyca/cryptography/commit/e295f3ab615775c3549b7bc2e051af5cff801619).