### PR TITLE
pkinit: make sure to have proper dictionary for Kerberos instance on upgrade

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1753,6 +1753,18 @@ def upgrade_configuration():
     krb.realm = api.env.realm
     krb.suffix = ipautil.realm_to_suffix(krb.realm)
     krb.subject_base = subject_base
+    krb.sub_dict = dict(FQDN=krb.fqdn,
+                        SUFFIX=krb.suffix,
+                        DOMAIN=api.env.domain,
+                        HOST=api.env.host,
+                        SERVER_ID=installutils.realm_to_serverid(krb.realm),
+                        REALM=krb.realm,
+                        KRB5KDC_KADM5_ACL=paths.KRB5KDC_KADM5_ACL,
+                        DICT_WORDS=paths.DICT_WORDS,
+                        KRB5KDC_KADM5_KEYTAB=paths.KRB5KDC_KADM5_KEYTAB,
+                        KDC_CERT=paths.KDC_CERT,
+                        KDC_KEY=paths.KDC_KEY,
+                        CACERT_PEM=paths.CACERT_PEM)
     if not os.path.exists(paths.KDC_CERT):
         krb.setup_pkinit()
         replacevars = dict()


### PR DESCRIPTION

When running PKINIT upgrade we need to make sure full substitution
dictionary is in place or otherwise executing LDAP updates will fail to
find proper objects because $SUFFIX, $DOMAIN, and other variables
will not be substituted.

Fixes https://fedorahosted.org/freeipa/ticket/6670