### PR TITLE
Remove non-sensical kdestroy on https stop

### DIFF
--- a/install/share/ipa-httpd.conf.template
+++ b/install/share/ipa-httpd.conf.template
@@ -1,7 +1,7 @@
 # Do not edit. Created by IPA installer.
 
 [Service]
+Environment=KRB5CCNAME=$KRB5CC_HTTPD
 Environment=GSS_USE_PROXY=yes
 Environment=KDCPROXY_CONFIG=$KDCPROXY_CONFIG
 ExecStartPre=$IPA_HTTPD_KDCPROXY
-ExecStopPost=$POST

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -351,5 +351,6 @@ class BasePathNamespace(object):
     IPA_GETKEYTAB = '/usr/sbin/ipa-getkeytab'
     EXTERNAL_SCHEMA_DIR = '/usr/share/ipa/schema.d'
     GSSPROXY_CONF = '/etc/gssproxy/10-ipa.conf'
+    KRB5CC_HTTPD = '/tmp/krb5cc-httpd'
 
 path_namespace = BasePathNamespace

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -89,7 +89,6 @@ class DebianPathNamespace(BasePathNamespace):
     VAR_OPENDNSSEC_DIR = "/var/lib/opendnssec"
     OPENDNSSEC_KASP_DB = "/var/lib/opendnssec/db/kasp.db"
     IPA_ODS_EXPORTER_CCACHE = "/var/lib/opendnssec/tmp/ipa-ods-exporter.ccache"
-    KRB5CC_HTTPD = "/var/run/apache2/ipa/krbcache/krb5ccache"
     IPA_CUSTODIA_SOCKET = "/run/apache2/ipa-custodia.sock"
     IPA_CUSTODIA_AUDIT_LOG = '/var/log/ipa-custodia.audit.log'
 

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -458,7 +458,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
             dict(
                 KDCPROXY_CONFIG=paths.KDCPROXY_CONFIG,
                 IPA_HTTPD_KDCPROXY=paths.IPA_HTTPD_KDCPROXY,
-                POST='-{kdestroy} -A'.format(kdestroy=paths.KDESTROY)
+                KRB5CC_HTTPD=paths.KRB5CC_HTTPD,
             )
         )
 


### PR DESCRIPTION
This kdestroy runs as root and wipes root's own ccachs ...
this is totally inappropriate.

https://fedorahosted.org/freeipa/ticket/6673

Signed-off-by: Simo Sorce <simo@redhat.com>