### PR TITLE
WebUI: Size limit warning on details pages fixed

### DIFF
--- a/install/ui/src/freeipa/rpc.js
+++ b/install/ui/src/freeipa/rpc.js
@@ -72,6 +72,12 @@ rpc.command = function(spec) {
     that.options = $.extend({}, spec.options || {});
 
     /**
+     * @property {Array} suppress_warnings array of message codes which
+     * are suppressed
+     */
+    that.suppress_warnings = spec.suppress_warnings || [];
+
+    /**
      * Success handler
      * @property {Function}
      * @param {Object} data
@@ -219,6 +225,7 @@ rpc.command = function(spec) {
 
         for (var i=0,l=msgs.length; i<l; i++) {
             var msg = lang.clone(msgs[i]);
+            if (that.suppress_warnings.indexOf(msg.code) > -1) continue;
             // escape and reformat message
             msg.message = util.beautify_message(msg.message);
             IPA.notify(msg.message, msg.type);

--- a/install/ui/src/freeipa/widget.js
+++ b/install/ui/src/freeipa/widget.js
@@ -5012,7 +5012,8 @@ IPA.entity_select_widget = function(spec) {
             entity: that.other_entity.name,
             method: 'find',
             args: [filter],
-            options: that.filter_options
+            options: that.filter_options,
+            suppress_warnings: [13017]
         });
         var no_members = metadata.get('@mc-opt:' + cmd.get_command() + ':no_members');
         if (no_members) {


### PR DESCRIPTION
Entity select fields accepted globally set size limit and in situations when
there were more entries than global size limit allows then the "Truncated" warning
shows up. Also only subset of items was shown.
All entity select widgets now uses find methods with sizelimit set to 0
which says get all entries.

This setting is configurable using search_all_entries attribute.

https://fedorahosted.org/freeipa/ticket/6618