### PR TITLE
Fix some privilege separation regressions

### DIFF
--- a/install/updates/05-pre_upgrade_plugins.update
+++ b/install/updates/05-pre_upgrade_plugins.update
@@ -8,4 +8,3 @@ plugin: update_referint
 plugin: update_uniqueness_plugins_to_new_syntax
 
 # last
-plugin: update_ra_cert_store

--- a/install/updates/90-post_upgrade_plugins.update
+++ b/install/updates/90-post_upgrade_plugins.update
@@ -15,6 +15,8 @@ plugin: update_idrange_type
 plugin: update_pacs
 plugin: update_service_principalalias
 plugin: update_upload_cacrt
+# update_ra_cert_store has to be executed after update_ca_renewal_master
+plugin: update_ra_cert_store
 
 # last
 # DNS version 1

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2284,7 +2284,7 @@ def install_check(options):
 
 def create_ipa_nssdb():
     db = certdb.NSSDatabase(paths.IPA_NSSDB_DIR)
-    db.create_db(backup=True)
+    db.create_db(mode=0o755, backup=True)
     os.chmod(db.pwd_file, 0o600)
     os.chmod(os.path.join(db.secdir, 'cert8.db'), 0o644)
     os.chmod(os.path.join(db.secdir, 'key3.db'), 0o644)

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -39,6 +39,7 @@ class BasePathNamespace(object):
     HOSTS = "/etc/hosts"
     ETC_HTTPD_DIR = "/etc/httpd"
     HTTPD_ALIAS_DIR = "/etc/httpd/alias"
+    OLD_KRA_AGENT_PEM = "/etc/httpd/alias/kra-agent.pem"
     IPA_RADB_DIR = "/var/lib/ipa/radb"
     HTTPD_CONF_D_DIR = "/etc/httpd/conf.d/"
     HTTPD_IPA_KDCPROXY_CONF = "/etc/ipa/kdcproxy/ipa-kdc-proxy.conf"

--- a/ipaserver/install/plugins/ca_renewal_master.py
+++ b/ipaserver/install/plugins/ca_renewal_master.py
@@ -74,7 +74,7 @@ class update_ca_renewal_master(Updater):
                 return False, []
 
         criteria = {
-            'cert-database': paths.IPA_RADB_DIR,
+            'cert-database': paths.HTTPD_ALIAS_DIR,
             'cert-nickname': 'ipaCert',
         }
         request_id = certmonger.get_request_id(criteria)

--- a/ipaserver/install/plugins/update_ra_cert_store.py
+++ b/ipaserver/install/plugins/update_ra_cert_store.py
@@ -22,6 +22,10 @@ class update_ra_cert_store(Updater):
     """
 
     def execute(self, **options):
+        ca_enabled = self.api.Command.ca_is_enabled()['result']
+        if not ca_enabled:
+            return False, []
+
         olddb = certdb.NSSDatabase(nssdir=paths.HTTPD_ALIAS_DIR)
         if not olddb.has_nickname('ipaCert'):
             # Nothign to do

--- a/ipaserver/install/plugins/upload_cacrt.py
+++ b/ipaserver/install/plugins/upload_cacrt.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from ipalib.install import certstore
+from ipaplatform.paths import paths
 from ipaserver.install import certs
 from ipalib import Registry, errors
 from ipalib import Updater
@@ -34,7 +35,7 @@ class update_upload_cacrt(Updater):
     """
 
     def execute(self, **options):
-        db = certs.CertDB(self.api.env.realm)
+        db = certs.CertDB(self.api.env.realm, paths.HTTPD_ALIAS_DIR)
         ca_cert = None
 
         ca_enabled = self.api.Command.ca_is_enabled()['result']

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -79,14 +79,12 @@ def uninstall_ipa_memcached():
     We can't use the full service uninstaller because that will attempt
     to stop and disable the service which by now doesn't exist. We just
     want to clean up sysrestore.state to remove all references to
-    ipa_kpasswd.
+    ipa_memcached.
     """
     ipa_memcached = service.SimpleServiceInstance('ipa_memcached')
 
-    enabled = not ipa_memcached.restore_state("enabled")
+    ipa_memcached.uninstall()
 
-    if enabled is not None and not enabled:
-        ipa_memcached.remove()
 
 def backup_file(filename, ext):
     """Make a backup of filename using ext as the extension. Do not overwrite

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1386,7 +1386,9 @@ def fix_trust_flags():
 def export_kra_agent_pem():
     root_logger.info('[Exporting KRA agent PEM file]')
 
-    if sysupgrade.get_upgrade_state('http', 'export_kra_agent_pem'):
+    sysupgrade.remove_upgrade_state('http', 'export_kra_agent_pem')
+
+    if os.path.exists(paths.KRA_AGENT_PEM):
         root_logger.info("KRA agent PEM file already exported")
         return
 
@@ -1395,8 +1397,7 @@ def export_kra_agent_pem():
         return
 
     krainstance.export_kra_agent_pem()
-
-    sysupgrade.set_upgrade_state('http', 'export_kra_agent_pem', True)
+    installutils.remove_file(paths.OLD_KRA_AGENT_PEM)
 
 
 def update_mod_nss_protocol(http):


### PR DESCRIPTION
**client install: create /etc/ipa/nssdb with correct mode**

The NSS database directory is created with mode 640, which causes the IPA
client to fail to connect to any IPA server, because it is unable to read
trusted CA certificates from the NSS database.

Create the directory with mode 644 to fix the issue.

**server upgrade: fix upgrade in CA-less**

Use /etc/httpd/alias instead of /var/lib/ipa/radb in upload_cacrt, as
/var/lib/ipa/radb is not populated in CA-less.

Do not migrate ipaCert from /etc/httpd/alias to /var/lib/ipa/radb in
CA-less, as it might be an incorrect certificate from previous CA-ful
install, and is not necessary anyway.

**server upgrade: fix upgrade from pre-4.0**

update_ca_renewal_master uses ipaCert certmonger tracking information to
decide whether the local server is the CA renewal master or not. The
information is lost when migrating from /etc/httpd/alias to
/var/lib/ipa/radb in update_ra_cert_store.

Make sure update_ra_cert_store is executed after update_ca_renewal_master
so that correct information is used.

**server upgrade: always upgrade KRA agent PEM file**

Before the KRA agent PEM file is exported in server upgrade, the sysupgrade
state file is consulted. This causes the KRA agent PEM file not to be
exported to the new location if the upgrade was executed in the past.

Do not consult the sysupgrade state file to decide whether to upgrade the
KRA agent PEM file or not, the existence of the file is enough to make this
decision.

https://fedorahosted.org/freeipa/ticket/5959
https://fedorahosted.org/freeipa/ticket/6675