### PR TITLE
Add options to run only ipaclient unittests

### DIFF
--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -7,13 +7,21 @@ import os
 import pprint
 import sys
 
+import pytest
+
 from ipalib import api
 from ipalib.cli import cli_plugins
+
+try:
+    import ipaplatform  # pylint: disable=unused-import
+except ImportError:
+    ipaplatform = None
 try:
     import ipaserver
 except ImportError:
     ipaserver = None
 
+HERE = os.path.dirname(os.path.abspath(__file__))
 
 pytest_plugins = [
     'ipatests.pytest_plugins.additional_config',
@@ -31,6 +39,7 @@ MARKERS = [
     'tier1: functional API tests',
     'cs_acceptance: Acceptance test suite for Dogtag Certificate Server',
     'ds_acceptance: Acceptance test suite for 389 Directory Server',
+    'skip_ipaclient_unittest: Skip in ipaclient unittest mode',
 ]
 
 
@@ -45,6 +54,7 @@ NO_RECURSE_DIRS = [
     # install/share/wsgi.py
     'install/share'
 ]
+
 
 INIVALUES = {
     'python_classes': ['test_', 'Test'],
@@ -75,13 +85,27 @@ def pytest_configure(config):
     config.option.doctestmodules = True
 
 
+def pytest_addoption(parser):
+    group = parser.getgroup("IPA integration tests")
+    group.addoption(
+        '--ipaclient-unittests',
+        help='Run ipaclient unit tests only (no RPC and ipaserver)',
+        action='store_true'
+    )
+
+
 def pytest_cmdline_main(config):
     api.bootstrap(
         context=u'cli', in_server=False, in_tree=True, fallback=False
     )
     for klass in cli_plugins:
         api.add_plugin(klass)
-    api.finalize()
+
+    # XXX workaround until https://fedorahosted.org/freeipa/ticket/6408 has
+    # been resolved.
+    if ipaserver is not None:
+        api.finalize()
+
     if config.option.verbose:
         print('api.env: ')
         pprint.pprint({k: api.env[k] for k in api.env})
@@ -89,3 +113,11 @@ def pytest_cmdline_main(config):
         print("euid: {}, egid: {}".format(os.geteuid(), os.getegid()))
         print("working dir: {}".format(os.path.abspath(os.getcwd())))
         print('sys.version: {}'.format(sys.version))
+
+
+def pytest_runtest_setup(item):
+    if isinstance(item, item.Function):
+        if item.get_marker('skip_ipaclient_unittest'):
+            # pylint: disable=no-member
+            if pytest.config.option.ipaclient_unittests:
+                pytest.skip("Skip in ipaclient unittest mode")

--- a/ipatests/pytest_plugins/integration.py
+++ b/ipatests/pytest_plugins/integration.py
@@ -30,9 +30,6 @@ from pytest_multihost import make_multihost_fixture
 
 from ipapython import ipautil
 from ipapython.ipa_log_manager import log_mgr
-from ipatests.test_integration import tasks
-from ipatests.test_integration.config import Config
-from ipatests.test_integration.env_config import get_global_config
 
 log = log_mgr.get_logger(__name__)
 
@@ -155,6 +152,11 @@ def integration_logs(class_integration_logs, request):
 def mh(request, class_integration_logs):
     """IPA's multihost fixture object
     """
+    # TODO: cleanup modules
+    from ipatests.test_integration import tasks
+    from ipatests.test_integration.config import Config
+    from ipatests.test_integration.env_config import get_global_config
+
     cls = request.cls
 
     domain_description = {

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -64,7 +64,6 @@ if __name__ == '__main__':
             "gssapi",
             "ipaclient",
             "ipalib",
-            "ipaplatform",
             "ipapython",
             "nose",
             "polib",

--- a/ipatests/test_cmdline/__init__.py
+++ b/ipatests/test_cmdline/__init__.py
@@ -1,3 +1,9 @@
 #
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
+
+import pytest
+
+
+if pytest.config.getoption('ipaclient_unittests', False):
+    pytest.skip("Skip in ipaclient unittest mode")

--- a/ipatests/test_install/__init__.py
+++ b/ipatests/test_install/__init__.py
@@ -20,3 +20,8 @@
 """
 Package containing LDAP updates unit tests.
 """
+import pytest
+
+
+if pytest.config.getoption('ipaclient_unittests', False):
+    pytest.skip("Skip in ipaclient unittest mode")

--- a/ipatests/test_integration/__init__.py
+++ b/ipatests/test_integration/__init__.py
@@ -16,3 +16,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import pytest
+
+
+if pytest.config.getoption('ipaclient_unittests', False):
+    pytest.skip("Skip in ipaclient unittest mode")

--- a/ipatests/test_ipalib/test_rpc.py
+++ b/ipatests/test_ipalib/test_rpc.py
@@ -23,6 +23,7 @@ Test the `ipalib.rpc` module.
 from __future__ import print_function
 
 import nose
+import pytest
 import six
 # pylint: disable=import-error
 from six.moves.xmlrpc_client import Binary, Fault, dumps, loads
@@ -256,6 +257,7 @@ class test_xmlclient(PluginTester):
         assert context.xmlclient.conn._calledall() is True
 
 
+@pytest.mark.skip_ipaclient_unittest
 class test_xml_introspection(object):
     @classmethod
     def setup_class(cls):

--- a/ipatests/test_ipaserver/__init__.py
+++ b/ipatests/test_ipaserver/__init__.py
@@ -20,3 +20,9 @@
 """
 Sub-package containing unit tests for `ipaserver` package.
 """
+
+import pytest
+
+
+if pytest.config.getoption('ipaclient_unittests', False):
+    pytest.skip("Skip in ipaclient unittest mode")

--- a/ipatests/test_ipaserver/test_install/test_adtrustinstance.py
+++ b/ipatests/test_ipaserver/test_install/test_adtrustinstance.py
@@ -19,12 +19,8 @@
 """
 Test `adtrustinstance`
 """
-
-import os
-
-import six
-import nose
 import pytest
+import six
 
 from ipaserver.install import adtrustinstance
 
@@ -33,7 +29,7 @@ if six.PY3:
 
 
 @pytest.mark.tier0
-class test_adtrustinstance:
+class test_adtrustinstance(object):
     """
     Test `adtrustinstance`.
     """

--- a/ipatests/test_webui/__init__.py
+++ b/ipatests/test_webui/__init__.py
@@ -20,3 +20,8 @@
 """
 Sub-package containing Web UI integration tests
 """
+import pytest
+
+
+if pytest.config.getoption('ipaclient_unittests', False):
+    pytest.skip("Skip in ipaclient unittest mode")

--- a/ipatests/test_xmlrpc/__init__.py
+++ b/ipatests/test_xmlrpc/__init__.py
@@ -20,3 +20,8 @@
 """
 Sub-package containing unit tests for `xmlrpc` package.
 """
+import pytest
+
+
+if pytest.config.getoption('ipaclient_unittests', False):
+    pytest.skip("Skip in ipaclient unittest mode")

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -39,12 +39,23 @@ import ldap.modlist
 
 import ipalib
 from ipalib import api
-from ipalib.install.kinit import kinit_keytab, kinit_password
 from ipalib.plugable import Plugin
 from ipalib.request import context
 from ipapython.dn import DN
 from ipapython.ipautil import run
-from ipaplatform.paths import paths
+
+try:
+    # not available with client-only wheel packages
+    from ipalib.install.kinit import kinit_keytab, kinit_password
+except ImportError:
+    kinit_keytab = kinit_password = None
+
+try:
+    # not available with client-only wheel packages
+    from ipaplatform.paths import paths
+except ImportError:
+    paths = None
+
 
 if six.PY3:
     unicode = str
@@ -336,7 +347,7 @@ def assert_deepequal(expected, got, doc='', stack=tuple()):
     their elements does not matter.
     """
     try:
-        pretty_print = pytest.config.getoption("pretty_print")  # pylint: disable=no-member
+        pretty_print = pytest.config.getoption("pretty_print")
     except (AttributeError, ValueError):
         pretty_print = False
 

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -7,12 +7,14 @@ from __future__ import print_function
 import copy
 import os.path
 import sys
+import textwrap
 
-from astroid import MANAGER
+from astroid import MANAGER, register_module_extender
 from astroid import scoped_nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import check_messages
 from pylint.interfaces import IAstroidChecker
+from astroid.builder import AstroidBuilder
 
 
 def register(linter):
@@ -256,6 +258,18 @@ def fix_ipa_classes(cls):
         fake_class(cls, ipa_class_members[class_name_with_module])
 
 MANAGER.register_transform(scoped_nodes.Class, fix_ipa_classes)
+
+
+def pytest_config_transform():
+    """pylint.config attribute
+    """
+    return AstroidBuilder(MANAGER).string_build(textwrap.dedent('''
+    from _pytest.config import get_config
+    config = get_config()
+    '''))
+
+
+register_module_extender(MANAGER, 'pytest', pytest_config_transform)
 
 
 class IPAChecker(BaseChecker):


### PR DESCRIPTION
A new option for ipa-run-tests makes the test runner ignore
subdirectories or skips tests that depend on the ipaserver package or on
a running framework for RPC integration tests. The new option enables
testing of client-only builds.

$ ipatests/ipa-run-tests --ipaclient-unittests
...
platform linux2 -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1
rootdir: /home/heimes/redhat, inifile: tox.ini
plugins: sourceorder-0.5, cov-2.3.0, betamax-0.7.1, multihost-1.1
collected 451 items

test_util.py ........
util.py ..
test_ipaclient/test_csrgen.py ..............ssss...
test_ipalib/test_aci.py ...................
test_ipalib/test_backend.py ........
test_ipalib/test_base.py ...............
test_ipalib/test_capabilities.py .
test_ipalib/test_cli.py ...
test_ipalib/test_config.py ...............
test_ipalib/test_crud.py ...............
test_ipalib/test_errors.py .......
test_ipalib/test_frontend.py ........................................
test_ipalib/test_messages.py ....
test_ipalib/test_output.py ...
test_ipalib/test_parameters.py .............................................................
test_ipalib/test_plugable.py ........
test_ipalib/test_rpc.py ......ssssssss
test_ipalib/test_text.py .............................
test_ipalib/test_x509.py ...
test_ipapython/test_cookie.py ............
test_ipapython/test_dn.py ...........................
test_ipapython/test_ipautil.py ..................................................................
test_ipapython/test_ipavalidate.py ..........
test_ipapython/test_kerberos.py ..............
test_ipapython/test_keyring.py ..........
test_ipapython/test_ssh.py ...............................
test_pkcs10/test_pkcs10.py .....

https://fedorahosted.org/freeipa/ticket/6517

Signed-off-by: Christian Heimes <cheimes@redhat.com>