### PR TITLE
Hide request_type doc string in cert-request help

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -479,7 +479,7 @@ class certreq(BaseCertObject):
             'request_type',
             default=u'pkcs10',
             autofill=True,
-            flags={'no_update', 'no_update', 'no_search'},
+            flags={'no_option', 'no_update', 'no_update', 'no_search'},
         ),
         Str(
             'profile_id?', validate_profile_id,


### PR DESCRIPTION
Fix hides description of request_type argument in cert-request
command help

Fixes https://pagure.io/freeipa/issue/6494
Fixes https://pagure.io/freeipa/issue/5734

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>