### PR TITLE
FIPS: Remove pkispawn cruft

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -265,8 +265,7 @@ def install_step_0(standalone, replica_config, options):
         'certmap.conf', 'subject_base', str(subject_base))
     dsinstance.write_certmap_conf(realm_name, ca_subject)
 
-    ca = cainstance.CAInstance(realm_name, paths.IPA_RADB_DIR,
-                               host_name=host_name)
+    ca = cainstance.CAInstance(realm_name, host_name=host_name)
     ca.configure_instance(host_name, dm_password, dm_password,
                           subject_base=subject_base,
                           ca_subject=ca_subject,
@@ -293,8 +292,7 @@ def install_step_1(standalone, replica_config, options):
     subject_base = options._subject_base
     basedn = ipautil.realm_to_suffix(realm_name)
 
-    ca = cainstance.CAInstance(realm_name, paths.IPA_RADB_DIR,
-                               host_name=host_name)
+    ca = cainstance.CAInstance(realm_name, host_name=host_name)
 
     ca.stop('pki-tomcat')
 
@@ -356,7 +354,7 @@ def install_step_1(standalone, replica_config, options):
 
 
 def uninstall():
-    ca_instance = cainstance.CAInstance(api.env.realm, paths.IPA_RADB_DIR)
+    ca_instance = cainstance.CAInstance(api.env.realm)
     ca_instance.stop_tracking_certificates()
     if ca_instance.is_configured():
         ca_instance.uninstall()

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -283,6 +283,27 @@ def cleanup_adtrust(fstore):
             root_logger.debug('Removing %s from backup', backed_up_file)
 
 
+def cleanup_dogtag():
+    """
+    pkispawn leaves some mess we were not cleaning up until recently. Try
+    to clean up what we can.
+    """
+    subsystems = []
+    if api.Command.ca_is_enabled()['result']:
+        subsystems.append('CA')
+        if api.Command.kra_is_enabled()['result']:
+            subsystems.append('KRA')
+
+    for system in subsystems:
+        root_logger.debug(
+            "Cleaning up after pkispawn for the {sub} subsystem"
+            .format(sub=system))
+        instance = dogtaginstance.DogtagInstance(
+            api.env.realm, system, service_desc=None,
+        )
+        instance.clean_pkispawn_files()
+
+
 def upgrade_adtrust_config():
     """
     Upgrade 'dedicated keytab file' in smb.conf to omit FILE: prefix
@@ -1672,6 +1693,7 @@ def upgrade_configuration():
 
     cleanup_kdc(fstore)
     cleanup_adtrust(fstore)
+    cleanup_dogtag()
     upgrade_adtrust_config()
 
     bind = bindinstance.BindInstance(fstore)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1540,7 +1540,7 @@ def upgrade_configuration():
         sub_dict['SUBJECT_BASE'] = subject_base
 
     ca = cainstance.CAInstance(
-            api.env.realm, paths.IPA_RADB_DIR, host_name=api.env.host)
+            api.env.realm, host_name=api.env.host)
     ca_running = ca.is_running()
 
     # create passswd.txt file in PKI_TOMCAT_ALIAS_DIR if it does not exist


### PR DESCRIPTION
`pkispawn` leaves some ugly files after its successful run. This patch:
a) makes sure the files are removed (say no to `__del__` in `DogtagInstance`)
b) prevents special requirements for DM password in FIPS as this was for some reason used to create an NSS database for `pkispawn`