### PR TITLE
Fix session logout

### DIFF
--- a/ipaserver/plugins/session.py
+++ b/ipaserver/plugins/session.py
@@ -23,6 +23,6 @@ class session_logout(Command):
         else:
             delattr(context, 'ccache_name')
 
-        setattr(context, 'logout_cookie', '')
+        setattr(context, 'logout_cookie', 'MagBearerToken=')
 
         return dict(result=None)

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -434,6 +434,10 @@ class WSGIExecutioner(Executioner):
             response = status.encode('utf-8')
             headers = [('Content-Type', 'text/plain; charset=utf-8')]
 
+        logout_cookie = getattr(context, 'logout_cookie', None)
+        if logout_cookie is not None:
+            headers.append(('IPASESSION', logout_cookie))
+
         start_response(status, headers)
         return [response]
 
@@ -638,10 +642,6 @@ class KerberosWSGIExecutioner(WSGIExecutioner, KerberosSession):
                 'KRB5CCNAME not defined in HTTP request environment')
 
             return self.marshal(None, CCacheError())
-
-        logout_cookie = getattr(context, 'logout_cookie', None)
-        if logout_cookie:
-            self.headers.append(('IPASESSION', logout_cookie))
 
         try:
             self.create_context(ccache=user_ccache)


### PR DESCRIPTION
There were 2 issues with session logouts, one is that the logout_cookie
was checked and acted on in the wrong place, the other is that the wrong
value was set in the IPASESSION header.

Fixes https://fedorahosted.org/freeipa/ticket/6685

Signed-off-by: Simo Sorce <simo@redhat.com>