### PR TITLE
Fix error in ca_cert_files validator

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3555,6 +3555,10 @@ class ClientInstall(ClientInstallInterface,
 
     @ca_cert_files.validator
     def ca_cert_files(self, value):
+        if not isinstance(value, list):
+            raise ValueError("Expected list, got {!r}".format(value))
+        # this is what init() does
+        value = value[-1]
         if not os.path.exists(value):
             raise ValueError("'%s' does not exist" % value)
         if not os.path.isfile(value):


### PR DESCRIPTION
ClientInstall expects a single ca_cert_file as a string but the
framework gives it a list.

https://fedorahosted.org/freeipa/ticket/6694