### PR TITLE
certdb: use certutil and match_hostname for cert verification

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -134,7 +134,6 @@ BuildRequires:  python-lesscpy
 # makeapi/makeaci is using Python 2 only for now
 #
 BuildRequires:  python-ldap
-BuildRequires:  python-nss
 BuildRequires:  python-netaddr
 BuildRequires:  python-pyasn1
 BuildRequires:  python-pyasn1-modules
@@ -635,7 +634,6 @@ Requires: python-gssapi >= 1.2.0
 Requires: gnupg
 Requires: keyutils
 Requires: pyOpenSSL
-Requires: python-nss >= 0.16
 Requires: python-cryptography >= 1.6
 Requires: python-netaddr
 Requires: python-libipa_hbac
@@ -684,7 +682,6 @@ Requires: python3-gssapi >= 1.2.0
 Requires: gnupg
 Requires: keyutils
 Requires: python3-pyOpenSSL
-Requires: python3-nss >= 0.16
 Requires: python3-cryptography >= 1.6
 Requires: python3-netaddr
 Requires: python3-libipa_hbac

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -160,8 +160,8 @@ BuildRequires:  python3-wheel
 #
 %if 0%{?with_lint}
 BuildRequires:  samba-python
-# 1.4: the version where Certificate.serial changed to .serial_number
-BuildRequires:  python-cryptography >= 1.4
+# 1.6: x509.Name.rdns (https://github.com/pyca/cryptography/issues/3199)
+BuildRequires:  python-cryptography >= 1.6
 BuildRequires:  python-gssapi >= 1.2.0
 BuildRequires:  pylint >= 1.6
 # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1096506
@@ -196,8 +196,8 @@ BuildRequires:  python2-jinja2
 %if 0%{?with_python3}
 # FIXME: this depedency is missing - server will not work
 #BuildRequires:  python3-samba
-# 1.4: the version where Certificate.serial changed to .serial_number
-BuildRequires:  python3-cryptography >= 1.4
+# 1.6: x509.Name.rdns (https://github.com/pyca/cryptography/issues/3199)
+BuildRequires:  python3-cryptography >= 1.6
 BuildRequires:  python3-gssapi >= 1.2.0
 BuildRequires:  python3-pylint >= 1.6
 # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1096506
@@ -636,7 +636,7 @@ Requires: gnupg
 Requires: keyutils
 Requires: pyOpenSSL
 Requires: python-nss >= 0.16
-Requires: python-cryptography >= 1.4
+Requires: python-cryptography >= 1.6
 Requires: python-netaddr
 Requires: python-libipa_hbac
 Requires: python-qrcode-core >= 5.0.0
@@ -685,7 +685,7 @@ Requires: gnupg
 Requires: keyutils
 Requires: python3-pyOpenSSL
 Requires: python3-nss >= 0.16
-Requires: python3-cryptography >= 1.4
+Requires: python3-cryptography >= 1.6
 Requires: python3-netaddr
 Requires: python3-libipa_hbac
 Requires: python3-qrcode-core >= 5.0.0
@@ -760,7 +760,7 @@ Requires: python-pytest-multihost >= 0.5
 Requires: python-pytest-sourceorder
 Requires: ldns-utils
 Requires: python-sssdconfig
-Requires: python2-cryptography >= 1.4
+Requires: python2-cryptography >= 1.6
 
 Provides: %{alt_name}-tests = %{version}
 Conflicts: %{alt_name}-tests
@@ -794,7 +794,7 @@ Requires: python3-pytest-multihost >= 0.5
 Requires: python3-pytest-sourceorder
 Requires: ldns-utils
 Requires: python3-sssdconfig
-Requires: python3-cryptography >= 1.4
+Requires: python3-cryptography >= 1.6
 
 %description -n python3-ipatests
 IPA is an integrated solution to provide centrally managed Identity (users,

--- a/ipalib/setup.py
+++ b/ipalib/setup.py
@@ -41,7 +41,6 @@ if __name__ == '__main__':
             "netaddr",
             "pyasn1",
             "pyasn1-modules",
-            "python-nss",
             "six",
         ],
         extras_require={

--- a/ipapython/setup.py
+++ b/ipapython/setup.py
@@ -46,7 +46,6 @@ if __name__ == '__main__':
             "pyldap",
             "netaddr",
             "netifaces",
-            "python-nss",
             "requests",
             "six",
         ],

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -63,7 +63,7 @@ if SETUPTOOLS_VERSION < (8, 0, 0):
 
 
 PACKAGE_VERSION = {
-    'cryptography': 'cryptography >= 1.4',
+    'cryptography': 'cryptography >= 1.6',
     'custodia': 'custodia >= 0.3.1',
     'dnspython': 'dnspython >= 1.15',
     'gssapi': 'gssapi >= 1.2.0',

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -75,7 +75,6 @@ PACKAGE_VERSION = {
     'kdcproxy': 'kdcproxy >= 0.3',
     'netifaces': 'netifaces >= 0.10.4',
     'pyldap': 'pyldap >= 2.4.15',
-    'python-nss': 'python-nss >= 0.16',
     'python-yubico': 'python-yubico >= 1.2.3',
     'qrcode': 'qrcode >= 5.0',
 }

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
         ],
         extras_require={
             "integration": ["dbus-python", "pyyaml", "ipaserver"],
-            "ipaserver": ["ipaserver", "python-nss"],
+            "ipaserver": ["ipaserver"],
             "webui": ["selenium", "pyyaml", "ipaserver"],
             "xmlrpc": ["ipaserver"],
         }

--- a/pylintrc
+++ b/pylintrc
@@ -16,8 +16,7 @@ extension-pkg-whitelist=
     _ldap,
     cryptography,
     gssapi,
-    netifaces,
-    nss
+    netifaces
 
 
 [MESSAGES CONTROL]


### PR DESCRIPTION
Use certutil and ssl.match_hostname calls instead of python-nss for
certificate verification.