### PR TITLE
Don't prepend option names with additional '--'

### DIFF
--- a/ipapython/install/cli.py
+++ b/ipapython/install/cli.py
@@ -321,7 +321,7 @@ class ConfigureTool(admintool.AdminTool):
                 index = self.positional_arguments.index(e.name)
             except ValueError:
                 cli_name = knob_cls.cli_names[0] or e.name.replace('_', '-')
-                desc = "option --{0}".format(cli_name)
+                desc = "option {0}".format(cli_name)
             else:
                 desc = "argument {0}".format(index + 1)
             self.option_parser.error("{0}: {1}".format(desc, e))


### PR DESCRIPTION
The options now have '--' prepended by their names already, don't
add it.

https://fedorahosted.org/freeipa/ticket/6392

The issue example:
running `ipa-client-install --ca-cert-file /home/cartman/nonexistent_file` gives
```
Usage: ipa-client-install [options]

ipa-client-install: error: option ----ca-cert-file: '/home/slaznick/pokus' is not a valid certificate file
```