### PR TITLE
config: remove meaningless defaults

### DIFF
--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -579,6 +579,20 @@ class Env(object):
         if 'log' not in self:
             self.log = self._join('logdir', '%s.log' % self.context)
 
+        if 'basedn' not in self and 'domain' in self:
+            self.basedn = DN(*(('dc', dc) for dc in self.domain.split('.')))
+
+        # Derive xmlrpc_uri from server
+        # (Note that this is done before deriving jsonrpc_uri from xmlrpc_uri
+        # and server from jsonrpc_uri so that when only server or xmlrpc_uri
+        # is specified, all 3 keys have a value.)
+        if 'xmlrpc_uri' not in self and 'server' in self:
+            self.xmlrpc_uri = 'https://{}/ipa/xml'.format(self.server)
+
+        # Derive ldap_uri from server
+        if 'ldap_uri' not in self and 'server' in self:
+            self.ldap_uri = 'ldap://{}'.format(self.server)
+
         # Derive jsonrpc_uri from xmlrpc_uri
         if 'jsonrpc_uri' not in self:
             if 'xmlrpc_uri' in self:

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -134,8 +134,9 @@ DEFAULT_CONFIG = (
     # Following values do not have any reasonable default.
     # Do not initialize them so the code which depends on them blows up early
     # and does not do crazy stuff with default values instead of real ones.
+    # ('server', 'localhost'),
     # ('xmlrpc_uri', 'http://localhost:8888/ipa/xml'),
-    # jsonrpc_uri is set in Env._finalize_core()
+    # ('jsonrpc_uri', 'http://localhost:8888/ipa/json'),
     # ('ldap_uri', 'ldap://localhost:389'),
 
     ('rpc_protocol', 'jsonrpc'),
@@ -245,8 +246,6 @@ DEFAULT_CONFIG = (
     ('in_server', object),  # Whether or not running in-server (bool)
     ('logdir', object),  # Directory containing log files
     ('log', object),  # Path to context specific log file
-    ('jsonrpc_uri', object),  # derived from xmlrpc_uri in Env._finalize_core()
-    ('server', object),  # derived from jsonrpc_uri in Env._finalize_core()
 
 )
 

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -69,9 +69,12 @@ DEFAULT_CONFIG = (
     ('version', VERSION),
 
     # Domain, realm, basedn:
-    ('domain', 'example.com'),
-    ('realm', 'EXAMPLE.COM'),
-    ('basedn', DN(('dc', 'example'), ('dc', 'com'))),
+    # Following values do not have any reasonable default.
+    # Do not initialize them so the code which depends on them blows up early
+    # and does not do crazy stuff with default values instead of real ones.
+    # ('domain', 'example.com'),
+    # ('realm', 'EXAMPLE.COM'),
+    # ('basedn', DN(('dc', 'example'), ('dc', 'com'))),
 
     # LDAP containers:
     ('container_accounts', DN(('cn', 'accounts'))),
@@ -128,9 +131,12 @@ DEFAULT_CONFIG = (
     ('container_certmaprules', DN(('cn', 'certmaprules'), ('cn', 'certmap'))),
 
     # Ports, hosts, and URIs:
-    ('xmlrpc_uri', 'http://localhost:8888/ipa/xml'),
+    # Following values do not have any reasonable default.
+    # Do not initialize them so the code which depends on them blows up early
+    # and does not do crazy stuff with default values instead of real ones.
+    # ('xmlrpc_uri', 'http://localhost:8888/ipa/xml'),
     # jsonrpc_uri is set in Env._finalize_core()
-    ('ldap_uri', 'ldap://localhost:389'),
+    # ('ldap_uri', 'ldap://localhost:389'),
 
     ('rpc_protocol', 'jsonrpc'),
 

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -704,21 +704,22 @@ class LDAPClient(object):
             If true, attributes are decoded to Python types according to their
             syntax.
         """
-        self.ldap_uri = ldap_uri
+        if ldap_uri is not None:
+            self.ldap_uri = ldap_uri
+            self.host = 'localhost'
+            self.port = None
+            url_data = urlparse(ldap_uri)
+            self._protocol = url_data.scheme
+            if self._protocol in ('ldap', 'ldaps'):
+                self.host = url_data.hostname
+                self.port = url_data.port
+
         self._start_tls = start_tls
         self._force_schema_updates = force_schema_updates
         self._no_schema = no_schema
         self._decode_attrs = decode_attrs
         self._cacert = cacert
         self._sasl_nocanon = sasl_nocanon
-
-        self.host = 'localhost'
-        self.port = None
-        url_data = urlparse(ldap_uri)
-        self._protocol = url_data.scheme
-        if self._protocol in ('ldap', 'ldaps'):
-            self.host = url_data.hostname
-            self.port = url_data.port
 
         self.log = log_mgr.get_logger(self)
         self._has_schema = False

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -738,9 +738,7 @@ class CAInstance(DogtagInstance):
         cert_data = self.ra_cert.public_bytes(serialization.Encoding.DER)
 
         # connect to CA database
-        server_id = installutils.realm_to_serverid(api.env.realm)
-        dogtag_uri = 'ldapi://%%2fvar%%2frun%%2fslapd-%s.socket' % server_id
-        conn = ldap2.ldap2(api, ldap_uri=dogtag_uri)
+        conn = ldap2.ldap2(api)
         conn.connect(autobind=True)
 
         # create ipara user with RA certificate
@@ -1355,14 +1353,12 @@ def __update_entry_from_cert(make_filter, make_entry, dercert):
     base_dn = DN(('o', 'ipaca'))
 
     attempts = 0
-    server_id = installutils.realm_to_serverid(api.env.realm)
-    dogtag_uri = 'ldapi://%%2fvar%%2frun%%2fslapd-%s.socket' % server_id
     updated = False
 
     while attempts < 10:
         conn = None
         try:
-            conn = ldap2.ldap2(api, ldap_uri=dogtag_uri)
+            conn = ldap2.ldap2(api)
             conn.connect(autobind=True)
 
             db_filter = make_filter(dercert)
@@ -1392,7 +1388,7 @@ def __update_entry_from_cert(make_filter, make_entry, dercert):
         except errors.NetworkError:
             syslog.syslog(
                 syslog.LOG_ERR,
-                'Connection to %s failed, sleeping 30s' % dogtag_uri)
+                'Connection to %s failed, sleeping 30s' % api.env.ldap_uri)
             time.sleep(30)
             attempts += 1
         except Exception as e:
@@ -1482,10 +1478,7 @@ def ensure_entry(dn, **attrs):
     otherwise add the entry and return ``True``.
 
     """
-    server_id = installutils.realm_to_serverid(api.env.realm)
-    dogtag_uri = 'ldapi://%%2fvar%%2frun%%2fslapd-%s.socket' % server_id
-
-    conn = ldap2.ldap2(api, ldap_uri=dogtag_uri)
+    conn = ldap2.ldap2(api)
     if not conn.isconnected():
         conn.connect(autobind=True)
 
@@ -1572,9 +1565,7 @@ def __get_profile_config(profile_id):
         '/usr/share/ipa/profiles/{}.cfg'.format(profile_id), sub_dict)
 
 def import_included_profiles():
-    server_id = installutils.realm_to_serverid(api.env.realm)
-    dogtag_uri = 'ldapi://%%2fvar%%2frun%%2fslapd-%s.socket' % server_id
-    conn = ldap2.ldap2(api, ldap_uri=dogtag_uri)
+    conn = ldap2.ldap2(api)
     if not conn.isconnected():
         conn.connect(autobind=True)
 

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -306,9 +306,7 @@ class KRAInstance(DogtagInstance):
         cert_data = cert.public_bytes(serialization.Encoding.DER)
 
         # connect to KRA database
-        server_id = installutils.realm_to_serverid(api.env.realm)
-        dogtag_uri = 'ldapi://%%2fvar%%2frun%%2fslapd-%s.socket' % server_id
-        conn = ldap2.ldap2(api, ldap_uri=dogtag_uri)
+        conn = ldap2.ldap2(api)
         conn.connect(autobind=True)
 
         # create ipakra user with RA agent certificate

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -67,18 +67,19 @@ class ldap2(CrudBackend, LDAPClient):
     LDAP Backend Take 2.
     """
 
-    def __init__(self, api, ldap_uri=None):
-        if ldap_uri is None:
-            ldap_uri = api.env.ldap_uri
-
+    def __init__(self, api):
         force_schema_updates = api.env.context in ('installer', 'updates')
 
         CrudBackend.__init__(self, api)
-        LDAPClient.__init__(self, ldap_uri,
+        LDAPClient.__init__(self, None,
                             force_schema_updates=force_schema_updates)
 
         self._time_limit = float(LDAPClient.time_limit)
         self._size_limit = int(LDAPClient.size_limit)
+
+    @property
+    def ldap_uri(self):
+        return self.api.env.ldap_uri
 
     @property
     def time_limit(self):

--- a/makeaci
+++ b/makeaci
@@ -99,8 +99,6 @@ def main(options):
         basedn=DN('dc=ipa,dc=example'),
         realm='IPA.EXAMPLE',
         domain="example.com",
-        xmlrpc_uri="http://localhost:8888/ipa/xml",
-        ldap_uri="ldap://localhost:389",
     )
 
     from ipaserver.install.plugins import update_managed_permissions

--- a/makeaci
+++ b/makeaci
@@ -98,6 +98,9 @@ def main(options):
         plugins_on_demand=False,
         basedn=DN('dc=ipa,dc=example'),
         realm='IPA.EXAMPLE',
+        domain="example.com",
+        xmlrpc_uri="http://localhost:8888/ipa/xml",
+        ldap_uri="ldap://localhost:389",
     )
 
     from ipaserver.install.plugins import update_managed_permissions

--- a/makeapi
+++ b/makeapi
@@ -40,6 +40,7 @@ from ipalib.parameters import Param
 from ipalib.output import Output
 from ipalib.text import Gettext, NGettext, ConcatenatedLazyText
 from ipalib.capabilities import capabilities
+from ipapython.dn import DN
 
 API_FILE='API.txt'
 
@@ -513,6 +514,11 @@ def main():
         enable_ra=True,
         mode='developer',
         plugins_on_demand=False,
+        basedn=DN(('dc', 'example'), ('dc', 'com')),
+        realm="EXAMPLE.COM",
+        domain="example.com",
+        xmlrpc_uri="http://localhost:8888/ipa/xml",
+        ldap_uri="ldap://localhost:389",
     )
 
     api.bootstrap(**cfg)

--- a/makeapi
+++ b/makeapi
@@ -40,7 +40,6 @@ from ipalib.parameters import Param
 from ipalib.output import Output
 from ipalib.text import Gettext, NGettext, ConcatenatedLazyText
 from ipalib.capabilities import capabilities
-from ipapython.dn import DN
 
 API_FILE='API.txt'
 
@@ -514,11 +513,8 @@ def main():
         enable_ra=True,
         mode='developer',
         plugins_on_demand=False,
-        basedn=DN(('dc', 'example'), ('dc', 'com')),
         realm="EXAMPLE.COM",
         domain="example.com",
-        xmlrpc_uri="http://localhost:8888/ipa/xml",
-        ldap_uri="ldap://localhost:389",
     )
 
     api.bootstrap(**cfg)

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -101,7 +101,9 @@ ipa_class_members = {
         'xmlrpc_uri',
         'validate_api',
         'startup_traceback',
-        'verbose'
+        'verbose',
+        'server',
+        {'domain': dir(str)},
     ] + LOGGING_ATTRS,
     'ipalib.errors.ACIError': [
         'info',


### PR DESCRIPTION
**ipalib.constants: Remove default domain, realm, basedn, xmlrpc_uri, ldap_uri**

Domain, realm, basedn, xmlrpc_uri, ldap_uri do not have any reasonable default.
This patch removes hardcoded default so the so the code which depends
on these values blows up early and does not do crazy stuff
with default values instead of real ones.

This should help to uncover issues caused by improper ipalib
initialization.

**config: provide defaults for `xmlrpc_uri`, `ldap_uri` and `basedn`**

Derive the default value of `xmlrpc_uri` and `ldap_uri` from `server`.
Derive the default value of `basedn` from `domain`.

This supersedes @pspacek's PR #113.