### PR TITLE
Fix ipa-server-upgrade

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -83,7 +83,8 @@ def uninstall_ipa_memcached():
     """
     ipa_memcached = service.SimpleServiceInstance('ipa_memcached')
 
-    ipa_memcached.uninstall()
+    if ipa_memcached.is_configured():
+        ipa_memcached.uninstall()
 
 
 def backup_file(filename, ext):


### PR DESCRIPTION
I was to eager to ACK https://github.com/freeipa/freeipa/pull/471.

Running ipa-server-upgrade would fail to stop ipa_memcached if
it's already uninstalled.