### PR TITLE
Use newer Certificate.serial_number in krainstance.py

### DIFF
--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -313,7 +313,7 @@ class KRAInstance(DogtagInstance):
             usertype=["undefined"],
             userCertificate=[cert_data],
             description=['2;%s;%s;%s' % (
-                cert.serial,
+                cert.serial_number,
                 DN(self.subject),
                 DN(('CN', 'IPA RA'), self.subject_base))])
         conn.add_entry(entry)


### PR DESCRIPTION
This bit was missed in https://github.com/freeipa/freeipa/pull/458