### PR TITLE
compat: fix `Any` params in `batch` and `dnsrecord`

### DIFF
--- a/ipaclient/remote_plugins/2_114/batch.py
+++ b/ipaclient/remote_plugins/2_114/batch.py
@@ -50,7 +50,7 @@ class batch(Command):
     NO_CLI = True
 
     takes_args = (
-        parameters.Str(
+        parameters.Any(
             'methods',
             required=False,
             multivalue=True,

--- a/ipaclient/remote_plugins/2_114/dns.py
+++ b/ipaclient/remote_plugins/2_114/dns.py
@@ -326,7 +326,7 @@ class dnsrecord(Object):
             'dnsclass',
             required=False,
         ),
-        parameters.Str(
+        parameters.Any(
             'dnsrecords',
             required=False,
             label=_(u'Records'),

--- a/ipaclient/remote_plugins/2_156/batch.py
+++ b/ipaclient/remote_plugins/2_156/batch.py
@@ -50,7 +50,7 @@ class batch(Command):
     NO_CLI = True
 
     takes_args = (
-        parameters.Str(
+        parameters.Any(
             'methods',
             required=False,
             multivalue=True,

--- a/ipaclient/remote_plugins/2_156/dns.py
+++ b/ipaclient/remote_plugins/2_156/dns.py
@@ -326,7 +326,7 @@ class dnsrecord(Object):
             'dnsclass',
             required=False,
         ),
-        parameters.Str(
+        parameters.Any(
             'dnsrecords',
             required=False,
             label=_(u'Records'),

--- a/ipaclient/remote_plugins/2_164/batch.py
+++ b/ipaclient/remote_plugins/2_164/batch.py
@@ -50,7 +50,7 @@ class batch(Command):
     NO_CLI = True
 
     takes_args = (
-        parameters.Str(
+        parameters.Any(
             'methods',
             required=False,
             multivalue=True,

--- a/ipaclient/remote_plugins/2_164/dns.py
+++ b/ipaclient/remote_plugins/2_164/dns.py
@@ -326,7 +326,7 @@ class dnsrecord(Object):
             'dnsclass',
             required=False,
         ),
-        parameters.Str(
+        parameters.Any(
             'dnsrecords',
             required=False,
             label=_(u'Records'),

--- a/ipaclient/remote_plugins/2_49/batch.py
+++ b/ipaclient/remote_plugins/2_49/batch.py
@@ -50,7 +50,7 @@ class batch(Command):
     NO_CLI = True
 
     takes_args = (
-        parameters.Str(
+        parameters.Any(
             'methods',
             required=False,
             multivalue=True,

--- a/ipaclient/remote_plugins/2_49/dns.py
+++ b/ipaclient/remote_plugins/2_49/dns.py
@@ -256,7 +256,7 @@ class dnsrecord(Object):
             label=_(u'Class'),
             doc=_(u'DNS class'),
         ),
-        parameters.Str(
+        parameters.Any(
             'dnsrecords',
             required=False,
             label=_(u'Records'),


### PR DESCRIPTION
The `methods` argument of `batch` and `dnsrecords` attribute of `dnsrecord`
were incorrectly defined as `Str` instead of `Any`.

https://fedorahosted.org/freeipa/ticket/6647