### PR TITLE
C compilation fixes and hardening

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,9 @@ LT_INIT
 
 AC_HEADER_STDC
 
+dnl fail hard when includes statements are missing
+CFLAGS+=" -Werror=implicit-function-declaration"
+
 PKG_PROG_PKG_CONFIG
 
 AC_ARG_ENABLE([server],

--- a/util/ipa_pwd_ntlm.c
+++ b/util/ipa_pwd_ntlm.c
@@ -26,6 +26,7 @@
 
 #include <stdlib.h>
 #include <stdbool.h>
+#include <string.h>
 #include <iconv.h>
 #include <openssl/md4.h>
 


### PR DESCRIPTION
Fix "implicit declaration of function ‘strlen’" in ipa_pwd_ntlm.c,
credits to Lukas.

Add -Werror=implicit-function-declaration to CFLAGS to point developers
to missing includes. It causes compilation to fail when a developer
forgets to add a required include. The problem is no longer hidden in a
massive wall of text from make.

Signed-off-by: Christian Heimes <cheimes@redhat.com>