### PR TITLE
Make pylint and jsl optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -146,6 +146,10 @@ JSLINT_TARGET = jslint
 endif WITH_JSLINT
 lint: acilint apilint $(POLINT_TARGET) $(PYLINT_TARGET) $(JSLINT_TARGET)
 
+.PHONY: $(top_builddir)/ipapython/version.py
+$(top_builddir)/ipapython/version.py:
+	(cd $(top_builddir)/ipapython && make version.py)
+
 .PHONY: acilint
 acilint: $(top_builddir)/ipapython/version.py
 	cd $(srcdir); ./makeaci --validate
@@ -162,10 +166,10 @@ polint:
 # folders rpmbuild, freeipa-* and dist. Skip (match, but don't print) .*,
 # *.in, *~. Finally print all python files, including scripts that do not
 # have python extension.
-.PHONY: pylint $(top_builddir)/ipapython/version.py
-$(top_builddir)/ipapython/version.py:
-	(cd $(top_builddir)/ipapython && make version.py)
 
+.PHONY: pylint
+
+if WITH_PYLINT
 pylint: $(top_builddir)/ipapython/version.py ipasetup.py
 	FILES=`find $(top_srcdir) \
 		-type d -exec test -e '{}/__init__.py' \; -print -prune -o \
@@ -183,9 +187,12 @@ pylint: $(top_builddir)/ipapython/version.py ipasetup.py
 		--rcfile=$(top_srcdir)/pylintrc \
 		--load-plugins pylint_plugins \
 		$${FILES}
+endif  # WITH_PYLINT
 
 .PHONY: jslint jslint-ui jslint-ui-test jslint-html \
 	$(top_builddir)/install/ui/src/libs/loader.js
+
+if WITH_JSLINT
 jslint: jslint-ui jslint-ui-test jslint-html
 
 $(top_builddir)/install/ui/src/libs/loader.js:
@@ -208,6 +215,7 @@ jslint-ui-test:
 jslint-html:
 	cd $(top_srcdir)/install/html; 				\
 	jsl -nologo -nosummary -nofilelisting -conf jsl.conf
+endif  # WITH_JSLINT
 
 .PHONY: bdist_wheel wheel_bundle wheel_placeholder pypi_packages
 WHEELDISTDIR = $(top_builddir)/dist/wheels

--- a/configure.ac
+++ b/configure.ac
@@ -375,17 +375,25 @@ AC_SUBST([i18ntests])
 AM_CONDITIONAL([WITH_POLINT], [test "x${enable_i18ntests}" == "xyes"])
 
 AC_ARG_ENABLE([pylint],
-	    AS_HELP_STRING([--disable-pylint],
-			   [skip Pylint in make lint target]),
+	    AS_HELP_STRING([--enable-pylint],
+			   [Require pylint. Default is autodetection with
+			    "python -m pylint".]),
 	    [PYLINT=$enableval],
-	    [PYLINT=yes]
+	    [PYLINT=check]
 )
+
 if test x$PYLINT != xno; then
     AC_MSG_CHECKING([for Pylint])
-    $PYTHON -m pylint --version > /dev/null
+    $PYTHON -m pylint --version >/dev/null 2>&1
     if test "$?" != "0"; then
-        AC_MSG_ERROR([cannot find pylint for $PYTHON])
+        if test x$PYLINT = xcheck; then
+            PYLINT=no
+            AC_MSG_NOTICE([cannot find optional pylint for $PYTHON])
+        else
+            AC_MSG_ERROR([cannot find pylint for $PYTHON])
+        fi
     else
+        PYLINT=yes
         AC_MSG_RESULT([yes])
     fi
 fi
@@ -397,13 +405,27 @@ AC_ARG_WITH([jslint],
         AS_HELP_STRING([--with-jslint=[FILE]],
                        [path to JavaScript linter. Default is autodetection of
                        utility "jsl" ]),
-dnl --without-jslint will set JSLINT=no
-        [JSLINT=$with_jslint],
-        [AC_PATH_PROG([JSLINT], [jsl])]
+        [JSLINT="$withval"],
+        [JSLINT=check]
 )
-if test "x${JSLINT}" == "x"; then
-	AC_MSG_ERROR([cannot find JS lint])
-fi
+
+AS_CASE([$JSLINT],
+    [yes], [AC_PATH_PROG([JSLINT], [jsl], [missing])
+            if test $JSLINT = missing; then
+                AC_MSG_FAILURE([jsl is missing])
+            fi],
+    [no], [],
+    [check], [AC_PATH_PROG([JSLINT], [jsl], [no])],
+    dnl user setting
+    [if ! test -f "$JSLINT"; then
+        AC_MSG_RESULT([$JSLINT non-existing])
+        AC_MSG_FAILURE([invalid value $JSLINT for jsl])
+     fi
+     if ! test -x "$JSLINT"; then
+        AC_MSG_RESULT([$JSLINT non-executable])
+        AC_MSG_FAILURE([invalid value $JSLINT for jsl])
+     fi]
+)
 AC_SUBST([JSLINT])
 AM_CONDITIONAL([WITH_JSLINT], [test "x${JSLINT}" != "xno"])
 
@@ -516,6 +538,9 @@ echo "
         source code location:     ${srcdir}
         compiler:                 ${CC}
         cflags:                   ${CFLAGS}
+        Python:                   ${PYTHON}
+        pylint:                   ${PYLINT}
+        jslint:                   ${JSLINT}
         LDAP libs:                ${LDAP_LIBS}
         OpenSSL crypto libs:      ${CRYPTO_LIBS}
         KRB5 libs:                ${KRB5_LIBS}"

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -11,10 +11,9 @@
 # lint is not executed during rpmbuild
 # %%global with_lint 1
 %if 0%{?with_lint}
-    %global enable_pylint_option --enable-pylint
+    %global linter_options --enable-pylint --with-jslint
 %else
-    %global enable_pylint_option --disable-pylint
-    %global without_jslint_option --without-jslint
+    %global linter_options --disable-pylint --without-jslint
 %endif
 
 # Python wheel support and PyPI packages
@@ -807,8 +806,7 @@ find \
 	-type f -exec grep -qsm1 '^#!.*\bpython' {} \; \
 	-exec sed -i -e '1 s|^#!.*\bpython[^ ]*|#!%{__python2}|' {} \;
 %configure --with-vendor-suffix=-%{release} \
-           %{enable_pylint_option} \
-           %{?without_jslint_option}
+           %{linter_options}
 
 # -Onone is workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1398405
 %make_build -Onone
@@ -825,8 +823,7 @@ find \
 	-type f -exec grep -qsm1 '^#!.*\bpython' {} \; \
 	-exec sed -i -e '1 s|^#!.*\bpython[^ ]*|#!%{__python3}|' {} \;
 %configure --with-vendor-suffix=-%{release} \
-           %{enable_pylint_option} \
-           %{?without_jslint_option}
+           %{linter_options}
 popd
 %endif # with_python3
 


### PR DESCRIPTION
./configure no longer fails when pylint or jsl are not available. The
make targets for pylint and jsl are no longer defined without the tools.

Rational:
pylint and jsl are not required to build FreeIPA. Both are useful
developer tools. It's more user friendly to make both components
optionally with default config arguments. There is no reason to
fail building on a build system without development tools.

It's still possible to enforce dependency checks with --with-jslint and
--enable-pylint.

https://fedorahosted.org/freeipa/ticket/6604

Signed-off-by: Christian Heimes <cheimes@redhat.com>