### PR TITLE
dns: fix `dnsrecord_add` interactive mode

### DIFF
--- a/ipaclient/plugins/dns.py
+++ b/ipaclient/plugins/dns.py
@@ -73,6 +73,10 @@ def prompt_parts(rrtype, cmd, mod_dnsvalue=None):
         return user_options
 
     for part_id, part in enumerate(rrobj.params()):
+        name = part_name_format % (rrtype.lower(), part.name)
+        if name not in cmd.params:
+            continue
+
         if mod_parts:
             default = mod_parts[part_id]
         else:
@@ -92,6 +96,8 @@ def prompt_missing_parts(rrtype, cmd, kw, prompt_optional=False):
 
     for part in rrobj.params():
         name = part_name_format % (rrtype.lower(), part.name)
+        if name not in cmd.params:
+            continue
 
         if name in kw:
             continue

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -3531,7 +3531,7 @@ for param in _dns_records:
             'dns{}record'.format(param.rrtype.lower()),
             (Object,),
             dict(
-                takes_params=(param.parts or ()) + (param.extra or ()),
+                takes_params=param.parts or (),
             )
         )
     )


### PR DESCRIPTION
`dnsrecord_add` interactive mode might prompt for value of non-existent
arguments `a_part_create_reverse` and `aaaa_part_create_reverse`. This
happens because `dnsrecord_add` extra flags are incorrectly defined as
parts of the respective DNS records.

Remove extra flags from DNS record parts to fix the interactive mode on old
clients talking to new servers. Skip non-existent arguments in the
interactive mode to fix new clients talking to old servers.

https://fedorahosted.org/freeipa/ticket/6457