### PR TITLE
Fix ipa.service unit re. gssproxy

### DIFF
--- a/init/systemd/ipa.service.in
+++ b/init/systemd/ipa.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Identity, Policy, Audit
 Requires=network.target
-Requires=gssproxy.service
+Wants=gssproxy.service
 After=network.target
 
 [Service]


### PR DESCRIPTION
ipa.service unit defines Requires=gssproxy. Because of this, during
ipa-server-upgrade, the restart of gssproxy triggers a restart of ipa unit
(hence stopping LDAP server and breaking the connection api.Backend.ldap2).
Calls using this connection after gssproxy restart fail and ipa-server-upgrade
exits on failure.
The fix defines Wants=gssproxy to avoid the restart of ipa.service

https://fedorahosted.org/freeipa/ticket/6705