### PR TITLE
Bump required version of gssproxy to 0.7.0

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -282,8 +282,7 @@ Requires: systemd-python
 Requires: %{etc_systemd_dir}
 Requires: gzip
 Requires: oddjob
-# Require 0.6.0 for the new delegation access control features
-Requires: gssproxy >= 0.6.0
+Requires: gssproxy >= 0.7.0
 # Require 1.15.1 for the certificate identity mapping feature
 Requires: sssd-dbus >= 1.15.1
 


### PR DESCRIPTION
https://fedorahosted.org/freeipa/ticket/6698