### PR TITLE
test_config: fix fips_mode key in Env

### DIFF
--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -268,7 +268,8 @@ class Env(object):
                 value = int(value)
             elif key == 'basedn':
                 value = DN(value)
-        assert type(value) in (unicode, int, float, bool, type(None), DN)
+        if type(value) not in (unicode, int, float, bool, type(None), DN):
+            raise TypeError(key, value)
         object.__setattr__(self, key, value)
         self.__d[key] = value
 

--- a/ipatests/test_ipalib/test_config.py
+++ b/ipatests/test_ipalib/test_config.py
@@ -562,9 +562,9 @@ class test_Env(ClassChecker):
 
         # Test using DEFAULT_CONFIG:
         defaults = dict(constants.DEFAULT_CONFIG)
-        defaults['fips_mode'] = object
         (o, home) = self.finalize_core(None, **defaults)
-        assert list(o) == sorted(defaults)
+        list_o = [key for key in o if key != 'fips_mode']
+        assert list_o == sorted(defaults)
         for (key, value) in defaults.items():
             if value is object:
                 continue


### PR DESCRIPTION
Setting fips_mode to object would fail if ipaplatform.tasks module
wasn't present.

https://fedorahosted.org/freeipa/ticket/5695