### PR TITLE
Limit sessions to 30 minutes by default

### DIFF
--- a/install/conf/ipa.conf
+++ b/install/conf/ipa.conf
@@ -67,6 +67,7 @@ WSGIScriptReloading Off
   Session On
   SessionCookieName ipa_session path=/ipa;httponly;secure;
   SessionHeader IPASESSION
+  SessionMaxAge 1800
   GssapiSessionKey file:/etc/httpd/alias/ipasession.key
 
   GssapiDelegCcacheDir /var/run/ipa/ccaches


### PR DESCRIPTION
When we changed the session handling code we unintentinally extended
sessions expiraion time to the whole ticket lifetime of 24h.

Related to https://fedorahosted.org/freeipa/ticket/5959

Signed-off-by: Simo Sorce <simo@redhat.com>