### PR TITLE
Use Custodia 0.3.1 features

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -181,7 +181,8 @@ BuildRequires:  pki-base-python2
 BuildRequires:  python-pytest-multihost
 BuildRequires:  python-pytest-sourceorder
 BuildRequires:  python-jwcrypto
-BuildRequires:  python-custodia
+# 0.3: sd_notify (https://pagure.io/freeipa/issue/5825)
+BuildRequires:  python-custodia >= 0.3.1
 BuildRequires:  dbus-python
 BuildRequires:  python-dateutil
 BuildRequires:  python-enum34
@@ -216,7 +217,8 @@ BuildRequires:  pki-base-python3
 BuildRequires:  python3-pytest-multihost
 BuildRequires:  python3-pytest-sourceorder
 BuildRequires:  python3-jwcrypto
-BuildRequires:  python3-custodia
+# 0.3: sd_notify (https://pagure.io/freeipa/issue/5825)
+BuildRequires:  python3-custodia >= 0.3.1
 BuildRequires:  python3-dbus
 BuildRequires:  python3-dateutil
 BuildRequires:  python3-enum34
@@ -337,6 +339,7 @@ BuildArch: noarch
 Requires: %{name}-server-common = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 Requires: python2-ipaclient = %{version}-%{release}
+Requires: python-custodia >= 0.3.1
 Requires: python-ldap >= 2.4.15
 Requires: python-lxml
 Requires: python-gssapi >= 1.2.0
@@ -367,6 +370,7 @@ BuildArch: noarch
 Requires: %{name}-server-common = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 Requires: python3-ipaclient = %{version}-%{release}
+Requires: python3-custodia >= 0.3.1
 Requires: python3-pyldap >= 2.4.15
 Requires: python3-lxml
 Requires: python3-gssapi >= 1.2.0
@@ -396,7 +400,7 @@ BuildArch: noarch
 Requires: %{name}-client-common = %{version}-%{release}
 Requires: httpd >= 2.4.6-31
 Requires: systemd-units >= 38
-Requires: custodia
+Requires: custodia >= 0.3.1
 
 Provides: %{alt_name}-server-common = %{version}
 Conflicts: %{alt_name}-server-common
@@ -647,7 +651,6 @@ Requires: python-jwcrypto
 Requires: python-cffi
 Requires: python-ldap >= 2.4.15
 Requires: python-requests
-Requires: python-custodia
 Requires: python-dns >= 1.15
 Requires: python-enum34
 Requires: python-netifaces >= 0.10.4
@@ -696,7 +699,6 @@ Requires: python3-six
 Requires: python3-jwcrypto
 Requires: python3-cffi
 Requires: python3-pyldap >= 2.4.15
-Requires: python3-custodia
 Requires: python3-requests
 Requires: python3-dns >= 1.15
 Requires: python3-netifaces >= 0.10.4
@@ -1157,6 +1159,7 @@ fi
 %{_libexecdir}/certmonger/dogtag-ipa-ca-renew-agent-submit
 %{_libexecdir}/certmonger/ipa-server-guard
 %dir %{_libexecdir}/ipa
+%{_libexecdir}/ipa/ipa-custodia
 %{_libexecdir}/ipa/ipa-dnskeysyncd
 %{_libexecdir}/ipa/ipa-dnskeysync-replica
 %{_libexecdir}/ipa/ipa-ods-exporter

--- a/init/systemd/Makefile.am
+++ b/init/systemd/Makefile.am
@@ -18,5 +18,6 @@ CLEANFILES = $(systemdsystemunit_DATA)
 		-e 's|@IPA_SYSCONF_DIR[@]|$(IPA_SYSCONF_DIR)|g' \
 		-e 's|@localstatedir[@]|$(localstatedir)|g' \
 		-e 's|@sbindir[@]|$(sbindir)|g' \
+		-e 's|@libexecdir[@]|$(libexecdir)|g' \
 		-e 's|@sysconfenvdir[@]|$(sysconfenvdir)|g' \
 		'$(srcdir)/$@.in' >$@

--- a/init/systemd/ipa-custodia.service.in
+++ b/init/systemd/ipa-custodia.service.in
@@ -2,9 +2,8 @@
 Description=IPA Custodia Service
 
 [Service]
-Type=simple
-
-ExecStart=@sbindir@/custodia @IPA_SYSCONF_DIR@/custodia/custodia.conf
+Type=notify
+ExecStart=@libexecdir@/ipa/ipa-custodia @IPA_SYSCONF_DIR@/custodia/custodia.conf
 PrivateTmp=yes
 Restart=on-failure
 RestartSec=60s

--- a/install/tools/Makefile.am
+++ b/install/tools/Makefile.am
@@ -32,6 +32,7 @@ dist_sbin_SCRIPTS =		\
 
 appdir = $(libexecdir)/ipa/
 dist_app_SCRIPTS =		\
+	ipa-custodia		\
 	ipa-httpd-kdcproxy	\
 	ipa-pki-retrieve-key	\
 	$(NULL)

--- a/install/tools/ipa-custodia
+++ b/install/tools/ipa-custodia
@@ -1,0 +1,6 @@
+#!/usr/bin/python2
+# Copyright (C) 2017  IPA Project Contributors, see COPYING for license
+from ipaserver.secrets.service import main
+
+if __name__ == '__main__':
+    main()

--- a/ipapython/setup.py
+++ b/ipapython/setup.py
@@ -38,7 +38,6 @@ if __name__ == '__main__':
         ],
         install_requires=[
             "cffi",
-            "custodia",
             "cryptography",
             "dnspython",
             "gssapi",

--- a/ipaserver/secrets/service.py
+++ b/ipaserver/secrets/service.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2017  IPA Project Contributors, see COPYING for license
+import argparse
+
+import custodia.server
+
+
+argparser = argparse.ArgumentParser(
+    prog='ipa-custodia',
+    description='IPA Custodia service'
+)
+argparser.add_argument(
+    '--debug',
+    action='store_true',
+    help='Debug mode'
+)
+argparser.add_argument(
+    'configfile',
+    nargs='?',
+    type=argparse.FileType('r'),
+    help="Path to IPA's custodia server config",
+    default='/etc/ipa/custodia/custodia.conf'
+)
+
+
+def main():
+    return custodia.server.main(argparser)
+
+
+if __name__ == '__main__':
+    main()

--- a/ipaserver/setup.py
+++ b/ipaserver/setup.py
@@ -47,6 +47,7 @@ if __name__ == '__main__':
         ],
         install_requires=[
             "cryptography",
+            "custodia",
             "dbus-python",
             "dnspython",
             "dogtag-pki",

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -64,6 +64,7 @@ if SETUPTOOLS_VERSION < (8, 0, 0):
 
 PACKAGE_VERSION = {
     'cryptography': 'cryptography >= 1.4',
+    'custodia': 'custodia >= 0.3.1',
     'dnspython': 'dnspython >= 1.15',
     'gssapi': 'gssapi >= 1.2.0',
     'ipaclient': 'ipaclient == {}'.format(VERSION),


### PR DESCRIPTION
Use Custodia 0.3 features

* Use sd-notify in ipa-custodia.service
* Introduce libexec/ipa/ipa-custodia script. It comes with correct
  default setting for IPA's config file. The new file also makes it
  simpler to run IPA's custodia instance with its own SELinux context.
* ipapython no longer depends on custodia

The patch addresses three issues:

* https://bugzilla.redhat.com/show_bug.cgi?id=1430247
  Forward compatibility with Custodia 0.3 in Fedora rawhide
* https://pagure.io/freeipa/issue/5825
  Use sd-notify
* https://pagure.io/freeipa/issue/6788
  Prepare for separate SELinux context

Signed-off-by: Christian Heimes <cheimes@redhat.com>
