### PR TITLE
WebUI: add sizelimit:0 to cert-find

### DIFF
--- a/install/ui/src/freeipa/host.js
+++ b/install/ui/src/freeipa/host.js
@@ -494,6 +494,7 @@ IPA.host.details_facet = function(spec, no_init) {
             retry: false,
             options: {
                 host: [ pkey ],
+                sizelimit: 0,
                 all: true
             }
         });

--- a/install/ui/src/freeipa/idviews.js
+++ b/install/ui/src/freeipa/idviews.js
@@ -435,6 +435,7 @@ idviews.id_override_user_details_facet = function(spec) {
             retry: false,
             options: {
                 idoverrideuser: [ pkey ],
+                sizelimit: 0,
                 all: true
             }
         });

--- a/install/ui/src/freeipa/service.js
+++ b/install/ui/src/freeipa/service.js
@@ -475,6 +475,7 @@ IPA.service.details_facet = function(spec, no_init) {
             retry: false,
             options: {
                 service: [ pkey ],
+                sizelimit: 0,
                 all: true
             }
         });

--- a/install/ui/src/freeipa/user.js
+++ b/install/ui/src/freeipa/user.js
@@ -598,6 +598,7 @@ IPA.user.details_facet = function(spec, no_init) {
             retry: false,
             options: {
                 user: [ pkey ],
+                sizelimit: 0,
                 all: true
             }
         });


### PR DESCRIPTION
It was not possible to get all arbitrary certificates which were added
using {user|host|service|idview}-add-cert method. Adding sizelimit:0
to this cert-find command fix the issue. It set sizelimit to unlimited.

https://pagure.io/freeipa/issue/6712