### PR TITLE
Add nsaccountlock to user attributes when a new user is created

### DIFF
--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -466,6 +466,7 @@ class baseuser_add(LDAPCreate):
                             **options):
         assert isinstance(dn, DN)
         set_krbcanonicalname(entry_attrs)
+        convert_nsaccountlock(entry_attrs)
         self.obj.convert_usercertificate_pre(entry_attrs)
 
     def post_common_callback(self, ldap, dn, entry_attrs, *keys, **options):


### PR DESCRIPTION
This adds a the `nsaccountlock` attribute to a user upon account creation. This addresses newly created accounts; however, it does not address the issue of existing accounts. If `nsaccountlock` does not exist for a user, `ipa user-find --disabled=False` should return `Accounts disabled: False`; however, it returns nothing.

So, the question is how to deal with `nsaccountlock` missing in existing user accounts? I am not sure how to extend the framework to return `Accounts disabled: False` if `nsaccountlock` is NoneType. 

For more info, see @MartinBasti's post merge comments in #444 