### PR TITLE
dogtag: remove redundant property definition

### DIFF
--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1386,26 +1386,6 @@ class ra(rabase.rabase, RestClient):
         self.error('%s.%s(): %s', type(self).__name__, func_name, err_msg)
         raise errors.CertificateOperationError(error=err_msg)
 
-    @cachedproperty
-    def ca_host(self):
-        """
-        :return:   host
-                   as str
-
-        Select our CA host.
-        """
-        ldap2 = self.api.Backend.ldap2
-        if host_has_service(api.env.ca_host, ldap2, "CA"):
-            return api.env.ca_host
-        if api.env.host != api.env.ca_host:
-            if host_has_service(api.env.host, ldap2, "CA"):
-                return api.env.host
-        host = select_any_master(ldap2)
-        if host:
-            return host
-        else:
-            return api.env.ca_host
-
     def _request(self, url, port, **kw):
         """
         :param url: The URL to post to.


### PR DESCRIPTION
The dogtag `ra` backend defines a `ca_host` property, which is also
defined (identically) by the `RestClient` class, which recently
became a superclass of `ra`.  Remove the redundant property
definition.

Part of: https://pagure.io/freeipa/issue/3473