### PR TITLE
server install: do not attempt to issue PKINIT cert in CA-less

### DIFF
--- a/ipaserver/install/ipa_replica_prepare.py
+++ b/ipaserver/install/ipa_replica_prepare.py
@@ -160,16 +160,21 @@ class ReplicaPrepare(admintool.AdminTool):
             self.option_parser.error("You cannot specify a --reverse-zone "
                 "option together with --no-reverse")
 
-        #Automatically disable pkinit w/ dogtag until that is supported
-        options.setup_pkinit = False
-
         # If any of the PKCS#12 options are selected, all are required.
         cert_file_req = (options.dirsrv_cert_files, options.http_cert_files)
         cert_file_opt = (options.pkinit_cert_files,)
+        if options.setup_pkinit:
+            cert_file_req += cert_file_opt
         if any(cert_file_req + cert_file_opt) and not all(cert_file_req):
             self.option_parser.error(
-                "--dirsrv-cert-file and --http-cert-file are required if any "
-                "PKCS#12 options are used.")
+                "--dirsrv-cert-file, --http-cert-file, and --pkinit-cert-file "
+                "or --no-pkinit are required if any key file options are used."
+            )
+        if not options.setup_pkinit and options.pkinit_cert_files:
+            self.option_parser.error(
+                "--no-pkinit and --pkinit-cert-file cannot be specified "
+                "together"
+            )
 
         if len(self.args) < 1:
             self.option_parser.error(

--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -347,10 +347,18 @@ class ServerInstallInterface(client.ClientInstallInterface,
         # If any of the key file options are selected, all are required.
         cert_file_req = (self.dirsrv_cert_files, self.http_cert_files)
         cert_file_opt = (self.pkinit_cert_files,)
+        if not self.no_pkinit:
+            cert_file_req += cert_file_opt
         if any(cert_file_req + cert_file_opt) and not all(cert_file_req):
             raise RuntimeError(
-                "--dirsrv-cert-file and --http-cert-file are required if any "
-                "key file options are used.")
+                "--dirsrv-cert-file, --http-cert-file, and --pkinit-cert-file "
+                "or --no-pkinit are required if any key file options are used."
+            )
+        if self.no_pkinit and self.pkinit_cert_files:
+            raise RuntimeError(
+                "--no-pkinit and --pkinit-cert-file cannot be specified "
+                "together"
+            )
 
         if not self.interactive:
             if self.dirsrv_cert_files and self.dirsrv_pin is None:
@@ -510,9 +518,6 @@ class ServerInstallInterface(client.ClientInstallInterface,
                     raise RuntimeError(
                         "You must specify at least one of --forwarder, "
                         "--auto-forwarders, or --no-forwarders options")
-
-        # Automatically enable pkinit w/ dogtag
-        self.no_pkinit = not self.setup_ca
 
 
 ServerMasterInstallInterface = installs_master(ServerInstallInterface)


### PR DESCRIPTION
Require the user to provide the PKINIT cert with --pkinit-cert-file or
disable PKINIT with --no-pkinit in CA-less ipa-server-install,
ipa-replica-prepare and ipa-replica-install.

Do not attempt to issue the PKINIT cert in CA-less ipa-server-upgrade.

https://pagure.io/freeipa/issue/5678