### PR TITLE
Fix CA-less upgrade

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1537,7 +1537,7 @@ def upgrade_configuration():
 
     # create passswd.txt file in PKI_TOMCAT_ALIAS_DIR if it does not exist
     # this file will be required on most actions over this NSS DB in FIPS
-    if not os.path.exists(os.path.join(
+    if ca.is_configured() and not os.path.exists(os.path.join(
             paths.PKI_TOMCAT_ALIAS_DIR, 'pwdfile.txt')):
         ca.create_certstore_passwdfile()
 


### PR DESCRIPTION
In CA-less mode there's no /etc/pki/pki-tomcat/password.conf so it
does not make sense to try to create a password file for an NSS
database from it (the NSS database does not exist either).

https://fedorahosted.org/freeipa/ticket/5695

Thanks @HonzaCholasta for discovering this.