### PR TITLE
installer: update time estimates

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -450,8 +450,13 @@ class CAInstance(DogtagInstance):
                 self.step("configuring certmonger renewal for lightweight CAs",
                           self.__add_lightweight_ca_tracking_requests)
 
+        if ra_only:
+            runtime = None
+        else:
+            runtime = 180
+
         try:
-            self.start_creation(runtime=210)
+            self.start_creation(runtime=runtime)
         finally:
             self.clean_pkispawn_files()
 

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -350,7 +350,7 @@ class DsInstance(service.Service):
 
         self.__common_post_setup()
 
-        self.start_creation(runtime=60)
+        self.start_creation(runtime=30)
 
     def enable_ssl(self):
         self.steps = []
@@ -359,7 +359,7 @@ class DsInstance(service.Service):
         self.step("restarting directory server", self.__restart_instance)
         self.step("adding CA certificate entry", self.__upload_ca_cert)
 
-        self.start_creation(runtime=10)
+        self.start_creation()
 
     def create_replica(self, realm_name, master_fqdn, fqdn,
                        domain_name, dm_password,
@@ -412,7 +412,7 @@ class DsInstance(service.Service):
 
         self.__common_post_setup()
 
-        self.start_creation(runtime=60)
+        self.start_creation(runtime=30)
 
 
     def __setup_replica(self):

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -185,7 +185,7 @@ class HTTPInstance(service.Service):
         self.step("configuring httpd to start on boot", self.__enable)
         self.step("enabling oddjobd", self.enable_and_start_oddjobd)
 
-        self.start_creation(runtime=60)
+        self.start_creation()
 
     def __start(self):
         self.backup_state("running", self.is_running())

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -132,7 +132,7 @@ class KRAInstance(DogtagInstance):
         self.step("enabling KRA instance", self.__enable_instance)
 
         try:
-            self.start_creation(runtime=126)
+            self.start_creation(runtime=120)
         finally:
             self.clean_pkispawn_files()
 

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -164,7 +164,7 @@ class KrbInstance(service.Service):
             self.step("installing X509 Certificate for PKINIT",
                       self.setup_pkinit)
 
-        self.start_creation(runtime=30)
+        self.start_creation()
 
         self.kpasswd = KpasswdInstance()
         self.kpasswd.create_instance('KPASSWD', self.fqdn, self.suffix,
@@ -189,7 +189,7 @@ class KrbInstance(service.Service):
 
         self.__common_post_setup()
 
-        self.start_creation(runtime=30)
+        self.start_creation()
 
         self.kpasswd = KpasswdInstance()
         self.kpasswd.create_instance('KPASSWD', self.fqdn, self.suffix)

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -365,7 +365,7 @@ class Service(object):
         self.steps.append((message, method, run_after_failure))
 
     def start_creation(self, start_message=None, end_message=None,
-        show_service_name=True, runtime=-1):
+                       show_service_name=True, runtime=None):
         """
         Starts creation of the service.
 
@@ -401,7 +401,7 @@ class Service(object):
                 else:
                     end_message = "Done configuring %s." % self.service_desc
 
-        if runtime > 0:
+        if runtime is not None and runtime > 0:
             self.print_msg('%s. Estimated time: %s' % (start_message,
                                                       format_seconds(runtime)))
         else:

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -120,7 +120,8 @@ class IPAUpgrade(service.Service):
         if ds_running:
             self.step("starting directory server", self.__start)
         self.start_creation(start_message="Upgrading IPA:",
-                            show_service_name=False)
+                            show_service_name=False,
+                            runtime=90)
 
     def __save_config(self):
         shutil.copy2(self.filename, self.savefilename)


### PR DESCRIPTION
Time estimates have been updated to be more accurate. Only
tasks that are estimated to take longer than 10 seconds have
the estimate displayed.

https://pagure.io/freeipa/issue/6596