### PR TITLE
httpinstance: disable system trust module in /etc/httpd/alias

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -165,6 +165,7 @@ class BasePathNamespace(object):
     BIN_KVNO = "/usr/bin/kvno"
     LDAPMODIFY = "/usr/bin/ldapmodify"
     LDAPPASSWD = "/usr/bin/ldappasswd"
+    MODUTIL = "/usr/bin/modutil"
     NET = "/usr/bin/net"
     BIN_NISDOMAINNAME = "/usr/bin/nisdomainname"
     NSUPDATE = "/usr/bin/nsupdate"


### PR DESCRIPTION
Currently the NSS database in /etc/httpd/alias is installed with the system
trust module enabled. This is problematic for a number of reasons:

* IPA has its own trust store, which is effectively bypassed when the
  system trust module is enabled in the database. This may cause IPA
  unrelated CAs to be trusted by httpd, or even IPA related CAs not to be
  trusted by httpd.

* On client install, the IPA trust configuration is copied to the system
  trust store for third parties. When this configuration is removed, it may
  cause loss of trust information in /etc/httpd/alias
  (https://bugzilla.redhat.com/show_bug.cgi?id=1427897).

* When a CA certificate provided by the user in CA-less install conflicts
  with a CA certificate in the system trust store, the latter may be used
  by httpd, leading to broken https
  (https://www.redhat.com/archives/freeipa-users/2016-July/msg00360.html).

Disable the system trust module on install and upgrade to prevent the
system trust store to be used in /etc/httpd/alias and fix all of the above
issues.

https://pagure.io/freeipa/issue/6132