### PR TITLE
Fix cookie with Max-Age processing

### DIFF
--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -759,9 +759,11 @@ class KerbTransport(SSLTransport):
         session_cookie = None
         try:
             for cookie in cookie_header:
-                session_cookie = \
-                    Cookie.get_named_cookie_from_string(cookie, COOKIE_NAME,
-                                                        request_url)
+                session_cookie = (
+                    Cookie.get_named_cookie_from_string(
+                        cookie, COOKIE_NAME, request_url,
+                        timestamp=datetime.datetime.utcnow())
+                    )
                 if session_cookie is not None:
                     break
         except Exception as e:
@@ -861,7 +863,9 @@ class RPCClient(Connectible):
 
         # Search for the session cookie within the cookie string
         try:
-            session_cookie = Cookie.get_named_cookie_from_string(cookie_string, COOKIE_NAME)
+            session_cookie = Cookie.get_named_cookie_from_string(
+                cookie_string, COOKIE_NAME,
+                timestamp=datetime.datetime.utcnow())
         except Exception:
             return None
 

--- a/ipapython/cookie.py
+++ b/ipapython/cookie.py
@@ -322,7 +322,8 @@ class Cookie(object):
         return cookies
 
     @classmethod
-    def get_named_cookie_from_string(cls, cookie_string, cookie_name, request_url=None):
+    def get_named_cookie_from_string(cls, cookie_string, cookie_name,
+                                     request_url=None, timestamp=None):
         '''
         A cookie string may contain multiple cookies, parse the cookie
         string and return the last cookie in the string matching the
@@ -344,6 +345,8 @@ class Cookie(object):
             if cookie.key == cookie_name:
                 target_cookie = cookie
 
+        if timestamp is not None:
+            target_cookie.timestamp = timestamp
         if request_url is not None:
             target_cookie.normalize(request_url)
         return target_cookie


### PR DESCRIPTION
When cookie has Max-Age set it tries to get expiration by adding
to a timestamp. Without this patch the timestamp would be set to
None and thus the addition of timestamp + max_age fails

https://pagure.io/freeipa/issue/6718