### PR TITLE
WebUI: Change structure of Identity submenu

### DIFF
--- a/install/ui/src/freeipa/group.js
+++ b/install/ui/src/freeipa/group.js
@@ -32,7 +32,17 @@ define([
         './entity'],
     function(on, IPA, $, phases, reg) {
 
-var exp = IPA.group = {};
+var exp = IPA.group = {
+    search_facet_group: {
+        name: 'search',
+        label: '@i18n:objects.group.group_categories',
+        facets: {
+            search_group: 'group_search',
+            search_hostgroup: 'hostgroup_search',
+            search_netgroup: 'netgroup_search'
+        }
+    }
+};
 
 var make_spec = function() {
 return {
@@ -40,6 +50,10 @@ return {
     facets: [
         {
             $type: 'search',
+            tab_label: '@i18n:objects.group.user_groups',
+            facet_groups: [IPA.group.search_facet_group],
+            tabs_in_sidebar: true,
+            disable_facet_tabs: false,
             columns: [
                 'cn',
                 'gidnumber',

--- a/install/ui/src/freeipa/hostgroup.js
+++ b/install/ui/src/freeipa/hostgroup.js
@@ -38,6 +38,10 @@ return {
     facets: [
         {
             $type: 'search',
+            tab_label: '@i18n:objects.hostgroup.host_group',
+            facet_groups: [IPA.group.search_facet_group],
+            tabs_in_sidebar: true,
+            disable_facet_tabs: false,
             columns: [
                 'cn',
                 'description'

--- a/install/ui/src/freeipa/navigation/menu_spec.js
+++ b/install/ui/src/freeipa/navigation/menu_spec.js
@@ -52,11 +52,26 @@ var nav = {};
                         }
                     ]
                 },
-                { entity: 'group' },
                 { entity: 'host' },
-                { entity: 'hostgroup' },
-                { entity: 'netgroup' },
                 { entity: 'service' },
+                {
+                    entity: 'group',
+                    label: '@i18n:objects.group.groups',
+                    facet: 'search',
+                    children: [
+                        {
+                            entity: 'hostgroup',
+                            facet: 'search',
+                            hidden: true
+                        },
+                        {
+                            entity: 'netgroup',
+                            facet: 'search',
+                            hidden: true
+                        }
+                    ]
+                },
+                { entity: 'idview' },
                 {
                     name: 'automember',
                     label: '@i18n:tabs.automember',
@@ -201,7 +216,6 @@ var nav = {};
                     ]
                 },
                 { entity: 'idrange' },
-                { entity: 'idview' },
                 { entity: 'realmdomains' },
                 {
                     name: 'trusts',

--- a/install/ui/src/freeipa/netgroup.js
+++ b/install/ui/src/freeipa/netgroup.js
@@ -43,6 +43,10 @@ var spec = {
     facets: [
         {
             $type: 'search',
+            tab_label: '@i18n:objects.netgroup.netgroups',
+            facet_groups: [IPA.group.search_facet_group],
+            tabs_in_sidebar: true,
+            disable_facet_tabs: false,
             columns: [
                 'cn',
                 'description'

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -522,11 +522,14 @@ class i18n_messages(Command):
             "group": {
                 "details": _("Group Settings"),
                 "external": _("External"),
+                "groups": _("Groups"),
+                "group_categories": _("Group categories"),
                 "make_external": _("Change to external group"),
                 "make_posix": _("Change to POSIX group"),
                 "nonposix": _("Non-POSIX"),
                 "posix": _("POSIX"),
                 "type": _("Group Type"),
+                "user_groups": _("User Groups"),
             },
             "hbacrule": {
                 "any_host": _("Any Host"),
@@ -587,6 +590,7 @@ class i18n_messages(Command):
                 "unprovisioned": _("Host unprovisioned"),
             },
             "hostgroup": {
+                "host_group": _("Host Groups"),
                 "identity": _("Host Group Settings"),
             },
             "idoverrideuser": {
@@ -629,6 +633,7 @@ class i18n_messages(Command):
                 "hostgroups": _("Host Groups"),
                 "hosts": _("Hosts"),
                 "identity": _("Netgroup Settings"),
+                "netgroups": _("Netgroups"),
                 "specified_hosts": _("Specified Hosts and Groups"),
                 "specified_users": _("Specified Users and Groups"),
                 "user": _("User"),


### PR DESCRIPTION
Previously there were 'User Groups', 'Host Groups' and 'Netgroups'
separately, now these three items are grouped into one named 'Groups'
which has sidebar with three items mentioned above.

This change allows us to move ID views into Identity submenu.

https://pagure.io/freeipa/issue/6717