### PR TITLE
ipa systemd unit should define Wants=network instead of Requires=network

### DIFF
--- a/init/systemd/ipa.service.in
+++ b/init/systemd/ipa.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Identity, Policy, Audit
-Requires=network.target
+Wants=network.target
 Wants=gssproxy.service
 After=network.target
 


### PR DESCRIPTION
The file ipa.service defines
    Requires=network.target
which means that ipa stack will be restarted each time the network stack
is restarted. This is not needed, and Wants=network.target will be sufficient.

https://fedorahosted.org/freeipa/ticket/6723