### PR TITLE
test_csrgen: adjusted comparison test scripts for CSRGenerator

### DIFF
--- a/ipatests/test_ipaclient/data/test_csrgen/scripts/caIPAserviceCert_openssl.sh
+++ b/ipatests/test_ipaclient/data/test_csrgen/scripts/caIPAserviceCert_openssl.sh
@@ -1,14 +1,15 @@
 #!/bin/bash -e
 
-if [[ $# -ne 2 ]]; then
-echo "Usage: $0 <outfile> <keyfile>"
+if [[ $# -lt 2 ]]; then
+echo "Usage: $0 <outfile> <keyfile> <other openssl arguments>"
 echo "Called as: $0 $@"
 exit 1
 fi
 
 CONFIG="$(mktemp)"
 CSR="$1"
-shift
+KEYFILE="$2"
+shift; shift
 
 echo \
 '[ req ]
@@ -29,5 +30,5 @@ DNS = machine.example.com
 subjectAltName = @sec1
 ' > "$CONFIG"
 
-openssl req -new -config "$CONFIG" -out "$CSR" -key $1
+openssl req -new -config "$CONFIG" -out "$CSR" -key "$KEYFILE" "$@"
 rm "$CONFIG"

--- a/ipatests/test_ipaclient/data/test_csrgen/scripts/userCert_openssl.sh
+++ b/ipatests/test_ipaclient/data/test_csrgen/scripts/userCert_openssl.sh
@@ -1,14 +1,15 @@
 #!/bin/bash -e
 
-if [[ $# -ne 2 ]]; then
-echo "Usage: $0 <outfile> <keyfile>"
+if [[ $# -lt 2 ]]; then
+echo "Usage: $0 <outfile> <keyfile> <other openssl arguments>"
 echo "Called as: $0 $@"
 exit 1
 fi
 
 CONFIG="$(mktemp)"
 CSR="$1"
-shift
+KEYFILE="$2"
+shift; shift
 
 echo \
 '[ req ]
@@ -29,5 +30,5 @@ email = testuser@example.com
 subjectAltName = @sec1
 ' > "$CONFIG"
 
-openssl req -new -config "$CONFIG" -out "$CSR" -key $1
+openssl req -new -config "$CONFIG" -out "$CSR" -key "$KEYFILE" "$@"
 rm "$CONFIG"


### PR DESCRIPTION
Commit ada91c2 introduced changes in "csrgen/templates/openssl_base.tmpl"
which broke the following 2 tests:

    test_CSRGenerator.test_userCert_OpenSSL
    test_CSRGenerator.test_caIPAserviceCert_OpenSSL

The tests use files caIPAserviceCert_openssl.sh and userCert_openssl.sh
as expected scripts in order to compare scripts generated by CSRGenerator.
E.g. as other parameter was introduced we are now not checking with
"if [[ $# -ne 2 ]]" but rather with if "[[ $# -lt 2 ]]".

https://pagure.io/freeipa/issue/6724