### PR TITLE
Define errors_by_code in ipalib.errors

### DIFF
--- a/ipalib/errors.py
+++ b/ipalib/errors.py
@@ -1995,5 +1995,7 @@ class GenericError(PublicError):
 public_errors = tuple(sorted(
     messages.iter_messages(globals(), PublicError), key=lambda E: E.errno))
 
+errors_by_code = dict((e.errno, e) for e in public_errors)
+
 if __name__ == '__main__':
     messages.print_report('public errors', public_errors)

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -50,7 +50,7 @@ from six.moves import urllib
 
 from ipalib.backend import Connectible
 from ipalib.constants import LDAP_GENERALIZED_TIME_FORMAT
-from ipalib.errors import (public_errors, UnknownError, NetworkError,
+from ipalib.errors import (errors_by_code, UnknownError, NetworkError,
     KerberosError, XMLRPCMarshallError, JSONError)
 from ipalib import errors, capabilities
 from ipalib.request import context, Connection
@@ -85,8 +85,6 @@ if six.PY3:
 
 COOKIE_NAME = 'ipa_session'
 KEYRING_COOKIE_NAME = '%s_cookie:%%s' % COOKIE_NAME
-
-errors_by_code = dict((e.errno, e) for e in public_errors)
 
 
 def client_session_keyring_keyname(principal):


### PR DESCRIPTION
The errors_by_code mapping will soon be used in more places, as part
of the Dogtag GSS-API authentication work.  Move its definition to
ipalib.errors.

Part of: https://pagure.io/freeipa/issue/5011