### PR TITLE
rabase.get_certificate: make serial number arg mandatory

### DIFF
--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1502,7 +1502,7 @@ class ra(rabase.rabase, RestClient):
 
         return cmd_result
 
-    def get_certificate(self, serial_number=None):
+    def get_certificate(self, serial_number):
         """
         Retrieve an existing certificate.
 

--- a/ipaserver/plugins/rabase.py
+++ b/ipaserver/plugins/rabase.py
@@ -59,7 +59,7 @@ class rabase(Backend):
         """
         raise errors.NotImplementedError(name='%s.check_request_status' % self.name)
 
-    def get_certificate(self, serial_number=None):
+    def get_certificate(self, serial_number):
         """
         Retrieve an existing certificate.
 


### PR DESCRIPTION
In rabase.get_certificate it does not make sense for the
serial_number argument to be optional.  Make it a mandatory
positional argument.

Part of: https://pagure.io/freeipa/issue/3473
Part of: https://pagure.io/freeipa/issue/5011