### PR TITLE
Add options to allow ticket caching

### DIFF
--- a/install/share/gssproxy.conf.template
+++ b/install/share/gssproxy.conf.template
@@ -4,6 +4,7 @@
   cred_store = keytab:$HTTP_KEYTAB
   cred_store = client_keytab:$HTTP_KEYTAB
   allow_protocol_transition = true
+  allow_client_ccache_sync = true
   cred_usage = both
   euid = $HTTPD_USER
 
@@ -12,5 +13,6 @@
   cred_store = keytab:$HTTP_KEYTAB
   cred_store = client_keytab:$HTTP_KEYTAB
   allow_constrained_delegation = true
+  allow_client_ccache_sync = true
   cred_usage = initiate
   euid = $IPAAPI_USER


### PR DESCRIPTION
This new option (planned to land in gssproxy 0.7) we cache the ldap
ticket properly and avoid a ticket lookup to the KDC on each and every
ldap connection. (Also requires krb5 libs 1.15.1 to benefit from caching).

NOTE: It is safe to apply this to master, if gssproxy does not support this option it simply is ignored.