### PR TITLE
install_check: require IPv6 stack to be enabled

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -354,5 +354,6 @@ class BasePathNamespace(object):
     EXTERNAL_SCHEMA_DIR = '/usr/share/ipa/schema.d'
     GSSPROXY_CONF = '/etc/gssproxy/10-ipa.conf'
     KRB5CC_HTTPD = '/tmp/krb5cc-httpd'
+    IF_INET6 = '/proc/net/if_inet6'
 
 path_namespace = BasePathNamespace

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -103,6 +103,11 @@ class BaseTaskNamespace(object):
 
         raise NotImplementedError()
 
+    def check_ipv6_stack_enabled(self):
+        """Check whether IPv6 kernel module is loaded"""
+
+        raise NotImplementedError()
+
     def restore_hostname(self, fstore, statestore):
         """
         Restores the original hostname as backed up in the

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -141,6 +141,20 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                                'Install the policycoreutils package and start '
                                'the installation again.' % restorecon)
 
+    def check_ipv6_stack_enabled(self):
+        """Checks whether IPv6 kernel module is loaded.
+
+        Function checks if /proc/net/if_inet6 is present. If IPv6 stack is
+        enabled, it exists and contains the interfaces configuration.
+
+        :raises: RuntimeError when IPv6 stack is disabled
+        """
+        if not os.path.exists(paths.IF_INET6):
+            raise RuntimeError(
+                "IPv6 kernel module has to be enabled. If you do not wish to "
+                "use IPv6, please disable it on the interfaces in "
+                "sysctl.conf and enable the IPv6 kernel module.")
+
     def restore_pre_ipa_client_configuration(self, fstore, statestore,
                                              was_sssd_installed,
                                              was_sssd_configured):

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -305,6 +305,7 @@ def install_check(installer):
     external_ca_file = installer._external_ca_file
     http_ca_cert = installer._ca_cert
 
+    tasks.check_ipv6_stack_enabled()
     tasks.check_selinux_status()
 
     if options.master_password:

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -567,6 +567,7 @@ def check_remote_version(client, local_version):
 
 
 def common_check(no_ntp):
+    tasks.check_ipv6_stack_enabled()
     tasks.check_selinux_status()
 
     if is_ipa_configured():


### PR DESCRIPTION
Add checks to install and replica install to verify IPv6 stack
is enabled. IPv6 is required by some IPA parts (AD, conncheck, ...).

https://pagure.io/freeipa/issue/6608

*edit*: please appy to `ipa-4-4` and `master`