### PR TITLE
Use GSS-SPNEGO if connecting locally

### DIFF
--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -52,6 +52,7 @@ if six.PY3:
 
 # Global variable to define SASL auth
 SASL_GSSAPI = ldap.sasl.sasl({}, 'GSSAPI')
+SASL_GSS_SPNEGO = ldap.sasl.sasl({}, 'GSS-SPNEGO')
 
 _debug_log_ldap = False
 
@@ -1112,7 +1113,10 @@ class LDAPClient(object):
         Perform SASL bind operation using the SASL GSSAPI mechanism.
         """
         with self.error_handler():
-            auth_tokens = ldap.sasl.sasl({}, 'GSSAPI')
+            if self._protocol == 'ldapi':
+                auth_tokens = SASL_GSS_SPNEGO
+            else:
+                auth_tokens = SASL_GSSAPI
             self._flush_schema()
             self.conn.sasl_interactive_bind_s(
                 '', auth_tokens, server_controls, client_controls)


### PR DESCRIPTION
GSS-SPNEGO allows us to negotiate a SASL bind with less roundtrips
therefore use it when possible.

We only enable it for local connections for now because we only
recently fixed Cyrus SASL to do proper GSS-SPNEGO negotiation. This
change means a newer and an older version are not compatible.

Restricting ourselves to the local host prevents issues with
incompatible services, and it is ok for us as we are only really
looking for speedups for the local short-lived connections performed
by the framework. Most other clients have longer lived connections,
so peformance improvements there are not as important.