### PR TITLE
man: add missing --setup-adtrust option to manpage

### DIFF
--- a/install/tools/man/ipa-replica-install.1
+++ b/install/tools/man/ipa-replica-install.1
@@ -201,6 +201,9 @@ Disable DNSSEC validation on this server.
 
 .SS "AD TRUST OPTIONS"
 .TP
+\fB\-\-setup\-adtrust\fR
+Configure AD Trust capability on a replica.
+.TP
 \fB\-\-netbios\-name\fR=\fINETBIOS_NAME\fR
 The NetBIOS name for the IPA domain. If not provided then this is determined
 based on the leading component of the DNS domain name. Running

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -198,6 +198,9 @@ Allow creatin of (reverse) zone even if the zone is already resolvable. Using th
 .SS "AD TRUST OPRIONS"
 
 .TP
+\fB\-\-setup\-adtrust\fR
+Configure AD Trust capability.
+.TP
 \fB\-\-netbios\-name\fR=\fINETBIOS_NAME\fR
 The NetBIOS name for the IPA domain. If not provided then this is determined
 based on the leading component of the DNS domain name. Running


### PR DESCRIPTION
ipa-server-install and ipa-replica-install manpages miss --setup-adtrust
options

https://pagure.io/freeipa/issue/6630