### PR TITLE
webui: fixes normalization of value in attributes widget

### DIFF
--- a/install/ui/src/freeipa/widget.js
+++ b/install/ui/src/freeipa/widget.js
@@ -2626,7 +2626,7 @@ IPA.custom_checkboxes_widget = function(spec) {
         that.populate();
         that.append();
         that.owb_create(that.container);
-        that.owb_update(values);
+        that.owb_update(that.values);
     };
 
     /**


### PR DESCRIPTION
Fix is in checkboxes widget but the only affected one is attributes widget.

Reproduction:
 1. Add permission with attribute with uppercase character
   $ ipa permission-add aa_test --type=stageuser --attrs=businessCategory --right=read
 2. Check if it is correctly displayed in Web UI

Actual result:
 - businesscategory is not checked
Expected result:
 - businesscategory is checked