### PR TITLE
ipa-managed-entries: use server-mode API

### DIFF
--- a/install/tools/ipa-managed-entries
+++ b/install/tools/ipa-managed-entries
@@ -63,6 +63,9 @@ def get_dirman_password():
 def main():
     retval = 0
     def_dn = None
+
+    installutils.check_server_configuration()
+
     options, args = parse_options()
 
     if options.list_managed_entries:

--- a/install/tools/ipa-managed-entries
+++ b/install/tools/ipa-managed-entries
@@ -73,7 +73,11 @@ def main():
         sys.exit("Unrecognized action [" + args[0] + "]")
     standard_logging_setup(None, debug=options.debug)
 
-    api.bootstrap(context='cli', debug=options.debug, confdir=paths.ETC_IPA)
+    api.bootstrap(
+        context='cli',
+        in_server=True,
+        debug=options.debug,
+        confdir=paths.ETC_IPA)
     api.finalize()
     api.Backend.ldap2.connect(bind_pw=options.dirman_password)
 


### PR DESCRIPTION
During LDAP connection management refactoring the ad-hoc ldap connection
in `ipa-managed-entries` was replaced by calls to ldap2 backend without
updating API initialization.

https://pagure.io/freeipa/issue/6735