### PR TITLE
ipapython: fix DEFAULT_PLUGINS in version.py

### DIFF
--- a/ipapython/Makefile.am
+++ b/ipapython/Makefile.am
@@ -1,5 +1,7 @@
 include $(top_srcdir)/Makefile.python.am
 
+MOSTLYCLEANFILES = .DEFAULT_PLUGINS
+
 EXTRA_DIST = version.py.in
 
 all-local: version.py
@@ -7,10 +9,15 @@ dist-hook: version.py
 install-exec-local: version.py
 bdist_wheel: version.py
 
-version.py: version.py.in $(top_builddir)/$(CONFIG_STATUS)
+.DEFAULT_PLUGINS: $(top_srcdir)/API.txt
+	$(AM_V_GEN)awk '$$1 == "default:" { print $$2 }' $< >$@
+
+version.py: version.py.in .DEFAULT_PLUGINS $(top_builddir)/$(CONFIG_STATUS)
 	$(AM_V_GEN)sed						\
 		-e 's|@API_VERSION[@]|$(API_VERSION)|g'		\
 		-e 's|@NUM_VERSION[@]|$(NUM_VERSION)|g'		\
 		-e 's|@VERSION[@]|$(VERSION)|g'			\
 		-e 's|@VENDOR_SUFFIX[@]|$(VENDOR_SUFFIX)|g'	\
+		-e '/@DEFAULT_PLUGINS[@]/r .DEFAULT_PLUGINS'	\
+		-e '/@DEFAULT_PLUGINS[@]/d'			\
 		$< > $@

--- a/ipapython/version.py.in
+++ b/ipapython/version.py.in
@@ -49,5 +49,5 @@ API_VERSION=u'@API_VERSION@'
 
 
 DEFAULT_PLUGINS = frozenset(l.strip() for l in """
-__DEFAULT_PLUGINS__
+@DEFAULT_PLUGINS@
 """.strip().splitlines())


### PR DESCRIPTION
Replace the placeholder with the actual value during build.

This fixes the client incorrectly assuming that the default version of all
plugins is 1.

https://pagure.io/freeipa/issue/6597