### PR TITLE
rpcserver: x509_login: Handle unsuccessful certificate login gracefully

### DIFF
--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -834,6 +834,16 @@ class login_kerberos(KerberosLogin):
 class login_x509(KerberosLogin):
     key = '/session/login_x509'
 
+    def __call__(self, environ, start_response):
+        self.debug('WSGI login_x509.__call__:')
+
+        if 'KRB5CCNAME' not in environ:
+            return self.unauthorized(
+                environ, start_response, 'KRB5CCNAME not set',
+                'Authentication failed')
+
+        super(login_x509, self).__call__(environ, start_response)
+
 
 class login_password(Backend, KerberosSession):
 


### PR DESCRIPTION
When mod_lookup_identity is unable to match user by certificate (and username)
it unsets http request's user. mod_auth_gssapi is then unable to get Kerberos
ticket and doesn't set KRB5CCNAME environment variable.
x509_login.__call__ now returns 401 in such case to indicate that request was
not authenticated.

https://pagure.io/freeipa/issue/6225