### PR TITLE
ldap2: fix crash in development mode

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -48,6 +48,8 @@ steps:
   install_server:
   - ipa-server-install -U --domain ${server_domain} --realm ${server_realm} -p ${server_password}
     -a ${server_password} --setup-dns --setup-kra --auto-forwarders
+  - sed -ri "s/mode = production/mode = development/" /etc/ipa/default.conf
+  - systemctl restart httpd.service
   lint:
   - PYTHON=/usr/bin/python2 make V=0 lint
   - PYTHON=/usr/bin/python3 make V=0 pylint

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1289,7 +1289,7 @@ class RestClient(Backend):
         cookies = ipapython.cookie.Cookie.parse(resp_headers.get('set-cookie', ''))
         if status != 200 or len(cookies) == 0:
             raise errors.RemoteRetrieveError(reason=_('Failed to authenticate to CA REST API'))
-        self.cookie = str(cookies[0])
+        object.__setattr__(self, 'cookie', str(cookies[0]))
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -1302,7 +1302,7 @@ class RestClient(Backend):
             client_keyfile=self.client_keyfile,
             method='GET'
         )
-        self.cookie = None
+        object.__setattr__(self, 'cookie', None)
 
     def _ssldo(self, method, path, headers=None, body=None, use_session=True):
         """

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -77,42 +77,42 @@ class ldap2(CrudBackend, LDAPClient):
         LDAPClient.__init__(self, ldap_uri,
                             force_schema_updates=force_schema_updates)
 
-        self.__time_limit = float(LDAPClient.time_limit)
-        self.__size_limit = int(LDAPClient.size_limit)
+        self._time_limit = float(LDAPClient.time_limit)
+        self._size_limit = int(LDAPClient.size_limit)
 
     @property
     def time_limit(self):
-        if self.__time_limit is None:
+        if self._time_limit is None:
             return float(self.get_ipa_config().single_value.get(
                 'ipasearchtimelimit', 2))
-        return self.__time_limit
+        return self._time_limit
 
     @time_limit.setter
     def time_limit(self, val):
         if val is not None:
             val = float(val)
-        self.__time_limit = val
+        object.__setattr__(self, '_time_limit', val)
 
     @time_limit.deleter
     def time_limit(self):
-        self.__time_limit = int(LDAPClient.size_limit)
+        object.__setattr__(self, '_time_limit', int(LDAPClient.size_limit))
 
     @property
     def size_limit(self):
-        if self.__size_limit is None:
+        if self._size_limit is None:
             return int(self.get_ipa_config().single_value.get(
                 'ipasearchrecordslimit', 0))
-        return self.__size_limit
+        return self._size_limit
 
     @size_limit.setter
     def size_limit(self, val):
         if val is not None:
             val = int(val)
-        self.__size_limit = val
+        object.__setattr__(self, '_size_limit', val)
 
     @size_limit.deleter
     def size_limit(self):
-        self.__size_limit = float(LDAPClient.time_limit)
+        object.__setattr__(self, '_size_limit', float(LDAPClient.time_limit))
 
     def _connect(self):
         # Connectible.conn is a proxy to thread-local storage;
@@ -158,9 +158,9 @@ class ldap2(CrudBackend, LDAPClient):
             cacert = paths.IPA_CA_CRT
 
         if time_limit is not _missing:
-            self.time_limit = time_limit
+            object.__setattr__(self, 'time_limit', time_limit)
         if size_limit is not _missing:
-            self.size_limit = size_limit
+            object.__setattr__(self, 'size_limit', size_limit)
 
         client = LDAPClient(self.ldap_uri,
                             force_schema_updates=self._force_schema_updates,
@@ -219,8 +219,8 @@ class ldap2(CrudBackend, LDAPClient):
             # ignore when trying to unbind multiple times
             pass
 
-        del self.time_limit
-        del self.size_limit
+        object.__delattr__(self, 'time_limit')
+        object.__delattr__(self, 'size_limit')
 
     def get_ipa_config(self, attrs_list=None):
         """Returns the IPA configuration entry (dn, entry_attrs)."""

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -628,8 +628,10 @@ class KerberosWSGIExecutioner(WSGIExecutioner, KerberosSession):
         self.debug('KerberosWSGIExecutioner.__call__:')
         user_ccache=environ.get('KRB5CCNAME')
 
-        self.headers = [('Content-Type',
-                         '%s; charset=utf-8' % self.content_type)]
+        object.__setattr__(
+            self, 'headers',
+            [('Content-Type', '%s; charset=utf-8' % self.content_type)]
+        )
 
         if user_ccache is None:
 


### PR DESCRIPTION
Do not set or delete attributes directly on the ldap2 instance, as that
raises an AttributeError in development mode because of ReadOnly locking.

Use the usual workaround of `object.__setattr__` and `object.__delattr__`
to fix the issue.

https://pagure.io/freeipa/issue/6625