### PR TITLE
Reconfigure Kerberos library config as the last step of KDC install

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -139,6 +139,8 @@ class KrbInstance(service.Service):
             pass
 
     def __common_post_setup(self):
+        self.step("configuring Kerberos library to use local KDC",
+                  self.__configure_krb5_conf)
         self.step("starting the KDC", self.__start_instance)
         self.step("configuring KDC to start on boot", self.__enable)
 
@@ -287,7 +289,6 @@ class KrbInstance(service.Service):
 
     def __configure_instance(self):
         self.__template_file(paths.KRB5KDC_KDC_CONF, chmod=None)
-        self.__template_file(paths.KRB5_CONF)
         self.__template_file(paths.HTML_KRB5_INI)
         self.__template_file(paths.KRB_CON)
         self.__template_file(paths.HTML_KRBREALM_CON)
@@ -313,6 +314,9 @@ class KrbInstance(service.Service):
                                                     replacevars=replacevars,
                                                     appendvars=appendvars)
         tasks.restore_context(paths.SYSCONFIG_KRB5KDC_DIR)
+
+    def __configure_krb5_conf(self):
+        self.__template_file(paths.KRB5_CONF)
 
     #add the password extop module
     def __add_pwd_extop_module(self):


### PR DESCRIPTION
During KDC installation, we overwrite the existing `/etc/krb5.conf` file
from client version to use only local KDC for client requests. However,
this means that services such as certmonger may try to kinit against
local KDC before it is up and running, resulting in subtle but serious
bugs.

The file should be updated only when KDC is set up properly and running.

https://pagure.io/freeipa/issue/6739