### PR TITLE
permissions: add permissions for reading and modifying external group members

### DIFF
--- a/ACI.txt
+++ b/ACI.txt
@@ -95,9 +95,13 @@ aci: (targetattr = "a6record || aaaarecord || afsdbrecord || aplrecord || arecor
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
 aci: (targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Add Groups";allow (add) groupdn = "ldap:///cn=System: Add Groups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
+aci: (targetattr = "ipaexternalmember")(targetfilter = "(objectclass=ipaexternalgroup)")(version 3.0;acl "permission:System: Modify External Group Membership";allow (write) groupdn = "ldap:///cn=System: Modify External Group Membership,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+dn: cn=groups,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "member")(targetfilter = "(&(!(cn=admins))(objectclass=ipausergroup))")(version 3.0;acl "permission:System: Modify Group Membership";allow (write) groupdn = "ldap:///cn=System: Modify Group Membership,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "cn || description || gidnumber || ipauniqueid || mepmanagedby || objectclass")(targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Modify Groups";allow (write) groupdn = "ldap:///cn=System: Modify Groups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+dn: cn=groups,cn=accounts,dc=ipa,dc=example
+aci: (targetattr = "ipaexternalmember")(targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Read External Group Membership";allow (compare,read,search) userdn = "ldap:///all";)
 dn: dc=ipa,dc=example
 aci: (targetattr = "cn || createtimestamp || entryusn || gidnumber || memberuid || modifytimestamp || objectclass")(target = "ldap:///cn=groups,cn=compat,dc=ipa,dc=example")(version 3.0;acl "permission:System: Read Group Compat Tree";allow (compare,read,search) userdn = "ldap:///anyone";)
 dn: cn=groups,cn=accounts,dc=ipa,dc=example

--- a/ipaserver/plugins/group.py
+++ b/ipaserver/plugins/group.py
@@ -194,6 +194,13 @@ class group(LDAPObject):
                 'member', 'memberof', 'memberuid', 'memberuser', 'memberhost',
             },
         },
+        'System: Read External Group Membership': {
+            'ipapermbindruletype': 'all',
+            'ipapermright': {'read', 'search', 'compare'},
+            'ipapermdefaultattr': {
+                'ipaexternalmember',
+            },
+        },
         'System: Add Groups': {
             'ipapermright': {'add'},
             'replaces': [
@@ -212,6 +219,16 @@ class group(LDAPObject):
                 '(targetattr = "member")(target = "ldap:///cn=*,cn=groups,cn=accounts,$SUFFIX")(version 3.0;acl "permission:Modify Group membership";allow (write) groupdn = "ldap:///cn=Modify Group membership,cn=permissions,cn=pbac,$SUFFIX";)',
                 '(targetfilter = "(!(cn=admins))")(targetattr = "member")(target = "ldap:///cn=*,cn=groups,cn=accounts,$SUFFIX")(version 3.0;acl "permission:Modify Group membership";allow (write) groupdn = "ldap:///cn=Modify Group membership,cn=permissions,cn=pbac,$SUFFIX";)',
             ],
+            'default_privileges': {
+                'Group Administrators', 'Modify Group membership'
+            },
+        },
+        'System: Modify External Group Membership': {
+            'ipapermright': {'write'},
+            'ipapermtargetfilter': [
+                '(objectclass=ipaexternalgroup)',
+            ],
+            'ipapermdefaultattr': {'ipaexternalmember'},
             'default_privileges': {
                 'Group Administrators', 'Modify Group membership'
             },


### PR DESCRIPTION
Issue: "User Administrator" role cannot add users to an External Group.

https://fedorahosted.org/freeipa/ticket/5504

