### PR TITLE
webui: do not warn about CAs if there is only one master

### DIFF
--- a/install/ui/src/freeipa/topology.js
+++ b/install/ui/src/freeipa/topology.js
@@ -497,6 +497,10 @@ topology.servers_search_facet = function(spec, no_init) {
             on_success(data, text_status, xhr);
 
             var result = data.result.results;
+
+            // Do not show warning if there is only one master
+            if (result.length <= 1) return;
+
             var counter = 0;
 
             for (var i=0, l=result.length; i<l; i++) {


### PR DESCRIPTION
Web UI showed pop-up dialog which recommends to install additional CA in
topology section when only 1 CA existed even if there was only one master.

Though behind the pop-up is to prevent situation, where multiple replicas
are installed but neither with --setup-ca option and thus risking to loose
CA when original master is lost.

The warning was displayed also if only one IPA server exists. It is unnecessary
to annoy admin only about CA because the entire IPA is not duplicated.

Therefore the pop-up is now shown only one IPA server exists.

https://pagure.io/freeipa/issue/6598