### PR TITLE
Configure KDC to use certs after they are deployed

### DIFF
--- a/install/share/kdc.conf.template
+++ b/install/share/kdc.conf.template
@@ -12,6 +12,6 @@
   dict_file = $DICT_WORDS
   default_principal_flags = +preauth
 ;  admin_keytab = $KRB5KDC_KADM5_KEYTAB
-  pkinit_identity = FILE:$KDC_CERT,$KDC_KEY
-  pkinit_anchors = FILE:$CACERT_PEM
+$NOPK  pkinit_identity = FILE:$KDC_CERT,$KDC_KEY
+$NOPK  pkinit_anchors = FILE:$CACERT_PEM
  }


### PR DESCRIPTION
Certmonger needs to access the KDC when it tries to obtain certs,
so make sure the KDC can run, then reconfigure it to use pkinit anchors
once certs are deployed.
