### PR TITLE
cert: include certificate chain in cert command output

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -782,11 +782,12 @@ option: Str('cacn?', autofill=True, cli_name='ca', default=u'ipa')
 option: Str('version?')
 output: Output('result')
 command: cert_request/1
-args: 1,8,3
+args: 1,9,3
 arg: Str('csr', cli_name='csr_file')
 option: Flag('add', autofill=True, default=False)
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('cacn?', autofill=True, cli_name='ca', default=u'ipa')
+option: Flag('chain', autofill=True, default=False)
 option: Principal('principal')
 option: Str('profile_id?')
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
@@ -803,10 +804,11 @@ option: Int('revocation_reason', autofill=True, default=0)
 option: Str('version?')
 output: Output('result')
 command: cert_show/1
-args: 1,6,3
+args: 1,7,3
 arg: Int('serial_number')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('cacn?', autofill=True, cli_name='ca', default=u'ipa')
+option: Flag('chain', autofill=True, default=False)
 option: Flag('no_members', autofill=True, default=False)
 option: Str('out?')
 option: Flag('raw', autofill=True, cli_name='raw', default=False)

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -73,8 +73,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-define(IPA_API_VERSION_MINOR, 220)
-# Last change: Add whoami command
+define(IPA_API_VERSION_MINOR, 221)
+# Last change: cert: include certificate chain in cert command output
 
 
 ########################################################

--- a/ipaclient/plugins/cert.py
+++ b/ipaclient/plugins/cert.py
@@ -57,7 +57,10 @@ class CertRetrieveOverride(MethodOverride):
         result = super(CertRetrieveOverride, self).forward(*args, **options)
 
         if certificate_out is not None:
-            certs = [result['result']['certificate']]
+            if options.get('chain', False):
+                certs = result['result']['certificate_chain']
+            else:
+                certs = [result['result']['certificate']]
             certs = (x509.normalize_certificate(cert) for cert in certs)
             certs = (x509.make_pem(base64.b64encode(cert)) for cert in certs)
             with open(certificate_out, 'w') as f:


### PR DESCRIPTION
**cert: add output file option to cert-request**

The certificate returned by cert-request can now be saved to a file in the
CLI using a new --certificate-out option.

**cert: include certificate chain in cert command output**

Include the full certificate chain in the output of cert-request, cert-show
and cert-find if --chain or --all is specified.

If output file is specified in the CLI together with --chain, the full
certificate chain is written to the file.

https://pagure.io/freeipa/issue/6547