### PR TITLE
rpc: fix crash in verbose mode

### DIFF
--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -1136,16 +1136,17 @@ class JSONServerProxy(object):
             verbose=self.__verbose >= 3,
         )
 
+        if print_json:
+            root_logger.info(
+                'Response: %s',
+                json.dumps(json.loads(response), sort_keys=True, indent=4)
+            )
+
         try:
             response = json_decode_binary(response)
         except ValueError as e:
             raise JSONError(error=str(e))
 
-        if print_json:
-            root_logger.info(
-                'Response: %s',
-                json.dumps(response, sort_keys=True, indent=4)
-            )
         error = response.get('error')
         if error:
             try:


### PR DESCRIPTION
Fix a crash caused by feeding incorrect data to `json.dumps()` in
`JSONServerProxy.__request()` introduced by commit
8159c2883bf66980582d1227c364df4e592bdd7e.

https://pagure.io/freeipa/issue/6655