### PR TITLE
ipa-replica-prepare fix

### DIFF
--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -368,8 +368,11 @@ class CertDB(object):
             with open(self.certder_fname, "r") as f:
                 dercert = f.read()
         finally:
-            os.unlink(self.certreq_fname)
-            os.unlink(self.certder_fname)
+            for fname in (self.certreq_fname, self.certder_fname):
+                try:
+                    os.unlink(fname)
+                except OSError:
+                    pass
 
         return dercert
 

--- a/ipaserver/install/ipa_replica_prepare.py
+++ b/ipaserver/install/ipa_replica_prepare.py
@@ -603,7 +603,8 @@ class ReplicaPrepare(admintool.AdminTool):
 
         try:
             db = certs.CertDB(
-                api.env.realm, nssdir=self.dir, subject_base=subject_base)
+                api.env.realm, nssdir=self.dir, subject_base=subject_base,
+                host_name=api.env.host)
             db.create_passwd_file()
             db.create_from_cacert()
             db.create_server_cert(nickname, hostname)


### PR DESCRIPTION
A regression was introduced in https://github.com/freeipa/freeipa/commit/0a54fac02cecad3b9e3bf8ad0c8a44df3b701857. Fix + don't fail if either file was not created during server-cert creation.