### PR TITLE
Installation must publish CA cert in /usr/share/ipa/html/ca.crt

### DIFF
--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -174,6 +174,7 @@ class HTTPInstance(service.Service):
             self.step("configure certmonger for renewals",
                       self.configure_certmonger_renewal_guard)
         self.step("importing CA certificates from LDAP", self.__import_ca_certs)
+        self.step("publish CA cert", self.__publish_ca_cert)
         self.step("clean up any existing httpd ccaches",
                   self.remove_httpd_ccaches)
         self.step("configuring SELinux for httpd", self.configure_selinux_for_httpd)
@@ -421,6 +422,11 @@ class HTTPInstance(service.Service):
         db = certs.CertDB(self.realm, nssdir=paths.HTTPD_ALIAS_DIR,
                           subject_base=self.subject_base)
         self.import_ca_certs(db, self.ca_is_configured)
+
+    def __publish_ca_cert(self):
+        ca_db = certs.CertDB(self.realm, nssdir=paths.HTTPD_ALIAS_DIR,
+                             subject_base=self.subject_base)
+        ca_db.publish_ca_cert(paths.CA_CRT)
 
     def is_kdcproxy_configured(self):
         """Check if KDC proxy has already been configured in the past"""


### PR DESCRIPTION
Regression introduced with commit d124e30.
ipa-server-install and ipa-replica-install must publish the CA cert
in /usr/share/ipa/html/ca.crt, otherwise the web page
http://ipaserver.ipadomain.com/ipa/config/ssbrowser.html has a link to
http://ipaserver.ipadomain.com/ipa/config/ca.crt but this file is missing.

https://pagure.io/freeipa/issue/6750