### PR TITLE
csrgen: hide cert-get-requestdata in CLI

### DIFF
--- a/ipaclient/plugins/csrgen.py
+++ b/ipaclient/plugins/csrgen.py
@@ -28,6 +28,8 @@ Commands to build certificate requests automatically
 class cert_get_requestdata(Local):
     __doc__ = _('Gather data for a certificate signing request.')
 
+    NO_CLI = True
+
     takes_options = (
         Principal(
             'principal',


### PR DESCRIPTION
The CSR generation feature is supposed to be used from cert-request, hide
the internal cert-get-requestdata command in the CLI.

https://fedorahosted.org/freeipa/ticket/4899