### PR TITLE
Backup KDC certificate pair

### DIFF
--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -163,6 +163,8 @@ class Backup(admintool.AdminTool):
         paths.CACERT_P12,
         paths.KRACERT_P12,
         paths.KRB5KDC_KDC_CONF,
+        paths.KDC_CERT,
+        paths.KDC_KEY,
         paths.SYSTEMD_IPA_SERVICE,
         paths.SYSTEMD_SSSD_SERVICE,
         paths.SYSTEMD_CERTMONGER_SERVICE,


### PR DESCRIPTION
KDC certificate pair was added but is not included in backup which
might cause issues when restoring the IPA service.

https://pagure.io/freeipa/issue/6748

This probably does not fix the issue as a whole but I am not sure
if there's more that we can do on the IPA side.