### PR TITLE
Remove pkinit from ipa-replica-prepare

### DIFF
--- a/ipaserver/install/ipa_replica_prepare.py
+++ b/ipaserver/install/ipa_replica_prepare.py
@@ -88,9 +88,6 @@ class ReplicaPrepare(admintool.AdminTool):
         parser.add_option("--allow-zone-overlap", dest="allow_zone_overlap",
             action="store_true", default=False, help="create DNS "
             "zone even if it already exists")
-        parser.add_option("--no-pkinit", dest="setup_pkinit",
-            action="store_false", default=True,
-            help="disables pkinit setup steps")
         parser.add_option("--ca", dest="ca_file", default=paths.CACERT_P12,
             metavar="FILE",
             help="location of CA PKCS#12 file, default /root/cacert.p12")
@@ -112,12 +109,6 @@ class ReplicaPrepare(admintool.AdminTool):
         group.add_option("--http_pkcs12", dest="http_cert_files",
             action="append",
             help=SUPPRESS_HELP)
-        group.add_option("--pkinit-cert-file", dest="pkinit_cert_files",
-            action="append", metavar="FILE",
-            help="File containing the Kerberos KDC SSL certificate and private key")
-        group.add_option("--pkinit_pkcs12", dest="pkinit_cert_files",
-            action="append",
-            help=SUPPRESS_HELP)
         group.add_option("--dirsrv-pin", dest="dirsrv_pin", sensitive=True,
             metavar="PIN",
             help="The password to unlock the Directory Server private key")
@@ -128,20 +119,12 @@ class ReplicaPrepare(admintool.AdminTool):
             help="The password to unlock the Apache Server private key")
         group.add_option("--http_pin", dest="http_pin", sensitive=True,
             help=SUPPRESS_HELP)
-        group.add_option("--pkinit-pin", dest="pkinit_pin", sensitive=True,
-            metavar="PIN",
-            help="The password to unlock the Kerberos KDC private key")
-        group.add_option("--pkinit_pin", dest="pkinit_pin", sensitive=True,
-            help=SUPPRESS_HELP)
         group.add_option("--dirsrv-cert-name", dest="dirsrv_cert_name",
             metavar="NAME",
             help="Name of the Directory Server SSL certificate to install")
         group.add_option("--http-cert-name", dest="http_cert_name",
             metavar="NAME",
             help="Name of the Apache Server SSL certificate to install")
-        group.add_option("--pkinit-cert-name", dest="pkinit_cert_name",
-            metavar="NAME",
-            help="Name of the Kerberos KDC SSL certificate to install")
         parser.add_option_group(group)
 
     def validate_options(self):
@@ -162,18 +145,10 @@ class ReplicaPrepare(admintool.AdminTool):
 
         # If any of the PKCS#12 options are selected, all are required.
         cert_file_req = (options.dirsrv_cert_files, options.http_cert_files)
-        cert_file_opt = (options.pkinit_cert_files,)
-        if options.setup_pkinit:
-            cert_file_req += cert_file_opt
-        if any(cert_file_req + cert_file_opt) and not all(cert_file_req):
+        if any(cert_file_req) and not all(cert_file_req):
             self.option_parser.error(
-                "--dirsrv-cert-file, --http-cert-file, and --pkinit-cert-file "
-                "or --no-pkinit are required if any key file options are used."
-            )
-        if not options.setup_pkinit and options.pkinit_cert_files:
-            self.option_parser.error(
-                "--no-pkinit and --pkinit-cert-file cannot be specified "
-                "together"
+                "--dirsrv-cert-file and --http-cert-file are required if any "
+                "key file options are used."
             )
 
         if len(self.args) < 1:
@@ -291,7 +266,7 @@ class ReplicaPrepare(admintool.AdminTool):
                                "--ip-address option." % zone)
                 raise admintool.ScriptError("Cannot add DNS record")
 
-        self.http_pin = self.dirsrv_pin = self.pkinit_pin = None
+        self.http_pin = self.dirsrv_pin = None
 
         if options.http_cert_files:
             if options.http_pin is None:
@@ -321,20 +296,6 @@ class ReplicaPrepare(admintool.AdminTool):
             self.dirsrv_pkcs12_file = dirsrv_pkcs12_file
             self.dirsrv_pin = dirsrv_pin
 
-        if options.pkinit_cert_files:
-            if options.pkinit_pin is None:
-                options.pkinit_pin = installutils.read_password(
-                    "Enter Kerberos KDC private key unlock",
-                    confirm=False, validate=False, retry=False)
-                if options.pkinit_pin is None:
-                    raise admintool.ScriptError(
-                        "Kerberos KDC private key unlock password required")
-            pkinit_pkcs12_file, pkinit_pin, _pkinit_ca_cert = self.load_pkcs12(
-                options.pkinit_cert_files, options.pkinit_pin,
-                options.pkinit_cert_name)
-            self.pkinit_pkcs12_file = pkinit_pkcs12_file
-            self.pkinit_pin = pkinit_pin
-
         if (options.http_cert_files and options.dirsrv_cert_files and
             http_ca_cert != dirsrv_ca_cert):
             raise admintool.ScriptError(
@@ -358,11 +319,7 @@ class ReplicaPrepare(admintool.AdminTool):
         os.chmod(self.dir, 0o700)
         try:
             self.copy_ds_certificate()
-
             self.copy_httpd_certificate()
-
-            if options.setup_pkinit:
-                self.copy_pkinit_certificate()
 
             self.retrieve_ca_certs()
             self.copy_misc_files()
@@ -434,20 +391,6 @@ class ReplicaPrepare(admintool.AdminTool):
 
             self.log.info("Exporting RA certificate")
             self.export_ra_pkcs12()
-
-    def copy_pkinit_certificate(self):
-        options = self.options
-
-        passwd_fname = os.path.join(self.dir, "pkinit_pin.txt")
-        with open(passwd_fname, "w") as fd:
-            fd.write("%s\n" % (self.pkinit_pin or ''))
-
-        if options.pkinit_cert_files:
-            self.log.info("Copying SSL certificate for the KDC")
-            self.copy_info_file(self.pkinit_pkcs12_file.name, "pkinitcert.p12")
-        else:
-            self.log.info("Creating SSL certificate for the KDC")
-            self.export_certdb("pkinitcert", passwd_fname, is_kdc=True)
 
     def copy_misc_files(self):
         self.log.info("Copying additional files")
@@ -586,20 +529,15 @@ class ReplicaPrepare(admintool.AdminTool):
         """
         installutils.remove_file(os.path.join(self.dir, filename))
 
-    def export_certdb(self, fname, passwd_fname, is_kdc=False):
+    def export_certdb(self, fname, passwd_fname):
         """Export a cert database
 
         :param fname: The file to export to (relative to the info directory)
         :param passwd_fname: File that holds the cert DB password
-        :param is_kdc: True if we're exporting KDC certs
         """
         hostname = self.replica_fqdn
         subject_base = self.subject_base
-
-        if is_kdc:
-            nickname = "KDC-Cert"
-        else:
-            nickname = "Server-Cert"
+        nickname = "Server-Cert"
 
         try:
             db = certs.CertDB(
@@ -611,11 +549,7 @@ class ReplicaPrepare(admintool.AdminTool):
             pkcs12_fname = os.path.join(self.dir, fname + ".p12")
 
             try:
-                if is_kdc:
-                    certs.export_pem_p12(pkcs12_fname, passwd_fname,
-                        nickname, os.path.join(self.dir, "kdc.pem"))
-                else:
-                    db.export_pkcs12(pkcs12_fname, passwd_fname, nickname)
+                db.export_pkcs12(pkcs12_fname, passwd_fname, nickname)
             except ipautil.CalledProcessError as e:
                 self.log.info("error exporting Server certificate: %s", e)
                 installutils.remove_file(pkcs12_fname)
@@ -625,9 +559,6 @@ class ReplicaPrepare(admintool.AdminTool):
             self.remove_info_file("key3.db")
             self.remove_info_file("secmod.db")
             self.remove_info_file("noise.txt")
-
-            if is_kdc:
-                self.remove_info_file("kdc.pem")
 
             orig_filename = passwd_fname + ".orig"
             if ipautil.file_exists(orig_filename):


### PR DESCRIPTION
The PKINIT feature is not available on domain level 0 so any
options about pkinit are false.

https://pagure.io/freeipa/issue/6759