### PR TITLE
Improve the implementation of PKINIT certificate retrieval

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -410,6 +410,12 @@ class KrbInstance(service.Service):
             root_logger.critical("krb5kdc service failed to restart")
             raise
 
+        with ipautil.private_ccache() as anon_ccache:
+            try:
+                ipautil.run([paths.KINIT, '-n', '-c', anon_ccache])
+            except ipautil.CalledProcessError as e:
+                raise RuntimeError("Failed to configure anonymous PKINIT")
+
     def enable_ssl(self):
         if self.config_pkinit:
             self.steps = []

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -177,7 +177,7 @@ def wait_for_entry(connection, dn, timeout=7200, attr='', quiet=True):
             pass  # no entry yet
         except Exception as e:  # badness
             root_logger.error("Error reading entry %s: %s", dn, e)
-            break
+            raise
         if not entry:
             if not quiet:
                 sys.stdout.write(".")
@@ -185,13 +185,10 @@ def wait_for_entry(connection, dn, timeout=7200, attr='', quiet=True):
             time.sleep(1)
 
     if not entry and int(time.time()) > timeout:
-        root_logger.error(
-            "wait_for_entry timeout for %s for %s", connection, dn)
+        raise errors.NotFound(
+            reason="wait_for_entry timeout for %s for %s" % (connection, dn))
     elif entry and not quiet:
         root_logger.error("The waited for entry is: %s", entry)
-    elif not entry:
-        root_logger.error(
-            "Error: could not read entry %s from %s", dn, connection)
 
 
 class ReplicationManager(object):

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -836,6 +836,9 @@ def install(installer):
 
     ca.set_subject_base_in_config(options.subject_base)
 
+    # configure PKINIT now that all required services are in place
+    krb.enable_ssl()
+
     # Apply any LDAP updates. Needs to be done after the configuration file
     # is created. DS is restarted in the process.
     service.print_msg("Applying LDAP updates")

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1461,6 +1461,9 @@ def install(installer):
         options.dm_password = config.dirman_password
         ca.install(False, config, options)
 
+    # configure PKINIT now that all required services are in place
+    krb.enable_ssl()
+
     # Apply any LDAP updates. Needs to be done after the replica is synced-up
     service.print_msg("Applying LDAP updates")
     ds.apply_updates()

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -229,9 +229,9 @@ def ca_kdc_check(api_instance, hostname):
             raise errors.NotFound()
 
     except errors.NotFound:
-        raise errors.ACIError(info=_(
-                "Host '%(hostname)s' is not an active KDC")
-                 % dict(hostname=hostname))
+        raise errors.ACIError(
+            info=_("Host '%(hostname)s' is not an active KDC")
+            % dict(hostname=hostname))
 
 
 def validate_certificate(value):


### PR DESCRIPTION
The original PKINIT cert request code contained numerous defects, namely:

   * nearly absent handling of rejected requests and CA errors which resulted
     e.g. in an unusable WebUI after replica installation
     and
   * certificate request logic that was not consistent with the rest of the
     installers (DS, HTTP for example): what caused hard errors in their case
     went unnoticed in PKINIT setup

This PR consolidates this code so that errors arising from CA rejecting the
PKINIT cert request cause the installers to abort immediately. The PKINIT step
was also split into a separate method executed before LDAP updates. The name
was chosen to be `enable_ssl` in order to make the planned refactoring of
certificate requesting code (https://pagure.io/freeipa/issue/6429) easier: the
method name is not accurate but at least it is consistent with e.g. LDAP
installer co the common code can be grepper with greater ease.

https://pagure.io/freeipa/issue/6739