### PR TITLE
Remove allow_constrained_delegation from gssproxy.conf

### DIFF
--- a/install/share/gssproxy.conf.template
+++ b/install/share/gssproxy.conf.template
@@ -4,7 +4,6 @@
   cred_store = keytab:$HTTP_KEYTAB
   cred_store = client_keytab:$HTTP_KEYTAB
   allow_protocol_transition = true
-  allow_constrained_delegation = true
   cred_usage = both
   euid = $HTTPD_USER
 


### PR DESCRIPTION
This change reverts option which breaks priviledge separation.

https://pagure.io/freeipa/issue/6225