### PR TITLE
CONFIGURE: Properly detect libpopt on el7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -155,7 +155,13 @@ AM_CHECK_WRAPPER(nss_wrapper, HAVE_NSS_WRAPPER)
 dnl ---------------------------------------------------------------------------
 dnl - Check for POPT
 dnl ---------------------------------------------------------------------------
-PKG_CHECK_MODULES([POPT], [popt])
+POPT_LIBS=
+PKG_CHECK_MODULES([POPT], [popt], [],
+    [AC_CHECK_HEADER([popt.h], [], [AC_MSG_ERROR([popt.h not found])])
+     AC_CHECK_LIB([popt], [poptGetContext], [POPT_LIBS="-lpopt"])
+     AC_SUBST(POPT_LIBS)
+    ]
+)
 
 dnl ---------------------------------------------------------------------------
 dnl - Check for SASL


### PR DESCRIPTION
libpopt added pkg-config file in 1.16 but there are still distributions
which has older version of library (el6, el7). And new features from
libpopt are not used anywhere. Configure should try to detect as much as
possible and users should not use workarounds with explicitely enabled
variables as parameters e.g.
   ./configure POPT_LIBS="-lpopt "

This change originating from PR #494 is required to make building upstream IPA possible on RHEL/CentOS 7.