### PR TITLE
Validate user input for cert-get-requestdata

### DIFF
--- a/ipaclient/plugins/csrgen.py
+++ b/ipaclient/plugins/csrgen.py
@@ -77,6 +77,10 @@ class cert_get_requestdata(Local):
             util.check_writable_file(options['out'])
 
         principal = options.get('principal')
+        if principal is None:
+            raise errors.InvocationError(
+                message=_('Principal is required')
+            )
         profile_id = options.get('profile_id')
         if profile_id is None:
             profile_id = dogtag.DEFAULT_PROFILE


### PR DESCRIPTION
Fix adds validatation for Principal and CSR generation
tool values

Fixes https://pagure.io/freeipa/issue/6742

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>