### PR TITLE
slapi plugins: fix CFLAGS

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-cldap/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-cldap/Makefile.am
@@ -10,6 +10,7 @@ AM_CPPFLAGS =							\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)						\
 	$(WARN_CFLAGS)						\
 	$(NDRNBT_CFLAGS)					\

--- a/daemons/ipa-slapi-plugins/ipa-dns/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-dns/Makefile.am
@@ -5,12 +5,12 @@ PLUGIN_COMMON_DIR = $(srcdir)/../common
 AM_CPPFLAGS =							\
 	-I$(srcdir)						\
 	-I$(PLUGIN_COMMON_DIR)					\
-	-I/usr/include/dirsrv					\
 	-DPREFIX=\""$(prefix)"\" 				\
 	-DBINDIR=\""$(bindir)"\"				\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)						\
 	$(WARN_CFLAGS)						\
 	$(NULL)

--- a/daemons/ipa-slapi-plugins/ipa-enrollment/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-enrollment/Makefile.am
@@ -10,6 +10,7 @@ AM_CPPFLAGS =							\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)					\
 	$(KRB5_CFLAGS)						\
 	$(WARN_CFLAGS)						\

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/Makefile.am
@@ -10,6 +10,7 @@ AM_CPPFLAGS =							\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)						\
 	$(WARN_CFLAGS)						\
 	$(SSSNSSIDMAP_CFLAGS)					\

--- a/daemons/ipa-slapi-plugins/ipa-lockout/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-lockout/Makefile.am
@@ -5,12 +5,12 @@ PLUGIN_COMMON_DIR = $(srcdir)/../common
 AM_CPPFLAGS =							\
 	-I$(srcdir)						\
 	-I$(PLUGIN_COMMON_DIR)					\
-	-I/usr/include/dirsrv					\
 	-DPREFIX=\""$(prefix)"\" 				\
 	-DBINDIR=\""$(bindir)"\"				\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)					\
 	$(WARN_CFLAGS)						\
 	$(NULL)

--- a/daemons/ipa-slapi-plugins/ipa-modrdn/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-modrdn/Makefile.am
@@ -5,12 +5,12 @@ PLUGIN_COMMON_DIR = $(srcdir)/../common
 AM_CPPFLAGS =							\
 	-I$(srcdir)						\
 	-I$(PLUGIN_COMMON_DIR)					\
-	-I/usr/include/dirsrv					\
 	-DPREFIX=\""$(prefix)"\" 				\
 	-DBINDIR=\""$(bindir)"\"				\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)					\
 	$(WARN_CFLAGS)						\
 	$(NULL)

--- a/daemons/ipa-slapi-plugins/ipa-otp-counter/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-otp-counter/Makefile.am
@@ -2,13 +2,13 @@ PLUGIN_COMMON_DIR = $(srcdir)/../common
 AM_CPPFLAGS =							\
 	-I$(srcdir)						\
 	-I$(PLUGIN_COMMON_DIR)					\
-	-I/usr/include/dirsrv					\
 	-DPREFIX=\""$(prefix)"\" 				\
 	-DBINDIR=\""$(bindir)"\"				\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
 	$(AM_CFLAGS)						\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)						\
 	$(WARN_CFLAGS)
 

--- a/daemons/ipa-slapi-plugins/ipa-otp-lasttoken/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-otp-lasttoken/Makefile.am
@@ -2,13 +2,13 @@ PLUGIN_COMMON_DIR = $(srcdir)/../common
 AM_CPPFLAGS =							\
 	-I$(srcdir)						\
 	-I$(PLUGIN_COMMON_DIR)					\
-	-I/usr/include/dirsrv					\
 	-DPREFIX=\""$(prefix)"\" 				\
 	-DBINDIR=\""$(bindir)"\"				\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
 	$(AM_CFLAGS)						\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)						\
 	$(WARN_CFLAGS)
 

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/Makefile.am
@@ -12,9 +12,11 @@ AM_CPPFLAGS =							\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(CRYPTO_CFLAGS)					\
 	$(LDAP_CFLAGS)						\
 	$(KRB5_CFLAGS)						\
+	$(NSPR_CFLAGS)						\
 	$(NSS_CFLAGS)						\
 	$(WARN_CFLAGS)						\
 	$(NULL)

--- a/daemons/ipa-slapi-plugins/ipa-range-check/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-range-check/Makefile.am
@@ -5,12 +5,12 @@ PLUGIN_COMMON_DIR = $(srcdir)/../common
 AM_CPPFLAGS =							\
 	-I$(srcdir)						\
 	-I$(PLUGIN_COMMON_DIR)					\
-	-I/usr/include/dirsrv					\
 	-DPREFIX=\""$(prefix)"\" 				\
 	-DBINDIR=\""$(bindir)"\"				\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)					\
 	$(WARN_CFLAGS)						\
 	$(NULL)

--- a/daemons/ipa-slapi-plugins/ipa-sidgen/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-sidgen/Makefile.am
@@ -5,12 +5,12 @@ PLUGIN_COMMON_DIR = $(srcdir)/../common
 AM_CPPFLAGS =							\
 	-I$(srcdir)						\
 	-I$(PLUGIN_COMMON_DIR)					\
-	-I/usr/include/dirsrv					\
 	-DPREFIX=\""$(prefix)"\" 				\
 	-DBINDIR=\""$(bindir)"\"				\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)					\
 	$(WARN_CFLAGS)						\
 	$(NULL)

--- a/daemons/ipa-slapi-plugins/ipa-uuid/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-uuid/Makefile.am
@@ -5,12 +5,12 @@ PLUGIN_COMMON_DIR = $(srcdir)/../common
 AM_CPPFLAGS =							\
 	-I$(srcdir)						\
 	-I$(PLUGIN_COMMON_DIR)					\
-	-I/usr/include/dirsrv					\
 	-DPREFIX=\""$(prefix)"\" 				\
 	-DBINDIR=\""$(bindir)"\"				\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)					\
 	$(WARN_CFLAGS)						\
 	$(NULL)

--- a/daemons/ipa-slapi-plugins/ipa-version/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-version/Makefile.am
@@ -6,12 +6,12 @@ AM_CPPFLAGS =							\
 	-I$(srcdir)						\
 	-I$(top_builddir)/daemons/				\
 	-I$(PLUGIN_COMMON_DIR)					\
-	-I/usr/include/dirsrv					\
 	-DPREFIX=\""$(prefix)"\" 				\
 	-DBINDIR=\""$(bindir)"\"				\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)					\
 	$(KRB5_CFLAGS)						\
 	$(WARN_CFLAGS)						\

--- a/daemons/ipa-slapi-plugins/ipa-winsync/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-winsync/Makefile.am
@@ -10,6 +10,7 @@ AM_CPPFLAGS =							\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)					\
 	$(WARN_CFLAGS)						\
 	$(NULL)

--- a/daemons/ipa-slapi-plugins/libotp/Makefile.am
+++ b/daemons/ipa-slapi-plugins/libotp/Makefile.am
@@ -1,6 +1,12 @@
+NULL =
+
 PLUGIN_COMMON_DIR = $(srcdir)/../common
-AM_CPPFLAGS = -I/usr/include/dirsrv		\
-	-I$(PLUGIN_COMMON_DIR)
+AM_CPPFLAGS =							\
+	-I$(PLUGIN_COMMON_DIR)					\
+	$(DIRSRV_CFLAGS)					\
+	$(NSPR_CFLAGS)						\
+	$(NSS_CFLAGS)						\
+	$(NULL)
 
 noinst_LTLIBRARIES = libhotp.la libotp.la
 libhotp_la_SOURCES = hotp.c hotp.h

--- a/daemons/ipa-slapi-plugins/topology/Makefile.am
+++ b/daemons/ipa-slapi-plugins/topology/Makefile.am
@@ -5,12 +5,12 @@ PLUGIN_COMMON_DIR = $(srcdir)/../common
 AM_CPPFLAGS =							\
 	-I$(srcdir)						\
 	-I$(PLUGIN_COMMON_DIR)					\
-	-I/usr/include/dirsrv					\
 	-DPREFIX=\""$(prefix)"\" 				\
 	-DBINDIR=\""$(bindir)"\"				\
 	-DLIBDIR=\""$(libdir)"\" 				\
 	-DLIBEXECDIR=\""$(libexecdir)"\"			\
 	-DDATADIR=\""$(datadir)"\"				\
+	$(DIRSRV_CFLAGS)					\
 	$(LDAP_CFLAGS)					\
 	$(WARN_CFLAGS)						\
 	$(NULL)

--- a/server.m4
+++ b/server.m4
@@ -23,6 +23,8 @@ fi
 
 dnl -- dirsrv is needed for the extdom unit tests --
 PKG_CHECK_MODULES([DIRSRV], [dirsrv  >= 1.3.0])
+# slapi-plugin.h includes nspr.h
+DIRSRV_CFLAGS="$DIRSRV_CFLAGS $NSPR_CFLAGS"
 
 dnl -- sss_idmap is needed by the extdom exop --
 PKG_CHECK_MODULES([SSSIDMAP], [sss_idmap])


### PR DESCRIPTION
Add explicit NSPR_CFLAGS and NSS_CFLAGS where NSPR_LIBS and NSS_LIBS is
used.

Use DIRSRV_CFLAGS rather than hardcode -I/usr/include/dirsrv.

Append NSPR_CFLAGS to DIRSRV_CFLAGS in ./configure as slapi-plugin.h
includes nspr.h.