### PR TITLE
Add make devcheck for developers 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -152,6 +152,35 @@ JSLINT_TARGET = jslint
 endif WITH_JSLINT
 lint: acilint apilint $(POLINT_TARGET) $(PYLINT_TARGET) $(JSLINT_TARGET)
 
+.PHONY: devcheck
+devcheck: all
+if ! WITH_POLINT
+	@echo "ERROR: polint not available"; exit 1
+endif
+if ! WITH_PYLINT
+	@echo "ERROR: pylint not available"; exit 1
+endif
+if ! WITH_JSLINT
+	@echo "ERROR: jslint not available"; exit 1
+endif
+if ! WITH_PYTHON2
+	@echo "ERROR: python2 not available"; exit 1
+endif
+	@ # run all linters, tests, and check with Python 2
+	PYTHONPATH=$(top_srcdir) $(PYTHON2) ipatests/ipa-run-tests \
+	    --ipaclient-unittests
+	$(MAKE) $(AM_MAKEFLAGS) acilint apilint polint jslint check
+	$(MAKE) $(AM_MAKEFLAGS) PYTHON=$(PYTHON2) pylint
+if WITH_PYTHON3
+	@ # just tests and pylint on Python 3
+	PYTHONPATH=$(top_srcdir) $(PYTHON3) ipatests/ipa-run-tests \
+	    --ipaclient-unittests
+	$(MAKE) $(AM_MAKEFLAGS) PYTHON=$(PYTHON3) pylint
+else
+	@echo "WARNING: python3 not available"
+endif
+	@echo "All tests passed."
+
 .PHONY: $(top_builddir)/ipapython/version.py
 $(top_builddir)/ipapython/version.py:
 	(cd $(top_builddir)/ipapython && make version.py)
@@ -188,7 +217,7 @@ pylint: $(top_builddir)/ipapython/version.py ipasetup.py
 		-name '*~' -o \
 		-name '*.py' -print -o \
 		-type f -exec grep -qsm1 '^#!.*\bpython' '{}' \; -print`; \
-	echo "Pylint is running, please wait ..."; \
+	echo "Pylint on $(PYTHON) is running, please wait ..."; \
 	PYTHONPATH=$(top_srcdir) $(PYTHON) -m pylint \
 		--rcfile=$(top_srcdir)/pylintrc \
 		--load-plugins pylint_plugins \

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,18 @@ if test "x$PYTHON" = "x" ; then
 fi
 
 dnl ---------------------------------------------------------------------------
+dnl - Check for Python 2/3 for devcheck
+dnl ---------------------------------------------------------------------------
+
+AC_PATH_PROG(PYTHON2, python2)
+AC_SUBST([PYTHON2])
+AM_CONDITIONAL([WITH_PYTHON2], [test "x${PYTHON2}" != "x"])
+
+AC_PATH_PROG(PYTHON3, python3)
+AC_SUBST([PYTHON3])
+AM_CONDITIONAL([WITH_PYTHON3], [test "x${PYTHON3}" != "x"])
+
+dnl ---------------------------------------------------------------------------
 dnl - Check for cmocka unit test framework http://cmocka.cryptomilk.org/
 dnl ---------------------------------------------------------------------------
 PKG_CHECK_EXISTS(cmocka,

--- a/ipatests/test_ipapython/test_session_storage.py
+++ b/ipatests/test_ipapython/test_session_storage.py
@@ -5,7 +5,6 @@
 """
 Test the `session_storage.py` module.
 """
-
 from ipapython import session_storage
 
 

--- a/ipatests/test_ipapython/test_session_storage.py
+++ b/ipatests/test_ipapython/test_session_storage.py
@@ -5,9 +5,12 @@
 """
 Test the `session_storage.py` module.
 """
+import pytest
+
 from ipapython import session_storage
 
 
+@pytest.mark.skip_ipaclient_unittest
 class test_session_storage(object):
     """
     Test the session storage interface


### PR DESCRIPTION
Ticket 6604 makes pylint and jsl optional dependencies. The change
is controversal, because some developers prefer that pylint and jsl
should be required unless explicitly disabled.

`make patchcheck` is my answer to address the concerns. It's a superior
solution to `make lint` as pre-commit check. It combines several
additional checks under a single, easy rememberable and convenient make
target:

* build all
* acilint, apiclient, jslint, polint
* make check
* pylint under Python 2 and 3
* subset of unit test suite

https://fedorahosted.org/freeipa/ticket/6604

Depends on 

- [X] #475
- [X] #587 
- [X] #594
- [x] #636
- [x] #670