### PR TITLE
Fix Python 3 pylint errors

### DIFF
--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -225,11 +225,11 @@ def install_master(safe_options, options):
     try:
         ca.subject_validator(ca.VALID_SUBJECT_BASE_ATTRS, options.subject_base)
     except ValueError as e:
-        sys.exit("Subject base: {}".format(e.message))
+        sys.exit("Subject base: {}".format(e))
     try:
         ca.subject_validator(ca.VALID_SUBJECT_ATTRS, options.ca_subject)
     except ValueError as e:
-        sys.exit("CA subject: {}".format(e.message))
+        sys.exit("CA subject: {}".format(e))
 
     ca.install_check(True, None, options)
     ca.install(True, None, options)

--- a/ipapython/install/core.py
+++ b/ipapython/install/core.py
@@ -11,7 +11,6 @@ import collections
 import functools
 import itertools
 import sys
-import types
 
 import six
 
@@ -24,6 +23,7 @@ __all__ = ['InvalidStateError', 'KnobValueError', 'Property', 'knob',
            'Configurable', 'group', 'Component', 'Composite']
 
 NoneType = type(None)
+builtin_type = type
 
 # Configurable states
 _VALIDATE_PENDING = 'VALIDATE_PENDING'
@@ -160,7 +160,7 @@ def _knob(type=_missing, default=_missing, bases=_missing, _order=_missing,
 
     if bases is _missing:
         bases = (KnobBase,)
-    elif isinstance(bases, types.TypeType):
+    elif isinstance(bases, builtin_type):
         bases = (bases,)
 
     if cli_names is None or isinstance(cli_names, str):

--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 
 import sys
 import tempfile
-from optparse import SUPPRESS_HELP
+from optparse import SUPPRESS_HELP  # pylint: disable=deprecated-module
 
 from textwrap import dedent
 from ipalib import api

--- a/ipatests/test_ipapython/test_dn.py
+++ b/ipatests/test_ipapython/test_dn.py
@@ -1202,7 +1202,7 @@ class TestDN(unittest.TestCase):
         longdn_rev = DN(longdn_x500)
         l = len(self.base_container_dn)
         for i in range(l):
-            self.assertEquals(longdn_rev[i], self.base_container_dn[l-1-i])
+            self.assertEqual(longdn_rev[i], self.base_container_dn[l-1-i])
 
 
 class TestEscapes(unittest.TestCase):


### PR DESCRIPTION
```
************* Module ipaserver.install.ipa_kra_install
ipaserver/install/ipa_kra_install.py:25: [W0402(deprecated-module), ] Uses of a deprecated module 'optparse')
************* Module ipapython.install.core
ipapython/install/core.py:163: [E1101(no-member), _knob] Module 'types' has no 'TypeType' member)
************* Module ipatests.test_ipapython.test_dn
ipatests/test_ipapython/test_dn.py:1205: [W1505(deprecated-method), TestDN.test_x500_text] Using deprecated method assertEquals())
************* Module ipa-ca-install
install/tools/ipa-ca-install:228: [E1101(no-member), install_master] Instance of 'ValueError' has no 'message' member)
install/tools/ipa-ca-install:232: [E1101(no-member), install_master] Instance of 'ValueError' has no 'message' member)
```

Signed-off-by: Christian Heimes <cheimes@redhat.com>