### PR TITLE
Add PYTHON_INSTALL_EXTRA_OPTIONS and --install-layout=deb

### DIFF
--- a/Makefile.python.am
+++ b/Makefile.python.am
@@ -28,7 +28,8 @@ install-exec-local: $(top_builddir)/ipasetup.py
 		        --prefix "$(DESTDIR)$(prefix)" \
 		        --single-version-externally-managed \
 		        --record "$(DESTDIR)$(pkgpythondir)/install_files.txt" \
-		        --optimize 1; \
+		        --optimize 1 \
+		        $(PYTHON_INSTALL_EXTRA_OPTIONS); \
 	fi
 
 uninstall-local:

--- a/configure.ac
+++ b/configure.ac
@@ -284,6 +284,14 @@ fi
 AC_SUBST([IPAPLATFORM])
 AC_MSG_RESULT([${IPAPLATFORM}])
 
+if test "x${IPAPLATFORM}" == "xdebian"; then
+    # see https://www.debian.org/doc/packaging-manuals/python-policy/ap-packaging_tools.html
+    PYTHON_INSTALL_EXTRA_OPTIONS="--install-layout=deb"
+else
+    PYTHON_INSTALL_EXTRA_OPTIONS=""
+fi
+AC_SUBST([PYTHON_INSTALL_EXTRA_OPTIONS])
+AC_MSG_RESULT([python setup.py install extra options ${PYTHON_INSTALL_EXTRA_OPTIONS}])
 
 dnl ---------------------------------------------------------------------------
 dnl Version information from VERSION.m4 and command line


### PR DESCRIPTION
Debian packages should be installed under dist-packages, not
site-packages. Debian has patched distutils and setuptools to add a new
flag '--install-layout'. For --with-ipaplatform=debian,
PYTHON_INSTALL_EXTRA_OPTIONS is set to '--install-layout=deb'.

https://pagure.io/freeipa/issue/6764

Signed-off-by: Christian Heimes <cheimes@redhat.com>