### PR TITLE
CONFIGURE: Improve detection of xmlrpc_c flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,7 +171,20 @@ PKG_CHECK_MODULES([SASL], [libsasl2])
 dnl ---------------------------------------------------------------------------
 dnl - Check for XMLRPC-C
 dnl ---------------------------------------------------------------------------
-PKG_CHECK_MODULES([XMLRPC], [xmlrpc xmlrpc_client xmlrpc_util])
+PKG_CHECK_MODULES([XMLRPC], [xmlrpc xmlrpc_client xmlrpc_util], [],
+                  [try_xmlrpc_fallback=true])
+if test x"$try_xmlrpc_fallback" = xtrue; then
+    XMLRPC_LIBS=
+    AC_CHECK_HEADER([xmlrpc-c/base.h], [],
+                    [AC_MSG_ERROR([xmlrpc-c/base.h not found])])
+
+    AC_CHECK_LIB([xmlrpc_client], [xmlrpc_client_init2],
+                 [XMLRPC_LIBS="-lxmlrpc -lxmlrpc_client -lxmlrpc_util"])
+    if test "x$XMLRPC_LIBS" = "x" ; then
+        AC_MSG_ERROR([xmlrpc-c not found])
+    fi
+    AC_SUBST(XMLRPC_LIBS)
+fi
 
 dnl ---------------------------------------------------------------------------
 dnl - Check for libintl


### PR DESCRIPTION
The pkg-config files for xmlrpc_c libraries are shipped just
in fedora/rhel due to downstream patch. Debian does not have
pkg-config files for xmlrpc_c. Therefore we need to fallback to older
method of detection XMLRPC_*FLAGS which was reverted
by the commit 1e0143c159134337a00a91d4ae64e614f72da62e