### PR TITLE
[4.5] Set zanata version to ipa-4-5

### DIFF
--- a/zanata.xml
+++ b/zanata.xml
@@ -2,7 +2,7 @@
 <config xmlns="http://zanata.org/namespace/config/">
   <url>https://fedora.zanata.org/</url>
   <project>freeipa</project>
-  <project-version>master</project-version>
+  <project-version>ipa-4-5</project-version>
   <project-type>gettext</project-type>
   <src-dir>.</src-dir>
   <trans-dir>.</trans-dir>


### PR DESCRIPTION
Regular after-releas update, zanata branch has been created https://fedora.zanata.org/iteration/view/freeipa/ipa-4-5