### PR TITLE
Backup ipa-specific httpd unit-file

### DIFF
--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -166,6 +166,7 @@ class Backup(admintool.AdminTool):
         paths.KDC_CERT,
         paths.KDC_KEY,
         paths.SYSTEMD_IPA_SERVICE,
+        paths.SYSTEMD_SYSTEM_HTTPD_IPA_CONF,
         paths.SYSTEMD_SSSD_SERVICE,
         paths.SYSTEMD_CERTMONGER_SERVICE,
         paths.SYSTEMD_PKI_TOMCAT_SERVICE,

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -414,6 +414,8 @@ class Restore(admintool.AdminTool):
                 sssd = services.service('sssd', api)
                 sssd.restart()
                 http.remove_httpd_ccaches()
+                # have the daemons pick up their restored configs
+                run([paths.SYSTEMCTL, "--system", "daemon-reload"])
         finally:
             try:
                 os.chdir(cwd)


### PR DESCRIPTION
On backup-restore, the ipa unit file for httpd was not backed up.
This file however contains setting for httpd to communicate with
gssproxy so not backing it up will result in httpd not knowing
how to get credentials.

https://pagure.io/freeipa/issue/6748