### PR TITLE
[4.4] Fix cookie with Max-Age processing

### DIFF
--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -699,8 +699,11 @@ class KerbTransport(SSLTransport):
 
         # Search for the session cookie
         try:
-            session_cookie = Cookie.get_named_cookie_from_string(cookie_header,
-                                                                 COOKIE_NAME, request_url)
+            session_cookie = (
+                    Cookie.get_named_cookie_from_string(
+                        cookie_header, COOKIE_NAME, request_url,
+                        timestamp=datetime.datetime.utcnow())
+            )
         except Exception as e:
             root_logger.error("unable to parse cookie header '%s': %s", cookie_header, e)
             return
@@ -794,8 +797,10 @@ class RPCClient(Connectible):
 
         # Search for the session cookie within the cookie string
         try:
-            session_cookie = Cookie.get_named_cookie_from_string(cookie_string, COOKIE_NAME)
-        except Exception as e:
+            session_cookie = Cookie.get_named_cookie_from_string(
+                cookie_string, COOKIE_NAME,
+                timestamp=datetime.datetime.utcnow())
+        except Exception:
             return None
 
         return session_cookie

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -800,7 +800,10 @@ class RPCClient(Connectible):
             session_cookie = Cookie.get_named_cookie_from_string(
                 cookie_string, COOKIE_NAME,
                 timestamp=datetime.datetime.utcnow())
-        except Exception:
+        except Exception as e:
+            self.log.debug(
+                'Error retrieving cookie from the persistent storage: {err}'
+                .format(err=e))
             return None
 
         return session_cookie

--- a/ipapython/cookie.py
+++ b/ipapython/cookie.py
@@ -320,7 +320,8 @@ class Cookie(object):
         return cookies
 
     @classmethod
-    def get_named_cookie_from_string(cls, cookie_string, cookie_name, request_url=None):
+    def get_named_cookie_from_string(cls, cookie_string, cookie_name,
+                                     request_url=None, timestamp=None):
         '''
         A cookie string may contain multiple cookies, parse the cookie
         string and return the last cookie in the string matching the
@@ -342,6 +343,8 @@ class Cookie(object):
             if cookie.key == cookie_name:
                 target_cookie = cookie
 
+        if timestamp is not None:
+            target_cookie.timestamp = timestamp
         if request_url is not None:
             target_cookie.normalize(request_url)
         return target_cookie


### PR DESCRIPTION
When cookie has Max-Age set it tries to get expiration by adding
to a timestamp. Without this patch the timestamp would be set to
None and thus the addition of timestamp + max_age fails

https://pagure.io/freeipa/issue/6718