### PR TITLE
[4.5] Constrain wheel package versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ freeipa2-dev-doc
 /rpmbuild/
 # Build
 /ipasetup.py
+/.wheelconstraints
 *.egg-info
 
 # Subdirectories

--- a/.wheelconstraints.in
+++ b/.wheelconstraints.in
@@ -1,0 +1,11 @@
+# placeholder
+freeipa == @VERSION@
+ipa == @VERSION@
+# actual packages
+ipaclient == @VERSION@
+ipalib == @VERSION@
+ipaplatform == @VERSION@
+ipapython == @VERSION@
+ipaserver == @VERSION@
+ipatests == @VERSION@
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,11 @@ ipasetup.py: ipasetup.py.in $(CONFIG_STATUS)
 		-e 's|@VERSION[@]|$(VERSION)|g'			\
 		$< > $@
 
+.wheelconstraints: .wheelconstraints.in $(CONFIG_STATUS)
+	$(AM_V_GEN)sed						\
+		-e 's|@VERSION[@]|$(VERSION)|g'			\
+		$< > $@
+
 EXTRA_DIST = .mailmap \
 	     ACI.txt \
 	     API.txt \
@@ -46,7 +51,8 @@ EXTRA_DIST = .mailmap \
 	     doc \
 	     freeipa.spec.in \
 	     ipasetup.py.in \
-	     pylintrc
+	     pylintrc \
+	     .wheelconstraints.in
 
 clean-local:
 	rm -rf "$(RPMBUILD)"
@@ -232,8 +238,15 @@ bdist_wheel: $(WHEELDISTDIR)
 	    $(MAKE) $(AM_MAKEFLAGS) -C $${dir} $@ || exit 1; \
 	done
 
-wheel_bundle: $(WHEELBUNDLEDIR) bdist_wheel
-	$(PYTHON) -m pip wheel --wheel-dir $(WHEELBUNDLEDIR) $(WHEELDISTDIR)/*.whl
+wheel_bundle: $(WHEELBUNDLEDIR) bdist_wheel .wheelconstraints
+	rm -f $(foreach item,$(IPACLIENT_SUBDIRS),$(WHEELBUNDLEDIR)/$(item)-*.whl)
+	$(PYTHON) -m pip wheel \
+	    --disable-pip-version-check \
+	    --constraint .wheelconstraints \
+	    --find-links $(WHEELDISTDIR) \
+	    --find-links $(WHEELBUNDLEDIR) \
+	    --wheel-dir $(WHEELBUNDLEDIR) \
+	    $(IPACLIENT_SUBDIRS)
 
 wheel_placeholder: $(WHEELDISTDIR)
 	for dir in $(IPA_PLACEHOLDERS); do \


### PR DESCRIPTION
The presence of IPA packages on PyPI revealed an interesting issue with
make wheel_bundle. pip gives final releases a higher precedence than our
development packages. make wheel_bundle downloads ipa 4.5.0 from PyPI
instead of using our own wheels.

Use a constraint file to enforce correct versions.

https://pagure.io/freeipa/issue/6468

Signed-off-by: Christian Heimes <cheimes@redhat.com>