### PR TITLE
httpinstance: clean up /etc/httpd/alias on uninstall

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -169,6 +169,19 @@ class NSSDatabase(object):
                     new_mode = filemode
                 os.chmod(path, new_mode)
 
+    def restore(self):
+        for filename in NSS_FILES:
+            path = os.path.join(self.secdir, filename)
+            backup_path = path + '.orig'
+            save_path = path + '.ipasave'
+            try:
+                if os.path.exists(path):
+                    os.rename(path, save_path)
+                if os.path.exists(backup_path):
+                    os.rename(backup_path, path)
+            except OSError as e:
+                root_logger.debug(e)
+
     def list_certs(self):
         """Return nicknames and cert flags for all certs in the database
 

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -234,6 +234,9 @@ class CertDB(object):
                              backup=True)
         self.set_perms(self.passwd_fname, write=True)
 
+    def restore(self):
+        self.nssdb.restore()
+
     def list_certs(self):
         """
         Return a tuple of tuples containing (nickname, trust)

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -635,7 +635,6 @@ class CertDB(object):
         self.cacert_name = ca_names[-1]
         self.trust_root_cert(self.cacert_name, trust_flags)
 
-        self.create_pin_file()
         self.export_ca_cert(nickname, False)
 
     def publish_ca_cert(self, location):

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -838,7 +838,8 @@ class DsInstance(service.Service):
                 certmonger.modify_ca_helper('IPA', prev_helper)
 
             self.dercert = dsdb.get_cert_from_db(self.nickname, pem=False)
-            dsdb.create_pin_file()
+
+        dsdb.create_pin_file()
 
         self.cacert_name = dsdb.cacert_name
 

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -555,6 +555,9 @@ class HTTPInstance(service.Service):
                 ca_iface.Set('org.fedorahosted.certmonger.ca',
                              'external-helper', helper)
 
+        db = certs.CertDB(self.realm, paths.HTTPD_ALIAS_DIR)
+        db.restore()
+
         for f in [paths.HTTPD_IPA_CONF, paths.HTTPD_SSL_CONF, paths.HTTPD_NSS_CONF]:
             try:
                 self.fstore.restore_file(f)


### PR DESCRIPTION
**certs: do not implicitly create DS pin.txt**

Do not implicitly create DS pin.txt in `CertDB.init_from_pkcs12()`, create
it explicitly in `DSInstance.__enable_ssl()`.

This stops the file from being created in /etc/httpd/alias during classic
replica install.

**httpinstance: clean up /etc/httpd/alias on uninstall**

Restore cert8.db, key3.db, pwdfile.txt and secmod.db in /etc/httpd/alias
from backup on uninstall.

Files modified by IPA are kept with .ipasave suffix.

https://pagure.io/freeipa/issue/4639