### PR TITLE
pytest 3.x compatibility

### DIFF
--- a/ipatests/test_cmdline/__init__.py
+++ b/ipatests/test_cmdline/__init__.py
@@ -1,9 +1,7 @@
 #
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
+import ipatests.util
 
-import pytest
 
-
-if pytest.config.getoption('ipaclient_unittests', False):
-    pytest.skip("Skip in ipaclient unittest mode")
+ipatests.util.check_ipaclient_unittests()

--- a/ipatests/test_install/__init__.py
+++ b/ipatests/test_install/__init__.py
@@ -20,8 +20,7 @@
 """
 Package containing LDAP updates unit tests.
 """
-import pytest
+import ipatests.util
 
 
-if pytest.config.getoption('ipaclient_unittests', False):
-    pytest.skip("Skip in ipaclient unittest mode")
+ipatests.util.check_ipaclient_unittests()

--- a/ipatests/test_integration/__init__.py
+++ b/ipatests/test_integration/__init__.py
@@ -16,8 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import pytest
+import ipatests.util
 
 
-if pytest.config.getoption('ipaclient_unittests', False):
-    pytest.skip("Skip in ipaclient unittest mode")
+ipatests.util.check_ipaclient_unittests()

--- a/ipatests/test_ipaserver/__init__.py
+++ b/ipatests/test_ipaserver/__init__.py
@@ -20,9 +20,7 @@
 """
 Sub-package containing unit tests for `ipaserver` package.
 """
+import ipatests.util
 
-import pytest
 
-
-if pytest.config.getoption('ipaclient_unittests', False):
-    pytest.skip("Skip in ipaclient unittest mode")
+ipatests.util.check_ipaclient_unittests()

--- a/ipatests/test_webui/__init__.py
+++ b/ipatests/test_webui/__init__.py
@@ -20,8 +20,7 @@
 """
 Sub-package containing Web UI integration tests
 """
-import pytest
+import ipatests.util
 
 
-if pytest.config.getoption('ipaclient_unittests', False):
-    pytest.skip("Skip in ipaclient unittest mode")
+ipatests.util.check_ipaclient_unittests()

--- a/ipatests/test_xmlrpc/__init__.py
+++ b/ipatests/test_xmlrpc/__init__.py
@@ -20,8 +20,7 @@
 """
 Sub-package containing unit tests for `xmlrpc` package.
 """
-import pytest
+import ipatests.util
 
 
-if pytest.config.getoption('ipaclient_unittests', False):
-    pytest.skip("Skip in ipaclient unittest mode")
+ipatests.util.check_ipaclient_unittests()

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -61,6 +61,22 @@ if six.PY3:
     unicode = str
 
 
+PYTEST_VERSION = tuple(int(v) for v in pytest.__version__.split('.'))
+
+
+def check_ipaclient_unittests(reason="Skip in ipaclient unittest mode"):
+    """Call this in a package to skip the package in ipaclient-unittest mode
+    """
+    if pytest.config.getoption('ipaclient_unittests', False):
+        if PYTEST_VERSION[0] >= 3:
+            # pytest 3+ does no longer allow pytest.skip() on module level
+            # pylint: disable=unexpected-keyword-arg
+            raise pytest.skip.Exception(reason, allow_module_level=True)
+            # pylint: enable=unexpected-keyword-arg
+        else:
+            raise pytest.skip(reason)
+
+
 class TempDir(object):
     def __init__(self):
         self.__path = tempfile.mkdtemp(prefix='ipa.tests.')


### PR DESCRIPTION
pytest 3.x does no longer support plain pytest.skip() on module level.

Signed-off-by: Christian Heimes <cheimes@redhat.com>