### PR TITLE
ipa-replica-install:  fix domain level 0 remote LDAP connection

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1391,7 +1391,16 @@ def install(installer):
     dsinstance.create_ds_user()
 
     try:
-        conn.connect(ccache=ccache)
+        if promote:
+            conn.connect(ccache=ccache)
+        else:
+            # dmlvl 0 replica install should always use DM credentials
+            # to create remote LDAP connection. Since ACIs permitting hosts
+            # to manage their own services were added in 4.2 release,
+            # the master denies this operations.
+            conn.connect(bind_dn=ipaldap.DIRMAN_DN, cacert=cafile,
+                         bind_pw=config.dirman_password)
+
         # Update and istall updated CA file
         cafile = install_ca_cert(conn, api.env.basedn, api.env.realm, cafile)
 


### PR DESCRIPTION
In order to fix https://pagure.io/freeipa/issue/6549. 

First of all, I tried at `ipaserver/server/install/replicainstall.py:1393`:
```python
try:
    domain_level = current_domain_level(remote_api)
    if domain_level != 0:
        conn.connect(bind_dn=ipaldap.DIRMAN_DN, bind_pw=config.dirman_password,
                 cacert=cafile)
    else:
        conn.connect(ccache=ccache)
```

However, the current_domain_level method was raising this exception:
```
ipa.ipapython.install.cli.install_tool(CompatServerReplicaInstall):
    ERROR    ldap2 is not connected (ldap2_140240602559056 in MainThread)
```

So, I created a connection first, then I check the domain level. 
If the domain level is 0 the connection is already created properly. If the domain level is not 0, then it should create using the ccache (how it was before). 

This PR fixes the error specified at the [bug #6549](https://pagure.io/freeipa/issue/6549), however it doesn't fix the entire ipa-replica-install process.  This is the output when running `sudo ipa-replica-install replica-info-vm-058-186.abc.idm.lab.eng.brq.redhat.com.gpg --skip-conncheck`

```
WARNING: conflicting time&date synchronization service 'chronyd' will
be disabled in favor of ntpd

Directory Manager (existing master) password: 

Configuring NTP daemon (ntpd)
  [1/4]: stopping ntpd
  [2/4]: writing configuration
  [3/4]: configuring ntpd to start on boot
  [4/4]: starting ntpd
Done configuring NTP daemon (ntpd).
Configuring directory server (dirsrv). Estimated time: 30 seconds
  [1/44]: creating directory server user
  [2/44]: creating directory server instance
  [3/44]: enabling ldapi
  [4/44]: configure autobind for root
  [5/44]: stopping directory server
  [6/44]: updating configuration in dse.ldif
  [7/44]: starting directory server
  [8/44]: adding default schema
  [9/44]: enabling memberof plugin
  [10/44]: enabling winsync plugin
  [11/44]: configuring replication version plugin
  [12/44]: enabling IPA enrollment plugin
  [13/44]: configuring uniqueness plugin
  [14/44]: configuring uuid plugin
  [15/44]: configuring modrdn plugin
  [16/44]: configuring DNS plugin
  [17/44]: enabling entryUSN plugin
  [18/44]: configuring lockout plugin
  [19/44]: configuring topology plugin
  [20/44]: creating indices
  [21/44]: enabling referential integrity plugin
  [22/44]: configuring TLS for DS instance
  [23/44]: configuring certmap.conf
  [24/44]: configure new location for managed entries
  [25/44]: configure dirsrv ccache
  [26/44]: enabling SASL mapping fallback
  [27/44]: restarting directory server
  [28/44]: creating DS keytab
  [29/44]: setting up initial replication
Starting replication, please wait until this has completed.
Update in progress, 6 seconds elapsed
Update succeeded

  [30/44]: adding sasl mappings to the directory
  [31/44]: updating schema
  [32/44]: setting Auto Member configuration
  [33/44]: enabling S4U2Proxy delegation
  [34/44]: importing CA certificates from LDAP
  [35/44]: initializing group membership
  [36/44]: adding master entry
  [37/44]: initializing domain level
  [38/44]: configuring Posix uid/gid generation
  [39/44]: adding replication acis
  [40/44]: enabling compatibility plugin
  [41/44]: activating sidgen plugin
  [42/44]: activating extdom plugin
  [43/44]: tuning directory server
  [44/44]: configuring directory to start on boot
Done configuring directory server (dirsrv).
Configuring Kerberos KDC (krb5kdc)
  [1/4]: configuring KDC
  [2/4]: adding the password extension to the directory
  [3/4]: starting the KDC
  [4/4]: configuring KDC to start on boot
Done configuring Kerberos KDC (krb5kdc).
Configuring kadmin
  [1/2]: starting kadmin 
  [2/2]: configuring kadmin to start on boot
Done configuring kadmin.
Restarting directory server to enable password extension plugin
Configuring the web interface (httpd)
  [1/22]: setting mod_nss port to 443
  [2/22]: setting mod_nss cipher suite
  [3/22]: setting mod_nss protocol list to TLSv1.0 - TLSv1.2
  [4/22]: setting mod_nss password file
  [5/22]: enabling mod_nss renegotiate
  [6/22]: adding URL rewriting rules
  [7/22]: configuring httpd
  [8/22]: setting up httpd keytab
  [9/22]: retrieving anonymous keytab
  [error] CalledProcessError: Command '/usr/sbin/ipa-getkeytab -k /var/lib/ipa/api/anon.keytab -p WELLKNOWN/ANONYMOUS -H ldapi://%2fvar%2frun%2fslapd-DOM-133-ABC-IDM-LAB-ENG-BRQ-REDHAT-COM.socket -Y EXTERNAL' returned non-zero exit status 9
Your system may be partly configured.
Run /usr/sbin/ipa-server-install --uninstall to clean up.

ipa.ipapython.install.cli.install_tool(CompatServerReplicaInstall): ERROR    Command '/usr/sbin/ipa-getkeytab -k /var/lib/ipa/api/anon.keytab -p WELLKNOWN/ANONYMOUS -H ldapi://%2fvar%2frun%2fslapd-DOM-133-ABC-IDM-LAB-ENG-BRQ-REDHAT-COM.socket -Y EXTERNAL' returned non-zero exit status 9
ipa.ipapython.install.cli.install_tool(CompatServerReplicaInstall): ERROR    The ipa-replica-install command failed. See /var/log/ipareplica-install.log for more information
```