### PR TITLE
replica prepare: fix wrong IPA CA nickname in replica file

### DIFF
--- a/ipaserver/install/ipa_replica_prepare.py
+++ b/ipaserver/install/ipa_replica_prepare.py
@@ -34,7 +34,7 @@ import dns.resolver
 from six.moves.configparser import SafeConfigParser
 # pylint: enable=import-error
 
-from ipaserver.install import certs, installutils, bindinstance, dsinstance
+from ipaserver.install import certs, installutils, bindinstance, dsinstance, ca
 from ipaserver.install.replication import enable_replication_version_checking
 from ipaserver.install.server.replicainstall import install_ca_cert
 from ipaserver.install.bindinstance import (
@@ -537,12 +537,13 @@ class ReplicaPrepare(admintool.AdminTool):
         """
         hostname = self.replica_fqdn
         subject_base = self.subject_base
+        ca_subject = ca.lookup_ca_subject(api, subject_base)
         nickname = "Server-Cert"
 
         try:
             db = certs.CertDB(
-                api.env.realm, nssdir=self.dir, subject_base=subject_base,
-                host_name=api.env.host)
+                api.env.realm, nssdir=self.dir, host_name=api.env.host,
+                subject_base=subject_base, ca_subject=ca_subject)
             db.create_passwd_file()
             db.create_from_cacert()
             db.create_server_cert(nickname, hostname)


### PR DESCRIPTION
Lookup IPA CA subject and pass it to CertDB when creating dscert.p12 and
httpcert.p12, otherwise a generic nickname will be used for the IPA CA
certificate instead of "$REALM IPA CA".

This fixes replica install on domain level 0 from a replica file created
using ipa-replica-install on IPA 4.5.

https://pagure.io/freeipa/issue/6777