### PR TITLE
client install: do not assume /etc/krb5.conf.d exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,6 @@ freeipa2-dev-doc
 /daemons/dnssec/ipa-ods-exporter.socket
 /daemons/ipa-kdb/ipa_kdb_tests
 /daemons/ipa-kdb/tests/.dirstamp
-/daemons/ipa-kdb/ipa-certauth
 /daemons/ipa-otpd/ipa-otpd
 /daemons/ipa-otpd/ipa-otpd.socket
 /daemons/ipa-otpd/ipa-otpd@.service

--- a/daemons/ipa-kdb/Makefile.am
+++ b/daemons/ipa-kdb/Makefile.am
@@ -44,12 +44,6 @@ dist_noinst_DATA = ipa_kdb.exports
 
 if BUILD_IPA_CERTAUTH_PLUGIN
 ipadb_la_SOURCES += ipa_kdb_certauth.c
-
-
-krb5confdir = $(sysconfdir)/krb5.conf.d
-krb5conf_DATA = ipa-certauth
-else
-dist_noinst_DATA += ipa-certauth
 endif
 
 ipadb_la_LDFLAGS = 		\

--- a/daemons/ipa-kdb/ipa-certauth
+++ b/daemons/ipa-kdb/ipa-certauth
@@ -1,5 +1,0 @@
-[plugins]
- certauth = {
-  module = ipakdb:kdb/ipadb.so
-  enable_only = ipakdb
- }

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1202,7 +1202,6 @@ fi
 %attr(0755,root,root) %{_libexecdir}/ipa/oddjob/org.freeipa.server.conncheck
 %config(noreplace) %{_sysconfdir}/dbus-1/system.d/org.freeipa.server.conf
 %config(noreplace) %{_sysconfdir}/oddjobd.conf.d/ipa-server.conf
-%config(noreplace) %{_sysconfdir}/krb5.conf.d/ipa-certauth
 %dir %{_libexecdir}/ipa/certmonger
 %attr(755,root,root) %{_libexecdir}/ipa/certmonger/*
 # NOTE: systemd specific section

--- a/install/share/krb5.conf.template
+++ b/install/share/krb5.conf.template
@@ -1,4 +1,4 @@
-includedir /etc/krb5.conf.d/
+$INCLUDES
 includedir /var/lib/sss/pubconf/krb5.include.d/
 
 [logging]
@@ -35,3 +35,8 @@ $OTHER_DOMAIN_REALM_MAPS
     db_library = ipadb.so
   }
 
+[plugins]
+ certauth = {
+  module = ipakdb:kdb/ipadb.so
+  enable_only = ipakdb
+ }

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -641,13 +641,17 @@ def configure_krb5_conf(
             'value': 'File modified by ipa-client-install'
         },
         krbconf.emptyLine(),
-        {
-            'name': 'includedir',
-            'type': 'option',
-            'value': paths.COMMON_KRB5_CONF_DIR,
-            'delim': ' '
-        }
     ]
+
+    if os.path.exists(paths.COMMON_KRB5_CONF_DIR):
+        opts.extend([
+            {
+                'name': 'includedir',
+                'type': 'option',
+                'value': paths.COMMON_KRB5_CONF_DIR,
+                'delim': ' '
+            }
+        ])
 
     # SSSD include dir
     if configure_sssd:

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -249,6 +249,11 @@ class KrbInstance(service.Service):
             root_logger.critical("krb5kdc service failed to start")
 
     def __setup_sub_dict(self):
+        if os.path.exists(paths.COMMON_KRB5_CONF_DIR):
+            includes = 'includedir {}'.format(paths.COMMON_KRB5_CONF_DIR)
+        else:
+            includes = ''
+
         self.sub_dict = dict(FQDN=self.fqdn,
                              IP=self.ip,
                              PASSWORD=self.kdc_password,
@@ -264,7 +269,8 @@ class KrbInstance(service.Service):
                              KDC_KEY=paths.KDC_KEY,
                              CACERT_PEM=paths.CACERT_PEM,
                              KDC_CA_BUNDLE_PEM=paths.KDC_CA_BUNDLE_PEM,
-                             CA_BUNDLE_PEM=paths.CA_BUNDLE_PEM)
+                             CA_BUNDLE_PEM=paths.CA_BUNDLE_PEM,
+                             INCLUDES=includes)
 
         # IPA server/KDC is not a subdomain of default domain
         # Proper domain-realm mapping needs to be specified


### PR DESCRIPTION
Add `includedir /etc/krb5.conf.d` to /etc/krb5.conf only if
/etc/krb5.conf.d exists.

This fixes client install on platforms which do not have /etc/krb5.conf.d.

https://pagure.io/freeipa/issue/6589