### PR TITLE
Use connection keep-alive

### DIFF
--- a/install/conf/ipa.conf
+++ b/install/conf/ipa.conf
@@ -1,5 +1,5 @@
 #
-# VERSION 24 - DO NOT REMOVE THIS LINE
+# VERSION 25 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -19,6 +19,11 @@ DirectoryIndex index.html
 # Substantially increase the request field size to support MS-PAC
 # requests, ticket #2767. This should easily support a 64KiB PAC.
 LimitRequestFieldSize 100000
+
+# Increase connection keep alive time. Default value is 5 seconds, which is too
+# short for interactive ipa commands. 30 seconds is a good compromise.
+KeepAlive On
+KeepAliveTimeout 30
 
 # ipa-rewrite.conf is loaded separately
 

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -686,7 +686,7 @@ class KerbTransport(SSLTransport):
                 return self.parse_response(response)
         except gssapi.exceptions.GSSError as e:
             self._handle_exception(e)
-        finally:
+        except BaseException:
             self.close()
 
     if six.PY3:


### PR DESCRIPTION
Do not forcefully close the connection after every request. This enables
HTTP connection keep-alive, also known as persistent TCP and TLS/SSL
connection. Keep-alive speed up consecutive HTTP requests by 15% (for
local, low-latency network connections to a fast server) to multiple
times (high latency connections or remote peers).

pache has a default keep alive timeout of 5 seconds. That's too low for
interactive commands, e.g. password prompts. 30 seconds sounds like a
good compromise.

https://pagure.io/freeipa/issue/6641