### PR TITLE
[RFC] remote plugins: add option to force compat plugins

### DIFF
--- a/ipaclient/remote_plugins/schema.py
+++ b/ipaclient/remote_plugins/schema.py
@@ -521,6 +521,9 @@ class Schema(object):
 
 
 def get_package(server_info, client):
+    if client.api.env.force_client_compat:
+        raise NotAvailable()
+
     NO_FINGERPRINT = object()
 
     fingerprint = NO_FINGERPRINT

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -196,6 +196,8 @@ DEFAULT_CONFIG = (
 
     # Ignore TTL. Perform schema call and download schema if not in cache.
     ('force_schema_check', False),
+    # Force client API to use compat remote plugins
+    ('force_client_compat', False),
 
     # ********************************************************
     #  The remaining keys are never set from the values here!


### PR DESCRIPTION
Add a new `force_client_compat` env flag to force client API not to do any
RPC calls to initialize remote plugins in `.finalize()` and use the newest
compat plugins instead.

Setting the flag serves as a workaround for `api.finalize()` requiring
valid Kerberos credentials.

https://pagure.io/freeipa/issue/6408