### PR TITLE
Add CI helper script invocation to Travis CI

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -59,6 +59,8 @@ steps:
   - echo ${server_password} > ~/.ipa/.dmpw
   - echo 'wait_for_dns=5' >> ~/.ipa/default.conf
   run_tests:
+  - ipa-test-config --help
+  - ipa-test-task --help
   - ipa-run-tests ${tests_ignore} -k-test_dns_soa ${tests_verbose} ${path}
 tests:
   ignore:


### PR DESCRIPTION
This tests whether changes in ipatests do not break any of the helper scripts
used for integration testing. The PR is rebased on
https://github.com/freeipa/freeipa/pull/626 so it should produce green build
with @cheimes's fixes