### PR TITLE
ipapython.ipautil.nolog_replace: Do not replace empty value

### DIFF
--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -505,7 +505,7 @@ def run(args, stdin=None, raiseonerr=True, nolog=(), env=None,
 def nolog_replace(string, nolog):
     """Replace occurences of strings given in `nolog` with XXXXXXXX"""
     for value in nolog:
-        if not isinstance(value, six.string_types):
+        if not value or not isinstance(value, six.string_types):
             continue
 
         quoted = urllib.parse.quote(value)


### PR DESCRIPTION
When provided empty value in nolog parameter nolog_replace added 'XXXXXXXX'
three (once for plain value, once for http quoted value and last time for shell
quoted value) times before every character (including terminating '\0') in the string.

https://pagure.io/freeipa/issue/6738