### PR TITLE
Upgrade: configure PKINIT after adding anonymous principal

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -410,6 +410,7 @@ class KrbInstance(service.Service):
             root_logger.critical("krb5kdc service failed to restart")
             raise
 
+    def test_anonymous_pkinit(self):
         with ipautil.private_ccache() as anon_ccache:
             try:
                 ipautil.run([paths.KINIT, '-n', '-c', anon_ccache])
@@ -421,6 +422,7 @@ class KrbInstance(service.Service):
             self.steps = []
             self.step("installing X509 Certificate for PKINIT",
                       self.setup_pkinit)
+            self.step("testing anonymous PKINIT", self.test_anonymous_pkinit)
 
             self.start_creation()
 

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -413,7 +413,7 @@ class KrbInstance(service.Service):
         with ipautil.private_ccache() as anon_ccache:
             try:
                 ipautil.run([paths.KINIT, '-n', '-c', anon_ccache])
-            except ipautil.CalledProcessError as e:
+            except ipautil.CalledProcessError:
                 raise RuntimeError("Failed to configure anonymous PKINIT")
 
     def enable_ssl(self):

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1809,9 +1809,9 @@ def upgrade_configuration():
                         KDC_CERT=paths.KDC_CERT,
                         KDC_KEY=paths.KDC_KEY,
                         CACERT_PEM=paths.CACERT_PEM)
-    setup_pkinit(krb)
     enable_anonymous_principal(krb)
     http.request_anon_keytab()
+    setup_pkinit(krb)
 
     if not ds_running:
         ds.stop(ds_serverid)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1499,15 +1499,14 @@ def enable_anonymous_principal(krb):
 def setup_pkinit(krb):
     root_logger.info("[Setup PKINIT]")
 
-    if os.path.exists(paths.KDC_CERT):
-        root_logger.info("PKINIT already set up")
-        return
-
     if not api.Command.ca_is_enabled()['result']:
         root_logger.info("CA is not enabled")
         return
 
-    krb.setup_pkinit()
+    if not os.path.exists(paths.KDC_CERT):
+        root_logger.info("Requesting PKINIT certificate")
+        krb.setup_pkinit()
+
     replacevars = dict()
     replacevars['pkinit_identity'] = 'FILE:{},{}'.format(
         paths.KDC_CERT,paths.KDC_KEY)
@@ -1519,6 +1518,7 @@ def setup_pkinit(krb):
     if krb.is_running():
         krb.stop()
     krb.start()
+    krb.test_anonymous_pkinit()
 
 
 def disable_httpd_system_trust(http):


### PR DESCRIPTION
In order to set up PKINIT, the anonymous principal must already be
created, otherwise the upgrade with fail when trying out anonymous
PKINIT. Switch the order of steps so that this issue does not occur.

https://pagure.io/freeipa/issue/6792