### PR TITLE
ipa-sam: create the gidNumber attribute in the trusted domain entry

### DIFF
--- a/install/updates/90-post_upgrade_plugins.update
+++ b/install/updates/90-post_upgrade_plugins.update
@@ -10,6 +10,7 @@ plugin: update_sigden_extdom_broken_config
 plugin: update_sids
 plugin: update_default_range
 plugin: update_default_trust_view
+plugin: update_tdo_gidnumber
 plugin: update_ca_renewal_master
 plugin: update_idrange_type
 plugin: update_pacs


### PR DESCRIPTION
When a trusted domain entry is created, the uidNumber attribute is created
but not the gidNumber attribute. This causes samba to log
	Failed to find a Unix account for DOM-AD$
because the samu structure does not contain a group_sid and is not put
in the cache.
The fix creates the gidNumber attribute in the trusted domain entry,
and initialises the group_sid field in the samu structure returned
by ldapsam_getsampwnam. This ensures that the entry is put in the cache.

Note that this is only a partial fix for 6660 as it does not prevent
_netr_ServerAuthenticate3 from failing with the log
	_netr_ServerAuthenticate3: netlogon_creds_server_check failed. Rejecting auth request from client VM-AD machine account dom-ad.example.com.

https://pagure.io/freeipa/issue/6827