### PR TITLE
ldap2: use LDAP whoami operation to retrieve bind DN for current connection

### DIFF
--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -286,12 +286,11 @@ class ldap2(CrudBackend, LDAPClient):
 
         assert isinstance(dn, DN)
 
-        principal = getattr(context, 'principal')
-        entry = self.find_entry_by_attr("krbprincipalname", principal,
-            "krbPrincipalAux", base_dn=self.api.env.basedn)
+        bind_dn = self.conn.whoami_s()[4:]
+
         sctrl = [
             GetEffectiveRightsControl(
-                True, "dn: {0}".format(entry.dn).encode('utf-8'))
+                True, "dn: {0}".format(bind_dn).encode('utf-8'))
         ]
         self.conn.set_option(_ldap.OPT_SERVER_CONTROLS, sctrl)
         try:


### PR DESCRIPTION
For external users which are mapped to some DN in LDAP server, we
wouldn't neccesary be able to find a kerberos data in their LDAP entry.
Instead of searching for Kerberos principal use actual DN we are bound
to because for get_effective_rights LDAP control we only need the DN
itself.

Fixes https://pagure.io/freeipa/issue/6797