### PR TITLE
Remove pkinit options from master/replica on DL0

### DIFF
--- a/install/tools/man/ipa-replica-install.1
+++ b/install/tools/man/ipa-replica-install.1
@@ -114,7 +114,7 @@ Install and configure a CA on this replica. If a CA is not configured then
 certificate operations will be forwarded to a master with a CA installed.
 .TP
 \fB\-\-no\-pkinit\fR
-Disables pkinit setup steps
+Disables pkinit setup steps. This is the default and only allowed behavior on domain level 0.
 .TP
 \fB\-\-dirsrv\-cert\-file\fR=FILE
 File containing the Directory Server SSL certificate and private key

--- a/install/tools/man/ipa-replica-prepare.1
+++ b/install/tools/man/ipa-replica-prepare.1
@@ -43,26 +43,17 @@ File containing the Directory Server SSL certificate and private key. The files 
 \fB\-\-http\-cert\-file\fR=\fIFILE\fR
 File containing the Apache Server SSL certificate and private key. The files are accepted in PEM and DER certificate, PKCS#7 certificate chain, PKCS#8 and raw private key and PKCS#12 formats. This option may be used multiple times.
 .TP
-\fB\-\-pkinit\-cert\-file\fR=\fIFILE\fR
-File containing the Kerberos KDC SSL certificate and private key. The files are accepted in PEM and DER certificate, PKCS#7 certificate chain, PKCS#8 and raw private key and PKCS#12 formats. This option may be used multiple times.
-.TP
 \fB\-\-dirsrv\-pin\fR=\fIPIN\fR
 The password to unlock the Directory Server private key
 .TP
 \fB\-\-http\-pin\fR=\fIPIN\fR
 The password to unlock the Apache Server private key
 .TP
-\fB\-\-pkinit\-pin\fR=\fIPIN\fR
-The password to unlock the Kerberos KDC private key
-.TP
 \fB\-\-dirsrv\-cert\-name\fR=\fINAME\fR
 Name of the Directory Server SSL certificate to install
 .TP
 \fB\-\-http\-cert\-name\fR=\fINAME\fR
 Name of the Apache Server SSL certificate to install
-.TP
-\fB\-\-pkinit\-cert\-name\fR=\fINAME\fR
-Name of the Kerberos KDC SSL certificate to install
 .TP
 \fB\-p\fR \fIDM_PASSWORD\fR, \fB\-\-password\fR=\fIDM_PASSWORD\fR
 Directory Manager (existing master) password
@@ -80,9 +71,6 @@ Do not create reverse DNS zone
 .TP
 \fB\-\-ca\fR=\fICA_FILE\fR
 Location of CA PKCS#12 file, default /root/cacert.p12
-.TP
-\fB\-\-no\-pkinit\fR
-Disables pkinit setup steps
 .TP
 \fB\-\-debug\fR
 Prints info log messages to the output

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -93,7 +93,7 @@ Type of the external CA. Possible values are "generic", "ms-cs". Default value i
 File containing the IPA CA certificate and the external CA certificate chain. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times.
 .TP
 \fB\-\-no\-pkinit\fR
-Disables pkinit setup steps
+Disables pkinit setup steps. This is the default and only allowed behavior on domain level 0.
 .TP
 \fB\-\-dirsrv\-cert\-file\fR=\fIFILE\fR
 File containing the Directory Server SSL certificate and private key. The files are accepted in PEM and DER certificate, PKCS#7 certificate chain, PKCS#8 and raw private key and PKCS#12 formats. This option may be used multiple times.

--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -340,15 +340,15 @@ class ServerInstallInterface(ServerCertificateInstallInterface,
         cert_file_opt = (self.pkinit_cert_files,)
         if not self.no_pkinit:
             cert_file_req += cert_file_opt
-        if any(cert_file_req + cert_file_opt) and not all(cert_file_req):
-            raise RuntimeError(
-                "--dirsrv-cert-file, --http-cert-file, and --pkinit-cert-file "
-                "or --no-pkinit are required if any key file options are used."
-            )
         if self.no_pkinit and self.pkinit_cert_files:
             raise RuntimeError(
                 "--no-pkinit and --pkinit-cert-file cannot be specified "
                 "together"
+            )
+        if any(cert_file_req + cert_file_opt) and not all(cert_file_req):
+            raise RuntimeError(
+                "--dirsrv-cert-file, --http-cert-file, and --pkinit-cert-file "
+                "or --no-pkinit are required if any key file options are used."
             )
 
         if not self.interactive:

--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -470,16 +470,8 @@ class ServerInstallInterface(ServerCertificateInstallInterface,
                     "idmax (%s) cannot be smaller than idstart (%s)" %
                     (self.idmax, self.idstart))
         else:
-            cert_file_req = (self.dirsrv_cert_files, self.http_cert_files)
-            cert_file_opt = (self.pkinit_cert_files,)
-
+            # replica installers
             if self.replica_file is None:
-                # If any of the PKCS#12 options are selected, all are required.
-                if any(cert_file_req + cert_file_opt) and not all(cert_file_req):
-                    raise RuntimeError(
-                        "--dirsrv-cert-file and --http-cert-file are required "
-                        "if any PKCS#12 options are used")
-
                 if self.servers and not self.domain_name:
                     raise RuntimeError(
                         "The --server option cannot be used without providing "


### PR DESCRIPTION
This patchset removes the ability of setting pkinit options on domain level 0 for server/replica installs. Also fixes a usability issue with `--no-pkinit` I noticed and did not care creating ticket for.