### PR TITLE
Set "KDC:Disable Last Success" by default

### DIFF
--- a/install/share/bootstrap-template.ldif
+++ b/install/share/bootstrap-template.ldif
@@ -410,6 +410,7 @@ ipaUserObjectClasses: ipasshuser
 ipaDefaultEmailDomain: $DOMAIN
 ipaMigrationEnabled: FALSE
 ipaConfigString: AllowNThash
+ipaConfigString: KDC:Disable Last Success
 ipaSELinuxUserMapOrder: guest_u:s0$$xguest_u:s0$$user_u:s0$$staff_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023
 ipaSELinuxUserMapDefault: unconfined_u:s0-s0:c0.c1023
 


### PR DESCRIPTION
In big deployments enabled recording of the last sucesfull login
this creates a huge changelog on DS side and cause performance
issues even if this is excluded from replication.

Actually this is not used directly by FreeIPA so it is safe to remove
in new installations. User who need this must manually remove
"KDC:Disable Last Success" using `ipa config-mod` command or WebUI.

https://pagure.io/freeipa/issue/5313