### PR TITLE
extdom: improve certificate request

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom.h
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom.h
@@ -95,7 +95,8 @@ enum response_types {
     RESP_USER,
     RESP_GROUP,
     RESP_USER_GROUPLIST,
-    RESP_GROUP_MEMBERS
+    RESP_GROUP_MEMBERS,
+    RESP_NAME_LIST
 };
 
 struct extdom_req {

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_common.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_common.c
@@ -515,7 +515,7 @@ int pack_ber_user(struct ipa_extdom_ctx *ctx,
     char *short_user_name = NULL;
 
     short_user_name = strdup(user_name);
-    if ((locat = strchr(short_user_name, SSSD_DOMAIN_SEPARATOR)) != NULL) {
+    if ((locat = strrchr(short_user_name, SSSD_DOMAIN_SEPARATOR)) != NULL) {
         if (strcasecmp(locat+1, domain_name) == 0  ) {
             locat[0] = '\0';
         } else {
@@ -626,7 +626,7 @@ int pack_ber_group(enum response_types response_type,
     char *short_group_name = NULL;
 
     short_group_name = strdup(group_name);
-    if ((locat = strchr(short_group_name, SSSD_DOMAIN_SEPARATOR)) != NULL) {
+    if ((locat = strrchr(short_group_name, SSSD_DOMAIN_SEPARATOR)) != NULL) {
         if (strcasecmp(locat+1, domain_name) == 0  ) {
             locat[0] = '\0';
         } else {
@@ -901,7 +901,7 @@ static int handle_sid_or_cert_request(struct ipa_extdom_ctx *ctx,
         goto done;
     }
 
-    sep = strchr(fq_name, SSSD_DOMAIN_SEPARATOR);
+    sep = strrchr(fq_name, SSSD_DOMAIN_SEPARATOR);
     if (sep == NULL) {
         set_err_msg(req, "Failed to split fully qualified name");
         ret = LDAP_OPERATIONS_ERROR;

--- a/server.m4
+++ b/server.m4
@@ -28,7 +28,7 @@ DIRSRV_CFLAGS="$DIRSRV_CFLAGS $NSPR_CFLAGS"
 
 dnl -- sss_idmap is needed by the extdom exop --
 PKG_CHECK_MODULES([SSSIDMAP], [sss_idmap])
-PKG_CHECK_MODULES([SSSNSSIDMAP], [sss_nss_idmap >= 1.13.90])
+PKG_CHECK_MODULES([SSSNSSIDMAP], [sss_nss_idmap >= 1.15.2])
 
 dnl -- sss_certmap and certauth.h are needed by the IPA KDB certauth plugin --
 PKG_CHECK_EXISTS([sss_certmap],


### PR DESCRIPTION
Certificates can be assigned to multiple user so the extdom plugin must use
sss_nss_getlistbycert() instead of sss_nss_getnamebycert() and return a
list of fully-qualified user names.

Due to issues on the SSSD side the current version of lookups by
certificates didn't work at all and the changes here won't break existing
clients.

Related to https://pagure.io/freeipa/issue/6646

Since I used the revers lookup for the domain separator in patch I added a
second patch which does this where needed in the reminder of the code as well
to be consistent. Allthough using @-signs in short names is not common practice
it might happen as can be see in https://pagure.io/SSSD/sssd/issue/3219.

The sss_nss_getlistbycert() call is added to SSSD in
https://github.com/SSSD/sssd/pull/207.