### PR TITLE
Create temporaty directories at the begining of uninstall

### DIFF
--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1042,6 +1042,10 @@ def uninstall(installer):
 
     rv = 0
 
+    # further steps assumes that temporary directories exists so rather
+    # ensure they are created
+    tasks.create_tmpfiles_dirs()
+
     print("Shutting down all IPA services")
     try:
         services.knownservices.ipa.stop()


### PR DESCRIPTION
Since commit 38c6689 temporary directories are no longer created at package
install time. Instead they're created at server install time.
Some steps in uninstall also assume that temporary direcories exist. Creating
the directories in the begining of server uninstall ensure that the uninstall
will go through.

https://pagure.io/freeipa/issue/6715