### PR TITLE
CA-less installation fix

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -576,12 +576,3 @@ class NSSDatabase(object):
             self.run_certutil(['-V', '-n', nickname, '-u', 'L'])
         except ipautil.CalledProcessError:
             raise ValueError('invalid for a CA')
-
-    def publish_ca_cert(self, canickname, location):
-        args = ["-L", "-n", canickname, "-a"]
-        result = self.run_certutil(args, capture_output=True)
-        cert = result.output
-        fd = open(location, "w+")
-        fd.write(cert)
-        fd.close()
-        os.chmod(location, 0o444)

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -640,9 +640,6 @@ class CertDB(object):
 
         self.export_ca_cert(nickname, False)
 
-    def publish_ca_cert(self, location):
-        self.nssdb.publish_ca_cert(self.cacert_name, location)
-
     def export_pem_cert(self, nickname, location):
         return self.nssdb.export_pem_cert(nickname, location)
 


### PR DESCRIPTION
These patches fix the CA-less installation by guessing the names for CA and server-cert nicknames in /etc/httpd/alias. The fix is not very nice since it's guessing but I am not sure if there's anything else we can do at this point.

Also, `HTTPInstance.start/stop_tracking_certificates` would probably not need the guessing since it's only relevant for CA-full installations where we know the server-cert nickname is `Server-Cert` so I can replace it there if you think that'd be better.