### PR TITLE
WebUI: Fix showing vault in selfservice view

### DIFF
--- a/install/ui/src/freeipa/navigation/menu_spec.js
+++ b/install/ui/src/freeipa/navigation/menu_spec.js
@@ -326,6 +326,7 @@ nav.self_service = {
         { entity: 'user' },
         { entity: 'otptoken' },
         {
+            name: 'vault',
             entity: 'vault',
             facet: 'search',
             children: [

--- a/install/ui/src/freeipa/vault.js
+++ b/install/ui/src/freeipa/vault.js
@@ -809,9 +809,11 @@ vault.config_sidebar_policy = function(spec) {
 
 
 vault.remove_vault_menu_item = function() {
-    if (!IPA.vault_enabled) {
-        menu.remove_item('network_services/vault');
-    }
+    if (IPA.vault_enabled) return;
+
+    var menu_location = IPA.is_selfservice ? 'vault' : 'network_services/vault';
+
+    menu.remove_item(menu_location);
 };
 
 vault.my_vault_spec = make_my_vault_spec();


### PR DESCRIPTION
Vaults menu item was shown even when the KRA service was not installed.
That was caused by different path to the menu item in admin's view
and in selfservice view.

The path is now set correctly for both situations. 'network_service/vault'
for admin's view and 'vault' for selfservice view.

https://pagure.io/freeipa/issue/6812