### PR TITLE
dogtag-ipa-ca-renew-agent-submit: fix the is_replicated() function

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -119,7 +119,7 @@ def is_renewable():
 
 
 def is_replicated():
-    return not get_nickname()
+    return bool(get_nickname())
 
 
 def is_renewal_master():


### PR DESCRIPTION
dogtag-ipa-ca-renew-agent-submit behaves differently depending on the
certificate it needs to renew. For instance, some certificates (such as IPA RA)
are the same on all the hosts and the renewal is actually done only on
the renewal master. On other nodes, the new cert is downloaded from LDAP.

The function is_replicated() is returning the opposite as what it should. If
the cert nickname is IPA RA, it should return that the cert is replicated but
it doesn't, and this leads to a wrong code path to renew the cert.

https://pagure.io/freeipa/issue/6813