### PR TITLE
Backup CA cert from kerberos folder

### DIFF
--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -165,6 +165,7 @@ class Backup(admintool.AdminTool):
         paths.KRB5KDC_KDC_CONF,
         paths.KDC_CERT,
         paths.KDC_KEY,
+        paths.CACERT_PEM,
         paths.SYSTEMD_IPA_SERVICE,
         paths.SYSTEMD_SYSTEM_HTTPD_IPA_CONF,
         paths.SYSTEMD_SSSD_SERVICE,


### PR DESCRIPTION
I have no idea how I missed this file in previous backup fixing attempts.

https://pagure.io/freeipa/issue/6748