### PR TITLE
git-commit-template: update ticket url to use pagure.io instead of fe…

### DIFF
--- a/.git-commit-template
+++ b/.git-commit-template
@@ -2,4 +2,4 @@ component: Subject
 
 Explanation
 
-https://fedorahosted.org/freeipa/ticket/XXXX
+https://pagure.io/freeipa/issue/XXXX


### PR DESCRIPTION
…dorahosted.org

After the migration to pagure.io, tickets are accessed through another URL.

In order to use the commit template:
git config commit.template .git-commit-template

https://pagure.io/freeipa/issue/6822