### PR TITLE
Generate PIN for PKI to help Dogtag in FIPS

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -541,6 +541,10 @@ class CAInstance(DogtagInstance):
         # CA key algorithm
         config.set("CA", "pki_ca_signing_key_algorithm", self.ca_signing_algorithm)
 
+        # generate pin which we know can be used for FIPS NSS database
+        pki_pin = ipautil.ipa_generate_password()
+        config.set("CA", "pki_pin", pki_pin)
+
         if self.clone:
 
             if self.no_db_setup:
@@ -613,7 +617,7 @@ class CAInstance(DogtagInstance):
         try:
             DogtagInstance.spawn_instance(
                 self, cfg_file,
-                nolog_list=(self.dm_password, self.admin_password)
+                nolog_list=(self.dm_password, self.admin_password, pki_pin)
             )
         finally:
             os.remove(cfg_file)

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -235,6 +235,10 @@ class KRAInstance(DogtagInstance):
             "KRA", "pki_share_dbuser_dn",
             str(DN(('uid', 'pkidbuser'), ('ou', 'people'), ('o', 'ipaca'))))
 
+        # generate pin which we know can be used for FIPS NSS database
+        pki_pin = ipautil.ipa_generate_password()
+        config.set("KRA", "pki_pin", pki_pin)
+
         _p12_tmpfile_handle, p12_tmpfile_name = tempfile.mkstemp(dir=paths.TMP)
 
         if self.clone:
@@ -275,7 +279,7 @@ class KRAInstance(DogtagInstance):
         try:
             DogtagInstance.spawn_instance(
                 self, cfg_file,
-                nolog_list=(self.dm_password, self.admin_password)
+                nolog_list=(self.dm_password, self.admin_password, pki_pin)
             )
         finally:
             os.remove(p12_tmpfile_name)


### PR DESCRIPTION
Dogtag is currently unable to generate a PIN it could use for
an NSS database creation in FIPS. Generate it for them so that
we don't fail.

https://pagure.io/freeipa/issue/6824