### PR TITLE
Allow erasing ipaDomainResolutionOrder attribute

### DIFF
--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -359,6 +359,11 @@ class config(LDAPObject):
 
         domain_resolution_order = entry_attrs[attr_name]
 
+        # setting up an empty string means that the previous configuration has
+        # to be cleaned up/removed. So, do nothing and let it pass
+        if not domain_resolution_order:
+            return
+
         # empty resolution order is signalized by single separator, do nothing
         # and let it pass
         if domain_resolution_order == DOMAIN_RESOLUTION_ORDER_SEPARATOR:


### PR DESCRIPTION
Currently when trying to erase the ipaDomainResolutionOrder attribute we
hit an internal error as the split() method is called on a None object.

By returning early in case of empty string we now allow removing the
ipaDomainResolutionOrder attribute by both doing calling delattr or
setting its value to an empty string.

https://pagure.io/freeipa/issue/6825

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>