### PR TITLE
idrange-add: properly handle empty --dom-name option

### DIFF
--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -411,7 +411,7 @@ class idrange_add(LDAPCreate):
 
         # This needs to stay in options since there is no
         # ipanttrusteddomainname attribute in LDAP
-        if 'ipanttrusteddomainname' in options:
+        if options.get('ipanttrusteddomainname'):
             if is_set('ipanttrusteddomainsid'):
                 raise errors.ValidationError(name='ID Range setup',
                     error=_('Options dom-sid and dom-name '


### PR DESCRIPTION
When idrange-add is called with --dom-name=, the CLI exits with
ipa: ERROR: an internal error has occurred
This happens because the code checks if the option is provided but does not
check if the value is None.

We need to handle empty dom-name as if the option was not specified.

https://pagure.io/freeipa/issue/6404