### PR TITLE
spec file: bump libsss_nss_idmap-devel BuildRequires

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -121,8 +121,8 @@ BuildRequires:  libtevent-devel
 BuildRequires:  libuuid-devel
 BuildRequires:  libsss_idmap-devel
 BuildRequires:  libsss_certmap-devel
-# 1.14.0: sss_nss_getnamebycert (https://fedorahosted.org/sssd/ticket/2897)
-BuildRequires:  libsss_nss_idmap-devel >= 1.14.0
+# 1.15.3: sss_nss_getlistbycert (https://pagure.io/SSSD/sssd/issue/3050)
+BuildRequires:  libsss_nss_idmap-devel >= 1.15.3
 BuildRequires:  rhino
 BuildRequires:  libverto-devel
 BuildRequires:  libunistring-devel


### PR DESCRIPTION
Bump BuildRequires on libsss_nss_idmap-devel to the version which
introduces the sss_nss_getlistbycert function.

This fixes RPM build failure when an older version of
libsss_nss_idmap-devel was installed.

https://pagure.io/freeipa/issue/6826