### PR TITLE
IPA-KDB: use relative path in ipa-certmap config snippet

### DIFF
--- a/daemons/ipa-kdb/Makefile.am
+++ b/daemons/ipa-kdb/Makefile.am
@@ -40,18 +40,16 @@ ipadb_la_SOURCES = 		\
 	ipa_kdb_audit_as.c	\
 	$(NULL)
 
+dist_noinst_DATA = ipa_kdb.exports
+
 if BUILD_IPA_CERTAUTH_PLUGIN
 ipadb_la_SOURCES += ipa_kdb_certauth.c
 
 
-%: %.in
-	sed \
-		-e 's|@plugindir@|$(plugindir)|g' \
-		'$(srcdir)/$@.in' >$@
-
 krb5confdir = $(sysconfdir)/krb5.conf.d
 krb5conf_DATA = ipa-certauth
-CLEANFILES = $(krb5conf_DATA)
+else
+dist_noinst_DATA += ipa-certauth
 endif
 
 ipadb_la_LDFLAGS = 		\
@@ -104,8 +102,6 @@ ipa_kdb_tests_LDADD =          \
        -lkdb5                  \
        -lsss_idmap             \
        $(NULL)
-
-dist_noinst_DATA = ipa_kdb.exports ipa-certauth.in
 
 clean-local:
 	rm -f tests/.dirstamp

--- a/daemons/ipa-kdb/ipa-certauth
+++ b/daemons/ipa-kdb/ipa-certauth
@@ -1,5 +1,5 @@
 [plugins]
  certauth = {
-  module = ipakdb:@plugindir@/ipadb.so
+  module = ipakdb:kdb/ipadb.so
   enable_only = ipakdb
  }


### PR DESCRIPTION
Architecture specific paths should be avoided in the global Kerberos
configuration because it is read e.g. by 32bit and 64bit libraries they
are installed in parallel.

Resolves https://pagure.io/freeipa/issue/6833