### PR TITLE
Replace hard-coded kdcproxy path with WSGI script

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1256,6 +1256,7 @@ fi
 # END
 %dir %{_usr}/share/ipa
 %{_usr}/share/ipa/wsgi.py*
+%{_usr}/share/ipa/kdcproxy.wsgi
 %{_usr}/share/ipa/*.ldif
 %{_usr}/share/ipa/*.uldif
 %{_usr}/share/ipa/*.template

--- a/install/conf/ipa-kdc-proxy.conf.template
+++ b/install/conf/ipa-kdc-proxy.conf.template
@@ -16,9 +16,9 @@
 
 WSGIDaemonProcess kdcproxy processes=2 threads=15 maximum-requests=5000 \
   user=kdcproxy group=kdcproxy display-name=%{GROUP}
-WSGIImportScript /usr/lib/python2.7/site-packages/kdcproxy/__init__.py \
+WSGIImportScript /usr/share/ipa/kdcproxy.wsgi \
   process-group=kdcproxy application-group=kdcproxy
-WSGIScriptAlias /KdcProxy /usr/lib/python2.7/site-packages/kdcproxy/__init__.py
+WSGIScriptAlias /KdcProxy /usr/share/ipa/kdcproxy.wsgi
 WSGIScriptReloading Off
 
 <Location "/KdcProxy">

--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -90,6 +90,7 @@ dist_app_DATA =				\
 	gssapi.login			\
 	ipa.conf.tmpfiles		\
 	gssproxy.conf.template		\
+	kdcproxy.wsgi			\
 	$(NULL)
 
 kdcproxyconfdir = $(IPA_SYSCONF_DIR)/kdcproxy

--- a/install/share/kdcproxy.wsgi
+++ b/install/share/kdcproxy.wsgi
@@ -1,0 +1,5 @@
+# Copyright (C) 2017  FreeIPA Contributors see COPYING for license
+"""WSGI entry point for kdcproxy
+"""
+from kdcproxy import application
+


### PR DESCRIPTION
mod_wsgi has no way to import a WSGI module by dotted module name. A new
kdcproxy.wsgi script is used to import kdcproxy from whatever Python
version mod_wsgi is compiled against. This will simplify moving FreeIPA
to Python 3 and solves an import problem on Debian.

Resolves: https://pagure.io/freeipa/issue/6834

Signed-off-by: Christian Heimes <cheimes@redhat.com>