### PR TITLE
ipa-ca-install man page: Add domain level 1 help

### DIFF
--- a/install/tools/man/ipa-ca-install.1
+++ b/install/tools/man/ipa-ca-install.1
@@ -1,5 +1,5 @@
 .\" A man page for ipa-ca-install
-.\" Copyright (C) 2011 Red Hat, Inc.
+.\" Copyright (C) 2011-2017 Red Hat, Inc.
 .\"
 .\" This program is free software; you can redistribute it and/or modify
 .\" it under the terms of the GNU General Public License as published by
@@ -16,17 +16,24 @@
 .\"
 .\" Author: Rob Crittenden <rcritten@redhat.com>
 .\"
-.TH "ipa-ca-install" "1" "Jun 17 2011" "FreeIPA" "FreeIPA Manual Pages"
+.TH "ipa-ca-install" "1" "Mar 30 2017" "FreeIPA" "FreeIPA Manual Pages"
 .SH "NAME"
 ipa\-ca\-install \- Install a CA on a server
 .SH "SYNOPSIS"
+.SS "DOMAIN LEVEL 0"
+.TP
 ipa\-ca\-install [\fIOPTION\fR]... [replica_file]
+.SS "DOMAIN LEVEL 1"
+.TP
+ipa\-ca\-install [\fIOPTION\fR]...
 .SH "DESCRIPTION"
 Adds a CA as an IPA\-managed service. This requires that the IPA server is already installed and configured.
 
+In a domain at domain level 0, you can run ipa\-ca\-install without replica_file to upgrade from CA-less to CA-full, or with replica_file to install the CA service on the replica.
+
 The replica_file is created using the ipa\-replica\-prepare utility and should be the same one used when originally installing the replica.
 
-Alternatively, you can run ipa\-ca\-install without replica_file to upgrade from CA-less to CA-full.
+In a domain at domain level 1, ipa\-ca\-install can be used to upgrade from CA-less to CA-full or to install the CA service on a replica, and does not require any replica file.
 .SH "OPTIONS"
 \fB\-d\fR, \fB\-\-debug\fR
 Enable debug logging when more verbose output is needed


### PR DESCRIPTION
In domain level 1 ipa-ca-install does not require a replica-file. Update the
man page to distinguish the domain level 0 or 1 usage.

https://pagure.io/freeipa/issue/5831