### PR TITLE
Make sure remote hosts have our keys

### DIFF
--- a/ipaserver/secrets/kem.py
+++ b/ipaserver/secrets/kem.py
@@ -24,6 +24,7 @@ import ldap
 
 IPA_REL_BASE_DN = 'cn=custodia,cn=ipa,cn=etc'
 IPA_KEYS_QUERY = '(&(ipaKeyUsage={usage:s})(memberPrincipal={princ:s}))'
+IPA_CHECK_QUERY = '(cn=enc/{host:s})'
 RFC5280_USAGE_MAP = {KEY_USAGE_SIG: 'digitalSignature',
                      KEY_USAGE_ENC: 'dataEncipherment'}
 
@@ -77,6 +78,17 @@ class KEMLdap(iSecLdap):
         jwk = self._parse_public_key(ipa_public_key)
         jwk['use'] = KEY_USAGE_MAP[usage]
         return json_encode(jwk)
+
+    def check_host_keys(self, host):
+        conn = self.connect()
+        scope = ldap.SCOPE_SUBTREE
+
+        ldap_filter = self.build_filter(IPA_CHECK_QUERY, {'host': host})
+        r = conn.search_s(self.keysbase, scope, ldap_filter)
+        if len(r) != 1:
+            raise ValueError("Incorrect number of results (%d) searching for"
+                             "public key for %s" % (len(r), host))
+        return True
 
     def _format_public_key(self, key):
         if isinstance(key, str):


### PR DESCRIPTION
In complex replication setups a replica may try to obtain CA keys from a
host that is not the master we initially create the keys against.
In this case race conditions may happen due to replication. So we need
to make sure the server we are contacting to get the CA keys has our
keys in LDAP. We do this by waiting to positively fetch our encryption
public key (the last one we create) from the target host LDAP server.

Fixes: https://pagure.io/freeipa/issue/6838

Signed-off-by: Simo Sorce <simo@redhat.com>