### PR TITLE
certdb: fix `AttributeError` in `verify_ca_cert_validity`

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -569,7 +569,7 @@ class NSSDatabase(object):
         except cryptography.x509.ExtensionNotFound:
             raise ValueError("missing basic constraints")
 
-        if not bc.ca:
+        if not bc.value.ca:
             raise ValueError("not a CA certificate")
 
         try:


### PR DESCRIPTION
`NSSDatabase.verify_ca_cert_validity` tries to access a property of basic
constraints extension on the extension object itself rather than its value.

Access the attribute on the correct object to fix the issue.