### PR TITLE
httpinstance: make sure NSS database is backed up

### DIFF
--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -373,10 +373,11 @@ class HTTPInstance(service.Service):
         return False
 
     def __setup_ssl(self):
+        truncate = not self.promote or not self.ca_is_configured
         db = certs.CertDB(self.realm, nssdir=paths.HTTPD_ALIAS_DIR,
                           subject_base=self.subject_base, user="root",
                           group=constants.HTTPD_GROUP,
-                          truncate=(not self.promote))
+                          truncate=truncate)
         self.disable_system_trust()
         if self.pkcs12_info:
             if self.ca_is_configured:


### PR DESCRIPTION
The NSS database at /etc/httpd/alias is not properly initialized and backed
up in CA-less replica promotion. This might cause the install to fail after
previous install and uninstall.

Make sure the NSS database is initialized and backed up even in CA-less
replica promotion to fix the issue.

https://pagure.io/freeipa/issue/4639