### PR TITLE
[4.5] Caless fix

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -596,12 +596,3 @@ class NSSDatabase(object):
         finally:
             del certdb, cert
             nss.nss_shutdown()
-
-    def publish_ca_cert(self, canickname, location):
-        args = ["-L", "-n", canickname, "-a"]
-        result = self.run_certutil(args, capture_output=True)
-        cert = result.output
-        fd = open(location, "w+")
-        fd.write(cert)
-        fd.close()
-        os.chmod(location, 0o444)

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -640,9 +640,6 @@ class CertDB(object):
 
         self.export_ca_cert(nickname, False)
 
-    def publish_ca_cert(self, location):
-        self.nssdb.publish_ca_cert(self.cacert_name, location)
-
     def export_pem_cert(self, nickname, location):
         return self.nssdb.export_pem_cert(nickname, location)
 


### PR DESCRIPTION
Get correct CA cert nickname in CA-less
    
During CA-less installation, we initialize the HTTPD alias
database from a pkcs12 file. This means there's going to
be different nicknames to the added certificates. Store
the CA certificate nickname in HTTPInstance__setup_ssl()
to be able to correctly export it late