### PR TITLE
Sort SRV records by priority

### DIFF
--- a/ipaclient/install/ipadiscovery.py
+++ b/ipaclient/install/ipadiscovery.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import operator
 import socket
 
 import six
@@ -493,6 +494,7 @@ class IPADiscovery(object):
 
         try:
             answers = resolver.query(qname, rdatatype.SRV)
+            answers = sorted(answers, key=operator.attrgetter('priority'))
         except DNSException as e:
             root_logger.debug("DNS record not found: %s", e.__class__.__name__)
             answers = []


### PR DESCRIPTION
In some cases where multiple SRV records are present, LDAP and Kerberos records were returned in different order, causing replication issues in a multi master enviorment.

## Replication:
DNS configuration (using PfSense):
```
srv-host=_kerberos._udp.example.com,server01.example.com,88,0,1
srv-host=_kerberos._tcp.example.com,server01.example.com,88,0,1
srv-host=_kerberos-master._tcp.example.com,server01.example.com,88,0,1
srv-host=_kerberos-master._udp.example.com,server01.example.com,88,0,1
srv-host=_kpasswd._tcp.example.com,server01.example.com,88,0,1
srv-host=_kpasswd._udp.example.com,server01.example.com,88,0,1
srv-host=_ldap._tcp.example.com,server01.example.com,389,0,1
srv-host=_kerberos._udp.example.com,server02.example.com,88,0,2
srv-host=_kerberos._tcp.example.com,server02.example.com,88,0,2
srv-host=_kerberos-master._tcp.example.com,server02.example.com,88,0,2
srv-host=_kerberos-master._udp.example.com,server02.example.com,88,0,2
srv-host=_kpasswd._tcp.example.com,server02.example.com,88,0,2
srv-host=_kpasswd._udp.example.com,server02.example.com,88,0,2
srv-host=_ldap._tcp.example.com,server02.example.com,389,0,2
txt-record=_kerberos.example.com,EXAMPLE.COM
```

Client installation:
Host record is added beforehand from web UI on server01.example.com ONLY.
`/usr/sbin/ipa-client-install --force-join --principal=bind_user --password=bind_pass --hostname=`hostname -f` --unattended`

/var/log/ipaclient-install.log:

> 2017-04-02T10:54:09Z DEBUG [IPA Discovery]
> 2017-04-02T10:54:09Z DEBUG Starting IPA discovery with domain=None, servers=None, hostname=client01.example.com
> 2017-04-02T10:54:09Z DEBUG Start searching for LDAP SRV record in "example.com" (domain of the hostname) and its sub-domains
> 2017-04-02T10:54:09Z DEBUG Search DNS for SRV record of _ldap._tcp.example.com
> 2017-04-02T10:54:09Z DEBUG DNS record found: 0 1 389 server01.example.com.
> 2017-04-02T10:54:09Z DEBUG DNS record found: 0 2 389 server02.example.com.
> 2017-04-02T10:54:09Z DEBUG [Kerberos realm search]
> 2017-04-02T10:54:09Z DEBUG Search DNS for TXT record of _kerberos.example.com
> 2017-04-02T10:54:09Z DEBUG DNS record not found: NoAnswer
> 2017-04-02T10:54:09Z DEBUG Search DNS for SRV record of _kerberos._udp.example.com
> 2017-04-02T10:54:09Z DEBUG DNS record found: 0 2 88 server02.example.com.
> 2017-04-02T10:54:09Z DEBUG DNS record found: 0 1 88 server01.example.com.

Notice the records are not in the same order, ipa-client-install did not return any error and the client machine could see user, groups, netgroups, but users could not authenticate.
Looking at the web UI, server01.example.com shows the client is not enrolled and no kerberos key is present, but server02.example.com shows the client is enrolled and has a key.

In cases were either server01 or server02 were returned first in IPA Discovery the installation and replication went fine.