### PR TITLE
server-install: remove broken no-pkinit check

### DIFF
--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -513,11 +513,6 @@ def install_check(installer):
         dirsrv_pkcs12_info = (dirsrv_pkcs12_file.name, dirsrv_pin)
 
     if options.pkinit_cert_files:
-        if not options.no_pkinit:
-            raise ScriptError("Cannot create KDC PKINIT certificate and use "
-                              "provided external PKINIT certificate at the "
-                              "same time. Please choose one of them.")
-
         if options.pkinit_pin is None:
             options.pkinit_pin = read_password(
                 "Enter Kerberos KDC private key unlock",


### PR DESCRIPTION
Don't check for no-pkinit option in case pkinit cert file was
provided. Setting no-pkinit is prohibited in this case, so without
this fix we have an impossible option-check if we want to provide
an own pkinit certificate and private key.

https://pagure.io/freeipa/issue/6807