### PR TITLE
Add force-join option to replica install

### DIFF
--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -166,7 +166,6 @@ class ServerInstallInterface(ServerCertificateInstallInterface,
     """
     description = "Server"
 
-    force_join = False
     kinit_attempts = 1
     fixed_primary = True
     ntp_servers = None
@@ -526,6 +525,7 @@ class ServerMasterInstall(ServerMasterInstallInterface):
     Server master installer
     """
 
+    force_join = False
     servers = None
     no_wait_for_dns = True
     host_password = None

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -948,6 +948,8 @@ def ensure_enrolled(installer):
             args.append("--no-sshd")
         if installer.mkhomedir:
             args.append("--mkhomedir")
+        if installer.force_join:
+            args.append("--force-join")
 
         ipautil.run(args, stdin=stdin, nolog=nolog, redirect_output=True)
         print()


### PR DESCRIPTION
This patchset adds the force-join option to the replica installer. It also tries to improve the developer's experience by narrowing down the scope of originally an all-eating try-except block.