### PR TITLE
RFC: implement local PKINIT deployment in server/replica install

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -50,7 +50,6 @@ class BasePathNamespace(object):
     HTTPD_SSL_CONF = "/etc/httpd/conf.d/ssl.conf"
     OLD_IPA_KEYTAB = "/etc/httpd/conf/ipa.keytab"
     HTTP_KEYTAB = "/var/lib/ipa/gssproxy/http.keytab"
-    ANON_KEYTAB = "/var/lib/ipa/api/anon.keytab"
     HTTPD_PASSWORD_CONF = "/etc/httpd/conf/password.conf"
     IDMAPD_CONF = "/etc/idmapd.conf"
     ETC_IPA = "/etc/ipa"

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -120,7 +120,6 @@ class Backup(admintool.AdminTool):
     )
 
     files = (
-        paths.ANON_KEYTAB,
         paths.NAMED_CONF,
         paths.NAMED_KEYTAB,
         paths.RESOLV_CONF,

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -475,13 +475,6 @@ class KrbInstance(service.Service):
         elif self.config_pkinit:
             self.issue_ipa_ca_signed_pkinit_certs()
 
-    def test_anonymous_pkinit(self):
-        with ipautil.private_ccache() as anon_ccache:
-            try:
-                ipautil.run([paths.KINIT, '-n', '-c', anon_ccache])
-            except ipautil.CalledProcessError:
-                raise RuntimeError("Failed to configure anonymous PKINIT")
-
     def enable_ssl(self):
         """
         generate PKINIT certificate for KDC. If `--no-pkinit` was specified,
@@ -496,8 +489,6 @@ class KrbInstance(service.Service):
             self.steps = []
             self.step("installing X509 Certificate for PKINIT",
                       self.setup_pkinit)
-            self.step("testing anonymous PKINIT", self.test_anonymous_pkinit)
-
             self.start_creation()
         else:
             self.issue_selfsigned_pkinit_certs()

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1795,7 +1795,6 @@ def upgrade_configuration():
                         KDC_KEY=paths.KDC_KEY,
                         CACERT_PEM=paths.CACERT_PEM)
     krb.add_anonymous_principal()
-    http.request_anon_keytab()
     setup_pkinit(krb)
 
     if not ds_running:

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1507,7 +1507,6 @@ def setup_pkinit(krb):
     if krb.is_running():
         krb.stop()
     krb.start()
-    krb.test_anonymous_pkinit()
 
 
 def disable_httpd_system_trust(http):

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -944,7 +944,7 @@ class login_password(Backend, KerberosSession):
         self.debug('Obtaining armor in ccache %s', armor_path)
 
         try:
-            kinit_armor(armor_path)
+            kinit_armor(armor_path, pkinit_anchor=paths.CACERT_PEM)
         except RuntimeError as e:
             self.error("Failed to obtain armor cache")
             # We try to continue w/o armor, 2FA will be impacted


### PR DESCRIPTION
This PR implements a basic local PKINIT functionality for server install with
'--no-pkinit' specified, and replica install against older masters or with
'--no-pkinit'.

These patches unblock WebUI logins/password auths on masters/replicas in the
cases proper PKINIT was not configured for whatever reasons.

Nevertheless, there are following things lacking in this PR that I will either
push on top of this one or create a new PR:

- [x] removal of anonymous keytab, asi it is now useless (and always was)
- [x] upgrade and transitions between PKINIT configurations
- [x] reporting PKINIT state in LDAP
- [ ] API for querying the PKINIT status on all masters

http://www.freeipa.org/page/V4/Kerberos_PKINIT