### PR TITLE
[4.4] Fix PKCS11 helper

### DIFF
--- a/daemons/dnssec/ipa-dnskeysync-replica
+++ b/daemons/dnssec/ipa-dnskeysync-replica
@@ -15,6 +15,7 @@ import os
 import sys
 
 import ipalib
+from ipalib.constants import SOFTHSM_DNSSEC_TOKEN_LABEL
 from ipapython.dn import DN
 from ipapython.ipa_log_manager import root_logger, standard_logging_setup
 from ipapython import ipaldap
@@ -154,8 +155,7 @@ ldapkeydb = LdapKeyDB(log, ldap,
         DN(('cn', 'keys'), ('cn', 'sec'), ipalib.api.env.container_dns,
            ipalib.api.env.basedn))
 
-# TODO: slot number could be configurable
-localhsm = LocalHSM(paths.LIBSOFTHSM2_SO, 0,
+localhsm = LocalHSM(paths.LIBSOFTHSM2_SO, SOFTHSM_DNSSEC_TOKEN_LABEL,
         open(paths.DNSSEC_SOFTHSM_PIN).read())
 
 ldap2replica_master_keys_sync(log, ldapkeydb, localhsm)

--- a/daemons/dnssec/ipa-ods-exporter
+++ b/daemons/dnssec/ipa-ods-exporter
@@ -32,6 +32,7 @@ import sqlite3
 import traceback
 
 import ipalib
+from ipalib.constants import SOFTHSM_DNSSEC_TOKEN_LABEL
 from ipapython.dn import DN
 from ipapython import ipaldap
 from ipapython import ipautil
@@ -645,7 +646,7 @@ log.debug('Connected')
 ldapkeydb = LdapKeyDB(log, ldap, DN(('cn', 'keys'), ('cn', 'sec'),
                                     ipalib.api.env.container_dns,
                                     ipalib.api.env.basedn))
-localhsm = LocalHSM(paths.LIBSOFTHSM2_SO, 0,
+localhsm = LocalHSM(paths.LIBSOFTHSM2_SO, SOFTHSM_DNSSEC_TOKEN_LABEL,
         open(paths.DNSSEC_SOFTHSM_PIN).read())
 
 ldap2master_replica_keys_sync(log, ldapkeydb, localhsm)

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -279,3 +279,5 @@ RENEWAL_CA_NAME = 'dogtag-ipa-ca-renew-agent'
 
 # regexp definitions
 PATTERN_GROUPUSER_NAME = '^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$'
+
+SOFTHSM_DNSSEC_TOKEN_LABEL = u'ipaDNSSEC'

--- a/ipapython/dnssec/localhsm.py
+++ b/ipapython/dnssec/localhsm.py
@@ -89,10 +89,11 @@ class Key(collections.MutableMapping):
     def __repr__(self):
         return self.__str__()
 
+
 class LocalHSM(AbstractHSM):
-    def __init__(self, library, slot, pin):
+    def __init__(self, library, label, pin):
         self.cache_replica_pubkeys = None
-        self.p11 = _ipap11helper.P11_Helper(slot, pin, library)
+        self.p11 = _ipap11helper.P11_Helper(label, pin, library)
         self.log = logging.getLogger()
 
     def __del__(self):

--- a/ipaserver/install/dnskeysyncinstance.py
+++ b/ipaserver/install/dnskeysyncinstance.py
@@ -26,10 +26,9 @@ from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipalib import errors, api
 from ipalib.constants import CACERT
+from ipalib.constants import SOFTHSM_DNSSEC_TOKEN_LABEL
 from ipaserver.install.bindinstance import dns_container_exists
 
-softhsm_token_label = u'ipaDNSSEC'
-softhsm_slot = 0
 replica_keylabel_template = u"dnssec-replica:%s"
 
 
@@ -289,8 +288,8 @@ class DNSKeySyncInstance(service.Service):
         command = [
             paths.SOFTHSM2_UTIL,
             '--init-token',
-            '--slot', str(softhsm_slot),
-            '--label', softhsm_token_label,
+            '--free',  # use random free slot
+            '--label', SOFTHSM_DNSSEC_TOKEN_LABEL,
             '--pin', pin,
             '--so-pin', pin_so,
         ]
@@ -309,7 +308,8 @@ class DNSKeySyncInstance(service.Service):
                 pin = f.read()
 
         os.environ["SOFTHSM2_CONF"] = paths.DNSSEC_SOFTHSM2_CONF
-        p11 = _ipap11helper.P11_Helper(softhsm_slot, pin, paths.LIBSOFTHSM2_SO)
+        p11 = _ipap11helper.P11_Helper(
+            SOFTHSM_DNSSEC_TOKEN_LABEL, pin, paths.LIBSOFTHSM2_SO)
 
         try:
             # generate replica keypair

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -18,10 +18,9 @@ from ipaplatform import services
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipalib import errors, api
-from ipaserver.install import dnskeysyncinstance
+from ipalib.constants import SOFTHSM_DNSSEC_TOKEN_LABEL
 
 KEYMASTER = u'dnssecKeyMaster'
-softhsm_slot = 0
 
 
 def get_dnssec_key_masters(conn):
@@ -72,7 +71,7 @@ class OpenDNSSECInstance(service.Service):
         self.ods_gid = None
         self.conf_file_dict = {
             'SOFTHSM_LIB': paths.LIBSOFTHSM2_SO,
-            'TOKEN_LABEL': dnskeysyncinstance.softhsm_token_label,
+            'TOKEN_LABEL': SOFTHSM_DNSSEC_TOKEN_LABEL,
             'KASP_DB': paths.OPENDNSSEC_KASP_DB,
             'ODS_USER': constants.ODS_USER,
             'ODS_GROUP': constants.ODS_GROUP,
@@ -247,7 +246,8 @@ class OpenDNSSECInstance(service.Service):
             pin = f.read()
 
         os.environ["SOFTHSM2_CONF"] = paths.DNSSEC_SOFTHSM2_CONF
-        p11 = p11helper.P11_Helper(softhsm_slot, pin, paths.LIBSOFTHSM2_SO)
+        p11 = p11helper.P11_Helper(
+            SOFTHSM_DNSSEC_TOKEN_LABEL, pin, paths.LIBSOFTHSM2_SO)
         try:
             # generate master key
             root_logger.debug("Creating master key")

--- a/ipatests/test_ipapython/test_ipap11helper.py
+++ b/ipatests/test_ipapython/test_ipap11helper.py
@@ -55,12 +55,12 @@ def p11(request):
     with open('softhsm2.conf', 'w') as cfg:
         cfg.write(CONFIG_DATA % token_path)
     os.environ['SOFTHSM2_CONF'] = os.path.join(token_path, 'softhsm2.conf')
-    subprocess.check_call([SOFTHSM2_UTIL, '--init-token', '--slot', '0',
+    subprocess.check_call([SOFTHSM2_UTIL, '--init-token', '--free',
                            '--label', 'test', '--pin', '1234', '--so-pin',
                            '1234'])
 
     try:
-        p11 = _ipap11helper.P11_Helper(0, "1234", LIBSOFTHSM)
+        p11 = _ipap11helper.P11_Helper('test', "1234", LIBSOFTHSM)
     except _ipap11helper.Error:
         pytest.fail('Failed to initialize the helper object.', pytrace=False)
 
@@ -70,6 +70,8 @@ def p11(request):
         except _ipap11helper.Error:
             pytest.fail('Failed to finalize the helper object.', pytrace=False)
         finally:
+            subprocess.call(
+                [SOFTHSM2_UTIL, '--delete-token', '--label', 'test'])
             del os.environ['SOFTHSM2_CONF']
 
     request.addfinalizer(fin)


### PR DESCRIPTION
Slots in HSM are not assigned statically, we have to chose proper
slot from token label.

Softhsm i2.2.0 changed this behavior and now slots can change over
time (it is allowed by pkcs11 standard).

Changelog:
* created method get_slot() that returns slot number from
  used label
* replaces usage of slot in __init__ method of P11_Helper
  with label
* slot is dynamically detected from token label before
  session is opened
* pkcs11-util --init-token now uses '--free' instead '--slot'
  which uses first free slot (we don't care about slot numbers
  anymore)

https://pagure.io/freeipa/issue/6692