### PR TITLE
Create system users for FreeIPA services during package installation

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1025,6 +1025,15 @@ if [ -e /usr/sbin/ipa_kpasswd ]; then
 # END
 fi
 
+# create users and groups
+# create kdcproxy group and user
+getent group kdcproxy >/dev/null || groupadd -f -r kdcproxy
+getent passwd kdcproxy >/dev/null || useradd -r -g kdcproxy -s /sbin/nologin -d / -c "IPA KDC Proxy User" kdcproxy
+# create ipaapi group and user
+getent group ipaapi >/dev/null || groupadd -f -r ipaapi
+getent passwd ipaapi >/dev/null || useradd -r -g ipaapi -s /sbin/nologin -d / -c "IPA Framework User" ipaapi
+# add apache to ipaaapi group
+id -Gn apache | grep '\bipaapi\b' >/dev/null || usermod apache -a -G ipaapi
 
 %postun server-trust-ad
 if [ "$1" -ge "1" ]; then

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -22,9 +22,6 @@
 This module contains default platform-specific implementations of system tasks.
 '''
 
-import pwd
-import grp
-
 from pkg_resources import parse_version
 
 from ipaplatform.paths import paths
@@ -185,56 +182,6 @@ class BaseTaskNamespace(object):
         """
 
         raise NotImplementedError()
-
-    def create_system_user(self, name, group, homedir, shell,
-                           uid=None, gid=None, comment=None,
-                           create_homedir=False, groups=None):
-        """Create a system user with a corresponding group"""
-        try:
-            grp.getgrnam(group)
-        except KeyError:
-            log.debug('Adding group %s', group)
-            args = [paths.GROUPADD, '-r', group]
-            if gid:
-                args += ['-g', str(gid)]
-            try:
-                ipautil.run(args)
-                log.debug('Done adding group')
-            except ipautil.CalledProcessError as e:
-                log.critical('Failed to add group: %s', e)
-                raise
-        else:
-            log.debug('group %s exists', group)
-
-        try:
-            pwd.getpwnam(name)
-        except KeyError:
-            log.debug('Adding user %s', name)
-            args = [
-                paths.USERADD,
-                '-g', group,
-                '-d', homedir,
-                '-s', shell,
-                '-r', name,
-            ]
-            if uid:
-                args += ['-u', str(uid)]
-            if comment:
-                args += ['-c', comment]
-            if create_homedir:
-                args += ['-m']
-            else:
-                args += ['-M']
-            if groups is not None:
-                args += ['-G', groups.join(',')]
-            try:
-                ipautil.run(args)
-                log.debug('Done adding user')
-            except ipautil.CalledProcessError as e:
-                log.critical('Failed to add user: %s', e)
-                raise
-        else:
-            log.debug('user %s exists', name)
 
     @staticmethod
     def parse_ipa_version(version):

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -431,32 +431,6 @@ class RedHatTaskNamespace(BaseTaskNamespace):
 
         return True
 
-    def create_system_user(self, name, group, homedir, shell,
-                           uid=None, gid=None, comment=None,
-                           create_homedir=False, groups=None):
-        """
-        Create a system user with a corresponding group
-
-        According to https://fedoraproject.org/wiki/Packaging:UsersAndGroups?rd=Packaging/UsersAndGroups#Soft_static_allocation
-        some system users should have fixed UID, GID and other parameters set.
-        This values should be constant and may be hardcoded.
-        Add other values for other users when needed.
-        """
-        if name == constants.PKI_USER:
-            if uid is None:
-                uid = 17
-            if gid is None:
-                gid = 17
-            if comment is None:
-                comment = 'CA System User'
-        if name == constants.DS_USER:
-            if comment is None:
-                comment = 'DS System User'
-
-        super(RedHatTaskNamespace, self).create_system_user(
-            name, group, homedir, shell, uid, gid, comment, create_homedir,
-            groups)
-
     def parse_ipa_version(self, version):
         """
         :param version: textual version

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -46,7 +46,6 @@ from ipalib import errors
 import ipalib.constants
 from ipalib.install import certmonger
 from ipaplatform import services
-from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks
 
@@ -263,16 +262,6 @@ def is_ca_installed_locally():
     return os.path.exists(paths.CA_CS_CFG_PATH)
 
 
-def create_ca_user():
-    """Create PKI user/group if it doesn't exist yet."""
-    tasks.create_system_user(
-        name=constants.PKI_USER,
-        group=constants.PKI_GROUP,
-        homedir=paths.VAR_LIB,
-        shell=paths.NOLOGIN,
-    )
-
-
 class CAInstance(DogtagInstance):
     """
     When using a dogtag CA the DS database contains just the
@@ -382,7 +371,6 @@ class CAInstance(DogtagInstance):
             has_ra_cert = False
 
         if not ra_only:
-            self.step("creating certificate server user", create_ca_user)
             if promote:
                 # Setup Database
                 self.step("creating certificate server db", self.__create_ds_db)

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -158,16 +158,6 @@ def is_ds_running(server_id=''):
     return services.knownservices.dirsrv.is_running(instance_name=server_id)
 
 
-def create_ds_user():
-    """Create DS user/group if it doesn't exist yet."""
-    tasks.create_system_user(
-        name=DS_USER,
-        group=DS_USER,
-        homedir=paths.VAR_LIB_DIRSRV,
-        shell=paths.NOLOGIN,
-    )
-
-
 def get_domain_level(api=api):
     ldap_uri = ipaldap.get_ldap_uri(protocol='ldapi', realm=api.env.realm)
     conn = ipaldap.LDAPClient(ldap_uri)
@@ -258,7 +248,6 @@ class DsInstance(service.Service):
 
     def __common_setup(self, enable_ssl=False):
 
-        self.step("creating directory server user", create_ds_user)
         self.step("creating directory server instance", self.__create_instance)
         self.step("enabling ldapi", self.__enable_ldapi)
         self.step("configure autobind for root", self.__root_autobind)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -102,18 +102,6 @@ def httpd_443_configured():
     return False
 
 
-def create_kdcproxy_user():
-    """Create KDC proxy user/group if it doesn't exist yet."""
-    tasks.create_system_user(
-        name=KDCPROXY_USER,
-        group=KDCPROXY_USER,
-        homedir=paths.VAR_LIB_KDCPROXY,
-        shell=paths.NOLOGIN,
-        comment="IPA KDC Proxy User",
-        create_homedir=True,
-    )
-
-
 class WebGuiInstance(service.SimpleServiceInstance):
     def __init__(self):
         service.SimpleServiceInstance.__init__(self, "ipa_webgui")
@@ -182,7 +170,6 @@ class HTTPInstance(service.Service):
                   self.remove_httpd_ccaches)
         self.step("configuring SELinux for httpd", self.configure_selinux_for_httpd)
         if not self.is_kdcproxy_configured():
-            self.step("create KDC proxy user", create_kdcproxy_user)
             self.step("create KDC proxy config", self.create_kdcproxy_conf)
             self.step("enable KDC proxy", self.enable_kdcproxy)
         self.step("restarting httpd", self.__start)

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -44,7 +44,6 @@ import six
 from six.moves.configparser import SafeConfigParser, NoOptionError
 # pylint: enable=import-error
 
-from ipalib.constants import IPAAPI_USER, IPAAPI_GROUP
 from ipalib.install import sysrestore
 from ipalib.install.kinit import kinit_password
 import ipaplatform
@@ -56,7 +55,6 @@ from ipalib import api, errors, x509
 from ipapython.dn import DN
 from ipaserver.install import certs, service, sysupgrade
 from ipaplatform import services
-from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks
 
@@ -1515,14 +1513,3 @@ def default_subject_base(realm_name):
 
 def default_ca_subject_dn(subject_base):
     return DN(('CN', 'Certificate Authority'), subject_base)
-
-
-def create_ipaapi_user():
-    """Create IPA API user/group if it doesn't exist yet."""
-    tasks.create_system_user(
-        name=IPAAPI_USER,
-        group=IPAAPI_GROUP,
-        homedir=paths.VAR_LIB,
-        shell=paths.NOLOGIN
-    )
-    tasks.add_user_to_group(constants.HTTPD_USER, IPAAPI_GROUP)

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -36,8 +36,6 @@ from ipapython import version, ipautil
 from ipapython.ipautil import run, user_input
 from ipapython import admintool
 from ipapython.dn import DN
-from ipaserver.install.dsinstance import create_ds_user
-from ipaserver.install.cainstance import create_ca_user
 from ipaserver.install.replication import (wait_for_task, ReplicationManager,
                                            get_cs_replication_manager)
 from ipaserver.install import installutils
@@ -296,7 +294,6 @@ class Restore(admintool.AdminTool):
                     not user_input("Continue to restore?", False)):
                 raise admintool.ScriptError("Aborted")
 
-        create_ds_user()
         pent = pwd.getpwnam(constants.DS_USER)
 
         # Temporary directory for decrypting files before restoring
@@ -379,15 +376,11 @@ class Restore(admintool.AdminTool):
             # We do either a full file restore or we restore data.
             if restore_type == 'FULL':
                 self.remove_old_files()
-                if 'CA' in self.backup_services:
-                    create_ca_user()
                 self.cert_restore_prepare()
                 self.file_restore(options.no_logs)
                 self.cert_restore()
                 if 'CA' in self.backup_services:
                     self.__create_dogtag_log_dirs()
-                if http.is_kdcproxy_configured():
-                    httpinstance.create_kdcproxy_user()
 
             # Always restore the data from ldif
             # We need to restore both userRoot and ipaca.

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -39,7 +39,7 @@ from ipaserver.install import (
 from ipaserver.install.installutils import (
     IPA_MODULES, BadHostError, get_fqdn, get_server_ip_address,
     is_ipa_configured, load_pkcs12, read_password, verify_fqdn,
-    update_hosts_file, create_ipaapi_user)
+    update_hosts_file)
 
 if six.PY3:
     unicode = str
@@ -721,11 +721,7 @@ def install(installer):
         update_hosts_file(ip_addresses, host_name, fstore)
 
     # Make sure tmpfiles dir exist before installing components
-    create_ipaapi_user()
     tasks.create_tmpfiles_dirs()
-
-    # Create DS user/group if it doesn't exist yet
-    dsinstance.create_ds_user()
 
     # Create a directory server instance
     if not options.external_cert_files:

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -42,8 +42,7 @@ from ipaserver.install import (
     installutils, kra, krbinstance,
     ntpinstance, otpdinstance, custodiainstance, service)
 from ipaserver.install.installutils import (
-    create_replica_config, ReplicaConfig, load_pkcs12, is_ipa_configured,
-    create_ipaapi_user)
+    create_replica_config, ReplicaConfig, load_pkcs12, is_ipa_configured)
 from ipaserver.install.replication import (
     ReplicationManager, replica_conn_check)
 import SSSDConfig
@@ -1359,7 +1358,6 @@ def install(installer):
     ccache = os.environ['KRB5CCNAME']
 
     # Make sure tmpfiles dir exist before installing components
-    create_ipaapi_user()
     tasks.create_tmpfiles_dirs()
 
     if promote:
@@ -1387,8 +1385,6 @@ def install(installer):
         ipaclient.install.ntpconf.force_ntpd(sstore)
         ntp = ntpinstance.NTPInstance()
         ntp.create_instance()
-
-    dsinstance.create_ds_user()
 
     try:
         if promote:

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1652,7 +1652,6 @@ def upgrade_configuration():
 
     if not http.is_kdcproxy_configured():
         root_logger.info('[Enabling KDC Proxy]')
-        httpinstance.create_kdcproxy_user()
         http.create_kdcproxy_conf()
         http.enable_kdcproxy()
 
@@ -1837,7 +1836,6 @@ def upgrade_check(options):
 
 def upgrade():
     # Do this early so that any code depending on these dirs will not fail
-    installutils.create_ipaapi_user()
     tasks.create_tmpfiles_dirs()
     tasks.configure_tmpfiles()
 


### PR DESCRIPTION
Previously system users needed by FreeIPA server services was created during
ipa-server-install. This led to problem when DBus policy was configured during
package installation but the user specified in the policy didn't exist yet (and
potentionally similar ones). Now systemd-sysusers service is used to ensure
users freeipa-server package needs exist before any installation or
configuration begins.

https://pagure.io/freeipa/issue/6743