### PR TITLE
install: request service certs after host keytab is set up

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -40,6 +40,7 @@ from cryptography.hazmat.backends import default_backend
 
 import six
 
+from ipalib.install.kinit import kinit_keytab
 from ipapython import ipautil
 from ipapython.dn import DN
 from ipalib import api, errors, x509
@@ -132,7 +133,7 @@ def ldap_connect():
     conn = None
     try:
         conn = ldap2(api)
-        conn.connect(autobind=True)
+        conn.connect(ccache=os.environ['KRB5CCNAME'])
         yield conn
     finally:
         if conn is not None and conn.isconnected():
@@ -526,6 +527,11 @@ def main():
     tmpdir = tempfile.mkdtemp(prefix="tmp-")
     certs.renewal_lock.acquire()
     try:
+        principal = str('host/%s@%s' % (api.env.host, api.env.realm))
+        ccache_filename = os.path.join(tmpdir, 'ccache')
+        os.environ['KRB5CCNAME'] = ccache_filename
+        kinit_keytab(principal, paths.KRB5_KEYTAB, ccache_filename)
+
         profile = os.environ.get('CERTMONGER_CA_PROFILE')
         if is_replicated():
             if profile or is_renewal_master():

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -518,7 +518,6 @@ def main():
 
     api.bootstrap(in_server=True, context='renew', confdir=paths.ETC_IPA)
     api.finalize()
-    api.Backend.ldap2.connect()
 
     operation = os.environ.get('CERTMONGER_OPERATION')
     if operation not in ('SUBMIT', 'POLL'):
@@ -531,6 +530,8 @@ def main():
         ccache_filename = os.path.join(tmpdir, 'ccache')
         os.environ['KRB5CCNAME'] = ccache_filename
         kinit_keytab(principal, paths.KRB5_KEYTAB, ccache_filename)
+
+        api.Backend.ldap2.connect()
 
         profile = os.environ.get('CERTMONGER_CA_PROFILE')
         if is_replicated():
@@ -547,9 +548,10 @@ def main():
             print(item)
         return res[0]
     finally:
+        if api.Backend.ldap2.isconnected():
+            api.Backend.ldap2.disconnect()
         certs.renewal_lock.release()
         shutil.rmtree(tmpdir)
-        api.Backend.ldap2.disconnect()
 
 
 try:

--- a/install/restart_scripts/renew_ca_cert
+++ b/install/restart_scripts/renew_ca_cert
@@ -42,7 +42,6 @@ def _main():
 
     api.bootstrap(in_server=True, context='restart', confdir=paths.ETC_IPA)
     api.finalize()
-    api.Backend.ldap2.connect()
 
     dogtag_service = services.knownservices['pki_tomcatd']
 
@@ -76,6 +75,8 @@ def _main():
         ccache_filename = os.path.join(tmpdir, 'ccache')
         kinit_keytab(principal, paths.KRB5_KEYTAB, ccache_filename)
         os.environ['KRB5CCNAME'] = ccache_filename
+
+        api.Backend.ldap2.connect()
 
         ca = cainstance.CAInstance(host_name=api.env.host)
         ca.update_cert_config(nickname, cert)
@@ -184,8 +185,9 @@ def _main():
                 if conn is not None and conn.isconnected():
                     conn.disconnect()
     finally:
+        if api.Backend.ldap2.isconnected():
+            api.Backend.ldap2.disconnect()
         shutil.rmtree(tmpdir)
-        api.Backend.ldap2.disconnect()
 
     # Now we can start the CA. Using the services start should fire
     # off the servlet to verify that the CA is actually up and responding so

--- a/install/restart_scripts/renew_ra_cert
+++ b/install/restart_scripts/renew_ra_cert
@@ -38,7 +38,6 @@ from ipaplatform.paths import paths
 def _main():
     api.bootstrap(in_server=True, context='restart', confdir=paths.ETC_IPA)
     api.finalize()
-    api.Backend.ldap2.connect()
 
     tmpdir = tempfile.mkdtemp(prefix="tmp-")
     try:
@@ -46,6 +45,8 @@ def _main():
         ccache_filename = os.path.join(tmpdir, 'ccache')
         kinit_keytab(principal, paths.KRB5_KEYTAB, ccache_filename)
         os.environ['KRB5CCNAME'] = ccache_filename
+
+        api.Backend.ldap2.connect()
 
         ca = cainstance.CAInstance(host_name=api.env.host)
         ra_certpath = paths.RA_AGENT_PEM
@@ -71,8 +72,9 @@ def _main():
             # Load it into dogtag
             cainstance.update_people_entry(dercert)
     finally:
+        if api.Backend.ldap2.isconnected():
+            api.Backend.ldap2.disconnect()
         shutil.rmtree(tmpdir)
-        api.Backend.ldap2.disconnect()
 
 
 def main():

--- a/install/restart_scripts/restart_dirsrv
+++ b/install/restart_scripts/restart_dirsrv
@@ -41,7 +41,7 @@ def _main():
 
     try:
         if services.knownservices.dirsrv.is_running():
-            services.knownservices.dirsrv.restart(instance)
+            services.knownservices.dirsrv.restart(instance, ldapi=True)
     except Exception as e:
         syslog.syslog(syslog.LOG_ERR, "Cannot restart dirsrv (instance: '%s'): %s" % (instance, str(e)))
 

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -837,6 +837,10 @@ class DsInstance(service.Service):
             finally:
                 certmonger.modify_ca_helper('IPA', prev_helper)
 
+            # restart_dirsrv in the request above restarts DS, reconnect ldap2
+            api.Backend.ldap2.disconnect()
+            api.Backend.ldap2.connect()
+
             self.dercert = dsdb.get_cert_from_db(self.nickname, pem=False)
 
         dsdb.create_pin_file()

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -160,6 +160,7 @@ class HTTPInstance(service.Service):
             self.ca_is_configured = ca_is_configured
         self.promote = promote
 
+        self.step("stopping httpd", self.__stop)
         self.step("setting mod_nss port to 443", self.__set_mod_nss_port)
         self.step("setting mod_nss cipher suite",
                   self.set_mod_nss_cipher_suite)
@@ -185,15 +186,15 @@ class HTTPInstance(service.Service):
             self.step("create KDC proxy user", create_kdcproxy_user)
             self.step("create KDC proxy config", self.create_kdcproxy_conf)
             self.step("enable KDC proxy", self.enable_kdcproxy)
-        self.step("restarting httpd", self.__start)
+        self.step("starting httpd", self.start)
         self.step("configuring httpd to start on boot", self.__enable)
         self.step("enabling oddjobd", self.enable_and_start_oddjobd)
 
         self.start_creation()
 
-    def __start(self):
+    def __stop(self):
         self.backup_state("running", self.is_running())
-        self.restart()
+        self.stop()
 
     def __enable(self):
         self.backup_state("enabled", self.is_enabled())

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -807,10 +807,6 @@ def install(installer):
     if setup_ca:
         ca.install_step_1(False, None, options)
 
-    # The DS instance is created before the keytab, add the SSL cert we
-    # generated
-    ds.add_cert_to_service()
-
     otpd = otpdinstance.OtpdInstance()
     otpd.create_instance('OTPD', host_name,
                          ipautil.realm_to_suffix(realm_name))

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -770,6 +770,13 @@ def install(installer):
             realm_name, host_name, domain_name, dm_password,
             options.subject_base, options.ca_subject, 1101, 1100, None)
 
+    krb = krbinstance.KrbInstance(fstore)
+    krb.create_instance(realm_name, host_name, domain_name,
+                        dm_password, master_password,
+                        setup_pkinit=not options.no_pkinit,
+                        pkcs12_info=pkinit_pkcs12_info,
+                        subject_base=options.subject_base)
+
     if setup_ca:
         if not options.external_cert_files and options.external_ca:
             # stage 1 of external CA installation
@@ -792,17 +799,6 @@ def install(installer):
 
     # we now need to enable ssl on the ds
     ds.enable_ssl()
-
-    krb = krbinstance.KrbInstance(fstore)
-    krb.create_instance(realm_name, host_name, domain_name,
-                        dm_password, master_password,
-                        setup_pkinit=not options.no_pkinit,
-                        pkcs12_info=pkinit_pkcs12_info,
-                        subject_base=options.subject_base)
-
-    # restart DS to enable ipa-pwd-extop plugin
-    print("Restarting directory server to enable password extension plugin")
-    ds.restart()
 
     if setup_ca:
         ca.install_step_1(False, None, options)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1422,9 +1422,8 @@ def install(installer):
         setup_pkinit=not options.no_pkinit,
         promote=promote)
 
-    # restart DS to enable ipa-pwd-extop plugin
-    print("Restarting directory server to enable password extension plugin")
-    ds.restart()
+    # we now need to enable ssl on the ds
+    ds.enable_ssl()
 
     install_http(
         config,


### PR DESCRIPTION
**dsinstance: reconnect ldap2 after DS is restarted by certmonger**

DS is restarted by certmonger in the restart_dirsrv script after the DS
certificate is saved. This breaks the ldap2 backend and makes any operation
fail with NetworkError until it is reconnected.

Reconnect ldap2 after the DS certificate request is finished to fix the
issue. Make sure restart_dirsrv waits for the ldapi socket so that the
reconnect does not fail.

**httpinstance: avoid httpd restart during certificate request**

httpd is restarted by certmonger in the restart_httpd script after the
httpd certificate is saved if it was previously running. The restart will
fail because httpd is not properly configured at this point.

Stop httpd at the beginning of httpd install to avoid the restart.

**dsinstance, httpinstance: consolidate certificate request code**

A different code path is used for DS and httpd certificate requests in
replica promotion. This is rather unnecessary and makes the certificate
request code not easy to follow.

Consolidate the non-promotion and promotion code paths into one.

**install: request service certs after host keytab is set up**

The certmonger renew agent and restart scripts use host keytab for
authentication. When they are executed during a certmonger request before
the host keytab is set up, the authentication will fail.

Make sure all certmonger requests in the installer are done after the host
keytab is set up.

**renew agent: revert to host keytab authentication**

Fixes an issue where the renew agent uses GSSAPI for LDAP connection but
fails because it is not authenticated.

This reverts commit 7462adec13c5b25b6868d2863dc38062c97d0ff7.

**renew agent, restart scripts: connect to LDAP after kinit**

Connect to LDAP after kinit is done, otherwise GSSAPI authentication will
fail.

https://pagure.io/freeipa/issue/6757
