### PR TITLE
ipaclient/ipapython macOS compatibility fixes

### DIFF
--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -603,7 +603,7 @@ class _TransportCertCache(object):
                 try:
                     f.write(pem)
                     f.flush()
-                    os.fdatasync(f.fileno())
+                    os.fsync(f.fileno())
                     f.close()
                     os.rename(f.name, filename)
                 except Exception:

--- a/ipaclient/remote_plugins/schema.py
+++ b/ipaclient/remote_plugins/schema.py
@@ -476,7 +476,7 @@ class Schema(object):
             try:
                 self._write_schema_data(f)
                 f.flush()
-                os.fdatasync(f.fileno())
+                os.fsync(f.fileno())
                 f.close()
             except Exception:
                 os.unlink(f.name)

--- a/ipapython/session_storage.py
+++ b/ipapython/session_storage.py
@@ -3,13 +3,18 @@
 #
 
 import ctypes
+import sys
 
 
 KRB5_CC_NOSUPP = -1765328137
 
+if sys.platform == 'darwin':
+    LIBKRB5_FILENAME = 'libkrb5.dylib'
+else:
+    LIBKRB5_FILENAME = 'libkrb5.so.3'
 
 try:
-    LIBKRB5 = ctypes.CDLL('libkrb5.so.3')
+    LIBKRB5 = ctypes.CDLL(LIBKRB5_FILENAME)
 except OSError as e:  # pragma: no cover
     raise ImportError(str(e))
 


### PR DESCRIPTION
libkrb5.so.3 is called libkrb5.dylib on macOS

