### PR TITLE
Use entry_points for ipa CLI

### DIFF
--- a/ipa
+++ b/ipa
@@ -24,8 +24,7 @@ Command Line Interface for IPA administration.
 
 The CLI functionality is implemented in ipalib/cli.py
 """
-
-from ipalib import api, cli
+from ipaclient.__main__ import main
 
 if __name__ == '__main__':
-    cli.run(api)
+    main()

--- a/ipaclient/__main__.py
+++ b/ipaclient/__main__.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2017  FreeIPA Contributors see COPYING for license
+"""
+Command Line Interface for IPA administration.
+
+The CLI functionality is implemented in ipalib/cli.py
+"""
+from ipalib import api, cli
+
+
+def main():
+    cli.run(api)
+
+
+if __name__ == '__main__':
+    main()

--- a/ipaclient/setup.py
+++ b/ipaclient/setup.py
@@ -31,7 +31,6 @@ if __name__ == '__main__':
     ipasetup(
         name="ipaclient",
         doc=__doc__,
-        scripts=['../ipa'],
         package_dir={'ipaclient': ''},
         packages=[
             "ipaclient",
@@ -60,6 +59,11 @@ if __name__ == '__main__':
             "qrcode",
             "six",
         ],
+        entry_points={
+            'console_scripts': [
+                'ipa = ipaclient.__main__:main'
+            ]
+        },
         extras_require={
             "install": ["ipaplatform"],
             "otptoken_yubikey": ["yubico", "usb"]


### PR DESCRIPTION
Fix problem with hard-coded shebang in ipa command line tool by using
a proper setuptools entry point for the console script. ipaclient is now
an executable Python package, too.

```
$ python -m ipaclient ping
```

is equivalent to

```
$ ipa ping
```

Related: https://pagure.io/freeipa/issue/6653
Closes: https://pagure.io/freeipa/issue/6850
Signed-off-by: Christian Heimes <cheimes@redhat.com>