### PR TITLE
ipa help doesn't always work

### DIFF
--- a/ipaclient/remote_plugins/schema.py
+++ b/ipaclient/remote_plugins/schema.py
@@ -516,7 +516,9 @@ class Schema(object):
 
     def get_help(self, namespace, member):
         if isinstance(self._help, bytes):
-            self._help = json.loads(self._help.decode('utf-8'))
+            self._help = json.loads(
+                self._help.decode('utf-8')  # pylint: disable=no-member
+            )
 
         return self._help[namespace][member]
 

--- a/ipaclient/remote_plugins/schema.py
+++ b/ipaclient/remote_plugins/schema.py
@@ -383,6 +383,7 @@ class Schema(object):
 
         if fingerprint is None:
             fingerprint, ttl = self._fetch(client, ignore_cache=read_failed)
+            self._help = self._generate_help(self._dict)
             try:
                 self._write_schema(fingerprint)
             except Exception as e:
@@ -498,7 +499,7 @@ class Schema(object):
 
             schema.writestr(
                 '_help',
-                json.dumps(self._generate_help(self._dict)).encode('utf-8')
+                json.dumps(self._help).encode('utf-8')
             )
 
     def read_namespace_member(self, namespace, member):


### PR DESCRIPTION
`ipa help` will not work when calling it when no schema is cached.