### PR TITLE
WebUI: cert login: Configure name of parameter used to pass username

### DIFF
--- a/install/conf/ipa.conf
+++ b/install/conf/ipa.conf
@@ -117,6 +117,7 @@ Alias /ipa/session/cookie "/usr/share/ipa/gssapi.login"
   NSSVerifyClient require
   NSSUserName SSL_CLIENT_CERT
   LookupUserByCertificate On
+  LookupUserByCertificateParamName "username"
   WSGIProcessGroup ipa
   WSGIApplicationGroup ipa
   GssapiImpersonate On


### PR DESCRIPTION
Directive LookupUserByCertificateParamName tells mod_lookup_identity module the
name of GET parameter that is used to provide username in case certificate is
mapped to multiple user accounts.
Without this directive login with certificate that's mapped to multiple users
doesn't work.

https://pagure.io/freeipa/issue/6860