### PR TITLE
Fix CA-less to CA-full upgrade

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -183,6 +183,8 @@ def install_check(standalone, replica_config, options):
             realm_name, nssdir=dirname, subject_base=options._subject_base)
 
         for db in (cadb, dsdb):
+            if not db.exists():
+                continue
             for nickname, _trust_flags in db.list_certs():
                 if nickname == certdb.get_ca_nickname(realm_name):
                     raise ScriptError(

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -379,7 +379,7 @@ class HTTPInstance(service.Service):
         db = certs.CertDB(self.realm, nssdir=paths.HTTPD_ALIAS_DIR,
                           subject_base=self.subject_base, user="root",
                           group=constants.HTTPD_GROUP,
-                          truncate=True)
+                          create=True)
         self.disable_system_trust()
         self.create_password_conf()
         if self.pkcs12_info:


### PR DESCRIPTION
CertDB would have always created a directory on initialization. This
behavior changes here by replacing the truncate argument with create
which will only create the database when really required.

https://pagure.io/freeipa/issue/6853