### PR TITLE
[ipatests] - added krb5kdc.log to pytest logging

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -314,6 +314,7 @@ class BasePathNamespace(object):
     IPASERVER_UNINSTALL_LOG = "/var/log/ipaserver-uninstall.log"
     IPAUPGRADE_LOG = "/var/log/ipaupgrade.log"
     KADMIND_LOG = "/var/log/kadmind.log"
+    KRB5KDC_LOG = "/var/log/krb5kdc.log"
     MESSAGES = "/var/log/messages"
     VAR_LOG_PKI_DIR = "/var/log/pki/"
     TOMCAT_TOPLEVEL_DIR = "/var/log/pki/pki-tomcat"

--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -77,6 +77,7 @@ def setup_server_logs_collecting(host):
 
     # kerberos related logs
     host.collect_log(paths.KADMIND_LOG)
+    host.collect_log(paths.KRB5KDC_LOG)
 
     # httpd logs
     host.collect_log(paths.VAR_LOG_HTTPD_ERROR)


### PR DESCRIPTION
KRB5KDC_LOG = '/var/log/krb5kdc.log' added to paths
host.collect_log(paths.KRB5KDC_LOG) added to tasks.py

Signed-off-by: Michal Reznik <mreznik@redhat.com>