### PR TITLE
WebUI: fix showing required asterisk '*'

### DIFF
--- a/install/ui/src/freeipa/field.js
+++ b/install/ui/src/freeipa/field.js
@@ -221,11 +221,25 @@ field.field = IPA.field = function(spec) {
     that.read_only = spec.read_only;
 
     /**
+     * Attribute for storing previous value of read_only attribute.
+     * It is set during changing read_only attribute.
+     * @property {boolean}
+     */
+    that.old_read_only = spec.read_only;
+
+    /**
      * Writable is set during load
      * @readonly
      * @property {boolean}
      */
     that.writable = true;
+
+    /**
+     * Attribute for storing previous value of writable attribute.
+     * It is set during changing writable attribute.
+     * @property {boolean}
+     */
+    that.old_writable = true;
 
     /**
      * Enabled
@@ -348,6 +362,19 @@ field.field = IPA.field = function(spec) {
         that.validators.push(IPA.metadata_validator());
     };
 
+
+    /**
+     * Evaluate if field was required before
+     * @return {boolean}
+     */
+    that.was_required = function() {
+        if (that.old_read_only) return false;
+        if (!that.old_writable) return false;
+
+        if (that.required !== undefined) return that.required;
+        return that.metadata && that.metadata.required;
+    };
+
     /**
      * Evaluate if field has to have some value
      * @return {boolean}
@@ -369,7 +396,7 @@ field.field = IPA.field = function(spec) {
      * @param {boolean} required
      */
     that.set_required = function(required) {
-        var old = that.is_required();
+        var old = that.was_required();
         that.required = required;
         var current = that.is_required();
 
@@ -570,9 +597,9 @@ field.field = IPA.field = function(spec) {
      */
     that.set_writable = function(writable) {
 
-        var old = !!that.writable;
+        that.old_writable = !!that.writable;
         that.writable = writable;
-        if (old !== writable) {
+        if (that.old_writable !== writable) {
             that.emit('writable-change', { source: that, writable: writable });
         }
 
@@ -586,11 +613,12 @@ field.field = IPA.field = function(spec) {
      */
     that.set_read_only = function(read_only) {
 
-        var old = !!that.read_only;
+        that.old_read_only = !!that.read_only;
         that.read_only = read_only;
-        if (old !== read_only) {
+        if (that.old_read_only !== read_only) {
             that.emit('readonly-change', { source: that, readonly: read_only });
         }
+
         that.set_required(that.required); // force update of required
     };
 


### PR DESCRIPTION
There was a bug that when user switch between two facets where is
required field and in one of them is writable and in second one
is not writable, then the asterisk which marks required field is
not shown. i.e. admin vs. user details page or global_passwd_policy
vs. other_passwd_policy details page.

That was caused by incorrect evaluation of required state of field.
Evaluation works that way: evaluate old required state, then evaluate
current required state and if states has changed then emit change event.
The evaluation depends on writable and read_only state of field.
Those two states are set before evaluation of required state, but
their old values (for evaluating previous required stated) were
not stored anywhere.

This commit adds two attributes which stores old writable
and read_only states. The required asterisk is then shown correctly.

https://pagure.io/freeipa/issue/6849