### PR TITLE
External CA fixes

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -786,9 +786,10 @@ class CAInstance(DogtagInstance):
         certlist = x509.pkcs7_to_pems(data, x509.DER)
 
         # We have all the certificates in certlist, write them to a PEM file
-        for cert in certlist:
-            with open(paths.IPA_CA_CRT, 'w') as ipaca_pem:
+        with open(paths.IPA_CA_CRT, 'w') as ipaca_pem:
+            for cert in certlist:
                 ipaca_pem.write(cert)
+                ipaca_pem.write('\n')
 
     def __request_ra_certificate(self):
         # create a temp file storing the pwd

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -762,11 +762,12 @@ def install(installer):
             options.subject_base, options.ca_subject, 1101, 1100, None)
 
     krb = krbinstance.KrbInstance(fstore)
-    krb.create_instance(realm_name, host_name, domain_name,
-                        dm_password, master_password,
-                        setup_pkinit=not options.no_pkinit,
-                        pkcs12_info=pkinit_pkcs12_info,
-                        subject_base=options.subject_base)
+    if not options.external_cert_files:
+        krb.create_instance(realm_name, host_name, domain_name,
+                            dm_password, master_password,
+                            setup_pkinit=not options.no_pkinit,
+                            pkcs12_info=pkinit_pkcs12_info,
+                            subject_base=options.subject_base)
 
     if setup_ca:
         if not options.external_cert_files and options.external_ca:


### PR DESCRIPTION
External CA installation would have failed for 2 reasons:
- Trying to perform Kerberos install twice
- Rewriting the CA cert file with each consecutive certificate in the certificate chain instead of appending them

This patchset fixes that behavior.