### PR TITLE
tox: use pylint 1.6.x for now

### DIFF
--- a/.wheelconstraints.in
+++ b/.wheelconstraints.in
@@ -9,3 +9,5 @@ ipapython == @VERSION@
 ipaserver == @VERSION@
 ipatests == @VERSION@
 
+# see https://pagure.io/freeipa/issue/6874
+pylint < 1.7


### PR DESCRIPTION
FreeIPA is not yet compatible with pylint 1.7.1+. Enforce pylint 1.6.x
until all issues have been addressed.

Related: https://pagure.io/freeipa/issue/6874
Signed-off-by: Christian Heimes <cheimes@redhat.com>