### PR TITLE
Store GSSAPI session key in /var/run/httpd

### DIFF
--- a/install/conf/ipa.conf
+++ b/install/conf/ipa.conf
@@ -1,5 +1,5 @@
 #
-# VERSION 25 - DO NOT REMOVE THIS LINE
+# VERSION 26 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -78,7 +78,7 @@ WSGIScriptReloading Off
   SessionCookieName ipa_session path=/ipa;httponly;secure;
   SessionHeader IPASESSION
   SessionMaxAge 1800
-  GssapiSessionKey file:/etc/httpd/alias/ipasession.key
+  GssapiSessionKey file:/var/run/ipa/session.key
 
   GssapiImpersonate On
   GssapiDelegCcacheDir /var/run/ipa/ccaches
@@ -127,7 +127,7 @@ Alias /ipa/session/cookie "/usr/share/ipa/gssapi.login"
   SessionCookieName ipa_session path=/ipa;httponly;secure;
   SessionHeader IPASESSION
   SessionMaxAge 1800
-  GssapiSessionKey file:/etc/httpd/alias/ipasession.key
+  GssapiSessionKey file:/var/run/ipa/session.key
 
   Header unset Set-Cookie
 </Location>


### PR DESCRIPTION
Runtime data should be stored in /var/run instead of /etc/httpd/alias.
This change is also compatible with selinux policy.

https://pagure.io/freeipa/issue/6880