### PR TITLE
upgrade: adtrust update_tdo_gidnumber plugin must check if adtrust is…

### DIFF
--- a/ipaserver/install/plugins/adtrust.py
+++ b/ipaserver/install/plugins/adtrust.py
@@ -329,6 +329,11 @@ class update_tdo_gidnumber(Updater):
     def execute(self, **options):
         ldap = self.api.Backend.ldap2
 
+        # First, see if trusts are enabled on the server
+        if not self.api.Command.adtrust_is_enabled()['result']:
+            self.log.debug('AD Trusts are not enabled on this server')
+            return False, []
+
         # Read the gidnumber of the fallback group
         dn = DN(('cn', ADTRUSTInstance.FALLBACK_GROUP_NAME),
                 self.api.env.container_group,


### PR DESCRIPTION
… installed

During upgrade, the plugin update_tdo_gidnumber is launched in order to
add a gidnumber to the Trusted Domain Object.
This plugin should not be run when ad trust is not installed, otherwise an
error message is displayed.

https://pagure.io/freeipa/issue/6881