### PR TITLE
Add check for directory name

### DIFF
--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -170,6 +170,10 @@ def check_writable_file(filename):
     """
     if filename is None:
         raise errors.FileError(reason=_('Filename is empty'))
+
+    if not os.path.isfile(filename):
+        raise errors.FileError(reason=_('Expected file but %(fname)s is not a '
+                                        'regular file' % dict(fname=filename)))
     try:
         if os.path.exists(filename):
             if not os.access(filename, os.W_OK):


### PR DESCRIPTION
Fix adds check to verify if user provided input is not
a directory when filename is required.

Fixes: https://pagure.io/freeipa/issue/6883

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>