### PR TITLE
ipa-cacert-manage: add --external-ca-type

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -451,6 +451,10 @@ def renew_ca_cert(reuse_existing, **kwargs):
     """
     This is used for automatic CA certificate renewal.
     """
+    csr = os.environ.get('CERTMONGER_CSR')
+    if not csr:
+        return (UNCONFIGURED, "Certificate request not provided")
+
     cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if not cert:
         return (REJECTED, "New certificate requests not supported")
@@ -462,6 +466,13 @@ def renew_ca_cert(reuse_existing, **kwargs):
 
         if is_self_signed and not reuse_existing and is_renewal_master():
             state = 'request'
+
+        csr_file = paths.IPA_CA_CSR
+        try:
+            with open(csr_file, 'wb') as f:
+                f.write(csr)
+        except Exception as e:
+            return (UNREACHABLE, "Failed to write %s: %s" % (csr_file, e))
     elif operation == 'POLL':
         cookie = os.environ.get('CERTMONGER_CA_COOKIE')
         if not cookie:

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -98,25 +98,7 @@ def get_nickname():
         DN('CN=IPA RA', subject_base): 'ipaCert',
     }
 
-    try:
-        return nickname_by_subject_dn[DN(subject)]
-    except KeyError:
-        cas = api.Command.ca_find(ipacasubjectdn=DN(subject))['result']
-        if len(cas) == 0:
-            return None
-        return 'caSigningCert cert-pki-ca {}'.format(cas[0]['ipacaid'][0])
-
-
-def is_lightweight_ca():
-    nickname = get_nickname() or ''
-    return nickname != IPA_CA_NICKNAME and nickname.startswith(IPA_CA_NICKNAME)
-
-def is_renewable():
-    cert = os.environ.get('CERTMONGER_CERTIFICATE')
-    if not cert:
-        return False
-    else:
-        return x509.is_self_signed(cert) or is_lightweight_ca()
+    return nickname_by_subject_dn.get(DN(subject))
 
 
 def is_replicated():
@@ -276,11 +258,6 @@ def store_cert():
     if not cert:
         return (REJECTED, "New certificate requests not supported")
 
-    if is_lightweight_ca():
-        # Lightweight CAs are updated in Dogtag's NSSDB
-        # by Dogtag itself, so do not store it
-        return (ISSUED, cert)
-
     dercert = x509.normalize_certificate(cert)
 
     dn = DN(('cn', nickname), ('cn', 'ca_renewal'),
@@ -405,12 +382,6 @@ def retrieve_cert_continuous():
     if old_cert:
         old_cert = x509.normalize_certificate(old_cert)
 
-    if is_lightweight_ca():
-        # Lightweight CAs are updated in Dogtag's NSSDB
-        # by Dogtag itself, so do not try to retrieve it.
-        # Everything is fine as is.
-        return (ISSUED, os.environ.get('CERTMONGER_CERTIFICATE'))
-
     result = call_handler(retrieve_or_reuse_cert)
     if result[0] != ISSUED:
         return result
@@ -466,12 +437,13 @@ def renew_ca_cert():
     cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if not cert:
         return (REJECTED, "New certificate requests not supported")
+    is_self_signed = x509.is_self_signed(cert)
 
     operation = os.environ.get('CERTMONGER_OPERATION')
     if operation == 'SUBMIT':
         state = 'retrieve'
 
-        if is_renewable() and is_renewal_master():
+        if is_self_signed and is_renewal_master():
             state = 'request'
     elif operation == 'POLL':
         cookie = os.environ.get('CERTMONGER_CA_COOKIE')
@@ -489,7 +461,7 @@ def renew_ca_cert():
 
     if state == 'retrieve':
         result = call_handler(retrieve_cert)
-        if result[0] == REJECTED and not is_renewable():
+        if result[0] == REJECTED and not is_self_signed:
             syslog.syslog(syslog.LOG_ALERT,
                           "Certificate with subject '%s' is about to expire, "
                           "use ipa-cacert-manage to renew it"

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -535,7 +535,7 @@ def main():
 
         profile = os.environ.get('CERTMONGER_CA_PROFILE')
         if is_replicated():
-            if profile or is_renewal_master():
+            if is_renewal_master():
                 handler = request_and_store_cert
             else:
                 handler = retrieve_cert_continuous

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -297,7 +297,7 @@ def store_cert(**kwargs):
             syslog.syslog(
                 syslog.LOG_ERR,
                 "Giving up. To retry storing the certificate, resubmit the "
-                "request with profile \"ipaStorage\"")
+                "request with CA \"dogtag-ipa-ca-renew-agent-reuse\"")
 
     return (ISSUED, cert)
 
@@ -420,33 +420,6 @@ def retrieve_cert(**kwargs):
     return result
 
 
-def export_csr(**kwargs):
-    """
-    This does not actually renew the cert, it just writes the CSR provided
-    by certmonger to /var/lib/ipa/ca.csr and returns the existing cert.
-    """
-    operation = os.environ.get('CERTMONGER_OPERATION')
-    if operation != 'SUBMIT':
-        return (OPERATION_NOT_SUPPORTED_BY_HELPER,)
-
-    csr = os.environ.get('CERTMONGER_CSR')
-    if not csr:
-        return (UNCONFIGURED, "Certificate request not provided")
-
-    cert = os.environ.get('CERTMONGER_CERTIFICATE')
-    if not cert:
-        return (REJECTED, "New certificate requests not supported")
-
-    csr_file = paths.IPA_CA_CSR
-    try:
-        with open(csr_file, 'wb') as f:
-            f.write(csr)
-    except Exception as e:
-        return (UNREACHABLE, "Failed to write %s: %s" % (csr_file, e))
-
-    return (ISSUED, cert)
-
-
 def renew_ca_cert(reuse_existing, **kwargs):
     """
     This is used for automatic CA certificate renewal.
@@ -497,12 +470,15 @@ def renew_ca_cert(reuse_existing, **kwargs):
                           "use ipa-cacert-manage to renew it"
                           % (os.environ.get("CERTMONGER_REQ_SUBJECT"),))
     elif state == 'request':
-        profile = os.environ['CERTMONGER_CA_PROFILE']
+        profile = os.environ.get('CERTMONGER_CA_PROFILE')
         os.environ['CERTMONGER_CA_PROFILE'] = 'caCACert'
         result = call_handler(request_and_store_cert,
                               reuse_existing=reuse_existing,
                               **kwargs)
-        os.environ['CERTMONGER_CA_PROFILE'] = profile
+        if profile is not None:
+            os.environ['CERTMONGER_CA_PROFILE'] = profile
+        else:
+            del os.environ['CERTMONGER_CA_PROFILE']
 
     if result[0] == WAIT:
         return (result[0], '%s:%s' % (state, result[1]))
@@ -522,14 +498,6 @@ def main():
     else:
         kwargs['reuse_existing'] = True
 
-    handlers = {
-        'ipaStorage':           store_cert,
-        'ipaRetrievalOrReuse':  retrieve_or_reuse_cert,
-        'ipaRetrieval':         retrieve_cert,
-        'ipaCSRExport':         export_csr,
-        'ipaCACertRenewal':     renew_ca_cert,
-    }
-
     api.bootstrap(in_server=True, context='renew', confdir=paths.ETC_IPA)
     api.finalize()
 
@@ -547,15 +515,15 @@ def main():
 
         api.Backend.ldap2.connect()
 
-        profile = os.environ.get('CERTMONGER_CA_PROFILE')
-        if is_replicated():
+        if get_nickname() == IPA_CA_NICKNAME:
+            handler = renew_ca_cert
+        elif is_replicated():
             if is_renewal_master():
                 handler = request_and_store_cert
             else:
                 handler = retrieve_cert_continuous
         else:
             handler = request_cert
-        handler = handlers.get(profile, handler)
 
         res = call_handler(handler, **kwargs)
         for item in res[1:]:

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -193,10 +193,18 @@ def call_handler(_handler, *args, **kwargs):
 
     return result
 
-def request_cert():
+
+def request_cert(reuse_existing, **kwargs):
     """
     Request certificate from IPA CA.
     """
+    if reuse_existing:
+        cert = os.environ.get('CERTMONGER_CERTIFICATE')
+        if cert:
+            return (ISSUED, cert)
+        else:
+            return (REJECTED, "New certificate requests not supported")
+
     syslog.syslog(syslog.LOG_NOTICE,
                   "Forwarding request to dogtag-ipa-renew-agent")
 
@@ -231,7 +239,8 @@ def request_cert():
     else:
         return (rc, stdout)
 
-def store_cert():
+
+def store_cert(**kwargs):
     """
     Store certificate in LDAP.
     """
@@ -292,7 +301,8 @@ def store_cert():
 
     return (ISSUED, cert)
 
-def request_and_store_cert():
+
+def request_and_store_cert(**kwargs):
     """
     Request certificate from IPA CA and store it in LDAP.
     """
@@ -318,7 +328,7 @@ def request_and_store_cert():
         else:
             os.environ['CERTMONGER_CA_COOKIE'] = cookie
 
-        result = call_handler(request_cert)
+        result = call_handler(request_cert, **kwargs)
         if result[0] == WAIT:
             return (result[0], 'request:%s' % result[1])
         elif result[0] == WAIT_WITH_DELAY:
@@ -337,7 +347,7 @@ def request_and_store_cert():
         os.environ['CERTMONGER_CA_COOKIE'] = cookie
     os.environ['CERTMONGER_CERTIFICATE'] = cert
 
-    result = call_handler(store_cert)
+    result = call_handler(store_cert, **kwargs)
     if result[0] == WAIT:
         return (result[0], 'store:%s:%s' % (cert, result[1]))
     elif result[0] == WAIT_WITH_DELAY:
@@ -345,7 +355,8 @@ def request_and_store_cert():
     else:
         return result
 
-def retrieve_or_reuse_cert():
+
+def retrieve_or_reuse_cert(**kwargs):
     """
     Retrieve certificate from LDAP. If the certificate is not available, reuse
     the old certificate.
@@ -373,7 +384,8 @@ def retrieve_or_reuse_cert():
 
     return (ISSUED, cert)
 
-def retrieve_cert_continuous():
+
+def retrieve_cert_continuous(reuse_existing, **kwargs):
     """
     Retrieve new certificate from LDAP. Repeat every eight hours until the
     certificate is available.
@@ -382,8 +394,10 @@ def retrieve_cert_continuous():
     if old_cert:
         old_cert = x509.normalize_certificate(old_cert)
 
-    result = call_handler(retrieve_or_reuse_cert)
-    if result[0] != ISSUED:
+    result = call_handler(retrieve_or_reuse_cert,
+                          reuse_existing=reuse_existing,
+                          **kwargs)
+    if result[0] != ISSUED or reuse_existing:
         return result
 
     new_cert = x509.normalize_certificate(result[1])
@@ -394,17 +408,19 @@ def retrieve_cert_continuous():
 
     return result
 
-def retrieve_cert():
+
+def retrieve_cert(**kwargs):
     """
     Retrieve new certificate from LDAP.
     """
-    result = call_handler(retrieve_cert_continuous)
+    result = call_handler(retrieve_cert_continuous, **kwargs)
     if result[0] == WAIT_WITH_DELAY:
         return (REJECTED, "Updated certificate not available")
 
     return result
 
-def export_csr():
+
+def export_csr(**kwargs):
     """
     This does not actually renew the cert, it just writes the CSR provided
     by certmonger to /var/lib/ipa/ca.csr and returns the existing cert.
@@ -430,7 +446,8 @@ def export_csr():
 
     return (ISSUED, cert)
 
-def renew_ca_cert():
+
+def renew_ca_cert(reuse_existing, **kwargs):
     """
     This is used for automatic CA certificate renewal.
     """
@@ -443,7 +460,7 @@ def renew_ca_cert():
     if operation == 'SUBMIT':
         state = 'retrieve'
 
-        if is_self_signed and is_renewal_master():
+        if is_self_signed and not reuse_existing and is_renewal_master():
             state = 'request'
     elif operation == 'POLL':
         cookie = os.environ.get('CERTMONGER_CA_COOKIE')
@@ -460,8 +477,10 @@ def renew_ca_cert():
         return (OPERATION_NOT_SUPPORTED_BY_HELPER,)
 
     if state == 'retrieve':
-        result = call_handler(retrieve_cert)
-        if result[0] == REJECTED and not is_self_signed:
+        result = call_handler(retrieve_cert,
+                              reuse_existing=reuse_existing,
+                              **kwargs)
+        if result[0] == REJECTED and not is_self_signed and not reuse_existing:
             syslog.syslog(syslog.LOG_ALERT,
                           "Certificate with subject '%s' is about to expire, "
                           "use ipa-cacert-manage to renew it"
@@ -469,7 +488,9 @@ def renew_ca_cert():
     elif state == 'request':
         profile = os.environ['CERTMONGER_CA_PROFILE']
         os.environ['CERTMONGER_CA_PROFILE'] = 'caCACert'
-        result = call_handler(request_and_store_cert)
+        result = call_handler(request_and_store_cert,
+                              reuse_existing=reuse_existing,
+                              **kwargs)
         os.environ['CERTMONGER_CA_PROFILE'] = profile
 
     if result[0] == WAIT:
@@ -480,6 +501,16 @@ def renew_ca_cert():
         return result
 
 def main():
+    kwargs = {
+        'reuse_existing': False,
+    }
+    try:
+        sys.argv.remove('--reuse-existing')
+    except ValueError:
+        pass
+    else:
+        kwargs['reuse_existing'] = True
+
     handlers = {
         'ipaStorage':           store_cert,
         'ipaRetrievalOrReuse':  retrieve_or_reuse_cert,
@@ -515,7 +546,7 @@ def main():
             handler = request_cert
         handler = handlers.get(profile, handler)
 
-        res = call_handler(handler)
+        res = call_handler(handler, **kwargs)
         for item in res[1:]:
             print(item)
         return res[0]

--- a/install/tools/man/ipa-cacert-manage.1
+++ b/install/tools/man/ipa-cacert-manage.1
@@ -78,6 +78,9 @@ Sign the renewed certificate by itself.
 \fB\-\-external\-ca\fR
 Sign the renewed certificate by external CA.
 .TP
+\fB\-\-external\-ca\-type\fR=\fITYPE\fR
+Type of the external CA. Possible values are "generic", "ms-cs". Default value is "generic". Use "ms-cs" to include template name required by Microsoft Certificate Services (MS CS) in the generated CSR.
+.TP
 \fB\-\-external\-cert\-file\fR=\fIFILE\fR
 File containing the IPA CA certificate and the external CA certificate chain. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times.
 .RE

--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -153,7 +153,7 @@ class CertUpdate(admintool.AdminTool):
 
             self.log.debug("resubmitting certmonger request '%s'", request_id)
             certmonger.resubmit_request(
-                request_id, profile='ipaRetrievalOrReuse')
+                request_id, ca='dogtag-ipa-ca-renew-agent-reuse', profile='')
             try:
                 state = certmonger.wait_for_request(request_id, timeout)
             except RuntimeError:
@@ -167,7 +167,7 @@ class CertUpdate(admintool.AdminTool):
                     "please check the request manually" % request_id)
 
             self.log.debug("modifying certmonger request '%s'", request_id)
-            certmonger.modify(request_id, profile='ipaCACertRenewal')
+            certmonger.modify(request_id, ca='dogtag-ipa-ca-renew-agent')
 
         self.update_file(paths.CA_CRT, certs)
 

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -501,18 +501,29 @@ def stop_tracking(secdir=None, request_id=None, nickname=None, certfile=None):
         request.parent.obj_if.remove_request(request.path)
 
 
-def modify(request_id, profile=None):
-    if profile:
+def modify(request_id, ca=None, profile=None):
+    if ca or profile:
         request = _get_request({'nickname': request_id})
-        if request:
-            request.obj_if.modify({'template-profile': profile})
+        update = {}
+        if ca is not None:
+            cm = _certmonger()
+            update['CA'] = cm.obj_if.find_ca_by_nickname(ca)
+        if profile is not None:
+            update['template-profile'] = profile
+        request.obj_if.modify(update)
 
 
-def resubmit_request(request_id, profile=None):
+def resubmit_request(request_id, ca=None, profile=None):
     request = _get_request({'nickname': request_id})
     if request:
-        if profile:
-            request.obj_if.modify({'template-profile': profile})
+        if ca or profile:
+            update = {}
+            if ca is not None:
+                cm = _certmonger()
+                update['CA'] = cm.obj_if.find_ca_by_nickname(ca)
+            if profile is not None:
+                update['template-profile'] = profile
+            request.obj_if.modify(update)
         request.obj_if.resubmit()
 
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -279,10 +279,10 @@ class CAInstance(DogtagInstance):
        2 = have signed cert, continue installation
     """
 
-    tracking_reqs = (('auditSigningCert cert-pki-ca', None),
-                     ('ocspSigningCert cert-pki-ca', None),
-                     ('subsystemCert cert-pki-ca', None),
-                     ('caSigningCert cert-pki-ca', 'ipaCACertRenewal'))
+    tracking_reqs = ('auditSigningCert cert-pki-ca',
+                     'ocspSigningCert cert-pki-ca',
+                     'subsystemCert cert-pki-ca',
+                     'caSigningCert cert-pki-ca')
     server_cert_name = 'Server-Cert cert-pki-ca'
 
     def __init__(self, realm=None, host_name=None):

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -964,9 +964,11 @@ class CAInstance(DogtagInstance):
         obj = bus.get_object('org.fedorahosted.certmonger',
                              '/org/fedorahosted/certmonger')
         iface = dbus.Interface(obj, 'org.fedorahosted.certmonger')
-        path = iface.find_ca_by_nickname('dogtag-ipa-ca-renew-agent')
-        if path:
-            iface.remove_known_ca(path)
+        for suffix in ['', '-reuse']:
+            name = 'dogtag-ipa-ca-renew-agent' + suffix
+            path = iface.find_ca_by_nickname(name)
+            if path:
+                iface.remove_known_ca(path)
 
         cmonger.stop()
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -822,7 +822,7 @@ class CAInstance(DogtagInstance):
              "-out", chain_file.name,
              ], stdin=data, capture_output=False)
 
-        agent_args = [paths.DOGTAG_IPA_CA_RENEW_AGENT_SUBMIT,
+        agent_args = [paths.CERTMONGER_DOGTAG_SUBMIT,
                       "--dbdir", self.tmp_agent_db,
                       "--nickname", "ipa-ca-agent",
                       "--cafile", chain_file.name,

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -436,7 +436,7 @@ class CAInstance(DogtagInstance):
                     self.step("adding 'ipa' CA entry", ensure_ipa_authority_entry)
 
                 self.step("configuring certmonger renewal for lightweight CAs",
-                          self.__add_lightweight_ca_tracking_requests)
+                          self.add_lightweight_ca_tracking_requests)
 
         if ra_only:
             runtime = None
@@ -1246,7 +1246,7 @@ class CAInstance(DogtagInstance):
         os.chmod(keyfile, 0o600)
         os.chown(keyfile, pent.pw_uid, pent.pw_gid)
 
-    def __add_lightweight_ca_tracking_requests(self):
+    def add_lightweight_ca_tracking_requests(self):
         try:
             lwcas = api.Backend.ldap2.get_entries(
                 base_dn=api.env.basedn,
@@ -1810,11 +1810,10 @@ def add_lightweight_ca_tracking_requests(logger, lwcas):
                     pin=certmonger.get_pin('internal'),
                     nickname=nickname,
                     ca=ipalib.constants.RENEWAL_CA_NAME,
+                    profile='caCACert',
                     pre_command='stop_pkicad',
                     post_command='renew_ca_cert "%s"' % nickname,
                 )
-                request_id = certmonger.get_request_id(criteria)
-                certmonger.modify(request_id, profile='ipaCACertRenewal')
                 logger.debug(
                     'Lightweight CA renewal: '
                     'added tracking request for "%s"', nickname)

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -275,7 +275,7 @@ class DogtagInstance(service.Service):
         """ Configure certmonger to renew system certs """
         pin = self.__get_pin()
 
-        for nickname, profile in self.tracking_reqs:
+        for nickname in self.tracking_reqs:
             try:
                 certmonger.start_tracking(
                     certpath=self.nss_db,
@@ -284,7 +284,7 @@ class DogtagInstance(service.Service):
                     pin=pin,
                     pre_command='stop_pkicad',
                     post_command='renew_ca_cert "%s"' % nickname,
-                    profile=profile)
+                )
             except RuntimeError as e:
                 self.log.error(
                     "certmonger failed to start tracking certificate: %s", e)
@@ -319,7 +319,7 @@ class DogtagInstance(service.Service):
         services.knownservices.messagebus.start()
         cmonger.start()
 
-        nicknames = [nickname for nickname, _profile in self.tracking_reqs]
+        nicknames = self.tracking_reqs
         if self.server_cert_name is not None:
             nicknames.append(self.server_cert_name)
 

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -253,12 +253,15 @@ class DogtagInstance(service.Service):
         obj = bus.get_object('org.fedorahosted.certmonger',
                              '/org/fedorahosted/certmonger')
         iface = dbus.Interface(obj, 'org.fedorahosted.certmonger')
-        path = iface.find_ca_by_nickname('dogtag-ipa-ca-renew-agent')
-        if not path:
-            iface.add_known_ca(
-                'dogtag-ipa-ca-renew-agent',
-                paths.DOGTAG_IPA_CA_RENEW_AGENT_SUBMIT,
-                dbus.Array([], dbus.Signature('s')))
+        for suffix, args in [('', ''), ('-reuse', ' --reuse-existing')]:
+            name = 'dogtag-ipa-ca-renew-agent' + suffix
+            path = iface.find_ca_by_nickname(name)
+            if not path:
+                command = paths.DOGTAG_IPA_CA_RENEW_AGENT_SUBMIT + args
+                iface.add_known_ca(
+                    name,
+                    command,
+                    dbus.Array([], dbus.Signature('s')))
 
     def __get_pin(self):
         try:

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -172,14 +172,14 @@ class CACertManage(admintool.AdminTool):
         except errors.NotFound:
             raise admintool.ScriptError("CA renewal master not found")
 
-        self.resubmit_request(ca, 'caCACert')
+        self.resubmit_request()
 
         print("CA certificate successfully renewed")
 
     def renew_external_step_1(self, ca):
         print("Exporting CA certificate signing request, please wait")
 
-        self.resubmit_request(ca, 'ipaCSRExport')
+        self.resubmit_request('dogtag-ipa-ca-renew-agent-reuse')
 
         print(("The next step is to get %s signed by your CA and re-run "
               "ipa-cacert-manage as:" % paths.IPA_CA_CSR))
@@ -282,15 +282,15 @@ class CACertManage(admintool.AdminTool):
         except errors.NotFound:
             raise admintool.ScriptError("CA renewal master not found")
 
-        self.resubmit_request(ca, 'ipaRetrieval')
+        self.resubmit_request('dogtag-ipa-ca-renew-agent-reuse')
 
         print("CA certificate successfully renewed")
 
-    def resubmit_request(self, ca, profile):
+    def resubmit_request(self, ca='dogtag-ipa-ca-renew-agent'):
         timeout = api.env.startup_timeout + 60
 
         self.log.debug("resubmitting certmonger request '%s'", self.request_id)
-        certmonger.resubmit_request(self.request_id, profile=profile)
+        certmonger.resubmit_request(self.request_id, ca=ca, profile='')
         try:
             state = certmonger.wait_for_request(self.request_id, timeout)
         except RuntimeError:
@@ -304,7 +304,7 @@ class CACertManage(admintool.AdminTool):
                 "please check the request manually" % self.request_id)
 
         self.log.debug("modifying certmonger request '%s'", self.request_id)
-        certmonger.modify(self.request_id, profile='ipaCACertRenewal')
+        certmonger.modify(self.request_id, ca='dogtag-ipa-ca-renew-agent')
 
     def install(self):
         print("Installing CA certificate, please wait")

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -60,9 +60,9 @@ class KRAInstance(DogtagInstance):
     be the same for both the CA and KRA.
     """
 
-    tracking_reqs = (('auditSigningCert cert-pki-kra', None),
-                     ('transportCert cert-pki-kra', None),
-                     ('storageCert cert-pki-kra', None))
+    tracking_reqs = ('auditSigningCert cert-pki-kra',
+                     'transportCert cert-pki-kra',
+                     'storageCert cert-pki-kra')
 
     def __init__(self, realm):
         super(KRAInstance, self).__init__(

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -937,7 +937,7 @@ def certificate_renewal_update(ca, ds, http):
             'cert-presave-command': template % 'stop_pkicad',
             'cert-postsave-command':
                 (template % 'renew_ca_cert "caSigningCert cert-pki-ca"'),
-            'template-profile': 'ipaCACertRenewal',
+            'template-profile': '',
         },
         {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,


### PR DESCRIPTION
**server upgrade: always fix certmonger tracking request**

Fix certmonger tracking requests on every run of ipa-server-upgrade rather
than only when the tracking configuration has changed and the requests have
not yet been updated.

This allows fixing broken tracking requests just by re-running
ipa-server-upgrade.

**cainstance: use correct profile for lightweight CA certificates**

Use Dogtag's `caCACert` CA certificate profile rather than the
`ipaCACertRenewal` virtual profile for lightweight CA certificates.

The `ipaCACertRenewal` virtual profile adds special handling of externally
signed CA certificates and LDAP replication of issued certificates on top
of `caCACert`, neither of which is relevant for lightweight CA
certificates.

Remove all of the special casing of lightweight CA certificates from
dogtag-ipa-ca-renew-agent-submit.

Make sure existing lightweight CA certmonger tracking requests are updated
on server upgrade.

**renew agent: allow reusing existing certs**

Add a switch which makes `dogtag-ipa-ca-renew-agent-submit` reuse the
existing certificate rather than request a new one from the CA while
maintaining LDAP replication of the certificate.

Make this available as a new `dogtag-ipa-ca-renew-agent-reuse` certmonger
CA.

This allows redoing the LDAP replication and reexecuting pre- and post-save
commands of a tracking request without reissuing the certificate.

**renew agent: always export CSR on IPA CA certificate renewal**

Make sure a CSR is exported for the IPA CA whenever certmonger detects that
the CA certificate is about to expire.

This is a pre-requisite for using the `dogtag-ipa-ca-renew-agent-reuse` CA
instead of the `ipaCSRExport` virtual profile to export the CSR.

**renew agent: get rid of virtual profiles**

Replace all uses of virtual profiles with `dogtag-ipa-ca-renew-agent-reuse`
and remove profile from the IPA CA certificate tracking request.

This prevents virtual profiles from making their way into CSRs and in turn
being rejected by certain CAs. This affected the IPA CA CSR with Microsoft
CS in particular.

**ipa-cacert-manage: add --external-ca-type**

Add the `--external-ca-type`, as known from `ipa-server-install` and
`ipa-ca-install`, to `ipa-cacert-manage`.

This allows creating IPA CA CSRs suitable for use with Microsoft CS using
`ipa-cacert-manage`:

```
ipa-cacert-manage renew --external-ca --external-ca-type=ms-cs
```

https://pagure.io/freeipa/issue/5799