### PR TITLE
ipa-custodia: use Dogtag's alias/pwdfile.txt

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -93,6 +93,7 @@ class BasePathNamespace(object):
     NSS_DB_DIR = "/etc/pki/nssdb"
     PKI_TOMCAT = "/etc/pki/pki-tomcat"
     PKI_TOMCAT_ALIAS_DIR = "/etc/pki/pki-tomcat/alias"
+    PKI_TOMCAT_ALIAS_PWDFILE_TXT = "/etc/pki/pki-tomcat/alias/pwdfile.txt"
     PKI_TOMCAT_PASSWORD_CONF = "/etc/pki/pki-tomcat/password.conf"
     ETC_REDHAT_RELEASE = "/etc/redhat-release"
     RESOLV_CONF = "/etc/resolv.conf"

--- a/ipaserver/secrets/store.py
+++ b/ipaserver/secrets/store.py
@@ -34,17 +34,6 @@ def log_error(error):
     print(error, file=sys.stderr)
 
 
-def PKI_TOMCAT_password_callback():
-    password = None
-    with open(paths.PKI_TOMCAT_PASSWORD_CONF) as f:
-        for line in f.readlines():
-            key, value = line.strip().split('=')
-            if key == 'internal':
-                password = value
-                break
-    return password
-
-
 class NSSWrappedCertDB(DBMAPHandler):
     '''
     Store that extracts private keys from an NSSDB, wrapped with the
@@ -55,27 +44,23 @@ class NSSWrappedCertDB(DBMAPHandler):
         if 'path' not in dbmap:
             raise ValueError(
                 'Configuration does not provide NSSDB path')
-        if 'pwcallback' not in dbmap:
-            raise ValueError(
-                'Configuration does not provide Password Calback')
+        if 'pwdfile' not in dbmap:
+            raise ValueError('Configuration does not provide password file')
         if 'wrap_nick' not in dbmap:
             raise ValueError(
                 'Configuration does not provide nickname of wrapping key')
         self.nssdb_path = dbmap['path']
-        self.nssdb_password = dbmap['pwcallback']()
+        self.nssdb_pwdfile = dbmap['pwdfile']
         self.wrap_nick = dbmap['wrap_nick']
         self.target_nick = nickname
 
     def export_key(self):
         tdir = tempfile.mkdtemp(dir=paths.TMP)
         try:
-            nsspwfile = os.path.join(tdir, 'nsspwfile')
-            with open(nsspwfile, 'w+') as f:
-                f.write(self.nssdb_password)
             wrapped_key_file = os.path.join(tdir, 'wrapped_key')
             certificate_file = os.path.join(tdir, 'certificate')
             ipautil.run([
-                paths.PKI, '-d', self.nssdb_path, '-C', nsspwfile,
+                paths.PKI, '-d', self.nssdb_path, '-C', self.nssdb_pwdfile,
                 'ca-authority-key-export',
                 '--wrap-nickname', self.wrap_nick,
                 '--target-nickname', self.target_nick,
@@ -103,18 +88,15 @@ class NSSCertDB(DBMAPHandler):
                              ' expected "NSSDB"' % (dbmap['type'],))
         if 'path' not in dbmap:
             raise ValueError('Configuration does not provide NSSDB path')
-        if 'pwcallback' not in dbmap:
-            raise ValueError('Configuration does not provide Password Calback')
+        if 'pwdfile' not in dbmap:
+            raise ValueError('Configuration does not provide password file')
         self.nssdb_path = dbmap['path']
+        self.nssdb_pwdfile = dbmap['pwdfile']
         self.nickname = nickname
-        self.nssdb_password = dbmap['pwcallback']()
 
     def export_key(self):
         tdir = tempfile.mkdtemp(dir=paths.TMP)
         try:
-            nsspwfile = os.path.join(tdir, 'nsspwfile')
-            with open(nsspwfile, 'w') as f:
-                f.write(self.nssdb_password)
             pk12pwfile = os.path.join(tdir, 'pk12pwfile')
             password = ipautil.ipa_generate_password()
             with open(pk12pwfile, 'w') as f:
@@ -124,7 +106,7 @@ class NSSCertDB(DBMAPHandler):
                          "-d", self.nssdb_path,
                          "-o", pk12file,
                          "-n", self.nickname,
-                         "-k", nsspwfile,
+                         "-k", self.nssdb_pwdfile,
                          "-w", pk12pwfile])
             with open(pk12file, 'rb') as f:
                 data = f.read()
@@ -137,9 +119,6 @@ class NSSCertDB(DBMAPHandler):
         v = json_decode(value)
         tdir = tempfile.mkdtemp(dir=paths.TMP)
         try:
-            nsspwfile = os.path.join(tdir, 'nsspwfile')
-            with open(nsspwfile, 'w') as f:
-                f.write(self.nssdb_password)
             pk12pwfile = os.path.join(tdir, 'pk12pwfile')
             with open(pk12pwfile, 'w') as f:
                 f.write(v['export password'])
@@ -150,7 +129,7 @@ class NSSCertDB(DBMAPHandler):
                          "-d", self.nssdb_path,
                          "-i", pk12file,
                          "-n", self.nickname,
-                         "-k", nsspwfile,
+                         "-k", self.nssdb_pwdfile,
                          "-w", pk12pwfile])
         finally:
             shutil.rmtree(tdir)
@@ -254,12 +233,12 @@ NAME_DB_MAP = {
         'type': 'NSSDB',
         'path': paths.PKI_TOMCAT_ALIAS_DIR,
         'handler': NSSCertDB,
-        'pwcallback': PKI_TOMCAT_password_callback,
+        'pwdfile': paths.PKI_TOMCAT_ALIAS_PWDFILE_TXT,
     },
     'ca_wrapped': {
         'handler': NSSWrappedCertDB,
         'path': paths.PKI_TOMCAT_ALIAS_DIR,
-        'pwcallback': PKI_TOMCAT_password_callback,
+        'pwdfile': paths.PKI_TOMCAT_ALIAS_PWDFILE_TXT,
         'wrap_nick': 'caSigningCert cert-pki-ca',
     },
     'ra': {


### PR DESCRIPTION
/etc/pki/pki-tomcat/password.conf contains additional passwords like
replicadb. ipa-custodia does not need these passwords.
/etc/pki/pki-tomcat/alias/pwdfile.txt holds the passphrase for Tomcat's
NSSDB. The file also simplifies implementation because it removes
another temporary file.

pwdfile.txt is created by CAInstance.create_certstore_passwdfile()

Related: https://pagure.io/freeipa/issue/6888
Signed-off-by: Christian Heimes <cheimes@redhat.com>