### PR TITLE
kerberos session: use CA cert with full cert chain for obtaining cookie

### DIFF
--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -602,7 +602,8 @@ class KerberosSession(HTTP_Status):
         try:
             target = self.api.env.host
             r = requests.get('http://{0}/ipa/session/cookie'.format(target),
-                             auth=NegotiateAuth(target, ccache_name))
+                             auth=NegotiateAuth(target, ccache_name),
+                             verify=paths.IPA_CA_CRT)
             session_cookie = r.cookies.get("ipa_session")
             if not session_cookie:
                 raise ValueError('No session cookie found')


### PR DESCRIPTION
Http request performed in finalize_kerberos_acquisition doesn't use
CA certificate/certificate store with full certificate chain of IPA server.
So it might happen that in case that IPA is installed with externally signed
CA certificate, the call can fail because of certificate validation
and e.g. prevent session acquisition.

If it will fail for sure is not known - the use case was not discovered,
but it is faster and safer to fix preemptively.

https://pagure.io/freeipa/issue/6876