### PR TITLE
automount install: do not wait for sssd restart on uninstallation

### DIFF
--- a/client/ipa-client-automount
+++ b/client/ipa-client-automount
@@ -193,7 +193,7 @@ def configure_autofs_sssd(fstore, statestore, autodiscover, options):
     sssdconfig.write(paths.SSSD_CONF)
     statestore.backup_state('autofs', 'sssd', True)
 
-    sssd = services.service('sssd')
+    sssd = services.service('sssd', api)
     sssd.restart()
     print("Restarting sssd, waiting for it to become available.")
     wait_for_sssd()
@@ -281,7 +281,7 @@ def uninstall(fstore, statestore):
                         break
                 sssdconfig.save_domain(domain)
                 sssdconfig.write(paths.SSSD_CONF)
-                sssd = services.service('sssd')
+                sssd = services.service('sssd', api)
                 sssd.restart()
                 wait_for_sssd()
             except Exception as e:
@@ -379,9 +379,6 @@ def main():
         paths.IPACLIENT_INSTALL_LOG, verbose=False, debug=options.debug,
         filemode='a', console_format='%(message)s')
 
-    if options.uninstall:
-        return uninstall(fstore, statestore)
-
     cfg = dict(
         context='cli_installer',
         confdir=paths.ETC_IPA,
@@ -390,8 +387,11 @@ def main():
         verbose=0,
     )
 
+    # Bootstrap API early so that env object is available
     api.bootstrap(**cfg)
-    api.finalize()
+
+    if options.uninstall:
+        return uninstall(fstore, statestore)
 
     ca_cert_path = None
     if os.path.exists(paths.IPA_CA_CRT):
@@ -449,6 +449,10 @@ def main():
             os.environ['KRB5CCNAME'] = ccache_name
         except gssapi.exceptions.GSSError as e:
             sys.exit("Failed to obtain host TGT: %s" % e)
+
+        # Finalize API when TGT obtained using host keytab exists
+        api.finalize()
+
         # Now we have a TGT, connect to IPA
         try:
             api.Backend.rpcclient.connect()


### PR DESCRIPTION
Change in 2d4d1a9dc0ef2bbe86751768d6e6b009a52c0dc9 no longer initializes
api in `ipa-client-automount --uninstallation` Which caused error in
wait_for_sssd which gets realm from initialized API.

In my opinion, there is no reason to check working sssd after uninstallation by running
id command. If anything depends on running sssd then it should do the check.

Also fix call of xxx_service_class_factory which requires api as param.

https://pagure.io/freeipa/issue/6861