### PR TITLE
Vault: Explicitly default to 3DES CBC

### DIFF
--- a/ipaserver/plugins/vault.py
+++ b/ipaserver/plugins/vault.py
@@ -38,6 +38,14 @@ from ipapython.dn import DN
 if api.env.in_server:
     import pki.account
     import pki.key
+    # pylint: disable=no-member
+    try:
+        # pki >= 10.4.0
+        from pki.crypto import DES_EDE3_CBC_OID
+    except ImportError:
+        DES_EDE3_CBC_OID = pki.key.KeyClient.DES_EDE3_CBC_OID
+    # pylint: enable=no-member
+
 
 if six.PY3:
     unicode = str
@@ -1059,8 +1067,8 @@ class vault_archive_internal(PKQuery):
                 pki.key.KeyClient.PASS_PHRASE_TYPE,
                 wrapped_vault_data,
                 wrapped_session_key,
-                None,
-                nonce,
+                algorithm_oid=DES_EDE3_CBC_OID,
+                nonce_iv=nonce,
             )
 
             kra_account.logout()


### PR DESCRIPTION
The server-side plugin for IPA Vault relied on the fact that the default
oid for encryption algorithm is 3DES in CBC mode (DES-EDE3-CBC). Dogtag
10.4 has changed the default from 3DES to AES. Pass the correct
algorithm OID to KeyClient.archive_encrypted_data().

Closes: https://pagure.io/freeipa/issue/6899
Signed-off-by: Christian Heimes <cheimes@redhat.com>