### PR TITLE
restore: restart gssproxy after restore

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -401,6 +401,9 @@ class Restore(admintool.AdminTool):
                 services.knownservices.pki_tomcatd.enable()
                 services.knownservices.pki_tomcatd.disable()
 
+                self.log.info('Restarting GSSAPI proxy')
+                gssproxy = services.service('gssproxy', api)
+                gssproxy.restart()
                 self.log.info('Starting IPA services')
                 run(['ipactl', 'start'])
                 self.log.info('Restarting SSSD')


### PR DESCRIPTION
So that gssproxy picks up new configuration and therefore related
usages like authentication of CLI against server works

https://pagure.io/freeipa/issue/6902

@simo5 btw, what is the proper name of gssproxy? Is it GSSAPI proxy, gss-proxy or gssproxy?

Note: if this patch is wrong, feel free to take over and abolish this PR.