### PR TITLE
6.9 -> 7.4 migration fixes

### DIFF
--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -34,7 +34,6 @@ import dns
 import encodings
 import sys
 import ssl
-from weakref import WeakKeyDictionary
 
 import netaddr
 from dns import resolver, rdatatype
@@ -491,39 +490,6 @@ def remove_sshpubkey_from_output_list_post(context, entries):
             entry_attrs.pop('ipasshpubkey', None)
         delattr(context, 'ipasshpubkey_added')
 
-
-class cachedproperty(object):
-    """
-    A property-like attribute that caches the return value of a method call.
-
-    When the attribute is first read, the method is called and its return
-    value is saved and returned. On subsequent reads, the saved value is
-    returned.
-
-    Typical usage:
-    class C(object):
-        @cachedproperty
-        def attr(self):
-            return 'value'
-    """
-    __slots__ = ('getter', 'store')
-
-    def __init__(self, getter):
-        self.getter = getter
-        self.store = WeakKeyDictionary()
-
-    def __get__(self, obj, cls):
-        if obj is None:
-            return None
-        if obj not in self.store:
-            self.store[obj] = self.getter(obj)
-        return self.store[obj]
-
-    def __set__(self, obj, value):
-        raise AttributeError("can't set attribute")
-
-    def __delete__(self, obj):
-        raise AttributeError("can't delete attribute")
 
 # regexp matching signed floating point number (group 1) followed by
 # optional whitespace followed by time unit, e.g. day, hour (group 7)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -425,6 +425,8 @@ class CAInstance(DogtagInstance):
                 self.step("Configure HTTP to proxy connections",
                           self.http_proxy)
                 self.step("restarting certificate server", self.restart_instance)
+                self.step("updating IPA configuration", update_ipa_conf)
+                self.step("enabling CA instance", self.__enable_instance)
                 if not promote:
                     self.step("migrating certificate profiles to LDAP",
                               migrate_profiles_to_ldap)
@@ -432,9 +434,6 @@ class CAInstance(DogtagInstance):
                               import_included_profiles)
                     self.step("adding default CA ACL", ensure_default_caacl)
                     self.step("adding 'ipa' CA entry", ensure_ipa_authority_entry)
-                self.step("updating IPA configuration", update_ipa_conf)
-
-                self.step("enabling CA instance", self.__enable_instance)
 
                 self.step("configuring certmonger renewal for lightweight CAs",
                           self.__add_lightweight_ca_tracking_requests)


### PR DESCRIPTION
**Allow rewriting of cached properties**
    
Cached property should not be treated anyway special from a normal
property. If we need to rewrite/remove it, we should be able to do
just so.

**Refresh Dogtag RestClient.ca_host property**
    
Refresh the ca_host property of the Dogtag's RestClient class when
it's requested as a context manager.
    
This solves the problem which would occur on DL0 when installing
CA against an old master which does not have port 8443 accessible.
The setup tries to update the cert profiles via this port but
fail. This operation should be performed against the local instance
anyway.

https://pagure.io/freeipa/issue/6878
