### PR TITLE
Revert "Store GSSAPI session key in /var/run/ipa"

### DIFF
--- a/install/conf/ipa.conf
+++ b/install/conf/ipa.conf
@@ -1,5 +1,5 @@
 #
-# VERSION 26 - DO NOT REMOVE THIS LINE
+# VERSION 25 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -78,7 +78,7 @@ WSGIScriptReloading Off
   SessionCookieName ipa_session path=/ipa;httponly;secure;
   SessionHeader IPASESSION
   SessionMaxAge 1800
-  GssapiSessionKey file:/var/run/ipa/session.key
+  GssapiSessionKey file:/etc/httpd/alias/ipasession.key
 
   GssapiImpersonate On
   GssapiDelegCcacheDir /var/run/ipa/ccaches
@@ -127,7 +127,7 @@ Alias /ipa/session/cookie "/usr/share/ipa/gssapi.login"
   SessionCookieName ipa_session path=/ipa;httponly;secure;
   SessionHeader IPASESSION
   SessionMaxAge 1800
-  GssapiSessionKey file:/var/run/ipa/session.key
+  GssapiSessionKey file:/etc/httpd/alias/ipasession.key
 
   Header unset Set-Cookie
 </Location>


### PR DESCRIPTION
This reverts commit 2bab2d4963daa99742875f3633a99966bc56f5a3. It was
pointed out that apache has no access to /var/lib/ipa directry breaking
the session handling.

https://pagure.io/freeipa/issue/6880