### PR TITLE
Added plugins directory to python2-ipaclient subpackage

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1421,6 +1421,7 @@ fi
 %doc README.md Contributors.txt
 %license COPYING
 %dir %{python3_sitelib}/ipaclient
+%dir %{python3_sitelib}/ipaclient/plugins
 %{python3_sitelib}/ipaclient/*.py
 %{python3_sitelib}/ipaclient/__pycache__/*.py*
 %{python3_sitelib}/ipaclient/install/*.py

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1402,6 +1402,7 @@ fi
 %doc README.md Contributors.txt
 %license COPYING
 %dir %{python_sitelib}/ipaclient
+%dir %{python_sitelib}/ipaclient/plugins
 %{python_sitelib}/ipaclient/*.py*
 %{python_sitelib}/ipaclient/install/*.py*
 %{python_sitelib}/ipaclient/plugins/*.py*


### PR DESCRIPTION
Subpackage does not own that directory and could create conflicts if a plugin creates it on its onwn