### PR TITLE
ipa-client-install: remove extra space in pkinit_anchors definition

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -710,7 +710,7 @@ def configure_krb5_conf(
         kropts.append(krbconf.setOption('default_domain', cli_domain))
 
     kropts.append(
-        krbconf.setOption('pkinit_anchors', 'FILE: %s' % paths.IPA_CA_CRT))
+        krbconf.setOption('pkinit_anchors', 'FILE:%s' % paths.IPA_CA_CRT))
     ropts = [{
         'name': cli_realm,
         'type': 'subsection',


### PR DESCRIPTION
ipa-client-install modifies /etc/krb5.conf and defines the following line:
    pkinit_anchors = FILE: /etc/ipa/ca.crt

The extra space between FILE: and /etc/ipa/ca.crt break pkinit.

https://pagure.io/freeipa/issue/6916