### PR TITLE
ipa-server-install with external CA: fix pkinit cert issuance

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -108,6 +108,14 @@ class KrbInstance(service.Service):
     suffix = ipautil.dn_attribute_property('_suffix')
     subject_base = ipautil.dn_attribute_property('_subject_base')
 
+    def init_info(self, realm_name, host_name, setup_pkinit=False,
+                  subject_base=None):
+        self.fqdn = host_name
+        self.realm = realm_name
+        self.suffix = ipautil.realm_to_suffix(realm_name)
+        self.subject_base = subject_base
+        self.config_pkinit = setup_pkinit
+
     def get_realm_suffix(self):
         return DN(('cn', self.realm), ('cn', 'kerberos'), self.suffix)
 

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -768,6 +768,10 @@ def install(installer):
                             setup_pkinit=not options.no_pkinit,
                             pkcs12_info=pkinit_pkcs12_info,
                             subject_base=options.subject_base)
+    else:
+        krb.init_info(realm_name, host_name,
+                      setup_pkinit=not options.no_pkinit,
+                      subject_base=options.subject_base)
 
     if setup_ca:
         if not options.external_cert_files and options.external_ca:


### PR DESCRIPTION
ipa-server-install with external CA fails to issue pkinit certs.
This happens because the installer calls
krb = krbinstance.KrbInstance(fstore)
then
krb.enable_ssl()
and in this code path self.config_pkinit is set to None, leading to a wrong
code path.

The fix initializes the required fields of the krbinstance before calling
krb.enable_ssl.

https://pagure.io/freeipa/issue/6921