### PR TITLE
ca, kra install: validate DM password

### DIFF
--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -117,17 +117,19 @@ def parse_options():
 
 
 def _get_dirman_password(password=None, unattended=False):
+    # sys.exit() is used on purpose, because otherwise user is advised to
+    # uninstall the component, even though it is not needed
     if not password:
         if unattended:
             sys.exit('Directory Manager password required')
-        try:
-            password = installutils.read_password(
-                "Directory Manager (existing master)", confirm=False,
-                validate=False)
-        except KeyboardInterrupt:
-            sys.exit(0)
-        if password is None:
-            sys.exit("Directory Manager password required")
+        password = installutils.read_password(
+            "Directory Manager (existing master)", confirm=False,
+            validate=False)
+    try:
+        installutils.validate_dm_password_ldap(password)
+    except ValueError:
+        sys.exit("Directory Manager password is invalid")
+
     return password
 
 

--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -116,9 +116,19 @@ def parse_options():
     return safe_options, options, filename
 
 
-def get_dirman_password():
-    return installutils.read_password(
-        "Directory Manager (existing master)", confirm=False, validate=False)
+def _get_dirman_password(password=None, unattended=False):
+    if not password:
+        if unattended:
+            sys.exit('Directory Manager password required')
+        try:
+            password = installutils.read_password(
+                "Directory Manager (existing master)", confirm=False,
+                validate=False)
+        except KeyboardInterrupt:
+            sys.exit(0)
+        if password is None:
+            sys.exit("Directory Manager password required")
+    return password
 
 
 def install_replica(safe_options, options, filename):
@@ -142,16 +152,8 @@ def install_replica(safe_options, options, filename):
         check_creds(options, api.env.realm)
 
     # get the directory manager password
-    dirman_password = options.password
-    if not dirman_password:
-        if options.unattended:
-            sys.exit('Directory Manager password required')
-        try:
-            dirman_password = get_dirman_password()
-        except KeyboardInterrupt:
-            sys.exit(0)
-        if dirman_password is None:
-            sys.exit("Directory Manager password required")
+    dirman_password = _get_dirman_password(
+        options.password, options.unattended)
 
     if (not options.promote and not options.admin_password and
             not options.skip_conncheck and options.unattended):
@@ -199,16 +201,8 @@ def install_replica(safe_options, options, filename):
 
 
 def install_master(safe_options, options):
-    dm_password = options.password
-    if not dm_password:
-        if options.unattended:
-            sys.exit('Directory Manager password required')
-        try:
-            dm_password = get_dirman_password()
-        except KeyboardInterrupt:
-            sys.exit(0)
-        if dm_password is None:
-            sys.exit("Directory Manager password required")
+    dm_password = _get_dirman_password(
+        options.password, options.unattended)
 
     options.realm_name = api.env.realm
     options.domain_name = api.env.domain

--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -137,6 +137,14 @@ class KRAInstaller(KRAInstall):
     def run(self):
         super(KRAInstaller, self).run()
 
+        # Verify DM password. This has to be called after ask_for_options(),
+        # so it can't be placed in validate_options().
+        try:
+            installutils.validate_dm_password_ldap(self.options.password)
+        except ValueError:
+            raise admintool.ScriptError(
+                "Directory Manager password is invalid")
+
         if not cainstance.is_ca_installed_locally():
             raise RuntimeError("Dogtag CA is not installed. "
                                "Please install the CA first")


### PR DESCRIPTION
Prevent CA and KRA installation from proceeding if provided DM password is invalid to avoid broken installations with no possibility to uninstall CA or KRA.

https://pagure.io/freeipa/issue/6892