### PR TITLE
kra install: update installation failure message

### DIFF
--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -103,7 +103,7 @@ class KRAInstaller(KRAInstall):
 
     FAIL_MESSAGE = '''
         Your system may be partly configured.
-        Run ipa-kra-install --uninstall to clean up.
+        If you run into issues, you may have to re-install IPA on this server.
     '''
 
     def validate_options(self, needs_root=True):


### PR DESCRIPTION
When installation fails, do not advise the user to use the
obsoleted --uninstall option.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>
Fixes https://pagure.io/freeipa/issue/6923