### PR TITLE
fix managed-entries printing IPA not installed

### DIFF
--- a/install/tools/ipa-managed-entries
+++ b/install/tools/ipa-managed-entries
@@ -20,6 +20,7 @@
 
 from __future__ import print_function
 
+import os
 import re
 import sys
 from optparse import OptionParser  # pylint: disable=deprecated-module
@@ -193,4 +194,6 @@ def main():
     return retval
 
 if __name__ == '__main__':
+    if not os.geteuid() == 0:
+        sys.exit("\nMust be run as root\n")
     installutils.run_script(main, operation_name='ipa-managed-entries')


### PR DESCRIPTION
ipa-managed-entries would print "IPA is not configured on this system."
even though this is not true if run as a normal user. Add check for
root running the script.

https://pagure.io/freeipa/issue/6928