### PR TITLE
Dogtag: fail if instance cannot be (re)started

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -156,22 +156,10 @@ class DogtagInstance(service.Service):
                       ignore_errors=True)
 
     def restart_instance(self):
-        try:
-            self.restart('pki-tomcat')
-        except Exception:
-            self.log.debug(traceback.format_exc())
-            self.log.critical(
-                "Failed to restart the Dogtag instance."
-                "See the installation log for details.")
+        self.restart('pki-tomcat')
 
     def start_instance(self):
-        try:
-            self.start('pki-tomcat')
-        except Exception:
-            self.log.debug(traceback.format_exc())
-            self.log.critical(
-                "Failed to restart the Dogtag instance."
-                "See the installation log for details.")
+        self.start('pki-tomcat')
 
     def stop_instance(self):
         try:

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -167,7 +167,7 @@ class DogtagInstance(service.Service):
         except Exception:
             self.log.debug(traceback.format_exc())
             self.log.critical(
-                "Failed to restart the Dogtag instance."
+                "Failed to stop the Dogtag instance."
                 "See the installation log for details.")
 
     def enable_client_auth_to_db(self, config):


### PR DESCRIPTION
**Make CA/KRA fail when they don't start**

Since all the services throw exceptions when we're unable to
start/restart them, CA/KRA should not be an exception to it.

**Fix wrong message on Dogtag instances stop**

https://pagure.io/freeipa/issue/6766