### PR TITLE
[4.5 backport] spec file: bump python-netaddr Requires

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -38,6 +38,8 @@
 %if 0%{?rhel}
 # 1.15.1-7: certauth (http://krbdev.mit.edu/rt/Ticket/Display.html?id=8561)
 %global krb5_version 1.15.1-4
+# 0.7.16: https://github.com/drkjam/netaddr/issues/71
+%global python_netaddr_version 0.7.5-8
 # Require 4.6.0-4 which brings RC4 for FIPS + trust fixes to priv. separation
 %global samba_version 4.6.0-4
 %global selinux_policy_version 3.12.1-153
@@ -45,6 +47,8 @@
 %else
 # 1.15.1-7: certauth (http://krbdev.mit.edu/rt/Ticket/Display.html?id=8561)
 %global krb5_version 1.15.1-7
+# 0.7.16: https://github.com/drkjam/netaddr/issues/71
+%global python_netaddr_version 0.7.16
 # Require 4.6.0-4 which brings RC4 for FIPS + trust fixes to priv. separation
 %global samba_version 2:4.6.0-4
 %global selinux_policy_version 3.13.1-158.4
@@ -646,7 +650,7 @@ Requires: pyOpenSSL
 Requires: python >= 2.7.9
 Requires: python-nss >= 0.16
 Requires: python-cryptography >= 1.4
-Requires: python-netaddr
+Requires: python-netaddr >= %{python_netaddr_version}
 Requires: python-libipa_hbac
 Requires: python-qrcode-core >= 5.0.0
 Requires: python-pyasn1
@@ -695,7 +699,7 @@ Requires: keyutils
 Requires: python3-pyOpenSSL
 Requires: python3-nss >= 0.16
 Requires: python3-cryptography >= 1.4
-Requires: python3-netaddr
+Requires: python3-netaddr >= %{python_netaddr_version}
 Requires: python3-libipa_hbac
 Requires: python3-qrcode-core >= 5.0.0
 Requires: python3-pyasn1


### PR DESCRIPTION
Bump python-netaddr Requires to the version which has correct private and
reserved IPv4 address ranges.

This fixes DNS server install failure when 0.0.0.0 is entered as a
forwarder.

Backport from: 0784e53f7f8a323acafbbff26a9d1c0276a229b0

https://pagure.io/freeipa/issue/6894