### PR TITLE
[4.5] upgrade: add missing DN suffix when enabling KDC proxy

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -639,6 +639,7 @@ Requires: python-gssapi >= 1.2.0
 Requires: gnupg
 Requires: keyutils
 Requires: pyOpenSSL
+Requires: python >= 2.7.9
 Requires: python-nss >= 0.16
 Requires: python-cryptography >= 1.4
 Requires: python-netaddr

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1638,6 +1638,7 @@ def upgrade_configuration():
     http = httpinstance.HTTPInstance(fstore)
     http.fqdn = fqdn
     http.realm = api.env.realm
+    http.suffix = ipautil.realm_to_suffix(api.env.realm)
     http.configure_selinux_for_httpd()
     http.change_mod_nss_port_from_http()
 

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -181,7 +181,7 @@ def set_service_entry_config(name, fqdn, config_values,
     except errors.NotFound:
         pass
     else:
-        existing_values = entry.get('ipaConnfigString', [])
+        existing_values = entry.get('ipaConfigString', [])
         for value in config_values:
             if case_insensitive_attr_has_value(existing_values, value):
                 root_logger.debug(


### PR DESCRIPTION
Original PR: #752 

---

This issue prevented from upgrading from IPA 4.1.

I also discovered a missing python dependency when I was running the ipa-server-upgrade manually. For packagers: the Python version that has the required symbols in CentOS is 2.7.5-24

https://pagure.io/freeipa/issue/6920