### PR TITLE
cert-show: writable files does not mean dirs

### DIFF
--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -171,7 +171,7 @@ def check_writable_file(filename):
     if filename is None:
         raise errors.FileError(reason=_('Filename is empty'))
     try:
-        if os.path.exists(filename):
+        if os.path.isfile(filename):
             if not os.access(filename, os.W_OK):
                 raise errors.FileError(reason=_('Permission denied: %(file)s') % dict(file=filename))
         else:


### PR DESCRIPTION
ipalib.util.check_writable_file didn't check whether the argument
is an actual file which is now fixed.

https://pagure.io/freeipa/issue/6883