### PR TITLE
cert-show: check if certificate_out is in options

### DIFF
--- a/ipaclient/plugins/ca.py
+++ b/ipaclient/plugins/ca.py
@@ -4,7 +4,7 @@
 
 import base64
 from ipaclient.frontend import MethodOverride
-from ipalib import util, x509, Str
+from ipalib import errors, util, x509, Str
 from ipalib.plugable import Registry
 from ipalib.text import _
 
@@ -26,7 +26,11 @@ class WithCertOutArgs(MethodOverride):
         filename = None
         if 'certificate_out' in options:
             filename = options.pop('certificate_out')
-            util.check_writable_file(filename)
+            try:
+                util.check_writable_file(filename)
+            except errors.FileError as e:
+                raise errors.ValidationError(name='certificate-out',
+                                             error=str(e))
 
         result = super(WithCertOutArgs, self).forward(*keys, **options)
         if filename:

--- a/ipaclient/plugins/cert.py
+++ b/ipaclient/plugins/cert.py
@@ -49,9 +49,15 @@ class CertRetrieveOverride(MethodOverride):
     )
 
     def forward(self, *args, **options):
-        certificate_out = options.pop('certificate_out', None)
-        if certificate_out is not None:
-            util.check_writable_file(certificate_out)
+        if 'certificate_out' in options:
+            certificate_out = options.pop('certificate_out')
+            try:
+                util.check_writable_file(certificate_out)
+            except errors.FileError as e:
+                raise errors.ValidationError(name='certificate-out',
+                                             error=str(e))
+        else:
+            certificate_out = None
 
         result = super(CertRetrieveOverride, self).forward(*args, **options)
 


### PR DESCRIPTION
If --certificate-out was specified on the command line, it will appear
among the options. If it was empty, it will be None, though.

https://pagure.io/freeipa/issue/6885