### PR TITLE
Travis CI: explicitly update pip before running the builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ env:
             test_pkcs10
             test_xmlrpc/test_[l-z]*.py"
 install:
+    - pip install --upgrade pip
+    - pip3 install --upgrade pip
     - pip install pep8
     - >
       pip3 install


### PR DESCRIPTION
This is to workaround around
https://github.com/travis-ci/travis-ci/issues/7733 and issues with
implicit requirement of python-requests on newer pip.