### PR TITLE
[WIP] Warn in cert-request if CSR doesn't contain SAN

### DIFF
--- a/install/ui/src/freeipa/dns.js
+++ b/install/ui/src/freeipa/dns.js
@@ -294,6 +294,11 @@ return {
         height: 300,
         sections: [
             {
+                name: 'dnszone_title',
+                label: 'Select the required zone type.',
+                fields: []
+            },
+            {
                 name: 'name',
                 layout: IPA.dnszone_name_section_layout,
                 fields: [
@@ -307,6 +312,7 @@ return {
                         $type: 'dnszone_name',
                         name: 'name_from_ip',
                         radio_name: 'dnszone_name_type',
+                        required: false,
                         validators: ['network']
                     }
                 ]
@@ -750,18 +756,12 @@ IPA.add_dns_zone_name_policy = function() {
             idnsname_w.input.prop('disabled', false);
             name_from_ip_w.input.prop('disabled', true);
 
-            idnsname_f.set_required(true);
-            name_from_ip_f.set_required(false);
-
             name_from_ip_f.reset();
         });
 
         name_from_ip_w.radio_clicked.attach(function() {
             idnsname_w.input.prop('disabled', true);
             name_from_ip_w.input.prop('disabled', false);
-
-            idnsname_f.set_required(false);
-            name_from_ip_f.set_required(true);
 
             idnsname_f.reset();
         });

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -771,6 +771,18 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
         cn = cns[-1].value  # "most specific" is end of list
 
         if principal_type in (SERVICE, HOST):
+
+            has_dns_in_san_ext = False
+            if ext_san:
+                for gn in x509.process_othernames(ext_san.value):
+                    if isinstance(gn, cryptography.x509.general_name.DNSName):
+                        has_dns_in_san_ext = True
+
+            if not ext_san or not has_dns_in_san_ext:
+                print('Warning: The SAN extension '
+                      'should be provided. Please, check the RFC 2818.')
+
+
             if not _dns_name_matches_principal(cn, principal, principal_obj):
                 raise errors.ValidationError(
                     name='csr',


### PR DESCRIPTION
The code is not "production-ready", however, I would like to know if I'm on the right path. 

AFAIK we should check if the SAN extension is provided and if it has DNSName info.

Fix: https://pagure.io/freeipa/issue/6663