### PR TITLE
[master, 4.5] Bump version of ipa.conf file

### DIFF
--- a/install/conf/ipa.conf
+++ b/install/conf/ipa.conf
@@ -1,5 +1,5 @@
 #
-# VERSION 25 - DO NOT REMOVE THIS LINE
+# VERSION 26 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #


### PR DESCRIPTION
In commit 157831a287c64106eed4 the version bump was forgotten and therefore the
ipa.conf file is not replaced during upgrade and login using certificate when
single certificate is mapped to multiple users doesn't work.

https://pagure.io/freeipa/issue/6944