### PR TITLE
server-del: update defaultServerList in cn=default,ou=profile,$BASE

### DIFF
--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -608,14 +608,14 @@ class server_del(LDAPDelete):
             dn = DN(('cn', 'default'), ('ou', 'profile'), env.basedn)
             ret = conn.get_entry(dn)
             srvlist = ret.single_value.get('defaultServerList', '')
-            srvlist = srvlist[0].split()
+            srvlist = srvlist.split()
             if master in srvlist:
                 srvlist.remove(master)
                 attr = ' '.join(srvlist)
-                mod = [(ldap.MOD_REPLACE, 'defaultServerList', attr)]
-                conn.conn.modify_s(str(dn), mod)
-        except (errors.NotFound, ldap.NO_SUCH_ATTRIBUTE,
-                ldap.TYPE_OR_VALUE_EXISTS):
+                ret['defaultServerList'] = attr
+                conn.update_entry(ret)
+        except (errors.NotFound, errors.MidairCollision,
+                errors.EmptyModlist):
             pass
         except Exception as e:
             self.add_message(


### PR DESCRIPTION
ipa server-del should remove the server from the entry
cn=default,ou=profile,$BASE
The entry contains an attribute
defaultServerList: srv1.domain.com srv2.domain.com srv3.domain.com

The code calls srvlist = ret.single_value.get('defaultServerList') which means
that srvlist contains a single value (string) containing all the servers
separated by a space, and not a list of attribute values. Because of that,
srvlist[0] corresponds to the first character of the value.
The fix splits srvlist and not srvlist[0].

https://pagure.io/freeipa/issue/6943