### PR TITLE
ipa-replica-manage del (dl 0): remove server from defaultServerList

### DIFF
--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1336,17 +1336,17 @@ class ReplicationManager(object):
             dn = DN(('cn', 'default'), ('ou', 'profile'), self.suffix)
             ret = self.conn.get_entry(dn)
             srvlist = ret.single_value.get('defaultServerList', '')
-            srvlist = srvlist[0].split()
+            srvlist = srvlist.split()
             if replica in srvlist:
                 srvlist.remove(replica)
                 attr = ' '.join(srvlist)
-                mod = [(ldap.MOD_REPLACE, 'defaultServerList', attr)]
-                self.conn.modify_s(dn, mod)
+                ret['defaultServerList'] = attr
+                self.conn.update_entry(ret)
         except errors.NotFound:
             pass
-        except ldap.NO_SUCH_ATTRIBUTE:
+        except errors.MidairCollision:
             pass
-        except ldap.TYPE_OR_VALUE_EXISTS:
+        except errors.EmptyModlist:
             pass
         except Exception as e:
             if force and err:


### PR DESCRIPTION
ipa-replica-manage del should remove the server from the entry
cn=default,ou=profile,$BASE
The entry contains an attribute
defaultServerList: srv1.domain.com srv2.domain.com srv3.domain.com

The code calls srvlist = ret.single_value.get('defaultServerList') which means
that srvlist contains a single value (string) containing all the servers
separated by a space, and not a list of attribute values. Because of that,
srvlist[0] corresponds to the first character of the value.
The fix splits srvlist and not srvlist[0].

https://pagure.io/freeipa/issue/6946