### PR TITLE
otptoken-add-yubikey: When --digits not provided use default value

### DIFF
--- a/ipaclient/plugins/otptoken_yubikey.py
+++ b/ipaclient/plugins/otptoken_yubikey.py
@@ -147,7 +147,10 @@ class otptoken_add_yubikey(Command):
 
         # Write the config.
         cfg = yk.init_config()
-        cfg.mode_oath_hotp(key, kwargs['ipatokenotpdigits'])
+        cfg.mode_oath_hotp(key, kwargs.get(
+            'ipatokenotpdigits',
+            self.get_default_of('ipatokenotpdigits')
+        ))
         cfg.extended_flag('SERIAL_API_VISIBLE', True)
         yk.write_config(cfg, slot=kwargs['slot'])
 


### PR DESCRIPTION
Since Thin client was introduced default values for options are not populated
in client side plugins. When option has default value and is needed in client
plugin it must be handled by explicitly.

https://pagure.io/freeipa/issue/6900