### PR TITLE
ipa-server-install: fix uninstall

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -319,7 +319,7 @@ class DogtagInstance(service.Service):
         services.knownservices.messagebus.start()
         cmonger.start()
 
-        nicknames = self.tracking_reqs
+        nicknames = list(self.tracking_reqs)
         if self.server_cert_name is not None:
             nicknames.append(self.server_cert_name)
 


### PR DESCRIPTION
ipa-server-install --uninstall fails to stop tracking the certificates
because it assigns a tuple to the variable nicknames, then tries to
call nicknames.append(). This is a regression introduced by 21f4cbf8.

Assignment should be done using nicknames = list(self.tracking_reqs) instead.

https://pagure.io/freeipa/issue/6950