### PR TITLE
ipasetup: fix dependencies handling based on python version

### DIFF
--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -147,10 +147,12 @@ def ipasetup(name, doc, **kwargs):
                 continue
             values = setup_kwargs['extras_require'].pop(k)
             req = setup_kwargs.setdefault('install_requires', [])
-            if k == ":python_version<'3'" and sys.version_info.major == 2:
-                req.extend(values)
-            elif k == ":python_version>='3'" and sys.version_info.major >= 3:
-                req.extend(values)
+            if k == ":python_version<'3'":
+                if sys.version_info.major == 2:
+                    req.extend(values)
+            elif k == ":python_version>='3'":
+                if sys.version_info.major >= 3:
+                    req.extend(values)
             else:
                 raise ValueError(k, values)
 


### PR DESCRIPTION
On RHEL system ipasetup is failing:
```
ValueError: (":python_version>='3'", ['pyldap'])
```

Our RHEL re-implementation of setuptools logic should ignore python3
packages when python3 is not available.

https://pagure.io/freeipa/issue/6875