### PR TITLE
[4.4] ipaclient: fix missing RPM ownership

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1308,9 +1308,10 @@ fi
 %doc README Contributors.txt
 %license COPYING
 %dir %{python_sitelib}/ipaclient
-%dir %{python_sitelib}/ipaclient/plugins
 %{python_sitelib}/ipaclient/*.py*
+%dir %{python_sitelib}/ipaclient/plugins
 %{python_sitelib}/ipaclient/plugins/*.py*
+%dir %{python_sitelib}/ipaclient/remote_plugins
 %{python_sitelib}/ipaclient/remote_plugins/*.py*
 %{python_sitelib}/ipaclient/remote_plugins/2_*/*.py*
 %{python_sitelib}/ipaclient-*.egg-info
@@ -1323,11 +1324,12 @@ fi
 %doc README Contributors.txt
 %license COPYING
 %dir %{python3_sitelib}/ipaclient
-%dir %{python3_sitelib}/ipaclient/plugins
 %{python3_sitelib}/ipaclient/*.py
 %{python3_sitelib}/ipaclient/__pycache__/*.py*
+%dir %{python3_sitelib}/ipaclient/plugins
 %{python3_sitelib}/ipaclient/plugins/*.py
 %{python3_sitelib}/ipaclient/plugins/__pycache__/*.py*
+%dir %{python3_sitelib}/ipaclient/remote_plugins
 %{python3_sitelib}/ipaclient/remote_plugins/*.py
 %{python3_sitelib}/ipaclient/remote_plugins/__pycache__/*.py*
 %{python3_sitelib}/ipaclient/remote_plugins/2_*/*.py


### PR DESCRIPTION
FreeIPA package should own all subdirectories to work properly with
3rd party packages/plugins.

https://pagure.io/freeipa/issue/6927