### PR TITLE
RFC: API for reporting PKINIT status

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -3736,6 +3736,20 @@ command: ping/1
 args: 0,1,1
 option: Str('version?')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+command: pkinit_status/1
+args: 1,7,4
+arg: Str('criteria?')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('server_server?', autofill=False, cli_name='server')
+option: Int('sizelimit?', autofill=False)
+option: StrEnum('status?', autofill=False, cli_name='status', values=[u'enabled', u'disabled'])
+option: Int('timelimit?', autofill=False)
+option: Str('version?')
+output: Output('count', type=[<type 'int'>])
+output: ListOfEntries('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: Output('truncated', type=[<type 'bool'>])
 command: plugins/1
 args: 0,3,3
 option: Flag('all', autofill=True, cli_name='all', default=True)
@@ -6804,6 +6818,7 @@ default: permission_remove_member/1
 default: permission_show/1
 default: ping/1
 default: pkinit/1
+default: pkinit_status/1
 default: plugins/1
 default: privilege/1
 default: privilege_add/1

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -73,8 +73,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-define(IPA_API_VERSION_MINOR, 226)
-# Last change: Remove the pkinit-anonymous command
+define(IPA_API_VERSION_MINOR, 227)
+# Last change: Add `pkinit-status` command
 
 
 ########################################################

--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -256,6 +256,12 @@ class config(LDAPObject):
             flags={'virtual_attribute', 'no_create'}
         ),
         Str(
+            'pkinit_server_server*',
+            label=_('IPA master capable of PKINIT'),
+            doc=_('IPA master which can process PKINIT requests'),
+            flags={'virtual_attribute', 'no_create', 'no_update'}
+        ),
+        Str(
             'ipadomainresolutionorder?',
             cli_name='domain_resolution_order',
             label=_('Domain resolution order'),

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -4184,16 +4184,6 @@ class dnsconfig(LDAPObject):
         if is_config_empty:
             result['summary'] = unicode(_('Global DNS configuration is empty'))
 
-    def show_servroles_attributes(self, entry_attrs, **options):
-        if options.get('raw', False):
-            return
-
-        backend = self.api.Backend.serverroles
-        entry_attrs.update(
-            backend.config_retrieve("DNS server")
-        )
-
-
 @register()
 class dnsconfig_mod(LDAPUpdate):
     __doc__ = _('Modify global DNS configuration.')
@@ -4247,7 +4237,8 @@ class dnsconfig_mod(LDAPUpdate):
         return result
 
     def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
-        self.obj.show_servroles_attributes(entry_attrs, **options)
+        self.api.Object.config.show_servroles_attributes(
+            entry_attrs, "DNS server", **options)
         return dn
 
 
@@ -4261,7 +4252,8 @@ class dnsconfig_show(LDAPRetrieve):
         return result
 
     def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
-        self.obj.show_servroles_attributes(entry_attrs, **options)
+        self.api.Object.config.show_servroles_attributes(
+            entry_attrs, "DNS server", **options)
         return dn
 
 

--- a/ipaserver/plugins/pkinit.py
+++ b/ipaserver/plugins/pkinit.py
@@ -3,10 +3,32 @@
 #
 
 from ipalib import Object
-from ipalib import _
+from ipalib import _, ngettext
+from ipalib.crud import Search
+from ipalib.parameters import Int, Str, StrEnum
 from ipalib.plugable import Registry
 
 register = Registry()
+
+__doc__ = _("""
+Kerberos PKINIT feature status reporting tools.
+
+Report IPA masters on which Kerberos PKINIT is enabled or disabled
+
+EXAMPLES:
+ List PKINIT status on all masters:
+   ipa pkinit-status
+
+ Check PKINIT status on `ipa.example.com`:
+   ipa pkinit-status --server ipa.example.com
+
+ List all IPA masters with disabled PKINIT:
+   ipa pkinit-status --status='disabled'
+
+For more info about PKINIT support see:
+
+https://www.freeipa.org/page/V4/Kerberos_PKINIT
+""")
 
 
 @register()
@@ -17,3 +39,88 @@ class pkinit(Object):
     object_name = _('pkinit')
 
     label = _('PKINIT')
+
+    takes_params = (
+        Str(
+            'server_server?',
+            cli_name='server',
+            label=_('Server name'),
+            doc=_('IPA server hostname'),
+        ),
+        StrEnum(
+            'status?',
+            cli_name='status',
+            label=_('PKINIT status'),
+            doc=_('Whether PKINIT is enabled or disabled'),
+            values=(u'enabled', u'disabled'),
+            flags={'virtual_attribute', 'no_create', 'no_update'}
+        )
+    )
+
+
+@register()
+class pkinit_status(Search):
+    __doc__ = _('Report PKINIT status on the IPA masters')
+
+    msg_summary = ngettext('%(count)s server matched',
+                           '%(count)s servers matched', 0)
+
+    takes_options = Search.takes_options + (
+        Int(
+            'timelimit?',
+            label=_('Time Limit'),
+            doc=_('Time limit of search in seconds (0 is unlimited)'),
+            flags=['no_display'],
+            minvalue=0,
+            autofill=False,
+        ),
+        Int(
+            'sizelimit?',
+            label=_('Size Limit'),
+            doc=_('Maximum number of entries returned (0 is unlimited)'),
+            flags=['no_display'],
+            minvalue=0,
+            autofill=False,
+        ),
+    )
+
+    def get_pkinit_status(self, server, status):
+        backend = self.api.Backend.serverroles
+        ipa_master_config = backend.config_retrieve("IPA master")
+
+        if server is not None:
+            servers = [server]
+        else:
+            servers = ipa_master_config['ipa_master_server']
+
+        pkinit_servers = ipa_master_config['pkinit_server_server']
+
+        for s in servers:
+            pkinit_status = {
+                u'server_server': s,
+                u'status': (
+                    u'enabled' if s in pkinit_servers else u'disabled'
+                )
+            }
+            if status is not None and pkinit_status[u'status'] != status:
+                continue
+
+            yield pkinit_status
+
+    def execute(self, *keys, **options):
+        if keys:
+            return dict(
+                result=[],
+                count=0,
+                truncated=False
+            )
+
+        server = options.get('server_server', None)
+        status = options.get('status', None)
+
+        if server is not None:
+            self.api.Object.server_role.ensure_master_exists(server)
+
+        result = sorted(self.get_pkinit_status(server, status))
+
+        return dict(result=result, count=len(result), truncated=False)

--- a/ipaserver/plugins/serverroles.py
+++ b/ipaserver/plugins/serverroles.py
@@ -136,9 +136,7 @@ class serverroles(Backend):
 
         for name, attr in assoc_attributes.items():
             attr_value = attr.get(self.api)
-
-            if attr_value is not None:
-                result.update({name: attr_value})
+            result.update({name: attr_value})
 
         return result
 

--- a/ipaserver/plugins/trust.py
+++ b/ipaserver/plugins/trust.py
@@ -1278,22 +1278,6 @@ class trustconfig(LDAPObject):
 
         entry_attrs['ipantfallbackprimarygroup'] = [groupdn[0][0].value]
 
-    def show_servroles(self, entry_attrs, **options):
-        if options.get('raw', False):
-            return
-
-        backend = self.api.Backend.serverroles
-
-        adtrust_agents = backend.config_retrieve(
-            "AD trust agent"
-        )
-        adtrust_controllers = backend.config_retrieve(
-            "AD trust controller"
-        )
-
-        entry_attrs.update(adtrust_agents)
-        entry_attrs.update(adtrust_controllers)
-
 
 @register()
 class trustconfig_mod(LDAPUpdate):
@@ -1314,7 +1298,8 @@ class trustconfig_mod(LDAPUpdate):
 
     def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
         self.obj._convert_groupdn(entry_attrs, options)
-        self.obj.show_servroles(entry_attrs, **options)
+        self.api.Object.config.show_servroles_attributes(
+            entry_attrs, "AD trust agent", "AD trust controller", **options)
         return dn
 
 
@@ -1333,7 +1318,8 @@ class trustconfig_show(LDAPRetrieve):
 
     def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
         self.obj._convert_groupdn(entry_attrs, options)
-        self.obj.show_servroles(entry_attrs, **options)
+        self.api.Object.config.show_servroles_attributes(
+            entry_attrs, "AD trust agent", "AD trust controller", **options)
 
         return dn
 

--- a/ipaserver/plugins/vault.py
+++ b/ipaserver/plugins/vault.py
@@ -997,9 +997,9 @@ class vaultconfig_show(Retrieve):
         with self.api.Backend.kra.get_client() as kra_client:
             transport_cert = kra_client.system_certs.get_transport_cert()
             config = {'transport_cert': transport_cert.binary}
-            config.update(
-                self.api.Backend.serverroles.config_retrieve("KRA server")
-            )
+
+        self.api.Object.config.show_servroles_attributes(
+            config, "KRA server", **options)
 
         return {
             'result': config,

--- a/ipaserver/servroles.py
+++ b/ipaserver/servroles.py
@@ -625,4 +625,11 @@ attribute_instances = (
         u"DNSSEC",
         u"dnssecKeyMaster",
     ),
+    ServerAttribute(
+        u"pkinit_server_server",
+        u"PKINIT enabled server",
+        u"ipa_master_server",
+        u"KDC",
+        u"pkinitEnabled"
+    )
 )

--- a/ipatests/test_ipaserver/test_serverroles.py
+++ b/ipatests/test_ipaserver/test_serverroles.py
@@ -706,7 +706,7 @@ class TestServerAttributes(object):
         actual_attr_masters = self.config_retrieve(
             assoc_role, mock_api)[attr_name]
 
-        assert actual_attr_masters == fqdn
+        assert actual_attr_masters == [fqdn]
 
     def test_set_attribute_on_the_same_provider_raises_emptymodlist(
             self, mock_api, mock_masters):
@@ -727,7 +727,7 @@ class TestServerAttributes(object):
         non_ca_fqdn = mock_masters.get_fqdn('trust-controller-dns')
 
         with pytest.raises(errors.ValidationError):
-            self.config_update(mock_api, **{attr_name: non_ca_fqdn})
+            self.config_update(mock_api, **{attr_name: [non_ca_fqdn]})
 
     def test_set_unknown_attribute_on_master_raises_notfound(
             self, mock_api, mock_masters):
@@ -735,7 +735,7 @@ class TestServerAttributes(object):
         fqdn = mock_masters.get_fqdn('trust-controller-ca')
 
         with pytest.raises(errors.NotFound):
-            self.config_update(mock_api, **{attr_name: fqdn})
+            self.config_update(mock_api, **{attr_name: [fqdn]})
 
     def test_set_ca_renewal_master_on_other_ca_and_back(self, mock_api,
                                                         mock_masters):
@@ -747,7 +747,7 @@ class TestServerAttributes(object):
         other_ca_server = mock_masters.get_fqdn('trust-controller-ca')
 
         for host in (other_ca_server, original_renewal_master):
-            self.config_update(mock_api, **{attr_name: host})
+            self.config_update(mock_api, **{attr_name: [host]})
 
             assert (
-                self.config_retrieve(role_name, mock_api)[attr_name] == host)
+                self.config_retrieve(role_name, mock_api)[attr_name] == [host])


### PR DESCRIPTION
This PR implements easily-consumable API that reports PKINIT status on masters
based on the presence of pkinitEnabled value in KDC entry's ipaConfigString
attribute.

https://pagure.io/freeipa/issue/6937