### PR TITLE
Travis CI: Add the server uninstaller as a last step of tests

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -62,6 +62,7 @@ steps:
   - ipa-test-config --help
   - ipa-test-task --help
   - ipa-run-tests ${tests_ignore} -k-test_dns_soa ${tests_verbose} ${path}
+  - ipa-server-install --uninstall -U
 tests:
   ignore:
   - test_integration


### PR DESCRIPTION
The explicit uninstall will help to catch regressions
such as recently reported https://pagure.io/freeipa/issue/6950