### PR TITLE
named.conf template: add modification warning

### DIFF
--- a/install/share/bind.named.conf.template
+++ b/install/share/bind.named.conf.template
@@ -43,6 +43,9 @@ zone "." IN {
 include "$RFC1912_ZONES";
 include "$ROOT_KEY";
 
+/* WARNING: This part of the config file is IPA-managed.
+ * Modifications may break IPA setup or upgrades.
+ */
 dyndb "ipa" "$BIND_LDAP_SO" {
 	uri "ldapi://%2fvar%2frun%2fslapd-$SERVER_ID.socket";
 	base "cn=dns, $SUFFIX";
@@ -51,3 +54,4 @@ dyndb "ipa" "$BIND_LDAP_SO" {
 	sasl_mech "GSSAPI";
 	sasl_user "DNS/$FQDN";
 };
+/* End of IPA-managed part. */


### PR DESCRIPTION
Based on our discussion with Brian Atkinsson, I think we should add some warning about making undocumented changes to the config files.

---

Warn the user some modifications may break IPA setup or upgrade.
All changes the user makes should be explicitly supported and mentioned
in the documentation. Undocumented and unsupported changes, such as
renaming dyndb part from "ipa" will break IPA.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>