### PR TITLE
Fixing backup_and_restore tests

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -58,6 +58,7 @@ def check_admin_in_ldap(host):
     assert entry.dn == user_dn
     assert entry['uid'] == ['admin']
 
+
     del entry['krbLastSuccessfulAuth']
 
     return entry


### PR DESCRIPTION
I'm trying to fix the `test_integration/test_backup_and_restore.py` tests using the ipa-vagrant-tool. However, I'm getting a lot of errors when running the tests. I need some help with that.

The steps that I did until now:
```bash
1) ipa-vagrant-ci-topology-create basic-test --replicas 1 --clients 1 --add-package={freeipa-server,freeipa-server-dns,freeipa-tests} --no-selinux-enforce
2) Generated rpms from master
3) Put rpms in build/
4) vagrant up --no-parallel # without the --no-parallel didn't work
5) vagrant ssh
6) IPATEST_YAML_CONFIG=/vagrant/ipa-test-config.yaml ipa-run-tests test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS --verbose --logging-level=debug
```

The error I'm getting: 
`Command '/bin/systemctl restart ipa.service' returned non-zero exit status 1`

The entire log: [https://pastebin.com/hhrSgq5V](https://pastebin.com/hhrSgq5V)

PS: I committed a blank line just to be able to create this PR to ask for help.
