### PR TITLE
dnskeysyncd: enable authlogin_nsswitch_use_ldap boolean

### DIFF
--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -27,4 +27,7 @@ class BaseConstantsNamespace(object):
     ODS_GROUP = "ods"
     # nfsd init variable used to enable kerberized NFS
     SECURE_NFS_VAR = "SECURE_NFS"
+    SELINUX_BOOLEAN_DNSKEYSYNCD = {
+        'authlogin_nsswitch_use_ldap': 'on',
+    }
     SSSD_USER = "sssd"

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1725,6 +1725,7 @@ def upgrade_configuration():
             if not dnskeysyncd.is_configured():
                 dnskeysyncd.create_instance(fqdn, api.env.realm)
                 dnskeysyncd.start_dnskeysyncd()
+            dnskeysyncd.configure_selinux()
 
     cleanup_kdc(fstore)
     cleanup_adtrust(fstore)


### PR DESCRIPTION
ipa-dnskeysyncd requires authlogin_nsswitch_use_ldap boolean to be able
to connect to LDAP

Ticket: https://pagure.io/freeipa/issue/6957
https://bugzilla.redhat.com/show_bug.cgi?id=1445630