### PR TITLE
httpinstance: wait until the service entry is replicated

### DIFF
--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -830,13 +830,13 @@ def install(installer):
     http = httpinstance.HTTPInstance(fstore)
     if options.http_cert_files:
         http.create_instance(
-            realm_name, host_name, domain_name,
+            realm_name, host_name, domain_name, dm_password,
             pkcs12_info=http_pkcs12_info, subject_base=options.subject_base,
             auto_redirect=not options.no_ui_redirect,
             ca_is_configured=setup_ca)
     else:
         http.create_instance(
-            realm_name, host_name, domain_name,
+            realm_name, host_name, domain_name, dm_password,
             subject_base=options.subject_base,
             auto_redirect=not options.no_ui_redirect,
             ca_is_configured=setup_ca)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -163,9 +163,10 @@ def install_http(config, auto_redirect, ca_is_configured, ca_file,
     http = httpinstance.HTTPInstance()
     http.create_instance(
         config.realm_name, config.host_name, config.domain_name,
-        pkcs12_info, auto_redirect=auto_redirect, ca_file=ca_file,
+        config.dirman_password, pkcs12_info,
+        auto_redirect=auto_redirect, ca_file=ca_file,
         ca_is_configured=ca_is_configured, promote=promote,
-        subject_base=config.subject_base)
+        subject_base=config.subject_base, master_fqdn=config.master_host_name)
 
     return http
 


### PR DESCRIPTION
Wait until the local HTTP service entry is replicated to the remote master
before requesting the server certificate.

This prevents a replication conflict between the service entry added
locally and service entry added remotely when requesting the certificate.

https://pagure.io/freeipa/issue/6867