### PR TITLE
Improve cert messages some more + do that for KDC certs as well

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -192,13 +192,17 @@ def verify_kdc_cert_validity(kdc_cert, ca_certs, realm):
 
         try:
             ipautil.run(
-                [OPENSSL, 'verify', '-CAfile', ca_file.name, kdc_file.name])
+                [OPENSSL, 'verify', '-CAfile', ca_file.name, kdc_file.name],
+                capture_output=True)
+        except ipautil.CalledProcessError as e:
+            raise ValueError(e.output)
+
+        try:
             eku = kdc_cert.extensions.get_extension_for_class(
                 cryptography.x509.ExtendedKeyUsage)
             list(eku.value).index(
                 cryptography.x509.ObjectIdentifier(x509.EKU_PKINIT_KDC))
-        except (ipautil.CalledProcessError,
-                cryptography.x509.ExtensionNotFound,
+        except (cryptography.x509.ExtensionNotFound,
                 ValueError):
             raise ValueError("invalid for a KDC")
 

--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -55,8 +55,6 @@ CA_NICKNAME_FMT = "%s IPA CA"
 
 NSS_FILES = ("cert8.db", "key3.db", "secmod.db", "pwdfile.txt")
 
-BAD_USAGE_ERR = 'Certificate key usage inadequate for attempted operation.'
-
 TrustFlags = collections.namedtuple('TrustFlags', 'has_key trusted ca usages')
 
 EMPTY_TRUST_FLAGS = TrustFlags(False, None, None, None)
@@ -690,10 +688,7 @@ class NSSDatabase(object):
         except ipautil.CalledProcessError as e:
             # certutil output in case of error is
             # 'certutil: certificate is invalid: <ERROR_STRING>\n'
-            msg = e.output.split(': ')[2].strip()
-            if msg == BAD_USAGE_ERR:
-                msg = 'invalid for a SSL server.'
-            raise ValueError(msg)
+            raise ValueError(e.output)
 
         try:
             x509.match_hostname(cert, hostname)
@@ -722,10 +717,7 @@ class NSSDatabase(object):
         except ipautil.CalledProcessError as e:
             # certutil output in case of error is
             # 'certutil: certificate is invalid: <ERROR_STRING>\n'
-            msg = e.output.split(': ')[2].strip()
-            if msg == BAD_USAGE_ERR:
-                msg = 'invalid for a CA.'
-            raise ValueError(msg)
+            raise ValueError(e.output)
 
     def verify_kdc_cert_validity(self, nickname, realm):
         nicknames = self.get_trust_chain(nickname)

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -38,7 +38,10 @@ _DEFAULT = object()
 
 assert_error = tasks.assert_error
 
-CERT_EXPIRED_MSG = "Peer's Certificate has expired."
+NSS_INVALID_FMT = "certutil: certificate is invalid: %s"
+CERT_EXPIRED_MSG = NSS_INVALID_FMT % "Peer's Certificate has expired."
+BAD_USAGE_MSG = NSS_INVALID_FMT % ("Certificate key usage inadequate for "
+                                   "attempted operation.")
 
 
 def get_install_stdin(cert_passwords=()):
@@ -557,8 +560,8 @@ class TestServerInstall(CALessBase):
         result = self.install_server(http_pkcs12='http.p12',
                                      dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in http.p12 is not valid: '
-                     'invalid for a SSL server')
+                     'The server certificate in http.p12 is not valid: {err}'
+                     .format(err=BAD_USAGE_MSG))
 
     @server_install_teardown
     def test_ds_bad_usage(self):
@@ -572,8 +575,8 @@ class TestServerInstall(CALessBase):
         result = self.install_server(http_pkcs12='http.p12',
                                      dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in dirsrv.p12 is not valid: '
-                     'invalid for a SSL server')
+                     'The server certificate in dirsrv.p12 is not valid: {err}'
+                     .format(err=BAD_USAGE_MSG))
 
     @server_install_teardown
     def test_revoked_http(self):
@@ -940,8 +943,8 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='http.p12',
                                       dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in http.p12 is not valid: '
-                     'invalid for a SSL server')
+                     'The server certificate in http.p12 is not valid: {err}'
+                     .format(err=BAD_USAGE_MSG))
 
     @replica_install_teardown
     def test_ds_bad_usage(self):
@@ -953,8 +956,8 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='http.p12',
                                       dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in dirsrv.p12 is not valid: '
-                     'invalid for a SSL server')
+                     'The server certificate in dirsrv.p12 is not valid: {err}'
+                     .format(err=BAD_USAGE_MSG))
 
     @replica_install_teardown
     def test_revoked_http(self):
@@ -1355,16 +1358,16 @@ class TestCertinstall(CALessBase):
 
         result = self.certinstall('w', 'ca1/server-badusage')
         assert_error(result,
-                     'The server certificate in server.p12 is not valid: '
-                     'invalid for a SSL server')
+                     'The server certificate in server.p12 is not valid: {err}'
+                     .format(err=BAD_USAGE_MSG))
 
     def test_ds_bad_usage(self):
         "Install new DS certificate with invalid key usage"
 
         result = self.certinstall('d', 'ca1/server-badusage')
         assert_error(result,
-                     'The server certificate in server.p12 is not valid: '
-                     'invalid for a SSL server')
+                     'The server certificate in server.p12 is not valid: {err}'
+                     .format(err=BAD_USAGE_MSG))
 
     def test_revoked_http(self):
         "Install new revoked HTTP certificate"


### PR DESCRIPTION
Some of the previous error message handling would not work in
a locale different from English so we just output the error message we get
from `certutil`.

Also, since this was previously done, there is now kdc cert validation that is
different from the others so make the error messages more verbose there.

OpenSSL prints quite verbose messages so you may want to grab only a
part of it, let me know what your opinion is.