### PR TITLE
ipatests: add systemd journal collection for multihost tests

### DIFF
--- a/ipatests/pytest_plugins/integration/__init__.py
+++ b/ipatests/pytest_plugins/integration/__init__.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 import os
 import tempfile
 import shutil
+import re
 
 import pytest
 from pytest_multihost import make_multihost_fixture
@@ -46,6 +47,14 @@ def pytest_addoption(parser):
         help="Directory to store integration test logs in.")
 
 
+def _get_logname_from_node(node):
+    name = node.nodeid
+    name = re.sub('\(\)/', '', name)      # remove ()/
+    name = re.sub('[()]', '', name)       # and standalone brackets
+    name = re.sub('(/|::)', '-', name)
+    return name
+
+
 def collect_test_logs(node, logs_dict, test_config):
     """Collect logs from a test
 
@@ -56,7 +65,7 @@ def collect_test_logs(node, logs_dict, test_config):
     :param test_config: Pytest configuration
     """
     collect_logs(
-        name=node.nodeid.replace('/', '-').replace('::', '-'),
+        name=_get_logname_from_node(node),
         logs_dict=logs_dict,
         logfile_dir=test_config.getoption('logfile_dir'),
         beakerlib_plugin=test_config.pluginmanager.getplugin('BeakerLibPlugin'),

--- a/ipatests/pytest_plugins/integration/config.py
+++ b/ipatests/pytest_plugins/integration/config.py
@@ -41,6 +41,7 @@ class Config(pytest_multihost.config.Config):
         'ad_admin_password',
         'dns_forwarder',
         'domain_level',
+        'log_journal_since',
     }
 
     def __init__(self, **kwargs):
@@ -62,6 +63,7 @@ class Config(pytest_multihost.config.Config):
         # 8.8.8.8 is probably the best-known public DNS
         self.dns_forwarder = kwargs.get('dns_forwarder') or '8.8.8.8'
         self.debug = False
+        self.log_journal_since = kwargs.get('log_journal_since') or '-1h'
         if self.domain_level is None:
             self.domain_level = MAX_DOMAIN_LEVEL
 

--- a/ipatests/pytest_plugins/integration/env_config.py
+++ b/ipatests/pytest_plugins/integration/env_config.py
@@ -63,6 +63,8 @@ _setting_infos = (
     _SettingInfo('ipv6', 'IPv6SETUP', False),
     _SettingInfo('debug', 'IPADEBUG', False),
     _SettingInfo('domain_level', 'DOMAINLVL', MAX_DOMAIN_LEVEL),
+
+    _SettingInfo('log_journal_since', 'LOG_JOURNAL_SINCE', '-1h'),
 )
 
 

--- a/ipatests/test_integration/test_testconfig.py
+++ b/ipatests/test_integration/test_testconfig.py
@@ -41,7 +41,8 @@ DEFAULT_OUTPUT_DICT = {
     "dirman_password": "Secret123",
     "ntp_server": "ntp.clock.test",
     "admin_password": "Secret123",
-    "domain_level": MAX_DOMAIN_LEVEL
+    "domain_level": MAX_DOMAIN_LEVEL,
+    "log_journal_since": "-1h",
 }
 
 DEFAULT_OUTPUT_ENV = {
@@ -60,6 +61,7 @@ DEFAULT_OUTPUT_ENV = {
     "IPv6SETUP": "",
     "IPADEBUG": "",
     "DOMAINLVL": str(MAX_DOMAIN_LEVEL),
+    "LOG_JOURNAL_SINCE": "-1h",
 }
 
 DEFAULT_INPUT_ENV = {


### PR DESCRIPTION
Some messages are only logged in journal. Collection of journal
makes debugging failed tests from logs easier.

Fixes: https://pagure.io/freeipa/issue/6971

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>