### PR TITLE
krb5: make sure KDC certificate is readable

### DIFF
--- a/install/restart_scripts/renew_kdc_cert
+++ b/install/restart_scripts/renew_kdc_cert
@@ -3,19 +3,15 @@
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #
 
-import os
 import syslog
 import traceback
 
 from ipaplatform import services
-from ipaplatform.paths import paths
 from ipaserver.install import certs
 
 
 def main():
     with certs.renewal_lock:
-        os.chmod(paths.KDC_CERT, 0o644)
-
         try:
             if services.knownservices.krb5kdc.is_running():
                 syslog.syslog(syslog.LOG_NOTICE, 'restarting krb5kdc')

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -432,7 +432,8 @@ class KrbInstance(service.Service):
                 dns=self.fqdn,
                 storage='FILE',
                 profile=KDC_PROFILE,
-                post_command='renew_kdc_cert')
+                post_command='renew_kdc_cert',
+                perms=(0o644, 0o600))
         except dbus.DBusException as e:
             # if the certificate is already tracked, ignore the error
             name = e.get_dbus_name()


### PR DESCRIPTION
When requesting certificate for KDC profile, make sure its public part
is actually readable to others.

Fixes https://pagure.io/freeipa/issue/6973