### PR TITLE
Support specifying external CA template (preliminary refactors)

### DIFF
--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -61,7 +61,7 @@ def parse_options():
                       default=False, help="unattended installation never prompts the user")
     parser.add_option("--external-ca", dest="external_ca", action="store_true",
                       default=False, help="Generate a CSR to be signed by an external CA")
-    ext_cas = ("generic", "ms-cs")
+    ext_cas = tuple(x.value for x in cainstance.ExternalCAType)
     parser.add_option("--external-ca-type", dest="external_ca_type",
                       type="choice", choices=ext_cas,
                       metavar="{{{0}}}".format(",".join(ext_cas)),

--- a/ipapython/config.py
+++ b/ipapython/config.py
@@ -79,16 +79,28 @@ def check_dn_option(option, opt, value):
     except Exception as e:
         raise OptionValueError("option %s: invalid DN: %s" % (opt, e))
 
+
+def check_constructor(option, opt, value):
+    con = option.constructor
+    assert con is not None, "Oops! Developer forgot to set 'constructor' kwarg"
+    try:
+        return con(value)
+    except Exception as e:
+        raise OptionValueError("option {} invalid: {}".format(opt, e))
+
+
 class IPAOption(Option):
     """
     optparse.Option subclass with support of options labeled as
     security-sensitive such as passwords.
     """
-    ATTRS = Option.ATTRS + ["sensitive"]
-    TYPES = Option.TYPES + ("ip", "dn")
+    ATTRS = Option.ATTRS + ["sensitive", "constructor"]
+    TYPES = Option.TYPES + ("ip", "dn", "constructor")
     TYPE_CHECKER = copy(Option.TYPE_CHECKER)
     TYPE_CHECKER["ip"] = check_ip_option
     TYPE_CHECKER["dn"] = check_dn_option
+    TYPE_CHECKER["constructor"] = check_constructor
+
 
 class IPAOptionParser(OptionParser):
     """

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -358,11 +358,6 @@ def uninstall():
         ca_instance.uninstall()
 
 
-class ExternalCAType(enum.Enum):
-    GENERIC = 'generic'
-    MS_CS = 'ms-cs'
-
-
 class CASigningAlgorithm(enum.Enum):
     SHA1_WITH_RSA = 'SHA1withRSA'
     SHA_256_WITH_RSA = 'SHA256withRSA'
@@ -408,7 +403,7 @@ class CAInstallInterface(dogtag.DogtagInstallInterface,
     external_ca = master_install_only(external_ca)
 
     external_ca_type = knob(
-        ExternalCAType, None,
+        cainstance.ExternalCAType, None,
         description="Type of the external CA",
     )
     external_ca_type = master_install_only(external_ca_type)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 
 import base64
 import dbus
+import enum
 import ldap
 import os
 import pwd
@@ -91,6 +92,11 @@ ADMIN_GROUPS = [
     'Enterprise KRA Administrators',
     'Security Domain Administrators'
 ]
+
+
+class ExternalCAType(enum.Enum):
+    GENERIC = 'generic'
+    MS_CS = 'ms-cs'
 
 
 def check_port():
@@ -352,7 +358,7 @@ class CAInstance(DogtagInstance):
         if ca_type is not None:
             self.ca_type = ca_type
         else:
-            self.ca_type = 'generic'
+            self.ca_type = ExternalCAType.GENERIC.value
         self.no_db_setup = promote
         self.use_ldaps = use_ldaps
 
@@ -570,7 +576,7 @@ class CAInstance(DogtagInstance):
             config.set("CA", "pki_external", "True")
             config.set("CA", "pki_external_csr_path", self.csr_file)
 
-            if self.ca_type == 'ms-cs':
+            if self.ca_type == ExternalCAType.MS_CS.value:
                 # Include MS template name extension in the CSR
                 config.set("CA", "pki_req_ext_add", "True")
                 config.set("CA", "pki_req_ext_oid", "1.3.6.1.4.1.311.20.2")

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -58,7 +58,7 @@ class CACertManage(admintool.AdminTool):
             "--self-signed", dest='self_signed',
             action='store_true',
             help="Sign the renewed certificate by itself")
-        ext_cas = ("generic", "ms-cs")
+        ext_cas = tuple(x.value for x in cainstance.ExternalCAType)
         renew_group.add_option(
             "--external-ca-type", dest="external_ca_type",
             type="choice", choices=ext_cas,
@@ -189,7 +189,8 @@ class CACertManage(admintool.AdminTool):
     def renew_external_step_1(self, ca):
         print("Exporting CA certificate signing request, please wait")
 
-        if self.options.external_ca_type == 'ms-cs':
+        if self.options.external_ca_type \
+                == cainstance.ExternalCAType.MS_CS.value:
             profile = 'SubCA'
         else:
             profile = ''


### PR DESCRIPTION
This PR contains a couple of refactorings, as groundwork for
upcoming support for specifying the external CA profile/template
during install / ca-install / cacert-manage renew / etc.

https://pagure.io/freeipa/issue/6858