### PR TITLE
[4.5] Remove pkinit-anonymous command

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -3736,11 +3736,6 @@ command: ping/1
 args: 0,1,1
 option: Str('version?')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
-command: pkinit_anonymous/1
-args: 1,1,1
-arg: Str('action')
-option: Str('version?')
-output: Output('result')
 command: plugins/1
 args: 0,3,3
 option: Flag('all', autofill=True, cli_name='all', default=True)
@@ -6803,7 +6798,6 @@ default: permission_remove_member/1
 default: permission_show/1
 default: ping/1
 default: pkinit/1
-default: pkinit_anonymous/1
 default: plugins/1
 default: privilege/1
 default: privilege_add/1

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -73,8 +73,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-define(IPA_API_VERSION_MINOR, 224)
-# Last change: Add rename option to sudorule objects
+define(IPA_API_VERSION_MINOR, 226)
+# Last change: Remove the pkinit-anonymous command
 
 
 ########################################################

--- a/ipaserver/plugins/pkinit.py
+++ b/ipaserver/plugins/pkinit.py
@@ -1,51 +1,13 @@
-# Authors:
-#   Simo Sorce <ssorce@redhat.com>
 #
-# Copyright (C) 2010  Red Hat
-# see file 'COPYING' for use and warranty information
+# Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ipalib import api, errors
-from ipalib import Str
-from ipalib import Object, Command
+from ipalib import Object
 from ipalib import _
 from ipalib.plugable import Registry
-from ipalib.constants import ANON_USER
-from ipapython.dn import DN
-
-__doc__ = _("""
-Kerberos pkinit options
-
-Enable or disable anonymous pkinit using the principal
-WELLKNOWN/ANONYMOUS@REALM. The server must have been installed with
-pkinit support.
-
-EXAMPLES:
-
- Enable anonymous pkinit:
-  ipa pkinit-anonymous enable
-
- Disable anonymous pkinit:
-  ipa pkinit-anonymous disable
-
-For more information on anonymous pkinit see:
-
-http://k5wiki.kerberos.org/wiki/Projects/Anonymous_pkinit
-""")
 
 register = Registry()
+
 
 @register()
 class pkinit(Object):
@@ -54,52 +16,4 @@ class pkinit(Object):
     """
     object_name = _('pkinit')
 
-    label=_('PKINIT')
-
-
-def valid_arg(ugettext, action):
-    """
-    Accepts only Enable/Disable.
-    """
-    a = action.lower()
-    if a != 'enable' and a != 'disable':
-        raise errors.ValidationError(
-            name='action',
-            error=_('Unknown command %s') % action
-        )
-
-@register()
-class pkinit_anonymous(Command):
-    __doc__ = _('Enable or Disable Anonymous PKINIT.')
-
-    princ_name = '%s@%s' % (ANON_USER, api.env.realm)
-    default_dn = DN(('krbprincipalname', princ_name), ('cn', api.env.realm), ('cn', 'kerberos'), api.env.basedn)
-
-    takes_args = (
-        Str('action', valid_arg),
-    )
-
-    def execute(self, action, **options):
-        ldap = self.api.Backend.ldap2
-        set_lock = False
-        lock = None
-
-        entry_attrs = ldap.get_entry(self.default_dn, ['nsaccountlock'])
-
-        if 'nsaccountlock' in entry_attrs:
-            lock = entry_attrs['nsaccountlock'][0].lower()
-
-        if action.lower() == 'enable':
-            if lock == 'true':
-                set_lock = True
-                lock = None
-        elif action.lower() == 'disable':
-            if lock != 'true':
-                set_lock = True
-                lock = 'TRUE'
-
-        if set_lock:
-            entry_attrs['nsaccountlock'] = lock
-            ldap.update_entry(entry_attrs)
-
-        return dict(result=True)
+    label = _('PKINIT')


### PR DESCRIPTION
Ever since from v4.5, FreeIPA expects at least some kind of
anonymous PKINIT to work. The pkinit-anonymous command was supposed
to enable/disable anonymous pkinit by locking/unlocking the
anonymous principal. We can't allow this for FreeIPA to work
so we are removing the command as it was never supported anyway.

https://pagure.io/freeipa/issue/6936