### PR TITLE
Refactoring cert-find to use API call directly instead of using

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1090,8 +1090,8 @@ class cert(BaseCertObject):
                 param = param.clone(flags=param.flags - {'no_search'})
             yield param
 
-        for owner in self._owners():
-            yield owner.primary_key.clone_rename(
+        for owner, search_key in self._owners():
+            yield search_key.clone_rename(
                 'owner_{0}'.format(owner.name),
                 required=False,
                 multivalue=True,
@@ -1101,15 +1101,22 @@ class cert(BaseCertObject):
             )
 
     def _owners(self):
-        for name in ('user', 'host', 'service'):
-            yield self.api.Object[name]
+        for obj_name, search_key in [('user', None),
+                                     ('host', None),
+                                     ('service', 'krbprincipalname')]:
+            obj = self.api.Object[obj_name]
+            if search_key is None:
+                pkey = obj.primary_key
+            else:
+                pkey = obj.params[search_key]
+            yield obj, pkey
 
     def _fill_owners(self, obj):
         dns = obj.pop('owner', None)
         if dns is None:
             return
 
-        for owner in self._owners():
+        for owner, _search_key in self._owners():
             container_dn = DN(owner.container_dn, self.api.env.basedn)
             name = 'owner_' + owner.name
             for dn in dns:
@@ -1373,8 +1380,8 @@ class cert_find(Search, CertMethod):
                 option = option.clone(default=None, autofill=None)
             yield option
 
-        for owner in self.obj._owners():
-            yield owner.primary_key.clone_rename(
+        for owner, search_key in self.obj._owners():
+            yield search_key.clone_rename(
                 '{0}'.format(owner.name),
                 required=False,
                 multivalue=True,
@@ -1385,7 +1392,7 @@ class cert_find(Search, CertMethod):
                      owner.object_name_plural),
                 label=owner.object_name,
             )
-            yield owner.primary_key.clone_rename(
+            yield search_key.clone_rename(
                 'no_{0}'.format(owner.name),
                 required=False,
                 multivalue=True,
@@ -1504,7 +1511,7 @@ class cert_find(Search, CertMethod):
         ldap = self.api.Backend.ldap2
 
         filters = []
-        for owner in self.obj._owners():
+        for owner, search_key in self.obj._owners():
             for prefix, rule in (('', ldap.MATCH_ALL),
                                  ('no_', ldap.MATCH_NONE)):
                 try:
@@ -1520,7 +1527,7 @@ class cert_find(Search, CertMethod):
                     filters.append(filter)
 
                 filter = ldap.make_filter_from_attr(
-                    owner.primary_key.name,
+                    search_key.name,
                     value,
                     rule)
                 filters.append(filter)


### PR DESCRIPTION
Refactoring cert-find to use API calls directly instead of using raw LDAP search.

Upstream ticket: https://pagure.io/freeipa/issue/6948

I removed the raw LDAP search and used the API directly. In the old code, the call ` self.obj._owners()` returns `service, hots and user`. However, when testing the code, only the service was being used, so I made it only use the service API. 

If there another scenario where `user and host` are used, I thought to do something like:

```python
for owner in self.obj._owners():
    api_name = owner.name
    response = api.Command[api_name+'_find'](options[api_name])
    ...  # continues
```
Is that correct?