### PR TITLE
Add Subject Key Identifier to CA cert validity check

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -717,6 +717,12 @@ class NSSDatabase(object):
             raise ValueError("not a CA certificate")
 
         try:
+            cert.extensions.get_extension_for_class(
+                    cryptography.x509.SubjectKeyIdentifier)
+        except cryptography.x509.ExtensionNotFound:
+            raise ValueError("missing subject key identifier extension")
+
+        try:
             self.run_certutil(['-V', '-n', nickname, '-u', 'L'],
                               capture_output=True)
         except ipautil.CalledProcessError as e:


### PR DESCRIPTION
CA certificates MUST have the Subject Key Identifier extension to
facilitiate certification path construction.  Not having this
extension on the IPA CA certificate will cause failures in Dogtag
during signing; it tries to copy the CA's Subject Key Identifier to
the new certificate's Authority Key Identifier extension, which
fails.

When installing an externally-signed CA, check that the Subject Key
Identifier extension is present in the CA certificate.

Fixes: https://pagure.io/freeipa/issue/6976