### PR TITLE
Add 'TIP' to enable copr repo.

### DIFF
--- a/BUILD.txt
+++ b/BUILD.txt
@@ -9,6 +9,12 @@ The quickest way to get the dependencies needed for building is:
 
 # dnf builddep -b -D "with_lint 1" --spec freeipa.spec.in
 
+TIP: For building with latest dependencies for freeipa master enable copr repo:
+
+# dnf copr enable @freeipa/freeipa-master
+
+see: https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master/
+
 Building
 --------
 


### PR DESCRIPTION
Copr repo @freeipa/freeipa-master provides dependencies for freeipa/master branch.