### PR TITLE
only stop/disable simple service if it is installed

### DIFF
--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -674,18 +674,21 @@ class SimpleServiceInstance(Service):
         else:
             self.ldap_enable(self.gensvc_name, self.fqdn, None, self.suffix)
 
+    def is_installed(self):
+        return self.service.is_installed()
+
     def uninstall(self):
         if self.is_configured():
             self.print_msg("Unconfiguring %s" % self.service_name)
 
-        self.stop()
-        self.disable()
-
         running = self.restore_state("running")
         enabled = self.restore_state("enabled")
 
-        # restore the original state of service
-        if running:
-            self.start()
-        if enabled:
-            self.enable()
+        if self.is_installed():
+            self.stop()
+            self.disable()
+
+            if running:
+                self.start()
+            if enabled:
+                self.enable()


### PR DESCRIPTION
The SimpleServiceInstance uninstaller assument that the service to
uninstall was always present on the system. This may not be valid in
some cases (e.g. containerized deployments) and thus we need to change
the service state only when we know that the unit file exists.

https://pagure.io/freeipa/issue/6977