### PR TITLE
[py3] Change ConfigParser to RawConfigParser

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -36,7 +36,7 @@ import tempfile
 
 import six
 # pylint: disable=import-error
-from six.moves.configparser import ConfigParser, RawConfigParser
+from six.moves.configparser import RawConfigParser
 # pylint: enable=import-error
 from cryptography.hazmat.primitives import serialization
 
@@ -465,7 +465,7 @@ class CAInstance(DogtagInstance):
         self.tmp_agent_pwd = ipautil.ipa_generate_password()
 
         # Create CA configuration
-        config = ConfigParser()
+        config = RawConfigParser()
         config.optionxform = str
         config.add_section("CA")
 

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -24,7 +24,7 @@ import tempfile
 
 import six
 # pylint: disable=import-error
-from six.moves.configparser import ConfigParser
+from six.moves.configparser import RawConfigParser
 # pylint: enable=import-error
 from cryptography.hazmat.primitives import serialization
 
@@ -153,7 +153,7 @@ class KRAInstance(DogtagInstance):
         tmp_agent_pwd = ipautil.ipa_generate_password()
 
         # Create KRA configuration
-        config = ConfigParser()
+        config = RawConfigParser()
         config.optionxform = str
         config.add_section("KRA")
 


### PR DESCRIPTION
In case ipa_generate_password() generates a sequence containing
'%', ConfigParser.set() will fail because it would think it is a
string that should be interpolated.

https://pagure.io/freeipa/issue/4985