### PR TITLE
Amend some regressions in backup/restore tests

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -58,7 +58,7 @@ def check_admin_in_ldap(host):
     assert entry.dn == user_dn
     assert entry['uid'] == ['admin']
 
-    del entry['krbLastSuccessfulAuth']
+    entry.pop('krbLastSuccessfulAuth', None)
 
     return entry
 

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -23,7 +23,6 @@ import os
 import re
 import contextlib
 
-from ipaplatform.constants import constants
 from ipapython.ipa_log_manager import log_mgr
 from ipapython.dn import DN
 from ipatests.test_integration.base import IntegrationTest
@@ -164,9 +163,6 @@ class TestBackupAndRestore(IntegrationTest):
             self.master.run_command(['ipa-server-install',
                                      '--uninstall',
                                      '-U'])
-
-            self.master.run_command(['userdel', constants.DS_USER])
-            self.master.run_command(['userdel', constants.PKI_USER])
 
             homedir = os.path.join(self.master.config.test_dir,
                                    'testuser_homedir')


### PR DESCRIPTION
After investigating the backup_restore test failures in CI I found out that
most of them were caused by recently introduced changes in 4.5 development and
are quite easy to fix.

The last one, however, is caused by some bug in Vault and may not be as easy as
it seems.

https://pagure.io/freeipa/issue/6956