### PR TITLE
fix incorrect suffix handling in topology checks

### DIFF
--- a/ipaserver/topology.py
+++ b/ipaserver/topology.py
@@ -72,12 +72,15 @@ def get_topology_connection_errors(graph):
 
 def map_masters_to_suffixes(masters):
     masters_to_suffix = {}
+    managed_suffix_attr = 'iparepltopomanagedsuffix_topologysuffix'
 
     for master in masters:
-        try:
-            managed_suffixes = master.get(
-                'iparepltopomanagedsuffix_topologysuffix')
-        except KeyError:
+        if managed_suffix_attr not in master:
+            continue
+
+        managed_suffixes = master[managed_suffix_attr]
+
+        if managed_suffixes is None:
             continue
 
         for suffix_name in managed_suffixes:


### PR DESCRIPTION
When trying to delete a partially removed master entry lacking
'iparepltopomanagedsuffix' attribute, the code that tries to retrieve
tha value for further computations passes None and causes unhandled
internal errors.

If the attribute is empty or not present, we should return empty list
instead as to not break calling cod attribute, the code that tries to
retrieve tha value for further computations passes None and causes
unhandled internal errors. We should return empty list instead.

https://pagure.io/freeipa/issue/6965