### PR TITLE
ca-add: validate Subject DN name attributes

### DIFF
--- a/ipapython/dn.py
+++ b/ipapython/dn.py
@@ -1131,7 +1131,7 @@ class DN(object):
         elif isinstance(value, cryptography.x509.name.Name):
             rdns = list(reversed([
                 [get_ava(
-                    _ATTR_NAME_BY_OID.get(ava.oid, ava.oid.dotted_string),
+                    ATTR_NAME_BY_OID.get(ava.oid, ava.oid.dotted_string),
                     ava.value)]
                 for ava in value
             ]))
@@ -1426,7 +1426,7 @@ class DN(object):
         return i
 
 
-_ATTR_NAME_BY_OID = {
+ATTR_NAME_BY_OID = {
     cryptography.x509.oid.NameOID.COMMON_NAME: 'CN',
     cryptography.x509.oid.NameOID.COUNTRY_NAME: 'C',
     cryptography.x509.oid.NameOID.LOCALITY_NAME: 'L',

--- a/ipatests/test_xmlrpc/test_ca_plugin.py
+++ b/ipatests/test_xmlrpc/test_ca_plugin.py
@@ -63,6 +63,16 @@ def subject_conflict_subca(request):
     return tracker
 
 
+@pytest.fixture(scope='class')
+def unrecognised_subject_dn_attrs_subca(request):
+    name = u'crud-subca-3'
+    subject = u'CN=crud subca test,DN=example.com,O=crud testing inc'
+    tracker = CATracker(name, subject)
+
+    # Should not get created, no need to delete
+    return tracker
+
+
 @pytest.mark.tier0
 class TestDefaultCA(XMLRPC_test):
     def test_default_ca_present(self, default_ca):
@@ -173,3 +183,8 @@ class TestCAbasicCRUD(XMLRPC_test):
 
         with pytest.raises(errors.DuplicateEntry):
             subject_conflict_subca.create()
+
+    def test_create_subca_with_unrecognised_subject_dn_attrs(
+            self, unrecognised_subject_dn_attrs_subca):
+        with pytest.raises(errors.ValidationError):
+            unrecognised_subject_dn_attrs_subca.create()


### PR DESCRIPTION
If the Subject DN is syntactically valid but contains unrecognised
name attributes, FreeIPA accepts it but Dogtag rejects it, returning
status 400 and causing the framework to raise RemoteRetrieveError.

Update the ca-add command to perform some additional validation on
the user-supplied Subject DN, making sure that we recognise all the
attributes.

Fixes: https://pagure.io/freeipa/issue/6987