### PR TITLE
Silence pytest.yield_fixture deprecation warning

### DIFF
--- a/ipatests/pytest_plugins/integration/__init__.py
+++ b/ipatests/pytest_plugins/integration/__init__.py
@@ -30,6 +30,7 @@ from pytest_multihost import make_multihost_fixture
 
 from ipapython import ipautil
 from ipapython.ipa_log_manager import log_mgr
+from ipatests.test_util import yield_fixture
 from .config import Config
 from .env_config import get_global_config
 from . import tasks
@@ -143,7 +144,7 @@ def class_integration_logs():
     return {}
 
 
-@pytest.yield_fixture
+@yield_fixture
 def integration_logs(class_integration_logs, request):
     """Provides access to test integration logs, and collects after each test
     """
@@ -151,7 +152,7 @@ def integration_logs(class_integration_logs, request):
     collect_test_logs(request.node, class_integration_logs, request.config)
 
 
-@pytest.yield_fixture(scope='class')
+@yield_fixture(scope='class')
 def mh(request, class_integration_logs):
     """IPA's multihost fixture object
     """

--- a/ipatests/test_ipapython/test_ipautil.py
+++ b/ipatests/test_ipapython/test_ipautil.py
@@ -31,53 +31,44 @@ from ipapython import ipautil
 pytestmark = pytest.mark.tier0
 
 
-def make_ipaddress_checker(addr, words=None, prefixlen=None):
-    def check_ipaddress():
-        try:
-            ip = ipautil.CheckedIPAddress(addr, match_local=False)
-            assert ip.words == words and ip.prefixlen == prefixlen
-        except Exception:
-            assert words is None and prefixlen is None
-    check_ipaddress.description = "Test IP address parsing and verification (%s)" % addr
-    return check_ipaddress
-
-
-def test_ip_address():
-    addrs = [
-        ('0.0.0.0/0',),
-        ('10.11.12.13',     (10, 11, 12, 13),   8),
-        ('10.11.12.13/14',  (10, 11, 12, 13),   14),
-        ('10.11.12.13%zoneid',),
-        ('10.11.12.13%zoneid/14',),
-        ('10.11.12.1337',),
-        ('10.11.12.13/33',),
-        ('127.0.0.1',),
-        ('241.1.2.3',),
-        ('169.254.1.2',),
-        ('10.11.12.0/24',   (10, 11, 12, 0),   24),
-        ('10.0.0.255',      (10, 0, 0, 255),   8),
-        ('224.5.6.7',),
-        ('10.11.12.255/24', (10, 11, 12, 255), 24),
-        ('255.255.255.255',),
-
-        ('::/0',),
-        ('2001::1',         (0x2001, 0, 0, 0, 0, 0, 0, 1), 64),
-        ('2001::1/72',      (0x2001, 0, 0, 0, 0, 0, 0, 1), 72),
-        ('2001::1%zoneid',  (0x2001, 0, 0, 0, 0, 0, 0, 1), 64),
-        ('2001::1%zoneid/72',),
-        ('2001::1beef',),
-        ('2001::1/129',),
-        ('::1',),
-        ('6789::1',),
-        ('fe89::1',),
-        ('2001::/64',       (0x2001, 0, 0, 0, 0, 0, 0, 0), 64),
-        ('ff01::1',),
-
-        ('junk',)
-    ]
-
-    for addr in addrs:
-        yield make_ipaddress_checker(*addr)
+@pytest.mark.parametrize("addr,words,prefixlen", [
+    ('0.0.0.0/0', None, None),
+    ('10.11.12.13', (10, 11, 12, 13), 8),
+    ('10.11.12.13/14', (10, 11, 12, 13), 14),
+    ('10.11.12.13%zoneid', None, None),
+    ('10.11.12.13%zoneid/14', None, None),
+    ('10.11.12.1337', None, None),
+    ('10.11.12.13/33', None, None),
+    ('127.0.0.1', None, None),
+    ('241.1.2.3', None, None),
+    ('169.254.1.2', None, None),
+    ('10.11.12.0/24', (10, 11, 12, 0), 24),
+    ('10.0.0.255', (10, 0, 0, 255), 8),
+    ('224.5.6.7', None, None),
+    ('10.11.12.255/24', (10, 11, 12, 255), 24),
+    ('255.255.255.255', None, None),
+    ('::/0', None, None),
+    ('2001::1', (0x2001, 0, 0, 0, 0, 0, 0, 1), 64),
+    ('2001::1/72', (0x2001, 0, 0, 0, 0, 0, 0, 1), 72),
+    ('2001::1%zoneid', (0x2001, 0, 0, 0, 0, 0, 0, 1), 64),
+    ('2001::1%zoneid/72', None, None),
+    ('2001::1beef', None, None),
+    ('2001::1/129', None, None),
+    ('::1', None, None),
+    ('6789::1', None, None),
+    ('fe89::1', None, None),
+    ('2001::/64', (0x2001, 0, 0, 0, 0, 0, 0, 0), 64),
+    ('ff01::1', None, None),
+    ('junk', None, None)
+])
+def test_ip_address(addr, words, prefixlen):
+    if words is None:
+        pytest.raises(
+            ValueError, ipautil.CheckedIPAddress, addr, match_local=False)
+    else:
+        ip = ipautil.CheckedIPAddress(addr, match_local=False)
+        assert ip.words == words
+        assert ip.prefixlen == prefixlen
 
 
 class TestCIDict(object):

--- a/ipatests/test_ipapython/test_ssh.py
+++ b/ipatests/test_ipapython/test_ssh.py
@@ -32,61 +32,53 @@ if six.PY3:
 
 pytestmark = pytest.mark.tier0
 
+b64 = 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDGAX3xAeLeaJggwTqMjxNwa6XHBUAikXPGMzEpVrlLDCZtv00djsFTBi38PkgxBJVkgRWMrcBsr/35lq7P6w8KGIwA8GI48Z0qBS2NBMJ2u9WQ2hjLN6GdMlo77O0uJY3251p12pCVIS/bHRSq8kHO2No8g7KA9fGGcagPfQH+ee3t7HUkpbQkFTmbPPN++r3V8oVUk5LxbryB3UIIVzNmcSIn3JrXynlvui4MixvrtX6zx+O/bBo68o8/eZD26QrahVbA09fivrn/4h3TM019Eu/c2jOdckfU3cHUV/3Tno5d6JicibyaoDDK7S/yjdn5jhaz8MSEayQvFkZkiF0L'
+raw = base64.b64decode(b64)
+openssh = 'ssh-rsa %s' % b64
 
-def make_public_key_checker(pk, out):
-    def check_public_key():
-        try:
-            parsed = ssh.SSHPublicKey(pk)
-            assert parsed.openssh() == out
-        except Exception as e:
-            assert type(e) is out
-    check_public_key.description = "Test SSH public key parsing (%s)" % repr(pk)
-    return check_public_key
 
-def test_public_key_parsing():
-    b64 = 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDGAX3xAeLeaJggwTqMjxNwa6XHBUAikXPGMzEpVrlLDCZtv00djsFTBi38PkgxBJVkgRWMrcBsr/35lq7P6w8KGIwA8GI48Z0qBS2NBMJ2u9WQ2hjLN6GdMlo77O0uJY3251p12pCVIS/bHRSq8kHO2No8g7KA9fGGcagPfQH+ee3t7HUkpbQkFTmbPPN++r3V8oVUk5LxbryB3UIIVzNmcSIn3JrXynlvui4MixvrtX6zx+O/bBo68o8/eZD26QrahVbA09fivrn/4h3TM019Eu/c2jOdckfU3cHUV/3Tno5d6JicibyaoDDK7S/yjdn5jhaz8MSEayQvFkZkiF0L'
-    raw = base64.b64decode(b64)
-    openssh = 'ssh-rsa %s' % b64
+@pytest.mark.parametrize("pk,out", [
+    (b'\xff', UnicodeDecodeError),
+    (u'\xff', ValueError),
 
-    pks = [
-        (b'\xff',                   UnicodeDecodeError),
-        (u'\xff',                   ValueError),
+    (raw, openssh),
+    (b'\0\0\0\x04none', u'none AAAABG5vbmU='),
+    (b'\0\0\0', ValueError),
+    (b'\0\0\0\0', ValueError),
+    (b'\0\0\0\x01', ValueError),
+    (b'\0\0\0\x01\xff', ValueError),
 
-        (raw,                       openssh),
-        (b'\0\0\0\x04none',         u'none AAAABG5vbmU='),
-        (b'\0\0\0',                 ValueError),
-        (b'\0\0\0\0',               ValueError),
-        (b'\0\0\0\x01',             ValueError),
-        (b'\0\0\0\x01\xff',         ValueError),
+    (u'\0\0\0\x04none', ValueError),
+    (u'\0\0\0', ValueError),
+    (u'\0\0\0\0', ValueError),
+    (u'\0\0\0\x01', ValueError),
+    (u'\0\0\0\x01\xff', ValueError),
 
-        (u'\0\0\0\x04none',         ValueError),
-        (u'\0\0\0',                 ValueError),
-        (u'\0\0\0\0',               ValueError),
-        (u'\0\0\0\x01',             ValueError),
-        (u'\0\0\0\x01\xff',         ValueError),
+    (b64, openssh),
+    (unicode(b64), openssh),
+    (b64.encode('ascii'), openssh),
+    (u'\n%s\n\n' % b64, openssh),
+    (u'AAAABG5vbmU=', u'none AAAABG5vbmU='),
+    (u'AAAAB', ValueError),
 
-        (b64,                       openssh),
-        (unicode(b64),              openssh),
-        (b64.encode('ascii'),       openssh),
-        (u'\n%s\n\n' % b64,         openssh),
-        (u'AAAABG5vbmU=',           u'none AAAABG5vbmU='),
-        (u'AAAAB',                  ValueError),
-
-        (openssh,                   openssh),
-        (unicode(openssh),          openssh),
-        (openssh.encode('ascii'),   openssh),
-        (u'none AAAABG5vbmU=',      u'none AAAABG5vbmU='),
-        (u'\t \t ssh-rsa \t \t%s\t \tthis is a comment\t \t ' % b64,
-                                    u'%s this is a comment' % openssh),
-        (u'opt3,opt2="\tx ",opt1,opt2="\\"x " %s comment ' % openssh,
-                                    u'opt1,opt2="\\"x ",opt3 %s comment' % openssh),
-        (u'ssh-rsa\n%s' % b64,      ValueError),
-        (u'ssh-rsa\t%s' % b64,      ValueError),
-        (u'vanitas %s' % b64,       ValueError),
-        (u'@opt %s' % openssh,      ValueError),
-        (u'opt=val %s' % openssh,   ValueError),
-        (u'opt, %s' % openssh,      ValueError),
-    ]
-
-    for pk in pks:
-        yield make_public_key_checker(*pk)
+    (openssh, openssh),
+    (unicode(openssh), openssh),
+    (openssh.encode('ascii'), openssh),
+    (u'none AAAABG5vbmU=', u'none AAAABG5vbmU='),
+    (u'\t \t ssh-rsa \t \t%s\t \tthis is a comment\t \t ' % b64,
+     u'%s this is a comment' % openssh),
+    (u'opt3,opt2="\tx ",opt1,opt2="\\"x " %s comment ' % openssh,
+     u'opt1,opt2="\\"x ",opt3 %s comment' % openssh),
+    (u'ssh-rsa\n%s' % b64, ValueError),
+    (u'ssh-rsa\t%s' % b64, ValueError),
+    (u'vanitas %s' % b64, ValueError),
+    (u'@opt %s' % openssh, ValueError),
+    (u'opt=val %s' % openssh, ValueError),
+    (u'opt, %s' % openssh, ValueError),
+])
+def test_public_key_parsing(pk, out):
+    if isinstance(out, type) and issubclass(out, Exception):
+        pytest.raises(out, ssh.SSHPublicKey, pk)
+    else:
+        parsed = ssh.SSHPublicKey(pk)
+        assert parsed.openssh() == out

--- a/ipatests/test_ipaserver/test_kadmin.py
+++ b/ipatests/test_ipaserver/test_kadmin.py
@@ -13,9 +13,10 @@ import tempfile
 from ipalib import api
 
 from ipaserver.install import installutils
+from ipatests.test_util import yield_fixture
 
 
-@pytest.yield_fixture()
+@yield_fixture()
 def keytab():
     fd, keytab_path = tempfile.mkstemp(suffix='.keytab')
     os.close(fd)

--- a/ipatests/test_util.py
+++ b/ipatests/test_util.py
@@ -35,6 +35,17 @@ if six.PY3:
 pytestmark = pytest.mark.tier0
 
 
+# pytest >= 2.10 supports yield based fixtures with pytest.fixture. In
+# pytest < 2.10 pytest.yield_fixture is required. But that function
+# also raises a deprecation warning in pytest >= 3.0.
+PYTEST_VERSION = tuple(int(p) for p in pytest.__version__.split('.'))
+
+if PYTEST_VERSION < (2, 10):
+    yield_fixture = pytest.yield_fixture
+else:
+    yield_fixture = pytest.fixture
+
+
 class Prop(object):
     def __init__(self, *ops):
         self.__ops = frozenset(ops)

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -34,6 +34,7 @@ from ipapython import ipautil
 from ipalib import api, errors, x509
 from ipapython.dn import DN
 from ipapython.dnsutil import DNSName
+from ipatests.test_util import yield_fixture
 from ipatests.test_xmlrpc.xmlrpc_test import (XMLRPC_test,
     fuzzy_uuid, fuzzy_digits, fuzzy_hash, fuzzy_date, fuzzy_issuer,
     fuzzy_hex, raises_exact)
@@ -505,7 +506,7 @@ class TestValidation(XMLRPC_test):
         ), result)
 
 
-@pytest.yield_fixture
+@yield_fixture
 def keytabname(request):
     keytabfd, keytabname = tempfile.mkstemp()
     try:
@@ -589,7 +590,7 @@ class TestHostFalsePwdChange(XMLRPC_test):
             command()
 
 
-@pytest.yield_fixture(scope='class')
+@yield_fixture(scope='class')
 def dns_setup(host):
     try:
         host.run_command('dnszone_del', dnszone, revzone, revipv6zone,

--- a/ipatests/test_xmlrpc/test_kerberos_principal_aliases.py
+++ b/ipatests/test_xmlrpc/test_kerberos_principal_aliases.py
@@ -10,6 +10,7 @@ from ipalib import errors, api
 from ipapython import ipautil
 from ipaplatform.paths import paths
 
+from ipatests.test_util import yield_fixture
 from ipatests.util import MockLDAP
 from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test
 from ipatests.test_xmlrpc.tracker.user_plugin import UserTracker
@@ -33,7 +34,7 @@ TRUSTED_DOMAIN_MOCK['ldif'] = get_trusted_dom_dict(
 )
 
 
-@pytest.yield_fixture
+@yield_fixture
 def trusted_domain():
     """Fixture providing mocked AD trust entries
 
@@ -51,7 +52,7 @@ def trusted_domain():
         ldap.del_entry(trusted_dom['dn'])
 
 
-@pytest.yield_fixture
+@yield_fixture
 def trusted_domain_with_suffix():
     """Fixture providing mocked AD trust entries
 


### PR DESCRIPTION
pytest >= 2.10 supports yield based fixtures with pytest.fixture. In
pytest < 2.10 pytest.yield_fixture is required. But that function
also raises a deprecation warning in pytest >= 3.0. FreeIPA has to stay
compatible with pytest < 2.10 for RHEL 7 testing.

https://docs.pytest.org/en/latest/fixture.html#fixture-finalization-executing-teardown-code

https://pagure.io/freeipa/issue/6591

Signed-off-by: Christian Heimes <cheimes@redhat.com>