### PR TITLE
kdc.key should not be visible to all

### DIFF
--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -370,8 +370,8 @@ def request_cert(
         request_parameters['cert-postsave-command'] = post_command
 
     if perms:
-        request_parameters['key-perms'] = perms[0]
-        request_parameters['cert-perms'] = perms[1]
+        request_parameters['cert-perms'] = perms[0]
+        request_parameters['key-perms'] = perms[1]
 
     result = cm.obj_if.add_request(request_parameters)
     try:


### PR DESCRIPTION
While the world certainly is interested in our privates, we
should not just go ahead and show it to them.

https://pagure.io/freeipa/issue/6973