### PR TITLE
Only warn when specified server IP addresses don't match intf

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -41,6 +41,7 @@ from ipalib.util import (
     broadcast_ip_address_warning,
     network_ip_address_warning,
     normalize_hostname,
+    no_matching_interface_for_ip_address_warning,
     verify_host_resolvable,
 )
 from ipaplatform import services
@@ -1300,6 +1301,7 @@ def update_dns(server, hostname, options):
 
     network_ip_address_warning(update_ips)
     broadcast_ip_address_warning(update_ips)
+    no_matching_interface_for_ip_address_warning(update_ips)
 
     update_txt = "debug\n"
     update_txt += ipautil.template_str(DELETE_TEMPLATE_A,
@@ -1445,7 +1447,7 @@ def check_ip_addresses(options):
     if options.ip_addresses:
         for ip in options.ip_addresses:
             try:
-                ipautil.CheckedIPAddress(ip, match_local=True)
+                ipautil.CheckedIPAddress(ip)
             except ValueError as e:
                 root_logger.error(e)
                 return False

--- a/ipalib/install/hostname.py
+++ b/ipalib/install/hostname.py
@@ -34,7 +34,7 @@ class HostNameInstallInterface(service.ServiceInstallInterface):
     def ip_addresses(self, values):
         for value in values:
             try:
-                CheckedIPAddress(value, match_local=True)
+                CheckedIPAddress(value)
             except Exception as e:
                 raise ValueError("invalid IP address {0}: {1}".format(
                     value, e))

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -1128,3 +1128,17 @@ def broadcast_ip_address_warning(addr_list):
             # print
             print("WARNING: IP address {} might be broadcast address".format(
                 ip), file=sys.stderr)
+
+
+def no_matching_interface_for_ip_address_warning(addr_list):
+    for ip in addr_list:
+        if not ip.get_matching_interface():
+            root_logger.warning(
+                "No network interface matches the IP address %s", ip)
+            # fixme: once when loggers will be fixed, we can remove this
+            # print
+            print(
+                "WARNING: No network interface matches the IP address "
+                "{}".format(ip),
+                file=sys.stderr
+            )

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -266,6 +266,7 @@ def install_check(standalone, api, replica, options, hostname):
 
     util.network_ip_address_warning(ip_addresses)
     util.broadcast_ip_address_warning(ip_addresses)
+    util.no_matching_interface_for_ip_address_warning(ip_addresses)
 
     if not options.forward_policy:
         # user did not specify policy, derive it: default is 'first' but

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -276,7 +276,7 @@ def read_ip_addresses():
         if not ip:
             break
         try:
-            ip_parsed = ipautil.CheckedIPAddress(ip, match_local=True)
+            ip_parsed = ipautil.CheckedIPAddress(ip)
         except Exception as e:
             print("Error: Invalid IP Address %s: %s" % (ip, e))
             continue
@@ -585,7 +585,7 @@ def get_server_ip_address(host_name, unattended, setup_dns, ip_addresses):
     if len(hostaddr):
         for ha in hostaddr:
             try:
-                ips.append(ipautil.CheckedIPAddress(ha, match_local=True))
+                ips.append(ipautil.CheckedIPAddress(ha, match_local=False))
             except ValueError as e:
                 root_logger.warning("Invalid IP address %s for %s: %s", ha, host_name, unicode(e))
 

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -29,6 +29,7 @@ from ipalib.util import (
     validate_domain_name,
     network_ip_address_warning,
     broadcast_ip_address_warning,
+    no_matching_interface_for_ip_address_warning,
 )
 import ipaclient.install.ntpconf
 from ipaserver.install import (
@@ -617,6 +618,7 @@ def install_check(installer):
         # check addresses here, dns module is doing own check
         network_ip_address_warning(ip_addresses)
         broadcast_ip_address_warning(ip_addresses)
+        no_matching_interface_for_ip_address_warning(ip_addresses)
 
     if options.setup_adtrust:
         adtrust.install_check(False, options, api)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -35,6 +35,7 @@ from ipalib.config import Env
 from ipalib.util import (
     network_ip_address_warning,
     broadcast_ip_address_warning,
+    no_matching_interface_for_ip_address_warning,
 )
 from ipaclient.install.client import configure_krb5_conf, purge_host_keytab
 from ipaserver.install import (
@@ -1285,6 +1286,7 @@ def promote_check(installer):
             # check addresses here, dns module is doing own check
             network_ip_address_warning(config.ips)
             broadcast_ip_address_warning(config.ips)
+            no_matching_interface_for_ip_address_warning(config.ips)
 
         if options.setup_adtrust:
             adtrust.install_check(False, options, remote_api)


### PR DESCRIPTION
In containers local addresses differ from public addresses and we need
a way to provide only public address to installers.

https://pagure.io/freeipa/issue/2715
https://pagure.io/freeipa/issue/4317