### PR TITLE
ca-add: fix permission issue

### DIFF
--- a/ACI.txt
+++ b/ACI.txt
@@ -23,7 +23,7 @@ aci: (targetattr = "automountmapname || description")(targetfilter = "(objectcla
 dn: cn=automount,dc=ipa,dc=example
 aci: (targetfilter = "(objectclass=automountmap)")(version 3.0;acl "permission:System: Remove Automount Maps";allow (delete) groupdn = "ldap:///cn=System: Remove Automount Maps,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=cas,cn=ca,dc=ipa,dc=example
-aci: (targetfilter = "(objectclass=ipaca)")(version 3.0;acl "permission:System: Add CA";allow (add) groupdn = "ldap:///cn=System: Add CA,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+aci: (targetfilter = "(objectclass=ipaca)")(version 3.0;acl "permission:System: Add CA";allow (add,delete,write) groupdn = "ldap:///cn=System: Add CA,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=cas,cn=ca,dc=ipa,dc=example
 aci: (targetfilter = "(objectclass=ipaca)")(version 3.0;acl "permission:System: Delete CA";allow (delete) groupdn = "ldap:///cn=System: Delete CA,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=cas,cn=ca,dc=ipa,dc=example


### PR DESCRIPTION
The ca-add command pre_callback uses ldap.can_add() to check whether
the user has permission to add CAs.  Alas, the GetEffectiveRights
control used by ldap.can_add() doesn't correctly interpret ACIs with
'targetfilter' constraints, and returns a false-negative for
non-admin users, even when they have the 'System: Add CA'
permission.

To work around this, add the CA object to FreeIPA before attempting
to create the CA in Dogtag.  If the CA creation in Dogtag succeds,
the user then updates the FreeIPA object with the Authority ID and
other authoritative data returned by Dogtag.  If the CA creation in
Dogtag fails, the user cleans up by deleting the newly-created CA
object from FreeIPA.

This modified procedure ensures that the user certainly has the
'System: Add CA' permission before the CA creation in Dogtag is
attempted.  But it also means that the user must have 'write' and
'delete' permission on 'ipaca' objects in FreeIPA, so that it can
complete the object after CA creation in Dogtag, or clean up if that
step fails.  Therefore, update the 'System: Add CA' permission to
confer 'write' and 'delete' access on 'ipaca' objects, as well as
'add' access.

Fixes: https://pagure.io/freeipa/issue/6609