### PR TITLE
Add Role 'Enrollment Administrator'

### DIFF
--- a/install/updates/45-roles.update
+++ b/install/updates/45-roles.update
@@ -91,3 +91,12 @@ add:member: cn=Security Architect,cn=roles,cn=accounts,$SUFFIX
 dn: cn=Password Policy Administrator,cn=privileges,cn=pbac,$SUFFIX
 add:member: cn=Security Architect,cn=roles,cn=accounts,$SUFFIX
 
+dn: cn=Enrollment Administrator,cn=roles,cn=accounts,$SUFFIX
+default:objectClass: groupofnames
+default:objectClass: nestedgroup
+default:objectClass: top
+default:cn: Enrollment Administrator
+default:description: Enrollment Administrator responsible for client(host) enrollment
+
+dn: cn=Host Enrollment,cn=privileges,cn=pbac,$SUFFIX
+add:member: cn=Enrollment Administrator,cn=roles,cn=accounts,$SUFFIX


### PR DESCRIPTION
User with the 'Enrollment Administrator' role assigned to is
able to enroll host against a FreeIPA server as a client
using the ipa-client-install command.

The 'Enrollment Administrator' contains 'Host Enrollment' privilege only.

Points to: https://pagure.io/freeipa/issue/6852