### PR TITLE
ipa-kdb: use canonical principal in certauth plugin

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_certauth.c
+++ b/daemons/ipa-kdb/ipa_kdb_certauth.c
@@ -274,7 +274,7 @@ static krb5_error_code ipa_certauth_authorize(krb5_context context,
         }
     }
 
-    ret = krb5_unparse_name(context, princ, &principal);
+    ret = krb5_unparse_name(context, db_entry->princ, &principal);
     if (ret != 0) {
         ret = KRB5KDC_ERR_CERTIFICATE_MISMATCH;
         goto done;


### PR DESCRIPTION
Currently the certauth plugin use the unmodified principal from the
request to lookup the user. This might fail if e.g. enterprise
principals are use. With this patch the canonical principal form the kdc
entry is used.

Resolves https://pagure.io/freeipa/issue/6993