### PR TITLE
Changed ownership of ldiffile to DS_USER

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -545,6 +545,10 @@ class Restore(admintool.AdminTool):
                 ldif_parser = RemoveRUVParser(in_file, ldif_writer, self.log)
                 ldif_parser.parse()
 
+        # Make sure the modified ldiffile is owned by DS_USER
+        pent = pwd.getpwnam(constants.DS_USER)
+        os.chown(ldiffile, pent.pw_uid, pent.pw_gid)
+
         if online:
             conn = self.get_connection()
             ent = conn.make_entry(


### PR DESCRIPTION
Changes the ownership of the modified ldiffile created by ipa-restore to dirsrv. If the file is owned by root, ipa-backup does not have permissions to touch it.

Resolves: 
https://pagure.io/freeipa/issue/7010