### PR TITLE
[WIP] Fixing test_installation.py tests

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -110,7 +110,6 @@ class ADTrustInstallTestBase(IntegrationTest):
 ##
 # Master X Replicas installation tests
 ##
-
 class TestInstallWithCA1(InstallTestBase1):
 
     @classmethod
@@ -119,18 +118,24 @@ class TestInstallWithCA1(InstallTestBase1):
 
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
-    def test_replica1_ipa_kra_install(self):
-        super(TestInstallWithCA1, self).test_replica1_ipa_kra_install()
+    def test_replica2_ipa_dns_install(self):
+        super(TestInstallWithCA1, self).test_replica2_ipa_dns_install()
+
+
+class TestInstallWithCA1_KRA1(InstallTestBase1):
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=False, setup_kra=True)
 
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
     def test_replica2_with_ca_kra_install(self):
-        super(TestInstallWithCA1, self).test_replica2_with_ca_kra_install()
+        super(TestInstallWithCA1_KRA1, 
+              self).test_replica2_with_ca_kra_install()
 
-    @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
-                        reason='does not work on DOMAIN_LEVEL_0 by design')
-    def test_replica2_ipa_dns_install(self):
-        super(TestInstallWithCA1, self).test_replica2_ipa_dns_install()
+    def test_replica1_ipa_kra_install(self):
+        super(TestInstallWithCA1_KRA1, self).test_replica1_ipa_kra_install()
 
 
 class TestInstallWithCA2(InstallTestBase2):


### PR DESCRIPTION
I've been working on the test_installation.py suite and figure out how to solve some of them.

The TestInstallWithCA1 have 9 tests failing; 6 of them can be fixed adding 
```bash
<ip> ipa-ca.$DOMAIN
```
into the master `/etc/hosts`. After that, three of them are still failing.
The log: https://paste.fedoraproject.org/paste/7n3CMEH5nhiHu~Vai8cObV5M1UNdIGYhyRLivL9gydE=. 

They are:
 * test_replica1_with_ca_install
 * test_replica2_with_ca_kra_install
 * test_replica1_ipa_kra_install

I've moved the tests 
 * test_replica2_with_ca_kra_install
 * test_replica1_ipa_kra_install

to a new class (TestInstallWithCA1_KRA1) and created a new install method, which use the `setup_kra=True` option in the install_master method. The tests are still failing, but for another reason, the logs: https://paste.fedoraproject.org/paste/ytzzIUDhh5ARcunpSfSubV5M1UNdIGYhyRLivL9gydE=

Ticket: https://pagure.io/freeipa/issue/6995