### PR TITLE
py3: fix regression in schemaupdate

### DIFF
--- a/ipaserver/install/schemaupdate.py
+++ b/ipaserver/install/schemaupdate.py
@@ -119,7 +119,7 @@ def update_schema(schema_files, ldapi=False, dm_password=None,):
 
     # The exact representation the DS gives us for each OID
     # (for debug logging)
-    old_entries_by_oid = {cls(attr.decode('utf-8')).oid: attr.decode('utf-8')
+    old_entries_by_oid = {cls(attr).oid: attr.decode('utf-8')
                           for (attrname, cls) in SCHEMA_ELEMENT_CLASSES
                           for attr in schema_entry[attrname]}
 


### PR DESCRIPTION
The python-ldap classes that process schema definitions require a
unicode string, not a byte string.  A recent py3 compatibility fix
(d89de4219d0e8ee33e81d6b6d1bc6c22ac9ffbaa) changed the constructor
argument to a unicode string to dispel a warning, but this broke
schema update.  Change it back to a bytestring.

Part of: https://fedorahosted.org/freeipa/ticket/4985