### PR TITLE
ipadiscovery: Return realm as a string

### DIFF
--- a/ipaclient/install/ipadiscovery.py
+++ b/ipaclient/install/ipadiscovery.py
@@ -514,7 +514,11 @@ class IPADiscovery(object):
         return servers
 
     def ipadnssearchkrbrealm(self, domain=None):
-        realm = None
+        """
+        :param domain: Domain to be searched in
+        :returns: string of a realm found in a TXT record
+                  None if no realm was found
+        """
         if not domain:
             domain = self.domain
         # now, check for a Kerberos realm the local host or domain is in
@@ -528,6 +532,7 @@ class IPADiscovery(object):
             root_logger.debug("DNS record not found: %s", e.__class__.__name__)
             answers = []
 
+        realm = None
         for answer in answers:
             root_logger.debug("DNS record found: %s", answer)
             if answer.strings:
@@ -539,8 +544,7 @@ class IPADiscovery(object):
                         .format(err=e))
                     continue
                 if realm:
-                    break
-        return realm
+                    return realm
 
     def ipadnssearchkrbkdc(self, domain=None):
         kdc = None

--- a/ipaclient/install/ipadiscovery.py
+++ b/ipaclient/install/ipadiscovery.py
@@ -531,7 +531,13 @@ class IPADiscovery(object):
         for answer in answers:
             root_logger.debug("DNS record found: %s", answer)
             if answer.strings:
-                realm = answer.strings[0]
+                try:
+                    realm = answer.strings[0].decode('utf-8')
+                except UnicodeDecodeError as e:
+                    root_logger.debug(
+                        'A TXT record cannot be decoded as UTF-8: {err}'
+                        .format(err=e))
+                    continue
                 if realm:
                     break
         return realm


### PR DESCRIPTION
We don't have a use for realm as a bytes instance, return it as a
string, otherwise there's a use of str() on bytes in py3.

https://pagure.io/freeipa/issue/4985