### PR TITLE
sssd.py: Deprecating no-sssd option.

### DIFF
--- a/ipaclient/install/sssd.py
+++ b/ipaclient/install/sssd.py
@@ -45,6 +45,7 @@ class SSSDInstallInterface(service.ServiceInstallInterface):
 
     no_sssd = knob(
         None,
+        deprecated=True,
         description="Do not configure the client to use SSSD for "
                     "authentication",
         cli_names=[None, '-S'],


### PR DESCRIPTION
Resolves: https://pagure.io/freeipa/issue/5860