### PR TITLE
session_storage: Correctly handle string/byte types

### DIFF
--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -887,7 +887,10 @@ class RPCClient(Connectible):
         # (possibly with more than one cookie).
         try:
             cookie_string = read_persistent_client_session_data(principal)
-        except Exception:
+            cookie_string = cookie_string.decode('utf-8')
+        except Exception as e:
+            self.log.debug('Error reading client session data: {err}'
+                           .format(err=e))
             return None
 
         # Search for the session cookie within the cookie string

--- a/ipapython/session_storage.py
+++ b/ipapython/session_storage.py
@@ -336,7 +336,7 @@ def get_data(princ_name, key):
             krb5_cc_end_seq_get(context, ccache, ctypes.byref(cursor))
 
         if got_creds:
-            data = creds.ticket.data.decode('utf-8')
+            data = creds.ticket.data
             krb5_free_cred_contents(context, ctypes.byref(creds))
             return data
 


### PR DESCRIPTION
In session_storage.py, store_data() stores data as the bytes data
type but get_data() is returning a string. Have get_data() return
bytes as well.

https://pagure.io/freeipa/issue/4985