### PR TITLE
Prevent issues with older clients

### DIFF
--- a/install/conf/ipa.conf
+++ b/install/conf/ipa.conf
@@ -1,5 +1,5 @@
 #
-# VERSION 26 - DO NOT REMOVE THIS LINE
+# VERSION 27 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -77,7 +77,9 @@ WSGIScriptReloading Off
   Session On
   SessionCookieName ipa_session path=/ipa;httponly;secure;
   SessionHeader IPASESSION
-  SessionMaxAge 1800
+  # Uncomment the following to have shorter sessions, but beware this may break
+  # old IPA client tols that incorrectly parse cookies.
+  # SessionMaxAge 1800
   GssapiSessionKey file:/etc/httpd/alias/ipasession.key
 
   GssapiImpersonate On

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -155,6 +155,7 @@ DEFAULT_CONFIG = (
     ('session_auth_duration', '20 minutes'),
     # How a session expiration is computed, see SessionManager.set_session_expiration_time()
     ('session_duration_type', 'inactivity_timeout'),
+    ('kinit_lifetime', None),
 
     # Debugging:
     ('verbose', 0),

--- a/ipalib/install/kinit.py
+++ b/ipalib/install/kinit.py
@@ -63,7 +63,7 @@ def kinit_keytab(principal, keytab, ccache_name, config=None, attempts=1):
 
 def kinit_password(principal, password, ccache_name, config=None,
                    armor_ccache_name=None, canonicalize=False,
-                   enterprise=False):
+                   enterprise=False, lifetime=None):
     """
     perform interactive kinit as principal using password. If using FAST for
     web-based authentication, use armor_ccache_path to specify http service
@@ -75,6 +75,9 @@ def kinit_password(principal, password, ccache_name, config=None,
         root_logger.debug("Using armor ccache %s for FAST webauth"
                           % armor_ccache_name)
         args.extend(['-T', armor_ccache_name])
+
+    if lifetime:
+        args.extend(['-l', lifetime])
 
     if canonicalize:
         root_logger.debug("Requesting principal canonicalization")

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -969,7 +969,8 @@ class login_password(Backend, KerberosSession):
                 password,
                 ccache_name,
                 armor_ccache_name=armor_path,
-                enterprise=True)
+                enterprise=True,
+                lifetime=self.api.env.kinit_lifetime)
 
             if armor_path:
                 self.debug('Cleanup the armor ccache')

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -69,6 +69,7 @@ fake_api_env = {'env': [
     'realm',
     'session_auth_duration',
     'session_duration_type',
+    'kinit_lifetime',
 ]}
 
 # this is due ipaserver.rpcserver.KerberosSession where api is undefined


### PR DESCRIPTION
Older clients have issues parsing cookies, and cannot handle well the MaxAge setting.
So the first patch is about removing it.

Unfortunately this means cookies will be valid for the duration of the authentication ticket which is set to 24h by default.
This is a bit high, so the second patch adds the ability to set the "kinit_lifetime" in /etc/api/default.conf so that users authenticating using username/password can have their tickets (and therefore their session) hard capped at whatever lifetime is set there.

Users that use HTTP negotiate can control their session duration by getting shorter lived tickets via kinit.

In all cases users can click on the logout button to blow away credentials.