### PR TITLE
adtrustinstance: pep8, py3 fixes

### DIFF
--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -354,7 +354,7 @@ class ADTRUSTInstance(service.Service):
 
             if abs(self.rid_base - self.secondary_rid_base) < size:
                 self.print_msg("Primary and secondary RID base are too close. "
-                      "They have to differ at least by %d." % size)
+                               "They have to differ at least by %d." % size)
                 raise RuntimeError("RID bases too close.\n")
 
             # Modify the range


### PR DESCRIPTION
There was a bug in adtrustinstance where there was a comparison
of a number to a string which was tailored so that it would always
pass (or at least in the default case). Luckily for us, Python 3 is a bit
more clever so it was throwing exceptions there.

We may want a ticket different from https://pagure.io/freeipa/issue/4985
for that but I am keeping that one for now, will only create a new one if
requested.