### PR TITLE
Bump version of python-gssapi

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -169,7 +169,7 @@ BuildRequires:  python3-wheel
 BuildRequires:  samba-python
 # 1.6: x509.Name.rdns (https://github.com/pyca/cryptography/issues/3199)
 BuildRequires:  python2-cryptography >= 1.6
-BuildRequires:  python-gssapi >= 1.2.0
+BuildRequires:  python-gssapi >= 1.2.0-5
 %if 0%{?fedora} >= 26
 BuildRequires:  python2-pylint
 %else
@@ -294,7 +294,7 @@ Requires: mod_session
 # 0.9.9: https://github.com/adelton/mod_lookup_identity/pull/3
 Requires: mod_lookup_identity >= 0.9.9
 Requires: python-ldap >= 2.4.15
-Requires: python-gssapi >= 1.2.0
+Requires: python-gssapi >= 1.2.0-5
 Requires: acl
 Requires: systemd-units >= 38
 Requires(pre): shadow-utils
@@ -361,7 +361,7 @@ Requires: python2-ipaclient = %{version}-%{release}
 Requires: python2-custodia >= 0.3.1
 Requires: python-ldap >= 2.4.15
 Requires: python-lxml
-Requires: python-gssapi >= 1.2.0
+Requires: python-gssapi >= 1.2.0-5
 Requires: python-sssdconfig
 Requires: python-pyasn1
 Requires: dbus-python
@@ -514,7 +514,7 @@ Requires: certmonger >= 0.78
 Requires: nss-tools
 Requires: bind-utils
 Requires: oddjob-mkhomedir
-Requires: python-gssapi >= 1.2.0
+Requires: python-gssapi >= 1.2.0-5
 Requires: libsss_autofs
 Requires: autofs
 Requires: libnfsidmap
@@ -651,7 +651,7 @@ Provides: python2-ipaplatform = %{version}-%{release}
 %{?python_provide:%python_provide python2-ipaplatform}
 %{!?python_provide:Provides: python-ipaplatform = %{version}-%{release}}
 Requires: %{name}-common = %{version}-%{release}
-Requires: python-gssapi >= 1.2.0
+Requires: python-gssapi >= 1.2.0-5
 Requires: gnupg
 Requires: keyutils
 Requires: pyOpenSSL


### PR DESCRIPTION
Complete fixing of the bug requires fix on python-gssapi side.
That fix is included in version 1.2.0-5.

Fixes: https://pagure.io/freeipa/issue/6796