### PR TITLE
Add CommonNameToSANDefault to default cert profile

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -303,8 +303,8 @@ Requires(post): systemd-units
 Requires: selinux-policy >= %{selinux_policy_version}
 Requires(post): selinux-policy-base >= %{selinux_policy_version}
 Requires: slapi-nis >= %{slapi_nis_version}
-Requires: pki-ca >= 10.3.5-11
-Requires: pki-kra >= 10.3.5-11
+Requires: pki-ca >= 10.4.0-1
+Requires: pki-kra >= 10.4.0-1
 Requires(preun): python systemd-units
 Requires(postun): python systemd-units
 Requires: policycoreutils >= 2.1.12-5

--- a/install/share/profiles/caIPAserviceCert.cfg
+++ b/install/share/profiles/caIPAserviceCert.cfg
@@ -12,7 +12,7 @@ input.i2.class_id=submitterInfoInputImpl
 output.list=o1
 output.o1.class_id=certOutputImpl
 policyset.list=serverCertSet
-policyset.serverCertSet.list=1,2,3,4,5,6,7,8,9,10,11
+policyset.serverCertSet.list=1,2,3,4,5,6,7,8,9,10,11,12
 policyset.serverCertSet.1.constraint.class_id=subjectNameConstraintImpl
 policyset.serverCertSet.1.constraint.name=Subject Name Constraint
 policyset.serverCertSet.1.constraint.params.pattern=CN=[^,]+,.+
@@ -107,3 +107,7 @@ policyset.serverCertSet.11.constraint.name=No Constraint
 policyset.serverCertSet.11.default.class_id=userExtensionDefaultImpl
 policyset.serverCertSet.11.default.name=User Supplied Extension Default
 policyset.serverCertSet.11.default.params.userExtOID=2.5.29.17
+policyset.serverCertSet.12.constraint.class_id=noConstraintImpl
+policyset.serverCertSet.12.constraint.name=No Constraint
+policyset.serverCertSet.12.default.class_id=commonNameToSANDefaultImpl
+policyset.serverCertSet.12.default.name=Copy Common Name to Subject Alternative Name


### PR DESCRIPTION
The CommonNameToSANDefault component was added to Dogtag 10.4.  When
a profile is configured to use it, this profile copies the CN in the
certificate to the Subjet Alternative Name extension as a dNSName
(if and only if it does look like a DNS name).

It is desirable that the default service profile use this component.
Add it to the default profile, for new installations only.  For
existing installations, until a proper profile update mechanism is
implemented, administrators who wish to use it must configure it via
the 'certprofile-mod' command.

Part of: https://pagure.io/freeipa/issue/4970