### PR TITLE
dnsserver.py: dnsserver-find no longer returns internal server error

### DIFF
--- a/ipaserver/plugins/dnsserver.py
+++ b/ipaserver/plugins/dnsserver.py
@@ -29,6 +29,7 @@ from ipaserver.plugins.baseldap import (
     LDAPDelete,
 )
 from .dns import dns_container_exists
+from ipapython.dn import DN
 
 
 __doc__ = _("""
@@ -165,6 +166,16 @@ class dnsserver_find(LDAPSearch):
         '%(count)d DNS server matched',
         '%(count)d DNS servers matched', 0
     )
+
+    def pre_callback(self, ldap, filters, attrs_list,
+                     base_dn, scope, *args, **options):
+        assert isinstance(base_dn, DN)
+
+        if not dns_container_exists(self.api.Backend.ldap2):
+            raise errors.InvocationError(
+                format=_('IPA DNS Server is not installed'))
+
+        return (filters, base_dn, scope)
 
 
 @register()


### PR DESCRIPTION
Invocation of the ipa dnsserver-find command failed with
internal server error when there is no DNS server in topology.

Fixes: https://pagure.io/freeipa/issue/6571