### PR TITLE
Create indexes for 'serverhostname' attribute

### DIFF
--- a/install/share/indices.ldif
+++ b/install/share/indices.ldif
@@ -278,3 +278,12 @@ objectClass: nsIndex
 nsSystemIndex: false
 nsIndexType: eq
 nsIndexType: sub
+
+dn: cn=serverhostname,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: serverhostname
+objectClass: top
+objectClass: nsIndex
+nsSystemIndex: false
+nsIndexType: eq
+nsIndexType: sub

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -259,3 +259,11 @@ default: objectClass: nsIndex
 only: nsSystemIndex: false
 only: nsIndexType: eq
 only: nsIndexType: sub
+
+dn: cn=serverhostname,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: serverhostname
+default: objectClass: top
+default: objectClass: nsIndex
+only: nsSystemIndex: false
+only: nsIndexType: eq
+only: nsIndexType: sub


### PR DESCRIPTION
IPA installation with large number of host entries gets timeout
when invoking ipaserver.plugins.host.get_dn() method.

Resolves: https://pagure.io/freeipa/issue/6939