### PR TITLE
ipatests: do not collect systemd journal when logfile_dir is missing

### DIFF
--- a/ipatests/pytest_plugins/integration/__init__.py
+++ b/ipatests/pytest_plugins/integration/__init__.py
@@ -82,6 +82,9 @@ def collect_systemd_journal(node, hosts, test_config):
     name = _get_logname_from_node(node)
     logfile_dir = test_config.getoption('logfile_dir')
 
+    if logfile_dir is None:
+        return
+
     for host in hosts:
         log.info("Collecting journal from: %s", host.hostname)
 


### PR DESCRIPTION
If logs aren't collected to logfile_dir, skip collection of systemd
journal.

Related https://pagure.io/freeipa/issue/6971

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>