### PR TITLE
Add a README to certificate profile templates directory

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1306,6 +1306,7 @@ fi
 %dir %{_usr}/share/ipa/advise/legacy
 %{_usr}/share/ipa/advise/legacy/*.template
 %dir %{_usr}/share/ipa/profiles
+%{_usr}/share/ipa/profiles/README
 %{_usr}/share/ipa/profiles/*.cfg
 %dir %{_usr}/share/ipa/html
 %{_usr}/share/ipa/html/ffconfig.js

--- a/install/share/profiles/Makefile.am
+++ b/install/share/profiles/Makefile.am
@@ -2,6 +2,7 @@ NULL =
 
 appdir = $(IPA_DATA_DIR)/profiles
 app_DATA =				\
+	README				\
 	caIPAserviceCert.cfg		\
 	IECUserRoles.cfg		\
 	KDCs_PKINIT_Certs.cfg		\

--- a/install/share/profiles/README
+++ b/install/share/profiles/README
@@ -1,0 +1,20 @@
+This directory contains profile TEMPLATES for certificate profiles
+included in FreeIPA.  Do not import these files or modifications
+thereof - it is likely that Dogtag will accept the configuration,
+but certificate issuance will fail with the updated configuration.
+At best, it will not give you the certificates you want.
+
+If you want to modify a profile configuration or create a new
+profile based on an existing profile configuration, you should
+export the current profile configuration with the command:
+
+    ipa certprofile-show --out FILENAME PROFILE_NAME
+
+After modifying the configuration, update the profile configuration:
+
+    ipa certprofile-mod --file FILENAME PROFILE_NAME
+
+Or if you are creating a new profile:
+
+    ipa certprofile-import --desc DESC --store 1 \
+        --file FILENAME NEW_PROFILE_NAME


### PR DESCRIPTION
There have been several instances of people using the profile
configuration template files as actual profile configurations,
resulting in failures and support load.  Add a README to the profile
template directory to explain that these files should not be used
and advise of the recommend procedure.

Fixes: https://pagure.io/freeipa/issue/7014