### PR TITLE
trust-mod: allow modifying list of UPNs of a trusted forest

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -5772,11 +5772,12 @@ output: ListOfEntries('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: Output('truncated', type=[<type 'bool'>])
 command: trust_mod/1
-args: 1,9,3
+args: 1,10,3
 arg: Str('cn', cli_name='realm')
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('delattr*', cli_name='delattr')
+option: Str('ipantadditionalsuffixes*', autofill=False, cli_name='upn_suffixes')
 option: Str('ipantsidblacklistincoming*', autofill=False, cli_name='sid_blacklist_incoming')
 option: Str('ipantsidblacklistoutgoing*', autofill=False, cli_name='sid_blacklist_outgoing')
 option: Flag('raw', autofill=True, cli_name='raw', default=False)

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -73,8 +73,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-define(IPA_API_VERSION_MINOR, 227)
-# Last change: Add `pkinit-status` command
+define(IPA_API_VERSION_MINOR, 228)
+# Last change: Expose ipaNTAdditionalSuffixes in trust-mod
 
 
 ########################################################

--- a/ipaserver/plugins/trust.py
+++ b/ipaserver/plugins/trust.py
@@ -553,8 +553,9 @@ class trust(LDAPObject):
             flags={'virtual_attribute', 'no_create', 'no_update', 'no_search'},
         ),
         Str('ipantadditionalsuffixes*',
+            cli_name='upn_suffixes',
             label=_('UPN suffixes'),
-            flags={'no_create', 'no_update', 'no_search'},
+            flags={'no_create', 'no_search'},
         ),
     )
 


### PR DESCRIPTION
There are two ways for maintaining user principal names (UPNs) in Active
Directory:
 - associate UPN suffixes with the forest root and then allow for each
   user account to choose UPN suffix for logon
 - directly modify userPrincipalName attribute in LDAP

Both approaches lead to the same result: AD DC accepts user@UPN-Suffix
as a proper principal in AS-REQ and TGS-REQ.

The latter (directly modify userPrincipalName) case has a consequence
that this UPN suffix is not visible via netr_DsRGetForestTrustInformation
DCE RPC call. As result, FreeIPA KDC will not know that a particular UPN
suffix does belong to a trusted Active Directory forest. As result, SSSD
will not be able to authenticate and validate this user from a trusted
Active Directory forest.

This is especially true for one-word UPNs which otherwise wouldn't work
properly on Kerberos level for both FreeIPA and Active Directory.

Administrators are responsible for amending the list of UPNs associated
with the forest in this case. With this commit, an option is added to
'ipa trust-mod' that allows specifying arbitrary UPN suffixes to a
trusted forest root.

As with all '-mod' commands, the change replaces existing UPNs when
applied, so administrators are responsible to specify all of them:

  ipa trust-mod ad.test --upns={existing.upn,another_upn,new}

Fixes: https://pagure.io/freeipa/issue/7015