### PR TITLE
WebUI: add support for changing trust UPN suffixes

### DIFF
--- a/install/ui/src/freeipa/trust.js
+++ b/install/ui/src/freeipa/trust.js
@@ -147,8 +147,7 @@ return {
                     fields: [
                         {
                             $type: 'multivalued',
-                            name: 'ipantadditionalsuffixes',
-                            read_only: true
+                            name: 'ipantadditionalsuffixes'
                         }
                     ]
                 },


### PR DESCRIPTION
It is now possible to change UPN suffixes in WebUI. This change
allows another way to changing UPN suffixes for AD users.

https://pagure.io/freeipa/issue/7015

WebUI counterpart for #867 .