### PR TITLE
Changing cert-find to go through the proxy instead of using the port 8080

### DIFF
--- a/install/conf/ipa-pki-proxy.conf
+++ b/install/conf/ipa-pki-proxy.conf
@@ -1,4 +1,4 @@
-# VERSION 10 - DO NOT REMOVE THIS LINE
+# VERSION 11 - DO NOT REMOVE THIS LINE
 
 ProxyRequests Off
 
@@ -27,7 +27,7 @@ ProxyRequests Off
 </LocationMatch>
 
 # matches for CA REST API
-<LocationMatch "^/ca/rest/account/login|^/ca/rest/account/logout|^/ca/rest/installer/installToken|^/ca/rest/securityDomain/domainInfo|^/ca/rest/securityDomain/installToken|^/ca/rest/profiles|^/ca/rest/authorities|^/ca/rest/certrequests|^/ca/rest/admin/kraconnector/remove">
+<LocationMatch "^/ca/rest/account/login|^/ca/rest/account/logout|^/ca/rest/installer/installToken|^/ca/rest/securityDomain/domainInfo|^/ca/rest/securityDomain/installToken|^/ca/rest/profiles|^/ca/rest/authorities|^/ca/rest/certrequests|^/ca/rest/admin/kraconnector/remove|^/ca/rest/certs/search">
     NSSOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
     NSSVerifyClient optional
     ProxyPassMatch ajp://localhost:$DOGTAG_PORT

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1903,7 +1903,7 @@ class ra(rabase.rabase, RestClient):
         self.debug('%s.find(): request: %s', type(self).__name__, payload)
 
         url = 'http://%s/ca/rest/certs/search?size=%d' % (
-            ipautil.format_netloc(self.ca_host, 8080),
+            ipautil.format_netloc(self.ca_host, 80),
             options.get('sizelimit', 0x7fffffff))
 
         opener = urllib.request.build_opener()


### PR DESCRIPTION
The cert-find command now uses the proxy to reach Dogtag, instead of using the port 8080. In order to accomplish that, it's necessary to change the proxy configuration adding the service URL.

Ticket: https://pagure.io/freeipa/issue/6966