### PR TITLE
Fix ip address checks

### DIFF
--- a/install/tools/ipa-dns-install
+++ b/install/tools/ipa-dns-install
@@ -47,7 +47,9 @@ def parse_options():
                       default=False, help="print debugging information")
     parser.add_option("--ip-address", dest="ip_addresses", metavar="IP_ADDRESS",
                       default=[], action="append",
-                      type="ip", ip_local=True, help="Master Server IP Address. This option can be used multiple times")
+                      type="ip",
+                      help="Master Server IP Address. This option can be used "
+                           "multiple times")
     parser.add_option("--forwarder", dest="forwarders", action="append",
                       type="ip", help="Add a DNS forwarder. This option can be used multiple times")
     parser.add_option("--no-forwarders", dest="no_forwarders", action="store_true",

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -38,8 +38,6 @@ from ipalib.install.kinit import kinit_keytab, kinit_password
 from ipalib.install.service import enroll_only, prepare_only
 from ipalib.rpc import delete_persistent_client_session_data
 from ipalib.util import (
-    broadcast_ip_address_warning,
-    network_ip_address_warning,
     normalize_hostname,
     no_matching_interface_for_ip_address_warning,
     verify_host_resolvable,
@@ -1299,8 +1297,6 @@ def update_dns(server, hostname, options):
         root_logger.info("Failed to determine this machine's ip address(es).")
         return
 
-    network_ip_address_warning(update_ips)
-    broadcast_ip_address_warning(update_ips)
     no_matching_interface_for_ip_address_warning(update_ips)
 
     update_txt = "debug\n"

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -1110,26 +1110,6 @@ def check_principal_realm_in_trust_namespace(api_instance, *keys):
                         'namespace'))
 
 
-def network_ip_address_warning(addr_list):
-    for ip in addr_list:
-        if ip.is_network_addr():
-            root_logger.warning("IP address %s might be network address", ip)
-            # fixme: once when loggers will be fixed, we can remove this
-            # print
-            print("WARNING: IP address {} might be network address".format(ip),
-                  file=sys.stderr)
-
-
-def broadcast_ip_address_warning(addr_list):
-    for ip in addr_list:
-        if ip.is_broadcast_addr():
-            root_logger.warning("IP address %s might be broadcast address", ip)
-            # fixme: once when loggers will be fixed, we can remove this
-            # print
-            print("WARNING: IP address {} might be broadcast address".format(
-                ip), file=sys.stderr)
-
-
 def no_matching_interface_for_ip_address_warning(addr_list):
     for ip in addr_list:
         if not ip.get_matching_interface():

--- a/ipapython/config.py
+++ b/ipapython/config.py
@@ -68,10 +68,9 @@ class IPAFormatter(IndentedHelpFormatter):
 def check_ip_option(option, opt, value):
     from ipapython.ipautil import CheckedIPAddress
 
-    ip_local = option.ip_local is True
     ip_netmask = option.ip_netmask is True
     try:
-        return CheckedIPAddress(value, parse_netmask=ip_netmask, match_local=ip_local)
+        return CheckedIPAddress(value, parse_netmask=ip_netmask)
     except Exception as e:
         raise OptionValueError("option %s: invalid IP address %s: %s" % (opt, value, e))
 
@@ -86,7 +85,7 @@ class IPAOption(Option):
     optparse.Option subclass with support of options labeled as
     security-sensitive such as passwords.
     """
-    ATTRS = Option.ATTRS + ["sensitive", "ip_local", "ip_netmask"]
+    ATTRS = Option.ATTRS + ["sensitive", "ip_netmask"]
     TYPES = Option.TYPES + ("ip", "dn")
     TYPE_CHECKER = copy(Option.TYPE_CHECKER)
     TYPE_CHECKER["ip"] = check_ip_option

--- a/ipapython/config.py
+++ b/ipapython/config.py
@@ -68,9 +68,8 @@ class IPAFormatter(IndentedHelpFormatter):
 def check_ip_option(option, opt, value):
     from ipapython.ipautil import CheckedIPAddress
 
-    ip_netmask = option.ip_netmask is True
     try:
-        return CheckedIPAddress(value, parse_netmask=ip_netmask)
+        return CheckedIPAddress(value)
     except Exception as e:
         raise OptionValueError("option %s: invalid IP address %s: %s" % (opt, value, e))
 
@@ -85,7 +84,7 @@ class IPAOption(Option):
     optparse.Option subclass with support of options labeled as
     security-sensitive such as passwords.
     """
-    ATTRS = Option.ATTRS + ["sensitive", "ip_netmask"]
+    ATTRS = Option.ATTRS + ["sensitive"]
     TYPES = Option.TYPES + ("ip", "dn")
     TYPE_CHECKER = copy(Option.TYPE_CHECKER)
     TYPE_CHECKER["ip"] = check_ip_option

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -135,7 +135,7 @@ class CheckedIPAddress(UnsafeIPAddress):
 
     Reserved or link-local addresses are never accepted.
     """
-    def __init__(self, addr, match_local=False, parse_netmask=True,
+    def __init__(self, addr, parse_netmask=True,
                  allow_loopback=False, allow_multicast=False):
         try:
             super(CheckedIPAddress, self).__init__(addr)
@@ -165,14 +165,6 @@ class CheckedIPAddress(UnsafeIPAddress):
                 "cannot use link-local IP address {}".format(addr))
         if not allow_multicast and self.is_multicast():
             raise ValueError("cannot use multicast IP address {}".format(addr))
-
-        if match_local:
-            intf_details = self.get_matching_interface()
-            if not intf_details:
-                raise ValueError('no network interface matches the IP address '
-                                 'and netmask {}'.format(addr))
-            else:
-                self.set_ip_net(intf_details.ifnet)
 
         if self._net is None:
             if self.version == 4:

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -216,10 +216,10 @@ class CheckedIPAddress(UnsafeIPAddress):
                     addr=ifaddr,
                     netmask=ifdata['netmask']
                 ))
-                if ifnet == self._net or (
-                                self._net is None and ifnet.ip == self):
-                    self._net = ifnet
+
+                if ifnet.ip == self:
                     iface = interface
+                    self._net = ifnet
                     break
 
         return iface

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -264,8 +264,6 @@ def install_check(standalone, api, replica, options, hostname):
     ip_addresses = get_server_ip_address(hostname, options.unattended,
                                          True, options.ip_addresses)
 
-    util.network_ip_address_warning(ip_addresses)
-    util.broadcast_ip_address_warning(ip_addresses)
     util.no_matching_interface_for_ip_address_warning(ip_addresses)
 
     if not options.forward_policy:

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -590,7 +590,7 @@ def get_server_ip_address(host_name, unattended, setup_dns, ip_addresses):
     if len(hostaddr):
         for ha in hostaddr:
             try:
-                ips.append(ipautil.CheckedIPAddress(ha, match_local=False))
+                ips.append(ipautil.CheckedIPAddress(ha))
             except ValueError as e:
                 root_logger.warning("Invalid IP address %s for %s: %s", ha, host_name, unicode(e))
 

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -27,8 +27,6 @@ from ipalib import api, errors, x509
 from ipalib.constants import DOMAIN_LEVEL_0
 from ipalib.util import (
     validate_domain_name,
-    network_ip_address_warning,
-    broadcast_ip_address_warning,
     no_matching_interface_for_ip_address_warning,
 )
 import ipaclient.install.ntpconf
@@ -616,8 +614,6 @@ def install_check(installer):
                                              options.ip_addresses)
 
         # check addresses here, dns module is doing own check
-        network_ip_address_warning(ip_addresses)
-        broadcast_ip_address_warning(ip_addresses)
         no_matching_interface_for_ip_address_warning(ip_addresses)
 
     if options.setup_adtrust:

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -854,6 +854,7 @@ def install_check(installer):
             # check addresses here, dns module is doing own check
             network_ip_address_warning(config.ips)
             broadcast_ip_address_warning(config.ips)
+            no_matching_interface_for_ip_address_warning(config.ips)
 
         if options.setup_adtrust:
             adtrust.install_check(False, options, remote_api)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -32,11 +32,7 @@ from ipaplatform.tasks import tasks
 from ipaplatform.paths import paths
 from ipalib import api, constants, create_api, errors, rpc, x509
 from ipalib.config import Env
-from ipalib.util import (
-    network_ip_address_warning,
-    broadcast_ip_address_warning,
-    no_matching_interface_for_ip_address_warning,
-)
+from ipalib.util import no_matching_interface_for_ip_address_warning
 from ipaclient.install.client import configure_krb5_conf, purge_host_keytab
 from ipaserver.install import (
     adtrust, bindinstance, ca, certs, dns, dsinstance, httpinstance,
@@ -852,8 +848,6 @@ def install_check(installer):
                 options.ip_addresses)
 
             # check addresses here, dns module is doing own check
-            network_ip_address_warning(config.ips)
-            broadcast_ip_address_warning(config.ips)
             no_matching_interface_for_ip_address_warning(config.ips)
 
         if options.setup_adtrust:
@@ -1285,8 +1279,6 @@ def promote_check(installer):
                 False, options.ip_addresses)
 
             # check addresses here, dns module is doing own check
-            network_ip_address_warning(config.ips)
-            broadcast_ip_address_warning(config.ips)
             no_matching_interface_for_ip_address_warning(config.ips)
 
         if options.setup_adtrust:

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -567,7 +567,7 @@ def add_records_for_host_validation(option_name, host, domain, ip_addresses, che
     for ip_address in ip_addresses:
         try:
             ip = CheckedIPAddress(
-                ip_address, match_local=False, allow_multicast=True)
+                ip_address, allow_multicast=True)
         except Exception as e:
             raise errors.ValidationError(name=option_name, error=unicode(e))
 
@@ -599,7 +599,7 @@ def add_records_for_host(host, domain, ip_addresses, add_forward=True, add_rever
 
     for ip_address in ip_addresses:
         ip = CheckedIPAddress(
-            ip_address, match_local=False, allow_multicast=True)
+            ip_address, allow_multicast=True)
 
         if add_forward:
             add_forward_record(domain, host, unicode(ip))

--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -245,7 +245,7 @@ def validate_ipaddr(ugettext, ipaddr):
     Verify that we have either an IPv4 or IPv6 address.
     """
     try:
-        CheckedIPAddress(ipaddr, match_local=False)
+        CheckedIPAddress(ipaddr)
     except Exception as e:
         return unicode(e)
     return None

--- a/ipatests/test_ipapython/test_ipautil.py
+++ b/ipatests/test_ipapython/test_ipautil.py
@@ -64,9 +64,9 @@ pytestmark = pytest.mark.tier0
 def test_ip_address(addr, words, prefixlen):
     if words is None:
         pytest.raises(
-            ValueError, ipautil.CheckedIPAddress, addr, match_local=False)
+            ValueError, ipautil.CheckedIPAddress, addr)
     else:
-        ip = ipautil.CheckedIPAddress(addr, match_local=False)
+        ip = ipautil.CheckedIPAddress(addr)
         assert ip.words == words
         assert ip.prefixlen == prefixlen
 


### PR DESCRIPTION
Fix various checks of IP address in installers, removal of some unneeded checks that are not working correctly,  and mainly causes only false positive errors.

This PR also fixes regressions caused by bf9886a84393d1d1546db7e49b102e08a16a83e7

https://pagure.io/freeipa/issue/4317