### PR TITLE
Travis: check for BytesWarnings in httpd error_log

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -62,6 +62,7 @@ steps:
   - ipa-test-config --help
   - ipa-test-task --help
   - ipa-run-tests ${tests_ignore} -k-test_dns_soa ${tests_verbose} ${path}
+  - '! grep -n -C5 BytesWarning /var/log/httpd/error_log'
   - ipa-server-install --uninstall -U
 tests:
   ignore:

--- a/.test_runner_config_py3_temp.yaml
+++ b/.test_runner_config_py3_temp.yaml
@@ -52,6 +52,7 @@ steps:
   - echo 'wait_for_dns=5' >> ~/.ipa/default.conf
   run_tests:
   - ipa-run-tests-3 ${tests_ignore} -k-test_dns_soa ${tests_verbose} ${path}
+  - '! grep -n -C5 BytesWarning /var/log/httpd/error_log'
 tests:
   verbose: true
   ignore:


### PR DESCRIPTION
This check should prevent regressions in already py3 ported server plugins.
Later it may be extened to multiple logs.