### PR TITLE
ipa-otptoken-import: Make PBKDF2 refer to the pkcs5 namespace

### DIFF
--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -55,6 +55,7 @@ class ValidationError(Exception):
 
 def fetchAll(element, xpath, conv=lambda x: x):
     return [conv(e) for e in element.xpath(xpath, namespaces={
+        "pkcs5": "http://www.rsasecurity.com/rsalabs/pkcs/schemas/pkcs-5v2-0#",
         "pskc": "urn:ietf:params:xml:ns:keyprov:pskc",
         "xenc11": "http://www.w3.org/2009/xmlenc11#",
         "xenc": "http://www.w3.org/2001/04/xmlenc#",
@@ -178,18 +179,14 @@ class XMLKeyDerivation(six.with_metaclass(abc.ABCMeta, object)):
 
 class PBKDF2KeyDerivation(XMLKeyDerivation):
     def __init__(self, enckey):
-        params = fetch(enckey, "./xenc11:DerivedKey/xenc11:KeyDerivationMethod/xenc11:PBKDF2-params")
+        params = fetch(enckey, "./xenc11:DerivedKey/xenc11:KeyDerivationMethod/pkcs5:PBKDF2-params")
         if params is None:
             raise ValueError("XML file is missing PBKDF2 parameters!")
 
-        salt = fetch(
-            params, "./xenc11:Salt/xenc11:Specified/text()", base64.b64decode)
-        itrs = fetch(
-            params, "./xenc11:IterationCount/text()", int)
-        klen = fetch(
-            params, "./xenc11:KeyLength/text()", int)
-        hmod = fetch(
-            params, "./xenc11:PRF/@Algorithm", convertHMACType, hashes.SHA1)
+        salt = fetch(params, "./Salt/Specified/text()", base64.b64decode)
+        itrs = fetch(params, "./IterationCount/text()", int)
+        klen = fetch(params, "./KeyLength/text()", int)
+        hmod = fetch(params, "./PRF/@Algorithm", convertHMACType, hashes.SHA1)
 
         if salt is None:
             raise ValueError("XML file is missing PBKDF2 salt!")

--- a/ipatests/test_ipaserver/data/pskc-figure7.xml
+++ b/ipatests/test_ipaserver/data/pskc-figure7.xml
@@ -8,14 +8,14 @@
     <xenc11:DerivedKey>
       <xenc11:KeyDerivationMethod
 	  Algorithm="http://www.rsasecurity.com/rsalabs/pkcs/schemas/pkcs-5v2-0#pbkdf2">
-        <xenc11:PBKDF2-params>
-          <xenc11:Salt>
-            <xenc11:Specified>Ej7/PEpyEpw=</xenc11:Specified>
-          </xenc11:Salt>
-          <xenc11:IterationCount>1000</xenc11:IterationCount>
-          <xenc11:KeyLength>16</xenc11:KeyLength>
-          <xenc11:PRF/>
-        </xenc11:PBKDF2-params>
+        <pkcs5:PBKDF2-params>
+          <Salt>
+            <Specified>Ej7/PEpyEpw=</Specified>
+          </Salt>
+          <IterationCount>1000</IterationCount>
+          <KeyLength>16</KeyLength>
+          <PRF/>
+        </pkcs5:PBKDF2-params>
       </xenc11:KeyDerivationMethod>
       <xenc:ReferenceList>
         <xenc:DataReference URI="#ED"/>


### PR DESCRIPTION
For some unknown reason, when I wrote the ipa-otptoken-import script
I used bad input data which had the PBKDF2 parameters in the wrong
XML namespace. I have corrected this input data to match RFC 6030.