### PR TITLE
*config-show: do not show empty roles/attributes

### DIFF
--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -278,8 +278,7 @@ class config(LDAPObject):
 
         role_config = backend.config_retrieve(role_name)
         for key, value in role_config.items():
-            if value:
-                entry_attrs.update({key: value})
+            entry_attrs.update({key: value})
 
 
     def show_servroles_attributes(self, entry_attrs, *roles, **options):

--- a/ipaserver/plugins/serverroles.py
+++ b/ipaserver/plugins/serverroles.py
@@ -81,13 +81,17 @@ class serverroles(Backend):
                 reason=_("{role}: role not found".format(role=role_name)))
 
     def _get_enabled_masters(self, role_name):
+        result = {}
         role = self._get_role(role_name)
 
         enabled_masters = [
             r[u'server_server'] for r in role.status(self.api, server=None) if
             r[u'status'] == ENABLED]
 
-        return {role.attr_name: enabled_masters}
+        if enabled_masters:
+            result.update({role.attr_name: enabled_masters})
+
+        return result
 
     def _get_assoc_attributes(self, role_name):
         role = self._get_role(role_name)
@@ -136,7 +140,9 @@ class serverroles(Backend):
 
         for name, attr in assoc_attributes.items():
             attr_value = attr.get(self.api)
-            result.update({name: attr_value})
+
+            if attr_value:
+                result.update({name: attr_value})
 
         return result
 


### PR DESCRIPTION
Do not break the intended semantics of optional Params in *config-show commands which states that if the attribute is not present (or there is no read access to it) the attribute will not be sent in the JSON-RPC response.

Previously, server roles/attributes containing an empty tuple were sent and we should maintain the consistency with other API commands.

https://pagure.io/freeipa/issue/7029