### PR TITLE
Fixing ipa-replica-install --setup-kra if it's the first KRA in topology

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -388,6 +388,9 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
         fix_apache_semaphores(replica)
         args.extend(['-r', replica.domain.realm])
 
+    if not stdin_text:
+        stdin_text = replica.config.dirman_password
+
     result = replica.run_command(args, raiseonerr=raiseonerr,
                                  stdin_text=stdin_text)
     if result.returncode == 0:


### PR DESCRIPTION
I'm trying to fix the ticket, but I'm not quite sure of how to do it. Until now, I removed the exception and called the api in kra to install it. However, I'm getting an exception:
```
bash-4.3$ sudo python /usr/sbin/ipa-replica-install -r DOM-116.ABC.IDM.LAB.ENG.BRQ.REDHAT.COM --setup-kra --setup-ca
WARNING: conflicting time&date synchronization service 'chronyd' will be disabled in favor of ntpd

IPA client is already configured on this system, ignoring the --domain, --server, --realm, --hostname, --password and --keytab options.
Your system may be partly configured.
Run /usr/sbin/ipa-server-install --uninstall to clean up.

ipa.ipapython.install.cli.install_tool(CompatServerReplicaInstall): ERROR    Timed out trying to obtain keys.
ipa.ipapython.install.cli.install_tool(CompatServerReplicaInstall): ERROR    The ipa-replica-install command failed. See /var/log/ipareplica-install.log for more information
```

from /var/log/ipareplica-install.log  
```
2017-06-23T18:38:44Z DEBUG stderr=
2017-06-23T18:38:44Z DEBUG Destroyed connection context.ldap2_140135237350736
2017-06-23T18:38:44Z DEBUG Created connection context.ldap2_140135237350736
2017-06-23T18:38:44Z DEBUG raw: hostgroup_show(u'ipaservers', rights=True, all=True, version=u'2.228')
2017-06-23T18:38:44Z DEBUG hostgroup_show(u'ipaservers', rights=True, all=True, raw=False, version=u'2.228', no_members=False)
2017-06-23T18:38:44Z DEBUG flushing ldaps://vm-116.abc.idm.lab.eng.brq.redhat.com from SchemaCache
2017-06-23T18:38:44Z DEBUG retrieving schema for SchemaCache url=ldaps://vm-116.abc.idm.lab.eng.brq.redhat.com conn=<ldap.ldapobject.SimpleLDAPObject instance at 0x7f73c6769f38>
2017-06-23T18:38:44Z DEBUG Destroyed connection context.ldap2_140135237350736
2017-06-23T18:38:44Z DEBUG Created connection context.ldap2_140135237350736
2017-06-23T18:38:44Z DEBUG flushing ldaps://vm-116.abc.idm.lab.eng.brq.redhat.com from SchemaCache
2017-06-23T18:38:44Z DEBUG retrieving schema for SchemaCache url=ldaps://vm-116.abc.idm.lab.eng.brq.redhat.com conn=<ldap.ldapobject.SimpleLDAPObject instance at 0x7f73c6769c20>
2017-06-23T18:38:44Z DEBUG No IPA DNS servers, skipping forward/reverse resolution check
2017-06-23T18:38:44Z DEBUG Initializing principal host/vm-058-064.abc.idm.lab.eng.brq.redhat.com@DOM-116.ABC.IDM.LAB.ENG.BRQ.REDHAT.COM using keytab /etc/krb5.keytab
2017-06-23T18:38:44Z DEBUG using ccache /tmp/krbcc9omA2g/ccache
2017-06-23T18:38:44Z DEBUG Attempt 1/1: success
2017-06-23T18:38:44Z DEBUG Loading StateFile from '/var/lib/ipa/sysrestore/sysrestore.state'
2017-06-23T18:38:44Z DEBUG Loading Index file from '/var/lib/ipa/sysrestore/sysrestore.index'
2017-06-23T18:38:44Z INFO Waiting up to 300 seconds to see our keys appear on host: None
2017-06-23T18:38:45Z DEBUG Transient error getting keys: '{'desc': "Can't contact LDAP server"}'
2017-06-23T18:43:45Z DEBUG Destroyed connection context.ldap2_140135237350736
2017-06-23T18:43:45Z DEBUG   File "/usr/lib/python2.7/site-packages/ipapython/admintool.py", line 172, in execute
    return_value = self.run()
  File "/usr/lib/python2.7/site-packages/ipapython/install/cli.py", line 333, in run
    cfgr.run()
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 366, in run
    self.validate()
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 375, in validate
    for _nothing in self._validator():
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 434, in __runner
    exc_handler(exc_info)
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 458, in _handle_validate_exception
    self._handle_exception(exc_info)
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 453, in _handle_exception
    six.reraise(*exc_info)
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 424, in __runner
    step()
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 421, in <lambda>
    step = lambda: next(self.__gen)
  File "/usr/lib/python2.7/site-packages/ipapython/install/util.py", line 81, in run_generator_with_yield_from
    six.reraise(*exc_info)
  File "/usr/lib/python2.7/site-packages/ipapython/install/util.py", line 59, in run_generator_with_yield_from
    value = gen.send(prev_value)
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 636, in _configure
    next(validator)
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 434, in __runner
    exc_handler(exc_info)
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 458, in _handle_validate_exception
    self._handle_exception(exc_info)
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 521, in _handle_exception
    self.__parent._handle_exception(exc_info)
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 453, in _handle_exception
    six.reraise(*exc_info)
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 518, in _handle_exception
    super(ComponentBase, self)._handle_exception(exc_info)
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 453, in _handle_exception
    six.reraise(*exc_info)
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 424, in __runner
    step()
  File "/usr/lib/python2.7/site-packages/ipapython/install/core.py", line 421, in <lambda>
    step = lambda: next(self.__gen)
  File "/usr/lib/python2.7/site-packages/ipapython/install/util.py", line 81, in run_generator_with_yield_from
    six.reraise(*exc_info)
  File "/usr/lib/python2.7/site-packages/ipapython/install/util.py", line 59, in run_generator_with_yield_from
    value = gen.send(prev_value)
  File "/usr/lib/python2.7/site-packages/ipapython/install/common.py", line 63, in _install
    for _nothing in self._installer(self.parent):
  File "/usr/lib/python2.7/site-packages/ipaserver/install/server/__init__.py", line 613, in main
    replica_promote_check(self)
  File "/usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py", line 386, in decorated
    func(installer)
  File "/usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py", line 408, in decorated
    func(installer)
  File "/usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py", line 1270, in promote_check
    raise ScriptError(e)

2017-06-23T18:43:45Z DEBUG The ipa-replica-install command failed, exception: ScriptError: Timed out trying to obtain keys.
2017-06-23T18:43:45Z ERROR Timed out trying to obtain keys.
2017-06-23T18:43:45Z ERROR The ipa-replica-install command failed. See /var/log/ipareplica-install.log for more information
```

There is a high chance that I'm getting the wrong path here, so if there is someone able to help me (pointing to some docs or explaining more details of it), it would be great.

Ticket https://pagure.io/freeipa/issue/7008