### PR TITLE
Ensure network is online prior to an upgrade

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1017,6 +1017,10 @@ fi
 python2 -c "import sys; from ipaserver.install import installutils; sys.exit(0 if installutils.is_ipa_configured() else 1);" > /dev/null 2>&1
 
 if [  $? -eq 0 ]; then
+    # This is necessary for Fedora system upgrades which by default
+    # work with the network being offline
+    /bin/systemctl start network-online.target
+
     # This must be run in posttrans so that updates from previous
     # execution that may no longer be shipped are not applied.
     /usr/sbin/ipa-server-upgrade --quiet >/dev/null || :


### PR DESCRIPTION
Fedora system upgrades don't necessary require the network to be up.
However, we do, so we have to make sure the network is online before
performing an upgrade.

https://pagure.io/freeipa/issue/7039