### PR TITLE
[py3] wsgi fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ env:
           TEST_RUNNER_CONFIG=".test_runner_config_py3_temp.yaml"
           TESTS_TO_RUN="test_cmdline
                 test_ipalib
+                test_ipaserver/test_changepw.py
                 test_pkcs10
                 test_xmlrpc/test_location_plugin.py
                 test_xmlrpc/test_nesting.py
@@ -98,7 +99,6 @@ env:
             # test_ipapython/test_kerberos.py
             # test_ipapython/test_ssh.py
             # test_ipaserver/httptest.py
-            # test_ipaserver/test_changepw.py
             # test_ipaserver/test_dnssec.py
             # test_ipaserver/test_install/test_adtrustinstance.py
             # test_ipaserver/test_install/test_service.py

--- a/install/wsgi/plugins.py
+++ b/install/wsgi/plugins.py
@@ -34,10 +34,12 @@ def get_plugin_index():
     index = 'define([],function(){return['
     index += ','.join("'"+x+"'" for x in dirs)
     index += '];});'
-    return index
+    return index.encode('utf-8')
 
 def get_failed():
-    return 'define([],function(){return[];});/*error occured: serving default */'
+    return (
+        b'define([],function(){return[];});/*error occured: serving default */'
+    )
 
 def application(environ, start_response):
     try:

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -545,7 +545,8 @@ class NegotiateAuth(AuthBase):
         return token
 
     def _set_authz_header(self, request, token):
-        request.headers['Authorization'] = 'Negotiate ' + b64encode(token)
+        request.headers['Authorization'] = (
+            'Negotiate {}'.format(b64encode(token).decode('utf-8')))
 
     def initial_step(self, request, response=None):
         if self.context is None:

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -650,7 +650,7 @@ class KerberosSession(HTTP_Status):
         headers.append(('IPASESSION', session_cookie))
 
         start_response(HTTP_STATUS_SUCCESS, headers)
-        return ['']
+        return [b'']
 
 
 class KerberosWSGIExecutioner(WSGIExecutioner, KerberosSession):
@@ -1090,7 +1090,7 @@ class change_password(Backend, HTTP_Status):
         start_response(status, response_headers)
         output = _success_template % dict(title=str(title),
                                           message=str(message))
-        return [output]
+        return [output.encode('utf-8')]
 
 class sync_token(Backend, HTTP_Status):
     content_type = 'text/plain'
@@ -1188,7 +1188,7 @@ class sync_token(Backend, HTTP_Status):
         start_response(status, response_headers)
         output = _success_template % dict(title=str(title),
                                           message=str(message))
-        return [output]
+        return [output.encode('utf-8')]
 
 class xmlserver_session(xmlserver, KerberosSession):
     """


### PR DESCRIPTION
These patches fix WebUI for FreeIPA when using python3-mod_wsgi. To get it working, however, one also needs to run Fedora 26 with python3-pyldap with the following fixes:
https://github.com/pyldap/pyldap/pull/104
https://github.com/pyldap/pyldap/commit/60801268c56784f86847caa400dc0aad1699eb26