### PR TITLE
whoami.py: type error when running test

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -6477,7 +6477,7 @@ output: PrimaryKey('value')
 command: whoami/1
 args: 0,1,3
 option: Str('version?')
-output: Output('arguments', type=[<type 'list'>])
+output: Output('arguments', type=[<type 'list'>, <type 'tuple'>])
 output: Output('command', type=[<type 'unicode'>])
 output: Output('object', type=[<type 'unicode'>])
 default: aci/1

--- a/ipaserver/plugins/whoami.py
+++ b/ipaserver/plugins/whoami.py
@@ -87,7 +87,8 @@ class whoami(Command):
     has_output = (
         output.Output('object', unicode, _('Object class name')),
         output.Output('command', unicode, _('Function to get details')),
-        output.Output('arguments', list, _('Arguments to details function')),
+        output.Output('arguments', (list, tuple),
+                      _('Arguments to details function')),
     )
 
     def execute(self, **options):


### PR DESCRIPTION
While writing xmlrpc test for this plugin I bumped into:

    TypeError: whoami.validate_output():
        output['arguments']: need (<type 'list'>,); got <type 'tuple'>: (u'krb_staged_user',)
