### PR TITLE
Warning the user when using a loopback IP as forwarder

### DIFF
--- a/install/tools/ipa-dns-install
+++ b/install/tools/ipa-dns-install
@@ -54,7 +54,7 @@ def parse_options():
                       help="Master Server IP Address. This option can be used "
                            "multiple times")
     parser.add_option("--forwarder", dest="forwarders", action="append",
-                      type="ip", help="Add a DNS forwarder. This option can be used multiple times")
+                      type="ip_with_loopback", help="Add a DNS forwarder. This option can be used multiple times")
     parser.add_option("--no-forwarders", dest="no_forwarders", action="store_true",
                       default=False, help="Do not add any DNS forwarders, use root servers instead")
     parser.add_option("--auto-forwarders", dest="auto_forwarders",

--- a/ipapython/install/cli.py
+++ b/ipapython/install/cli.py
@@ -16,7 +16,8 @@ import six
 
 from ipapython import admintool
 from ipapython.ipa_log_manager import standard_logging_setup
-from ipapython.ipautil import CheckedIPAddress, private_ccache
+from ipapython.ipautil import (CheckedIPAddress, CheckedIPAddressLoopback,
+                               private_ccache)
 
 from . import core, common
 
@@ -166,6 +167,8 @@ class ConfigureTool(admintool.AdminTool):
                 kwargs['type'] = 'int'
             elif knob_scalar_type is long:
                 kwargs['type'] = 'long'
+            elif knob_scalar_type is CheckedIPAddressLoopback:
+                kwargs['type'] = 'ip_with_loopback'
             elif knob_scalar_type is CheckedIPAddress:
                 kwargs['type'] = 'ip'
             elif issubclass(knob_scalar_type, enum.Enum):

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -245,6 +245,25 @@ class CheckedIPAddress(UnsafeIPAddress):
         self._net = ifnet
 
 
+class CheckedIPAddressLoopback(CheckedIPAddress):
+    """IPv4 or IPv6 address with additional constraints with
+    possibility to use a loopback IP.
+    Reserved or link-local addresses are never accepted.
+    """
+    def __init__(self, addr, parse_netmask=True, allow_multicast=False):
+
+        super(CheckedIPAddressLoopback, self).__init__(
+                addr, parse_netmask=parse_netmask,
+                allow_multicast=allow_multicast,
+                allow_loopback=True)
+
+        if self.is_loopback():
+            # print is being used instead of a logger, because at this
+            # moment, in execution process, there is no logger configured
+            print("WARNING: You are using a loopback IP: {}".format(addr),
+                  file=sys.stderr)
+
+
 def valid_ip(addr):
     return netaddr.valid_ipv4(addr) or netaddr.valid_ipv6(addr)
 

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -490,7 +490,7 @@ class DNSInstallInterface(hostname.HostNameInstallInterface):
 
     forwarders = knob(
         # pylint: disable=invalid-sequence-index
-        typing.List[ipautil.CheckedIPAddress], None,
+        typing.List[ipautil.CheckedIPAddressLoopback], None,
         description=("Add a DNS forwarder. This option can be used multiple "
                      "times"),
         cli_names='--forwarder',


### PR DESCRIPTION
Now, the user can pass a loopback IP in the --forwarder option.
Previously, an error would be raised, now we just show a warning message.

Fixes: https://pagure.io/freeipa/issue/5801