### PR TITLE
ipatests: do not finalize api when IPA is not configured

### DIFF
--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -18,6 +18,7 @@ except ImportError:
     ipaplatform = None
 try:
     import ipaserver
+    from ipaserver.install import installutils
 except ImportError:
     ipaserver = None
 
@@ -105,7 +106,7 @@ def pytest_cmdline_main(config):
 
     # XXX workaround until https://fedorahosted.org/freeipa/ticket/6408 has
     # been resolved.
-    if ipaserver is not None:
+    if ipaserver is not None and installutils.is_ipa_configured():
         api.finalize()
 
     if config.option.verbose:


### PR DESCRIPTION
Pytest can be executed from a machine that doesn't have IPA configured.
In this case, api can't be finalized because values such as basedn are
unknown and missing.

Fixes https://pagure.io/freeipa/issue/7046

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>

Tests passed: https://fedorapeople.org/groups/freeipa/prci/jobs/756acbea-657f-11e7-bdab-c85b762c9683