### PR TITLE
WebUI: fix for negative number in pagination size settings

### DIFF
--- a/install/ui/src/freeipa/Application_controller.js
+++ b/install/ui/src/freeipa/Application_controller.js
@@ -312,7 +312,7 @@ define([
                         $type: 'text',
                         name: 'pagination_size',
                         label: '@i18n:customization.table_pagination',
-                        validators: ['integer']
+                        validators: ['positive_integer']
                     }
                 ]
             });

--- a/install/ui/src/freeipa/field.js
+++ b/install/ui/src/freeipa/field.js
@@ -1049,8 +1049,50 @@ field.validator = IPA.validator = function(spec) {
          return that.true_result();
      };
 
+     that.integer_validate = that.validate;
+
      return that;
  };
+
+
+/**
+ * Javascript positive integer validator
+ *
+ * It allows to insert only positive integer.
+ *
+ * @class
+ * @alternateClassName IPA.positive_integer_validator
+ * @extends IPA.validator
+ */
+ field.positive_integer_validator = IPA.positive_integer_validator = function(spec) {
+
+    var that = IPA.integer_validator(spec);
+
+    /**
+    * @inheritDoc
+    */
+
+    that.validate = function(value) {
+
+        var integer_check = that.integer_validate(value);
+
+        if (!integer_check.valid) {
+            return integer_check;
+        }
+
+        var num = parseInt(value);
+
+        if (num <= 0) {
+            return that.false_result(
+                text.get('@i18n:widget.validation.positive_number'));
+        }
+
+        return that.true_result();
+    };
+
+    return that;
+ };
+
 
 /**
  * Metadata validator
@@ -1871,6 +1913,7 @@ field.register = function() {
     v.register('unsupported', field.unsupported_validator);
     v.register('same_password', field.same_password_validator);
     v.register('integer', field.integer_validator);
+    v.register('positive_integer', field.positive_integer_validator);
 
     l.register('adapter', field.Adapter);
     l.register('object_adapter', field.ObjectAdapter);

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -982,6 +982,7 @@ class i18n_messages(Command):
                 "min_value": _("Minimum value is ${value}"),
                 "net_address": _("Not a valid network address (examples: 2001:db8::/64, 192.0.2.0/24)"),
                 "parse": _("Parse error"),
+                "positive_number": _("Must be a positive number"),
                 "port": _("'${port}' is not a valid port"),
                 "required": _("Required field"),
                 "unsupported": _("Unsupported value"),


### PR DESCRIPTION
This PR adds new validator which allows to input only positive numbers into fiels. The new validator is then used in field for setting the length of tables (number of rows) on search facets.

https://pagure.io/freeipa/issue/6980