### PR TITLE
[4-5 only] replica install: drop-in IPA specific config to tmpfiles.d

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1515,6 +1515,9 @@ def install(installer):
         # remove the extracted replica file
         remove_replica_info_dir(installer)
 
+    # Make sure the files we crated in /var/run are recreated at startup
+    tasks.configure_tmpfiles()
+
     # Everything installed properly, activate ipa service.
     services.knownservices.ipa.enable()
 


### PR DESCRIPTION
While server installation and upgrade code configures the IPA specific
tmpfiles location and creates relevant directories, the replica
installer code path is covered incompletely and one step is missing.

https://pagure.io/freeipa/issue/7053