### PR TITLE
[master only] Move tmpfiles.d configuration handling back to spec file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -558,6 +558,7 @@ AC_CONFIG_FILES([
     daemons/ipa-slapi-plugins/ipa-range-check/Makefile
     daemons/ipa-slapi-plugins/topology/Makefile
     init/systemd/Makefile
+    init/tmpfilesd/Makefile
     init/Makefile
     install/Makefile
     install/certmonger/Makefile

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1089,6 +1089,7 @@ fi
 /bin/systemctl reload-or-try-restart dbus
 /bin/systemctl reload-or-try-restart oddjobd
 
+%tmpfiles_create ipa.conf
 
 %posttrans server
 # don't execute upgrade and restart of IPA when server is not installed
@@ -1375,6 +1376,8 @@ fi
 %config(noreplace) %{_sysconfdir}/sysconfig/ipa-dnskeysyncd
 %config(noreplace) %{_sysconfdir}/sysconfig/ipa-ods-exporter
 %config(noreplace) %{_sysconfdir}/ipa/kdcproxy/kdcproxy.conf
+# NOTE: systemd specific section
+%{_tmpfilesdir}/ipa.conf
 %attr(644,root,root) %{_unitdir}/ipa-custodia.service
 %ghost %attr(644,root,root) %{etc_systemd_dir}/httpd.d/ipa.conf
 # END
@@ -1384,7 +1387,6 @@ fi
 %{_usr}/share/ipa/*.ldif
 %{_usr}/share/ipa/*.uldif
 %{_usr}/share/ipa/*.template
-%{_usr}/share/ipa/ipa.conf.tmpfiles
 %dir %{_usr}/share/ipa/advise
 %dir %{_usr}/share/ipa/advise/legacy
 %{_usr}/share/ipa/advise/legacy/*.template

--- a/init/Makefile.am
+++ b/init/Makefile.am
@@ -2,7 +2,7 @@
 #
 AUTOMAKE_OPTIONS = 1.7
 
-SUBDIRS = systemd
+SUBDIRS = systemd tmpfilesd
 
 dist_sysconfenv_DATA = 		\
 	ipa-dnskeysyncd		\

--- a/init/tmpfilesd/Makefile.am
+++ b/init/tmpfilesd/Makefile.am
@@ -1,0 +1,10 @@
+dist_noinst_DATA =     \
+	ipa.conf.in
+
+systemdtmpfiles_DATA =         \
+	ipa.conf
+
+CLEANFILES = $(systemdtmpfiles_DATA)
+
+%: %.in Makefile
+	sed -e 's|@localstatedir[@]|$(localstatedir)|g' '$(srcdir)/$@.in' >$@

--- a/init/tmpfilesd/ipa.conf.in
+++ b/init/tmpfilesd/ipa.conf.in
@@ -1,0 +1,2 @@
+d @localstatedir@/run/ipa 0711 root root
+d @localstatedir@/run/ipa/ccaches 0770 ipaapi ipaapi

--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -87,7 +87,6 @@ dist_app_DATA =				\
 	kdcproxy-disable.uldif		\
 	ipa-httpd.conf.template		\
 	gssapi.login			\
-	ipa.conf.tmpfiles		\
 	gssproxy.conf.template		\
 	kdcproxy.wsgi			\
 	ipakrb5.aug			\

--- a/install/share/ipa.conf.tmpfiles
+++ b/install/share/ipa.conf.tmpfiles
@@ -1,2 +1,0 @@
-d /var/run/ipa 0711 root root
-d /var/run/ipa/ccaches 0770 ipaapi ipaapi

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -130,7 +130,6 @@ class BasePathNamespace(object):
     SYSTEMD_SSSD_SERVICE = "/etc/systemd/system/multi-user.target.wants/sssd.service"
     SYSTEMD_PKI_TOMCAT_SERVICE = "/etc/systemd/system/pki-tomcatd.target.wants/pki-tomcatd@pki-tomcat.service"
     ETC_TMPFILESD_DIRSRV = "/etc/tmpfiles.d/dirsrv-%s.conf"
-    ETC_TMPFILESD_IPA = "/etc/tmpfiles.d/ipa.conf"
     DNSSEC_TRUSTED_KEY = "/etc/trusted-key.key"
     HOME_DIR = "/home"
     PROC_FIPS_ENABLED = "/proc/sys/crypto/fips_enabled"

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -200,14 +200,6 @@ class BaseTaskNamespace(object):
         """
         raise NotImplementedError()
 
-    def configure_tmpfiles(self):
-        """Configure tmpfiles to be created at boot"""
-        raise NotImplementedError()
-
-    def create_tmpfiles_dirs(self):
-        """Create run dirs for the install phase"""
-        raise NotImplementedError()
-
     def configure_httpd_service_ipa_conf(self):
         """Configure httpd service to work with IPA"""
         raise NotImplementedError()

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -27,8 +27,6 @@ from __future__ import print_function
 
 import logging
 import os
-import pwd
-import shutil
 import socket
 import traceback
 import errno
@@ -511,25 +509,6 @@ class RedHatTaskNamespace(BaseTaskNamespace):
             # exist
             pass
         return False
-
-    def _create_tmpfiles_dir(self, name, mode, uid, gid):
-        if not os.path.exists(name):
-            os.mkdir(name)
-        os.chmod(name, mode)
-        os.chown(name, uid, gid)
-
-    def create_tmpfiles_dirs(self):
-        parent = os.path.dirname(paths.IPA_CCACHES)
-        pent = pwd.getpwnam(IPAAPI_USER)
-        self._create_tmpfiles_dir(parent, 0o711, 0, 0)
-        self._create_tmpfiles_dir(paths.IPA_CCACHES, 0o770,
-                                  pent.pw_uid, pent.pw_gid)
-
-    def configure_tmpfiles(self):
-        shutil.copy(
-            os.path.join(paths.USR_SHARE_IPA_DIR, 'ipa.conf.tmpfiles'),
-            paths.ETC_TMPFILESD_IPA
-        )
 
 
 tasks = RedHatTaskNamespace()

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -722,9 +722,6 @@ def install(installer):
     if installer._update_hosts_file:
         update_hosts_file(ip_addresses, host_name, fstore)
 
-    # Make sure tmpfiles dir exist before installing components
-    tasks.create_tmpfiles_dirs()
-
     # Create a directory server instance
     if not options.external_cert_files:
         # Configure ntpd
@@ -897,9 +894,6 @@ def install(installer):
     except Exception:
         raise ScriptError("Configuration of client side components failed!")
 
-    # Make sure the files we crated in /var/run are recreated at startup
-    tasks.configure_tmpfiles()
-
     # Everything installed properly, activate ipa service.
     services.knownservices.ipa.enable()
 
@@ -1049,10 +1043,6 @@ def uninstall(installer):
     sstore = installer._sstore
 
     rv = 0
-
-    # further steps assumes that temporary directories exists so rather
-    # ensure they are created
-    tasks.create_tmpfiles_dirs()
 
     print("Shutting down all IPA services")
     try:

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1355,9 +1355,6 @@ def install(installer):
     conn = remote_api.Backend.ldap2
     ccache = os.environ['KRB5CCNAME']
 
-    # Make sure tmpfiles dir exist before installing components
-    tasks.create_tmpfiles_dirs()
-
     if promote:
         if installer._add_to_ipaservers:
             try:

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1927,10 +1927,6 @@ def upgrade_check(options):
 
 
 def upgrade():
-    # Do this early so that any code depending on these dirs will not fail
-    tasks.create_tmpfiles_dirs()
-    tasks.configure_tmpfiles()
-
     realm = api.env.realm
     schema_files = [os.path.join(paths.USR_SHARE_IPA_DIR, f) for f
                     in dsinstance.ALL_SCHEMA_FILES]


### PR DESCRIPTION
Since ipaapi user is now created during RPM install and not in runtime,
we may switch back to shipping tmpfiles.d configuration directly in RPMs
and not create it in runtime, which is a preferred way to handle drop-in
configuration anyway.

This also means that the drop-in config will be shipped in /usr/lib
instead of /etc according to Fedora packaging guidelines.

This partially reverts commit 38c66896de1769077cd5b057133606ec5eeaf62b.

https://pagure.io/freeipa/issue/7053