### PR TITLE
dcerpc: support Python 3

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -188,7 +188,7 @@ class ExtendedDNControl(LDAPControl):
         self.integerValue = 1
 
     def encodeControlValue(self, value=None):
-        return '0\x03\x02\x01\x01'
+        return b'0\x03\x02\x01\x01'
 
 
 class DomainValidator(object):
@@ -820,6 +820,8 @@ class DomainValidator(object):
 
 
 def string_to_array(what):
+    if six.PY3 and isinstance(what, bytes):
+        return [v for v in what]
     return [ord(v) for v in what]
 
 
@@ -940,6 +942,14 @@ class TrustDomainInstance(object):
         search_result = None
         try:
             _objtype, res = conn.search_s('', _ldap.SCOPE_BASE)[0]
+            for o in res.keys():
+                if isinstance(res[o], list):
+                    t = res[o]
+                    for z, v in enumerate(t):
+                        if isinstance(v, bytes):
+                            t[z] = v.decode('utf-8')
+                elif isinstance(res[o], bytes):
+                    res[o] = res[o].decode('utf-8')
             search_result = res['defaultNamingContext'][0]
             self.info['dns_hostname'] = res['dnsHostName'][0]
         except _ldap.LDAPError as e:


### PR DESCRIPTION
Make 'ipa trust-add' work under Python 3. One needs patches from
https://lists.samba.org/archive/samba-technical/2017-July/121746.html
to Samba too.

Marked as WIP until Samba patches are released as part of 4.7.0-RC2.

Since we haven't switched whole ipa server environment to Python 3 yet,
following packages need to be installed to make trust code working under
Python 3:

 - python3-libsss_nss_idmap
 - python3-sss
 - python3-samba
 - python3-mod_wsgi