### PR TITLE
client.py: Using Augeas to configure kerberos

### DIFF
--- a/ipaclient/setup.py
+++ b/ipaclient/setup.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
             ]
         },
         extras_require={
-            "install": ["ipaplatform"],
+            "install": ["ipaplatform", "python-augeas"],
             "otptoken_yubikey": ["python-yubico", "pyusb"],
             "csrgen": ["cffi", "jinja2"],
         },

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -67,6 +67,7 @@ class BasePathNamespace(object):
     COMMON_KRB5_CONF_DIR = "/etc/krb5.conf.d/"
     KRB5_CONF = "/etc/krb5.conf"
     KRB5_KEYTAB = "/etc/krb5.keytab"
+    IPACLIENT_KRB5_CONF_NAME = "ipaclient_krb5.conf"
     LDAP_CONF = "/etc/ldap.conf"
     LIBNSS_LDAP_CONF = "/etc/libnss-ldap.conf"
     NAMED_CONF = "/etc/named.conf"

--- a/ipaserver/setup.py
+++ b/ipaserver/setup.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
             # These packages are currently not available on PyPI.
             "dcerpc": ["samba", "pysss", "pysss_nss_idmap"],
             "hbactest": ["pyhbac"],
-            "install": ["SSSDConfig"],
+            "install": ["python-augeas", "SSSDConfig"],
             "trust": ["pysss_murmur", "pysss_nss_idmap"],
         }
     )


### PR DESCRIPTION
This patch moves default kerberos configuration for ipa
client to separate confifuration file located in default
'/etc/krb5.conf.d/' directory instead of rewriting file
'/etc/krb5.conf'. When include directory is not provided
by distribution, administrator should specify one which
will be used to client configuration file to be stored in.
In general, using Augeas to configure kerberos configuration
should avoid issues like #5912.

https://pagure.io/freeipa/issue/5913