### PR TITLE
logging: make sure logging level is set to proper value

### DIFF
--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -461,21 +461,7 @@ class API(ReadOnly):
             if not match:
                 continue
 
-            value = match.group(1)
-            try:
-                level = int(value)
-            except ValueError:
-                try:
-                    level = {
-                        'debug': logging.DEBUG,
-                        'info': logging.INFO,
-                        'warn': logging.WARNING,
-                        'warning': logging.WARNING,
-                        'error': logging.ERROR,
-                        'critical': logging.CRITICAL
-                    }[value]
-                except KeyError:
-                    raise ValueError('unknown log level (%s)' % value)
+            level = ipa_log_manager.convert_log_level(match.group(1))
 
             value = getattr(self.env, attr)
             regexps = re.split('\s*,\s*', value)

--- a/ipapython/ipa_log_manager.py
+++ b/ipapython/ipa_log_manager.py
@@ -181,6 +181,24 @@ def standard_logging_setup(filename=None, verbose=False, debug=False,
     root_logger.addHandler(console_handler)
 
 
+def convert_log_level(value):
+    try:
+        level = int(value)
+    except ValueError:
+        try:
+            level = {
+                'debug': logging.DEBUG,
+                'info': logging.INFO,
+                'warn': logging.WARNING,
+                'warning': logging.WARNING,
+                'error': logging.ERROR,
+                'critical': logging.CRITICAL
+            }[value.lower()]
+        except KeyError:
+            raise ValueError('unknown log level (%s)' % value)
+    return level
+
+
 # Single shared instance of log manager
 log_mgr = sys.modules[__name__]
 

--- a/ipatests/pytest_plugins/nose_compat.py
+++ b/ipatests/pytest_plugins/nose_compat.py
@@ -23,7 +23,7 @@ import os
 import sys
 import logging
 
-from ipapython.ipa_log_manager import Formatter
+from ipapython.ipa_log_manager import Formatter, convert_log_level
 
 
 def pytest_addoption(parser):
@@ -61,8 +61,10 @@ def pytest_configure(config):
                     capture._capturing.resume_capturing()
                 sys.stdout, sys.stderr = orig_stdout, orig_stderr
 
+        level = convert_log_level(config.getoption('logging_level'))
+
         handler = LogHandler()
         handler.setFormatter(Formatter('[%(name)s] %(message)s'))
-        handler.setLevel(config.getoption('logging_level'))
+        handler.setLevel(level)
         root_logger = logging.getLogger()
         root_logger.addHandler(handler)


### PR DESCRIPTION
During py.test initialization, the value 'debug' is passed instead
of logging.DEBUG.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>