### PR TITLE
py3: fixing zonemgr_callback

### DIFF
--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -379,7 +379,7 @@ def validate_domain_name(domain_name, allow_underscore=False, allow_slash=False)
 
 def validate_zonemgr(zonemgr):
     assert isinstance(zonemgr, DNSName)
-    if any('@' in label for label in zonemgr.labels):
+    if any(b'@' in label for label in zonemgr.labels):
         raise ValueError(_('too many \'@\' characters'))
 
 

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -423,7 +423,11 @@ def zonemgr_callback(option, opt_str, value, parser):
             encoding = getattr(sys.stdin, 'encoding', None)
             if encoding is None:
                 encoding = 'utf-8'
-            value = value.decode(encoding)
+
+            # value is of a string type in both py2 and py3
+            if not isinstance(value, unicode):
+                value = value.decode(encoding)
+
             validate_zonemgr_str(value)
         except ValueError as e:
             # FIXME we can do this in better way
@@ -433,7 +437,7 @@ def zonemgr_callback(option, opt_str, value, parser):
             if stderr_encoding is None:
                 stderr_encoding = 'utf-8'
             error = unicode(e).encode(stderr_encoding)
-            parser.error("invalid zonemgr: " + error)
+            parser.error(b"invalid zonemgr: " + error)
 
     parser.values.zonemgr = value
 


### PR DESCRIPTION
Previously, `zonemgr_callback` was expecting unicode, but getting bytes.

https://pagure.io/freeipa/issue/5990