### PR TITLE
README: Fix trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ http://www.freeipa.org/page/Quick_Start_Guide
 * Building FreeIPA from source
     * http://www.freeipa.org/page/Build
     * See the BUILD.txt file in the source root directory
- 
+
 ## Licensing
 
 Please see the file called COPYING.


### PR DESCRIPTION
be2fba0 introduced a trailing whitespace in our README.md, this
patch removes it