### PR TITLE
WebUI: Cockpit integration

### DIFF
--- a/install/ui/src/freeipa/widget.js
+++ b/install/ui/src/freeipa/widget.js
@@ -5209,6 +5209,7 @@ IPA.link_widget = function(spec) {
         that.link.text('');
     };
 
+    that.create_link = that.create;
 
     return that;
 };

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -593,6 +593,14 @@ class i18n_messages(Command):
             "host": {
                 "certificate": _("Host Certificate"),
                 "cn": _("Host Name"),
+                "cockpit_title": _("Cockpit"),
+                "cockpit_detected": _(
+                    "Cockpit has been detected on host."
+                ),
+                "cockpit_not_detected": _(
+                    "Cockpit has not been detected on ${host}."
+                ),
+                "cockpit_link": _("[Open Cockpit]"),
                 "delete_key_unprovision": _("Delete Key, Unprovision"),
                 "details": _("Host Settings"),
                 "enrolled": _("Enrolled"),


### PR DESCRIPTION
Link to the cockpit is placed to each host details page in case
the Cockpit is installed on the server.

Showing or hiding cockpit link is possible because of Cockpit's API
which provides public URL for check whether Cockpit is the software
which listen on given port.

https://pagure.io/freeipa/issue/4891