### PR TITLE
WebUI: fix jslint error

### DIFF
--- a/install/ui/src/freeipa/field.js
+++ b/install/ui/src/freeipa/field.js
@@ -1080,7 +1080,7 @@ field.validator = IPA.validator = function(spec) {
             return integer_check;
         }
 
-        var num = parseInt(value);
+        var num = parseInt(value, 10);
 
         if (num <= 0) {
             return that.false_result(


### PR DESCRIPTION
jslint warned about parsing string to integer without explicit radix.
This error was introduced in commit 3cac851.

The PR is without ticket as it is only one liner.