### PR TITLE
install: allow specifying external CA template

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -320,8 +320,7 @@ Requires(preun): python systemd-units
 Requires(postun): python systemd-units
 Requires: policycoreutils >= 2.1.12-5
 Requires: tar
-# certmonger-0.79.4-2 fixes newlines in PEM files
-Requires(pre): certmonger >= 0.79.4-2
+Requires(pre): certmonger >= 0.79.5-1
 Requires(pre): 389-ds-base >= 1.3.5.14
 Requires: fontawesome-fonts
 Requires: open-sans-fonts
@@ -540,8 +539,7 @@ Requires: libcurl >= 7.21.7-2
 Requires: xmlrpc-c >= 1.27.4
 Requires: sssd >= 1.14.0
 Requires: python-sssdconfig
-# certmonger-0.79.4-2 fixes newlines in PEM files
-Requires: certmonger >= 0.79.4-2
+Requires: certmonger >= 0.79.5-1
 Requires: nss-tools
 Requires: bind-utils
 Requires: oddjob-mkhomedir

--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -64,7 +64,7 @@ def parse_options():
                       default=False, help="unattended installation never prompts the user")
     parser.add_option("--external-ca", dest="external_ca", action="store_true",
                       default=False, help="Generate a CSR to be signed by an external CA")
-    ext_cas = ("generic", "ms-cs")
+    ext_cas = tuple(x.value for x in cainstance.ExternalCAType)
     parser.add_option("--external-ca-type", dest="external_ca_type",
                       type="choice", choices=ext_cas,
                       metavar="{{{0}}}".format(",".join(ext_cas)),

--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -69,6 +69,11 @@ def parse_options():
                       type="choice", choices=ext_cas,
                       metavar="{{{0}}}".format(",".join(ext_cas)),
                       help="Type of the external CA. Default: generic")
+    parser.add_option("--external-ca-profile", dest="external_ca_profile",
+                      type='constructor', constructor=cainstance.ExternalCAProfile,
+                      default=None, metavar="PROFILE-SPEC",
+                      help="Specify the certificate profile/template to use "
+                           "at the external CA")
     parser.add_option("--external-cert-file", dest="external_cert_files",
                       action="append", metavar="FILE",
                       help="File containing the IPA CA certificate and the external CA certificate chain")
@@ -115,6 +120,11 @@ def parse_options():
         if options.external_ca_type and not options.external_ca:
             parser.error(
                 "You cannot specify --external-ca-type without --external-ca")
+
+        if options.external_ca_profile and not options.external_ca:
+            parser.error(
+                "You cannot specify --external-ca-profile "
+                "without --external-ca")
 
     return safe_options, options, filename
 

--- a/install/tools/man/ipa-ca-install.1
+++ b/install/tools/man/ipa-ca-install.1
@@ -48,7 +48,26 @@ Admin user Kerberos password used for connection check
 Generate a CSR for the IPA CA certificate to be signed by an external CA.
 .TP
 \fB\-\-external\-ca\-type\fR=\fITYPE\fR
-Type of the external CA. Possible values are "generic", "ms-cs". Default value is "generic". Use "ms-cs" to include template name required by Microsoft Certificate Services (MS CS) in the generated CSR.
+Type of the external CA. Possible values are "generic", "ms-cs". Default value is "generic". Use "ms-cs" to include the template name required by Microsoft Certificate Services (MS CS) in the generated CSR (see \fB\-\-external\-ca\-profile\fR for full details).
+
+.TP
+\fB\-\-external\-ca\-profile\fR=\fIPROFILE_SPEC\fR
+Specify the certificate profile or template to use at the external CA.
+
+When \fB\-\-external\-ca\-type\fR is "ms-cs" the following specifiers may be used:
+
+.RS
+.TP
+\fB<oid>:<majorVersion>[:<minorVersion>]\fR
+Specify a certificate template by OID and major version, optionally also specifying minor version.
+.TP
+\fB<name>\fR
+Specify a certificate template by name.  The name cannot contain any \fI:\fR characters and cannot be an OID (otherwise the OID-based template specifier syntax takes precedence).
+.TP
+\fBdefault\fR
+If no template is specified, the template name "SubCA" is used.
+.RE
+
 .TP
 \fB\-\-external\-cert\-file\fR=\fIFILE\fR
 File containing the IPA CA certificate and the external CA certificate chain. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times.

--- a/install/tools/man/ipa-cacert-manage.1
+++ b/install/tools/man/ipa-cacert-manage.1
@@ -79,7 +79,26 @@ Sign the renewed certificate by itself.
 Sign the renewed certificate by external CA.
 .TP
 \fB\-\-external\-ca\-type\fR=\fITYPE\fR
-Type of the external CA. Possible values are "generic", "ms-cs". Default value is "generic". Use "ms-cs" to include template name required by Microsoft Certificate Services (MS CS) in the generated CSR.
+Type of the external CA. Possible values are "generic", "ms-cs". Default value is "generic". Use "ms-cs" to include the template name required by Microsoft Certificate Services (MS CS) in the generated CSR (see \fB\-\-external\-ca\-profile\fR for full details).
+
+.TP
+\fB\-\-external\-ca\-profile\fR=\fIPROFILE_SPEC\fR
+Specify the certificate profile or template to use at the external CA.
+
+When \fB\-\-external\-ca\-type\fR is "ms-cs" the following specifiers may be used:
+
+.RS
+.TP
+\fB<oid>:<majorVersion>[:<minorVersion>]\fR
+Specify a certificate template by OID and major version, optionally also specifying minor version.
+.TP
+\fB<name>\fR
+Specify a certificate template by name.  The name cannot contain any \fI:\fR characters and cannot be an OID (otherwise the OID-based template specifier syntax takes precedence).
+.TP
+\fBdefault\fR
+If no template is specified, the template name "SubCA" is used.
+.RE
+
 .TP
 \fB\-\-external\-cert\-file\fR=\fIFILE\fR
 File containing the IPA CA certificate and the external CA certificate chain. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times.

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -87,7 +87,26 @@ The path to LDIF file that will be used to modify configuration of dse.ldif duri
 Generate a CSR for the IPA CA certificate to be signed by an external CA.
 .TP
 \fB\-\-external\-ca\-type\fR=\fITYPE\fR
-Type of the external CA. Possible values are "generic", "ms-cs". Default value is "generic". Use "ms-cs" to include template name required by Microsoft Certificate Services (MS CS) in the generated CSR.
+Type of the external CA. Possible values are "generic", "ms-cs". Default value is "generic". Use "ms-cs" to include the template name required by Microsoft Certificate Services (MS CS) in the generated CSR (see \fB\-\-external\-ca\-profile\fR for full details).
+
+.TP
+\fB\-\-external\-ca\-profile\fR=\fIPROFILE_SPEC\fR
+Specify the certificate profile or template to use at the external CA.
+
+When \fB\-\-external\-ca\-type\fR is "ms-cs" the following specifiers may be used:
+
+.RS
+.TP
+\fB<oid>:<majorVersion>[:<minorVersion>]\fR
+Specify a certificate template by OID and major version, optionally also specifying minor version.
+.TP
+\fB<name>\fR
+Specify a certificate template by name.  The name cannot contain any \fI:\fR characters and cannot be an OID (otherwise the OID-based template specifier syntax takes precedence).
+.TP
+\fBdefault\fR
+If no template is specified, the template name "SubCA" is used.
+.RE
+
 .TP
 \fB\-\-external\-cert\-file\fR=\fIFILE\fR
 File containing the IPA CA certificate and the external CA certificate chain. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times.

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -286,6 +286,7 @@ IPA_CA_CN = u'ipa'
 IPA_CA_RECORD = "ipa-ca"
 IPA_CA_NICKNAME = 'caSigningCert cert-pki-ca'
 RENEWAL_CA_NAME = 'dogtag-ipa-ca-renew-agent'
+RENEWAL_REUSE_CA_NAME = 'dogtag-ipa-ca-renew-agent-reuse'
 
 # regexp definitions
 PATTERN_GROUPUSER_NAME = '^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$'

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -508,14 +508,14 @@ def stop_tracking(secdir=None, request_id=None, nickname=None, certfile=None):
 
 
 def modify(request_id, ca=None, profile=None):
-    if ca or profile:
+    update = {}
+    if ca is not None:
+        cm = _certmonger()
+        update['CA'] = cm.obj_if.find_ca_by_nickname(ca)
+    if profile is not None:
+        update['template-profile'] = profile
+    if len(update) > 0:
         request = _get_request({'nickname': request_id})
-        update = {}
-        if ca is not None:
-            cm = _certmonger()
-            update['CA'] = cm.obj_if.find_ca_by_nickname(ca)
-        if profile is not None:
-            update['template-profile'] = profile
         request.obj_if.modify(update)
 
 
@@ -528,16 +528,17 @@ def resubmit_request(request_id, ca=None, profile=None, is_ca=False):
     """
     request = _get_request({'nickname': request_id})
     if request:
-        if ca or profile or is_ca:
-            update = {}
-            if ca is not None:
-                cm = _certmonger()
-                update['CA'] = cm.obj_if.find_ca_by_nickname(ca)
-            if profile is not None:
-                update['template-profile'] = profile
-            if is_ca:
-                update['template-is-ca'] = True
-                update['template-ca-path-length'] = -1  # no path length
+        update = {}
+        if ca is not None:
+            cm = _certmonger()
+            update['CA'] = cm.obj_if.find_ca_by_nickname(ca)
+        if profile is not None:
+            update['template-profile'] = profile
+        if is_ca:
+            update['template-is-ca'] = True
+            update['template-ca-path-length'] = -1  # no path length
+
+        if len(update) > 0:
             request.obj_if.modify(update)
         request.obj_if.resubmit()
 

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -507,23 +507,36 @@ def stop_tracking(secdir=None, request_id=None, nickname=None, certfile=None):
         request.parent.obj_if.remove_request(request.path)
 
 
-def modify(request_id, ca=None, profile=None):
+def modify(request_id, ca=None, profile=None, template_v2=None):
     update = {}
     if ca is not None:
         cm = _certmonger()
         update['CA'] = cm.obj_if.find_ca_by_nickname(ca)
     if profile is not None:
         update['template-profile'] = profile
+    if template_v2 is not None:
+        update['template-ms-certificate-template'] = template_v2
+
     if len(update) > 0:
         request = _get_request({'nickname': request_id})
         request.obj_if.modify(update)
 
 
-def resubmit_request(request_id, ca=None, profile=None, is_ca=False):
+def resubmit_request(
+        request_id,
+        ca=None,
+        profile=None,
+        template_v2=None,
+        is_ca=False):
     """
     :param request_id: the certmonger numeric request ID
     :param ca: the nickname for the certmonger CA, e.g. IPA or SelfSign
-    :param profile: the dogtag template profile to use, e.g. SubCA
+    :param profile: the profile to use, e.g. SubCA.  For requests using the
+                    Dogtag CA, this is the profile to use.  This also causes
+                    the Microsoft certificate tempalte name extension to the
+                    CSR (for telling AD CS what template to use).
+    :param template_v2: Microsoft V2 template specifier extension value.
+                        Format: <oid>:<major-version>[:<minor-version>]
     :param is_ca: boolean that if True adds the CA basic constraint
     """
     request = _get_request({'nickname': request_id})
@@ -534,6 +547,8 @@ def resubmit_request(request_id, ca=None, profile=None, is_ca=False):
             update['CA'] = cm.obj_if.find_ca_by_nickname(ca)
         if profile is not None:
             update['template-profile'] = profile
+        if template_v2 is not None:
+            update['template-ms-certificate-template'] = template_v2
         if is_ca:
             update['template-is-ca'] = True
             update['template-ca-path-length'] = -1  # no path length

--- a/ipapython/config.py
+++ b/ipapython/config.py
@@ -79,16 +79,28 @@ def check_dn_option(option, opt, value):
     except Exception as e:
         raise OptionValueError("option %s: invalid DN: %s" % (opt, e))
 
+
+def check_constructor(option, opt, value):
+    con = option.constructor
+    assert con is not None, "Oops! Developer forgot to set 'constructor' kwarg"
+    try:
+        return con(value)
+    except Exception as e:
+        raise OptionValueError("option {} invalid: {}".format(opt, e))
+
+
 class IPAOption(Option):
     """
     optparse.Option subclass with support of options labeled as
     security-sensitive such as passwords.
     """
-    ATTRS = Option.ATTRS + ["sensitive"]
-    TYPES = Option.TYPES + ("ip", "dn")
+    ATTRS = Option.ATTRS + ["sensitive", "constructor"]
+    TYPES = Option.TYPES + ("ip", "dn", "constructor")
     TYPE_CHECKER = copy(Option.TYPE_CHECKER)
     TYPE_CHECKER["ip"] = check_ip_option
     TYPE_CHECKER["dn"] = check_dn_option
+    TYPE_CHECKER["constructor"] = check_constructor
+
 
 class IPAOptionParser(OptionParser):
     """

--- a/ipapython/install/cli.py
+++ b/ipapython/install/cli.py
@@ -8,7 +8,6 @@ Command line support.
 
 import collections
 import enum
-import functools
 import logging
 import optparse  # pylint: disable=deprecated-module
 import signal
@@ -105,17 +104,6 @@ def uninstall_tool(configurable_class, command_name, log_file_name,
     )
 
 
-def _option_callback(action, option, opt_str, value, parser, opt_type):
-    try:
-        value = opt_type(value)
-    except ValueError as e:
-        raise optparse.OptionValueError(
-            "option {0}: {1}".format(opt_str, e))
-
-    option.take_action(
-        action, option.dest, opt_str, value, parser.values, parser)
-
-
 class ConfigureTool(admintool.AdminTool):
     configurable_class = None
     debug_option = False
@@ -186,24 +174,16 @@ class ConfigureTool(admintool.AdminTool):
                 kwargs['metavar'] = "{{{0}}}".format(
                                                 ",".join(kwargs['choices']))
             else:
-                kwargs['nargs'] = 1
-                kwargs['callback_args'] = (knob_scalar_type,)
+                kwargs['type'] = 'constructor'
+                kwargs['constructor'] = knob_scalar_type
             kwargs['dest'] = name
             if issubclass(knob_type, list):
-                if 'type' not in kwargs:
-                    kwargs['action'] = 'callback'
-                    kwargs['callback'] = (
-                        functools.partial(_option_callback, 'append'))
-                elif kwargs['type'] is None:
+                if kwargs['type'] is None:
                     kwargs['action'] = 'append_const'
                 else:
                     kwargs['action'] = 'append'
             else:
-                if 'type' not in kwargs:
-                    kwargs['action'] = 'callback'
-                    kwargs['callback'] = (
-                        functools.partial(_option_callback, 'store'))
-                elif kwargs['type'] is None:
+                if kwargs['type'] is None:
                     kwargs['action'] = 'store_const'
                 else:
                     kwargs['action'] = 'store'

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -363,11 +363,6 @@ def uninstall():
         ca_instance.uninstall()
 
 
-class ExternalCAType(enum.Enum):
-    GENERIC = 'generic'
-    MS_CS = 'ms-cs'
-
-
 class CASigningAlgorithm(enum.Enum):
     SHA1_WITH_RSA = 'SHA1withRSA'
     SHA_256_WITH_RSA = 'SHA256withRSA'
@@ -413,7 +408,7 @@ class CAInstallInterface(dogtag.DogtagInstallInterface,
     external_ca = master_install_only(external_ca)
 
     external_ca_type = knob(
-        ExternalCAType, None,
+        cainstance.ExternalCAType, None,
         description="Type of the external CA",
     )
     external_ca_type = master_install_only(external_ca_type)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -25,6 +25,7 @@ import base64
 import logging
 
 import dbus
+import enum
 import ldap
 import os
 import pwd
@@ -93,6 +94,11 @@ ADMIN_GROUPS = [
     'Enterprise KRA Administrators',
     'Security Domain Administrators'
 ]
+
+
+class ExternalCAType(enum.Enum):
+    GENERIC = 'generic'
+    MS_CS = 'ms-cs'
 
 
 def check_port():
@@ -353,7 +359,7 @@ class CAInstance(DogtagInstance):
         if ca_type is not None:
             self.ca_type = ca_type
         else:
-            self.ca_type = 'generic'
+            self.ca_type = ExternalCAType.GENERIC.value
         self.no_db_setup = promote
         self.use_ldaps = use_ldaps
 
@@ -565,7 +571,7 @@ class CAInstance(DogtagInstance):
             config.set("CA", "pki_external", "True")
             config.set("CA", "pki_external_csr_path", self.csr_file)
 
-            if self.ca_type == 'ms-cs':
+            if self.ca_type == ExternalCAType.MS_CS.value:
                 # Include MS template name extension in the CSR
                 config.set("CA", "pki_req_ext_add", "True")
                 config.set("CA", "pki_req_ext_oid", "1.3.6.1.4.1.311.20.2")

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -22,6 +22,7 @@
 from __future__ import print_function
 
 import base64
+import binascii
 import logging
 
 import dbus
@@ -41,6 +42,9 @@ import six
 # pylint: disable=import-error
 from six.moves.configparser import RawConfigParser
 # pylint: enable=import-error
+from pyasn1.codec.der import encoder
+from pyasn1.type import char, univ, namedtype
+import pyasn1.error
 
 from ipalib import api
 from ipalib import x509
@@ -324,7 +328,8 @@ class CAInstance(DogtagInstance):
                            master_replication_port=None,
                            subject_base=None, ca_subject=None,
                            ca_signing_algorithm=None,
-                           ca_type=None, ra_p12=None, ra_only=False,
+                           ca_type=None, external_ca_profile=None,
+                           ra_p12=None, ra_only=False,
                            promote=False, use_ldaps=False):
         """Create a CA instance.
 
@@ -360,6 +365,8 @@ class CAInstance(DogtagInstance):
             self.ca_type = ca_type
         else:
             self.ca_type = ExternalCAType.GENERIC.value
+        self.external_ca_profile = external_ca_profile
+
         self.no_db_setup = promote
         self.use_ldaps = use_ldaps
 
@@ -573,10 +580,16 @@ class CAInstance(DogtagInstance):
 
             if self.ca_type == ExternalCAType.MS_CS.value:
                 # Include MS template name extension in the CSR
+                template = self.external_ca_profile
+                if template is None:
+                    # default template name
+                    template = MSCSTemplateV1(u"SubCA")
+
+                ext_data = binascii.hexlify(template.get_ext_data())
                 config.set("CA", "pki_req_ext_add", "True")
-                config.set("CA", "pki_req_ext_oid", "1.3.6.1.4.1.311.20.2")
+                config.set("CA", "pki_req_ext_oid", template.ext_oid)
                 config.set("CA", "pki_req_ext_critical", "False")
-                config.set("CA", "pki_req_ext_data", "1E0A00530075006200430041")
+                config.set("CA", "pki_req_ext_data", ext_data.decode('ascii'))
 
         elif self.external == 2:
             cert_file = tempfile.NamedTemporaryFile()
@@ -1877,6 +1890,168 @@ def update_ipa_conf():
     parser.remove_option('global', 'ca_host')
     with open(paths.IPA_DEFAULT_CONF, 'w') as f:
         parser.write(f)
+
+
+class ExternalCAProfile(object):
+    """
+    An external CA profile configuration.  Currently the only
+    subclasses are for Microsoft CAs, for providing data in the
+    "Certificate Template" extension.
+
+    Constructing this class will actually return an instance of a
+    subclass.
+
+    Subclasses MUST set ``valid_for``.
+
+    """
+    def __init__(self, s=None):
+        self.unparsed_input = s
+
+    # Which external CA types is the data valid for?
+    # A set of VALUES of the ExternalCAType enum.
+    valid_for = set()
+
+    def __new__(cls, s=None):
+        """Construct the ExternalCAProfile value.
+
+        Return an instance of a subclass determined by
+        the format of the argument.
+
+        """
+        # we are directly constructing a subclass; instantiate
+        # it and be done
+        if cls is not ExternalCAProfile:
+            return super(ExternalCAProfile, cls).__new__(cls)
+
+        # construction via the base class; therefore the string
+        # argument is required, and is used to determine which
+        # subclass to construct
+        if s is None:
+            raise ValueError('string argument is required')
+
+        parts = s.split(':')
+
+        try:
+            # Is the first part on OID?
+            _oid = univ.ObjectIdentifier(parts[0])
+
+            # It is; construct a V2 template
+            return MSCSTemplateV2.__new__(MSCSTemplateV2, s)
+
+        except pyasn1.error.PyAsn1Error:
+            # It is not an OID; treat as a template name
+            return MSCSTemplateV1.__new__(MSCSTemplateV1, s)
+
+    def __getstate__(self):
+        return self.unparsed_input
+
+    def __setstate__(self, state):
+        # explicitly call __init__ method to initialise object
+        self.__init__(state)
+
+
+class MSCSTemplate(ExternalCAProfile):
+    """
+    An Microsoft AD-CS Template specifier.
+
+    Subclasses MUST set ext_oid.
+
+    Subclass constructors MUST set asn1obj.
+
+    """
+    valid_for = set([ExternalCAType.MS_CS.value])
+
+    ext_oid = None  # extension OID, as a Python str
+    asn1obj = None  # unencoded extension data
+
+    def get_ext_data(self):
+        """Return DER-encoded extension data."""
+        return encoder.encode(self.asn1obj)
+
+
+class MSCSTemplateV1(MSCSTemplate):
+    """
+    A v1 template specifier, per
+    https://msdn.microsoft.com/en-us/library/cc250011.aspx.
+
+    ::
+
+        CertificateTemplateName ::= SEQUENCE {
+           Name            UTF8String
+        }
+
+    But note that a bare BMPString is used in practice.
+
+    """
+    ext_oid = "1.3.6.1.4.1.311.20.2"
+
+    def __init__(self, s):
+        super(MSCSTemplateV1, self).__init__(s)
+        parts = s.split(':')
+        if len(parts) > 1:
+            raise ValueError(
+                "Cannot specify certificate template version when using name.")
+        self.asn1obj = char.BMPString(six.text_type(parts[0]))
+
+
+class MSCSTemplateV2(MSCSTemplate):
+    """
+    A v2 template specifier, per
+    https://msdn.microsoft.com/en-us/library/windows/desktop/aa378274(v=vs.85).aspx
+
+    ::
+
+        CertificateTemplate ::= SEQUENCE {
+            templateID              EncodedObjectID,
+            templateMajorVersion    TemplateVersion,
+            templateMinorVersion    TemplateVersion OPTIONAL
+        }
+
+        TemplateVersion ::= INTEGER (0..4294967295)
+
+    """
+    ext_oid = "1.3.6.1.4.1.311.21.7"
+
+    @staticmethod
+    def check_version_in_range(desc, n):
+        if n < 0 or n >= 2**32:
+            raise ValueError(
+                "Template {} version must be in range 0..4294967295"
+                .format(desc))
+
+    def __init__(self, s):
+        super(MSCSTemplateV2, self).__init__(s)
+
+        parts = s.split(':')
+
+        obj = CertificateTemplateV2()
+        if len(parts) < 2 or len(parts) > 3:
+            raise ValueError(
+                "Incorrect template specification; required format is: "
+                "<oid>:<majorVersion>[:<minorVersion>]")
+        try:
+            obj['templateID'] = univ.ObjectIdentifier(parts[0])
+
+            major = int(parts[1])
+            self.check_version_in_range("major", major)
+            obj['templateMajorVersion'] = major
+
+            if len(parts) > 2:
+                minor = int(parts[2])
+                self.check_version_in_range("minor", minor)
+                obj['templateMinorVersion'] = int(parts[2])
+
+        except pyasn1.error.PyAsn1Error:
+            raise ValueError("Could not parse certificate template specifier.")
+        self.asn1obj = obj
+
+
+class CertificateTemplateV2(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('templateID', univ.ObjectIdentifier()),
+        namedtype.NamedType('templateMajorVersion', univ.Integer()),
+        namedtype.OptionalNamedType('templateMinorVersion', univ.Integer())
+    )
 
 
 if __name__ == "__main__":

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -60,7 +60,7 @@ class CACertManage(admintool.AdminTool):
             "--self-signed", dest='self_signed',
             action='store_true',
             help="Sign the renewed certificate by itself")
-        ext_cas = ("generic", "ms-cs")
+        ext_cas = tuple(x.value for x in cainstance.ExternalCAType)
         renew_group.add_option(
             "--external-ca-type", dest="external_ca_type",
             type="choice", choices=ext_cas,
@@ -191,7 +191,8 @@ class CACertManage(admintool.AdminTool):
     def renew_external_step_1(self, ca):
         print("Exporting CA certificate signing request, please wait")
 
-        if self.options.external_ca_type == 'ms-cs':
+        if self.options.external_ca_type \
+                == cainstance.ExternalCAType.MS_CS.value:
             profile = 'SubCA'
         else:
             profile = ''

--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -437,6 +437,11 @@ class ServerInstallInterface(ServerCertificateInstallInterface,
                     "You cannot specify --external-ca-type without "
                     "--external-ca")
 
+            if self.external_ca_profile and not self.external_ca:
+                raise RuntimeError(
+                    "You cannot specify --external-ca-profile without "
+                    "--external-ca")
+
             if self.uninstalling:
                 if (self.realm_name or self.admin_password or
                         self.master_password):

--- a/ipatests/test_ipaserver/test_install/test_cainstance.py
+++ b/ipatests/test_ipaserver/test_install/test_cainstance.py
@@ -1,0 +1,125 @@
+#
+# Copyright (C) 2017  FreeIPA Contributors see COPYING for license
+#
+
+from binascii import hexlify
+import pickle
+# pylint: disable=import-error
+from six.moves.configparser import RawConfigParser
+# pylint: enable=import-error
+from six import StringIO
+import pytest
+from ipaserver.install import cainstance
+
+pytestmark = pytest.mark.tier0
+
+
+class test_ExternalCAProfile(object):
+    def test_MSCSTemplateV1_good(self):
+        o = cainstance.MSCSTemplateV1("MySubCA")
+        assert hexlify(o.get_ext_data()) == b'1e0e004d007900530075006200430041'
+
+    def test_MSCSTemplateV1_bad(self):
+        with pytest.raises(ValueError):
+            cainstance.MSCSTemplateV1("MySubCA:1")
+
+    def test_MSCSTemplateV1_pickle_roundtrip(self):
+        o = cainstance.MSCSTemplateV1("MySubCA")
+        s = pickle.dumps(o)
+        assert o.get_ext_data() == pickle.loads(s).get_ext_data()
+
+    def test_MSCSTemplateV2_too_few_parts(self):
+        with pytest.raises(ValueError):
+            cainstance.MSCSTemplateV2("1.2.3.4")
+
+    def test_MSCSTemplateV2_too_many_parts(self):
+        with pytest.raises(ValueError):
+            cainstance.MSCSTemplateV2("1.2.3.4:100:200:300")
+
+    def test_MSCSTemplateV2_bad_oid(self):
+        with pytest.raises(ValueError):
+            cainstance.MSCSTemplateV2("not_an_oid:1")
+
+    def test_MSCSTemplateV2_non_numeric_major_version(self):
+        with pytest.raises(ValueError):
+            cainstance.MSCSTemplateV2("1.2.3.4:major:200")
+
+    def test_MSCSTemplateV2_non_numeric_minor_version(self):
+        with pytest.raises(ValueError):
+            cainstance.MSCSTemplateV2("1.2.3.4:100:minor")
+
+    def test_MSCSTemplateV2_major_version_lt_zero(self):
+        with pytest.raises(ValueError):
+            cainstance.MSCSTemplateV2("1.2.3.4:-1:200")
+
+    def test_MSCSTemplateV2_minor_version_lt_zero(self):
+        with pytest.raises(ValueError):
+            cainstance.MSCSTemplateV2("1.2.3.4:100:-1")
+
+    def test_MSCSTemplateV2_major_version_gt_max(self):
+        with pytest.raises(ValueError):
+            cainstance.MSCSTemplateV2("1.2.3.4:4294967296:200")
+
+    def test_MSCSTemplateV2_minor_version_gt_max(self):
+        with pytest.raises(ValueError):
+            cainstance.MSCSTemplateV2("1.2.3.4:100:4294967296")
+
+    def test_MSCSTemplateV2_good_major(self):
+        o = cainstance.MSCSTemplateV2("1.2.3.4:4294967295")
+        assert hexlify(o.get_ext_data()) == b'300c06032a0304020500ffffffff'
+
+    def test_MSCSTemplateV2_good_major_minor(self):
+        o = cainstance.MSCSTemplateV2("1.2.3.4:4294967295:0")
+        assert hexlify(o.get_ext_data()) \
+            == b'300f06032a0304020500ffffffff020100'
+
+    def test_MSCSTemplateV2_pickle_roundtrip(self):
+        o = cainstance.MSCSTemplateV2("1.2.3.4:4294967295:0")
+        s = pickle.dumps(o)
+        assert o.get_ext_data() == pickle.loads(s).get_ext_data()
+
+    def test_ExternalCAProfile_dispatch(self):
+        """
+        Test that constructing ExternalCAProfile actually returns an
+        instance of the appropriate subclass.
+        """
+        assert isinstance(
+            cainstance.ExternalCAProfile("MySubCA"),
+            cainstance.MSCSTemplateV1)
+        assert isinstance(
+            cainstance.ExternalCAProfile("1.2.3.4:100"),
+            cainstance.MSCSTemplateV2)
+
+    def test_write_pkispawn_config_file_MSCSTemplateV1(self):
+        template = cainstance.MSCSTemplateV1(u"SubCA")
+        expected = (
+            '[CA]\n'
+            'pki_req_ext_oid = 1.3.6.1.4.1.311.20.2\n'
+            'pki_req_ext_data = 1e0a00530075006200430041\n\n'
+        )
+        self._test_write_pkispawn_config_file(template, expected)
+
+    def test_write_pkispawn_config_file_MSCSTemplateV2(self):
+        template = cainstance.MSCSTemplateV2(u"1.2.3.4:4294967295")
+        expected = (
+            '[CA]\n'
+            'pki_req_ext_oid = 1.3.6.1.4.1.311.21.7\n'
+            'pki_req_ext_data = 300c06032a0304020500ffffffff\n\n'
+        )
+        self._test_write_pkispawn_config_file(template, expected)
+
+    def _test_write_pkispawn_config_file(self, template, expected):
+        """
+        Test that the values we read from an ExternalCAProfile
+        object can be used to produce a reasonable-looking pkispawn
+        configuration.
+        """
+        config = RawConfigParser()
+        config.optionxform = str
+        config.add_section("CA")
+        config.set("CA", "pki_req_ext_oid", template.ext_oid)
+        config.set("CA", "pki_req_ext_data",
+                   hexlify(template.get_ext_data()).decode('ascii'))
+        out = StringIO()
+        config.write(out)
+        assert out.getvalue() == expected


### PR DESCRIPTION
This PR allow an admin to specify an AD-CS target certificate template
by name or OID, via the new option --external-ca-profile.
The profile may be specified by name (string) or OID + version + optional minor version.

https://pagure.io/freeipa/issue/6858

The approach is:

1. preliminary refactor to the IPAOptionParser to allow easily specifying a custom
data constructor (this is used for the data type that holds the template specifier).

2. refactor to reduce duplication of external CA type enum values.

3. the main thing:
   - add data type for template specifier
   - add ipa-server-install `--external-ca-profile` CLI option
   - update CA installation to add the appropriate *pkispawn* config based on the template
    specifier
   - update *ipa-server-install* man page

4. add the `external-ca-profile` option to *ipa-ca-install* and update man page.

5. update ipa-cacert-manage to be able to specify the new options

6. tests, minor fixes and cleanups

**NOTE FOR TESTERS**

*python-cryptography* had a bug parsing long OIDs.  AD-CS creates and uses OIDs long enough to trigger the bug as a matter of course.  The bug is fixed as of v1.9.  **f26** and **f27**
include a fixed version.

certmonger-0.79.5 is required.  It is available for **f27** and a build for f26 is available in
the **freeipa-master COPR**.

**HOW TO TEST**

1. Install AD-CS in a Windows machine and create a custom profile by copying the *SubCA*
profile.

2. Two-step external CA ipa-server-install:

```
$ ipa-server-install \
    --external-ca --external-ca-type=ms-cs \
    --external-ca-profile=1.3.6.1.4.1.311.21.8.8950086.10656446.2706058.12775672.480128.147.7130143.4405632:1
```

(Use the actual OID of the custom profile).  If everything works, hooray!

3. Start over with ca-less deployment.  Then add CA via ``ipa-ca-install --external-ca-... # as before``.
  If everything works, hooray.

4. test that `ipa-cacert-manage renew` with the new options results in the template extensions being included in the new CSR.