### PR TITLE
ipactl: log check_version exception

### DIFF
--- a/install/tools/ipactl
+++ b/install/tools/ipactl
@@ -138,7 +138,8 @@ def version_check():
     try:
         installutils.check_version()
     except (installutils.UpgradeMissingVersionError,
-            installutils.UpgradeDataOlderVersionError):
+            installutils.UpgradeDataOlderVersionError) as exc:
+        emit_err("IPA version error: %s" % exc)
         emit_err("Upgrade required: please run ipa-server-upgrade command")
         raise IpactlError("Aborting ipactl")
     except installutils.UpgradeVersionError as e:


### PR DESCRIPTION
When version is mismatched and ipa-server-upgrade is required,
log the version mismatch properly in journal.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>