### PR TITLE
replica-conncheck: log when failed to RPC connect

### DIFF
--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -589,7 +589,8 @@ def main():
                     finally:
                         if api.Backend.rpcclient.isconnected():
                             api.Backend.rpcclient.disconnect()
-            except Exception:
+            except Exception as e:
+                logger.debug("RPC connection failed: %s", e)
                 logger.info("Retrying using SSH...")
 
                 # Ticket 5812 Always qualify requests for admin


### PR DESCRIPTION
It's nearly impossible to find out what happened when doing
replica connection check and it fails during the RPC phase.
The error is now logged.