### PR TITLE
Checks if Directory Server is installed and running before installation

### DIFF
--- a/ipaplatform/redhat/services.py
+++ b/ipaplatform/redhat/services.py
@@ -121,6 +121,10 @@ class RedHatDirectoryService(RedHatService):
 
         return True
 
+    def is_installed(self, instance_name):
+        file_path = "{}/{}-{}".format(paths.ETC_DIRSRV, "slapd", instance_name)
+        return os.path.exists(file_path)
+
     def restart(self, instance_name="", capture_output=True, wait=True,
                 ldapi=False):
     # We need to explicitly enable instances to install proper symlinks as

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -618,6 +618,14 @@ def install_check(installer):
         # check addresses here, dns module is doing own check
         no_matching_interface_for_ip_address_warning(ip_addresses)
 
+    instance_name = "-".join(realm_name.split("."))
+    dirsrv = services.knownservices.dirsrv
+    if (options.external_cert_files
+           and dirsrv.is_installed(instance_name)
+           and not dirsrv.is_running(instance_name)):
+        logger.debug('Starting Directory Server')
+        services.knownservices.dirsrv.start(instance_name)
+
     if options.setup_adtrust:
         adtrust.install_check(False, options, api)
 


### PR DESCRIPTION
In cases when IPA is installed in two steps (external CA), it's necessary to check (in the second step) if Directory Server is running and if it's installed before continue with the IPA installation.

Fixes: https://pagure.io/freeipa/issue/6611