### PR TITLE
Configuring log handlers during the validation of input parameters

### DIFF
--- a/ipapython/admintool.py
+++ b/ipapython/admintool.py
@@ -136,6 +136,8 @@ class AdminTool(object):
         :param argv: Command-line arguments.
         :return: Command exit code
         """
+        standard_logging_setup(None, verbose=True)
+
         if cls not in cls._option_parsers:
             # We use cls._option_parsers, a dictionary keyed on class, to check
             # if we need to create a parser. This is because cls.option_parser

--- a/ipapython/ipa_log_manager.py
+++ b/ipapython/ipa_log_manager.py
@@ -157,6 +157,7 @@ def standard_logging_setup(filename=None, verbose=False, debug=False,
 
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
+    root_logger.handlers = []
 
     # File output is always logged at debug level
     if filename is not None:


### PR DESCRIPTION
Previously, a log handler would be configured only after all the input parameters be validated, as can be checked in `ipapython/admintool.py::AdminTool::main`. So, any call to `logger.[warning,info,error,debug]`, during that phase, doesn't work and it also raises an exception. 

Now, log handlers are setup before the input parameters validation phase.

Fixes: https://pagure.io/freeipa/issue/7071