### PR TITLE
client: make ipa-client-install py3 compatible

### DIFF
--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -61,7 +61,7 @@ PEM = 0
 DER = 1
 
 PEM_REGEX = re.compile(
-    r'-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----',
+    b'-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----',
     re.DOTALL)
 
 EKU_SERVER_AUTH = '1.3.6.1.5.5.7.3.1'

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -298,7 +298,8 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                 obj += "trusted: true\n"
             elif trusted is False:
                 obj += "x-distrusted: true\n"
-            obj += "{pem}\n\n".format(pem=cert.public_bytes(x509.Encoding.PEM))
+            obj += "{pem}\n\n".format(
+                pem=cert.public_bytes(x509.Encoding.PEM).decode('ascii'))
             f.write(obj)
 
             if ext_key_usage is not None and public_key_info not in has_eku:


### PR DESCRIPTION
This commit enables ipa-client-install to be installable in
Python 3 and makes it run in Python 3 by default.

https://pagure.io/freeipa/issue/4985