### PR TITLE
Changing how commands handles error when it can't connect to IPA server

### DIFF
--- a/client/ipa-client-automount
+++ b/client/ipa-client-automount
@@ -46,6 +46,7 @@ from ipaclient.install import ipachangeconf, ipadiscovery
 from ipalib import api, errors
 from ipalib.install import sysrestore
 from ipalib.install.kinit import kinit_keytab
+from ipalib.util import check_client_configuration
 from ipapython import ipautil
 from ipapython.ipa_log_manager import standard_logging_setup
 from ipapython.dn import DN
@@ -53,6 +54,8 @@ from ipaplatform.constants import constants
 from ipaplatform.tasks import tasks
 from ipaplatform import services
 from ipaplatform.paths import paths
+from ipapython.admintool import ScriptError
+
 
 logger = logging.getLogger(os.path.basename(__file__))
 
@@ -376,11 +379,13 @@ def configure_nfs(fstore, statestore):
                      rpcgssd.service_name, str(e))
 
 def main():
+    try:
+        check_client_configuration()
+    except ScriptError as e:
+        sys.exit(e)
 
     fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
     statestore = sysrestore.StateFile(paths.IPA_CLIENT_SYSRESTORE)
-    if not fstore.has_files() and not os.path.exists(paths.IPA_DEFAULT_CONF):
-        sys.exit('IPA client is not configured on this system.\n')
 
     options, _args = parse_options()
 

--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -34,6 +34,7 @@ from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks
 from ipalib import api, errors, x509
 from ipalib.constants import IPA_CA_NICKNAME, RENEWAL_CA_NAME
+from ipalib.util import check_client_configuration
 
 logger = logging.getLogger(__name__)
 
@@ -50,11 +51,7 @@ class CertUpdate(admintool.AdminTool):
         super(CertUpdate, self).validate_options(needs_root=True)
 
     def run(self):
-        fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
-        if (not fstore.has_files() and
-            not os.path.exists(paths.IPA_DEFAULT_CONF)):
-            raise admintool.ScriptError(
-                "IPA client is not configured on this system.")
+        check_client_configuration()
 
         api.bootstrap(context='cli_installer', confdir=paths.ETC_IPA)
         api.finalize()

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -55,7 +55,9 @@ from ipalib.constants import CLI_TAB, LDAP_GENERALIZED_TIME_FORMAT
 from ipalib.parameters import File, Str, Enum, Any, Flag
 from ipalib.text import _
 from ipalib import api  # pylint: disable=unused-import
+from ipalib.util import check_client_configuration
 from ipapython.dnsutil import DNSName
+from ipapython.admintool import ScriptError
 
 import datetime
 
@@ -1346,6 +1348,12 @@ def run(api):
     error = None
     try:
         (_options, argv) = api.bootstrap_with_global_options(context='cli')
+
+        try:
+            check_client_configuration()
+        except ScriptError as e:
+            sys.exit(e)
+
         for klass in cli_plugins:
             api.add_plugin(klass)
         api.finalize()

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -55,10 +55,15 @@ from ipalib.constants import (
     TLS_VERSIONS, TLS_VERSION_MINIMAL, TLS_HIGH_CIPHERS
 )
 from ipalib.text import _
+# pylint: disable=ipa-forbidden-import
+from ipalib.install import sysrestore
+from ipaplatform.paths import paths
+# pylint: enable=ipa-forbidden-import
 from ipapython.ssh import SSHPublicKey
 from ipapython.dn import DN, RDN
 from ipapython.dnsutil import DNSName
 from ipapython.dnsutil import resolve_ip_addresses
+from ipapython.admintool import ScriptError
 
 if six.PY3:
     unicode = str
@@ -1067,6 +1072,15 @@ def ensure_krbcanonicalname_set(ldap, entry_attrs):
     old_entry.pop('objectclass', None)
 
     entry_attrs.update(old_entry)
+
+
+def check_client_configuration():
+    """
+    Check if IPA client is configured on the system.
+    """
+    fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
+    if not fstore.has_files() and not os.path.exists(paths.IPA_DEFAULT_CONF):
+        raise ScriptError('IPA client is not configured on this system')
 
 
 def check_principal_realm_in_trust_namespace(api_instance, *keys):


### PR DESCRIPTION
Checking if env has the server attribute. If it doesn't, it means that an IPA server was not configured.

https://pagure.io/freeipa/issue/6261