### PR TITLE
replica: fix SetuptoolsVersion comparison

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1116,7 +1116,7 @@ def promote_check(installer):
     installer._remote_api = remote_api
 
     with rpc_client(remote_api) as client:
-        check_remote_version(client, api.env.version)
+        check_remote_version(client, parse_version(api.env.version))
         check_remote_fips_mode(client, api.env.fips_mode)
 
     conn = remote_api.Backend.ldap2


### PR DESCRIPTION
Python 3 does not allow comparing SetuptoolsVersion and str
instances.

https://pagure.io/freeipa/issue/4985

-----------------------
Note that this does not allow full ipa-replica-install completion since that's now blocked by Custodia: https://bugzilla.redhat.com/show_bug.cgi?id=1476150