### PR TITLE
Enable replica installation on DL0

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -875,6 +875,7 @@ install/tools/ipa-compat-manage
 install/tools/ipa-dns-install
 install/tools/ipa-managed-entries
 install/tools/ipa-nis-manage
+install/tools/ipa-replica-prepare
 install/tools/ipactl
 '
 for P in $PY3_SUBST_PATHS; do

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -380,7 +380,7 @@ class CertDB(object):
             self.issue_server_cert(self.certreq_fname, self.certder_fname)
             self.import_cert(self.certder_fname, nickname)
 
-            with open(self.certder_fname, "r") as f:
+            with open(self.certder_fname, "rb") as f:
                 dercert = f.read()
                 return x509.load_der_x509_certificate(dercert)
         finally:
@@ -459,7 +459,7 @@ class CertDB(object):
 
         # Write the certificate to a file. It will be imported in a later
         # step. This file will be read later to be imported.
-        with open(cert_fname, "w") as f:
+        with open(cert_fname, "wb") as f:
             f.write(cert)
 
     def issue_signing_cert(self, certreq_fname, cert_fname):
@@ -503,7 +503,7 @@ class CertDB(object):
 
         # Write the certificate to a file. It will be imported in a later
         # step. This file will be read later to be imported.
-        with open(cert_fname, "w") as f:
+        with open(cert_fname, "wb") as f:
             f.write(cert)
 
     def add_cert(self, cert, nick, flags):


### PR DESCRIPTION
This patchset fixes the `ipa-replica-prepare` script and thus
enables running `ipa-replica-install` in DL0 successfully.
It then makes `ipa-replica-prepare` to be run in DL0 by
default.

https://pagure.io/freeipa/issue/4985