### PR TITLE
freeipa-pr-ci: enable pull-request CI

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,0 +1,24 @@
+jobs:
+  fedora-25/build:
+    requires: []
+    priority: 100
+    job:
+      class: Build
+      args:
+        git_repo: '{git_repo}'
+        git_refspec: '{git_refspec}'
+        template: &ci-master-f25
+          name: freeipa/ci-master-f25
+          version: 0.2.11
+        timeout: 1800
+
+  fedora-25/simple_replication:
+    requires: [fedora-25/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-25/build_url}'
+        test_suite: test_integration/test_simple_replication.py
+        template: *ci-master-f25
+        timeout: 3600


### PR DESCRIPTION
This config file defines jobs to be executed as a part of the
pull-request CI. For more information, see:

https://github.com/freeipa/freeipa-pr-ci
https://www.freeipa.org/page/V4/Pull-Request_CI

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>