### PR TITLE
DNS update: reduce timeout for CA records

### DIFF
--- a/ipaserver/dns_data_management.py
+++ b/ipaserver/dns_data_management.py
@@ -55,6 +55,8 @@ IPA_DEFAULT_NTP_SRV_REC = (
     (DNSName("_ntp._udp"), 123),
 )
 
+CA_RECORDS_DNS_TIMEOUT = 30  # timeout in seconds
+
 
 class IPADomainIsNotManagedByIPAError(Exception):
     pass
@@ -134,7 +136,7 @@ class IPASystemRecords(object):
         assert isinstance(hostname, DNSName) and hostname.is_absolute()
         r_name = DNSName('ipa-ca') + self.domain_abs
         rrsets = []
-        end_time = time() + 120  # timeout in seconds
+        end_time = time() + CA_RECORDS_DNS_TIMEOUT
         while time() < end_time:
             try:
                 rrsets = resolve_rrsets(hostname, (rdatatype.A, rdatatype.AAAA))


### PR DESCRIPTION
Timeout 120 seconds is quite long and it makes uninstallation too long
for. Given that this is non critical operation and may be executed
manually later, waiting 120 seconds is too much. Usually waiting longer
will not help at all to resolve missing record.

30 seconds is long enough 🕯