### PR TITLE
Misc Python 3 fixes for ipaserver.secrets

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -191,7 +191,8 @@ BuildRequires:  python2-yubico
 BuildRequires:  pki-base-python2
 BuildRequires:  python-pytest-multihost
 BuildRequires:  python-pytest-sourceorder
-BuildRequires:  python-jwcrypto
+# 0.4.2: Py3 fix https://bugzilla.redhat.com/show_bug.cgi?id=1476150
+BuildRequires:  python-jwcrypto >= 0.4.2
 # 0.3: sd_notify (https://pagure.io/freeipa/issue/5825)
 BuildRequires:  python2-custodia >= 0.3.1
 BuildRequires:  dbus-python
@@ -228,7 +229,8 @@ BuildRequires:  python3-yubico
 BuildRequires:  pki-base-python3
 BuildRequires:  python3-pytest-multihost
 BuildRequires:  python3-pytest-sourceorder
-BuildRequires:  python3-jwcrypto
+# 0.4.2: Py3 fix https://bugzilla.redhat.com/show_bug.cgi?id=1476150
+BuildRequires:  python3-jwcrypto >= 0.4.2
 # 0.3: sd_notify (https://pagure.io/freeipa/issue/5825)
 BuildRequires:  python3-custodia >= 0.3.1
 BuildRequires:  python3-dbus
@@ -679,7 +681,8 @@ Requires: python2-sss-murmur
 Requires: dbus-python
 Requires: python2-setuptools
 Requires: python-six
-Requires: python-jwcrypto
+# 0.4.2: Py3 fix https://bugzilla.redhat.com/show_bug.cgi?id=1476150
+Requires: python-jwcrypto >= 0.4.2
 Requires: python2-cffi
 Requires: python-ldap >= 2.4.15
 Requires: python2-requests
@@ -727,7 +730,8 @@ Requires: python3-sss-murmur
 Requires: python3-dbus
 Requires: python3-setuptools
 Requires: python3-six
-Requires: python3-jwcrypto
+# 0.4.2: Py3 fix https://bugzilla.redhat.com/show_bug.cgi?id=1476150
+Requires: python3-jwcrypto >= 0.4.2
 Requires: python3-cffi
 Requires: python3-pyldap >= 2.4.15
 Requires: python3-requests

--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -180,7 +180,7 @@ class CustodiaInstance(SimpleServiceInstance):
                 with open(pk12pwfile, 'w+') as f:
                     f.write(v['export password'])
                 pk12file = os.path.join(tmpnssdir, 'pk12file')
-                with open(pk12file, 'w+') as f:
+                with open(pk12file, 'wb') as f:
                     f.write(b64decode(v['pkcs12 data']))
                 ipautil.run([paths.PK12UTIL,
                              '-d', tmpdb.secdir,

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -73,6 +73,7 @@ PACKAGE_VERSION = {
     'ipaplatform': 'ipaplatform == {}'.format(VERSION),
     'ipapython': 'ipapython == {}'.format(VERSION),
     'ipaserver': 'ipaserver == {}'.format(VERSION),
+    'jwcrypto': 'jwcrpyto >= 0.4.2',
     'kdcproxy': 'kdcproxy >= 0.3',
     'netifaces': 'netifaces >= 0.10.4',
     'pyldap': 'pyldap >= 2.4.15',


### PR DESCRIPTION
bytes/str fixes for LDAP data, JSON encoding and temp files.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1476150