### PR TITLE
host, service: fix adding host/svc with a cert

### DIFF
--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -691,7 +691,6 @@ class host_add(LDAPCreate):
             # save the password so it can be displayed in post_callback
             setattr(context, 'randompassword', entry_attrs['userpassword'])
 
-        entry_attrs['usercertificate'] = options.get('usercertificate', [])
         entry_attrs['managedby'] = dn
         entry_attrs['objectclass'].append('ieee802device')
         entry_attrs['objectclass'].append('ipasshhost')

--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -623,8 +623,6 @@ class service_add(LDAPCreate):
 
         self.obj.validate_ipakrbauthzdata(entry_attrs)
 
-        entry_attrs['usercertificate'] = options.get('usercertificate', [])
-
         if not options.get('force', False):
             # We know the host exists if we've gotten this far but we
             # really want to discourage creating services for hosts that


### PR DESCRIPTION
ipaldap.LDAPEntry expects that entry attributes, if multi-valued,
are lists.

The recent cert refactoring made it possible to pass certificate
values from options directly to LDAPEntry instance but options
store multi-values as tuples. This caused crashes since the
whole tuple was stuck in a list instead of the values of the
tuples to be extracted in the list.

https://pagure.io/freeipa/issue/7077