### PR TITLE
py3 conncheck + service plugin fixes

### DIFF
--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -346,9 +346,9 @@ class PortResponder(threading.Thread):
                 sock.listen(1)
 
             logger.debug('%d %s: Started listening', port, proto)
-        except socket.error as e:
+        except socket.error:
             logger.warning('%d %s: Failed to bind', port, proto)
-            logger.debug("%s", traceback.format_exc(e))
+            logger.debug("%s", traceback.format_exc())
         else:
             self._sockets.append(sock)
 

--- a/ipapython/kerberos.py
+++ b/ipapython/kerberos.py
@@ -93,6 +93,18 @@ class Principal(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __lt__(self, other):
+        return unicode(self) < unicode(other)
+
+    def __le__(self, other):
+        return self.__lt__(other) or self.__eq__(other)
+
+    def __gt__(self, other):
+        return not self.__le__(other)
+
+    def __ge__(self, other):
+        return self.__gt__(other) or self.__eq__(other)
+
     def __hash__(self):
         return hash(self.components + (self.realm,))
 


### PR DESCRIPTION
commit 09942d0268f02ed15df5f7f3aad3220196c5a41c (HEAD -> py3-conncheck, private/py3-conncheck)
Author: Stanislav Laznicka <slaznick@redhat.com>
Date:   Wed Aug 2 16:05:16 2017 +0200

    conncheck: fix progression on failure
    
    traceback.format_exc() does not take exception object as an argument.
    This made Python 3 get stuck amid ipa-replica-conncheck, probably
    because it was waiting for a thread to finish.
    
    https://pagure.io/freeipa/issue/4985

commit fe820cbc1f3469150ab90af401b119d5d316f3ab
Author: Stanislav Laznicka <slaznick@redhat.com>
Date:   Wed Aug 2 15:59:39 2017 +0200

    kerberos: fix sorting Principal objects
    
    When service-find was issued under Python 3, the command fails
    because it tried to sort a list of Principal objects which was not
    possible.
    
    https://pagure.io/freeipa/issue/4985
