### PR TITLE
host_port_open: revert to old behavior where one iface is sufficient

### DIFF
--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -380,7 +380,8 @@ def port_check(host, port_list):
         try:
             port_open = ipautil.host_port_open(
                 host, port.port, port.port_type,
-                socket_timeout=CONNECT_TIMEOUT, log_errors=True)
+                socket_timeout=CONNECT_TIMEOUT, log_errors=True,
+                check_all_ifaces=True)
         except socket.gaierror:
             raise RuntimeError("Port check failed! Unable to resolve host name '%s'" % host)
         if port_open:

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -960,14 +960,16 @@ def user_input(prompt, default = None, allow_empty = True):
 
 
 def host_port_open(host, port, socket_type=socket.SOCK_STREAM,
-                   socket_timeout=None, log_errors=False):
+                   socket_timeout=None, log_errors=False,
+                   check_all_ifaces=False):
     """
     host: either hostname or IP address;
           if hostname is provided, port MUST be open on ALL resolved IPs
 
     returns True is port is open, False otherwise
     """
-    port_open = True
+    all_open = True
+    some_open = False
 
     # port has to be open on ALL resolved IPs
     for res in socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket_type):
@@ -984,9 +986,10 @@ def host_port_open(host, port, socket_type=socket.SOCK_STREAM,
             if socket_type == socket.SOCK_DGRAM:
                 s.send('')
                 s.recv(512)
-        except socket.error:
-            port_open = False
 
+            some_open = True
+        except socket.error:
+            all_open = False
             if log_errors:
                 msg = ('Failed to connect to port %(port)d %(proto)s on '
                        '%(addr)s' % dict(port=port,
@@ -1003,7 +1006,7 @@ def host_port_open(host, port, socket_type=socket.SOCK_STREAM,
             if s is not None:
                 s.close()
 
-    return port_open
+    return all_open if check_all_ifaces else some_open
 
 
 def reverse_record_exists(ip_address):


### PR DESCRIPTION
Commit a24cd01304aaef77b66d0e178585c9ec8bbce9b5

Changed behavior of host_port_open to require all discovered interfaces to
listed on the port.

But usage of host_port_open function in wait_for_open_ports function which is
indirectly used from service.start might be still ok with only one interface.

Requiring all interfaces might then cause issue(waiting till timeout) in IPA upgrader in specific DNS
or network setups.

https://pagure.io/freeipa/issue/7083