### PR TITLE
Log progress of wait_for_open_ports

### DIFF
--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -376,11 +376,16 @@ class PortResponder(threading.Thread):
 def port_check(host, port_list):
     ports_failed = []
     ports_udp_warning = []  # conncheck could not verify that port is open
+    log_level = {
+        SOCK_DGRAM: logging.WARNING,
+        SOCK_STREAM: logging.ERROR
+    }
     for port in port_list:
         try:
             port_open = ipautil.host_port_open(
                 host, port.port, port.port_type,
-                socket_timeout=CONNECT_TIMEOUT, log_errors=True)
+                socket_timeout=CONNECT_TIMEOUT, log_errors=True,
+                log_level=log_level[port.port_type])
         except socket.gaierror:
             raise RuntimeError("Port check failed! Unable to resolve host name '%s'" % host)
         if port_open:

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -1224,14 +1224,19 @@ def wait_for_open_ports(host, ports, timeout=0):
     op_timeout = time.time() + timeout
 
     for port in ports:
+        logger.debug('waiting for port: %s', port)
+        log_error = True
         while True:
-            port_open = host_port_open(host, port)
+            port_open = host_port_open(host, port, log_errors=log_error)
+            log_error = False  # Log only first err so that the log is readable
 
             if port_open:
+                logger.debug('SUCCESS: port: %s', port)
                 break
             if timeout and time.time() > op_timeout: # timeout exceeded
                 raise socket.timeout("Timeout exceeded")
             time.sleep(1)
+
 
 def wait_for_open_socket(socket_name, timeout=0):
     """

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -960,7 +960,8 @@ def user_input(prompt, default = None, allow_empty = True):
 
 
 def host_port_open(host, port, socket_type=socket.SOCK_STREAM,
-                   socket_timeout=None, log_errors=False):
+                   socket_timeout=None, log_errors=False,
+                   log_level=logging.DEBUG):
     """
     host: either hostname or IP address;
           if hostname is provided, port MUST be open on ALL resolved IPs
@@ -986,19 +987,12 @@ def host_port_open(host, port, socket_type=socket.SOCK_STREAM,
                 s.recv(512)
         except socket.error:
             port_open = False
-
             if log_errors:
-                msg = ('Failed to connect to port %(port)d %(proto)s on '
+                msg = ('Failed to connect to port %(port)s %(proto)s on '
                        '%(addr)s' % dict(port=port,
                                          proto=PROTOCOL_NAMES[socket_type],
                                          addr=sa[0]))
-
-                # Do not log udp failures as errors (to be consistent with
-                # the rest of the code that checks for open ports)
-                if socket_type == socket.SOCK_DGRAM:
-                    logger.warning('%s', msg)
-                else:
-                    logger.error('%s', msg)
+                logger.log(log_level, msg)
         finally:
             if s is not None:
                 s.close()


### PR DESCRIPTION
### control logging of host_port_open from caller

host_port_open copied logging behavior of ipa-replica-conncheck utility
which doesn't make it much reusable.

Now log level can be controlled from caller so other callers might use
other logging level without host_port_open guessing what was the
intention.

### log progress of wait_for_open_ports

To know what to focus on when some check fail. E.g. to detect that
IPv6 address or its resolution for localhost is misconfigured.

Also gradually increases wait time so that it won't log 600 same
messages when wait time is 600.

https://pagure.io/freeipa/issue/7083