### PR TITLE
schema cache: Generate help after fetching schema from server

### DIFF
--- a/ipaclient/remote_plugins/schema.py
+++ b/ipaclient/remote_plugins/schema.py
@@ -427,6 +427,7 @@ class Schema(object):
         except KeyError as e:
             logger.warning("Failed to fetch schema: %s", e)
             raise NotAvailable()
+        self._help = self._generate_help(self._dict)
 
         return (fp, ttl,)
 


### PR DESCRIPTION
When schema is not in cache and is fetched from server help must be generated
otherwise `ipa help` call fails with traceback.

https://pagure.io/freeipa/issue/7092