### PR TITLE
tests: Add LDAP URI to ldappasswd explicitelly

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1318,7 +1318,8 @@ def ldappasswd_user_change(user, oldpw, newpw, master):
     basedn = master.domain.basedn
 
     userdn = "uid={},{},{}".format(user, container_user, basedn)
+    master_ldap_uri = "ldap://{}".format(master.external_hostname)
 
     args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
-            '-s', newpw, '-x']
+            '-s', newpw, '-x', '-H', master_ldap_uri]
     master.run_command(args)

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -750,7 +750,7 @@ def unlock_principal_password(user, oldpw, newpw):
         user, api.env.container_user, api.env.basedn)
 
     args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
-            '-s', newpw, '-x']
+            '-s', newpw, '-x', '-H', api.env.ldap_uri]
     return run(args)
 
 


### PR DESCRIPTION
https://fedorahosted.org/freeipa/ticket/6622

This PR replaces PR #404 which is orphaned and I'm no longer able to push into it.