### PR TITLE
[ipa-4-5] Changing how commands handles error when it can't connect to IPA server

### DIFF
--- a/client/ipa-client-automount
+++ b/client/ipa-client-automount
@@ -45,6 +45,7 @@ from ipaclient.install import ipachangeconf, ipadiscovery
 from ipalib import api, errors
 from ipalib.install import sysrestore
 from ipalib.install.kinit import kinit_keytab
+from ipalib.util import check_client_configuration
 from ipapython import ipautil
 from ipapython.ipa_log_manager import root_logger, standard_logging_setup
 from ipapython.dn import DN
@@ -52,6 +53,8 @@ from ipaplatform.constants import constants
 from ipaplatform.tasks import tasks
 from ipaplatform import services
 from ipaplatform.paths import paths
+from ipapython.admintool import ScriptError
+
 
 def parse_options():
     usage = "%prog [options]\n"
@@ -367,11 +370,13 @@ def configure_nfs(fstore, statestore):
         root_logger.error("Failed to enable automatic startup of the %s daemon: %s" % (rpcgssd.service_name, str(e)))
 
 def main():
+    try:
+        check_client_configuration()
+    except ScriptError as e:
+        sys.exit(e)
 
     fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
     statestore = sysrestore.StateFile(paths.IPA_CLIENT_SYSRESTORE)
-    if not fstore.has_files() and not os.path.exists(paths.IPA_DEFAULT_CONF):
-        sys.exit('IPA client is not configured on this system.\n')
 
     options, _args = parse_options()
 

--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -33,6 +33,7 @@ from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks
 from ipalib import api, errors, x509
 from ipalib.constants import IPA_CA_NICKNAME, RENEWAL_CA_NAME
+from ipalib.util import check_client_configuration
 
 
 class CertUpdate(admintool.AdminTool):
@@ -47,11 +48,7 @@ class CertUpdate(admintool.AdminTool):
         super(CertUpdate, self).validate_options(needs_root=True)
 
     def run(self):
-        fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
-        if (not fstore.has_files() and
-            not os.path.exists(paths.IPA_DEFAULT_CONF)):
-            raise admintool.ScriptError(
-                "IPA client is not configured on this system.")
+        check_client_configuration()
 
         api.bootstrap(context='cli_installer', confdir=paths.ETC_IPA)
         api.finalize()

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -54,7 +54,9 @@ from ipalib.constants import CLI_TAB, LDAP_GENERALIZED_TIME_FORMAT
 from ipalib.parameters import File, Str, Enum, Any, Flag
 from ipalib.text import _
 from ipalib import api  # pylint: disable=unused-import
+from ipalib.util import check_client_configuration
 from ipapython.dnsutil import DNSName
+from ipapython.admintool import ScriptError
 
 import datetime
 
@@ -1343,6 +1345,12 @@ def run(api):
     error = None
     try:
         (_options, argv) = api.bootstrap_with_global_options(context='cli')
+
+        try:
+            check_client_configuration()
+        except ScriptError as e:
+            sys.exit(e)
+
         for klass in cli_plugins:
             api.add_plugin(klass)
         api.finalize()

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -54,12 +54,15 @@ from ipalib.constants import (
     TLS_VERSIONS, TLS_VERSION_MINIMAL, TLS_HIGH_CIPHERS
 )
 from ipalib.text import _
+# pylint: disable=ipa-forbidden-import
+from ipalib.install import sysrestore
+from ipaplatform.paths import paths
+# pylint: enable=ipa-forbidden-import
 from ipapython.ssh import SSHPublicKey
 from ipapython.dn import DN, RDN
-from ipapython.dnsutil import DNSName
-from ipapython.dnsutil import resolve_ip_addresses
+from ipapython.dnsutil import DNSName, resolve_ip_addresses
 from ipapython.ipa_log_manager import root_logger
-
+from ipapython.admintool import ScriptError
 
 if six.PY3:
     unicode = str
@@ -1071,6 +1074,15 @@ def ensure_krbcanonicalname_set(ldap, entry_attrs):
     old_entry.pop('objectclass', None)
 
     entry_attrs.update(old_entry)
+
+
+def check_client_configuration():
+    """
+    Check if IPA client is configured on the system.
+    """
+    fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
+    if not fstore.has_files() and not os.path.exists(paths.IPA_DEFAULT_CONF):
+        raise ScriptError('IPA client is not configured on this system')
 
 
 def check_principal_realm_in_trust_namespace(api_instance, *keys):


### PR DESCRIPTION
Creating a method to check if ipa client is configured. Also, changing scripts to use it instead of duplicating the check.

https://pagure.io/freeipa/issue/6261

Reviewed-By: Florence Blanc-Renaud <frenaud@redhat.com>

Backport of PR #939 