### PR TITLE
build: checkout *.po files at the end of makerpms.sh

### DIFF
--- a/makerpms.sh
+++ b/makerpms.sh
@@ -26,4 +26,8 @@ test ! -f "Makefile" && ./configure --enable-silent-rules \
 	"$@"
 make rpms
 
+# Workaround to ignore re-generated *.po files in git repo
+# See https://pagure.io/freeipa/issue/6605
+git checkout po/*.po
+
 popd


### PR DESCRIPTION
*.po are re-generated during build. These changes shouldn't be
comitted to git unless translation have been updated (during
release).

Fixes https://pagure.io/freeipa/issue/6605

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>