### PR TITLE
Make most of the stuff run in Python 3 by default

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -876,16 +876,54 @@ find \
 # TODO: workaround: some scripts are copied over, so the are always py2.
 # We have to explicitly set python3 here for ported files here
 PY3_SUBST_PATHS='
+client/ipa-certupdate
+client/ipa-client-automount
+client/ipa-client-install
+daemons/dnssec/ipa-dnskeysync-replica
+daemons/dnssec/ipa-dnskeysyncd
+daemons/dnssec/ipa-ods-exporter
+daemons/ipa-otpd/test.py
+install/certmonger/ipa-server-guard
+install/certmonger/dogtag-ipa-ca-renew-agent-submit
+install/oddjob/com.redhat.idm.trust-fetch-domains
+install/restart_scripts/renew_ra_cert_pre
+install/restart_scripts/renew_ca_cert
+install/restart_scripts/renew_ra_cert
+install/restart_scripts/restart_httpd
+install/restart_scripts/renew_kdc_cert
+install/restart_scripts/stop_pkicad
+install/restart_scripts/restart_dirsrv
+install/tools/ipa-advise
+install/tools/ipa-adtrust-install
 install/tools/ipa-backup
+install/tools/ipa-ca-install
+install/tools/ipa-cacert-manage
 install/tools/ipa-compat-manage
+install/tools/ipa-csreplica-manage
+install/tools/ipa-custodia
 install/tools/ipa-dns-install
+install/tools/ipa-httpd-kdcproxy
+install/tools/ipa-kra-install
+install/tools/ipa-ldap-updater
 install/tools/ipa-managed-entries
 install/tools/ipa-nis-manage
+install/tools/ipa-otptoken-import
+install/tools/ipa-pkinit-manage
+install/tools/ipa-pki-retrieve-key
+install/tools/ipa-replica-conncheck
+install/tools/ipa-replica-install
+install/tools/ipa-replica-manage
 install/tools/ipa-replica-prepare
+install/tools/ipa-restore
+install/tools/ipa-server-certinstall
+install/tools/ipa-server-install
+install/tools/ipa-server-upgrade
+install/tools/ipa-winsync-migrate
 install/tools/ipactl
+ipa
 '
 for P in $PY3_SUBST_PATHS; do
-    sed -i -e '1 s|^#!.*\bpython[^ ]*|#!%{__python3}|' $P
+    sed -i -e '1 s|^#!.*\bpython[0-9]*\(\s\+-\)\?|#!%{__python3} -bb|' $P
 done;
 
 %endif # with_python3

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -293,7 +293,11 @@ Requires: krb5-pkinit-openssl >= %{krb5_version}
 Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: ntp
 Requires: httpd >= 2.4.6-31
+%if 0%{with_python3}
+Requires: python3-mod_wsgi
+%else
 Requires: mod_wsgi
+%endif
 Requires: mod_auth_gssapi >= 1.5.0
 # 1.0.14-3: https://bugzilla.redhat.com/show_bug.cgi?id=1431206
 Requires: mod_nss >= 1.0.14-3


### PR DESCRIPTION
commit ee17a770965d5a3ab02ba4c6c593678c3be1ae47 (HEAD -> py3_team_test, private/py3_team_test)
Author: Stanislav Laznicka <slaznick@redhat.com>
Date:   Tue Aug 15 14:14:09 2017 +0200

    Make the IPA server run under Python 3 by default
    
    Set python3-mod_wsgi as a requirement for FreeIPA in the spec file
    so that httpd runs IPA server under Python 3.
    
    https://pagure.io/freeipa/issue/4985

commit 86f0cf3da55a25e526966b8cf30fad9b7013ae5a
Author: Stanislav Laznicka <slaznick@redhat.com>
Date:   Tue Aug 15 14:10:27 2017 +0200

    Turn IPA scripts to python3 -bb for testing
    
    This is a commit which expands current scripts being run under
    python3 by default. We set the -bb option so that any Bytes/Str
    error breaks execution.
    
    This commit shall be reverted before reaching production.
    
    https://pagure.io/freeipa/issue/4985