### PR TITLE
WebUI: fix incorrectly shown links in association tables

### DIFF
--- a/install/ui/src/freeipa/association.js
+++ b/install/ui/src/freeipa/association.js
@@ -1103,7 +1103,7 @@ exp.association_facet = IPA.association_facet = function (spec, no_init) {
         var columns = that.columns.values;
         for (i=0; i<columns.length; i++) {
             column = columns[i];
-            column.link = spec.link;
+            if (column.primary_key) column.link = spec.link;
         }
 
         that.init_table(that.other_entity);


### PR DESCRIPTION
Previously all columns was shown as links, that was caused by setting
link attribute of each column to true. This true value was there because
of possibility to turn off links in whole table on self-service pages.

Now only column which is primary key is set to be shown as link.

https://pagure.io/freeipa/issue/7066