### PR TITLE
Fixing and porting dogtag-ipa-ca-renew-agent-submit

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -379,10 +379,10 @@ def retrieve_or_reuse_cert(**kwargs):
     if not nickname:
         return (REJECTED, "Nickname could not be determined")
 
-    cert = x509.load_pem_x509_certificate(
-        fix_pem(os.environ.get('CERTMONGER_CERTIFICATE'))) # TODO: the fix_pem somehow got there early, so making this comment way too long to get rid of it later
+    cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if not cert:
         return (REJECTED, "New certificate requests not supported")
+    cert = x509.load_pem_x509_certificate(fix_pem(cert.encode('ascii')))
 
     with ldap_connect() as conn:
         try:

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -314,7 +314,7 @@ def store_cert(**kwargs):
                 "Giving up. To retry storing the certificate, resubmit the "
                 "request with CA \"dogtag-ipa-ca-renew-agent-reuse\"")
 
-    return (ISSUED, cert)
+    return (ISSUED, cert.public_bytes(x509.Encoding.PEM).decode('ascii'))
 
 
 def request_and_store_cert(**kwargs):

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -281,8 +281,7 @@ def store_cert(**kwargs):
     cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if not cert:
         return (REJECTED, "New certificate requests not supported")
-    cert = x509.load_pem_x509_certificate(fix_pem(cert))
-    dercert = cert.public_bytes(x509.Encoding.DER)
+    cert = x509.load_pem_x509_certificate(fix_pem(cert.encode('ascii')))
 
     dn = DN(('cn', nickname), ('cn', 'ca_renewal'),
             ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
@@ -290,14 +289,14 @@ def store_cert(**kwargs):
         with ldap_connect() as conn:
             try:
                 entry = conn.get_entry(dn, ['usercertificate'])
-                entry['usercertificate'] = [dercert]
+                entry['usercertificate'] = [cert]
                 conn.update_entry(entry)
             except errors.NotFound:
                 entry = conn.make_entry(
                     dn,
                     objectclass=['top', 'pkiuser', 'nscontainer'],
                     cn=[nickname],
-                    usercertificate=[dercert])
+                    usercertificate=[cert])
                 conn.add_entry(entry)
             except errors.EmptyModlist:
                 pass
@@ -394,8 +393,7 @@ def retrieve_or_reuse_cert(**kwargs):
         except errors.NotFound:
             pass
         else:
-            cert = x509.load_der_x509_certificate(
-                entry.single_value['usercertificate'])
+            cert = entry.single_value['usercertificate']
 
     return (ISSUED, cert.public_bytes(x509.Encoding.PEM))
 

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -89,7 +89,7 @@ def get_nickname():
     # an OpenSSL certificate for which we have to reverse the order of its DN
     # components thus changing the CERTMONGER_REQ_SUBJECT
     # https://pagure.io/certmonger/issue/62
-    csr = os.environ.get('CERTMONGER_CSR')
+    csr = os.environ.get('CERTMONGER_CSR').encode('ascii')
     csr_obj = crypto_x509.load_pem_x509_csr(csr, default_backend())
     subject = csr_obj.subject
     if not subject:
@@ -166,7 +166,8 @@ def call_handler(_handler, *args, **kwargs):
                 if profile is not None:
                     if not isinstance(profile, unicode):
                         raise TypeError
-                    profile = profile.encode('raw_unicode_escape')
+                    profile = (profile.encode('raw_unicode_escape')
+                               .decode('ascii'))
             except (TypeError, UnicodeEncodeError):
                 return (UNCONFIGURED,
                         "Invalid 'profile' in cookie: %r" % profile)
@@ -183,7 +184,7 @@ def call_handler(_handler, *args, **kwargs):
             try:
                 if not isinstance(cookie, unicode):
                     raise TypeError
-                cookie = cookie.encode('raw_unicode_escape')
+                cookie = cookie.encode('raw_unicode_escape').decode('ascii')
             except (TypeError, UnicodeEncodeError):
                 return (UNCONFIGURED,
                         "Invalid 'cookie' in cookie: %r" % cookie)
@@ -194,11 +195,12 @@ def call_handler(_handler, *args, **kwargs):
     result = _handler(*args, **kwargs)
 
     if result[0] in (WAIT, WAIT_WITH_DELAY):
-        context['cookie'] = result[-1].decode('raw_unicode_escape')
+        context['cookie'] = (result[-1].encode('ascii')
+                             .decode('raw_unicode_escape'))
 
     profile = os.environ.get('CERTMONGER_CA_PROFILE')
     if profile is not None:
-        profile = profile.decode('raw_unicode_escape')
+        profile = profile.encode('ascii').decode('raw_unicode_escape')
     context['profile'] = profile
 
     cookie = json.dumps(context)
@@ -232,7 +234,7 @@ def request_cert(reuse_existing, **kwargs):
     if os.environ.get('CERTMONGER_CA_PROFILE') == 'caCACert':
         args += ['-N', '-O', 'bypassCAnotafter=true']
     result = ipautil.run(args, raiseonerr=False, env=os.environ,
-                        capture_output=True)
+                         capture_output=True)
     if six.PY2:
         sys.stderr.write(result.raw_error_output)
     else:
@@ -395,7 +397,7 @@ def retrieve_or_reuse_cert(**kwargs):
         else:
             cert = entry.single_value['usercertificate']
 
-    return (ISSUED, cert.public_bytes(x509.Encoding.PEM))
+    return (ISSUED, cert.public_bytes(x509.Encoding.PEM).decode('ascii'))
 
 
 def retrieve_cert_continuous(reuse_existing, **kwargs):
@@ -405,7 +407,8 @@ def retrieve_cert_continuous(reuse_existing, **kwargs):
     """
     old_cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if old_cert:
-        old_cert = x509.load_pem_x509_certificate(fix_pem(old_cert))
+        old_cert = x509.load_pem_x509_certificate(
+                fix_pem(old_cert.encode('ascii')))
 
     result = call_handler(retrieve_or_reuse_cert,
                           reuse_existing=reuse_existing,
@@ -413,7 +416,8 @@ def retrieve_cert_continuous(reuse_existing, **kwargs):
     if result[0] != ISSUED or reuse_existing:
         return result
 
-    new_cert = x509.load_pem_x509_certificate(fix_pem(result[1]))
+    new_cert = x509.load_pem_x509_certificate(
+            fix_pem(result[1].encode('ascii')))
     if new_cert == old_cert:
         syslog.syslog(syslog.LOG_INFO, "Updated certificate not available")
         # No cert available yet, tell certmonger to wait another 8 hours
@@ -437,14 +441,14 @@ def renew_ca_cert(reuse_existing, **kwargs):
     """
     This is used for automatic CA certificate renewal.
     """
-    csr = os.environ.get('CERTMONGER_CSR')
+    csr = os.environ.get('CERTMONGER_CSR').encode('ascii')
     if not csr:
         return (UNCONFIGURED, "Certificate request not provided")
 
     cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if not cert:
         return (REJECTED, "New certificate requests not supported")
-    cert = x509.load_pem_x509_certificate(fix_pem(cert))
+    cert = x509.load_pem_x509_certificate(fix_pem(cert.encode('ascii')))
     is_self_signed = cert.is_self_signed()
 
     operation = os.environ.get('CERTMONGER_OPERATION')

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -351,7 +351,8 @@ class DogtagInstance(service.Service):
                 cs_cfg,
                 directive,
                 # the cert must be only the base64 string without headers
-                base64.b64encode(cert.public_bytes(x509.Encoding.DER)),
+                (base64.b64encode(cert.public_bytes(x509.Encoding.DER))
+                 .decode('ascii')),
                 quotes=False,
                 separator='=')
 


### PR DESCRIPTION
This PR fixes several issues with the `dogtag-ipa-ca-renew-agent-submit` script that were introduced in the recent certificate refactoring and eventually ports the script and its scriptlets to Python 3.

https://pagure.io/freeipa/issue/4985

To properly test the port, you will need https://github.com/freeipa/freeipa/pull/975