### PR TITLE
makerpms.sh: make git checkout optional

### DIFF
--- a/makerpms.sh
+++ b/makerpms.sh
@@ -28,6 +28,6 @@ make rpms
 
 # Workaround to ignore re-generated *.po files in git repo
 # See https://pagure.io/freeipa/issue/6605
-git checkout po/*.po
+git checkout po/*.po ||:
 
 popd


### PR DESCRIPTION
In case someone is using the script from tarball, outside of git,
the git checkout command shouldn't fail the script.

Related https://pagure.io/freeipa/issue/6605

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>