### PR TITLE
ipautil: port host_port_open() to python 3

### DIFF
--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -983,7 +983,7 @@ def host_port_open(host, port, socket_type=socket.SOCK_STREAM,
             s.connect(sa)
 
             if socket_type == socket.SOCK_DGRAM:
-                s.send('')
+                s.send(b'')
                 s.recv(512)
         except socket.error:
             port_open = False


### PR DESCRIPTION
socket.send() expects `Bytes` instance, not string

https://pagure.io/freeipa/issue/4985

This causes issues with `ipa-replica-conncheck` when installing a replica.