### PR TITLE
component: Certificate renewal

### DIFF
--- a/install/restart_scripts/renew_ca_cert
+++ b/install/restart_scripts/renew_ca_cert
@@ -30,11 +30,13 @@ import traceback
 from ipalib.install import certstore
 from ipapython import ipautil
 from ipalib import api, errors
+from ipalib import x509
 from ipalib.install.kinit import kinit_keytab
 from ipaserver.install import certs, cainstance, installutils
 from ipaserver.plugins.ldap2 import ldap2
 from ipaplatform import services
 from ipaplatform.paths import paths
+from ipapython.certdb import TrustFlags
 
 
 def _main():
@@ -180,7 +182,11 @@ def _main():
                 # Pass Dogtag's self-tests
                 for ca_nick in db.find_root_cert(nickname)[-2:-1]:
                     ca_flags = dict(cc[1:] for cc in ca_certs)[ca_nick]
-                    db.trust_root_cert(ca_nick, 'C' + ca_flags)
+                    usages = ca_flags.usages or set()
+                    ca_flags_modified = TrustFlags(ca_flags.has_key,
+                        True, True,
+                        usages | {x509.EKU_SERVER_AUTH})
+                    db.trust_root_cert(ca_nick, ca_flags_modified)
             finally:
                 if conn is not None and conn.isconnected():
                     conn.disconnect()

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -215,7 +215,7 @@ class CACertManage(admintool.AdminTool):
         cert_file, ca_file = installutils.load_external_cert(
             options.external_cert_files, DN(old_cert.subject))
 
-        with open(cert_file.name) as f:
+        with open(cert_file.name, 'rb') as f:
             new_cert_data = f.read()
         new_cert = x509.load_pem_x509_certificate(new_cert_data)
         new_spki = new_cert.public_key_info_bytes


### PR DESCRIPTION
Fix certificate renewal scripts that use IPACertificate object:
- dogtag-ipa-ca-renew-agent-submit must print the renewed cert
in the stdout for certmonger to pick it
- renew_ca_cert adds the C flag to the trust flags and needs to
be adapted to IPACertificate object

https://pagure.io/freeipa/issue/4985