### PR TITLE
Removing part of circular dependency of ipalib in ipaplatform

### DIFF
--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -47,10 +47,6 @@ from ipaplatform.paths import paths
 from ipaplatform.redhat.authconfig import RedHatAuthConfig
 from ipaplatform.base.tasks import BaseTaskNamespace
 
-# pylint: disable=ipa-forbidden-import
-from ipalib.constants import IPAAPI_USER
-# pylint: enable=ipa-forbidden-import
-
 logger = logging.getLogger(__name__)
 
 _ffi = FFI()
@@ -453,7 +449,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
         ipautil.run([paths.SYSTEMCTL, "--system", "daemon-reload"],
                     raiseonerr=False)
 
-    def configure_http_gssproxy_conf(self):
+    def configure_http_gssproxy_conf(self, ipaapi_user):
         ipautil.copy_template_file(
             os.path.join(paths.USR_SHARE_IPA_DIR, 'gssproxy.conf.template'),
             paths.GSSPROXY_CONF,
@@ -461,7 +457,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                 HTTP_KEYTAB=paths.HTTP_KEYTAB,
                 HTTP_CCACHE=paths.HTTP_CCACHE,
                 HTTPD_USER=constants.HTTPD_USER,
-                IPAAPI_USER=IPAAPI_USER,
+                IPAAPI_USER=ipaapi_user,
             )
         )
 

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -46,6 +46,7 @@ from ipapython.dn import DN
 import ipapython.errors
 from ipaserver.install import sysupgrade
 from ipalib import api
+from ipalib.constants import IPAAPI_USER
 from ipaplatform.constants import constants
 from ipaplatform.tasks import tasks
 from ipaplatform.paths import paths
@@ -233,7 +234,7 @@ class HTTPInstance(service.Service):
         os.chmod(target_fname, 0o644)
 
     def configure_gssproxy(self):
-        tasks.configure_http_gssproxy_conf()
+        tasks.configure_http_gssproxy_conf(IPAAPI_USER)
         services.knownservices.gssproxy.restart()
 
     def change_mod_nss_port_from_http(self):


### PR DESCRIPTION
After commit  cac3475a0454b730d6e5b2093c2e63d395acd387, ipa-backup is broken due to circular dependencies. This fixes it, removing circular dependency of ipalib. The ipalib.constants.IPAAPI_USER is now passed as parameter to the functions that use it.

https://pagure.io/freeipa/issue/7108