### PR TITLE
Pylint fixes

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -27,7 +27,7 @@ steps:
   - make V=0 ${make_target}
   builddep:
   - rm -rf /var/cache/dnf/*
-  - "dnf makecache fast || :"
+  - "dnf makecache || :"
   - dnf builddep -y ${builddep_opts} --spec freeipa.spec.in --best --allowerasing
   cleanup:
   - chown -R ${uid}:${gid} ${container_working_dir}

--- a/.test_runner_config_py3_temp.yaml
+++ b/.test_runner_config_py3_temp.yaml
@@ -29,7 +29,7 @@ steps:
   - make V=0 ${make_target}
   builddep:
   - rm -rf /var/cache/dnf/*
-  - "dnf makecache fast || :"
+  - "dnf makecache || :"
   - dnf builddep -y ${builddep_opts} --spec freeipa.spec.in --best --allowerasing
   cleanup:
   - chown -R ${uid}:${gid} ${container_working_dir}

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 cache: pip
 env:
     global:
-        - TEST_RUNNER_IMAGE="martbab/freeipa-fedora-test-runner:master-latest"
+        - TEST_RUNNER_IMAGE="freeipa/freeipa-test-runner:master-latest"
           PEP8_ERROR_LOG="pep8_errors.log"
           CI_RESULTS_LOG="ci_results_${TRAVIS_BRANCH}.log"
           CI_BACKLOG_SIZE=5000

--- a/.wheelconstraints.in
+++ b/.wheelconstraints.in
@@ -9,5 +9,5 @@ ipapython == @VERSION@
 ipaserver == @VERSION@
 ipatests == @VERSION@
 
-# see https://pagure.io/freeipa/issue/6874
-pylint < 1.7
+# we include some checks available only in pylint-1.7 and on
+pylint >= 1.7

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -175,7 +175,7 @@ BuildRequires:  python-gssapi >= 1.2.0-5
 %if 0%{?fedora} >= 26
 BuildRequires:  python2-pylint
 %else
-BuildRequires:  pylint >= 1.6
+BuildRequires:  pylint >= 1.7
 %endif
 # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1096506
 BuildRequires:  python2-polib
@@ -214,7 +214,7 @@ BuildRequires:  python2-augeas
 # 1.6: x509.Name.rdns (https://github.com/pyca/cryptography/issues/3199)
 BuildRequires:  python3-cryptography >= 1.6
 BuildRequires:  python3-gssapi >= 1.2.0
-BuildRequires:  python3-pylint >= 1.6
+BuildRequires:  python3-pylint >= 1.7
 # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1096506
 BuildRequires:  python3-polib
 BuildRequires:  python3-libipa_hbac

--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -318,7 +318,7 @@ class PortResponder(threading.Thread):
             logger.debug('%d %s: Stopped listening', port, proto)
 
     def _is_closing(self):
-        with self._close_lock:
+        with self._close_lock:  # pylint: disable=not-context-manager
             return self._close
 
     def _bind_to_port(self, port, socket_type):
@@ -369,7 +369,7 @@ class PortResponder(threading.Thread):
     def stop(self):
         logger.debug('Stopping listening thread.')
 
-        with self._close_lock:
+        with self._close_lock:  # pylint: disable=not-context-manager
             self._close = True
 
 

--- a/ipaclient/csrgen.py
+++ b/ipaclient/csrgen.py
@@ -12,6 +12,7 @@ import os.path
 import pipes
 import subprocess
 import traceback
+import codecs
 
 import pkg_resources
 
@@ -438,7 +439,10 @@ class OpenSSLAdaptor(object):
             padding.PKCS1v15(),
             hashes.SHA256()
         )
-        asn1sig = univ.BitString("'%s'H" % signature.encode('hex'))
+        asn1sig = univ.BitString("'{sig}'H".format(
+                                    sig=codecs.encode(signature, 'hex')
+                                    .decode('ascii'))
+                                 )
         csr.setComponentByName('signature', asn1sig)
         return encoder.encode(csr)
 

--- a/ipaclient/remote_plugins/schema.py
+++ b/ipaclient/remote_plugins/schema.py
@@ -586,7 +586,7 @@ def get_package(server_info, client):
     for plugin_cls in (_SchemaCommandPlugin, _SchemaObjectPlugin):
         for full_name in schema[plugin_cls.schema_key]:
             plugin = plugin_cls(schema, str(full_name))
-            plugin = module.register()(plugin)
+            plugin = module.register()(plugin)  # pylint: disable=no-member
     sys.modules[module_name] = module
 
     for full_name, topic in six.iteritems(schema['topics']):

--- a/ipalib/aci.py
+++ b/ipalib/aci.py
@@ -46,6 +46,8 @@ class ACI(object):
     entry in LDAP.  Has methods to parse an ACI string and export to an
     ACI String.
     """
+    __hash__ = None
+
     def __init__(self,acistr=None):
         self.name = None
         self.source_group = None

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -999,7 +999,9 @@ class Collector(object):
                 value = v + (value,)
             else:
                 value = (v, value)
+        # pylint: disable=unsupported-assignment-operation
         self.__options[name] = value
+        # pylint: enable=unsupported-assignment-operation
         object.__setattr__(self, name, value)
 
     def __todict__(self):

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -273,7 +273,9 @@ class Env(object):
         if type(value) not in (unicode, int, float, bool, type(None), DN):
             raise TypeError(key, value)
         object.__setattr__(self, key, value)
+        # pylint: disable=unsupported-assignment-operation
         self.__d[key] = value
+        # pylint: enable=unsupported-assignment-operation
 
     def __getitem__(self, key):
         """

--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -1227,7 +1227,7 @@ class Decimal(Number):
     def _enforce_precision(self, value):
         assert type(value) is decimal.Decimal
         if self.precision is not None:
-            quantize_exp = decimal.Decimal(10) ** -self.precision
+            quantize_exp = decimal.Decimal(10) ** -int(self.precision)
             try:
                 value = value.quantize(quantize_exp)
             except decimal.DecimalException as e:

--- a/ipalib/text.py
+++ b/ipalib/text.py
@@ -146,6 +146,7 @@ class LazyText(object):
     """
 
     __slots__ = ('domain', 'localedir', 'key', 'args')
+    __hash__ = None
 
     def __init__(self, domain=None, localedir=None):
         """

--- a/ipapython/install/util.py
+++ b/ipapython/install/util.py
@@ -82,6 +82,7 @@ def run_generator_with_yield_from(gen):
 
 
 class InnerClassMeta(type):
+    # pylint: disable=no-value-for-parameter
     def __new__(mcs, name, bases, class_dict):
         class_dict.pop('__outer_class__', None)
         class_dict.pop('__outer_name__', None)

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -174,6 +174,8 @@ class LDAPEntry(collections.MutableMapping):
                  '_not_list', '_orig_raw', '_raw_view',
                  '_single_value_view')
 
+    __hash__ = None
+
     def __init__(self, _conn, _dn=None, _obj=None, **kwargs):
         """
         LDAPEntry constructor.

--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -1275,7 +1275,9 @@ class TrustDomainInstance(object):
             self._pipe.DeleteTrustedDomain(self._policy_handle,
                                            res.info_ex.sid)
         except RuntimeError as e:
-            num, message = e.args  # pylint: disable=unpacking-non-sequence
+            # pylint: disable=unbalanced-tuple-unpacking
+            num, _message = e.args
+            # pylint: enable=unbalanced-tuple-unpacking
             # Ignore anything but access denied (NT_STATUS_ACCESS_DENIED)
             if num == -1073741790:
                 raise access_denied_error

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -2920,7 +2920,7 @@ class dnszone_find(DNSZoneBase_find):
         if options.get('forward_only', False):
             search_kw = {}
             search_kw['idnsname'] = [revzone.ToASCII() for revzone in
-                                     REVERSE_DNS_ZONES.keys()]
+                                     REVERSE_DNS_ZONES]
             rev_zone_filter = ldap.make_filter(search_kw,
                                                rules=ldap.MATCH_NONE,
                                                exact=False,
@@ -3094,7 +3094,7 @@ class dnsrecord(LDAPObject):
 
         if not zone_len:
             allowed_zones = ', '.join([unicode(revzone) for revzone in
-                                       REVERSE_DNS_ZONES.keys()])
+                                       REVERSE_DNS_ZONES])
             raise errors.ValidationError(name='ptrrecord',
                     error=unicode(_('Reverse zone for PTR record should be a sub-zone of one the following fully qualified domains: %s') % allowed_zones))
 

--- a/ipaserver/plugins/schema.py
+++ b/ipaserver/plugins/schema.py
@@ -377,8 +377,10 @@ class topic_(MetaObject):
                     'full_name': topic_full_name,
                 }
                 topics.append(topic)
+                # pylint: disable=unsupported-assignment-operation
                 topics_by_key[topic_name] = topic
                 topics_by_key[topic_full_name] = topic
+                # pylint: enable=unsupported-assignment-operation
 
                 for package in self.api.packages:
                     module_name = '.'.join((package.__name__, topic_name))

--- a/ipaserver/plugins/sudocmd.py
+++ b/ipaserver/plugins/sudocmd.py
@@ -126,7 +126,7 @@ class sudocmd(LDAPObject):
 
     def get_dn(self, *keys, **options):
         if keys[-1].endswith('.'):
-            keys[-1] = keys[-1][:-1]
+            keys = (keys[:-1] + (keys[-1][:-1], ))
         dn = super(sudocmd, self).get_dn(*keys, **options)
         try:
             self.backend.get_entry(dn, [''])

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -715,8 +715,7 @@ class xmlserver(KerberosWSGIExecutioner):
         """list methods for XML-RPC introspection"""
         if params:
             raise errors.ZeroArgumentError(name='system.listMethods')
-        return (tuple(unicode(cmd.name) for cmd in self.Command()
-                      if cmd is self.Command[cmd.name]) +
+        return (tuple(unicode(cmd.name) for cmd in self.api.Command) +
                 tuple(unicode(name) for name in self._system_commands))
 
     def _get_method_name(self, name, *params):

--- a/ipaserver/secrets/client.py
+++ b/ipaserver/secrets/client.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2015  IPA Project Contributors, see COPYING for license
 
 from __future__ import print_function
+# pylint: disable=relative-import
 from custodia.message.kem import KEMClient, KEY_USAGE_SIG, KEY_USAGE_ENC
+# pylint: enable=relative-import
 from jwcrypto.common import json_decode
 from jwcrypto.jwk import JWK
 from ipaserver.secrets.kem import IPAKEMKeys

--- a/ipaserver/secrets/kem.py
+++ b/ipaserver/secrets/kem.py
@@ -12,8 +12,10 @@ from ipapython.dn import DN
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa, ec
+# pylint: disable=relative-import
 from custodia.message.kem import KEMKeysStore
 from custodia.message.kem import KEY_USAGE_SIG, KEY_USAGE_ENC, KEY_USAGE_MAP
+# pylint: enable=relative-import
 from jwcrypto.common import json_decode, json_encode
 from jwcrypto.common import base64url_encode
 from jwcrypto.jwk import JWK

--- a/ipaserver/secrets/service.py
+++ b/ipaserver/secrets/service.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2017  IPA Project Contributors, see COPYING for license
 import argparse
 
-import custodia.server
+import custodia.server  # pylint: disable=relative-import
 
 
 argparser = argparse.ArgumentParser(

--- a/ipaserver/secrets/store.py
+++ b/ipaserver/secrets/store.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function
 from base64 import b64encode, b64decode
-from custodia.store.interface import CSStore
+from custodia.store.interface import CSStore  # pylint: disable=relative-import
 from jwcrypto.common import json_decode, json_encode
 from ipaplatform.paths import paths
 from ipapython import ipautil

--- a/ipatests/test_ipapython/test_dn.py
+++ b/ipatests/test_ipapython/test_dn.py
@@ -528,6 +528,7 @@ class TestRDN(unittest.TestCase):
     def test_assignments(self):
         rdn = RDN((self.attr1, self.value1))
         with self.assertRaises(TypeError):
+            # pylint: disable=unsupported-assignment-operation
             rdn[0] = self.ava2
 
     def test_iter(self):
@@ -954,8 +955,10 @@ class TestDN(unittest.TestCase):
     def test_assignments(self):
         dn = DN('t=0,t=1,t=2,t=3,t=4,t=5,t=6,t=7,t=8,t=9')
         with self.assertRaises(TypeError):
+            # pylint: disable=unsupported-assignment-operation
             dn[0] = RDN('t=a')
         with self.assertRaises(TypeError):
+            # pylint: disable=unsupported-assignment-operation
             dn[0:1] = [RDN('t=a'), RDN('t=b')]
 
     def test_iter(self):

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -247,6 +247,8 @@ class Fuzzy(object):
     Fuzzy('.+', <... 'str'>, <function <lambda> at 0x...>)
     """
 
+    __hash__ = None
+
     def __init__(self, regex=None, type=None, test=None):
         """
         Initialize.

--- a/pylintrc
+++ b/pylintrc
@@ -92,7 +92,6 @@ disable=
     useless-super-delegation,  # new in pylint 1.7
     redefined-argument-from-local,  # new in pylint 1.7
     consider-merging-isinstance,  # new in pylint 1.7
-    unsupported-assignment-operation  # new in pylint 1.7
 
 
 [REPORTS]

--- a/pylintrc
+++ b/pylintrc
@@ -93,7 +93,6 @@ disable=
     redefined-argument-from-local,  # new in pylint 1.7
     consider-merging-isinstance,  # new in pylint 1.7
     unsupported-assignment-operation  # new in pylint 1.7
-    consider-iterating-dictionary,  # wontfix for better python2/3 code
 
 
 [REPORTS]


### PR DESCRIPTION
Pylint check on Fedora 26 fails horribly with multitude of errors. This PR tries to fix that. Notice that to successfully run `pylint` on Fedora 26 with `make lint`, you need to have `python2-pylint` installed.

Fixes: https://pagure.io/freeipa/issue/6874
Fixes: https://pagure.io/freeipa/issue/7133

This PR should also unblock having Travis CI running in F26 container once https://bugzilla.redhat.com/show_bug.cgi?id=1483869 is fixed.