### PR TITLE
certmonger: remove temporary workaround

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -320,7 +320,8 @@ Requires(preun): python systemd-units
 Requires(postun): python systemd-units
 Requires: policycoreutils >= 2.1.12-5
 Requires: tar
-Requires(pre): certmonger >= 0.78
+# certmonger-0.79.4-2 fixes newlines in PEM files
+Requires(pre): certmonger >= 0.79.4-2
 Requires(pre): 389-ds-base >= 1.3.5.14
 Requires: fontawesome-fonts
 Requires: open-sans-fonts
@@ -525,7 +526,8 @@ Requires: libcurl >= 7.21.7-2
 Requires: xmlrpc-c >= 1.27.4
 Requires: sssd >= 1.14.0
 Requires: python-sssdconfig
-Requires: certmonger >= 0.78
+# certmonger-0.79.4-2 fixes newlines in PEM files
+Requires: certmonger >= 0.79.4-2
 Requires: nss-tools
 Requires: bind-utils
 Requires: oddjob-mkhomedir

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -68,22 +68,6 @@ if six.PY3:
 IPA_CA_NICKNAME = 'caSigningCert cert-pki-ca'
 
 
-def fix_pem(pem_cert):
-    """
-    This function fixes the PEM certificate formatting returned by Certmonger
-    so that it removes the empty line after the base64-encoded string before
-    the ending header. It makes it readable for OpenSSL this way otherwise
-    it fails horribly to read the certificate.
-
-    ===== THIS FUNCTION SHOULD BE REMOVED BEFORE IPA 4.6 IS RELEASED =====
-    If you're seeing this after FreeIPA 4.6 release then I'm sorry and either
-    I, FreeIPA or Certmonger teams failed horribly to fix their issues and
-    this is here for the time being.
-    """
-    # TODO: remove this when https://pagure.io/certmonger/issue/76 is fixed
-    return b'\n'.join(l for l in pem_cert.split(b'\n') if l != b'')
-
-
 def get_nickname():
     # we need to get the subject from a CSR in case we are requesting
     # an OpenSSL certificate for which we have to reverse the order of its DN
@@ -283,7 +267,7 @@ def store_cert(**kwargs):
     cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if not cert:
         return (REJECTED, "New certificate requests not supported")
-    cert = x509.load_pem_x509_certificate(fix_pem(cert.encode('ascii')))
+    cert = x509.load_pem_x509_certificate(cert.encode('ascii'))
 
     dn = DN(('cn', nickname), ('cn', 'ca_renewal'),
             ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
@@ -384,7 +368,7 @@ def retrieve_or_reuse_cert(**kwargs):
     cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if not cert:
         return (REJECTED, "New certificate requests not supported")
-    cert = x509.load_pem_x509_certificate(fix_pem(cert.encode('ascii')))
+    cert = x509.load_pem_x509_certificate(cert.encode('ascii'))
 
     with ldap_connect() as conn:
         try:
@@ -407,8 +391,7 @@ def retrieve_cert_continuous(reuse_existing, **kwargs):
     """
     old_cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if old_cert:
-        old_cert = x509.load_pem_x509_certificate(
-                fix_pem(old_cert.encode('ascii')))
+        old_cert = x509.load_pem_x509_certificate(old_cert.encode('ascii'))
 
     result = call_handler(retrieve_or_reuse_cert,
                           reuse_existing=reuse_existing,
@@ -416,8 +399,7 @@ def retrieve_cert_continuous(reuse_existing, **kwargs):
     if result[0] != ISSUED or reuse_existing:
         return result
 
-    new_cert = x509.load_pem_x509_certificate(
-            fix_pem(result[1].encode('ascii')))
+    new_cert = x509.load_pem_x509_certificate(result[1].encode('ascii'))
     if new_cert == old_cert:
         syslog.syslog(syslog.LOG_INFO, "Updated certificate not available")
         # No cert available yet, tell certmonger to wait another 8 hours
@@ -448,7 +430,7 @@ def renew_ca_cert(reuse_existing, **kwargs):
     cert = os.environ.get('CERTMONGER_CERTIFICATE')
     if not cert:
         return (REJECTED, "New certificate requests not supported")
-    cert = x509.load_pem_x509_certificate(fix_pem(cert.encode('ascii')))
+    cert = x509.load_pem_x509_certificate(cert.encode('ascii'))
     is_self_signed = cert.is_self_signed()
 
     operation = os.environ.get('CERTMONGER_OPERATION')


### PR DESCRIPTION
During recent refactoring, a workaround was added to make it
possible for OpenSSL backend of python-cryptography to read PEM
certificates returned by dogtag-ipa-renew-agent-submit. This was
fixed in latest certmonger version.