### PR TITLE
py3: fix schema response for py2 server with py3 client

### DIFF
--- a/ipaserver/plugins/schema.py
+++ b/ipaserver/plugins/schema.py
@@ -399,8 +399,8 @@ class topic_(MetaObject):
                         continue
                     if topic_value is not None:
                         topic_name = unicode(topic_value)
-                        topic['topic_topic'] = '{}/{}'.format(topic_name,
-                                                              topic_version)
+                        topic['topic_topic'] = u'{}/{}'.format(topic_name,
+                                                               topic_version)
                     else:
                         topic.pop('topic_topic', None)
 


### PR DESCRIPTION
The schema RPC response can include a bytes value for the
'topic_topic' field (when the server is running in Python 2).
In this case, a Python 3 client fails to initialise the API
when a schema fetch is required, because it cannot serialise
the bytes values in the schema object to JSON.

Ensure the 'topic_topic' value is unicode.

Part of: https://pagure.io/freeipa/issue/4985