### PR TITLE
ipa-pki-retrieve-key: ensure we do not crash

### DIFF
--- a/install/tools/ipa-pki-retrieve-key
+++ b/install/tools/ipa-pki-retrieve-key
@@ -4,29 +4,39 @@ from __future__ import print_function
 
 import os
 import sys
+import traceback
 
 from ipalib import constants
 from ipalib.config import Env
 from ipaplatform.paths import paths
 from ipaserver.secrets.client import CustodiaClient
 
-env = Env()
-env._finalize()
 
-keyname = "ca_wrapped/" + sys.argv[1]
-servername = sys.argv[2]
+def main():
+    env = Env()
+    env._finalize()
 
-service = constants.PKI_GSSAPI_SERVICE_NAME
-client_keyfile = os.path.join(paths.PKI_TOMCAT, service + '.keys')
-client_keytab = os.path.join(paths.PKI_TOMCAT, service + '.keytab')
+    keyname = "ca_wrapped/" + sys.argv[1]
+    servername = sys.argv[2]
 
-# pylint: disable=no-member
-client = CustodiaClient(
-    client_service='%s@%s' % (service, env.host), server=servername,
-    realm=env.realm, ldap_uri="ldaps://" + env.host,
-    keyfile=client_keyfile, keytab=client_keytab,
-    )
+    service = constants.PKI_GSSAPI_SERVICE_NAME
+    client_keyfile = os.path.join(paths.PKI_TOMCAT, service + '.keys')
+    client_keytab = os.path.join(paths.PKI_TOMCAT, service + '.keytab')
 
-# Print the response JSON to stdout; it is already in the format
-# that Dogtag's ExternalProcessKeyRetriever expects
-print(client.fetch_key(keyname, store=False))
+    # pylint: disable=no-member
+    client = CustodiaClient(
+        client_service='%s@%s' % (service, env.host), server=servername,
+        realm=env.realm, ldap_uri="ldaps://" + env.host,
+        keyfile=client_keyfile, keytab=client_keytab,
+        )
+
+    # Print the response JSON to stdout; it is already in the format
+    # that Dogtag's ExternalProcessKeyRetriever expects
+    print(client.fetch_key(keyname, store=False))
+
+
+try:
+    main()
+except BaseException:
+    traceback.print_exc()
+    sys.exit(1)


### PR DESCRIPTION
If ipa-pki-retrieve-key fails for some reason (which may be a
"legitimate" reason, e.g. the server it is attempting to contact
being offline), the program terminates with an uncaught exception,
resulting in crash report.

Catch all exceptions; if an exception gets raised, report the
traceback and exit with nonzero status.

Fixes: https://pagure.io/freeipa/issue/7115