### PR TITLE
Unify storing certificates in LDAP

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -40,7 +40,6 @@ import six
 # pylint: disable=import-error
 from six.moves.configparser import RawConfigParser
 # pylint: enable=import-error
-from cryptography.hazmat.primitives import serialization
 
 from ipalib import api
 from ipalib import x509
@@ -730,9 +729,6 @@ class CAInstance(DogtagInstance):
         the appropriate groups for accessing CA services.
         """
 
-        # get RA certificate
-        cert_data = self.ra_cert.public_bytes(serialization.Encoding.DER)
-
         # connect to CA database
         conn = ldap2.ldap2(api)
         conn.connect(autobind=True)
@@ -748,7 +744,7 @@ class CAInstance(DogtagInstance):
             cn=["ipara"],
             usertype=["agentType"],
             userstate=["1"],
-            userCertificate=[cert_data],
+            userCertificate=[self.ra_cert],
             description=['2;%s;%s;%s' % (
                 self.ra_cert.serial_number,
                 DN(self.ca_subject),

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -275,17 +275,16 @@ class CACertManage(admintool.AdminTool):
         dn = DN(('cn', self.cert_nickname), ('cn', 'ca_renewal'),
                 ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
 
-        new_cert_der = new_cert.public_bytes(x509.Encoding.DER)
         try:
             entry = conn.get_entry(dn, ['usercertificate'])
-            entry['usercertificate'] = [new_cert_der]
+            entry['usercertificate'] = [new_cert]
             conn.update_entry(entry)
         except errors.NotFound:
             entry = conn.make_entry(
                 dn,
                 objectclass=['top', 'pkiuser', 'nscontainer'],
                 cn=[self.cert_nickname],
-                usercertificate=[new_cert_der])
+                usercertificate=[new_cert])
             conn.add_entry(entry)
         except errors.EmptyModlist:
             pass

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -306,7 +306,6 @@ class KRAInstance(DogtagInstance):
 
         # get RA agent certificate
         cert = x509.load_certificate_from_file(paths.RA_AGENT_PEM)
-        cert_data = cert.public_bytes(x509.Encoding.DER)
 
         # connect to KRA database
         conn = ldap2.ldap2(api)
@@ -322,7 +321,7 @@ class KRAInstance(DogtagInstance):
             sn=["IPA KRA User"],
             cn=["IPA KRA User"],
             usertype=["undefined"],
-            userCertificate=[cert_data],
+            userCertificate=[cert],
             description=['2;%s;%s;%s' % (
                 cert.serial_number,
                 DN(self.subject),

--- a/ipaserver/install/plugins/upload_cacrt.py
+++ b/ipaserver/install/plugins/upload_cacrt.py
@@ -22,7 +22,7 @@ import logging
 from ipalib.install import certstore
 from ipaplatform.paths import paths
 from ipaserver.install import certs
-from ipalib import Registry, errors, x509
+from ipalib import Registry, errors
 from ipalib import Updater
 from ipapython import certdb
 from ipapython.dn import DN
@@ -90,7 +90,6 @@ class update_upload_cacrt(Updater):
                         pass
 
         if ca_cert:
-            dercert = ca_cert.public_bytes(x509.Encoding.DER)
             dn = DN(('cn', 'CACert'), ('cn', 'ipa'), ('cn','etc'),
                     self.api.env.basedn)
             try:
@@ -99,11 +98,11 @@ class update_upload_cacrt(Updater):
                 entry = ldap.make_entry(dn)
                 entry['objectclass'] = ['nsContainer', 'pkiCA']
                 entry.single_value['cn'] = 'CAcert'
-                entry.single_value['cACertificate;binary'] = dercert
+                entry.single_value['cACertificate;binary'] = ca_cert
                 ldap.add_entry(entry)
             else:
                 if b'' in entry['cACertificate;binary']:
-                    entry.single_value['cACertificate;binary'] = dercert
+                    entry.single_value['cACertificate;binary'] = ca_cert
                     ldap.update_entry(entry)
 
         return False, []

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -32,7 +32,7 @@ from ipalib.install import certstore, sysrestore
 from ipapython import ipautil
 from ipapython.dn import DN
 from ipapython import kerberos
-from ipalib import api, errors, x509
+from ipalib import api, errors
 from ipaplatform import services
 from ipaplatform.paths import paths
 
@@ -370,8 +370,7 @@ class Service(object):
         dn = DN(('krbprincipalname', self.principal), ('cn', 'services'),
                 ('cn', 'accounts'), self.suffix)
         entry = api.Backend.ldap2.get_entry(dn)
-        entry.setdefault('userCertificate', []).append(
-            self.cert.public_bytes(x509.Encoding.DER))
+        entry.setdefault('userCertificate', []).append(self.cert)
         try:
             api.Backend.ldap2.update_entry(entry)
         except Exception as e:

--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -27,7 +27,6 @@ import dns.resolver
 import six
 
 from ipalib import api, errors, util
-from ipalib.x509 import Encoding as x509_Encoding
 from ipalib import messages
 from ipalib import Str, Flag
 from ipalib.parameters import Principal, Certificate
@@ -902,9 +901,9 @@ class host_mod(LDAPUpdate):
             except errors.NotFound:
                 self.obj.handle_not_found(*keys)
             old_certs = entry_attrs_old.get('usercertificate', [])
-            removed_certs_der = set(old_certs) - set(certs)
-            for der in removed_certs_der:
-                rm_certs = api.Command.cert_find(certificate=der)['result']
+            removed_certs = set(old_certs) - set(certs)
+            for cert in removed_certs:
+                rm_certs = api.Command.cert_find(certificate=cert)['result']
                 revoke_certs(rm_certs)
 
         if certs:
@@ -1340,8 +1339,7 @@ class host_remove_cert(LDAPRemoveAttributeViaOption):
         assert isinstance(dn, DN)
 
         for cert in options.get('usercertificate', []):
-            revoke_certs(api.Command.cert_find(
-                certificate=cert.public_bytes(x509_Encoding.DER))['result'])
+            revoke_certs(api.Command.cert_find(certificate=cert)['result'])
 
         return dn
 

--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -983,8 +983,7 @@ class service_remove_cert(LDAPRemoveAttributeViaOption):
         assert isinstance(dn, DN)
 
         for cert in options.get('usercertificate', []):
-            revoke_certs(api.Command.cert_find(
-                certificate=cert.public_bytes(x509.Encoding.DER))['result'])
+            revoke_certs(api.Command.cert_find(certificate=cert)['result'])
 
         return dn
 


### PR DESCRIPTION
Recent certificate refactoring left the system in a state where
the certificates are somewhere converted to DER format, somewhere
directly sent to ipaldap as IPACertificate objects. The latter
is the desirable way, make sure it's the one commonly used.

https://pagure.io/freeipa/issue/4985