### PR TITLE
Fix CA-less installation

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -579,8 +579,8 @@ class NSSDatabase(object):
             self.add_cert(cert, nickname, EMPTY_TRUST_FLAGS)
 
         if extracted_key:
-            with tempfile.NamedTemporaryFile(), tempfile.NamedTemporaryFile() \
-                    as (in_file, out_file):
+            with tempfile.NamedTemporaryFile() as in_file, \
+                    tempfile.NamedTemporaryFile() as out_file:
                 x509.write_certificate_list(extracted_certs, in_file.name)
                 in_file.write(extracted_key)
                 in_file.flush()

--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -581,7 +581,8 @@ class NSSDatabase(object):
         if extracted_key:
             with tempfile.NamedTemporaryFile() as in_file, \
                     tempfile.NamedTemporaryFile() as out_file:
-                x509.write_certificate_list(extracted_certs, in_file.name)
+                for cert in extracted_certs:
+                    in_file.write(cert.public_bytes(x509.Encoding.PEM))
                 in_file.write(extracted_key)
                 in_file.flush()
                 out_password = ipautil.ipa_generate_password()


### PR DESCRIPTION
Fix CA-less installation failure due to an incorrect use of with
statement.

Fixes: https://pagure.io/freeipa/issue/7118