### PR TITLE
Fix ipa config-mod --ca-renewal-master

### DIFF
--- a/ipatests/test_ipaserver/test_serverroles.py
+++ b/ipatests/test_ipaserver/test_serverroles.py
@@ -715,7 +715,7 @@ class TestServerAttributes(object):
         non_ca_fqdn = mock_masters.get_fqdn('trust-controller-dns')
 
         with pytest.raises(errors.ValidationError):
-            self.config_update(mock_api, **{attr_name: [non_ca_fqdn]})
+            self.config_update(mock_api, **{attr_name: non_ca_fqdn})
 
     def test_set_unknown_attribute_on_master_raises_notfound(
             self, mock_api, mock_masters):
@@ -732,7 +732,7 @@ class TestServerAttributes(object):
         original_renewal_master = self.config_retrieve(
             role_name, mock_api)[attr_name]
 
-        other_ca_server = [mock_masters.get_fqdn('trust-controller-ca')]
+        other_ca_server = mock_masters.get_fqdn('trust-controller-ca')
 
         for host in (other_ca_server, original_renewal_master):
             self.config_update(mock_api, **{attr_name: host})


### PR DESCRIPTION
commit bddb90f38a3505a2768862d2f814c5e749a7dcde added the support for
multivalued server attributes (for pkinit_server_server), but this
introduced an API change where the setter and getter of ServerAttribute
are expecting list of values.

When a SingleValuedServerAttribute is used, we need to convert one elem
into a list containing this elem and vice-versa, so that the ipa config-mod
and ipa config_show APIs are not modified.

https://pagure.io/freeipa/issue/7120