### PR TITLE
Fix external renewal for CA with non-default subject DN

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -45,7 +45,7 @@ from ipapython.dn import DN
 from ipalib import api, errors, x509
 from ipaplatform.paths import paths
 from ipaserver.plugins.ldap2 import ldap2
-from ipaserver.install import cainstance, dsinstance, certs
+from ipaserver.install import ca, cainstance, dsinstance, certs
 
 # This is a certmonger CA helper script for IPA CA subsystem cert renewal. See
 # https://git.fedorahosted.org/cgit/certmonger.git/tree/doc/submit.txt for more
@@ -99,9 +99,10 @@ def get_nickname():
     if not subject_base:
         return None
 
+    ca_subject_dn = ca.lookup_ca_subject(api, subject_base)
+
     nickname_by_subject_dn = {
-        DN('CN=Certificate Authority', subject_base):
-            'caSigningCert cert-pki-ca',
+        DN(ca_subject_dn): 'caSigningCert cert-pki-ca',
         DN('CN=CA Audit', subject_base): 'auditSigningCert cert-pki-ca',
         DN('CN=OCSP Subsystem', subject_base): 'ocspSigningCert cert-pki-ca',
         DN('CN=CA Subsystem', subject_base): 'subsystemCert cert-pki-ca',


### PR DESCRIPTION
When running ``ipa-cacert-manage renew --external-ca`` with an IPA
CA having a subject DN that does not correspond to ``CN=Certificate
Authority, {subject-base}``, the CSR for submission to the external
CA does not generated.  dogtag-ipa-ca-renew-agent-submit is wrongly
assuming the default form of the CA subject DN.

Update dogtag-ipa-ca-renew-agent-submit to look up the actual
subject DN.

Fixes: https://pagure.io/freeipa/issue/7123