### PR TITLE
py3: Fix searching for yubikeys

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -730,7 +730,8 @@ Requires: python3-qrcode-core >= 5.0.0
 Requires: python3-pyasn1
 Requires: python3-pyasn1-modules
 Requires: python3-dateutil
-Requires: python3-yubico >= 1.2.3
+# fixes searching for yubikeys in python3
+Requires: python3-yubico >= 1.3.2-7
 Requires: python3-sss-murmur
 Requires: python3-dbus
 Requires: python3-setuptools


### PR DESCRIPTION
Bumping the requirements for the python-yubikey package. This is
unfortunately most probably fixed only in Fedora because there was no
upstream release for about a year and a half now. That also means
bumping the version in ipasetup.py.in would be pointless.

https://pagure.io/freeipa/issue/7121