### PR TITLE
py3: fix vault public key decoding

### DIFF
--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -890,7 +890,7 @@ class vault_archive(ModVaultData):
 
         elif vault_type == u'asymmetric':
 
-            public_key = vault['ipavaultpublickey'][0].encode('utf-8')
+            public_key = vault['ipavaultpublickey'][0]
 
             # generate encryption key
             encryption_key = base64.b64encode(os.urandom(32))


### PR DESCRIPTION
Part of: https://pagure.io/freeipa/issue/7033

This commit fixes one issue in FreeIPA related to vault.  It does not fully
resolve #7033 because there are changes needed in Dogtag too.