### PR TITLE
Adds whoami DS plugin in case that plugin is missing

### DIFF
--- a/install/updates/20-whoami.update
+++ b/install/updates/20-whoami.update
@@ -1,0 +1,14 @@
+dn: cn=whoami,cn=plugins,cn=config
+default:objectClass: top
+default:objectClass: nsSlapdPlugin
+default:objectClass: extensibleObject
+default:cn: whoami
+default:nsslapd-plugin-depends-on-type: database
+default:nsslapd-pluginDescription: whoami extended operation plugin
+default:nsslapd-pluginEnabled: on
+default:nsslapd-pluginId: whoami-plugin
+default:nsslapd-pluginInitfunc: whoami_init
+default:nsslapd-pluginPath: libwhoami-plugin
+default:nsslapd-pluginType: extendedop
+default:nsslapd-pluginVendor: 389 Project
+default:nsslapd-pluginVersion: 1.0

--- a/install/updates/Makefile.am
+++ b/install/updates/Makefile.am
@@ -24,6 +24,7 @@ app_DATA =				\
 	20-idoverride_index.update	\
 	20-uuid.update  \
 	20-default_password_policy.update \
+	20-whoami.update	\
 	21-replicas_container.update	\
 	21-ca_renewal_container.update	\
 	21-certstore_container.update	\


### PR DESCRIPTION
When first installation of IPA has been done when whoami
plugin was not enabled in DS by default and then IPA was
upgraded to newer versions, then after upgrade to IPA 4.5
WebUI stops working. This is caused by new requirement on
whoami DS plugin which is used to obtain information about
logged in entity.

This fix adds check whether the plugin is enabled and if not
then IPA enables the plugin during upgrade.

https://pagure.io/freeipa/issue/7126