### PR TITLE
csrgen: support openssl 1.0 and 1.1

### DIFF
--- a/ipaclient/csrgen_ffi.py
+++ b/ipaclient/csrgen_ffi.py
@@ -34,6 +34,9 @@ char *NCONF_get_string(const CONF *conf, const char *group, const char *name);
 /* openssl/stack.h */
 typedef ... _STACK;
 
+int OPENSSL_sk_num(const _STACK *);
+void *OPENSSL_sk_value(const _STACK *, int);
+
 int sk_num(const _STACK *);
 void *sk_value(const _STACK *, int);
 
@@ -125,8 +128,12 @@ NCONF_get_section = _libcrypto.NCONF_get_section
 NCONF_get_string = _libcrypto.NCONF_get_string
 
 # openssl/stack.h
-sk_num = _libcrypto.sk_num
-sk_value = _libcrypto.sk_value
+try:
+    sk_num = _libcrypto.OPENSSL_sk_num
+    sk_value = _libcrypto.OPENSSL_sk_value
+except AttributeError as e:
+    sk_num = _libcrypto.sk_num
+    sk_value = _libcrypto.sk_value
 
 
 def sk_CONF_VALUE_num(sk):


### PR DESCRIPTION
Support both openssl 1.0 and 1.1 APIs where sk_* functions got prefixed
with OPENSSL_ in the latter version.

Since referencing a symbol from a dynamically loaded library generates
exception, use the AttributeError exception to catch it and fall back to
the older method.

Fixes https://pagure.io/freeipa/issue/7110