### PR TITLE
Python3: Fix winsync replication agreement

### DIFF
--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1089,7 +1089,8 @@ class ReplicationManager(object):
                                    ['defaultNamingContext'])
             for dn,entry in res:
                 if dn == "":
-                    self.ad_suffix = entry['defaultNamingContext'][0]
+                    ad_suffix = entry['defaultNamingContext'][0]
+                    self.ad_suffix = ad_suffix.decode('utf-8')
                     logger.info("AD Suffix is: %s", self.ad_suffix)
             if self.ad_suffix == "":
                 raise RuntimeError("Failed to lookup AD's Ldap suffix")


### PR DESCRIPTION
When configuring a winsync replication agreement, the tool performs a search
on AD for defaultNamingContext. The entry contains the value as a bytes, it
needs to be decoded otherwise subsequent calls to
DN(WIN_USER_CONTAINER, self.ad_suffix) will fail.

https://pagure.io/freeipa/issue/4985