### PR TITLE
py3: turn all shebangs to python3

### DIFF
--- a/client/ipa-certupdate
+++ b/client/ipa-certupdate
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Jan Cholasta <jcholast@redhat.com>
 #
 # Copyright (C) 2014  Red Hat

--- a/client/ipa-client-automount
+++ b/client/ipa-client-automount
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -E
+#!/usr/bin/python3 -E
 #
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>

--- a/client/ipa-client-install
+++ b/client/ipa-client-install
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Simo Sorce <ssorce@redhat.com>
 #          Karl MacMillan <kmacmillan@mentalrootkit.com>
 #

--- a/contrib/copy-schema-to-ca-RHEL6.py
+++ b/contrib/copy-schema-to-ca-RHEL6.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python2
+#!/usr/bin/python2
 
 """Copy the IPA schema to the CA directory server instance
 

--- a/daemons/dnssec/ipa-dnskeysync-replica
+++ b/daemons/dnssec/ipa-dnskeysync-replica
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 #
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #

--- a/daemons/dnssec/ipa-dnskeysyncd
+++ b/daemons/dnssec/ipa-dnskeysyncd
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 #
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #

--- a/daemons/dnssec/ipa-ods-exporter
+++ b/daemons/dnssec/ipa-ods-exporter
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 #
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #

--- a/daemons/ipa-otpd/test.py
+++ b/daemons/ipa-otpd/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 #
 # FreeIPA 2FA companion daemon
 #

--- a/doc/examples/python-api.py
+++ b/doc/examples/python-api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Authors:
 #   Jason Gerard DeRose <jderose@redhat.com>
 #

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -929,6 +929,8 @@ export JAVA_STACK_SIZE="8m"
 # PATH is workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1005235
 export PATH=/usr/bin:/usr/sbin:$PATH
 export PYTHON=%{__python2}
+
+%if ! 0%{?with_python3}
 # Workaround: make sure all shebangs are pointing to Python 2
 # This should be solved properly using setuptools
 # and this hack should be removed.
@@ -937,64 +939,7 @@ find \
 	! -name '*.pyo' -a \
 	-type f -exec grep -qsm1 '^#!.*\bpython' {} \; \
 	-exec sed -i -e '1 s|^#!.*\bpython[^ ]*|#!%{__python2}|' {} \;
-
-%if 0%{?with_python3}
-# TODO: temporary solution until all scripts are ported to python3,
-# TODO: workaround: some scripts are copied over, so the are always py2.
-# We have to explicitly set python3 here for ported files here
-PY3_SUBST_PATHS='
-client/ipa-certupdate
-client/ipa-client-automount
-client/ipa-client-install
-daemons/dnssec/ipa-dnskeysyncd
-daemons/dnssec/ipa-dnskeysync-replica
-daemons/dnssec/ipa-ods-exporter
-daemons/ipa-otpd/test.py
-install/certmonger/ipa-server-guard
-install/certmonger/dogtag-ipa-ca-renew-agent-submit
-install/oddjob/com.redhat.idm.trust-fetch-domains
-install/restart_scripts/renew_ra_cert_pre
-install/restart_scripts/renew_ca_cert
-install/restart_scripts/renew_ra_cert
-install/restart_scripts/restart_httpd
-install/restart_scripts/renew_kdc_cert
-install/restart_scripts/stop_pkicad
-install/restart_scripts/restart_dirsrv
-install/tools/ipa-advise
-install/tools/ipa-adtrust-install
-install/tools/ipa-backup
-install/tools/ipa-ca-install
-install/tools/ipa-cacert-manage
-install/tools/ipa-compat-manage
-install/tools/ipa-csreplica-manage
-install/tools/ipa-custodia
-install/tools/ipa-custodia-check
-install/tools/ipa-dns-install
-install/tools/ipa-httpd-kdcproxy
-install/tools/ipa-kra-install
-install/tools/ipa-ldap-updater
-install/tools/ipa-managed-entries
-install/tools/ipa-nis-manage
-install/tools/ipa-otptoken-import
-install/tools/ipa-pkinit-manage
-install/tools/ipa-pki-retrieve-key
-install/tools/ipa-replica-conncheck
-install/tools/ipa-replica-install
-install/tools/ipa-replica-manage
-install/tools/ipa-replica-prepare
-install/tools/ipa-restore
-install/tools/ipa-server-certinstall
-install/tools/ipa-server-install
-install/tools/ipa-server-upgrade
-install/tools/ipa-winsync-migrate
-install/tools/ipactl
-ipa
-'
-for P in $PY3_SUBST_PATHS; do
-    sed -i -e '1 s|^#!\s\?.*\bpython[0-9]*|#!%{__python3}|' $P
-done;
-
-%endif # with_python3
+%endif # ! with_python3
 
 %configure --with-vendor-suffix=-%{release} \
            %{enable_server_option} \
@@ -1005,22 +950,14 @@ done;
 %make_build -Onone
 
 %if 0%{?with_python3}
-pushd %{_builddir}/freeipa-%{version}-python3
 export PYTHON=%{__python3}
-# Workaround: make sure all shebangs are pointing to Python 3
-# This should be solved properly using setuptools
-# and this hack should be removed.
-find \
-	! -name '*.pyc' -a \
-	! -name '*.pyo' -a \
-	-type f -exec grep -qsm1 '^#!.*\bpython' {} \; \
-	-exec sed -i -e '1 s|^#!.*\bpython[^ ]*|#!%{__python3}|' {} \;
+pushd %{_builddir}/freeipa-%{version}-python3
 %configure --with-vendor-suffix=-%{release} \
            %{enable_server_option} \
            %{with_ipatests_option} \
            %{linter_options}
 popd
-%endif # with_python3
+%endif  # with_python3
 
 %check
 make %{?_smp_mflags} check VERBOSE=yes LIBDIR=%{_libdir}

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -E
+#!/usr/bin/python3 -E
 #
 # Authors:
 #   Jan Cholasta <jcholast@redhat.com>

--- a/install/certmonger/ipa-server-guard
+++ b/install/certmonger/ipa-server-guard
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -E
+#!/usr/bin/python3 -E
 #
 # Authors:
 #   Jan Cholasta <jcholast@redhat.com>

--- a/install/oddjob/com.redhat.idm.trust-fetch-domains
+++ b/install/oddjob/com.redhat.idm.trust-fetch-domains
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 from ipaserver import dcerpc
 from ipaserver.install.installutils import is_ipa_configured, ScriptError

--- a/install/restart_scripts/renew_ca_cert
+++ b/install/restart_scripts/renew_ca_cert
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -E
+#!/usr/bin/python3 -E
 #
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>

--- a/install/restart_scripts/renew_kdc_cert
+++ b/install/restart_scripts/renew_kdc_cert
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -E
+#!/usr/bin/python3 -E
 #
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #

--- a/install/restart_scripts/renew_ra_cert
+++ b/install/restart_scripts/renew_ra_cert
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -E
+#!/usr/bin/python3 -E
 #
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>

--- a/install/restart_scripts/renew_ra_cert_pre
+++ b/install/restart_scripts/renew_ra_cert_pre
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -E
+#!/usr/bin/python3 -E
 #
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #

--- a/install/restart_scripts/restart_dirsrv
+++ b/install/restart_scripts/restart_dirsrv
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -E
+#!/usr/bin/python3 -E
 #
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>

--- a/install/restart_scripts/restart_httpd
+++ b/install/restart_scripts/restart_httpd
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -E
+#!/usr/bin/python3 -E
 #
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>

--- a/install/restart_scripts/stop_pkicad
+++ b/install/restart_scripts/stop_pkicad
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -E
+#!/usr/bin/python3 -E
 #
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>

--- a/install/tools/ipa-adtrust-install
+++ b/install/tools/ipa-adtrust-install
@@ -1,4 +1,4 @@
-#! /usr/bin/python2
+#!/usr/bin/python3
 #
 # Authors: Sumit Bose <sbose@redhat.com>
 # Based on ipa-server-install by Karl MacMillan <kmacmillan@mentalrootkit.com>

--- a/install/tools/ipa-advise
+++ b/install/tools/ipa-advise
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Tomas Babej <tbabej@redhat.com>
 #
 # Copyright (C) 2013  Red Hat

--- a/install/tools/ipa-backup
+++ b/install/tools/ipa-backup
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Rob Crittenden <rcritten@redhat.com>
 #
 # Copyright (C) 2013  Red Hat

--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Rob Crittenden <rcritten@redhat.com>
 #
 # Copyright (C) 2011  Red Hat

--- a/install/tools/ipa-cacert-manage
+++ b/install/tools/ipa-cacert-manage
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Jan Cholasta <jcholast@redhat.com>
 #
 # Copyright (C) 2014  Red Hat

--- a/install/tools/ipa-compat-manage
+++ b/install/tools/ipa-compat-manage
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Authors: Rob Crittenden <rcritten@redhat.com>
 # Authors: Simo Sorce <ssorce@redhat.com>
 #

--- a/install/tools/ipa-csreplica-manage
+++ b/install/tools/ipa-csreplica-manage
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Rob Crittenden <rcritten@redhat.com>
 #
 # Based on ipa-replica-manage by Karl MacMillan <kmacmillan@mentalrootkit.com>

--- a/install/tools/ipa-custodia
+++ b/install/tools/ipa-custodia
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Copyright (C) 2017  IPA Project Contributors, see COPYING for license
 from ipaserver.secrets.service import main
 

--- a/install/tools/ipa-dns-install
+++ b/install/tools/ipa-dns-install
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Martin Nagy <mnagy@redhat.com>
 # Based on ipa-server-install by Karl MacMillan <kmacmillan@mentalrootkit.com>
 #

--- a/install/tools/ipa-httpd-kdcproxy
+++ b/install/tools/ipa-httpd-kdcproxy
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Authors:
 #   Christian Heimes <cheimes@redhat.com>
 #

--- a/install/tools/ipa-kra-install
+++ b/install/tools/ipa-kra-install
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Ade Lee <alee@redhat.com>
 #
 # Copyright (C) 2014  Red Hat

--- a/install/tools/ipa-ldap-updater
+++ b/install/tools/ipa-ldap-updater
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Authors: Rob Crittenden <rcritten@redhat.com>
 #
 # Copyright (C) 2008  Red Hat

--- a/install/tools/ipa-managed-entries
+++ b/install/tools/ipa-managed-entries
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Authors: Jr Aquino <jr.aquino@citrix.com>
 #
 # Copyright (C) 2011  Red Hat

--- a/install/tools/ipa-nis-manage
+++ b/install/tools/ipa-nis-manage
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Authors: Rob Crittenden <rcritten@redhat.com>
 # Authors: Simo Sorce <ssorce@redhat.com>
 #

--- a/install/tools/ipa-otptoken-import
+++ b/install/tools/ipa-otptoken-import
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Nathaniel McCallum <npmccallum@redhat.com>
 #
 # Copyright (C) 2014  Red Hat

--- a/install/tools/ipa-pki-retrieve-key
+++ b/install/tools/ipa-pki-retrieve-key
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 from __future__ import print_function
 

--- a/install/tools/ipa-pkinit-manage
+++ b/install/tools/ipa-pkinit-manage
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 #
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #

--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Martin Kosek <mkosek@redhat.com>
 #
 # Copyright (C) 2011  Red Hat

--- a/install/tools/ipa-replica-install
+++ b/install/tools/ipa-replica-install
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Karl MacMillan <kmacmillan@mentalrootkit.com>
 #
 # Copyright (C) 2007  Red Hat

--- a/install/tools/ipa-replica-manage
+++ b/install/tools/ipa-replica-manage
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Karl MacMillan <kmacmillan@mentalrootkit.com>
 #
 # Copyright (C) 2007  Red Hat

--- a/install/tools/ipa-replica-prepare
+++ b/install/tools/ipa-replica-prepare
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Petr Viktorin <pviktori@redhat.com>
 #
 # Copyright (C) 2012  Red Hat

--- a/install/tools/ipa-restore
+++ b/install/tools/ipa-restore
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Rob Crittenden <rcritten@redhat.com>
 #
 # Copyright (C) 2013  Red Hat

--- a/install/tools/ipa-server-certinstall
+++ b/install/tools/ipa-server-certinstall
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Jan Cholasta <jcholast@redhat.com>
 #
 # Copyright (C) 2013  Red Hat

--- a/install/tools/ipa-server-install
+++ b/install/tools/ipa-server-install
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Karl MacMillan <kmacmillan@mentalrootkit.com>
 #          Simo Sorce <ssorce@redhat.com>
 #          Rob Crittenden <rcritten@redhat.com>

--- a/install/tools/ipa-server-upgrade
+++ b/install/tools/ipa-server-upgrade
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 #
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #

--- a/install/tools/ipa-winsync-migrate
+++ b/install/tools/ipa-winsync-migrate
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Tomas Babej <tbabej@redhat.com>
 #
 # Copyright (C) 2015  Red Hat

--- a/install/tools/ipactl
+++ b/install/tools/ipactl
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Authors: Simo Sorce <ssorce@redhat.com>
 #
 # Copyright (C) 2008-2010  Red Hat

--- a/ipa
+++ b/ipa
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 # Authors:
 #   Jason Gerard DeRose <jderose@redhat.com>

--- a/ipaclient/csrgen_ffi.py
+++ b/ipaclient/csrgen_ffi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from cffi import FFI
 import ctypes.util

--- a/ipaclient/setup.py
+++ b/ipaclient/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Copyright (C) 2007  Red Hat
 # see file 'COPYING' for use and warranty information
 #

--- a/ipalib/setup.py
+++ b/ipalib/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Copyright (C) 2007  Red Hat
 # see file 'COPYING' for use and warranty information
 #

--- a/ipaplatform/setup.py
+++ b/ipaplatform/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Copyright (C) 2014  Red Hat
 # see file 'COPYING' for use and warranty information
 #

--- a/ipapython/setup.py
+++ b/ipapython/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Copyright (C) 2007  Red Hat
 # see file 'COPYING' for use and warranty information
 #

--- a/ipaserver/dnssec/localhsm.py
+++ b/ipaserver/dnssec/localhsm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 #
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #

--- a/ipaserver/dnssec/odsmgr.py
+++ b/ipaserver/dnssec/odsmgr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 #
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #

--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 # Authors: Ade Lee <alee@redhat.com>
 #
 # Copyright (C) 2014  Red Hat

--- a/ipaserver/setup.py
+++ b/ipaserver/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 # Authors:
 #   Jason Gerard DeRose <jderose@redhat.com>

--- a/ipatests/i18n.py
+++ b/ipatests/i18n.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Authors:
 #   John Dennis <jdennis@redhat.com>
 #

--- a/ipatests/ipa-run-tests
+++ b/ipatests/ipa-run-tests
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 # Authors:
 #   Petr Viktorin <pviktori@redhat.com>

--- a/ipatests/ipa-test-config
+++ b/ipatests/ipa-test-config
@@ -1,4 +1,4 @@
-#! /usr/bin/python2
+#!/usr/bin/python3
 
 # Authors:
 #   Petr Viktorin <pviktori@redhat.com>

--- a/ipatests/ipa-test-task
+++ b/ipatests/ipa-test-task
@@ -1,4 +1,4 @@
-#! /usr/bin/python2
+#!/usr/bin/python3
 
 # Authors:
 #   Petr Viktorin <pviktori@redhat.com>

--- a/ipatests/pytest_plugins/beakerlib.py
+++ b/ipatests/pytest_plugins/beakerlib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Copyright (C) 2014  Red Hat
 # see file 'COPYING' for use and warranty information
 #

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Copyright (C) 2007  Red Hat
 # see file 'COPYING' for use and warranty information
 #

--- a/ipatests/test_ipapython/test_ipavalidate.py
+++ b/ipatests/test_ipapython/test_ipavalidate.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -E
+#!/usr/bin/python3 -E
 #
 # Copyright (C) 2007    Red Hat
 # see file 'COPYING' for use and warranty information

--- a/makeaci
+++ b/makeaci
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Authors:
 #   Petr Viktorin <pviktori@redhat.com>
 #   John Dennis <jdennis@redhat.com>

--- a/makeapi
+++ b/makeapi
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>
 #   John Dennis <jdennis@redhat.com>


### PR DESCRIPTION
This patchset turns all shebangs in IPA scripts to Python 3. Note that this may seem like going against what we agreed on some two months ago but the outcome to turn everything to `/usr/bin/python` to use default python version would be a setback in the Fedora planning: https://fedoraproject.org/wiki/FinalizingFedoraSwitchtoPython3 and there is no reason not to use the up-till-now long running Python 3 effort.

This also required to regenerate the `API.txt` file so that our checks don't fail to validate for python2/3 type discrepancies.