### PR TITLE
ipatests: collect log after ipa-ca-install

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1176,7 +1176,9 @@ def install_ca(host, domain_level=None, first_instance=False, raiseonerr=True):
     if domain_level == DOMAIN_LEVEL_0 and not first_instance:
         replica_file = get_replica_filename(host)
         command.append(replica_file)
-    return host.run_command(command, raiseonerr=raiseonerr)
+    result = host.run_command(command, raiseonerr=raiseonerr)
+    setup_server_logs_collecting(host)
+    return result
 
 
 def install_dns(host, raiseonerr=True):


### PR DESCRIPTION
Make sure logs are collected after calling ipa-ca-install command.

Related: https://pagure.io/freeipa/issue/7060

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>