### PR TITLE
Backport PR 1025 to ipa-4-5

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1172,7 +1172,9 @@ def install_ca(host, domain_level=None, first_instance=False, raiseonerr=True):
     if domain_level == DOMAIN_LEVEL_0 and not first_instance:
         replica_file = get_replica_filename(host)
         command.append(replica_file)
-    return host.run_command(command, raiseonerr=raiseonerr)
+    result = host.run_command(command, raiseonerr=raiseonerr)
+    setup_server_logs_collecting(host)
+    return result
 
 
 def install_dns(host, raiseonerr=True):


### PR DESCRIPTION
This PR was opened automatically because PR #1025 was pushed to master and backport to ipa-4-5 is required.