### PR TITLE
Python3 - depend on python3-* packages by default in Fedora

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -932,7 +932,7 @@ install/tools/ipactl
 ipa
 '
 for P in $PY3_SUBST_PATHS; do
-    sed -i -e '1 s|^#!.*\bpython[0-9]*\(\s\+-\)\?|#!%{__python3} -bb|' $P
+    sed -i -e '1 s|^#!\s\?.*\bpython[0-9]*|#!%{__python3}|' $P
 done;
 
 %endif # with_python3

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -826,8 +826,7 @@ Summary: IPA tests and test tools
 BuildArch: noarch
 %{?python_provide:%python_provide python3-ipatests}
 Requires: python3-ipaclient = %{version}-%{release}
-# FIXME: uncomment once there's python3-ipaserver
-#Requires: python3-ipaserver = %{version}-%{release}
+Requires: python3-ipaserver = %{version}-%{release}
 Requires: tar
 Requires: xz
 Requires: python3-nose

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -281,8 +281,9 @@ Requires: %{name}-client = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 %if 0%{?with_python3}
 Requires: python3-ipaserver = %{version}-%{release}
-%endif
+%else
 Requires: python2-ipaserver = %{version}-%{release}
+%endif
 Requires: 389-ds-base >= 1.3.5.14
 Requires: openldap-clients > 2.4.35-4
 Requires: nss >= 3.14.3-12.0
@@ -512,8 +513,9 @@ Requires: %{name}-client-common = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 %if 0%{?with_python3}
 Requires: python3-ipaclient = %{version}-%{release}
-%endif
+%else
 Requires: python2-ipaclient = %{version}-%{release}
+%endif
 Requires: python-ldap
 Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: ntp
@@ -635,8 +637,9 @@ Provides: %{name}-python = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 %if 0%{?with_python3}
 Requires: python3-ipalib = %{version}-%{release}
-%endif
+%else
 Requires: python2-ipalib = %{version}-%{release}
+%endif
 
 Provides: %{alt_name}-python-compat = %{version}
 Conflicts: %{alt_name}-python-compat


### PR DESCRIPTION
This patchset is an easier way for a more proper solution in https://github.com/freeipa/freeipa/pull/1024. We should investigate the proper solution more to see why it fails but there's currently not enough time before release.

https://pagure.io/freeipa/issue/4985