### PR TITLE
WebUI: ID user override causes traceback in httpd/error_log

### DIFF
--- a/install/ui/src/freeipa/idviews.js
+++ b/install/ui/src/freeipa/idviews.js
@@ -257,8 +257,7 @@ return {
                         {
                             $type: 'link',
                             name: 'ipaanchoruuid',
-                            label: '@i18n:objects.idoverrideuser.anchor_label',
-                            other_entity: 'user'
+                            label: '@i18n:objects.idoverrideuser.anchor_label'
                         },
                         {
                             $type: 'textarea',


### PR DESCRIPTION
The 'ipaanchoruuid' is link widget and it had set 'other_entity'
attribute to 'user'. That means that WebUI automatically checks
whether the created link is available (whether there is an existing
user with the name set as value of the 'ipaanchoruuid' field).
The user with that name is not obviously found because it tries to
find a user while the value is ipaanchoruuid (AD user).

Removing 'other_entity' from specification tells WebUI to not
check the link.

The link widget is even set to non-clicable state. So the check does not
makes sense now.

https://pagure.io/freeipa/issue/7139