### PR TITLE
Fixing tox and pylint errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
             test_ipapython
             test_ipaserver
             test_pkcs10
+            test_integration/test_ipalib_util.py
             test_xmlrpc/test_[l-z]*.py"
         - TASK_TO_RUN="run-tests"
           PYTHON=/usr/bin/python3
@@ -46,6 +47,7 @@ env:
                 test_ipapython
                 test_ipaserver
                 test_pkcs10
+                test_integration/test_ipalib_util.py
                 test_xmlrpc/test_[l-uw-z]*.py"
                 # FIXME: add vault tests once PKI finally fixes vault
 install:

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -55,10 +55,6 @@ from ipalib.constants import (
     TLS_VERSIONS, TLS_VERSION_MINIMAL, TLS_HIGH_CIPHERS
 )
 from ipalib.text import _
-# pylint: disable=ipa-forbidden-import
-from ipalib.install import sysrestore
-from ipaplatform.paths import paths
-# pylint: enable=ipa-forbidden-import
 from ipapython.ssh import SSHPublicKey
 from ipapython.dn import DN, RDN
 from ipapython.dnsutil import DNSName
@@ -67,6 +63,9 @@ from ipapython.admintool import ScriptError
 
 if six.PY3:
     unicode = str
+
+_IPA_CLIENT_SYSRESTORE = "/var/lib/ipa-client/sysrestore"
+_IPA_DEFAULT_CONF = "/etc/ipa/default.conf"
 
 logger = logging.getLogger(__name__)
 
@@ -1078,8 +1077,9 @@ def check_client_configuration():
     """
     Check if IPA client is configured on the system.
     """
-    fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
-    if not fstore.has_files() and not os.path.exists(paths.IPA_DEFAULT_CONF):
+    if (not os.path.isfile(_IPA_DEFAULT_CONF) or
+       not os.path.isdir(_IPA_CLIENT_SYSRESTORE) or
+       not os.listdir(_IPA_CLIENT_SYSRESTORE)):
         raise ScriptError('IPA client is not configured on this system')
 
 

--- a/ipatests/test_integration/test_ipalib_util.py
+++ b/ipatests/test_integration/test_ipalib_util.py
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2017  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Test the `ipalib.util` module.
+This tests is in test_integration beucase we only can import ipaplatform here.
+"""
+
+from ipalib import util
+from ipaplatform.paths import paths
+
+import pytest
+pytestmark = pytest.mark.tier0
+
+
+def test_hardcoded_paths_are_right():
+    """
+    Test if constants created in ipalib.util are in sync with
+    paths declared in ipaplatform.paths
+    """
+    assert util._IPA_CLIENT_SYSRESTORE == paths.IPA_CLIENT_SYSRESTORE
+    assert util._IPA_DEFAULT_CONF == paths.IPA_DEFAULT_CONF


### PR DESCRIPTION
Fixing import errors introduced by commit cac3475a0454b730d6e5b2093c2e63d395acd387.

https://pagure.io/freeipa/issue/7132

Output of tox commands:
<details>
<summary>tox -e py27</summary>

<p>

```
fbarreto@freeipa (fix-tox-imports) tox -e py27
py27 recreate: /home/fbarreto/projects/freeipa/.tox/py27
py27 installdeps: ipaclient[csrgen], ipatests
py27 installed: asn1crypto==0.22.0,cffi==1.10.0,cryptography==2.0.3,decorator==4.1.2,dnspython==1.15.0,enum34==1.1.6,gssapi==1.2.0,idna==2.6,ipaclient==4.6.90.dev201709041448+gitac6e4cb61,ipaddress==1.0.18,ipalib==4.6.90.dev201709041448+gitac6e4cb61,ipapython==4.6.90.dev201709041448+gitac6e4cb61,ipatests==4.6.90.dev201709041448+gitac6e4cb61,Jinja2==2.9.6,MarkupSafe==1.0,netaddr==0.7.19,netifaces==0.10.6,nose==1.3.7,polib==1.0.8,py==1.4.34,pyasn1==0.3.3,pyasn1-modules==0.1.1,pycparser==2.18,pytest==3.2.1,pytest-multihost==1.1.1,python-ldap==2.4.42,qrcode==5.3,six==1.10.0
py27 runtests: PYTHONHASHSEED='3471542700'
py27 runtests: commands[0] | /home/fbarreto/projects/freeipa/.tox/py27/bin/ipa --help
Usage: ipa [global-options] COMMAND [command-options]

Manage an IPA domain

Options:
  --version          show program's version number and exit
  -h, --help         Show this help message and exit
  -e KEY=VAL         Set environment variable KEY to VAL
  -c FILE            Load configuration from FILE.
  -d, --debug        Produce full debuging output
  --delegate         Delegate the TGT to the IPA server
  -v, --verbose      Produce more verbose output. A second -v displays the
                     XML-RPC request
  -a, --prompt-all   Prompt for ALL values (even if optional)
  -n, --no-prompt    Prompt for NO values (even if required)
  -f, --no-fallback  Only use the server configured in /etc/ipa/default.conf

See "ipa help topics" for available help topics.
See "ipa help <TOPIC>" for more information on a specific topic.
See "ipa help commands" for the full list of commands.
See "ipa <COMMAND> --help" for more information on a specific command.
py27 runtests: commands[1] | /home/fbarreto/projects/freeipa/.tox/py27/bin/python -bb /home/fbarreto/projects/freeipa/.tox/py27/bin/ipa-run-tests --ipaclient-unittests
========================================== test session starts ==========================================
platform linux2 -- Python 2.7.13, pytest-3.2.1, py-1.4.34, pluggy-0.4.0
rootdir: /home/fbarreto/projects/freeipa/.tox/py27/lib/python2.7/site-packages/ipatests, inifile:
plugins: multihost-1.1.1
collected 451 items / 285 skipped

test_util.py ........
util.py ..
test_ipaclient/test_csrgen.py .................
test_ipalib/test_aci.py ...................
test_ipalib/test_backend.py ........
test_ipalib/test_base.py ...............
test_ipalib/test_capabilities.py .
test_ipalib/test_cli.py ...
test_ipalib/test_config.py ...............
test_ipalib/test_crud.py ...............
test_ipalib/test_errors.py .......
test_ipalib/test_frontend.py ........................................
test_ipalib/test_messages.py ....
test_ipalib/test_output.py ...
test_ipalib/test_parameters.py .............................................................
test_ipalib/test_plugable.py ........
test_ipalib/test_rpc.py ......ssssssss
test_ipalib/test_text.py .............................
test_ipalib/test_x509.py ...
test_ipapython/test_cookie.py ............
test_ipapython/test_dn.py ............................
test_ipapython/test_ipautil.py ..................................................................
test_ipapython/test_ipavalidate.py ..........
test_ipapython/test_kerberos.py ..............
test_ipapython/test_keyring.py ..........
test_ipapython/test_session_storage.py sss
test_ipapython/test_ssh.py ...............................
test_pkcs10/test_pkcs10.py .....

=============================== 440 passed, 296 skipped in 14.63 seconds ================================
________________________________________________ summary ________________________________________________
  py27: commands succeeded
  congratulations :)

```
</p>
</details>


<details>
<summary>tox -e pylint2</summary>

<p>

```

fbarreto@freeipa (fix-tox-imports) tox -e pylint2
pylint2 recreate: /home/fbarreto/projects/freeipa/.tox/pylint2
pylint2 installdeps: ipaclient[csrgen,otptoken_yubikey], pylint
pylint2 installed: asn1crypto==0.22.0,astroid==1.4.9,backports.functools-lru-cache==1.4,cffi==1.10.0,configparser==3.5.0,cryptography==2.0.3,decorator==4.1.2,dnspython==1.15.0,enum34==1.1.6,gssapi==1.2.0,idna==2.6,ipaclient==4.6.90.dev201709041448+gitac6e4cb61,ipaddress==1.0.18,ipalib==4.6.90.dev201709041448+gitac6e4cb61,ipapython==4.6.90.dev201709041448+gitac6e4cb61,isort==4.2.15,Jinja2==2.9.6,lazy-object-proxy==1.3.1,MarkupSafe==1.0,mccabe==0.6.1,netaddr==0.7.19,netifaces==0.10.6,pyasn1==0.3.3,pyasn1-modules==0.1.1,pycparser==2.18,pylint==1.6.5,python-ldap==2.4.42,python-yubico==1.3.2,pyusb==1.0.0,qrcode==5.3,six==1.10.0,wrapt==1.10.11
pylint2 runtests: PYTHONHASHSEED='2133013788'
pylint2 runtests: commands[0] | /home/fbarreto/projects/freeipa/.tox/pylint2/bin/python -m pylint --rcfile=/home/fbarreto/projects/freeipa/pylintrc --load-plugins pylint_plugins /home/fbarreto/projects/freeipa/.tox/pylint2/lib/python2.7/site-packages/ipaclient /home/fbarreto/projects/freeipa/.tox/pylint2/lib/python2.7/site-packages/ipalib /home/fbarreto/projects/freeipa/.tox/pylint2/lib/python2.7/site-packages/ipapython
________________________________________________ summary ________________________________________________
  pylint2: commands succeeded
  congratulations :)

```
</p>
</details>

<details>
<summary>tox -e py35</summary>

<p>

```
fbarreto@freeipa (fix-tox-imports) tox -e py35
py35 create: /home/fbarreto/projects/freeipa/.tox/py35
py35 installdeps: ipaclient[csrgen], ipatests
py35 installed: asn1crypto==0.22.0,cffi==1.10.0,cryptography==2.0.3,decorator==4.1.2,dnspython==1.15.0,gssapi==1.2.0,idna==2.6,ipaclient==4.6.90.dev201709041448+gitac6e4cb61,ipalib==4.6.90.dev201709041448+gitac6e4cb61,ipapython==4.6.90.dev201709041448+gitac6e4cb61,ipatests==4.6.90.dev201709041448+gitac6e4cb61,Jinja2==2.9.6,MarkupSafe==1.0,netaddr==0.7.19,netifaces==0.10.6,nose==1.3.7,polib==1.0.8,py==1.4.34,pyasn1==0.3.3,pyasn1-modules==0.1.1,pycparser==2.18,pyldap==2.4.37,pytest==3.2.1,pytest-multihost==1.1.1,qrcode==5.3,six==1.10.0
py35 runtests: PYTHONHASHSEED='3317488747'
py35 runtests: commands[0] | /home/fbarreto/projects/freeipa/.tox/py35/bin/ipa --help
Usage: ipa [global-options] COMMAND [command-options]

Manage an IPA domain

Options:
  --version          show program's version number and exit
  -h, --help         Show this help message and exit
  -e KEY=VAL         Set environment variable KEY to VAL
  -c FILE            Load configuration from FILE.
  -d, --debug        Produce full debuging output
  --delegate         Delegate the TGT to the IPA server
  -v, --verbose      Produce more verbose output. A second -v displays the
                     XML-RPC request
  -a, --prompt-all   Prompt for ALL values (even if optional)
  -n, --no-prompt    Prompt for NO values (even if required)
  -f, --no-fallback  Only use the server configured in /etc/ipa/default.conf

See "ipa help topics" for available help topics.
See "ipa help <TOPIC>" for more information on a specific topic.
See "ipa help commands" for the full list of commands.
See "ipa <COMMAND> --help" for more information on a specific command.
py35 runtests: commands[1] | /home/fbarreto/projects/freeipa/.tox/py35/bin/python -bb /home/fbarreto/projects/freeipa/.tox/py35/bin/ipa-run-tests --ipaclient-unittests
========================================== test session starts ==========================================
platform linux -- Python 3.5.3, pytest-3.2.1, py-1.4.34, pluggy-0.4.0
rootdir: /home/fbarreto/projects/freeipa/.tox/py35/lib/python3.5/site-packages/ipatests, inifile:
plugins: multihost-1.1.1
collected 451 items / 285 skipped

test_util.py ........
util.py ..
test_ipaclient/test_csrgen.py .................
test_ipalib/test_aci.py ...................
test_ipalib/test_backend.py ........
test_ipalib/test_base.py ...............
test_ipalib/test_capabilities.py .
test_ipalib/test_cli.py ...
test_ipalib/test_config.py ...............
test_ipalib/test_crud.py ...............
test_ipalib/test_errors.py .......
test_ipalib/test_frontend.py ........................................
test_ipalib/test_messages.py ....
test_ipalib/test_output.py ...
test_ipalib/test_parameters.py .............................................................
test_ipalib/test_plugable.py ........
test_ipalib/test_rpc.py ......ssssssss
test_ipalib/test_text.py .............................
test_ipalib/test_x509.py ...
test_ipapython/test_cookie.py ............
test_ipapython/test_dn.py ............................
test_ipapython/test_ipautil.py ....................................s.............................
test_ipapython/test_ipavalidate.py ..........
test_ipapython/test_kerberos.py ..............
test_ipapython/test_keyring.py ..........
test_ipapython/test_session_storage.py sss
test_ipapython/test_ssh.py ...............................
test_pkcs10/test_pkcs10.py .....

=============================== 439 passed, 297 skipped in 15.41 seconds ================================
________________________________________________ summary ________________________________________________
  py35: commands succeeded
  congratulations :)
```
</p>
</details>
