### PR TITLE
spec: bump 389-ds-base to 1.3.7.3-1

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -283,7 +283,8 @@ Requires: python3-ipaserver = %{version}-%{release}
 %else
 Requires: python2-ipaserver = %{version}-%{release}
 %endif
-Requires: 389-ds-base >= 1.3.7.0
+# 1.3.7.6-1: https://bugzilla.redhat.com/show_bug.cgi?id=1488295
+Requires: 389-ds-base >= 1.3.7.6-1
 Requires: openldap-clients > 2.4.35-4
 Requires: nss >= 3.14.3-12.0
 Requires: nss-tools >= 3.14.3-12.0
@@ -321,7 +322,8 @@ Requires(postun): python systemd-units
 Requires: policycoreutils >= 2.1.12-5
 Requires: tar
 Requires(pre): certmonger >= 0.79.5-1
-Requires(pre): 389-ds-base >= 1.3.7.0
+# 1.3.7.6-1: https://bugzilla.redhat.com/show_bug.cgi?id=1488295
+Requires(pre): 389-ds-base >= 1.3.7.6-1
 Requires: fontawesome-fonts
 Requires: open-sans-fonts
 Requires: openssl


### PR DESCRIPTION
To avoid insidious bug during server installation on Fedora 27,
the dependency of 389-ds-base is bumped.

https://bugzilla.redhat.com/show_bug.cgi?id=1488295

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>