### PR TITLE
pkinit: don't fail when no pkinit servers found

### DIFF
--- a/ipaserver/plugins/pkinit.py
+++ b/ipaserver/plugins/pkinit.py
@@ -93,7 +93,9 @@ class pkinit_status(Search):
         else:
             servers = ipa_master_config['ipa_master_server']
 
-        pkinit_servers = ipa_master_config['pkinit_server_server']
+        pkinit_servers = ipa_master_config.get('pkinit_server_server')
+        if pkinit_servers is None:
+            return
 
         for s in servers:
             pkinit_status = {


### PR DESCRIPTION
If we issue pkinit-status after an upgrade from a pre-4.5 ipa
version, it would have failed with KeyError since the
pkinit_server_server of IPA config was never initialized.

https://pagure.io/freeipa/issue/7144