### PR TITLE
Use the user-provided CA chain file in connections & check for file existence

### DIFF
--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -556,7 +556,7 @@ class SSLTransport(LanguageAwareTransport):
 
         conn = create_https_connection(
             host, 443,
-            api.env.tls_ca_cert,
+            getattr(context, 'ca_certfile', None),
             tls_version_min=api.env.tls_version_min,
             tls_version_max=api.env.tls_version_max)
 

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -292,6 +292,10 @@ def create_https_connection(
         raise RuntimeError("cafile argument is required to perform server "
                            "certificate verification")
 
+    if not os.path.isfile(cafile) or not os.access(cafile, os.R_OK):
+        raise RuntimeError("cafile \'{file}\' doesn't exist or is unreadable".
+                           format(file=cafile))
+
     # remove the slice of negating protocol options according to options
     tls_span = get_proper_tls_version_span(tls_version_min, tls_version_max)
 


### PR DESCRIPTION
The user now may provide their own CA chain to the make API commands but it isn't honored. This is in effect a regression from when the crypto library was switched from NSS to OpenSSL. It is very useful if you want to be able to create a connection to an IPA server without enrolling as an IPA client. This is used in OpenStack to bootstrap some entries and create an OTP used later during enrollment.

The value is also not checked for existence throwing a generic "no such file" error rather than "file <foo> doesn't exist"