### PR TITLE
ldif: handle attribute names as strings

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1434,6 +1434,7 @@ class ModifyLDIF(ldif.LDIFParser):
 
             if "replace" in entry:
                 for attr in entry["replace"]:
+                    attr = attr.decode('utf-8')
                     try:
                         self.replace_value(dn, attr, entry[attr])
                     except KeyError:
@@ -1441,9 +1442,11 @@ class ModifyLDIF(ldif.LDIFParser):
                                          "missing".format(dn=dn, attr=attr))
             elif "delete" in entry:
                 for attr in entry["delete"]:
+                    attr = attr.decode('utf-8')
                     self.remove_value(dn, attr, entry.get(attr, None))
             elif "add" in entry:
                 for attr in entry["add"]:
+                    attr = attr.decode('utf-8')
                     try:
                         self.replace_value(dn, attr, entry[attr])
                     except KeyError:


### PR DESCRIPTION
ldif.LDIFRecordList handles all attribute names as utf-8 strings
and all attribute values as bytes. If we take the attribute value
and try to search for it in the entry (= dictionary), if it contains
the attribute name as a key (which is a string), their hashes match.
However, even if hashes match, Python needs to make sure those two
are the same in case of a hash collision, so it tries to compare them.
This causes BytesWarning exception when running in strict mode
because `bytes` and `str` instances cannot be compared. KeyError
would be thrown in a non-strict mode.

Also, when later passing the attr to replace_value(), we need for it
to be `str` otherwise the modifications handler fails because it
tries to sort the attributes it's modifying but that's a bit less
poetic issue than the first one.

https://pagure.io/freeipa/issue/7129