### PR TITLE
travis: temporary workaround for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+group: deprecated-2017Q3
 services:
     - docker
 


### PR DESCRIPTION
Travis upgraded their environment but broke some deployments. Wait
for them to fix the issue with python3.