### PR TITLE
travis: run the same tests in python2/3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,67 +35,19 @@ env:
         - TASK_TO_RUN="run-tests"
           PYTHON=/usr/bin/python3
           TEST_RUNNER_CONFIG=".test_runner_config_py3_temp.yaml"
-          TESTS_TO_RUN="test_xmlrpc/test_add_remove_cert_cmd.py
-            test_xmlrpc/test_attr.py
-            test_xmlrpc/test_automember_plugin.py
-            test_xmlrpc/test_automount_plugin.py
-            test_xmlrpc/test_baseldap_plugin.py
-            test_xmlrpc/test_batch_plugin.py
-            test_xmlrpc/test_cert_plugin.py
-            test_xmlrpc/test_certprofile_plugin.py
-            test_xmlrpc/test_config_plugin.py
-            test_xmlrpc/test_delegation_plugin.py
-            test_xmlrpc/test_group_plugin.py
-            test_xmlrpc/test_hbac_plugin.py
-            test_xmlrpc/test_hbacsvcgroup_plugin.py
-            test_xmlrpc/test_hbactest_plugin.py
-            test_xmlrpc/test_host_plugin.py
-            test_xmlrpc/test_hostgroup_plugin.py
-            test_xmlrpc/test_krbtpolicy.py
-            test_xmlrpc/test_kerberos_principal_aliases.py"
-            ### Tests which haven't been ported to py3 yet ###
-            ## test_xmlrpc/test_[a-k]*.py
-            # test_xmlrpc/test_ca_plugin.py
-            # test_xmlrpc/test_caacl_plugin.py
-            # test_xmlrpc/test_caacl_profile_enforcement.py
-            # test_xmlrpc/test_dns_plugin.py
-            # test_xmlrpc/test_dns_realmdomains_integration.py
-            # test_xmlrpc/test_external_members.py
-            # test_xmlrpc/test_idviews_plugin.py
+          TESTS_TO_RUN="test_xmlrpc/test_[a-k]*.py"
         - TASK_TO_RUN="run-tests"
           PYTHON=/usr/bin/python3
           TEST_RUNNER_CONFIG=".test_runner_config_py3_temp.yaml"
           TESTS_TO_RUN="test_cmdline
+                test_install
+                test_ipaclient
                 test_ipalib
                 test_ipapython
                 test_ipaserver
                 test_pkcs10
-                test_xmlrpc/test_location_plugin.py
-                test_xmlrpc/test_nesting.py
-                test_xmlrpc/test_netgroup_plugin.py
-                test_xmlrpc/test_old_permission_plugin.py
-                test_xmlrpc/test_passwd_plugin.py
-                test_xmlrpc/test_permission_plugin.py
-                test_xmlrpc/test_ping_plugin.py
-                test_xmlrpc/test_privilege_plugin.py
-                test_xmlrpc/test_pwpolicy_plugin.py
-                test_xmlrpc/test_radiusproxy_plugin.py
-                test_xmlrpc/test_realmdomains_plugin.py
-                test_xmlrpc/test_replace.py
-                test_xmlrpc/test_role_plugin.py
-                test_xmlrpc/test_selfservice_plugin.py
-                test_xmlrpc/test_selinuxusermap_plugin.py
-                test_xmlrpc/test_service_plugin.py
-                test_xmlrpc/test_servicedelegation_plugin.py
-                test_xmlrpc/test_stageuser_plugin.py
-                test_xmlrpc/test_sudocmd_plugin.py
-                test_xmlrpc/test_sudocmdgroup_plugin.py
-                test_xmlrpc/test_sudorule_plugin.py"
-            ### Tests which haven't been ported to py3 yet ###
-            ## test_xmlrpc/test_[l-z]*.py
-            # test_xmlrpc/test_range_plugin.py
-            # test_xmlrpc/test_trust_plugin.py
-            # test_xmlrpc/test_vault_plugin.py
+                test_xmlrpc/test_[l-uw-z]*.py"
+                # FIXME: add vault tests once PKI finally fixes vault
 install:
     - pip install --upgrade pip
     - pip3 install --upgrade pip

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -39,8 +39,8 @@
 %global krb5_version 1.15.1-4
 # 0.7.16: https://github.com/drkjam/netaddr/issues/71
 %global python_netaddr_version 0.7.5-8
-# Require 4.6.0-4 which brings RC4 for FIPS + trust fixes to priv. separation
-%global samba_version 4.6.0-4
+# Require 4.7.0 which brings Python 3 bindings
+%global samba_version 4.7.0
 %global selinux_policy_version 3.12.1-153
 %global slapi_nis_version 0.56.0-4
 %else
@@ -48,8 +48,8 @@
 %global krb5_version 1.15.1-7
 # 0.7.16: https://github.com/drkjam/netaddr/issues/71
 %global python_netaddr_version 0.7.16
-# Require 4.6.0-4 which brings RC4 for FIPS + trust fixes to priv. separation
-%global samba_version 2:4.6.0-4
+# Require 4.7.0 which brings Python 3 bindings
+%global samba_version 2:4.7.0
 %global selinux_policy_version 3.13.1-158.4
 %global slapi_nis_version 0.56.1
 %endif
@@ -209,8 +209,7 @@ BuildRequires:  python2-jinja2
 BuildRequires:  python2-augeas
 
 %if 0%{?with_python3}
-# FIXME: this depedency is missing - server will not work
-#BuildRequires:  python3-samba
+BuildRequires:  python3-samba
 # 1.6: x509.Name.rdns (https://github.com/pyca/cryptography/issues/3199)
 BuildRequires:  python3-cryptography >= 1.6
 BuildRequires:  python3-gssapi >= 1.2.0
@@ -483,12 +482,21 @@ Summary: Virtual package to install packages required for Active Directory trust
 Group: System Environment/Base
 Requires: %{name}-server = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
-Requires: samba-python
+
 Requires: samba >= %{samba_version}
 Requires: samba-winbind
 Requires: libsss_idmap
-Requires: python-libsss_nss_idmap
-Requires: python-sss
+
+%if 0%{?with_python3}
+Requires: python3-samba
+Requires: python3-libsss_nss_idmap
+Requires: python3-sss
+%else
+Requires: python2-samba
+Requires: python2-libsss_nss_idmap
+Requires: python2-sss
+%endif  # with_python3
+
 # We use alternatives to divert winbind_krb5_locator.so plugin to libkrb5
 # on the installes where server-trust-ad subpackage is installed because
 # IPA AD trusts cannot be used at the same time with the locator plugin

--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -37,8 +37,6 @@ import os
 import struct
 import random
 
-# TODO: Remove pylint disable when Python 3 bindings are available.
-# pylint: disable=import-error
 from samba import param
 from samba import credentials
 from samba.dcerpc import security, lsa, drsblobs, nbt, netlogon
@@ -46,7 +44,6 @@ from samba.ndr import ndr_pack, ndr_print
 from samba import net
 from samba import arcfour_encrypt
 import samba
-# pylint: enable=import-error
 
 import ldap as _ldap
 from ipapython import ipaldap

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -353,7 +353,7 @@ class ldap2(CrudBackend, LDAPClient):
 
         attrs = self.get_effective_rights(dn, ["*"])
         if 'entrylevelrights' in attrs:
-            entry_rights = attrs['entrylevelrights'][0].decode('UTF-8')
+            entry_rights = attrs['entrylevelrights'][0]
             if 'd' in entry_rights:
                 return True
 
@@ -366,7 +366,7 @@ class ldap2(CrudBackend, LDAPClient):
         assert isinstance(dn, DN)
         attrs = self.get_effective_rights(dn, ["*"])
         if 'entrylevelrights' in attrs:
-            entry_rights = attrs['entrylevelrights'][0].decode('UTF-8')
+            entry_rights = attrs['entrylevelrights'][0]
             if 'a' in entry_rights:
                 return True
 

--- a/ipatests/test_xmlrpc/tracker/certmapdata.py
+++ b/ipatests/test_xmlrpc/tracker/certmapdata.py
@@ -1,6 +1,8 @@
 #
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
+import base64
+
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from nose.tools import assert_raises
@@ -50,11 +52,9 @@ class CertmapdataMixin(object):
                     certs = [certs]
 
             for cert in certs:
-                cert = x509.load_pem_x509_certificate(
-                    (b'-----BEGIN CERTIFICATE-----\n'
-                     b'{}-----END CERTIFICATE-----\n'
-                     .format(cert)),
-                    default_backend()
+                cert = x509.load_der_x509_certificate(
+                    base64.b64decode(cert),
+                    backend=default_backend()
                 )
                 issuer = DN(cert.issuer).x500_text()
                 subject = DN(cert.subject).x500_text()


### PR DESCRIPTION
We missed running some tests in python3

https://pagure.io/freeipa/issue/7131

------------

When meddling with the Travis CI settings, I noticed that we still don't run all the tests in both Python versions. I wish I noticed earlier.