### PR TITLE
Remove temporary workaround for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-group: deprecated-2017Q3
 services:
     - docker
 


### PR DESCRIPTION
Once Travis fixes their issue/will post resolution, we can remove the workaround.