### PR TITLE
Backport PR 976 to ipa-4-6

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,5 +1,5 @@
 jobs:
-  fedora-25/build:
+  fedora-26/build:
     requires: []
     priority: 100
     job:
@@ -7,28 +7,29 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-f25
-          name: freeipa/ci-master-f25
-          version: 0.2.11
+        template: &ci-master-f26
+          name: freeipa/ci-master-f26
+          version: 0.1.2
         timeout: 1800
 
-  fedora-25/simple_replication:
-    requires: [fedora-25/build]
+  fedora-26/simple_replication:
+    requires: [fedora-26/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-25/build_url}'
+        build_url: '{fedora-26/build_url}'
         test_suite: test_integration/test_simple_replication.py
-        template: *ci-master-f25
+        template: *ci-master-f26
         timeout: 3600
 
-  fedora-25/caless:
-    requires: [fedora-25/build]
+  fedora-26/caless:
+    requires: [fedora-26/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-25/build_url}'
+        build_url: '{fedora-26/build_url}'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *ci-master-f25
+        template: *ci-master-f26
+        timeout: 3600


### PR DESCRIPTION
This PR was opened automatically because PR #976 was pushed to master and backport to ipa-4-6 is required.