### PR TITLE
[Backport][ipa-4-6] issue_server_cert: avoid application of str to bytes

### DIFF
--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -437,7 +437,7 @@ class CertDB(object):
             client_keyfile=paths.RA_AGENT_KEY,
             **params)
         http_status, _http_headers, http_body = result
-        logger.debug("CA answer: %s", http_body)
+        logger.debug("CA answer: %r", http_body)
 
         if http_status != 200:
             raise CertificateOperationError(


### PR DESCRIPTION
This PR was opened automatically because PR #1050 was pushed to master and backport to ipa-4-6 is required.