### PR TITLE
[Backport][ipa-4-6] pkinit: fix sorting dicts

### DIFF
--- a/ipaserver/plugins/pkinit.py
+++ b/ipaserver/plugins/pkinit.py
@@ -121,6 +121,7 @@ class pkinit_status(Search):
         if server is not None:
             self.api.Object.server_role.ensure_master_exists(server)
 
-        result = sorted(self.get_pkinit_status(server, status))
+        result = sorted(self.get_pkinit_status(server, status),
+                        key=lambda d: d.get('server_server'))
 
         return dict(result=result, count=len(result), truncated=False)


### PR DESCRIPTION
This PR was opened automatically because PR #1029 was pushed to master and backport to ipa-4-6 is required.