### PR TITLE
[Backport][ipa-4-6] pkinit: don't fail when no pkinit servers found

### DIFF
--- a/ipaserver/plugins/pkinit.py
+++ b/ipaserver/plugins/pkinit.py
@@ -93,7 +93,9 @@ class pkinit_status(Search):
         else:
             servers = ipa_master_config['ipa_master_server']
 
-        pkinit_servers = ipa_master_config['pkinit_server_server']
+        pkinit_servers = ipa_master_config.get('pkinit_server_server')
+        if pkinit_servers is None:
+            return
 
         for s in servers:
             pkinit_status = {


### PR DESCRIPTION
This PR was opened automatically because PR #1046 was pushed to master and backport to ipa-4-6 is required.