### PR TITLE
client: fix retrieving certs from HTTP

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1615,7 +1615,7 @@ def get_ca_certs_from_http(url, warn=True):
         result = run([paths.BIN_CURL, "-o", "-", url], capture_output=True)
     except CalledProcessError:
         raise errors.NoCertificateError(entry=url)
-    stdout = result.output
+    stdout = result.raw_output
 
     try:
         certs = x509.load_certificate_list(stdout)


### PR DESCRIPTION
We're applying bytes regex on the result of a command but were
using decoded stdout instead of raw.

https://pagure.io/freeipa/issue/7131