### PR TITLE
[Backport][ipa-4-6] client: fix retrieving certs from HTTP

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1615,7 +1615,7 @@ def get_ca_certs_from_http(url, warn=True):
         result = run([paths.BIN_CURL, "-o", "-", url], capture_output=True)
     except CalledProcessError:
         raise errors.NoCertificateError(entry=url)
-    stdout = result.output
+    stdout = result.raw_output
 
     try:
         certs = x509.load_certificate_list(stdout)


### PR DESCRIPTION
This PR was opened automatically because PR #1071 was pushed to master and backport to ipa-4-6 is required.