### PR TITLE
[backport][ipa-4-5] Fixing how sssd.conf is updated when promoting a client to replica

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -432,30 +432,27 @@ def promote_sssd(host_name):
     sssdconfig.import_config()
     domains = sssdconfig.list_active_domains()
 
-    ipa_domain = None
-
     for name in domains:
         domain = sssdconfig.get_domain(name)
         try:
             hostname = domain.get_option('ipa_hostname')
             if hostname == host_name:
-                ipa_domain = domain
+                break
         except SSSDConfig.NoOptionError:
             continue
-
-    if ipa_domain is None:
-        raise RuntimeError("Couldn't find IPA domain in sssd.conf")
     else:
-        domain.set_option('ipa_server', host_name)
-        domain.set_option('ipa_server_mode', True)
-        sssdconfig.save_domain(domain)
-        sssdconfig.write()
+        raise RuntimeError("Couldn't find IPA domain in sssd.conf")
 
-        sssd = services.service('sssd', api)
-        try:
-            sssd.restart()
-        except CalledProcessError:
-            root_logger.warning("SSSD service restart was unsuccessful.")
+    domain.set_option('ipa_server', host_name)
+    domain.set_option('ipa_server_mode', True)
+    sssdconfig.save_domain(domain)
+    sssdconfig.write()
+
+    sssd = services.service('sssd', api)
+    try:
+        sssd.restart()
+    except CalledProcessError:
+        root_logger.warning("SSSD service restart was unsuccessful.")
 
 
 def promote_openldap_conf(hostname, master):

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1817,10 +1817,14 @@ def upgrade_configuration():
         cainstance.ensure_ipa_authority_entry()
 
     set_sssd_domain_option('ipa_server_mode', 'True')
+    set_sssd_domain_option('ipa_server', api.env.host)
 
     sssdconfig = SSSDConfig.SSSDConfig()
     sssdconfig.import_config()
     sssd_enable_service(sssdconfig, 'ifp')
+
+    sssd = services.service('sssd', api)
+    sssd.restart()
 
     krb = krbinstance.KrbInstance(fstore)
     krb.fqdn = fqdn


### PR DESCRIPTION
When promoting a client to a replica we have to change sssd.conf,
deleting _srv_ part from 'ipa_server' property and setting 'ipa_server_mode' to true.

Previously, the wrong domain could be updated since the ipa_domain variable was not being used properly.

https://pagure.io/freeipa/issue/7127