### PR TITLE
[Backport][ipa-4-6] dsinstance: Restore context after changing dse.ldif

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -596,6 +596,7 @@ class DsInstance(service.Service):
                 parser.parse()
             new_dse_ldif.flush()
         shutil.copy2(temp_filename, dse_filename)
+        tasks.restore_context(dse_filename)
         try:
             os.remove(temp_filename)
         except OSError as e:


### PR DESCRIPTION
This PR was opened automatically because PR #1062 was pushed to master and backport to ipa-4-6 is required.