### PR TITLE
Increase dbus client timeouts during CA install

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -281,6 +281,8 @@ IPA_CA_CN = u'ipa'
 IPA_CA_RECORD = "ipa-ca"
 IPA_CA_NICKNAME = 'caSigningCert cert-pki-ca'
 RENEWAL_CA_NAME = 'dogtag-ipa-ca-renew-agent'
+# How long dbus clients should wait for CA certificate RPCs [seconds]
+CA_DBUS_TIMEOUT = 120
 
 # regexp definitions
 PATTERN_GROUPUSER_NAME = '^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$'

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -31,6 +31,7 @@ import shlex
 import subprocess
 import tempfile
 from ipalib import api
+from ipalib.constants import CA_DBUS_TIMEOUT
 from ipapython.ipa_log_manager import root_logger
 from ipapython.dn import DN
 from ipaplatform.paths import paths
@@ -595,7 +596,9 @@ def modify_ca_helper(ca_name, helper):
         old_helper = ca_iface.Get('org.fedorahosted.certmonger.ca',
                                   'external-helper')
         ca_iface.Set('org.fedorahosted.certmonger.ca',
-                     'external-helper', helper)
+                     'external-helper', helper,
+                     # Give dogtag extra time to generate cert
+                     timeout=CA_DBUS_TIMEOUT)
         return old_helper
 
 

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -29,6 +29,7 @@ import pki.system
 
 from ipalib import api, errors
 from ipalib.install import certmonger
+from ipalib.constants import CA_DBUS_TIMEOUT
 from ipaplatform import services
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
@@ -261,7 +262,9 @@ class DogtagInstance(service.Service):
                 iface.add_known_ca(
                     name,
                     command,
-                    dbus.Array([], dbus.Signature('s')))
+                    dbus.Array([], dbus.Signature('s')),
+                     # Give dogtag extra time to generate cert
+                    timeout=CA_DBUS_TIMEOUT)
 
     def __get_pin(self):
         try:


### PR DESCRIPTION
In FreeIPA 4.5 and 4.6, the `ipa-server-install` program can fail during the "Configuring certificate server (pki-tomcatd)" stage on a heavily-loaded host.

The dogtag service is memory intensive, and on a memory-constrained system, can be unresponsive right after start-up, especially for expensive operations that generate new certificates.

These delays can cause failures when dbus clients time out while attempting to run
new certificate operations through certmonger.  This patch changes dbus client timeouts for some such operations to 120 seconds (from the default 25 seconds).
