### PR TITLE
ipa-server-upgrade: fix the logic for tracking certs

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -925,7 +925,7 @@ def certificate_renewal_update(ca, ds, http):
         {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
             'cert-nickname': 'auditSigningCert cert-pki-ca',
-            'ca': 'dogtag-ipa-ca-renew-agent',
+            'ca-name': 'dogtag-ipa-ca-renew-agent',
             'cert-presave-command': template % 'stop_pkicad',
             'cert-postsave-command':
                 (template % 'renew_ca_cert "auditSigningCert cert-pki-ca"'),
@@ -933,7 +933,7 @@ def certificate_renewal_update(ca, ds, http):
         {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
             'cert-nickname': 'ocspSigningCert cert-pki-ca',
-            'ca': 'dogtag-ipa-ca-renew-agent',
+            'ca-name': 'dogtag-ipa-ca-renew-agent',
             'cert-presave-command': template % 'stop_pkicad',
             'cert-postsave-command':
                 (template % 'renew_ca_cert "ocspSigningCert cert-pki-ca"'),
@@ -941,7 +941,7 @@ def certificate_renewal_update(ca, ds, http):
         {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
             'cert-nickname': 'subsystemCert cert-pki-ca',
-            'ca': 'dogtag-ipa-ca-renew-agent',
+            'ca-name': 'dogtag-ipa-ca-renew-agent',
             'cert-presave-command': template % 'stop_pkicad',
             'cert-postsave-command':
                 (template % 'renew_ca_cert "subsystemCert cert-pki-ca"'),
@@ -949,16 +949,16 @@ def certificate_renewal_update(ca, ds, http):
         {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
             'cert-nickname': 'caSigningCert cert-pki-ca',
-            'ca': 'dogtag-ipa-ca-renew-agent',
+            'ca-name': 'dogtag-ipa-ca-renew-agent',
             'cert-presave-command': template % 'stop_pkicad',
             'cert-postsave-command':
                 (template % 'renew_ca_cert "caSigningCert cert-pki-ca"'),
-            'template-profile': '',
+            'template-profile': None,
         },
         {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
             'cert-nickname': 'Server-Cert cert-pki-ca',
-            'ca': 'dogtag-ipa-ca-renew-agent',
+            'ca-name': 'dogtag-ipa-ca-renew-agent',
             'cert-presave-command': template % 'stop_pkicad',
             'cert-postsave-command':
                 (template % 'renew_ca_cert "Server-Cert cert-pki-ca"'),
@@ -966,20 +966,20 @@ def certificate_renewal_update(ca, ds, http):
         {
             'cert-file': paths.RA_AGENT_PEM,
             'key-file': paths.RA_AGENT_KEY,
-            'ca': 'dogtag-ipa-ca-renew-agent',
+            'ca-name': 'dogtag-ipa-ca-renew-agent',
             'cert-presave-command': template % 'renew_ra_cert_pre',
             'cert-postsave-command': template % 'renew_ra_cert',
         },
         {
             'cert-database': paths.HTTPD_ALIAS_DIR,
             'cert-nickname': http.get_mod_nss_nickname(),
-            'ca': 'IPA',
+            'ca-name': 'IPA',
             'cert-postsave-command': template % 'restart_httpd',
         },
         {
-            'cert-database': dsinstance.config_dirname(serverid),
+            'cert-database': dsinstance.config_dirname(serverid)[:-1],
             'cert-nickname': ds.get_server_cert_nickname(serverid),
-            'ca': 'IPA',
+            'ca-name': 'IPA',
             'cert-postsave-command':
                 '%s %s' % (template % 'restart_dirsrv', serverid),
         }
@@ -997,7 +997,7 @@ def certificate_renewal_update(ca, ds, http):
                 {
                     'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
                     'cert-nickname': nickname,
-                    'ca': 'dogtag-ipa-ca-renew-agent',
+                    'ca-name': 'dogtag-ipa-ca-renew-agent',
                     'cert-presave-command': template % 'stop_pkicad',
                     'cert-postsave-command':
                         (template % ('renew_ca_cert "%s"' % nickname)),


### PR DESCRIPTION
ipa-server-upgrade needs to configure certmonger with the right options
in order to track PKI, HTTP and LDAP certs (for instance the RA agent cert
location has changed from older releases).
The upgrade code looks for existing tracking requests with the expected
options by using criteria (location of the NSSDB, nickname, CA helper...)
If a tracking request is not found, it means that it is either using wrong
options or not configured. In this case, the upgrade stop tracking
all the certs, reconfigures the helpers, starts tracking the certs so that
the config is up-to-date.

The issue is that the criteria is using the keyword 'ca' instead of
'ca-name' and this leads to upgrade believing that the config needs to be
updated in all the cases.

https://pagure.io/freeipa/issue/7151