### PR TITLE
OTP import: support hash names with HMAC- prefix

### DIFF
--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -95,7 +95,9 @@ def convertTokenType(value):
 def convertHashName(value):
     "Converts hash names to their canonical names."
 
-    return {
+    default_hash = u"sha1"
+    known_prefixes = ("", "hmac-",)
+    known_hashes = {
         "sha1":    u"sha1",
         "sha224":  u"sha224",
         "sha256":  u"sha256",
@@ -106,7 +108,24 @@ def convertHashName(value):
         "sha-256": u"sha256",
         "sha-384": u"sha384",
         "sha-512": u"sha512",
-    }.get(value.lower(), u"sha1")
+    }
+
+    if value is None:
+        return default_hash
+
+    v = value.lower()
+    for prefix in known_prefixes:
+        if prefix:
+            w = v[len(prefix):]
+        else:
+            w = v
+        result = known_hashes.get(w)
+        if result is not None:
+            break
+    else:
+        result = default_hash
+
+    return result
 
 
 def convertHMACType(value):

--- a/ipatests/test_ipaserver/test_otptoken_import.py
+++ b/ipatests/test_ipaserver/test_otptoken_import.py
@@ -22,6 +22,7 @@ import os
 import pytest
 
 from ipaserver.install.ipa_otptoken_import import PSKCDocument, ValidationError
+from ipaserver.install.ipa_otptoken_import import convertHashName
 
 basename = os.path.join(os.path.dirname(__file__), "data")
 
@@ -129,3 +130,21 @@ class test_otptoken_import(object):
                 'ipatokenotpdigits': 8,
                 'type': u'hotp',
             })]
+
+    def test_valid_tokens(self):
+        assert convertHashName('sha1') == u'sha1'
+        assert convertHashName('hmac-sha1') == u'sha1'
+        assert convertHashName('sha224') == u'sha224'
+        assert convertHashName('hmac-sha224') == u'sha224'
+        assert convertHashName('sha256') == u'sha256'
+        assert convertHashName('hmac-sha256') == u'sha256'
+        assert convertHashName('sha384') == u'sha384'
+        assert convertHashName('hmac-sha384') == u'sha384'
+        assert convertHashName('sha512') == u'sha512'
+        assert convertHashName('hmac-sha512') == u'sha512'
+
+    def test_invalid_tokens(self):
+        """The conversion defaults to sha1 on unknown hashing"""
+        assert convertHashName('something-sha256') == u'sha1'
+        assert convertHashName('') == u'sha1'
+        assert convertHashName(None) == u'sha1'


### PR DESCRIPTION
Refactor convertHashName() method to accept hash names prefixed with
HMAC- or any other prefix. Extending the method should be easier in
future.

Fixes https://pagure.io/freeipa/issue/7146