### PR TITLE
[Backport][ipa-4-6] Python3: Fix winsync replication agreement

### DIFF
--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1089,7 +1089,8 @@ class ReplicationManager(object):
                                    ['defaultNamingContext'])
             for dn,entry in res:
                 if dn == "":
-                    self.ad_suffix = entry['defaultNamingContext'][0]
+                    ad_suffix = entry['defaultNamingContext'][0]
+                    self.ad_suffix = ad_suffix.decode('utf-8')
                     logger.info("AD Suffix is: %s", self.ad_suffix)
             if self.ad_suffix == "":
                 raise RuntimeError("Failed to lookup AD's Ldap suffix")


### PR DESCRIPTION
This PR was opened automatically because PR #1018 was pushed to master and backport to ipa-4-6 is required.