### PR TITLE
Fall back to using configuration to determine server config status

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1467,7 +1467,7 @@ fi
 %dir %{_localstatedir}/lib/ipa
 %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/backup
 %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/gssproxy
-%attr(700,root,root) %dir %{_localstatedir}/lib/ipa/sysrestore
+%attr(711,root,root) %dir %{_localstatedir}/lib/ipa/sysrestore
 %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/sysupgrade
 %attr(755,root,root) %dir %{_localstatedir}/lib/ipa/pki-ca
 %ghost %{_localstatedir}/lib/ipa/pki-ca/publish


### PR DESCRIPTION
The original method for determining whether IPA was configured or
not depended on being able to read the sysrestore files which are
only readable by root.

Add a fallback that uses the IPA config to determine the status.
The ldap_uri should only be set on servers and as an extra check
look for an ldapi uri.

https://pagure.io/freeipa/issue/7157