### PR TITLE
[Backport][ipa-4-6] pylint: fix missing module on F27+

### DIFF
--- a/ipaserver/secrets/client.py
+++ b/ipaserver/secrets/client.py
@@ -13,6 +13,7 @@ from base64 import b64encode
 import ldapurl
 import gssapi
 import os
+import urllib3
 import requests
 
 
@@ -65,8 +66,9 @@ class CustodiaClient(object):
 
         self.keystore = self._keystore(realm, ldap_uri, auth_type)
 
-        # FIXME: Remove warnings about missig subjAltName
-        requests.packages.urllib3.disable_warnings()
+        # FIXME: Remove warnings about missing subjAltName for the
+        #        requests module
+        urllib3.disable_warnings()
 
     def init_creds(self):
         name = gssapi.Name(self.client_service,


### PR DESCRIPTION
This PR was opened automatically because PR #1085 was pushed to master and backport to ipa-4-6 is required.