### PR TITLE
[Backport][ipa-4-6] Don't write p11-kit EKU extension object if no EKU

### DIFF
--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -295,8 +295,11 @@ class IPACertificate(object):
 
     @property
     def extended_key_usage_bytes(self):
+        eku = self.extended_key_usage
+        if eku is None:
+            return
+
         ekurfc = rfc2459.ExtKeyUsageSyntax()
-        eku = self.extended_key_usage or {EKU_PLACEHOLDER}
         for i, oid in enumerate(eku):
             ekurfc[i] = univ.ObjectIdentifier(oid)
         ekurfc = encoder.encode(ekurfc)

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -257,7 +257,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                 "\n")
 
         has_eku = set()
-        for cert, nickname, trusted, ext_key_usage in ca_certs:
+        for cert, nickname, trusted, _ext_key_usage in ca_certs:
             try:
                 subject = cert.subject_bytes
                 issuer = cert.issuer_bytes
@@ -296,7 +296,8 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                 pem=cert.public_bytes(x509.Encoding.PEM).decode('ascii'))
             f.write(obj)
 
-            if ext_key_usage is not None and public_key_info not in has_eku:
+            if (cert.extended_key_usage is not None and
+                    public_key_info not in has_eku):
                 try:
                     ext_key_usage = cert.extended_key_usage_bytes
                 except PyAsn1Error as e:


### PR DESCRIPTION
This PR was opened automatically because PR #1090 was pushed to master and backport to ipa-4-6 is required.