### PR TITLE
Backport 4-5: Fix ipa-server-upgrade with server cert tracking

### DIFF
--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -42,6 +42,7 @@ from ipapython.certdb import get_ca_nickname, find_cert_from_txt, NSSDatabase
 from ipapython.dn import DN
 from ipalib import pkcs10, x509, api
 from ipalib.errors import CertificateOperationError
+from ipalib.install import certstore
 from ipalib.text import _
 from ipaplatform.paths import paths
 
@@ -668,6 +669,32 @@ class CertDB(object):
                                              principal=principal,
                                              subject=host,
                                              passwd_fname=self.passwd_fname)
+
+    def is_ipa_issued_cert(self, api, nickname):
+        """
+        Return True if the certificate contained in the CertDB with the
+        provided nickname has been issued by IPA.
+
+        Note that this method can only be executed if api has been initialized
+        """
+        # This method needs to compare the cert issuer (from the NSS DB
+        # and the subject from the CA (from LDAP), because nicknames are not
+        # always aligned.
+
+        cacert_subject = certstore.get_ca_subject(
+            api.Backend.ldap2,
+            api.env.container_ca,
+            api.env.basedn)
+
+        # The cert can be issued directly by IPA. In this case, the cert
+        # issuer is IPA CA subject.
+        cert = self.get_cert_from_db(nickname)
+        if cert is None:
+            raise RuntimeError("Could not find the cert %s in %s"
+                               % (nickname, self.secdir))
+        issuer = DN(x509.load_certificate(cert).issuer)
+
+        return issuer == cacert_subject
 
 
 class _CrossProcessLock(object):

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -267,6 +267,11 @@ class HTTPInstance(service.Service):
         installutils.set_directive(
             paths.HTTPD_NSS_CONF, 'NSSNickname', quoted_nickname, quotes=False)
 
+    def get_mod_nss_nickname(self):
+        cert = installutils.get_directive(paths.HTTPD_NSS_CONF, 'NSSNickname')
+        nickname = installutils.unquote_directive_value(cert, quote_char="'")
+        return nickname
+
     def set_mod_nss_protocol(self):
         installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSProtocol', 'TLSv1.0,TLSv1.1,TLSv1.2', False)
 
@@ -583,12 +588,17 @@ class HTTPInstance(service.Service):
 
     def stop_tracking_certificates(self):
         db = certs.CertDB(api.env.realm, nssdir=paths.HTTPD_ALIAS_DIR)
-        db.untrack_server_cert(self.cert_nickname)
+        db.untrack_server_cert(self.get_mod_nss_nickname())
 
     def start_tracking_certificates(self):
         db = certs.CertDB(self.realm, nssdir=paths.HTTPD_ALIAS_DIR)
-        db.track_server_cert(self.cert_nickname, self.principal,
-                             db.passwd_fname, 'restart_httpd')
+        nickname = self.get_mod_nss_nickname()
+        if db.is_ipa_issued_cert(api, nickname):
+            db.track_server_cert(nickname, self.principal,
+                                 db.passwd_fname, 'restart_httpd')
+        else:
+            root_logger.debug("Will not track HTTP server cert %s as it is "
+                              "not issued by IPA", nickname)
 
     def request_service_keytab(self):
         super(HTTPInstance, self).request_service_keytab()

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -958,13 +958,13 @@ def certificate_renewal_update(ca, ds, http):
         },
         {
             'cert-database': paths.HTTPD_ALIAS_DIR,
-            'cert-nickname': 'Server-Cert',
+            'cert-nickname': http.get_mod_nss_nickname(),
             'ca': 'IPA',
             'cert-postsave-command': template % 'restart_httpd',
         },
         {
             'cert-database': dsinstance.config_dirname(serverid),
-            'cert-nickname': 'Server-Cert',
+            'cert-nickname': ds.get_server_cert_nickname(serverid),
             'ca': 'IPA',
             'cert-postsave-command':
                 '%s %s' % (template % 'restart_dirsrv', serverid),


### PR DESCRIPTION
ipa-server-upgrade fails with Server-Cert not found, when trying to
track httpd/ldap server certificates. There are 2 issues in the upgrade:
- the certificates should be tracked only if they were issued by IPA CA
(it is possible to have CA configured but 3rd part certs)
- the certificate nickname can be different from Server-Cert

The fix provides methods to find the server crt nickname for http and ldap,
and a method to check if the server certs are issued by IPA and need to be
tracked by certmonger.

https://pagure.io/freeipa/issue/7141

Reviewed-By: Stanislav Laznicka <slaznick@redhat.com>
Reviewed-By: Fraser Tweedale <ftweedal@redhat.com>