### PR TITLE
rpc: don't decode cookie_string if it's None

### DIFF
--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -901,6 +901,8 @@ class RPCClient(Connectible):
         # (possibly with more than one cookie).
         try:
             cookie_string = read_persistent_client_session_data(principal)
+            if cookie_string is None:
+                return
             cookie_string = cookie_string.decode('utf-8')
         except Exception as e:
             logger.debug('Error reading client session data: %s', e)


### PR DESCRIPTION
This removes an ugly debug message from client installation