### PR TITLE
tests: add host zone with overlap

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1322,3 +1322,29 @@ def ldappasswd_user_change(user, oldpw, newpw, master):
     args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
             '-s', newpw, '-x']
     master.run_command(args)
+
+
+def add_dns_zone(master, zone, skip_overlap_check=False,
+                 dynamic_update=False, add_a_record_hosts=None):
+    """
+    Add DNS zone if it is not already added.
+    """
+
+    result = master.run_command(
+        ['ipa', 'dnszone-show', zone], raiseonerr=False)
+
+    if result.returncode != 0:
+        command = ['ipa', 'dnszone-add', zone]
+        if skip_overlap_check:
+            command.append('--skip-overlap-check')
+        if dynamic_update:
+            command.append('--dynamic-update=True')
+
+        master.run_command(command)
+
+        if add_a_record_hosts:
+            for host in add_a_record_hosts:
+                master.run_command(['ipa', 'dnsrecord-add', zone,
+                                    host.hostname + ".", '--a-rec', host.ip])
+    else:
+        logger.debug('Zone %s already added.', zone)


### PR DESCRIPTION
This patch is mainly for test_forced_client_reenrolment suite
where when we are not in control of our client DNS we create an
overlap zone in order to get the host records updated. This also
sets resolv.conf before every ipa-client-install to the ipa master.