### PR TITLE
Collect group membership without a size limit

### DIFF
--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -715,7 +715,9 @@ class LDAPObject(Object):
             result = self.backend.get_entries(
                 self.api.env.basedn,
                 filter=filter,
-                attrs_list=[''])
+                attrs_list=[''],
+                size_limit=-1,  # paged search will get everything anyway
+                paged_search=True)
         except errors.NotFound:
             result = []
 


### PR DESCRIPTION
If the # of group memberships exceeded the search size limit
then SizeLimitExceeded was raised. Being in too many groups
should not cause a *_show to fail.

https://pagure.io/freeipa/issue/7112