### PR TITLE
ipalib.x509 autumn cleanup

### DIFF
--- a/ipaclient/plugins/cert.py
+++ b/ipaclient/plugins/cert.py
@@ -209,6 +209,7 @@ class cert_find(MethodOverride):
                 raise errors.MutuallyExclusiveError(
                     reason=_("cannot specify both raw certificate and file"))
             if 'certificate' not in options and 'file' in options:
-                options['certificate'] = x509.strip_header(options.pop('file'))
+                options['certificate'] = x509.load_unknown_x509_certificate(
+                                            options.pop('file'))
 
         return super(cert_find, self).forward(*args, **options)

--- a/ipaclient/plugins/certmap.py
+++ b/ipaclient/plugins/certmap.py
@@ -40,7 +40,7 @@ class certmap_match(MethodOverride):
                 raise errors.MutuallyExclusiveError(
                     reason=_("cannot specify both raw certificate and file"))
             if args:
-                args = [x509.strip_header(args[0])]
+                args = [x509.load_unknown_x509_certificate(args[0])]
             elif 'certificate' in options:
                 args = [options.pop('certificate')]
             else:

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -51,7 +51,6 @@ from pyasn1_modules import rfc2315, rfc2459
 import six
 
 from ipalib import errors
-from ipapython.dn import DN
 from ipapython.dnsutil import DNSName
 
 if six.PY3:
@@ -75,18 +74,6 @@ EKU_PLACEHOLDER = '1.3.6.1.4.1.3319.6.10.16'
 
 SAN_UPN = '1.3.6.1.4.1.311.20.2.3'
 SAN_KRB5PRINCIPALNAME = '1.3.6.1.5.2.2'
-
-_subject_base = None
-
-def subject_base():
-    from ipalib import api
-    global _subject_base
-
-    if _subject_base is None:
-        config = api.Command['config_show']()['result']
-        _subject_base = DN(config['ipacertificatesubjectbase'][0])
-
-    return _subject_base
 
 
 @crypto_utils.register_interface(crypto_x509.Certificate)

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -88,21 +88,6 @@ def subject_base():
 
     return _subject_base
 
-def strip_header(pem):
-    """
-    Remove the header and footer from a certificate.
-    """
-    regexp = (
-        u"^-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----"
-    )
-    if isinstance(pem, bytes):
-        regexp = regexp.encode('ascii')
-    s = re.search(regexp, pem, re.MULTILINE | re.DOTALL)
-    if s is not None:
-        return s.group(1)
-    else:
-        return pem
-
 
 @crypto_utils.register_interface(crypto_x509.Certificate)
 class IPACertificate(object):

--- a/ipatests/test_xmlrpc/test_cert_plugin.py
+++ b/ipatests/test_xmlrpc/test_cert_plugin.py
@@ -30,11 +30,11 @@ import six
 import tempfile
 from ipalib import api
 from ipalib import errors
-from ipalib import x509
 from ipaplatform.paths import paths
 from ipapython import ipautil
 from ipapython.dn import DN
 from ipapython.ipautil import run
+from ipatests.test_xmlrpc.testcert import subject_base
 from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test
 from nose.tools import raises, assert_raises
 
@@ -109,7 +109,7 @@ class BaseCert(XMLRPC_test):
         # Create our temporary NSS database
         self.run_certutil(["-N", "-f", self.pwname])
 
-        self.subject = DN(('CN', self.host_fqdn), x509.subject_base())
+        self.subject = DN(('CN', self.host_fqdn), subject_base())
 
     def teardown(self):
         shutil.rmtree(self.reqdir, ignore_errors=True)

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -31,7 +31,7 @@ import base64
 import pytest
 
 from ipapython import ipautil
-from ipalib import api, errors, x509
+from ipalib import api, errors
 from ipapython.dn import DN
 from ipapython.dnsutil import DNSName
 from ipatests.test_util import yield_fixture
@@ -41,7 +41,7 @@ from ipatests.test_xmlrpc.xmlrpc_test import (XMLRPC_test,
 from ipatests.test_xmlrpc.test_user_plugin import get_group_dn
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.test_xmlrpc.tracker.host_plugin import HostTracker
-from ipatests.test_xmlrpc.testcert import get_testcert
+from ipatests.test_xmlrpc.testcert import get_testcert, subject_base
 from ipatests.util import assert_deepequal
 from ipaplatform.paths import paths
 
@@ -97,7 +97,7 @@ hostgroup1 = u'testhostgroup1'
 hostgroup1_dn = DN(('cn',hostgroup1),('cn','hostgroups'),('cn','accounts'),
                     api.env.basedn)
 
-host_cert = get_testcert(DN(('CN', api.env.host), x509.subject_base()),
+host_cert = get_testcert(DN(('CN', api.env.host), subject_base()),
                          'host/%s@%s' % (api.env.host, api.env.realm))
 
 
@@ -237,7 +237,7 @@ class TestCRUD(XMLRPC_test):
                         serial_number_hex=fuzzy_hex,
                         sha1_fingerprint=fuzzy_hash,
                         sha256_fingerprint=fuzzy_hash,
-                        subject=DN(('CN', api.env.host), x509.subject_base()),
+                        subject=DN(('CN', api.env.host), subject_base()),
                         valid_not_before=fuzzy_date,
                         valid_not_after=fuzzy_date,
                     ))

--- a/ipatests/test_xmlrpc/test_service_plugin.py
+++ b/ipatests/test_xmlrpc/test_service_plugin.py
@@ -21,12 +21,12 @@
 Test the `ipaserver/plugins/service.py` module.
 """
 
-from ipalib import api, errors, x509
+from ipalib import api, errors
 from ipatests.test_xmlrpc.xmlrpc_test import Declarative, fuzzy_uuid, fuzzy_hash
 from ipatests.test_xmlrpc.xmlrpc_test import fuzzy_digits, fuzzy_date, fuzzy_issuer
 from ipatests.test_xmlrpc.xmlrpc_test import fuzzy_hex, XMLRPC_test
 from ipatests.test_xmlrpc import objectclasses
-from ipatests.test_xmlrpc.testcert import get_testcert
+from ipatests.test_xmlrpc.testcert import get_testcert, subject_base
 from ipatests.test_xmlrpc.test_user_plugin import get_user_result, get_group_dn
 
 from ipatests.test_xmlrpc.tracker.service_plugin import ServiceTracker
@@ -50,8 +50,8 @@ host3dn = DN(('fqdn',fqdn3),('cn','computers'),('cn','accounts'),api.env.basedn)
 role1 = u'Test Role'
 role1_dn = DN(('cn', role1), api.env.container_rolegroup, api.env.basedn)
 
-servercert= get_testcert(DN(('CN', api.env.host), x509.subject_base()),
-                         'unittest/%s@%s' % (api.env.host, api.env.realm))
+servercert = get_testcert(DN(('CN', api.env.host), subject_base()),
+                          'unittest/%s@%s' % (api.env.host, api.env.realm))
 randomissuercert = (
     "MIICbzCCAdigAwIBAgICA/4wDQYJKoZIhvcNAQEFBQAwKTEnMCUGA1UEAxMeSVBBIFRlc3Q"
     "gQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTEwMDgwOTE1MDIyN1oXDTIwMDgwOTE1MDIyN1"
@@ -485,7 +485,7 @@ class test_service(Declarative):
                     managedby_host=[fqdn1],
                     valid_not_before=fuzzy_date,
                     valid_not_after=fuzzy_date,
-                    subject=DN(('CN',api.env.host),x509.subject_base()),
+                    subject=DN(('CN', api.env.host), subject_base()),
                     serial_number=fuzzy_digits,
                     serial_number_hex=fuzzy_hex,
                     sha1_fingerprint=fuzzy_hash,
@@ -522,7 +522,7 @@ class test_service(Declarative):
                     ipakrbauthzdata=[u'MS-PAC'],
                     valid_not_before=fuzzy_date,
                     valid_not_after=fuzzy_date,
-                    subject=DN(('CN',api.env.host),x509.subject_base()),
+                    subject=DN(('CN', api.env.host), subject_base()),
                     serial_number=fuzzy_digits,
                     serial_number_hex=fuzzy_hex,
                     sha1_fingerprint=fuzzy_hash,
@@ -551,7 +551,7 @@ class test_service(Declarative):
                     # test case.
                     valid_not_before=fuzzy_date,
                     valid_not_after=fuzzy_date,
-                    subject=DN(('CN',api.env.host),x509.subject_base()),
+                    subject=DN(('CN', api.env.host), subject_base()),
                     serial_number=fuzzy_digits,
                     serial_number_hex=fuzzy_hex,
                     sha1_fingerprint=fuzzy_hash,
@@ -576,7 +576,7 @@ class test_service(Declarative):
                     ipakrbauthzdata=[u'MS-PAC'],
                     valid_not_before=fuzzy_date,
                     valid_not_after=fuzzy_date,
-                    subject=DN(('CN',api.env.host),x509.subject_base()),
+                    subject=DN(('CN', api.env.host), subject_base()),
                     serial_number=fuzzy_digits,
                     serial_number_hex=fuzzy_hex,
                     sha1_fingerprint=fuzzy_hash,
@@ -604,7 +604,7 @@ class test_service(Declarative):
                     ipakrbauthzdata=[u'MS-PAC'],
                     valid_not_before=fuzzy_date,
                     valid_not_after=fuzzy_date,
-                    subject=DN(('CN',api.env.host),x509.subject_base()),
+                    subject=DN(('CN', api.env.host), subject_base()),
                     serial_number=fuzzy_digits,
                     serial_number_hex=fuzzy_hex,
                     sha1_fingerprint=fuzzy_hash,
@@ -630,7 +630,7 @@ class test_service(Declarative):
                     ipakrbauthzdata=[u'MS-PAC'],
                     valid_not_before=fuzzy_date,
                     valid_not_after=fuzzy_date,
-                    subject=DN(('CN',api.env.host),x509.subject_base()),
+                    subject=DN(('CN', api.env.host), subject_base()),
                     serial_number=fuzzy_digits,
                     serial_number_hex=fuzzy_hex,
                     sha1_fingerprint=fuzzy_hash,

--- a/ipatests/test_xmlrpc/testcert.py
+++ b/ipatests/test_xmlrpc/testcert.py
@@ -35,10 +35,24 @@ import re
 from ipalib import api, x509
 from ipaserver.plugins import rabase
 from ipapython import ipautil
+from ipapython.dn import DN
 from ipaplatform.paths import paths
 
 if six.PY3:
     unicode = str
+
+
+_subject_base = None
+
+
+def subject_base():
+    global _subject_base
+
+    if _subject_base is None:
+        config = api.Command['config_show']()['result']
+        _subject_base = DN(config['ipacertificatesubjectbase'][0])
+
+    return _subject_base
 
 
 def strip_cert_header(pem):


### PR DESCRIPTION
This is a cleanup of the x509 module which removes an ugly hack that prevents a circular dependency and the `strip_header()` function which is properly replaced by the `load_unknown_x509_certificate()` function where needed.