### PR TITLE
Use 389-ds provided method for file limits tuning

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -283,7 +283,7 @@ Requires: python3-ipaserver = %{version}-%{release}
 %else
 Requires: python2-ipaserver = %{version}-%{release}
 %endif
-Requires: 389-ds-base >= 1.3.5.14
+Requires: 389-ds-base >= 1.3.7.0
 Requires: openldap-clients > 2.4.35-4
 Requires: nss >= 3.14.3-12.0
 Requires: nss-tools >= 3.14.3-12.0
@@ -321,7 +321,7 @@ Requires(postun): python systemd-units
 Requires: policycoreutils >= 2.1.12-5
 Requires: tar
 Requires(pre): certmonger >= 0.79.5-1
-Requires(pre): 389-ds-base >= 1.3.5.14
+Requires(pre): 389-ds-base >= 1.3.7.0
 Requires: fontawesome-fonts
 Requires: open-sans-fonts
 Requires: openssl

--- a/ipaplatform/debian/services.py
+++ b/ipaplatform/debian/services.py
@@ -121,10 +121,6 @@ class DebianSysvService(base_services.PlatformService):
     def remove():
         return True
 
-    @staticmethod
-    def tune_nofile_platform():
-        return True
-
 
 # For services which have no Debian counterpart
 class DebianNoService(base_services.PlatformService):

--- a/ipaplatform/redhat/services.py
+++ b/ipaplatform/redhat/services.py
@@ -27,7 +27,6 @@ import os
 import time
 import contextlib
 
-from ipaplatform.tasks import tasks
 from ipaplatform.base import services as base_services
 
 from ipapython import ipautil, dogtag
@@ -92,34 +91,6 @@ class RedHatService(base_services.SystemdService):
 
 
 class RedHatDirectoryService(RedHatService):
-
-    def tune_nofile_platform(self, num=8192, fstore=None):
-        """
-        Increase the number of files descriptors available to directory server
-        from the default 1024 to 8192. This will allow to support a greater
-        number of clients out of the box.
-
-        This is a part of the implementation that is systemd-specific.
-
-        Returns False if the setting of the nofile limit needs to be skipped.
-        """
-
-        if os.path.exists(paths.SYSCONFIG_DIRSRV_SYSTEMD):
-            # We need to enable LimitNOFILE=8192 in the dirsrv@.service
-            # Since 389-ds-base-1.2.10-0.8.a7 the configuration of the
-            # service parameters is performed via
-            # /etc/sysconfig/dirsrv.systemd file which is imported by systemd
-            # into dirsrv@.service unit
-
-            replacevars = {'LimitNOFILE': str(num)}
-            ipautil.inifile_replace_variables(paths.SYSCONFIG_DIRSRV_SYSTEMD,
-                                              'service',
-                                              replacevars=replacevars)
-            tasks.restore_context(paths.SYSCONFIG_DIRSRV_SYSTEMD)
-            ipautil.run(["/bin/systemctl", "--system", "daemon-reload"],
-                        raiseonerr=False)
-
-        return True
 
     def is_installed(self, instance_name):
         file_path = "{}/{}-{}".format(paths.ETC_DIRSRV, "slapd", instance_name)

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -288,7 +288,6 @@ class DsInstance(service.Service):
         self.step("adding replication acis", self.__add_replication_acis)
         self.step("activating sidgen plugin", self._add_sidgen_plugin)
         self.step("activating extdom plugin", self._add_extdom_plugin)
-        self.step("tuning directory server", self.__tuning)
 
         self.step("configuring directory to start on boot", self.__enable)
 
@@ -1134,30 +1133,6 @@ class DsInstance(service.Service):
         self.start()
 
         return status
-
-    def tune_nofile(self, num=8192):
-        """
-        Increase the number of files descriptors available to directory server
-        from the default 1024 to 8192. This will allow to support a greater
-        number of clients out of the box.
-        """
-
-        # Do the platform-specific changes
-        proceed = services.knownservices.dirsrv.tune_nofile_platform(
-                    num=num, fstore=self.fstore)
-
-        if proceed:
-            # finally change also DS configuration
-            # NOTE: dirsrv will not allow you to set max file descriptors unless
-            # the user limits allow it, so we have to restart dirsrv before
-            # attempting to change them in cn=config
-            self.__restart_instance()
-
-            nf_sub_dict = dict(NOFILES=str(num))
-            self._ldap_mod("ds-nfiles.ldif", nf_sub_dict)
-
-    def __tuning(self):
-        self.tune_nofile(8192)
 
     def __root_autobind(self):
         self._ldap_mod("root-autobind.ldif",


### PR DESCRIPTION
Previously IPA would set the LimitNOFILE value to 8192 to increase
the number of concurrent clients. 389-ds-base does this by default
as of 1.3.7.0.

Remove the IPA-specific tuning and rely on the out-of-the-box
389-ds-base tuning.

Bump the required version of 389-ds-base to 1.3.7.0.

Any other tuning added by 389-ds-base will result in a
dirsrv.systemd.rpmsave file which admins will need to merge
in manually, like typical .rpmsave config changes.

https://pagure.io/freeipa/issue/6994