### PR TITLE
Enable ephemeral KRA requests

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -322,7 +322,7 @@ def install_step_1(standalone, replica_config, options):
     ca.stop('pki-tomcat')
 
     # This is done within stopped_service context, which restarts CA
-    ca.enable_client_auth_to_db(paths.CA_CS_CFG_PATH)
+    ca.enable_client_auth_to_db()
 
     # Lightweight CA key retrieval is configured in step 1 instead
     # of CAInstance.configure_instance (which is invoked from step

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -396,14 +396,18 @@ class CAInstance(DogtagInstance):
                       self.__spawn_instance)
             self.step("exporting Dogtag certificate store pin",
                       self.create_certstore_passwdfile)
-            self.step("stopping certificate server instance to update CS.cfg", self.stop_instance)
-            self.step("backing up CS.cfg", self.backup_config)
+            self.step("stopping certificate server instance to update CS.cfg",
+                      self.stop_instance)
+            self.step("backing up CS.cfg", self.safe_backup_config)
             self.step("disabling nonces", self.__disable_nonce)
             self.step("set up CRL publishing", self.__enable_crl_publish)
-            self.step("enable PKIX certificate path discovery and validation", self.enable_pkix)
+            self.step("enable PKIX certificate path discovery and validation",
+                      self.enable_pkix)
             if promote:
-                self.step("destroying installation admin user", self.teardown_admin)
-            self.step("starting certificate server instance", self.start_instance)
+                self.step("destroying installation admin user",
+                          self.teardown_admin)
+            self.step("starting certificate server instance",
+                      self.start_instance)
         # Step 1 of external is getting a CSR so we don't need to do these
         # steps until we get a cert back from the external CA.
         if self.external != 1:
@@ -641,9 +645,16 @@ class CAInstance(DogtagInstance):
 
         logger.debug("completed creating ca instance")
 
-    def backup_config(self):
+    def safe_backup_config(self):
+        """
+        Safely handle exceptions if backup_config fails
+
+        The parent class raises an exception if the configuration
+        cannot be backed up. Catch that and log the message but
+        don't stop the current installer.
+        """
         try:
-            backup_config()
+            super(CAInstance, self).backup_config()
         except Exception as e:
             logger.warning("Failed to backup CS.cfg: %s", e)
 
@@ -1250,7 +1261,7 @@ class CAInstance(DogtagInstance):
                       'Server-Cert cert-pki-ca': 'ca.sslserver.cert'}
 
         try:
-            backup_config()
+            self.backup_config()
         except Exception as e:
             syslog.syslog(syslog.LOG_ERR, "Failed to backup CS.cfg: %s" % e)
 
@@ -1425,16 +1436,6 @@ def replica_ca_install_check(config, promote):
             '--skip-schema-check.')
         exit('IPA schema missing on master CA directory server')
 
-
-def backup_config():
-    """
-    Create a backup copy of CS.cfg
-    """
-    path = paths.CA_CS_CFG_PATH
-    if services.knownservices['pki_tomcatd'].is_running('pki-tomcat'):
-        raise RuntimeError(
-            "Dogtag must be stopped when creating backup of %s" % path)
-    shutil.copy(path, path + '.ipabkp')
 
 def __update_entry_from_cert(make_filter, make_entry, cert):
     """

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -89,7 +89,8 @@ class DogtagInstance(service.Service):
     server_cert_name = None
 
     def __init__(self, realm, subsystem, service_desc, host_name=None,
-                 nss_db=paths.PKI_TOMCAT_ALIAS_DIR, service_prefix=None):
+                 nss_db=paths.PKI_TOMCAT_ALIAS_DIR, service_prefix=None,
+                 config=None):
         """Initializer"""
 
         super(DogtagInstance, self).__init__(
@@ -118,6 +119,7 @@ class DogtagInstance(service.Service):
         self.master_replication_port = None
         self.subject_base = None
         self.nss_db = nss_db
+        self.config = config  # Path to CS.cfg
 
     def is_installed(self):
         """
@@ -172,44 +174,43 @@ class DogtagInstance(service.Service):
                 "Failed to stop the Dogtag instance."
                 "See the installation log for details.")
 
-    def enable_client_auth_to_db(self, config):
+    def enable_client_auth_to_db(self):
         """
         Enable client auth connection to the internal db.
-        Path to CS.cfg config file passed in.
         """
 
         with stopped_service('pki-tomcatd', 'pki-tomcat'):
             installutils.set_directive(
-                config,
+                self.config,
                 'authz.instance.DirAclAuthz.ldap.ldapauth.authtype',
                 'SslClientAuth', quotes=False, separator='=')
             installutils.set_directive(
-                config,
+                self.config,
                 'authz.instance.DirAclAuthz.ldap.ldapauth.clientCertNickname',
                 'subsystemCert cert-pki-ca', quotes=False, separator='=')
             installutils.set_directive(
-                config,
+                self.config,
                 'authz.instance.DirAclAuthz.ldap.ldapconn.port', '636',
                 quotes=False, separator='=')
             installutils.set_directive(
-                config,
+                self.config,
                 'authz.instance.DirAclAuthz.ldap.ldapconn.secureConn',
                 'true', quotes=False, separator='=')
 
             installutils.set_directive(
-                config,
+                self.config,
                 'internaldb.ldapauth.authtype',
                 'SslClientAuth', quotes=False, separator='=')
 
             installutils.set_directive(
-                config,
+                self.config,
                 'internaldb.ldapauth.clientCertNickname',
                 'subsystemCert cert-pki-ca', quotes=False, separator='=')
             installutils.set_directive(
-                config,
+                self.config,
                 'internaldb.ldapconn.port', '636', quotes=False, separator='=')
             installutils.set_directive(
-                config,
+                self.config,
                 'internaldb.ldapconn.secureConn', 'true', quotes=False,
                 separator='=')
             # Remove internaldb password as is not needed anymore
@@ -338,8 +339,7 @@ class DogtagInstance(service.Service):
         if stop_certmonger:
             cmonger.stop()
 
-    @staticmethod
-    def update_cert_cs_cfg(directive, cert, cs_cfg):
+    def update_cert_cs_cfg(self, directive, cert):
         """
         When renewing a Dogtag subsystem certificate the configuration file
         needs to get the new certificate as well.
@@ -351,7 +351,7 @@ class DogtagInstance(service.Service):
 
         with stopped_service('pki-tomcatd', 'pki-tomcat'):
             installutils.set_directive(
-                cs_cfg,
+                self.config,
                 directive,
                 # the cert must be only the base64 string without headers
                 (base64.b64encode(cert.public_bytes(x509.Encoding.DER))
@@ -455,6 +455,10 @@ class DogtagInstance(service.Service):
         api.Backend.ldap2.delete_entry(self.admin_dn)
 
     def _use_ldaps_during_spawn(self, config, ds_cacert=paths.IPA_CA_CRT):
+        """
+        config is a RawConfigParser object
+        cs_cacert is path to a PEM CA certificate
+        """
         config.set(self.subsystem, "pki_ds_ldaps_port", "636")
         config.set(self.subsystem, "pki_ds_secure_connection", "True")
         config.set(self.subsystem, "pki_ds_secure_connection_ca_pem_file",

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -463,3 +463,13 @@ class DogtagInstance(service.Service):
         config.set(self.subsystem, "pki_ds_secure_connection", "True")
         config.set(self.subsystem, "pki_ds_secure_connection_ca_pem_file",
                    ds_cacert)
+
+    def backup_config(self):
+        """
+        Create a backup copy of CS.cfg
+        """
+        path = self.config
+        if services.knownservices['pki_tomcatd'].is_running('pki-tomcat'):
+            raise RuntimeError(
+                "Dogtag must be stopped when creating backup of %s" % path)
+        shutil.copy(path, path + '.ipabkp')

--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -125,7 +125,7 @@ def install(api, replica_config, options):
     _service.print_msg("Restarting the directory server")
     ds = dsinstance.DsInstance()
     ds.restart()
-    kra.enable_client_auth_to_db(paths.KRA_CS_CFG_PATH)
+    kra.enable_client_auth_to_db()
 
     # Restart apache for new proxy config file
     services.knownservices.httpd.restart(capture_output=True)

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -121,6 +121,7 @@ class KRAInstance(DogtagInstance):
         if promote:
             self.step("destroying installation admin user",
                       self.teardown_admin)
+        self.step("enabling ephemeral requests", self.enable_ephemeral)
         self.step("restarting KRA", self.restart_instance)
         self.step("configure certmonger for renewals",
                   self.configure_certmonger_renewal)

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -71,6 +71,7 @@ class KRAInstance(DogtagInstance):
             realm=realm,
             subsystem="KRA",
             service_desc="KRA server",
+            config=paths.KRA_CS_CFG_PATH,
         )
 
         self.basedn = DN(('o', 'kra'), ('o', 'ipaca'))
@@ -348,8 +349,20 @@ class KRAInstance(DogtagInstance):
                                    sub_dict=sub_dict)
         ld.update([os.path.join(paths.UPDATES_DIR, '40-vault.update')])
 
-    @staticmethod
-    def update_cert_config(nickname, cert):
+    def enable_ephemeral(self):
+        """
+        Enable ephemeral KRA requests to reduce the number of LDAP
+        write operations.
+        """
+        with installutils.stopped_service('pki-tomcatd', 'pki-tomcat'):
+            installutils.set_directive(
+                self.config,
+                'kra.ephemeralRequests',
+                'true', quotes=False, separator='=')
+
+        # A restart is required
+
+    def update_cert_config(self, nickname, cert):
         """
         When renewing a KRA subsystem certificate the configuration file
         needs to get the new certificate as well.
@@ -367,8 +380,8 @@ class KRAInstance(DogtagInstance):
             'Server-Cert cert-pki-ca': 'kra.sslserver.cert'}
 
         if nickname in directives:
-            DogtagInstance.update_cert_cs_cfg(
-                directives[nickname], cert, paths.KRA_CS_CFG_PATH)
+            super(KRAInstance, self).update_cert_cs_cfg(
+                directives[nickname], cert)
 
     def __enable_instance(self):
         self.ldap_enable('KRA', self.fqdn, None, self.suffix)


### PR DESCRIPTION
Enabling ephemeral KRA requests will reduce the amount of LDAP
write operations and improve overall performance.

https://pagure.io/freeipa/issue/6703

NOTE: I'm not 100% sure on the upgrade for existing instances. My logic is that tomcat is always stopped and then within that block the CA (if any) will be updated. Given that the KRA runs in the same service that is why I stuck that update code there. It worked in my testing.