### PR TITLE
tests_py3: decode get_file_contents() result

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -228,7 +228,7 @@ def restore_files(host):
 def restore_hostname(host):
     backupname = os.path.join(host.config.test_dir, 'backup_hostname')
     try:
-        hostname = host.get_file_contents(backupname)
+        hostname = host.get_file_contents(backupname, encoding='utf-8')
     except IOError:
         logger.debug('No hostname backed up on %s', host.hostname)
     else:


### PR DESCRIPTION
When running tests in python3 we get bytes object instead of
bytestring and when passing it to multihost run_command we later
fail on concatenation in shell_quote().