### PR TITLE
ipa-cacert-manage renew: switch from ext-signed CA to self-signed

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -438,7 +438,7 @@ def renew_ca_cert(reuse_existing, **kwargs):
     if operation == 'SUBMIT':
         state = 'retrieve'
 
-        if is_self_signed and not reuse_existing and is_renewal_master():
+        if not reuse_existing and is_renewal_master():
             state = 'request'
 
         csr_file = paths.IPA_CA_CSR


### PR DESCRIPTION
The scenario switching from externally signed CA to self-signed CA is
currently failing because the certmonger helper goes through the wrong
code path when the cert is not self-signed.

When the cert is not self-signed but the admin wants to switch to self-signed
a new cert needs to be requested, not retrieved from LDAP.

https://pagure.io/freeipa/issue/7173