### PR TITLE
tests: Mark failing tests as failing

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -111,6 +111,7 @@ class ADTrustInstallTestBase(IntegrationTest):
 # Master X Replicas installation tests
 ##
 
+@pytest.mark.xfail(reason="FreeIPA ticket 7008")
 class TestInstallWithCA1(InstallTestBase1):
 
     @classmethod
@@ -133,6 +134,7 @@ class TestInstallWithCA1(InstallTestBase1):
         super(TestInstallWithCA1, self).test_replica2_ipa_dns_install()
 
 
+@pytest.mark.xfail(reason="FreeIPA ticket 7008")
 class TestInstallWithCA2(InstallTestBase2):
 
     @classmethod
@@ -165,6 +167,7 @@ class TestInstallWithCA_KRA1(InstallTestBase1):
         tasks.install_kra(self.replicas[0], first_instance=False)
 
 
+@pytest.mark.xfail(reason="FreeIPA ticket 7220")
 class TestInstallWithCA_KRA2(InstallTestBase2):
 
     @classmethod
@@ -172,6 +175,7 @@ class TestInstallWithCA_KRA2(InstallTestBase2):
         tasks.install_master(cls.master, setup_dns=False, setup_kra=True)
 
 
+@pytest.mark.xfail(reason="FreeIPA ticket 7008")
 class TestInstallWithCA_DNS1(InstallTestBase1):
 
     @classmethod
@@ -194,6 +198,7 @@ class TestInstallWithCA_DNS1(InstallTestBase1):
         super(TestInstallWithCA_DNS1, self).test_replica2_ipa_dns_install()
 
 
+@pytest.mark.xfail(reason="FreeIPA ticket 7008")
 class TestInstallWithCA_DNS2(InstallTestBase2):
 
     @classmethod
@@ -229,6 +234,7 @@ class TestInstallWithCA_KRA_DNS1(InstallTestBase1):
         tasks.install_kra(self.replicas[0], first_instance=False)
 
 
+@pytest.mark.xfail(reason="FreeIPA ticket 7220")
 class TestInstallWithCA_KRA_DNS2(InstallTestBase2):
 
     @classmethod


### PR DESCRIPTION
Some tests from installation suite assume that it is possible
to --setup-kra, respectively --setup-ca if there is no kra,
respectively ca on IPA master.

This patch marks those tests as failing.

Signed-off-by: Petr Čech <pcech@redhat.com>