### PR TITLE
Remove the `message` attribute from exceptions

### DIFF
--- a/ipalib/errors.py
+++ b/ipalib/errors.py
@@ -369,7 +369,7 @@ class ServerCommandError(PublicError):
     For example:
 
     >>> e = CommandError(name='foobar')
-    >>> raise ServerCommandError(error=e.message, server='https://localhost')
+    >>> raise ServerCommandError(error=str(e), server='https://localhost')
     Traceback (most recent call last):
       ...
     ServerCommandError: error on server 'https://localhost': unknown command 'foobar'

--- a/ipalib/messages.py
+++ b/ipalib/messages.py
@@ -129,11 +129,6 @@ class PublicMessage(UserWarning):
             data=self.kw,
         )
 
-    if six.PY3:
-        @property
-        def message(self):
-            return str(self)
-
 
 class VersionMissing(PublicMessage):
     """

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -969,7 +969,7 @@ def handle_error(error, log_file_name=None):
         return error, 1
 
     if isinstance(error, errors.ACIError):
-        return error.message, 1
+        return str(error), 1
     if isinstance(error, ldap.INVALID_CREDENTIALS):
         return "Invalid password", 1
     if isinstance(error, ldap.INSUFFICIENT_ACCESS):

--- a/ipaserver/plugins/group.py
+++ b/ipaserver/plugins/group.py
@@ -439,7 +439,7 @@ class group_mod(LDAPUpdate):
         # using --setattr.
         if call_func.__name__ == 'update_entry':
             if isinstance(exc, errors.ObjectclassViolation):
-                if 'gidNumber' in exc.message and 'posixGroup' in exc.message:
+                if 'gidNumber' in str(exc) and 'posixGroup' in str(exc):
                     raise errors.RequirementError(name='gidnumber')
         raise exc
 

--- a/ipatests/test_ipalib/test_errors.py
+++ b/ipatests/test_ipalib/test_errors.py
@@ -65,7 +65,6 @@ class PrivateExceptionTester(object):
         for (key, value) in kw.items():
             assert getattr(inst, key) is value
         assert str(inst) == self.klass.format % kw
-        assert inst.message == str(inst)
         return inst
 
 
@@ -119,7 +118,6 @@ class test_SubprocessError(PrivateExceptionTester):
         assert inst.returncode == 1
         assert inst.argv == (bin_false,)
         assert str(inst) == "return code 1 from ('{}',)".format(bin_false)
-        assert inst.message == str(inst)
 
 
 class test_PluginSubclassError(PrivateExceptionTester):
@@ -138,7 +136,6 @@ class test_PluginSubclassError(PrivateExceptionTester):
         assert inst.bases == ('base1', 'base2')
         assert str(inst) == \
             "'bad' not subclass of any base in ('base1', 'base2')"
-        assert inst.message == str(inst)
 
 
 class test_PluginDuplicateError(PrivateExceptionTester):
@@ -155,7 +152,6 @@ class test_PluginDuplicateError(PrivateExceptionTester):
         inst = self.new(plugin='my_plugin')
         assert inst.plugin == 'my_plugin'
         assert str(inst) == "'my_plugin' was already registered"
-        assert inst.message == str(inst)
 
 
 class test_PluginOverrideError(PrivateExceptionTester):
@@ -174,7 +170,6 @@ class test_PluginOverrideError(PrivateExceptionTester):
         assert inst.name == 'cmd'
         assert inst.plugin == 'my_cmd'
         assert str(inst) == "unexpected override of Base.cmd with 'my_cmd'"
-        assert inst.message == str(inst)
 
 
 class test_PluginMissingOverrideError(PrivateExceptionTester):
@@ -193,8 +188,6 @@ class test_PluginMissingOverrideError(PrivateExceptionTester):
         assert inst.name == 'cmd'
         assert inst.plugin == 'my_cmd'
         assert str(inst) == "Base.cmd not registered, cannot override with 'my_cmd'"
-        assert inst.message == str(inst)
-
 
 
 ##############################################################################
@@ -250,7 +243,7 @@ class test_PublicError(PublicExceptionTester):
         # Test with format=str, message=None
         inst = self.klass(format, **kw)
         assert inst.format is format
-        assert_equal(inst.message, format % kw)
+        assert_equal(str(inst), format % kw)
         assert inst.forwarded is False
         assert inst.key1 is val1
         assert inst.key2 is val2
@@ -258,7 +251,7 @@ class test_PublicError(PublicExceptionTester):
         # Test with format=None, message=unicode
         inst = self.klass(message=message, **kw)
         assert inst.format is None
-        assert inst.message is message
+        assert str(inst) == message
         assert inst.strerror is message
         assert inst.forwarded is True
         assert inst.key1 is val1
@@ -281,7 +274,7 @@ class test_PublicError(PublicExceptionTester):
         inst = self.new(format, **kw)
         assert isinstance(inst, self.klass)
         assert inst.format is format
-        assert_equal(inst.message, format % kw)
+        assert_equal(str(inst), format % kw)
         assert inst.forwarded is False
         assert inst.key1 is val1
         assert inst.key2 is val2
@@ -290,7 +283,7 @@ class test_PublicError(PublicExceptionTester):
         inst = self.new(message=message, **kw)
         assert isinstance(inst, self.klass)
         assert inst.format is None
-        assert inst.message is message
+        assert str(inst) == message
         assert inst.strerror is message
         assert inst.forwarded is True
         assert inst.key1 is val1
@@ -312,7 +305,7 @@ class test_PublicError(PublicExceptionTester):
         # Test with format=None, message=None:
         inst = subclass(**kw)
         assert inst.format is subclass.format
-        assert_equal(inst.message, subclass.format % kw)
+        assert_equal(str(inst), subclass.format % kw)
         assert inst.forwarded is False
         assert inst.true is True
         assert inst.text is kw['text']
@@ -321,7 +314,7 @@ class test_PublicError(PublicExceptionTester):
         # Test with format=None, message=unicode:
         inst = subclass(message=message, **kw)
         assert inst.format is subclass.format
-        assert inst.message is message
+        assert str(inst) == message
         assert inst.strerror is message
         assert inst.forwarded is True
         assert inst.true is True

--- a/ipatests/test_webui/test_user.py
+++ b/ipatests/test_webui/test_user.py
@@ -383,7 +383,8 @@ class test_user_no_private_group(UI_driver):
 
         with pytest.raises(AssertionError) as e:
             self.add_record(user.ENTITY, user.DATA3)
-        assert e.value.message == u'Unexpected error: Default group for new users is not POSIX'
+        assert (str(e.value) == 'Unexpected error: Default group for new '
+                'users is not POSIX')
 
     @screenshot
     def test_noprivate_posix(self):

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -1156,8 +1156,8 @@ class test_dns(Declarative):
                                                                      % zone1_ns]}),
             expected=lambda x, output: (
                 type(x) == errors.ValidationError and
-                x.message.endswith(u'Raw value of a DNS record was already '
-                                   u'set by "srv_rec" option'),
+                str(x).endswith('Raw value of a DNS record was already '
+                                'set by "srv_rec" option'),
             ),
         ),
 


### PR DESCRIPTION
This is causing python2 tests print ugly warnings about the
deprecation of the `message` attribute in python2.6.

https://pagure.io/freeipa/issue/7131

====================
I had some time between reviews when the tests were running and noticed some ugly strings in python2 test results so I'm posting this.