### PR TITLE
 travis: make tests fail if pep8 does not pass 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ install:
 script:
     - mkdir -p $CI_RUNNER_LOGS_DIR
     - travis_wait 50 ./.travis_run_task.sh
+    - test -z "`cat $PEP8_ERROR_LOG`"
 after_failure:
     - echo "Test runner output:"; tail -n $CI_BACKLOG_SIZE $CI_RESULTS_LOG
     - echo "PEP-8 errors:"; cat $PEP8_ERROR_LOG


### PR DESCRIPTION
Currently, pep8 does not seem to fail even though there may be errors, let's see if this helps it.