### PR TITLE
[Backport][ipa-4-5-4]  backport: otptoken_yubikey.py: Removed traceback when package missing.

### DIFF
--- a/ipaclient/plugins/otptoken_yubikey.py
+++ b/ipaclient/plugins/otptoken_yubikey.py
@@ -126,6 +126,9 @@ class otptoken_add_yubikey(Command):
             raise NotFound(reason="No YubiKey found: %s" % e.strerror)
         except yubico.yubikey.YubiKeyError as e:
             raise NotFound(reason=e.reason)
+        except ValueError as e:
+            raise NotFound(reason=str(e) + ". Please install 'libyubikey' "
+                           "and 'libusb' packages first.")
 
         assert yk.version_num() >= (2, 1)
 


### PR DESCRIPTION
IPA should suggest user to install dependent packages instead
of throwing traceback. To work with IPA and Yubikey, packages
libyubikey(not in official RHEL repo) and libusb are required.

Resolves: https://pagure.io/freeipa/issue/6979