### PR TITLE
Backport PR 1109 to ipa-4-6

### DIFF
--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -715,7 +715,9 @@ class LDAPObject(Object):
             result = self.backend.get_entries(
                 self.api.env.basedn,
                 filter=filter,
-                attrs_list=[''])
+                attrs_list=[''],
+                size_limit=-1,  # paged search will get everything anyway
+                paged_search=True)
         except errors.NotFound:
             result = []
 


### PR DESCRIPTION
This PR was opened automatically because PR #1109 was pushed to master and backport to ipa-4-6 is required.