### PR TITLE
[4.5] Use correct container for ipa-4-5 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 cache: pip
 env:
     global:
-        - TEST_RUNNER_IMAGE="martbab/freeipa-fedora-test-runner:master-latest"
+        - TEST_RUNNER_IMAGE="freeipa/freeipa-test-runner:ipa-4-5_f25"
           TEST_RUNNER_CONFIG=".test_runner_config.yaml"
           PEP8_ERROR_LOG="pep8_errors.log"
           CI_RESULTS_LOG="ci_results_${TRAVIS_BRANCH}.log"


### PR DESCRIPTION
@freeipa/freeipa-master no longer provides Fedora 25 dependencies
but is still used in the current container for testing ipa-4-5.
Since ipa-4-5 won't pass F26 pylint check we can't use the master
branch container, thus we'll use an ad hoc one.