### PR TITLE
ipaclient.plugins.dns: Cast DNS name to unicode.

### DIFF
--- a/ipaclient/plugins/dns.py
+++ b/ipaclient/plugins/dns.py
@@ -62,7 +62,7 @@ def __get_part_param(rrtype, cmd, part, output_kw, default=None):
 def prompt_parts(rrtype, cmd, mod_dnsvalue=None):
     mod_parts = None
     if mod_dnsvalue is not None:
-        name = record_name_format % rrtype.lower()
+        name = record_name_format % unicode(rrtype.lower())
         mod_parts = cmd.api.Command.dnsrecord_split_parts(
             name, mod_dnsvalue)['result']
 


### PR DESCRIPTION
cmd.api.Command.dnsrecord_split_parts expects name to be unicode
string and instead gets ascii. It leads to an error:
ipa: ERROR: invalid 'name': must be Unicode text

This commit's change is casting name's type to unicode so
'ipa dnsrecord-mod' will not fail with error above.

https://pagure.io/freeipa/issue/7185