### PR TITLE
KRA install: log into security domain on master

### DIFF
--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -253,7 +253,13 @@ class KRAInstance(DogtagInstance):
             os.chown(p12_tmpfile_name, pent.pw_uid, pent.pw_gid)
 
             # Security domain registration
-            config.set("KRA", "pki_security_domain_hostname", self.fqdn)
+            #
+            # We log into the security domain on master_host instead of self
+            # to avoid replication lag causing authentication failure when
+            # the security domain session is created on the REPLICA, but
+            # validated on the MASTER during KRA configuration
+            #
+            config.set("KRA", "pki_security_domain_hostname", self.master_host)
             config.set("KRA", "pki_security_domain_https_port", "443")
             config.set("KRA", "pki_security_domain_user", self.admin_user)
             config.set("KRA", "pki_security_domain_password",


### PR DESCRIPTION
KRA clone installation can fail due to security domain token
authentication failure that arises because:

1. The security domain session gets created on the replica's CA
   instance.

2. The "updateNumberRange" is performed against the master's KRA
   subsystem, and results in a token authentication request to
   the CA subsystem on the same host (i.e. the master)

3. LDAP replication lag means that the master does not yet see
   the security domain session that was created on the replica.

To avoid this problem, update the KRA pkispawn configuration for
cloning to log into the security domain on the master, instead of
the CA subsystem on the replica.

Fixes: https://pagure.io/freeipa/issue/7087


-----

How to test:

- Install DL0 master.  Perform replica installation with CA and KRA
  (`--setup-ca --setup-kra`).

- Install DL0 master.  Perform replica installation with CA.  Perform subsequent KRA installation with `ipa-kra-install`.

- Install DL1 master.  Perform replica installation with CA and KRA
  (i.e. check that this still works)