### PR TITLE
ipatests: Fix interactive prompt in ca_less tests

### DIFF
--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -65,6 +65,9 @@ def get_install_stdin(cert_passwords=()):
 
 def get_replica_prepare_stdin(cert_passwords=()):
     lines = list(cert_passwords)  # Enter foo.p12 unlock password
+    lines += [
+        'yes',  # Continue [no]?
+    ]
     return '\n'.join(lines + [''])
 
 


### PR DESCRIPTION
This fix adds additional prompt which was missing previously
in test_interactive_missing_ds_pkcs_password and
test_interactive_missing_http_pkcs_password under CA-less integration
testsuite.

Fixes: https://pagure.io/freeipa/issue/7182

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>