### PR TITLE
[tests] Fix negative tests in CA-less testsuite

### DIFF
--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -266,9 +266,16 @@ class CALessBase(IntegrationTest):
         tasks.prepare_host(master)
         tasks.prepare_host(replica)
         for filename in set(files_to_copy):
+            filepath = os.path.join(self.cert_dir, filename)
+            if not os.path.exists(filepath):
+                # Negative tests passes non-existent file names,
+                # there is no point in copying them.
+                logger.info("File '%s' not found, copying to "
+                            "destination skipped", filepath)
+                continue
             try:
                 destination_host.transport.put_file(
-                    os.path.join(self.cert_dir, filename),
+                    filepath,
                     os.path.join(destination_host.config.test_dir, filename))
             except OSError:
                 pass


### PR DESCRIPTION
This fix adds check for non-existing files which are given
by negative testcases to copy from controller to system under tests.
This fixes test_nonexistent_ds_pkcs12_file and test_nonexistent_http_pkcs12_file
tests in CA-less testsuite.

Fixes: https://pagure.io/freeipa/issue/7182

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>