### PR TITLE
Ignore ACI errors when pwpolicy-del fails in group-del

### DIFF
--- a/ipaserver/plugins/group.py
+++ b/ipaserver/plugins/group.py
@@ -367,7 +367,10 @@ class group_del(LDAPDelete):
         assert isinstance(dn, DN)
         try:
             api.Command['pwpolicy_del'](keys[-1])
-        except errors.NotFound:
+        # we catch ACI error because of CVE fixed in DS
+        # when an entry does not exist and we have no privilege reading it,
+        # there's err=50 instead of err=32
+        except (errors.NotFound, errors.ACIError):
             pass
 
         return True


### PR DESCRIPTION
The definitive fix to deal with the DS CVE would be to remove the ipaPermTargetFilter: (objectclass=<objectclass value>) from the "Remove <Object>" permissions during ipa-server-upgrade, for instance, and re-run the task to generate the acl's (if this not done automatically when modifying the permission entry).

this has been also discussed in BZ1441262

https://bugzilla.redhat.com/show_bug.cgi?id=1441262