### PR TITLE
tests: correct usage of host.hostname in logger in tasks

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1096,11 +1096,11 @@ def add_a_records_for_hosts_in_master_domain(master):
         # domain
         try:
             verify_host_resolvable(host.hostname)
-            logger.debug("The host (%s) is resolvable.", host.domain.name)
+            logger.debug("The host (%s) is resolvable.", host.hostname)
         except errors.DNSNotARecordError:
             logger.debug("Hostname (%s) does not have A/AAAA record. Adding "
                          "new one.",
-                         master.hostname)
+                         host.hostname)
             add_a_record(master, host)
 
 


### PR DESCRIPTION
This fix adds correct usage of host.hostname in logger.

Fixes: https://pagure.io/freeipa/issue/7190

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>