### PR TITLE
[ipa-4-5] WebUI: Fix calling undefined method during reset passwords

### DIFF
--- a/install/ui/src/freeipa/ipa.js
+++ b/install/ui/src/freeipa/ipa.js
@@ -191,7 +191,7 @@ var IPA = function () {
             }
         }));
 
-        batch.add_command(that.get_whoami_command(true));
+        batch.add_command(that.get_whoami_command());
 
         batch.add_command(rpc.command({
             method: 'env',
@@ -259,10 +259,8 @@ var IPA = function () {
     /**
      * Prepares `user-find --whoami` command
      * @protected
-     * @param {boolean} batch - Specifies if it will be used as single command or
-     *                          in a batch.
      */
-    that.get_whoami_command = function(batch) {
+    that.get_whoami_command = function() {
         return rpc.command({
             method: 'whoami',
             on_success: function(data, text_status, xhr) {

--- a/install/ui/src/freeipa/ipa.js
+++ b/install/ui/src/freeipa/ipa.js
@@ -264,18 +264,19 @@ var IPA = function () {
         return rpc.command({
             method: 'whoami',
             on_success: function(data, text_status, xhr) {
-                that.whoami.metadata = data;
+                that.whoami.metadata = data.result || data;
+                var wa_data = that.whoami.metadata;
 
                 rpc.command({
-                    method: data.details || data.command,
-                    args: data.arguments,
+                    method: wa_data.details || wa_data.command,
+                    args: wa_data.arguments,
                     options: function() {
-                        var options = data.options || [];
+                        var options = wa_data.options || [];
                         $.extend(options, {all: true});
                         return options;
                     }(),
                     on_success: function(data, text_status, xhr) {
-                        that.whoami.data = false ? data.result[0] : data.result.result;
+                        that.whoami.data = data.result.result;
                         var entity = that.whoami.metadata.object;
 
                         if (entity === 'user') {


### PR DESCRIPTION
When calling reset password the whoami command is not called in batch
command, therefore the result is different then in calling
during reset password operation. That needs to be handled to properly
set entity_show method which needs to be called after to gather
data about logged in entity.

https://pagure.io/freeipa/issue/7175

**PUSH ONLY TO ipa-4-5 BRANCH - IT IS BACKPORT**