### PR TITLE
[Backport][ipa-4-6] tests: Add LDAP URI to ldappasswd explicitelly

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1326,9 +1326,10 @@ def ldappasswd_user_change(user, oldpw, newpw, master):
     basedn = master.domain.basedn
 
     userdn = "uid={},{},{}".format(user, container_user, basedn)
+    master_ldap_uri = "ldap://{}".format(master.external_hostname)
 
     args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
-            '-s', newpw, '-x']
+            '-s', newpw, '-x', '-H', master_ldap_uri]
     master.run_command(args)
 
 

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -750,7 +750,7 @@ def unlock_principal_password(user, oldpw, newpw):
         user, api.env.container_user, api.env.basedn)
 
     args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
-            '-s', newpw, '-x']
+            '-s', newpw, '-x', '-H', api.env.ldap_uri]
     return run(args)
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #960 was pushed to master and backport to ipa-4-6 is required.