### PR TITLE
Time skew fixes during initial replication

### DIFF
--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -38,6 +38,7 @@ dist_app_DATA =				\
 	default-trust-view.ldif		\
 	delegation.ldif			\
 	replica-acis.ldif		\
+	replica-prevent-time-skew.ldif  \
 	ds-nfiles.ldif			\
 	dns.ldif			\
 	dnssec.ldif			\

--- a/install/share/replica-prevent-time-skew.ldif
+++ b/install/share/replica-prevent-time-skew.ldif
@@ -1,0 +1,4 @@
+dn: cn=config
+changetype: modify
+replace: nsslapd-ignore-time-skew
+nsslapd-ignore-time-skew: $SKEWVALUE

--- a/install/tools/ipa-replica-manage
+++ b/install/tools/ipa-replica-manage
@@ -1235,8 +1235,14 @@ def force_sync(realm, thishost, fromhost, dirman_passwd, nolookup=False):
         repl = replication.ReplicationManager(realm, thishost, dirman_passwd)
         repl.force_sync(repl.conn, fromhost)
     else:
+        ds = dsinstance.DsInstance(realm_name=realm)
+        ds.ldapi = os.getegid() == 0
+        ds.replica_manage_time_skew(prevent=False)
         repl = replication.ReplicationManager(realm, fromhost, dirman_passwd)
         repl.force_sync(repl.conn, thishost)
+        agreement = repl.get_replication_agreement(thishost)
+        repl.wait_for_repl_init(repl.conn, agreement.dn)
+        ds.replica_manage_time_skew(prevent=True)
 
 def show_DNA_ranges(hostname, master, realm, dirman_passwd, nextrange=False,
                     nolookup=False):


### PR DESCRIPTION
This patchset implements time skew fixes for initial replication as required in the bug https://bugzilla.redhat.com/show_bug.cgi?id=1493150. This approach allows creating or re-initializing replicas in the situation when there are time differences between data centers.

Note that by default 389-ds does not allow for time skew in replication, this is generally a good approach and should be our default state. This patchset makes possible to unlock an impasse with cases where one would get replication state out of control due to various external reasons like a failed attempt at a parallel IPA upgrade.