### PR TITLE
p11-kit: add serial number in DER format

### DIFF
--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -123,18 +123,21 @@ class IPACertificate(object):
         # some field types encode-decoding is not strongly defined
         self._subject = self.__get_der_field('subject')
         self._issuer = self.__get_der_field('issuer')
+        self._serial_number = self.__get_der_field('serialNumber')
 
     def __getstate__(self):
         state = {
             '_cert': self.public_bytes(Encoding.DER),
             '_subject': self.subject_bytes,
             '_issuer': self.issuer_bytes,
+            '_serial_number': self._serial_number,
         }
         return state
 
     def __setstate__(self, state):
         self._subject = state['_subject']
         self._issuer = state['_issuer']
+        self._issuer = state['_serial_number']
         self._cert = crypto_x509.load_der_x509_certificate(
             state['_cert'], backend=default_backend())
 
@@ -214,6 +217,10 @@ class IPACertificate(object):
     @property
     def serial_number(self):
         return self._cert.serial_number
+
+    @property
+    def serial_number_bytes(self):
+        return self._serial_number
 
     @property
     def version(self):

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -274,7 +274,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
             try:
                 subject = cert.subject_bytes
                 issuer = cert.issuer_bytes
-                serial_number = cert.serial_number
+                serial_number = cert.serial_number_bytes
                 public_key_info = cert.public_key_info_bytes
             except (PyAsn1Error, ValueError, CertificateError) as e:
                 logger.warning(
@@ -284,7 +284,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
             label = urllib.parse.quote(nickname)
             subject = urllib.parse.quote(subject)
             issuer = urllib.parse.quote(issuer)
-            serial_number = urllib.parse.quote(str(serial_number))
+            serial_number = urllib.parse.quote(serial_number)
             public_key_info = urllib.parse.quote(public_key_info)
 
             obj = ("[p11-kit-object-v1]\n"


### PR DESCRIPTION
This causes Firefox to report our CA certificate as not-trustworthy.
We were previously doing this correctly, however it slipped as an
error due to certificate refactoring.

https://pagure.io/freeipa/issue/7210