### PR TITLE
[4.6] Block PyOpenSSL to prevent SELinux execmem in wsgi

### DIFF
--- a/install/share/wsgi.py
+++ b/install/share/wsgi.py
@@ -25,6 +25,18 @@ WSGI appliction for IPA server.
 """
 import logging
 import os
+import sys
+
+# Some dependencies like Dogtag's pki.client library and custodia use
+# python-requsts to make HTTPS connection. python-requests prefers
+# PyOpenSSL over Python's stdlib ssl module. PyOpenSSL is build on top
+# of python-cryptography which trigger a execmem SELinux violation
+# in the context of Apache HTTPD (httpd_execmem).
+# When requests is imported, it always tries to import pyopenssl glue
+# code from urllib3's contrib directory. The import of PyOpenSSL is
+# enough to trigger the SELinux denial.
+# Block any import of PyOpenSSL's SSL module by raising an ImportError
+sys.modules['OpenSSL.SSL'] = None
 
 from ipaplatform.paths import paths
 from ipalib import api


### PR DESCRIPTION
Some dependencies like Dogtag's pki.client library and custodia use
python-requsts to make HTTPS connection. python-requests prefers
PyOpenSSL over Python's stdlib ssl module. PyOpenSSL is build on top
of python-cryptography which trigger a execmem SELinux violation
in the context of Apache HTTPD (httpd_execmem).

When requests is imported, it always tries to import pyopenssl glue
code from urllib3's contrib directory. The import of PyOpenSSL is
enough to trigger the SELinux denial.

Block any import of PyOpenSSL's SSL module in wsgi by raising an
ImportError. The block is compatible with new python-requests with
unbundled urllib3, too.

Fixes: https://pagure.io/freeipa/issue/5442
Fixes: RHBZ#1491508
Signed-off-by: Christian Heimes <cheimes@redhat.com>