### PR TITLE
[Backport][ipa-4-5] kra-install: better warning message

### DIFF
--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -147,7 +147,8 @@ class KRAInstaller(KRAInstall):
 
         if not cainstance.is_ca_installed_locally():
             raise RuntimeError("Dogtag CA is not installed. "
-                               "Please install the CA first")
+                               "Please install a CA first with the "
+                               "`ipa-ca-install` command.")
 
         # check if KRA is not already installed
         _kra = krainstance.KRAInstance(api)


### PR DESCRIPTION
This PR was opened automatically because PR #1162 was pushed to master and backport to ipa-4-5 is required.