### PR TITLE
Increase dbus client timeouts during CA install

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -287,6 +287,8 @@ IPA_CA_RECORD = "ipa-ca"
 IPA_CA_NICKNAME = 'caSigningCert cert-pki-ca'
 RENEWAL_CA_NAME = 'dogtag-ipa-ca-renew-agent'
 RENEWAL_REUSE_CA_NAME = 'dogtag-ipa-ca-renew-agent-reuse'
+# How long dbus clients should wait for CA certificate RPCs [seconds]
+CA_DBUS_TIMEOUT = 120
 
 # regexp definitions
 PATTERN_GROUPUSER_NAME = '^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$'

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -32,6 +32,7 @@ import shlex
 import subprocess
 import tempfile
 from ipalib import api
+from ipalib.constants import CA_DBUS_TIMEOUT
 from ipapython.dn import DN
 from ipaplatform.paths import paths
 from ipaplatform import services
@@ -620,7 +621,9 @@ def modify_ca_helper(ca_name, helper):
         old_helper = ca_iface.Get('org.fedorahosted.certmonger.ca',
                                   'external-helper')
         ca_iface.Set('org.fedorahosted.certmonger.ca',
-                     'external-helper', helper)
+                     'external-helper', helper,
+                     # Give dogtag extra time to generate cert
+                     timeout=CA_DBUS_TIMEOUT)
         return old_helper
 
 

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -31,6 +31,7 @@ import pki.system
 
 from ipalib import api, errors, x509
 from ipalib.install import certmonger
+from ipalib.constants import CA_DBUS_TIMEOUT
 from ipaplatform import services
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
@@ -262,7 +263,9 @@ class DogtagInstance(service.Service):
                 iface.add_known_ca(
                     name,
                     command,
-                    dbus.Array([], dbus.Signature('s')))
+                    dbus.Array([], dbus.Signature('s')),
+                    # Give dogtag extra time to generate cert
+                    timeout=CA_DBUS_TIMEOUT)
 
     def __get_pin(self):
         try:


### PR DESCRIPTION
See original PR: #1078 

---

When running on memory-constrained systems, the `ipa-server-install`
program often fails during the "Configuring certificate server
(pki-tomcatd)" stage in FreeIPA 4.5 and 4.6.

The memory-intensive dogtag service causes swapping on low-memory
systems right after start-up, and especially new certificate
operations requested via certmonger can exceed the dbus client default
25 second timeout.

This patch changes dbus client timeouts for some such operations to
120 seconds (from the default 25 seconds, IIRC).

See more discussion in FreeIPA PR #1078 [1] and FreeIPA container
issue #157 [2].  Upstream ticket at [3].

[1]: https://github.com/freeipa/freeipa/pull/1078
[2]: https://github.com/freeipa/freeipa-container/issues/157
[3]: https://pagure.io/freeipa/issue/7213