### PR TITLE
[Backport][ipa-4-5] ipa-cacert-manage renew: switch from ext-signed CA to self-signed

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -438,7 +438,7 @@ def renew_ca_cert(reuse_existing, **kwargs):
     if operation == 'SUBMIT':
         state = 'retrieve'
 
-        if is_self_signed and not reuse_existing and is_renewal_master():
+        if not reuse_existing and is_renewal_master():
             state = 'request'
 
         csr_file = paths.IPA_CA_CSR


### PR DESCRIPTION
This PR was opened automatically because PR #1119 was pushed to master and backport to ipa-4-5 is required.