### PR TITLE
[Backport][ipa-4-5] ipatests: Fix on logs collection

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1159,8 +1159,10 @@ def install_kra(host, domain_level=None, first_instance=False, raiseonerr=True):
     if domain_level == DOMAIN_LEVEL_0 and not first_instance:
         replica_file = get_replica_filename(host)
         command.append(replica_file)
-    result = host.run_command(command, raiseonerr=raiseonerr)
-    setup_server_logs_collecting(host)
+    try:
+        result = host.run_command(command, raiseonerr=raiseonerr)
+    finally:
+        setup_server_logs_collecting(host)
     return result
 
 
@@ -1172,8 +1174,10 @@ def install_ca(host, domain_level=None, first_instance=False, raiseonerr=True):
     if domain_level == DOMAIN_LEVEL_0 and not first_instance:
         replica_file = get_replica_filename(host)
         command.append(replica_file)
-    result = host.run_command(command, raiseonerr=raiseonerr)
-    setup_server_logs_collecting(host)
+    try:
+        result = host.run_command(command, raiseonerr=raiseonerr)
+    finally:
+        setup_server_logs_collecting(host)
     return result
 
 


### PR DESCRIPTION
Original PR: #1168 

---

If the function `install_kra` or `install_ca` fails
on call `host.run_command(command, raiseonerr=raiseonerr)`
then the logs are not collected.

This situation is not optimal because we need to see what happend
during the debbuging the tests.

So, this patch solves this situation and it adds try--finally
construction.

https://pagure.io/freeipa/issue/7214