### PR TITLE
[Backport][ipa-4-6] ipatests: Fix on logs collection

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1163,8 +1163,10 @@ def install_kra(host, domain_level=None, first_instance=False, raiseonerr=True):
     if domain_level == DOMAIN_LEVEL_0 and not first_instance:
         replica_file = get_replica_filename(host)
         command.append(replica_file)
-    result = host.run_command(command, raiseonerr=raiseonerr)
-    setup_server_logs_collecting(host)
+    try:
+        result = host.run_command(command, raiseonerr=raiseonerr)
+    finally:
+        setup_server_logs_collecting(host)
     return result
 
 
@@ -1184,8 +1186,10 @@ def install_ca(host, domain_level=None, first_instance=False,
     if cert_files:
         for fname in cert_files:
             command.extend(['--external-cert-file', fname])
-    result = host.run_command(command, raiseonerr=raiseonerr)
-    setup_server_logs_collecting(host)
+    try:
+        result = host.run_command(command, raiseonerr=raiseonerr)
+    finally:
+        setup_server_logs_collecting(host)
     return result
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #1168 was pushed to master and backport to ipa-4-6 is required.