### PR TITLE
[Backport][ipa-4-6] Increase dbus client timeouts during CA install

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -287,6 +287,8 @@ IPA_CA_RECORD = "ipa-ca"
 IPA_CA_NICKNAME = 'caSigningCert cert-pki-ca'
 RENEWAL_CA_NAME = 'dogtag-ipa-ca-renew-agent'
 RENEWAL_REUSE_CA_NAME = 'dogtag-ipa-ca-renew-agent-reuse'
+# How long dbus clients should wait for CA certificate RPCs [seconds]
+CA_DBUS_TIMEOUT = 120
 
 # regexp definitions
 PATTERN_GROUPUSER_NAME = '^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$'

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -32,6 +32,7 @@ import shlex
 import subprocess
 import tempfile
 from ipalib import api
+from ipalib.constants import CA_DBUS_TIMEOUT
 from ipapython.dn import DN
 from ipaplatform.paths import paths
 from ipaplatform import services
@@ -620,7 +621,9 @@ def modify_ca_helper(ca_name, helper):
         old_helper = ca_iface.Get('org.fedorahosted.certmonger.ca',
                                   'external-helper')
         ca_iface.Set('org.fedorahosted.certmonger.ca',
-                     'external-helper', helper)
+                     'external-helper', helper,
+                     # Give dogtag extra time to generate cert
+                     timeout=CA_DBUS_TIMEOUT)
         return old_helper
 
 

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -31,6 +31,7 @@ import pki.system
 
 from ipalib import api, errors, x509
 from ipalib.install import certmonger
+from ipalib.constants import CA_DBUS_TIMEOUT
 from ipaplatform import services
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
@@ -262,7 +263,9 @@ class DogtagInstance(service.Service):
                 iface.add_known_ca(
                     name,
                     command,
-                    dbus.Array([], dbus.Signature('s')))
+                    dbus.Array([], dbus.Signature('s')),
+                    # Give dogtag extra time to generate cert
+                    timeout=CA_DBUS_TIMEOUT)
 
     def __get_pin(self):
         try:


### PR DESCRIPTION
This PR was opened automatically because PR #1170 was pushed to master and backport to ipa-4-6 is required.