### PR TITLE
[Backport][ipa-4-6] ipaclient.plugins.dns: Cast DNS name to unicode

### DIFF
--- a/ipaclient/plugins/dns.py
+++ b/ipaclient/plugins/dns.py
@@ -62,7 +62,7 @@ def __get_part_param(rrtype, cmd, part, output_kw, default=None):
 def prompt_parts(rrtype, cmd, mod_dnsvalue=None):
     mod_parts = None
     if mod_dnsvalue is not None:
-        name = record_name_format % rrtype.lower()
+        name = record_name_format % unicode(rrtype.lower())
         mod_parts = cmd.api.Command.dnsrecord_split_parts(
             name, mod_dnsvalue)['result']
 


### PR DESCRIPTION
This PR was opened automatically because PR #1175 was pushed to master and backport to ipa-4-6 is required.