### PR TITLE
Drop import of ipaplatform to fix PyPI packages

### DIFF
--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -55,10 +55,6 @@ from ipalib.constants import (
     TLS_VERSIONS, TLS_VERSION_MINIMAL, TLS_HIGH_CIPHERS
 )
 from ipalib.text import _
-# pylint: disable=ipa-forbidden-import
-from ipalib.install import sysrestore
-from ipaplatform.paths import paths
-# pylint: enable=ipa-forbidden-import
 from ipapython.ssh import SSHPublicKey
 from ipapython.dn import DN, RDN
 from ipapython.dnsutil import DNSName
@@ -67,6 +63,11 @@ from ipapython.admintool import ScriptError
 
 if six.PY3:
     unicode = str
+
+
+_IPA_CLIENT_SYSRESTORE = "/var/lib/ipa-client/sysrestore"
+_IPA_DEFAULT_CONF = "/etc/ipa/default.conf"
+
 
 logger = logging.getLogger(__name__)
 
@@ -1078,8 +1079,9 @@ def check_client_configuration():
     """
     Check if IPA client is configured on the system.
     """
-    fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
-    if not fstore.has_files() and not os.path.exists(paths.IPA_DEFAULT_CONF):
+    if (not os.path.isfile(_IPA_DEFAULT_CONF) or
+            not os.path.isdir(_IPA_CLIENT_SYSRESTORE) or
+            not os.listdir(_IPA_CLIENT_SYSRESTORE)):
         raise ScriptError('IPA client is not configured on this system')
 
 


### PR DESCRIPTION
ipalib.util imports ipaplatform but ipaplatform package is not available
as wheel package on PyPI. Fixes import errors introduced by commits
cac3475a and 0b7d9c5.

https://pagure.io/freeipa/issue/7132

Original patch by Felipe Barreto Volpone <fbarreto@redhat.com>
Signed-off-by: Christian Heimes <cheimes@redhat.com>