### PR TITLE
Add a notice to restart ipa services after certs are installed

### DIFF
--- a/install/tools/man/ipa-server-certinstall.1
+++ b/install/tools/man/ipa-server-certinstall.1
@@ -28,7 +28,8 @@ PKCS#12 is a file format used to safely transport SSL certificates and public/pr
 
 They may be generated and managed using the NSS pk12util command or the OpenSSL pkcs12 command.
 
-The service(s) are not automatically restarted. In order to use the newly installed certificate(s) you will need to manually restart the Directory and/or Apache servers.
+The service(s) are not automatically restarted. In order to use the newly installed certificate(s) you will need to manually restart the Directory, Apache and/or Krb5kdc servers.
+
 .SH "OPTIONS"
 .TP 
 \fB\-d\fR, \fB\-\-dirsrv\fR

--- a/ipaserver/install/ipa_server_certinstall.py
+++ b/ipaserver/install/ipa_server_certinstall.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function
 
 import os
 import os.path
@@ -120,6 +121,10 @@ class ServerCertInstall(admintool.AdminTool):
 
         if self.options.kdc:
             self.install_kdc_cert()
+
+        print(
+            "Please restart ipa services after installing certificate "
+            "(ipactl restart)")
 
         api.Backend.ldap2.disconnect()
 


### PR DESCRIPTION
Adding notice for user to restart services after
ipa-server-certinstall.

https://pagure.io/freeipa/issue/7016