### PR TITLE
ldap: limit the retro changelog to dns subtree

### DIFF
--- a/install/updates/20-syncrepl.update
+++ b/install/updates/20-syncrepl.update
@@ -4,7 +4,7 @@ only:nsslapd-pluginEnabled: on
 # Remember original nsuniqueid for objects referenced from cn=changelog
 add:nsslapd-attribute: nsuniqueid:targetUniqueId
 add:nsslapd-changelogmaxage: 2d
-add:nsslapd-exclude-suffix: o=ipaca
+add:nsslapd-include-suffix: cn=dns,$SUFFIX
 
 # Keep memberOf and referential integrity plugins away from cn=changelog.
 # It is necessary for performance reasons because we don't have appropriate


### PR DESCRIPTION
The content synchronization plugin can be limited to the dns subtree in
Directory Server. This increases performance and helps to prevent some
potential issues.

Fixes: https://pagure.io/freeipa/issue/6515
Signed-off-by: Tomas Krizek <tkrizek@redhat.com>