### PR TITLE
Fix ipa-replica-conncheck when called with --principal

### DIFF
--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -530,6 +530,9 @@ def main():
                 if result.returncode != 0:
                     raise RuntimeError("Could not get ticket for master server: %s" %
                                         result.error_output)
+                # Now that the cred cache file is initialized,
+                # use it for the IPA API calls
+                os.environ['KRB5CCNAME'] = CCACHE_FILE
 
             try:
                 logger.info("Check RPC connection to remote master")


### PR DESCRIPTION
ipa-replica-conncheck can be called with --principal / --password or
with an existing Kerberos credential cache in order to supply the
authorized identity logging in to the master machine (in
auto-master-check mode).

In domain-level 0, the tool is called with --principal and password
and tries to obtain a TGT by performing kinit, but does not set the
env var KRB5CCNAME. Subsequent calls to IPA API do not use the
credential cache and fail. In this case, ipa-replica-conncheck falls
back to using SSH to check master connectivity instead of IPA API,
and the ssh check is less robust.

The code should set the KRB5CCNAME env var for IPA API to use the
credential cache.

Fixes:
https://pagure.io/freeipa/issue/7221