### PR TITLE
ipa-ca-install: mention REPLICA_FILE as optional in help

### DIFF
--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -45,7 +45,7 @@ log_file_name = paths.IPAREPLICA_CA_INSTALL_LOG
 REPLICA_INFO_TOP_DIR = None
 
 def parse_options():
-    usage = "%prog [options] REPLICA_FILE"
+    usage = "%prog [options] [REPLICA_FILE]"
     parser = IPAOptionParser(usage=usage, version=version.VERSION)
     parser.add_option("-d", "--debug", dest="debug", action="store_true",
                       default=False, help="gather extra debugging information")


### PR DESCRIPTION
As man page already does it, update the help text to show REPLICA_FILE
as optional.

Fixes https://pagure.io/freeipa/issue/7223

Signed-off-by: Rishabh Dave <rishabhddave@gmail.com>