### PR TITLE
py3 spec: remove python2 dependencies for python3 packages

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -143,7 +143,7 @@ BuildRequires:  python-lesscpy
 # Build dependencies for makeapi/makeaci
 # makeapi/makeaci is using Python 2 only for now
 #
-BuildRequires:  python2-ldap
+BuildRequires:  python-ldap
 BuildRequires:  python2-netaddr
 BuildRequires:  python2-pyasn1
 BuildRequires:  python2-pyasn1-modules
@@ -175,7 +175,7 @@ BuildRequires:  python3-wheel
 BuildRequires:  python2-samba
 # 1.6: x509.Name.rdns (https://github.com/pyca/cryptography/issues/3199)
 BuildRequires:  python2-cryptography >= 1.6
-BuildRequires:  python-gssapi >= 1.2.0-5
+BuildRequires:  python2-gssapi >= 1.2.0-5
 %if 0%{?fedora} >= 26
 BuildRequires:  python2-pylint
 %else
@@ -208,7 +208,7 @@ BuildRequires:  python2-sss-murmur
 BuildRequires:  python2-sssdconfig
 BuildRequires:  python2-nose
 BuildRequires:  python2-paste
-BuildRequires:  systemd-python
+BuildRequires:  python2-systemd
 BuildRequires:  python2-jinja2
 BuildRequires:  python2-augeas
 
@@ -284,8 +284,10 @@ Requires: %{name}-client = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 %if 0%{?with_python3}
 Requires: python3-ipaserver = %{version}-%{release}
+Requires: python3-pyldap >= 2.4.15
 %else
 Requires: python2-ipaserver = %{version}-%{release}
+Requires: python-ldap >= 2.4.15
 %endif
 # 1.3.7.6-1: https://bugzilla.redhat.com/show_bug.cgi?id=1488295
 Requires: 389-ds-base >= 1.3.7.6-1
@@ -299,8 +301,16 @@ Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: ntp
 Requires: httpd >= 2.4.6-31
 %if 0%{with_python3}
+Requires(preun): python3
+Requires(postun): python3
+Requires: python3-gssapi >= 1.2.0-5
 Requires: python3-mod_wsgi
+Requires: python3-systemd
 %else
+Requires(preun): python2
+Requires(postun): python2
+Requires: python2-gssapi >= 1.2.0-5
+Requires: python2-systemd
 Requires: mod_wsgi
 %endif
 Requires: mod_auth_gssapi >= 1.5.0
@@ -309,8 +319,6 @@ Requires: mod_nss >= 1.0.14-3
 Requires: mod_session
 # 0.9.9: https://github.com/adelton/mod_lookup_identity/pull/3
 Requires: mod_lookup_identity >= 0.9.9
-Requires: python-ldap >= 2.4.15
-Requires: python-gssapi >= 1.2.0-5
 Requires: acl
 Requires: systemd-units >= 38
 Requires(pre): shadow-utils
@@ -321,8 +329,8 @@ Requires(post): selinux-policy-base >= %{selinux_policy_version}
 Requires: slapi-nis >= %{slapi_nis_version}
 Requires: pki-ca >= 10.4.0-1
 Requires: pki-kra >= 10.4.0-1
-Requires(preun): python systemd-units
-Requires(postun): python systemd-units
+Requires(preun): systemd-units
+Requires(postun): systemd-units
 Requires: policycoreutils >= 2.1.12-5
 Requires: tar
 Requires(pre): certmonger >= 0.79.5-1
@@ -333,7 +341,6 @@ Requires: open-sans-fonts
 Requires: openssl
 Requires: softhsm >= 2.0.0rc1-1
 Requires: p11-kit
-Requires: systemd-python
 Requires: %{etc_systemd_dir}
 Requires: gzip
 Requires: oddjob
@@ -378,7 +385,7 @@ Requires: python2-ipaclient = %{version}-%{release}
 Requires: python2-custodia >= 0.3.1
 Requires: python-ldap >= 2.4.15
 Requires: python2-lxml
-Requires: python-gssapi >= 1.2.0-5
+Requires: python2-gssapi >= 1.2.0-5
 Requires: python2-sssdconfig
 Requires: python2-pyasn1 >= 0.3.2-2
 Requires: python2-dbus
@@ -529,11 +536,14 @@ Group: System Environment/Base
 Requires: %{name}-client-common = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 %if 0%{?with_python3}
+Requires: python3-gssapi >= 1.2.0-5
 Requires: python3-ipaclient = %{version}-%{release}
+Requires: python3-pyldap
 %else
+Requires: python2-gssapi >= 1.2.0-5
 Requires: python2-ipaclient = %{version}-%{release}
-%endif
 Requires: python-ldap
+%endif
 Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: ntp
 Requires: krb5-workstation >= %{krb5_version}
@@ -549,7 +559,6 @@ Requires: certmonger >= 0.79.5-1
 Requires: nss-tools
 Requires: bind-utils
 Requires: oddjob-mkhomedir
-Requires: python-gssapi >= 1.2.0-5
 Requires: libsss_autofs
 Requires: autofs
 Requires: libnfsidmap
@@ -690,7 +699,7 @@ Provides: python2-ipaplatform = %{version}-%{release}
 %{?python_provide:%python_provide python2-ipaplatform}
 %{!?python_provide:Provides: python-ipaplatform = %{version}-%{release}}
 Requires: %{name}-common = %{version}-%{release}
-Requires: python-gssapi >= 1.2.0-5
+Requires: python2-gssapi >= 1.2.0-5
 Requires: gnupg
 Requires: keyutils
 Requires: pyOpenSSL

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -102,8 +102,8 @@ BuildRequires:  automake
 BuildRequires:  libtool
 BuildRequires:  gettext
 BuildRequires:  gettext-devel
-BuildRequires:  python-devel
-BuildRequires:  python-setuptools
+BuildRequires:  python2-devel
+BuildRequires:  python2-setuptools
 %if 0%{?with_python3}
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
@@ -143,12 +143,12 @@ BuildRequires:  python-lesscpy
 # Build dependencies for makeapi/makeaci
 # makeapi/makeaci is using Python 2 only for now
 #
-BuildRequires:  python-ldap
-BuildRequires:  python-netaddr
+BuildRequires:  python2-ldap
+BuildRequires:  python2-netaddr
 BuildRequires:  python2-pyasn1
 BuildRequires:  python2-pyasn1-modules
 BuildRequires:  python2-dns
-BuildRequires:  python-six
+BuildRequires:  python2-six
 BuildRequires:  python2-libsss_nss_idmap
 BuildRequires:  python2-cffi
 
@@ -172,7 +172,7 @@ BuildRequires:  python3-wheel
 # Build dependencies for lint
 #
 %if 0%{?with_lint}
-BuildRequires:  samba-python
+BuildRequires:  python2-samba
 # 1.6: x509.Name.rdns (https://github.com/pyca/cryptography/issues/3199)
 BuildRequires:  python2-cryptography >= 1.6
 BuildRequires:  python-gssapi >= 1.2.0-5
@@ -193,16 +193,16 @@ BuildRequires:  jsl
 BuildRequires:  python2-yubico
 # pki Python package
 BuildRequires:  pki-base-python2
-BuildRequires:  python-pytest-multihost
-BuildRequires:  python-pytest-sourceorder
+BuildRequires:  python2-pytest-multihost
+BuildRequires:  python2-pytest-sourceorder
 # 0.4.2: Py3 fix https://bugzilla.redhat.com/show_bug.cgi?id=1476150
-BuildRequires:  python-jwcrypto >= 0.4.2
+BuildRequires:  python2-jwcrypto >= 0.4.2
 # 0.3: sd_notify (https://pagure.io/freeipa/issue/5825)
 BuildRequires:  python2-custodia >= 0.3.1
-BuildRequires:  dbus-python
+BuildRequires:  python2-dbus
 BuildRequires:  python2-dateutil
-BuildRequires:  python-enum34
-BuildRequires:  python-netifaces
+BuildRequires:  python2-enum34
+BuildRequires:  python2-netifaces
 BuildRequires:  python2-sss
 BuildRequires:  python2-sss-murmur
 BuildRequires:  python2-sssdconfig
@@ -381,9 +381,9 @@ Requires: python2-lxml
 Requires: python-gssapi >= 1.2.0-5
 Requires: python2-sssdconfig
 Requires: python2-pyasn1 >= 0.3.2-2
-Requires: dbus-python
+Requires: python2-dbus
 Requires: python2-dns >= 1.15
-Requires: python-kdcproxy >= 0.3
+Requires: python2-kdcproxy >= 0.3
 Requires: rpm-libs
 Requires: pki-base-python2
 Requires: python2-augeas
@@ -544,7 +544,7 @@ Requires: initscripts
 Requires: libcurl >= 7.21.7-2
 Requires: xmlrpc-c >= 1.27.4
 Requires: sssd >= 1.14.0
-Requires: python-sssdconfig
+Requires: python2-sssdconfig
 Requires: certmonger >= 0.79.5-1
 Requires: nss-tools
 Requires: bind-utils
@@ -694,9 +694,9 @@ Requires: python-gssapi >= 1.2.0-5
 Requires: gnupg
 Requires: keyutils
 Requires: pyOpenSSL
-Requires: python >= 2.7.9
+Requires: python2 >= 2.7.9
 Requires: python2-cryptography >= 1.6
-Requires: python-netaddr >= %{python_netaddr_version}
+Requires: python2-netaddr >= %{python_netaddr_version}
 Requires: python2-libipa_hbac
 Requires: python-qrcode-core >= 5.0.0
 Requires: python2-pyasn1 >= 0.3.2-2
@@ -704,17 +704,17 @@ Requires: python2-pyasn1-modules >= 0.3.2-2
 Requires: python2-dateutil
 Requires: python2-yubico >= 1.2.3
 Requires: python2-sss-murmur
-Requires: dbus-python
+Requires: python2-dbus
 Requires: python2-setuptools
-Requires: python-six
+Requires: python2-six
 # 0.4.2: Py3 fix https://bugzilla.redhat.com/show_bug.cgi?id=1476150
-Requires: python-jwcrypto >= 0.4.2
+Requires: python2-jwcrypto >= 0.4.2
 Requires: python2-cffi
 Requires: python-ldap >= 2.4.15
 Requires: python2-requests
 Requires: python2-dns >= 1.15
-Requires: python-enum34
-Requires: python-netifaces >= 0.10.4
+Requires: python2-enum34
+Requires: python2-netifaces >= 0.10.4
 Requires: pyusb
 
 Conflicts: %{alt_name}-python < %{version}
@@ -818,8 +818,8 @@ Requires: python2-paste
 Requires: python2-coverage
 # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1096506
 Requires: python2-polib
-Requires: python-pytest-multihost >= 0.5
-Requires: python-pytest-sourceorder
+Requires: python2-pytest-multihost >= 0.5
+Requires: python2-pytest-sourceorder
 Requires: ldns-utils
 Requires: python2-sssdconfig
 Requires: python2-cryptography >= 1.6

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -500,10 +500,12 @@ Requires: samba-winbind
 Requires: libsss_idmap
 
 %if 0%{?with_python3}
+Requires(post): python3
 Requires: python3-samba
 Requires: python3-libsss_nss_idmap
 Requires: python3-sss
 %else
+Requires(post): python2
 Requires: python2-samba
 Requires: python2-libsss_nss_idmap
 Requires: python2-sss
@@ -514,7 +516,6 @@ Requires: python2-sss
 # IPA AD trusts cannot be used at the same time with the locator plugin
 # since Winbindd will be configured in a different mode
 Requires(post): %{_sbindir}/update-alternatives
-Requires(post): python
 Requires(postun): %{_sbindir}/update-alternatives
 Requires(preun): %{_sbindir}/update-alternatives
 


### PR DESCRIPTION
py3 spec: use proper python2 package names

Package names for python2 were updated. Changed:
  dbus-python -> python2-dbus
  python -> python2
  python-devel -> python2-devel
  python-enum34 -> python2-enum34
  python-jwcrypto -> python2-jwcrypto
  python-kdcproxy -> python2-kdcproxy
  python-lesscpy -> python2-lesscpy
  python-netifaces -> python2-netifaces
  python-netaddr ->  python2-netaddr
  python-pytest-multihost -> python2-pytest-multihost
  python-pytest-sourceorder -> python2-pytest-sourceorder
  python-setuptools -> python2-setuptools
  python-six -> python2-six
  python-sssdconfig -> python2-sssdconfig
  samba-python -> python2-samba

Part of: https://pagure.io/freeipa/issue/7131
Signed-off-by: Tomas Krizek <tkrizek@redhat.com>

---

py3 spec: remove python2 dependencies from freeipa-server

When building the package with for python3, use only python3
dependencies. Changed:
  python -> python2 / python3
  python-gssapi -> python2-gssapi / python3-gssapi
  python-ldap -> python2-ldap / python3-pyldap
  systemd-python -> python2-systemd / python3-systemd

Part of: https://pagure.io/freeipa/issue/7131
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1489509
Signed-off-by: Tomas Krizek <tkrizek@redhat.com>

---

py3 spec: remove python2 dependencies from server-trust-ad

Use only python3 dependencies when building server-trust-ad for python3.

Part of: https://pagure.io/freeipa/issue/7131
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1489509
Signed-off-by: Tomas Krizek <tkrizek@redhat.com>