### PR TITLE
[Backport][ipa-4-6] ipatests: use python3 if built with python3

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -9,7 +9,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f26
           name: freeipa/ci-master-f26
-          version: 0.1.3
+          version: 0.1.7
         timeout: 1800
 
   fedora-26/simple_replication:

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1027,10 +1027,21 @@ mv %{buildroot}%{_bindir}/ipa-test-task %{buildroot}%{_bindir}/ipa-test-task-%{p
 ln -s %{_bindir}/ipa-run-tests-%{python2_version} %{buildroot}%{_bindir}/ipa-run-tests-2
 ln -s %{_bindir}/ipa-test-config-%{python2_version} %{buildroot}%{_bindir}/ipa-test-config-2
 ln -s %{_bindir}/ipa-test-task-%{python2_version} %{buildroot}%{_bindir}/ipa-test-task-2
-# test framework defaults to Python 2
+%endif # with_ipatests
+
+# Decide which Python (2 or 3) should be used as default for tests
+%if 0%{?with_ipatests}
+%if 0%{?with_python3}
+# Building with python3 => make it default for tests
+ln -s %{_bindir}/ipa-run-tests-%{python3_version} %{buildroot}%{_bindir}/ipa-run-tests
+ln -s %{_bindir}/ipa-test-config-%{python3_version} %{buildroot}%{_bindir}/ipa-test-config
+ln -s %{_bindir}/ipa-test-task-%{python3_version} %{buildroot}%{_bindir}/ipa-test-task
+%else
+# Building python2 only => make it default for tests
 ln -s %{_bindir}/ipa-run-tests-%{python2_version} %{buildroot}%{_bindir}/ipa-run-tests
 ln -s %{_bindir}/ipa-test-config-%{python2_version} %{buildroot}%{_bindir}/ipa-test-config
 ln -s %{_bindir}/ipa-test-task-%{python2_version} %{buildroot}%{_bindir}/ipa-test-task
+%endif # with_python3
 %endif # with_ipatests
 
 # remove files which are useful only for make uninstall

--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1045,7 +1045,7 @@ def _entries_to_ldif(entries):
     io = StringIO()
     writer = LDIFWriter(io)
     for entry in entries:
-        writer.unparse(str(entry.dn), dict(entry))
+        writer.unparse(str(entry.dn), dict(entry.raw))
     return io.getvalue()
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #1112 was pushed to master and backport to ipa-4-6 is required.