### PR TITLE
[Backport][ipa-4-6] Fix ipa-replica-conncheck when called with --principal

### DIFF
--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -530,6 +530,9 @@ def main():
                 if result.returncode != 0:
                     raise RuntimeError("Could not get ticket for master server: %s" %
                                         result.error_output)
+                # Now that the cred cache file is initialized,
+                # use it for the IPA API calls
+                os.environ['KRB5CCNAME'] = CCACHE_FILE
 
             try:
                 logger.info("Check RPC connection to remote master")


### PR DESCRIPTION
This PR was opened automatically because PR #1195 was pushed to master and backport to ipa-4-6 is required.