### PR TITLE
Py3: fix ipa-replica-conncheck

### DIFF
--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -290,7 +290,7 @@ class PortResponder(threading.Thread):
         self._sockets = []
         self._close = False
         self._close_lock = threading.Lock()
-        self.responder_data = 'FreeIPA'
+        self.responder_data = b'FreeIPA'
         self.ports_opened = False
         self.ports_open_cond = threading.Condition()
 


### PR DESCRIPTION
ipa-replica-conncheck is using the socket methods sendall()
and sendto() with str. Theses methods expect str params in
python2 but bytes in python3.

Related to
https://pagure.io/freeipa/issue/7131