### PR TITLE
Add indexing to improve host-find performance

### DIFF
--- a/install/share/indices.ldif
+++ b/install/share/indices.ldif
@@ -108,6 +108,7 @@ cn: fqdn
 nsSystemIndex: false
 nsIndexType: eq
 nsIndexType: pres
+nsIndexType: sub
 
 dn: cn=macAddress,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 changetype: add

--- a/install/share/indices.ldif
+++ b/install/share/indices.ldif
@@ -288,3 +288,48 @@ objectClass: nsIndex
 nsSystemIndex: false
 nsIndexType: eq
 nsIndexType: sub
+
+dn: cn=description,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: description
+objectClass: top
+objectClass: nsindex
+nssystemindex: false
+nsindextype: eq
+nsindextype: sub
+
+dn: cn=l,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: l
+objectClass: top
+objectClass: nsindex
+nssystemindex: false
+nsindextype: eq
+nsindextype: sub
+
+dn: cn=nsOsVersion,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: nsOsVersion
+objectClass: top
+objectClass: nsindex
+nssystemindex: false
+nsindextype: eq
+nsindextype: sub
+
+dn: cn=nsHardwarePlatform,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: nsHardwarePlatform
+objectClass: top
+objectClass: nsindex
+nssystemindex: false
+nsindextype: eq
+nsindextype: sub
+
+dn: cn=nsHostLocation,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: nsHostLocation
+objectClass: top
+objectClass: nsindex
+nssystemindex: false
+nsindextype: eq
+nsindextype: sub

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -70,8 +70,9 @@ default:cn: fqdn
 default:ObjectClass: top
 default:ObjectClass: nsIndex
 default:nsSystemIndex: false
-default:nsIndexType: eq
-default:nsIndexType: pres
+only:nsIndexType: eq
+only:nsIndexType: pres
+only:nsIndexType: sub
 
 dn: cn=macAddress,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 default:cn: macAddress

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -268,3 +268,43 @@ default: objectClass: nsIndex
 only: nsSystemIndex: false
 only: nsIndexType: eq
 only: nsIndexType: sub
+
+dn: cn=description,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+default: cn: description
+default: objectclass: top
+default: objectclass: nsindex
+default: nssystemindex: false
+default: nsindextype: eq
+default: nsindextype: sub
+
+dn: cn=l,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+default: cn: l
+default: objectclass: top
+default: objectclass: nsindex
+default: nssystemindex: false
+default: nsindextype: eq
+default: nsindextype: sub
+
+dn: cn=nsOsVersion,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+default: cn: nsOsVersion
+default: objectclass: top
+default: objectclass: nsindex
+default: nssystemindex: false
+default: nsindextype: eq
+default: nsindextype: sub
+
+dn: cn=nsHardwarePlatform,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+default: cn: nsHardwarePlatform
+default: objectclass: top
+default: objectclass: nsindex
+default: nssystemindex: false
+default: nsindextype: eq
+default: nsindextype: sub
+
+dn: cn=nsHostLocation,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+default: cn: nsHostLocation
+default: objectclass: top
+default: objectclass: nsindex
+default: nssystemindex: false
+default: nsindextype: eq
+default: nsindextype: sub


### PR DESCRIPTION
host-find <host_name> command performance gets deteriorated when
there's way too many hosts in the LDAP tree. We're adding indices
to try and mitigate this behavior.

https://pagure.io/freeipa/issue/6371

============================
Untested, our lab is down and my private virtual machine segfaults during the provisioning process due to lack of memory.