### PR TITLE
 [Backport][ipa-4-5]  Include the CA basic constraint in CSRs when renewing a CA

### DIFF
--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -519,16 +519,25 @@ def modify(request_id, ca=None, profile=None):
         request.obj_if.modify(update)
 
 
-def resubmit_request(request_id, ca=None, profile=None):
+def resubmit_request(request_id, ca=None, profile=None, is_ca=False):
+    """
+    :param request_id: the certmonger numeric request ID
+    :param ca: the nickname for the certmonger CA, e.g. IPA or SelfSign
+    :param profile: the dogtag template profile to use, e.g. SubCA
+    :param is_ca: boolean that if True adds the CA basic constraint
+    """
     request = _get_request({'nickname': request_id})
     if request:
-        if ca or profile:
+        if ca or profile or is_ca:
             update = {}
             if ca is not None:
                 cm = _certmonger()
                 update['CA'] = cm.obj_if.find_ca_by_nickname(ca)
             if profile is not None:
                 update['template-profile'] = profile
+            if is_ca:
+                update['template-is-ca'] = True
+                update['template-ca-path-length'] = -1  # no path length
             request.obj_if.modify(update)
         request.obj_if.resubmit()
 

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -310,7 +310,8 @@ class CACertManage(admintool.AdminTool):
         timeout = api.env.startup_timeout + 60
 
         self.log.debug("resubmitting certmonger request '%s'", self.request_id)
-        certmonger.resubmit_request(self.request_id, ca=ca, profile=profile)
+        certmonger.resubmit_request(self.request_id, ca=ca, profile=profile,
+                                    is_ca=True)
         try:
             state = certmonger.wait_for_request(self.request_id, timeout)
         except RuntimeError:


### PR DESCRIPTION
Opened manually as backport of #963
manual changes done on cherry-pick are:

```diff
diff --cc ipaserver/install/ipa_cacert_manage.py
index fcbf091,86243d3..0000000
--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@@ -309,8 -302,9 +309,9 @@@ class CACertManage(admintool.AdminTool)
      def resubmit_request(self, ca='dogtag-ipa-ca-renew-agent', profile=''):
          timeout = api.env.startup_timeout + 60
  
 -        logger.debug("resubmitting certmonger request '%s'", self.request_id)
 +        self.log.debug("resubmitting certmonger request '%s'", self.request_id)
-         certmonger.resubmit_request(self.request_id, ca=ca, profile=profile)
+         certmonger.resubmit_request(self.request_id, ca=ca, profile=profile,
+                                     is_ca=True)
          try:
              state = certmonger.wait_for_request(self.request_id, timeout)
          except RuntimeError:

```
(there was conflict in logging)

https://pagure.io/freeipa/issue/7088