### PR TITLE
[Backport][ipa-4-6] ipa-ca-install: mention REPLICA_FILE as optional in help

### DIFF
--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -45,7 +45,7 @@ log_file_name = paths.IPAREPLICA_CA_INSTALL_LOG
 REPLICA_INFO_TOP_DIR = None
 
 def parse_options():
-    usage = "%prog [options] REPLICA_FILE"
+    usage = "%prog [options] [REPLICA_FILE]"
     parser = IPAOptionParser(usage=usage, version=version.VERSION)
     parser.add_option("-d", "--debug", dest="debug", action="store_true",
                       default=False, help="gather extra debugging information")


### PR DESCRIPTION
This PR was opened automatically because PR #1198 was pushed to master and backport to ipa-4-6 is required.