### PR TITLE
Run server upgrade in ipactl start/restart

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1148,17 +1148,14 @@ if [  $? -eq 0 ]; then
     # work with the network being offline
     /bin/systemctl start network-online.target
 
-    # This must be run in posttrans so that updates from previous
-    # execution that may no longer be shipped are not applied.
-    /usr/sbin/ipa-server-upgrade --quiet >/dev/null || :
-
     # Restart IPA processes. This must be also run in postrans so that plugins
-    # and software is in consistent state
+    # and software is in consistent state. This will also perform the
+    # system upgrade.
     # NOTE: systemd specific section
 
     /bin/systemctl is-enabled ipa.service >/dev/null 2>&1
     if [  $? -eq 0 ]; then
-        /bin/systemctl restart ipa.service >/dev/null 2>&1 || :
+        /bin/systemctl restart ipa.service >/dev/null
     fi
 fi
 # END

--- a/install/tools/ipactl
+++ b/install/tools/ipactl
@@ -32,6 +32,7 @@ from ipaserver.install.installutils import is_ipa_configured, ScriptError
 from ipalib import api, errors
 from ipapython.ipaldap import LDAPClient
 from ipapython.ipautil import wait_for_open_ports, wait_for_open_socket
+from ipapython.ipautil import run
 from ipapython import config
 from ipaplatform.tasks import tasks
 from ipapython.dn import DN
@@ -140,10 +141,22 @@ def version_check():
     except (installutils.UpgradeMissingVersionError,
             installutils.UpgradeDataOlderVersionError) as exc:
         emit_err("IPA version error: %s" % exc)
-        emit_err("Upgrade required: please run ipa-server-upgrade command")
-        raise IpactlError("Aborting ipactl")
     except installutils.UpgradeVersionError as e:
         emit_err("IPA version error: %s" % e)
+    else:
+        return
+
+    emit_err("Automatically running upgrade, for details see {}".format(
+             paths.IPAUPGRADE_LOG))
+    emit_err("Be patient, this may take a few minutes.")
+
+    # Fork out to call ipa-server-upgrade so that logging is sane.
+    result = run([paths.IPA_SERVER_UPGRADE], raiseonerr=False,
+                  capture_error=True)
+    if result.returncode != 0:
+        emit_err("Automatic upgrade failed: %s" % result.error_output)
+        emit_err("See the upgrade log for more details and/or run {} again".
+                 format(paths.IPA_SERVER_UPGRADE))
         raise IpactlError("Aborting ipactl")
 
 
@@ -366,7 +379,16 @@ def ipa_stop(options):
 
 def ipa_restart(options):
     if not options.skip_version_check:
-        version_check()
+        try:
+            version_check()
+        except Exception as e:
+            try:
+                ipa_stop(options)
+            except Exception:
+                # We don't care about errors that happened while stopping.
+                # We need to raise the upgrade error.
+                pass
+            raise e
     else:
         print("Skipping version check")
 

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -357,6 +357,7 @@ class BasePathNamespace(object):
     KRB5CC_HTTPD = '/tmp/krb5cc-httpd'
     IF_INET6 = '/proc/net/if_inet6'
     AUTHCONFIG = None
+    IPA_SERVER_UPGRADE = '/usr/sbin/ipa-server-upgrade'
 
 
 paths = BasePathNamespace()

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1970,10 +1970,10 @@ def upgrade():
         else:
             logger.info('Update complete, no data were modified')
 
-    # store new data version after upgrade
-    installutils.store_version()
-
     print('Upgrading IPA services')
     logger.info('Upgrading the configuration of the IPA services')
     upgrade_configuration()
     logger.info('The IPA services were upgraded')
+
+    # store new data version after upgrade
+    installutils.store_version()


### PR DESCRIPTION
During a distro upgrade, e.g. F-26 to F-27, networking may not be available which will cause the upgrade to fail. Despite this the IPA service can be subsequently restarted running new code with old data.

This patch relies on the existing version-check cdoe to determine when/if an upgrade is required and will do so during an ipactl start or restart.

The upgrade is now run implicitly in the spec file and will cause the server to be stopped after the package is installed if the upgrade fails.

Also changes the admin tool logging setup to remove all existing stderr loggers instead of just the first one found. This eliminates double output.

Fixes: https://pagure.io/freeipa/issue/6968