### PR TITLE
[Backport][ipa-4-6] Py3: fix ipa-replica-conncheck

### DIFF
--- a/install/tools/ipa-replica-conncheck
+++ b/install/tools/ipa-replica-conncheck
@@ -290,7 +290,7 @@ class PortResponder(threading.Thread):
         self._sockets = []
         self._close = False
         self._close_lock = threading.Lock()
-        self.responder_data = 'FreeIPA'
+        self.responder_data = b'FreeIPA'
         self.ports_opened = False
         self.ports_open_cond = threading.Condition()
 


### PR DESCRIPTION
This PR was opened automatically because PR #1212 was pushed to master and backport to ipa-4-6 is required.