### PR TITLE
Fix log capture when running pytests_multihosts commands

### DIFF
--- a/ipatests/pytest_plugins/integration/config.py
+++ b/ipatests/pytest_plugins/integration/config.py
@@ -71,7 +71,9 @@ class Config(pytest_multihost.config.Config):
         return Domain
 
     def get_logger(self, name):
-        return logging.getLogger(name)
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.DEBUG)
+        return logger
 
     @property
     def ad_domains(self):


### PR DESCRIPTION
The pytests_plugins/integration/config.py::Config class
provides the get_logger method in order to customize the
default log of the plugin.

Previously, before commit 07229c8ff66669ba87b7d6599c3ec0d362ef2be4,
the code was using ipa_log_manager, a custom log solution. After
moving to use the default python way, the log is not configured anymore.

This PR address it changing the level to DEBUG in order to capture
the output of pytest_multihosts commands.

As an example, when running `ipa-server-install`, you will be able
to see an output like this:
```
[[...].Host.master.cmd2] Checking DNS domain ipa.test, please wait ...
[[...].Host.master.cmd2]
[[...].Host.master.cmd2] The log file for this installation can be found in /var/log/ipaserver-install.log
[[...].Host.master.cmd2] ==============================================================================
[[...].Host.master.cmd2] This program will set up the FreeIPA Server.
[[...].Host.master.cmd2]
[[...].Host.master.cmd2] This includes:
[[...].Host.master.cmd2]   * Configure a stand-alone CA (dogtag) for certificate management
[[...].Host.master.cmd2]   * Configure the Network Time Daemon (ntpd)
[[...].Host.master.cmd2]   * Create and configure an instance of Directory Server
[[...].Host.master.cmd2]   * Create and configure a Kerberos Key Distribution Center (KDC)
```

Fixes: https://pagure.io/freeipa/issue/7186