### PR TITLE
[Backport][ipa-4-6] Fix log capture when running pytests_multihosts commands

### DIFF
--- a/ipatests/pytest_plugins/integration/config.py
+++ b/ipatests/pytest_plugins/integration/config.py
@@ -71,7 +71,9 @@ class Config(pytest_multihost.config.Config):
         return Domain
 
     def get_logger(self, name):
-        return logging.getLogger(name)
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.DEBUG)
+        return logger
 
     @property
     def ad_domains(self):


### PR DESCRIPTION
This PR was opened automatically because PR #1234 was pushed to master and backport to ipa-4-6 is required.