### PR TITLE
[Backport][ipa-4-6] test_forced_client: decode get_file_contents() result

### DIFF
--- a/ipatests/test_integration/test_forced_client_reenrollment.py
+++ b/ipatests/test_integration/test_forced_client_reenrollment.py
@@ -289,7 +289,8 @@ class TestForcedClientReenrollment(IntegrationTest):
         """
         Put server's ip address at the top of resolv.conf
         """
-        contents = client.get_file_contents(paths.RESOLV_CONF)
+        contents = client.get_file_contents(paths.RESOLV_CONF,
+                                            encoding='utf-8')
         nameserver = 'nameserver %s\n' % server.ip
 
         if not contents.startswith(nameserver):


### PR DESCRIPTION
This PR was opened automatically because PR #1230 was pushed to master and backport to ipa-4-6 is required.