### PR TITLE
Don't allow OTP or RADIUS in FIPS mode

### DIFF
--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -31,6 +31,7 @@ from .baseldap import (
     LDAPAddAttributeViaOption, LDAPRemoveAttributeViaOption,
     add_missing_object_class)
 from ipaserver.plugins.service import (validate_realm, normalize_principal)
+from ipaserver.plugins.config import check_fips_auth_opts
 from ipalib.request import context
 from ipalib import _
 from ipalib.constants import PATTERN_GROUPUSER_NAME
@@ -480,6 +481,7 @@ class baseuser_add(LDAPCreate):
                             **options):
         assert isinstance(dn, DN)
         set_krbcanonicalname(entry_attrs)
+        check_fips_auth_opts(fips_mode=self.api.env.fips_mode, **options)
         self.obj.convert_usercertificate_pre(entry_attrs)
 
     def post_common_callback(self, ldap, dn, entry_attrs, *keys, **options):
@@ -603,6 +605,7 @@ class baseuser_mod(LDAPUpdate):
         assert isinstance(dn, DN)
         add_sshpubkey_to_attrs_pre(self.context, attrs_list)
 
+        check_fips_auth_opts(fips_mode=self.api.env.fips_mode, **options)
         self.check_namelength(ldap, **options)
 
         self.check_mail(entry_attrs)


### PR DESCRIPTION
RADIUS, which is also internally used in the process of OTP
authentication by ipa-otpd, requires MD5 checksums which
makes it impossible to be used in FIPS mode. Don't allow users
setting OTP or RADIUS authentication if in FIPS mode.

https://pagure.io/freeipa/issue/7168