### PR TITLE
[Backport][ipa-4-6]Fix ipa-restore (python2)

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -836,7 +836,7 @@ class Restore(admintool.AdminTool):
         try:
             dsinstance.DsInstance().stop_tracking_certificates(
                 installutils.realm_to_serverid(api.env.realm))
-        except OSError:
+        except (OSError, IOError):
             # When IPA is not installed, DS NSS DB does not exist
             pass
 


### PR DESCRIPTION
Backport of PR #1228 to ipa-4-6

In order to stop tracking LDAP server cert, ipa-restore is using
dse.ldif to find the certificate name. But when ipa-server-install
--uninstall has been called, the file does not exist, leading to a
IOError exception (regression introduced by 87540fe).

The ipa-restore code properly catches the exception in python3 because
IOError is a subclass of OSError, but in python2 this is not the case.
The fix catches IOError and OSError to work properly with both version.

Fixes:
https://pagure.io/freeipa/issue/7231

Reviewed-By: Rob Crittenden <rcritten@redhat.com>