### PR TITLE
Bump pki-kra for python3 vaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,7 @@ env:
                 test_ipapython
                 test_ipaserver
                 test_integration/test_ipalib_util.py
-                test_xmlrpc/test_[l-uw-z]*.py"
-                # FIXME: add vault tests once PKI finally fixes vault
+                test_xmlrpc/test_[l-z]*.py"
 install:
     - pip install --upgrade pip
     - pip3 install --upgrade pip

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -320,7 +320,8 @@ Requires: selinux-policy >= %{selinux_policy_version}
 Requires(post): selinux-policy-base >= %{selinux_policy_version}
 Requires: slapi-nis >= %{slapi_nis_version}
 Requires: pki-ca >= 10.4.0-1
-Requires: pki-kra >= 10.4.0-1
+# pki-kra 10.5.x fixes vaults in python3
+Requires: pki-kra >= 10.5.1-1
 Requires(preun): python systemd-units
 Requires(postun): python systemd-units
 Requires: policycoreutils >= 2.1.12-5


### PR DESCRIPTION
Dogtag fixed vaults in the latest version of pki, bump it in our
spec.

https://pagure.io/freeipa/issue/7033