### PR TITLE
[Backport][ipa-4-6] ipatests: Fix interactive prompt in ca_less tests

### DIFF
--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -65,6 +65,9 @@ def get_install_stdin(cert_passwords=()):
 
 def get_replica_prepare_stdin(cert_passwords=()):
     lines = list(cert_passwords)  # Enter foo.p12 unlock password
+    lines += [
+        'yes',  # Continue [no]?
+    ]
     return '\n'.join(lines + [''])
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #1142 was pushed to master and backport to ipa-4-6 is required.