### PR TITLE
test_vault: increase WAIT_AFTER_ARCHIVE

### DIFF
--- a/ipatests/test_integration/test_vault.py
+++ b/ipatests/test_integration/test_vault.py
@@ -7,7 +7,7 @@ import time
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_plugins.integration import tasks
 
-WAIT_AFTER_ARCHIVE = 30  # give some time to replication
+WAIT_AFTER_ARCHIVE = 45  # give some time to replication
 
 
 class TestInstallKRA(IntegrationTest):


### PR DESCRIPTION
Fixes failing "ipa vault-retrieve" on replica due to a vault
not already replicated. Increase from 30 to 45 seems to be enough.