### PR TITLE
[Backport][ipa-4-6] manpage: ipa-replica-conncheck - fix minor typo

### DIFF
--- a/install/tools/man/ipa-replica-conncheck.1
+++ b/install/tools/man/ipa-replica-conncheck.1
@@ -40,7 +40,7 @@ Automatically log in to master machine and execute the master machine part of th
 The Kerberos realm name for the IPA server
 .TP
 \fB\-k\fR \fIKDC\fR, \fB\-\-kdc\fR=\fIKDC\fR
-KDC server address. Defaults t \fIMASTER\fR
+KDC server address. Defaults to \fIMASTER\fR
 .TP
 \fB\-p\fR \fIPRINCIPAL\fR, \fB\-\-principal\fR=\fIPRINCIPAL\fR
 Authorized Kerberos principal to use to log in to master machine. Defaults to \fIadmin\fR


### PR DESCRIPTION
This PR was opened automatically because PR #1270 was pushed to master and backport to ipa-4-6 is required.