### PR TITLE
[Backport][ipa-4-5] ipatests: fix circular import for collect_logs ack

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -88,6 +88,22 @@ def setup_server_logs_collecting(host):
     # setup_sssd_debugging)
 
 
+def collect_logs(func):
+    def wrapper(*args):
+        try:
+            func(*args)
+        finally:
+            if hasattr(args[0], 'master'):
+                setup_server_logs_collecting(args[0].master)
+            if hasattr(args[0], 'replicas') and args[0].replicas:
+                for replica in args[0].replicas:
+                    setup_server_logs_collecting(replica)
+            if hasattr(args[0], 'clients') and args[0].clients:
+                for client in args[0].clients:
+                    setup_server_logs_collecting(client)
+    return wrapper
+
+
 def check_arguments_are(slice, instanceof):
     """
     :param: slice - tuple of integers denoting the beginning and the end

--- a/ipatests/test_integration/test_external_ca.py
+++ b/ipatests/test_integration/test_external_ca.py
@@ -21,7 +21,6 @@ import base64
 
 from ipatests.pytest_plugins.integration import tasks
 from ipatests.test_integration.base import IntegrationTest
-from ipatests.util import collect_logs
 
 
 EXTERNAL_CA_KEY_ID = base64.b64encode(os.urandom(64))
@@ -32,7 +31,7 @@ class TestExternalCA(IntegrationTest):
     """
     Test of FreeIPA server installation with exernal CA
     """
-    @collect_logs
+    @tasks.collect_logs
     def test_external_ca(self):
         # Step 1 of ipa-server-install
         self.master.run_command([

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -43,8 +43,6 @@ from ipalib.plugable import Plugin
 from ipalib.request import context
 from ipapython.dn import DN
 from ipapython.ipautil import run
-from ipatests.pytest_plugins.integration.tasks import (
-    setup_server_logs_collecting)
 
 
 try:
@@ -837,19 +835,3 @@ def get_group_dn(cn):
 
 def get_user_dn(uid):
     return DN(('uid', uid), api.env.container_user, api.env.basedn)
-
-
-def collect_logs(func):
-    def wrapper(*args):
-        try:
-            func(*args)
-        finally:
-            if hasattr(args[0], 'master'):
-                setup_server_logs_collecting(args[0].master)
-            if hasattr(args[0], 'replicas') and args[0].replicas:
-                for replica in args[0].replicas:
-                    setup_server_logs_collecting(replica)
-            if hasattr(args[0], 'clients') and args[0].clients:
-                for client in args[0].clients:
-                    setup_server_logs_collecting(client)
-    return wrapper


### PR DESCRIPTION
Move collect_logs function from util to avoid a circular import.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>