### PR TITLE
Log contents of config files when updating/writing them

### DIFF
--- a/ipaclient/install/ipachangeconf.py
+++ b/ipaclient/install/ipachangeconf.py
@@ -19,6 +19,7 @@
 #
 
 import fcntl
+import logging
 import os
 import shutil
 
@@ -26,6 +27,8 @@ import six
 
 if six.PY3:
     unicode = str
+
+logger = logging.getLogger(__name__)
 
 def openLocked(filename, perms):
     fd = -1
@@ -506,6 +509,8 @@ class IPAChangeConf(object):
                     f.close()
             except IOError:
                 pass
+        logger.debug("Updating configuration file %s", file)
+        logger.debug(output)
         return True
 
     def newConf(self, file, options, file_perms=0o644):
@@ -541,6 +546,8 @@ class IPAChangeConf(object):
                     f.close()
             except IOError:
                 pass
+        logger.debug("Writing configuration file %s", file)
+        logger.debug(output)
         return True
 
     @staticmethod


### PR DESCRIPTION
This was originally going to be a PR to log the contents of default.conf for debugging purposes, mostly for replicas where in DL1 it gets written several times. Given that other config files like nsswitch.conf also use the same functions we get even more output as an extra benefit. The file sizes are currently not that big so it doesn't bloat the logs too much IMHO.

One patch adds the logging and the other patch changes the server installer to use the configuration writing too rather than manually creating the file.