### PR TITLE
Py3: Fix vault tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,7 @@ env:
                 test_ipaplatform
                 test_ipapython
                 test_ipaserver
-                test_xmlrpc/test_[l-uw-z]*.py"
-                # FIXME: add vault tests once PKI finally fixes vault
+                test_xmlrpc/test_[l-z]*.py"
 install:
     - pip install --upgrade pip
     - pip3 install --upgrade pip

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -192,7 +192,7 @@ BuildRequires:  python2-dns >= 1.15
 BuildRequires:  jsl
 BuildRequires:  python2-yubico
 # pki Python package
-BuildRequires:  pki-base-python2
+BuildRequires:  pki-base-python2 >= 10.5.1-2
 BuildRequires:  python2-pytest-multihost
 BuildRequires:  python2-pytest-sourceorder
 # 0.4.2: Py3 fix https://bugzilla.redhat.com/show_bug.cgi?id=1476150
@@ -229,7 +229,7 @@ BuildRequires:  python3-qrcode-core >= 5.0.0
 BuildRequires:  python3-dns >= 1.15
 BuildRequires:  python3-yubico
 # pki Python package
-BuildRequires:  pki-base-python3
+BuildRequires:  pki-base-python3 >= 10.5.1-2
 BuildRequires:  python3-pytest-multihost
 BuildRequires:  python3-pytest-sourceorder
 # 0.4.2: Py3 fix https://bugzilla.redhat.com/show_bug.cgi?id=1476150
@@ -327,8 +327,9 @@ Requires(post): systemd-units
 Requires: selinux-policy >= %{selinux_policy_version}
 Requires(post): selinux-policy-base >= %{selinux_policy_version}
 Requires: slapi-nis >= %{slapi_nis_version}
-Requires: pki-ca >= 10.4.0-1
-Requires: pki-kra >= 10.4.0-1
+# 10.5.1-2 contains Python 3 vault fix
+Requires: pki-ca >= 10.5.1-2
+Requires: pki-kra >= 10.5.1-2
 Requires(preun): systemd-units
 Requires(postun): systemd-units
 Requires: policycoreutils >= 2.1.12-5
@@ -392,7 +393,7 @@ Requires: python2-dbus
 Requires: python2-dns >= 1.15
 Requires: python2-kdcproxy >= 0.3
 Requires: rpm-libs
-Requires: pki-base-python2
+Requires: pki-base-python2 >= 10.5.1-2
 Requires: python2-augeas
 
 %description -n python2-ipaserver
@@ -426,7 +427,7 @@ Requires: python3-dns >= 1.15
 Requires: python3-kdcproxy >= 0.3
 Requires: python3-augeas
 Requires: rpm-libs
-Requires: pki-base-python3
+Requires: pki-base-python3 >= 10.5.1-2
 
 %description -n python3-ipaserver
 IPA is an integrated solution to provide centrally managed Identity (users,

--- a/ipatests/test_xmlrpc/test_vault_plugin.py
+++ b/ipatests/test_xmlrpc/test_vault_plugin.py
@@ -22,9 +22,12 @@ Test the `ipaserver/plugins/vault.py` module.
 """
 
 import nose
-from ipalib import api
-from ipatests.test_xmlrpc.xmlrpc_test import Declarative, fuzzy_string
 import pytest
+import six
+
+from ipalib import api
+from ipatests.test_xmlrpc.xmlrpc_test import Declarative, fuzzy_bytes
+
 
 vault_name = u'test_vault'
 service_name = u'HTTP/server.example.com'
@@ -35,12 +38,15 @@ symmetric_vault_name = u'symmetric_test_vault'
 asymmetric_vault_name = u'asymmetric_test_vault'
 
 # binary data from \x00 to \xff
-secret = ''.join(chr(c) for c in range(0, 256))
+if six.PY2:
+    secret = b''.join(chr(c) for c in range(0, 256))
+else:
+    secret = bytes(range(0, 256))
 
 password = u'password'
 other_password = u'other_password'
 
-public_key = """
+public_key = b"""
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnT61EFxUOQgCJdM0tmw/
 pRRPDPGchTClnU1eBtiQD3ItKYf1+weMGwGOSJXPtkto7NlE7Qs8WHAr0UjyeBDe
@@ -52,7 +58,7 @@ pVThop+Xivcre3SpI0kt6oZPhBw9i8gbMnqifVmGFpVdhq+QVBqp+MVJvTbhRPG6
 -----END PUBLIC KEY-----
 """
 
-private_key = """
+private_key = b"""
 -----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAnT61EFxUOQgCJdM0tmw/pRRPDPGchTClnU1eBtiQD3ItKYf1
 +weMGwGOSJXPtkto7NlE7Qs8WHAr0UjyeBDek/zeB6nSVdk47OdaW1AHrJL+44r2
@@ -82,7 +88,7 @@ kUlCMj24a8XsShzYTWBIyW2ngvGe3pQ9PfjkUdm0LGZjYITCBvgOKw==
 -----END RSA PRIVATE KEY-----
 """
 
-other_public_key = """
+other_public_key = b"""
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv7E/QLVyKjrgDctZ50U7
 rmtL7Ks1QLoccp9WvZJ6WI1rYd0fX5FySS4dI6QTNZc6qww8NeNuZtkoxT9m1wkk
@@ -94,7 +100,7 @@ TwIDAQAB
 -----END PUBLIC KEY-----
 """
 
-other_private_key = """
+other_private_key = b"""
 -----BEGIN RSA PRIVATE KEY-----
 MIIEpgIBAAKCAQEAv7E/QLVyKjrgDctZ50U7rmtL7Ks1QLoccp9WvZJ6WI1rYd0f
 X5FySS4dI6QTNZc6qww8NeNuZtkoxT9m1wkkRl/3wK7fWNLenH/+VHOaTQc20exg
@@ -678,7 +684,7 @@ class test_vault_plugin(Declarative):
                 'result': {
                     'cn': [standard_vault_name],
                     'ipavaulttype': [u'symmetric'],
-                    'ipavaultsalt': [fuzzy_string],
+                    'ipavaultsalt': [fuzzy_bytes],
                     'owner_user': [u'admin'],
                     'username': u'admin',
                 },
@@ -724,7 +730,7 @@ class test_vault_plugin(Declarative):
                     'objectclass': [u'top', u'ipaVault'],
                     'cn': [symmetric_vault_name],
                     'ipavaulttype': [u'symmetric'],
-                    'ipavaultsalt': [fuzzy_string],
+                    'ipavaultsalt': [fuzzy_bytes],
                     'owner_user': [u'admin'],
                     'username': u'admin',
                 },
@@ -784,7 +790,7 @@ class test_vault_plugin(Declarative):
                 'result': {
                     'cn': [symmetric_vault_name],
                     'ipavaulttype': [u'symmetric'],
-                    'ipavaultsalt': [fuzzy_string],
+                    'ipavaultsalt': [fuzzy_bytes],
                     'owner_user': [u'admin'],
                     'username': u'admin',
                 },


### PR DESCRIPTION
* Bump PKI to 10.5.1-2, which fixes an issue with KRA under Python 3
* Correct encoding of secret, certs, keys, and salt

https://pagure.io/freeipa/issue/7033
Obsoletes: #1261
Signed-off-by: Christian Heimes <cheimes@redhat.com>