### PR TITLE
[Backport][ipa-4-6] test_caless: fix fix http.p12 is not valid and provide domain_level for replica tests

### DIFF
--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -799,6 +799,7 @@ class TestReplicaInstall(CALessBase):
         cls.prepare_cacert('ca1')
         result = cls.install_server()
         assert result.returncode == 0
+        cls.domain_level = tasks.domainlevel(cls.master)
 
     @replica_install_teardown
     def test_no_certs(self):

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -526,7 +526,8 @@ class TestServerInstall(CALessBase):
     def test_invalid_ds_cn(self):
         "IPA server install with DS certificate with invalid CN"
 
-        self.create_pkcs12('ca1/replica', filename='dirsrv.p12')
+        self.create_pkcs12('ca1/server', filename='http.p12')
+        self.create_pkcs12('ca1/server-badname', filename='dirsrv.p12')
         self.prepare_cacert('ca1')
 
         result = self.install_server(http_pkcs12='http.p12',


### PR DESCRIPTION
This PR was opened automatically because PR #1266 was pushed to master and backport to ipa-4-6 is required.