### PR TITLE
[Backport][ipa-4-5] WebUI: make Domain Resolution Order writable

### DIFF
--- a/install/ui/src/freeipa/idviews.js
+++ b/install/ui/src/freeipa/idviews.js
@@ -101,6 +101,7 @@ return {
                         'cn',
                         {
                             name: 'ipadomainresolutionorder',
+                            flags: ['w_if_no_aci'],
                             tooltip: '@mc-opt:idview_mod:ipadomainresolutionorder:doc'
                         },
                         {


### PR DESCRIPTION
This PR was opened automatically because PR #1178 was pushed to master and backport to ipa-4-5 is required.