### PR TITLE
Use Python 3 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
-group: deprecated-2017Q3
 services:
     - docker
 
 python:
-    - "2.7"
+    - "3.6"
 cache: pip
 env:
     global:
@@ -50,9 +49,8 @@ env:
         - TASK_TO_RUN="tox"
           TEST_RUNNER_CONFIG=".test_runner_config.yaml"
 install:
-    - pip install --upgrade pip
     - pip3 install --upgrade pip
-    - pip install pycodestyle
+    - pip3 install pycodestyle
     - >
       pip3 install
       git+https://github.com/freeipa/ipa-docker-test-runner@release-0-2-2


### PR DESCRIPTION
Removes Travis workaround "group: deprecated-2017Q3"