### PR TITLE
Prevent installation of Py2 and Py3 mod_wsgi

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -304,14 +304,16 @@ Requires: httpd >= 2.4.6-31
 Requires(preun): python3
 Requires(postun): python3
 Requires: python3-gssapi >= 1.2.0-5
-Requires: python3-mod_wsgi
 Requires: python3-systemd
+Requires: python3-mod_wsgi
+Conflicts: mod_wsgi
 %else
 Requires(preun): python2
 Requires(postun): python2
 Requires: python2-gssapi >= 1.2.0-5
 Requires: python2-systemd
 Requires: mod_wsgi
+Conflicts: python3-mod_wsgi
 %endif
 Requires: mod_auth_gssapi >= 1.5.0
 # 1.0.14-3: https://bugzilla.redhat.com/show_bug.cgi?id=1431206


### PR DESCRIPTION
FreeIPA is either compatible with Python 2 mod_wsgi or Python 3
mod_wsgi. mod_wsgi can not coexist in the same Apache process as
mod_wsgi_python3. When both mod_wsgi and python3-mod_wsgi are installed,
the first loaded module wins and the other one is never loaded.

Add conflict on the other module to prevent installation of both
modules.

https://pagure.io/freeipa/issue/7161

Signed-off-by: Christian Heimes <cheimes@redhat.com>