### PR TITLE
[Backport][ipa-4-6]  Run tox tests for PyPI packages on Travis

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -28,7 +28,7 @@ steps:
   builddep:
   - rm -rf /var/cache/dnf/*
   - "dnf makecache || :"
-  - dnf builddep -y ${builddep_opts} --spec freeipa.spec.in --best --allowerasing
+  - dnf builddep -y ${builddep_opts} -D "with_wheels 1" --spec freeipa.spec.in --best --allowerasing
   cleanup:
   - chown -R ${uid}:${gid} ${container_working_dir}
   - journalctl -b --no-pager > systemd_journal.log
@@ -53,6 +53,9 @@ steps:
   lint:
   - make PYTHON=/usr/bin/python2 V=0 lint
   - make PYTHON=/usr/bin/python3 V=0 pylint
+  tox:
+  # just run one pylint and one Python 3 target (time/coverage trade-off)
+  - tox -e py27,py36,pypi,pylint3
   prepare_tests:
   - echo ${server_password} | kinit admin && ipa ping
   - cp -r /etc/ipa/* ~/.ipa/

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,15 @@ env:
                 test_ipapython
                 test_ipaserver
                 test_xmlrpc/test_[l-z]*.py"
+        - TASK_TO_RUN="tox"
+          TEST_RUNNER_CONFIG=".test_runner_config.yaml"
 install:
     - pip install --upgrade pip
     - pip3 install --upgrade pip
     - pip install pycodestyle
     - >
       pip3 install
-      git+https://github.com/freeipa/ipa-docker-test-runner@release-0-2-1
+      git+https://github.com/freeipa/ipa-docker-test-runner@release-0-2-2
 
 script:
     - mkdir -p $CI_RUNNER_LOGS_DIR

--- a/.travis_run_task.sh
+++ b/.travis_run_task.sh
@@ -5,7 +5,6 @@
 # NOTE: this script is intended to run in Travis CI only
 
 test_set=""
-developer_mode_opt="--developer-mode"
 
 if [[ $PYTHON == "/usr/bin/python2" ]]
 then
@@ -14,6 +13,15 @@ else
 env_opt=""
 fi
 
+case "$TASK_TO_RUN" in
+    lint|tox)
+        # disable developer mode for lint and tox tasks.
+        developer_mode_opt=""
+        ;;
+    *)
+        developer_mode_opt="--developer-mode"
+        ;;
+esac
 
 function truncate_log_to_test_failures() {
     # chop off everything in the CI_RESULTS_LOG preceding pytest error output
@@ -32,9 +40,6 @@ then
     then
         git diff origin/$TRAVIS_BRANCH -U0 | pycodestyle --diff &> $PEP8_ERROR_LOG ||:
     fi 
-
-    # disable developer mode for lint task, otherwise we get an error
-    developer_mode_opt=""
 fi
 
 if [[ -n "$TESTS_TO_RUN" ]]


### PR DESCRIPTION
Manual backport of #1293 to 4.6

Signed-off-by: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Tomas Krizek <tkrizek@redhat.com>