### PR TITLE
[Backport][ipa-4-6] libotp: add libraries after objects

### DIFF
--- a/daemons/ipa-slapi-plugins/libotp/Makefile.am
+++ b/daemons/ipa-slapi-plugins/libotp/Makefile.am
@@ -15,4 +15,4 @@ libotp_la_LIBADD = libhotp.la
 
 check_PROGRAMS = t_hotp
 TESTS = $(check_PROGRAMS)
-t_hotp_LDADD = $(NSPR_LIBS) $(NSS_LIBS) libhotp.la
+t_hotp_LDADD = libhotp.la $(NSPR_LIBS) $(NSS_LIBS)


### PR DESCRIPTION
This PR was opened automatically because PR #1305 was pushed to master and backport to ipa-4-6 is required.