### PR TITLE
Fix ipa-replica-install when key not protected by PIN

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1030,7 +1030,7 @@ def promote_check(installer):
         if options.http_pin is None:
             options.http_pin = installutils.read_password(
                 "Enter Apache Server private key unlock",
-                confirm=False, validate=False)
+                confirm=False, validate=False, retry=False)
             if options.http_pin is None:
                 raise ScriptError(
                     "Apache Server private key unlock password required")
@@ -1046,7 +1046,7 @@ def promote_check(installer):
         if options.dirsrv_pin is None:
             options.dirsrv_pin = installutils.read_password(
                 "Enter Directory Server private key unlock",
-                confirm=False, validate=False)
+                confirm=False, validate=False, retry=False)
             if options.dirsrv_pin is None:
                 raise ScriptError(
                     "Directory Server private key unlock password required")
@@ -1062,7 +1062,7 @@ def promote_check(installer):
         if options.pkinit_pin is None:
             options.pkinit_pin = installutils.read_password(
                 "Enter Kerberos KDC private key unlock",
-                confirm=False, validate=False)
+                confirm=False, validate=False, retry=False)
             if options.pkinit_pin is None:
                 raise ScriptError(
                     "Kerberos KDC private key unlock password required")


### PR DESCRIPTION
When ipa-replica-install is called in a CA-less environment, the certs,
keys and pins need to be provided with --{http|dirsrv|pkinit}-cert-file and
--{http|dirsrv|pkinit}-pin. If the pin is not provided in the CLI options,
and in interactive mode, the installer prompts for the PIN.
The issue happens when the keys are not protected by any PIN, the installer
does not accept an empty string and keeps on asking for a PIN.

The fix makes sure that the installer accepts an empty PIN. A similar fix
was done for ipa-server-install in
https://pagure.io/freeipa/c/4ee426a68ec60370eee6f5aec917ecce444840c7

Fixes:
https://pagure.io/freeipa/issue/7274