### PR TITLE
[Backport][ipa-4-6] Prevent installation of Py2 and Py3 mod_wsgi

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -300,14 +300,16 @@ Requires: httpd >= 2.4.6-31
 Requires(preun): python3
 Requires(postun): python3
 Requires: python3-gssapi >= 1.2.0-5
-Requires: python3-mod_wsgi
 Requires: python3-systemd
+Requires: python3-mod_wsgi
+Conflicts: mod_wsgi
 %else
 Requires(preun): python2
 Requires(postun): python2
 Requires: python2-gssapi >= 1.2.0-5
 Requires: python2-systemd
 Requires: mod_wsgi
+Conflicts: python3-mod_wsgi
 %endif
 Requires: mod_auth_gssapi >= 1.5.0
 # 1.0.14-3: https://bugzilla.redhat.com/show_bug.cgi?id=1431206


### PR DESCRIPTION
This PR was opened automatically because PR #1306 was pushed to master and backport to ipa-4-6 is required.