### PR TITLE
[Backport][ipa-4-5] Prevent installation of Py2 and Py3 mod_wsgi

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -279,6 +279,7 @@ Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: ntp
 Requires: httpd >= 2.4.6-31
 Requires: mod_wsgi
+Conflicts: python3-mod_wsgi
 Requires: mod_auth_gssapi >= 1.5.0
 # 1.0.14-3: https://bugzilla.redhat.com/show_bug.cgi?id=1431206
 Requires: mod_nss >= 1.0.14-3


### PR DESCRIPTION
This PR was opened manually because PR #1306 was pushed to master and backport to ipa-4-5 is required.