### PR TITLE
[WIP] Fixing translation problems

### DIFF
--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -387,7 +387,7 @@ class textui(backend.Backend):
             for key in order:
                 if key not in entry:
                     continue
-                label = labels.get(key, key)
+                label = unicode(_(labels.get(key, key)))
                 flag = flags.get(key, [])
                 value = entry[key]
                 if ('suppress_empty' in flag and
@@ -438,6 +438,9 @@ class textui(backend.Backend):
         ------------------
         Only dashed above.
         """
+        if not isinstance(string, six.string_types):
+            string = unicode(string)
+
         assert isinstance(dash, six.string_types)
         assert len(dash) == 1
         dashes = dash * len(string)
@@ -900,7 +903,7 @@ class help(frontend.Local):
                 for c in commands:
                     writer.append(
                         '  {0}  {1}'.format(
-                            to_cli(c.name).ljust(mcl), c.summary))
+                            to_cli(c.name).ljust(mcl), _(c.summary)))
                 writer.append()
                 writer.append(_('To get command help, use:'))
                 writer.append(_('  ipa <command> --help'))

--- a/ipalib/frontend.py
+++ b/ipalib/frontend.py
@@ -1096,7 +1096,8 @@ class Command(HasParam):
                 # success or failure. Ignore these.
                 pass
             elif isinstance(result, int):
-                textui.print_count(result, '%s %%d' % unicode(self.output[o].doc))
+                textui.print_count(
+                    result, '%s %%d' % unicode(_(self.output[o].doc)))
 
         return rv
 

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -334,7 +334,6 @@ class WSGIExecutioner(Executioner):
         result = None
         error = None
         _id = None
-        lang = os.environ['LANG']
         name = None
         args = ()
         options = {}
@@ -346,15 +345,6 @@ class WSGIExecutioner(Executioner):
         if not environ['HTTP_REFERER'].startswith('https://%s/ipa' % self.api.env.host) and not self.env.in_tree:
             return self.marshal(result, RefererError(referer=environ['HTTP_REFERER']), _id)
         try:
-            if ('HTTP_ACCEPT_LANGUAGE' in environ):
-                lang_reg_w_q = environ['HTTP_ACCEPT_LANGUAGE'].split(',')[0]
-                lang_reg = lang_reg_w_q.split(';')[0]
-                lang_ = lang_reg.split('-')[0]
-                if '-' in lang_reg:
-                    reg = lang_reg.split('-')[1].upper()
-                else:
-                    reg = lang_.upper()
-                os.environ['LANG'] = '%s_%s' % (lang_, reg)
             if (
                 environ.get('CONTENT_TYPE', '').startswith(self.content_type)
                 and environ['REQUEST_METHOD'] == 'POST'
@@ -378,8 +368,6 @@ class WSGIExecutioner(Executioner):
                 'non-public: %s: %s', e.__class__.__name__, str(e)
             )
             error = InternalError()
-        finally:
-            os.environ['LANG'] = lang
 
         principal = getattr(context, 'principal', 'UNKNOWN')
         if command is not None:


### PR DESCRIPTION
Hello guys!

So I'm having some progress with this weird translation related bug and I already achieved the following behaviour:
```
# LANG=de_DE.UTF-8 ipa user-find admin
--------------
1 user matched
--------------
  Anmeldename: admin
  Nachname: Administrator
  Home-Verzeichnis: /home/admin
  Anmeldeshell: /bin/bash
  Principal alias: admin@DOM-023.ABC.IDM.LAB.ENG.BRQ.REDHAT.COM
  UID: 1026200000
  Gruppen-ID: 1026200000
  Konto ist deaktiviert: False
-------------------------------------
Anzahl der zurückgegebenen Einträge 1
-------------------------------------
# LANG=zh_CN.UTF-8 ipa user-find admin
--------------
1 user matched
--------------
  用户登录名: admin
  姓: Administrator
  主目录: /home/admin
  登录shell: /bin/bash
  主体别名: admin@DOM-023.ABC.IDM.LAB.ENG.BRQ.REDHAT.COM
  UID: 1026200000
  GID: 1026200000
  禁用账户: False
--------
返回的条目数 1
--------
# LANG=en_US.UTF-8 ipa user-find admin
--------------
1 user matched
--------------
  User login: admin
  Last name: Administrator
  Home directory: /home/admin
  Login shell: /bin/bash
  Principal alias: admin@DOM-023.ABC.IDM.LAB.ENG.BRQ.REDHAT.COM
  UID: 1026200000
  GID: 1026200000
  Account disabled: False
----------------------------
Number of entries returned 1
----------------------------
```

As you can see now I don't need as a user to clean `~/.cache/ipa` to get the information in my native locale. But, there is this summary (in this case it's `1 user matched`) which is getting generated on the server and I'm kind of struggling with it now as I removed this `LANG` changing piece of code from rpcserver.

Any help, review and comment are needed and very appreciated. :)

pagure: https://pagure.io/freeipa/issue/7238