### PR TITLE
Fix ca less IPA install on fips mode

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -605,9 +605,13 @@ class NSSDatabase(object):
                                 "Can't load private key from both %s and %s" %
                                 (key_file, filename))
 
+                        # the args -v2 aes256 -v2prf hmacWithSHA256 are needed
+                        # on OpenSSL 1.0.2 (fips mode). As soon as FreeIPA
+                        # requires OpenSSL 1.1.0 we'll be able to drop them
                         args = [
                             paths.OPENSSL, 'pkcs8',
                             '-topk8',
+                            '-v2', 'aes256', '-v2prf', 'hmacWithSHA256',
                             '-passout', 'file:' + self.pwd_file,
                         ]
                         if ((label != b'PRIVATE KEY' and key_password) or


### PR DESCRIPTION
When ipa-server-install is run in fips mode and ca-less, the installer
fails when the keys are provided with --{http|dirsrv|pkinit}-cert-file
in a separate key file.

The installer transforms the key into PKCS#8 format using
openssl pkcs8 -topk8
but this command fails on a fips-enabled server, unless the options
-v2 aes256 -v2prf hmacWithSHA256
are also provided.

Fixes:
https://pagure.io/freeipa/issue/7280