### PR TITLE
renew_ra_cert: fix update of IPA RA user entry

### DIFF
--- a/install/restart_scripts/renew_ra_cert
+++ b/install/restart_scripts/renew_ra_cert
@@ -27,8 +27,6 @@ import tempfile
 import shutil
 import traceback
 
-from cryptography.hazmat.primitives import serialization
-
 from ipalib.install.kinit import kinit_keytab
 from ipalib import api, x509
 from ipaserver.install import certs, cainstance
@@ -67,10 +65,8 @@ def _main():
                 )
                 sys.exit(1)
 
-            dercert = cert.public_bytes(serialization.Encoding.DER)
-
             # Load it into dogtag
-            cainstance.update_people_entry(dercert)
+            cainstance.update_people_entry(cert)
     finally:
         if api.Backend.ldap2.isconnected():
             api.Backend.ldap2.disconnect()


### PR DESCRIPTION
The post-save hook for the RA Agent certificate invokes
cainstance.update_people_entry with the DER certificate instead of a
python-cryptograpy Certificate object.  Apply to correct type.

Fixes: https://pagure.io/freeipa/issue/7282

A statically typed programming language would have excluded this bug.