### PR TITLE
[Backport][ipa-4-6] Fix  dnsrecord_show for structured record

### DIFF
--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -3206,7 +3206,7 @@ class dnsrecord(LDAPObject):
 
     def postprocess_record(self, record, **options):
         if options.get('structured', False):
-            for attr in record.keys():
+            for attr in tuple(record.keys()):
                 # attributes in LDAPEntry may not be normalized
                 attr = attr.lower()
                 try:


### PR DESCRIPTION
This PR was opened automatically because PR #1324 was pushed to master and backport to ipa-4-6 is required.