### PR TITLE
[Backport][ipa-4-6] Fix ca less IPA install on fips mode

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -490,9 +490,13 @@ class NSSDatabase(object):
                                 "Can't load private key from both %s and %s" %
                                 (key_file, filename))
 
+                        # the args -v2 aes256 -v2prf hmacWithSHA256 are needed
+                        # on OpenSSL 1.0.2 (fips mode). As soon as FreeIPA
+                        # requires OpenSSL 1.1.0 we'll be able to drop them
                         args = [
                             paths.OPENSSL, 'pkcs8',
                             '-topk8',
+                            '-v2', 'aes256', '-v2prf', 'hmacWithSHA256',
                             '-passout', 'file:' + self.pwd_file,
                         ]
                         if ((label != b'PRIVATE KEY' and key_password) or


### PR DESCRIPTION
This PR was opened because PR #1333 was pushed to master and backport to ipa-4-6 is required.