### PR TITLE
Bump 389-ds-base to 1.3.7.8-1

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -289,8 +289,9 @@ Requires: python3-pyldap >= 2.4.15
 Requires: python2-ipaserver = %{version}-%{release}
 Requires: python-ldap >= 2.4.15
 %endif
-# 1.3.7.6-1: https://bugzilla.redhat.com/show_bug.cgi?id=1488295
-Requires: 389-ds-base >= 1.3.7.6-1
+# 1.3.7.8-1: https://pagure.io/freeipa/issue/7228
+#            https://pagure.io/freeipa/issue/7165
+Requires: 389-ds-base >= 1.3.7.8-1
 Requires: openldap-clients > 2.4.35-4
 Requires: nss >= 3.14.3-12.0
 Requires: nss-tools >= 3.14.3-12.0
@@ -337,7 +338,8 @@ Requires(postun): systemd-units
 Requires: policycoreutils >= 2.1.12-5
 Requires: tar
 Requires(pre): certmonger >= 0.79.5-1
-# 1.3.7.6-1: https://bugzilla.redhat.com/show_bug.cgi?id=1488295
+# 1.3.7.8-1: https://pagure.io/freeipa/issue/7228
+#            https://pagure.io/freeipa/issue/7165
 Requires(pre): 389-ds-base >= 1.3.7.6-1
 Requires: fontawesome-fonts
 Requires: open-sans-fonts


### PR DESCRIPTION
Bump 389-ds-version due to problems with replication and connections
not being closed.

https://pagure.io/freeipa/issue/7165
https://pagure.io/freeipa/issue/7228