### PR TITLE
[Backport][ipa-4-6] Add workaround for pytest 3.3.0 bug

### DIFF
--- a/ipatests/test_ipapython/test_ssh.py
+++ b/ipatests/test_ipapython/test_ssh.py
@@ -74,8 +74,11 @@ openssh = 'ssh-rsa %s' % b64
     (u'vanitas %s' % b64, ValueError),
     (u'@opt %s' % openssh, ValueError),
     (u'opt=val %s' % openssh, ValueError),
-    (u'opt, %s' % openssh, ValueError),
-])
+    (u'opt, %s' % openssh, ValueError)],
+    # ids=repr is workaround for pytest issue with NULL bytes,
+    # see https://github.com/pytest-dev/pytest/issues/2644
+    ids=repr
+)
 def test_public_key_parsing(pk, out):
     if isinstance(out, type) and issubclass(out, Exception):
         pytest.raises(out, ssh.SSHPublicKey, pk)


### PR DESCRIPTION
Backport of #1340 

pytest is setting an env var PYTEST_CURRENT_TEST to the test name + test
parameters. If parameters happen to contain NULL bytes, the putenv()
call fails with "ValueError: embedded null byte". The workaround uses
repr() of test parameters as parameter id.

See https://github.com/pytest-dev/pytest/issues/2957
Signed-off-by: Christian Heimes <cheimes@redhat.com>