### PR TITLE
Don't use admin cert during KRA installation

### DIFF
--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -153,6 +153,10 @@ class KRAInstance(DogtagInstance):
                 prefix="tmp-", dir=paths.VAR_LIB_IPA)
         tmp_agent_pwd = ipautil.ipa_generate_password()
 
+        # Create a temporary file for the admin PKCS #12 file
+        (admin_p12_fd, admin_p12_file) = tempfile.mkstemp()
+        os.close(admin_p12_fd)
+
         # Create KRA configuration
         config = RawConfigParser()
         config.optionxform = str
@@ -187,9 +191,8 @@ class KRAInstance(DogtagInstance):
         config.set("KRA", "pki_admin_nickname", "ipa-ca-agent")
         config.set("KRA", "pki_admin_subject_dn",
                    str(DN(('cn', 'ipa-ca-agent'), self.subject_base)))
-        config.set("KRA", "pki_import_admin_cert", "True")
-        config.set("KRA", "pki_admin_cert_file", paths.ADMIN_CERT_PATH)
-        config.set("KRA", "pki_client_admin_cert_p12", paths.DOGTAG_ADMIN_P12)
+        config.set("KRA", "pki_import_admin_cert", "False")
+        config.set("KRA", "pki_client_admin_cert_p12", admin_p12_file)
 
         # Directory server
         config.set("KRA", "pki_ds_ldap_port", "389")
@@ -294,6 +297,7 @@ class KRAInstance(DogtagInstance):
         finally:
             os.remove(p12_tmpfile_name)
             os.remove(cfg_file)
+            os.remove(admin_p12_file)
 
         shutil.move(paths.KRA_BACKUP_KEYS_P12, paths.KRACERT_P12)
         logger.debug("completed creating KRA instance")


### PR DESCRIPTION
KRA installation currently imports the admin cert.  FreeIPA does not
track this cert and it may be expired, causing installation to fail.
Do not import the existing admin cert, and discard the new admin
cert that gets created during KRA installation.

Part of: https://pagure.io/freeipa/issue/7287

-----

How to test:

**NOTE** this also requires other patches

- https://github.com/freeipa/freeipa/pull/1334
- https://github.com/freeipa/freeipa/pull/1347

1. Install ipa master

2. get expiration date from /root/ca-agent.p12:

```
openssl pkcs12 -in ca-agent.p12 -out ca-agent.pem -nodes
cat ca-agent.pem | openssl x509 -noout -enddate
```

3. Move date forward to 20 days before ca-agent.p12 expires

4. Wait for certs to be renewed (watch with ``getcert list``).
   You could ``systemctl restart certmonger`` to hurry it along a bit.

5. Move system time to AFTER ca-agent.p12 `notAfter` date.

6. ``ipactl restart``

7. ``ipa-kra-install``