### PR TITLE
[Backport][ipa-4-6] ipa-extdom-extop: refactor nsswitch operations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -140,30 +140,6 @@ PKG_CHECK_EXISTS(cmocka,
 )
 AM_CONDITIONAL([HAVE_CMOCKA], [test x$have_cmocka = xyes])
 
-dnl A macro to check presence of a cwrap (http://cwrap.org) wrapper on the system
-dnl Usage:
-dnl     AM_CHECK_WRAPPER(name, conditional)
-dnl If the cwrap library is found, sets the HAVE_$name conditional
-AC_DEFUN([AM_CHECK_WRAPPER],
-[
-    FOUND_WRAPPER=0
-
-    AC_MSG_CHECKING([for $1])
-    PKG_CHECK_EXISTS([$1],
-                     [
-                        AC_MSG_RESULT([yes])
-                        FOUND_WRAPPER=1
-                     ],
-                     [
-                        AC_MSG_RESULT([no])
-                        AC_MSG_WARN([cwrap library $1 not found, some tests will not run])
-                     ])
-
-    AM_CONDITIONAL($2, [ test x$FOUND_WRAPPER = x1])
-])
-
-AM_CHECK_WRAPPER(nss_wrapper, HAVE_NSS_WRAPPER)
-
 dnl ---------------------------------------------------------------------------
 dnl - Check for POPT
 dnl ---------------------------------------------------------------------------
@@ -235,6 +211,7 @@ dnl ---------------------------------------------------------------------------
 AM_COND_IF([ENABLE_SERVER], [
     m4_include(server.m4)
 ])
+AM_CONDITIONAL([USE_SSS_NSS_TIMEOUT], [test "x$ac_cv_have_decl_sss_nss_getpwnam_timeout" = xyes])
 
 dnl ---------------------------------------------------------------------------
 dnl - Check if IPA certauth plugin can be build

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/Makefile.am
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/Makefile.am
@@ -25,6 +25,7 @@ libipa_extdom_extop_la_SOURCES = 	\
 	ipa_extdom.h			\
 	ipa_extdom_extop.c		\
 	ipa_extdom_common.c		\
+	back_extdom.h			\
 	$(NULL)
 
 libipa_extdom_extop_la_LDFLAGS = -avoid-version
@@ -34,20 +35,29 @@ libipa_extdom_extop_la_LIBADD = 	\
 	$(SSSNSSIDMAP_LIBS)		\
 	$(NULL)
 
+# We have two backends for nss operations:
+# (1) directly loading nss_sss.so.2
+# (2) using timeout-enabled API from libsss_nss_idmap
+# We prefer (2) if available
+if USE_SSS_NSS_TIMEOUT
+libipa_extdom_extop_la_SOURCES += back_extdom_sss_idmap.c
+else
+libipa_extdom_extop_la_SOURCES += back_extdom_nss_sss.c
+endif
+
+
 TESTS =
 check_PROGRAMS =
 
 if HAVE_CMOCKA
-if HAVE_NSS_WRAPPER
-TESTS_ENVIRONMENT = . ./test_data/test_setup.sh;
 TESTS += extdom_cmocka_tests
 check_PROGRAMS += extdom_cmocka_tests
-endif
 endif
 
 extdom_cmocka_tests_SOURCES = 		\
 	ipa_extdom_cmocka_tests.c	\
 	ipa_extdom_common.c		\
+	back_extdom_nss_sss.c		\
 	$(NULL)
 extdom_cmocka_tests_CFLAGS = $(CMOCKA_CFLAGS)
 extdom_cmocka_tests_LDFLAGS = 	\
@@ -58,6 +68,7 @@ extdom_cmocka_tests_LDADD = 	\
 	$(LDAP_LIBS)		\
 	$(DIRSRV_LIBS)		\
 	$(SSSNSSIDMAP_LIBS)	\
+	-ldl			\
 	$(NULL)
 
 

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/back_extdom.h
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/back_extdom.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * This Program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This Program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this Program; if not, write to the
+ *
+ *   Free Software Foundation, Inc.
+ *   59 Temple Place, Suite 330
+ *   Boston, MA 02111-1307 USA
+ *
+ */
+
+#ifndef BACK_EXTDOM_H
+#define BACK_EXTDOM_H
+#include <unistd.h>
+#include <pwd.h>
+#include <grp.h>
+
+/* Possible results of lookup using a nss_* function.
+ * Note: don't include nss.h as its path gets overriden by NSS library */
+enum nss_status {
+    NSS_STATUS_TRYAGAIN = -2,
+    NSS_STATUS_UNAVAIL,
+    NSS_STATUS_NOTFOUND,
+    NSS_STATUS_SUCCESS,
+    NSS_STATUS_RETURN
+};
+
+/* NSS backend operations implemented using either nss_sss.so.2 or libsss_nss_idmap API */
+struct nss_ops_ctx;
+
+int back_extdom_init_context(struct nss_ops_ctx **nss_context);
+void back_extdom_free_context(struct nss_ops_ctx **nss_context);
+void back_extdom_set_timeout(struct nss_ops_ctx *nss_context,
+                             unsigned int timeout);
+void back_extdom_evict_user(struct nss_ops_ctx *nss_context,
+                            const char *name);
+void back_extdom_evict_group(struct nss_ops_ctx *nss_context,
+                             const char *name);
+
+enum nss_status back_extdom_getpwnam(struct nss_ops_ctx *nss_context,
+                                     const char *name, struct passwd *pwd,
+                                     char *buffer, size_t buflen,
+                                     struct passwd **result,
+                                     int *lerrno);
+
+enum nss_status back_extdom_getpwuid(struct nss_ops_ctx *nss_context,
+                                     uid_t uid, struct passwd *pwd,
+                                     char *buffer, size_t buflen,
+                                     struct passwd **result,
+                                     int *lerrno);
+
+enum nss_status back_extdom_getgrnam(struct nss_ops_ctx *nss_context,
+                                     const char *name, struct group *grp,
+                                     char *buffer, size_t buflen,
+                                     struct group **result,
+                                     int *lerrno);
+
+enum nss_status back_extdom_getgrgid(struct nss_ops_ctx *nss_context,
+                                     gid_t gid, struct group *grp,
+                                     char *buffer, size_t buflen,
+                                     struct group **result,
+                                     int *lerrno);
+
+enum nss_status back_extdom_getgrouplist(struct nss_ops_ctx *nss_context,
+                                         const char *name, gid_t group,
+                                         gid_t *groups, int *ngroups,
+                                         int *lerrno);
+
+#endif /* BACK_EXTDOM_H */

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/back_extdom_nss_sss.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/back_extdom_nss_sss.c
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2013-2017 Red Hat, Inc.
+ *
+ * This Program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This Program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this Program; if not, write to the
+ *
+ *   Free Software Foundation, Inc.
+ *   59 Temple Place, Suite 330
+ *   Boston, MA 02111-1307 USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <sys/types.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <pwd.h>
+#include <grp.h>
+#include <sys/param.h>
+#include "back_extdom.h"
+
+struct nss_ops_ctx {
+    void *dl_handle;
+    long int initgroups_start;
+
+    enum nss_status (*getpwnam_r)(const char *name, struct passwd *result,
+                                  char *buffer, size_t buflen, int *errnop);
+    enum nss_status (*getpwuid_r)(uid_t uid, struct passwd *result,
+                                  char *buffer, size_t buflen, int *errnop);
+    enum nss_status (*getgrnam_r)(const char *name, struct group *result,
+                                  char *buffer, size_t buflen, int *errnop);
+    enum nss_status (*getgrgid_r)(gid_t gid, struct group *result,
+                                  char *buffer, size_t buflen, int *errnop);
+    enum nss_status (*initgroups_dyn)(const char *user, gid_t group,
+                                      long int *start, long int *size,
+                                      gid_t **groups, long int limit,
+                                      int *errnop);
+};
+
+void back_extdom_free_context(struct nss_ops_ctx **nss_context)
+{
+    if ((nss_context == NULL) || (*nss_context == NULL)) {
+        return;
+    }
+
+    if ((*nss_context)->dl_handle != NULL) {
+        dlclose((*nss_context)->dl_handle);
+    }
+
+    free((*nss_context));
+    *nss_context = NULL;
+}
+
+int back_extdom_init_context(struct nss_ops_ctx **nss_context)
+{
+    struct nss_ops_ctx *ctx = NULL;
+
+    if (nss_context == NULL) {
+        return EINVAL;
+    }
+
+    ctx = calloc(1, sizeof(struct nss_ops_ctx));
+    if (ctx == NULL) {
+        return ENOMEM;
+    }
+    *nss_context = ctx;
+
+    ctx->dl_handle = dlopen("libnss_sss.so.2", RTLD_NOW);
+    if (ctx->dl_handle == NULL) {
+        goto fail;
+    }
+
+    ctx->getpwnam_r = dlsym(ctx->dl_handle, "_nss_sss_getpwnam_r");
+    if (ctx->getpwnam_r == NULL) {
+        goto fail;
+    }
+
+    ctx->getpwuid_r = dlsym(ctx->dl_handle, "_nss_sss_getpwuid_r");
+    if (ctx->getpwuid_r == NULL) {
+        goto fail;
+    }
+
+    ctx->getgrnam_r = dlsym(ctx->dl_handle, "_nss_sss_getgrnam_r");
+    if (ctx->getgrnam_r == NULL) {
+        goto fail;
+    }
+
+    ctx->getgrgid_r = dlsym(ctx->dl_handle, "_nss_sss_getgrgid_r");
+    if (ctx->getgrgid_r == NULL) {
+        goto fail;
+    }
+
+    ctx->initgroups_dyn = dlsym(ctx->dl_handle, "_nss_sss_initgroups_dyn");
+    if (ctx->initgroups_dyn == NULL) {
+        goto fail;
+    }
+
+    return 0;
+
+fail:
+    back_extdom_free_context(nss_context);
+
+    return EINVAL;
+}
+
+
+/* Following three functions cannot be implemented with nss_sss.so.2
+ * As result, we simply do nothing here */
+
+void back_extdom_set_timeout(struct nss_ops_ctx *nss_context,
+                             unsigned int timeout) {
+        /* no operation */
+}
+
+void back_extdom_evict_user(struct nss_ops_ctx *nss_context,
+                            const char *name) {
+        /* no operation */
+}
+
+void back_extdom_evict_group(struct nss_ops_ctx *nss_context,
+                             const char *name) {
+        /* no operation */
+}
+
+enum nss_status back_extdom_getpwnam(struct nss_ops_ctx *nss_context,
+                                     const char *name, struct passwd *pwd,
+                                     char *buffer, size_t buflen,
+                                     struct passwd **result,
+                                     int *lerrno) {
+    enum nss_status ret;
+
+    if (nss_context == NULL) {
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    ret = nss_context->getpwnam_r(name, pwd,
+                                  buffer, buflen,
+                                  lerrno);
+
+    if ((ret == NSS_STATUS_SUCCESS) && (result != NULL)) {
+        *result = pwd;
+        *lerrno = 0;
+    }
+
+    return ret;
+}
+
+enum nss_status back_extdom_getpwuid(struct nss_ops_ctx *nss_context,
+                                     uid_t uid, struct passwd *pwd,
+                                     char *buffer, size_t buflen,
+                                     struct passwd **result,
+                                     int *lerrno) {
+    enum nss_status ret;
+
+    if (nss_context == NULL) {
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    ret = nss_context->getpwuid_r(uid, pwd,
+                                  buffer, buflen,
+                                  lerrno);
+
+    if ((ret == NSS_STATUS_SUCCESS) && (result != NULL)) {
+        *result = pwd;
+        *lerrno = 0;
+    }
+
+    return ret;
+}
+
+enum nss_status back_extdom_getgrnam(struct nss_ops_ctx *nss_context,
+                                     const char *name, struct group *grp,
+                                     char *buffer, size_t buflen,
+                                     struct group **result,
+                                     int *lerrno) {
+    enum nss_status ret;
+
+    if (nss_context == NULL) {
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    ret = nss_context->getgrnam_r(name, grp,
+                                  buffer, buflen,
+                                  lerrno);
+
+    if ((ret == NSS_STATUS_SUCCESS) && (result != NULL)) {
+        *result = grp;
+        *lerrno = 0;
+    }
+
+    return ret;
+}
+
+enum nss_status back_extdom_getgrgid(struct nss_ops_ctx *nss_context,
+                                     gid_t gid, struct group *grp,
+                                     char *buffer, size_t buflen,
+                                     struct group **result,
+                                     int *lerrno) {
+
+    enum nss_status ret;
+
+    if (nss_context == NULL) {
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    ret = nss_context->getgrgid_r(gid, grp,
+                                  buffer, buflen,
+                                  lerrno);
+
+    if ((ret == NSS_STATUS_SUCCESS) && (result != NULL)) {
+        *result = grp;
+        *lerrno = 0;
+    }
+
+    return ret;
+}
+
+enum nss_status back_extdom_getgrouplist(struct nss_ops_ctx *nss_context,
+                                         const char *name, gid_t group,
+                                         gid_t *groups, int *ngroups,
+                                         int *lerrno) {
+
+    enum nss_status ret = NSS_STATUS_UNAVAIL;
+    long int tsize = MAX (1, *ngroups);
+    gid_t *newgroups = NULL;
+
+    if (nss_context == NULL) {
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    newgroups = (gid_t *) calloc (tsize, sizeof (gid_t));
+    if (newgroups == NULL) {
+        *lerrno = ENOMEM;
+        return NSS_STATUS_TRYAGAIN;
+    }
+
+    newgroups[0] = group;
+    nss_context->initgroups_start = 1;
+
+    ret = nss_context->initgroups_dyn(name, group,
+                                      &nss_context->initgroups_start,
+                                      &tsize, &newgroups,
+                                      -1, lerrno);
+
+    (void) memcpy(groups, newgroups,
+                  MIN(*ngroups, nss_context->initgroups_start) * sizeof(gid_t));
+    free(newgroups);
+
+    if (*ngroups < nss_context->initgroups_start) {
+        ret = NSS_STATUS_TRYAGAIN;
+        *lerrno = ERANGE;
+    }
+
+    *ngroups = (int) nss_context->initgroups_start;
+
+    nss_context->initgroups_start = 0;
+
+    return ret;
+}
+

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/back_extdom_sss_idmap.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/back_extdom_sss_idmap.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2013-2017 Red Hat, Inc.
+ *
+ * This Program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This Program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this Program; if not, write to the
+ *
+ *   Free Software Foundation, Inc.
+ *   59 Temple Place, Suite 330
+ *   Boston, MA 02111-1307 USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <sys/types.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <errno.h>
+#include <pwd.h>
+#include <grp.h>
+#include "back_extdom.h"
+
+/* SSSD only exposes *_timeout() variants if the following symbol is defined */
+#define IPA_389DS_PLUGIN_HELPER_CALLS
+#include <sss_nss_idmap.h>
+
+struct nss_ops_ctx {
+    unsigned int timeout;
+};
+
+static enum nss_status __convert_sss_nss2nss_status(int errcode) {
+    switch(errcode) {
+    case 0:
+        return NSS_STATUS_SUCCESS;
+    case ENOENT:
+        return NSS_STATUS_NOTFOUND;
+    case ETIME:
+        /* fall-through */
+    case ERANGE:
+        return NSS_STATUS_TRYAGAIN;
+    case ETIMEDOUT:
+        /* fall-through */
+    default:
+        return NSS_STATUS_UNAVAIL;
+    }
+    return NSS_STATUS_UNAVAIL;
+}
+
+int back_extdom_init_context(struct nss_ops_ctx **nss_context)
+{
+    struct nss_ops_ctx *ctx = NULL;
+
+    if (nss_context == NULL) {
+        return EINVAL;
+    }
+
+    ctx = calloc(1, sizeof(struct nss_ops_ctx));
+
+    if (ctx == NULL) {
+        return ENOMEM;
+    }
+    *nss_context = ctx;
+    return 0;
+}
+
+void back_extdom_free_context(struct nss_ops_ctx **nss_context)
+{
+    if ((nss_context == NULL) || (*nss_context == NULL)) {
+        return;
+    }
+
+    free((*nss_context));
+    *nss_context = NULL;
+}
+
+
+void back_extdom_set_timeout(struct nss_ops_ctx *nss_context,
+                             unsigned int timeout) {
+    if (nss_context == NULL) {
+        return;
+    }
+
+    nss_context->timeout = timeout;
+}
+
+void back_extdom_evict_user(struct nss_ops_ctx *nss_context,
+                            const char *name) {
+    if (nss_context == NULL) {
+        return;
+    }
+
+    (void) sss_nss_getpwnam_timeout(name, NULL,
+                                    NULL, 0,
+                                    NULL,
+                                    SSS_NSS_EX_FLAG_INVALIDATE_CACHE,
+                                    nss_context->timeout);
+}
+
+void back_extdom_evict_group(struct nss_ops_ctx *nss_context,
+                             const char *name) {
+    if (nss_context == NULL) {
+            return;
+    }
+
+    (void) sss_nss_getgrnam_timeout(name, NULL,
+                                    NULL, 0,
+                                    NULL,
+                                    SSS_NSS_EX_FLAG_INVALIDATE_CACHE,
+                                    nss_context->timeout);
+}
+
+enum nss_status back_extdom_getpwnam(struct nss_ops_ctx *nss_context,
+                                     const char *name, struct passwd *pwd,
+                                     char *buffer, size_t buflen,
+                                     struct passwd **result,
+                                     int *lerrno) {
+    int ret = 0;
+
+    if (nss_context == NULL) {
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    ret = sss_nss_getpwnam_timeout(name, pwd,
+                                   buffer, buflen,
+                                   result,
+                                   SSS_NSS_EX_FLAG_NO_FLAGS,
+                                   nss_context->timeout);
+
+    /* SSSD uses the same infrastructure to handle sss_nss_get* calls
+     * as nss_sss.so.2 module where 'int *errno' is passed to the helper
+     * but writes down errno into return code so we propagate it in case
+     * of error and translate the return code */
+    if (lerrno != NULL) {
+        *lerrno = ret;
+    }
+    return __convert_sss_nss2nss_status(ret);
+}
+
+enum nss_status back_extdom_getpwuid(struct nss_ops_ctx *nss_context,
+                                     uid_t uid, struct passwd *pwd,
+                                     char *buffer, size_t buflen,
+                                     struct passwd **result,
+                                     int *lerrno) {
+
+    int ret = 0;
+
+    if (nss_context == NULL) {
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    ret = sss_nss_getpwuid_timeout(uid, pwd,
+                                   buffer, buflen,
+                                   result,
+                                   SSS_NSS_EX_FLAG_NO_FLAGS,
+                                   nss_context->timeout);
+
+    /* SSSD uses the same infrastructure to handle sss_nss_get* calls
+     * as nss_sss.so.2 module where 'int *errno' is passed to the helper
+     * but writes down errno into return code so we propagate it in case
+     * of error and translate the return code */
+    if (lerrno != NULL) {
+        *lerrno = ret;
+    }
+    return __convert_sss_nss2nss_status(ret);
+}
+
+enum nss_status back_extdom_getgrnam(struct nss_ops_ctx *nss_context,
+                                     const char *name, struct group *grp,
+                                     char *buffer, size_t buflen,
+                                     struct group **result,
+                                     int *lerrno) {
+
+    int ret = 0;
+
+    if (nss_context == NULL) {
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    ret = sss_nss_getgrnam_timeout(name, grp,
+                                   buffer, buflen,
+                                   result,
+                                   SSS_NSS_EX_FLAG_NO_FLAGS,
+                                   nss_context->timeout);
+
+    /* SSSD uses the same infrastructure to handle sss_nss_get* calls
+     * as nss_sss.so.2 module where 'int *errno' is passed to the helper
+     * but writes down errno into return code so we propagate it in case
+     * of error and translate the return code */
+    if (lerrno != NULL) {
+        *lerrno = ret;
+    }
+    return __convert_sss_nss2nss_status(ret);
+}
+
+enum nss_status back_extdom_getgrgid(struct nss_ops_ctx *nss_context,
+                                     gid_t gid, struct group *grp,
+                                     char *buffer, size_t buflen,
+                                     struct group **result,
+                                     int *lerrno) {
+
+    int ret = 0;
+
+    if (nss_context == NULL) {
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    ret = sss_nss_getgrgid_timeout(gid, grp,
+                                   buffer, buflen,
+                                   result,
+                                   SSS_NSS_EX_FLAG_NO_FLAGS,
+                                   nss_context->timeout);
+
+    /* SSSD uses the same infrastructure to handle sss_nss_get* calls
+     * as nss_sss.so.2 module where 'int *errno' is passed to the helper
+     * but writes down errno into return code so we propagate it in case
+     * of error and translate the return code */
+    if (lerrno != NULL) {
+        *lerrno = ret;
+    }
+    return __convert_sss_nss2nss_status(ret);
+}
+
+enum nss_status back_extdom_getgrouplist(struct nss_ops_ctx *nss_context,
+                                         const char *name, gid_t group,
+                                         gid_t *groups, int *ngroups,
+                                         int *lerrno) {
+    int ret = 0;
+
+    if (nss_context == NULL) {
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    ret = sss_nss_getgrouplist_timeout(name, group,
+                                       groups, ngroups,
+                                       SSS_NSS_EX_FLAG_NO_FLAGS,
+                                       nss_context->timeout);
+
+    /* SSSD uses the same infrastructure to handle sss_nss_get* calls
+     * as nss_sss.so.2 module where 'int *errno' is passed to the helper
+     * but writes down errno into return code so we propagate it in case
+     * of error and translate the return code */
+    if (lerrno != NULL) {
+        *lerrno = ret;
+    }
+    return __convert_sss_nss2nss_status(ret);
+}
+

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom.h
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom.h
@@ -150,10 +150,13 @@ struct extdom_res {
     } data;
 };
 
+struct nss_ops_ctx;
+
 struct ipa_extdom_ctx {
     Slapi_ComponentId *plugin_id;
     char *base_dn;
     size_t max_nss_buf_size;
+    struct nss_ops_ctx *nss_ctx;
 };
 
 struct domain_info {
@@ -179,15 +182,15 @@ int handle_request(struct ipa_extdom_ctx *ctx, struct extdom_req *req,
                    struct berval **berval);
 int pack_response(struct extdom_res *res, struct berval **ret_val);
 int get_buffer(size_t *_buf_len, char **_buf);
-int getpwnam_r_wrapper(size_t buf_max, const char *name,
+int getpwnam_r_wrapper(struct ipa_extdom_ctx *ctx, const char *name,
                        struct passwd *pwd, char **_buf, size_t *_buf_len);
-int getpwuid_r_wrapper(size_t buf_max, uid_t uid,
+int getpwuid_r_wrapper(struct ipa_extdom_ctx *ctx, uid_t uid,
                        struct passwd *pwd, char **_buf, size_t *_buf_len);
-int getgrnam_r_wrapper(size_t buf_max, const char *name,
+int getgrnam_r_wrapper(struct ipa_extdom_ctx *ctx, const char *name,
                        struct group *grp, char **_buf, size_t *_buf_len);
-int getgrgid_r_wrapper(size_t buf_max, gid_t gid,
+int getgrgid_r_wrapper(struct ipa_extdom_ctx *ctx, gid_t gid,
                        struct group *grp, char **_buf, size_t *_buf_len);
-int get_user_grouplist(const char *name, gid_t gid,
+int get_user_grouplist(struct ipa_extdom_ctx *ctx, const char *name, gid_t gid,
                        size_t *_ngroups, gid_t **_groups);
 int pack_ber_sid(const char *sid, struct berval **berval);
 int pack_ber_name(const char *domain_name, const char *name,

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_common.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_common.c
@@ -43,11 +43,12 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <sys/param.h>
 
 #include "ipa_extdom.h"
+#include "back_extdom.h"
 #include "util.h"
 
-#define MAX(a,b) (((a)>(b))?(a):(b))
 #define SSSD_DOMAIN_SEPARATOR '@'
 
 int get_buffer(size_t *_buf_len, char **_buf)
@@ -97,134 +98,137 @@ static int inc_buffer(size_t buf_max, size_t *_buf_len, char **_buf)
     return 0;
 }
 
-int getpwnam_r_wrapper(size_t buf_max, const char *name,
-                       struct passwd *pwd, char **_buf, size_t *_buf_len)
+int __nss_to_err(enum nss_status errcode)
 {
-    char *buf = NULL;
-    size_t buf_len = 0;
-    int ret;
+    switch(errcode) {
+    case NSS_STATUS_SUCCESS:
+        return 0;
+    case NSS_STATUS_NOTFOUND:
+        return ENOENT;
+    case NSS_STATUS_TRYAGAIN:
+        return ERANGE;
+    case NSS_STATUS_UNAVAIL:
+        return ETIMEDOUT;
+    }
+
+    return -1;
+}
+
+int getpwnam_r_wrapper(struct ipa_extdom_ctx *ctx, const char *name,
+                       struct passwd *pwd, char **buf, size_t *buf_len)
+{
+    int ret, lerrno = 0;
     struct passwd *result = NULL;
+    enum nss_status rc;
 
-    buf = *_buf;
-    buf_len = *_buf_len;
-
-    while (buf != NULL
-            && (ret = getpwnam_r(name, pwd, buf, buf_len, &result)) == ERANGE) {
-        ret = inc_buffer(buf_max, &buf_len, &buf);
-        if (ret != 0) {
-            if (ret == ERANGE) {
-                LOG("Buffer too small, increase ipaExtdomMaxNssBufSize.\n");
-            }
-            goto done;
+    for(rc = NSS_STATUS_TRYAGAIN; rc == NSS_STATUS_TRYAGAIN;) {
+        rc = back_extdom_getpwnam(ctx->nss_ctx, name, pwd, *buf, *buf_len, &result, &lerrno);
+        ret = __nss_to_err(rc);
+        if (ret == ERANGE) {
+            ret = inc_buffer(ctx->max_nss_buf_size, buf_len, buf);
+            if (ret != 0) goto done;
         }
     }
 
-    if (ret == 0 && result == NULL) {
-        ret = ENOENT;
-    }
-
 done:
-    *_buf = buf;
-    *_buf_len = buf_len;
-
+    switch(ret) {
+    case 0:
+        if (result == NULL) ret = ENOENT;
+        break;
+    case ERANGE:
+        LOG("Buffer too small, increase ipaExtdomMaxNssBufSize.\n");
+    default:
+        break;
+    }
     return ret;
 }
 
-int getpwuid_r_wrapper(size_t buf_max, uid_t uid,
-                       struct passwd *pwd, char **_buf, size_t *_buf_len)
+int getpwuid_r_wrapper(struct ipa_extdom_ctx *ctx, uid_t uid,
+                       struct passwd *pwd, char **buf, size_t *buf_len)
 {
-    char *buf = NULL;
-    size_t buf_len = 0;
-    int ret;
+    int ret, lerrno;
     struct passwd *result = NULL;
+    enum nss_status rc;
 
-    buf = *_buf;
-    buf_len = *_buf_len;
-
-    while (buf != NULL
-            && (ret = getpwuid_r(uid, pwd, buf, buf_len, &result)) == ERANGE) {
-        ret = inc_buffer(buf_max, &buf_len, &buf);
-        if (ret != 0) {
-            if (ret == ERANGE) {
-                LOG("Buffer too small, increase ipaExtdomMaxNssBufSize.\n");
-            }
-            goto done;
+    for(rc = NSS_STATUS_TRYAGAIN; rc == NSS_STATUS_TRYAGAIN;) {
+        rc = back_extdom_getpwuid(ctx->nss_ctx, uid, pwd, *buf, *buf_len, &result, &lerrno);
+        ret = __nss_to_err(rc);
+        if (ret == ERANGE) {
+            ret = inc_buffer(ctx->max_nss_buf_size, buf_len, buf);
+            if (ret != 0) goto done;
         }
     }
 
-    if (ret == 0 && result == NULL) {
-        ret = ENOENT;
-    }
-
 done:
-    *_buf = buf;
-    *_buf_len = buf_len;
+    switch(ret) {
+    case 0:
+        if (result == NULL) ret = ENOENT;
+        break;
+    case ERANGE:
+        LOG("Buffer too small, increase ipaExtdomMaxNssBufSize.\n");
+    default:
+        break;
+    }
 
     return ret;
 }
 
-int getgrnam_r_wrapper(size_t buf_max, const char *name,
-                       struct group *grp, char **_buf, size_t *_buf_len)
+int getgrnam_r_wrapper(struct ipa_extdom_ctx *ctx, const char *name,
+                       struct group *grp, char **buf, size_t *buf_len)
 {
-    char *buf = NULL;
-    size_t buf_len = 0;
-    int ret;
+    int ret, lerrno;
     struct group *result = NULL;
+    enum nss_status rc;
 
-    buf = *_buf;
-    buf_len = *_buf_len;
-
-    while (buf != NULL
-            && (ret = getgrnam_r(name, grp, buf, buf_len, &result)) == ERANGE) {
-        ret = inc_buffer(buf_max, &buf_len, &buf);
-        if (ret != 0) {
-            if (ret == ERANGE) {
-                LOG("Buffer too small, increase ipaExtdomMaxNssBufSize.\n");
-            }
-            goto done;
+    for(rc = NSS_STATUS_TRYAGAIN; rc == NSS_STATUS_TRYAGAIN;) {
+        rc = back_extdom_getgrnam(ctx->nss_ctx, name, grp, *buf, *buf_len, &result, &lerrno);
+        ret = __nss_to_err(rc);
+        if (ret == ERANGE) {
+            ret = inc_buffer(ctx->max_nss_buf_size, buf_len, buf);
+            if (ret != 0) goto done;
         }
     }
 
-    if (ret == 0 && result == NULL) {
-        ret = ENOENT;
-    }
-
 done:
-    *_buf = buf;
-    *_buf_len = buf_len;
+    switch(ret) {
+    case 0:
+        if (result == NULL) ret = ENOENT;
+        break;
+    case ERANGE:
+        LOG("Buffer too small, increase ipaExtdomMaxNssBufSize.\n");
+    default:
+        break;
+    }
 
     return ret;
 }
 
-int getgrgid_r_wrapper(size_t buf_max, gid_t gid,
-                       struct group *grp, char **_buf, size_t *_buf_len)
+int getgrgid_r_wrapper(struct ipa_extdom_ctx *ctx, gid_t gid,
+                       struct group *grp, char **buf, size_t *buf_len)
 {
-    char *buf = NULL;
-    size_t buf_len = 0;
-    int ret;
+    int ret, lerrno;
     struct group *result = NULL;
+    enum nss_status rc;
 
-    buf = *_buf;
-    buf_len = *_buf_len;
-
-    while (buf != NULL
-            && (ret = getgrgid_r(gid, grp, buf, buf_len, &result)) == ERANGE) {
-        ret = inc_buffer(buf_max, &buf_len, &buf);
-        if (ret != 0) {
-            if (ret == ERANGE) {
-                LOG("Buffer too small, increase ipaExtdomMaxNssBufSize.\n");
-            }
-            goto done;
+    for(rc = NSS_STATUS_TRYAGAIN; rc == NSS_STATUS_TRYAGAIN;) {
+        rc = back_extdom_getgrgid(ctx->nss_ctx, gid, grp, *buf, *buf_len, &result, &lerrno);
+        ret = __nss_to_err(rc);
+        if (ret == ERANGE) {
+            ret = inc_buffer(ctx->max_nss_buf_size, buf_len, buf);
+            if (ret != 0) goto done;
         }
     }
 
-    if (ret == 0 && result == NULL) {
-        ret = ENOENT;
-    }
-
 done:
-    *_buf = buf;
-    *_buf_len = buf_len;
+    switch(ret) {
+    case 0:
+        if (result == NULL) ret = ENOENT;
+        break;
+    case ERANGE:
+        LOG("Buffer too small, increase ipaExtdomMaxNssBufSize.\n");
+    default:
+        break;
+    }
 
     return ret;
 }
@@ -406,13 +410,14 @@ int check_request(struct extdom_req *req, enum extdom_version version)
     return LDAP_SUCCESS;
 }
 
-int get_user_grouplist(const char *name, gid_t gid,
+int get_user_grouplist(struct ipa_extdom_ctx *ctx, const char *name, gid_t gid,
                        size_t *_ngroups, gid_t **_groups)
 {
-    int ret;
+    int lerrno;
     int ngroups;
     gid_t *groups;
     gid_t *new_groups;
+    enum nss_status rc;
 
     ngroups = 128;
     groups = malloc(ngroups * sizeof(gid_t));
@@ -420,19 +425,18 @@ int get_user_grouplist(const char *name, gid_t gid,
         return LDAP_OPERATIONS_ERROR;
     }
 
-    ret = getgrouplist(name, gid, groups, &ngroups);
-    if (ret == -1) {
-        new_groups = realloc(groups, ngroups * sizeof(gid_t));
-        if (new_groups == NULL) {
-            free(groups);
-            return LDAP_OPERATIONS_ERROR;
-        }
-        groups = new_groups;
-
-        ret = getgrouplist(name, gid, groups, &ngroups);
-        if (ret == -1) {
-            free(groups);
-            return LDAP_OPERATIONS_ERROR;
+    for(rc = NSS_STATUS_TRYAGAIN; rc == NSS_STATUS_TRYAGAIN;) {
+        rc = back_extdom_getgrouplist(ctx->nss_ctx, name, gid, groups, &ngroups, &lerrno);
+        if (rc == NSS_STATUS_TRYAGAIN) {
+            new_groups = NULL;
+            if (lerrno == ERANGE) {
+                new_groups = realloc(groups, ngroups * sizeof(gid_t));
+            }
+            if ((new_groups == NULL) || (lerrno == ENOMEM)) {
+                free(groups);
+                return LDAP_OPERATIONS_ERROR;
+            }
+            groups = new_groups;
         }
     }
 
@@ -538,7 +542,7 @@ int pack_ber_user(struct ipa_extdom_ctx *ctx,
     }
 
     if (response_type == RESP_USER_GROUPLIST) {
-        ret = get_user_grouplist(user_name, gid, &ngroups, &groups);
+        ret = get_user_grouplist(ctx, user_name, gid, &ngroups, &groups);
         if (ret != LDAP_SUCCESS) {
             goto done;
         }
@@ -561,7 +565,7 @@ int pack_ber_user(struct ipa_extdom_ctx *ctx,
         }
 
         for (c = 0; c < ngroups; c++) {
-            ret = getgrgid_r_wrapper(ctx->max_nss_buf_size,
+            ret = getgrgid_r_wrapper(ctx,
                                      groups[c], &grp, &buf, &buf_len);
             if (ret != 0) {
                 if (ret == ENOMEM || ret == ERANGE) {
@@ -841,8 +845,7 @@ static int handle_uid_request(struct ipa_extdom_ctx *ctx,
 
         ret = pack_ber_sid(sid_str, berval);
     } else {
-        ret = getpwuid_r_wrapper(ctx->max_nss_buf_size, uid, &pwd, &buf,
-                                 &buf_len);
+        ret = getpwuid_r_wrapper(ctx, uid, &pwd, &buf, &buf_len);
         if (ret != 0) {
             if (ret == ENOMEM || ret == ERANGE) {
                 ret = LDAP_OPERATIONS_ERROR;
@@ -913,8 +916,7 @@ static int handle_gid_request(struct ipa_extdom_ctx *ctx,
 
         ret = pack_ber_sid(sid_str, berval);
     } else {
-        ret = getgrgid_r_wrapper(ctx->max_nss_buf_size, gid, &grp, &buf,
-                                 &buf_len);
+        ret = getgrgid_r_wrapper(ctx, gid, &grp, &buf, &buf_len);
         if (ret != 0) {
             if (ret == ENOMEM || ret == ERANGE) {
                 ret = LDAP_OPERATIONS_ERROR;
@@ -1053,8 +1055,7 @@ static int handle_sid_request(struct ipa_extdom_ctx *ctx,
     switch(id_type) {
     case SSS_ID_TYPE_UID:
     case SSS_ID_TYPE_BOTH:
-        ret = getpwnam_r_wrapper(ctx->max_nss_buf_size, fq_name, &pwd, &buf,
-                                 &buf_len);
+        ret = getpwnam_r_wrapper(ctx, fq_name, &pwd, &buf, &buf_len);
         if (ret != 0) {
             if (ret == ENOMEM || ret == ERANGE) {
                 ret = LDAP_OPERATIONS_ERROR;
@@ -1086,8 +1087,7 @@ static int handle_sid_request(struct ipa_extdom_ctx *ctx,
                             pwd.pw_shell, kv_list, berval);
         break;
     case SSS_ID_TYPE_GID:
-        ret = getgrnam_r_wrapper(ctx->max_nss_buf_size, fq_name, &grp, &buf,
-                                 &buf_len);
+        ret = getgrnam_r_wrapper(ctx, fq_name, &grp, &buf, &buf_len);
         if (ret != 0) {
             if (ret == ENOMEM || ret == ERANGE) {
                 ret = LDAP_OPERATIONS_ERROR;
@@ -1181,8 +1181,7 @@ static int handle_name_request(struct ipa_extdom_ctx *ctx,
             goto done;
         }
 
-        ret = getpwnam_r_wrapper(ctx->max_nss_buf_size, fq_name, &pwd, &buf,
-                                 &buf_len);
+        ret = getpwnam_r_wrapper(ctx, fq_name, &pwd, &buf, &buf_len);
         if (ret == 0) {
             if (request_type == REQ_FULL_WITH_GROUPS) {
                 ret = sss_nss_getorigbyname(pwd.pw_name, &kv_list, &id_type);
@@ -1211,8 +1210,7 @@ static int handle_name_request(struct ipa_extdom_ctx *ctx,
              * error codes which can indicate that the user was not found. To
              * be on the safe side we fail back to the group lookup on all
              * errors. */
-            ret = getgrnam_r_wrapper(ctx->max_nss_buf_size, fq_name, &grp, &buf,
-                                     &buf_len);
+            ret = getgrnam_r_wrapper(ctx, fq_name, &grp, &buf, &buf_len);
             if (ret != 0) {
                 if (ret == ENOMEM || ret == ERANGE) {
                     ret = LDAP_OPERATIONS_ERROR;

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/test_data/test_setup.sh
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/test_data/test_setup.sh
@@ -1,3 +1,0 @@
-export LD_PRELOAD=$(pkg-config --libs nss_wrapper)
-export NSS_WRAPPER_PASSWD=./test_data/passwd
-export NSS_WRAPPER_GROUP=./test_data/group

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -257,7 +257,6 @@ BuildRequires:  python3-pyldap
 #
 %if ! %{ONLY_CLIENT}
 BuildRequires:  libcmocka-devel
-BuildRequires:  nss_wrapper
 # Required by ipa_kdb_tests
 BuildRequires:  %{_libdir}/krb5/plugins/kdb/db2.so
 %endif # ONLY_CLIENT

--- a/server.m4
+++ b/server.m4
@@ -35,6 +35,16 @@ AC_CHECK_LIB([sss_nss_idmap],
              [AC_MSG_ERROR([Required sss_nss_getlistbycert symbol in sss_nss_idmap not found])],
              [])
 
+dnl --- if sss_nss_idmap provides _timeout() API, use it
+bck_cflags="$CFLAGS"
+CFLAGS="$CFLAGS -DIPA_389DS_PLUGIN_HELPER_CALLS"
+AC_CHECK_DECLS([sss_nss_getpwnam_timeout], [], [], [[#include <sss_nss_idmap.h>]])
+CFLAGS="$bck_cflags"
+
+if test "x$ac_cv_have_decl_sss_nss_getpwnam_timeout" = xyes ; then
+    AC_DEFINE(USE_SSS_NSS_TIMEOUT,1,[Use extended NSS API provided by SSSD])
+fi
+
 dnl -- sss_certmap and certauth.h are needed by the IPA KDB certauth plugin --
 PKG_CHECK_EXISTS([sss_certmap],
                  [PKG_CHECK_MODULES([SSSCERTMAP], [sss_certmap])],


### PR DESCRIPTION
This PR was opened automatically because PR #1302 was pushed to master and backport to ipa-4-6 is required.