### PR TITLE
[Backport][ipa-4-6] Update builddep command to install Python 3 and tox deps

### DIFF
--- a/BUILD.txt
+++ b/BUILD.txt
@@ -7,7 +7,7 @@ For more information, see http://www.freeipa.org/page/Build
 
 The quickest way to get the dependencies needed for building is:
 
-# dnf builddep -b -D "with_lint 1" --spec freeipa.spec.in
+# dnf builddep -b -D "with_python3 1" -D "with_wheels 1" -D "with_lint 1" --spec freeipa.spec.in --best --allowerasing
 
 TIP: For building with latest dependencies for freeipa master enable copr repo:
 


### PR DESCRIPTION
This PR was opened automatically because PR #1341 was pushed to master and backport to ipa-4-6 is required.