### PR TITLE
install: report CA Subject DN and subject base to be used

### DIFF
--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -18,6 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import print_function
+
 import logging
 import sys
 import os
@@ -252,6 +254,15 @@ def install_master(safe_options, options):
         sys.exit("CA subject: {}".format(e))
 
     ca.install_check(True, None, options)
+
+    ca.print_ca_configuration(options)
+    print()
+
+    if not options.unattended:
+        if not ipautil.user_input(
+                "Continue to configure the CA with these values?", False):
+            sys.exit("Installation aborted")
+
     ca.install(True, None, options)
 
     # Run ipa-certupdate to add the new CA certificate to

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -99,6 +99,20 @@ def set_subject_base_in_config(subject_base):
         pass
 
 
+def print_ca_configuration(options):
+    """Print info about how the CA will be configured.
+
+    Does not print trailing empty line.
+
+    """
+    print("The CA will be configured with:")
+    print("Subject DN:   {}".format(options.ca_subject))
+    print("Subject base: {}".format(options.subject_base))
+    print("Chaining:     {}".format(
+        "externally signed (two-step installation)" if options.external_ca
+        else "self-signed"))
+
+
 def install_check(standalone, replica_config, options):
     global external_cert_file
     global external_ca_file

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -647,6 +647,10 @@ def install_check(installer):
     print("Realm name:     %s" % realm_name)
     print()
 
+    if setup_ca:
+        ca.print_ca_configuration(options)
+        print()
+
     if options.setup_dns:
         print("BIND DNS server will be configured to serve IPA domain with:")
         print("Forwarders:       %s" % (


### PR DESCRIPTION
Currently we do not report what Subject DN or subject base will be
used for the CA installation.  This leads to situations where the
administrator wants a different Subject DN later.  Display these
data as part of the "summary" prior to the final go/no-go prompt in
ipa-server-install and ipa-ca-install.

The go/no-go prompt in ipa-ca-install is new.  It is suppressed for
unattended installations.

Fixes: https://pagure.io/freeipa/issue/7246