### PR TITLE
Add python_requires to Python package metadata

### DIFF
--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -97,6 +97,7 @@ common_args = dict(
     url="http://www.freeipa.org/",
     download_url="http://www.freeipa.org/page/Downloads",
     platforms=["Linux", "Solaris", "Unix"],
+    python_requires=">=2.7.5,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: System Administrators",


### PR DESCRIPTION
freeIPA 4.6 and 4.7 requires Python 2.7 or >= 3.5.

https://pagure.io/freeipa/issue/7294

Signed-off-by: Christian Heimes <cheimes@redhat.com>