### PR TITLE
Travis CI failures: Revert PR#1047

### DIFF
--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -561,7 +561,7 @@ class SSLTransport(LanguageAwareTransport):
 
         conn = create_https_connection(
             host, 443,
-            getattr(context, 'ca_certfile', None),
+            api.env.tls_ca_cert,
             tls_version_min=api.env.tls_version_min,
             tls_version_max=api.env.tls_version_max)
 

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -313,10 +313,6 @@ def create_https_connection(
         raise RuntimeError("cafile argument is required to perform server "
                            "certificate verification")
 
-    if not os.path.isfile(cafile) or not os.access(cafile, os.R_OK):
-        raise RuntimeError("cafile \'{file}\' doesn't exist or is unreadable".
-                           format(file=cafile))
-
     # remove the slice of negating protocol options according to options
     tls_span = get_proper_tls_version_span(tls_version_min, tls_version_max)
 

--- a/ipatests/test_ipalib/test_rpc.py
+++ b/ipatests/test_ipalib/test_rpc.py
@@ -28,10 +28,8 @@ import six
 # pylint: disable=import-error
 from six.moves.xmlrpc_client import Binary, Fault, dumps, loads
 # pylint: enable=import-error
-from six.moves import urllib
 
 from ipatests.util import raises, assert_equal, PluginTester, DummyClass
-from ipatests.util import Fuzzy
 from ipatests.data import binary_bytes, utf8_bytes, unicode_str
 from ipalib.frontend import Command
 from ipalib.request import context, Connection
@@ -343,52 +341,3 @@ class test_xml_introspection(object):
                 "command 'system.methodHelp' takes at most 1 argument")
         else:
             raise AssertionError('did not raise')
-
-
-class test_rpcclient_context(PluginTester):
-    """
-    Test the context in `ipalib.rpc.rpcclient` plugin.
-    """
-    def setup(self):
-        try:
-            api.Backend.rpcclient.connect(ca_certfile='foo')
-        except (errors.NetworkError, IOError):
-            raise nose.SkipTest('%r: Server not available: %r' %
-                                (__name__, api.env.xmlrpc_uri))
-
-    def teardown(self):
-        if api.Backend.rpcclient.isconnected():
-            api.Backend.rpcclient.disconnect()
-
-    def test_context_cafile(self):
-        """
-        Test that ca_certfile is set in `ipalib.rpc.rpcclient.connect`
-        """
-        ca_certfile = getattr(context, 'ca_certfile', None)
-        assert_equal(ca_certfile, 'foo')
-
-    def test_context_principal(self):
-        """
-        Test that principal is set in `ipalib.rpc.rpcclient.connect`
-        """
-        principal = getattr(context, 'principal', None)
-        assert_equal(principal, 'admin@%s' % api.env.realm)
-
-    def test_context_request_url(self):
-        """
-        Test that request_url is set in `ipalib.rpc.rpcclient.connect`
-        """
-        request_url = getattr(context, 'request_url', None)
-        assert_equal(request_url, 'https://%s/ipa/session/json' % api.env.host)
-
-    def test_context_session_cookie(self):
-        """
-        Test that session_cookie is set in `ipalib.rpc.rpcclient.connect`
-        """
-        fuzzy_cookie = Fuzzy('^ipa_session=MagBearerToken=[A-Za-z0-9+\/]+=*;$')
-
-        session_cookie = getattr(context, 'session_cookie', None)
-        # pylint-2 is incorrectly spewing Too many positional arguments
-        # pylint: disable=E1121
-        unquoted = urllib.parse.unquote(session_cookie)
-        assert(unquoted == fuzzy_cookie)


### PR DESCRIPTION
PR#1047 was recently merged, but it was tested 2 months ago. The Travis CI passed, because it used older docker image. Once this was merged, it started to cause failures with the new image.

It is causing failures in Travis CI in our master branch. This is an attempt to hotfix the issue. If merged, we should reopen #1047 and test it properly (rebase, fix issues etc.).