### PR TITLE
Replace nose with unittest and pytest

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -217,7 +217,6 @@ BuildRequires:  python2-netifaces
 BuildRequires:  python2-sss
 BuildRequires:  python2-sss-murmur
 BuildRequires:  python2-sssdconfig
-BuildRequires:  python2-nose
 BuildRequires:  python2-paste
 BuildRequires:  python2-systemd
 BuildRequires:  python2-jinja2
@@ -256,7 +255,6 @@ BuildRequires:  python3-sss
 BuildRequires:  python3-sss-murmur
 BuildRequires:  python3-sssdconfig
 BuildRequires:  python3-libsss_nss_idmap
-BuildRequires:  python3-nose
 BuildRequires:  python3-paste
 BuildRequires:  python3-systemd
 BuildRequires:  python3-jinja2
@@ -836,7 +834,6 @@ Requires: python2-ipaclient = %{version}-%{release}
 Requires: python2-ipaserver = %{version}-%{release}
 Requires: tar
 Requires: xz
-Requires: python2-nose
 Requires: pytest >= 2.6
 Requires: python2-paste
 Requires: python2-coverage
@@ -872,7 +869,6 @@ Requires: python3-ipaclient = %{version}-%{release}
 Requires: python3-ipaserver = %{version}-%{release}
 Requires: tar
 Requires: xz
-Requires: python3-nose
 Requires: python3-pytest >= 2.6
 Requires: python3-coverage
 Requires: python3-polib

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -67,7 +67,6 @@ if __name__ == '__main__':
             "ipalib",
             "ipaplatform",
             "ipapython",
-            "nose",
             "polib",
             "pytest",
             "pytest_multihost",

--- a/ipatests/test_cmdline/cmdline.py
+++ b/ipatests/test_cmdline/cmdline.py
@@ -21,9 +21,9 @@
 Base class for all cmdline tests
 """
 
-import nose
 import distutils.spawn
 import os
+import unittest
 
 from ipalib import api
 from ipalib import errors
@@ -65,6 +65,6 @@ class cmdline_test(XMLRPC_test):
             )
         super(cmdline_test, cls).setup_class()
         if not server_available:
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 'Server not available: %r' % api.env.xmlrpc_uri
             )

--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -3,8 +3,8 @@ import os
 import shlex
 import subprocess
 import sys
+import unittest
 
-import nose
 import six
 from six import StringIO
 
@@ -43,7 +43,7 @@ class TestCLIParsing(object):
         try:
             api.Command[command_name](**kw)
         except errors.NetworkError:
-            raise nose.SkipTest('%r: Server not available: %r' %
+            raise unittest.SkipTest('%r: Server not available: %r' %
                                 (self.__module__, api.env.xmlrpc_uri))
 
     @contextlib.contextmanager
@@ -122,7 +122,7 @@ class TestCLIParsing(object):
         try:
             self.run_command('dnszone_add', idnsname=TEST_ZONE)
         except errors.NotFound:
-            raise nose.SkipTest('DNS is not configured')
+            raise unittest.SkipTest('DNS is not configured')
         try:
             self.run_command('dnsrecord_add',
                 dnszoneidnsname=TEST_ZONE,
@@ -150,7 +150,7 @@ class TestCLIParsing(object):
         try:
             self.run_command('dnszone_add', idnsname=TEST_ZONE)
         except errors.NotFound:
-            raise nose.SkipTest('DNS is not configured')
+            raise unittest.SkipTest('DNS is not configured')
         try:
             records = (u'1 1 E3B72BA346B90570EED94BE9334E34AA795CED23',
                        u'2 1 FD2693C1EFFC11A8D2BE57229212A04B45663791')
@@ -230,7 +230,7 @@ class TestCLIParsing(object):
             self.run_command(
                 'dnszone_add', idnsname=TEST_ZONE)
         except errors.NotFound:
-            raise nose.SkipTest('DNS is not configured')
+            raise unittest.SkipTest('DNS is not configured')
         try:
             self.run_command(
                 'dnsrecord_add',

--- a/ipatests/test_install/test_updates.py
+++ b/ipatests/test_install/test_updates.py
@@ -20,10 +20,9 @@
 Test the `ipaserver/install/ldapupdate.py` module.
 """
 
-import unittest
 import os
+import unittest
 
-import nose
 import pytest
 
 from ipalib import api
@@ -62,7 +61,7 @@ class test_update(unittest.TestCase):
             self.dm_password = fp.read().rstrip()
             fp.close()
         else:
-            raise nose.SkipTest("No directory manager password")
+            raise unittest.SkipTest("No directory manager password")
         self.updater = LDAPUpdate(dm_password=self.dm_password, sub_dict={})
         ldap_uri = ipaldap.get_ldap_uri(fqdn)
         self.ld = ipaldap.LDAPClient(ldap_uri)
@@ -71,7 +70,7 @@ class test_update(unittest.TestCase):
         self.testdir = os.path.abspath(os.path.dirname(__file__))
         if not os.path.isfile(os.path.join(self.testdir,
                                                 "0_reset.update")):
-            raise nose.SkipTest("Unable to find test update files")
+            raise unittest.SkipTest("Unable to find test update files")
 
         self.container_dn = DN(self.updater._template_str('cn=test, cn=accounts, $SUFFIX'))
         self.user_dn = DN(self.updater._template_str('uid=tuser, cn=test, cn=accounts, $SUFFIX'))

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -23,7 +23,8 @@ import tempfile
 import shutil
 import glob
 import contextlib
-import nose
+import unittest
+
 import pytest
 import six
 
@@ -604,7 +605,7 @@ class TestServerInstall(CALessBase):
                                      dirsrv_pkcs12='dirsrv.p12')
 
         if result.returncode == 0:
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 "Known CA-less installation defect, see "
                 "https://fedorahosted.org/freeipa/ticket/4270")
 
@@ -622,7 +623,7 @@ class TestServerInstall(CALessBase):
                                      dirsrv_pkcs12='dirsrv.p12')
 
         if result.returncode == 0:
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 "Known CA-less installation defect, see "
                 "https://fedorahosted.org/freeipa/ticket/4270")
 
@@ -968,7 +969,7 @@ class TestReplicaInstall(CALessBase):
                                       dirsrv_pkcs12='dirsrv.p12')
 
         if result.returncode == 0:
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 "Known CA-less installation defect, see "
                 "https://fedorahosted.org/freeipa/ticket/4270")
 
@@ -985,7 +986,7 @@ class TestReplicaInstall(CALessBase):
                                       dirsrv_pkcs12='dirsrv.p12')
 
         if result.returncode == 0:
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 "Known CA-less installation defect, see "
                 "https://fedorahosted.org/freeipa/ticket/4270")
 
@@ -1368,7 +1369,7 @@ class TestCertInstall(CALessBase):
         result = self.certinstall('w', 'ca1/server-revoked')
 
         if result.returncode == 0:
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 "Known CA-less installation defect, see "
                 "https://fedorahosted.org/freeipa/ticket/4270")
 
@@ -1380,7 +1381,7 @@ class TestCertInstall(CALessBase):
         result = self.certinstall('d', 'ca1/server-revoked')
 
         if result.returncode == 0:
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 "Known CA-less installation defect, see "
                 "https://fedorahosted.org/freeipa/ticket/4270")
 

--- a/ipatests/test_integration/test_legacy_clients.py
+++ b/ipatests/test_integration/test_legacy_clients.py
@@ -22,8 +22,8 @@
 
 import os
 import re
+import unittest
 
-import nose
 from ipaplatform.paths import paths
 
 from ipatests.pytest_plugins.integration import tasks
@@ -159,7 +159,7 @@ class BaseTestLegacyClient(object):
 
     def test_login_ipa_user(self):
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise nose.SkipTest('Package sshpass not available on %s'
+            raise unittest.SkipTest('Package sshpass not available on %s'
                                  % self.master.hostname)
 
         result = self.master.run_command(
@@ -176,7 +176,7 @@ class BaseTestLegacyClient(object):
 
     def test_login_ad_user(self):
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise nose.SkipTest('Package sshpass not available on %s'
+            raise unittest.SkipTest('Package sshpass not available on %s'
                                  % self.master.hostname)
 
         testuser = 'testuser@%s' % self.ad.domain.name
@@ -193,7 +193,7 @@ class BaseTestLegacyClient(object):
 
     def test_login_disabled_ipa_user(self):
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise nose.SkipTest('Package sshpass not available on %s'
+            raise unittest.SkipTest('Package sshpass not available on %s'
                                  % self.master.hostname)
 
         self.clear_sssd_caches()
@@ -213,7 +213,7 @@ class BaseTestLegacyClient(object):
 
     def test_login_disabled_ad_user(self):
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise nose.SkipTest('Package sshpass not available on %s'
+            raise unittest.SkipTest('Package sshpass not available on %s'
                                  % self.master.hostname)
 
         testuser = 'disabledaduser@%s' % self.ad.domain.name
@@ -231,7 +231,7 @@ class BaseTestLegacyClient(object):
 
     def test_getent_subdomain_ad_user(self):
         if not self.ad_subdomain:
-            raise nose.SkipTest('AD for the subdomain is not available.')
+            raise unittest.SkipTest('AD for the subdomain is not available.')
 
         self.clear_sssd_caches()
         testuser = 'subdomaintestuser@%s' % self.ad_subdomain
@@ -252,7 +252,7 @@ class BaseTestLegacyClient(object):
 
     def test_getent_subdomain_ad_group(self):
         if not self.ad_subdomain:
-            raise nose.SkipTest('AD for the subdomain is not available.')
+            raise unittest.SkipTest('AD for the subdomain is not available.')
 
         self.clear_sssd_caches()
         testgroup = 'subdomaintestgroup@%s' % self.ad_subdomain
@@ -264,7 +264,7 @@ class BaseTestLegacyClient(object):
 
     def test_id_subdomain_ad_user(self):
         if not self.ad_subdomain:
-            raise nose.SkipTest('AD for the subdomain is not available.')
+            raise unittest.SkipTest('AD for the subdomain is not available.')
 
         self.clear_sssd_caches()
         testuser = 'subdomaintestuser@%s' % self.ad_subdomain
@@ -289,10 +289,10 @@ class BaseTestLegacyClient(object):
 
     def test_login_subdomain_ad_user(self):
         if not self.ad_subdomain:
-            raise nose.SkipTest('AD for the subdomain is not available.')
+            raise unittest.SkipTest('AD for the subdomain is not available.')
 
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise nose.SkipTest('Package sshpass not available on %s'
+            raise unittest.SkipTest('Package sshpass not available on %s'
                                  % self.master.hostname)
 
         testuser = 'subdomaintestuser@%s' % self.ad_subdomain
@@ -309,10 +309,10 @@ class BaseTestLegacyClient(object):
 
     def test_login_disabled_subdomain_ad_user(self):
         if not self.ad_subdomain:
-            raise nose.SkipTest('AD for the subdomain is not available.')
+            raise unittest.SkipTest('AD for the subdomain is not available.')
 
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise nose.SkipTest('Package sshpass not available on %s'
+            raise unittest.SkipTest('Package sshpass not available on %s'
                                  % self.master.hostname)
 
         testuser = 'subdomaindisabledaduser@%s' % self.ad_subdomain
@@ -330,7 +330,7 @@ class BaseTestLegacyClient(object):
 
     def test_getent_treedomain_ad_user(self):
         if not self.ad_treedomain:
-            raise nose.SkipTest('AD tree root domain is not available.')
+            raise unittest.SkipTest('AD tree root domain is not available.')
 
         self.clear_sssd_caches()
         testuser = 'treetestuser@{0}'.format(self.ad_treedomain)
@@ -346,7 +346,7 @@ class BaseTestLegacyClient(object):
 
     def test_getent_treedomain_ad_group(self):
         if not self.ad_treedomain:
-            raise nose.SkipTest('AD tree root domain is not available')
+            raise unittest.SkipTest('AD tree root domain is not available')
 
         self.clear_sssd_caches()
         testgroup = 'treetestgroup@{0}'.format(self.ad_treedomain)
@@ -359,7 +359,7 @@ class BaseTestLegacyClient(object):
 
     def test_id_treedomain_ad_user(self):
         if not self.ad_treedomain:
-            raise nose.SkipTest('AD tree root domain is not available')
+            raise unittest.SkipTest('AD tree root domain is not available')
 
         self.clear_sssd_caches()
 
@@ -388,11 +388,13 @@ class BaseTestLegacyClient(object):
 
     def test_login_treedomain_ad_user(self):
         if not self.ad_treedomain:
-            raise nose.SkipTest('AD tree root domain is not available.')
+            raise unittest.SkipTest('AD tree root domain is not available.')
 
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise nose.SkipTest('Package sshpass not available on {}'.format(
-                                self.master.hostname))
+            raise unittest.SkipTest(
+                'Package sshpass not available on {}'.format(
+                    self.master.hostname)
+            )
 
         result = self.master.run_command(
             'sshpass -p {0} ssh -o StrictHostKeyChecking=no '

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -17,8 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import nose
 import re
+import unittest
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_plugins.integration import tasks
@@ -35,7 +35,7 @@ class ADTrustBase(IntegrationTest):
     @classmethod
     def install(cls, mh):
         if not cls.master.transport.file_exists('/usr/bin/rpcclient'):
-            raise nose.SkipTest("Package samba-client not available "
+            raise unittest.SkipTest("Package samba-client not available "
                                 "on {}".format(cls.master.hostname))
         super(ADTrustBase, cls).install(mh)
         cls.ad = cls.ad_domains[0].ads[0]
@@ -99,7 +99,7 @@ class ADTrustBase(IntegrationTest):
         """
 
         if self.ad_subdomain is None:
-            raise nose.SkipTest('AD subdomain is not available.')
+            raise unittest.SkipTest('AD subdomain is not available.')
 
         result = self.master.run_command(['ipa',
                                           'trustdomain-find',
@@ -125,7 +125,7 @@ class ADTrustSubdomainBase(ADTrustBase):
     def install(cls, mh):
         super(ADTrustSubdomainBase, cls).install(mh)
         if not cls.ad_subdomain:
-            raise nose.SkipTest('AD subdomain is not available.')
+            raise unittest.SkipTest('AD subdomain is not available.')
 
 
 class ADTrustTreedomainBase(ADTrustBase):
@@ -142,7 +142,7 @@ class ADTrustTreedomainBase(ADTrustBase):
     def install(cls, mh):
         super(ADTrustTreedomainBase, cls).install(mh)
         if not cls.ad_treedomain:
-            raise nose.SkipTest('AD tree root domain is not available.')
+            raise unittest.SkipTest('AD tree root domain is not available.')
 
 
 class TestBasicADTrust(ADTrustBase):
@@ -353,7 +353,7 @@ class TestNonexternalTrustWithSubdomain(ADTrustSubdomainBase):
             self.ad_subdomain) in result.stderr_text)
 
     def test_all_trustdomains_found(self):
-        raise nose.SkipTest(
+        raise unittest.SkipTest(
             'Test case unapplicable, present for inheritance reason only')
 
 
@@ -420,7 +420,7 @@ class TestNonexternalTrustWithTreedomain(ADTrustTreedomainBase):
             self.ad_treedomain) in result.stderr_text)
 
     def test_all_trustdomains_found(self):
-        raise nose.SkipTest(
+        raise unittest.SkipTest(
             'Test case unapplicable, present for inheritance reason only')
 
 

--- a/ipatests/test_ipalib/test_rpc.py
+++ b/ipatests/test_ipalib/test_rpc.py
@@ -22,7 +22,8 @@ Test the `ipalib.rpc` module.
 """
 from __future__ import print_function
 
-import nose
+import unittest
+
 import pytest
 import six
 # pylint: disable=import-error
@@ -267,7 +268,7 @@ class test_xml_introspection(object):
         try:
             api.Backend.xmlclient.connect()
         except (errors.NetworkError, IOError):
-            raise nose.SkipTest('%r: Server not available: %r' %
+            raise unittest.SkipTest('%r: Server not available: %r' %
                                 (__name__, api.env.xmlrpc_uri))
 
     @classmethod
@@ -356,7 +357,7 @@ class test_rpcclient_context(PluginTester):
         try:
             api.Backend.rpcclient.connect(ca_certfile='foo')
         except (errors.NetworkError, IOError):
-            raise nose.SkipTest('%r: Server not available: %r' %
+            raise unittest.SkipTest('%r: Server not available: %r' %
                                 (__name__, api.env.xmlrpc_uri))
 
     def teardown(self):

--- a/ipatests/test_ipalib/test_text.py
+++ b/ipatests/test_ipalib/test_text.py
@@ -25,8 +25,8 @@ from __future__ import print_function
 import os
 import shutil
 import tempfile
+import unittest
 
-import nose
 import six
 import pytest
 
@@ -102,15 +102,17 @@ class test_TestLang(object):
 
         result = create_po(self.pot_file, self.po_file, self.mo_file)
         if result:
-            raise nose.SkipTest('Unable to create po file "%s" & mo file "%s" from pot file "%s"' %
-                                (self.po_file, self.mo_file, self.pot_file))
+            raise unittest.SkipTest(
+                'Unable to create po file "%s" & mo file "%s" from pot '
+                'file "%s"' % (self.po_file, self.mo_file, self.pot_file)
+            )
 
         if not os.path.isfile(self.po_file):
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 'Test po file unavailable: {}'.format(self.po_file))
 
         if not os.path.isfile(self.mo_file):
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 'Test mo file unavailable: {}'.format(self.mo_file))
 
         self.po_file_iterate = po_file_iterate

--- a/ipatests/test_ipapython/test_ipautil.py
+++ b/ipatests/test_ipapython/test_ipautil.py
@@ -22,7 +22,6 @@
 Test the `ipapython/ipautil.py` module.
 """
 
-import nose
 import pytest
 import six
 import tempfile
@@ -30,6 +29,11 @@ import tempfile
 from ipapython import ipautil
 
 pytestmark = pytest.mark.tier0
+
+
+def assert_equal(a, b):
+    __tracebackhide__ = True
+    assert a == b
 
 
 @pytest.mark.parametrize("addr,words,prefixlen", [
@@ -92,30 +96,30 @@ class TestCIDict(object):
         assert dict(cidict.items()) == {'a': 2, 'b': 3, 'C': 4}
 
     def test_len(self):
-        nose.tools.assert_equal(3, len(self.cidict))
+        assert_equal(3, len(self.cidict))
 
     def test_getitem(self):
-        nose.tools.assert_equal("val1", self.cidict["Key1"])
-        nose.tools.assert_equal("val1", self.cidict["key1"])
-        nose.tools.assert_equal("val2", self.cidict["KEY2"])
-        nose.tools.assert_equal("VAL3", self.cidict["key3"])
-        nose.tools.assert_equal("VAL3", self.cidict["KEY3"])
-        with nose.tools.assert_raises(KeyError):
+        assert_equal("val1", self.cidict["Key1"])
+        assert_equal("val1", self.cidict["key1"])
+        assert_equal("val2", self.cidict["KEY2"])
+        assert_equal("VAL3", self.cidict["key3"])
+        assert_equal("VAL3", self.cidict["KEY3"])
+        with pytest.raises(KeyError):
             self.cidict["key4"]  # pylint: disable=pointless-statement
 
     def test_get(self):
-        nose.tools.assert_equal("val1", self.cidict.get("Key1"))
-        nose.tools.assert_equal("val1", self.cidict.get("key1"))
-        nose.tools.assert_equal("val2", self.cidict.get("KEY2"))
-        nose.tools.assert_equal("VAL3", self.cidict.get("key3"))
-        nose.tools.assert_equal("VAL3", self.cidict.get("KEY3"))
-        nose.tools.assert_equal("default", self.cidict.get("key4", "default"))
+        assert_equal("val1", self.cidict.get("Key1"))
+        assert_equal("val1", self.cidict.get("key1"))
+        assert_equal("val2", self.cidict.get("KEY2"))
+        assert_equal("VAL3", self.cidict.get("key3"))
+        assert_equal("VAL3", self.cidict.get("KEY3"))
+        assert_equal("default", self.cidict.get("key4", "default"))
 
     def test_setitem(self):
         self.cidict["key4"] = "val4"
-        nose.tools.assert_equal("val4", self.cidict["key4"])
+        assert_equal("val4", self.cidict["key4"])
         self.cidict["KEY4"] = "newval4"
-        nose.tools.assert_equal("newval4", self.cidict["key4"])
+        assert_equal("newval4", self.cidict["key4"])
 
     def test_del(self):
         assert "Key1" in self.cidict
@@ -127,9 +131,9 @@ class TestCIDict(object):
         assert "key2" not in self.cidict
 
     def test_clear(self):
-        nose.tools.assert_equal(3, len(self.cidict))
+        assert_equal(3, len(self.cidict))
         self.cidict.clear()
-        nose.tools.assert_equal(0, len(self.cidict))
+        assert_equal(0, len(self.cidict))
         assert self.cidict == {}
         assert list(self.cidict) == []
         assert list(self.cidict.values()) == []
@@ -143,10 +147,10 @@ class TestCIDict(object):
     def test_copy(self):
         copy = self.cidict.copy()
         assert copy == self.cidict
-        nose.tools.assert_equal(3, len(copy))
+        assert_equal(3, len(copy))
         assert "Key1" in copy
         assert "key1" in copy
-        nose.tools.assert_equal("val1", copy["Key1"])
+        assert_equal("val1", copy["Key1"])
 
     @pytest.mark.skipif(not six.PY2, reason="Python 2 only")
     def test_haskey(self):
@@ -165,7 +169,7 @@ class TestCIDict(object):
 
     def test_items(self):
         items = list(self.cidict.items())
-        nose.tools.assert_equal(3, len(items))
+        assert_equal(3, len(items))
         items_set = set(items)
         assert ("Key1", "val1") in items_set
         assert ("key2", "val2") in items_set
@@ -182,7 +186,7 @@ class TestCIDict(object):
         items = []
         for (k,v) in self.cidict.iteritems():
             items.append((k,v))
-        nose.tools.assert_equal(3, len(items))
+        assert_equal(3, len(items))
         items_set = set(items)
         assert ("Key1", "val1") in items_set
         assert ("key2", "val2") in items_set
@@ -192,7 +196,7 @@ class TestCIDict(object):
         keys = []
         for k in self.cidict.iterkeys():
             keys.append(k)
-        nose.tools.assert_equal(3, len(keys))
+        assert_equal(3, len(keys))
         keys_set = set(keys)
         assert "Key1" in keys_set
         assert "key2" in keys_set
@@ -202,7 +206,7 @@ class TestCIDict(object):
         values = []
         for k in self.cidict.itervalues():
             values.append(k)
-        nose.tools.assert_equal(3, len(values))
+        assert_equal(3, len(values))
         values_set = set(values)
         assert "val1" in values_set
         assert "val2" in values_set
@@ -210,7 +214,7 @@ class TestCIDict(object):
 
     def test_keys(self):
         keys = list(self.cidict.keys())
-        nose.tools.assert_equal(3, len(keys))
+        assert_equal(3, len(keys))
         keys_set = set(keys)
         assert "Key1" in keys_set
         assert "key2" in keys_set
@@ -220,7 +224,7 @@ class TestCIDict(object):
 
     def test_values(self):
         values = list(self.cidict.values())
-        nose.tools.assert_equal(3, len(values))
+        assert_equal(3, len(values))
         values_set = set(values)
         assert "val1" in values_set
         assert "val2" in values_set
@@ -232,10 +236,10 @@ class TestCIDict(object):
         newdict = { "KEY2": "newval2",
                     "key4": "val4" }
         self.cidict.update(newdict)
-        nose.tools.assert_equal(4, len(self.cidict))
+        assert_equal(4, len(self.cidict))
 
         items = list(self.cidict.items())
-        nose.tools.assert_equal(4, len(items))
+        assert_equal(4, len(items))
         items_set = set(items)
         assert ("Key1", "val1") in items_set
         # note the update "overwrites" the case of the key2
@@ -256,15 +260,15 @@ class TestCIDict(object):
             'Key1': 'val1', 'key2': 'val2', 'KEY3': 'VAL3'}
 
     def test_update_duplicate_values_dict(self):
-        with nose.tools.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             self.cidict.update({'a': 'va', 'A': None, 'b': 3})
 
     def test_update_duplicate_values_list(self):
-        with nose.tools.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             self.cidict.update([('a', 'va'), ('A', None), ('b', 3)])
 
     def test_update_duplicate_values_kwargs(self):
-        with nose.tools.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             self.cidict.update(a='va', A=None, b=3)
 
     def test_update_kwargs(self):
@@ -273,45 +277,45 @@ class TestCIDict(object):
             'b': 'vb', 'Key1': 'val1', 'key2': 'val2', 'KEY3': 'VAL3'}
 
     def test_setdefault(self):
-        nose.tools.assert_equal("val1", self.cidict.setdefault("KEY1", "default"))
+        assert_equal("val1", self.cidict.setdefault("KEY1", "default"))
 
         assert "KEY4" not in self.cidict
-        nose.tools.assert_equal("default", self.cidict.setdefault("KEY4", "default"))
+        assert_equal("default", self.cidict.setdefault("KEY4", "default"))
         assert "KEY4" in self.cidict
-        nose.tools.assert_equal("default", self.cidict["key4"])
+        assert_equal("default", self.cidict["key4"])
 
         assert "KEY5" not in self.cidict
-        nose.tools.assert_equal(None, self.cidict.setdefault("KEY5"))
+        assert_equal(None, self.cidict.setdefault("KEY5"))
         assert "KEY5" in self.cidict
-        nose.tools.assert_equal(None, self.cidict["key5"])
+        assert_equal(None, self.cidict["key5"])
 
     def test_pop(self):
-        nose.tools.assert_equal("val1", self.cidict.pop("KEY1", "default"))
+        assert_equal("val1", self.cidict.pop("KEY1", "default"))
         assert "key1" not in self.cidict
 
-        nose.tools.assert_equal("val2", self.cidict.pop("KEY2"))
+        assert_equal("val2", self.cidict.pop("KEY2"))
         assert "key2" not in self.cidict
 
-        nose.tools.assert_equal("default", self.cidict.pop("key4", "default"))
-        with nose.tools.assert_raises(KeyError):
+        assert_equal("default", self.cidict.pop("key4", "default"))
+        with pytest.raises(KeyError):
             self.cidict.pop("key4")
 
     def test_popitem(self):
         items = set(self.cidict.items())
-        nose.tools.assert_equal(3, len(self.cidict))
+        assert_equal(3, len(self.cidict))
 
         item = self.cidict.popitem()
-        nose.tools.assert_equal(2, len(self.cidict))
+        assert_equal(2, len(self.cidict))
         assert item in items
         items.discard(item)
 
         item = self.cidict.popitem()
-        nose.tools.assert_equal(1, len(self.cidict))
+        assert_equal(1, len(self.cidict))
         assert item in items
         items.discard(item)
 
         item = self.cidict.popitem()
-        nose.tools.assert_equal(0, len(self.cidict))
+        assert_equal(0, len(self.cidict))
         assert item in items
         items.discard(item)
 
@@ -326,55 +330,55 @@ class TestTimeParser(object):
         timestr = "20070803"
 
         time = ipautil.parse_generalized_time(timestr)
-        nose.tools.assert_equal(2007, time.year)
-        nose.tools.assert_equal(8, time.month)
-        nose.tools.assert_equal(3, time.day)
-        nose.tools.assert_equal(0, time.hour)
-        nose.tools.assert_equal(0, time.minute)
-        nose.tools.assert_equal(0, time.second)
+        assert_equal(2007, time.year)
+        assert_equal(8, time.month)
+        assert_equal(3, time.day)
+        assert_equal(0, time.hour)
+        assert_equal(0, time.minute)
+        assert_equal(0, time.second)
 
     def test_hour_min_sec(self):
         timestr = "20051213141205"
 
         time = ipautil.parse_generalized_time(timestr)
-        nose.tools.assert_equal(2005, time.year)
-        nose.tools.assert_equal(12, time.month)
-        nose.tools.assert_equal(13, time.day)
-        nose.tools.assert_equal(14, time.hour)
-        nose.tools.assert_equal(12, time.minute)
-        nose.tools.assert_equal(5, time.second)
+        assert_equal(2005, time.year)
+        assert_equal(12, time.month)
+        assert_equal(13, time.day)
+        assert_equal(14, time.hour)
+        assert_equal(12, time.minute)
+        assert_equal(5, time.second)
 
     def test_fractions(self):
         timestr = "2003092208.5"
 
         time = ipautil.parse_generalized_time(timestr)
-        nose.tools.assert_equal(2003, time.year)
-        nose.tools.assert_equal(9, time.month)
-        nose.tools.assert_equal(22, time.day)
-        nose.tools.assert_equal(8, time.hour)
-        nose.tools.assert_equal(30, time.minute)
-        nose.tools.assert_equal(0, time.second)
+        assert_equal(2003, time.year)
+        assert_equal(9, time.month)
+        assert_equal(22, time.day)
+        assert_equal(8, time.hour)
+        assert_equal(30, time.minute)
+        assert_equal(0, time.second)
 
         timestr = "199203301544,25"
 
         time = ipautil.parse_generalized_time(timestr)
-        nose.tools.assert_equal(1992, time.year)
-        nose.tools.assert_equal(3, time.month)
-        nose.tools.assert_equal(30, time.day)
-        nose.tools.assert_equal(15, time.hour)
-        nose.tools.assert_equal(44, time.minute)
-        nose.tools.assert_equal(15, time.second)
+        assert_equal(1992, time.year)
+        assert_equal(3, time.month)
+        assert_equal(30, time.day)
+        assert_equal(15, time.hour)
+        assert_equal(44, time.minute)
+        assert_equal(15, time.second)
 
         timestr = "20060401185912,8"
 
         time = ipautil.parse_generalized_time(timestr)
-        nose.tools.assert_equal(2006, time.year)
-        nose.tools.assert_equal(4, time.month)
-        nose.tools.assert_equal(1, time.day)
-        nose.tools.assert_equal(18, time.hour)
-        nose.tools.assert_equal(59, time.minute)
-        nose.tools.assert_equal(12, time.second)
-        nose.tools.assert_equal(800000, time.microsecond)
+        assert_equal(2006, time.year)
+        assert_equal(4, time.month)
+        assert_equal(1, time.day)
+        assert_equal(18, time.hour)
+        assert_equal(59, time.minute)
+        assert_equal(12, time.second)
+        assert_equal(800000, time.microsecond)
 
     def test_time_zones(self):
         # pylint: disable=no-member
@@ -382,36 +386,36 @@ class TestTimeParser(object):
         timestr = "20051213141205Z"
 
         time = ipautil.parse_generalized_time(timestr)
-        nose.tools.assert_equal(0, time.tzinfo.houroffset)
-        nose.tools.assert_equal(0, time.tzinfo.minoffset)
+        assert_equal(0, time.tzinfo.houroffset)
+        assert_equal(0, time.tzinfo.minoffset)
         offset = time.tzinfo.utcoffset(time.tzinfo.dst())
-        nose.tools.assert_equal(0, offset.seconds)
+        assert_equal(0, offset.seconds)
 
         timestr = "20051213141205+0500"
 
         time = ipautil.parse_generalized_time(timestr)
-        nose.tools.assert_equal(5, time.tzinfo.houroffset)
-        nose.tools.assert_equal(0, time.tzinfo.minoffset)
+        assert_equal(5, time.tzinfo.houroffset)
+        assert_equal(0, time.tzinfo.minoffset)
         offset = time.tzinfo.utcoffset(time.tzinfo.dst())
-        nose.tools.assert_equal(5 * 60 * 60, offset.seconds)
+        assert_equal(5 * 60 * 60, offset.seconds)
 
         timestr = "20051213141205-0500"
 
         time = ipautil.parse_generalized_time(timestr)
-        nose.tools.assert_equal(-5, time.tzinfo.houroffset)
-        nose.tools.assert_equal(0, time.tzinfo.minoffset)
+        assert_equal(-5, time.tzinfo.houroffset)
+        assert_equal(0, time.tzinfo.minoffset)
         # NOTE - the offset is always positive - it's minutes
         #        _east_ of UTC
         offset = time.tzinfo.utcoffset(time.tzinfo.dst())
-        nose.tools.assert_equal((24 - 5) * 60 * 60, offset.seconds)
+        assert_equal((24 - 5) * 60 * 60, offset.seconds)
 
         timestr = "20051213141205-0930"
 
         time = ipautil.parse_generalized_time(timestr)
-        nose.tools.assert_equal(-9, time.tzinfo.houroffset)
-        nose.tools.assert_equal(-30, time.tzinfo.minoffset)
+        assert_equal(-9, time.tzinfo.houroffset)
+        assert_equal(-30, time.tzinfo.minoffset)
         offset = time.tzinfo.utcoffset(time.tzinfo.dst())
-        nose.tools.assert_equal(((24 - 9) * 60 * 60) - (30 * 60), offset.seconds)
+        assert_equal(((24 - 9) * 60 * 60) - (30 * 60), offset.seconds)
 
 
 def test_run():

--- a/ipatests/test_ipapython/test_keyring.py
+++ b/ipatests/test_ipapython/test_keyring.py
@@ -20,7 +20,6 @@
 Test the `kernel_keyring.py` module.
 """
 
-from nose.tools import raises  # pylint: disable=E0611
 from ipapython import kernel_keyring
 
 import pytest
@@ -81,13 +80,13 @@ class test_keyring(object):
         except ValueError:
             pass
 
-    @raises(ValueError)
     def test_03(self):
         """
         Add a duplicate key
         """
         kernel_keyring.add_key(TEST_KEY, TEST_VALUE)
-        kernel_keyring.add_key(TEST_KEY, TEST_VALUE)
+        with pytest.raises(ValueError):
+            kernel_keyring.add_key(TEST_KEY, TEST_VALUE)
 
     def test_04(self):
         """
@@ -106,12 +105,12 @@ class test_keyring(object):
 
         kernel_keyring.del_key(TEST_KEY)
 
-    @raises(ValueError)
     def test_05(self):
         """
         Read a non-existent key
         """
-        kernel_keyring.read_key(TEST_KEY)
+        with pytest.raises(ValueError):
+            kernel_keyring.read_key(TEST_KEY)
 
     def test_06(self):
         """

--- a/ipatests/test_ipaserver/test_changepw.py
+++ b/ipatests/test_ipaserver/test_changepw.py
@@ -17,7 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import nose
+import unittest
+
 import ldap
 import pytest
 
@@ -41,7 +42,7 @@ class test_changepw(XMLRPC_test, Unauthorized_HTTP_test):
             api.Command['user_add'](uid=testuser, givenname=u'Test', sn=u'User')
             api.Command['passwd'](testuser, password=u'old_password')
         except errors.ExecutionError as e:
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 'Cannot set up test user: %s' % e
             )
 

--- a/ipatests/test_ipaserver/test_ldap.py
+++ b/ipatests/test_ipaserver/test_ldap.py
@@ -27,10 +27,9 @@
 
 import os
 import sys
+import unittest
 
 import pytest
-import nose
-from nose.tools import assert_raises  # pylint: disable=E0611
 import six
 
 from ipaplatform.paths import paths
@@ -89,7 +88,9 @@ class test_ldap(object):
             with open(pwfile, "r") as fp:
                 dm_password = fp.read().rstrip()
         else:
-            raise nose.SkipTest("No directory manager password in %s" % pwfile)
+            raise unittest.SkipTest(
+                "No directory manager password in %s" % pwfile
+            )
         self.conn = ldap2(api)
         self.conn.connect(bind_dn=DN(('cn', 'directory manager')), bind_pw=dm_password)
         entry_attrs = self.conn.get_entry(self.dn, ['usercertificate'])
@@ -113,7 +114,9 @@ class test_ldap(object):
             with open(pwfile, "r") as fp:
                 dm_password = fp.read().rstrip()
         else:
-            raise nose.SkipTest("No directory manager password in %s" % pwfile)
+            raise unittest.SkipTest(
+                "No directory manager password in %s" % pwfile
+            )
         myapi.Backend.ldap2.connect(bind_dn=DN(('cn', 'Directory Manager')), bind_pw=dm_password)
 
         result = myapi.Command['service_show']('ldap/%s@%s' %  (api.env.host, api.env.realm,))
@@ -129,7 +132,7 @@ class test_ldap(object):
         try:
             self.conn.connect(autobind=True)
         except errors.ACIError:
-            raise nose.SkipTest("Only executed as root")
+            raise unittest.SkipTest("Only executed as root")
         entry_attrs = self.conn.get_entry(self.dn, ['usercertificate'])
         cert = entry_attrs.get('usercertificate')[0]
         assert cert.serial_number is not None
@@ -229,7 +232,7 @@ class test_LDAPEntry(object):
         assert e.pop('cn') == self.cn1
         assert 'cn' not in e
         assert e.pop('cn', 'default') is 'default'
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             e.pop('cn')
 
     def test_clear(self):

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -24,13 +24,12 @@ Contains browser driver and common tasks.
 """
 from __future__ import print_function
 
-import nose
 from datetime import datetime
 import time
 import re
 import os
 from functools import wraps
-from nose.plugins.skip import SkipTest
+import unittest
 
 # pylint: disable=import-error
 from six.moves.urllib.error import URLError
@@ -99,7 +98,7 @@ def screenshot(fn):
     def screenshot_wrapper(*args):
         try:
             return fn(*args)
-        except SkipTest:
+        except unittest.SkipTest:
             raise
         except Exception:
             self = args[0]
@@ -121,7 +120,7 @@ class UI_driver(object):
     @classmethod
     def setup_class(cls):
         if NO_SELENIUM:
-            raise nose.SkipTest('Selenium not installed')
+            raise unittest.SkipTest('Selenium not installed')
 
     def setup(self, driver=None, config=None):
         self.request_timeout = 30
@@ -151,9 +150,11 @@ class UI_driver(object):
                 with open(path, 'r') as conf:
                     self.config = yaml.load(conf)
             except yaml.YAMLError as e:
-                raise nose.SkipTest("Invalid Web UI config.\n%s" % e)
+                raise unittest.SkipTest("Invalid Web UI config.\n%s" % e)
             except IOError as e:
-                raise nose.SkipTest("Can't load Web UI test config: %s" % e)
+                raise unittest.SkipTest(
+                    "Can't load Web UI test config: %s" % e
+                )
         else:
             self.config = {}
 
@@ -189,7 +190,7 @@ class UI_driver(object):
 
         if driver_type == 'remote':
             if 'host' not in self.config:
-                raise nose.SkipTest('Selenium server host not configured')
+                raise unittest.SkipTest('Selenium server host not configured')
             host = self.config["host"]
 
             if browser == 'chrome':
@@ -205,9 +206,13 @@ class UI_driver(object):
                     command_executor='http://%s:%d/wd/hub' % (host, port),
                     desired_capabilities=capabilities)
             except URLError as e:
-                raise nose.SkipTest('Error connecting to selenium server: %s' % e)
+                raise unittest.SkipTest(
+                    'Error connecting to selenium server: %s' % e
+                )
             except RuntimeError as e:
-                raise nose.SkipTest('Error while establishing webdriver: %s' % e)
+                raise unittest.SkipTest(
+                    'Error while establishing webdriver: %s' % e
+                )
         else:
             try:
                 if browser == 'chrome' or browser == 'chromium':
@@ -221,9 +226,13 @@ class UI_driver(object):
                     ff_log_path = self.config.get("geckodriver_log_path")
                     driver = webdriver.Firefox(fp, log_path=ff_log_path)
             except URLError as e:
-                raise nose.SkipTest('Error connecting to selenium server: %s' % e)
+                raise unittest.SkipTest(
+                    'Error connecting to selenium server: %s' % e
+                )
             except RuntimeError as e:
-                raise nose.SkipTest('Error while establishing webdriver: %s' % e)
+                raise unittest.SkipTest(
+                    'Error while establishing webdriver: %s' % e
+                )
 
         return driver
 
@@ -1570,7 +1579,7 @@ class UI_driver(object):
         """
         Skip tests
         """
-        raise nose.SkipTest(reason)
+        raise unittest.SkipTest(reason)
 
     def assert_text(self, selector, value, parent=None):
         """

--- a/ipatests/test_xmlrpc/test_automount_plugin.py
+++ b/ipatests/test_xmlrpc/test_automount_plugin.py
@@ -24,14 +24,14 @@ Test the `ipaserver/plugins/automount.py' module.
 import textwrap
 import tempfile
 import shutil
-import pytest
 
 from ipalib import api
 from ipalib import errors
 from ipapython.dn import DN
+
+import pytest
 import six
 
-from nose.tools import raises, assert_raises  # pylint: disable=E0611
 from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test, assert_attr_equal
 from ipatests.util import assert_deepequal
 
@@ -179,13 +179,13 @@ class test_automount(AutomountTest):
         assert res
         assert_attr_equal(res, 'automountkey', self.keyname)
 
-    @raises(errors.DuplicateEntry)
     def test_4_automountkey_add(self):
         """
         Test adding a duplicate key using `xmlrpc.automountkey_add` method.
         """
-        api.Command['automountkey_add'](
-            self.locname, self.mapname, **self.key_kw)
+        with pytest.raises(errors.DuplicateEntry):
+            api.Command['automountkey_add'](
+                self.locname, self.mapname, **self.key_kw)
 
     def test_5_automountmap_show(self):
         """
@@ -302,7 +302,7 @@ class test_automount(AutomountTest):
         assert not res['failed']
 
         # Verify that it is gone
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['automountkey_show'](self.locname, self.mapname, **delkey_kw)
 
     def test_c_automountlocation_del(self):
@@ -314,7 +314,7 @@ class test_automount(AutomountTest):
         assert not res['failed']
 
         # Verify that it is gone
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['automountlocation_show'](self.locname)
 
     def test_d_automountmap_del(self):
@@ -323,7 +323,7 @@ class test_automount(AutomountTest):
         """
         # Verify that the second key we added is gone
         key_kw = {'automountkey': self.keyname2, 'automountinformation': self.info, 'raw': True}
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['automountkey_show'](self.locname, self.mapname, **key_kw)
 
 
@@ -364,13 +364,13 @@ class test_automount_direct(AutomountTest):
         assert res
         assert_attr_equal(res, 'automountmapname', self.mapname)
 
-    @raises(errors.DuplicateEntry)
     def test_2_automountmap_add_duplicate(self):
         """
         Test adding a duplicate direct map.
         """
-        api.Command['automountmap_add_indirect'](
-            self.locname, self.mapname, **self.direct_kw)
+        with pytest.raises(errors.DuplicateEntry):
+            api.Command['automountmap_add_indirect'](
+                self.locname, self.mapname, **self.direct_kw)
 
     def test_2a_automountmap_tofiles(self):
         """Test the `automountmap_tofiles` command"""
@@ -385,7 +385,7 @@ class test_automount_direct(AutomountTest):
         assert not res['failed']
 
         # Verity that it is gone
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['automountlocation_show'](self.locname)
 
     def test_z_import_roundtrip(self):
@@ -433,12 +433,14 @@ class test_automount_indirect(AutomountTest):
         assert res
         assert_attr_equal(res, 'automountmapname', self.mapname)
 
-    @raises(errors.DuplicateEntry)
     def test_1a_automountmap_add_indirect(self):
         """
         Test adding a duplicate indirect map.
         """
-        api.Command['automountmap_add_indirect'](self.locname, self.mapname, **self.map_kw)
+        with pytest.raises(errors.DuplicateEntry):
+            api.Command['automountmap_add_indirect'](
+                self.locname, self.mapname, **self.map_kw
+            )
 
     def test_2_automountmap_show(self):
         """
@@ -461,7 +463,7 @@ class test_automount_indirect(AutomountTest):
         assert not res['failed']
 
         # Verify that it is gone
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['automountkey_show'](self.locname, self.parentmap, **self.key_kw)
 
     def test_4_automountmap_del(self):
@@ -473,7 +475,7 @@ class test_automount_indirect(AutomountTest):
         assert not res['failed']
 
         # Verify that it is gone
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['automountmap_show'](self.locname, self.mapname)
 
     def test_5_automountlocation_del(self):
@@ -485,7 +487,7 @@ class test_automount_indirect(AutomountTest):
         assert not res['failed']
 
         # Verity that it is gone
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['automountlocation_show'](self.locname)
 
     def test_z_import_roundtrip(self):
@@ -570,7 +572,7 @@ class test_automount_indirect_no_parent(AutomountTest):
         assert not res['failed']
 
         # Verify that it is gone
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['automountkey_show'](self.locname, self.parentmap, **delkey_kw)
 
     def test_4_automountmap_del(self):
@@ -582,7 +584,7 @@ class test_automount_indirect_no_parent(AutomountTest):
         assert not res['failed']
 
         # Verify that it is gone
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['automountmap_show'](self.locname, self.mapname)
 
     def test_5_automountlocation_del(self):
@@ -594,5 +596,5 @@ class test_automount_indirect_no_parent(AutomountTest):
         assert not res['failed']
 
         # Verity that it is gone
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['automountlocation_show'](self.locname)

--- a/ipatests/test_xmlrpc/test_certmap_plugin.py
+++ b/ipatests/test_xmlrpc/test_certmap_plugin.py
@@ -3,7 +3,6 @@
 #
 
 import itertools
-from nose.tools import assert_raises
 import pytest
 
 from ipalib import api, errors
@@ -259,7 +258,7 @@ class EWE(object):
         self.change_principal_cm.__enter__()  # pylint: disable=no-member
 
         if self.exception:
-            self.assert_raises_cm = assert_raises(self.exception)
+            self.assert_raises_cm = pytest.raises(self.exception)
             self.assert_raises_cm.__enter__()
 
         return self

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -20,7 +20,8 @@
 Test the `ipaserver/plugins/dns.py` module.
 """
 
-import nose
+import unittest
+
 from ipalib import api, errors
 from ipalib.util import normalize_zone
 from ipapython.dnsutil import DNSName
@@ -433,10 +434,13 @@ class test_dns(Declarative):
             api.Backend.rpcclient.connect()
 
         if not have_ldap2:
-            raise nose.SkipTest('server plugin not available')
+            raise unittest.SkipTest('server plugin not available')
 
         if get_nameservers_error is not None:
-            raise nose.SkipTest('unable to get list of nameservers (%s)' % get_nameservers_error)
+            raise unittest.SkipTest(
+                'unable to get list of nameservers (%s)' %
+                get_nameservers_error
+            )
 
         try:
            api.Command['dnszone_add'](zone1,
@@ -444,7 +448,7 @@ class test_dns(Declarative):
            )
            api.Command['dnszone_del'](zone1)
         except errors.NotFound:
-            raise nose.SkipTest('DNS is not configured')
+            raise unittest.SkipTest('DNS is not configured')
         except errors.DuplicateEntry:
             pass
 
@@ -3209,16 +3213,19 @@ class test_root_zone(Declarative):
             api.Backend.rpcclient.connect()
 
         if not have_ldap2:
-            raise nose.SkipTest('server plugin not available')
+            raise unittest.SkipTest('server plugin not available')
 
         if get_nameservers_error is not None:
-            raise nose.SkipTest('unable to get list of nameservers (%s)' % get_nameservers_error)
+            raise unittest.SkipTest(
+                'unable to get list of nameservers (%s)' %
+                get_nameservers_error
+            )
 
         try:
             api.Command['dnszone_add'](zone1, idnssoarname=zone1_rname,)
             api.Command['dnszone_del'](zone1)
         except errors.NotFound:
-            raise nose.SkipTest('DNS is not configured')
+            raise unittest.SkipTest('DNS is not configured')
         except errors.DuplicateEntry:
             pass
 
@@ -3292,13 +3299,13 @@ class test_forward_zones(Declarative):
             api.Backend.rpcclient.connect()
 
         if not have_ldap2:
-            raise nose.SkipTest('server plugin not available')
+            raise unittest.SkipTest('server plugin not available')
 
         try:
             api.Command['dnszone_add'](zone1, idnssoarname=zone1_rname,)
             api.Command['dnszone_del'](zone1)
         except errors.NotFound:
-            raise nose.SkipTest('DNS is not configured')
+            raise unittest.SkipTest('DNS is not configured')
         except errors.DuplicateEntry:
             pass
 
@@ -4501,13 +4508,13 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
             api.Backend.rpcclient.connect()
 
         if not have_ldap2:
-            raise nose.SkipTest('server plugin not available')
+            raise unittest.SkipTest('server plugin not available')
 
         try:
             api.Command['dnszone_add'](zone1, idnssoarname=zone1_rname,)
             api.Command['dnszone_del'](zone1)
         except errors.NotFound:
-            raise nose.SkipTest('DNS is not configured')
+            raise unittest.SkipTest('DNS is not configured')
         except errors.DuplicateEntry:
             pass
 
@@ -4876,13 +4883,13 @@ class test_forwardzone_delegation_warnings(Declarative):
             api.Backend.rpcclient.connect()
 
         if not have_ldap2:
-            raise nose.SkipTest('server plugin not available')
+            raise unittest.SkipTest('server plugin not available')
 
         try:
             api.Command['dnszone_add'](zone1, idnssoarname=zone1_rname,)
             api.Command['dnszone_del'](zone1)
         except errors.NotFound:
-            raise nose.SkipTest('DNS is not configured')
+            raise unittest.SkipTest('DNS is not configured')
         except errors.DuplicateEntry:
             pass
 
@@ -5387,17 +5394,17 @@ class test_dns_soa(Declarative):
             api.Backend.rpcclient.connect()
 
         if not have_ldap2:
-            raise nose.SkipTest('server plugin not available')
+            raise unittest.SkipTest('server plugin not available')
 
         if get_nameservers_error is not None:
-            raise nose.SkipTest('unable to get list of nameservers (%s)' %
+            raise unittest.SkipTest('unable to get list of nameservers (%s)' %
                                 get_nameservers_error)
         try:
             api.Command['dnszone_add'](zone1,
                                        idnssoarname=zone1_rname,)
             api.Command['dnszone_del'](zone1)
         except errors.NotFound:
-            raise nose.SkipTest('DNS is not configured')
+            raise unittest.SkipTest('DNS is not configured')
         except errors.DuplicateEntry:
             pass
 

--- a/ipatests/test_xmlrpc/test_external_members.py
+++ b/ipatests/test_xmlrpc/test_external_members.py
@@ -21,7 +21,8 @@ Test adding/removing external members (trusted domain objects) to IPA groups.
 These tests are skipped if trust is not established.
 """
 
-import nose
+import unittest
+
 from ipalib import api
 from ipapython.dn import DN
 from ipatests.test_xmlrpc import objectclasses
@@ -53,7 +54,7 @@ class test_external_members(Declarative):
 
         trusts = api.Command['trust_find']()
         if trusts['count'] == 0:
-            raise nose.SkipTest('Trust is not established')
+            raise unittest.SkipTest('Trust is not established')
 
     cleanup_commands = [
         ('group_del', [group_name], {}),

--- a/ipatests/test_xmlrpc/test_hbactest_plugin.py
+++ b/ipatests/test_xmlrpc/test_hbactest_plugin.py
@@ -24,7 +24,6 @@ Test the `ipaserver/plugins/hbactest.py` module.
 from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test
 from ipalib import api
 from ipalib import errors
-from nose.tools import raises
 import pytest
 
 # Test strategy:
@@ -187,19 +186,19 @@ class test_hbactest(XMLRPC_test):
         for rule in self.rule_names:
             assert u'%s_1x1' % (rule) in ret['error']
 
-    @raises(errors.ValidationError)
     def test_f_hbactest_check_sourcehost_option_is_deprecated(self):
         """
         Test running 'ipa hbactest' with --srchost option raises ValidationError
         """
-        api.Command['hbactest'](
-            user=self.test_user,
-            targethost=self.test_host,
-            sourcehost=self.test_sourcehost,
-            service=self.test_service,
-            rules=[u'%s_1x1' % rule for rule in self.rule_names],
-            nodetail=True
-        )
+        with pytest.raises(errors.ValidationError):
+            api.Command['hbactest'](
+                user=self.test_user,
+                targethost=self.test_host,
+                sourcehost=self.test_sourcehost,
+                service=self.test_service,
+                rules=[u'%s_1x1' % rule for rule in self.rule_names],
+                nodetail=True
+            )
 
     def test_g_hbactest_clear_testing_data(self):
         """

--- a/ipatests/test_xmlrpc/test_netgroup_plugin.py
+++ b/ipatests/test_xmlrpc/test_netgroup_plugin.py
@@ -1399,7 +1399,9 @@ class test_netgroup(Declarative):
 #            entries = conn.find_entries('cn=%s' % self.ng_cn,
 #                      base_dn='cn=ng,cn=compat,%s' % api.env.basedn)
 #        except errors.NotFound:
-#            raise nose.SkipTest('compat and nis are not enabled, skipping test')
+#            raise unittest.SkipTest(
+#                'compat and nis are not enabled, skipping test'
+#            )
 #        finally:
 #            conn.disconnect()
 #        triples = entries[0][0]['nisnetgrouptriple']

--- a/ipatests/test_xmlrpc/test_passwd_plugin.py
+++ b/ipatests/test_xmlrpc/test_passwd_plugin.py
@@ -19,13 +19,11 @@
 """
 Test the `ipaserver/plugins/passwd.py` module.
 """
-
-from nose.tools import assert_raises  # pylint: disable=E0611
+import pytest
 
 from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test, assert_attr_equal
 from ipalib import api
 from ipalib import errors
-import pytest
 
 
 @pytest.mark.tier1
@@ -65,5 +63,5 @@ class test_passwd(XMLRPC_test):
         api.Command['user_del'](self.uid)
 
         # Verify that it is gone
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['user_show'](self.uid)

--- a/ipatests/test_xmlrpc/test_permission_plugin.py
+++ b/ipatests/test_xmlrpc/test_permission_plugin.py
@@ -24,8 +24,7 @@ Test the `ipaserver/plugins/permission.py` module.
 from __future__ import print_function
 
 import os
-
-import nose
+import unittest
 
 from ipalib import api, errors
 from ipatests.test_xmlrpc import objectclasses
@@ -3448,7 +3447,7 @@ class test_managed_permissions(Declarative):
         super(test_managed_permissions, cls).setup_class()
 
         if not have_ldap2:
-            raise nose.SkipTest('server plugin not available')
+            raise unittest.SkipTest('server plugin not available')
 
     def add_managed_permission(self):
         """Add a managed permission and the corresponding ACI"""

--- a/ipatests/test_xmlrpc/test_pwpolicy_plugin.py
+++ b/ipatests/test_xmlrpc/test_pwpolicy_plugin.py
@@ -21,7 +21,7 @@
 Test the `ipaserver/plugins/pwpolicy.py` module.
 """
 
-from nose.tools import assert_raises  # pylint: disable=E0611
+import pytest
 
 from ipalib import api
 from ipalib import errors
@@ -29,7 +29,6 @@ from ipapython.dn import DN
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.test_xmlrpc.xmlrpc_test import (XMLRPC_test, assert_attr_equal,
                                               Declarative)
-import pytest
 
 
 @pytest.mark.tier1
@@ -213,7 +212,7 @@ class test_pwpolicy(XMLRPC_test):
     def test_d_pwpolicy_show(self):
         """Test that deleting a group removes its pwpolicy"""
         api.Command['group_del'](self.group3)
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['pwpolicy_show'](self.group3)
 
     def test_e_pwpolicy_del(self):

--- a/ipatests/test_xmlrpc/test_sudorule_plugin.py
+++ b/ipatests/test_xmlrpc/test_sudorule_plugin.py
@@ -21,13 +21,12 @@
 Test the `ipaserver/plugins/sudorule.py` module.
 """
 
-from nose.tools import raises, assert_raises  # pylint: disable=E0611
+import pytest
 import six
 
 from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test, assert_attr_equal
 from ipalib import api
 from ipalib import errors
-import pytest
 
 # pylint: disable=unused-variable
 
@@ -79,14 +78,14 @@ class test_sudorule(XMLRPC_test):
         assert_attr_equal(entry, 'cn', self.rule_name)
         assert_attr_equal(entry, 'description', self.rule_desc)
 
-    @raises(errors.DuplicateEntry)
     def test_1_sudorule_add(self):
         """
         Test adding an duplicate Sudo rule using `xmlrpc.sudorule_add'.
         """
-        api.Command['sudorule_add'](
-            self.rule_name
-        )
+        with pytest.raises(errors.DuplicateEntry):
+            api.Command['sudorule_add'](
+                self.rule_name
+            )
 
     def test_2_sudorule_show(self):
         """
@@ -606,91 +605,107 @@ class test_sudorule(XMLRPC_test):
         assert 'memberdenycmd_sudocmd' not in entry
         assert 'memberdenycmd_sudocmdgroup' not in entry
 
-    @raises(errors.MutuallyExclusiveError)
     def test_c_sudorule_exclusiveuser(self):
         """
         Test adding a user to an Sudo rule when usercat='all'
         """
         api.Command['sudorule_mod'](self.rule_name, usercategory=u'all')
         try:
-            api.Command['sudorule_add_user'](self.rule_name, user=u'admin')
+            with pytest.raises(errors.MutuallyExclusiveError):
+                api.Command['sudorule_add_user'](
+                    self.rule_name, user=u'admin'
+                )
         finally:
             api.Command['sudorule_mod'](self.rule_name, usercategory=u'')
 
-    @raises(errors.MutuallyExclusiveError)
     def test_d_sudorule_exclusiveuser(self):
         """
         Test setting usercat='all' in an Sudo rule when there are users
         """
         api.Command['sudorule_add_user'](self.rule_name, user=u'admin')
         try:
-            api.Command['sudorule_mod'](self.rule_name, usercategory=u'all')
+            with pytest.raises(errors.MutuallyExclusiveError):
+                api.Command['sudorule_mod'](
+                    self.rule_name, usercategory=u'all'
+                )
         finally:
             api.Command['sudorule_remove_user'](self.rule_name, user=u'admin')
 
-    @raises(errors.MutuallyExclusiveError)
     def test_e_sudorule_exclusivehost(self):
         """
         Test adding a host to an Sudo rule when hostcat='all'
         """
         api.Command['sudorule_mod'](self.rule_name, hostcategory=u'all')
         try:
-            api.Command['sudorule_add_host'](self.rule_name, host=self.test_host)
+            with pytest.raises(errors.MutuallyExclusiveError):
+                api.Command['sudorule_add_host'](
+                    self.rule_name, host=self.test_host
+                )
         finally:
             api.Command['sudorule_mod'](self.rule_name, hostcategory=u'')
 
-    @raises(errors.MutuallyExclusiveError)
     def test_f_sudorule_exclusivehost(self):
         """
         Test setting hostcat='all' in an Sudo rule when there are hosts
         """
         api.Command['sudorule_add_host'](self.rule_name, host=self.test_host)
         try:
-            api.Command['sudorule_mod'](self.rule_name, hostcategory=u'all')
+            with pytest.raises(errors.MutuallyExclusiveError):
+                api.Command['sudorule_mod'](
+                    self.rule_name, hostcategory=u'all'
+                )
         finally:
             api.Command['sudorule_remove_host'](self.rule_name, host=self.test_host)
 
-    @raises(errors.MutuallyExclusiveError)
     def test_g_sudorule_exclusivecommand(self):
         """
         Test adding a command to an Sudo rule when cmdcategory='all'
         """
         api.Command['sudorule_mod'](self.rule_name, cmdcategory=u'all')
         try:
-            api.Command['sudorule_add_allow_command'](self.rule_name, sudocmd=self.test_command)
+            with pytest.raises(errors.MutuallyExclusiveError):
+                api.Command['sudorule_add_allow_command'](
+                    self.rule_name, sudocmd=self.test_command
+                )
         finally:
             api.Command['sudorule_mod'](self.rule_name, cmdcategory=u'')
 
-    @raises(errors.MutuallyExclusiveError)
     def test_h_sudorule_exclusivecommand(self):
         """
         Test setting cmdcategory='all' in an Sudo rule when there are commands
         """
         api.Command['sudorule_add_allow_command'](self.rule_name, sudocmd=self.test_command)
         try:
-            api.Command['sudorule_mod'](self.rule_name, cmdcategory=u'all')
+            with pytest.raises(errors.MutuallyExclusiveError):
+                api.Command['sudorule_mod'](
+                    self.rule_name, cmdcategory=u'all'
+                )
         finally:
             api.Command['sudorule_remove_allow_command'](self.rule_name, sudocmd=self.test_command)
 
-    @raises(errors.MutuallyExclusiveError)
     def test_i_sudorule_exclusiverunas(self):
         """
         Test adding a runasuser to an Sudo rule when ipasudorunasusercategory='all'
         """
         api.Command['sudorule_mod'](self.rule_name, ipasudorunasusercategory=u'all')
         try:
-            api.Command['sudorule_add_runasuser'](self.rule_name, user=self.test_user)
+            with pytest.raises(errors.MutuallyExclusiveError):
+                api.Command['sudorule_add_runasuser'](
+                    self.rule_name, user=self.test_user
+                )
         finally:
             api.Command['sudorule_mod'](self.rule_name, ipasudorunasusercategory=u'')
 
-    @raises(errors.MutuallyExclusiveError)
     def test_j_1_sudorule_exclusiverunas(self):
         """
         Test setting ipasudorunasusercategory='all' in an Sudo rule when there are runas users
         """
         api.Command['sudorule_add_runasuser'](self.rule_name, user=self.test_user)
         try:
-            api.Command['sudorule_mod'](self.rule_name, ipasudorunasusercategory=u'all')
+            with pytest.raises(errors.MutuallyExclusiveError):
+                api.Command['sudorule_mod'](
+                    self.rule_name, ipasudorunasusercategory=u'all'
+                )
         finally:
             api.Command['sudorule_remove_runasuser'](self.rule_name, user=self.test_command)
 
@@ -766,17 +781,17 @@ class test_sudorule(XMLRPC_test):
         api.Command['sudorule_del'](self.rule_name2)
 
         # add a new rule with a duplicate order
-        with assert_raises(errors.ValidationError):
+        with pytest.raises(errors.ValidationError):
             api.Command['sudorule_add'](self.rule_name2, sudoorder=1)
 
         # add a new rule with a unique order
         api.Command['sudorule_add'](self.rule_name2, sudoorder=2)
-        with assert_raises(errors.ValidationError):
+        with pytest.raises(errors.ValidationError):
             api.Command['sudorule_mod'](self.rule_name2, sudoorder=1)
 
         # Try setting both to 0
         api.Command['sudorule_mod'](self.rule_name2, sudoorder=0)
-        with assert_raises(errors.ValidationError):
+        with pytest.raises(errors.ValidationError):
             api.Command['sudorule_mod'](self.rule_name, sudoorder=0)
 
         # Try unsetting sudoorder from both rules
@@ -803,6 +818,6 @@ class test_sudorule(XMLRPC_test):
         """
         api.Command['sudorule_del'](self.rule_name)
         # verify that it's gone
-        with assert_raises(errors.NotFound):
+        with pytest.raises(errors.NotFound):
             api.Command['sudorule_show'](self.rule_name)
         api.Command['sudorule_del'](self.rule_name2)

--- a/ipatests/test_xmlrpc/test_trust_plugin.py
+++ b/ipatests/test_xmlrpc/test_trust_plugin.py
@@ -20,7 +20,8 @@
 Test the `ipaserver/plugins/trust.py` module.
 """
 
-import nose
+import unittest
+
 import six
 
 from ipalib import api, errors
@@ -55,7 +56,7 @@ class test_trustconfig(Declarative):
         try:
            api.Command['trustconfig_show'](trust_type=u'ad')
         except errors.NotFound:
-            raise nose.SkipTest('Trusts are not configured')
+            raise unittest.SkipTest('Trusts are not configured')
 
     cleanup_commands = [
         ('group_del', [testgroup], {}),

--- a/ipatests/test_xmlrpc/test_vault_plugin.py
+++ b/ipatests/test_xmlrpc/test_vault_plugin.py
@@ -21,7 +21,8 @@
 Test the `ipaserver/plugins/vault.py` module.
 """
 
-import nose
+import unittest
+
 import pytest
 import six
 
@@ -140,7 +141,7 @@ class test_vault_plugin(Declarative):
             api.Backend.rpcclient.connect()
 
         if not api.Command.kra_is_enabled()['result']:
-            raise nose.SkipTest('KRA service is not enabled')
+            raise unittest.SkipTest('KRA service is not enabled')
 
         super(test_vault_plugin, cls).setup_class()
 

--- a/ipatests/test_xmlrpc/tracker/certmapdata.py
+++ b/ipatests/test_xmlrpc/tracker/certmapdata.py
@@ -5,7 +5,7 @@ import base64
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
-from nose.tools import assert_raises
+import pytest
 
 from ipalib.errors import MutuallyExclusiveError, RequirementError
 from ipapython.dn import DN
@@ -84,7 +84,7 @@ class CertmapdataMixin(object):
         try:
             expected_certmapdata = self._data_from_options(**kwargs)
         except Exception as e:
-            with assert_raises(type(e)):
+            with pytest.raises(type(e)):
                 cmd(**kwargs)
         else:
             result = cmd(**kwargs)
@@ -112,7 +112,7 @@ class CertmapdataMixin(object):
         try:
             expected_certmapdata = self._data_from_options(**kwargs)
         except Exception as e:
-            with assert_raises(type(e)):
+            with pytest.raises(type(e)):
                 cmd(**kwargs)
         else:
             result = cmd(**kwargs)

--- a/ipatests/test_xmlrpc/xmlrpc_test.py
+++ b/ipatests/test_xmlrpc/xmlrpc_test.py
@@ -25,8 +25,8 @@ from __future__ import print_function
 import collections
 import datetime
 import inspect
+import unittest
 
-import nose
 import contextlib
 import six
 
@@ -204,7 +204,7 @@ class XMLRPC_test(object):
     @classmethod
     def setup_class(cls):
         if not server_available:
-            raise nose.SkipTest('%r: Server not available: %r' %
+            raise unittest.SkipTest('%r: Server not available: %r' %
                                 (cls.__module__, api.env.xmlrpc_uri))
         if not api.Backend.rpcclient.isconnected():
             api.Backend.rpcclient.connect()
@@ -316,7 +316,7 @@ class Declarative(XMLRPC_test):
         (cmd, args, options) = command
         print('Cleanup:', cmd, args, options)
         if cmd not in api.Command:
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 'cleanup command %r not in api.Command' % cmd
             )
         try:
@@ -338,7 +338,7 @@ class Declarative(XMLRPC_test):
         (cmd, args, options) = command
         options.setdefault('version', self.default_version)
         if cmd not in api.Command:
-            raise nose.SkipTest('%r not in api.Command' % cmd)
+            raise unittest.SkipTest('%r not in api.Command' % cmd)
         if isinstance(expected, errors.PublicError):
             self.check_exception(nice, cmd, args, options, expected)
         elif hasattr(expected, '__call__'):


### PR DESCRIPTION
* Replace raise nose.SkipTest with raise unittest.SkipTest
* Replace nose.tools.assert_equal(a, b) with assert a == b
* Replace nose.tools.raises with pytest.raises
* Convert raises decorator to pytest.raises() but just for relevant lines
* Remove nose dependency

I left the nose_compat pytest plugin in place. It can be removed in
another request in case it is no longer used.

https://pagure.io/freeipa/issue/7301

Signed-off-by: Christian Heimes <cheimes@redhat.com>