### PR TITLE
Re-enable some KRA installation tests

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -167,7 +167,6 @@ class TestInstallWithCA_KRA1(InstallTestBase1):
         tasks.install_kra(self.replicas[0], first_instance=False)
 
 
-@pytest.mark.xfail(reason="FreeIPA ticket 7220")
 class TestInstallWithCA_KRA2(InstallTestBase2):
 
     @classmethod
@@ -234,7 +233,6 @@ class TestInstallWithCA_KRA_DNS1(InstallTestBase1):
         tasks.install_kra(self.replicas[0], first_instance=False)
 
 
-@pytest.mark.xfail(reason="FreeIPA ticket 7220")
 class TestInstallWithCA_KRA_DNS2(InstallTestBase2):
 
     @classmethod


### PR DESCRIPTION
Some KRA installation tests were disabled due to failures caused by
security domain session replication lag.  This problem has been
addressed in Dogtag by introducing a default 5 second sleep after
security domain login, to give more time for session data to be
replicated to other hosts.  There is still a possibility for this
kind of failure, but the delay minimises it.

FreeIPA depends on the version of Dogtag that contains this change,
so remove the failing-test annotations.

Fixes: https://pagure.io/freeipa/issue/7220