### PR TITLE
[Backport][ipa-4-6] Use correct version of Python in RPM scripts

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -25,6 +25,12 @@
 %endif
 %endif
 
+%if 0%{?with_python3}
+%global python %{__python3}
+%else
+%global python %{__python2}
+%endif
+
 # lint is not executed during rpmbuild
 # %%global with_lint 1
 %if 0%{?with_lint}
@@ -1131,7 +1137,7 @@ fi
 
 %posttrans server
 # don't execute upgrade and restart of IPA when server is not installed
-python2 -c "import sys; from ipaserver.install import installutils; sys.exit(0 if installutils.is_ipa_configured() else 1);" > /dev/null 2>&1
+%{python} -c "import sys; from ipaserver.install import installutils; sys.exit(0 if installutils.is_ipa_configured() else 1);" > /dev/null 2>&1
 
 if [  $? -eq 0 ]; then
     # This is necessary for Fedora system upgrades which by default
@@ -1200,7 +1206,7 @@ fi
 
 
 %posttrans server-trust-ad
-python2 -c "import sys; from ipaserver.install import installutils; sys.exit(0 if installutils.is_ipa_configured() else 1);" > /dev/null 2>&1
+%{python} -c "import sys; from ipaserver.install import installutils; sys.exit(0 if installutils.is_ipa_configured() else 1);" > /dev/null 2>&1
 if [  $? -eq 0 ]; then
 # NOTE: systemd specific section
     /bin/systemctl try-restart httpd.service >/dev/null 2>&1 || :
@@ -1251,7 +1257,7 @@ if [ $1 -gt 1 ] ; then
     fi
 
     if [ $restore -ge 2 ]; then
-        python2 -c 'from ipaclient.install.client import update_ipa_nssdb; update_ipa_nssdb()' >/var/log/ipaupgrade.log 2>&1
+        %{python} -c 'from ipaclient.install.client import update_ipa_nssdb; update_ipa_nssdb()' >/var/log/ipaupgrade.log 2>&1
     fi
 fi
 


### PR DESCRIPTION
This PR was opened automatically because PR #1357 was pushed to master and backport to ipa-4-6 is required.