### PR TITLE
[Backport][ipa-4-6] Re-enable some KRA installation tests

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -167,7 +167,6 @@ class TestInstallWithCA_KRA1(InstallTestBase1):
         tasks.install_kra(self.replicas[0], first_instance=False)
 
 
-@pytest.mark.xfail(reason="FreeIPA ticket 7220")
 class TestInstallWithCA_KRA2(InstallTestBase2):
 
     @classmethod
@@ -234,7 +233,6 @@ class TestInstallWithCA_KRA_DNS1(InstallTestBase1):
         tasks.install_kra(self.replicas[0], first_instance=False)
 
 
-@pytest.mark.xfail(reason="FreeIPA ticket 7220")
 class TestInstallWithCA_KRA_DNS2(InstallTestBase2):
 
     @classmethod


### PR DESCRIPTION
This PR was opened automatically because PR #1366 was pushed to master and backport to ipa-4-6 is required.