### PR TITLE
[Backport][ipa-4-6] Update to python-ldap 3.0.0

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -43,6 +43,7 @@
 %global samba_version 4.7.0
 %global selinux_policy_version 3.12.1-153
 %global slapi_nis_version 0.56.0-4
+%global python_ldap_version 2.4.15
 %else
 # 1.15.1-7: certauth (http://krbdev.mit.edu/rt/Ticket/Display.html?id=8561)
 %global krb5_version 1.15.1-7
@@ -52,7 +53,9 @@
 %global samba_version 2:4.7.0
 %global selinux_policy_version 3.13.1-158.4
 %global slapi_nis_version 0.56.1
+%global python_ldap_version 3.0.0
 %endif
+
 
 %define krb5_base_version %(LC_ALL=C rpm -q --qf '%%{VERSION}' krb5-devel | grep -Eo '^[^.]+\.[^.]+')
 
@@ -139,7 +142,7 @@ BuildRequires:  python-lesscpy
 # Build dependencies for makeapi/makeaci
 # makeapi/makeaci is using Python 2 only for now
 #
-BuildRequires:  python-ldap
+BuildRequires:  python2-ldap >= %{python_ldap_version}
 BuildRequires:  python2-netaddr
 BuildRequires:  python2-pyasn1
 BuildRequires:  python2-pyasn1-modules
@@ -248,7 +251,7 @@ BuildRequires:  python3-augeas
 BuildRequires:  python3-netaddr
 BuildRequires:  python3-pyasn1
 BuildRequires:  python3-pyasn1-modules
-BuildRequires:  python3-pyldap
+BuildRequires:  python3-ldap >= %{python_ldap_version}
 %endif # with_python3
 %endif # with_lint
 
@@ -279,10 +282,10 @@ Requires: %{name}-client = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 %if 0%{?with_python3}
 Requires: python3-ipaserver = %{version}-%{release}
-Requires: python3-pyldap >= 2.4.15
+Requires: python3-ldap >= %{python_ldap_version}
 %else
 Requires: python2-ipaserver = %{version}-%{release}
-Requires: python-ldap >= 2.4.15
+Requires: python2-ldap >= %{python_ldap_version}
 %endif
 # 1.3.7.6-1: https://bugzilla.redhat.com/show_bug.cgi?id=1488295
 Requires: 389-ds-base >= 1.3.7.6-1
@@ -381,7 +384,7 @@ Requires: %{name}-server-common = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 Requires: python2-ipaclient = %{version}-%{release}
 Requires: python2-custodia >= 0.3.1
-Requires: python-ldap >= 2.4.15
+Requires: python2-ldap >= %{python_ldap_version}
 Requires: python2-lxml
 Requires: python2-gssapi >= 1.2.0-5
 Requires: python2-sssdconfig
@@ -414,7 +417,7 @@ Requires: %{name}-common = %{version}-%{release}
 Requires: python3-ipaclient = %{version}-%{release}
 Requires: python3-custodia >= 0.3.1
 # we need pre-requires since earlier versions may break upgrade
-Requires(pre): python3-pyldap >= 2.4.35.1-2
+Requires(pre): python3-ldap >= %{python_ldap_version}
 Requires: python3-lxml
 Requires: python3-gssapi >= 1.2.0
 Requires: python3-sssdconfig
@@ -537,11 +540,11 @@ Requires: %{name}-common = %{version}-%{release}
 %if 0%{?with_python3}
 Requires: python3-gssapi >= 1.2.0-5
 Requires: python3-ipaclient = %{version}-%{release}
-Requires: python3-pyldap
+Requires: python3-ldap >= %{python_ldap_version}
 %else
 Requires: python2-gssapi >= 1.2.0-5
 Requires: python2-ipaclient = %{version}-%{release}
-Requires: python-ldap
+Requires: python2-ldap >= %{python_ldap_version}
 %endif
 Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: ntp
@@ -718,7 +721,7 @@ Requires: python2-six
 # 0.4.2: Py3 fix https://bugzilla.redhat.com/show_bug.cgi?id=1476150
 Requires: python2-jwcrypto >= 0.4.2
 Requires: python2-cffi
-Requires: python-ldap >= 2.4.15
+Requires: python2-ldap >= %{python_ldap_version}
 Requires: python2-requests
 Requires: python2-dns >= 1.15
 Requires: python2-enum34
@@ -769,7 +772,7 @@ Requires: python3-six
 Requires: python3-jwcrypto >= 0.4.2
 Requires: python3-cffi
 # we need pre-requires since earlier versions may break upgrade
-Requires(pre): python3-pyldap >= 2.4.35.1-2
+Requires(pre): python3-ldap >= %{python_ldap_version}
 Requires: python3-requests
 Requires: python3-dns >= 1.15
 Requires: python3-netifaces >= 0.10.4

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -29,6 +29,7 @@ import contextlib
 import collections
 import os
 import pwd
+import warnings
 
 # pylint: disable=import-error
 from six.moves.urllib.parse import urlparse
@@ -74,6 +75,20 @@ TRUNCATED_TIME_LIMIT = object()
 TRUNCATED_ADMIN_LIMIT = object()
 
 DIRMAN_DN = DN(('cn', 'directory manager'))
+
+
+if six.PY2:
+    # XXX silence python-ldap's BytesWarnings
+    warnings.filterwarnings(
+        action="ignore",
+        message="Under Python 2, python-ldap uses bytes",
+        category=BytesWarning
+    )
+    warnings.filterwarnings(
+        action="ignore",
+        message="Received non-bytes value",
+        category=BytesWarning
+    )
 
 
 class _ServerSchema(object):

--- a/ipapython/setup.py
+++ b/ipapython/setup.py
@@ -45,11 +45,11 @@ if __name__ == '__main__':
             "ipaplatform",
             "netaddr",
             "netifaces",
+            "python-ldap",
             "six",
         ],
         extras_require={
-            ":python_version<'3'": ["enum34", "python-ldap"],
-            ":python_version>='3'": ["pyldap"],
+            ":python_version<'3'": ["enum34"],
             "install": ["dbus-python"],  # for certmonger
         },
     )

--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -185,17 +185,13 @@ def assess_dcerpc_error(error):
 
 
 class ExtendedDNControl(LDAPControl):
-    # This class attempts to implement LDAP control that would work
-    # with both python-ldap 2.4.x and 2.3.x, thus there is mix of properties
-    # from both worlds and encodeControlValue has default parameter
     def __init__(self):
-        self.controlValue = 1
-        self.controlType = "1.2.840.113556.1.4.529"
-        self.criticality = False
-        self.integerValue = 1
-
-    def encodeControlValue(self, value=None):
-        return b'0\x03\x02\x01\x01'
+        LDAPControl.__init__(
+            self,
+            controlType="1.2.840.113556.1.4.529",
+            criticality=False,
+            encodedControlValue=b'0\x03\x02\x01\x01'
+        )
 
 
 class DomainValidator(object):

--- a/ipaserver/dnssec/syncrepl.py
+++ b/ipaserver/dnssec/syncrepl.py
@@ -9,9 +9,7 @@ to a local dict.
 
 import logging
 
-# Import the python-ldap modules
 import ldap
-# Import specific classes from python-ldap
 from ldap.cidict import cidict
 from ldap.ldapobject import ReconnectLDAPObject
 from ldap.syncrepl import SyncreplConsumer

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -38,20 +38,7 @@ from ipapython.dn import DN
 from ipapython.ipaldap import (LDAPClient, AUTOBIND_AUTO, AUTOBIND_ENABLED,
                                AUTOBIND_DISABLED)
 
-
-try:
-    from ldap.controls.simple import GetEffectiveRightsControl
-except ImportError:
-    """
-    python-ldap 2.4.x introduced a new API for effective rights control, which
-    needs to be used or otherwise bind dn is not passed correctly. The following
-    class is created for backward compatibility with python-ldap 2.3.x.
-    Relevant BZ: https://bugzilla.redhat.com/show_bug.cgi?id=802675
-    """
-    from ldap.controls import LDAPControl
-    class GetEffectiveRightsControl(LDAPControl):
-        def __init__(self, criticality, authzId=None):
-            LDAPControl.__init__(self, '1.3.6.1.4.1.42.2.27.9.5.2', criticality, authzId)
+from ldap.controls.simple import GetEffectiveRightsControl
 
 from ipalib import Registry, errors, _
 from ipalib.crud import CrudBackend

--- a/ipaserver/setup.py
+++ b/ipaserver/setup.py
@@ -62,6 +62,7 @@ if __name__ == '__main__':
             "requests",
             "six",
             "python-augeas",
+            "python-ldap",
         ],
         entry_points={
             'custodia.authorizers': [
@@ -72,8 +73,6 @@ if __name__ == '__main__':
             ],
         },
         extras_require={
-            ":python_version<'3'": ["python-ldap"],
-            ":python_version>='3'": ["pyldap"],
             # These packages are currently not available on PyPI.
             "dcerpc": ["samba", "pysss", "pysss_nss_idmap"],
             "hbactest": ["pyhbac"],

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -81,7 +81,7 @@ PACKAGE_VERSION = {
     'jwcrypto': 'jwcrpyto >= 0.4.2',
     'kdcproxy': 'kdcproxy >= 0.3',
     'netifaces': 'netifaces >= 0.10.4',
-    'pyldap': 'pyldap >= 2.4.15',
+    'python-ldap': 'python-ldap >= 3.0.0b1',  # install --pre
     'python-yubico': 'python-yubico >= 1.2.3',
     'qrcode': 'qrcode >= 5.0',
 }

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -71,11 +71,10 @@ if __name__ == '__main__':
             "polib",
             "pytest",
             "pytest_multihost",
+            "python-ldap",
             "six",
         ],
         extras_require={
-            ":python_version<'3'": ["python-ldap"],
-            ":python_version>='3'": ["pyldap"],
             "integration": ["dbus-python", "pyyaml", "ipaserver"],
             "ipaserver": ["ipaserver"],
             "webui": ["selenium", "pyyaml", "ipaserver"],


### PR DESCRIPTION
Manual backport of PR #1356 

Replace python3-pyldap with python3-ldap.

Remove some old code for compatibility with very old python-ldap.

Signed-off-by: Christian Heimes <cheimes@redhat.com>