### PR TITLE
[Backport][ipa-4-6] NSSDB: use preferred convert command

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1612,9 +1612,14 @@ fi
 %ghost %attr(0644,root,apache) %config(noreplace) %{_sysconfdir}/ipa/default.conf
 %ghost %attr(0644,root,apache) %config(noreplace) %{_sysconfdir}/ipa/ca.crt
 %dir %attr(0755,root,root) %{_sysconfdir}/ipa/nssdb
+# old dbm format
 %ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/cert8.db
 %ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/key3.db
 %ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/secmod.db
+# new sql format
+%ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/cert9.db
+%ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/key4.db
+%ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/pkcs11.txt
 %ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/pwdfile.txt
 %ghost %config(noreplace) %{_sysconfdir}/pki/ca-trust/source/ipa.p11-kit
 %dir %{_localstatedir}/lib/ipa-client

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2304,9 +2304,6 @@ def create_ipa_nssdb():
     db = certdb.NSSDatabase(paths.IPA_NSSDB_DIR)
     db.create_db(mode=0o755, backup=True)
     os.chmod(db.pwd_file, 0o600)
-    os.chmod(os.path.join(db.secdir, 'cert8.db'), 0o644)
-    os.chmod(os.path.join(db.secdir, 'key3.db'), 0o644)
-    os.chmod(os.path.join(db.secdir, 'secmod.db'), 0o644)
 
 
 def update_ipa_nssdb():
@@ -3067,11 +3064,8 @@ def uninstall(options):
             logger.error("%s failed to stop tracking certificate: %s",
                          cmonger.service_name, e)
 
-    for filename in (os.path.join(ipa_db.secdir, 'cert8.db'),
-                     os.path.join(ipa_db.secdir, 'key3.db'),
-                     os.path.join(ipa_db.secdir, 'secmod.db'),
-                     os.path.join(ipa_db.secdir, 'pwdfile.txt')):
-        remove_file(filename)
+    for filename in certdb.NSS_FILES:
+        remove_file(os.path.join(ipa_db.secdir, filename))
 
     # Remove any special principal names we added to the IPA CA helper
     certmonger.remove_principal_from_cas()

--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -37,6 +37,7 @@ class BaseConstantsNamespace(object):
         'httpd_dbus_sssd': 'on',
     }
     SSSD_USER = "sssd"
-
+    # sql (new format), dbm (old format)
+    NSS_DEFAULT_DBTYPE = 'dbm'
 
 constants = BaseConstantsNamespace()

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -25,20 +25,13 @@ import time
 import pwd
 
 import six
-# pylint: disable=import-error
-if six.PY3:
-    # The SafeConfigParser class has been renamed to ConfigParser in Py3
-    from configparser import ConfigParser as SafeConfigParser
-else:
-    from ConfigParser import SafeConfigParser
-# pylint: enable=import-error
 
 from ipaplatform.paths import paths
 from ipaplatform import services
 from ipalib import api, errors
 from ipapython import version
 from ipapython.ipautil import run, write_tmp_file
-from ipapython import admintool
+from ipapython import admintool, certdb
 from ipapython.dn import DN
 from ipaserver.install.replication import wait_for_task
 from ipaserver.install import installutils
@@ -46,7 +39,13 @@ from ipapython import ipaldap
 from ipaplatform.constants import constants
 from ipaplatform.tasks import tasks
 
-
+# pylint: disable=import-error
+if six.PY3:
+    # The SafeConfigParser class has been renamed to ConfigParser in Py3
+    from configparser import ConfigParser as SafeConfigParser
+else:
+    from ConfigParser import SafeConfigParser
+# pylint: enable=import-error
 ISO8601_DATETIME_FMT = '%Y-%m-%dT%H:%M:%S'
 
 logger = logging.getLogger(__name__)
@@ -194,7 +193,7 @@ class Backup(admintool.AdminTool):
         paths.HOSTS,
     ) + tuple(
         os.path.join(paths.IPA_NSSDB_DIR, file)
-        for file in ('cert8.db', 'key3.db', 'secmod.db')
+        for file in (certdb.NSS_DBM_FILES + certdb.NSS_SQL_FILES)
     )
 
     logs=(

--- a/ipaserver/install/ipa_replica_prepare.py
+++ b/ipaserver/install/ipa_replica_prepare.py
@@ -32,6 +32,20 @@ from optparse import OptionGroup, SUPPRESS_HELP
 
 import dns.resolver
 import six
+
+from ipaserver.install import certs, installutils, bindinstance, dsinstance, ca
+from ipaserver.install.replication import enable_replication_version_checking
+from ipaserver.install.server.replicainstall import install_ca_cert
+from ipaserver.install.bindinstance import (
+    add_zone, add_fwd_rr, add_ptr_rr, dns_container_exists)
+from ipapython import ipautil, admintool, certdb
+from ipapython.dn import DN
+from ipapython import version
+from ipalib import api
+from ipalib import errors
+from ipaplatform.paths import paths
+from ipalib.constants import DOMAIN_LEVEL_0
+
 # pylint: disable=import-error
 if six.PY3:
     # The SafeConfigParser class has been renamed to ConfigParser in Py3
@@ -40,18 +54,6 @@ else:
     from ConfigParser import SafeConfigParser
 # pylint: enable=import-error
 
-from ipaserver.install import certs, installutils, bindinstance, dsinstance, ca
-from ipaserver.install.replication import enable_replication_version_checking
-from ipaserver.install.server.replicainstall import install_ca_cert
-from ipaserver.install.bindinstance import (
-    add_zone, add_fwd_rr, add_ptr_rr, dns_container_exists)
-from ipapython import ipautil, admintool
-from ipapython.dn import DN
-from ipapython import version
-from ipalib import api
-from ipalib import errors
-from ipaplatform.paths import paths
-from ipalib.constants import DOMAIN_LEVEL_0
 
 logger = logging.getLogger(__name__)
 
@@ -565,9 +567,8 @@ class ReplicaPrepare(admintool.AdminTool):
                 installutils.remove_file(pkcs12_fname)
                 installutils.remove_file(passwd_fname)
 
-            self.remove_info_file("cert8.db")
-            self.remove_info_file("key3.db")
-            self.remove_info_file("secmod.db")
+            for fname in (certdb.NSS_SQL_FILES + certdb.NSS_SQL_FILES):
+                self.remove_info_file(fname)
             self.remove_info_file("noise.txt")
 
             orig_filename = passwd_fname + ".orig"

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -27,20 +27,13 @@ import ldif
 import itertools
 
 import six
-# pylint: disable=import-error
-if six.PY3:
-    # The SafeConfigParser class has been renamed to ConfigParser in Py3
-    from configparser import ConfigParser as SafeConfigParser
-else:
-    from ConfigParser import SafeConfigParser
-# pylint: enable=import-error
 
 from ipaclient.install.client import update_ipa_nssdb
 from ipalib import api, errors
 from ipalib.constants import FQDN
 from ipapython import version, ipautil
 from ipapython.ipautil import run, user_input
-from ipapython import admintool
+from ipapython import admintool, certdb
 from ipapython.dn import DN
 from ipaserver.install.replication import (wait_for_task, ReplicationManager,
                                            get_cs_replication_manager)
@@ -57,6 +50,14 @@ try:
     from ipaserver.install import adtrustinstance
 except ImportError:
     adtrustinstance = None
+
+# pylint: disable=import-error
+if six.PY3:
+    # The SafeConfigParser class has been renamed to ConfigParser in Py3
+    from configparser import ConfigParser as SafeConfigParser
+else:
+    from ConfigParser import SafeConfigParser
+# pylint: enable=import-error
 
 logger = logging.getLogger(__name__)
 
@@ -847,7 +848,7 @@ class Restore(admintool.AdminTool):
 
         krbinstance.KrbInstance().stop_tracking_certs()
 
-        for basename in ('cert8.db', 'key3.db', 'secmod.db', 'pwdfile.txt'):
+        for basename in certdb.NSS_FILES:
             filename = os.path.join(paths.IPA_NSSDB_DIR, basename)
             try:
                 ipautil.backup_file(filename)

--- a/ipaserver/install/ipa_server_certinstall.py
+++ b/ipaserver/install/ipa_server_certinstall.py
@@ -30,9 +30,10 @@ from ipalib.install import certmonger
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipapython import admintool
-from ipapython.certdb import (get_ca_nickname,
-                              NSSDatabase,
-                              verify_kdc_cert_validity)
+from ipapython.certdb import (
+    NSS_DBM_FILES, NSS_SQL_FILES, NSSDatabase, get_ca_nickname,
+    verify_kdc_cert_validity
+)
 from ipapython.dn import DN
 from ipalib import api, errors
 from ipaserver.install import certs, dsinstance, installutils, krbinstance
@@ -170,14 +171,12 @@ class ServerCertInstall(admintool.AdminTool):
             quotes=False)
 
         # Fix the database permissions
-        os.chmod(os.path.join(dirname, 'cert8.db'), 0o640)
-        os.chmod(os.path.join(dirname, 'key3.db'), 0o640)
-        os.chmod(os.path.join(dirname, 'secmod.db'), 0o640)
-
         pent = pwd.getpwnam(constants.HTTPD_USER)
-        os.chown(os.path.join(dirname, 'cert8.db'), 0, pent.pw_gid)
-        os.chown(os.path.join(dirname, 'key3.db'), 0, pent.pw_gid)
-        os.chown(os.path.join(dirname, 'secmod.db'), 0, pent.pw_gid)
+        for filename in (NSS_DBM_FILES + NSS_SQL_FILES):
+            absname = os.path.join(dirname, filename)
+            if os.path.isfile(absname):
+                os.chmod(absname, 0o640)
+                os.chown(absname, 0, pent.pw_gid)
 
     def install_kdc_cert(self):
         ca_cert_file = paths.CA_BUNDLE_PEM

--- a/ipaserver/secrets/store.py
+++ b/ipaserver/secrets/store.py
@@ -6,6 +6,7 @@ from custodia.store.interface import CSStore  # pylint: disable=relative-import
 from jwcrypto.common import json_decode, json_encode
 from ipaplatform.paths import paths
 from ipapython import ipautil
+from ipapython.certdb import NSSDatabase
 from ipaserver.secrets.common import iSecLdap
 import ldap
 import os
@@ -80,10 +81,11 @@ class NSSWrappedCertDB(DBMAPHandler):
                 '--wrap-nickname', self.wrap_nick,
                 '--target-nickname', self.target_nick,
                 '-o', wrapped_key_file])
-            ipautil.run([
-                paths.CERTUTIL, '-d', self.nssdb_path,
+            nssdb = NSSDatabase(self.nssdb_path)
+            nssdb.run_certutil([
                 '-L', '-n', self.target_nick,
-                '-a', '-o', certificate_file])
+                '-a', '-o', certificate_file,
+            ])
             with open(wrapped_key_file, 'rb') as f:
                 wrapped_key = f.read()
             with open(certificate_file, 'r') as f:
@@ -120,12 +122,13 @@ class NSSCertDB(DBMAPHandler):
             with open(pk12pwfile, 'w') as f:
                 f.write(password)
             pk12file = os.path.join(tdir, 'pk12file')
-            ipautil.run([paths.PK12UTIL,
-                         "-d", self.nssdb_path,
-                         "-o", pk12file,
-                         "-n", self.nickname,
-                         "-k", nsspwfile,
-                         "-w", pk12pwfile])
+            nssdb = NSSDatabase(self.nssdb_path)
+            nssdb.run_pk12util([
+                "-o", pk12file,
+                "-n", self.nickname,
+                "-k", nsspwfile,
+                "-w", pk12pwfile,
+            ])
             with open(pk12file, 'rb') as f:
                 data = f.read()
         finally:
@@ -146,12 +149,13 @@ class NSSCertDB(DBMAPHandler):
             pk12file = os.path.join(tdir, 'pk12file')
             with open(pk12file, 'wb') as f:
                 f.write(b64decode(v['pkcs12 data']))
-            ipautil.run([paths.PK12UTIL,
-                         "-d", self.nssdb_path,
-                         "-i", pk12file,
-                         "-n", self.nickname,
-                         "-k", nsspwfile,
-                         "-w", pk12pwfile])
+            nssdb = NSSDatabase(self.nssdb_path)
+            nssdb.run_pk12util([
+                "-i", pk12file,
+                "-n", self.nickname,
+                "-k", nsspwfile,
+                "-w", pk12pwfile,
+            ])
         finally:
             shutil.rmtree(tdir)
 

--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -35,6 +35,7 @@ from six import StringIO
 
 from ipapython import ipautil
 from ipaplatform.paths import paths
+from ipaplatform.constants import constants
 from ipapython.dn import DN
 from ipalib import errors
 from ipalib.util import get_reverse_zone_default, verify_host_resolvable
@@ -1262,9 +1263,12 @@ def run_server_del(host, server_to_delete, force=False,
     return host.run_command(args, raiseonerr=False)
 
 
-def run_certutil(host, args, reqdir, stdin=None, raiseonerr=True):
-    new_args = [paths.CERTUTIL, "-d", reqdir]
-    new_args = " ".join(new_args + args)
+def run_certutil(host, args, reqdir, dbtype=None,
+                 stdin=None, raiseonerr=True):
+    if dbtype is None:
+        dbtype = constants.NSS_DEFAULT_DBTYPE
+    new_args = [paths.CERTUTIL, '-d', '{}:{}'.format(dbtype, reqdir)]
+    new_args.extend(args)
     return host.run_command(new_args, raiseonerr=raiseonerr,
                             stdin_text=stdin)
 

--- a/ipatests/test_ipapython/test_certdb.py
+++ b/ipatests/test_ipapython/test_certdb.py
@@ -1,0 +1,133 @@
+import os
+
+from ipapython.certdb import NSSDatabase, TRUSTED_PEER_TRUST_FLAGS
+
+CERTNICK = 'testcert'
+
+
+def create_selfsigned(nssdb):
+    # create self-signed cert + key
+    noisefile = os.path.join(nssdb.secdir, 'noise')
+    with open(noisefile, 'wb') as f:
+        f.write(os.urandom(64))
+    try:
+        nssdb.run_certutil([
+            '-S', '-x',
+            '-z', noisefile,
+            '-k', 'rsa', '-g', '2048', '-Z', 'SHA256',
+            '-t', 'CTu,Cu,Cu',
+            '-s', 'CN=testcert',
+            '-n', CERTNICK,
+            '-m', '365',
+        ])
+    finally:
+        os.unlink(noisefile)
+
+
+def test_dbm_tmp():
+    with NSSDatabase(dbtype='dbm') as nssdb:
+        assert nssdb.dbtype == 'dbm'
+
+        for filename in nssdb.filenames:
+            assert not os.path.isfile(filename)
+
+        nssdb.create_db()
+        for filename in nssdb.filenames:
+            assert os.path.isfile(filename)
+            assert os.path.dirname(filename) == nssdb.secdir
+
+        assert os.path.basename(nssdb.certdb) == 'cert8.db'
+        assert nssdb.certdb in nssdb.filenames
+        assert os.path.basename(nssdb.keydb) == 'key3.db'
+        assert os.path.basename(nssdb.secmod) == 'secmod.db'
+
+
+def test_sql_tmp():
+    with NSSDatabase(dbtype='sql') as nssdb:
+        assert nssdb.dbtype == 'sql'
+
+        for filename in nssdb.filenames:
+            assert not os.path.isfile(filename)
+
+        nssdb.create_db()
+        for filename in nssdb.filenames:
+            assert os.path.isfile(filename)
+            assert os.path.dirname(filename) == nssdb.secdir
+
+        assert os.path.basename(nssdb.certdb) == 'cert9.db'
+        assert nssdb.certdb in nssdb.filenames
+        assert os.path.basename(nssdb.keydb) == 'key4.db'
+        assert os.path.basename(nssdb.secmod) == 'pkcs11.txt'
+
+
+def test_convert_db():
+    with NSSDatabase(dbtype='dbm') as nssdb:
+        assert nssdb.dbtype == 'dbm'
+
+        nssdb.create_db()
+
+        create_selfsigned(nssdb)
+
+        oldcerts = nssdb.list_certs()
+        assert len(oldcerts) == 1
+        oldkeys = nssdb.list_keys()
+        assert len(oldkeys) == 1
+
+        nssdb.convert_db()
+
+        assert nssdb.dbtype == 'sql'
+        newcerts = nssdb.list_certs()
+        assert len(newcerts) == 1
+        assert newcerts == oldcerts
+        newkeys = nssdb.list_keys()
+        assert len(newkeys) == 1
+        assert newkeys == oldkeys
+
+        for filename in nssdb.filenames:
+            assert os.path.isfile(filename)
+            assert os.path.dirname(filename) == nssdb.secdir
+
+        assert os.path.basename(nssdb.certdb) == 'cert9.db'
+        assert nssdb.certdb in nssdb.filenames
+        assert os.path.basename(nssdb.keydb) == 'key4.db'
+        assert os.path.basename(nssdb.secmod) == 'pkcs11.txt'
+
+
+def test_convert_db_nokey():
+    with NSSDatabase(dbtype='dbm') as nssdb:
+        assert nssdb.dbtype == 'dbm'
+        nssdb.create_db()
+
+        create_selfsigned(nssdb)
+
+        assert len(nssdb.list_certs()) == 1
+        assert len(nssdb.list_keys()) == 1
+        # remove key, readd cert
+        cert = nssdb.get_cert(CERTNICK)
+        nssdb.run_certutil(['-F', '-n', CERTNICK])
+        nssdb.add_cert(cert, CERTNICK, TRUSTED_PEER_TRUST_FLAGS)
+        assert len(nssdb.list_keys()) == 0
+        oldcerts = nssdb.list_certs()
+        assert len(oldcerts) == 1
+
+        nssdb.convert_db()
+        assert nssdb.dbtype == 'sql'
+        newcerts = nssdb.list_certs()
+        assert len(newcerts) == 1
+        assert newcerts == oldcerts
+        assert nssdb.get_cert(CERTNICK) == cert
+        newkeys = nssdb.list_keys()
+        assert newkeys == ()
+
+        for filename in nssdb.filenames:
+            assert os.path.isfile(filename)
+            assert os.path.dirname(filename) == nssdb.secdir
+
+        old = os.path.join(nssdb.secdir, 'cert8.db')
+        assert not os.path.isfile(old)
+        assert os.path.isfile(old + '.migrated')
+
+        assert os.path.basename(nssdb.certdb) == 'cert9.db'
+        assert nssdb.certdb in nssdb.filenames
+        assert os.path.basename(nssdb.keydb) == 'key4.db'
+        assert os.path.basename(nssdb.secmod) == 'pkcs11.txt'


### PR DESCRIPTION
Manual backport of PR #1351 and PR #1254

After further testing, Kai Engert proposed to use -N with -f -@ to
convert a NSSDB from DBM to SQL format.

https://fedoraproject.org/wiki/Changes/NSSDefaultFileFormatSql#Upgrade.2Fcompatibility_impact

https://pagure.io/freeipa/issue/7049

Signed-off-by: Christian Heimes <cheimes@redhat.com>