### PR TITLE
[Backport][ipa-4-6] Remove Custodia keys on uninstall

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1280,6 +1280,12 @@ class CAInstance(DogtagInstance):
         os.chmod(keyfile, 0o600)
         os.chown(keyfile, pent.pw_uid, pent.pw_gid)
 
+    def __remove_lightweight_ca_key_retrieval_custodia(self):
+        keyfile = os.path.join(paths.PKI_TOMCAT,
+                               self.service_prefix + '.keys')
+        keystore = IPAKEMKeys({'server_keys': keyfile})
+        keystore.remove_keys(self.service_prefix)
+
     def add_lightweight_ca_tracking_requests(self):
         try:
             lwcas = api.Backend.ldap2.get_entries(

--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -64,10 +64,22 @@ class CustodiaInstance(SimpleServiceInstance):
                                                       realm=self.realm)
         sysupgrade.set_upgrade_state('custodia', 'installed', True)
 
+    def uninstall(self):
+        super(CustodiaInstance, self).uninstall()
+        keystore = IPAKEMKeys({
+            'server_keys': self.server_keys,
+            'ldap_uri': self.ldap_uri
+        })
+        keystore.remove_server_keys()
+        installutils.remove_file(self.config_file)
+        sysupgrade.set_upgrade_state('custodia', 'installed', False)
+
     def __gen_keys(self):
-        KeyStore = IPAKEMKeys({'server_keys': self.server_keys,
-                               'ldap_uri': self.ldap_uri})
-        KeyStore.generate_server_keys()
+        keystore = IPAKEMKeys({
+            'server_keys': self.server_keys,
+            'ldap_uri': self.ldap_uri
+        })
+        keystore.generate_server_keys()
 
     def upgrade_instance(self):
         if not sysupgrade.get_upgrade_state("custodia", "installed"):


### PR DESCRIPTION
This PR was opened automatically because PR #1297 was pushed to master and backport to ipa-4-6 is required.