### PR TITLE
Extend ui_driver to support geckodriver log_path

### DIFF
--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -217,7 +217,8 @@ class UI_driver(object):
                     fp = None
                     if "ff_profile" in self.config:
                         fp = webdriver.FirefoxProfile(self.config["ff_profile"])
-                    driver = webdriver.Firefox(fp)
+                    ff_log_path = self.config.get("geckodriver_log_path")
+                    driver = webdriver.Firefox(fp, log_path=ff_log_path)
             except URLError as e:
                 raise nose.SkipTest('Error connecting to selenium server: %s' % e)
             except RuntimeError as e:


### PR DESCRIPTION
Geckodriver automatically logs into geckodriver.log file which
is placed in the same directory from which tests are run. In case
of running tests using ipa-run-tests the current working directory is
/usr/lib/python*/site-packages/ipatests where most of users cannot
write because of priviledges.

By adding "geckodriver_log_path" into test configuration we allow to
set path where user who run tests have priviledges to write.

Config file can be seen here:
https://www.freeipa.org/page/Web_UI_Integration_Tests#Running_tests

Fixes: https://pagure.io/freeipa/issue/7311