### PR TITLE
test_server_del: Added automation for bugzilla bz1506188.

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1381,3 +1381,29 @@ def add_dns_zone(master, zone, skip_overlap_check=False,
                                     host.hostname + ".", '--a-rec', host.ip])
     else:
         logger.debug('Zone %s already added.', zone)
+
+
+def run_dnsserver_find(host, server_to_find, returncode=None):
+    """
+    Find DNS-server details
+    """
+    kinit_admin(host)
+    cmd = host.run_command(["ipa", "dnsserver-find", server_to_find],
+                           raiseonerr=False)
+    if cmd.returncode == returncode:
+        print cmd.stdout_text
+    else:
+        print cmd.stderr_text
+
+
+def run_server_find(host, server_to_find, returncode=None):
+    """
+    Find server details
+    """
+    kinit_admin(host)
+    cmd = host.run_command(["ipa", "server-find", server_to_find],
+                           raiseonerr=False)
+    if cmd.returncode == returncode:
+        print cmd.stdout_text
+    else:
+        print cmd.stderr_text

--- a/ipatests/test_integration/test_server_del.py
+++ b/ipatests/test_integration/test_server_del.py
@@ -300,3 +300,29 @@ class TestLastServices(ServerDelBase):
             self.replicas[0], self.master.hostname,
             ignore_last_of_role=True
         )
+
+
+class TestServerDelReplicaRemoval(IntegrationTest):
+    """
+    Test the checks for Removal of Replica during server-del
+    as part for verification of bz1506188
+    """
+    num_replicas = 1
+    domain_level = DOMAIN_LEVEL_1
+    topology = 'line'
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_topo(
+            cls.topology, cls.master, cls.replicas, [],
+            domain_level=cls.domain_level, setup_replica_cas=False)
+
+    def test_removal_of_replica(self):
+        """
+        test that removal of replica bz1506188.
+        """
+        tasks.run_server_find(self.master, self.replicas[0].hostname, 0)
+        tasks.run_dnsserver_find(self.master, self.replicas[0].hostname, 0)
+        tasks.run_server_del(self.master, self.replicas[0].hostname, 0)
+        tasks.run_server_find(self.master, self.replicas[0].hostname, 1)
+        tasks.run_dnsserver_find(self.master, self.replicas[0].hostname, 1)


### PR DESCRIPTION
 Patch1:
  1) Added automation for verification steps for bz1506188.
  2) The code setusp up IPA-Master/ Replica and then checks for
     deletion of Replica using 'ipa server-del' command.
  3) It also checks for verification of 'ipa dnsserver-find' command
     output once the replica server details are removed.

 Patch2:
  1) Removed unsed assert statement inside code.
  2) Realigned code for doc-string information within
     80 character limit length.

Signed-off-by: Nikhil Dehadrai <ndehadra@redhat.com>