### PR TITLE
Prevent set_directive from clobbering other keys / safe directive setter

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -952,7 +952,7 @@ class CAInstance(DogtagInstance):
         installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.enable', 'true', quotes=False, separator='=')
         installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.mapper', 'NoMap', quotes=False, separator='=')
         installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.pluginName', 'Rule', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.predicate=', '', quotes=False, separator='')
+        installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.predicate', '', quotes=False, separator='=')
         installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.publisher', 'FileBaseCRLPublisher', quotes=False, separator='=')
         installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.type', 'crl', quotes=False, separator='=')
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -928,52 +928,63 @@ class CAInstance(DogtagInstance):
 
         https://access.redhat.com/knowledge/docs/en-US/Red_Hat_Certificate_System/8.0/html/Admin_Guide/Setting_up_Publishing.html
         """
-        caconfig = paths.CA_CS_CFG_PATH
 
-        publishdir = self.prepare_crl_publish_dir()
+        def put(k, v):
+            installutils.set_directive(
+                paths.CA_CS_CFG_PATH, k, v, quotes=False, separator='=')
 
         # Enable file publishing, disable LDAP
-        installutils.set_directive(caconfig, 'ca.publish.enable', 'true', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.ldappublish.enable', 'false', quotes=False, separator='=')
+        put('ca.publish.enable', 'true')
+        put('ca.publish.ldappublish.enable', 'false')
 
         # Create the file publisher, der only, not b64
-        installutils.set_directive(caconfig, 'ca.publish.publisher.impl.FileBasedPublisher.class','com.netscape.cms.publish.publishers.FileBasedPublisher', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.publisher.instance.FileBaseCRLPublisher.crlLinkExt', 'bin', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.publisher.instance.FileBaseCRLPublisher.directory', publishdir, quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.publisher.instance.FileBaseCRLPublisher.latestCrlLink', 'true', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.publisher.instance.FileBaseCRLPublisher.pluginName', 'FileBasedPublisher', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.publisher.instance.FileBaseCRLPublisher.timeStamp', 'LocalTime', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.publisher.instance.FileBaseCRLPublisher.zipCRLs', 'false', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.publisher.instance.FileBaseCRLPublisher.zipLevel', '9', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.publisher.instance.FileBaseCRLPublisher.Filename.b64', 'false', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.publisher.instance.FileBaseCRLPublisher.Filename.der', 'true', quotes=False, separator='=')
+        put('ca.publish.publisher.impl.FileBasedPublisher.class',
+            'com.netscape.cms.publish.publishers.FileBasedPublisher')
+        put('ca.publish.publisher.instance.FileBaseCRLPublisher.crlLinkExt',
+            'bin')
+        put('ca.publish.publisher.instance.FileBaseCRLPublisher.directory',
+            self.prepare_crl_publish_dir())
+        put('ca.publish.publisher.instance.FileBaseCRLPublisher.latestCrlLink',
+            'true')
+        put('ca.publish.publisher.instance.FileBaseCRLPublisher.pluginName',
+            'FileBasedPublisher')
+        put('ca.publish.publisher.instance.FileBaseCRLPublisher.timeStamp',
+            'LocalTime')
+        put('ca.publish.publisher.instance.FileBaseCRLPublisher.zipCRLs',
+            'false')
+        put('ca.publish.publisher.instance.FileBaseCRLPublisher.zipLevel', '9')
+        put('ca.publish.publisher.instance.FileBaseCRLPublisher.Filename.b64',
+            'false')
+        put('ca.publish.publisher.instance.FileBaseCRLPublisher.Filename.der',
+            'true')
 
         # The publishing rule
-        installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.enable', 'true', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.mapper', 'NoMap', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.pluginName', 'Rule', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.predicate', '', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.publisher', 'FileBaseCRLPublisher', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.rule.instance.FileCrlRule.type', 'crl', quotes=False, separator='=')
+        put('ca.publish.rule.instance.FileCrlRule.enable', 'true')
+        put('ca.publish.rule.instance.FileCrlRule.mapper', 'NoMap')
+        put('ca.publish.rule.instance.FileCrlRule.pluginName', 'Rule')
+        put('ca.publish.rule.instance.FileCrlRule.predicate', '')
+        put('ca.publish.rule.instance.FileCrlRule.publisher',
+            'FileBaseCRLPublisher')
+        put('ca.publish.rule.instance.FileCrlRule.type', 'crl')
 
         # Now disable LDAP publishing
-        installutils.set_directive(caconfig, 'ca.publish.rule.instance.LdapCaCertRule.enable', 'false', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.rule.instance.LdapCrlRule.enable', 'false', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.rule.instance.LdapUserCertRule.enable', 'false', quotes=False, separator='=')
-        installutils.set_directive(caconfig, 'ca.publish.rule.instance.LdapXCertRule.enable', 'false', quotes=False, separator='=')
+        put('ca.publish.rule.instance.LdapCaCertRule.enable', 'false')
+        put('ca.publish.rule.instance.LdapCrlRule.enable', 'false')
+        put('ca.publish.rule.instance.LdapUserCertRule.enable', 'false')
+        put('ca.publish.rule.instance.LdapXCertRule.enable', 'false')
 
         # If we are the initial master then we are the CRL generator, otherwise
         # we point to that master for CRLs.
         if not self.clone:
             # These next two are defaults, but I want to be explicit that the
             # initial master is the CRL generator.
-            installutils.set_directive(caconfig, 'ca.crl.MasterCRL.enableCRLCache', 'true', quotes=False, separator='=')
-            installutils.set_directive(caconfig, 'ca.crl.MasterCRL.enableCRLUpdates', 'true', quotes=False, separator='=')
-            installutils.set_directive(caconfig, 'ca.listenToCloneModifications', 'true', quotes=False, separator='=')
+            put('ca.crl.MasterCRL.enableCRLCache', 'true')
+            put('ca.crl.MasterCRL.enableCRLUpdates', 'true')
+            put('ca.listenToCloneModifications', 'true')
         else:
-            installutils.set_directive(caconfig, 'ca.crl.MasterCRL.enableCRLCache', 'false', quotes=False, separator='=')
-            installutils.set_directive(caconfig, 'ca.crl.MasterCRL.enableCRLUpdates', 'false', quotes=False, separator='=')
-            installutils.set_directive(caconfig, 'ca.listenToCloneModifications', 'false', quotes=False, separator='=')
+            put('ca.crl.MasterCRL.enableCRLCache', 'false')
+            put('ca.crl.MasterCRL.enableCRLUpdates', 'false')
+            put('ca.listenToCloneModifications', 'false')
 
     def uninstall(self):
         # just eat state

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -929,62 +929,61 @@ class CAInstance(DogtagInstance):
         https://access.redhat.com/knowledge/docs/en-US/Red_Hat_Certificate_System/8.0/html/Admin_Guide/Setting_up_Publishing.html
         """
 
-        def put(k, v):
-            installutils.set_directive(
-                paths.CA_CS_CFG_PATH, k, v, quotes=False, separator='=')
+        with installutils.DirectiveSetter(paths.CA_CS_CFG_PATH,
+                                          quotes=False, separator='=') as ds:
 
-        # Enable file publishing, disable LDAP
-        put('ca.publish.enable', 'true')
-        put('ca.publish.ldappublish.enable', 'false')
+            # Enable file publishing, disable LDAP
+            ds.set('ca.publish.enable', 'true')
+            ds.set('ca.publish.ldappublish.enable', 'false')
 
-        # Create the file publisher, der only, not b64
-        put('ca.publish.publisher.impl.FileBasedPublisher.class',
-            'com.netscape.cms.publish.publishers.FileBasedPublisher')
-        put('ca.publish.publisher.instance.FileBaseCRLPublisher.crlLinkExt',
-            'bin')
-        put('ca.publish.publisher.instance.FileBaseCRLPublisher.directory',
-            self.prepare_crl_publish_dir())
-        put('ca.publish.publisher.instance.FileBaseCRLPublisher.latestCrlLink',
-            'true')
-        put('ca.publish.publisher.instance.FileBaseCRLPublisher.pluginName',
-            'FileBasedPublisher')
-        put('ca.publish.publisher.instance.FileBaseCRLPublisher.timeStamp',
-            'LocalTime')
-        put('ca.publish.publisher.instance.FileBaseCRLPublisher.zipCRLs',
-            'false')
-        put('ca.publish.publisher.instance.FileBaseCRLPublisher.zipLevel', '9')
-        put('ca.publish.publisher.instance.FileBaseCRLPublisher.Filename.b64',
-            'false')
-        put('ca.publish.publisher.instance.FileBaseCRLPublisher.Filename.der',
-            'true')
+            # Create the file publisher, der only, not b64
+            ds.set(
+                'ca.publish.publisher.impl.FileBasedPublisher.class',
+                'com.netscape.cms.publish.publishers.FileBasedPublisher'
+            )
+            prefix = 'ca.publish.publisher.instance.FileBaseCRLPublisher.'
+            ds.set(prefix + 'crlLinkExt', 'bin')
+            ds.set(prefix + 'directory', self.prepare_crl_publish_dir())
+            ds.set(prefix + 'latestCrlLink', 'true')
+            ds.set(prefix + 'pluginName', 'FileBasedPublisher')
+            ds.set(prefix + 'timeStamp', 'LocalTime')
+            ds.set(prefix + 'zipCRLs', 'false')
+            ds.set(prefix + 'zipLevel', '9')
+            ds.set(prefix + 'Filename.b64', 'false')
+            ds.set(prefix + 'Filename.der', 'true')
 
-        # The publishing rule
-        put('ca.publish.rule.instance.FileCrlRule.enable', 'true')
-        put('ca.publish.rule.instance.FileCrlRule.mapper', 'NoMap')
-        put('ca.publish.rule.instance.FileCrlRule.pluginName', 'Rule')
-        put('ca.publish.rule.instance.FileCrlRule.predicate', '')
-        put('ca.publish.rule.instance.FileCrlRule.publisher',
-            'FileBaseCRLPublisher')
-        put('ca.publish.rule.instance.FileCrlRule.type', 'crl')
+            # The publishing rule
+            ds.set('ca.publish.rule.instance.FileCrlRule.enable', 'true')
+            ds.set('ca.publish.rule.instance.FileCrlRule.mapper', 'NoMap')
+            ds.set('ca.publish.rule.instance.FileCrlRule.pluginName', 'Rule')
+            ds.set('ca.publish.rule.instance.FileCrlRule.predicate', '')
+            ds.set(
+                'ca.publish.rule.instance.FileCrlRule.publisher',
+                'FileBaseCRLPublisher'
+            )
+            ds.set('ca.publish.rule.instance.FileCrlRule.type', 'crl')
 
-        # Now disable LDAP publishing
-        put('ca.publish.rule.instance.LdapCaCertRule.enable', 'false')
-        put('ca.publish.rule.instance.LdapCrlRule.enable', 'false')
-        put('ca.publish.rule.instance.LdapUserCertRule.enable', 'false')
-        put('ca.publish.rule.instance.LdapXCertRule.enable', 'false')
+            # Now disable LDAP publishing
+            ds.set('ca.publish.rule.instance.LdapCaCertRule.enable', 'false')
+            ds.set('ca.publish.rule.instance.LdapCrlRule.enable', 'false')
+            ds.set(
+                'ca.publish.rule.instance.LdapUserCertRule.enable',
+                'false'
+            )
+            ds.set('ca.publish.rule.instance.LdapXCertRule.enable', 'false')
 
-        # If we are the initial master then we are the CRL generator, otherwise
-        # we point to that master for CRLs.
-        if not self.clone:
-            # These next two are defaults, but I want to be explicit that the
-            # initial master is the CRL generator.
-            put('ca.crl.MasterCRL.enableCRLCache', 'true')
-            put('ca.crl.MasterCRL.enableCRLUpdates', 'true')
-            put('ca.listenToCloneModifications', 'true')
-        else:
-            put('ca.crl.MasterCRL.enableCRLCache', 'false')
-            put('ca.crl.MasterCRL.enableCRLUpdates', 'false')
-            put('ca.listenToCloneModifications', 'false')
+            # If we are the initial master then we are the CRL generator,
+            # otherwise we point to that master for CRLs.
+            if not self.clone:
+                # These next two are defaults, but I want to be explicit
+                # that the initial master is the CRL generator.
+                ds.set('ca.crl.MasterCRL.enableCRLCache', 'true')
+                ds.set('ca.crl.MasterCRL.enableCRLUpdates', 'true')
+                ds.set('ca.listenToCloneModifications', 'true')
+            else:
+                ds.set('ca.crl.MasterCRL.enableCRLCache', 'false')
+                ds.set('ca.crl.MasterCRL.enableCRLUpdates', 'false')
+                ds.set('ca.listenToCloneModifications', 'false')
 
     def uninstall(self):
         # just eat state

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -214,7 +214,7 @@ class DogtagInstance(service.Service):
                 separator='=')
             # Remove internaldb password as is not needed anymore
             installutils.set_directive(paths.PKI_TOMCAT_PASSWORD_CONF,
-                                       'internaldb', None)
+                                       'internaldb', None, separator='=')
 
     def uninstall(self):
         if self.is_installed():

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -452,34 +452,44 @@ def set_directive(filename, directive, value, quotes=True, separator=' '):
     :param separator: character serving as separator between directive and
         value.  Correct value required even when dropping a directive.
     """
-
-    new_directive_value = ""
-    if value is not None:
-        value_to_set = quote_directive_value(value, '"') if quotes else value
-
-        new_directive_value = "".join(
-            [directive, separator, value_to_set, '\n'])
-
-    valueset = False
     st = os.stat(filename)
-    fd = open(filename)
-    newfile = []
-    for line in fd:
-        if re.match(r'\s*{}'.format(re.escape(directive + separator)), line):
-            valueset = True
-            if value is not None:
-                newfile.append(new_directive_value)
-        else:
-            newfile.append(line)
-    fd.close()
-    if not valueset:
-        if value is not None:
-            newfile.append(new_directive_value)
+    with open(filename, 'r') as f:
+        lines = list(f)  # read the whole file
+        new_lines = set_directive_lines(
+            quotes, separator, directive, value, lines)
+    with open(filename, 'w') as f:
+        # don't construct the whole string; write line-wise
+        for line in new_lines:
+            f.write(line)
+    os.chown(filename, st.st_uid, st.st_gid)  # reset perms
 
-    fd = open(filename, "w")
-    fd.write("".join(newfile))
-    fd.close()
-    os.chown(filename, st.st_uid, st.st_gid) # reset perms
+
+def set_directive_lines(quotes, separator, k, v, lines):
+    """Set a name/value pair in a configuration (iterable of lines).
+
+    Replaces the value of the key if found, otherwise adds it at
+    end.  If value is ``None``, remove the key if found.
+
+    Takes an iterable of lines (with trailing newline).
+    Yields lines (with trailing newline).
+
+    """
+    new_line = ""
+    if v is not None:
+        v_quoted = quote_directive_value(v, '"') if quotes else v
+        new_line = ''.join([k, separator, v_quoted, '\n'])
+
+    found = False
+    for line in lines:
+        if re.match(r'\s*{}'.format(re.escape(k + separator)), line):
+            found = True
+            if v is not None:
+                yield new_line
+        else:
+            yield line
+
+    if not found and v is not None:
+        yield new_line
 
 
 def get_directive(filename, directive, separator=' '):

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -441,7 +441,7 @@ def set_directive(filename, directive, value, quotes=True, separator=' '):
 
     A value of None means to drop the directive.
 
-    This has only been tested with nss.conf
+    Does not tolerate (or put) spaces around the separator.
 
     :param filename: input filename
     :param directive: directive name
@@ -450,7 +450,7 @@ def set_directive(filename, directive, value, quotes=True, separator=' '):
         any existing double quotes are first escaped to avoid
         unparseable directives.
     :param separator: character serving as separator between directive and
-        value
+        value.  Correct value required even when dropping a directive.
     """
 
     new_directive_value = ""
@@ -465,7 +465,7 @@ def set_directive(filename, directive, value, quotes=True, separator=' '):
     fd = open(filename)
     newfile = []
     for line in fd:
-        if line.lstrip().startswith(directive):
+        if re.match(r'\s*{}'.format(re.escape(directive + separator)), line):
             valueset = True
             if value is not None:
                 newfile.append(new_directive_value)

--- a/ipatests/test_ipaserver/test_install/test_installutils.py
+++ b/ipatests/test_ipaserver/test_install/test_installutils.py
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2017  FreeIPA Contributors.  See COPYING for license
+#
+
+import os
+import tempfile
+
+from ipaserver.install import installutils
+
+EXAMPLE_CONFIG = [
+    'foo=1\n',
+    'foobar=2\n',
+]
+
+
+class test_set_directive_lines(object):
+    def test_remove_directive(self):
+        lines = installutils.set_directive_lines(
+            False, '=', 'foo', None, EXAMPLE_CONFIG)
+        assert list(lines) == ['foobar=2\n']
+
+    def test_add_directive(self):
+        lines = installutils.set_directive_lines(
+            False, '=', 'baz', '4', EXAMPLE_CONFIG)
+        assert list(lines) == ['foo=1\n', 'foobar=2\n', 'baz=4\n']
+
+    def test_set_directive_does_not_clobber_suffix_key(self):
+        lines = installutils.set_directive_lines(
+            False, '=', 'foo', '3', EXAMPLE_CONFIG)
+        assert list(lines) == ['foo=3\n', 'foobar=2\n']
+
+
+class test_set_directive(object):
+    def test_set_directive(self):
+        """Check that set_directive writes the new data and preserves mode."""
+        fd, filename = tempfile.mkstemp()
+        try:
+            os.close(fd)
+            stat_pre = os.stat(filename)
+
+            with open(filename, 'w') as f:
+                for line in EXAMPLE_CONFIG:
+                    f.write(line)
+
+            installutils.set_directive(filename, 'foo', '3', False, '=')
+
+            stat_post = os.stat(filename)
+            with open(filename, 'r') as f:
+                lines = list(f)
+
+            assert lines == ['foo=3\n', 'foobar=2\n']
+            assert stat_pre.st_mode == stat_post.st_mode
+            assert stat_pre.st_uid == stat_post.st_uid
+            assert stat_pre.st_gid == stat_post.st_gid
+
+        finally:
+            os.remove(filename)


### PR DESCRIPTION
This PR combines @frasertweedale PR #1347 with a safe directive setter (https://pagure.io/freeipa/issue/7312)

## Original PR message

`set_directive` only looks for a prefix of the line matching the
given directive (key).  If a directive is encountered for which the
given key is prefix, it will be vanquished.

This occurs in the case of `{ca,kra}.sslserver.cert[req]`; the
`cert` directive gets updated after certificate renewal, and the
`certreq` directive gets clobbered.  This can cause failures later
on during KRA installation, and possibly cloning.

Match the whole directive to avoid this issue.

Fixes: https://pagure.io/freeipa/issue/7288

-----

Cause: corner case.

How to test:

1. ensure `ca.sslserver.certreq=<base64 CSR>` exists in `ca/CS.cfg`.
2. resubmit Certmonger tracking request for `Server-Cert cert-pki-ca` Dogtag system cert.
3. verify that `ca.sslserver.certreq=<base64 CSR>` still exists in `ca/CS.cfg`.

## safe DirectiveSetter

The new context manager ``DirectiveSetter`` avoids several possible issues that can lead to destroyed configuration files.