### PR TITLE
[Backport][ipa-4-6]   ipatest: replica install with existing entry on master 

### DIFF
--- a/ipatests/test_integration/test_replication_layouts.py
+++ b/ipatests/test_integration/test_replication_layouts.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015  FreeIPA Contributors see COPYING for license
+# Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #
 
 import time


### PR DESCRIPTION
This PR was opened automatically because PR #1320 was pushed to master and backport to ipa-4-6 is required.