### PR TITLE
[Backport][ipa-4-6] Add python_requires to Python package metadata

### DIFF
--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -97,6 +97,7 @@ common_args = dict(
     url="http://www.freeipa.org/",
     download_url="http://www.freeipa.org/page/Downloads",
     platforms=["Linux", "Solaris", "Unix"],
+    python_requires=">=2.7.5,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: System Administrators",


### PR DESCRIPTION
This PR was opened automatically because PR #1361 was pushed to master and backport to ipa-4-6 is required.