### PR TITLE
[WIP] Add :1/128 in Travis CI in case it misses

### DIFF
--- a/.travis_run_task.sh
+++ b/.travis_run_task.sh
@@ -49,6 +49,11 @@ then
     popd
 fi
 
+if ! /sbin/ip -6 addr show to ::1/128 > /dev/null
+then
+   /sbin/ip -6 addr add ::1/128 dev lo up ||:
+fi
+
 docker pull $TEST_RUNNER_IMAGE
 
 ipa-docker-test-runner -l $CI_RESULTS_LOG \


### PR DESCRIPTION
Recently IPv6 got enabled in Travis CI with newer Ubuntu images.
If ::1/128 is missing on localhost, add it as we expect at least that.