### PR TITLE
Travis: Add workaround for missing IPv6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
 services:
     - docker
+# workaround for missing IPv6 address support
+# https://github.com/travis-ci/travis-ci/issues/8891
+sudo: required
+dist: trusty
+group: deprecated-2017Q4
 
 python:
     - "3.6"
@@ -48,6 +53,13 @@ env:
                 test_xmlrpc/test_[l-z]*.py"
         - TASK_TO_RUN="tox"
           TEST_RUNNER_CONFIG=".test_runner_config.yaml"
+
+before_install:
+    - ip addr show
+    - ls /proc/net
+    - cat /proc/net/if_inet6
+    - ip addr show dev lo | grep -q inet6 || (echo "No IPv6 address found"; exit 1)
+
 install:
     - pip3 install --upgrade pip
     - pip3 install pycodestyle


### PR DESCRIPTION
Latest Travis CI image lacks IPv6 address on localhost. Use image from
old group.

Signed-off-by: Christian Heimes <cheimes@redhat.com>