### PR TITLE
 [Backport][ipa-4-6] Travis: Add workaround for missing IPv6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 services:
     - docker
-
+# workaround for missing IPv6 address support
+# https://github.com/travis-ci/travis-ci/issues/8891
+group: deprecated-2017Q4
 python:
     - "3.6"
 cache: pip


### PR DESCRIPTION
Backport of PR #1393 

Latest Travis CI image lacks IPv6 address on localhost. Use image from
old group.

Signed-off-by: Christian Heimes <cheimes@redhat.com>