### PR TITLE
[Backport][ipa-4-6] Travis: Add workaround for missing IPv6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
+# workaround for missing IPv6 address support
+# https://github.com/travis-ci/travis-ci/issues/8891
+sudo: required
+dist: trusty
+group: deprecated-2017Q4
+
 language: python
+
 services:
     - docker
-
 python:
     - "3.6"
 cache: pip
@@ -48,6 +54,13 @@ env:
                 test_xmlrpc/test_[l-z]*.py"
         - TASK_TO_RUN="tox"
           TEST_RUNNER_CONFIG=".test_runner_config.yaml"
+
+before_install:
+    - ip addr show
+    - ls /proc/net
+    - cat /proc/net/if_inet6
+#    - ip addr show dev lo | grep -q inet6 || (echo "No IPv6 address found"; exit 1)
+
 install:
     - pip3 install --upgrade pip
     - pip3 install pycodestyle

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -152,6 +152,12 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                 "globally, disable it on the specific interfaces in "
                 "sysctl.conf except 'lo' interface.")
 
+        # XXX This is a hack to work around an issue with Travis CI by
+        # skipping IPv6 address test. The Dec 2017 update removed ::1 from
+        # loopback, see https://github.com/travis-ci/travis-ci/issues/8891.
+        if os.environ.get('TRAVIS') == 'true':
+            return
+
         try:
             localhost6 = ipautil.CheckedIPAddress('::1', allow_loopback=True)
             if localhost6.get_matching_interface() is None:


### PR DESCRIPTION
This PR was opened automatically because PR #1395 was pushed to master and backport to ipa-4-6 is required.