### PR TITLE
[Backport][ipa-4-5] Travis: Add workaround for missing IPv6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
-language: python
 group: deprecated-2017Q3
+
+language: python
+
 services:
     - docker
-
 python:
     - "2.7"
 cache: pip
@@ -28,10 +29,17 @@ env:
             test_ipaserver
             test_pkcs10
             test_xmlrpc/test_[l-z]*.py"
+
+before_install:
+    - ip addr show
+    - ls /proc/net
+    - cat /proc/net/if_inet6
+#    - ip addr show dev lo | grep -q inet6 || (echo "No IPv6 address found"; exit 1)
+
 install:
     - pip install --upgrade pip
     - pip3 install --upgrade pip
-    - pip install pycodestyle
+    - pip3 install pycodestyle
     - >
       pip3 install
       git+https://github.com/freeipa/ipa-docker-test-runner@release-0-2-1

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -156,6 +156,12 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                 "globally, disable it on the specific interfaces in "
                 "sysctl.conf except 'lo' interface.")
 
+        # XXX This is a hack to work around an issue with Travis CI by
+        # skipping IPv6 address test. The Dec 2017 update removed ::1 from
+        # loopback, see https://github.com/travis-ci/travis-ci/issues/8891.
+        if os.environ.get('TRAVIS') == 'true':
+            return
+
         try:
             localhost6 = ipautil.CheckedIPAddress('::1', allow_loopback=True)
             if localhost6.get_matching_interface() is None:


### PR DESCRIPTION
This PR was opened automatically because PR #1395 was pushed to master and backport to ipa-4-5 is required.