### PR TITLE
[Backport][ipa-4-6] prci: bump ci-master-f27 template to 1.0.2

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -23,7 +23,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f27
           name: freeipa/ci-master-f27
-          version: 1.0.1
+          version: 1.0.2
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Signed-off-by: Tomas Krizek <tkrizek@redhat.com>