### PR TITLE
Fix pylint warnings inconsistent-return-statements

### DIFF
--- a/ipaclient/plugins/migration.py
+++ b/ipaclient/plugins/migration.py
@@ -77,3 +77,4 @@ can use their Kerberos accounts.''')
                                ldapuri)
             return 1
         textui.print_plain(unicode(self.pwd_migration_msg))
+        return None

--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -118,6 +118,8 @@ def encrypt(data, symmetric_key=None, public_key=None):
                 label=None
             )
         )
+    else:
+        return None
 
 
 def decrypt(data, symmetric_key=None, private_key=None):
@@ -150,6 +152,8 @@ def decrypt(data, symmetric_key=None, private_key=None):
         except ValueError:
             raise errors.AuthenticationError(
                 message=_('Invalid credentials'))
+    else:
+        return None
 
 
 @register(no_fail=True)

--- a/ipalib/backend.py
+++ b/ipalib/backend.py
@@ -135,20 +135,16 @@ class Executioner(Backend):
         destroy_context()
 
     def execute(self, _name, *args, **options):
-        error = None
         try:
             if _name not in self.Command:
                 raise CommandError(name=_name)
-            result = self.Command[_name](*args, **options)
-        except PublicError as e:
-            error = e
+            return self.Command[_name](*args, **options)
+        except PublicError:
+            raise
         except Exception as e:
             logger.exception(
                 'non-public: %s: %s', e.__class__.__name__, str(e)
             )
-            error = InternalError()
-        destroy_context()
-        if error is None:
-            return result
-        assert isinstance(error, PublicError)
-        raise error #pylint: disable=E0702
+            raise InternalError()
+        finally:
+            destroy_context()

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -103,7 +103,8 @@ class textui(backend.Backend):
                                       struct.pack('HHHH', 0, 0, 0, 0))
                 return struct.unpack('HHHH', winsize)[1]
             except IOError:
-                return None
+                pass
+        return None
 
     def max_col_width(self, rows, col=None):
         """
@@ -607,6 +608,8 @@ class textui(backend.Backend):
             elif default is not None and data == u'':
                 return default
 
+        return default  # pylint consinstent return statements
+
     def prompt_password(self, label, confirm=True):
         """
         Prompt user for a password or read it in via stdin depending
@@ -622,7 +625,9 @@ class textui(backend.Backend):
                 pw2 = self.prompt_helper(repeat_prompt, label, prompt_func=getpass.getpass)
                 if pw1 == pw2:
                     return pw1
-                self.print_error( _('Passwords do not match!'))
+                else:
+                    self.print_error(_('Passwords do not match!'))
+                    return None
         else:
             return self.decode(sys.stdin.readline().strip())
 
@@ -1146,7 +1151,7 @@ class cli(backend.Executioner):
     def run(self, argv):
         cmd = self.get_command(argv)
         if cmd is None:
-            return
+            return None
         name = cmd.full_name
         kw = self.parse(cmd, argv[1:])
         if not isinstance(cmd, frontend.Local):
@@ -1166,6 +1171,7 @@ class cli(backend.Executioner):
                     return 0
         finally:
             self.destroy_context()
+        return None
 
     def parse(self, cmd, argv):
         parser = self.build_parser(cmd)
@@ -1249,7 +1255,7 @@ class cli(backend.Executioner):
 
     def __get_arg_name(self, arg, format_name=True):
         if arg.password:
-            return
+            return None
 
         name = to_cli(arg.cli_name).upper()
         if not format_name:

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -368,17 +368,17 @@ class Env(object):
         :param config_file: Path of the configuration file to load.
         """
         if not path.isfile(config_file):
-            return
+            return None
         parser = RawConfigParser()
         try:
             parser.read(config_file)
         except ParsingError:
-            return
+            return None
         if not parser.has_section(CONFIG_SECTION):
             parser.add_section(CONFIG_SECTION)
         items = parser.items(CONFIG_SECTION)
         if len(items) == 0:
-            return (0, 0)
+            return 0, 0
         i = 0
         for (key, value) in items:
             if key not in self:
@@ -386,7 +386,7 @@ class Env(object):
                 i += 1
         if 'config_loaded' not in self: # we loaded at least 1 file
             self['config_loaded'] = True
-        return (i, len(items))
+        return i, len(items)
 
     def _join(self, key, *parts):
         """
@@ -401,6 +401,8 @@ class Env(object):
         """
         if key in self and self[key] is not None:
             return path.join(self[key], *parts)
+        else:
+            return None
 
     def __doing(self, name):
         if name in self.__done:

--- a/ipalib/frontend.py
+++ b/ipalib/frontend.py
@@ -1005,6 +1005,8 @@ class Command(HasParam):
     def get_summary_default(self, output):
         if self.msg_summary:
             return self.msg_summary % output
+        else:
+            return None
 
     def log_messages(self, output):
         logger_functions = dict(
@@ -1035,7 +1037,7 @@ class Command(HasParam):
         Subclasses can override this method, if custom output is needed.
         """
         if not isinstance(output, dict):
-            return
+            return None
 
         rv = 0
 

--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -255,11 +255,12 @@ class DefaultFrom(ReadOnly):
         """
         vals = tuple(kw.get(k, None) for k in self.keys)
         if None in vals:
-            return
+            return None
         try:
             return self.callback(*vals)
         except Exception:
             pass
+        return None
 
     def __json__(self):
         return self.keys
@@ -1139,6 +1140,8 @@ class Int(Number):
             return _('must be at least %(minvalue)d') % dict(
                 minvalue=self.minvalue,
             )
+        else:
+            return None
 
     def _rule_maxvalue(self, _, value):
         """
@@ -1149,6 +1152,8 @@ class Int(Number):
             return _('can be at most %(maxvalue)d') % dict(
                 maxvalue=self.maxvalue,
             )
+        else:
+            return None
 
 
 class Decimal(Number):
@@ -1211,6 +1216,8 @@ class Decimal(Number):
             return _('must be at least %(minvalue)s') % dict(
                 minvalue=self.minvalue,
             )
+        else:
+            return None
 
     def _rule_maxvalue(self, _, value):
         """
@@ -1221,6 +1228,8 @@ class Decimal(Number):
             return _('can be at most %(maxvalue)s') % dict(
                 maxvalue=self.maxvalue,
             )
+        else:
+            return None
 
     def _enforce_numberclass(self, value):
         numberclass = value.number_class()
@@ -1352,6 +1361,8 @@ class Data(Param):
                 return _('must match pattern "%(pattern)s"') % dict(
                     pattern=self.pattern,
                 )
+        else:
+            return None
 
 
 class Bytes(Data):
@@ -1389,6 +1400,8 @@ class Bytes(Data):
             return _('must be at least %(minlength)d bytes') % dict(
                 minlength=self.minlength,
             )
+        else:
+            return None
 
     def _rule_maxlength(self, _, value):
         """
@@ -1399,6 +1412,8 @@ class Bytes(Data):
             return _('can be at most %(maxlength)d bytes') % dict(
                 maxlength=self.maxlength,
             )
+        else:
+            return None
 
     def _rule_length(self, _, value):
         """
@@ -1409,6 +1424,8 @@ class Bytes(Data):
             return _('must be exactly %(length)d bytes') % dict(
                 length=self.length,
             )
+        else:
+            return None
 
     def _convert_scalar(self, value, index=None):
         if isinstance(value, unicode):
@@ -1556,9 +1573,11 @@ class Str(Data):
         """
         assert type(value) is unicode
         if self.noextrawhitespace is False:
-            return
+            return None
         if len(value) != len(value.strip()):
             return _('Leading and trailing spaces are not allowed')
+        else:
+            return None
 
     def _rule_minlength(self, _, value):
         """
@@ -1569,6 +1588,8 @@ class Str(Data):
             return _('must be at least %(minlength)d characters') % dict(
                 minlength=self.minlength,
             )
+        else:
+            return None
 
     def _rule_maxlength(self, _, value):
         """
@@ -1579,6 +1600,8 @@ class Str(Data):
             return _('can be at most %(maxlength)d characters') % dict(
                 maxlength=self.maxlength,
             )
+        else:
+            return None
 
     def _rule_length(self, _, value):
         """
@@ -1589,6 +1612,8 @@ class Str(Data):
             return _('must be exactly %(length)d characters') % dict(
                 length=self.length,
             )
+        else:
+            return None
 
     def sort_key(self, value):
         return value.lower()
@@ -1658,6 +1683,8 @@ class Enum(Param):
             else:
                 values = u', '.join("'%s'" % value for value in self.values)
                 return _('must be one of %(values)s') % dict(values=values)
+        else:
+            return None
 
 class BytesEnum(Enum):
     """
@@ -2064,10 +2091,14 @@ class DNSNameParam(Param):
     def _rule_only_absolute(self, _, value):
         if self.only_absolute and not value.is_absolute():
             return _('must be absolute')
+        else:
+            return None
 
     def _rule_only_relative(self, _, value):
         if self.only_relative and value.is_absolute():
             return _('must be relative')
+        else:
+            return None
 
 
 class Dict(Param):

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -907,7 +907,7 @@ class RPCClient(Connectible):
         try:
             cookie_string = read_persistent_client_session_data(principal)
             if cookie_string is None:
-                return
+                return None
             cookie_string = cookie_string.decode('utf-8')
         except Exception as e:
             logger.debug('Error reading client session data: %s', e)

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -452,11 +452,15 @@ def validate_hostname(hostname, check_fqdn=True, allow_underscore=False, allow_s
 def normalize_sshpubkey(value):
     return SSHPublicKey(value).openssh()
 
+
 def validate_sshpubkey(ugettext, value):
     try:
         SSHPublicKey(value)
     except (ValueError, UnicodeDecodeError):
         return _('invalid SSH public key')
+    else:
+        return None
+
 
 def validate_sshpubkey_no_options(ugettext, value):
     try:
@@ -466,6 +470,8 @@ def validate_sshpubkey_no_options(ugettext, value):
 
     if pubkey.has_options():
         return _('options are not allowed')
+    else:
+        return None
 
 
 def convert_sshpubkey_post(entry_attrs):
@@ -685,18 +691,23 @@ def get_reverse_zone_default(ip_address):
 
     return normalize_zone('.'.join(items))
 
+
 def validate_rdn_param(ugettext, value):
     try:
         RDN(value)
     except Exception as e:
         return str(e)
-    return None
+    else:
+        return None
+
 
 def validate_hostmask(ugettext, hostmask):
     try:
         netaddr.IPNetwork(hostmask)
     except (ValueError, AddrFormatError):
         return _('invalid hostmask')
+    else:
+        return None
 
 
 class ForwarderValidationError(Exception):

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -276,7 +276,7 @@ class IPACertificate(object):
     def extended_key_usage_bytes(self):
         eku = self.extended_key_usage
         if eku is None:
-            return
+            return None
 
         ekurfc = rfc2459.ExtKeyUsageSyntax()
         for i, oid in enumerate(eku):

--- a/ipapython/config.py
+++ b/ipapython/config.py
@@ -246,6 +246,8 @@ def __discover_config(discover_server = True):
 
     except Exception:
         pass
+    return None
+
 
 def add_standard_options(parser):
     parser.add_option("--realm", dest="realm", help="Override default IPA realm")

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -232,6 +232,7 @@ class CheckedIPAddress(UnsafeIPAddress):
 
                 if ifnet.ip == self:
                     return InterfaceDetails(interface, ifnet)
+        return None
 
     def set_ip_net(self, ifnet):
         """Set IP Network details for this address. IPNetwork is valid only
@@ -928,7 +929,7 @@ def ipa_generate_password(entropy_bits=256, uppercase=1, lowercase=1, digits=1,
 
 
 def user_input(prompt, default = None, allow_empty = True):
-    if default == None:
+    if default is None:
         while True:
             try:
                 ret = input("%s: " % prompt)
@@ -979,6 +980,8 @@ def user_input(prompt, default = None, allow_empty = True):
                 return default
             else:
                 return ret
+
+    return None
 
 
 def host_port_open(host, port, socket_type=socket.SOCK_STREAM,

--- a/ipapython/session_storage.py
+++ b/ipapython/session_storage.py
@@ -353,6 +353,7 @@ def get_data(princ_name, key):
             krb5_cc_close(context, ccache)
         if context:
             krb5_free_context(context)
+    return None
 
 
 def remove_data(princ_name, key):

--- a/ipapython/ssh.py
+++ b/ipapython/ssh.py
@@ -205,7 +205,7 @@ class SSHPublicKey(object):
         elif self._keytype == 'ssh-ed25519':
             keytype = 4
         else:
-            return
+            return None
         fp = fpfunc(self._key).hexdigest().upper()
         return u'%d %d %s' % (keytype, fptype, fp)
 


### PR DESCRIPTION
Add consistent return to all functions and methods that are covered by
tox -e pylint[23]. I haven't checked if return None is always a good
idea or if we should rather raise an error.

See: https://pagure.io/freeipa/issue/7326
Signed-off-by: Christian Heimes <cheimes@redhat.com>