### PR TITLE
Use pylint 1.7.5 with fix for bad python3 import

### DIFF
--- a/.wheelconstraints.in
+++ b/.wheelconstraints.in
@@ -9,5 +9,5 @@ ipapython == @VERSION@
 ipaserver == @VERSION@
 ipatests == @VERSION@
 
-# we include some checks available only in pylint-1.7 and on
-pylint >= 1.7
+# upstream pylint 1.7.5 fixed bad python3 import of stat module
+pylint >= 1.7.5

--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -25,7 +25,7 @@ import io
 import pwd
 import grp
 import re
-import stat  # pylint: disable=bad-python3-import
+import stat
 import tempfile
 from tempfile import NamedTemporaryFile
 import shutil

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -33,7 +33,7 @@ import fileinput
 import sys
 import tempfile
 import shutil
-import stat  # pylint: disable=bad-python3-import
+import stat
 import traceback
 import textwrap
 from contextlib import contextmanager


### PR DESCRIPTION
Closes: https://pagure.io/freeipa/issue/7315
Signed-off-by: Christian Heimes <cheimes@redhat.com>