### PR TITLE
[Backport][ipa-4-6] Require python-ldap 3.0.0b2

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -59,7 +59,7 @@
 %global samba_version 2:4.7.0
 %global selinux_policy_version 3.13.1-158.4
 %global slapi_nis_version 0.56.1
-%global python_ldap_version 3.0.0
+%global python_ldap_version 3.0.0-0.2.b2
 %endif
 
 

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -77,17 +77,11 @@ TRUNCATED_ADMIN_LIMIT = object()
 DIRMAN_DN = DN(('cn', 'directory manager'))
 
 
-if six.PY2:
+if six.PY2 and hasattr(ldap, 'LDAPBytesWarning'):
     # XXX silence python-ldap's BytesWarnings
     warnings.filterwarnings(
         action="ignore",
-        message="Under Python 2, python-ldap uses bytes",
-        category=BytesWarning
-    )
-    warnings.filterwarnings(
-        action="ignore",
-        message="Received non-bytes value",
-        category=BytesWarning
+        category=ldap.LDAPBytesWarning,  # pylint: disable=no-member
     )
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #1390 was pushed to master and backport to ipa-4-6 is required.