### PR TITLE
Match Common Name attribute in Subject

### DIFF
--- a/ipaclient/remote_plugins/2_114/cert.py
+++ b/ipaclient/remote_plugins/2_114/cert.py
@@ -132,7 +132,7 @@ class cert_find(Command):
         parameters.Str(
             'subject',
             required=False,
-            label=_(u'Subject'),
+            label=_(u'Match cn attribute in subject'),
         ),
         parameters.Int(
             'revocation_reason',

--- a/ipaclient/remote_plugins/2_156/cert.py
+++ b/ipaclient/remote_plugins/2_156/cert.py
@@ -132,7 +132,7 @@ class cert_find(Command):
         parameters.Str(
             'subject',
             required=False,
-            label=_(u'Subject'),
+            label=_(u'Match cn attribute in subject'),
         ),
         parameters.Int(
             'revocation_reason',

--- a/ipaclient/remote_plugins/2_164/cert.py
+++ b/ipaclient/remote_plugins/2_164/cert.py
@@ -132,7 +132,7 @@ class cert_find(Command):
         parameters.Str(
             'subject',
             required=False,
-            label=_(u'Subject'),
+            label=_(u'Match cn attribute in subject'),
         ),
         parameters.Int(
             'revocation_reason',

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1295,7 +1295,7 @@ class cert_find(Search, CertMethod):
     takes_options = (
         Str('subject?',
             label=_('Subject'),
-            doc=_('Subject'),
+            doc=_('Match cn attribute in subject'),
             autofill=False,
         ),
         Int('min_serial_number?',


### PR DESCRIPTION
ipa cert_find command has an option called --subject. 
The option is documented as --subject=STR Subject. 
It is expected that a --subject option searches by X.509 subject field but it does not do so. 
It searches for CN not cert subject. Hence changing content of --subject help option.

Resolves: https://pagure.io/freeipa/issue/7322