### PR TITLE
Fixing how to parse the backup dir in test_backup_and_restore

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -126,8 +126,7 @@ def backup(host):
 
     # Get the backup location from the command's output
     for line in result.stderr_text.splitlines():
-        prefix = ('ipa.ipaserver.install.ipa_backup.Backup: '
-                  'INFO: Backed up to ')
+        prefix = 'ipaserver.install.ipa_backup: INFO: Backed up to'
         if line.startswith(prefix):
             backup_path = line[len(prefix):].strip()
             logger.info('Backup path for %s is %s', host, backup_path)


### PR DESCRIPTION
Fixing how the test_backup_and_restore.py suite parses the output
from the `ipa-backup -v` command in order to get the backup directory.

Fixes: [#7339](https://pagure.io/freeipa/issue/7339)