### PR TITLE
Check if replication exist before enable it

### DIFF
--- a/install/tools/ipa-replica-manage
+++ b/install/tools/ipa-replica-manage
@@ -1206,8 +1206,11 @@ def re_initialize(realm, thishost, fromhost, dirman_passwd, nolookup=False):
         repl = replication.ReplicationManager(realm, fromhost, dirman_passwd)
         agreement = repl.get_replication_agreement(thishost)
 
-        thisrepl.enable_agreement(fromhost)
-        repl.enable_agreement(thishost)
+        try:
+            thisrepl.enable_agreement(fromhost)
+            repl.enable_agreement(thishost)
+        except errors.NotFound as e:
+            sys.exit(e)
 
         repl.force_sync(repl.conn, thishost)
 

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -32,6 +32,7 @@ import ldap
 
 from ipalib import api, errors
 from ipalib.cli import textui
+from ipalib.text import _
 from ipapython import ipautil, ipaldap, kerberos
 from ipapython.admintool import ScriptError
 from ipapython.dn import DN
@@ -1547,6 +1548,11 @@ class ReplicationManager(object):
         Disable the replication agreement to hostname.
         """
         entry = self.get_replication_agreement(hostname)
+        if not entry:
+            raise errors.NotFound(reason=_(
+                "Replication agreement for %(hostname)s not found") % {
+                    'hostname': hostname
+                })
         entry['nsds5ReplicaEnabled'] = 'off'
 
         try:
@@ -1561,6 +1567,11 @@ class ReplicationManager(object):
         Note: for replication to work it needs to be enabled both ways.
         """
         entry = self.get_replication_agreement(hostname)
+        if not entry:
+            raise errors.NotFound(reason=_(
+                "Replication agreement for %(hostname)s not found") % {
+                    'hostname': hostname
+                })
         entry['nsds5ReplicaEnabled'] = 'on'
 
         try:


### PR DESCRIPTION
If the replication does not exist a custom exception is raised explaining the problem.

Fixes: [#7201](https://pagure.io/freeipa/issue/7201)