### PR TITLE
Avoid to use non existent attributes

### DIFF
--- a/ipaclient/remote_plugins/schema.py
+++ b/ipaclient/remote_plugins/schema.py
@@ -560,7 +560,7 @@ def get_package(server_info, client):
             ttl = schema.ttl
 
         server_info['fingerprint'] = fingerprint
-        server_info.update_validity(ttl)
+        server_info.update_validity(client, ttl=ttl)
 
     if fingerprint is None:
         raise NotAvailable()


### PR DESCRIPTION
Closes: https://pagure.io/freeipa/issue/7345

2nd commit: about `path` used by `ServerInfo._read` and `ServerInfo._write`, I am not sure what value could be used here (with this patch both methods do nothing). Should the domain be used there (for example: `~/.cache/ipa/servers/ipa.test`) or network location extracted from `ipalib.request.context.request_url` ?

Related: 3f6411a49c49da7013341ff8feae3a63e75e0fbf.