### PR TITLE
Make fastlint even faster

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -210,17 +210,17 @@ endif
 	FILES=$$(git diff --name-only $${MERGEBASE} \
 	    | grep -E '\.py$$'); \
 	if [ -n "$${FILES}" ]; then \
-		echo "Fast linting files: $${FILES}"; \
-		echo "pylint"; \
-		echo "------"; \
-	    PYTHONPATH=$(abspath $(top_srcdir)) $(PYTHON) -m pylint \
-	        --rcfile=$(top_srcdir)/pylintrc \
-	        --load-plugins pylint_plugins \
-	        $${FILES} || exit $?; \
+	    echo -e "Fast linting files:\n$${FILES}\n"; \
 	    echo "pycodestyle"; \
 	    echo "-----------"; \
 	    git diff $${MERGEBASE} | \
-	        $(PYTHON) -m pycodestyle --diff || exit $?; \
+	        $(PYTHON) -m pycodestyle --diff || exit $$?; \
+	    echo -e "\npylint"; \
+	    echo "------"; \
+	    PYTHONPATH=$(abspath $(top_srcdir)) $(PYTHON) -m pylint \
+	        --rcfile=$(top_srcdir)/pylintrc \
+	        --load-plugins pylint_plugins \
+	        $${FILES} || exit $$?; \
 	else \
 	    echo "No modified Python files found"; \
 	fi


### PR DESCRIPTION
- Check pycodestyle before pylint. pycodestyle takes seconds while
  pylint can easily take half a minute or more.
- Fix exit, needs two $
- Add some newlines to make output more readable

Signed-off-by: Christian Heimes <cheimes@redhat.com>