### PR TITLE
Sort external schema files

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -185,7 +185,7 @@ def get_all_external_schema_files(root):
         for name in files:
             if fnmatch.fnmatch(name, "*.ldif"):
                 f.append(os.path.join(path, name))
-    return f
+    return sorted(f)
 
 
 INF_TEMPLATE = """


### PR DESCRIPTION
get_all_external_schema_files() now returns schema files sorted.

Fixes: https://pagure.io/freeipa/issue/7338

Signed-off-by: Christian Heimes <cheimes@redhat.com>