### PR TITLE
Removing ipaCert Private key & certificate after ipa upgrade

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -791,7 +791,7 @@ class NSSDatabase(object):
         self.run_certutil(args, stdin=cert.public_bytes(x509.Encoding.PEM))
 
     def delete_cert(self, nick):
-        self.run_certutil(["-D", "-n", nick])
+        self.run_certutil(["-F", "-n", nick])
 
     def verify_server_cert_validity(self, nickname, hostname):
         """Verify a certificate is valid for a SSL server with given hostname


### PR DESCRIPTION
 `# yum install ipa-server -y  {IPA 4.4}`
 `# ipa-server-install`
 `#yum update ipa-* -y`
 `# ls -ltr /etc/httpd/alias`

 Presently "-D" option only removes Cert.
 **`certutil ... -D -n ipaCert`**

 Using '-F' option to remove Private key and cert both
 **`certutil ... -F -n ipaCert`**

Resolves: https://pagure.io/freeipa/issue/7329