### PR TITLE
Fixing test_backup_and_restore assert to do not rely on the order of returned data

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -65,6 +65,15 @@ def check_admin_in_ldap(host):
 def check_admin_in_cli(host):
     result = host.run_command(['ipa', 'user-show', 'admin'])
     assert 'User login: admin' in result.stdout_text, result.stdout_text
+
+    # LDAP do not guarantee any order, so the test cannot assume it. Based on
+    # that, the code bellow order the 'Member of groups' field to able to
+    # assert it latter.
+    data = dict(re.findall("\W*(.+):\W*(.+)\W*", result.stdout_text))
+    data["Member of groups"] = ', '.join(sorted(data["Member of groups"]
+                                                .split(", ")))
+    result.stdout_text = ''.join([' {}: {}\n'.format(k, v)
+                                  for k, v in data.items()])
     return result
 
 


### PR DESCRIPTION
Since we cannot assume that LDAP will return data in an ordered way,
the test should be changed to do not rely on that.

Instead of just comparing the output of the show-user command, this change
first order the groups returned in the 'Member of Group' field before
compare them.

https://pagure.io/freeipa/issue/7339

The result (green tests) can be checked here:
https://fedorapeople.org/groups/freeipa/prci/jobs/c43c46d0-f4aa-11e7-925b-001a4a2316ab/

This PR depends on the PR #1354 