### PR TITLE
Custom ca-subject logging

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1284,7 +1284,8 @@ def load_external_cert(files, ca_subject):
 
         if ca_nickname is None:
             raise ScriptError(
-                "IPA CA certificate not found in %s" % (", ".join(files)))
+                "IPA CA certificate with subject '%s' "
+                "was not found in %s." % (ca_subject, (",".join(files))))
 
         trust_chain = list(reversed(nssdb.get_trust_chain(ca_nickname)))
         ca_cert_chain = []


### PR DESCRIPTION
Present Situation:
Logging is a bit incomplete when using a custom CA subject passed in via --ca-subject.
If there is a problem finding the IPA CA certificate then the installer will log:
>ERROR IPA CA certificate not found in /tmp/servercert.pem, /tmp/cacert.pem

After the Fix this sort of log is seen:
>ipa.ipapython.install.cli.install_tool(Server): DEBUG    The ipa-server-install command failed, exception: ScriptError:
>IPA CA certificate not found in /root/ipa.cert, /root/rootCA.crt.
>Wrong CA Certificate File found
>CA certificate subject 'CN=testers,OU=Hong Kong CA Org,O=Hong Kong CA,L=Hong Kong,ST=BRazial,C=US'

Resolves: https://pagure.io/freeipa/issue/7245