### PR TITLE
test_caless: add SAN extension to server certs

### DIFF
--- a/ipatests/pytest_plugins/integration/create_caless_pki.py
+++ b/ipatests/pytest_plugins/integration/create_caless_pki.py
@@ -384,14 +384,14 @@ def gen_server_certs(nick_base, hostname, org, ca=None):
                 x509.NameAttribute(NameOID.ORGANIZATION_NAME, org),
                 x509.NameAttribute(NameOID.COMMON_NAME, hostname)
              ]),
-             ca
+             ca, dns_name=hostname
              )
     gen_cert(profile_server, nick_base + u'-badname',
              x509.Name([
                 x509.NameAttribute(NameOID.ORGANIZATION_NAME, org),
                 x509.NameAttribute(NameOID.COMMON_NAME, u'not-' + hostname)
              ]),
-             ca
+             ca, dns_name=u'not-' + hostname
              )
     gen_cert(profile_server, nick_base + u'-altname',
              x509.Name([
@@ -407,7 +407,7 @@ def gen_server_certs(nick_base, hostname, org, ca=None):
                                    u'Expired'),
                 x509.NameAttribute(NameOID.COMMON_NAME, hostname)
              ]),
-             ca, warp=-2 * YEAR
+             ca, dns_name=hostname, warp=-2 * YEAR
              )
     gen_cert(profile_server, nick_base + u'-badusage',
              x509.Name([
@@ -416,7 +416,7 @@ def gen_server_certs(nick_base, hostname, org, ca=None):
                                    u'Bad Usage'),
                 x509.NameAttribute(NameOID.COMMON_NAME, hostname)
              ]),
-             ca, badusage=True
+             ca, dns_name=hostname, badusage=True
              )
     revoked = gen_cert(profile_server, nick_base + u'-revoked',
                        x509.Name([
@@ -425,7 +425,7 @@ def gen_server_certs(nick_base, hostname, org, ca=None):
                                               u'Revoked'),
                            x509.NameAttribute(NameOID.COMMON_NAME, hostname)
                        ]),
-                       ca
+                       ca, dns_name=hostname
                        )
     revoke_cert(ca, revoked.cert.serial_number)
 


### PR DESCRIPTION
Currently when testing we are using SAN extension only in
KDC, wildcard certs and not in the valid http/ds certs.
During replica installation we then see a warning about certs
having no `subjectAltName`.
  
`[ipatests.pytest_plugins.integration.host.Host.replica.cmd1047]   [7/41]: adding default schema
[ipatests.pytest_plugins.integration.host.Host.replica.cmd1047] /usr/lib/python3.6/site-packages/requests/packages/urllib3/connection.py:340: SubjectAltNameWarning: Certificate for replica.ipa.test has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/shazow/urllib3/issues/497 for details.)`