### PR TITLE
Switch from mod_nss to mod_ssl

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1515,6 +1515,7 @@ fi
 %attr(711,root,root) %dir %{_localstatedir}/lib/ipa/sysrestore
 %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/sysupgrade
 %attr(755,root,root) %dir %{_localstatedir}/lib/ipa/pki-ca
+%attr(755,root,root) %dir %{_localstatedir}/lib/ipa/certs
 %ghost %{_localstatedir}/lib/ipa/pki-ca/publish
 %ghost %{_localstatedir}/named/dyndb-ldap/ipa
 %dir %attr(0700,root,root) %{_sysconfdir}/ipa/custodia

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -342,8 +342,7 @@ Requires: python2-systemd
 Requires: mod_wsgi
 %endif
 Requires: mod_auth_gssapi >= 1.5.0
-# 1.0.14-3: https://bugzilla.redhat.com/show_bug.cgi?id=1431206
-Requires: mod_nss >= 1.0.14-3
+Requires: mod_ssl
 Requires: mod_session
 # 0.9.9: https://github.com/adelton/mod_lookup_identity/pull/3
 Requires: mod_lookup_identity >= 0.9.9

--- a/install/Makefile.am
+++ b/install/Makefile.am
@@ -24,10 +24,12 @@ install-exec-local:
 	$(INSTALL) -d -m 700 $(DESTDIR)$(localstatedir)/lib/ipa/sysrestore
 	$(INSTALL) -d -m 700 $(DESTDIR)$(localstatedir)/lib/ipa/sysupgrade
 	$(INSTALL) -d -m 755 $(DESTDIR)$(localstatedir)/lib/ipa/pki-ca
+	$(INSTALL) -d -m 755 $(DESTDIR)$(localstatedir)/lib/ipa/certs
 
 uninstall-local:
 	-rmdir $(DESTDIR)$(localstatedir)/lib/ipa/sysrestore
 	-rmdir $(DESTDIR)$(localstatedir)/lib/ipa/sysupgrade
+	-rmdir $(DESTDIR)$(localstatedir)/lib/ipa/certs
 	-rmdir $(DESTDIR)$(localstatedir)/lib/ipa
 
 EXTRA_DIST = README.schema

--- a/install/share/ipa-pki-proxy.conf.template
+++ b/install/share/ipa-pki-proxy.conf.template
@@ -1,43 +1,43 @@
-# VERSION 11 - DO NOT REMOVE THIS LINE
+# VERSION 12 - DO NOT REMOVE THIS LINE
 
 ProxyRequests Off
 
 # matches for ee port
 <LocationMatch "^/ca/ee/ca/checkRequest|^/ca/ee/ca/getCertChain|^/ca/ee/ca/getTokenInfo|^/ca/ee/ca/tokenAuthenticate|^/ca/ocsp|^/ca/ee/ca/updateNumberRange|^/ca/ee/ca/getCRL|^/ca/ee/ca/profileSubmit">
-    NSSOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
-    NSSVerifyClient none
+    SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
+    SSLVerifyClient none
     ProxyPassMatch ajp://localhost:$DOGTAG_PORT
     ProxyPassReverse ajp://localhost:$DOGTAG_PORT
 </LocationMatch>
 
 # matches for admin port and installer
 <LocationMatch "^/ca/admin/ca/getCertChain|^/ca/admin/ca/getConfigEntries|^/ca/admin/ca/getCookie|^/ca/admin/ca/getStatus|^/ca/admin/ca/securityDomainLogin|^/ca/admin/ca/getDomainXML|^/ca/admin/ca/updateNumberRange|^/ca/admin/ca/tokenAuthenticate|^/ca/admin/ca/updateNumberRange|^/ca/admin/ca/updateDomainXML|^/ca/admin/ca/updateConnector|^/ca/admin/ca/getSubsystemCert|^/kra/admin/kra/updateNumberRange|^/kra/admin/kra/getConfigEntries">
-    NSSOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
-    NSSVerifyClient none
+    SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
+    SSLVerifyClient none
     ProxyPassMatch ajp://localhost:$DOGTAG_PORT
     ProxyPassReverse ajp://localhost:$DOGTAG_PORT
 </LocationMatch>
 
 # matches for agent port and eeca port
 <LocationMatch "^/ca/agent/ca/displayBySerial|^/ca/agent/ca/doRevoke|^/ca/agent/ca/doUnrevoke|^/ca/agent/ca/updateDomainXML|^/ca/eeca/ca/profileSubmitSSLClient|^/kra/agent/kra/connector">
-    NSSOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
-    NSSVerifyClient require
+    SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
+    SSLVerifyClient require
     ProxyPassMatch ajp://localhost:$DOGTAG_PORT
     ProxyPassReverse ajp://localhost:$DOGTAG_PORT
 </LocationMatch>
 
 # matches for CA REST API
 <LocationMatch "^/ca/rest/account/login|^/ca/rest/account/logout|^/ca/rest/installer/installToken|^/ca/rest/securityDomain/domainInfo|^/ca/rest/securityDomain/installToken|^/ca/rest/profiles|^/ca/rest/authorities|^/ca/rest/certrequests|^/ca/rest/admin/kraconnector/remove|^/ca/rest/certs/search">
-    NSSOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
-    NSSVerifyClient optional
+    SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
+    SSLVerifyClient optional
     ProxyPassMatch ajp://localhost:$DOGTAG_PORT
     ProxyPassReverse ajp://localhost:$DOGTAG_PORT
 </LocationMatch>
 
 # matches for KRA REST API
 <LocationMatch "^/kra/rest/config/cert/transport|^/kra/rest/account|^/kra/rest/agent/keyrequests|^/kra/rest/agent/keys">
-    NSSOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
-    NSSVerifyClient optional
+    SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
+    SSLVerifyClient optional
     ProxyPassMatch ajp://localhost:$DOGTAG_PORT
     ProxyPassReverse ajp://localhost:$DOGTAG_PORT
 </LocationMatch>

--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -113,8 +113,8 @@ Alias /ipa/session/cookie "/usr/share/ipa/gssapi.login"
   AuthType none
   GssapiDelegCcacheDir $IPA_CCACHES
   GssapiDelegCcachePerms mode:0660 gid:ipaapi
-  NSSVerifyClient require
-  NSSUserName SSL_CLIENT_CERT
+  SSLVerifyClient require
+  SSLUserName SSL_CLIENT_CERT
   LookupUserByCertificate On
   LookupUserByCertificateParamName "username"
   WSGIProcessGroup ipa

--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -150,7 +150,6 @@ def update_server(certs):
     if services.knownservices.dirsrv.is_running():
         services.knownservices.dirsrv.restart(instance)
 
-    update_db(paths.HTTPD_ALIAS_DIR, certs)
     if services.knownservices.httpd.is_running():
         services.knownservices.httpd.restart()
 

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -670,11 +670,3 @@ def wait_for_request(request_id, timeout=120):
         raise RuntimeError("request timed out")
 
     return state
-
-if __name__ == '__main__':
-    request_id = request_cert(paths.HTTPD_ALIAS_DIR,
-                              "cn=tiger.example.com,O=IPA",
-                              "HTTP/tiger.example.com@EXAMPLE.COM", "Test")
-    csr = get_request_value(request_id, 'csr')
-    print(csr)
-    stop_tracking(request_id)

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -421,7 +421,7 @@ def load_unknown_x509_certificate(data):
         return load_der_x509_certificate(data)
 
 
-def load_certificate_from_file(filename, dbdir=None):
+def load_certificate_from_file(filename):
     """
     Load a certificate from a PEM file.
 

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -31,6 +31,7 @@
 
 from __future__ import print_function
 
+import os
 import binascii
 import datetime
 import ipaddress
@@ -41,8 +42,9 @@ import re
 from cryptography import x509 as crypto_x509
 from cryptography import utils as crypto_utils
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.serialization import (
-    Encoding, PublicFormat
+    Encoding, PublicFormat, PrivateFormat, load_pem_private_key
 )
 from pyasn1.type import univ, char, namedtype, tag
 from pyasn1.codec.der import decoder, encoder
@@ -59,8 +61,12 @@ if six.PY3:
 PEM = 0
 DER = 1
 
-PEM_REGEX = re.compile(
+PEM_CERT_REGEX = re.compile(
     b'-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----',
+    re.DOTALL)
+PEM_PRIV_REGEX = re.compile(
+    b'-----BEGIN(?: ENCRYPTED)?(?: (?:RSA|DSA|DH|EC))? PRIVATE KEY-----.*?'
+    b'-----END(?: ENCRYPTED)?(?: (?:RSA|DSA|DH|EC))? PRIVATE KEY-----',
     re.DOTALL)
 
 EKU_SERVER_AUTH = '1.3.6.1.5.5.7.3.1'
@@ -431,7 +437,7 @@ def load_certificate_list(data):
 
     Return a list of python-cryptography ``Certificate`` objects.
     """
-    certs = PEM_REGEX.findall(data)
+    certs = PEM_CERT_REGEX.findall(data)
     return [load_pem_x509_certificate(cert) for cert in certs]
 
 
@@ -444,6 +450,35 @@ def load_certificate_list_from_file(filename):
     """
     with open(filename, 'rb') as f:
         return load_certificate_list(f.read())
+
+
+def load_private_key_list(data, password=None):
+    """
+    Load a private key list from a sequence of concatenated PEMs.
+
+    :param data: bytes containing the private keys
+    :param password: bytes, the password to encrypted keys in the bundle
+
+    :returns: List of python-cryptography ``PrivateKey`` objects
+    """
+    crypto_backend = default_backend()
+    priv_keys = []
+
+    for match in re.finditer(PEM_PRIV_REGEX, data):
+        if re.search(b"ENCRYPTED", match.group()) is not None:
+            if password is None:
+                raise RuntimeError("Password is required for the encrypted "
+                                   "keys in the bundle.")
+            # Load private key as encrypted
+            priv_keys.append(
+                load_pem_private_key(match.group(), password,
+                                     backend=crypto_backend))
+        else:
+            priv_keys.append(
+                load_pem_private_key(match.group(), None,
+                                     backend=crypto_backend))
+
+    return priv_keys
 
 
 def pkcs7_to_certs(data, datatype=PEM):
@@ -531,6 +566,24 @@ def write_certificate_list(certs, filename):
         with open(filename, 'wb') as f:
             for cert in certs:
                 f.write(cert.public_bytes(Encoding.PEM))
+    except (IOError, OSError) as e:
+        raise errors.FileError(reason=str(e))
+
+
+def write_pem_private_key(priv_key, filename):
+    """
+    Write a private key to a file in PEM format. Will force 0x600 permissions
+    on file.
+
+    :param priv_key: cryptography ``PrivateKey`` object
+    """
+    try:
+        with open(filename, 'wb') as fp:
+            os.fchmod(fp.fileno(), 0o600)
+            fp.write(priv_key.private_bytes(
+                Encoding.PEM,
+                PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption()))
     except (IOError, OSError) as e:
         raise errors.FileError(reason=str(e))
 

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -543,8 +543,7 @@ def write_certificate(cert, filename):
     """
     Write the certificate to a file in PEM format.
 
-    The cert value can be either DER or PEM-encoded, it will be normalized
-    to DER regardless, then back out to PEM.
+    :param cert: cryptograpy ``Certificate`` object
     """
 
     try:

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -51,6 +51,8 @@ class BasePathNamespace(object):
     HTTPD_IPA_CONF = "/etc/httpd/conf.d/ipa.conf"
     HTTPD_NSS_CONF = "/etc/httpd/conf.d/nss.conf"
     HTTPD_SSL_CONF = "/etc/httpd/conf.d/ssl.conf"
+    HTTPD_CERT_FILE = "/etc/pki/tls/certs/httpd.crt"
+    HTTPD_KEY_FILE = "/etc/pki/tls/private/httpd.key"
     # only used on Fedora
     HTTPD_IPA_WSGI_MODULES_CONF = None
     OLD_IPA_KEYTAB = "/etc/httpd/conf/ipa.keytab"

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -51,8 +51,8 @@ class BasePathNamespace(object):
     HTTPD_IPA_CONF = "/etc/httpd/conf.d/ipa.conf"
     HTTPD_NSS_CONF = "/etc/httpd/conf.d/nss.conf"
     HTTPD_SSL_CONF = "/etc/httpd/conf.d/ssl.conf"
-    HTTPD_CERT_FILE = "/etc/pki/tls/certs/httpd.crt"
-    HTTPD_KEY_FILE = "/etc/pki/tls/private/httpd.key"
+    HTTPD_CERT_FILE = "/var/lib/ipa/certs/httpd.crt"
+    HTTPD_KEY_FILE = "/var/lib/ipa/certs/httpd.key"
     # only used on Fedora
     HTTPD_IPA_WSGI_MODULES_CONF = None
     OLD_IPA_KEYTAB = "/etc/httpd/conf/ipa.keytab"

--- a/ipaserver/advise/plugins/smart_card_auth.py
+++ b/ipaserver/advise/plugins/smart_card_auth.py
@@ -2,13 +2,11 @@
 # Copyright (C) 2017 FreeIPA Contributors see COPYING for license
 #
 
-import os
-
 from ipalib.plugable import Registry
 from ipaplatform import services
 from ipaplatform.paths import paths
 from ipaserver.advise.base import Advice
-from ipaserver.install.httpinstance import NSS_OCSP_ENABLED
+from ipaserver.install.httpinstance import OCSP_ENABLED, OCSP_DIRECTIVE
 
 register = Registry()
 
@@ -93,8 +91,7 @@ class config_server_for_smart_card_auth(common_smart_card_auth_config):
                    "whole topology you have to run the script on each master")
 
     nss_conf = paths.HTTPD_NSS_CONF
-    nss_ocsp_directive = 'NSSOCSP'
-    nss_nickname_directive = 'NSSNickname'
+    nss_ocsp_directive = OCSP_DIRECTIVE
     kdc_service_name = services.knownservices.krb5kdc.systemd_name
 
     def get_info(self):
@@ -104,7 +101,6 @@ class config_server_for_smart_card_auth(common_smart_card_auth_config):
         self.check_hostname_is_in_masters()
         self.resolve_ipaca_records()
         self.enable_nss_ocsp()
-        self.mark_httpd_cert_as_trusted()
         self.restart_httpd()
         self.record_httpd_ocsp_status()
         self.check_and_enable_pkinit()
@@ -173,27 +169,6 @@ class config_server_for_smart_card_auth(common_smart_card_auth_config):
     def _format_command(self, fmt_line, directive, filename):
         return fmt_line.format(directive=directive, filename=filename)
 
-    def mark_httpd_cert_as_trusted(self):
-        httpd_nss_database_pwd_file = os.path.join(
-            paths.HTTPD_ALIAS_DIR, 'pwdfile.txt')
-        self.log.comment(
-            'mark the HTTP certificate as trusted peer to avoid '
-            'chicken-egg startup issue')
-        self.log.command(
-            self._interpolate_nssnickname_directive_file_into_command(
-                "http_cert_nick=$(grep '{directive}' {filename} |"
-                " cut -f 2 -d ' ')"))
-
-        self.log.exit_on_failed_command(
-            'certutil -M -n $http_cert_nick -d "{}" -f {} -t "Pu,u,u"'.format(
-                paths.HTTPD_ALIAS_DIR,
-                httpd_nss_database_pwd_file),
-            ['Can not set trust flags on HTTP certificate'])
-
-    def _interpolate_nssnickname_directive_file_into_command(self, fmt_line):
-        return self._format_command(
-            fmt_line, self.nss_nickname_directive, self.nss_conf)
-
     def restart_httpd(self):
         self.log.comment('finally restart apache')
         self.log.command('systemctl restart httpd')
@@ -203,7 +178,7 @@ class config_server_for_smart_card_auth(common_smart_card_auth_config):
         self.log.command(
             "python -c 'from ipaserver.install import sysupgrade; "
             "sysupgrade.set_upgrade_state(\"httpd\", "
-            "\"{}\", True)'".format(NSS_OCSP_ENABLED))
+            "\"{}\", True)'".format(OCSP_ENABLED))
 
     def check_and_enable_pkinit(self):
         self.log.comment('check whether PKINIT is configured on the master')

--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -225,7 +225,7 @@ class CustodiaInstance(SimpleServiceInstance):
 
             # Add CA certificates
             self.suffix = ipautil.realm_to_suffix(self.realm)
-            self.import_ca_certs(tmpdb, True)
+            self.import_ca_certs_nssdb(tmpdb, True)
 
             # Now that we gathered all certs, re-export
             ipautil.run([paths.PKCS12EXPORT,

--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -225,7 +225,7 @@ class CustodiaInstance(SimpleServiceInstance):
 
             # Add CA certificates
             self.suffix = ipautil.realm_to_suffix(self.realm)
-            self.import_ca_certs_nssdb(tmpdb, True)
+            self.export_ca_certs_nssdb(tmpdb, True)
 
             # Now that we gathered all certs, re-export
             ipautil.run([paths.PKCS12EXPORT,

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -938,7 +938,7 @@ class DsInstance(service.Service):
         conn.simple_bind(bind_dn=ipaldap.DIRMAN_DN,
                          bind_password=self.dm_password)
 
-        self.import_ca_certs_nssdb(dsdb, self.ca_is_configured, conn)
+        self.export_ca_certs_nssdb(dsdb, self.ca_is_configured, conn)
 
         conn.unbind()
 

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -938,7 +938,7 @@ class DsInstance(service.Service):
         conn.simple_bind(bind_dn=ipaldap.DIRMAN_DN,
                          bind_password=self.dm_password)
 
-        self.import_ca_certs(dsdb, self.ca_is_configured, conn)
+        self.import_ca_certs_nssdb(dsdb, self.ca_is_configured, conn)
 
         conn.unbind()
 

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -593,6 +593,7 @@ class HTTPInstance(service.Service):
         self.configure_mod_ssl_certs()
         self.set_mod_ssl_protocol()
         self.set_mod_ssl_logdir()
+        self.__add_include()
 
         self.cert = x509.load_certificate_from_file(paths.HTTPD_CERT_FILE)
 

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -577,6 +577,7 @@ class HTTPInstance(service.Service):
                                        pk12_password,
                                        paths.HTTPD_KEY_FILE)
 
+        self.backup_ssl_conf()
         self.configure_mod_ssl_certs()
         self.set_mod_ssl_protocol()
         self.set_mod_ssl_logdir()

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -212,7 +212,6 @@ class HTTPInstance(service.Service):
         # There is no safe way to co-exist since there is no safe port
         # to make mod_nss use, disable it completely.
         if os.path.exists(paths.HTTPD_NSS_CONF):
-            self.fstore.backup_file(paths.HTTPD_NSS_CONF)
             installutils.remove_file(paths.HTTPD_NSS_CONF)
 
     def set_mod_ssl_protocol(self):

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -419,7 +419,7 @@ class HTTPInstance(service.Service):
                                    paths.IPA_CA_CRT, False)
 
     def __publish_ca_cert(self):
-        self.import_ca_certs_file(paths.CA_CRT, self.ca_is_configured)
+        self.export_ca_certs_file(paths.CA_CRT, self.ca_is_configured)
 
     def is_kdcproxy_configured(self):
         """Check if KDC proxy has already been configured in the past"""

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -18,24 +18,20 @@
 #
 
 from __future__ import print_function
+from __future__ import absolute_import
 
 import logging
 import os
 import os.path
-import pwd
-import re
 import dbus
 import shlex
 import pipes
-import locale
+import tempfile
 
-import six
 from augeas import Augeas
 
 from ipalib.install import certmonger
 from ipapython import ipaldap
-from ipapython.certdb import (IPA_CA_TRUST_FLAGS,
-                              EXTERNAL_CA_TRUST_FLAGS)
 from ipaserver.install import replication
 from ipaserver.install import service
 from ipaserver.install import certs
@@ -45,7 +41,7 @@ from ipapython import ipautil
 from ipapython.dn import DN
 import ipapython.errors
 from ipaserver.install import sysupgrade
-from ipalib import api
+from ipalib import api, x509
 from ipalib.constants import IPAAPI_USER
 from ipaplatform.constants import constants
 from ipaplatform.tasks import tasks
@@ -57,51 +53,9 @@ logger = logging.getLogger(__name__)
 HTTPD_USER = constants.HTTPD_USER
 KDCPROXY_USER = constants.KDCPROXY_USER
 
-# See contrib/nsscipersuite/nssciphersuite.py
-NSS_CIPHER_SUITE = [
-    '+aes_128_sha_256', '+aes_256_sha_256',
-    '+ecdhe_ecdsa_aes_128_gcm_sha_256', '+ecdhe_ecdsa_aes_128_sha',
-    '+ecdhe_ecdsa_aes_256_gcm_sha_384', '+ecdhe_ecdsa_aes_256_sha',
-    '+ecdhe_rsa_aes_128_gcm_sha_256', '+ecdhe_rsa_aes_128_sha',
-    '+ecdhe_rsa_aes_256_gcm_sha_384', '+ecdhe_rsa_aes_256_sha',
-    '+rsa_aes_128_gcm_sha_256', '+rsa_aes_128_sha',
-    '+rsa_aes_256_gcm_sha_384', '+rsa_aes_256_sha'
-]
-NSS_CIPHER_REVISION = '20160129'
+OCSP_DIRECTIVE = 'SSLOCSPEnable'
 
-OCSP_DIRECTIVE = 'NSSOCSP'
-
-NSS_OCSP_ENABLED = 'nss_ocsp_enabled'
-
-
-def httpd_443_configured():
-    """
-    We now allow mod_ssl to be installed so don't automatically disable it.
-    However it can't share the same listen port as mod_nss, so check for that.
-
-    Returns True if something other than mod_nss is listening on 443.
-    False otherwise.
-    """
-    try:
-        result = ipautil.run([paths.HTTPD, '-t', '-D', 'DUMP_VHOSTS'],
-                             capture_output=True)
-    except ipautil.CalledProcessError as e:
-        service.print_msg("WARNING: cannot check if port 443 is already configured")
-        service.print_msg("httpd returned error when checking: %s" % e)
-        return False
-
-    port_line_re = re.compile(r'(?P<address>\S+):(?P<port>\d+)')
-    stdout = result.raw_output
-    if six.PY3:
-        stdout = stdout.decode(locale.getpreferredencoding(), errors='replace')
-    for line in stdout.splitlines():
-        m = port_line_re.match(line)
-        if m and int(m.group('port')) == 443:
-            service.print_msg("Apache is already configured with a listener on port 443:")
-            service.print_msg(line)
-            return True
-
-    return False
+OCSP_ENABLED = 'ocsp_enabled'
 
 
 class WebGuiInstance(service.SimpleServiceInstance):
@@ -160,14 +114,13 @@ class HTTPInstance(service.Service):
         self.master_fqdn = master_fqdn
 
         self.step("stopping httpd", self.__stop)
-        self.step("setting mod_nss port to 443", self.__set_mod_nss_port)
-        self.step("setting mod_nss cipher suite",
-                  self.set_mod_nss_cipher_suite)
-        self.step("setting mod_nss protocol list to TLSv1.0 - TLSv1.2",
-                  self.set_mod_nss_protocol)
-        self.step("setting mod_nss password file", self.__set_mod_nss_passwordfile)
-        self.step("enabling mod_nss renegotiate", self.enable_mod_nss_renegotiate)
-        self.step("disabling mod_nss OCSP", self.disable_mod_nss_ocsp)
+        self.step("backing up ssl.conf", self.backup_ssl_conf)
+        self.step("disabling nss.conf", self.disable_nss_conf)
+        self.step("setting mod_ssl protocol list to TLSv1.0 - TLSv1.2",
+                  self.set_mod_ssl_protocol)
+        self.step("configuring mod_ssl log directory",
+                  self.set_mod_ssl_logdir)
+        self.step("disabling mod_ssl OCSP", self.disable_mod_ssl_ocsp)
         self.step("adding URL rewriting rules", self.__add_include)
         self.step("configuring httpd", self.__configure_http)
         self.step("setting up httpd keytab", self.request_service_keytab)
@@ -176,7 +129,6 @@ class HTTPInstance(service.Service):
         if self.ca_is_configured:
             self.step("configure certmonger for renewals",
                       self.configure_certmonger_renewal_guard)
-        self.step("importing CA certificates from LDAP", self.__import_ca_certs)
         self.step("publish CA cert", self.__publish_ca_cert)
         self.step("clean up any existing httpd ccaches",
                   self.remove_httpd_ccaches)
@@ -246,63 +198,50 @@ class HTTPInstance(service.Service):
         tasks.configure_http_gssproxy_conf(IPAAPI_USER)
         services.knownservices.gssproxy.restart()
 
-    def change_mod_nss_port_from_http(self):
-        # mod_ssl enforces SSLEngine on for vhost on 443 even though
-        # the listener is mod_nss. This then crashes the httpd as mod_nss
-        # listened port obviously does not match mod_ssl requirements.
-        #
-        # The workaround for this was to change port to http. It is no longer
-        # necessary, as mod_nss now ships with default configuration which
-        # sets SSLEngine off when mod_ssl is installed.
-        #
-        # Remove the workaround.
-        if sysupgrade.get_upgrade_state('nss.conf', 'listen_port_updated'):
-            installutils.set_directive(paths.HTTPD_NSS_CONF, 'Listen', '443', quotes=False)
-            sysupgrade.set_upgrade_state('nss.conf', 'listen_port_updated', False)
+    def backup_ssl_conf(self):
+        self.fstore.backup_file(paths.HTTPD_SSL_CONF)
 
-    def __set_mod_nss_port(self):
-        self.fstore.backup_file(paths.HTTPD_NSS_CONF)
-        if installutils.update_file(paths.HTTPD_NSS_CONF, '8443', '443') != 0:
-            print("Updating port in %s failed." % paths.HTTPD_NSS_CONF)
+    def disable_nss_conf(self):
+        # There is no safe way to co-exist since there is no safe port
+        # to make mod_nss use, disable it completely.
+        if os.path.exists(paths.HTTPD_NSS_CONF):
+            self.fstore.backup_file(paths.HTTPD_NSS_CONF)
+            installutils.remove_file(paths.HTTPD_NSS_CONF)
 
-    def __set_mod_nss_nickname(self, nickname):
-        quoted_nickname = installutils.quote_directive_value(
-            nickname, quote_char="'")
-        installutils.set_directive(
-            paths.HTTPD_NSS_CONF, 'NSSNickname', quoted_nickname, quotes=False)
+    def set_mod_ssl_protocol(self):
+        installutils.set_directive(paths.HTTPD_SSL_CONF,
+                                   'SSLProtocol',
+                                   '+TLSv1 +TLSv1.1 +TLSv1.2', False)
 
-    def get_mod_nss_nickname(self):
-        cert = installutils.get_directive(paths.HTTPD_NSS_CONF, 'NSSNickname')
-        nickname = installutils.unquote_directive_value(cert, quote_char="'")
-        return nickname
+    def set_mod_ssl_logdir(self):
+        installutils.set_directive(paths.HTTPD_SSL_CONF,
+                                   'ErrorLog',
+                                   'logs/error_log', False)
+        installutils.set_directive(paths.HTTPD_SSL_CONF,
+                                   'TransferLog',
+                                   'logs/access_log', False)
 
-    def set_mod_nss_protocol(self):
-        installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSProtocol', 'TLSv1.0,TLSv1.1,TLSv1.2', False)
+    def disable_mod_ssl_ocsp(self):
+        if sysupgrade.get_upgrade_state('http', OCSP_ENABLED) is None:
+            self.__disable_mod_ssl_ocsp()
+            sysupgrade.set_upgrade_state('http', OCSP_ENABLED, False)
+>>>>>>> 754c26ef6... Revisions for ocsp
 
-    def enable_mod_nss_renegotiate(self):
-        installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSRenegotiation', 'on', False)
-        installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSRequireSafeNegotiation', 'on', False)
-
-    def disable_mod_nss_ocsp(self):
-        if sysupgrade.get_upgrade_state('http', NSS_OCSP_ENABLED) is None:
-            self.__disable_mod_nss_ocsp()
-            sysupgrade.set_upgrade_state('http', NSS_OCSP_ENABLED, False)
-
-    def __disable_mod_nss_ocsp(self):
+    def __disable_mod_ssl_ocsp(self):
         aug = Augeas(flags=Augeas.NO_LOAD | Augeas.NO_MODL_AUTOLOAD)
 
         aug.set('/augeas/load/Httpd/lens', 'Httpd.lns')
-        aug.set('/augeas/load/Httpd/incl', paths.HTTPD_NSS_CONF)
+        aug.set('/augeas/load/Httpd/incl', paths.HTTPD_SSL_CONF)
         aug.load()
 
-        path = '/files{}/VirtualHost'.format(paths.HTTPD_NSS_CONF)
+        path = '/files{}/VirtualHost'.format(paths.HTTPD_SSL_CONF)
         ocsp_path = '{}/directive[.="{}"]'.format(path, OCSP_DIRECTIVE)
         ocsp_arg = '{}/arg'.format(ocsp_path)
         ocsp_comment = '{}/#comment[.="{}"]'.format(path, OCSP_DIRECTIVE)
 
         ocsp_dir = aug.get(ocsp_path)
 
-        # there is NSSOCSP directive in nss.conf file, comment it
+        # there is SSLOCSPEnable directive in nss.conf file, comment it
         # otherwise just do nothing
         if ocsp_dir is not None:
             ocsp_state = aug.get(ocsp_arg)
@@ -311,18 +250,16 @@ class HTTPInstance(service.Service):
             aug.set(ocsp_comment, '{} {}'.format(OCSP_DIRECTIVE, ocsp_state))
             aug.save()
 
-
-    def set_mod_nss_cipher_suite(self):
-        ciphers = ','.join(NSS_CIPHER_SUITE)
-        installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSCipherSuite', ciphers, False)
-
-    def __set_mod_nss_passwordfile(self):
-        installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSPassPhraseDialog', 'file:' + paths.HTTPD_PASSWORD_CONF)
-
     def __add_include(self):
         """This should run after __set_mod_nss_port so is already backed up"""
-        if installutils.update_file(paths.HTTPD_NSS_CONF, '</VirtualHost>', 'Include {path}\n</VirtualHost>'.format(path=paths.HTTPD_IPA_REWRITE_CONF)) != 0:
-            print("Adding Include conf.d/ipa-rewrite to %s failed." % paths.HTTPD_NSS_CONF)
+        if installutils.update_file(paths.HTTPD_SSL_CONF,
+                                    '</VirtualHost>',
+                                    'Include {path}\n'
+                                    '</VirtualHost>'.format(
+                                        path=paths.HTTPD_IPA_REWRITE_CONF)
+                                    ) != 0:
+            self.print_msg("Adding Include conf.d/ipa-rewrite to "
+                           "%s failed." % paths.HTTPD_SSL_CONF)
 
     def configure_certmonger_renewal_guard(self):
         certmonger = services.knownservices.certmonger
@@ -354,79 +291,32 @@ class HTTPInstance(service.Service):
             if certmonger_stopped:
                 certmonger.stop()
 
-    def create_password_conf(self):
-        """
-        This is the format of mod_nss pin files.
-        """
-        pwd_conf = paths.HTTPD_PASSWORD_CONF
-        ipautil.backup_file(pwd_conf)
-
-        passwd_fname = os.path.join(paths.HTTPD_ALIAS_DIR, 'pwdfile.txt')
-        with open(passwd_fname, 'r') as pwdfile:
-            password = pwdfile.read()
-
-        with open(pwd_conf, "w") as f:
-            f.write("internal:")
-            f.write(password)
-            f.write("\nNSS FIPS 140-2 Certificate DB:")
-            f.write(password)
-            # make sure other processes can access the file contents ASAP
-            f.flush()
-        pent = pwd.getpwnam(constants.HTTPD_USER)
-        os.chown(pwd_conf, pent.pw_uid, pent.pw_gid)
-        os.chmod(pwd_conf, 0o400)
-
-    def disable_system_trust(self):
-        name = 'Root Certs'
-        args = [paths.MODUTIL, '-dbdir', paths.HTTPD_ALIAS_DIR, '-force']
-
-        try:
-            result = ipautil.run(args + ['-list', name],
-                                 env={},
-                                 capture_output=True)
-        except ipautil.CalledProcessError as e:
-            if e.returncode == 29:  # ERROR: Module not found in database.
-                logger.debug(
-                    'Module %s not available, treating as disabled', name)
-                return False
-            raise
-
-        if 'Status: Enabled' in result.output:
-            ipautil.run(args + ['-disable', name], env={})
-            return True
-
-        return False
-
     def __setup_ssl(self):
         db = certs.CertDB(self.realm, nssdir=paths.HTTPD_ALIAS_DIR,
                           subject_base=self.subject_base, user="root",
                           group=constants.HTTPD_GROUP,
                           create=True)
-        self.disable_system_trust()
-        self.create_password_conf()
 
         if self.pkcs12_info:
-            if self.ca_is_configured:
-                trust_flags = IPA_CA_TRUST_FLAGS
-            else:
-                trust_flags = EXTERNAL_CA_TRUST_FLAGS
-            db.init_from_pkcs12(self.pkcs12_info[0], self.pkcs12_info[1],
-                                ca_file=self.ca_file,
-                                trust_flags=trust_flags)
+            # db.init_from_pkcs12(self.pkcs12_info[0], self.pkcs12_info[1],
+            #                    ca_file=self.ca_file,
+            #                    trust_flags=trust_flags)
             server_certs = db.find_server_certs()
             if len(server_certs) == 0:
-                raise RuntimeError("Could not find a suitable server cert in import in %s" % self.pkcs12_info[0])
+                raise RuntimeError(
+                    "Could not find a suitable server cert in import in %s"
+                    % self.pkcs12_info[0]
+                )
 
             # We only handle one server cert
             nickname = server_certs[0][0]
             if nickname == 'ipaCert':
                 nickname = server_certs[1][0]
-            self.cert = db.get_cert_from_db(nickname)
+            self.cert = x509.load_der_x509_certificate(paths.HTTPD_CERT_FILE)
 
             if self.ca_is_configured:
-                db.track_server_cert(nickname, self.principal, db.passwd_fname, 'restart_httpd')
+                self.start_tracking_certificates()
 
-            self.__set_mod_nss_nickname(nickname)
             self.add_cert_to_service()
 
         else:
@@ -445,41 +335,47 @@ class HTTPInstance(service.Service):
                 prev_helper = None
             try:
                 certmonger.request_and_wait_for_cert(
-                    certpath=db.secdir,
-                    nickname=self.cert_nickname,
+                    certpath=(paths.HTTPD_CERT_FILE, paths.HTTPD_KEY_FILE),
                     principal=self.principal,
-                    passwd_fname=db.passwd_fname,
                     subject=str(DN(('CN', self.fqdn), self.subject_base)),
                     ca='IPA',
                     profile=dogtag.DEFAULT_PROFILE,
                     dns=[self.fqdn],
-                    post_command='restart_httpd')
+                    post_command='restart_httpd',
+                    storage='FILE',
+                )
             finally:
                 if prev_helper is not None:
                     certmonger.modify_ca_helper('IPA', prev_helper)
-
-            self.cert = db.get_cert_from_db(self.cert_nickname)
+                self.cert = x509.load_der_x509_certificate(
+                    paths.HTTPD_CERT_FILE
+                )
 
             if prev_helper is not None:
                 self.add_cert_to_service()
 
             # Verify we have a valid server cert
-            server_certs = db.find_server_certs()
-            if not server_certs:
-                raise RuntimeError("Could not find a suitable server cert.")
+            # FIXME: come up with openssl equivalent
+            #  server_certs = db.find_server_certs()
+            #  if not server_certs:
+            #      raise RuntimeError("Could not find a suitable server cert.")
 
         # store the CA cert nickname so that we can publish it later on
-        self.cacert_nickname = db.cacert_name
+        # self.cacert_nickname = db.cacert_name
+        # FIXME: figure this out too
 
-    def __import_ca_certs(self):
-        db = certs.CertDB(self.realm, nssdir=paths.HTTPD_ALIAS_DIR,
-                          subject_base=self.subject_base)
-        self.import_ca_certs(db, self.ca_is_configured)
+        installutils.set_directive(paths.HTTPD_SSL_CONF,
+                                   'SSLCertificateFile',
+                                   paths.HTTPD_CERT_FILE, False)
+        installutils.set_directive(paths.HTTPD_SSL_CONF,
+                                   'SSLCertificateKeyFile',
+                                   paths.HTTPD_KEY_FILE, False)
+        installutils.set_directive(paths.HTTPD_SSL_CONF,
+                                   'SSLCACertificateFile',
+                                   paths.IPA_CA_CRT, False)
 
     def __publish_ca_cert(self):
-        ca_db = certs.CertDB(self.realm, nssdir=paths.HTTPD_ALIAS_DIR,
-                             subject_base=self.subject_base)
-        ca_db.export_pem_cert(self.cacert_nickname, paths.CA_CRT)
+        self.import_ca_certs_file(paths.CA_CRT, self.ca_is_configured)
 
     def is_kdcproxy_configured(self):
         """Check if KDC proxy has already been configured in the past"""
@@ -558,10 +454,9 @@ class HTTPInstance(service.Service):
                 ca_iface.Set('org.fedorahosted.certmonger.ca',
                              'external-helper', helper)
 
-        db = certs.CertDB(self.realm, paths.HTTPD_ALIAS_DIR)
-        db.restore()
-
-        for f in [paths.HTTPD_IPA_CONF, paths.HTTPD_SSL_CONF, paths.HTTPD_NSS_CONF]:
+        # FIXME: at some point don't backup/restore nss.conf
+        for f in [paths.HTTPD_IPA_CONF, paths.HTTPD_SSL_CONF,
+                  paths.HTTPD_NSS_CONF]:
             try:
                 self.fstore.restore_file(f)
             except ValueError as error:
@@ -571,6 +466,8 @@ class HTTPInstance(service.Service):
         installutils.remove_file(paths.HTTP_CCACHE)
 
         # Remove the configuration files we create
+        installutils.remove_file(paths.HTTPD_CERT_FILE)
+        installutils.remove_file(paths.HTTPD_KEY_FILE)
         installutils.remove_file(paths.HTTPD_IPA_REWRITE_CONF)
         installutils.remove_file(paths.HTTPD_IPA_CONF)
         installutils.remove_file(paths.HTTPD_IPA_PKI_PROXY_CONF)
@@ -595,18 +492,25 @@ class HTTPInstance(service.Service):
             self.enable()
 
     def stop_tracking_certificates(self):
-        db = certs.CertDB(api.env.realm, nssdir=paths.HTTPD_ALIAS_DIR)
-        db.untrack_server_cert(self.get_mod_nss_nickname())
+        try:
+            certmonger.stop_tracking(certfile=paths.HTTPD_CERT_FILE)
+        except RuntimeError as e:
+            logger.error("certmonger failed to stop tracking certificate: %s",
+                         str(e))
 
     def start_tracking_certificates(self):
-        db = certs.CertDB(self.realm, nssdir=paths.HTTPD_ALIAS_DIR)
-        nickname = self.get_mod_nss_nickname()
-        if db.is_ipa_issued_cert(api, nickname):
-            db.track_server_cert(nickname, self.principal,
-                                 db.passwd_fname, 'restart_httpd')
+        cert = x509.load_pem_x509_certificate(paths.HTTPD_CERT_FILE)
+        if certs.is_ipa_issued_cert(api, cert):
+            request_id = certmonger.start_tracking(
+                certpath=(paths.HTTPD_CERT_FILE, paths.HTTPD_CERT_KEY),
+                post_command='restart_httpd'
+            )
+            subject = str(DN(cert.subject))
+            certmonger.add_principal(request_id, principal)
+            certmonger.add_subject(request_id, subject)
         else:
             logger.debug("Will not track HTTP server cert %s as it is not "
-                         "issued by IPA", nickname)
+                         "issued by IPA", cert.subject)
 
     def request_service_keytab(self):
         super(HTTPInstance, self).request_service_keytab()

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -209,9 +209,17 @@ class HTTPInstance(service.Service):
         self.fstore.backup_file(paths.HTTPD_SSL_CONF)
 
     def disable_nss_conf(self):
-        # There is no safe way to co-exist since there is no safe port
-        # to make mod_nss use, disable it completely.
+        """
+        Backs up and removes the original nss.conf file.
+
+        There is no safe way to co-exist since there is no safe port
+        to make mod_nss use, disable it completely.
+        """
         if os.path.exists(paths.HTTPD_NSS_CONF):
+            # check that we don't have a backup already
+            # (mod_nss -> mod_ssl upgrade scenario)
+            if not self.fstore.has_file(paths.HTTPD_NSS_CONF):
+                self.fstore.backup_file(paths.HTTPD_NSS_CONF)
             installutils.remove_file(paths.HTTPD_NSS_CONF)
 
     def set_mod_ssl_protocol(self):
@@ -498,7 +506,6 @@ class HTTPInstance(service.Service):
                 ca_iface.Set('org.fedorahosted.certmonger.ca',
                              'external-helper', helper)
 
-        # FIXME: at some point don't backup/restore nss.conf
         for f in [paths.HTTPD_IPA_CONF, paths.HTTPD_SSL_CONF,
                   paths.HTTPD_NSS_CONF]:
             try:

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -263,35 +263,6 @@ class HTTPInstance(service.Service):
             aug.set(ocsp_comment, '{} {}'.format(OCSP_DIRECTIVE, ocsp_state))
             aug.save()
 
-#    def disable_mod_nss_ocsp(self):
-#        if sysupgrade.get_upgrade_state('http', NSS_OCSP_ENABLED) is None:
-#            self.__disable_mod_nss_ocsp()
-#            sysupgrade.set_upgrade_state('http', NSS_OCSP_ENABLED, False)
-
-#    def __disable_mod_nss_ocsp(self):
-#        aug = Augeas(flags=Augeas.NO_LOAD | Augeas.NO_MODL_AUTOLOAD)
-#
-#        aug.set('/augeas/load/Httpd/lens', 'Httpd.lns')
-#        aug.set('/augeas/load/Httpd/incl', paths.HTTPD_NSS_CONF)
-#        aug.load()
-#
-#        path = '/files{}/VirtualHost'.format(paths.HTTPD_NSS_CONF)
-#        ocsp_path = '{}/directive[.="{}"]'.format(path, OCSP_DIRECTIVE)
-#        ocsp_arg = '{}/arg'.format(ocsp_path)
-#        ocsp_comment = '{}/#comment[.="{}"]'.format(path, OCSP_DIRECTIVE)
-#
-#        ocsp_dir = aug.get(ocsp_path)
-#
-#        # there is NSSOCSP directive in nss.conf file, comment it
-#        # otherwise just do nothing
-#        if ocsp_dir is not None:
-#            ocsp_state = aug.get(ocsp_arg)
-#            aug.remove(ocsp_arg)
-#            aug.rename(ocsp_path, '#comment')
-#            aug.set(ocsp_comment, '{} {}'.format(OCSP_DIRECTIVE, ocsp_state))
-#            aug.save()
-
-
     def __add_include(self):
         """This should run after __set_mod_nss_port so is already backed up"""
         if installutils.update_file(paths.HTTPD_SSL_CONF,

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -403,11 +403,16 @@ class HTTPInstance(service.Service):
             if prev_helper is not None:
                 self.add_cert_to_service()
 
+            with open(paths.HTTPD_KEY_FILE, 'rb') as f:
+                priv_key = x509.load_pem_private_key(
+                    f.read(), None, backend=x509.default_backend())
+
             # Verify we have a valid server cert
-            # FIXME: come up with openssl equivalent
-            #  server_certs = db.find_server_certs()
-            #  if not server_certs:
-            #      raise RuntimeError("Could not find a suitable server cert.")
+            if (priv_key.public_key().public_numbers()
+                    != self.cert.public_key().public_numbers()):
+                raise RuntimeError(
+                    "The public key of the issued HTTPD service certificate "
+                    "does not match its private key.")
 
         # store the CA cert nickname so that we can publish it later on
         # self.cacert_nickname = db.cacert_name

--- a/ipaserver/install/plugins/upload_cacrt.py
+++ b/ipaserver/install/plugins/upload_cacrt.py
@@ -20,8 +20,8 @@
 import logging
 
 from ipalib.install import certstore
-from ipaplatform.paths import paths
-from ipaserver.install import certs
+from ipaserver.install import certs, dsinstance
+from ipaserver.install.installutils import realm_to_serverid
 from ipalib import Registry, errors
 from ipalib import Updater
 from ipapython import certdb
@@ -39,7 +39,9 @@ class update_upload_cacrt(Updater):
     """
 
     def execute(self, **options):
-        db = certs.CertDB(self.api.env.realm, paths.HTTPD_ALIAS_DIR)
+        serverid = realm_to_serverid(self.api.env.realm)
+        db = certs.CertDB(self.api.env.realm,
+                          nssdir=dsinstance.config_dirname(serverid))
         ca_cert = None
 
         ca_enabled = self.api.Command.ca_is_enabled()['result']

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -421,10 +421,6 @@ def install_check(installer):
         except ipaclient.install.ntpconf.NTPConfigurationError:
             pass
 
-    # Check to see if httpd is already configured to listen on 443
-    if httpinstance.httpd_443_configured():
-        raise ScriptError("Aborting installation")
-
     if not options.setup_dns and installer.interactive:
         if ipautil.user_input("Do you want to configure integrated DNS "
                               "(BIND)?", False):

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -563,10 +563,6 @@ def common_check(no_ntp):
             "If you want to reinstall the IPA server, please uninstall "
             "it first using 'ipa-server-install --uninstall'.")
 
-    # Check to see if httpd is already configured to listen on 443
-    if httpinstance.httpd_443_configured():
-        raise ScriptError("Aborting installation")
-
     check_dirsrv()
 
     if not no_ntp:

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -208,23 +208,6 @@ def check_certs():
     else:
         logger.debug('Certificate file exists')
 
-def upgrade_pki(ca, fstore):
-    """
-    Update/add the dogtag proxy configuration. The IPA side of this is
-    handled in ipa-pki-proxy.conf.
-
-    This requires enabling SSL renegotiation.
-    """
-    logger.info('[Verifying that CA proxy configuration is correct]')
-    if not ca.is_configured():
-        logger.info('CA is not configured')
-        return
-
-    http = httpinstance.HTTPInstance(fstore)
-    http.enable_mod_nss_renegotiate()
-
-    logger.debug('Proxy configuration up-to-date')
-
 def update_dbmodules(realm, filename=paths.KRB5_CONF):
     newfile = []
     found_dbrealm = False
@@ -1717,7 +1700,6 @@ def upgrade_configuration():
                 os.path.join(ds_dirname, "certmap.conf"),
                 os.path.join(paths.USR_SHARE_IPA_DIR, "certmap.conf.template")
             )
-        upgrade_pki(ca, fstore)
 
         if kra.is_installed():
             logger.info('[Ensuring ephemeralRequest is enabled in KRA]')
@@ -1762,7 +1744,6 @@ def upgrade_configuration():
     http.realm = api.env.realm
     http.suffix = ipautil.realm_to_suffix(api.env.realm)
     http.configure_selinux_for_httpd()
-    http.change_mod_nss_port_from_http()
 
     http.configure_certmonger_renewal_guard()
 

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -379,9 +379,9 @@ class Service(object):
             logger.critical("Could not add certificate to service %s entry: "
                             "%s", self.principal, str(e))
 
-    def import_ca_certs_file(self, cafile, ca_is_configured, conn=None):
+    def export_ca_certs_file(self, cafile, ca_is_configured, conn=None):
         """
-        Import the CA certificates stored in LDAP into a file
+        Export the CA certificates stored in LDAP into a file
 
         :param cafile: the file to write the CA certificates to
         :param ca_is_configured: whether IPA is CA-less or not
@@ -401,9 +401,9 @@ class Service(object):
                 for cert, _unused, _unused, _unused in ca_certs:
                     fd.write(cert.public_bytes(x509.Encoding.PEM))
 
-    def import_ca_certs_nssdb(self, db, ca_is_configured, conn=None):
+    def export_ca_certs_nssdb(self, db, ca_is_configured, conn=None):
         """
-        Import the CA certificates stored in LDAP into an NSS database
+        Export the CA certificates stored in LDAP into an NSS database
 
         :param db: the target NSS database
         :param ca_is_configured: whether IPA is CA-less or not

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import logging
 import sys
 import os
@@ -32,7 +34,7 @@ from ipalib.install import certstore, sysrestore
 from ipapython import ipautil
 from ipapython.dn import DN
 from ipapython import kerberos
-from ipalib import api, errors
+from ipalib import api, errors, x509
 from ipaplatform import services
 from ipaplatform.paths import paths
 
@@ -377,7 +379,36 @@ class Service(object):
             logger.critical("Could not add certificate to service %s entry: "
                             "%s", self.principal, str(e))
 
-    def import_ca_certs(self, db, ca_is_configured, conn=None):
+    def import_ca_certs_file(self, cafile, ca_is_configured, conn=None):
+        """
+        Import the CA certificates stored in LDAP into a file
+
+        :param cafile: the file to write the CA certificates to
+        :param ca_is_configured: whether IPA is CA-less or not
+        :param conn: an optional LDAP connection to use
+        """
+        if conn is None:
+            conn = api.Backend.ldap2
+
+        ca_certs = None
+        try:
+            ca_certs = certstore.get_ca_certs(
+                conn, self.suffix, self.realm, ca_is_configured)
+        except errors.NotFound:
+            pass
+        else:
+            with open(cafile, 'wb') as fd:
+                for cert, _unused, _unused, _unused in ca_certs:
+                    fd.write(cert.public_bytes(x509.Encoding.PEM))
+
+    def import_ca_certs_nssdb(self, db, ca_is_configured, conn=None):
+        """
+        Import the CA certificates stored in LDAP into an NSS database
+
+        :param db: the target NSS database
+        :param ca_is_configured: whether IPA is CA-less or not
+        :param conn: an optional LDAP connection to use
+        """
         if conn is None:
             conn = api.Backend.ldap2
 

--- a/ipatests/test_ipaserver/test_install/test_installutils.py
+++ b/ipatests/test_ipaserver/test_install/test_installutils.py
@@ -30,17 +30,17 @@ def tempdir(request):
 class test_set_directive_lines(object):
     def test_remove_directive(self):
         lines = installutils.set_directive_lines(
-            False, '=', 'foo', None, EXAMPLE_CONFIG)
+            False, '=', 'foo', None, EXAMPLE_CONFIG, comment="#")
         assert list(lines) == ['foobar=2\n']
 
     def test_add_directive(self):
         lines = installutils.set_directive_lines(
-            False, '=', 'baz', '4', EXAMPLE_CONFIG)
+            False, '=', 'baz', '4', EXAMPLE_CONFIG, comment="#")
         assert list(lines) == ['foo=1\n', 'foobar=2\n', 'baz=4\n']
 
     def test_set_directive_does_not_clobber_suffix_key(self):
         lines = installutils.set_directive_lines(
-            False, '=', 'foo', '3', EXAMPLE_CONFIG)
+            False, '=', 'foo', '3', EXAMPLE_CONFIG, comment="#")
         assert list(lines) == ['foo=3\n', 'foobar=2\n']
 
 
@@ -56,7 +56,7 @@ class test_set_directive(object):
                 for line in EXAMPLE_CONFIG:
                     f.write(line)
 
-            installutils.set_directive(filename, 'foo', '3', False, '=')
+            installutils.set_directive(filename, 'foo', '3', False, '=', "#")
 
             stat_post = os.stat(filename)
             with open(filename, 'r') as f:


### PR DESCRIPTION
New installs using an IPA CA should work
Upgrades should work

Not tested and some known to not work:
- [x] CA-less install
- [x] promoting a replica
- [x] promoting a replica CA-less - DL1
- [x] promoting a replica CA-less - DL0
- [x] backup and restore (particularly edge cases like restoring from a mod_nss backup)
- [x] domain level 0 replica install with old master
- [x] domain level 0 replica install with new master

This PR is meant to to obtain status of current patches and as a jumping-off point to finish the rest of the transition.