### PR TITLE
[Backport][ipa-4-5] Idviews: fix objectclass violation on idview-add

### DIFF
--- a/ipaserver/plugins/idviews.py
+++ b/ipaserver/plugins/idviews.py
@@ -22,10 +22,11 @@ import re
 import six
 
 from .baseldap import (LDAPQuery, LDAPObject, LDAPCreate,
-                                     LDAPDelete, LDAPUpdate, LDAPSearch,
-                                     LDAPAddAttributeViaOption,
-                                     LDAPRemoveAttributeViaOption,
-                                     LDAPRetrieve, global_output_params)
+                       LDAPDelete, LDAPUpdate, LDAPSearch,
+                       LDAPAddAttributeViaOption,
+                       LDAPRemoveAttributeViaOption,
+                       LDAPRetrieve, global_output_params,
+                       add_missing_object_class)
 from .hostgroup import get_complete_hostgroup_member_list
 from .service import validate_certificate
 from ipalib import api, Str, Int, Bytes, Flag, _, ngettext, errors, output
@@ -169,6 +170,12 @@ class idview_add(LDAPCreate):
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys, **options):
         self.api.Object.config.validate_domain_resolution_order(entry_attrs)
 
+        # The objectclass ipaNameResolutionData may not be present on
+        # the id view. We need to add it if we define a new
+        # value for ipaDomainResolutionOrder
+        if 'ipadomainresolutionorder' in entry_attrs:
+            add_missing_object_class(ldap, u'ipanameresolutiondata', dn,
+                                     entry_attrs, update=False)
         return dn
 
 

--- a/ipatests/test_xmlrpc/test_idviews_plugin.py
+++ b/ipatests/test_xmlrpc/test_idviews_plugin.py
@@ -1704,4 +1704,39 @@ class test_idviews(Declarative):
             ),
         ),
 
+        # Delete the ID View
+
+        dict(
+            desc='Delete ID View "%s"' % idview1,
+            command=('idview_del', [idview1], {}),
+            expected=dict(
+                result=dict(failed=[]),
+                summary=u'Deleted ID View "%s"' % idview1,
+                value=[idview1],
+            ),
+        ),
+
+        # Test the creation of ID view with domain resolution order
+        # Non-regression test for issue 7350
+
+        dict(
+            desc='Create ID View "%s"' % idview1,
+            command=(
+                'idview_add',
+                [idview1],
+                dict(ipadomainresolutionorder=u'%s' % api.env.domain)
+            ),
+            expected=dict(
+                value=idview1,
+                summary=u'Added ID View "%s"' % idview1,
+                result=dict(
+                    dn=get_idview_dn(idview1),
+                    objectclass=objectclasses.idview +
+                    [u'ipanameresolutiondata'],
+                    cn=[idview1],
+                    ipadomainresolutionorder=[api.env.domain]
+                )
+            ),
+        ),
+
     ]


### PR DESCRIPTION
When the option --domain-resolution-order is used with the command
ipa idview-add, the resulting LDAP object stores the value in
ipadomainresolutionorder attribute.
The issue is that the add command does not add the needed object
class (ipaNameResolutionData) because it is part of
possible_objectclasses but not of object_class.

The fix makes sure to add the objectclass when the option
--domain-resolution-order is used, and adds a non-regression test.

Note that idview-mod does not have any issue as it correctly handles
the addition of missing possible objectclasses.

Fixes:
https://pagure.io/freeipa/issue/7350

Reviewed-By: Alexander Bokovoy <abokovoy@redhat.com>

Manual backport of PR #1437