### PR TITLE
[Backport][ipa-4-6] 10-config.update: remove nsslapd-sasl-max-buffer-size override as htt…

### DIFF
--- a/install/updates/10-config.update
+++ b/install/updates/10-config.update
@@ -58,12 +58,6 @@ addifnew:nsSaslMapPriority: 10
 dn: cn=Name Only,cn=mapping,cn=sasl,cn=config
 addifnew:nsSaslMapPriority: 10
 
-# Default SASL buffer size was too small and could lead for example to
-# migration errors
-# Can be removed when https://fedorahosted.org/389/ticket/47457 is fixed
-dn: cn=config
-only:nsslapd-sasl-max-buffer-size:2097152
-
 # Allow hashed passwords to be added by non-DM users. Without this
 # setting, password migration fails
 dn: cn=config


### PR DESCRIPTION
…ps://pagure.io/389-ds-base/issue/47457 was fixed directly in 389 Directory Server.

The patch addresses:
https://bugzilla.redhat.com/show_bug.cgi?id=1527020
"nsslapd-sasl-max-buffer-size is hardcoded to '2097152' during
install even if another value was provided in an LDIF
( --dirsrv-config-file )"

Fixes: https://pagure.io/freeipa/issue/7341

Tested against RHEL 7.4, the nsslapd-sasl-max-buffer-size parameter
is still 2097152 after this change and the change allows overriding
its value using --dirsrv-config-file properly.

Fix suggested by Florence Blanc-Renaud.

Signed-off-by: François Cami <fcami@fedoraproject.org>
Reviewed-By: Florence Blanc-Renaud <frenaud@redhat.com>

Manual backport of PR #1422 