### PR TITLE
[Backport][ipa-4-6] Sort external schema files

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -185,7 +185,7 @@ def get_all_external_schema_files(root):
         for name in files:
             if fnmatch.fnmatch(name, "*.ldif"):
                 f.append(os.path.join(path, name))
-    return f
+    return sorted(f)
 
 
 INF_TEMPLATE = """


### PR DESCRIPTION
This PR was opened automatically because PR #1439 was pushed to master and backport to ipa-4-6 is required.