### PR TITLE
ipa-run-tests: make --ignore absolute, too

### DIFF
--- a/ipatests/ipa-run-tests
+++ b/ipatests/ipa-run-tests
@@ -70,6 +70,15 @@ class ArgsManglePlugin(object):
                 # a file or directory relative to ipatests package
                 args[idx] = sep.join((os.path.join(HERE, filename), suffix))
 
+        # replace ignores, e.g. "--ignore test_integration" is changed to
+        # "--ignore path/to/ipatests/test_integration"
+        if ns.ignore:
+            for ignore in ns.ignore:
+                idx = args.index(ignore)
+                if os.path.exists(ignore):
+                    continue
+                args[idx] = os.path.join(HERE, ignore)
+
         # rebuild early_config's known args with new args. The known args
         # are used for initial conftest.py from ipatests, which adds
         # additional arguments.


### PR DESCRIPTION
ipa-run-tests now applies the same logic to --ignore then to included
paths.

https://pagure.io/freeipa/issue/7355

Signed-off-by: Christian Heimes <cheimes@redhat.com>