### PR TITLE
Prepare migration of mod_nss NSSDB to sql format

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -43,6 +43,7 @@ steps:
       systemd_journal.log
       `find daemons -name '*.log' -print`
   - chown ${uid}:${gid} ${container_working_dir}/var_log.tar
+  - ls -laZ /etc/dirsrv/slapd-*/ /etc/httpd/alias/ /etc/pki/pki-tomcat/alias/ || true
   configure:
   - ./autogen.sh
   install_packages:

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -788,8 +788,13 @@ def configure_certmonger(
     try:
         certmonger.request_cert(
             certpath=paths.IPA_NSSDB_DIR,
-            nickname='Local IPA host', subject=subject, dns=[hostname],
-            principal=principal, passwd_fname=passwd_fname)
+            storage='NSSDB',
+            nickname='Local IPA host',
+            subject=subject,
+            dns=[hostname],
+            principal=principal,
+            passwd_fname=passwd_fname
+        )
     except Exception as ex:
         logger.error(
             "%s request for host certificate failed: %s",

--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -40,4 +40,5 @@ class BaseConstantsNamespace(object):
     # sql (new format), dbm (old format)
     NSS_DEFAULT_DBTYPE = 'dbm'
 
+
 constants = BaseConstantsNamespace()

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -45,7 +45,9 @@ from ipalib.errors import CertificateOperationError
 from ipalib.install import certstore
 from ipalib.util import strip_csr_header
 from ipalib.text import _
+from ipaplatform.constants import constants
 from ipaplatform.paths import paths
+
 
 logger = logging.getLogger(__name__)
 
@@ -107,14 +109,10 @@ class CertDB(object):
                  dbtype='auto'):
         self.nssdb = NSSDatabase(nssdir, dbtype=dbtype)
 
-        self.secdir = nssdir
         self.realm = realm
 
         self.noise_fname = os.path.join(self.secdir, "noise.txt")
 
-        self.certdb_fname = self.nssdb.certdb
-        self.keydb_fname = self.nssdb.keydb
-        self.secmod_fname = self.nssdb.secmod
         self.pk12_fname = os.path.join(self.secdir, "cacert.p12")
         self.pin_fname = os.path.join(self.secdir + "pin.txt")
         self.reqdir = None
@@ -166,6 +164,26 @@ class CertDB(object):
     subject_base = ipautil.dn_attribute_property('_subject_base')
 
     @property
+    def secdir(self):
+        return self.nssdb.secdir
+
+    @property
+    def dbtype(self):
+        return self.nssdb.dbtype
+
+    @property
+    def certdb_fname(self):
+        return self.nssdb.certdb
+
+    @property
+    def keydb_fname(self):
+        return self.nssdb.keydb
+
+    @property
+    def secmod_fname(self):
+        return self.nssdb.secmod
+
+    @property
     def passwd_fname(self):
         return self.nssdb.pwd_file
 
@@ -173,10 +191,7 @@ class CertDB(object):
         """
         Checks whether all NSS database files + our pwd_file exist
         """
-        for f in self.nssdb.filenames:
-            if not os.path.exists(f):
-                return False
-        return True
+        return self.nssdb.exists()
 
     def __del__(self):
         if self.reqdir is not None:
@@ -221,6 +236,9 @@ class CertDB(object):
     def run_certutil(self, args, stdin=None, **kwargs):
         return self.nssdb.run_certutil(args, stdin, **kwargs)
 
+    def run_modutil(self, args, stdin=None, **kwargs):
+        return self.nssdb.run_modutil(args, stdin, **kwargs)
+
     def create_noise_file(self):
         if os.path.isfile(self.noise_fname):
             os.remove(self.noise_fname)
@@ -238,8 +256,10 @@ class CertDB(object):
                 f.write(ipautil.ipa_generate_password())
 
     def create_certdbs(self):
-        self.nssdb.create_db(user=self.user, group=self.group, mode=self.mode,
-                             backup=True)
+        self.nssdb.create_db(
+            user=self.user, group=self.group, mode=self.mode,
+            backup=True
+        )
         self.set_perms(self.passwd_fname, write=True)
 
     def restore(self):
@@ -629,6 +649,49 @@ class CertDB(object):
                                % (nickname, self.secdir))
 
         return DN(cert.issuer) == cacert_subject
+
+    def disable_system_trust(self):
+        """Disable system trust module of NSSDB
+        """
+        name = 'Root Certs'
+        try:
+            result = self.run_modutil(
+                ['-force', '-list', name],
+                env={},
+                capture_output=True
+            )
+        except ipautil.CalledProcessError as e:
+            if e.returncode == 29:  # ERROR: Module not found in database.
+                logger.debug(
+                    'Module %s not available, treating as disabled', name)
+                return False
+            raise
+
+        if 'Status: Enabled' in result.output:
+            self.run_modutil(
+                ['-force', '-disable', name],
+                env={}
+            )
+            return True
+
+        return False
+
+    def needs_upgrade_format(self):
+        """Check if NSSDB file format needs upgrade
+
+        Only upgrade if it's an existing dbm database and default
+        database type is no 'dbm'.
+        """
+        return (
+            self.nssdb.dbtype == 'dbm' and
+            self.nssdb.dbtype != constants.NSS_DEFAULT_DBTYPE and
+            self.exists()
+        )
+
+    def upgrade_format(self):
+        """Upgrade NSSDB to new file format
+        """
+        self.nssdb.convert_db()
 
 
 class _CrossProcessLock(object):

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -619,11 +619,14 @@ class CertDB(object):
         return self.nssdb.export_pem_cert(nickname, location)
 
     def request_service_cert(self, nickname, principal, host):
-        certmonger.request_and_wait_for_cert(certpath=self.secdir,
-                                             nickname=nickname,
-                                             principal=principal,
-                                             subject=host,
-                                             passwd_fname=self.passwd_fname)
+        certmonger.request_and_wait_for_cert(
+            certpath=self.secdir,
+            storage='NSSDB',
+            nickname=nickname,
+            principal=principal,
+            subject=host,
+            passwd_fname=self.passwd_fname
+        )
 
     def is_ipa_issued_cert(self, api, nickname):
         """

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -832,6 +832,7 @@ class DsInstance(service.Service):
                 cmd = 'restart_dirsrv %s' % self.serverid
                 certmonger.request_and_wait_for_cert(
                     certpath=dirname,
+                    storage='NSSDB',
                     nickname=self.nickname,
                     principal=self.principal,
                     passwd_fname=dsdb.passwd_fname,
@@ -839,7 +840,8 @@ class DsInstance(service.Service):
                     ca='IPA',
                     profile=dogtag.DEFAULT_PROFILE,
                     dns=[self.fqdn],
-                    post_command=cmd)
+                    post_command=cmd
+                )
             finally:
                 if prev_helper is not None:
                     certmonger.modify_ca_helper('IPA', prev_helper)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -469,6 +469,7 @@ class HTTPInstance(service.Service):
             try:
                 certmonger.request_and_wait_for_cert(
                     certpath=db.secdir,
+                    storage='NSSDB',
                     nickname=self.cert_nickname,
                     principal=self.principal,
                     passwd_fname=db.passwd_fname,
@@ -476,7 +477,8 @@ class HTTPInstance(service.Service):
                     ca='IPA',
                     profile=dogtag.DEFAULT_PROFILE,
                     dns=[self.fqdn],
-                    post_command='restart_httpd')
+                    post_command='restart_httpd'
+                )
             finally:
                 if prev_helper is not None:
                     certmonger.modify_ca_helper('IPA', prev_helper)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -128,6 +128,18 @@ class HTTPInstance(service.Service):
 
     subject_base = ipautil.dn_attribute_property('_subject_base')
 
+    def _get_certdb(self, create=False):
+        return certs.CertDB(
+            self.realm,
+            fstore=self.fstore,
+            nssdir=paths.HTTPD_ALIAS_DIR,
+            subject_base=self.subject_base,
+            user="root",
+            group=constants.HTTPD_GROUP,
+            create=create,
+            dbtype='auto'
+        )
+
     def create_instance(self, realm, fqdn, domain_name, dm_password=None,
                         pkcs12_info=None,
                         subject_base=None, auto_redirect=True, ca_file=None,
@@ -160,9 +172,12 @@ class HTTPInstance(service.Service):
                   self.set_mod_nss_cipher_suite)
         self.step("setting mod_nss protocol list to TLSv1.0 - TLSv1.2",
                   self.set_mod_nss_protocol)
-        self.step("setting mod_nss password file", self.__set_mod_nss_passwordfile)
-        self.step("enabling mod_nss renegotiate", self.enable_mod_nss_renegotiate)
+        self.step("setting mod_nss password file",
+                  self.__set_mod_nss_passwordfile)
+        self.step("enabling mod_nss renegotiate",
+                  self.enable_mod_nss_renegotiate)
         self.step("disabling mod_nss OCSP", self.disable_mod_nss_ocsp)
+        self.step("adjusting certdb setting", self.set_mod_nss_certdb)
         self.step("adding URL rewriting rules", self.__add_include)
         self.step("configuring httpd", self.__configure_http)
         self.step("setting up httpd keytab", self.request_service_keytab)
@@ -302,13 +317,41 @@ class HTTPInstance(service.Service):
             aug.set(ocsp_comment, '{} {}'.format(OCSP_DIRECTIVE, ocsp_state))
             aug.save()
 
-
     def set_mod_nss_cipher_suite(self):
         ciphers = ','.join(NSS_CIPHER_SUITE)
-        installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSCipherSuite', ciphers, False)
+        installutils.set_directive(
+            paths.HTTPD_NSS_CONF,
+            'NSSCipherSuite',
+            ciphers,
+            False
+        )
 
     def __set_mod_nss_passwordfile(self):
-        installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSPassPhraseDialog', 'file:' + paths.HTTPD_PASSWORD_CONF)
+        installutils.set_directive(
+            paths.HTTPD_NSS_CONF,
+            'NSSPassPhraseDialog', 'file:' + paths.HTTPD_PASSWORD_CONF
+        )
+
+    def set_mod_nss_certdb(self):
+        db = self._get_certdb()
+        if db.dbtype == 'sql':
+            certdb = '{}:{}'.format(db.dbtype, db.secdir)
+        else:
+            certdb = db.secdir
+        installutils.set_directive(
+            paths.HTTPD_NSS_CONF,
+            'NSSCertificateDatabase',
+            certdb
+        )
+
+    def migrate_nssdb_sql(self):
+        # need to shut down all access to NSSDB first
+        if self.is_running():
+            raise RuntimeError("Cannot upgrade while HTTPD is running")
+        db = self._get_certdb()
+        if db.needs_upgrade_format():
+            logger.debug("Upgrading NSSDB")
+            db.upgrade_format()
 
     def __add_include(self):
         """This should run after __set_mod_nss_port so is already backed up"""
@@ -368,33 +411,22 @@ class HTTPInstance(service.Service):
         os.chmod(pwd_conf, 0o400)
 
     def disable_system_trust(self):
-        name = 'Root Certs'
-        args = [paths.MODUTIL, '-dbdir', paths.HTTPD_ALIAS_DIR, '-force']
-
-        try:
-            result = ipautil.run(args + ['-list', name],
-                                 env={},
-                                 capture_output=True)
-        except ipautil.CalledProcessError as e:
-            if e.returncode == 29:  # ERROR: Module not found in database.
-                logger.debug(
-                    'Module %s not available, treating as disabled', name)
-                return False
-            raise
-
-        if 'Status: Enabled' in result.output:
-            ipautil.run(args + ['-disable', name], env={})
-            return True
-
-        return False
+        db = self._get_certdb()
+        return db.disable_system_trust()
 
     def __setup_ssl(self):
-        db = certs.CertDB(self.realm, nssdir=paths.HTTPD_ALIAS_DIR,
-                          subject_base=self.subject_base, user="root",
-                          group=constants.HTTPD_GROUP,
-                          create=True)
+        db = self._get_certdb(create=True)
+        if not db.exists() or db.dbtype != constants.NSS_DEFAULT_DBTYPE:
+            raise RuntimeError(
+                "DB creation failed: {}:{}".format(db.dbtype, db.secdir)
+            )
         self.disable_system_trust()
         self.create_password_conf()
+        logger.info(
+            "HTTPD NSSDB '%s': %s",
+            paths.HTTPD_ALIAS_DIR,
+            ", ".join(sorted(os.listdir(paths.HTTPD_ALIAS_DIR)))
+        )
 
         if self.pkcs12_info:
             if self.ca_is_configured:
@@ -450,6 +482,12 @@ class HTTPInstance(service.Service):
                     certmonger.modify_ca_helper('IPA', prev_helper)
 
             self.cert = db.get_cert_from_db(self.cert_nickname)
+            if self.cert is None:
+                raise RuntimeError(
+                    "{} has no valid cert {}".format(
+                        db.secdir, self.cert_nickname
+                    )
+                )
 
             if prev_helper is not None:
                 self.add_cert_to_service()
@@ -463,14 +501,12 @@ class HTTPInstance(service.Service):
         self.cacert_nickname = db.cacert_name
 
     def __import_ca_certs(self):
-        db = certs.CertDB(self.realm, nssdir=paths.HTTPD_ALIAS_DIR,
-                          subject_base=self.subject_base)
+        db = self._get_certdb()
         self.import_ca_certs(db, self.ca_is_configured)
 
     def __publish_ca_cert(self):
-        ca_db = certs.CertDB(self.realm, nssdir=paths.HTTPD_ALIAS_DIR,
-                             subject_base=self.subject_base)
-        ca_db.export_pem_cert(self.cacert_nickname, paths.CA_CRT)
+        db = self._get_certdb()
+        db.export_pem_cert(self.cacert_nickname, paths.CA_CRT)
 
     def is_kdcproxy_configured(self):
         """Check if KDC proxy has already been configured in the past"""
@@ -546,12 +582,17 @@ class HTTPInstance(service.Service):
                 ca_iface.Set('org.fedorahosted.certmonger.ca',
                              'external-helper', helper)
 
-        db = certs.CertDB(self.realm, paths.HTTPD_ALIAS_DIR)
+        db = self._get_certdb()
         db.restore()
 
-        for f in [paths.HTTPD_IPA_CONF, paths.HTTPD_SSL_CONF, paths.HTTPD_NSS_CONF]:
+        configs = [
+            paths.HTTPD_IPA_CONF,
+            paths.HTTPD_SSL_CONF,
+            paths.HTTPD_NSS_CONF
+        ]
+        for config in configs:
             try:
-                self.fstore.restore_file(f)
+                self.fstore.restore_file(config)
             except ValueError as error:
                 logger.debug("%s", error)
 

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -430,18 +430,21 @@ class KrbInstance(service.Service):
                     '--agent-submit'
                 ]
                 helper = " ".join(ca_args)
-                prev_helper = certmonger.modify_ca_helper(certmonger_ca, helper)
+                prev_helper = certmonger.modify_ca_helper(
+                    certmonger_ca, helper
+                )
 
             certmonger.request_and_wait_for_cert(
-                certpath,
-                subject,
-                krbtgt,
+                certpath=certpath,
+                subject=subject,
+                principal=krbtgt,
                 ca=certmonger_ca,
                 dns=self.fqdn,
                 storage='FILE',
                 profile=KDC_PROFILE,
                 post_command='renew_kdc_cert',
-                perms=(0o644, 0o600))
+                perms=(0o644, 0o600)
+            )
         except dbus.DBusException as e:
             # if the certificate is already tracked, ignore the error
             name = e.get_dbus_name()

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1788,6 +1788,8 @@ def upgrade_configuration():
     fix_trust_flags()
     update_http_keytab(http)
     http.configure_gssproxy()
+    http.migrate_nssdb_sql()
+    http.set_mod_nss_certdb()
     http.start()
 
     uninstall_selfsign(ds, http)

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -367,6 +367,8 @@ class Service(object):
 
         This server cert should be in DER format.
         """
+        if self.cert is None:
+            raise ValueError("{} has no cert".format(self.service_name))
         dn = DN(('krbprincipalname', self.principal), ('cn', 'services'),
                 ('cn', 'accounts'), self.suffix)
         entry = api.Backend.ldap2.get_entry(dn)

--- a/ipatests/test_ipapython/test_certdb.py
+++ b/ipatests/test_ipapython/test_certdb.py
@@ -30,11 +30,13 @@ def test_dbm_tmp():
 
         for filename in nssdb.filenames:
             assert not os.path.isfile(filename)
+        assert not nssdb.exists()
 
         nssdb.create_db()
         for filename in nssdb.filenames:
             assert os.path.isfile(filename)
             assert os.path.dirname(filename) == nssdb.secdir
+        assert nssdb.exists()
 
         assert os.path.basename(nssdb.certdb) == 'cert8.db'
         assert nssdb.certdb in nssdb.filenames
@@ -48,11 +50,13 @@ def test_sql_tmp():
 
         for filename in nssdb.filenames:
             assert not os.path.isfile(filename)
+        assert not nssdb.exists()
 
         nssdb.create_db()
         for filename in nssdb.filenames:
             assert os.path.isfile(filename)
             assert os.path.dirname(filename) == nssdb.secdir
+        assert nssdb.exists()
 
         assert os.path.basename(nssdb.certdb) == 'cert9.db'
         assert nssdb.certdb in nssdb.filenames
@@ -65,6 +69,7 @@ def test_convert_db():
         assert nssdb.dbtype == 'dbm'
 
         nssdb.create_db()
+        assert nssdb.exists()
 
         create_selfsigned(nssdb)
 
@@ -74,6 +79,7 @@ def test_convert_db():
         assert len(oldkeys) == 1
 
         nssdb.convert_db()
+        assert nssdb.exists()
 
         assert nssdb.dbtype == 'sql'
         newcerts = nssdb.list_certs()


### PR DESCRIPTION
- Refactor CertDB to look up values from its NSSDatabase.
- Add run_modutil() helpers to support sql format. modutil does not
  auto-detect the NSSDB format.
- Add migration helpers to CertDB.
- Add explicit DB format to NSSCertificateDatabase stanza
- Restore SELinux context when migrating NSSDB.
- Add some debugging and sanity checks to httpinstance.

The actual database format is still dbm. Certmonger on Fedora 26 does
neither auto-detect DB format nor support SQL out of the box.

https://pagure.io/freeipa/issue/7354