### PR TITLE
Make IntegrationTest fail if an error happened during uninstall

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -711,7 +711,7 @@ def uninstall_master(host, ignore_topology_disconnect=True,
     if ignore_last_of_role and host_domain_level != DOMAIN_LEVEL_0:
         uninstall_cmd.append('--ignore-last-of-role')
 
-    host.run_command(uninstall_cmd, raiseonerr=False)
+    host.run_command(uninstall_cmd)
     host.run_command(['pkidestroy', '-s', 'CA', '-i', 'pki-tomcat'],
                      raiseonerr=False)
     host.run_command(['rm', '-rf',

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -162,8 +162,6 @@ class CALessBase(IntegrationTest):
     def uninstall(cls, mh):
         # Remove the NSS database
         shutil.rmtree(cls.cert_dir)
-        for host in cls.get_all_hosts():
-            tasks.uninstall_master(host)
         super(CALessBase, cls).uninstall(mh)
 
     @classmethod


### PR DESCRIPTION
Before this change, if the uninstall process fails, the test would not fail, due to the raiseonerr=False.

Fixes: https://pagure.io/freeipa/issue/7357

The results can be checked here:
https://fedorapeople.org/groups/freeipa/prci/jobs/e0c64916-f6ff-11e7-baa4-001a4a23169a/
https://fedorapeople.org/groups/freeipa/prci/jobs/05d5be8a-f700-11e7-a97e-001a4a231699/