### PR TITLE
[Backport][ipa-4-5] Checks if Dir Server is installed and running before IPA installation

### DIFF
--- a/ipaplatform/redhat/services.py
+++ b/ipaplatform/redhat/services.py
@@ -119,6 +119,10 @@ class RedHatDirectoryService(RedHatService):
 
         return True
 
+    def is_installed(self, instance_name):
+        file_path = "{}/{}-{}".format(paths.ETC_DIRSRV, "slapd", instance_name)
+        return os.path.exists(file_path)
+
     def restart(self, instance_name="", capture_output=True, wait=True,
                 ldapi=False):
     # We need to explicitly enable instances to install proper symlinks as

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -616,6 +616,14 @@ def install_check(installer):
         # check addresses here, dns module is doing own check
         no_matching_interface_for_ip_address_warning(ip_addresses)
 
+    instance_name = "-".join(realm_name.split("."))
+    dirsrv = services.knownservices.dirsrv
+    if (options.external_cert_files
+           and dirsrv.is_installed(instance_name)
+           and not dirsrv.is_running(instance_name)):
+        root_logger.debug('Starting Directory Server')
+        services.knownservices.dirsrv.start(instance_name)
+
     if options.setup_adtrust:
         adtrust.install_check(False, options, api)
 


### PR DESCRIPTION
In cases when IPA is installed in two steps (external CA), it's
necessary to check (in the second step) if Dir. Server is
running before continue with the installation. If it's not,
start Directory Server.

https://pagure.io/freeipa/issue/6611

Reviewed-By: Fraser Tweedale <ftweedal@redhat.com>