### PR TITLE
RFE: ipa client should setup openldap for GSSAPI

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -522,8 +522,12 @@ def configure_openldap_conf(fstore, cli_basedn, cli_server):
         {
             'name': 'comment',
             'type': 'comment',
-            'value': '   URI, BASE and TLS_CACERT have been added if they '
-                     'were not set.'
+            'value': '   URI, BASE, TLS_CACERT and SASL_MECH'
+        },
+        {
+            'name': 'comment',
+            'type': 'comment',
+            'value': '   have been added if they were not set.'
         },
         {
             'name': 'comment',
@@ -572,6 +576,12 @@ def configure_openldap_conf(fstore, cli_basedn, cli_server):
             'name': 'TLS_CACERT',
             'type': 'option',
             'value': paths.IPA_CA_CRT
+        },
+        {
+            'action': 'addifnotset',
+            'name': 'SASL_MECH',
+            'type': 'option',
+            'value': 'GSSAPI'
         },
     ]
 


### PR DESCRIPTION
The IPA client installer currently edits /etc/openldap/ldap.conf, setting up
the client to consume LDAP data from IPA.  It currently sets:
>URI
>BASE
>TLS_CACERT

This PR makes ipa-client to add these two AV pair:
>SASL_MECH GSSAPI
>TLS_REQCERT demand

Resolves: https://pagure.io/freeipa/issue/7366