### PR TITLE
Add a helpful comment to ca.py:install_check()

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -217,6 +217,7 @@ def install_check(standalone, replica_config, options):
         dsdb = certs.CertDB(
             realm_name, nssdir=dirname, subject_base=options._subject_base)
 
+        # Check that we can add our CA cert to DS and PKI NSS databases
         for db in (cadb, dsdb):
             if not db.exists():
                 continue


### PR DESCRIPTION
Such a comment could have saved me ~30 seconds. Hopefully you'll find it useful, too.