### PR TITLE
replica_prepare: Remove the correct NSS DB files

### DIFF
--- a/ipaserver/install/ipa_replica_prepare.py
+++ b/ipaserver/install/ipa_replica_prepare.py
@@ -569,7 +569,7 @@ class ReplicaPrepare(admintool.AdminTool):
                 installutils.remove_file(pkcs12_fname)
                 installutils.remove_file(passwd_fname)
 
-            for fname in (certdb.NSS_SQL_FILES + certdb.NSS_SQL_FILES):
+            for fname in (certdb.NSS_DBM_FILES + certdb.NSS_SQL_FILES):
                 self.remove_info_file(fname)
             self.remove_info_file("noise.txt")
 


### PR DESCRIPTION
Mistake in recent fixes made the ipa-replica-prepare include
some extra files in the info file should the legacy format of
NSS databases be used.