### PR TITLE
Prepare migration of NSS databases to sql format 

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -43,6 +43,7 @@ steps:
       systemd_journal.log
       `find daemons -name '*.log' -print`
   - chown ${uid}:${gid} ${container_working_dir}/var_log.tar
+  - ls -laZ /etc/dirsrv/slapd-*/ /etc/httpd/alias/ /etc/pki/pki-tomcat/alias/ || true
   configure:
   - ./autogen.sh
   install_packages:

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2306,8 +2306,9 @@ def install_check(options):
         raise ScriptError(rval=CLIENT_INSTALL_ERROR)
 
 
-def create_ipa_nssdb():
-    db = certdb.NSSDatabase(paths.IPA_NSSDB_DIR)
+def create_ipa_nssdb(db=None):
+    if db is None:
+        db = certdb.NSSDatabase(paths.IPA_NSSDB_DIR)
     db.create_db(mode=0o755, backup=True)
     os.chmod(db.pwd_file, 0o600)
 
@@ -2316,8 +2317,10 @@ def update_ipa_nssdb():
     ipa_db = certdb.NSSDatabase(paths.IPA_NSSDB_DIR)
     sys_db = certdb.NSSDatabase(paths.NSS_DB_DIR)
 
-    if not os.path.exists(os.path.join(ipa_db.secdir, 'cert8.db')):
-        create_ipa_nssdb()
+    if not ipa_db.exists():
+        create_ipa_nssdb(ipa_db)
+    if ipa_db.dbtype == 'dbm':
+        ipa_db.convert_db(rename_old=False)
 
     for nickname, trust_flags in (
             ('IPA CA', certdb.IPA_CA_TRUST_FLAGS),

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -788,8 +788,13 @@ def configure_certmonger(
     try:
         certmonger.request_cert(
             certpath=paths.IPA_NSSDB_DIR,
-            nickname='Local IPA host', subject=subject, dns=[hostname],
-            principal=principal, passwd_fname=passwd_fname)
+            storage='NSSDB',
+            nickname='Local IPA host',
+            subject=subject,
+            dns=[hostname],
+            principal=principal,
+            passwd_fname=passwd_fname
+        )
     except Exception as ex:
         logger.error(
             "%s request for host certificate failed: %s",

--- a/ipaplatform/_importhook.py
+++ b/ipaplatform/_importhook.py
@@ -70,7 +70,7 @@ class IpaMetaImporter(object):
         if sys.platform.startswith('linux'):
             # Linux, get distribution from /etc/os-release
             try:
-                platforms.extend(self._parse_osrelease())
+                platforms.extend(self._parse_platform())
             except Exception as e:
                 warnings.warn("Failed to read /etc/os-release: {}".format(e))
         elif sys.platform == 'win32':
@@ -91,14 +91,17 @@ class IpaMetaImporter(object):
 
         return platforms
 
-    def _parse_osrelease(self, filename='/etc/os-release'):
+    def parse_osrelease(self, filename='/etc/os-release'):
         release = {}
         with io.open(filename, encoding='utf-8') as f:
             for line in f:
                 mo = _osrelease_line.match(line)
                 if mo is not None:
                     release[mo.group('name')] = mo.group('value')
+        return release
 
+    def _parse_platform(self, filename='/etc/os-release'):
+        release = self.parse_osrelease(filename)
         platforms = [
             release['ID'],
         ]

--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -37,8 +37,6 @@ class BaseConstantsNamespace(object):
         'httpd_dbus_sssd': 'on',
     }
     SSSD_USER = "sssd"
-    # sql (new format), dbm (old format)
-    NSS_DEFAULT_DBTYPE = 'dbm'
     # WSGI module override, only used on Fedora
     MOD_WSGI_PYTHON2 = None
     MOD_WSGI_PYTHON3 = None

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -34,13 +34,11 @@ logger = logging.getLogger(__name__)
 
 class BaseTaskNamespace(object):
 
-    def restore_context(self, filepath):
-        """
-        Restore SELinux security context on the given filepath.
+    def restore_context(self, filepath, force=False):
+        """Restore SELinux security context on the given filepath.
 
         No return value expected.
         """
-
         raise NotImplementedError()
 
     def backup_hostname(self, fstore, statestore):

--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -308,15 +308,6 @@ class NSSDatabase(object):
         new_args.extend(args)
         return ipautil.run(new_args, stdin, **kwargs)
 
-    def run_modutil(self, args, stdin=None, **kwargs):
-        self._check_db()
-        new_args = [
-            paths.MODUTIL,
-            '-dbdir', '{}:{}'.format(self.dbtype, self.secdir)
-        ]
-        new_args.extend(args)
-        return ipautil.run(new_args, stdin, **kwargs)
-
     def exists(self):
         """Check DB exists (all files are present)
         """

--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -34,6 +34,7 @@ import cryptography.x509
 
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
+from ipaplatform.tasks import tasks
 from ipapython.dn import DN
 from ipapython.kerberos import Principal
 from ipapython import ipautil
@@ -239,19 +240,28 @@ class NSSDatabase(object):
         self.pwd_file = os.path.join(self.secdir, 'pwdfile.txt')
         self.dbtype = None
         self.certdb = self.keydb = self.secmod = None
+        # files in actual db
         self.filenames = ()
+        # all files that are handled by create_db(backup=True)
+        self.backup_filenames = ()
         self._set_filenames(dbtype)
 
     def _set_filenames(self, dbtype):
         self.dbtype = dbtype
+        dbmfiles = (
+            os.path.join(self.secdir, "cert8.db"),
+            os.path.join(self.secdir, "key3.db"),
+            os.path.join(self.secdir, "secmod.db")
+        )
+        sqlfiles = (
+            os.path.join(self.secdir, "cert9.db"),
+            os.path.join(self.secdir, "key4.db"),
+            os.path.join(self.secdir, "pkcs11.txt")
+        )
         if dbtype == 'dbm':
-            self.certdb = os.path.join(self.secdir, "cert8.db")
-            self.keydb = os.path.join(self.secdir, "key3.db")
-            self.secmod = os.path.join(self.secdir, "secmod.db")
+            self.certdb, self.keydb, self.secmod = dbmfiles
         elif dbtype == 'sql':
-            self.certdb = os.path.join(self.secdir, "cert9.db")
-            self.keydb = os.path.join(self.secdir, "key4.db")
-            self.secmod = os.path.join(self.secdir, "pkcs11.txt")
+            self.certdb, self.keydb, self.secmod = sqlfiles
         else:
             raise ValueError(dbtype)
         self.filenames = (
@@ -260,6 +270,9 @@ class NSSDatabase(object):
             self.secmod,
             self.pwd_file,
         )
+        self.backup_filenames = (
+            self.pwd_file,
+        ) + sqlfiles + dbmfiles
 
     def close(self):
         if self._is_temporary:
@@ -288,6 +301,19 @@ class NSSDatabase(object):
         new_args.extend(args)
         return ipautil.run(new_args, stdin, **kwargs)
 
+    def run_modutil(self, args, stdin=None, **kwargs):
+        new_args = [
+            paths.MODUTIL,
+            '-dbdir', '{}:{}'.format(self.dbtype, self.secdir)
+        ]
+        new_args.extend(args)
+        return ipautil.run(new_args, stdin, **kwargs)
+
+    def exists(self):
+        """Check DB exists (all files are present)
+        """
+        return all(os.path.isfile(filename) for filename in self.filenames)
+
     def create_db(self, user=None, group=None, mode=None, backup=False):
         """Create cert DB
 
@@ -313,9 +339,8 @@ class NSSDatabase(object):
             gid = grp.getgrnam(group).gr_gid
 
         if backup:
-            for filename in self.filenames:
-                path = os.path.join(self.secdir, filename)
-                ipautil.backup_file(path)
+            for filename in self.backup_filenames:
+                ipautil.backup_file(filename)
 
         if not os.path.exists(self.secdir):
             os.makedirs(self.secdir, dirmode)
@@ -328,7 +353,8 @@ class NSSDatabase(object):
                 f.write(ipautil.ipa_generate_password())
                 f.flush()
 
-        self.run_certutil(["-N", "-f", self.pwd_file])
+        # -@ in case it's an old db and it must be migrated
+        self.run_certutil(['-N', '-@', self.pwd_file])
 
         # Finally fix up perms
         os.chown(self.secdir, uid, gid)
@@ -383,7 +409,7 @@ class NSSDatabase(object):
             oldstat = os.stat(oldname)
             os.chmod(newname, stat.S_IMODE(oldstat.st_mode))
             os.chown(newname, oldstat.st_uid, oldstat.st_gid)
-            # XXX also retain SELinux context?
+            tasks.restore_context(newname)
 
         self._set_filenames('sql')
         self.list_certs()  # self-test

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -639,11 +639,14 @@ class CertDB(object):
         return self.nssdb.export_pem_cert(nickname, location)
 
     def request_service_cert(self, nickname, principal, host):
-        certmonger.request_and_wait_for_cert(certpath=self.secdir,
-                                             nickname=nickname,
-                                             principal=principal,
-                                             subject=host,
-                                             passwd_fname=self.passwd_fname)
+        certmonger.request_and_wait_for_cert(
+            certpath=self.secdir,
+            storage='NSSDB',
+            nickname=nickname,
+            principal=principal,
+            subject=host,
+            passwd_fname=self.passwd_fname
+        )
 
     def is_ipa_issued_cert(self, api, nickname):
         """

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -276,9 +276,6 @@ class CertDB(object):
     def run_certutil(self, args, stdin=None, **kwargs):
         return self.nssdb.run_certutil(args, stdin, **kwargs)
 
-    def run_modutil(self, args, stdin=None, **kwargs):
-        return self.nssdb.run_modutil(args, stdin, **kwargs)
-
     def create_noise_file(self):
         if os.path.isfile(self.noise_fname):
             os.remove(self.noise_fname)
@@ -689,32 +686,6 @@ class CertDB(object):
                                % (nickname, self.secdir))
 
         return is_ipa_issued_cert(api, cert)
-
-    def disable_system_trust(self):
-        """Disable system trust module of NSSDB
-        """
-        name = 'Root Certs'
-        try:
-            result = self.run_modutil(
-                ['-force', '-list', name],
-                env={},
-                capture_output=True
-            )
-        except ipautil.CalledProcessError as e:
-            if e.returncode == 29:  # ERROR: Module not found in database.
-                logger.debug(
-                    'Module %s not available, treating as disabled', name)
-                return False
-            raise
-
-        if 'Status: Enabled' in result.output:
-            self.run_modutil(
-                ['-force', '-disable', name],
-                env={}
-            )
-            return True
-
-        return False
 
     def needs_upgrade_format(self):
         """Check if NSSDB file format needs upgrade

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -45,7 +45,6 @@ from ipalib.errors import CertificateOperationError
 from ipalib.install import certstore
 from ipalib.util import strip_csr_header
 from ipalib.text import _
-from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 
 
@@ -725,7 +724,6 @@ class CertDB(object):
         """
         return (
             self.nssdb.dbtype == 'dbm' and
-            self.nssdb.dbtype != constants.NSS_DEFAULT_DBTYPE and
             self.exists()
         )
 

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -832,6 +832,7 @@ class DsInstance(service.Service):
                 cmd = 'restart_dirsrv %s' % self.serverid
                 certmonger.request_and_wait_for_cert(
                     certpath=dirname,
+                    storage='NSSDB',
                     nickname=self.nickname,
                     principal=self.principal,
                     passwd_fname=dsdb.passwd_fname,
@@ -839,7 +840,8 @@ class DsInstance(service.Service):
                     ca='IPA',
                     profile=dogtag.DEFAULT_PROFILE,
                     dns=[self.fqdn],
-                    post_command=cmd)
+                    post_command=cmd
+                )
             finally:
                 if prev_helper is not None:
                     certmonger.modify_ca_helper('IPA', prev_helper)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -361,7 +361,8 @@ class HTTPInstance(service.Service):
                     ca='IPA',
                     profile=dogtag.DEFAULT_PROFILE,
                     dns=[self.fqdn],
-                    post_command='restart_httpd'
+                    post_command='restart_httpd',
+                    storage='FILE',
                 )
             finally:
                 if prev_helper is not None:

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -361,8 +361,7 @@ class HTTPInstance(service.Service):
                     ca='IPA',
                     profile=dogtag.DEFAULT_PROFILE,
                     dns=[self.fqdn],
-                    post_command='restart_httpd',
-                    storage='FILE',
+                    post_command='restart_httpd'
                 )
             finally:
                 if prev_helper is not None:

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -430,18 +430,21 @@ class KrbInstance(service.Service):
                     '--agent-submit'
                 ]
                 helper = " ".join(ca_args)
-                prev_helper = certmonger.modify_ca_helper(certmonger_ca, helper)
+                prev_helper = certmonger.modify_ca_helper(
+                    certmonger_ca, helper
+                )
 
             certmonger.request_and_wait_for_cert(
-                certpath,
-                subject,
-                krbtgt,
+                certpath=certpath,
+                subject=subject,
+                principal=krbtgt,
                 ca=certmonger_ca,
                 dns=self.fqdn,
                 storage='FILE',
                 profile=KDC_PROFILE,
                 post_command='renew_kdc_cert',
-                perms=(0o644, 0o600))
+                perms=(0o644, 0o600)
+            )
         except dbus.DBusException as e:
             # if the certificate is already tracked, ignore the error
             name = e.get_dbus_name()

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -369,6 +369,8 @@ class Service(object):
 
         This server cert should be in DER format.
         """
+        if self.cert is None:
+            raise ValueError("{} has no cert".format(self.service_name))
         dn = DN(('krbprincipalname', self.principal), ('cn', 'services'),
                 ('cn', 'accounts'), self.suffix)
         entry = api.Backend.ldap2.get_entry(dn)

--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -35,7 +35,6 @@ from six import StringIO
 
 from ipapython import ipautil
 from ipaplatform.paths import paths
-from ipaplatform.constants import constants
 from ipapython.dn import DN
 from ipalib import errors
 from ipalib.util import get_reverse_zone_default, verify_host_resolvable
@@ -1267,9 +1266,8 @@ def run_server_del(host, server_to_delete, force=False,
 
 def run_certutil(host, args, reqdir, dbtype=None,
                  stdin=None, raiseonerr=True):
-    if dbtype is None:
-        dbtype = constants.NSS_DEFAULT_DBTYPE
-    new_args = [paths.CERTUTIL, '-d', '{}:{}'.format(dbtype, reqdir)]
+    dbdir = reqdir if dbtype is None else '{}:{}'.format(dbtype, reqdir)
+    new_args = [paths.CERTUTIL, '-d', dbdir]
     new_args.extend(args)
     return host.run_command(new_args, raiseonerr=raiseonerr,
                             stdin_text=stdin)

--- a/ipatests/test_ipaplatform/test_importhook.py
+++ b/ipatests/test_ipaplatform/test_importhook.py
@@ -50,5 +50,5 @@ def test_importhook(mod, name):
     (os.path.join(DATA, 'os-release-ubuntu'), ['ubuntu', 'debian']),
 ])
 def test_parse_os_release(filename, expected_platforms):
-    parsed = metaimporter._parse_osrelease(filename)
+    parsed = metaimporter._parse_platform(filename)
     assert parsed == expected_platforms

--- a/ipatests/test_ipapython/test_certdb.py
+++ b/ipatests/test_ipapython/test_certdb.py
@@ -30,11 +30,13 @@ def test_dbm_tmp():
 
         for filename in nssdb.filenames:
             assert not os.path.isfile(filename)
+        assert not nssdb.exists()
 
         nssdb.create_db()
         for filename in nssdb.filenames:
             assert os.path.isfile(filename)
             assert os.path.dirname(filename) == nssdb.secdir
+        assert nssdb.exists()
 
         assert os.path.basename(nssdb.certdb) == 'cert8.db'
         assert nssdb.certdb in nssdb.filenames
@@ -48,11 +50,13 @@ def test_sql_tmp():
 
         for filename in nssdb.filenames:
             assert not os.path.isfile(filename)
+        assert not nssdb.exists()
 
         nssdb.create_db()
         for filename in nssdb.filenames:
             assert os.path.isfile(filename)
             assert os.path.dirname(filename) == nssdb.secdir
+        assert nssdb.exists()
 
         assert os.path.basename(nssdb.certdb) == 'cert9.db'
         assert nssdb.certdb in nssdb.filenames
@@ -65,6 +69,7 @@ def test_convert_db():
         assert nssdb.dbtype == 'dbm'
 
         nssdb.create_db()
+        assert nssdb.exists()
 
         create_selfsigned(nssdb)
 
@@ -74,6 +79,7 @@ def test_convert_db():
         assert len(oldkeys) == 1
 
         nssdb.convert_db()
+        assert nssdb.exists()
 
         assert nssdb.dbtype == 'sql'
         newcerts = nssdb.list_certs()


### PR DESCRIPTION
This is a reduced version of PR #1458, just refactoring and additional SQL format support without an actual migration. This bits and pieces are useful for master and 4.6. The missing pieces are only relevant for 4.6 support on rawhide.

- Refactor CertDB to look up values from its NSSDatabase.
- Add run_modutil() helpers to support sql format. modutil does not
  auto-detect the NSSDB format.
- Add migration helpers to CertDB.
- Restore SELinux context when migrating NSSDB.
- Add some debugging and sanity checks to httpinstance.
