### PR TITLE
[Backport][ipa-4-6] Checks if Dir Server is installed and running before IPA installation

### DIFF
--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -620,6 +620,14 @@ def install_check(installer):
         # check addresses here, dns module is doing own check
         no_matching_interface_for_ip_address_warning(ip_addresses)
 
+    instance_name = "-".join(realm_name.split("."))
+    dirsrv = services.knownservices.dirsrv
+    if (options.external_cert_files
+            and dirsrv.is_installed(instance_name)
+            and not dirsrv.is_running(instance_name)):
+        logger.debug('Starting Directory Server')
+        services.knownservices.dirsrv.start(instance_name)
+
     if options.setup_adtrust:
         adtrust.install_check(False, options, api)
 


### PR DESCRIPTION
In cases when IPA is installed in two steps (external CA), it's
necessary to check (in the second step) if Dir. Server is
running before continue with the installation. If it's not,
start Directory Server.

https://pagure.io/freeipa/issue/6611

Reviewed-By: Fraser Tweedale <ftweedal@redhat.com>