### PR TITLE
IntegrationTests now collects logs from all test methods

### DIFF
--- a/ipatests/pytest_plugins/integration/__init__.py
+++ b/ipatests/pytest_plugins/integration/__init__.py
@@ -179,8 +179,6 @@ def collect_logs(name, logs_dict, logfile_dir=None, beakerlib_plugin=None):
             else:
                 shutil.rmtree(topdirname)
 
-        logs_dict.clear()
-
 
 @pytest.fixture(scope='class')
 def class_integration_logs():


### PR DESCRIPTION
`logs_dict` should not be cleared. It's filled once per class and it
should not be cleared after running the first test.

https://pagure.io/freeipa/issue/7310
https://pagure.io/freeipa/issue/7335