### PR TITLE
[Backport][ipa-4-6] Lower python-ldap requirement for F27

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -49,7 +49,7 @@
 %global samba_version 4.7.0
 %global selinux_policy_version 3.12.1-153
 %global slapi_nis_version 0.56.0-4
-%global python_ldap_version 2.4.15
+%global python2_ldap_version 2.4.15
 %else
 # 1.15.1-7: certauth (http://krbdev.mit.edu/rt/Ticket/Display.html?id=8561)
 %global krb5_version 1.15.1-7
@@ -59,7 +59,18 @@
 %global samba_version 2:4.7.0
 %global selinux_policy_version 3.13.1-158.4
 %global slapi_nis_version 0.56.1
-%global python_ldap_version 3.0.0-0.2.b2
+
+# Use python3-pyldap to be compatible with old python3-pyldap 2.x and new
+# python3-ldap 3.0. The python3-ldap package also provides python3-pyldap.
+%if 0%{?fedora} >= 28
+# https://pagure.io/freeipa/issue/7257 DNSSEC daemons on Python 3
+%global python2_ldap_version 3.0.0-0.4.b4
+%global python3_ldap_version 3.0.0-0.4.b4
+%else
+%global python2_ldap_version 2.4.15
+%global python3_ldap_version 2.4.35.1-2
+%endif
+
 %endif
 
 
@@ -152,7 +163,7 @@ BuildRequires:  python-lesscpy
 # Build dependencies for makeapi/makeaci
 # makeapi/makeaci is using Python 2 only for now
 #
-BuildRequires:  python2-ldap >= %{python_ldap_version}
+BuildRequires:  python2-ldap >= %{python2_ldap_version}
 BuildRequires:  python2-netaddr
 BuildRequires:  python2-pyasn1
 BuildRequires:  python2-pyasn1-modules
@@ -264,7 +275,7 @@ BuildRequires:  python3-augeas
 BuildRequires:  python3-netaddr
 BuildRequires:  python3-pyasn1
 BuildRequires:  python3-pyasn1-modules
-BuildRequires:  python3-ldap >= %{python_ldap_version}
+BuildRequires:  python3-pyldap >= %{python3_ldap_version}
 %endif # with_python3
 %endif # with_lint
 
@@ -295,10 +306,10 @@ Requires: %{name}-client = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 %if 0%{?with_python3}
 Requires: python3-ipaserver = %{version}-%{release}
-Requires: python3-ldap >= %{python_ldap_version}
+Requires: python3-pyldap >= %{python3_ldap_version}
 %else
 Requires: python2-ipaserver = %{version}-%{release}
-Requires: python2-ldap >= %{python_ldap_version}
+Requires: python2-ldap >= %{python2_ldap_version}
 %endif
 # 1.3.7.6-1: https://bugzilla.redhat.com/show_bug.cgi?id=1488295
 Requires: 389-ds-base >= 1.3.7.6-1
@@ -397,7 +408,7 @@ Requires: %{name}-server-common = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 Requires: python2-ipaclient = %{version}-%{release}
 Requires: python2-custodia >= 0.3.1
-Requires: python2-ldap >= %{python_ldap_version}
+Requires: python2-ldap >= %{python2_ldap_version}
 Requires: python2-lxml
 Requires: python2-gssapi >= 1.2.0-5
 Requires: python2-sssdconfig
@@ -430,7 +441,7 @@ Requires: %{name}-common = %{version}-%{release}
 Requires: python3-ipaclient = %{version}-%{release}
 Requires: python3-custodia >= 0.3.1
 # we need pre-requires since earlier versions may break upgrade
-Requires(pre): python3-ldap >= %{python_ldap_version}
+Requires(pre): python3-pyldap >= %{python3_ldap_version}
 Requires: python3-lxml
 Requires: python3-gssapi >= 1.2.0
 Requires: python3-sssdconfig
@@ -553,11 +564,11 @@ Requires: %{name}-common = %{version}-%{release}
 %if 0%{?with_python3}
 Requires: python3-gssapi >= 1.2.0-5
 Requires: python3-ipaclient = %{version}-%{release}
-Requires: python3-ldap >= %{python_ldap_version}
+Requires: python3-pyldap >= %{python3_ldap_version}
 %else
 Requires: python2-gssapi >= 1.2.0-5
 Requires: python2-ipaclient = %{version}-%{release}
-Requires: python2-ldap >= %{python_ldap_version}
+Requires: python2-ldap >= %{python2_ldap_version}
 %endif
 Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: ntp
@@ -734,7 +745,7 @@ Requires: python2-six
 # 0.4.2: Py3 fix https://bugzilla.redhat.com/show_bug.cgi?id=1476150
 Requires: python2-jwcrypto >= 0.4.2
 Requires: python2-cffi
-Requires: python2-ldap >= %{python_ldap_version}
+Requires: python2-ldap >= %{python2_ldap_version}
 Requires: python2-requests
 Requires: python2-dns >= 1.15
 Requires: python2-enum34
@@ -785,7 +796,7 @@ Requires: python3-six
 Requires: python3-jwcrypto >= 0.4.2
 Requires: python3-cffi
 # we need pre-requires since earlier versions may break upgrade
-Requires(pre): python3-ldap >= %{python_ldap_version}
+Requires(pre): python3-pyldap >= %{python3_ldap_version}
 Requires: python3-requests
 Requires: python3-dns >= 1.15
 Requires: python3-netifaces >= 0.10.4


### PR DESCRIPTION
This PR was opened automatically because PR #1481 was pushed to master and backport to ipa-4-6 is required.