### PR TITLE
Fix pylint error in ipapython/dn.py

### DIFF
--- a/ipapython/dn.py
+++ b/ipapython/dn.py
@@ -1320,9 +1320,11 @@ class DN(object):
             return not self._cmp_sequence(pattern, start, pat_len)
         return 0
 
-
     def __contains__(self, other):
-        'Return the outcome of the test other in self. Note the reversed operands.'
+        """Return the outcome of the test other in self.
+
+        Note the reversed operands.
+        """
 
         if isinstance(other, RDN):
             other = DN(other)
@@ -1336,9 +1338,9 @@ class DN(object):
                     return True
                 i += 1
             return False
-        else:
-            raise TypeError("expected DN or RDN but got %s" % (other.__class__.__name__))
-
+        raise TypeError(
+            "expected DN or RDN but got %s" % other.__class__.__name__
+        )
 
     def find(self, pattern, start=None, end=None):
         '''


### PR DESCRIPTION
```
ipapython/dn.py:1324: [R1710(inconsistent-return-statements), DN.__contains__]
Either all return statements in a function should return an expression, or none of them should.)
```

Signed-off-by: Christian Heimes <cheimes@redhat.com>