### PR TITLE
Require dbus-python on F27

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -221,7 +221,11 @@ BuildRequires:  python2-pytest-sourceorder
 BuildRequires:  python2-jwcrypto >= 0.4.2
 # 0.3: sd_notify (https://pagure.io/freeipa/issue/5825)
 BuildRequires:  python2-custodia >= 0.3.1
+%if 0%{?fedora} >= 28
 BuildRequires:  python2-dbus
+%else
+BuildRequires:  dbus-python
+%endif
 BuildRequires:  python2-dateutil
 BuildRequires:  python2-enum34
 BuildRequires:  python2-netifaces
@@ -411,7 +415,11 @@ Requires: python2-lxml
 Requires: python2-gssapi >= 1.2.0-5
 Requires: python2-sssdconfig
 Requires: python2-pyasn1 >= 0.3.2-2
-Requires: python2-dbus
+%if 0%{?fedora} >= 28
+BuildRequires:  python2-dbus
+%else
+BuildRequires:  dbus-python
+%endif
 Requires: python2-dns >= 1.15
 Requires: python2-kdcproxy >= 0.3
 Requires: rpm-libs
@@ -737,7 +745,11 @@ Requires: python2-pyasn1-modules >= 0.3.2-2
 Requires: python2-dateutil
 Requires: python2-yubico >= 1.2.3
 Requires: python2-sss-murmur
-Requires: python2-dbus
+%if 0%{?fedora} >= 28
+BuildRequires:  python2-dbus
+%else
+BuildRequires:  dbus-python
+%endif
 Requires: python2-setuptools
 Requires: python2-six
 # 0.4.2: Py3 fix https://bugzilla.redhat.com/show_bug.cgi?id=1476150


### PR DESCRIPTION
Partly revert b03d5155. python2-dbus is not available on F27. The
package only provides dbus-python:

```
$ dnf install python2-dbus dbus-python
Last metadata expiration check: 0:18:39 ago on 2018-01-23T18:59:22 CET.
No match for argument: python2-dbus
Package dbus-python-1.2.4-8.fc27.x86_64 is already installed, skipping.
Error: Unable to find a match
```

Part of: https://pagure.io/freeipa/issue/7131
Signed-off-by: Christian Heimes <cheimes@redhat.com>