### PR TITLE
Give ODS socket a bit of time

### DIFF
--- a/daemons/dnssec/ipa-ods-exporter
+++ b/daemons/dnssec/ipa-ods-exporter
@@ -449,17 +449,21 @@ def hex_set(s):
         out.add("0x%s" % hexlify(i))
     return out
 
+
 def receive_systemd_command():
     fds = systemd.daemon.listen_fds()
     if len(fds) != 1:
         raise KeyError('Exactly one socket is expected.')
 
     sck = socket.fromfd(fds[0], socket.AF_UNIX, socket.SOCK_STREAM)
-    rlist, _wlist, _xlist = select.select([sck], [], [], 0)
+    timeout = 1  # give the socket a bit of time
+    rlist, _wlist, _xlist = select.select([sck], [], [], timeout)
     if not rlist:
-        logger.critical('socket activation did not return socket with a '
-                        'command')
-        sys.exit(0)
+        logger.critical(
+            'socket activation did not return a readable socket with a '
+            'command.'
+        )
+        sys.exit(1)
 
     logger.debug('accepting new connection')
     conn, _addr = sck.accept()


### PR DESCRIPTION
ipa-ods-exporter uses systemd socket activation. The script uses
select() to check if the socket is readable. A timeout of 0 is a bit too
aggressive. Sometimes select() doesn't consider the systemd socket as
readable. This causes ODS to fail silently

A timeout of one second seems to remove the problem. A proper error code
also signals that something went wrong.

Closes: https://pagure.io/freeipa/issue/7378
Signed-off-by: Christian Heimes <cheimes@redhat.com>