### PR TITLE
Fixing translation problems

### DIFF
--- a/ipaclient/remote_plugins/__init__.py
+++ b/ipaclient/remote_plugins/__init__.py
@@ -30,9 +30,9 @@ class ServerInfo(collections.MutableMapping):
 
         # copy-paste from ipalib/rpc.py
         try:
-            self._language = (
-                 locale.setlocale(locale.LC_ALL, '').split('.')[0].lower()
-            )
+            self._language = locale.setlocale(
+                locale.LC_MESSAGES, ''
+            ).split('.')[0].lower()
         except locale.Error:
             self._language = 'en_us'
 

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -536,7 +536,9 @@ class LanguageAwareTransport(MultiProtocolTransport):
             self, host)
 
         try:
-            lang = locale.setlocale(locale.LC_ALL, '').split('.')[0].lower()
+            lang = locale.setlocale(
+                locale.LC_MESSAGES, ''
+            ).split('.')[0].lower()
         except locale.Error:
             # fallback to default locale
             lang = 'en_us'

--- a/ipaserver/plugins/schema.py
+++ b/ipaserver/plugins/schema.py
@@ -16,6 +16,7 @@ from ipalib.frontend import Command, Local, Method, Object
 from ipalib.output import Entry, ListOfEntries, ListOfPrimaryKeys, PrimaryKey
 from ipalib.parameters import Bool, Dict, Flag, Str
 from ipalib.plugable import Registry
+from ipalib.request import context
 from ipalib.text import _
 from ipapython.version import API_VERSION
 
@@ -833,11 +834,15 @@ class schema(Command):
         return schema
 
     def execute(self, *args, **kwargs):
-        try:
-            schema = self.api._schema
-        except AttributeError:
+        langs = "".join(getattr(context, "languages", []))
+
+        if getattr(self.api, "_schema", None) is None:
+            setattr(self.api, "_schema", {})
+
+        schema = self.api._schema.get(langs)
+        if schema is None:
             schema = self._generate_schema(**kwargs)
-            setattr(self.api, '_schema', schema)
+            self.api._schema[langs] = schema
 
         schema['ttl'] = SCHEMA_TTL
 


### PR DESCRIPTION
ipa rpc server did set the LANG environment variable on each
request and it was not thread safe which led to the problems
which are described in the pagure ticket. Also, there were
mistakes regarding setting the Accept-Language HTTP header.

Now on each request we're setting the "languages" property
in the context thread local variable and client is setting the
Accept-Language HTTP header correctly.

Also, as the server is caching the schema and the schema can be
generated for several languages it's good to store different
schema fingerprint for each language separately.

pagure: https://pagure.io/freeipa/issue/7238