### PR TITLE
clear sssd cache when uninstalling client

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -149,6 +149,7 @@ BuildRequires:  nss-devel
 BuildRequires:  openssl-devel
 BuildRequires:  libini_config-devel
 BuildRequires:  cyrus-sasl-devel
+BuildRequires:  sssd-tools
 %if ! %{ONLY_CLIENT}
 # 1.3.3.9: DS_Sleep (https://fedorahosted.org/389/ticket/48005)
 BuildRequires:  389-ds-base-devel >= 1.3.3.9

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3140,6 +3140,14 @@ def uninstall(options):
     remove_file(paths.SSSD_MC_GROUP)
     remove_file(paths.SSSD_MC_PASSWD)
 
+    try:
+        run([paths.SSSCTL, "cache-remove", "-o", "--stop", "--start"])
+    except Exception:
+        logger.info(
+            "An error occurred while removing SSSD's cache."
+            "Please remove the cache manually by executing "
+            "sssctl cache-remove -o.")
+
     if ipa_domain:
         sssd_domain_ldb = "cache_" + ipa_domain + ".ldb"
         sssd_ldb_file = os.path.join(paths.SSSD_DB, sssd_domain_ldb)

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -378,6 +378,6 @@ class BasePathNamespace(object):
     KEYCTL = '/usr/bin/keyctl'
     GETENT = '/usr/bin/getent'
     SSHD = '/usr/sbin/sshd'
-
+    SSSCTL = '/usr/sbin/sssctl'
 
 paths = BasePathNamespace()

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -380,4 +380,5 @@ class BasePathNamespace(object):
     SSHD = '/usr/sbin/sshd'
     SSSCTL = '/usr/sbin/sssctl'
 
+
 paths = BasePathNamespace()


### PR DESCRIPTION
The SSSD cache is not cleared when uninstalling an IPA client. For tidiness we should wipe the cache. This can be done with sssctl.
Note that this tool is in sssd-tools which is not currently a dependency.

Resolves: https://pagure.io/freeipa/issue/7376