### PR TITLE
Remove special characters in host_add random OTP generation

### DIFF
--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -686,7 +686,7 @@ class host_add(LDAPCreate):
                 entry_attrs['objectclass'].remove('krbprincipal')
         if options.get('random'):
             entry_attrs['userpassword'] = ipa_generate_password(
-                entropy_bits=TMP_PWD_ENTROPY_BITS)
+                entropy_bits=TMP_PWD_ENTROPY_BITS, special=None)
             # save the password so it can be displayed in post_callback
             setattr(context, 'randompassword', entry_attrs['userpassword'])
 


### PR DESCRIPTION
Remove special characters in host_add random OTP generation

This fixes a regression in how random host-add OTP passwords are generated. Some shells try and interpret certain special characters when they confront them in unattended ipa-client-install where the OTP is used. Before 4.5.0, this was fixed by excluding an arbitrary list of special characters during OTP random password generation. This fix goes a step further and removes ALL special characters when the OTP is generated. In my opinion, the period of time between random OTP generation and use is small and the password is useless after the host is installed so removing special characters presents minimal security risk

https://pagure.io/freeipa/issue/7380