### PR TITLE
ipa-server-upgrade now checks custodia server keys

### DIFF
--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -92,7 +92,17 @@ class CustodiaInstance(SimpleServiceInstance):
         keystore.generate_server_keys()
 
     def upgrade_instance(self):
-        if not sysupgrade.get_upgrade_state("custodia", "installed"):
+        installed = sysupgrade.get_upgrade_state("custodia", "installed")
+        if installed:
+            if (not os.path.isfile(self.server_keys)
+                    or not os.path.isfile(self.config_file)):
+                logger.warning(
+                    "Custodia server keys or config are missing, forcing "
+                    "reinstallation of ipa-custodia."
+                )
+                installed = False
+
+        if not installed:
             logger.info("Custodia service is being configured")
             self.create_instance()
         else:


### PR DESCRIPTION
The ipa-server-upgrade command now checks for presence of ipa-custodia's
config and server keys. In case any of the files is missing, it
re-creates both files.

Partly resolves https://pagure.io/freeipa/issue/6893. The upgrader does
not auto-detect broken or mismatching keys yet.

Signed-off-by: Christian Heimes <cheimes@redhat.com>