### PR TITLE
Bump SELinux policy for DNSSEC

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -57,7 +57,8 @@
 %global python_netaddr_version 0.7.16
 # Require 4.7.0 which brings Python 3 bindings
 %global samba_version 2:4.7.0
-%global selinux_policy_version 3.13.1-158.4
+# DNSSEC AVC violation, RHBZ#1537971
+%global selinux_policy_version 3.13.1-283.24
 %global slapi_nis_version 0.56.1
 
 # Use python3-pyldap to be compatible with old python3-pyldap 2.x and new


### PR DESCRIPTION
selinux-policy-3.13.1-283.24 fixes an AVC with OpenDNSSEC ods-signer.

Lukas has submitted F27 update https://bodhi.fedoraproject.org/updates/FEDORA-2018-a144eca5a8 . Please upvote the update, too.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1537971
See: https://pagure.io/freeipa/issue/7378
Signed-off-by: Christian Heimes <cheimes@redhat.com>