### PR TITLE
Fix detection of KRA installation so upgrades can succeed

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1710,7 +1710,7 @@ def upgrade_configuration():
             )
         upgrade_pki(ca, fstore)
 
-        if kra.is_configured():
+        if kra.is_installed():
             logger.info('[Ensuring ephemeralRequest is enabled in KRA]')
             kra.backup_config()
             value = installutils.get_directive(
@@ -1728,7 +1728,7 @@ def upgrade_configuration():
     # by checking status using http
     if ca.is_configured():
         ca.start('pki-tomcat')
-    if kra.is_configured() and not kra.is_running():
+    if kra.is_installed() and not kra.is_running():
         # This is for future-proofing in case the KRA is ever standalone.
         kra.start('pki-tomcat')
 

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Module provides tests to verify that the upgrade script works.
+"""
+
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_plugins.integration import tasks
+
+
+class TestUpgrade(IntegrationTest):
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=False)
+
+    def test_invoke_upgrader(self):
+        cmd = self.master.run_command(['ipa-server-upgrade'],
+                                      raiseonerr=False)
+        assert cmd.returncode == 0


### PR DESCRIPTION
To determine whether KRA needs to be updated the standard
service.is_configured() was used. Since the KRA and CA share
the same service name (pki-tomcatd) this wasn't being detected
properly.

Add an additional check to see if the KRA CS.cfg is present.

https://pagure.io/freeipa/issue/7389

Signed-off-by: Rob Crittenden <rcritten@redhat.com>