### PR TITLE
ldap2: fix implementation of can_add

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -315,8 +315,10 @@ Requires: python3-pyldap >= %{python3_ldap_version}
 Requires: python2-ipaserver = %{version}-%{release}
 Requires: python2-ldap >= %{python2_ldap_version}
 %endif
-# 1.3.7.6-1: https://bugzilla.redhat.com/show_bug.cgi?id=1488295
-Requires: 389-ds-base >= 1.3.7.6-1
+# 1.3.7.9-1: https://bugzilla.redhat.com/show_bug.cgi?id=1459946
+#            https://bugzilla.redhat.com/show_bug.cgi?id=1511462
+#            https://bugzilla.redhat.com/show_bug.cgi?id=1514033
+Requires: 389-ds-base >= 1.3.7.9-1
 Requires: openldap-clients > 2.4.35-4
 Requires: nss >= 3.14.3-12.0
 Requires: nss-tools >= 3.14.3-12.0
@@ -363,8 +365,10 @@ Requires(postun): systemd-units
 Requires: policycoreutils >= 2.1.12-5
 Requires: tar
 Requires(pre): certmonger >= 0.79.5-1
-# 1.3.7.6-1: https://bugzilla.redhat.com/show_bug.cgi?id=1488295
-Requires(pre): 389-ds-base >= 1.3.7.6-1
+# 1.3.7.9-1: https://bugzilla.redhat.com/show_bug.cgi?id=1459946
+#            https://bugzilla.redhat.com/show_bug.cgi?id=1511462
+#            https://bugzilla.redhat.com/show_bug.cgi?id=1514033
+Requires(pre): 389-ds-base >= 1.3.7.9-1
 Requires: fontawesome-fonts
 Requires: open-sans-fonts
 Requires: openssl

--- a/ipaserver/plugins/ca.py
+++ b/ipaserver/plugins/ca.py
@@ -235,7 +235,7 @@ class ca_add(LDAPCreate):
 
     def pre_callback(self, ldap, dn, entry, entry_attrs, *keys, **options):
         ca_enabled_check(self.api)
-        if not ldap.can_add(dn[1:]):
+        if not ldap.can_add(dn[1:], 'ipaca'):
             raise errors.ACIError(
                 info=_("Insufficient 'add' privilege for entry '%s'.") % dn)
 

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -38,8 +38,6 @@ from ipapython.dn import DN
 from ipapython.ipaldap import (LDAPClient, AUTOBIND_AUTO, AUTOBIND_ENABLED,
                                AUTOBIND_DISABLED)
 
-from ldap.controls.simple import GetEffectiveRightsControl
-
 from ipalib import Registry, errors, _
 from ipalib.crud import CrudBackend
 from ipalib.request import context
@@ -274,22 +272,8 @@ class ldap2(CrudBackend, LDAPClient):
            Returns 2 attributes, the attributeLevelRights for the given list of
            attributes and the entryLevelRights for the entry itself.
         """
-
         assert isinstance(dn, DN)
-
-        bind_dn = self.conn.whoami_s()[4:]
-
-        sctrl = [
-            GetEffectiveRightsControl(
-                True, "dn: {0}".format(bind_dn).encode('utf-8'))
-        ]
-        self.conn.set_option(_ldap.OPT_SERVER_CONTROLS, sctrl)
-        try:
-            entry = self.get_entry(dn, attrs_list)
-        finally:
-            # remove the control so subsequent operations don't include GER
-            self.conn.set_option(_ldap.OPT_SERVER_CONTROLS, [])
-        return entry
+        return self.get_entry(dn, attrs_list, get_effective_rights=True)
 
     def can_write(self, dn, attr):
         """Returns True/False if the currently bound user has write permissions


### PR DESCRIPTION
ldap2.can_add checks for add permission of a given entry. It did not work
properly due to a defect in 389 DS.  Now that the defect has been fixed, we
also need to update can_add to work with the mechanism 389 DS provides for
checking add permission for entries where ACIs are in effect.

Update the spec file to require 389-ds-base-1.3.7.9-1 which is the first
release containing the fix.

Update the ldap2.can_add implementation to perform the add permission check
properly.  Also update call sites accordingly.

Fixes: https://pagure.io/freeipa/issue/6609