### PR TITLE
ipa host-add: do not raise exception when reverse record not added

### DIFF
--- a/ipalib/messages.py
+++ b/ipalib/messages.py
@@ -476,6 +476,17 @@ class CertificateInvalid(PublicMessage):
                "%(reason)s")
 
 
+class FailedToAddHostDNSRecords(PublicMessage):
+    """
+    **13030** Failed to add host DNS records
+    """
+
+    errno = 13030
+    type = "warning"
+    format = _("The host was added but the DNS update failed with: "
+               "%(reason)s")
+
+
 def iter_messages(variables, base):
     """Return a tuple with all subclasses
     """


### PR DESCRIPTION
When ipa host-add --random is unable to add a reverse record (for instance
because the server does not manage any reverse zone), the command
adds the host but exits (return code=1) with an error without actually
outputing the random password generated.
With this fix, the behavior is modified. The commands succeeds (return code=0)
but prints a warning.

This commit also adds a unit test.

https://pagure.io/freeipa/issue/7374