### PR TITLE
Replace wsgi package conflict with config file

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -330,14 +330,12 @@ Requires(postun): python3
 Requires: python3-gssapi >= 1.2.0-5
 Requires: python3-systemd
 Requires: python3-mod_wsgi
-Conflicts: mod_wsgi
 %else
 Requires(preun): python2
 Requires(postun): python2
 Requires: python2-gssapi >= 1.2.0-5
 Requires: python2-systemd
 Requires: mod_wsgi
-Conflicts: python3-mod_wsgi
 %endif
 Requires: mod_auth_gssapi >= 1.5.0
 # 1.0.14-3: https://bugzilla.redhat.com/show_bug.cgi?id=1431206

--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -85,6 +85,7 @@ dist_app_DATA =				\
 	kdcproxy-enable.uldif		\
 	kdcproxy-disable.uldif		\
 	ipa-httpd.conf.template		\
+	ipa-httpd-wsgi.conf.template	\
 	gssapi.login			\
 	gssproxy.conf.template		\
 	kdcproxy.wsgi			\

--- a/install/share/ipa-httpd-wsgi.conf.template
+++ b/install/share/ipa-httpd-wsgi.conf.template
@@ -1,0 +1,7 @@
+# Do not edit. Created by IPA installer.
+
+# Some platforms allow parallel installation of Python 2 and 3 mod_wsgi
+# modules, but the modules can't coexist. Enforce loading of correct
+# WSGI module before the package's default config.
+
+LoadModule wsgi_module $WSGI_MODULE

--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -39,5 +39,9 @@ class BaseConstantsNamespace(object):
     SSSD_USER = "sssd"
     # sql (new format), dbm (old format)
     NSS_DEFAULT_DBTYPE = 'dbm'
+    # WSGI module override, only used on Fedora
+    MOD_WSGI_PYTHON2 = None
+    MOD_WSGI_PYTHON3 = None
+
 
 constants = BaseConstantsNamespace()

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -48,6 +48,8 @@ class BasePathNamespace(object):
     HTTPD_IPA_CONF = "/etc/httpd/conf.d/ipa.conf"
     HTTPD_NSS_CONF = "/etc/httpd/conf.d/nss.conf"
     HTTPD_SSL_CONF = "/etc/httpd/conf.d/ssl.conf"
+    # only used on Fedora
+    HTTPD_IPA_WSGI_MODULES_CONF = None
     OLD_IPA_KEYTAB = "/etc/httpd/conf/ipa.keytab"
     HTTP_KEYTAB = "/var/lib/ipa/gssproxy/http.keytab"
     HTTPD_PASSWORD_CONF = "/etc/httpd/conf/password.conf"

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -211,6 +211,10 @@ class BaseTaskNamespace(object):
         """Remove configuration of httpd service of IPA"""
         raise NotImplementedError()
 
+    def configure_httpd_wsgi_conf(self):
+        """Configure WSGI for correct Python version"""
+        raise NotImplementedError()
+
     def is_fips_enabled(self):
         return False
 

--- a/ipaplatform/debian/tasks.py
+++ b/ipaplatform/debian/tasks.py
@@ -47,4 +47,9 @@ class DebianTaskNamespace(RedHatTaskNamespace):
     def parse_ipa_version(version):
         return BaseTaskNamespace.parse_ipa_version(version)
 
+    def configure_httpd_wsgi_conf(self):
+        # Debian doesn't require special mod_wsgi configuration
+        pass
+
+
 tasks = DebianTaskNamespace()

--- a/ipaplatform/fedora/constants.py
+++ b/ipaplatform/fedora/constants.py
@@ -11,6 +11,10 @@ from ipaplatform.redhat.constants import RedHatConstantsNamespace
 
 
 class FedoraConstantsNamespace(RedHatConstantsNamespace):
-    pass
+    # Fedora allows installation of Python 2 and 3 mod_wsgi, but the modules
+    # can't coexist. For Apache to load correct module.
+    MOD_WSGI_PYTHON2 = "modules/mod_wsgi.so"
+    MOD_WSGI_PYTHON3 = "modules/mod_wsgi_python3.so"
+
 
 constants = FedoraConstantsNamespace()

--- a/ipaplatform/fedora/paths.py
+++ b/ipaplatform/fedora/paths.py
@@ -27,7 +27,9 @@ from ipaplatform.redhat.paths import RedHatPathNamespace
 
 
 class FedoraPathNamespace(RedHatPathNamespace):
-    pass
+    HTTPD_IPA_WSGI_MODULES_CONF = (
+        "/etc/httpd/conf.modules.d/02-ipa-wsgi.conf"
+    )
 
 
 paths = FedoraPathNamespace()

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -213,6 +213,7 @@ class HTTPInstance(service.Service):
 
     def __configure_http(self):
         self.update_httpd_service_ipa_conf()
+        self.update_httpd_wsgi_conf()
 
         target_fname = paths.HTTPD_IPA_CONF
         http_txt = ipautil.template_file(
@@ -508,6 +509,9 @@ class HTTPInstance(service.Service):
     def update_httpd_service_ipa_conf(self):
         tasks.configure_httpd_service_ipa_conf()
 
+    def update_httpd_wsgi_conf(self):
+        tasks.configure_httpd_wsgi_conf()
+
     def uninstall(self):
         if self.is_configured():
             self.print_msg("Unconfiguring web server")
@@ -564,7 +568,8 @@ class HTTPInstance(service.Service):
         installutils.remove_file(paths.HTTPD_IPA_PKI_PROXY_CONF)
         installutils.remove_file(paths.HTTPD_IPA_KDCPROXY_CONF_SYMLINK)
         installutils.remove_file(paths.HTTPD_IPA_KDCPROXY_CONF)
-        tasks.remove_httpd_service_ipa_conf()
+        if paths.HTTPD_IPA_WSGI_MODULES_CONF is not None:
+            installutils.remove_file(paths.HTTPD_IPA_WSGI_MODULES_CONF)
 
         # Restore SELinux boolean states
         boolean_states = {name: self.restore_state(name)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1458,9 +1458,15 @@ def update_mod_nss_cipher_suite(http):
         'cipher_suite_updated',
         httpinstance.NSS_CIPHER_REVISION)
 
+
 def update_ipa_httpd_service_conf(http):
     logger.info('[Updating HTTPD service IPA configuration]')
     http.update_httpd_service_ipa_conf()
+
+
+def update_ipa_http_wsgi_conf(http):
+    logger.info('[Updating HTTPD service IPA WSGI configuration]')
+    http.update_httpd_wsgi_conf()
 
 
 def update_http_keytab(http):
@@ -1782,6 +1788,7 @@ def upgrade_configuration():
     http.stop()
     disable_httpd_system_trust(http)
     update_ipa_httpd_service_conf(http)
+    update_ipa_http_wsgi_conf(http)
     update_mod_nss_protocol(http)
     update_mod_nss_cipher_suite(http)
     disable_mod_nss_ocsp(http)


### PR DESCRIPTION
Instead of a package conflict, freeIPA now uses an Apache config file to
enforce the correct wsgi module. The workaround only applies to Fedora
since it is the only platform that permits parallel installation of
Python 2 and Python 3 mod_wsgi modules. RHEL 7 has only Python 2 and
Debian doesn't permit installation of both variants.

Fixes: https://pagure.io/freeipa/issue/7394
Signed-off-by: Christian Heimes <cheimes@redhat.com>