### PR TITLE
tests: ca-less to ca-full - remove certupdate

### DIFF
--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -1572,18 +1572,24 @@ class TestServerReplicaCALessToCAFull(CALessBase):
     def test_server_ipa_ca_install(self):
         """Install CA on master"""
 
-        ca_master = tasks.install_ca(self.master)
-        assert ca_master.returncode == 0
-        cert_update_master = self.master.run_command(['ipa-certupdate'])
-        assert cert_update_master.returncode == 0
-        cert_update_replica = self.replicas[0].run_command(['ipa-certupdate'])
-        assert cert_update_replica.returncode == 0
+        tasks.install_ca(self.master)
+        # We are not calling ipa-certupdate on replica here since the next step
+        # installs CA clone there.
+
+        ca_show = self.master.run_command(['ipa', 'ca-show', 'ipa'])
+        assert 'Subject DN: CN=Certificate Authority,O={}'.format(
+            self.master.domain.realm) in ca_show.stdout_text
 
     def test_replica_ipa_ca_install(self):
         """Install CA on replica"""
 
-        ca_replica = tasks.install_ca(self.replicas[0])
-        assert ca_replica.returncode == 0
+        replica = self.replicas[0]
+
+        tasks.install_ca(replica)
+
+        ca_show = replica.run_command(['ipa', 'ca-show', 'ipa'])
+        assert 'Subject DN: CN=Certificate Authority,O={}'.format(
+            self.master.domain.realm) in ca_show.stdout_text
 
 
 class TestReplicaCALessToCAFull(CALessBase):


### PR DESCRIPTION
After commits 8960141 and 97942a7 we do not need to run
ipa-certupdate command anymore when switching to ca-full.

This patch removes the above mentioned commands in order to
properly test the scenario.

https://pagure.io/freeipa/issue/7309