### PR TITLE
[Backport][ipa-4-6] IntegrationTests now collects logs from all test methods

### DIFF
--- a/ipatests/pytest_plugins/integration/__init__.py
+++ b/ipatests/pytest_plugins/integration/__init__.py
@@ -179,8 +179,6 @@ def collect_logs(name, logs_dict, logfile_dir=None, beakerlib_plugin=None):
             else:
                 shutil.rmtree(topdirname)
 
-        logs_dict.clear()
-
 
 @pytest.fixture(scope='class')
 def class_integration_logs():


### PR DESCRIPTION
This PR was opened automatically because PR #1480 was pushed to master and backport to ipa-4-6 is required.