### PR TITLE
Fix multiple uninstallation of server

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -74,6 +74,8 @@ steps:
   - ipa-run-tests ${tests_ignore} -k-test_dns_soa ${tests_verbose} ${path}
   - '! grep -n -C5 BytesWarning /var/log/httpd/error_log'
   - ipa-server-install --uninstall -U
+  # second uninstall to verify that --uninstall without installation works
+  - ipa-server-install --uninstall -U
 tests:
   ignore:
   - test_integration

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -576,6 +576,16 @@ class Env(object):
         if 'log' not in self:
             self.log = self._join('logdir', '%s.log' % self.context)
 
+        # Workaround for ipa-server-install --uninstall. When no config file
+        # is available, we set realm, domain, and basedn to RFC 2606 reserved
+        # suffix to suppress attribute errors during uninstallation.
+        if (self.in_server and self.context == 'installer' and
+                not getattr(self, 'config_loaded', False)):
+            if 'realm' not in self:
+                self.realm = 'UNCONFIGURED.INVALID'
+            if 'domain' not in self:
+                self.domain = self.realm.lower()
+
         if 'basedn' not in self and 'domain' in self:
             self.basedn = DN(*(('dc', dc) for dc in self.domain.split('.')))
 


### PR DESCRIPTION
"ipa-server-install --uninstall" no longer fails with error message
"'Env' object has no attribute 'basedn'" when executed on a system that
has no freeIPA server installation.

Fixes: https://pagure.io/freeipa/issue/7063
Signed-off-by: Christian Heimes <cheimes@redhat.com>