### PR TITLE
[Backport][ipa-4-6] ipa-kdb: use magic value to check if ipadb is used

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -522,6 +522,7 @@ static krb5_error_code ipadb_init_module(krb5_context kcontext,
     if (!ipactx) {
         return ENOMEM;
     }
+    ipactx->magic = IPA_CONTEXT_MAGIC;
 
     /* only check for unsupported 'temporary' value for now */
     for (i = 0; db_args != NULL && db_args[i] != NULL; i++) {

--- a/daemons/ipa-kdb/ipa_kdb.h
+++ b/daemons/ipa-kdb/ipa_kdb.h
@@ -101,7 +101,9 @@ struct ipadb_global_config {
     bool disable_preauth_for_spns;
 };
 
+#define IPA_CONTEXT_MAGIC 0x0c027ea7
 struct ipadb_context {
+    int magic;
     char *uri;
     char *base;
     char *realm;

--- a/daemons/ipa-kdb/ipa_kdb_certauth.c
+++ b/daemons/ipa-kdb/ipa_kdb_certauth.c
@@ -131,7 +131,7 @@ static krb5_error_code ipa_get_init_data(krb5_context kcontext,
     krb5_klog_syslog(LOG_INFO, "Initializing IPA certauth plugin.");
 
     ipactx = ipadb_get_context(kcontext);
-    if (ipactx == NULL) {
+    if (ipactx == NULL || ipactx->magic != IPA_CONTEXT_MAGIC) {
         return KRB5_KDB_DBNOTINITED;
     }
 


### PR DESCRIPTION
This PR was opened automatically because PR #1537 was pushed to master and backport to ipa-4-6 is required.