### PR TITLE
[Backport][ipa-4-5] ipa-kdb: use magic value to check if ipadb is used

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -522,6 +522,7 @@ static krb5_error_code ipadb_init_module(krb5_context kcontext,
     if (!ipactx) {
         return ENOMEM;
     }
+    ipactx->magic = IPA_CONTEXT_MAGIC;
 
     /* only check for unsupported 'temporary' value for now */
     for (i = 0; db_args != NULL && db_args[i] != NULL; i++) {

--- a/daemons/ipa-kdb/ipa_kdb.h
+++ b/daemons/ipa-kdb/ipa_kdb.h
@@ -101,7 +101,9 @@ struct ipadb_global_config {
     bool disable_preauth_for_spns;
 };
 
+#define IPA_CONTEXT_MAGIC 0x0c027ea7
 struct ipadb_context {
+    int magic;
     char *uri;
     char *base;
     char *realm;

--- a/daemons/ipa-kdb/ipa_kdb_certauth.c
+++ b/daemons/ipa-kdb/ipa_kdb_certauth.c
@@ -131,7 +131,7 @@ static krb5_error_code ipa_get_init_data(krb5_context kcontext,
     krb5_klog_syslog(LOG_INFO, "Initializing IPA certauth plugin.");
 
     ipactx = ipadb_get_context(kcontext);
-    if (ipactx == NULL) {
+    if (ipactx == NULL || ipactx->magic != IPA_CONTEXT_MAGIC) {
         return KRB5_KDB_DBNOTINITED;
     }
 


### PR DESCRIPTION
Manual backport of PR #1537 

The certauth plugin is configured in /etc/krb5.conf independently form
the database module. As a result the IPA certauth plugin can be added to
the configuration without the IPA DAL driver. Since the IPA certauth
plugin depends on the presence of the IPA DAL driver this patch adds a
magic value at the beginning of struct ipadb_context which can be
checked to see if the IPA DAL driver is properly initialized.

Resolves https://pagure.io/freeipa/issue/7261

Reviewed-By: Christian Heimes <cheimes@redhat.com>