### PR TITLE
[Backport][ipa-4-6] Bump python-ldap version to fix syncrepl bug

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -67,7 +67,8 @@
 %global python2_ldap_version 3.0.0-0.4.b4
 %global python3_ldap_version 3.0.0-0.4.b4
 %else
-%global python2_ldap_version 2.4.15
+# syncrepl fix, https://pagure.io/freeipa/issue/7240
+%global python2_ldap_version 2.4.25-9
 %global python3_ldap_version 2.4.35.1-2
 %endif
 


### PR DESCRIPTION
This PR was opened automatically because PR #1530 was pushed to master and backport to ipa-4-6 is required.