### PR TITLE
Update existing 389-DS cn=RSA,cn=encryption config

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -878,7 +878,11 @@ class DsInstance(service.Service):
             nsSSLToken=["internal (software)"],
             nsSSLActivation=["on"],
         )
-        conn.add_entry(entry)
+        try:
+            conn.add_entry(entry)
+        except errors.DuplicateEntry:
+            # 389-DS >= 1.4.0 has a default entry, update it.
+            conn.update_entry(entry)
 
         conn.unbind()
 


### PR DESCRIPTION
389-DS >= 1.4.0 on Fedora 28 has a default entry for
cn=RSA,cn=encryption,cn=config. The installer now updates the entry in
case it already exists. This ensures that token and personality are
correct for freeIPA

Fixes: https://pagure.io/freeipa/issue/7393
Signed-off-by: Christian Heimes <cheimes@redhat.com>