### PR TITLE
[Backport][ipa-4-6] Update existing 389-DS cn=RSA,cn=encryption config

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -878,7 +878,11 @@ class DsInstance(service.Service):
             nsSSLToken=["internal (software)"],
             nsSSLActivation=["on"],
         )
-        conn.add_entry(entry)
+        try:
+            conn.add_entry(entry)
+        except errors.DuplicateEntry:
+            # 389-DS >= 1.4.0 has a default entry, update it.
+            conn.update_entry(entry)
 
         conn.unbind()
 


### PR DESCRIPTION
This PR was opened automatically because PR #1547 was pushed to master and backport to ipa-4-6 is required.