### PR TITLE
[Backport][ipa-4-6] Restart named-pkcs11 after KRA installation

### DIFF
--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -129,6 +129,11 @@ def install(api, replica_config, options):
 
     # Restart apache for new proxy config file
     services.knownservices.httpd.restart(capture_output=True)
+    # Restarted named-pkcs11 to restore bind-dyndb-ldap operation, see
+    # https://pagure.io/freeipa/issue/5813
+    named = services.knownservices.named  # alias for named-pkcs11
+    if named.is_running():
+        named.restart(capture_output=True)
 
 
 def uninstall():


### PR DESCRIPTION
This PR was opened automatically because PR #1522 was pushed to master and backport to ipa-4-6 is required.