### PR TITLE
ipa host-add --ip-address: properly handle NoNameservers

### DIFF
--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -539,7 +539,14 @@ def get_reverse_zone(ipaddr):
     """
     ip = netaddr.IPAddress(str(ipaddr))
     revdns = DNSName(unicode(ip.reverse_dns))
-    revzone = DNSName(dns.resolver.zone_for_name(revdns))
+    try:
+        revzone = DNSName(dns.resolver.zone_for_name(revdns))
+    except dns.resolver.NoNameservers:
+        raise errors.NotFound(
+            reason=_(
+                'All nameservers failed to answer the query '
+                'for DNS reverse zone %(revdns)s') % dict(revdns=revdns)
+        )
 
     try:
         api.Command['dnszone_show'](revzone)


### PR DESCRIPTION
When ipa host-add --ip-address is called but no DNS server is able to answer
for the reverse zone, get_reverse_zone raises a NoNameservers exception.
The exception is not managed by add_records_for_host_validation, and this
leads to the command exiting on failure with an InternalError:
    $ ipa host-add testhost.ipadomain.com --ip-address 172.16.30.22
    ipa: ERROR: an internal error has occurred
A traceback is also logged in httpd error_log.

This commit properly handles the exception, and adds a test.

https://pagure.io/freeipa/issue/7397