### PR TITLE
test_dnssec: re-add named-pkcs11 workarounds

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -270,6 +270,18 @@ def enable_replication_debugging(host, log_level=0):
                      stdin_text=logging_ldif)
 
 
+def set_default_ttl_for_ipa_dns_zone(host, raiseonerr=True):
+    args = [
+        'ipa', 'dnszone-mod', host.domain.name,
+        '--default-ttl', '1',
+        '--ttl', '1'
+    ]
+    result = host.run_command(args, raiseonerr=raiseonerr, stdin_text=None)
+    if result.returncode != 0:
+        logger.info('Failed to set TTL and default TTL for DNS zone %s to 1',
+                    host.domain.name)
+
+
 def install_master(host, setup_dns=True, setup_kra=False, setup_adtrust=False,
                    extra_args=(), domain_level=None, unattended=True,
                    stdin_text=None, raiseonerr=True):
@@ -308,6 +320,10 @@ def install_master(host, setup_dns=True, setup_kra=False, setup_adtrust=False,
         enable_replication_debugging(host)
         setup_sssd_debugging(host)
         kinit_admin(host)
+        if setup_dns:
+            # fixup DNS zone default TTL for IPA DNS zone
+            # For tests we should not wait too long
+            set_default_ttl_for_ipa_dns_zone(host, raiseonerr=raiseonerr)
     return result
 
 

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -11,6 +11,7 @@ import dns.dnssec
 import dns.resolver
 import dns.name
 import time
+import pytest
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_plugins.integration import tasks
@@ -64,7 +65,6 @@ def wait_until_record_is_signed(nameserver, record, rtype="SOA",
     Returns True if record is signed, or False on timeout
     :param nameserver: nameserver to query
     :param record: query
-    :param log: logger
     :param rtype: record type
     :param timeout:
     :return: True if records is signed, False if timeout
@@ -113,6 +113,7 @@ class TestInstallDNSSECLast(IntegrationTest):
         ]
         self.master.run_command(args)
 
+        tasks.restart_named(self.master, self.replicas[0])
         # test master
         assert wait_until_record_is_signed(
             self.master.ip, test_zone, timeout=100
@@ -133,6 +134,7 @@ class TestInstallDNSSECLast(IntegrationTest):
         ]
         self.replicas[0].run_command(args)
 
+        tasks.restart_named(self.replicas[0])
         # test replica
         assert wait_until_record_is_signed(
             self.replicas[0].ip, test_zone_repl, timeout=300
@@ -179,6 +181,7 @@ class TestInstallDNSSECLast(IntegrationTest):
         ]
         self.master.run_command(args)
 
+        tasks.restart_named(self.master)
         # test master
         assert wait_until_record_is_signed(
             self.master.ip, test_zone, timeout=100
@@ -227,6 +230,8 @@ class TestInstallDNSSECLast(IntegrationTest):
         ]
         self.master.run_command(args)
 
+        tasks.restart_named(self.master, self.replicas[0])
+
         # test master
         assert wait_until_record_is_signed(
             self.master.ip, test_zone_repl, timeout=100
@@ -240,6 +245,75 @@ class TestInstallDNSSECLast(IntegrationTest):
         dnskey_new = resolve_with_dnssec(self.replicas[0].ip, test_zone_repl,
                                          rtype="DNSKEY").rrset
         assert dnskey_old != dnskey_new, "DNSKEY should be different"
+
+
+class TestZoneSigningWithoutNamedRestart(IntegrationTest):
+    """Test if https://pagure.io/freeipa/issue/5348 is already fixed.
+    """
+    num_replicas = 1
+    topology = 'star'
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=False)
+        args = [
+            "ipa-dns-install",
+            "--dnssec-master",
+            "--forwarder", cls.master.config.dns_forwarder,
+            "-U",
+        ]
+        cls.master.run_command(args)
+
+        tasks.install_replica(cls.master, cls.replicas[0], setup_dns=True)
+
+        # backup trusted key
+        tasks.backup_file(cls.master, paths.DNSSEC_TRUSTED_KEY)
+        tasks.backup_file(cls.replicas[0], paths.DNSSEC_TRUSTED_KEY)
+
+    @classmethod
+    def uninstall(cls, mh):
+        # restore trusted key
+        tasks.restore_files(cls.master)
+        tasks.restore_files(cls.replicas[0])
+
+        super(TestZoneSigningWithoutNamedRestart, cls).uninstall(mh)
+
+    def test_sign_root_zone_no_named_restart(self):
+        args = [
+            "ipa", "dnszone-add", root_zone, "--dnssec", "true",
+            "--skip-overlap-check",
+        ]
+        self.master.run_command(args)
+
+        # make BIND happy: add the glue record and delegate zone
+        args = [
+            "ipa", "dnsrecord-add", root_zone, self.master.hostname,
+            "--a-rec=" + self.master.ip
+        ]
+        self.master.run_command(args)
+        args = [
+            "ipa", "dnsrecord-add", root_zone, self.replicas[0].hostname,
+            "--a-rec=" + self.replicas[0].ip
+        ]
+        self.master.run_command(args)
+
+        # sleep a bit until data are provided by bind-dyndb-ldap
+        time.sleep(10)
+
+        args = [
+            "ipa", "dnsrecord-add", root_zone, self.master.domain.name,
+            "--ns-rec=" + self.master.hostname
+        ]
+        self.master.run_command(args)
+        # test master
+        assert wait_until_record_is_signed(
+            self.master.ip, root_zone, timeout=100
+        ), "Zone %s is not signed (master)" % root_zone
+
+        # test replica
+        assert wait_until_record_is_signed(
+            self.replicas[0].ip, root_zone, timeout=300
+        ), "Zone %s is not signed (replica)" % root_zone
 
 
 class TestInstallDNSSECFirst(IntegrationTest):
@@ -300,6 +374,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
             "--ns-rec=" + self.master.hostname
         ]
         self.master.run_command(args)
+        tasks.restart_named(self.master, self.replicas[0])
         # test master
         assert wait_until_record_is_signed(
             self.master.ip, root_zone, timeout=100
@@ -331,6 +406,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
             "--ns-rec=" + self.master.hostname
         ]
         self.master.run_command(args)
+        tasks.restart_named(self.master, self.replicas[0])
         # wait until zone is signed
         assert wait_until_record_is_signed(
             self.master.ip, example_test_zone, timeout=100
@@ -468,6 +544,7 @@ class TestMigrateDNSSECMaster(IntegrationTest):
 
         self.master.run_command(args)
 
+        tasks.restart_named(self.master, self.replicas[0])
         # wait until zone is signed
         assert wait_until_record_is_signed(
             self.master.ip, example_test_zone, timeout=100
@@ -524,6 +601,7 @@ class TestMigrateDNSSECMaster(IntegrationTest):
             "--skip-overlap-check",
         ]
         self.replicas[0].run_command(args)
+        tasks.restart_named(self.master, self.replicas[0])
         # wait until zone is signed
         assert wait_until_record_is_signed(
             self.replicas[0].ip, example2_test_zone, timeout=100
@@ -556,6 +634,7 @@ class TestMigrateDNSSECMaster(IntegrationTest):
             "--skip-overlap-check",
         ]
         self.replicas[1].run_command(args)
+        tasks.restart_named(self.replicas[0], self.replicas[1])
         # wait until zone is signed
         assert wait_until_record_is_signed(
             self.replicas[1].ip, example3_test_zone, timeout=200

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -5,12 +5,11 @@
 from __future__ import absolute_import
 
 import logging
-import pytest
+import time
 
 import dns.dnssec
 import dns.resolver
 import dns.name
-import time
 import pytest
 
 from ipatests.test_integration.base import IntegrationTest
@@ -18,6 +17,10 @@ from ipatests.pytest_plugins.integration import tasks
 from ipaplatform.paths import paths
 
 logger = logging.getLogger(__name__)
+
+# Sleep 5 seconds at most when waiting for LDAP updates
+# for DNSSEC changes. Test zones should be updated with 1 second TTL
+DNSSEC_SLEEP = 5
 
 test_zone = "dnssec.test."
 test_zone_repl = "dnssec-replica.test."
@@ -79,6 +82,20 @@ def wait_until_record_is_signed(nameserver, record, rtype="SOA",
     return False
 
 
+def dnszone_add_dnssec(host, test_zone):
+    """Add dnszone with dnssec and short TTL
+    """
+    args = [
+        "ipa",
+        "dnszone-add", test_zone,
+        "--skip-overlap-check",
+        "--dnssec", "true",
+        "--ttl", "1",
+        "--default-ttl", "1",
+    ]
+    return host.run_command(args)
+
+
 class TestInstallDNSSECLast(IntegrationTest):
     """Simple DNSSEC test
 
@@ -105,14 +122,7 @@ class TestInstallDNSSECLast(IntegrationTest):
 
     def test_if_zone_is_signed_master(self):
         # add zone with enabled DNSSEC signing on master
-        args = [
-            "ipa",
-            "dnszone-add", test_zone,
-            "--skip-overlap-check",
-            "--dnssec", "true",
-        ]
-        self.master.run_command(args)
-
+        dnszone_add_dnssec(self.master, test_zone)
         tasks.restart_named(self.master, self.replicas[0])
         # test master
         assert wait_until_record_is_signed(
@@ -126,14 +136,7 @@ class TestInstallDNSSECLast(IntegrationTest):
 
     def test_if_zone_is_signed_replica(self):
         # add zone with enabled DNSSEC signing on replica
-        args = [
-            "ipa",
-            "dnszone-add", test_zone_repl,
-            "--skip-overlap-check",
-            "--dnssec", "true",
-        ]
-        self.replicas[0].run_command(args)
-
+        dnszone_add_dnssec(self.replicas[0], test_zone_repl)
         tasks.restart_named(self.replicas[0])
         # test replica
         assert wait_until_record_is_signed(
@@ -161,7 +164,7 @@ class TestInstallDNSSECLast(IntegrationTest):
         ]
         self.master.run_command(args)
 
-        time.sleep(20)  # sleep a bit until LDAP changes are applied to DNS
+        time.sleep(DNSSEC_SLEEP)
 
         # test master
         assert not is_record_signed(
@@ -210,7 +213,7 @@ class TestInstallDNSSECLast(IntegrationTest):
         ]
         self.master.run_command(args)
 
-        time.sleep(20)  # sleep a bit until LDAP changes are applied to DNS
+        time.sleep(DNSSEC_SLEEP)
 
         # test master
         assert not is_record_signed(
@@ -279,11 +282,7 @@ class TestZoneSigningWithoutNamedRestart(IntegrationTest):
         super(TestZoneSigningWithoutNamedRestart, cls).uninstall(mh)
 
     def test_sign_root_zone_no_named_restart(self):
-        args = [
-            "ipa", "dnszone-add", root_zone, "--dnssec", "true",
-            "--skip-overlap-check",
-        ]
-        self.master.run_command(args)
+        dnszone_add_dnssec(self.master, root_zone)
 
         # make BIND happy: add the glue record and delegate zone
         args = [
@@ -298,7 +297,7 @@ class TestZoneSigningWithoutNamedRestart(IntegrationTest):
         self.master.run_command(args)
 
         # sleep a bit until data are provided by bind-dyndb-ldap
-        time.sleep(10)
+        time.sleep(DNSSEC_SLEEP)
 
         args = [
             "ipa", "dnsrecord-add", root_zone, self.master.domain.name,
@@ -350,11 +349,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
         super(TestInstallDNSSECFirst, cls).uninstall(mh)
 
     def test_sign_root_zone(self):
-        args = [
-            "ipa", "dnszone-add", root_zone, "--dnssec", "true",
-            "--skip-overlap-check",
-        ]
-        self.master.run_command(args)
+        dnszone_add_dnssec(self.master, root_zone)
 
         # make BIND happy: add the glue record and delegate zone
         args = [
@@ -367,7 +362,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
             "--a-rec=" + self.replicas[0].ip
         ]
         self.master.run_command(args)
-        time.sleep(10)  # sleep a bit until data are provided by bind-dyndb-ldap
+        time.sleep(DNSSEC_SLEEP)
 
         args = [
             "ipa", "dnsrecord-add", root_zone, self.master.domain.name,
@@ -391,14 +386,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
         Validate signed DNS records, using our own signed root zone
         :return:
         """
-
-        # add test zone
-        args = [
-            "ipa", "dnszone-add", example_test_zone, "--dnssec", "true",
-            "--skip-overlap-check",
-        ]
-
-        self.master.run_command(args)
+        dnszone_add_dnssec(self.master, example_test_zone)
 
         # delegation
         args = [
@@ -491,7 +479,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
                                            root_keys_rrset.to_text() + '\n')
 
         # verify signatures
-        time.sleep(1)
+        time.sleep(DNSSEC_SLEEP)
         args = [
             "drill", "@localhost", "-k",
             paths.DNSSEC_TRUSTED_KEY, "-S",
@@ -537,13 +525,7 @@ class TestMigrateDNSSECMaster(IntegrationTest):
         replica_backup_filename = "/tmp/ipa-kasp.db.backup"
 
         # add test zone
-        args = [
-            "ipa", "dnszone-add", example_test_zone, "--dnssec", "true",
-            "--skip-overlap-check",
-        ]
-
-        self.master.run_command(args)
-
+        dnszone_add_dnssec(self.master, example_test_zone)
         tasks.restart_named(self.master, self.replicas[0])
         # wait until zone is signed
         assert wait_until_record_is_signed(
@@ -596,11 +578,7 @@ class TestMigrateDNSSECMaster(IntegrationTest):
         assert dnskey_old == dnskey_new, "DNSKEY should be the same"
 
         # add test zone
-        args = [
-            "ipa", "dnszone-add", example2_test_zone, "--dnssec", "true",
-            "--skip-overlap-check",
-        ]
-        self.replicas[0].run_command(args)
+        dnszone_add_dnssec(self.replicas[0], example2_test_zone)
         tasks.restart_named(self.master, self.replicas[0])
         # wait until zone is signed
         assert wait_until_record_is_signed(
@@ -629,11 +607,7 @@ class TestMigrateDNSSECMaster(IntegrationTest):
             % example2_test_zone)
 
         # add new zone to new replica
-        args = [
-            "ipa", "dnszone-add", example3_test_zone, "--dnssec", "true",
-            "--skip-overlap-check",
-        ]
-        self.replicas[1].run_command(args)
+        dnszone_add_dnssec(self.replicas[0], example3_test_zone)
         tasks.restart_named(self.replicas[0], self.replicas[1])
         # wait until zone is signed
         assert wait_until_record_is_signed(


### PR DESCRIPTION
DNSSEC tests starrted to fail again, probably due to a bug in
some underlaying component.

This reverts commit 8bc677512296a7e94c29edd0c1a96aa7273f352a
and makes the xfail test check less strict - it will no longer
mark the test suite red if it passes.

Related https://pagure.io/freeipa/issue/5348

Clone of @tomaskrizek PR #973 