### PR TITLE
Use system-wide crypto-policies on Fedora

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -867,6 +867,7 @@ Requires: ldns-utils
 Requires: python2-sssdconfig
 Requires: python2-cryptography >= 1.6
 Requires: iptables
+Requires: python2-mock
 
 Provides: %{alt_name}-tests = %{version}
 Conflicts: %{alt_name}-tests

--- a/install/share/bind.named.conf.template
+++ b/install/share/bind.named.conf.template
@@ -21,6 +21,9 @@ options {
 	bindkeys-file "$BINDKEYS_FILE";
 
 	managed-keys-directory "$MANAGED_KEYS_DIR";
+
+	/* crypto policy snippet on platforms with system-wide policy. */
+	$INCLUDE_CRYPTO_POLICY
 };
 
 /* If you want to enable debugging, eg. using the 'rndc trace' command,

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -304,9 +304,7 @@ TLS_VERSIONS = [
     "tls1.2"
 ]
 TLS_VERSION_MINIMAL = "tls1.0"
-# high ciphers without RC4, MD5, TripleDES, pre-shared key
-# and secure remote password
-TLS_HIGH_CIPHERS = "HIGH:!aNULL:!eNULL:!MD5:!RC4:!3DES:!PSK:!SRP"
+
 
 # Use cache path
 USER_CACHE_PATH = (

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -56,9 +56,10 @@ except ImportError:
 from ipalib import errors, messages
 from ipalib.constants import (
     DOMAIN_LEVEL_0,
-    TLS_VERSIONS, TLS_VERSION_MINIMAL, TLS_HIGH_CIPHERS
+    TLS_VERSIONS, TLS_VERSION_MINIMAL
 )
 from ipalib.text import _
+from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipapython.ssh import SSHPublicKey
 from ipapython.dn import DN, RDN
@@ -330,9 +331,9 @@ def create_https_connection(
         ssl.OP_SINGLE_ECDH_USE
     )
 
-    # high ciphers without RC4, MD5, TripleDES, pre-shared key
-    # and secure remote password
-    ctx.set_ciphers(TLS_HIGH_CIPHERS)
+    # high ciphers without RC4, MD5, TripleDES, pre-shared key and secure
+    # remote password. Uses system crypto policies on some platforms.
+    ctx.set_ciphers(constants.TLS_HIGH_CIPHERS)
 
     # pylint: enable=no-member
     # set up the correct TLS version flags for the SSL context

--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -42,6 +42,9 @@ class BaseConstantsNamespace(object):
     # WSGI module override, only used on Fedora
     MOD_WSGI_PYTHON2 = None
     MOD_WSGI_PYTHON3 = None
+    # high ciphers without RC4, MD5, TripleDES, pre-shared key, secure
+    # remote password, and DSA cert authentication.
+    TLS_HIGH_CIPHERS = "HIGH:!aNULL:!eNULL:!MD5:!RC4:!3DES:!PSK:!SRP:!aDSS"
 
 
 constants = BaseConstantsNamespace()

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -81,6 +81,7 @@ class BasePathNamespace(object):
     NAMED_ROOT_KEY = "/etc/named.root.key"
     NAMED_BINDKEYS_FILE = "/etc/named.iscdlv.key"
     NAMED_MANAGED_KEYS_DIR = "/var/named/dynamic"
+    NAMED_CRYPTO_POLICY_FILE = None
     NSLCD_CONF = "/etc/nslcd.conf"
     NSS_LDAP_CONF = "/etc/nss_ldap.conf"
     NSSWITCH_CONF = "/etc/nsswitch.conf"

--- a/ipaplatform/fedora/constants.py
+++ b/ipaplatform/fedora/constants.py
@@ -16,5 +16,10 @@ class FedoraConstantsNamespace(RedHatConstantsNamespace):
     MOD_WSGI_PYTHON2 = "modules/mod_wsgi.so"
     MOD_WSGI_PYTHON3 = "modules/mod_wsgi_python3.so"
 
+    # System-wide crypto policy, but without TripleDES, pre-shared key,
+    # secure remote password, and DSA cert authentication.
+    # see https://fedoraproject.org/wiki/Changes/CryptoPolicy
+    TLS_HIGH_CIPHERS = "PROFILE=SYSTEM:!3DES:!PSK:!SRP:!aDSS"
+
 
 constants = FedoraConstantsNamespace()

--- a/ipaplatform/fedora/paths.py
+++ b/ipaplatform/fedora/paths.py
@@ -30,6 +30,7 @@ class FedoraPathNamespace(RedHatPathNamespace):
     HTTPD_IPA_WSGI_MODULES_CONF = (
         "/etc/httpd/conf.modules.d/02-ipa-wsgi.conf"
     )
+    NAMED_CRYPTO_POLICY_FILE = "/etc/crypto-policies/back-ends/bind.config"
 
 
 paths = FedoraPathNamespace()

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -768,6 +768,13 @@ class BindInstance(service.Service):
             logger.debug("Unable to mask named (%s)", e)
 
     def __setup_sub_dict(self):
+        if paths.NAMED_CRYPTO_POLICY_FILE is not None:
+            crypto_policy = 'include "{}";'.format(
+                paths.NAMED_CRYPTO_POLICY_FILE
+            )
+        else:
+            crypto_policy = "// not available"
+
         self.sub_dict = dict(
             FQDN=self.fqdn,
             SERVER_ID=installutils.realm_to_serverid(self.realm),
@@ -780,7 +787,8 @@ class BindInstance(service.Service):
             NAMED_PID=paths.NAMED_PID,
             NAMED_VAR_DIR=paths.NAMED_VAR_DIR,
             BIND_LDAP_SO=paths.BIND_LDAP_SO,
-            )
+            INCLUDE_CRYPTO_POLICY=crypto_policy,
+        )
 
     def __setup_dns_container(self):
         self._ldap_mod("dns.ldif", self.sub_dict)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -912,6 +912,29 @@ def named_add_server_id():
     return True
 
 
+def named_add_crypto_policy():
+    """Add crypto policy include
+    """
+    if sysupgrade.get_upgrade_state('named.conf', 'add_crypto_policy'):
+        # upgrade was done already
+        return False
+    policy_file = paths.NAMED_CRYPTO_POLICY_FILE
+    if policy_file is None:
+        # no crypto policy
+        return False
+
+    if bindinstance.named_conf_include_exists(policy_file):
+        sysupgrade.set_upgrade_state('named.conf', 'add_crypto_policy', True)
+        return False
+
+    logger.info('[Adding crypto policy include to named.conf]')
+    bindinstance.named_conf_set_directive(
+        'include', policy_file, section=bindinstance.NAMED_SECTION_OPTIONS
+    )
+    sysupgrade.set_upgrade_state('named.conf', 'add_crypto_policy', True)
+    return True
+
+
 def certificate_renewal_update(ca, ds, http):
     """
     Update certmonger certificate renewal configuration.
@@ -1854,6 +1877,7 @@ def upgrade_configuration():
                           mask_named_regular(),
                           fix_dyndb_ldap_workdir_permissions(),
                           named_add_server_id(),
+                          named_add_crypto_policy(),
                          )
 
     if any(named_conf_changes):

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -483,7 +483,7 @@ def named_remove_deprecated_options():
 
     except IOError as e:
         logger.error('Cannot modify DNS configuration in %s: %s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
 
     # Log only the changed options
     if not removed_options:
@@ -518,7 +518,7 @@ def named_set_minimum_connections():
         connections = bindinstance.named_conf_get_directive('connections')
     except IOError as e:
         logger.debug('Cannot retrieve connections option from %s: %s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
         return changed
 
     try:
@@ -536,7 +536,7 @@ def named_set_minimum_connections():
                 logger.debug('Connections set to %d', minimum_connections)
             except IOError as e:
                 logger.error('Cannot update connections in %s: %s',
-                             bindinstance.NAMED_CONF, e)
+                             paths.NAMED_CONF, e)
             else:
                 changed = True
 
@@ -567,11 +567,11 @@ def named_update_gssapi_configuration():
         return False
 
     try:
-        gssapi_keytab = bindinstance.named_conf_get_directive('tkey-gssapi-keytab',
-                bindinstance.NAMED_SECTION_OPTIONS)
+        gssapi_keytab = bindinstance.named_conf_get_directive(
+            'tkey-gssapi-keytab', bindinstance.NAMED_SECTION_OPTIONS)
     except IOError as e:
         logger.error('Cannot retrieve tkey-gssapi-keytab option from %s: %s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
         return False
     else:
         if gssapi_keytab:
@@ -587,12 +587,12 @@ def named_update_gssapi_configuration():
     except IOError as e:
         logger.error('Cannot retrieve tkey-gssapi-credential option from %s: '
                      '%s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
         return False
 
     if not tkey_credential or not tkey_domain:
         logger.error('Either tkey-gssapi-credential or tkey-domain is missing '
-                     'in %s. Skip update.', bindinstance.NAMED_CONF)
+                     'in %s. Skip update.', paths.NAMED_CONF)
         return False
 
     try:
@@ -607,7 +607,7 @@ def named_update_gssapi_configuration():
             bindinstance.NAMED_SECTION_OPTIONS)
     except IOError as e:
         logger.error('Cannot update GSSAPI configuration in %s: %s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
         return False
     else:
         logger.debug('GSSAPI configuration updated')
@@ -632,11 +632,11 @@ def named_update_pid_file():
         return False
 
     try:
-        pid_file = bindinstance.named_conf_get_directive('pid-file',
-                bindinstance.NAMED_SECTION_OPTIONS)
+        pid_file = bindinstance.named_conf_get_directive(
+            'pid-file', bindinstance.NAMED_SECTION_OPTIONS)
     except IOError as e:
         logger.error('Cannot retrieve pid-file option from %s: %s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
         return False
     else:
         if pid_file:
@@ -645,11 +645,11 @@ def named_update_pid_file():
             return False
 
     try:
-        bindinstance.named_conf_set_directive('pid-file', paths.NAMED_PID,
-                                              bindinstance.NAMED_SECTION_OPTIONS)
+        bindinstance.named_conf_set_directive(
+            'pid-file', paths.NAMED_PID, bindinstance.NAMED_SECTION_OPTIONS)
     except IOError as e:
         logger.error('Cannot update pid-file configuration in %s: %s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
         return False
     else:
         logger.debug('pid-file configuration updated')
@@ -674,10 +674,10 @@ def named_enable_dnssec():
                                                   str_val=False)
         except IOError as e:
             logger.error('Cannot update dnssec-enable configuration in %s: %s',
-                         bindinstance.NAMED_CONF, e)
+                         paths.NAMED_CONF, e)
             return False
     else:
-        logger.debug('dnssec-enabled in %s', bindinstance.NAMED_CONF)
+        logger.debug('dnssec-enabled in %s', paths.NAMED_CONF)
 
     sysupgrade.set_upgrade_state('named.conf', 'dnssec_enabled', True)
     return True
@@ -707,14 +707,17 @@ def named_validate_dnssec():
         except IOError as e:
             logger.error('Cannot update dnssec-validate configuration in %s: '
                          '%s',
-                         bindinstance.NAMED_CONF, e)
+                         paths.NAMED_CONF, e)
             return False
     else:
         logger.debug('dnssec-validate already configured in %s',
-                     bindinstance.NAMED_CONF)
+                     paths.NAMED_CONF)
 
-    sysupgrade.set_upgrade_state('named.conf', 'dnssec_validation_upgraded', True)
+    sysupgrade.set_upgrade_state(
+        'named.conf', 'dnssec_validation_upgraded', True
+    )
     return True
+
 
 def named_bindkey_file_option():
     """
@@ -730,11 +733,11 @@ def named_bindkey_file_option():
         return False
 
     try:
-        bindkey_file = bindinstance.named_conf_get_directive('bindkey-file',
-                bindinstance.NAMED_SECTION_OPTIONS)
+        bindkey_file = bindinstance.named_conf_get_directive(
+            'bindkey-file', bindinstance.NAMED_SECTION_OPTIONS)
     except IOError as e:
         logger.error('Cannot retrieve bindkey-file option from %s: %s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
         return False
     else:
         if bindkey_file:
@@ -744,12 +747,13 @@ def named_bindkey_file_option():
 
     logger.info('[Setting "bindkeys-file" option in named.conf]')
     try:
-        bindinstance.named_conf_set_directive('bindkeys-file',
-                                              paths.NAMED_BINDKEYS_FILE,
-                                              bindinstance.NAMED_SECTION_OPTIONS)
+        bindinstance.named_conf_set_directive(
+            'bindkeys-file', paths.NAMED_BINDKEYS_FILE,
+            section=bindinstance.NAMED_SECTION_OPTIONS
+        )
     except IOError as e:
         logger.error('Cannot update bindkeys-file configuration in %s: %s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
         return False
 
 
@@ -775,7 +779,7 @@ def named_managed_keys_dir_option():
     except IOError as e:
         logger.error('Cannot retrieve managed-keys-directory option from %s: '
                      '%s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
         return False
     else:
         if managed_keys:
@@ -792,7 +796,7 @@ def named_managed_keys_dir_option():
     except IOError as e:
         logger.error('Cannot update managed-keys-directory configuration in '
                      '%s: %s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
         return False
 
 
@@ -816,7 +820,7 @@ def named_root_key_include():
         root_key = bindinstance.named_conf_include_exists(paths.NAMED_ROOT_KEY)
     except IOError as e:
         logger.error('Cannot check root key include in %s: %s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
         return False
     else:
         if root_key:
@@ -829,7 +833,7 @@ def named_root_key_include():
         bindinstance.named_conf_add_include(paths.NAMED_ROOT_KEY)
     except IOError as e:
         logger.error('Cannot update named root key include in %s: %s',
-                     bindinstance.NAMED_CONF, e)
+                     paths.NAMED_CONF, e)
         return False
 
 

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -78,5 +78,6 @@ if __name__ == '__main__':
             "ipaserver": ["ipaserver"],
             "webui": ["selenium", "pyyaml", "ipaserver"],
             "xmlrpc": ["ipaserver"],
+            ":python_version<'3'": ["mock"],
         }
     )

--- a/ipatests/test_ipaserver/test_install/test_bindinstance.py
+++ b/ipatests/test_ipaserver/test_install/test_bindinstance.py
@@ -1,0 +1,71 @@
+#
+# Copyright (C) 2018  FreeIPA Contributors.  See COPYING for license
+#
+
+import tempfile
+
+import pytest
+
+from ipaplatform.paths import paths
+from ipaserver.install.server.upgrade import named_add_crypto_policy
+
+try:
+    from unittest.mock import patch  # pylint: disable=import-error
+except ImportError:
+    from mock import patch  # pylint: disable=import-error
+
+
+TEST_CONFIG = """
+options {
+\tdnssec-enable yes;
+\tdnssec-validation yes;
+};
+
+include "random/file";
+"""
+
+
+EXPECTED_CONFIG = """
+options {
+\tdnssec-enable yes;
+\tdnssec-validation yes;
+\tinclude "/etc/crypto-policies/back-ends/bind.config";
+};
+
+include "random/file";
+"""
+
+POLICY_FILE = "/etc/crypto-policies/back-ends/bind.config"
+
+
+@pytest.fixture
+def namedconf():
+    with tempfile.NamedTemporaryFile('w+') as f:
+        with patch.multiple(paths,
+                            NAMED_CONF=f.name,
+                            NAMED_CRYPTO_POLICY_FILE=POLICY_FILE):
+            yield f.name
+
+
+@patch('ipaserver.install.sysupgrade.get_upgrade_state')
+@patch('ipaserver.install.sysupgrade.set_upgrade_state')
+def test_add_crypto_policy(m_set, m_get, namedconf):
+    m_get.return_value = False
+    with open(namedconf, 'w') as f:
+        f.write(TEST_CONFIG)
+
+    named_add_crypto_policy()
+    m_get.assert_called_with('named.conf', 'add_crypto_policy')
+    m_set.assert_called_with('named.conf', 'add_crypto_policy', True)
+
+    with open(namedconf) as f:
+        content = f.read()
+    assert content == EXPECTED_CONFIG
+
+    m_get.reset_mock()
+    m_set.reset_mock()
+
+    m_get.return_value = True
+    named_add_crypto_policy()
+    m_get.assert_called_with('named.conf', 'add_crypto_policy')
+    m_set.assert_not_called()


### PR DESCRIPTION
HTTPS connections from IPA framework now uses system-wide
crypto-policies on Fedora.

The 'DEFAULT' crypto policy also includes unnecessary ciphers for
PSK, SRP, aDSS and 3DES. Since these ciphers are not used by freeIPA,
they are explicitly excluded.

Fixes: https://pagure.io/freeipa/issue/4853
Signed-off-by: Christian Heimes <cheimes@redhat.com>