### PR TITLE
[Backport][ipa-4-5] Enable and start oddjobd after ipa-restore

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -409,6 +409,12 @@ class Restore(admintool.AdminTool):
                 self.log.info('Restarting SSSD')
                 sssd = services.service('sssd', api)
                 sssd.restart()
+                self.log.info('Restarting oddjobd')
+                oddjobd = services.service('oddjobd', api)
+                if not oddjobd.is_enabled():
+                    self.log.info("Enabling oddjobd")
+                    oddjobd.enable()
+                oddjobd.start()
                 http.remove_httpd_ccaches()
                 # have the daemons pick up their restored configs
                 run([paths.SYSTEMCTL, "--system", "daemon-reload"])


### PR DESCRIPTION
If after ipa-restore the service oddjobd is not running,
domain-level1 replica installation will fail during
ipa-replica-conncheck because this step is using oddjob
to start the process ipa-replica-conncheck on the master.

This patch fixes it. Also added regression test.

https://pagure.io/freeipa/issue/7234

https://github.com/freeipa/freeipa/pull/1472

Reviewed-By: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Florence Blanc-Renaud <flo@redhat.com>