### PR TITLE
freeipa-server no longer supports i686 arch on F28

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1,3 +1,11 @@
+# 389-ds-base 1.4 no longer supports i686 platform, build only client
+# packages, https://bugzilla.redhat.com/show_bug.cgi?id=1544386
+%if 0%{?fedora} >= 28 || 0%{?rhel} > 7
+%ifarch %{ix86}
+%{!?ONLY_CLIENT:%global ONLY_CLIENT 1}
+%endif
+%endif
+
 # Define ONLY_CLIENT to only make the ipa-client and ipa-python
 # subpackages
 %{!?ONLY_CLIENT:%global ONLY_CLIENT 0}


### PR DESCRIPTION
389-ds-base 1.4 is going to drop 32bit i686 arch support in Fedora 28,
https://bugzilla.redhat.com/show_bug.cgi?id=1530832 . Add ExcludeArch to
add freeipa-server related packages (freeipa-server, python[23]-ipaserver,
freeipa-server-common, freeipa-server-dns, freeipa-server-trust-ad).

Fixes: https://pagure.io/freeipa/issue/7400
Signed-off-by: Christian Heimes <cheimes@redhat.com>