### PR TITLE
[Backport][ipa-4-6] ipa host-add --ip-address: properly handle NoNameservers

### DIFF
--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -539,7 +539,14 @@ def get_reverse_zone(ipaddr):
     """
     ip = netaddr.IPAddress(str(ipaddr))
     revdns = DNSName(unicode(ip.reverse_dns))
-    revzone = DNSName(dns.resolver.zone_for_name(revdns))
+    try:
+        revzone = DNSName(dns.resolver.zone_for_name(revdns))
+    except dns.resolver.NoNameservers:
+        raise errors.NotFound(
+            reason=_(
+                'All nameservers failed to answer the query '
+                'for DNS reverse zone %(revdns)s') % dict(revdns=revdns)
+        )
 
     try:
         api.Command['dnszone_show'](revzone)


### PR DESCRIPTION
This PR was opened automatically because PR #1551 was pushed to master and backport to ipa-4-6 is required.