### PR TITLE
[Backport][ipa-4-5] - ipatest: replica install with existing entry on master

### DIFF
--- a/ipatests/test_integration/test_replication_layouts.py
+++ b/ipatests/test_integration/test_replication_layouts.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015  FreeIPA Contributors see COPYING for license
+# Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #
 
 import time


### PR DESCRIPTION
    replica install might fail because of existing entry for replica like
    `cn=ipa-http-delegation,cn=s4u2proxy,cn=etc,$SUFFIX` etc. The situation
    may arise due to incorrect uninstall of replica or ipa server-del is
    not executed on master.

    related bug : https://pagure.io/freeipa/issue/7174

Fixes: https://pagure.io/freeipa/issue/7276

Signed-off-by: Mohammad Rizwan Yusuf <myusuf@redhat.com>
Reviewed-By: Christian Heimes <cheimes@redhat.com>