### PR TITLE
Add workaround for netiface wheel bug

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -335,6 +335,7 @@ wheel_bundle: $(WHEELBUNDLEDIR) bdist_wheel .wheelconstraints
 	MAKEFLAGS= $(PYTHON) -m pip wheel \
 	    --disable-pip-version-check \
 	    --constraint .wheelconstraints \
+	    --no-binary netiface \
 	    --find-links $(WHEELDISTDIR) \
 	    --find-links $(WHEELBUNDLEDIR) \
 	    --wheel-dir $(WHEELBUNDLEDIR) \


### PR DESCRIPTION
Don't use binary wheel for netiface to workaround a bug in
netifaces-0.10.6-cp27-cp27mu-manylinux1_x86_64.whl. The shared library
uses UCS2 APIs although the wide unicode build should use UCS4 APIs.

See: https://github.com/al45tair/netifaces/issues/2
Signed-off-by: Christian Heimes <cheimes@redhat.com>

Alastair Houghton removed the bogus netiface wheels. This PR should do the trick in case the removal isn't sufficient.