### PR TITLE
ipa-custodia-checker now uses python3 shebang

### DIFF
--- a/install/tools/ipa-custodia-check
+++ b/install/tools/ipa-custodia-check
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 """Test client for ipa-custodia
 
 The test script is expected to be executed on an IPA server with existing


### PR DESCRIPTION
#1024 missed one script that was introduced later.

https://pagure.io/freeipa/issue/4985

Signed-off-by: Christian Heimes <cheimes@redhat.com>