### PR TITLE
webui: hbactest: add tooltips to 'enabled' and 'disabled' checkboxes

### DIFF
--- a/install/ui/src/freeipa/hbactest.js
+++ b/install/ui/src/freeipa/hbactest.js
@@ -441,7 +441,8 @@ IPA.hbac.test_rules_facet = function(spec) {
 
         $('<label/>', {
             'for': 'hbactest-rules-include-enabled',
-            text: text.get('@i18n:objects.hbactest.include_enabled')
+            text: text.get('@i18n:objects.hbactest.include_enabled'),
+            title: text.get('@mc-opt:hbactest:enabled:doc')
         }).appendTo(header);
 
         that.disabled = $('<input/>', {
@@ -452,7 +453,8 @@ IPA.hbac.test_rules_facet = function(spec) {
 
         $('<label/>', {
             'for': 'hbactest-rules-include-disabled',
-            text: text.get('@i18n:objects.hbactest.include_disabled')
+            text: text.get('@i18n:objects.hbactest.include_disabled'),
+            title: text.get('@mc-opt:hbactest:disabled:doc')
         }).appendTo(header);
 
         var content = $('<div/>', {


### PR DESCRIPTION
"Include enabled" and "Include disabled" checkboxes on "Rules" tab
of HBAC Test Web UI page don't have any descriptions. It is not
clear what they do from only the labels.

This patch adds tooltips with metadata doc text of respected API
options. I.e. in practice it adds the same as CLI help when user
hovers over the checkbox label.
```
  --enabled        Include all enabled IPA rules into test [default]
  --disabled       Include all disabled IPA rules into test
```