### PR TITLE
webui:test realm domain add with DNS check

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -11,6 +11,10 @@ topologies:
     name: master_1repl_1client
     cpu: 4
     memory: 6700
+  ipaserver: &ipaserver
+    name: ipaserver
+    cpu: 1
+    memory: 2400
 
 jobs:
   fedora-27/build:
@@ -23,42 +27,18 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f27
           name: freeipa/ci-master-f27
-          version: 1.0.2
+          version: 1.0.3
         timeout: 1800
         topology: *build
 
-  fedora-27/simple_replication:
+  fedora-27/webui_tests:
     requires: [fedora-27/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-27/build_url}'
-        test_suite: test_integration/test_simple_replication.py
+        test_suite: test_webui/test_realmdomains.py test_webui/test_dns.py
         template: *ci-master-f27
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-27/caless:
-    requires: [fedora-27/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-27/build_url}'
-        test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *ci-master-f27
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-27/external_ca:
-    requires: [fedora-27/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-27/build_url}'
-        test_suite: test_integration/test_external_ca.py
-        template: *ci-master-f27
-        timeout: 3600
-        topology: *master_1repl
+        timeout: 8000
+        topology: *ipaserver

--- a/ipatests/test_webui/data_dns.py
+++ b/ipatests/test_webui/data_dns.py
@@ -1,0 +1,63 @@
+#
+# Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+#
+
+ZONE_ENTITY = 'dnszone'
+FORWARD_ZONE_ENTITY = 'dnsforwardzone'
+RECORD_ENTITY = 'dnsrecord'
+CONFIG_ENTITY = 'dnsconfig'
+
+ZONE_DEFAULT_FACET = 'records'
+
+ZONE_PKEY = 'foo.itest.'
+
+ZONE_DATA = {
+    'pkey': ZONE_PKEY,
+    'add': [
+        ('textbox', 'idnsname', ZONE_PKEY),
+    ],
+    'mod': [
+        ('checkbox', 'idnsallowsyncptr', 'checked'),
+    ],
+}
+
+FORWARD_ZONE_PKEY = 'forward.itest.'
+
+FORWARD_ZONE_DATA = {
+    'pkey': FORWARD_ZONE_PKEY,
+    'add': [
+        ('textbox', 'idnsname', FORWARD_ZONE_PKEY),
+        ('multivalued', 'idnsforwarders', [
+            ('add', '192.168.2.1'),
+        ]),
+        ('radio', 'idnsforwardpolicy', 'only'),
+    ],
+    'mod': [
+        ('multivalued', 'idnsforwarders', [
+            ('add', '192.168.3.1'),
+        ]),
+        ('checkbox', 'idnsforwardpolicy', 'first'),
+    ],
+}
+
+RECORD_PKEY = 'itest'
+A_IP = '192.168.1.10'
+RECORD_ADD_DATA = {
+    'pkey': RECORD_PKEY,
+    'add': [
+        ('textbox', 'idnsname', RECORD_PKEY),
+        ('textbox', 'a_part_ip_address', A_IP),
+    ]
+}
+
+RECORD_MOD_DATA = {
+    'fields': [
+        ('textbox', 'a_part_ip_address', '192.168.1.11'),
+    ]
+}
+
+CONFIG_MOD_DATA = {
+    'mod': [
+        ('checkbox', 'idnsallowsyncptr', 'checked'),
+    ],
+}

--- a/ipatests/test_webui/test_dns.py
+++ b/ipatests/test_webui/test_dns.py
@@ -23,67 +23,13 @@ DNS tests
 
 from ipatests.test_webui.ui_driver import UI_driver
 from ipatests.test_webui.ui_driver import screenshot
+from ipatests.test_webui.data_dns import (
+    ZONE_ENTITY, FORWARD_ZONE_ENTITY, CONFIG_ENTITY,
+    ZONE_DEFAULT_FACET, ZONE_PKEY, ZONE_DATA, FORWARD_ZONE_PKEY,
+    FORWARD_ZONE_DATA, RECORD_PKEY, A_IP, RECORD_ADD_DATA, RECORD_MOD_DATA,
+    CONFIG_MOD_DATA
+)
 import pytest
-
-ZONE_ENTITY = 'dnszone'
-FORWARD_ZONE_ENTITY = 'dnsforwardzone'
-RECORD_ENTITY = 'dnsrecord'
-CONFIG_ENTITY = 'dnsconfig'
-
-ZONE_DEFAULT_FACET = 'records'
-
-ZONE_PKEY = 'foo.itest.'
-
-ZONE_DATA = {
-    'pkey': ZONE_PKEY,
-    'add': [
-        ('textbox', 'idnsname', ZONE_PKEY),
-    ],
-    'mod': [
-        ('checkbox', 'idnsallowsyncptr', 'checked'),
-    ],
-}
-
-FORWARD_ZONE_PKEY = 'forward.itest.'
-
-FORWARD_ZONE_DATA = {
-    'pkey': FORWARD_ZONE_PKEY,
-    'add': [
-        ('textbox', 'idnsname', FORWARD_ZONE_PKEY),
-        ('multivalued', 'idnsforwarders', [
-            ('add', '192.168.2.1'),
-        ]),
-        ('radio', 'idnsforwardpolicy', 'only'),
-    ],
-    'mod': [
-        ('multivalued', 'idnsforwarders', [
-            ('add', '192.168.3.1'),
-        ]),
-        ('checkbox', 'idnsforwardpolicy', 'first'),
-    ],
-}
-
-RECORD_PKEY = 'itest'
-A_IP = '192.168.1.10'
-RECORD_ADD_DATA = {
-    'pkey': RECORD_PKEY,
-    'add': [
-        ('textbox', 'idnsname', RECORD_PKEY),
-        ('textbox', 'a_part_ip_address', A_IP),
-    ]
-}
-
-RECORD_MOD_DATA = {
-    'fields': [
-        ('textbox', 'a_part_ip_address', '192.168.1.11'),
-    ]
-}
-
-CONFIG_MOD_DATA = {
-    'mod': [
-        ('checkbox', 'idnsallowsyncptr', 'checked'),
-    ],
-}
 
 
 @pytest.mark.tier1

--- a/ipatests/test_webui/test_realmdomains.py
+++ b/ipatests/test_webui/test_realmdomains.py
@@ -23,6 +23,9 @@ Realm domains tests
 
 from ipatests.test_webui.ui_driver import UI_driver
 from ipatests.test_webui.ui_driver import screenshot
+from ipatests.test_webui.data_dns import (
+    ZONE_ENTITY, ZONE_DATA, ZONE_PKEY, ZONE_DEFAULT_FACET
+)
 import pytest
 
 ENTITY = 'realmdomains'
@@ -30,6 +33,12 @@ ENTITY = 'realmdomains'
 
 @pytest.mark.tier1
 class test_realmdomains(UI_driver):
+
+    def del_realm_domain(self, realmdomain, button):
+        self.del_multivalued('associateddomain', realmdomain)
+        self.facet_button_click('save')
+        self.dialog_button_click(button)
+        self.wait_for_request()
 
     @screenshot
     def test_read(self):
@@ -39,15 +48,60 @@ class test_realmdomains(UI_driver):
         self.init_app()
         self.navigate_to_entity(ENTITY)
 
-        # add
+        # add with force - skipping DNS check
         self.add_multivalued('associateddomain', 'itest.bar')
         self.facet_button_click('save')
         self.dialog_button_click('force')
         self.wait_for_request()
 
         # delete
-        self.del_multivalued('associateddomain', 'itest.bar')
+        self.del_realm_domain('itest.bar', 'force')
+        self.wait_for_request()
+
+        # Try adding and deleting with "Check DNS" (in html 'ok' button)
+
+        # DNS check expects that the added domain will have DNS record:
+        #    TXT _kerberos.$domain "$REALM"
+        # When a new domain is added using dnszone-add it automatically adds
+        # this TXT record and adds a realm domain. So in order to test without
+        # external DNS we must get into state where realm domain is not added
+        # (in order to add it) but DNS domain with the TXT record
+        # exists.
+
+        # add DNS domain
+        self.navigate_to_entity(ZONE_ENTITY)
+        self.add_record(ZONE_ENTITY, ZONE_DATA)
+
+        realmdomain = ZONE_PKEY.strip('.')
+        realm = self.config.get('ipa_realm')
+
+        # remove the added domain from Realm Domain
+        self.navigate_to_entity(ENTITY)
+        self.del_realm_domain(realmdomain, 'ok')
+
+        # re-add _TXT kerberos.$domain "$REALM"
+        self.navigate_to_entity(ZONE_ENTITY)
+        self.navigate_to_record(ZONE_PKEY)
+
+        DNS_RECORD_ADD_DATA = {
+            'pkey': '_kerberos',
+            'add': [
+                ('textbox', 'idnsname', '_kerberos'),
+                ('selectbox', 'record_type', 'txtrecord'),
+                ('textbox', 'txt_part_data', realm),
+            ]
+        }
+        self.add_record(ZONE_ENTITY, DNS_RECORD_ADD_DATA,
+                        facet=ZONE_DEFAULT_FACET, navigate=False)
+
+        # add Realm Domain and Check DNS
+        self.navigate_to_entity(ENTITY)
+        self.add_multivalued('associateddomain', realmdomain)
         self.facet_button_click('save')
-        self.dialog_button_click('force')
+        self.dialog_button_click('ok')
         self.wait_for_request()
-        self.wait_for_request()
+
+        # cleanup
+        self.del_realm_domain(realmdomain, 'ok')
+        self.navigate_to_entity(ZONE_ENTITY)
+        self.delete_record(ZONE_PKEY)

--- a/ipatests/test_webui/test_realmdomains.py
+++ b/ipatests/test_webui/test_realmdomains.py
@@ -39,6 +39,7 @@ class test_realmdomains(UI_driver):
         self.facet_button_click('save')
         self.dialog_button_click(button)
         self.wait_for_request()
+        self.close_notifications()
 
     @screenshot
     def test_read(self):
@@ -53,6 +54,7 @@ class test_realmdomains(UI_driver):
         self.facet_button_click('save')
         self.dialog_button_click('force')
         self.wait_for_request()
+        self.close_notifications()
 
         # delete
         self.del_realm_domain('itest.bar', 'force')
@@ -78,6 +80,7 @@ class test_realmdomains(UI_driver):
         # remove the added domain from Realm Domain
         self.navigate_to_entity(ENTITY)
         self.del_realm_domain(realmdomain, 'ok')
+        self.close_notifications()
 
         # re-add _TXT kerberos.$domain "$REALM"
         self.navigate_to_entity(ZONE_ENTITY)

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -711,6 +711,21 @@ class UI_driver(object):
         # possible dialog transition effect
         self.wait(0.5)
 
+    def close_notifications(self):
+        """
+        Close all notifications like success messages, warnings, infos
+        """
+        self.wait()
+        while True:
+            # get close button of notification
+            s = ".notification-area .alert button"
+            button = self.find(s, By.CSS_SELECTOR, strict=False)
+            if button:
+                button.click()
+                self.wait()
+            else:
+                break
+
     def get_form(self):
         """
         Get last dialog or visible facet


### PR DESCRIPTION
Try adding and deleting with "Check DNS" (in html 'ok' button)

DNS check expects that the added domain will have DNS record:
    TXT _kerberos.$domain "$REALM"

When a new domain is added using dnszone-add it automatically adds
this TXT record and adds a realm domain. So in order to test without
external DNS we must get into state where realm domain is not added
(in order to add it) but DNS domain with the TXT record exists.
