### PR TITLE
[Backport][ipa-4-6] fastcheck: do not test context in pycodestyle

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -215,7 +215,7 @@ endif
 	    echo -e "Fast linting files:\n$${FILES}\n"; \
 	    echo "pycodestyle"; \
 	    echo "-----------"; \
-	    git diff $${MERGEBASE} | \
+	    git diff -U0 $${MERGEBASE} | \
 	        $(PYTHON) -m pycodestyle --diff || exit $$?; \
 	    echo -e "\npylint"; \
 	    echo "------"; \


### PR DESCRIPTION
`git diff` shows also context lines by default. When passed to pycodestyle
it can produce errors unrelated to changed lines. It prevents running of
subsequent checks.

Limiting context to 0 lines by `git diff -U0` enables to test only the
modified lines and allows to run subsequent checks.

Reviewed-By: Christian Heimes <cheimes@redhat.com>