### PR TITLE
Uninstalling IPA requires on being in a existent working directory

### DIFF
--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -126,9 +126,9 @@ class CertDB(object):
 
         try:
             self.cwd = os.path.abspath(os.getcwd())
-        except OSError as e:
-            raise RuntimeError(
-                "Unable to determine the current directory: %s" % str(e))
+        except OSError:
+            os.chdir("/root")
+            self.cwd = os.path.abspath(os.getcwd())
 
         self.cacert_name = get_ca_nickname(self.realm)
 


### PR DESCRIPTION
Presently freeipa tests current working directory with os.getcwd()
which throws exception when called on non-existant directory.
Solution can be to call
os.chdir("/root") and set self.cwd variable accordingly.

Tests done:
//console-1
`# mkdir test-delete`
`# cd test-delete`

`# rm -rf /root/test-delete //From console-2`

`# ipa-server-install --uninstall`
  ..successful..

`# cd /root`
`# ipa-server-install`
  ..successful..

Still need to address installation of ipa-server from deleted dir.
Can handle in seperate PR.

Resolves: https://pagure.io/freeipa/issue/7416