### PR TITLE
Use sane default settings for ldap connections

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -80,6 +80,7 @@ ipa_join_SOURCES =		\
 	$(NULL)
 
 ipa_join_LDADD = 		\
+	$(top_builddir)/util/libutil.la	\
 	$(KRB5_LIBS)		\
 	$(LDAP_LIBS)		\
 	$(SASL_LIBS)		\

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1572,7 +1572,7 @@ def cert_summary(msg, certs, indent='    '):
 
 def get_certs_from_ldap(server, base_dn, realm, ca_enabled):
     ldap_uri = ipaldap.get_ldap_uri(server)
-    conn = ipaldap.LDAPClient(ldap_uri, sasl_nocanon=True)
+    conn = ipaldap.LDAPClient(ldap_uri)
     try:
         conn.gssapi_bind()
         certs = certstore.get_ca_certs(conn, base_dn, realm, ca_enabled)

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -20,6 +20,7 @@
 #
 
 import binascii
+import errno
 import logging
 import time
 import datetime
@@ -87,28 +88,34 @@ if six.PY2 and hasattr(ldap, 'LDAPBytesWarning'):
 
 def ldap_initialize(uri, cacertfile=None):
     """Wrapper around ldap.initialize()
+
+    The function undoes global and local ldap.conf settings that may cause
+    issues or reduce security:
+
+    * Canonization of SASL host names is disabled.
+    * With cacertfile=None, the connection uses OpenSSL's default verify
+      locations, also known as system-wide trust store.
+    * Cert validation is enforced.
+    * SSLv2 and SSLv3 are disabled.
     """
     conn = ldap.initialize(uri)
 
+    # Do not perform reverse DNS lookups to canonicalize SASL host names
+    conn.set_option(ldap.OPT_X_SASL_NOCANON, ldap.OPT_ON)
+
     if not uri.startswith('ldapi://'):
         if cacertfile:
+            if not os.path.isfile(cacertfile):
+                raise IOError(errno.ENOENT, cacertfile)
             conn.set_option(ldap.OPT_X_TLS_CACERTFILE, cacertfile)
-            newctx = True
-        else:
-            newctx = False
 
-        req_cert = conn.get_option(ldap.OPT_X_TLS_REQUIRE_CERT)
-        if req_cert != ldap.OPT_X_TLS_DEMAND:
-            # libldap defaults to cert validation, but the default can be
-            # overridden in global or user local ldap.conf.
-            conn.set_option(
-                ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND
-            )
-            newctx = True
-
-        # reinitialize TLS context
-        if newctx:
-            conn.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
+        # SSLv3 and SSLv2 are insecure
+        conn.set_option(ldap.OPT_X_TLS_PROTOCOL_MIN, 0x301)  # TLS 1.0
+        # libldap defaults to cert validation, but the default can be
+        # overridden in global or user local ldap.conf.
+        conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)
+        # reinitialize TLS context to materialize settings
+        conn.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
 
     return conn
 
@@ -733,7 +740,7 @@ class LDAPClient(object):
 
     def __init__(self, ldap_uri, start_tls=False, force_schema_updates=False,
                  no_schema=False, decode_attrs=True, cacert=None,
-                 sasl_nocanon=False):
+                 sasl_nocanon=True):
         """Create LDAPClient object.
 
         :param ldap_uri: The LDAP URI to connect to
@@ -1120,8 +1127,10 @@ class LDAPClient(object):
     def _connect(self):
         with self.error_handler():
             conn = ldap_initialize(self.ldap_uri, cacertfile=self._cacert)
-            if self._sasl_nocanon:
-                conn.set_option(ldap.OPT_X_SASL_NOCANON, ldap.OPT_ON)
+            # SASL_NOCANON is set to ON in Fedora's default ldap.conf and
+            # in the ldap_initialize() function.
+            if not self._sasl_nocanon:
+                conn.set_option(ldap.OPT_X_SASL_NOCANON, ldap.OPT_OFF)
 
             if self._start_tls:
                 conn.start_tls_s()

--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -728,11 +728,8 @@ class DomainValidator(object):
                     conn = ipaldap.LDAPClient(
                         ldap_uri,
                         no_schema=True,
-                        decode_attrs=False,
-                        sasl_nocanon=True)
-                    # sasl_nocanon used to avoid hard requirement for PTR
-                    # records pointing back to the same host name
-
+                        decode_attrs=False
+                    )
                     conn.gssapi_bind()
 
                     if basedn is None:

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -16,6 +16,7 @@ import textwrap
 
 import six
 
+from ipaclient.install.client import check_ldap_conf
 from ipaclient.install.ipachangeconf import IPAChangeConf
 from ipalib.install import certmonger, sysrestore
 from ipapython import ipautil
@@ -312,6 +313,7 @@ def install_check(installer):
 
     tasks.check_ipv6_stack_enabled()
     tasks.check_selinux_status()
+    check_ldap_conf()
 
     if options.master_password:
         msg = ("WARNING:\noption '-P/--master-password' is deprecated. "

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -22,6 +22,7 @@ import traceback
 from pkg_resources import parse_version
 import six
 
+from ipaclient.install.client import check_ldap_conf
 from ipaclient.install.ipachangeconf import IPAChangeConf
 import ipaclient.install.timeconf
 from ipalib.install import certstore, sysrestore
@@ -570,6 +571,7 @@ def check_remote_version(client, local_version):
 def common_check(no_ntp):
     tasks.check_ipv6_stack_enabled()
     tasks.check_selinux_status()
+    check_ldap_conf()
 
     if is_ipa_configured():
         raise ScriptError(

--- a/ipatests/test_install/test_install_checks.py
+++ b/ipatests/test_install/test_install_checks.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+
+from __future__ import absolute_import
+
+import tempfile
+
+import pytest
+
+from ipaclient.install.client import check_ldap_conf
+from ipapython.admintool import ScriptError
+
+
+@pytest.mark.parametrize("lines,expected", [
+    (["PORT 389"], "PORT"),
+    (["HOST example.org"], "HOST"),
+    (["HOST example.org", "# PORT 389"], "HOST"),
+    (["\tHOST example.org", "# PORT 389"], "HOST"),
+    (["HOST example.org", "PORT 389"], "HOST, PORT"),
+    (["# HOST example.org", "# PORT 389"], None),
+    (["URI PORT"], None),
+    ([], None),
+])
+def test_check_ldap(lines, expected):
+    with tempfile.NamedTemporaryFile('w+') as f:
+        for line in lines:
+            f.write(line)
+            f.write('\n')
+        f.write('\n')
+        f.flush()
+
+        if expected is None:
+            assert check_ldap_conf(f.name) is True
+        else:
+            with pytest.raises(ScriptError) as e:
+                check_ldap_conf(f.name)
+            msg = e.value.msg
+            assert msg.endswith(expected)

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -859,7 +859,8 @@ def get_entity_keytab(principal, options=None):
 
         yield keytab_filename
     finally:
-        os.remove(keytab_filename)
+        if os.path.isfile(keytab_filename):
+            os.remove(keytab_filename)
 
 
 @contextmanager

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -7,6 +7,8 @@ noinst_LTLIBRARIES = libutil.la
 libutil_la_SOURCES =	ipa_krb5.c \
 			ipa_krb5.h \
 			ipa_mspac.h \
+			ipa_ldap.c \
+			ipa_ldap.h \
 			ipa_pwd.c \
 			ipa_pwd.h \
 			ipa_pwd_ntlm.c

--- a/util/ipa_ldap.c
+++ b/util/ipa_ldap.c
@@ -1,0 +1,118 @@
+/* Authors: Christian Heimes <cheimes@redhat.com>
+ *          Simo Sorce <ssorce@redhat.com>
+ *
+ * Copyright (C) 2018  Red Hat
+ * see file 'COPYING' for use and warranty information
+ *
+ * This program is free software you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+
+#include "ipa_ldap.h"
+
+/** Initialize LDAP context
+ *
+ * Initializes an LDAP context for a given LDAP URI. LDAP protocol version
+ * and SASL canonization are disabled.
+ *
+ */
+int ipa_ldap_init(LDAP **ld, const char *ldap_uri)
+{
+    int ret = 0;
+    int version = LDAP_VERSION3;
+    ret = ldap_initialize(ld, ldap_uri);
+
+    if (ret != LDAP_SUCCESS) {
+        fprintf(
+            stderr,
+            _("Unable to initialize connection to ldap server %1$s: %1$s\n"),
+            ldap_uri,
+            ldap_err2string(ret)
+        );
+        return ret;
+    }
+
+    /* StartTLS and other features need LDAP protocol version 3 */
+    ret = ldap_set_option(*ld, LDAP_OPT_PROTOCOL_VERSION, &version);
+    if (ret != LDAP_SUCCESS) {
+        fprintf(stderr, _("Unable to set LDAP_OPT_PROTOCOL_VERSION\n"));
+        return ret;
+    }
+
+#ifdef LDAP_OPT_X_SASL_NOCANON
+    /* Don't do DNS canonization */
+    ret = ldap_set_option(*ld, LDAP_OPT_X_SASL_NOCANON, LDAP_OPT_ON);
+    if (ret != LDAP_SUCCESS) {
+        fprintf(stderr, _("Unable to set LDAP_OPT_X_SASL_NOCANON\n"));
+        return ret;
+    }
+#endif
+
+    return ret;
+}
+
+/** Configure TLS/SSL and perform StartTLS for ldap://
+ *
+ * The LDAP connection is configured for secure TLS.
+ *
+ */
+int ipa_tls_ssl_init(LDAP *ld, const char *ldap_uri,
+                     const char *ca_cert_file)
+{
+    int ret = LDAP_SUCCESS;
+    int tls_demand = LDAP_OPT_X_TLS_DEMAND;
+    int tlsv1_0 = LDAP_OPT_X_TLS_PROTOCOL_TLS1_0;
+    int newctx = 0;  /* client context */
+
+    if (strncmp(ldap_uri, SCHEMA_LDAPI, sizeof(SCHEMA_LDAPI) - 1) == 0) {
+        /* Nothing to do for LDAPI */
+        return ret;
+    }
+
+    ret = ldap_set_option(ld, LDAP_OPT_X_TLS_CACERTFILE, ca_cert_file);
+    if (ret != LDAP_OPT_SUCCESS) {
+        fprintf(stderr, _("Unable to set LDAP_OPT_X_TLS_CACERTFILE\n"));
+        return ret;
+    }
+    /* Require a valid certificate */
+    ret = ldap_set_option(ld, LDAP_OPT_X_TLS_REQUIRE_CERT, &tls_demand);
+    if (ret != LDAP_OPT_SUCCESS) {
+        fprintf(stderr, _("Unable to set LDAP_OPT_X_TLS_REQUIRE_CERT\n"));
+        return ret;
+    }
+    /* Disable SSLv2 and SSLv3 */
+    ret = ldap_set_option(ld, LDAP_OPT_X_TLS_PROTOCOL_MIN, &tlsv1_0);
+    if (ret != LDAP_OPT_SUCCESS) {
+        fprintf(stderr, _("Unable to set LDAP_OPT_X_TLS_PROTOCOL_MIN\n"));
+        return ret;
+    }
+    /* Apply TLS settings and create new client context */
+    ret = ldap_set_option(ld, LDAP_OPT_X_TLS_NEWCTX, &newctx);
+    if (ret != LDAP_OPT_SUCCESS) {
+        fprintf(stderr, _("Unable to set LDAP_OPT_X_TLS_NEWCTX\n"));
+        return ret;
+    }
+
+    if (strncmp(ldap_uri, SCHEMA_LDAP, sizeof(SCHEMA_LDAP) - 1) == 0) {
+        ret = ldap_start_tls_s(ld, NULL, NULL);
+        if (ret != LDAP_SUCCESS) {
+            fprintf(stderr, _("Unable to initialize STARTTLS session\n"));
+            return ret;
+        }
+    }
+    return ret;
+}

--- a/util/ipa_ldap.h
+++ b/util/ipa_ldap.h
@@ -1,0 +1,39 @@
+/* Authors: Christian Heimes <cheimes@redhat.com>
+ *          Simo Sorce <ssorce@redhat.com>
+ *
+ * Copyright (C) 2018  Red Hat
+ * see file 'COPYING' for use and warranty information
+ *
+ * This program is free software you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <ldap.h>
+
+#define DEFAULT_CA_CERT_FILE "/etc/ipa/ca.crt"
+
+#define LDAP_SASL_EXTERNAL "EXTERNAL"
+#define LDAP_SASL_GSSAPI "GSSAPI"
+
+#define SCHEMA_LDAPI "ldapi://"
+#define SCHEMA_LDAP "ldap://"
+#define SCHEMA_LDAPS "ldaps://"
+
+#ifndef _
+#include <libintl.h>
+#define _(STRING) gettext(STRING)
+#endif
+
+int ipa_ldap_init(LDAP **ld, const char *ldap_uri);
+int ipa_tls_ssl_init(LDAP *ld, const char *ldap_uri,
+                     const char *ca_cert_file);


### PR DESCRIPTION
LDAP connections no longer depend on sane settings in global ldap.conf
and use good default settings for cert validation, CA, and SASL canonization.

https://pagure.io/freeipa/issue/7418
