### PR TITLE
[Backport][ipa-4-5] - test_caless: add caless to external CA test

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1182,7 +1182,8 @@ def install_kra(host, domain_level=None, first_instance=False, raiseonerr=True):
     return result
 
 
-def install_ca(host, domain_level=None, first_instance=False, raiseonerr=True):
+def install_ca(host, domain_level=None, first_instance=False,
+               external_ca=False, cert_files=None, raiseonerr=True):
     if domain_level is None:
         domain_level = domainlevel(host)
     command = ["ipa-ca-install", "-U", "-p", host.config.dirman_password,
@@ -1190,6 +1191,13 @@ def install_ca(host, domain_level=None, first_instance=False, raiseonerr=True):
     if domain_level == DOMAIN_LEVEL_0 and not first_instance:
         replica_file = get_replica_filename(host)
         command.append(replica_file)
+    # First step of ipa-ca-install --external-ca
+    if external_ca:
+        command.append('--external-ca')
+    # Continue with ipa-ca-install --external-ca
+    if cert_files:
+        for fname in cert_files:
+            command.extend(['--external-cert-file', fname])
     try:
         result = host.run_command(command, raiseonerr=raiseonerr)
     finally:

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -34,6 +34,7 @@ from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.test_integration import create_caless_pki
+from ipatests.test_integration.create_external_ca import ExternalCA
 from ipatests.pytest_plugins.integration import tasks
 from ipalib.constants import DOMAIN_LEVEL_0
 
@@ -1589,3 +1590,47 @@ class TestReplicaCALessToCAFull(CALessBase):
 
         ca_replica = tasks.install_ca(self.replicas[0])
         assert ca_replica.returncode == 0
+
+
+class TestServerCALessToExternalCA(CALessBase):
+    """Test server caless to extarnal CA scenario"""
+
+    def test_install_caless_server(self):
+        """Install CA-less master"""
+
+        self.create_pkcs12('ca1/server')
+        self.prepare_cacert('ca1')
+
+        master = self.install_server()
+        assert master.returncode == 0
+
+    def test_server_ipa_ca_install_external(self):
+        """Install external CA on master"""
+
+        # First step of ipa-ca-install (get CSR)
+        ca_master_pre = tasks.install_ca(self.master, external_ca=True)
+        assert ca_master_pre.returncode == 0
+
+        # Create external CA
+        external_ca = ExternalCA()
+        root_ca = external_ca.create_ca()
+
+        # Get IPA CSR as string
+        ipa_csr = self.master.get_file_contents('/root/ipa.csr')
+        # Have CSR signed by the external CA
+        ipa_ca = external_ca.sign_csr(ipa_csr)
+
+        test_dir = self.master.config.test_dir
+
+        root_ca_fname = os.path.join(test_dir, 'root_ca.crt')
+        ipa_ca_fname = os.path.join(test_dir, 'ipa_ca.crt')
+
+        # Transport certificates (string > file) to master
+        self.master.put_file_contents(root_ca_fname, root_ca)
+        self.master.put_file_contents(ipa_ca_fname, ipa_ca)
+
+        cert_files = [root_ca_fname, ipa_ca_fname]
+
+        # Continue with ipa-ca-install
+        ca_master_post = tasks.install_ca(self.master, cert_files=cert_files)
+        assert ca_master_post.returncode == 0


### PR DESCRIPTION
Add caless to external CA test as the suite is currently
missing one.

https://pagure.io/freeipa/issue/7155

Reviewed-By: Stanislav Laznicka <slaznick@redhat.com>