### PR TITLE
autoconf now prefers Python 3 over 2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,8 @@
 ACLOCAL_AMFLAGS = -I m4
 
 if ENABLE_SERVER
-    SERVER_SUBDIRS = daemons init install ipaserver
+    IPASERVER_SUBDIRS = ipaserver
+    SERVER_SUBDIRS = daemons init install
 endif
 
 if WITH_IPATESTS
@@ -9,9 +10,9 @@ if WITH_IPATESTS
 endif
 
 IPACLIENT_SUBDIRS = ipaclient ipalib ipaplatform ipapython
+PYTHON_SUBDIRS = $(IPACLIENT_SUBDIRS) $(IPATESTS_SUBDIRS) $(IPASERVER_SUBDIRS)
 IPA_PLACEHOLDERS = freeipa ipa ipaserver ipatests
-SUBDIRS = asn1 util client contrib po pypi \
-	$(IPACLIENT_SUBDIRS) $(IPATESTS_SUBDIRS) $(SERVER_SUBDIRS)
+SUBDIRS = asn1 util client contrib po pypi $(PYTHON_SUBDIRS) $(SERVER_SUBDIRS)
 
 GENERATED_PYTHON_FILES = \
 	$(top_builddir)/ipaplatform/override.py \
@@ -357,6 +358,12 @@ pypi_packages: $(WHEELPYPIDIR) .wheelconstraints
 	done
 	@echo -e "\n\nTo upload packages to PyPI, run:\n"
 	@echo -e "    twine upload $(WHEELPYPIDIR)/*-$(VERSION)-py2.py3-none-any.whl\n"
+
+.PHONY: python_install
+python_install:
+	for dir in $(PYTHON_SUBDIRS); do \
+	    $(MAKE) $(AM_MAKEFLAGS) -C $${dir} install || exit 1; \
+	done
 
 .PHONY:
 strip-po:

--- a/configure.ac
+++ b/configure.ac
@@ -100,27 +100,28 @@ PKG_CHECK_MODULES([CRYPTO], [libcrypto])
 
 dnl ---------------------------------------------------------------------------
 dnl - Check for Python
-dnl ---------------------------------------------------------------------------
-
-AC_MSG_NOTICE([Checking for Python])
-have_python=no
-AM_PATH_PYTHON(2.7)
-
-if test "x$PYTHON" = "x" ; then
-  AC_MSG_ERROR([Python not found])
-fi
-
-dnl ---------------------------------------------------------------------------
 dnl - Check for Python 2/3 for devcheck
 dnl ---------------------------------------------------------------------------
 
+AC_MSG_NOTICE([Checking for Python 3])
+AC_PATH_PROG(PYTHON3, python3)
+AC_SUBST([PYTHON3])
+AM_CONDITIONAL([WITH_PYTHON3], [test "x${PYTHON3}" != "x"])
+
+AC_MSG_NOTICE([Checking for Python 2])
 AC_PATH_PROG(PYTHON2, python2)
 AC_SUBST([PYTHON2])
 AM_CONDITIONAL([WITH_PYTHON2], [test "x${PYTHON2}" != "x"])
 
-AC_PATH_PROG(PYTHON3, python3)
-AC_SUBST([PYTHON3])
-AM_CONDITIONAL([WITH_PYTHON3], [test "x${PYTHON3}" != "x"])
+if test \( "x${PYTHON3}" = "x" -o "x${PYTHON}" != "x" \); then
+    dnl Python 3 is not available *or* user has set PYTHON variable.
+    dnl Accept Python >= 2.7 as default Python. We also accept any Python 3
+    dnl version from PYTHON environment variable.
+    AM_PATH_PYTHON(2.7)
+elif test "x${PYTHON3}" != "x"; then
+    dnl Found Python 3, but no user override. Use Python >= 3.6 as default.
+    AM_PATH_PYTHON(3.6)
+fi
 
 dnl ---------------------------------------------------------------------------
 dnl - Check for cmocka unit test framework http://cmocka.cryptomilk.org/
@@ -590,7 +591,9 @@ echo "
         source code location:     ${srcdir}
         compiler:                 ${CC}
         cflags:                   ${CFLAGS}
-        Python:                   ${PYTHON}
+        Default Python:           ${PYTHON} (${PYTHON_VERSION})
+        Python 2:                 ${PYTHON2}
+        Python 3:                 ${PYTHON3}
         pylint:                   ${PYLINT}
         jslint:                   ${JSLINT}
         LDAP libs:                ${LDAP_LIBS}

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -990,16 +990,7 @@ make %{?_smp_mflags} check VERBOSE=yes LIBDIR=%{_libdir}
 # will overwrite /usr/bin/ipa and other scripts with variants using
 # python2 shebang.
 pushd %{_builddir}/freeipa-%{version}-python3
-(cd ipaclient && %make_install)
-(cd ipalib && %make_install)
-(cd ipaplatform && %make_install)
-(cd ipapython && %make_install)
-%if ! %{ONLY_CLIENT}
-(cd ipaserver && %make_install)
-%endif # ONLY_CLIENT
-%if 0%{?with_ipatests}
-(cd ipatests && %make_install)
-%endif # with_ipatests
+%{__make} python_install DESTDIR=%{?buildroot} INSTALL="%{__install} -p"
 popd
 
 %if 0%{?with_ipatests}


### PR DESCRIPTION
The configure script now looks for Python 3.6 or newer, then falls back to Python 2. All Makefile default to Python 3 if Python 3 is available.

Move logic for installing just the Python packages out of the spec file and into our root Makefile. It removes code duplication to simplify a spec file that supports building without Python 2

https://pagure.io/freeipa/issue/7131
