### PR TITLE
OTP FIPS mode fixes

### DIFF
--- a/daemons/ipa-slapi-plugins/libotp/hotp.c
+++ b/daemons/ipa-slapi-plugins/libotp/hotp.c
@@ -46,6 +46,7 @@
 #include <time.h>
 
 #include <nss.h>
+#include <blapit.h>
 #include <pk11pub.h>
 #include <hasht.h>
 #include <prnetdb.h>
@@ -65,6 +66,49 @@ static const struct {
     { "sha512", CKM_SHA512_HMAC },
     { }
 };
+
+static PK11SymKey *
+import_key(PK11SlotInfo *slot, CK_MECHANISM_TYPE mech, SECItem *key)
+{
+    uint8_t ct[(key->len / AES_BLOCK_SIZE + 1) * AES_BLOCK_SIZE];
+    uint8_t iv[AES_BLOCK_SIZE] = {};
+    SECItem ivitem = { .data = iv, .len = sizeof(iv), .type = siBuffer };
+    SECItem ctitem = { .data = ct, .len = sizeof(ct), .type = siBuffer };
+    PK11SymKey *ekey = NULL;
+    PK11SymKey *skey = NULL;
+
+    /* Try to import the key directly. */
+    skey = PK11_ImportSymKey(slot, mech, PK11_OriginUnwrap,
+                             CKA_SIGN, key, NULL);
+    if (skey)
+        return skey;
+
+    /* If we get here, we are probably in FIPS mode. Let's encrypt the key so
+     * that we can unseal it instead of loading it directly. */
+
+    /* Generate an ephemeral key. */
+    ekey = PK11_TokenKeyGenWithFlags(slot, CKM_AES_CBC_PAD, NULL,
+                                     AES_128_KEY_LENGTH, NULL,
+                                     CKF_ENCRYPT | CKF_UNWRAP,
+                                     PK11_ATTR_SESSION |
+                                     PK11_ATTR_PRIVATE |
+                                     PK11_ATTR_SENSITIVE, NULL);
+    if (!ekey)
+        goto egress;
+
+    /* Encrypt the input key. */
+    if (PK11_Encrypt(ekey, CKM_AES_CBC_PAD, &ivitem, ctitem.data, &ctitem.len,
+                     ctitem.len, key->data, key->len) != SECSuccess)
+        goto egress;
+
+    /* Unwrap the input key. */
+    skey = PK11_UnwrapSymKey(ekey, CKM_AES_CBC_PAD, &ivitem,
+                             &ctitem, mech, CKA_SIGN, key->len);
+
+egress:
+    PK11_FreeSymKey(ekey);
+    return skey;
+}
 
 /*
  * This code is mostly cargo-cult taken from here:
@@ -90,8 +134,7 @@ static bool hmac(SECItem *key, CK_MECHANISM_TYPE mech, const SECItem *in,
         }
     }
 
-    symkey = PK11_ImportSymKey(slot, mech, PK11_OriginUnwrap,
-                               CKA_SIGN, key, NULL);
+    symkey = import_key(slot, mech, key);
     if (symkey == NULL)
         goto done;
 

--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -31,7 +31,6 @@ from .baseldap import (
     LDAPAddAttributeViaOption, LDAPRemoveAttributeViaOption,
     add_missing_object_class)
 from ipaserver.plugins.service import (validate_realm, normalize_principal)
-from ipaserver.plugins.config import check_fips_auth_opts
 from ipalib.request import context
 from ipalib import _
 from ipalib.constants import PATTERN_GROUPUSER_NAME
@@ -481,7 +480,6 @@ class baseuser_add(LDAPCreate):
                             **options):
         assert isinstance(dn, DN)
         set_krbcanonicalname(entry_attrs)
-        check_fips_auth_opts(fips_mode=self.api.env.fips_mode, **options)
         self.obj.convert_usercertificate_pre(entry_attrs)
 
     def post_common_callback(self, ldap, dn, entry_attrs, *keys, **options):
@@ -605,7 +603,6 @@ class baseuser_mod(LDAPUpdate):
         assert isinstance(dn, DN)
         add_sshpubkey_to_attrs_pre(self.context, attrs_list)
 
-        check_fips_auth_opts(fips_mode=self.api.env.fips_mode, **options)
         self.check_namelength(ldap, **options)
 
         self.check_mail(entry_attrs)

--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -85,20 +85,6 @@ EXAMPLES:
 
 register = Registry()
 
-
-def check_fips_auth_opts(fips_mode, **options):
-    """
-    OTP and RADIUS are not allowed in FIPS mode since they use MD5
-    checksums (OTP uses our RADIUS responder daemon ipa-otpd).
-    """
-    if 'ipauserauthtype' in options and fips_mode:
-        if ('otp' in options['ipauserauthtype'] or
-                'radius' in options['ipauserauthtype']):
-            raise errors.InvocationError(
-                'OTP and RADIUS authentication in FIPS is '
-                'not yet supported')
-
-
 @register()
 class config(LDAPObject):
     """
@@ -412,8 +398,6 @@ class config_mod(LDAPUpdate):
 
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys, **options):
         assert isinstance(dn, DN)
-        check_fips_auth_opts(fips_mode=self.api.env.fips_mode, **options)
-
         if 'ipadefaultprimarygroup' in entry_attrs:
             group=entry_attrs['ipadefaultprimarygroup']
             try:

--- a/ipaserver/plugins/otptoken.py
+++ b/ipaserver/plugins/otptoken.py
@@ -72,7 +72,7 @@ TOKEN_TYPES = {
 }
 
 # NOTE: For maximum compatibility, KEY_LENGTH % 5 == 0
-KEY_LENGTH = 20
+KEY_LENGTH = 35
 
 class OTPTokenKey(Bytes):
     """A binary password type specified in base32."""


### PR DESCRIPTION
The following patches add various fixes for using OTP on a server running in FIPS mode.