### PR TITLE
Don't return None on mismatched interactive passwords

### DIFF
--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -627,7 +627,6 @@ class textui(backend.Backend):
                     return pw1
                 else:
                     self.print_error(_('Passwords do not match!'))
-                    return None
         else:
             return self.decode(sys.stdin.readline().strip())
 


### PR DESCRIPTION
This will cause the command to continue with no password set
at all which is not what we want.

We want to loop forever until the passwords match or the
user gives up and types ^D or ^C.

https://pagure.io/freeipa/issue/7383

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

Note that automated testing of this is difficult to impossible because the client code detects when data is being passed in via a pipe. so we can't pass in the mismatch passwords via stdin_text, it would have to be some much more complicated I fear.