### PR TITLE
Silence some GCC warnings

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -631,6 +631,7 @@ static krb5_error_code ipadb_get_age(krb5_context kcontext,
     return 0;
 }
 
+#if KRB5_KDB_DAL_MAJOR_VERSION == 5
 static void *ipadb_alloc(krb5_context context, void *ptr, size_t size)
 {
     return realloc(ptr, size);
@@ -640,6 +641,7 @@ static void ipadb_free(krb5_context context, void *ptr)
 {
     free(ptr);
 }
+#endif
 
 /* KDB Virtual Table */
 

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_common.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_common.c
@@ -109,9 +109,9 @@ int __nss_to_err(enum nss_status errcode)
         return ERANGE;
     case NSS_STATUS_UNAVAIL:
         return ETIMEDOUT;
+    default:
+        return -1;
     }
-
-    return -1;
 }
 
 int getpwnam_r_wrapper(struct ipa_extdom_ctx *ctx, const char *name,


### PR DESCRIPTION
The ipadb_free() and ipadb_alloc() functions are only used with
KRB5_KDB_DAL_MAJOR_VERSION 5.

```
ipa_extdom_common.c:103:5: warning: enumeration value ‘NSS_STATUS_RETURN’ not handled in switch [-Wswitch]
ipa_kdb.c:639:13: warning: ‘ipadb_free’ defined but not used [-Wunused-function]
ipa_kdb.c:634:14: warning: ‘ipadb_alloc’ defined but not used [-Wunused-function]
```

Signed-off-by: Christian Heimes <cheimes@redhat.com>