### PR TITLE
[Backport][ipa-4-6] Don't return None on mismatched interactive passwords

### DIFF
--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -627,7 +627,6 @@ class textui(backend.Backend):
                     return pw1
                 else:
                     self.print_error(_('Passwords do not match!'))
-                    return None
         else:
             return self.decode(sys.stdin.readline().strip())
 


### PR DESCRIPTION
This PR was opened automatically because PR #1622 was pushed to master and backport to ipa-4-6 is required.