### PR TITLE
[Backport][ipa-4-6] ipa host-add: do not raise exception when reverse record not added

### DIFF
--- a/ipalib/messages.py
+++ b/ipalib/messages.py
@@ -476,6 +476,17 @@ class CertificateInvalid(PublicMessage):
                "%(reason)s")
 
 
+class FailedToAddHostDNSRecords(PublicMessage):
+    """
+    **13030** Failed to add host DNS records
+    """
+
+    errno = 13030
+    type = "warning"
+    format = _("The host was added but the DNS update failed with: "
+               "%(reason)s")
+
+
 def iter_messages(variables, base):
     """Return a tuple with all subclasses
     """


### PR DESCRIPTION
This PR was opened automatically because PR #1521 was pushed to master and backport to ipa-4-6 is required.