### PR TITLE
Return a value if exceptions are raised in server uninstall

### DIFF
--- a/ipapython/install/cli.py
+++ b/ipapython/install/cli.py
@@ -316,10 +316,10 @@ class ConfigureTool(admintool.AdminTool):
         if self.use_private_ccache:
             with private_ccache():
                 super(ConfigureTool, self).run()
-                cfgr.run()
+                return cfgr.run()
         else:
             super(ConfigureTool, self).run()
-            cfgr.run()
+            return cfgr.run()
 
     @staticmethod
     def __signal_handler(signum, frame):

--- a/ipapython/install/common.py
+++ b/ipapython/install/common.py
@@ -7,12 +7,11 @@ Common stuff.
 """
 
 import logging
-import traceback
 
 from . import core
 from .util import from_
 
-__all__ = ['step', 'Installable', 'Interactive', 'Continuous', 'installer',
+__all__ = ['step', 'Installable', 'Interactive', 'installer',
            'uninstaller']
 
 logger = logging.getLogger(__name__)
@@ -86,16 +85,6 @@ class Step(Installable):
 
 class Interactive(core.Configurable):
     interactive = core.Property(False)
-
-
-class Continuous(core.Configurable):
-    def _handle_execute_exception(self, exc_info):
-        try:
-            super(Continuous, self)._handle_execute_exception(exc_info)
-        except BaseException as e:
-            logger.debug("%s", traceback.format_exc())
-            if isinstance(e, Exception):
-                logger.error("%s", e)
 
 
 def installer(cls):

--- a/ipapython/install/common.py
+++ b/ipapython/install/common.py
@@ -109,7 +109,7 @@ def installer(cls):
 
 
 def uninstaller(cls):
-    class Uninstaller(Continuous, cls, Installable):
+    class Uninstaller(cls, Installable):
         def __init__(self, **kwargs):
             super(Uninstaller, self).__init__(uninstalling=True,
                                               **kwargs)

--- a/ipapython/install/core.py
+++ b/ipapython/install/core.py
@@ -361,7 +361,7 @@ class Configurable(six.with_metaclass(abc.ABCMeta, object)):
 
         self.validate()
         if self.__state == _EXECUTE_PENDING:
-            self.execute()
+            return self.execute()
 
     def validate(self):
         """
@@ -384,9 +384,13 @@ class Configurable(six.with_metaclass(abc.ABCMeta, object)):
         """
         Run the execution part of the configurable.
         """
+        return_value = 0
 
-        for _nothing in self._executor():
-            pass
+        for rval in self._executor():
+            if rval is not None and rval > return_value:
+                return_value = rval
+
+        return return_value
 
     def _executor(self):
         """

--- a/ipatests/test_integration/test_uninstallation.py
+++ b/ipatests/test_integration/test_uninstallation.py
@@ -1,0 +1,79 @@
+#
+# Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Module provides tests that uninstallation is successful.
+
+It is important not to leave the remote system in an inconsistent
+state. Every failed uninstall should successfully remove remaining
+pieces if possible.
+"""
+
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_plugins.integration import tasks
+from ipaplatform.paths import paths
+from ipaserver.install.installutils import realm_to_serverid
+from ipaserver.install import dsinstance
+
+
+class TestUninstallBase(IntegrationTest):
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=False)
+
+    def test_failed_uninstall(self):
+        self.master.run_command(['ipactl', 'stop'])
+
+        serverid = realm_to_serverid(self.master.domain.realm)
+        instance_name = ''.join([dsinstance.DS_INSTANCE_PREFIX, serverid])
+
+        try:
+            # Moving the DS instance out of the way will cause the
+            # uninstaller to raise an exception and return with a
+            # non-zero return code.
+            self.master.run_command([
+                '/usr/bin/mv',
+                '%s/%s' % (paths.ETC_DIRSRV, instance_name),
+                '%s/%s.test' % (paths.ETC_DIRSRV, instance_name)
+            ])
+
+            cmd = self.master.run_command([
+                'ipa-server-install',
+                '--uninstall', '-U'],
+                raiseonerr=False
+            )
+            assert cmd.returncode == 1
+        finally:
+            # Be paranoid. If something really went wrong then DS may
+            # be marked as uninstalled so server cert will still be
+            # tracked and the instances may remain. This can cause
+            # subsequent installations to fail so be thorough.
+            ds = dsinstance.DsInstance()
+            ds_running = ds.is_running()
+            if ds_running:
+                ds.stop(serverid)
+
+            # Moving it back should allow the uninstall to finish
+            # successfully.
+            self.master.run_command([
+                '/usr/bin/mv',
+                '%s/%s.test' % (paths.ETC_DIRSRV, instance_name),
+                '%s/%s' % (paths.ETC_DIRSRV, instance_name)
+            ])
+
+            # DS has been marked as uninstalled so force the issue
+            ds.stop_tracking_certificates(serverid)
+
+            self.master.run_command([
+                paths.REMOVE_DS_PL,
+                '-i', instance_name
+            ])
+
+            cmd = self.master.run_command([
+                'ipa-server-install',
+                '--uninstall', '-U'],
+                raiseonerr=False
+            )
+            assert cmd.returncode == 0


### PR DESCRIPTION
The server uninstall relies on the Continuous class which will
not re-raise exceptions, only log them.

The AdminTool class purports to "call sys.exit() with the return
value" but most of the run implementations returned no value, or
the methods they called returned nothing so there was nothing to
return, so this was a no-op.

The fix is to capture and bubble up the return values and to
return 1 if any exceptions are caught in Continuous, the exception
being SystemExit which is what is raised when sys.exit() is called.

This potentially affects other users in that when executing the
steps of an installer or uninstaller the highest return code
will be the exit value of that installer.

https://pagure.io/freeipa/issue/7330

Signed-off-by: Rob Crittenden <rcritten@redhat.com>