### PR TITLE
Fixing cleanup process in test_caless

### DIFF
--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -105,15 +105,14 @@ def replica_install_teardown(func):
             replica = args[0].replicas[0]
             master = args[0].master
             tasks.kinit_admin(master)
+            tasks.clean_replication_agreement(master, replica, cleanup=True,
+                                              raiseonerr=False)
+            master.run_command(['ipa', 'host-del', replica.hostname],
+                               raiseonerr=False)
             tasks.uninstall_master(replica, clean=False)
             # Now let's uninstall client for the cases when client promotion
             # was not successful
             tasks.uninstall_client(replica)
-            tasks.clean_replication_agreement(master, replica, cleanup=True,
-                                              raiseonerr=False)
-            master.run_command(['ipa', 'host-del',
-                                replica.hostname],
-                               raiseonerr=False)
             ipa_certs_cleanup(replica)
     return wrapped
 


### PR DESCRIPTION
After commit bbe615e, if the uninstall process fails (in the test cleanup) the error is not hidden anymore.
That brought light to errors in the cleanup process on `TestReplicaInstall` test, like this:
```
RUN ['ipa-server-install', '--uninstall', '-U']
ipapython.admintool: ERROR    Server removal aborted:
Replication topology in suffix 'domain' is disconnected:
Topology does not allow server master.ipa.test to replicate with servers:
    replica0.ipa.test.
ipapython.admintool: ERROR    The ipa-server-install command failed
```

This commit changes the order of how a replica should be removed from the topology.

Other errors can be checked [here](https://fedorapeople.org/groups/freeipa/prci/jobs/1b27ac12-1bfe-11e8-9b66-fa163e97f492/).