### PR TITLE
Removing extra spaces present in man ipa-server-install

### DIFF
--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -101,7 +101,7 @@ When \fB\-\-external\-ca\-type\fR is "ms-cs" the following specifiers may be use
 Specify a certificate template by OID and major version, optionally also specifying minor version.
 .TP
 \fB<name>\fR
-Specify a certificate template by name.  The name cannot contain any \fI:\fR characters and cannot be an OID (otherwise the OID-based template specifier syntax takes precedence).
+Specify a certificate template by name. The name cannot contain any \fI:\fR characters and cannot be an OID (otherwise the OID-based template specifier syntax takes precedence).
 .TP
 \fBdefault\fR
 If no template is specified, the template name "SubCA" is used.
@@ -145,10 +145,10 @@ Name of the Kerberos KDC SSL certificate to install.
 File containing the CA certificate of the CA which issued the Directory Server, Apache Server and Kerberos KDC certificates. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times. Use this option if the CA certificate is not present in the certificate files.
 .TP
 \fB\-\-ca\-subject\fR=\fISUBJECT\fR
-The CA certificate subject DN (default CN=Certificate Authority,O=REALM.NAME).  RDNs are in LDAP order (most specific RDN first).
+The CA certificate subject DN (default CN=Certificate Authority,O=REALM.NAME). RDNs are in LDAP order (most specific RDN first).
 .TP
 \fB\-\-subject\-base\fR=\fISUBJECT\fR
-The subject base for certificates issued by IPA (default O=REALM.NAME).  RDNs are in LDAP order (most specific RDN first).
+The subject base for certificates issued by IPA (default O=REALM.NAME). RDNs are in LDAP order (most specific RDN first).
 .TP
 \fB\-\-ca\-signing\-algorithm\fR=\fIALGORITHM\fR
 Signing algorithm of the IPA CA certificate. Possible values are SHA1withRSA, SHA256withRSA, SHA512withRSA. Default value is SHA256withRSA. Use this option with --external-ca if the external CA does not support the default signing algorithm.


### PR DESCRIPTION
There are extras space present in man page. PR removes
identified extra spaces.