### PR TITLE
vault: fix vault-retrieve to a file

### DIFF
--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -1143,7 +1143,7 @@ class vault_retrieve(ModVaultData):
                 error=_('Invalid vault type'))
 
         if output_file:
-            with open(output_file, 'w') as f:
+            with open(output_file, 'wb') as f:
                 f.write(data)
 
         else:


### PR DESCRIPTION
`data` is bytes but we were opening the "--out" file as
a text.

https://pagure.io/freeipa/issue/7430