### PR TITLE
[Backport][ipa-4-6] vault: fix vault-retrieve to a file

### DIFF
--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -1135,7 +1135,7 @@ class vault_retrieve(ModVaultData):
                 error=_('Invalid vault type'))
 
         if output_file:
-            with open(output_file, 'w') as f:
+            with open(output_file, 'wb') as f:
                 f.write(data)
 
         else:


### PR DESCRIPTION
This PR was opened automatically because PR #1653 was pushed to master and backport to ipa-4-6 is required.