### PR TITLE
Misleading error message XXX-del for non-existent objects

### DIFF
--- a/ipaserver/plugins/ca.py
+++ b/ipaserver/plugins/ca.py
@@ -292,7 +292,7 @@ class ca_add(LDAPCreate):
 class ca_del(LDAPDelete):
     __doc__ = _('Delete a CA.')
 
-    msg_summary = _('Deleted CA "%(value)s"')
+    msg_summary = _('Trying to Delete CA "%(value)s"')
 
     def pre_callback(self, ldap, dn, *keys, **options):
         ca_enabled_check(self.api)


### PR DESCRIPTION
ipa ca-del does not provide relevant log message when
ipa-server user tries deleting non-exitant CA.

`# ipa ca-del SubCA_9 SubCA_10 --continue`
`-------------`
Deleted CA ""
`-------------`
  Failed to remove: SubCA_9, SubCA_10

--continue option itself says Don't stop on errors.
So it will try deleting CAs anyhow.

I believe better would be to change text from
Deleted CA
to something:
Trying to Delete CA

Resolves: https://pagure.io/freeipa/issue/6106