### PR TITLE
Do not check deleted files with `make fastlint`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -209,7 +209,7 @@ endif
 	@echo "Fast linting with $(PYTHON) from branch '$(GIT_BRANCH)'"
 
 	@MERGEBASE=$$(git merge-base --fork-point $(GIT_BRANCH)); \
-	FILES=$$(git diff --name-only $${MERGEBASE} \
+	FILES=$$(git diff --name-only --diff-filter=d $${MERGEBASE} \
 	    | grep -E '\.py$$'); \
 	if [ -n "$${FILES}" ]; then \
 	    echo -e "Fast linting files:\n$${FILES}\n"; \


### PR DESCRIPTION
When any file from FreeIPA tree has been deleted there was
a failure like:
```
 pylint
 ------
 ************* Module ipaserver/install/ntpinstance.py
 ipaserver/install/ntpinstance.py:1: [F0001(fatal), ] No module named ipaserver/install/ntpinstance.py)
```
Adding --diff-filter to fastlint will not list deleted files
in git diff --names-only output to not include not existing
files to checklist.