### PR TITLE
ipa-server-install: handle error when calling kdb5_util create

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -332,8 +332,9 @@ class KrbInstance(service.Service):
         )
         try:
             ipautil.run(args, nolog=(self.master_password,), stdin=''.join(dialogue))
-        except ipautil.CalledProcessError:
-            print("Failed to initialize the realm container")
+        except ipautil.CalledProcessError as error:
+            logger.debug("kdb5_util failed with %s", error)
+            raise RuntimeError("Failed to initialize kerberos container")
 
     def __configure_instance(self):
         self.__template_file(paths.KRB5KDC_KDC_CONF, chmod=None)


### PR DESCRIPTION
ipa-server-install creates the kerberos container by calling
kdb5_util create -s -r $REALM -x ipa-setup-override-restrictions

but does not react on failure of this command. The installer fails later
when trying to create a ldap principal, and it is difficult to diagnose the
root cause.

The fix raises a RuntimeException when kdb5_util fails, to make sure
that the installer exits immediately with a proper error message.

Note: no test added because there is no easy reproducer. One would need to
stop dirsrv just before calling kdb5_util to simulate a failure.

https://pagure.io/freeipa/issue/7438