### PR TITLE
test_caless: adjust try/except to capture IOError

### DIFF
--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -273,8 +273,9 @@ class CALessBase(IntegrationTest):
                 destination_host.transport.put_file(
                     os.path.join(self.cert_dir, filename),
                     os.path.join(destination_host.config.test_dir, filename))
-            except OSError:
+            except (IOError, OSError):
                 pass
+
         extra_args = []
         if http_pkcs12_exists:
             extra_args.extend(['--http-cert-file', http_pkcs12])


### PR DESCRIPTION
While testing on RHEL we are getting IOError instead of OSError.
Add also IOError.

This is mostly for compatibility reasons however should not cause
any issue as IOError is alias for OSError on Python3.