### PR TITLE
ipa-restore: remove /etc/httpd/conf.d/nss.conf

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -147,7 +147,9 @@ class Restore(admintool.AdminTool):
         paths.DNSSEC_TOKENS_DIR,
     ]
 
-    FILES_TO_BE_REMOVED = []
+    FILES_TO_BE_REMOVED = [
+        paths.HTTPD_NSS_CONF,
+    ]
 
     def __init__(self, options, args):
         super(Restore, self).__init__(options, args)


### PR DESCRIPTION
When ipa-restore is called, it needs to delete the file
nss.conf, otherwise httpd server will try to initialize
the NSS engine and access NSSCertificateDatabase.
This is a regression introduced with the switch from NSS
to SSL.

https://pagure.io/freeipa/issue/7440