### PR TITLE
[Backport][ipa-4-5] ipa-server-install: handle error when calling kdb5_util create

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -324,8 +324,9 @@ class KrbInstance(service.Service):
         )
         try:
             ipautil.run(args, nolog=(self.master_password,), stdin=''.join(dialogue))
-        except ipautil.CalledProcessError:
-            print("Failed to initialize the realm container")
+        except ipautil.CalledProcessError as error:
+            root_logger.debug("kdb5_util failed with %s", error)
+            raise RuntimeError("Failed to initialize kerberos container")
 
     def __configure_instance(self):
         self.__template_file(paths.KRB5KDC_KDC_CONF, chmod=None)


### PR DESCRIPTION
This PR was opened automatically because PR #1664 was pushed to master and backport to ipa-4-5 is required.