### PR TITLE
[Backport][ipa-4-5] test_caless: adjust try/except to capture IOError

### DIFF
--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -270,8 +270,9 @@ class CALessBase(IntegrationTest):
                 destination_host.transport.put_file(
                     os.path.join(self.cert_dir, filename),
                     os.path.join(destination_host.config.test_dir, filename))
-            except OSError:
+            except (IOError, OSError):
                 pass
+
         extra_args = []
         if http_pkcs12_exists:
             extra_args.extend(['--http-cert-file', http_pkcs12])


### PR DESCRIPTION
This PR was opened automatically because PR #1669 was pushed to master and backport to ipa-4-5 is required.