### PR TITLE
[Backport][ipa-4-6] Error message while adding idrange with untrusted domain

### DIFF
--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -424,10 +424,10 @@ class idrange_add(LDAPCreate):
             if sid is not None:
                 entry_attrs['ipanttrusteddomainsid'] = sid
             else:
-                raise errors.ValidationError(name='ID Range setup',
-                    error=_('SID for the specified trusted domain name could '
-                            'not be found. Please specify the SID directly '
-                            'using dom-sid option.'))
+                raise errors.ValidationError(
+                    name='ID Range setup',
+                    error=_('Specified trusted domain name could not be '
+                            'found.'))
 
         # ipaNTTrustedDomainSID attribute set, this is AD Trusted domain range
         if is_set('ipanttrusteddomainsid'):


### PR DESCRIPTION
This PR was opened automatically because PR #1667 was pushed to master and backport to ipa-4-6 is required.