### PR TITLE
Make WebUI unit tests to generate results as JUnit

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -60,7 +60,7 @@ steps:
   - dnf install -y npm
   - cd ${container_working_dir}/install/ui/js/libs && make
   - cd ${container_working_dir}/install/ui && npm install
-  - cd ${container_working_dir}/install/ui && node_modules/grunt/bin/grunt --verbose qunit
+  - cd ${container_working_dir}/install/ui && node_modules/grunt/bin/grunt --verbose test
   tox:
   # just run one pylint and one Python 3 target (time/coverage trade-off)
   - tox -e py27,py36,pypi,pylint3

--- a/install/ui/Gruntfile.js
+++ b/install/ui/Gruntfile.js
@@ -1,5 +1,8 @@
 module.exports = function(grunt) {
     grunt.initConfig({
+        qunit_junit: {
+            options: {}
+        },
         qunit: {
             all: [
                 'test/all_tests.html'
@@ -7,5 +10,7 @@ module.exports = function(grunt) {
         }
     });
 
+    grunt.loadNpmTasks('grunt-qunit-junit');
     grunt.loadNpmTasks('grunt-contrib-qunit');
+    grunt.registerTask('test', ['qunit_junit', 'qunit']);
 };

--- a/install/ui/src/freeipa/package.json
+++ b/install/ui/src/freeipa/package.json
@@ -42,7 +42,8 @@
   },
   "devDependencies": {
     "grunt": "^1.0.1",
-    "grunt-contrib-qunit": "^2.0.0"
+    "grunt-contrib-qunit": "^2.0.0",
+    "grunt-qunit-junit": "^0.3.1"
   },
   "dependencies": {
     "dojo": "~1.8.1"


### PR DESCRIPTION
Now WebUI unit tests are generating results in qunit format which
is not consumable well by Jenkins.

This patch adds NPM dependency for adding generation results in
JUnit XML format so it can be easily processed.