### PR TITLE
Processing of server roles should ignore errors.EmptyResult

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1617,7 +1617,12 @@ def upgrade_configuration():
         AUTOREDIR='' if auto_redirect else '#',
         CRL_PUBLISH_PATH=paths.PKI_CA_PUBLISH_DIR,
         DOGTAG_PORT=8009,
-        CLONE='#'
+        CLONE='#',
+        WSGI_PREFIX_DIR=paths.WSGI_PREFIX_DIR,
+        GSSAPI_SESSION_KEY=paths.GSSAPI_SESSION_KEY,
+        FONTS_DIR=paths.FONTS_DIR,
+        IPA_CCACHES=paths.IPA_CCACHES,
+        IPA_CUSTODIA_SOCKET=paths.IPA_CUSTODIA_SOCKET
     )
 
     subject_base = find_subject_base()

--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -276,9 +276,20 @@ class config(LDAPObject):
     def update_entry_with_role_config(self, role_name, entry_attrs):
         backend = self.api.Backend.serverroles
 
-        role_config = backend.config_retrieve(role_name)
+        try:
+            role_config = backend.config_retrieve(role_name)
+        except errors.EmptyResult:
+            # No role config means current user identity
+            # has no rights to see it, return with no action
+            return
+
         for key, value in role_config.items():
-            entry_attrs.update({key: value})
+            try:
+                entry_attrs.update({key: value})
+            except errors.EmptyResult:
+                # An update that doesn't change an entry is fine here
+                # Just ignore and move to the next key pair
+                pass
 
 
     def show_servroles_attributes(self, entry_attrs, *roles, **options):


### PR DESCRIPTION
When non-admin user issues a command that utilizes
api.Object.config.show_servroles_attributes(), some server roles might
return errors.EmptyResult, indicating that a role is not visible to this
identity.

Most of the callers to api.Object.config.show_servroles_attributes() do
not process errors.EmptyResult so it goes up to an API caller. In case
of Web UI it breaks retrieval of the initial configuration due to ipa
config-show failing completely rather than avoiding to show available
server roles.

Fixes: https://pagure.io/freeipa/issue/7452
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>