### PR TITLE
[Backport][ipa-4-6] More cleanup after uninstall

### DIFF
--- a/ipaserver/install/dnskeysyncinstance.py
+++ b/ipaserver/install/dnskeysyncinstance.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 
 import logging
+import errno
 import os
 import pwd
 import grp
@@ -463,9 +464,15 @@ class DNSKeySyncInstance(service.Service):
         # remove softhsm pin, to make sure new installation will generate
         # new token database
         # do not delete *so pin*, user can need it to get token data
+        installutils.remove_file(paths.DNSSEC_SOFTHSM_PIN)
+        installutils.remove_file(paths.DNSSEC_SOFTHSM2_CONF)
+
         try:
-            os.remove(paths.DNSSEC_SOFTHSM_PIN)
-        except Exception:
-            pass
+            shutil.rmtree(paths.DNSSEC_TOKENS_DIR)
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                logger.exception(
+                    "Failed to remove %s", paths.DNSSEC_TOKENS_DIR
+                )
 
         installutils.remove_keytab(self.keytab)

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -938,14 +938,14 @@ def check_server_configuration():
 
 
 def remove_file(filename):
-    """
-    Remove a file and log any exceptions raised.
+    """Remove a file and log any exceptions raised.
     """
     try:
-        if os.path.lexists(filename):
-            os.unlink(filename)
+        os.unlink(filename)
     except Exception as e:
-        logger.error('Error removing %s: %s', filename, str(e))
+        # ignore missing file
+        if getattr(e, 'errno', None) != errno.ENOENT:
+            logger.error('Error removing %s: %s', filename, str(e))
 
 
 def rmtree(path):


### PR DESCRIPTION
Manual backport of PR #1705

Remove more files during ipaserver uninstallation:

* /etc/gssproxy/10-ipa.conf
* /etc/httpd/alias/*.ipasave
* /etc/httpd/conf/password.conf
* /etc/ipa/dnssec/softhsm2.conf
* /etc/systemd/system/httpd.service.d/
* /var/lib/ipa/dnssec/tokens

Fixes: https://pagure.io/freeipa/issue/7183
See: https://pagure.io/freeipa/issue/2694
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Alexander Koksharov <akokshar@redhat.com>