### PR TITLE
use LDAP Whoami command when creating an OTP token

### DIFF
--- a/ipaserver/plugins/otptoken.py
+++ b/ipaserver/plugins/otptoken.py
@@ -311,13 +311,12 @@ class otptoken_add(LDAPCreate):
         # If owner was not specified, default to the person adding this token.
         # If managedby was not specified, attempt a sensible default.
         if 'ipatokenowner' not in entry_attrs or 'managedby' not in entry_attrs:
-            result = self.api.Command.user_find(
-                whoami=True, no_members=False)['result']
-            if result:
-                cur_uid = result[0]['uid'][0]
+            cur_dn = DN(self.api.Backend.ldap2.conn.whoami_s()[4:])
+            if cur_dn:
+                cur_uid = cur_dn[0].value
                 prev_uid = entry_attrs.setdefault('ipatokenowner', cur_uid)
                 if cur_uid == prev_uid:
-                    entry_attrs.setdefault('managedby', result[0]['dn'])
+                    entry_attrs.setdefault('managedby', cur_dn.ldap_text())
 
         # Resolve the owner's dn
         _normalize_owner(self.api.Object.user, entry_attrs)


### PR DESCRIPTION
ipa user-find --whoami is used by ipa otptoken-add to populate
ipaTokenOwner and managedBy attributes. These attributes, in turn are
checked by the self-service ACI which allows to create OTP tokens
assigned to the creator.

With 389-ds-base 1.4.0.6-2.fc28 in Fedora 28 beta there is a bug in
searches with scope 'one' that result in ipa user-find --whoami
returning 0 results.

Because ipa user-find --whoami does not work, non-admin user cannot
create a token. This is a regression that can be fixed by using LDAP
Whoami command.

Fixes: https://pagure.io/freeipa/issue/7456