### PR TITLE
Fix installer CA port check to include 8080

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ freeipa2-dev-doc
 
 # Root directory
 /freeipa.spec
+/freeipa-builddep.spec
 /dist/
 /.tox/
 /.cache/

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -205,8 +205,8 @@ def install_check(standalone, replica_config, options):
                     )
 
     if not options.external_cert_files:
-        if not cainstance.check_port():
-            print("IPA requires port 8443 for PKI but it is currently in use.")
+        if not cainstance.check_ports():
+            print("IPA requires ports 8443 and 8080 for PKI but one or more are currently in use.")
             raise ScriptError("Aborting installation")
 
     if standalone:

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -105,13 +105,14 @@ class ExternalCAType(enum.Enum):
     MS_CS = 'ms-cs'
 
 
-def check_port():
+def check_ports():
     """
-    Check that dogtag port (8443) is available.
+    Check that dogtag ports (8443, 8080) are available.
 
-    Returns True when the port is free, False if it's taken.
+    Returns True when all ports are free, False if any are taken.
     """
-    return not ipautil.host_port_open(None, 8443)
+    return all([ipautil.host_port_free(None, 8443),
+                ipautil.host_port_free(None, 8080)]) 
 
 def get_preop_pin(instance_root, instance_name):
     # Only used for Dogtag 9

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -506,6 +506,8 @@ class HTTPInstance(service.Service):
         installutils.remove_file(paths.HTTPD_IPA_KDCPROXY_CONF)
         if paths.HTTPD_IPA_WSGI_MODULES_CONF is not None:
             installutils.remove_file(paths.HTTPD_IPA_WSGI_MODULES_CONF)
+        if paths.GSSPROXY_CONF is not None:
+            installutils.remove_file(paths.GSSPROXY_CONF)
 
         # Restore SELinux boolean states
         boolean_states = {name: self.restore_state(name)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -506,8 +506,6 @@ class HTTPInstance(service.Service):
         installutils.remove_file(paths.HTTPD_IPA_KDCPROXY_CONF)
         if paths.HTTPD_IPA_WSGI_MODULES_CONF is not None:
             installutils.remove_file(paths.HTTPD_IPA_WSGI_MODULES_CONF)
-        if paths.GSSPROXY_CONF is not None:
-            installutils.remove_file(paths.GSSPROXY_CONF)
 
         # Restore SELinux boolean states
         boolean_states = {name: self.restore_state(name)


### PR DESCRIPTION
   component: installer - CA
   
   The installer was not checking the availability of port 8080, cainstance.check_port() function has been renamed to cainstance.check_ports() and updated to check for port 8080 also.
   The ipautil.host_port_open() function was being used incorrectly to test for a free port, I have added a new  ipautil.host_port_free() function based on host_port_open() with different logic.
   cainstance.check_port() now calls ipautil.host_port_free() instead of negating the result from ipautil.host_port_open().
   
   https://pagure.io/freeipa/issue/7415