### PR TITLE
Remove py35 env from tox testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion=2.3.1
-envlist=py27,py35,py36,pylint2,pylint3,pypi
+envlist=py27,py36,pylint2,pylint3,pypi
 skip_missing_interpreters=true
 skipsdist=true
 


### PR DESCRIPTION
Ever since fa94ef04, only Python3 versions >=3.6 are supported.
Removing py35 env from tox tests.