### PR TITLE
[Backport][ipa-4-6] Remove py35 env from tox testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion=2.3.1
-envlist=py27,py35,py36,pylint2,pylint3,pypi
+envlist=py27,py36,pylint2,pylint3,pypi
 skip_missing_interpreters=true
 skipsdist=true
 


### PR DESCRIPTION
This PR was opened automatically because PR #1730 was pushed to master and backport to ipa-4-6 is required.