### PR TITLE
webui tests: fix test_host:test_crud failure

### DIFF
--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -1373,6 +1373,8 @@ class UI_driver(object):
                         dialog_btn=add_dialog_btn
                         )
 
+        self.close_notifications()
+
         # Find
         self.find_record(parent_entity, data, search_facet)
 
@@ -1391,6 +1393,8 @@ class UI_driver(object):
             self.mod_record(entity, data, details_facet, update_btn)
             self.validate_fields(data.get('mod_v'))
 
+        self.close_notifications()
+
         if not breadcrumb:
             self.navigate_to_entity(entity, search_facet)
         else:
@@ -1399,6 +1403,7 @@ class UI_driver(object):
         # 5. Delete record
         if delete:
             self.delete_record(pkey, data.get('del'))
+            self.close_notifications()
 
     def add_table_record(self, name, data, parent=None):
         """


### PR DESCRIPTION
test_host.py::test_host::test_crud fails in nightly tests in delete record
step.

It started to fail probably after commit 4295df17a42897f6f59be21c25c5dd03984e35d3
which changed host-add behavior into showing a warning message about DNS resolution
instead of raising an error. This warning notification stays displayed for some
time, as all longer, notifications. By being open it takes some area on the page.
Given that webui tests proceeds quicker than a user, the notification can
cover some elements.

The test fails because web driver cannot click on an element which is covered
by the notification. In this case, it cannot open a deleter dialog.

So the fix is to close the notification(s). This is OK since a user would do
it as well if it was in a way.

This kind of issue is harder to reproduce when testing locally because
most people uses screen resolution 1920x1200 or full HD. PR-CI uses
1400x1200 for web ui testing.
  /usr/bin/Xvfb $DISPLAY -ac -noreset -screen 0 1400x1200x8

So alternative fix would be to change resolution used by the PR-CI. Combination
of both could be the best.