### PR TITLE
Adding hostname parameter to install IPA in TestInstallMasterReservedIPasForwarder

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -182,3 +182,16 @@ jobs:
         template: *ci-master-f27
         timeout: 3600
         topology: *master_1repl
+
+  fedora-27/test_installation_TestInstallMasterReservedIPasForwarder:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_1repl
+

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -346,13 +346,15 @@ class TestInstallMasterReservedIPasForwarder(IntegrationTest):
 
         server_install_options = (
                 "yes\n"
+                "{hostname}\n"
                 "{dmname}\n\n"
                 "{dm_pass}\n{dm_pass}"
                 "\n{admin_pass}\n{admin_pass}\n"
                 "yes\nyes\n0.0.0.0\n".format(
                     dm_pass=self.master.config.dirman_password,
                     admin_pass=self.master.config.admin_password,
-                    dmname=self.master.domain.name))
+                    dmname=self.master.domain.name,
+                    hostname=self.master.hostname))
 
         cmd = self.master.run_command(['ipa-server-install'],
                                       stdin_text=server_install_options,


### PR DESCRIPTION
When installing IPA in interactive mode, it's necessary to provide the hostname. This will make the test pass.

I've added a temporary commit to run the test in PR CI on this PR. Once this PR gets approved I'll remove it.
You can check the test running (and failing) on the nightly PRs, like [this one](https://fedorapeople.org/groups/freeipa/prci/jobs/7191d19c-315a-11e8-98dd-fa163e0e8ed9/report.html)