### PR TITLE
Enable SPAKE support where avilable

### DIFF
--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -51,6 +51,7 @@ dist_app_DATA =				\
 	kdc_req.conf.template		\
 	krb5.conf.template		\
 	krb5.ini.template		\
+	freeipa.template		\
 	krb.con.template		\
 	krbrealm.con.template		\
 	smb.conf.template		\

--- a/install/share/freeipa.template
+++ b/install/share/freeipa.template
@@ -1,0 +1,2 @@
+[libdefaults]
+    spake_preauth_groups = edwards25519

--- a/install/share/kdc.conf.template
+++ b/install/share/kdc.conf.template
@@ -2,6 +2,7 @@
  kdc_ports = 88
  kdc_tcp_ports = 88
  restrict_anonymous_to_tgt = true
+ spake_preauth_kdc_challenge = edwards25519
 
 [realms]
  $REALM = {

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -627,6 +627,16 @@ def configure_krb5_conf(
         filename, client_domain, client_hostname, force=False,
         configure_sssd=True):
 
+    # First, write a snippet to krb5.conf.d.  Currently this doesn't support
+    # templating, but that could be changed in the future.
+    template = os.path.join(
+        paths.USR_SHARE_IPA_DIR,
+        os.path.basename(paths.KRB5_FREEIPA) + ".template")
+    contents = open(template).read()
+    open(paths.KRB5_FREEIPA, "w+").write(contents)
+    os.chmod(paths.KRB5_FREEIPA, 0x644)
+
+    # Then, perform the rest of our configuration into krb5.conf itself.
     krbconf = IPAChangeConf("IPA Installer")
     krbconf.setOptionAssignment((" = ", " "))
     krbconf.setSectionNameDelimiters(("[", "]"))

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -21,6 +21,7 @@ import gssapi
 import netifaces
 import os
 import SSSDConfig
+import shutil
 import socket
 import sys
 import tempfile
@@ -631,9 +632,9 @@ def configure_krb5_conf(
     # templating, but that could be changed in the future.
     template = os.path.join(
         paths.USR_SHARE_IPA_DIR,
-        os.path.basename(paths.KRB5_FREEIPA) + ".template")
-    contents = open(template).read()
-    open(paths.KRB5_FREEIPA, "w+").write(contents)
+        os.path.basename(paths.KRB5_FREEIPA) + ".template"
+    )
+    shutil.copy(template, paths.KRB5_FREEIPA)
     os.chmod(paths.KRB5_FREEIPA, 0x644)
 
     # Then, perform the rest of our configuration into krb5.conf itself.

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -74,6 +74,7 @@ class BasePathNamespace(object):
     IPA_NSSDB_PWDFILE_TXT = "/etc/ipa/nssdb/pwdfile.txt"
     COMMON_KRB5_CONF_DIR = "/etc/krb5.conf.d/"
     KRB5_CONF = "/etc/krb5.conf"
+    KRB5_FREEIPA = COMMON_KRB5_CONF_DIR + "freeipa"
     KRB5_KEYTAB = "/etc/krb5.keytab"
     LDAP_CONF = "/etc/ldap.conf"
     LIBNSS_LDAP_CONF = "/etc/libnss-ldap.conf"

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -339,6 +339,7 @@ class KrbInstance(service.Service):
     def __configure_instance(self):
         self.__template_file(paths.KRB5KDC_KDC_CONF, chmod=None)
         self.__template_file(paths.KRB5_CONF)
+        self.__template_file(paths.KRB5_FREEIPA)
         self.__template_file(paths.HTML_KRB5_INI)
         self.__template_file(paths.KRB_CON)
         self.__template_file(paths.HTML_KRBREALM_CON)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1563,6 +1563,37 @@ def setup_pkinit(krb):
         aug.close()
 
 
+def setup_spake(krb):
+    logger.info("[Setup SPAKE]")
+
+    aug = Augeas(flags=Augeas.NO_LOAD | Augeas.NO_MODL_AUTOLOAD,
+                 loadpath=paths.USR_SHARE_IPA_DIR)
+    try:
+        aug.transform("IPAKrb5", paths.KRB5KDC_KDC_CONF)
+        aug.load()
+
+        path = "/files{}/libdefaults/spake_preauth_kdc_challenge"
+        path = path.format(paths.KRB5KDC_KDC_CONF)
+        value = "edwards25519"
+        if aug.match(path):
+            return
+
+        aug.remove(path)
+        aug.set(path, value)
+        try:
+            aug.save()
+        except IOError:
+            for error_path in aug.match('/augeas//error'):
+                logger.error('augeas: %s', aug.get(error_path))
+                raise
+
+        if krb.is_running():
+            krb.stop()
+            krb.start()
+    finally:
+        aug.close()
+
+
 def enable_certauth(krb):
     logger.info("[Enable certauth]")
 
@@ -1942,6 +1973,7 @@ def upgrade_configuration():
                         KDC_CA_BUNDLE_PEM=paths.KDC_CA_BUNDLE_PEM,
                         CA_BUNDLE_PEM=paths.CA_BUNDLE_PEM)
     krb.add_anonymous_principal()
+    setup_spake(krb)
     setup_pkinit(krb)
     enable_certauth(krb)
 


### PR DESCRIPTION
Because krb5 silently ignores unrecognized options, this is safe on
all versions.  It lands upstream in krb5-1.17; in Fedora, it was added
in krb5-1.6-17.

Upstream documentation can be found in-tree at
https://github.com/krb5/krb5/blob/master/doc/admin/spake.rst