### PR TITLE
Fix upgrade when named.conf does not exist

### DIFF
--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -93,6 +93,10 @@ def create_reverse():
 
 
 def named_conf_exists():
+    """
+    Checks that named.conf exists AND that it contains IPA-related config.
+
+    """
     try:
         with open(paths.NAMED_CONF, 'r') as named_fd:
             lines = named_fd.readlines()

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -905,6 +905,10 @@ def named_add_server_id():
 def named_add_crypto_policy():
     """Add crypto policy include
     """
+    if not bindinstance.named_conf_exists():
+        logger.info('DNS is not configured')
+        return False
+
     if sysupgrade.get_upgrade_state('named.conf', 'add_crypto_policy'):
         # upgrade was done already
         return False


### PR DESCRIPTION
Commit aee0d2180c7119bef30ab7cafea81dc3df1170b7 adds an upgrade step
that adds system crypto policy include to named.conf.  This step
omitted the named.conf existence check; upgrade fails when it does
not exist.  Add the existence check.

Part of: https://pagure.io/freeipa/issue/4853