### PR TITLE
Allow anonymous access to parentID attribute

### DIFF
--- a/install/updates/20-aci.update
+++ b/install/updates/20-aci.update
@@ -21,6 +21,10 @@ add:aci:(targetattr="ipasshpubkey")(version 3.0; acl "Hosts can manage other hos
 dn: $SUFFIX
 add:aci:(targetfilter="(objectclass=domain)")(targetattr="objectclass || dc || info || nisDomain || associatedDomain")(version 3.0; acl "Anonymous read access to DIT root"; allow(read, search, compare) userdn = "ldap:///anyone";)
 
+# Read access to parentID information to allow filter optimizations in 389-ds
+dn: $SUFFIX
+add:aci:(targetattr="parentid")(version 3.0; acl "Anonymous read access to parentID information"; allow(read, search, compare) userdn = "ldap:///anyone";)
+
 # Read access to containers
 dn: $SUFFIX
 add:aci:(targetfilter="(&(objectclass=nsContainer)(!(objectclass=krbPwdPolicy)))")(target!="ldap:///cn=masters,cn=ipa,cn=etc,$SUFFIX")(targetattr="objectclass || cn")(version 3.0; acl "Anonymous read access to containers"; allow(read, search, compare) userdn = "ldap:///anyone";)


### PR DESCRIPTION
Due to optimizations in 389-ds performed as result of
https://pagure.io/389-ds-base/issue/49372, LDAP search filter
is rewritten to include parentID information. It implies that parentID
has to be readable for a bound identity performing the search. This is
what 389-ds expects right now but FreeIPA DS instance does not allow it.

As result, searches with a one-level scope fail to return results that
otherwise are matched in a sub scope search.

While 389-ds developers are working on the fix for issue
https://pagure.io/389-ds-base/issue/49617, we can fix it by adding an
explicit ACI to allow reading parentID attribute at the suffix level.

Fixes: https://pagure.io/freeipa/issue/7466
