### PR TITLE
Fix installer CA port check for port 8080

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -205,8 +205,11 @@ def install_check(standalone, replica_config, options):
                     )
 
     if not options.external_cert_files:
-        if not cainstance.check_port():
-            print("IPA requires port 8443 for PKI but it is currently in use.")
+        if not cainstance.check_ports():
+            print(
+                "IPA requires ports 8080 and 8443 for PKI, but one or more "
+                "are currently in use."
+            )
             raise ScriptError("Aborting installation")
 
     if standalone:

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -105,13 +105,14 @@ class ExternalCAType(enum.Enum):
     MS_CS = 'ms-cs'
 
 
-def check_port():
-    """
-    Check that dogtag port (8443) is available.
+def check_ports():
+    """Check that dogtag ports (8080, 8443) are available.
 
-    Returns True when the port is free, False if it's taken.
+    Returns True when ports are free, False if they are taken.
     """
-    return not ipautil.host_port_open(None, 8443)
+    return all([ipautil.check_port_bindable(8443),
+                ipautil.check_port_bindable(8080)])
+
 
 def get_preop_pin(instance_root, instance_name):
     # Only used for Dogtag 9


### PR DESCRIPTION
The installer now checks that port 8080 is available and not in use by
any other application.

The port checker has been rewritten to use bind() rather than just
checking if a server responds on localhost. It's much more reliable and
detects more problems.

Original patch by m3gat0nn4ge.

Co-authored-by: Mega Tonnage <m3gat0nn4ge@gmail.com>
Fixes: https://pagure.io/freeipa/issue/7415
Signed-off-by: Christian Heimes <cheimes@redhat.com>

Replaces PR #1722 