### PR TITLE
[Test fix] TestBasicADTrust.test_ipauser_authentication

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1353,7 +1353,7 @@ def ldappasswd_user_change(user, oldpw, newpw, master):
     master_ldap_uri = "ldap://{}".format(master.external_hostname)
 
     args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
-            '-s', newpw, '-x', '-H', master_ldap_uri]
+            '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
     master.run_command(args)
 
 


### PR DESCRIPTION
test_ipauser_authentication is failing with error: "Confidentiality required"
Password operation must be performed over a secure connection

To start TLS encryption added -ZZ option, in order to be connection successful

https://pagure.io/freeipa/issue/7470