### PR TITLE
Temporarily disable authconfig backup and restore

### DIFF
--- a/ipaplatform/fedora/tasks.py
+++ b/ipaplatform/fedora/tasks.py
@@ -27,7 +27,22 @@ from ipaplatform.redhat.tasks import RedHatTaskNamespace
 
 
 class FedoraTaskNamespace(RedHatTaskNamespace):
-    pass
+
+    def backup_auth_configuration(self, path):
+        """Dummy method
+
+        On Fedora 28, authconfig from authselect-compat does not implement
+        backup and restore.
+        """
+        pass
+
+    def restore_auth_configuration(self, path):
+        """Dummy method
+
+        On Fedora 28, authconfig from authselect-compat does not implement
+        backup and restore.
+        """
+        pass
 
 
 tasks = FedoraTaskNamespace()


### PR DESCRIPTION
The authconfig command from authselect-compat-0.3.2-1 does not support
backup and restore at all. Temporarily disable backup and restore of
auth config to fix broken ipa-backup.

Fixes: https://pagure.io/freeipa/issue/7478
Signed-off-by: Christian Heimes <cheimes@redhat.com>