### PR TITLE
Change remove_segment to take a config object

### DIFF
--- a/ipatests/test_integration/test_topology.py
+++ b/ipatests/test_integration/test_topology.py
@@ -27,7 +27,7 @@ def find_segment(master, replica):
             return '-to-'.join(segment)
 
 
-def remove_segment(master, host1, host2):
+def remove_segment(config):
     """
     This removes a segment between host1 and host2 on master. The function is
     needed because test_add_remove_segment expects only one segment, but due to
@@ -39,6 +39,10 @@ def remove_segment(master, host1, host2):
             try:
                 func(*args, **kwargs)
             finally:
+                master = config.domains[0].master
+                host1 = config.domains[0].master
+                host2 = config.domains[0].replicas[1]
+
                 segment = find_segment(host1, host2)
                 master.run_command(['ipa', 'topologysegment-del',
                                     DOMAIN_SUFFIX_NAME, segment],
@@ -84,10 +88,9 @@ class TestTopologyOptions(IntegrationTest):
                               )
         return result
 
+    @pytest.mark.skipif(len(config.domains) == 0, reason='single master')
     @pytest.mark.xfail(reason="Trac 6250", strict=True)
-    @remove_segment(config.domains[0].master,
-                    config.domains[0].master,
-                    config.domains[0].replicas[1])
+    @remove_segment(config)
     def test_topology_updated_on_replica_install_remove(self):
         """
         Install and remove a replica and make sure topology information is


### PR DESCRIPTION
This is to handle the case where there is no integration test
YAML provided where config.domains is an empty list.

https://pagure.io/freeipa/issue/7483

Note that I considered populating config with an empty set of domains and replicas but that would have required much more code and IMHO been more fragile. Given there is only a single caller to remove_segment I think this is fastest, safest route. If we end up with more callers needing it we can revisit.

The use-case for this is to:

- Install IPA
- Install the test pkgs
- mkdir ~/.ipa
- ln -s /etc/ipa/default.conf ~/.ipa/default.conf
- ln -s /etc/ipa/ca.crt ~/.ipa/ca.crt
- kinit admin
- ipa-run-tests

The simplest possible way to execute the tests in IPA.