### PR TITLE
Fix order of commands in test for removing topology segments

### DIFF
--- a/ipatests/test_integration/test_topology.py
+++ b/ipatests/test_integration/test_topology.py
@@ -27,26 +27,6 @@ def find_segment(master, replica):
             return '-to-'.join(segment)
 
 
-def remove_segment(master, host1, host2):
-    """
-    This removes a segment between host1 and host2 on master. The function is
-    needed because test_add_remove_segment expects only one segment, but due to
-    track tickete N 6250, the test_topology_updated_on_replica_install_remove
-    leaves 2 topology segments
-    """
-    def wrapper(func):
-        def wrapped(*args, **kwargs):
-            try:
-                func(*args, **kwargs)
-            finally:
-                segment = find_segment(host1, host2)
-                master.run_command(['ipa', 'topologysegment-del',
-                                    DOMAIN_SUFFIX_NAME, segment],
-                                   raiseonerr=False)
-        return wrapped
-    return wrapper
-
-
 @pytest.mark.skipif(config.domain_level == 0, reason=reasoning)
 class TestTopologyOptions(IntegrationTest):
     num_replicas = 2
@@ -84,10 +64,7 @@ class TestTopologyOptions(IntegrationTest):
                               )
         return result
 
-    @pytest.mark.xfail(reason="Trac 6250", strict=True)
-    @remove_segment(config.domains[0].master,
-                    config.domains[0].master,
-                    config.domains[0].replicas[1])
+
     def test_topology_updated_on_replica_install_remove(self):
         """
         Install and remove a replica and make sure topology information is
@@ -120,8 +97,11 @@ class TestTopologyOptions(IntegrationTest):
         assert_deepequal(result3.stdout_text,  result4.stdout_text)
         # Now let's check that uninstalling the replica will update the topology
         # info on the rest of replicas.
-        tasks.uninstall_master(self.replicas[1])
+        # first step of uninstallation is removal of the replica on other
+        # master, then it can be uninstalled. Doing it the other way is also
+        # possible, but not reliable - some data might not be replicated.
         tasks.clean_replication_agreement(self.master, self.replicas[1])
+        tasks.uninstall_master(self.replicas[1])
         result5 = self.master.run_command(['ipa', 'topologysegment-find',
                                            DOMAIN_SUFFIX_NAME])
         num_entries = self.noentries_re.search(result5.stdout_text).group(1)


### PR DESCRIPTION
this is an alternative approach to PR #1766 

test_topology_updated_on_replica_install_remove from the beginning used
invalid sequence of commands for removing a replica.

Proper order is:
  master$ ipa server-del $REPLICA
  replica$ ipa-server-install --uninstall

Alternatively usage of `ipa-replica-manage del $replica` instead of
`ipa server-del $replica` is possible. In essence ipa-replica-manage
calls the server-del command.

At some point there  was a plan to achieve uninstalation only through
`ipa-server-install --uninstall` but that was never achieved to this
date.

This change also removes the ugly wrapper which makes test collection
fail if no environment config is provided (i.e. replicas cannot be
indexed).
  $ pytest --collect-test ipatests/test_integration

https://pagure.io/freeipa/issue/6250