### PR TITLE
Check if ldap_uri is on /etc/ipa/default.conf

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -195,3 +195,14 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-27/test_replica_promotion_TestReplicaPromotionLevel0:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel0
+        template: *ci-master-f27
+        timeout: 8000
+        topology: *master_1repl

--- a/ipaserver/secrets/kem.py
+++ b/ipaserver/secrets/kem.py
@@ -213,7 +213,7 @@ class IPAKEMKeys(KEMKeysStore):
         if conf.read(ipaconf):
             self.host = conf.get('global', 'host')
             self.realm = conf.get('global', 'realm')
-            if self.ldap_uri is None:
+            if self.ldap_uri is None and conf.has_option('global', 'ldap_uri'):
                 self.ldap_uri = conf.get('global', 'ldap_uri', raw=True)
 
         self._server_keys = None


### PR DESCRIPTION
When removing a replica there are cases when ldap_uri is not on the
/etc/ipa/default.conf file anymore. So, before trying to get the value
of it, now the code checks if it's there first.

https://pagure.io/freeipa/issue/7474

This PR fixes the test `test_replica_promotion.py::TestReplicaPromotionLevel0::test_promotion_disabled `

Full log:
https://fedorapeople.org/groups/freeipa/prci/jobs/48fd7274-3162-11e8-8f04-fa163efc0cae/report.htm