### PR TITLE
ctypes.util.find_library() replacement

### DIFF
--- a/ipaclient/csrgen_ffi.py
+++ b/ipaclient/csrgen_ffi.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 from cffi import FFI
-import ctypes.util
+from ipaplatform.base.fl import find_library
 
 from ipalib import errors
 
@@ -116,7 +116,7 @@ unsigned long ERR_get_error(void);
 char *ERR_error_string(unsigned long e, char *buf);
 ''')
 
-_libcrypto = _ffi.dlopen(ctypes.util.find_library('crypto'))
+_libcrypto = _ffi.dlopen(find_library('crypto'))
 
 NULL = _ffi.NULL
 

--- a/ipaplatform/base/find_library.py
+++ b/ipaplatform/base/find_library.py
@@ -1,0 +1,48 @@
+# Author: Mega Tonnage <m3gat0nn4ge@gmail.com>
+#
+# Copyright (C) 2018
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+'''
+This base module contains a find_library() replacement for 
+ ctypes.util.find_library.
+'''
+
+from __future__ import print_function
+
+import os
+import subprocess
+import logging
+
+logger = logging.getLogger(__name__)
+
+def find_library(name):
+    logger.debug("Checking ldconfig output for: %s", name)
+    process = subprocess.Popen("ldconfig -N -p | grep '%s '" % name,
+              shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    output,stderr = process.communicate()
+    status = process.poll()
+
+    # do we need to check we only have one matching line?
+    if output:
+        return output.rsplit(None, 1)[-1]
+    else:
+        return None
+        
+assert(find_library("libcrypto.so") == "/lib64/libcrypto.so")
+assert(find_library("librpm.so.8") == "/lib64/librpm.so.8")
+assert(find_library("libp11-kit.so.0") == "/lib64/libp11-kit.so.0")

--- a/ipaplatform/base/find_library.py
+++ b/ipaplatform/base/find_library.py
@@ -23,6 +23,7 @@ This base module contains a find_library() replacement for
 '''
 
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import subprocess
@@ -32,14 +33,16 @@ logger = logging.getLogger(__name__)
 
 def find_library(name):
     logger.debug("Checking ldconfig output for: %s", name)
-    process = subprocess.Popen("ldconfig -N -p | grep '%s '" % name,
-              shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    process = subprocess.Popen(
+              "ldconfig -N -p | awk '{print $1, $NF}' | grep '^%s'"
+              % name, shell=True, stdout=subprocess.PIPE, 
+              stderr=subprocess.STDOUT)
     output,stderr = process.communicate()
     status = process.poll()
 
     # do we need to check we only have one matching line?
     if output:
-        return output.rsplit(None, 1)[-1]
+        return output.rsplit(None, 1)[-1].decode('utf8')
     else:
         return None
         

--- a/ipaplatform/base/fl.py
+++ b/ipaplatform/base/fl.py
@@ -18,26 +18,26 @@
 #
 
 '''
-This base module contains a find_library() replacement for 
+This base module contains a find_library() replacement for
  ctypes.util.find_library.
 '''
 
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
 import subprocess
 import logging
 
 logger = logging.getLogger(__name__)
 
+
 def find_library(name):
     logger.debug("Checking ldconfig output for: %s", name)
     process = subprocess.Popen(
-              "ldconfig -N -p | awk '{print $1, $NF}' | grep '^%s'"
-              % name, shell=True, stdout=subprocess.PIPE, 
-              stderr=subprocess.STDOUT)
-    output,stderr = process.communicate()
+          "ldconfig -N -p | awk '{print $1, $NF}' | grep '^lib%s\.so.*'"
+          % name, shell=True, stdout=subprocess.PIPE,
+          stderr=subprocess.STDOUT)
+    output, stderr = process.communicate()
     status = process.poll()
 
     # do we need to check we only have one matching line?
@@ -45,7 +45,8 @@ def find_library(name):
         return output.rsplit(None, 1)[-1].decode('utf8')
     else:
         return None
-        
-assert(find_library("libcrypto.so") == "/lib64/libcrypto.so")
-assert(find_library("librpm.so.8") == "/lib64/librpm.so.8")
-assert(find_library("libp11-kit.so.0") == "/lib64/libp11-kit.so.0")
+
+
+# assert(find_library("crypto") == "/lib64/libcrypto.so")
+# assert(find_library("rpm") == "/lib64/librpm.so.8")
+# assert(find_library("p11-kit") == "/lib64/libp11-kit.so.0")

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -32,7 +32,6 @@ import traceback
 import errno
 import sys
 
-from ctypes.util import find_library
 from functools import total_ordering
 from subprocess import CalledProcessError
 
@@ -44,6 +43,7 @@ from ipapython import ipautil
 import ipapython.errors
 
 from ipaplatform.constants import constants
+from ipaplatform.base.fl import find_library
 from ipaplatform.paths import paths
 from ipaplatform.redhat.authconfig import RedHatAuthConfig
 from ipaplatform.base.tasks import BaseTaskNamespace
@@ -55,8 +55,6 @@ _ffi.cdef("""
 int rpmvercmp (const char *a, const char *b);
 """)
 
-# use ctypes loader to get correct librpm.so library version according to
-# https://cffi.readthedocs.org/en/latest/overview.html#id8
 _librpm = _ffi.dlopen(find_library("rpm"))
 
 

--- a/ipaserver/p11helper.py
+++ b/ipaserver/p11helper.py
@@ -3,7 +3,6 @@
 #
 
 import random
-import ctypes.util
 import binascii
 import struct
 
@@ -12,6 +11,8 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 from cffi import FFI
+
+from ipaplatform.base.fl import find_library
 
 if six.PY3:
     unicode = str
@@ -339,7 +340,7 @@ struct ck_rsa_pkcs_oaep_params {
 typedef struct ck_rsa_pkcs_oaep_params CK_RSA_PKCS_OAEP_PARAMS;
 ''')
 
-_libp11_kit = _ffi.dlopen(ctypes.util.find_library('p11-kit'))
+_libp11_kit = _ffi.dlopen(find_library('p11-kit'))
 
 
 # utility


### PR DESCRIPTION
   component: ipaclient/csrgen_ffi.py,  ipaserver/p11helper.py, ipaplatform/redhat/tasks.py
   
   Create a dumbed down replacement for ctypes.util.find_library().. parses ldconfig output
   
   https://pagure.io/freeipa/issue/6851