### PR TITLE
Load librpm on demand for IPAVersion

### DIFF
--- a/ipatests/test_ipaplatform/test_tasks.py
+++ b/ipatests/test_ipaplatform/test_tasks.py
@@ -1,0 +1,28 @@
+#
+# Copyright (C) 2017  FreeIPA Contributors see COPYING for license
+#
+
+from ipaplatform.tasks import tasks
+
+
+def test_ipa_version():
+    v3 = tasks.parse_ipa_version('3.0')
+    assert v3.version == u'3.0'
+    if hasattr(v3, '_rpmvercmp'):
+        assert v3._rpmvercmp_func is None
+        v3._rpmvercmp(b'1', b'2')
+        assert v3._rpmvercmp_func is not None
+
+    v4 = tasks.parse_ipa_version('4.0')
+    assert v4.version == u'4.0'
+    if hasattr(v4, '_rpmvercmp'):
+        assert v4._rpmvercmp_func is not None
+
+    assert v3 < v4
+    assert v3 <= v4
+    assert v3 <= v3
+    assert v3 != v4
+    assert v3 == v3
+    assert not v3 == v4
+    assert v4 > v3
+    assert v4 >= v3


### PR DESCRIPTION
ctypes.util.find_library() is costly and slows down startup of ipa CLI.
ipaplatform.redhat.tasks now defers loading of librpm until its needed.
CFFI has been replaced with ctypes, too.

See: https://pagure.io/freeipa/issue/6851
Signed-off-by: Christian Heimes <cheimes@redhat.com>