### PR TITLE
Defer import of ipaclient.csrgen

### DIFF
--- a/ipaclient/plugins/cert.py
+++ b/ipaclient/plugins/cert.py
@@ -23,7 +23,6 @@ import base64
 
 import six
 
-from ipaclient import csrgen
 from ipaclient.frontend import MethodOverride
 from ipalib import errors
 from ipalib import x509
@@ -111,6 +110,10 @@ class cert_request(CertRetrieveOverride):
         password_file = options.pop('password_file', None)
 
         if csr is None:
+            # Deferred import, ipaclient.csrgen is expensive to load.
+            # see https://pagure.io/freeipa/issue/7484
+            from ipaclient import csrgen
+
             if database:
                 adaptor = csrgen.NSSAdaptor(database, password_file)
             elif private_key:

--- a/ipaclient/plugins/csrgen.py
+++ b/ipaclient/plugins/csrgen.py
@@ -16,13 +16,6 @@ from ipalib.plugable import Registry
 from ipalib.text import _
 from ipapython import dogtag
 
-try:
-    import jinja2  # pylint: disable=unused-import
-except ImportError:
-    raise errors.SkipPluginModule(reason=_("jinja2 is not installed."))
-else:
-    from ipaclient import csrgen
-    from ipaclient import csrgen_ffi
 
 if six.PY3:
     unicode = str
@@ -79,6 +72,11 @@ class cert_get_requestdata(Local):
     )
 
     def execute(self, *args, **options):
+        # Deferred import, ipaclient.csrgen is expensive to load.
+        # see https://pagure.io/freeipa/issue/7484
+        from ipaclient import csrgen
+        from ipaclient import csrgen_ffi
+
         if 'out' in options:
             util.check_writable_file(options['out'])
 


### PR DESCRIPTION
The modules ipaclient.csrgen and ipaclient.csrgen_ffi are expensive to load,
but rarely used. On demand loading speeds up ipa CLI by about 200ms.

Fixes: https://pagure.io/freeipa/issue/7484
Signed-off-by: Christian Heimes <cheimes@redhat.com>