### PR TITLE
 certdb: Move chdir into subprocess call

### DIFF
--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -168,12 +168,6 @@ class CertDB(object):
         self.ca_subject = ca_subject
         self.subject_base = subject_base
 
-        try:
-            self.cwd = os.path.abspath(os.getcwd())
-        except OSError as e:
-            raise RuntimeError(
-                "Unable to determine the current directory: %s" % str(e))
-
         self.cacert_name = get_ca_nickname(self.realm)
 
         self.user = user
@@ -245,10 +239,6 @@ class CertDB(object):
             shutil.rmtree(self.reqdir, ignore_errors=True)
             self.reqdir = None
         self.nssdb.close()
-        try:
-            os.chdir(self.cwd)
-        except OSError:
-            pass
 
     def setup_cert_request(self):
         """
@@ -264,10 +254,6 @@ class CertDB(object):
         self.reqdir = tempfile.mkdtemp('', 'ipa-', paths.VAR_LIB_IPA)
         self.certreq_fname = self.reqdir + "/tmpcertreq"
         self.certder_fname = self.reqdir + "/tmpcert.der"
-
-        # When certutil makes a request it creates a file in the cwd, make
-        # sure we are in a unique place when this happens
-        os.chdir(self.reqdir)
 
     def set_perms(self, fname, write=False):
         perms = stat.S_IRUSR

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import functools
 import logging
 import os
 import tempfile
@@ -178,10 +179,14 @@ class CALessBase(IntegrationTest):
         if host is None:
             host = cls.master
 
-        extra_args = ['--http-cert-file', http_pkcs12,
-                      '--dirsrv-cert-file', dirsrv_pkcs12,
-                      '--ca-cert-file', root_ca_file,
-                      '--ip-address', host.ip]
+        destname = functools.partial(os.path.join, host.config.test_dir)
+
+        extra_args = [
+            '--http-cert-file', destname(http_pkcs12),
+            '--dirsrv-cert-file', destname(dirsrv_pkcs12),
+            '--ca-cert-file', destname(root_ca_file),
+            '--ip-address', host.ip
+        ]
 
         if http_pin is _DEFAULT:
             http_pin = cls.cert_password
@@ -197,7 +202,9 @@ class CALessBase(IntegrationTest):
             files_to_copy.append(dirsrv_pkcs12)
         if pkinit_pkcs12_exists:
             files_to_copy.append(pkinit_pkcs12)
-            extra_args.extend(['--pkinit-cert-file', pkinit_pkcs12])
+            extra_args.extend(
+                ['--pkinit-cert-file', destname(pkinit_pkcs12)]
+            )
         else:
             extra_args.append('--no-pkinit')
         for filename in set(files_to_copy):
@@ -277,11 +284,20 @@ class CALessBase(IntegrationTest):
 
         extra_args = []
         if http_pkcs12_exists:
-            extra_args.extend(['--http-cert-file', http_pkcs12])
+            extra_args.extend([
+                '--http-cert-file',
+                os.path.join(destination_host.config.test_dir, http_pkcs12)
+            ])
         if dirsrv_pkcs12_exists:
-            extra_args.extend(['--dirsrv-cert-file', dirsrv_pkcs12])
+            extra_args.extend([
+                '--dirsrv-cert-file',
+                os.path.join(destination_host.config.test_dir, dirsrv_pkcs12)
+            ])
         if pkinit_pkcs12_exists and domain_level != DOMAIN_LEVEL_0:
-            extra_args.extend(['--pkinit-cert-file', pkinit_pkcs12])
+            extra_args.extend([
+                '--pkinit-cert-file',
+                os.path.join(destination_host.config.test_dir, pkinit_pkcs12)
+            ])
         else:
             extra_args.append('--no-pkinit')
 

--- a/ipatests/test_ipaserver/test_ipap11helper.py
+++ b/ipatests/test_ipaserver/test_ipap11helper.py
@@ -47,17 +47,25 @@ replica_non_existent_label = u"replica-nonexistent"
 
 
 @pytest.fixture(scope="module")
-def p11(request):
+def token_path():
     token_path = tempfile.mkdtemp(prefix='pytest_', suffix='_pkcs11')
-    os.chdir(token_path)
-    os.mkdir('tokens')
+    os.mkdir(os.path.join(token_path, 'tokens'))
+    return token_path
 
-    with open('softhsm2.conf', 'w') as cfg:
+
+@pytest.fixture(scope="module")
+def p11(request, token_path):
+    with open(os.path.join(token_path, 'softhsm2.conf'), 'w') as cfg:
         cfg.write(CONFIG_DATA % token_path)
+
+    args = [
+        SOFTHSM2_UTIL, '--init-token', '--free',
+        '--label', 'test',
+        '--pin', '1234',
+        '--so-pin', '1234'
+    ]
     os.environ['SOFTHSM2_CONF'] = os.path.join(token_path, 'softhsm2.conf')
-    subprocess.check_call([SOFTHSM2_UTIL, '--init-token', '--free',
-                           '--label', 'test', '--pin', '1234', '--so-pin',
-                           '1234'])
+    subprocess.check_call(args, cwd=token_path)
 
     try:
         p11 = _ipap11helper.P11_Helper('test', "1234", LIBSOFTHSM)
@@ -71,7 +79,9 @@ def p11(request):
             pytest.fail('Failed to finalize the helper object.', pytrace=False)
         finally:
             subprocess.call(
-                [SOFTHSM2_UTIL, '--delete-token', '--label', 'test'])
+                [SOFTHSM2_UTIL, '--delete-token', '--label', 'test'],
+                cwd=token_path
+            )
             del os.environ['SOFTHSM2_CONF']
 
     request.addfinalizer(fin)
@@ -134,13 +144,14 @@ class test_p11helper(object):
                                      "'%s' should not exist" %
                                      replica_non_existent_label)
 
-    def test_export_import_of_public_key(self, p11):
+    def test_export_import_of_public_key(self, p11, token_path):
         rep1_pub = p11.find_keys(_ipap11helper.KEY_CLASS_PUBLIC_KEY,
                                  label=replica1_key_label, cka_wrap=True)[0]
         pub = p11.export_public_key(rep1_pub)
 
         log.debug("Exported public key %s", hexlify(pub))
-        with open("public_key.asn1.der", "wb") as f:
+        pubfile = os.path.join(token_path, "public_key.asn1.der")
+        with open(pubfile, "wb") as f:
             f.write(pub)
 
         rep1_pub_import = p11.import_public_key(replica1_import_label,
@@ -166,7 +177,7 @@ class test_p11helper(object):
         log.debug('rep1_pub_exp_import = 0x%s', hexlify(rep1_pub_exp_import))
         assert rep1_pub_exp_import == rep1_pub_exp_orig
 
-    def test_wrap_unwrap_key_by_master_key_with_AES(self, p11):
+    def test_wrap_unwrap_key_by_master_key_with_AES(self, p11, token_path):
         master_key = p11.find_keys(_ipap11helper.KEY_CLASS_SECRET_KEY,
                                    label=master_key_label, id=master_key_id)[0]
         rep2_priv = p11.find_keys(_ipap11helper.KEY_CLASS_PRIVATE_KEY,
@@ -179,7 +190,8 @@ class test_p11helper(object):
         assert wrapped_priv
 
         log.debug("wrapped_dnssec priv key: %s", hexlify(wrapped_priv))
-        with open("wrapped_priv.der", "wb") as f:
+        privfile = os.path.join(token_path, "wrapped_priv.der")
+        with open(privfile, "wb") as f:
             f.write(wrapped_priv)
 
         assert p11.import_wrapped_private_key(


### PR DESCRIPTION
According to a comment, certutil may create files in the current working
directory. Rather than changing the cwd of the current process,
FreeIPA's certutil wrapper now changes cwd for the subprocess only.

See: pagure.io/freeipa/issue/7416

## Remove os.chdir() from test_ipap11helper

test_ipap11helper no longer changes directory for the entire test suite.
The fix revealed a bug in another test suite. test_secrets now uses a
proper temporary directory.