### PR TITLE
webui: refresh complex pages after modification

### DIFF
--- a/install/ui/src/freeipa/host.js
+++ b/install/ui/src/freeipa/host.js
@@ -518,6 +518,12 @@ IPA.host.details_facet = function(spec, no_init) {
         return that.entity.name+'_show_'+that.get_pkey();
     };
 
+    that.update_on_success = function(data, text_status, xhr) {
+        that.on_update.notify();
+        that.nofify_update_success();
+        that.refresh();
+    };
+
     if (!no_init) that.init_details_facet();
 
     return that;

--- a/install/ui/src/freeipa/idviews.js
+++ b/install/ui/src/freeipa/idviews.js
@@ -450,6 +450,12 @@ idviews.id_override_user_details_facet = function(spec) {
         return batch;
     };
 
+    that.update_on_success = function(data, text_status, xhr) {
+        that.on_update.notify();
+        that.nofify_update_success();
+        that.refresh();
+    };
+
     return that;
 };
 

--- a/install/ui/src/freeipa/service.js
+++ b/install/ui/src/freeipa/service.js
@@ -500,6 +500,12 @@ IPA.service.details_facet = function(spec, no_init) {
         return batch;
     };
 
+    that.update_on_success = function(data, text_status, xhr) {
+        that.on_update.notify();
+        that.nofify_update_success();
+        that.refresh();
+    };
+
     if (!no_init) that.init_details_facet();
 
     return that;

--- a/install/ui/src/freeipa/user.js
+++ b/install/ui/src/freeipa/user.js
@@ -621,6 +621,11 @@ IPA.user.details_facet = function(spec, no_init) {
         return batch;
     };
 
+    that.update_on_success = function(data, text_status, xhr) {
+        that.on_update.notify();
+        that.nofify_update_success();
+        that.refresh();
+    };
 
     if (!no_init) that.init_details_facet();
 


### PR DESCRIPTION
Details facet for user, hosts, service, user override entities require
complex reload as they gather information from multiple sources - e.g.
all of them do cert-find. On update only $entity-mod is execute and its
result doesn't have all information required for refresh of the page
therefore some fields are missing or empty.

This patch modifies the facets to do full refresh instead of default
load and thus the pages will have all required info.

https://pagure.io/freeipa/issue/5776