### PR TITLE
[Test fix] Fix in IPA's multihost fixture

### DIFF
--- a/ipatests/pytest_plugins/integration/__init__.py
+++ b/ipatests/pytest_plugins/integration/__init__.py
@@ -218,7 +218,11 @@ def mh(request, class_integration_logs):
     for _i in range(cls.num_ad_domains):
         domain_descriptions.append({
             'type': 'AD',
-            'hosts': {'ad': 1, 'ad_subdomain': 1, 'ad_treedomain': 1},
+            'hosts': {
+                'ad': 1,
+                'ad_subdomain': cls.num_ad_domains,
+                'ad_treedomain': cls.num_ad_domains,
+            }
         })
 
     mh = make_multihost_fixture(


### PR DESCRIPTION
AD related tests, which aren't require all set of AD machines were skipped with error msg: Not enough resources configured. Domain 1 not configured: {'hosts': {'ad_subdomain': 1, 'ad': 1, 'ad_treedomain': 1}, 'type': 'AD'}

Changed hard coded number of AD machines to use