### PR TITLE
replica-install: pass --ip-address to client install

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -947,6 +947,10 @@ def ensure_enrolled(installer):
         args.append("--force-join")
     if installer.no_ntp:
         args.append("--no-ntp")
+    if installer.ip_addresses:
+        for ip in installer.ip_addresses:
+            # installer.ip_addresses is of type [CheckedIPAddress]
+            args.extend(("--ip-address", str(ip)))
 
     try:
         # Call client install script


### PR DESCRIPTION
In replica DL1 installation, the --ip-address option was not passed
down to the ipa-client-install script (when not promoting client).
This resulted in creating DNS records for all of the host's interface
IP adresses instead of just those specified.

This patch passes all the --ip-address options down to the client
installation script.

https://pagure.io/freeipa/issue/7405