### PR TITLE
Travis - use F28 for testing

### DIFF
--- a/install/migration/migration.py
+++ b/install/migration/migration.py
@@ -19,6 +19,7 @@
 """
 Password migration script
 """
+from __future__ import absolute_import
 
 import cgi
 import errno

--- a/install/share/wsgi.py
+++ b/install/share/wsgi.py
@@ -23,6 +23,8 @@
 """
 WSGI appliction for IPA server.
 """
+from __future__ import absolute_import
+
 import logging
 import os
 import sys

--- a/install/wsgi/plugins.py
+++ b/install/wsgi/plugins.py
@@ -20,6 +20,7 @@
 """
 Plugin index generation script
 """
+from __future__ import absolute_import
 
 import logging
 import os

--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import logging
 import os
 import tempfile

--- a/ipaclient/install/ipa_client_install.py
+++ b/ipaclient/install/ipa_client_install.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 from ipaclient.install import client
 from ipaplatform.paths import paths
 from ipapython.install import cli

--- a/ipaclient/install/ipadiscovery.py
+++ b/ipaclient/install/ipadiscovery.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import logging
 import operator
 import socket

--- a/ipaclient/install/timeconf.py
+++ b/ipaclient/install/timeconf.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import absolute_import
+
 import logging
 import os
 import shutil

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -22,7 +22,7 @@
 # This is used so we can add tracking to the Apache and 389-ds
 # server certificates created during the IPA server installation.
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 import os

--- a/ipalib/install/kinit.py
+++ b/ipalib/install/kinit.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import logging
 import os
 import time

--- a/ipalib/install/sysrestore.py
+++ b/ipalib/install/sysrestore.py
@@ -23,6 +23,8 @@
 # parts of the system configuration to the way it was
 # before ipa-server-install was first run
 
+from __future__ import absolute_import
+
 import logging
 import os
 import os.path

--- a/ipaplatform/_importhook.py
+++ b/ipaplatform/_importhook.py
@@ -1,6 +1,8 @@
 #
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #
+from __future__ import absolute_import
+
 """Meta import hook for ipaplatform.
 
 Known Linux distros with /etc/os-release

--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -23,6 +23,8 @@ This base module contains default implementations of IPA interface for
 interacting with system services.
 '''
 
+from __future__ import absolute_import
+
 import os
 import json
 import time

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -22,6 +22,8 @@
 This module contains default platform-specific implementations of system tasks.
 '''
 
+from __future__ import absolute_import
+
 import logging
 
 from pkg_resources import parse_version

--- a/ipaplatform/constants.py
+++ b/ipaplatform/constants.py
@@ -3,6 +3,8 @@
 #
 """IpaMetaImporter replaces this module with ipaplatform.$NAME.constants.
 """
+from __future__ import absolute_import
+
 import ipaplatform._importhook
 
 ipaplatform._importhook.fixup_module('ipaplatform.constants')

--- a/ipaplatform/debian/constants.py
+++ b/ipaplatform/debian/constants.py
@@ -7,6 +7,8 @@ This Debian family platform module exports platform dependant constants.
 '''
 
 # Fallback to default path definitions
+from __future__ import absolute_import
+
 from ipaplatform.base.constants import BaseConstantsNamespace
 
 

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -8,6 +8,8 @@ in Debian-based systems.
 """
 
 # Fallback to default path definitions
+from __future__ import absolute_import
+
 from ipaplatform.base.paths import BasePathNamespace
 import sysconfig
 

--- a/ipaplatform/debian/services.py
+++ b/ipaplatform/debian/services.py
@@ -6,6 +6,8 @@
 Contains Debian-specific service class implementations.
 """
 
+from __future__ import absolute_import
+
 from ipaplatform.base import services as base_services
 from ipaplatform.redhat import services as redhat_services
 from ipapython import ipautil

--- a/ipaplatform/debian/tasks.py
+++ b/ipaplatform/debian/tasks.py
@@ -6,6 +6,8 @@
 This module contains default Debian-specific implementations of system tasks.
 """
 
+from __future__ import absolute_import
+
 from ipaplatform.base.tasks import BaseTaskNamespace
 from ipaplatform.redhat.tasks import RedHatTaskNamespace
 

--- a/ipaplatform/fedora/constants.py
+++ b/ipaplatform/fedora/constants.py
@@ -7,6 +7,8 @@ This Fedora base platform module exports platform related constants.
 '''
 
 # Fallback to default constant definitions
+from __future__ import absolute_import
+
 from ipaplatform.redhat.constants import RedHatConstantsNamespace
 
 

--- a/ipaplatform/fedora/paths.py
+++ b/ipaplatform/fedora/paths.py
@@ -23,6 +23,8 @@ in Fedora-based systems.
 '''
 
 # Fallback to default path definitions
+from __future__ import absolute_import
+
 from ipaplatform.redhat.paths import RedHatPathNamespace
 
 

--- a/ipaplatform/fedora/services.py
+++ b/ipaplatform/fedora/services.py
@@ -22,6 +22,8 @@
 Contains Fedora-specific service class implementations.
 """
 
+from __future__ import absolute_import
+
 from ipaplatform.redhat import services as redhat_services
 
 # Mappings from service names as FreeIPA code references to these services

--- a/ipaplatform/fedora/tasks.py
+++ b/ipaplatform/fedora/tasks.py
@@ -23,6 +23,8 @@
 This module contains default Fedora-specific implementations of system tasks.
 '''
 
+from __future__ import absolute_import
+
 from ipaplatform.redhat.tasks import RedHatTaskNamespace
 
 

--- a/ipaplatform/paths.py
+++ b/ipaplatform/paths.py
@@ -3,6 +3,8 @@
 #
 """IpaMetaImporter replaces this module with ipaplatform.$NAME.paths.
 """
+from __future__ import absolute_import
+
 import ipaplatform._importhook
 
 ipaplatform._importhook.fixup_module('ipaplatform.paths')

--- a/ipaplatform/redhat/authconfig.py
+++ b/ipaplatform/redhat/authconfig.py
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
+
 from ipaplatform.paths import paths
 from ipapython import ipautil
 from ipapython.admintool import ScriptError

--- a/ipaplatform/redhat/constants.py
+++ b/ipaplatform/redhat/constants.py
@@ -8,6 +8,8 @@ related constants for the Red Hat OS family-based systems.
 '''
 
 # Fallback to default path definitions
+from __future__ import absolute_import
+
 from ipaplatform.base.constants import BaseConstantsNamespace
 
 

--- a/ipaplatform/redhat/paths.py
+++ b/ipaplatform/redhat/paths.py
@@ -22,6 +22,8 @@ This Red Hat OS family base platform module exports default filesystem paths as
 common in Red Hat OS family-based systems.
 '''
 
+from __future__ import absolute_import
+
 import sys
 
 # Fallback to default path definitions

--- a/ipaplatform/redhat/services.py
+++ b/ipaplatform/redhat/services.py
@@ -22,6 +22,8 @@
 Contains Red Hat OS family-specific service class implementations.
 """
 
+from __future__ import absolute_import
+
 import logging
 import os
 import time

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -23,7 +23,7 @@
 This module contains default Red Hat OS family-specific implementations of
 system tasks.
 '''
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import ctypes
 import logging

--- a/ipaplatform/rhel/constants.py
+++ b/ipaplatform/rhel/constants.py
@@ -7,6 +7,8 @@ This RHEL base platform module exports platform related constants.
 '''
 
 # Fallback to default constant definitions
+from __future__ import absolute_import
+
 from ipaplatform.redhat.constants import RedHatConstantsNamespace
 
 

--- a/ipaplatform/rhel/paths.py
+++ b/ipaplatform/rhel/paths.py
@@ -23,6 +23,8 @@ in RHEL-based systems.
 '''
 
 # Fallback to default path definitions
+from __future__ import absolute_import
+
 from ipaplatform.redhat.paths import RedHatPathNamespace
 
 

--- a/ipaplatform/rhel/services.py
+++ b/ipaplatform/rhel/services.py
@@ -22,6 +22,8 @@
 Contains RHEL-specific service class implementations.
 """
 
+from __future__ import absolute_import
+
 from ipaplatform.redhat import services as redhat_services
 
 # Mappings from service names as FreeIPA code references to these services

--- a/ipaplatform/rhel/tasks.py
+++ b/ipaplatform/rhel/tasks.py
@@ -21,6 +21,8 @@
 This module contains default RHEL-specific implementations of system tasks.
 '''
 
+from __future__ import absolute_import
+
 from ipaplatform.redhat.tasks import RedHatTaskNamespace
 
 

--- a/ipaplatform/services.py
+++ b/ipaplatform/services.py
@@ -3,6 +3,8 @@
 #
 """IpaMetaImporter replaces this module with ipaplatform.$NAME.services.
 """
+from __future__ import absolute_import
+
 import ipaplatform._importhook
 
 ipaplatform._importhook.fixup_module('ipaplatform.services')

--- a/ipaplatform/tasks.py
+++ b/ipaplatform/tasks.py
@@ -3,6 +3,8 @@
 #
 """IpaMetaImporter replaces this module with ipaplatform.$NAME.tasks.
 """
+from __future__ import absolute_import
+
 import ipaplatform._importhook
 
 ipaplatform._importhook.fixup_module('ipaplatform.tasks')

--- a/ipapython/kernel_keyring.py
+++ b/ipapython/kernel_keyring.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import os
 import six
 

--- a/ipaserver/advise/base.py
+++ b/ipaserver/advise/base.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 from contextlib import contextmanager
 import logging

--- a/ipaserver/advise/plugins/legacy_clients.py
+++ b/ipaserver/advise/plugins/legacy_clients.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import absolute_import
+
 import os
 
 from ipalib import api

--- a/ipaserver/advise/plugins/smart_card_auth.py
+++ b/ipaserver/advise/plugins/smart_card_auth.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2017 FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 from ipalib.plugable import Registry
 from ipaplatform import services
 from ipaplatform.paths import paths

--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -22,6 +22,8 @@
 # Make sure we only run this module at the server where samba4-python
 # package is installed to avoid issues with unavailable modules
 
+from __future__ import absolute_import
+
 import logging
 import re
 import time

--- a/ipaserver/dnssec/bindmgr.py
+++ b/ipaserver/dnssec/bindmgr.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 from datetime import datetime
 import logging
 

--- a/ipaserver/dnssec/keysyncer.py
+++ b/ipaserver/dnssec/keysyncer.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import logging
 
 import ldap.dn

--- a/ipaserver/dnssec/ldapkeydb.py
+++ b/ipaserver/dnssec/ldapkeydb.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 from binascii import hexlify
 import collections

--- a/ipaserver/dnssec/localhsm.py
+++ b/ipaserver/dnssec/localhsm.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import collections
 import os

--- a/ipaserver/install/adtrust.py
+++ b/ipaserver/install/adtrust.py
@@ -6,7 +6,7 @@
 AD trust installer module
 """
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 import os

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 import os

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -6,7 +6,7 @@
 CA installer module
 """
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import enum
 import logging

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -19,7 +19,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import base64
 import binascii

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import logging
 import os
 import stat

--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015 FreeIPa Project Contributors, see 'COPYING' for license.
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 

--- a/ipaserver/install/dnskeysyncinstance.py
+++ b/ipaserver/install/dnskeysyncinstance.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 import errno

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import base64
 import logging
 

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 import shutil

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import logging
 import os
 import shutil

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 import os

--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 import os

--- a/ipaserver/install/ipa_ldap_updater.py
+++ b/ipaserver/install/ipa_ldap_updater.py
@@ -23,7 +23,7 @@
 # TODO
 # save undo files?
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 import os

--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import abc
 import base64
 import datetime

--- a/ipaserver/install/ipa_pkinit_manage.py
+++ b/ipaserver/install/ipa_pkinit_manage.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 

--- a/ipaserver/install/ipa_replica_install.py
+++ b/ipaserver/install/ipa_replica_install.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 from ipapython.install import cli
 from ipapython.install.core import knob, extend_knob
 from ipaplatform.paths import paths

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import logging
 import os
 import shutil

--- a/ipaserver/install/ipa_server_certinstall.py
+++ b/ipaserver/install/ipa_server_certinstall.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import os
 import os.path

--- a/ipaserver/install/ipa_server_install.py
+++ b/ipaserver/install/ipa_server_install.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 from ipapython.install import cli
 from ipapython.install.core import extend_knob
 from ipaplatform.paths import paths

--- a/ipaserver/install/ipa_server_upgrade.py
+++ b/ipaserver/install/ipa_server_upgrade.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import logging
 
 from ipalib import api

--- a/ipaserver/install/ipa_winsync_migrate.py
+++ b/ipaserver/install/ipa_winsync_migrate.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import logging
 
 import gssapi

--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -6,6 +6,8 @@
 KRA installer module
 """
 
+from __future__ import absolute_import
+
 import os
 import shutil
 

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import logging
 import os
 import pwd

--- a/ipaserver/install/odsexporterinstance.py
+++ b/ipaserver/install/odsexporterinstance.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import logging
 import os
 import pwd

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import logging
 import os
 import pwd

--- a/ipaserver/install/plugins/ca_renewal_master.py
+++ b/ipaserver/install/plugins/ca_renewal_master.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
+
 import logging
 
 from ipaserver.install import installutils, cainstance

--- a/ipaserver/install/plugins/update_ca_topology.py
+++ b/ipaserver/install/plugins/update_ca_topology.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import logging
 
 from ipalib import errors

--- a/ipaserver/install/plugins/update_nis.py
+++ b/ipaserver/install/plugins/update_nis.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import logging
 
 from ipalib.plugable import Registry

--- a/ipaserver/install/plugins/update_ra_cert_store.py
+++ b/ipaserver/install/plugins/update_ra_cert_store.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import logging
 import os
 import tempfile

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -17,8 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
-from __future__ import absolute_import
+from __future__ import print_function, absolute_import
 
 import logging
 

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import errno
 import logging

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import contextlib
 import logging

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 import re

--- a/ipaserver/install/sysupgrade.py
+++ b/ipaserver/install/sysupgrade.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import logging
 import os
 import os.path

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+
 import logging
 
 import ldif

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -239,6 +239,8 @@ digits and nothing else follows.
 
 '''
 
+from __future__ import absolute_import
+
 import datetime
 import json
 import logging

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -27,6 +27,8 @@ Backend plugin for LDAP.
 # binding encodes them into the appropriate representation. This applies to
 # everything except the CrudBackend methods, where dn is part of the entry dict.
 
+from __future__ import absolute_import
+
 import logging
 import os
 

--- a/ipaserver/plugins/migration.py
+++ b/ipaserver/plugins/migration.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
+
 import logging
 import re
 from ldap import MOD_ADD

--- a/ipaserver/plugins/rabase.py
+++ b/ipaserver/plugins/rabase.py
@@ -30,6 +30,8 @@ certificates via the following methods:
     * `ra.take_certificate_off_hold()` - take a certificate off hold.
 """
 
+from __future__ import absolute_import
+
 from ipalib import Backend
 from ipalib import errors
 import os

--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import logging
 
 import dbus

--- a/ipaserver/plugins/stageuser.py
+++ b/ipaserver/plugins/stageuser.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
+
 import logging
 import posixpath
 from copy import deepcopy

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
+
 import logging
 import time
 from time import gmtime, strftime

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -23,6 +23,8 @@ RPC server.
 Also see the `ipalib.rpc` module.
 """
 
+from __future__ import absolute_import
+
 import logging
 from xml.sax.saxutils import escape
 import os

--- a/ipaserver/secrets/client.py
+++ b/ipaserver/secrets/client.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015  IPA Project Contributors, see COPYING for license
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 # pylint: disable=relative-import
 from custodia.message.kem import KEMClient, KEY_USAGE_SIG, KEY_USAGE_ENC
 # pylint: enable=relative-import

--- a/ipaserver/secrets/kem.py
+++ b/ipaserver/secrets/kem.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015  IPA Project Contributors, see COPYING for license
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import errno
 import os

--- a/ipaserver/secrets/store.py
+++ b/ipaserver/secrets/store.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015  IPA Project Contributors, see COPYING for license
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 from base64 import b64encode, b64decode
 from custodia.store.interface import CSStore  # pylint: disable=relative-import
 from jwcrypto.common import json_decode, json_encode

--- a/ipatests/pytest_plugins/integration/__init__.py
+++ b/ipatests/pytest_plugins/integration/__init__.py
@@ -19,7 +19,7 @@
 
 """Pytest plugin for IPA Integration tests"""
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 import os

--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -19,6 +19,8 @@
 
 """Common tasks for FreeIPA integration tests"""
 
+from __future__ import absolute_import
+
 import logging
 import os
 import textwrap

--- a/ipatests/test_cmdline/cmdline.py
+++ b/ipatests/test_cmdline/cmdline.py
@@ -21,6 +21,8 @@
 Base class for all cmdline tests
 """
 
+from __future__ import absolute_import
+
 import distutils.spawn
 import os
 import unittest

--- a/ipatests/test_cmdline/test_ipagetkeytab.py
+++ b/ipatests/test_cmdline/test_ipagetkeytab.py
@@ -20,6 +20,8 @@
 Test `ipa-getkeytab`
 """
 
+from __future__ import absolute_import
+
 import os
 import shutil
 import tempfile

--- a/ipatests/test_install/test_updates.py
+++ b/ipatests/test_install/test_updates.py
@@ -20,6 +20,8 @@
 Test the `ipaserver/install/ldapupdate.py` module.
 """
 
+from __future__ import absolute_import
+
 import os
 import unittest
 

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 import os

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
+
 import functools
 import logging
 import os

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import logging
 
 import dns.dnssec

--- a/ipatests/test_integration/test_external_ca.py
+++ b/ipatests/test_integration/test_external_ca.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
+
 import re
 import time
 

--- a/ipatests/test_integration/test_forced_client_reenrollment.py
+++ b/ipatests/test_integration/test_forced_client_reenrollment.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
+
 import logging
 import os
 import subprocess

--- a/ipatests/test_integration/test_http_kdc_proxy.py
+++ b/ipatests/test_integration/test_http_kdc_proxy.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import six
 from ipatests.pytest_plugins.integration import tasks
 from ipatests.test_integration.base import IntegrationTest

--- a/ipatests/test_integration/test_idviews.py
+++ b/ipatests/test_integration/test_idviews.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import os
 import re
 import string

--- a/ipatests/test_integration/test_legacy_clients.py
+++ b/ipatests/test_integration/test_legacy_clients.py
@@ -20,6 +20,8 @@
 # FIXME: Pylint errors
 # pylint: disable=no-member
 
+from __future__ import absolute_import
+
 import os
 import re
 import unittest

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import time
 import re
 from tempfile import NamedTemporaryFile

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
+
 import re
 import unittest
 

--- a/ipatests/test_integration/test_uninstallation.py
+++ b/ipatests/test_integration/test_uninstallation.py
@@ -10,6 +10,8 @@ state. Every failed uninstall should successfully remove remaining
 pieces if possible.
 """
 
+from __future__ import absolute_import
+
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_plugins.integration import tasks
 from ipaplatform.paths import paths

--- a/ipatests/test_ipaplatform/test_importhook.py
+++ b/ipatests/test_ipaplatform/test_importhook.py
@@ -1,6 +1,8 @@
 #
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #
+from __future__ import absolute_import
+
 import os
 import sys
 

--- a/ipatests/test_ipaplatform/test_tasks.py
+++ b/ipatests/test_ipaplatform/test_tasks.py
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #
+from __future__ import absolute_import
 
 from ipaplatform.tasks import tasks
 

--- a/ipatests/test_ipapython/test_certdb.py
+++ b/ipatests/test_ipapython/test_certdb.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 
 import pytest

--- a/ipatests/test_ipapython/test_ipautil.py
+++ b/ipatests/test_ipapython/test_ipautil.py
@@ -21,6 +21,8 @@
 """
 Test the `ipapython/ipautil.py` module.
 """
+from __future__ import absolute_import
+
 import socket
 import sys
 import tempfile

--- a/ipatests/test_ipaserver/test_install/test_bindinstance.py
+++ b/ipatests/test_ipaserver/test_install/test_bindinstance.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2018  FreeIPA Contributors.  See COPYING for license
 #
 
+from __future__ import absolute_import
+
 import tempfile
 
 import pytest

--- a/ipatests/test_ipaserver/test_ipap11helper.py
+++ b/ipatests/test_ipaserver/test_ipap11helper.py
@@ -7,6 +7,8 @@ Test the `ipapython/ipap11helper/p11helper.c` module.
 """
 
 
+from __future__ import absolute_import
+
 from binascii import hexlify
 import os
 import os.path

--- a/ipatests/test_ipaserver/test_ldap.py
+++ b/ipatests/test_ipaserver/test_ldap.py
@@ -25,6 +25,8 @@
 
 # The DM password needs to be set in ~/.ipa/.dmpw
 
+from __future__ import absolute_import
+
 import os
 import sys
 import unittest

--- a/ipatests/test_ipaserver/test_serverroles.py
+++ b/ipatests/test_ipaserver/test_serverroles.py
@@ -6,6 +6,8 @@
 Tests for the serverroles backend
 """
 
+from __future__ import absolute_import
+
 from collections import namedtuple
 
 import ldap

--- a/ipatests/test_ipaserver/test_version_comparison.py
+++ b/ipatests/test_ipaserver/test_version_comparison.py
@@ -6,6 +6,8 @@
 tests for correct RPM version comparison
 """
 
+from __future__ import absolute_import
+
 from ipaplatform.tasks import tasks
 import pytest
 

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -22,7 +22,7 @@ Base class for UI integration tests.
 
 Contains browser driver and common tasks.
 """
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 from datetime import datetime
 import time

--- a/ipatests/test_xmlrpc/test_caacl_profile_enforcement.py
+++ b/ipatests/test_xmlrpc/test_caacl_profile_enforcement.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 import os
 import pytest
 import tempfile

--- a/ipatests/test_xmlrpc/test_cert_plugin.py
+++ b/ipatests/test_xmlrpc/test_cert_plugin.py
@@ -19,7 +19,7 @@
 """
 Test the `ipaserver/plugins/cert.py` module against a RA.
 """
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import base64
 import os

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -22,7 +22,7 @@
 """
 Test the `ipalib.plugins.host` module.
 """
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import os
 import tempfile

--- a/ipatests/test_xmlrpc/test_kerberos_principal_aliases.py
+++ b/ipatests/test_xmlrpc/test_kerberos_principal_aliases.py
@@ -2,6 +2,8 @@
 #
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
+from __future__ import absolute_import
+
 import copy
 import ldap
 import pytest

--- a/ipatests/test_xmlrpc/testcert.py
+++ b/ipatests/test_xmlrpc/testcert.py
@@ -25,6 +25,8 @@ The certificate in cached in a global variable so it only has to be created
 once per test run.
 """
 
+from __future__ import absolute_import
+
 import os
 import tempfile
 import shutil

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -21,6 +21,8 @@
 Common utility functions and classes for unit tests.
 """
 
+from __future__ import absolute_import
+
 import inspect
 import os
 from os import path


### PR DESCRIPTION
python2 pylint fails on Fedora 28 with errors about relative imports from `ipapplatform` that seem to be false-positives. Use only python3 pylint for Travis.

The Fedora 28 test-runner container in this commit is only to show that the tests pass, I'll update the Fedora 28 container in DockerHub FreeIPA repo once we agree on this PR.