### PR TITLE
Require more recent glibc on F27

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -879,6 +879,11 @@ Requires: python2-sssdconfig
 Requires: python2-cryptography >= 1.6
 Requires: iptables
 Requires: python2-mock
+%if 0%{?fedora} == 27
+# workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1564527
+# Tests are failing because ntpd restarts segfaults on some CPU archs.
+Requires: glibc >= 2.26-24
+%endif
 
 Provides: %{alt_name}-tests = %{version}
 Conflicts: %{alt_name}-tests
@@ -912,6 +917,11 @@ Requires: ldns-utils
 Requires: python3-sssdconfig
 Requires: python3-cryptography >= 1.6
 Requires: iptables
+%if 0%{?fedora} == 27
+# workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1564527
+# Tests are failing because ntpd restarts segfaults on some CPU archs.
+Requires: glibc >= 2.26-24
+%endif
 
 %description -n python3-ipatests
 IPA is an integrated solution to provide centrally managed Identity (users,


### PR DESCRIPTION
On CPUs with AVX-512 instruction set, ntpd sometimes segfaults because
PTHREAD_STACK_MIN is too small. The bug has been fixed in
glibc-2.26-24.fc27.x86_64 or later.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1564527
Signed-off-by: Christian Heimes <cheimes@redhat.com>