### PR TITLE
[Backport][ipa-4-6] [Test fix] Fix in IPA's multihost fixture

### DIFF
--- a/ipatests/pytest_plugins/integration/__init__.py
+++ b/ipatests/pytest_plugins/integration/__init__.py
@@ -217,7 +217,11 @@ def mh(request, class_integration_logs):
     for _i in range(cls.num_ad_domains):
         domain_descriptions.append({
             'type': 'AD',
-            'hosts': {'ad': 1, 'ad_subdomain': 1, 'ad_treedomain': 1},
+            'hosts': {
+                'ad': 1,
+                'ad_subdomain': cls.num_ad_domains,
+                'ad_treedomain': cls.num_ad_domains,
+            }
         })
 
     mh = make_multihost_fixture(


### PR DESCRIPTION
This PR was opened automatically because PR #1783 was pushed to master and backport to ipa-4-6 is required.