### PR TITLE
ipa tests: Set default TTL for the IPA zone to 1 second

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -39,6 +39,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-27/dnssec_tests:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_dnssec.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-27/caless:
     requires: [fedora-27/build]
     priority: 50

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -22,6 +22,9 @@ example_test_zone = "example.test."
 example2_test_zone = "example2.test."
 example3_test_zone = "example3.test."
 
+# Sleep 5 seconds at most when waiting for LDAP updates
+# for DNSSEC changes. Test zones should be updated with 1 second TTL
+DNSSEC_SLEEP = 5
 
 def resolve_with_dnssec(nameserver, query, rtype="SOA"):
     res = dns.resolver.Resolver()
@@ -159,7 +162,7 @@ class TestInstallDNSSECLast(IntegrationTest):
         ]
         self.master.run_command(args)
 
-        time.sleep(20)  # sleep a bit until LDAP changes are applied to DNS
+        time.sleep(DNSSEC_SLEEP)
 
         # test master
         assert not is_record_signed(
@@ -206,7 +209,7 @@ class TestInstallDNSSECLast(IntegrationTest):
         ]
         self.master.run_command(args)
 
-        time.sleep(20)  # sleep a bit until LDAP changes are applied to DNS
+        time.sleep(DNSSEC_SLEEP)
 
         # test master
         assert not is_record_signed(
@@ -292,7 +295,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
             "--a-rec=" + self.replicas[0].ip
         ]
         self.master.run_command(args)
-        time.sleep(10)  # sleep a bit until data are provided by bind-dyndb-ldap
+        time.sleep(DNSSEC_SLEEP)
 
         args = [
             "ipa", "dnsrecord-add", root_zone, self.master.domain.name,

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -107,6 +107,8 @@ class TestInstallDNSSECLast(IntegrationTest):
             "dnszone-add", test_zone,
             "--skip-overlap-check",
             "--dnssec", "true",
+            "--ttl", "1",
+            "--default-ttl", "1",
         ]
         self.master.run_command(args)
 
@@ -127,6 +129,8 @@ class TestInstallDNSSECLast(IntegrationTest):
             "dnszone-add", test_zone_repl,
             "--skip-overlap-check",
             "--dnssec", "true",
+            "--ttl", "1",
+            "--default-ttl", "1",
         ]
         self.replicas[0].run_command(args)
 
@@ -315,6 +319,8 @@ class TestInstallDNSSECFirst(IntegrationTest):
         args = [
             "ipa", "dnszone-add", example_test_zone, "--dnssec", "true",
             "--skip-overlap-check",
+            "--ttl", "1",
+            "--default-ttl", "1",
         ]
 
         self.master.run_command(args)
@@ -458,6 +464,8 @@ class TestMigrateDNSSECMaster(IntegrationTest):
         args = [
             "ipa", "dnszone-add", example_test_zone, "--dnssec", "true",
             "--skip-overlap-check",
+            "--ttl", "1",
+            "--default-ttl", "1",
         ]
 
         self.master.run_command(args)
@@ -516,6 +524,8 @@ class TestMigrateDNSSECMaster(IntegrationTest):
         args = [
             "ipa", "dnszone-add", example2_test_zone, "--dnssec", "true",
             "--skip-overlap-check",
+            "--ttl", "1",
+            "--default-ttl", "1",
         ]
         self.replicas[0].run_command(args)
         # wait until zone is signed
@@ -548,6 +558,8 @@ class TestMigrateDNSSECMaster(IntegrationTest):
         args = [
             "ipa", "dnszone-add", example3_test_zone, "--dnssec", "true",
             "--skip-overlap-check",
+            "--ttl", "1",
+            "--default-ttl", "1",
         ]
         self.replicas[1].run_command(args)
         # wait until zone is signed


### PR DESCRIPTION
When running IPA tests, a default TTL for the zone should be set
very low to allow get rid of timeouts in the tests. Zone updates should
be propagated to the clients as soon as possible.

This is not something that should be used in production so the change is
done purely at install time within the tests. As zone information is
replicated, we only modify it when creating a master with integrated
DNS.

This change should fix a number of DNSSEC-related tests where default
TTL is longer than what a test expects and a change of DNSSEC keys
never gets noticed by the BIND. As result, DNSSEC tests never match
their expected output with what they received from the BIND.
