### PR TITLE
[Backport][ipa-4-6] Provide ldap_uri in Custodia uninstaller

### DIFF
--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -16,7 +16,6 @@ from ipaserver.install import ldapupdate
 from ipaserver.install import sysupgrade
 from base64 import b64decode
 from jwcrypto.common import json_decode
-import ldap
 import shutil
 import os
 import stat
@@ -28,11 +27,11 @@ logger = logging.getLogger(__name__)
 
 
 class CustodiaInstance(SimpleServiceInstance):
-    def __init__(self, host_name=None, realm=None):
+    def __init__(self, host_name=None, realm=None, ldap_uri=None):
         super(CustodiaInstance, self).__init__("ipa-custodia")
         self.config_file = paths.IPA_CUSTODIA_CONF
         self.server_keys = paths.IPA_CUSTODIA_KEYS
-        self.ldap_uri = None
+        self.ldap_uri = ldap_uri
         self.fqdn = host_name
         self.realm = realm
 
@@ -71,16 +70,7 @@ class CustodiaInstance(SimpleServiceInstance):
             'server_keys': self.server_keys,
             'ldap_uri': self.ldap_uri
         })
-        # Call remove_server_keys_file explicitly to ensure that the key
-        # file is always removed.
         keystore.remove_server_keys_file()
-        try:
-            keystore.remove_server_keys()
-        except (ldap.CONNECT_ERROR, ldap.SERVER_DOWN):
-            logger.debug(
-                "Cannot remove custodia keys now, server_del takes care of "
-                "them later."
-            )
         installutils.remove_file(self.config_file)
         sysupgrade.set_upgrade_state('custodia', 'installed', False)
 

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1073,7 +1073,9 @@ def uninstall(installer):
     dsinstance.DsInstance(fstore=fstore).uninstall()
     if _server_trust_ad_installed:
         adtrustinstance.ADTRUSTInstance(fstore).uninstall()
-    custodiainstance.CustodiaInstance().uninstall()
+    # ldap_uri isn't used, but IPAKEMKeys parses /etc/ipa/default.conf
+    # otherwise, see https://pagure.io/freeipa/issue/7474 .
+    custodiainstance.CustodiaInstance(ldap_uri='ldapi://invalid').uninstall()
     otpdinstance.OtpdInstance().uninstall()
     tasks.restore_hostname(fstore, sstore)
     fstore.restore_all_files()


### PR DESCRIPTION
This PR was opened automatically because PR #1776 was pushed to master and backport to ipa-4-6 is required.