### PR TITLE
Reverting commit 6b145bf3e696e6d40b74055ccdf8d14da7828a09

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -182,16 +182,3 @@ jobs:
         template: *ci-master-f27
         timeout: 3600
         topology: *master_1repl
-
-  fedora-27/test_installation_TestInstallMasterReservedIPasForwarder:
-    requires: [fedora-27/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-27/build_url}'
-        test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
-        template: *ci-master-f27
-        timeout: 10800
-        topology: *master_1repl
-


### PR DESCRIPTION
Commit 6b145bf should not be pushed, because it was not the intention to add a new test to .freeipa-pr-ci.
This commits reverts its change.