### PR TITLE
Handle whitespace, add separator to regex in set_directive_lines

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -565,11 +565,15 @@ def set_directive_lines(quotes, separator, k, v, lines, comment):
         v_quoted = quote_directive_value(v, '"') if quotes else v
         new_line = ''.join([k, separator, v_quoted, '\n'])
 
+    # Special case: consider space as "white space" so tabs are allowed
+    if separator == ' ':
+        separator = '[ \t]+'
+
     found = False
     addnext = False  # add on next line, found a comment
-    matcher = re.compile(r'\s*{}'.format(re.escape(k + separator)))
-    cmatcher = re.compile(r'\s*{}\s*{}'.format(comment,
-                                               re.escape(k + separator)))
+    matcher = re.compile(r'\s*{}\s*{}'.format(re.escape(k), separator))
+    cmatcher = re.compile(r'\s*{}\s*{}\s*{}'.format(comment,
+                                                    re.escape(k), separator))
     for line in lines:
         if matcher.match(line):
             found = True

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -605,13 +605,20 @@ def get_directive(filename, directive, separator=' '):
 
     :returns: The (unquoted) value if the directive was found, None otherwise
     """
+    # Special case: consider space as "white space" so tabs are allowed
+    if separator == ' ':
+        separator = '[ \t]+'
+
     fd = open(filename, "r")
     for line in fd:
         if line.lstrip().startswith(directive):
             line = line.strip()
 
-            (directive, sep, value) = line.partition(separator)
-            if not sep or not value:
+            match = re.match(r'{}\s*{}\s*(.*)'.format(directive, separator),
+                             line)
+            if match:
+                value = match.group(1)
+            else:
                 raise ValueError("Malformed directive: {}".format(line))
 
             result = unquote_directive_value(value.strip(), '"')

--- a/ipatests/test_ipaserver/test_install/test_installutils.py
+++ b/ipatests/test_ipaserver/test_install/test_installutils.py
@@ -98,6 +98,30 @@ class test_set_directive(object):
             os.remove(filename)
 
 
+class test_get_directive(object):
+    def test_get_directive(self, tmpdir):
+        configfile = tmpdir.join('config')
+        configfile.write(''.join(EXAMPLE_CONFIG))
+
+        assert '1' == installutils.get_directive(str(configfile),
+                                                 'foo',
+                                                 separator='=')
+        assert '2' == installutils.get_directive(str(configfile),
+                                                 'foobar',
+                                                 separator='=')
+
+
+class test_get_directive_whitespace(object):
+    def test_get_directive(self, tmpdir):
+        configfile = tmpdir.join('config')
+        configfile.write(''.join(WHITESPACE_CONFIG))
+
+        assert '1' == installutils.get_directive(str(configfile),
+                                                 'foo')
+        assert '2' == installutils.get_directive(str(configfile),
+                                                 'foobar')
+
+
 def test_directivesetter(tempdir):
     filename = os.path.join(tempdir, 'example.conf')
     with open(filename, 'w') as f:

--- a/ipatests/test_ipaserver/test_install/test_installutils.py
+++ b/ipatests/test_ipaserver/test_install/test_installutils.py
@@ -15,6 +15,11 @@ EXAMPLE_CONFIG = [
     'foobar=2\n',
 ]
 
+WHITESPACE_CONFIG = [
+    'foo 1\n',
+    'foobar\t2\n',
+]
+
 
 @pytest.fixture
 def tempdir(request):
@@ -42,6 +47,28 @@ class test_set_directive_lines(object):
         lines = installutils.set_directive_lines(
             False, '=', 'foo', '3', EXAMPLE_CONFIG, comment="#")
         assert list(lines) == ['foo=3\n', 'foobar=2\n']
+
+
+class test_set_directive_lines_whitespace(object):
+    def test_remove_directive(self):
+        lines = installutils.set_directive_lines(
+            False, ' ', 'foo', None, WHITESPACE_CONFIG, comment="#")
+        assert list(lines) == ['foobar\t2\n']
+
+    def test_add_directive(self):
+        lines = installutils.set_directive_lines(
+            False, ' ', 'baz', '4', WHITESPACE_CONFIG, comment="#")
+        assert list(lines) == ['foo 1\n', 'foobar\t2\n', 'baz 4\n']
+
+    def test_set_directive_does_not_clobber_suffix_key(self):
+        lines = installutils.set_directive_lines(
+            False, ' ', 'foo', '3', WHITESPACE_CONFIG, comment="#")
+        assert list(lines) == ['foo 3\n', 'foobar\t2\n']
+
+    def test_set_directive_with_tab(self):
+        lines = installutils.set_directive_lines(
+            False, ' ', 'foobar', '6', WHITESPACE_CONFIG, comment="#")
+        assert list(lines) == ['foo 1\n', 'foobar 6\n']
 
 
 class test_set_directive(object):


### PR DESCRIPTION
We added the separator to the regex in set_directive_lines to avoid
grabbing just a prefix. This doesn't allow for whitespace around
the separator.

For the Apache case we expected that the separator would be just
spaces but it can also use tabs (like Ubuntu 18). Add a special
case so that passing in a space separator is treated as whitespace
(tab or space).

https://pagure.io/freeipa/issue/7490

Signed-off-by: Rob Crittenden <rcritten@redhat.com>