### PR TITLE
[Backport][ipa-4-6] Add nsds5ReplicaReleaseTimeout to replica config

### DIFF
--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -474,20 +474,30 @@ class ReplicationManager(object):
 
         try:
             entry = conn.get_entry(dn)
+        except errors.NotFound:
+            pass
+        else:
             managers = {DN(m) for m in entry.get('nsDS5ReplicaBindDN', [])}
 
+            mods = []
             if replica_binddn not in managers:
                 # Add the new replication manager
-                mod = [(ldap.MOD_ADD, 'nsDS5ReplicaBindDN',
-                        replica_binddn)]
-                conn.modify_s(dn, mod)
+                mods.append(
+                    (ldap.MOD_ADD, 'nsDS5ReplicaBindDN', replica_binddn)
+                )
+            if 'nsds5replicareleasetimeout' not in entry:
+                # See https://pagure.io/freeipa/issue/7488
+                mods.append(
+                    (ldap.MOD_ADD, 'nsds5replicareleasetimeout', ['60'])
+                )
+
+            if mods:
+                conn.modify_s(dn, mods)
 
             self.set_replica_binddngroup(conn, entry)
 
             # replication is already configured
             return
-        except errors.NotFound:
-            pass
 
         replica_type = self.get_replica_type()
 
@@ -502,6 +512,7 @@ class ReplicationManager(object):
             nsds5replicabinddn=[replica_binddn],
             nsds5replicabinddngroup=[self.repl_man_group_dn],
             nsds5replicabinddngroupcheckinterval=["60"],
+            nsds5replicareleasetimeout=["60"],
             nsds5replicalegacyconsumer=["off"],
         )
         conn.add_entry(entry)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1640,7 +1640,11 @@ def update_replica_config(db_suffix):
         ('cn', 'replica'), ('cn', db_suffix), ('cn', 'mapping tree'),
         ('cn', 'config')
     )
-    entry = api.Backend.ldap2.get_entry(dn)
+    try:
+        entry = api.Backend.ldap2.get_entry(dn)
+    except ipalib.errors.NotFound:
+        return  # entry does not exist until a replica is installed
+
     if 'nsds5replicareleasetimeout' not in entry:
         # See https://pagure.io/freeipa/issue/7488
         logger.info("Adding nsds5replicaReleaseTimeout=60 to %s", dn)


### PR DESCRIPTION
Manual backport of PR #1800 

The nsds5ReplicaReleaseTimeout setting prevents the monopolization of
replicas during initial or busy master-master replication. 389-DS
documentation suggets a timeout of 60 seconds to improve convergence of
replicas.

See: http://directory.fedoraproject.org/docs/389ds/design/repl-conv-design.html
Fixes: https://pagure.io/freeipa/issue/7488
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Florence Blanc-Renaud <frenaud@redhat.com>