### PR TITLE
Fixes for ipatests.test_integration.test_caless.TestCertInstall

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -308,7 +308,7 @@ class NSSDatabase(object):
             "-d", '{}:{}'.format(self.dbtype, self.secdir)
         ]
         new_args.extend(args)
-        return ipautil.run(new_args, stdin, cwd=self.secdir, **kwargs)
+        return ipautil.run(new_args, stdin, **kwargs)
 
     def exists(self):
         """Check DB exists (all files are present)

--- a/ipaserver/install/ipa_server_certinstall.py
+++ b/ipaserver/install/ipa_server_certinstall.py
@@ -174,7 +174,7 @@ class ServerCertInstall(admintool.AdminTool):
     def replace_kdc_cert(self):
         # pass in `realm` to perform `NSSDatabase.verify_kdc_cert_validity()`
         cert, key, ca_cert = self.load_pkcs12(
-            ca_chain_fname=paths.CA_BUNDLE_PEM, realm=api.env.realm)
+            ca_chain_fname=paths.CA_BUNDLE_PEM, realm_name=api.env.realm)
 
         self.replace_key_cert_files(
             cert, key, paths.KDC_CERT, paths.KDC_KEY, ca_cert,

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -1426,7 +1426,6 @@ class TestCertInstall(CALessBase):
 
         assert result.returncode > 0
 
-    @pytest.mark.xfail(reason='freeipa ticket 6959')
     def test_http_intermediate_ca(self):
         "Install new HTTP certificate issued by intermediate CA"
 

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -422,8 +422,8 @@ class TestServerInstall(CALessBase):
 
         result = self.install_server(root_ca_file='does_not_exist')
         assert_error(result,
-                     'Failed to open does_not_exist: No such file '
-                     'or directory')
+                     'Failed to open %s/does_not_exist: No such file '
+                     'or directory' % self.master.config.test_dir)
 
     @server_install_teardown
     def test_unknown_ca(self):
@@ -434,7 +434,8 @@ class TestServerInstall(CALessBase):
 
         result = self.install_server()
         assert_error(result,
-                     'The full certificate chain is not present in server.p12')
+                     'The full certificate chain is not present in '
+                     '%s/server.p12' % self.master.config.test_dir)
 
     @server_install_teardown
     def test_ca_server_cert(self):
@@ -445,7 +446,8 @@ class TestServerInstall(CALessBase):
 
         result = self.install_server()
         assert_error(result,
-                     'The full certificate chain is not present in server.p12')
+                     'The full certificate chain is not present in '
+                     '%s/server.p12' % self.master.config.test_dir)
 
     @pytest.mark.xfail(reason='Ticket N 6289')
     @server_install_teardown
@@ -471,7 +473,8 @@ class TestServerInstall(CALessBase):
 
         result = self.install_server(http_pkcs12='does_not_exist',
                                      http_pkcs12_exists=False)
-        assert_error(result, 'Failed to open does_not_exist')
+        assert_error(result, 'Failed to open %s/does_not_exist' %
+                     self.master.config.test_dir)
 
     @server_install_teardown
     def test_nonexistent_ds_pkcs12_file(self):
@@ -482,7 +485,8 @@ class TestServerInstall(CALessBase):
 
         result = self.install_server(dirsrv_pkcs12='does_not_exist',
                                      dirsrv_pkcs12_exists=False)
-        assert_error(result, 'Failed to open does_not_exist')
+        assert_error(result, 'Failed to open %s/does_not_exist' %
+                     self.master.config.test_dir)
 
     @server_install_teardown
     def test_missing_http_password(self):
@@ -541,8 +545,9 @@ class TestServerInstall(CALessBase):
         result = self.install_server(http_pkcs12='http.p12',
                                      dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in http.p12 is not valid: '
-                     'invalid for server %s' % self.master.hostname)
+                     'The server certificate in %s/http.p12 is not valid: '
+                     'invalid for server %s' %
+                     (self.master.config.test_dir, self.master.hostname))
 
     @server_install_teardown
     def test_invalid_ds_cn(self):
@@ -555,8 +560,9 @@ class TestServerInstall(CALessBase):
         result = self.install_server(http_pkcs12='http.p12',
                                      dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in dirsrv.p12 is not valid: '
-                     'invalid for server %s' % self.master.hostname)
+                     'The server certificate in %s/dirsrv.p12 is not valid: '
+                     'invalid for server %s' %
+                     (self.master.config.test_dir, self.master.hostname))
 
     @server_install_teardown
     def test_expired_http(self):
@@ -569,8 +575,9 @@ class TestServerInstall(CALessBase):
         result = self.install_server(http_pkcs12='http.p12',
                                      dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in http.p12 is not valid: {err}'
-                     .format(err=CERT_EXPIRED_MSG))
+                     'The server certificate in {dir}/http.p12 is not valid: '
+                     '{err}'.format(dir=self.master.config.test_dir,
+                                    err=CERT_EXPIRED_MSG))
 
     @server_install_teardown
     def test_expired_ds(self):
@@ -583,8 +590,9 @@ class TestServerInstall(CALessBase):
         result = self.install_server(http_pkcs12='http.p12',
                                      dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in dirsrv.p12 is not valid: {err}'
-                     .format(err=CERT_EXPIRED_MSG))
+                     'The server certificate in {dir}/dirsrv.p12 is not '
+                     'valid: {err}'.format(dir=self.master.config.test_dir,
+                                           err=CERT_EXPIRED_MSG))
 
     @server_install_teardown
     def test_http_bad_usage(self):
@@ -597,8 +605,9 @@ class TestServerInstall(CALessBase):
         result = self.install_server(http_pkcs12='http.p12',
                                      dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in http.p12 is not valid: {err}'
-                     .format(err=BAD_USAGE_MSG))
+                     'The server certificate in {dir}/http.p12 is not '
+                     'valid: {err}'.format(dir=self.master.config.test_dir,
+                                           err=BAD_USAGE_MSG))
 
     @server_install_teardown
     def test_ds_bad_usage(self):
@@ -611,8 +620,9 @@ class TestServerInstall(CALessBase):
         result = self.install_server(http_pkcs12='http.p12',
                                      dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in dirsrv.p12 is not valid: {err}'
-                     .format(err=BAD_USAGE_MSG))
+                     'The server certificate in {dir}/dirsrv.p12 is not '
+                     'valid: {err}'.format(dir=self.master.config.test_dir,
+                                           err=BAD_USAGE_MSG))
 
     @server_install_teardown
     def test_revoked_http(self):
@@ -842,7 +852,8 @@ class TestReplicaInstall(CALessBase):
 
         result = self.prepare_replica(dirsrv_pkcs12='does_not_exist',
                                       http_pkcs12='http.p12')
-        assert_error(result, 'Failed to open does_not_exist')
+        assert_error(result, 'Failed to open %s/does_not_exist' %
+                     self.master.config.test_dir)
 
     @replica_install_teardown
     def test_nonexistent_ds_pkcs12_file(self):
@@ -852,7 +863,8 @@ class TestReplicaInstall(CALessBase):
 
         result = self.prepare_replica(http_pkcs12='does_not_exist',
                                       dirsrv_pkcs12='dirsrv.p12')
-        assert_error(result, 'Failed to open does_not_exist')
+        assert_error(result, 'Failed to open %s/does_not_exist' %
+                     self.master.config.test_dir)
 
     @pytest.mark.xfail(reason='freeipa ticket 5378')
     @replica_install_teardown
@@ -911,8 +923,9 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='http.p12',
                                       dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in http.p12 is not valid: '
-                     'invalid for server %s' % self.replicas[0].hostname)
+                     'The server certificate in %s/http.p12 is not valid: '
+                     'invalid for server %s' %
+                     (self.master.config.test_dir, self.replicas[0].hostname))
 
     @replica_install_teardown
     def test_invalid_ds_cn(self):
@@ -924,8 +937,9 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='http.p12',
                                       dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in dirsrv.p12 is not valid: '
-                     'invalid for server %s' % self.replicas[0].hostname)
+                     'The server certificate in %s/dirsrv.p12 is not valid: '
+                     'invalid for server %s' %
+                     (self.master.config.test_dir, self.replicas[0].hostname))
 
     @replica_install_teardown
     def test_expired_http(self):
@@ -937,8 +951,9 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='http.p12',
                                       dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in http.p12 is not valid: {err}'
-                     .format(err=CERT_EXPIRED_MSG))
+                     'The server certificate in {dir}/http.p12 is not '
+                     'valid: {err}'.format(dir=self.master.config.test_dir,
+                                           err=CERT_EXPIRED_MSG))
 
     @replica_install_teardown
     def test_expired_ds(self):
@@ -950,8 +965,9 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='http.p12',
                                       dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in http.p12 is not valid: {err}'
-                     .format(err=CERT_EXPIRED_MSG))
+                     'The server certificate in {dir}/http.p12 is not '
+                     'valid: {err}'.format(dir=self.master.config.test_dir,
+                                           err=CERT_EXPIRED_MSG))
 
     @replica_install_teardown
     def test_http_bad_usage(self):
@@ -963,8 +979,9 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='http.p12',
                                       dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in http.p12 is not valid: {err}'
-                     .format(err=BAD_USAGE_MSG))
+                     'The server certificate in {dir}/http.p12 is not '
+                     'valid: {err}'.format(dir=self.master.config.test_dir,
+                                           err=BAD_USAGE_MSG))
 
     @replica_install_teardown
     def test_ds_bad_usage(self):
@@ -976,8 +993,9 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='http.p12',
                                       dirsrv_pkcs12='dirsrv.p12')
         assert_error(result,
-                     'The server certificate in dirsrv.p12 is not valid: {err}'
-                     .format(err=BAD_USAGE_MSG))
+                     'The server certificate in {dir}/dirsrv.p12 is not '
+                     'valid: {err}'.format(dir=self.master.config.test_dir,
+                                           err=BAD_USAGE_MSG))
 
     @replica_install_teardown
     def test_revoked_http(self):


### PR DESCRIPTION
Don't change working directories when calling pk12util because this breaks passing in non-absolute filenames (regression)

Fix argument passed into load_pkcs12, s/realm/realm_name/

https://pagure.io/freeipa/issue/7489

NOTE: Don't push without removing the addition of the caless test to .freeipa-pr-ci.yaml