### PR TITLE
Fix upgrade (update_replica_config) in single master mode

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1642,7 +1642,11 @@ def update_replica_config(db_suffix):
         ('cn', 'replica'), ('cn', db_suffix), ('cn', 'mapping tree'),
         ('cn', 'config')
     )
-    entry = api.Backend.ldap2.get_entry(dn)
+    try:
+        entry = api.Backend.ldap2.get_entry(dn)
+    except ipalib.errors.NotFound:
+        return  # entry does not exist until a replica is installed
+
     if 'nsds5replicareleasetimeout' not in entry:
         # See https://pagure.io/freeipa/issue/7488
         logger.info("Adding nsds5replicaReleaseTimeout=60 to %s", dn)


### PR DESCRIPTION
Commit afc0d4b62d043cd568ce87400f60e8fa8273495f added an upgrade
step that add an attribute to a replica config entry.  The entry
only exists after a replica has been added, so upgrade was broken
for standalone server.  Catch and suppress the NotFound error.

Related to: https://pagure.io/freeipa/issue/7488