### PR TITLE
Change cronyd option from -q to -Q

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -662,7 +662,7 @@ def sync_time(host, server):
     """
 
     host.run_command(['systemctl', 'stop', 'chronyd'])
-    host.run_command(['chronyd', '-q',
+    host.run_command(['chronyd', '-Q',
                       '"server {srv} iburst"'.format(srv=server.hostname)])
 
 


### PR DESCRIPTION
chronyd run with -q option is meant to start chronyd daemon
syncinng to server or pool provided as another option.
option -q also needs root privileges to star daemon.

For syncing time with another server than configured using
already running daemon is used option -Q.

Addresses: https://pagure.io/freeipa/issue/7487