### PR TITLE
upgrade: treat duplicate entry when updating as not an error

### DIFF
--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -21,6 +21,7 @@
 
 # TODO
 # save undo files?
+from __future__ import absolute_import
 
 import base64
 import logging
@@ -848,6 +849,9 @@ class LDAPUpdate(object):
                 updated = False
             except errors.DatabaseError as e:
                 logger.error("Update failed: %s", e)
+                updated = False
+            except errors.DuplicateEntry as e:
+                logger.debug("Update already exists, skip it: %s", e)
                 updated = False
             except errors.ACIError as e:
                 logger.error("Update failed: %s", e)


### PR DESCRIPTION
When we attempt to update an entry during upgrade, it may have already
contain the data in question between the check and the update. Ignore
the change in this case and record it in the log.

Fixes: https://pagure.io/freeipa/issue/7450