### PR TITLE
replication: support error messages from 389-ds 1.3.5 or later

### DIFF
--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -18,6 +18,7 @@
 #
 
 from __future__ import print_function
+from __future__ import absolute_import
 
 import logging
 
@@ -981,7 +982,13 @@ class ReplicationManager(object):
             if status: # always check for errors
                 # status will usually be a number followed by a string
                 # number != 0 means error
-                rc, msg = status.split(' ', 1)
+                # Since 389-ds-base 1.3.5 it is 'Error (%d) %s'
+                # so we need to remove a prefix string and parentheses
+                if status.startswith('Error '):
+                    rc, msg = status[6:].split(' ', 1)
+                    rc = rc.strip('()')
+                else:
+                    rc, msg = status.split(' ', 1)
                 if rc != '0':
                     hasError = 1
                     error_message = msg


### PR DESCRIPTION
389-ds 1.3.5 changed the error message format for
nsds5ReplicaLastUpdateStatus value. Now it produces
"Error (%d) %s" instead of "%d %s".

Change the check_repl_update() to handle both formats.

Fixes: https://pagure.io/freeipa/issue/7442