### PR TITLE
CA replica PKCS12 workaround for SQL NSSDB

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -84,7 +84,7 @@
 %endif
 
 # Require Dogtag PKI 10.6.0 with Python 3 and SQL NSSDB fixes
-%global pki_version 10.6.0-0.2
+%global pki_version 10.6.0-1
 
 %define krb5_base_version %(LC_ALL=C rpm -q --qf '%%{VERSION}' krb5-devel | grep -Eo '^[^.]+\.[^.]+')
 

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -58,6 +58,7 @@
 %global selinux_policy_version 3.12.1-153
 %global slapi_nis_version 0.56.0-4
 %global python2_ldap_version 2.4.15
+%global ds_version 1.3.7.9-1
 %else
 # 1.15.1-7: certauth (http://krbdev.mit.edu/rt/Ticket/Display.html?id=8561)
 %global krb5_version 1.15.1-7
@@ -79,6 +80,17 @@
 # syncrepl fix, https://pagure.io/freeipa/issue/7240
 %global python2_ldap_version 2.4.25-9
 %global python3_ldap_version 2.4.35.1-2
+%endif
+
+%if 0%{?fedora} >= 28
+# Fix for "Crash when failing to read from SASL connection"
+# https://pagure.io/389-ds-base/issue/49639
+%global ds_version 1.4.0.8-1
+%else
+# 1.3.7.9-1: https://bugzilla.redhat.com/show_bug.cgi?id=1459946
+#            https://bugzilla.redhat.com/show_bug.cgi?id=1511462
+#            https://bugzilla.redhat.com/show_bug.cgi?id=1514033
+%global ds_version 1.3.7.9-1
 %endif
 
 %endif
@@ -151,8 +163,7 @@ BuildRequires:  libini_config-devel
 BuildRequires:  cyrus-sasl-devel
 BuildRequires:  sssd-tools
 %if ! %{ONLY_CLIENT}
-# 1.3.3.9: DS_Sleep (https://fedorahosted.org/389/ticket/48005)
-BuildRequires:  389-ds-base-devel >= 1.3.3.9
+BuildRequires:  389-ds-base-devel >= %{ds_version}
 BuildRequires:  svrcore-devel
 %if 0%{?rhel}
 BuildRequires:  samba-devel >= 4.0.0
@@ -326,10 +337,7 @@ Requires: python3-pyldap >= %{python3_ldap_version}
 Requires: python2-ipaserver = %{version}-%{release}
 Requires: python2-ldap >= %{python2_ldap_version}
 %endif
-# 1.3.7.9-1: https://bugzilla.redhat.com/show_bug.cgi?id=1459946
-#            https://bugzilla.redhat.com/show_bug.cgi?id=1511462
-#            https://bugzilla.redhat.com/show_bug.cgi?id=1514033
-Requires: 389-ds-base >= 1.3.7.9-1
+Requires: 389-ds-base >= %{ds_version}
 Requires: openldap-clients > 2.4.35-4
 Requires: nss >= 3.14.3-12.0
 Requires: nss-tools >= 3.14.3-12.0
@@ -373,10 +381,7 @@ Requires(postun): systemd-units
 Requires: policycoreutils >= 2.1.12-5
 Requires: tar
 Requires(pre): certmonger >= 0.79.5-1
-# 1.3.7.9-1: https://bugzilla.redhat.com/show_bug.cgi?id=1459946
-#            https://bugzilla.redhat.com/show_bug.cgi?id=1511462
-#            https://bugzilla.redhat.com/show_bug.cgi?id=1514033
-Requires(pre): 389-ds-base >= 1.3.7.9-1
+Requires(pre): 389-ds-base >= %{ds_version}
 Requires: fontawesome-fonts
 Requires: open-sans-fonts
 Requires: openssl


### PR DESCRIPTION
CA replica installation fails, because 'caSigningCert cert-pki-ca' is
imported a second time under a different name. The issue is caused
by the fact, that SQL NSS DB handles duplicated certificates differently
than DBM format.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1561730
Signed-off-by: Christian Heimes <cheimes@redhat.com>