### PR TITLE
install: validate AD trust-related options in installers

### DIFF
--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -424,6 +424,27 @@ class ServerInstallInterface(ServerCertificateInstallInterface,
                 "You cannot specify a --auto-reverse option together with "
                 "--no-reverse")
 
+        if not self.setup_adtrust:
+            if self.add_agents:
+                raise RuntimeError(
+                    "You cannot specify an --add-agents option without the "
+                    "--setup-adtrust option")
+
+            if self.enable_compat:
+                raise RuntimeError(
+                    "You cannot specify an --enable-compat option without the "
+                    "--setup-adtrust option")
+
+            if self.netbios_name:
+                raise RuntimeError(
+                    "You cannot specify a --netbios-name option without the "
+                    "--setup-adtrust option")
+
+            if self.no_msdcs:
+                raise RuntimeError(
+                    "You cannot specify a --no-msdcs option without the "
+                    "--setup-adtrust option")
+
         if not hasattr(self, 'replica_file'):
             if self.external_cert_files and self.dirsrv_cert_files:
                 raise RuntimeError(


### PR DESCRIPTION
We already validate that --setup-dns is specified when any of
DNS-related options provided by a user. Do the same for --setup-adtrust
case.

Fixes: https://pagure.io/freeipa/issue/7410