### PR TITLE
Fix format string passed to pytest-multihost

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -663,7 +663,7 @@ def sync_time(host, server):
 
     host.run_command(['systemctl', 'stop', 'chronyd'])
     host.run_command(['chronyd', '-q',
-                      '"server {srv} iburst"'.format(srv=server.hostname)])
+                      "server {srv} iburst".format(srv=server.hostname)])
 
 
 def connect_replica(master, replica, domain_level=None):


### PR DESCRIPTION
Integration trust test suit failed with error trying to
start chronyd because of bad formating of passed string

See: https://pagure.io/python-pytest-multihost/issue/15
Resolves: https://pagure.io/freeipa/issue/7487