### PR TITLE
certprofile: reject config with multiple profileIds

### DIFF
--- a/ipaserver/plugins/certprofile.py
+++ b/ipaserver/plugins/certprofile.py
@@ -236,14 +236,25 @@ class certprofile_import(LDAPCreate):
         ca_enabled_check(self.api)
         context.profile = options['file']
 
-        match = self.PROFILE_ID_PATTERN.search(options['file'])
-        if match is None:
+        matches = self.PROFILE_ID_PATTERN.findall(options['file'])
+        if len(matches) == 0:
             # no profileId found, use CLI value as profileId.
             context.profile = u'profileId=%s\n%s' % (keys[0], context.profile)
-        elif keys[0] != match.group(1):
-            raise errors.ValidationError(name='file',
-                error=_("Profile ID '%(cli_value)s' does not match profile data '%(file_value)s'")
-                    % {'cli_value': keys[0], 'file_value': match.group(1)}
+        elif len(matches) > 1:
+            raise errors.ValidationError(
+                name='file',
+                error=_(
+                    "Profile data specifies profileId multiple times: "
+                    "%(values)s"
+                ) % dict(values=matches)
+            )
+        elif keys[0] != matches[0]:
+            raise errors.ValidationError(
+                name='file',
+                error=_(
+                    "Profile ID '%(cli_value)s' "
+                    "does not match profile data '%(file_value)s'"
+                ) % dict(cli_value=keys[0], file_value=matches[0])
             )
         return dn
 

--- a/ipatests/test_xmlrpc/data/caIPAserviceCert_mod.cfg.tmpl
+++ b/ipatests/test_xmlrpc/data/caIPAserviceCert_mod.cfg.tmpl
@@ -1,6 +1,5 @@
 auth.instance_id=raCertAuth
 classId=caEnrollImpl
-profileId=caIPAserviceCert_mod
 visible=false
 desc=This certificate profile is for enrolling server certificates with IPA-RA agent authentication.
 enable=true

--- a/ipatests/test_xmlrpc/tracker/certprofile_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/certprofile_plugin.py
@@ -57,7 +57,14 @@ class CertprofileTracker(Tracker):
             content = f.read()
         return unicode(content)
 
-    def make_create_command(self):
+    def make_create_command(self, extra_lines=None):
+        """
+        :param extra_lines: list of extra lines to append to profile config.
+
+        """
+        if extra_lines is None:
+            extra_lines = []
+
         if not self.profile:
             raise RuntimeError('Tracker object without path to profile '
                                'cannot be used to create profile entry.')
@@ -65,7 +72,7 @@ class CertprofileTracker(Tracker):
         return self.make_command('certprofile_import', self.name,
                                  description=self.description,
                                  ipacertprofilestoreissued=self.store,
-                                 file=self.profile)
+                                 file=u'\n'.join([self.profile] + extra_lines))
 
     def check_create(self, result):
         assert_deepequal(dict(


### PR DESCRIPTION
In certprofile-import if the config file contains two profileId directives
with different values, with the first matching the profile ID CLI argument
and the second differing, the profile gets imported under the second ID.
This leads to:

- failure to enable the profile
- failure to add the IPA "tracking" certprofile object
- inability to delete the misnamed profile from Dogtag (via ipa CLI)

To avert this scenario, detect and reject profile configurations where
profileId is specified multiple times (whether or not the values differ).

https://pagure.io/freeipa/issue/7503