### PR TITLE
Fixing test_topology tests

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -340,10 +340,25 @@ def master_authoritative_for_client_domain(master, client):
                                 raiseonerr=False)
     return result.returncode == 0
 
+
+def _config_replica_resolvconf_with_master_data(master, replica):
+    """
+    Configure replica /etc/resolv.conf to use master as DNS server
+    """
+    content = ('search {domain}\nnameserver {master_ip}'
+               .format(domain=master.domain.name, master_ip=master.ip))
+    replica.put_file_contents(paths.RESOLV_CONF, content)
+
+
 def replica_prepare(master, replica, extra_args=(),
                     raiseonerr=True, stdin_text=None):
     fix_apache_semaphores(replica)
     prepare_reverse_zone(master, replica.ip)
+
+    # in domain level 0 there is no autodiscovery, so it's necessary to
+    # change /etc/resolv.conf to find master DNS server
+    _config_replica_resolvconf_with_master_data(master, replica)
+
     args = ['ipa-replica-prepare',
             '-p', replica.config.dirman_password,
             replica.hostname]

--- a/ipatests/test_integration/test_topology.py
+++ b/ipatests/test_integration/test_topology.py
@@ -239,6 +239,9 @@ class TestCASpecificRUVs(IntegrationTest):
         assert(res1.count(replica.hostname) == 2), (
             "Did not find proper number of replica hostname (%s) occurrencies"
             " in the command output: %s" % (replica.hostname, res1))
+
+        master.run_command(['ipa-replica-manage', 'del', replica.hostname,
+                            '-p', master.config.dirman_password])
         tasks.uninstall_master(replica)
         res2 = master.run_command(['ipa-replica-manage', 'list-ruv', '-p',
                                   master.config.dirman_password]).stdout_text


### PR DESCRIPTION
#### Fixing TestCASpecificRUVs::test_replica_uninstall_deletes_ruvs
This test will setup a master and a replica, uninstall replica and check
for the replica RUVs on the master. It was missing the step of running
ipa-replica-manage del <replica hostname> to properly remove the RUVs.

#### Fixing tests on TestReplicaManageDel
This commit fixes the tests on class TestReplicaManageDel:
- test_replica_managed_del_domlevel1
- test_clean_dangling_ruv_multi_ca
- test_replica_managed_del_domlevel0

Given that domain level 0 doest not have autodiscovery, we need to
configure /etc/resolv.conf with the master data (search <domain> and
nameserver <master_ip>) in order to ipa-replica-install succeed.

---
**Atention**: This patch should not be pushed until PR #1748 get merged.
As usual, as soon as we have an ack, I'll rebase the PR and remove the temp commit.