### PR TITLE
WebUI tests: Extend netgroup tests with more scenarios

### DIFF
--- a/ipatests/test_webui/data_netgroup.py
+++ b/ipatests/test_webui/data_netgroup.py
@@ -41,3 +41,62 @@ DATA2 = {
         ('textarea', 'description', 'test-netgroup2 desc modified'),
     ],
 }
+
+PKEY3 = 'itest-netgroup3'
+DATA3 = {
+    'pkey': PKEY3,
+    'add': [
+        ('textbox', 'cn', PKEY3),
+        ('textarea', 'description', 'test-netgroup3 desc'),
+    ]
+}
+
+PKEY4 = 'itest-netgroup4'
+DATA4 = {
+    'pkey': PKEY4,
+    'add': [
+        ('textbox', 'cn', PKEY4),
+        ('textarea', 'description', 'test-netgroup4 desc'),
+    ]
+}
+
+PKEY5 = 'NewNetGroup'
+DATA_MIXED_CASE = {
+    'pkey': PKEY5,
+    'add': [
+        ('textbox', 'cn', PKEY5),
+        ('textarea', 'description', 'Trying to add mixed case netgroup name'),
+    ]
+}
+
+PKEY6 = 'long-netgroup-name_{}'.format('long' * 15)
+DATA_LONG_NAME = {
+    'pkey': PKEY6,
+    'add': [
+        ('textbox', 'cn', PKEY6),
+        ('textarea', 'description', 'Trying to add long netgroup name'),
+    ]
+}
+
+PKEY7 = 'a'
+DATA_SINGLE_CHAR = {
+    'pkey': PKEY7,
+    'add': [
+        ('textbox', 'cn', PKEY7),
+        ('textarea', 'description', 'Trying to add single character netgroup'
+                                    ' name'),
+    ]
+}
+
+PKEY8 = 'itest-netgroup8'
+DATA8 = {
+    'pkey': PKEY8,
+    'add': [
+        ('textbox', 'cn', PKEY8),
+        ('textarea', 'description', 'test-netgroup8 desc'),
+    ],
+    'mod': [
+        ('textarea', 'description', 'description modified for testing buttons'
+         ),
+    ],
+}

--- a/ipatests/test_webui/test_netgroup.py
+++ b/ipatests/test_webui/test_netgroup.py
@@ -30,6 +30,12 @@ import ipatests.test_webui.data_hostgroup as hostgroup
 from ipatests.test_webui.test_host import host_tasks, ENTITY as HOST_ENTITY
 import pytest
 
+try:
+    from selenium.webdriver.common.keys import Keys
+    from selenium.webdriver.common.action_chains import ActionChains
+except ImportError:
+    pass
+
 
 @pytest.mark.tier1
 class test_netgroup(UI_driver):
@@ -41,6 +47,242 @@ class test_netgroup(UI_driver):
         """
         self.init_app()
         self.basic_crud(netgroup.ENTITY, netgroup.DATA)
+
+    @screenshot
+    def test_basic_workflows(self):
+        """
+        add and delete netgroup with various scenarios.
+        """
+        self.init_app()
+
+        # add mixed case netgroup name
+        self.add_record(netgroup.ENTITY, netgroup.DATA_MIXED_CASE)
+        pkey = netgroup.DATA_MIXED_CASE['pkey'].lower()
+        self.delete_record(pkey)
+
+        # add long netgroup name
+        self.add_record(netgroup.ENTITY, netgroup.DATA_LONG_NAME, delete=True)
+
+        # add single character netgroup name ticket#2671
+        self.add_record(netgroup.ENTITY, netgroup.DATA_SINGLE_CHAR,
+                        delete=True)
+
+        # add netgroup using enter
+        self.add_record(netgroup.ENTITY, netgroup.DATA, negative=True)
+        actions = ActionChains(self.driver)
+        actions.send_keys(Keys.ENTER).perform()
+        self.wait_for_request()
+        self.assert_record(netgroup.PKEY)
+        self.close_notifications()
+
+        # delete netgroup using enter
+        self.select_record(netgroup.PKEY)
+        self.facet_button_click('remove')
+        self.wait_for_request()
+        actions.send_keys(Keys.ENTER).perform()
+        self.wait_for_request()
+        self.assert_record(netgroup.PKEY, negative=True)
+        self.close_all_dialogs()
+
+        # delete and cancel
+        self.add_record(netgroup.ENTITY, netgroup.DATA)
+        self.select_record(netgroup.PKEY)
+        self.facet_button_click('remove')
+        self.dialog_button_click('cancel')
+        self.assert_record(netgroup.PKEY)
+        self.select_record(netgroup.PKEY, unselect=True)
+        self.delete_record(netgroup.PKEY)
+
+        # add multiple records using add_and_another button
+        self.add_record(netgroup.ENTITY, [netgroup.DATA, netgroup.DATA2,
+                                          netgroup.DATA3, netgroup.DATA4])
+        # search record
+        pkey = netgroup.DATA2['pkey']
+        self.search_pkey(pkey)
+        self.assert_record(pkey)
+
+        # Negative search
+        pkey = netgroup.DATA_MIXED_CASE['pkey']
+        self.search_pkey(pkey)
+        self.assert_record(pkey, negative=True)
+
+        # delete multiple records
+        records = [netgroup.DATA, netgroup.DATA2, netgroup.DATA3]
+        self.navigate_to_entity(netgroup.ENTITY)
+        self.select_multiple_records(records)
+        self.facet_button_click('remove')
+        self.dialog_button_click('ok')
+
+        # Find and delete
+        pkey = netgroup.DATA4['pkey']
+        self.search_pkey(pkey)
+        self.select_record(pkey)
+        self.facet_button_click('remove')
+        self.dialog_button_click('ok')
+
+    def search_pkey(self, pkey):
+        search_field_s = '.search-filter input[name=filter]'
+        self.fill_text(search_field_s, pkey)
+        self.action_button_click('find', parent=None)
+        self.wait_for_request(n=2)
+
+    @screenshot
+    def test_add_netgroup_negative(self):
+        """
+        Negative test for adding netgroup
+        """
+        self.init_app()
+
+        # add then cancel
+        self.add_record(netgroup.ENTITY, netgroup.DATA, dialog_btn='cancel')
+
+        # add duplicate
+        self.add_record(netgroup.ENTITY, netgroup.DATA)
+        expected_error = 'group with name "%s" already exists' % netgroup.PKEY
+        self.navigate_to_entity(netgroup.ENTITY)
+        self.facet_button_click('add')
+        self.fill_input('cn', netgroup.PKEY)
+        self.cancel_retry_dialog(expected_error)
+        self.delete_record(netgroup.PKEY)
+
+        # empty netgroup
+        self.navigate_to_entity(netgroup.ENTITY)
+        self.facet_button_click('add')
+        self.dialog_button_click('add')
+        elem = self.find(".widget[name='cn']")
+        self.assert_field_validation_required(elem)
+        self.dialog_button_click('cancel')
+
+        # invalid_group_name
+        expected_error = 'may only include letters, numbers, _, -, and .'
+        pkey = ';test-gr@up'
+        self.navigate_to_entity(netgroup.ENTITY)
+        self.facet_button_click('add')
+        self.fill_input('cn', pkey)
+        elem = self.find(".widget[name='cn']")
+        self.assert_field_validation(expected_error, parent=elem)
+        self.dialog_button_click('cancel')
+
+    def cancel_retry_dialog(self, expected_error):
+        self.dialog_button_click('add')
+        dialog = self.get_last_error_dialog()
+        assert (expected_error in dialog.text)
+        self.wait_for_request()
+        # Key press for Retry
+        actions = ActionChains(self.driver)
+        actions.send_keys(Keys.ENTER).perform()
+        self.wait_for_request(n=2)
+        self.dialog_button_click('cancel')
+        self.wait_for_request(n=2)
+        self.dialog_button_click('cancel')
+
+    @screenshot
+    def test_unsaved_changes(self):
+        """
+        verifying unsaved changes dialog ticket#2075
+        """
+        self.init_app()
+        self.add_record(netgroup.ENTITY, netgroup.DATA8,
+                        dialog_btn='add_and_edit')
+        mod_description = (netgroup.DATA8['mod'][0][2])
+
+        # verifying Cancel button
+        self.fill_fields(netgroup.DATA8['mod'])
+        self.click_on_link('Netgroups')
+        self.assert_dialog()
+        self.dialog_button_click('cancel')
+        self.assert_facet_button_enabled('save')
+
+        # verifying Revert button
+        self.click_on_link('Netgroups')
+        self.assert_dialog()
+        self.dialog_button_click('revert')
+        self.navigate_to_record(netgroup.PKEY8)
+        self.verify_btn_action(mod_description)
+
+        # verifying Save button
+        self.fill_fields(netgroup.DATA8['mod'])
+        self.click_on_link('Netgroups')
+        self.assert_dialog()
+        self.dialog_button_click('save')
+        self.navigate_to_record(netgroup.PKEY8)
+        self.verify_btn_action(mod_description, negative=True)
+
+    @screenshot
+    def test_add_and_edit_group(self):
+        """
+        1. add and switch to edit mode
+        2. verifying Save, Revert, Refresh and Undo button
+        """
+        self.init_app()
+
+        # add and edit record
+        self.add_record(netgroup.ENTITY, netgroup.DATA8,
+                        dialog_btn='add_and_edit')
+        mod_description = (netgroup.DATA8['mod'][0][2])
+
+        # verifying undo button
+        self.fill_fields(netgroup.DATA8['mod'])
+        self.undo_click()
+        self.verify_btn_action(mod_description)
+        self.wait_for_request(n=2)
+
+        # verifying revert button
+        self.mod_record(netgroup.ENTITY, netgroup.DATA8, facet_btn='revert')
+        self.wait_for_request()
+        self.verify_btn_action(mod_description)
+        self.wait_for_request(n=2)
+
+        # verifying refresh button
+        self.fill_fields(netgroup.DATA8['mod'], undo=True)
+        self.facet_button_click('refresh')
+        self.verify_btn_action(mod_description)
+        self.wait_for_request(n=2)
+
+        # verifying Save button
+        self.mod_record(netgroup.ENTITY, netgroup.DATA8)
+        self.wait_for_request()
+        self.verify_btn_action(mod_description, negative=True)
+        self.wait_for_request(n=2)
+
+        # clean up
+        self.navigate_to_entity(netgroup.ENTITY)
+        self.delete_record(netgroup.PKEY8)
+
+    def undo_click(self):
+        facet = self.get_facet()
+        s = ".textarea-widget button[name='undo']"
+        self._button_click(s, facet)
+
+    def verify_btn_action(self, mod_description, negative=False):
+        """
+        camparing current description with modified description
+        """
+        current_description = self.get_field_value("description",
+                                                   element="textarea")
+        if negative:
+            assert current_description == mod_description
+        else:
+            assert current_description != mod_description
+
+    @screenshot
+    def test_add_members(self):
+        """
+        Adding members and membersof
+        """
+        self.init_app()
+
+        records = [netgroup.DATA, netgroup.DATA2, netgroup.DATA3,
+                   netgroup.DATA4, netgroup.DATA8]
+        self.add_record(netgroup.ENTITY, records)
+        # adding netgroup "members"
+        self.navigate_to_record(netgroup.PKEY2)
+        self.add_associations([netgroup.PKEY3, netgroup.PKEY4],
+                              'member_netgroup', delete=True, search=True)
+        # adding netgroup "memberof"
+        self.add_associations([netgroup.PKEY, netgroup.PKEY8],
+                              'memberof_netgroup', delete=True)
+        self.delete(netgroup.ENTITY, records)
 
     @screenshot
     def test_mod(self):
@@ -77,6 +319,45 @@ class test_netgroup(UI_driver):
         ]
 
         self.mod_rule_tables(tables, categories, [])
+
+        # add associations then cancel
+        def get_t_vals(t):
+            table = t[0]
+            k = t[1]
+            e = []
+            if len(t) > 2:
+                e = t[2]
+            return table, k, e
+
+        for t in tables:
+            table, keys, _exts = get_t_vals(t)
+            self.add_table_associations(table, [keys[0]], negative=True)
+
+            # verifying members listed as links ticket#2670
+            self.add_table_associations(table, [keys[0]])
+            self.wait_for_request(n=2)
+            self.navigate_to_record(keys[0], table_name=table)
+            page_pkey = self.get_text('.facet-pkey')
+            assert keys[0] in page_pkey
+            self.navigate_to_record(netgroup.PKEY, entity=netgroup.ENTITY)
+
+        for cat in categories:
+            # verifying undo on memberships
+            self.check_option(cat, 'all')
+            self.assert_facet_button_enabled('save', enabled=True)
+            undo = "div[name = %s] > button[name='undo']" % cat
+            self._button_click(undo, parent=None)
+            self.assert_facet_button_enabled('save', enabled=False)
+
+            # verifying Revert on memberships
+            self.check_option(cat, 'all')
+            self.facet_button_click('revert')
+            self.assert_facet_button_enabled('save', enabled=False)
+
+            # verifying refresh on memberships
+            self.check_option(cat, 'all')
+            self.facet_button_click('refresh')
+            self.assert_facet_button_enabled('save', enabled=False)
 
         # cleanup
         # -------

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -1550,7 +1550,7 @@ class UI_driver(object):
             self.assert_record(key, negative=True)
 
     def add_table_associations(self, table_name, pkeys, parent=False,
-                               delete=False):
+                               delete=False, negative=False):
         """
         Add value to table (association|rule|...)
         """
@@ -1570,7 +1570,12 @@ class UI_driver(object):
             self.button_click('add')
             self.wait()
 
-        self.dialog_button_click('add')
+        if negative:
+            self.dialog_button_click('cancel')
+            self.assert_record(key, parent, table_name, negative=True)
+            return
+        else:
+            self.dialog_button_click('add')
         self.wait_for_request(n=2)
 
         for key in pkeys:


### PR DESCRIPTION
    Extended webui group automation test with below scenarios
    Scenarios
     *add netgroup with invalid names
     *add and delete records in various scenarios
     *verify button's action in various scenarios.
    
    https://pagure.io/freeipa/issue/7505