### PR TITLE
[Test fix] Fix trust tests for Posix Support

### DIFF
--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -208,8 +208,10 @@ class TestPosixADTrust(ADTrustBase):
     """Integration test for Active Directory with POSIX support"""
 
     def test_establish_trust(self):
-        # Not specifying the --range-type directly, it should be detected
-        tasks.establish_trust_with_ad(self.master, self.ad_domain)
+        tasks.establish_trust_with_ad(
+            self.master, self.ad_domain,
+            extra_args=['--range-type', 'ipa-ad-trust-posix']
+        )
 
     def test_range_properties_in_posix_trust(self):
         # Check the properties of the created range


### PR DESCRIPTION
Test ecxpects auto-detection of trust type, Windows Server 2016 doesn't have
support for MFU/NIS (SFU - Services for Unix), so auto detection doesn't work

Fix is to pass extra arguments to the trust-add command,
such as --range-type="ipa-ad-trust-posix" to enforce a particular range type

https://pagure.io/freeipa/issue/7508