### PR TITLE
Fixing TestBackupAndRestore

### DIFF
--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -190,6 +190,7 @@ class Backup(admintool.AdminTool):
         paths.IPA_DNSKEYSYNCD_KEYTAB,
         paths.IPA_CUSTODIA_KEYS,
         paths.IPA_CUSTODIA_CONF,
+        paths.GSSPROXY_CONF,
         paths.HOSTS,
     ) + tuple(
         os.path.join(paths.IPA_NSSDB_DIR, file)

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -177,6 +177,8 @@ class TestBackupAndRestore(IntegrationTest):
 
     def test_full_backup_and_restore_with_removed_users(self):
         """regression test for https://fedorahosted.org/freeipa/ticket/3866"""
+        tasks.uninstall_master(self.master)
+        tasks.install_master(self.master)
         with restore_checker(self.master):
             backup_path = backup(self.master)
 
@@ -200,6 +202,8 @@ class TestBackupAndRestore(IntegrationTest):
 
     def test_full_backup_and_restore_with_selinux_booleans_off(self):
         """regression test for https://fedorahosted.org/freeipa/ticket/4157"""
+        tasks.uninstall_master(self.master)
+        tasks.install_master(self.master)
         with restore_checker(self.master):
             backup_path = backup(self.master)
 


### PR DESCRIPTION
#### Adding GSSPROXY_CONF to be backed up on ipa-backup
Without GSSPROXY_CONF being backed up, we would get this error
"ipa: ERROR: No valid Negotiate header in server response"
when running any ipa command after a ipa backup and restore.

This commit also fixes the tests:
- TestBackupAndRestore::test_full_backup_and_restore
- TesttBackupAndRestore::test_full_backup_and_restore_with_selinux_booleans_off

https://pagure.io/freeipa/issue/7473


#### Fixing TestBackupAndRestore::test_full_backup_and_restore_with_removed_users
The test as it was, was testing the backup and restore based on previous
backups and restore, not with an actual installation.

Now, with a clear setup for each test, the test mentioned above will not
fail to do a lookup (using the host command, in check_dns method) for
the master domain.

---
Once we have an ack, I'll remove the temp commit.