### PR TITLE
Add augeas dependency to client package

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -642,6 +642,7 @@ Requires: %{name}-common = %{version}-%{release}
 Requires: python2-ipalib = %{version}-%{release}
 Requires: python2-dns >= 1.15
 Requires: python2-jinja2
+Requires: python2-augeas
 
 %description -n python2-ipaclient
 IPA is an integrated solution to provide centrally managed Identity (users,
@@ -665,6 +666,7 @@ Requires: %{name}-common = %{version}-%{release}
 Requires: python3-ipalib = %{version}-%{release}
 Requires: python3-dns >= 1.15
 Requires: python3-jinja2
+Requires: python3-augeas
 
 %description -n python3-ipaclient
 IPA is an integrated solution to provide centrally managed Identity (users,


### PR DESCRIPTION
Commit 5d9c749e830819e0e12bdd9388b6b0c2542cf906 add dependency on augeas
Python package, but freeipa.spec was not updated. The python[23]-ipaclient
packages now correctly depend on python[23]-augeas.

Fixes: https://pagure.io/freeipa/issue/7512
Signed-off-by: Christian Heimes <cheimes@redhat.com>