### PR TITLE
Create users in server-common pre hook

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1155,6 +1155,8 @@ if [ -e /usr/sbin/ipa_kpasswd ]; then
 # END
 fi
 
+
+%pre server-common
 # create users and groups
 # create kdcproxy group and user
 getent group kdcproxy >/dev/null || groupadd -f -r kdcproxy


### PR DESCRIPTION
The ipaapi user was created in the server package but referenced by a
config file in the server-common package. The server-common package can
be installed without the server package. This caused an error

   Unknown user 'ipaapi'

with systemd-tmpfiles --create. The users are now created in the
server-common package.

Signed-off-by: Christian Heimes <cheimes@redhat.com>