### PR TITLE
Fix typo in ipa-getkeytab --help

### DIFF
--- a/client/ipa-getkeytab.c
+++ b/client/ipa-getkeytab.c
@@ -763,7 +763,8 @@ int main(int argc, const char *argv[])
               _("The principal to get a keytab for (ex: ftp/ftp.example.com@EXAMPLE.COM)"),
               _("Kerberos Service Principal Name") },
             { "keytab", 'k', POPT_ARG_STRING, &keytab, 0,
-              _("File were to store the keytab information"),
+              _("The keytab file to append the new key to (will be "
+                "created if it does not exist)."),
               _("Keytab File Name") },
 	    { "enctypes", 'e', POPT_ARG_STRING, &enctypes_string, 0,
               _("Encryption types to request"),


### PR DESCRIPTION
Fix the typo in ipa-getkeytab -k option description by
replacing the text with the one from man