### PR TITLE
Require authselect-compat >= 0.4-2 on F28

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -597,7 +597,12 @@ Requires: python2-sssdconfig
 Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: chrony
 Requires: krb5-workstation >= %{krb5_version}
+%if 0%{?fedora} >= 28
+# Fix for oddjobd bug, https://bugzilla.redhat.com/show_bug.cgi?id=1571844
+Requires: authselect-compat >= 0.4-2
+%else
 Requires: authconfig
+%endif
 Requires: curl
 # NIS domain name config: /usr/lib/systemd/system/*-domainname.service
 Requires: initscripts


### PR DESCRIPTION
authconfig from authselect-compat < 0.4-2 has a bug. It disabled oddjobd
unless mkhomedir option is passed down. The issue breaks FreeIPA replica
installation and AD trust. The latest release 0.4-2 contains a fix.

Fixes: https://pagure.io/freeipa/issue/7465
See: https://bugzilla.redhat.com/show_bug.cgi?id=1571844
Signed-off-by: Christian Heimes <cheimes@redhat.com>