### PR TITLE
[Backport][ipa-4-5] Use single Custodia instance in installers

### DIFF
--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -31,6 +31,7 @@ from ipaserver.install.installutils import create_replica_config
 from ipaserver.install.installutils import check_creds, ReplicaConfig
 from ipaserver.install import dsinstance, ca
 from ipaserver.install import cainstance, service
+from ipaserver.install import custodiainstance
 from ipapython import version
 from ipalib import api
 from ipalib.constants import DOMAIN_LEVEL_0
@@ -193,13 +194,17 @@ def install_replica(safe_options, options, filename):
     options.domain_name = config.domain_name
     options.dm_password = config.dirman_password
     options.host_name = config.host_name
+    options.ca_host_name = config.ca_host_name
     if os.path.exists(cafile):
         options.ca_cert_file = cafile
     else:
         options.ca_cert_file = None
 
     ca.install_check(True, config, options)
-    ca.install(True, config, options)
+
+    custodia = custodiainstance.get_custodia_instance(
+        options, custodiainstance.CustodiaModes.CA_PEER)
+    ca.install(True, config, options, custodia=custodia)
 
 
 def install_master(safe_options, options):
@@ -228,7 +233,11 @@ def install_master(safe_options, options):
         sys.exit("CA subject: {}".format(e.message))
 
     ca.install_check(True, None, options)
-    ca.install(True, None, options)
+
+    # No CA peer available yet.
+    custodia = custodiainstance.get_custodia_instance(
+        options, custodiainstance.CustodiaModes.STANDALONE)
+    ca.install(True, None, options, custodia=custodia)
 
 
 def install(safe_options, options, filename):

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -59,7 +59,6 @@ from ipapython.ipa_log_manager import log_mgr,\
 from ipaserver.secrets.kem import IPAKEMKeys
 
 from ipaserver.install import certs
-from ipaserver.install import custodiainstance
 from ipaserver.install import dsinstance
 from ipaserver.install import installutils
 from ipaserver.install import ldapupdate
@@ -285,7 +284,7 @@ class CAInstance(DogtagInstance):
                      'caSigningCert cert-pki-ca')
     server_cert_name = 'Server-Cert cert-pki-ca'
 
-    def __init__(self, realm=None, host_name=None):
+    def __init__(self, realm=None, host_name=None, custodia=None):
         super(CAInstance, self).__init__(
             realm=realm,
             subsystem="CA",
@@ -310,6 +309,8 @@ class CAInstance(DogtagInstance):
         self.no_db_setup = False
         self.keytab = os.path.join(
             paths.PKI_TOMCAT, self.service_prefix + '.keytab')
+        # Custodia instance for RA key retrieval
+        self._custodia = custodia
 
     def configure_instance(self, host_name, dm_password, admin_password,
                            pkcs12_info=None, master_host=None, csr_file=None,
@@ -711,9 +712,7 @@ class CAInstance(DogtagInstance):
         self.configure_agent_renewal()
 
     def __import_ra_key(self):
-        custodia = custodiainstance.CustodiaInstance(host_name=self.fqdn,
-                                                     realm=self.realm)
-        custodia.import_ra_key(self.master_host)
+        self._custodia.import_ra_key(self.master_host)
         self.__set_ra_cert_perms()
 
         self.configure_agent_renewal()

--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -16,7 +16,6 @@ from ipaplatform.paths import paths
 from ipapython import certdb
 from ipapython import ipautil
 from ipapython.install.core import group
-from ipaserver.install import custodiainstance
 from ipaserver.install import cainstance
 from ipaserver.install import krainstance
 from ipaserver.install import dsinstance
@@ -68,7 +67,7 @@ def install_check(api, replica_config, options):
                                    "new replica file.")
 
 
-def install(api, replica_config, options):
+def install(api, replica_config, options, custodia):
     if replica_config is None:
         if not options.setup_kra:
             return
@@ -91,9 +90,6 @@ def install(api, replica_config, options):
                     'host/{env.host}@{env.realm}'.format(env=api.env),
                     paths.KRB5_KEYTAB,
                     ccache)
-                custodia = custodiainstance.CustodiaInstance(
-                    replica_config.host_name,
-                    replica_config.realm_name)
                 custodia.get_kra_keys(
                     replica_config.kra_host_name,
                     krafile,

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -709,6 +709,7 @@ def install(installer):
     host_name = options.host_name
     ip_addresses = options.ip_addresses
     setup_ca = options.setup_ca
+    options.promote = False  # first master, no promotion
 
     # Installation has started. No IPA sysrestore items are restored in case of
     # failure to enable root cause investigation
@@ -789,6 +790,10 @@ def install(installer):
                       setup_pkinit=not options.no_pkinit,
                       subject_base=options.subject_base)
 
+    custodia = custodiainstance.get_custodia_instance(
+        options, custodiainstance.CustodiaModes.MASTER_PEER)
+    custodia.create_instance()
+
     if setup_ca:
         if not options.external_cert_files and options.external_ca:
             # stage 1 of external CA installation
@@ -803,7 +808,7 @@ def install(installer):
                           if n in options.__dict__}
             write_cache(cache_vars)
 
-        ca.install_step_0(False, None, options)
+        ca.install_step_0(False, None, options, custodia=custodia)
     else:
         # Put the CA cert where other instances expect it
         x509.write_certificate(http_ca_cert, paths.IPA_CA_CRT)
@@ -823,14 +828,11 @@ def install(installer):
     ds.enable_ssl()
 
     if setup_ca:
-        ca.install_step_1(False, None, options)
+        ca.install_step_1(False, None, options, custodia=custodia)
 
     otpd = otpdinstance.OtpdInstance()
     otpd.create_instance('OTPD', host_name,
                          ipautil.realm_to_suffix(realm_name))
-
-    custodia = custodiainstance.CustodiaInstance(host_name, realm_name)
-    custodia.create_instance()
 
     # Create a HTTP instance
     http = httpinstance.HTTPInstance(fstore)
@@ -863,7 +865,7 @@ def install(installer):
     krb.restart()
 
     if options.setup_kra:
-        kra.install(api, None, options)
+        kra.install(api, None, options, custodia=custodia)
 
     if options.setup_dns:
         dns.install(False, False, options)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1357,6 +1357,7 @@ def install(installer):
     fstore = installer._fstore
     sstore = installer._sstore
     config = installer._config
+    config.promote = installer.promote
     promote = installer.promote
     cafile = installer._ca_file
     dirsrv_pkcs12_info = installer._dirsrv_pkcs12_info
@@ -1483,19 +1484,19 @@ def install(installer):
     otpd.create_instance('OTPD', config.host_name,
                          ipautil.realm_to_suffix(config.realm_name))
 
-    custodia = custodiainstance.CustodiaInstance(config.host_name,
-                                                 config.realm_name)
-    if promote:
-        custodia.create_replica(config.master_host_name)
+    if ca_enabled:
+        mode = custodiainstance.CustodiaModes.CA_PEER
     else:
-        custodia.create_instance()
+        mode = custodiainstance.CustodiaModes.MASTER_PEER
+    custodia = custodiainstance.get_custodia_instance(config, mode)
+    custodia.create_instance()
 
     if ca_enabled:
         options.realm_name = config.realm_name
         options.domain_name = config.domain_name
         options.host_name = config.host_name
         options.dm_password = config.dirman_password
-        ca.install(False, config, options)
+        ca.install(False, config, options, custodia=custodia)
 
     # configure PKINIT now that all required services are in place
     krb.enable_ssl()
@@ -1505,7 +1506,7 @@ def install(installer):
     ds.apply_updates()
 
     if kra_enabled:
-        kra.install(api, config, options)
+        kra.install(api, config, options, custodia=custodia)
 
     service.print_msg("Restarting the KDC")
     krb.restart()


### PR DESCRIPTION
Manual backport of PR #1860 

Installers now pass a single CustodiaInstance object around, instead of
creating new instances on demand. In case of replica promotion with CA,
the instance gets all secrets from a master with CA present. Before, an
installer created multiple instances and may have requested CA key
material from a different machine than DM password hash.

In case of Domain Level 1 and replica promotion, the CustodiaInstance no
longer adds the keys to the local instance and waits for replication to
other replica. Instead the installer directly uploads the new public
keys to the remote 389-DS instance.

Without promotion, new Custodia public keys are still added to local
389-DS over LDAPI.

Fixes: https://pagure.io/freeipa/issue/7518
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Simo Sorce <ssorce@redhat.com>