### PR TITLE
idoverrideuser-add: allow adding ssh key in web ui

### DIFF
--- a/install/ui/src/freeipa/idviews.js
+++ b/install/ui/src/freeipa/idviews.js
@@ -317,6 +317,10 @@ return {
                 $type: 'cert_textarea',
                 name: 'usercertificate'
             },
+            {
+                $type: 'sshkey',
+                name: 'ipasshpubkey'
+            },
             'loginshell',
             'homedirectory',
             {


### PR DESCRIPTION
CLI already allows to pass public SSH key when creating an ID override
for a user. Web UI allows to add public SSH keys after the ID override
was created.

Add SSH key field to allow passing public SSH key in one go when
creating an ID override for a user.

Fixes: https://pagure.io/freeipa/issue/7519