### PR TITLE
[Backport][ipa-4-5] Redirect CRL requests to the http port, not the https port

### DIFF
--- a/install/conf/ipa-pki-proxy.conf
+++ b/install/conf/ipa-pki-proxy.conf
@@ -1,4 +1,4 @@
-# VERSION 11 - DO NOT REMOVE THIS LINE
+# VERSION 12 - DO NOT REMOVE THIS LINE
 
 ProxyRequests Off
 
@@ -43,4 +43,4 @@ ProxyRequests Off
 </LocationMatch>
 
 # Only enable this on servers that are not generating a CRL
-${CLONE}RewriteRule ^/ipa/crl/MasterCRL.bin https://$FQDN/ca/ee/ca/getCRL?op=getCRL&crlIssuingPoint=MasterCRL [L,R=301,NC]
+${CLONE}RewriteRule ^/ipa/crl/MasterCRL.bin http://$FQDN/ca/ee/ca/getCRL?op=getCRL&crlIssuingPoint=MasterCRL [L,R=301,NC]


### PR DESCRIPTION
https://pagure.io/freeipa/issue/7433

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
Reviewed-By: Christian Heimes <cheimes@redhat.com>

Manual backport of PR 1695