### PR TITLE
[Backport][ipa-4-6] idoverrideuser-add: allow adding ssh key in web ui

### DIFF
--- a/install/ui/src/freeipa/idviews.js
+++ b/install/ui/src/freeipa/idviews.js
@@ -317,6 +317,10 @@ return {
                 $type: 'cert_textarea',
                 name: 'usercertificate'
             },
+            {
+                $type: 'sshkey',
+                name: 'ipasshpubkey'
+            },
             'loginshell',
             'homedirectory',
             {


### PR DESCRIPTION
This PR was opened automatically because PR #1870 was pushed to master and backport to ipa-4-6 is required.