### PR TITLE
Compatibility with pytest 3.4

### DIFF
--- a/ipatests/pytest_plugins/nose_compat.py
+++ b/ipatests/pytest_plugins/nose_compat.py
@@ -54,11 +54,23 @@ def pytest_configure(config):
                 capture = config.pluginmanager.getplugin('capturemanager')
                 orig_stdout, orig_stderr = sys.stdout, sys.stderr
                 if capture:
-                    capture._capturing.suspend_capturing()
+                    # pylint: disable=no-member
+                    if hasattr(capture, 'suspend_global_capture'):
+                        # pytest >= 3.3
+                        capture.suspend_global_capture()
+                    else:
+                        # legacy support for pytest <= 3.2 (Fedora 27)
+                        capture._capturing.suspend_capturing()
+                    # pylint: enable=no-member
                 sys.stderr.write(self.format(record))
                 sys.stderr.write('\n')
                 if capture:
-                    capture._capturing.resume_capturing()
+                    # pylint: disable=no-member
+                    if hasattr(capture, 'resume_global_capture'):
+                        capture.resume_global_capture()
+                    else:
+                        capture._capturing.resume_capturing()
+                    # pylint: enable=no-member
                 sys.stdout, sys.stderr = orig_stdout, orig_stderr
 
         level = convert_log_level(config.getoption('logging_level'))


### PR DESCRIPTION
The nose_compat plugin uses internal pytest APIs to suspend and resume
the capture manager. In pytest 3.4, the internal APIs have changed and a
public API was added.

The fix is required to run integration tests under Fedora 28.

Signed-off-by: Christian Heimes <cheimes@redhat.com>