### PR TITLE
ipactl: Correction of named to named-pkcs11

### DIFF
--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -48,7 +48,7 @@ if six.PY3:
 SERVICE_LIST = {
     'KDC': ('krb5kdc', 10),
     'KPASSWD': ('kadmin', 20),
-    'DNS': ('named', 30),
+    'DNS': ('named-pkcs11', 30),
     'HTTP': ('httpd', 40),
     'KEYS': ('ipa-custodia', 41),
     'CA': ('pki-tomcatd', 50),


### PR DESCRIPTION
Whenever ipactl status is run it returned:
Directory Service: RUNNING
krb5kdc Service: RUNNING
kadmin Service: RUNNING
named Service: RUNNING
...

This PR changes ipactl o/p to:
Directory Service: RUNNING
krb5kdc Service: RUNNING
kadmin Service: RUNNING
named-pkcs11 Service: RUNNING

Resolves: https://pagure.io/freeipa/issue/7446