### PR TITLE
[Backport][ipa-4-6] Load certificate files as binary data

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -62,3 +62,16 @@ jobs:
         template: *ci-master-f27
         timeout: 3600
         topology: *master_1repl
+
+  fedora-27/test_ipa_cli:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_ipa_cli.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+

--- a/ipaclient/plugins/cert.py
+++ b/ipaclient/plugins/cert.py
@@ -27,7 +27,7 @@ from ipaclient.frontend import MethodOverride
 from ipalib import errors
 from ipalib import x509
 from ipalib import util
-from ipalib.parameters import File, Flag, Str
+from ipalib.parameters import BinaryFile, File, Flag, Str
 from ipalib.plugable import Registry
 from ipalib.text import _
 
@@ -196,7 +196,7 @@ class cert_remove_hold(MethodOverride):
 @register(override=True, no_fail=True)
 class cert_find(MethodOverride):
     takes_options = (
-        File(
+        BinaryFile(
             'file?',
             label=_("Input filename"),
             doc=_('File to load the certificate from.'),

--- a/ipaclient/plugins/certmap.py
+++ b/ipaclient/plugins/certmap.py
@@ -4,7 +4,7 @@
 
 from ipaclient.frontend import MethodOverride
 from ipalib import errors, x509
-from ipalib.parameters import File
+from ipalib.parameters import BinaryFile
 from ipalib.plugable import Registry
 from ipalib.text import _
 
@@ -14,7 +14,7 @@ register = Registry()
 @register(override=True, no_fail=True)
 class certmap_match(MethodOverride):
     takes_args = (
-        File(
+        BinaryFile(
             'file?',
             label=_("Input file"),
             doc=_("File to load the certificate from"),

--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -1753,16 +1753,28 @@ class Any(Param):
 
 
 class File(Str):
-    """
-    File parameter type.
+    """Text file parameter type.
 
     Accepts file names and loads their content into the parameter value.
     """
+    open_mode = 'r'
     kwargs = Data.kwargs + (
         # valid for CLI, other backends (e.g. webUI) can ignore this
         ('stdin_if_missing', bool, False),
         ('noextrawhitespace', bool, False),
     )
+
+
+class BinaryFile(Bytes):
+    """Binary file parameter type
+    """
+    open_mode = 'rb'
+    kwargs = Data.kwargs + (
+        # valid for CLI, other backends (e.g. webUI) can ignore this
+        ('stdin_if_missing', bool, False),
+        ('noextrawhitespace', bool, False),
+    )
+
 
 class DateTime(Param):
     """

--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -3,12 +3,14 @@ import os
 import shlex
 import subprocess
 import sys
+import tempfile
 
 import nose
 import six
 from six import StringIO
 
 from ipatests import util
+from ipatests.test_ipalib.test_x509 import goodcert_headers
 from ipalib import api, errors
 import pytest
 
@@ -311,6 +313,16 @@ class TestCLIParsing(object):
 
         if not adtrust_is_enabled:
             mockldap.del_entry(adtrust_dn)
+
+    def test_certfind(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(goodcert_headers)
+            f.flush()
+            self.check_command(
+                'cert_find --file={}'.format(f.name),
+                'cert_find',
+                file=goodcert_headers
+            )
 
 
 def test_cli_fsencoding():

--- a/ipatests/test_integration/test_ipa_cli.py
+++ b/ipatests/test_integration/test_ipa_cli.py
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+#
+"""Misc test for 'ipa' CLI regressions
+"""
+from __future__ import absolute_import
+
+import base64
+import ssl
+
+
+from ipaplatform.paths import paths
+
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_plugins.integration import tasks
+
+
+class TestIPACommand(IntegrationTest):
+    topology = 'line'
+
+    def get_cert_base64(self, host, path):
+        """Retrieve cert and return content as single line, base64 encoded
+        """
+        cacrt = host.get_file_contents(path, encoding='ascii')
+        cader = ssl.PEM_cert_to_DER_cert(cacrt)
+        return base64.b64encode(cader).decode('ascii')
+
+    def test_certmap_match_issue7520(self):
+        # https://pagure.io/freeipa/issue/7520
+        tasks.kinit_admin(self.master)
+        result = self.master.run_command(
+            ['ipa', 'certmap-match', paths.IPA_CA_CRT],
+            raiseonerr=False
+        )
+        assert result.returncode == 1
+        assert not result.stderr_text
+        assert "0 users matched" in result.stdout_text
+
+        cab64 = self.get_cert_base64(self.master, paths.IPA_CA_CRT)
+        result = self.master.run_command(
+            ['ipa', 'certmap-match', '--certificate', cab64],
+            raiseonerr=False
+        )
+        assert result.returncode == 1
+        assert not result.stderr_text
+        assert "0 users matched" in result.stdout_text
+
+    def test_cert_find_issue7520(self):
+        # https://pagure.io/freeipa/issue/7520
+        tasks.kinit_admin(self.master)
+        subject = 'CN=Certificate Authority,O={}'.format(
+            self.master.domain.realm)
+
+        # by cert file
+        result = self.master.run_command(
+            ['ipa', 'cert-find', '--file', paths.IPA_CA_CRT]
+        )
+        assert subject in result.stdout_text
+        assert '1 certificate matched' in result.stdout_text
+
+        # by base64 cert
+        cab64 = self.get_cert_base64(self.master, paths.IPA_CA_CRT)
+        result = self.master.run_command(
+            ['ipa', 'cert-find', '--certificate', cab64]
+        )
+        assert subject in result.stdout_text
+        assert '1 certificate matched' in result.stdout_text

--- a/tox.ini
+++ b/tox.ini
@@ -52,3 +52,8 @@ deps=
     ipatests
 commands=
     {envpython} -m pytest {toxinidir}/pypi/test_placeholder.py
+
+[pycodestyle]
+# E402 module level import not at top of file
+ignore = E402
+


### PR DESCRIPTION
Manual backport of PR #1867 

In Python 3, cryptography requires certificate data to be binary. Even
PEM encoded files are treated as binary content.

certmap-match and cert-find were loading certificates as text files. A
new BinaryFile type loads files as binary content.

Fixes: https://pagure.io/freeipa/issue/7520
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Stanislav Laznicka <slaznick@redhat.com>
Reviewed-By: Florence Blanc-Renaud <frenaud@redhat.com>