### PR TITLE
Disable message about log in ipa-backup if IPA is not configured

### DIFF
--- a/install/tools/man/ipa-backup.1
+++ b/install/tools/man/ipa-backup.1
@@ -69,6 +69,8 @@ Log to the given file
 0 if the command was successful
 
 1 if an error occurred
+
+2 if IPA is not configured
 .SH "FILES"
 .PP
 \fI/var/lib/ipa/backup\fR

--- a/ipapython/admintool.py
+++ b/ipapython/admintool.py
@@ -32,6 +32,10 @@ from ipapython import version
 from ipapython import config
 from ipapython.ipa_log_manager import standard_logging_setup
 
+SUCCESS = 0
+SERVER_INSTALL_ERROR = 1
+SERVER_NOT_CONFIGURED = 2
+
 logger = logging.getLogger(__name__)
 
 
@@ -301,7 +305,9 @@ class AdminTool(object):
         if error_message:
             logger.error('%s', error_message)
         message = "The %s command failed." % self.command_name
-        if self.log_file_name:
+        if self.log_file_name and return_value != 2:
+            # magic value because this is common between server and client
+            # but imports are not straigthforward
             message += " See %s for more information" % self.log_file_name
         logger.error('%s', message)
 

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -56,7 +56,7 @@ from ipalib.install import sysrestore
 from ipalib.install.kinit import kinit_password
 import ipaplatform
 from ipapython import ipautil, admintool, version
-from ipapython.admintool import ScriptError
+from ipapython.admintool import ScriptError, SERVER_NOT_CONFIGURED  # noqa: E402
 from ipapython.certdb import EXTERNAL_CA_TRUST_FLAGS
 from ipapython.ipaldap import DIRMAN_DN, LDAPClient
 from ipalib.util import validate_hostname
@@ -959,7 +959,8 @@ def check_server_configuration():
     """
     server_fstore = sysrestore.FileStore(paths.SYSRESTORE)
     if not server_fstore.has_files():
-        raise RuntimeError("IPA is not configured on this system.")
+        raise ScriptError("IPA is not configured on this system.",
+                          rval=SERVER_NOT_CONFIGURED)
 
 
 def remove_file(filename):


### PR DESCRIPTION
Introduce server installation constants similar to the client
but only tie in SERVER_NOT_CONFIGURED right now.

For the case of not configured don't spit out the "See <some log>
for more information" because no logging was actually done.

In the case of ipa-backup this could also be confusing if the
--log-file option was also passed in because it would not be
used.

https://pagure.io/freeipa/issue/6843

Signed-off-by: Rob Crittenden <rcritten@redhat.com>