### PR TITLE
install: fix reported external CA configuration

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -105,9 +105,13 @@ def print_ca_configuration(options):
     print("The CA will be configured with:")
     print("Subject DN:   {}".format(options.ca_subject))
     print("Subject base: {}".format(options.subject_base))
-    print("Chaining:     {}".format(
-        "externally signed (two-step installation)" if options.external_ca
-        else "self-signed"))
+    if options.external_ca:
+        chaining = "externally signed (two-step installation)"
+    elif options.external_cert_files:
+        chaining = "externally signed"
+    else:
+        chaining = "self-signed"
+    print("Chaining:     {}".format(chaining))
 
 
 def install_check(standalone, replica_config, options):


### PR DESCRIPTION
The installer reports the CA configuration that will be used,
including whether the CA is self-signed or externally-signed.

Installation with external CA takes two steps. The first step
correctly reports the externally signed configuration (like the
above), but the second step reports a self-signed configuration.

The CA *is* externally signed, but the configuration gets reported
incorrectly at step 2.  This could confuse the administrator.  Fix
the message.

Fixes: https://pagure.io/freeipa/issue/7523