### PR TITLE
[Backport][ipa-4-6] Validate the Directory Manager password before starting restore

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -668,7 +668,7 @@ class Restore(admintool.AdminTool):
         '''
         Restore paths.IPA_DEFAULT_CONF to temporary directory.
 
-        Primary purpose of this method is to get cofiguration for api
+        Primary purpose of this method is to get configuration for api
         finalization when restoring ipa after uninstall.
         '''
         cwd = os.getcwd()
@@ -882,3 +882,10 @@ class Restore(admintool.AdminTool):
 
         self.instances = [installutils.realm_to_serverid(api.env.realm)]
         self.backends = ['userRoot', 'ipaca']
+
+        try:
+            ReplicationManager(api.env.realm, api.env.host,
+                               self.dirman_password)
+        except errors.ACIError:
+            logger.error("Incorrect Directory Manager password provided")
+            raise


### PR DESCRIPTION
This PR was opened automatically because PR #1892 was pushed to master and backport to ipa-4-6 is required.