### PR TITLE
Make ipatests' create_external_ca a script

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -43,7 +43,7 @@ from ipalib.util import get_reverse_zone_default, verify_host_resolvable
 from ipalib.constants import (
     DEFAULT_CONFIG, DOMAIN_SUFFIX_NAME, DOMAIN_LEVEL_0)
 
-from .create_external_ca import ExternalCA
+from ipatests.create_external_ca import ExternalCA
 from .env_config import env_to_script
 from .host import Host
 

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -37,7 +37,7 @@ from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_plugins.integration import tasks
-from ipatests.pytest_plugins.integration.create_external_ca import ExternalCA
+from ipatests.create_external_ca import ExternalCA
 from ipatests.pytest_plugins.integration import create_caless_pki
 from ipalib.constants import DOMAIN_LEVEL_0
 

--- a/ipatests/test_integration/test_external_ca.py
+++ b/ipatests/test_integration/test_external_ca.py
@@ -27,7 +27,7 @@ from ipatests.test_integration.base import IntegrationTest
 from ipaplatform.paths import paths
 
 from itertools import chain, repeat
-from ipatests.pytest_plugins.integration.create_external_ca import ExternalCA
+from ipatests.create_external_ca import ExternalCA
 
 IPA_CA = 'ipa_ca.crt'
 ROOT_CA = 'root_ca.crt'


### PR DESCRIPTION
The test helper create_external_ca is useful to create an external root
CA and sign ipa.csr for external CA testing. I also moved the file into
ipatests top package to make the import shorter and to avoid an import
warning.

Usage:

```
   ipa-server-install --external-ca ...
   python3 -m ipatests.create_external_ca
   ipa-server-install --external-cert-file=/tmp/rootca.pem \
       --external-cert-file=/tmp/ipaca.pem
```

Signed-off-by: Christian Heimes <cheimes@redhat.com>