### PR TITLE
Use temporary pid file for chronyd -q task

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -665,7 +665,8 @@ def sync_time(host, server):
 
     host.run_command(['systemctl', 'stop', 'chronyd'])
     host.run_command(['chronyd', '-q',
-                      "server {srv} iburst".format(srv=server.hostname)])
+                      "server {srv} iburst".format(srv=server.hostname),
+                      'pidfile /tmp/chronyd.pid', 'bindcmdaddress /'])
 
 
 def connect_replica(master, replica, domain_level=None):


### PR DESCRIPTION
chrony is causing an SELinux denial because of chronyd
was not spawned using systemd and the command creates
a pidfile for unconfined proccess in /var/run with SELinux label:
`unconfined_u:object_r:var_run_t:s0`
Following chronyd daemon enablement with systemd will fail
due to mismatched SELinux labels on chronyd pidfile.
chronyd pidfile should be labeled with the following label:
`system_u:object_r:chronyd_var_run_t:s0`
This also changes bindcmdaddress to not touch /var/run/chrony.