### PR TITLE
authselect improvements

### DIFF
--- a/ipatests/test_integration/test_authselect.py
+++ b/ipatests/test_integration/test_authselect.py
@@ -172,7 +172,7 @@ class TestClientInstallation(IntegrationTest):
 
 
 @pytest.mark.skipif(
-    ipaplatform.NAME not in ['fedora', 'rhel', 'centos'],
+    ipaplatform.paths.paths.AUTHSELECT is None,
     reason="Authselect is only available in fedora-like distributions")
 class TestServerInstallation(IntegrationTest):
     """


### PR DESCRIPTION
Improvements for authselect migration:
- rely on a stable interface to read the current profile (authselect current --raw)
- run tests only when authselect command is available

Related to
https://pagure.io/freeipa/issue/7377