### PR TITLE
ipa-client package needs sssd-tool

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -161,7 +161,6 @@ BuildRequires:  nss-devel
 BuildRequires:  openssl-devel
 BuildRequires:  libini_config-devel
 BuildRequires:  cyrus-sasl-devel
-BuildRequires:  sssd-tools
 %if ! %{ONLY_CLIENT}
 BuildRequires:  389-ds-base-devel >= %{ds_version}
 BuildRequires:  svrcore-devel
@@ -612,6 +611,7 @@ Requires: libsss_autofs
 Requires: autofs
 Requires: libnfsidmap
 Requires: nfs-utils
+Requires: sssd-tools
 Requires(post): policycoreutils
 
 Provides: %{alt_name}-client = %{version}


### PR DESCRIPTION
Commit ccec8c6c4193a204428b7ba0f93dac6f0eb26020 add a call to sssctl but
the providing package sssd-tools was not added to ipa-client package.
The tool is not need to build packages.

See: https://pagure.io/freeipa/issue/7376
Signed-off-by: Christian Heimes <cheimes@redhat.com>