### PR TITLE
Create missing /etc/httpd/alias for ipasession.key

### DIFF
--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -175,6 +175,12 @@ class HTTPInstance(service.Service):
         self.update_httpd_service_ipa_conf()
         self.update_httpd_wsgi_conf()
 
+        # create /etc/httpd/alias, see https://pagure.io/freeipa/issue/7529
+        session_dir = os.path.dirname(self.sub_dict['GSSAPI_SESSION_KEY'])
+        if not os.path.isdir(session_dir):
+            os.makedirs(session_dir)
+            os.chmod(session_dir, 0o755)
+
         target_fname = paths.HTTPD_IPA_CONF
         http_txt = ipautil.template_file(
             os.path.join(paths.USR_SHARE_IPA_DIR,


### PR DESCRIPTION
The director /etc/httpd/alias was created by mod_nss. Since FreeIPA no
longer depends on mod_nss, the directory is no longer created on fresh
systems.

Note: At first I wanted to move the file to /var/lib/ipa/private/ or
/var/lib/httpd/. SELinux prevents write of httpd_t to ipa_var_lib_t. I'm
going to move the file after a new SELinux policy is available.

See: https://pagure.io/freeipa/issue/7529
Signed-off-by: Christian Heimes <cheimes@redhat.com>