### PR TITLE
mod_ssl: add SSLVerifyDepth for external CA installs

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -319,3 +319,6 @@ USER_CACHE_PATH = (
 )
 
 SOFTHSM_DNSSEC_TOKEN_LABEL = u'ipaDNSSEC'
+# Apache's mod_ssl SSLVerifyDepth value (Maximum depth of CA
+# Certificates in Client Certificate verification)
+MOD_SSL_VERIFY_DEPTH = '5'

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -43,7 +43,7 @@ from ipapython.dn import DN
 import ipapython.errors
 from ipaserver.install import sysupgrade
 from ipalib import api, x509
-from ipalib.constants import IPAAPI_USER
+from ipalib.constants import IPAAPI_USER, MOD_SSL_VERIFY_DEPTH
 from ipaplatform.constants import constants
 from ipaplatform.tasks import tasks
 from ipaplatform.paths import paths
@@ -418,6 +418,11 @@ class HTTPInstance(service.Service):
         installutils.set_directive(paths.HTTPD_SSL_CONF,
                                    'SSLCACertificateFile',
                                    paths.IPA_CA_CRT, False)
+        # set SSLVerifyDepth for external CA installations
+        installutils.set_directive(paths.HTTPD_SSL_CONF,
+                                   'SSLVerifyDepth',
+                                   MOD_SSL_VERIFY_DEPTH,
+                                   quotes=False)
 
     def __publish_ca_cert(self):
         ca_subject = self.cert.issuer

--- a/ipatests/test_integration/test_external_ca.py
+++ b/ipatests/test_integration/test_external_ca.py
@@ -111,6 +111,8 @@ class TestExternalCA(IntegrationTest):
     """
     Test of FreeIPA server installation with exernal CA
     """
+    num_replicas = 1
+
     @tasks.collect_logs
     def test_external_ca(self):
         # Step 1 of ipa-server-install.
@@ -130,6 +132,9 @@ class TestExternalCA(IntegrationTest):
         tasks.kinit_admin(self.master)
         result = self.master.run_command(['ipa', 'user-show', 'admin'])
         assert 'User login: admin' in result.stdout_text
+
+        # check that we can also install replica
+        tasks.install_replica(self.master, self.replicas[0])
 
 
 class TestSelfExternalSelf(IntegrationTest):


### PR DESCRIPTION
mod_ssl's limiting of client cert verification depth was causing
the replica installs to fail when master had been installed with
external CA since the SSLCACertificateFile was pointing to a file
with more than one certificate. This is caused by the default
SSLVerifyDepth value of 1. We set it to 5 as that should be
just about enough even for possible sub-CAs.

https://pagure.io/freeipa/issue/7530