### PR TITLE
Revert "Validate the Directory Manager password"

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -670,7 +670,7 @@ class Restore(admintool.AdminTool):
         '''
         Restore paths.IPA_DEFAULT_CONF to temporary directory.
 
-        Primary purpose of this method is to get configuration for api
+        Primary purpose of this method is to get cofiguration for api
         finalization when restoring ipa after uninstall.
         '''
         cwd = os.getcwd()
@@ -884,10 +884,3 @@ class Restore(admintool.AdminTool):
 
         self.instances = [installutils.realm_to_serverid(api.env.realm)]
         self.backends = ['userRoot', 'ipaca']
-
-        try:
-            ReplicationManager(api.env.realm, api.env.host,
-                               self.dirman_password)
-        except errors.ACIError:
-            logger.error("Incorrect Directory Manager password provided")
-            raise


### PR DESCRIPTION
This reverts commit 0653d2a17e67a32c9adcca8145afa231f228b855. The commit
broke full ipa-restore.

See: https://pagure.io/freeipa/issue/7469
See: https://pagure.io/freeipa/issue/7535
Signed-off-by: Christian Heimes <cheimes@redhat.com>