### PR TITLE
Validate the Directory Manager password in ipa-restore (take 2)

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -210,6 +210,10 @@ class Restore(admintool.AdminTool):
         options = self.options
         super(Restore, self).ask_for_options()
 
+        # no IPA config means we are reinstalling from nothing so
+        # there is no need for the DM password
+        if not os.path.exists(paths.IPA_DEFAULT_CONF):
+            return
         # get the directory manager password
         self.dirman_password = options.password
         if not options.password:
@@ -670,7 +674,7 @@ class Restore(admintool.AdminTool):
         '''
         Restore paths.IPA_DEFAULT_CONF to temporary directory.
 
-        Primary purpose of this method is to get cofiguration for api
+        Primary purpose of this method is to get configuration for api
         finalization when restoring ipa after uninstall.
         '''
         cwd = os.getcwd()
@@ -884,3 +888,18 @@ class Restore(admintool.AdminTool):
 
         self.instances = [installutils.realm_to_serverid(api.env.realm)]
         self.backends = ['userRoot', 'ipaca']
+
+        # no IPA config means we are reinstalling from nothing so
+        # there is nothing to test the DM password against.
+        if os.path.exists(paths.IPA_DEFAULT_CONF):
+            instance_name = installutils.realm_to_serverid(api.env.realm)
+            if not services.knownservices.dirsrv.is_running(instance_name):
+                raise admintool.ScriptError(
+                    "directory server instance is not running"
+                )
+            try:
+                ReplicationManager(api.env.realm, api.env.host,
+                                   self.dirman_password)
+            except errors.ACIError:
+                logger.error("Incorrect Directory Manager password provided")
+                raise

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -482,10 +482,9 @@ class TestBackupAndRestoreWithReplica(IntegrationTest):
                 "systemctl", "disable", "oddjobd"
             ])
 
-            dirman_password = self.master.config.dirman_password
             self.master.run_command(
                 ["ipa-restore", backup_path],
-                stdin_text=dirman_password + '\nyes'
+                stdin_text='yes'
             )
 
             status = self.master.run_command([
@@ -547,3 +546,36 @@ class TestUserrootFilesOwnership(IntegrationTest):
         unexp_str = "CRITICAL: db2ldif failed:"
         assert cmd.returncode == 0
         assert unexp_str not in cmd.stdout_text
+
+
+class TestBackupAndRestoreDMPassword(IntegrationTest):
+    """Negative tests for incorrect DM password"""
+    topology = 'star'
+
+    def test_restore_bad_dm_password(self):
+        """backup, uninstall, restore, wrong DM password (expect failure)"""
+        with restore_checker(self.master):
+            backup_path = backup(self.master)
+
+            # No uninstall, just pure restore, the only case where
+            # prompting for the DM password matters.
+            result = self.master.run_command(['ipa-restore', backup_path],
+                                             stdin_text='badpass\nyes',
+                                             raiseonerr=False)
+            assert result.returncode == 1
+
+    def test_restore_dirsrv_not_running(self):
+        """backup, restore, dirsrv not running (expect failure)"""
+
+        # Flying blind without the restore_checker so we can have
+        # an error thrown when dirsrv is down.
+        backup_path = backup(self.master)
+
+        self.master.run_command(['ipactl', 'stop'])
+
+        dirman_password = self.master.config.dirman_password
+        result = self.master.run_command(
+            ['ipa-restore', backup_path],
+            stdin_text=dirman_password + '\nyes',
+            raiseonerr=False)
+        assert result.returncode == 1


### PR DESCRIPTION
Validate the DM password before starting the actual restoration if /etc/ipa/default.conf exists AND dirsrv is running. If default.conf exists and dirsrv is not running raise an error.

Add two tests to validate this behavior.

https://pagure.io/freeipa/issue/7535