### PR TITLE
tests: Fix on test_sudo_rule_restricted_to_one_hostmask_negative

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -23,7 +23,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f27
           name: freeipa/ci-master-f27
-          version: 1.0.3
+          version: 1.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -358,8 +358,7 @@ class TestSudo(IntegrationTest):
     def test_sudo_rule_restricted_to_one_hostmask_negative(self):
         result1 = self.list_sudo_commands("testuser1")
         assert result1.returncode != 0
-        assert "Sorry, user testuser1 may not run sudo on {}.".format(
-            self.clientname) in result1.stderr_text
+        assert "sudo: a password is required" in result1.stderr_text
 
     def test_sudo_rule_restricted_to_one_hostmask_negative_teardown(self):
         # Remove the master's hostmask from the rule


### PR DESCRIPTION
The error message was changed. This patch fix the test
to current situation.

https://pagure.io/freeipa/issue/7543