### PR TITLE
ui_tests: extend test_selinuxusermap.py suite

### DIFF
--- a/ipatests/test_webui/data_selinuxusermap.py
+++ b/ipatests/test_webui/data_selinuxusermap.py
@@ -1,0 +1,100 @@
+#
+# Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+#
+
+ENTITY = 'selinuxusermap'
+
+PKEY = 'itest-selinuxusermap'
+DATA = {
+    'pkey': PKEY,
+    'add': [
+        ('textbox', 'cn', PKEY),
+        ('textbox', 'ipaselinuxuser', 'user_u:s0'),
+    ],
+    'mod': [
+        ('textarea', 'description', 'itest-selinuxusermap desc'),
+    ],
+}
+
+PKEY2 = 'itest-selinuxusermap2'
+DATA2 = {
+    'pkey': PKEY2,
+    'add': [
+        ('textbox', 'cn', PKEY2),
+        ('textbox', 'ipaselinuxuser', 'unconfined_u:s0-s0:c0.c1023'),
+    ],
+    'mod': [
+        ('textarea', 'description', 'itest-selinuxusermap desc2'),
+    ],
+}
+
+PKEY_MLS_RANGE = 'itest-selinuxusermap_MLS_range'
+DATA_MLS_RANGE = {
+    'pkey': PKEY_MLS_RANGE,
+    'add': [
+        ('textbox', 'cn', PKEY_MLS_RANGE),
+        ('textbox', 'ipaselinuxuser', 'user_u:s0-s1'),
+    ],
+}
+
+PKEY_MCS_RANGE = 'itest-selinuxusermap_MLS_range'
+DATA_MCS_RANGE = {
+    'pkey': PKEY_MCS_RANGE,
+    'add': [
+        ('textbox', 'cn', PKEY_MCS_RANGE),
+        ('textbox', 'ipaselinuxuser', 'user_u:s0-s15:c0.c1023'),
+    ],
+}
+
+PKEY_MCS_COMMAS = 'itest-selinuxusermap_MCS_commas'
+DATA_MCS_COMMAS = {
+    'pkey': PKEY_MCS_COMMAS,
+    'add': [
+        ('textbox', 'cn', PKEY_MCS_COMMAS),
+        ('textbox', 'ipaselinuxuser', 'user_u:s0-s1:c0,c2,c15.c26'),
+    ],
+}
+
+PKEY_MLS_SINGLE_VAL = 'itest-selinuxusermap_MLS_single_val'
+DATA_MLS_SINGLE_VAL = {
+    'pkey': PKEY_MLS_SINGLE_VAL,
+    'add': [
+        ('textbox', 'cn', PKEY_MLS_SINGLE_VAL),
+        ('textbox', 'ipaselinuxuser', 'user_u:s0-s0:c0.c1023'),
+    ],
+}
+
+PKEY_NON_EXIST_SEUSER = 'itest-selinuxusermap_nonexistent_user'
+DATA_NON_EXIST_SEUSER = {
+    'pkey': PKEY_NON_EXIST_SEUSER,
+    'add': [
+        ('textbox', 'cn', PKEY_NON_EXIST_SEUSER),
+        ('textbox', 'ipaselinuxuser', 'abc:s0'),
+    ],
+}
+
+PKEY_INVALID_MCS = 'itest-selinuxusermap_invalid_MCS'
+DATA_INVALID_MCS = {
+    'pkey': PKEY_INVALID_MCS,
+    'add': [
+        ('textbox', 'cn', PKEY_INVALID_MCS),
+        ('textbox', 'ipaselinuxuser', 'user:s0:c'),
+    ],
+}
+
+PKEY_INVALID_MLS = 'itest-selinuxusermap_invalid_MLS'
+DATA_INVALID_MLS = {
+    'pkey': PKEY_INVALID_MLS,
+    'add': [
+        ('textbox', 'cn', PKEY_INVALID_MLS),
+        ('textbox', 'ipaselinuxuser', 'user'),
+    ],
+}
+
+PKEY_FIELD_REQUIRED = 'itest-selinuxusermap_without_SELinux_user'
+DATA_FIELD_REQUIRED = {
+    'pkey': PKEY_FIELD_REQUIRED,
+    'add': [
+        ('textbox', 'cn', PKEY_FIELD_REQUIRED),
+    ],
+}

--- a/ipatests/test_webui/test_netgroup.py
+++ b/ipatests/test_webui/test_netgroup.py
@@ -68,10 +68,11 @@ class test_netgroup(UI_driver):
                         delete=True)
 
         # add netgroup using enter
-        self.add_record(netgroup.ENTITY, netgroup.DATA, negative=True)
+        self.add_record(netgroup.ENTITY, netgroup.DATA, dialog_btn=None)
         actions = ActionChains(self.driver)
+        actions.send_keys(Keys.TAB)
         actions.send_keys(Keys.ENTER).perform()
-        self.wait_for_request()
+        self.wait_for_request(d=0.5)
         self.assert_record(netgroup.PKEY)
         self.close_notifications()
 
@@ -79,8 +80,9 @@ class test_netgroup(UI_driver):
         self.select_record(netgroup.PKEY)
         self.facet_button_click('remove')
         self.wait_for_request()
+        actions = ActionChains(self.driver)
         actions.send_keys(Keys.ENTER).perform()
-        self.wait_for_request()
+        self.wait_for_request(d=0.5)
         self.assert_record(netgroup.PKEY, negative=True)
         self.close_all_dialogs()
 
@@ -331,7 +333,7 @@ class test_netgroup(UI_driver):
 
         for t in tables:
             table, keys, _exts = get_t_vals(t)
-            self.add_table_associations(table, [keys[0]], negative=True)
+            self.add_table_associations(table, [keys[0]], confirm_btn='cancel')
 
             # verifying members listed as links ticket#2670
             self.add_table_associations(table, [keys[0]])

--- a/ipatests/test_webui/test_selinuxusermap.py
+++ b/ipatests/test_webui/test_selinuxusermap.py
@@ -25,22 +25,29 @@ from ipatests.test_webui.ui_driver import UI_driver
 from ipatests.test_webui.ui_driver import screenshot
 import ipatests.test_webui.data_user as user
 import ipatests.test_webui.data_group as group
+import ipatests.test_webui.data_selinuxusermap as selinuxmap
 import ipatests.test_webui.data_hostgroup as hostgroup
+import ipatests.test_webui.data_hbac as hbac
 from ipatests.test_webui.test_host import host_tasks, ENTITY as HOST_ENTITY
 import pytest
 
-ENTITY = 'selinuxusermap'
-PKEY = 'itest-selinuxusermap'
-DATA = {
-    'pkey': PKEY,
-    'add': [
-        ('textbox', 'cn', PKEY),
-        ('textbox', 'ipaselinuxuser', 'user_u:s0'),
-    ],
-    'mod': [
-        ('textarea', 'description', 'itest-selinuxusermap desc'),
-    ],
-}
+try:
+    from selenium.webdriver.common.keys import Keys
+    from selenium.webdriver.common.action_chains import ActionChains
+except ImportError:
+    pass
+
+RULE_ALR_EXIST = 'SELinux User Map rule with name "{}" already exists'
+RULE_UPDATED = 'SELinux User Map {} updated'
+RULE_ADDED = 'SELinux User Map successfully added'
+INVALID_SEUSER = 'SELinux user {} not found in ordering list (in config)'
+INVALID_MCS = ("invalid 'selinuxuser': Invalid MCS value, must match c[0-1023]"
+               ".c[0-1023] and/or c[0-1023]-c[0-c0123]")
+INVALID_MLS = ("invalid 'selinuxuser': Invalid MLS value, must match "
+               "s[0-15](-s[0-15])")
+HBAC_DEL_ERR = ('{} cannot be deleted because SELinux User Map {} requires '
+                'it')
+HBAC_MEMBER_ERR = 'HBAC rule and local members cannot both be set'
 
 
 @pytest.mark.tier1
@@ -52,7 +59,7 @@ class test_selinuxusermap(UI_driver):
         Basic CRUD: selinuxusermap
         """
         self.init_app()
-        self.basic_crud(ENTITY, DATA)
+        self.basic_crud(selinuxmap.ENTITY, selinuxmap.DATA)
 
     @screenshot
     def test_mod(self):
@@ -68,12 +75,14 @@ class test_selinuxusermap(UI_driver):
         self.add_record(group.ENTITY, group.DATA)
         self.add_record(group.ENTITY, group.DATA2, navigate=False)
         self.add_record(HOST_ENTITY, host.data)
+        self.close_notifications()
         self.add_record(HOST_ENTITY, host.data2, navigate=False)
+        self.close_notifications()
         self.add_record(hostgroup.ENTITY, hostgroup.DATA)
         self.add_record(hostgroup.ENTITY, hostgroup.DATA2, navigate=False)
-        self.add_record(ENTITY, DATA)
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA)
 
-        self.navigate_to_record(PKEY)
+        self.navigate_to_record(selinuxmap.PKEY)
 
         tables = [
             ['memberuser_user', [user.PKEY, user.PKEY2], ],
@@ -89,9 +98,15 @@ class test_selinuxusermap(UI_driver):
 
         self.mod_rule_tables(tables, categories, [])
 
+        # add associations then cancel
+        for t in tables:
+            table = t[0]
+            keys = t[1]
+            self.add_table_associations(table, [keys[0]], confirm_btn='cancel')
+
         # cleanup
         # -------
-        self.delete(ENTITY, [DATA])
+        self.delete(selinuxmap.ENTITY, [selinuxmap.DATA])
         self.delete(user.ENTITY, [user.DATA, user.DATA2])
         self.delete(group.ENTITY, [group.DATA, group.DATA2])
         self.delete(HOST_ENTITY, [host.data, host.data2])
@@ -104,9 +119,248 @@ class test_selinuxusermap(UI_driver):
         """
         self.init_app()
 
-        self.add_record(ENTITY, DATA)
-        self.navigate_to_record(PKEY)
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA)
+        self.navigate_to_record(selinuxmap.PKEY)
 
         self.disable_action()
         self.enable_action()
-        self.delete_action(ENTITY, PKEY)
+        self.delete_action(selinuxmap.ENTITY, selinuxmap.PKEY)
+
+    @screenshot
+    def test_misc(self):
+        """
+        Test various miscellaneous test cases under one roof to save init time
+        """
+        self.init_app()
+
+        # test add and add another record
+        self.add_record(selinuxmap.ENTITY, [selinuxmap.DATA, selinuxmap.DATA2])
+
+        # test delete multiple records
+        self.delete_record([selinuxmap.DATA, selinuxmap.DATA2])
+
+        # test add and cancel adding record
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA,
+                        dialog_btn='cancel')
+
+        # test add and edit record
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA,
+                        dialog_btn='add_and_edit')
+
+        # test add duplicate rule (should FAIL)
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA, negative=True,
+                        pre_delete=False)
+        self.assert_last_error_dialog(RULE_ALR_EXIST.format(selinuxmap.PKEY))
+        self.close_all_dialogs()
+
+        # test add disabled HBAC rule to SElinux rule
+        self.add_record(hbac.RULE_ENTITY, hbac.RULE_DATA)
+        self.navigate_to_record(hbac.RULE_PKEY)
+        self.disable_action()
+        self.navigate_to_record(selinuxmap.PKEY, entity=selinuxmap.ENTITY)
+        self.facet_button_click('refresh')
+        self.select_combobox('seealso', hbac.RULE_PKEY)
+        self.facet_button_click('save')
+        self.wait_for_request()
+        self.assert_notification(assert_text=RULE_UPDATED.format(
+            selinuxmap.PKEY))
+        self.close_all_dialogs()
+
+        # test deleting HBAC rule used in SELinux user map (should FAIL)
+        self.delete(hbac.RULE_ENTITY, [hbac.RULE_DATA])
+        self.assert_last_error_dialog(
+            HBAC_DEL_ERR.format(hbac.RULE_PKEY, selinuxmap.PKEY), details=True)
+        self.close_all_dialogs()
+        self.select_record(hbac.RULE_PKEY, unselect=True)
+
+        # test adding user to SELinux map together with HBAC rule (should FAIL)
+        self.navigate_to_record(selinuxmap.PKEY, entity=selinuxmap.ENTITY)
+        self.add_table_associations('memberuser_user', ['admin'],
+                                    negative=True)
+        self.assert_last_error_dialog(HBAC_MEMBER_ERR)
+        self.close_all_dialogs()
+
+        # test adding HBAC rule together with user (should FAIL)
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA2)
+        self.navigate_to_record(selinuxmap.PKEY2)
+        self.add_table_associations('memberuser_user', ['admin'],
+                                    negative=True)
+        self.select_combobox('seealso', hbac.RULE_PKEY)
+        self.facet_button_click('save')
+        self.assert_last_error_dialog(HBAC_MEMBER_ERR)
+        self.close_all_dialogs()
+
+        # test add rule without "SELinux user" (requires the field)
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA_FIELD_REQUIRED,
+                        negative=True)
+        self.assert_field_validation_required(field='ipaselinuxuser')
+        self.close_all_dialogs()
+
+        # test add rule with non-existent SELinux user
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA_NON_EXIST_SEUSER,
+                        negative=True)
+        self.assert_last_error_dialog(expected_err=INVALID_SEUSER.format(
+            selinuxmap.DATA_NON_EXIST_SEUSER['add'][1][2]))
+        self.close_all_dialogs()
+
+        # test add invalid MCS
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA_INVALID_MCS,
+                        negative=True)
+        self.assert_last_error_dialog(expected_err=INVALID_MCS)
+        self.close_all_dialogs()
+
+        # test add invalid MLS
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA_INVALID_MLS,
+                        negative=True)
+        self.assert_last_error_dialog(expected_err=INVALID_MLS)
+        self.close_all_dialogs()
+
+        # test search SELinux usermap
+        self.find_record(selinuxmap.ENTITY, selinuxmap.DATA)
+
+        # test disable enable multiple SELinux rules
+        self.select_multiple_records([selinuxmap.DATA, selinuxmap.DATA2])
+        self.facet_button_click('disable')
+        self.dialog_button_click('ok')
+        self.assert_notification(assert_text='2 item(s) disabled')
+        self.close_notifications()
+        self.assert_record_value('Disabled',
+                                 [selinuxmap.PKEY, selinuxmap.PKEY2],
+                                 'ipaenabledflag')
+        self.select_multiple_records([selinuxmap.DATA, selinuxmap.DATA2])
+        self.facet_button_click('enable')
+        self.dialog_button_click('ok')
+        self.assert_notification(assert_text='2 item(s) enabled')
+        self.close_notifications()
+        self.assert_record_value('Enabled',
+                                 [selinuxmap.PKEY, selinuxmap.PKEY2],
+                                 'ipaenabledflag')
+        self.delete(selinuxmap.ENTITY, [selinuxmap.DATA])
+
+        # test add / delete SELinux usermap confirming using ENTER key
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA, dialog_btn=None)
+        actions = ActionChains(self.driver)
+        actions.send_keys(Keys.ENTER).perform()
+        self.wait_for_request(d=0.5)
+        self.assert_notification(assert_text=RULE_ADDED)
+        self.assert_record(selinuxmap.PKEY)
+        self.close_notifications()
+        self.delete_record(selinuxmap.PKEY, confirm_btn=None)
+        actions = ActionChains(self.driver)
+        actions.send_keys(Keys.ENTER).perform()
+        self.wait_for_request(d=0.5)
+        self.assert_notification(assert_text='1 item(s) deleted')
+        self.assert_record(selinuxmap.PKEY, negative=True)
+        self.close_notifications()
+
+        # cleanup
+        self.delete(selinuxmap.ENTITY, [selinuxmap.DATA2])
+        self.delete(hbac.RULE_ENTITY, [hbac.RULE_DATA])
+
+    @screenshot
+    def test_add_different_rules(self):
+        """
+        Test adding different SELinux usermap rules
+        """
+        self.init_app()
+
+        self.navigate_to_entity('config')
+        old_selinux_order = self.get_field_value('ipaselinuxusermaporder')
+        new_selinux_order = '{}${}${}${}${}'.format(
+            old_selinux_order,
+            selinuxmap.DATA_MLS_RANGE['add'][1][2],
+            selinuxmap.DATA_MCS_RANGE['add'][1][2],
+            selinuxmap.DATA_MCS_COMMAS['add'][1][2],
+            selinuxmap.DATA_MLS_SINGLE_VAL['add'][1][2])
+        self.fill_input('ipaselinuxusermaporder', new_selinux_order)
+        self.facet_button_click('save')
+
+        # test add MLS range rule
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA_MLS_RANGE)
+        self.assert_record(selinuxmap.PKEY_MLS_RANGE)
+
+        # test add MCS range rule
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA_MCS_RANGE)
+        self.assert_record(selinuxmap.PKEY_MCS_RANGE)
+
+        # test add MCS rule with commas
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA_MCS_COMMAS)
+        self.assert_record(selinuxmap.PKEY_MCS_COMMAS)
+
+        # test add MLS single value rule
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA_MLS_SINGLE_VAL)
+        self.assert_record(selinuxmap.PKEY_MLS_SINGLE_VAL)
+
+        # restore original SELinux user map order
+        self.navigate_to_entity('config')
+        self.fill_input('ipaselinuxusermaporder', old_selinux_order)
+        self.facet_button_click('save')
+
+        # cleanup
+        self.delete(selinuxmap.ENTITY,
+                    [selinuxmap.DATA_MLS_RANGE,
+                     selinuxmap.DATA_MCS_RANGE,
+                     selinuxmap.DATA_MCS_COMMAS,
+                     selinuxmap.DATA_MLS_SINGLE_VAL]
+                    )
+
+    @screenshot
+    def test_undo_refresh_reset_update_cancel(self):
+        """
+        Test undo/refresh/reset/update/cancel buttons
+        """
+        self.init_app()
+
+        mod_description = (selinuxmap.DATA['mod'][0][2])
+
+        # test selinux usermap undo button
+        self.add_record(selinuxmap.ENTITY, selinuxmap.DATA)
+        self.navigate_to_record(selinuxmap.PKEY)
+        self.fill_fields(selinuxmap.DATA['mod'])
+        self.click_undo_button('description')
+        self.verify_btn_action(mod_description)
+
+        # test refresh button
+        self.fill_fields(selinuxmap.DATA['mod'], undo=True)
+        self.facet_button_click('refresh')
+        self.verify_btn_action(mod_description)
+
+        # test reset button
+        self.mod_record(selinuxmap.ENTITY, selinuxmap.DATA, facet_btn='revert')
+        self.wait_for_request()
+        self.verify_btn_action(mod_description)
+
+        # test update button
+        self.fill_fields(selinuxmap.DATA['mod'], undo=True)
+        self.facet_button_click('refresh')
+        self.verify_btn_action(mod_description)
+
+        # test reset button after trying to leave the details page
+        self.fill_fields(selinuxmap.DATA2['mod'], undo=True)
+        self.click_on_link('SELinux User Maps')
+        self.dialog_button_click('revert')
+        self.navigate_to_record(selinuxmap.PKEY)
+        self.verify_btn_action(mod_description)
+        self.wait_for_request(n=2)
+
+        # test update button after trying to leave the details page
+        self.fill_fields(selinuxmap.DATA['mod'], undo=True)
+        self.click_on_link('SELinux User Maps')
+        self.dialog_button_click('save')
+        self.navigate_to_record(selinuxmap.PKEY)
+        self.verify_btn_action(mod_description, negative=True)
+        self.wait_for_request(n=2)
+
+        # cleanup
+        self.delete(selinuxmap.ENTITY, [selinuxmap.DATA])
+
+    def verify_btn_action(self, mod_description, negative=False):
+        """
+        camparing current description with modified description
+        """
+        current_description = self.get_field_value("description",
+                                                   element="textarea")
+        if negative:
+            assert current_description == mod_description
+        else:
+            assert current_description != mod_description

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -1381,6 +1381,9 @@ class UI_driver(object):
             if record != last_element:
                 btn = add_another_btn
 
+            if not dialog_btn:
+                return
+
             self.dialog_button_click(btn)
             self.wait_for_request()
             self.wait_for_request()
@@ -1611,7 +1614,8 @@ class UI_driver(object):
             self.assert_record(key, negative=True)
 
     def add_table_associations(self, table_name, pkeys, parent=False,
-                               delete=False, negative=False):
+                               delete=False, confirm_btn='add',
+                               negative=False):
         """
         Add value to table (association|rule|...)
         """
@@ -1631,13 +1635,15 @@ class UI_driver(object):
             self.button_click('add')
             self.wait()
 
-        if negative:
-            self.dialog_button_click('cancel')
+        self.dialog_button_click(confirm_btn)
+
+        if confirm_btn == 'cancel':
             self.assert_record(key, parent, table_name, negative=True)
             return
-        else:
-            self.dialog_button_click('add')
         self.wait_for_request(n=2)
+
+        if negative:
+            return
 
         for key in pkeys:
             self.assert_record(key, parent, table_name)

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -646,6 +646,16 @@ class UI_driver(object):
         link = self.find(text, By.LINK_TEXT, parent, strict=True)
         link.click()
 
+    def click_undo_button(self, field, parent=None):
+        """
+        Click undo button/s of particular field
+        """
+        self.assert_undo_button(field)
+        undo_btns = self.get_undo_buttons(field, parent)
+        for btn in undo_btns:
+            btn.click()
+        self.assert_undo_button(field, visible=False)
+
     def facet_button_click(self, name):
         """
         Click on facet button with given name


### PR DESCRIPTION
Extend test_selinuxusermap.py suite with new test cases. Details in the ticket.
    
We also modify "add_table_associations" to handle "cancel" and "negative" in the way other methods works.
    
Lastly, we start using dialog_btn=None to test keyboard confirmation as we did use it incorrectly with "Negative=True" where it was already confirmed by "click".