### PR TITLE
[Backport][ipa-4-5] Don't try to backup CS.cfg during upgrade if CA is not configured

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1630,7 +1630,8 @@ def upgrade_configuration():
 
     with installutils.stopped_service('pki-tomcatd', 'pki-tomcat'):
         # Dogtag must be stopped to be able to backup CS.cfg config
-        ca.backup_config()
+        if ca.is_configured():
+            ca.backup_config()
 
         # migrate CRL publish dir before the location in ipa.conf is updated
         ca_restart = migrate_crl_publish_dir(ca)


### PR DESCRIPTION
This is a manual backport of PR #1637 to ipa-4-5
https://pagure.io/freeipa/issue/7409

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
Reviewed-By: Fraser Tweedale <ftweedal@redhat.com>