### PR TITLE
Install shared templates for client setup too

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 if ENABLE_SERVER
     IPASERVER_SUBDIRS = ipaserver
-    SERVER_SUBDIRS = daemons init install
+    SERVER_SUBDIRS = daemons init
 endif
 
 if WITH_IPATESTS
@@ -12,7 +12,7 @@ endif
 IPACLIENT_SUBDIRS = ipaclient ipalib ipaplatform ipapython
 PYTHON_SUBDIRS = $(IPACLIENT_SUBDIRS) $(IPATESTS_SUBDIRS) $(IPASERVER_SUBDIRS)
 IPA_PLACEHOLDERS = freeipa ipa ipaserver ipatests
-SUBDIRS = asn1 util client contrib po pypi $(PYTHON_SUBDIRS) $(SERVER_SUBDIRS)
+SUBDIRS = asn1 util client contrib po pypi install $(PYTHON_SUBDIRS) $(SERVER_SUBDIRS)
 
 GENERATED_PYTHON_FILES = \
 	$(top_builddir)/ipaplatform/override.py \

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1106,6 +1106,8 @@ touch %{buildroot}%{_libdir}/krb5/plugins/libkrb5/winbind_krb5_locator.so
 mkdir -p %{buildroot}%{_sysconfdir}/cron.d
 %endif # ONLY_CLIENT
 
+# Collect templates and filter out non-server ones
+find %{buildroot}%{_usr}/share/ipa -maxdepth 1 -name '*.template' -a ! -name 'freeipa.template' -fprintf server-templates '%{_usr}/share/ipa/%f\n'
 
 %clean
 rm -rf %{buildroot}
@@ -1398,7 +1400,7 @@ fi
 %endif # with_python3
 
 
-%files server-common
+%files server-common -f server-templates
 %defattr(-,root,root,-)
 %doc README.md Contributors.txt
 %license COPYING
@@ -1414,7 +1416,6 @@ fi
 %{_usr}/share/ipa/kdcproxy.wsgi
 %{_usr}/share/ipa/*.ldif
 %{_usr}/share/ipa/*.uldif
-%{_usr}/share/ipa/*.template
 %dir %{_usr}/share/ipa/advise
 %dir %{_usr}/share/ipa/advise/legacy
 %{_usr}/share/ipa/advise/legacy/*.template

--- a/install/Makefile.am
+++ b/install/Makefile.am
@@ -4,7 +4,8 @@ AUTOMAKE_OPTIONS = 1.7
 
 NULL =
 
-SUBDIRS =			\
+if ENABLE_SERVER
+SERVER_SUBDIRS =		\
         certmonger		\
         html			\
         migration		\
@@ -16,7 +17,13 @@ SUBDIRS =			\
         wsgi			\
         oddjob			\
 	$(NULL)
+endif
 
+SUBDIRS = share 		\
+	  $(SERVER_SUBDIRS)	\
+	  $(NULL)
+
+if ENABLE_SERVER
 install-exec-local:
 	$(INSTALL) -d -m 700 $(DESTDIR)$(IPA_SYSCONF_DIR)/custodia
 	$(INSTALL) -d -m 700 $(DESTDIR)$(localstatedir)/lib/ipa/backup
@@ -37,3 +44,4 @@ uninstall-local:
 	-rmdir $(DESTDIR)$(localstatedir)/lib/ipa
 
 EXTRA_DIST = README.schema
+endif

--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -1,12 +1,20 @@
 NULL =
+appdir = $(IPA_DATA_DIR)
 
+# FreeIPA has two major build modes:
+# server build: full install is needed
+# client build: only few templates needed
+#
+# If changes or additions required, make
+# sure to handle both branches of the
+# following conditional
+if ENABLE_SERVER
 SUBDIRS =  				\
 	advise				\
 	profiles			\
 	schema.d			\
 	$(NULL)
 
-appdir = $(IPA_DATA_DIR)
 dist_app_DATA =				\
 	05rfc2247.ldif			\
 	15rfc2307bis.ldif		\
@@ -100,3 +108,11 @@ dist_app_DATA =				\
 kdcproxyconfdir = $(IPA_SYSCONF_DIR)/kdcproxy
 dist_kdcproxyconf_DATA =			\
 	kdcproxy.conf
+else
+# For the client build we have a separate setup
+
+dist_app_DATA =				\
+	freeipa.template		\
+	$(NULL)
+
+endif


### PR DESCRIPTION
This patchset updates a spec file and our Make files to allow installing shared templates for the client build as well. So far we only have a single template for krb5.conf.d (freeipa.template) but there might be potentially more coming in.

This is a proper solution -- in Fedora 28/29 builds downstream I'm copying the files manually to avoid re-spinning a tarball with 4.7.0rc2. We still need to filter out client side templates from the server side in the spec file, so there is not a single place to define all files, unfortunately, but that's good enough for now as we have only a single file used by the client side.