### PR TITLE
test_server_del: fix TestServerDel suite

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -11,6 +11,9 @@ topologies:
     name: master_1repl_1client
     cpu: 4
     memory: 6700
+  master_2repl_1client: &master_2repl_1client
+    name: master_2repl_1client
+    memory: 9100
 
 jobs:
   fedora-28/build:
@@ -27,195 +30,26 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-28/simple_replication:
+  fedora-28/server_del:
     requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_simple_replication.py
+        test_suite: test_integration/test_server_del.py::TestServerDel
         template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/caless:
+  fedora-28/server_del_last_services:
     requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
+        test_suite: test_integration/test_server_del.py::TestLastServices
         template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/external_ca_1:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_external_ca.py::TestExternalCA
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl_1client
-
-  fedora-28/external_ca_2:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_topologies:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_topologies.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_sudo:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_sudo.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl_1client
-
-  fedora-28/test_commands:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_commands.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_kerberos_flags:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_kerberos_flags.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl_1client
-
-  fedora-28/test_http_kdc_proxy:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_http_kdc_proxy.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl_1client
-
-  fedora-28/test_forced_client_enrolment:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl_1client
-
-  fedora-28/test_advise:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_advise.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_testconfig:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_testconfig.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_service_permissions:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_service_permissions.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_netgroup:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_netgroup.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_vault:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_vault.py
-        template: *ci-master-f28
-        timeout: 4500
-        topology: *master_1repl
-
-  fedora-28/test_authconfig:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_authselect.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl_1client
-
+        timeout: 7200
+        topology: *master_2repl_1client

--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -738,11 +738,19 @@ def kinit_admin(host, raiseonerr=True):
 
 
 def uninstall_master(host, ignore_topology_disconnect=True,
-                     ignore_last_of_role=True, clean=True):
+                     ignore_last_of_role=True, clean=True,
+                     domain_level=None):
     host.collect_log(paths.IPASERVER_UNINSTALL_LOG)
     uninstall_cmd = ['ipa-server-install', '--uninstall', '-U']
 
-    host_domain_level = domainlevel(host)
+    # in some cases, like uninstalling of replica already removed by
+    # server-del where removal of principals was replicated, dynamic
+    # domain resolution doesn't work as connecting to the API on that
+    # server might no longer work
+    if domain_level is None:
+        host_domain_level = domainlevel(host)
+    else:
+        host_domain_level = domain_level
 
     if ignore_topology_disconnect and host_domain_level != DOMAIN_LEVEL_0:
         uninstall_cmd.append('--ignore-topology-disconnect')

--- a/ipatests/test_integration/test_server_del.py
+++ b/ipatests/test_integration/test_server_del.py
@@ -167,8 +167,8 @@ class TestServerDel(ServerDelBase):
 
     def test_ignore_topology_disconnect_replica1(self):
         """
-        tests that removal of replica1 with '--ignore-topology-disconnect'
-        destroys master for good
+        tests that server-del of replica1 with '--ignore-topology-disconnect'
+        passes
         """
         check_master_removal(
             self.master,
@@ -177,13 +177,13 @@ class TestServerDel(ServerDelBase):
         )
 
         # reinstall the replica
-        tasks.uninstall_master(self.replica1)
+        tasks.uninstall_master(self.replica1, domain_level=DOMAIN_LEVEL_1)
         tasks.install_replica(self.master, self.replica1, setup_ca=True)
 
     def test_ignore_topology_disconnect_replica2(self):
         """
-        tests that removal of replica2 with '--ignore-topology-disconnect'
-        destroys master for good
+        tests that server-del of replica2 with '--ignore-topology-disconnect'
+        passes
         """
         check_master_removal(
             self.master,
@@ -192,7 +192,7 @@ class TestServerDel(ServerDelBase):
         )
 
         # reinstall the replica
-        tasks.uninstall_master(self.replica2)
+        tasks.uninstall_master(self.replica2, domain_level=DOMAIN_LEVEL_1)
         tasks.install_replica(self.master, self.replica2, setup_ca=True)
 
     def test_removal_of_master_disconnects_both_topologies(self):
@@ -207,7 +207,7 @@ class TestServerDel(ServerDelBase):
 
     def test_removal_of_replica1(self):
         """
-        tests the removal of replica1 which should now pass without errors
+        tests the server-del of replica1 which should now pass without errors
         """
         check_master_removal(
             self.master,
@@ -216,7 +216,7 @@ class TestServerDel(ServerDelBase):
 
     def test_removal_of_replica2(self):
         """
-        tests the removal of replica2 which should now pass without errors
+        tests the server-del of replica2 which should now pass without errors
         """
         check_master_removal(
             self.master,

--- a/ipatests/test_integration/test_server_del.py
+++ b/ipatests/test_integration/test_server_del.py
@@ -178,7 +178,8 @@ class TestServerDel(ServerDelBase):
 
         # reinstall the replica
         tasks.uninstall_master(self.replica1, domain_level=DOMAIN_LEVEL_1)
-        tasks.install_replica(self.master, self.replica1, setup_ca=True)
+        tasks.install_replica(self.master, self.replica1, setup_ca=True,
+                              setup_dns=True)
 
     def test_ignore_topology_disconnect_replica2(self):
         """

--- a/ipatests/test_integration/test_server_del.py
+++ b/ipatests/test_integration/test_server_del.py
@@ -71,15 +71,13 @@ def check_removal_disconnects_topology(
 
 class ServerDelBase(IntegrationTest):
     num_replicas = 2
-    num_clients = 1
+    num_clients = 0
     domain_level = DOMAIN_LEVEL_1
     topology = 'star'
 
     @classmethod
     def install(cls, mh):
         super(ServerDelBase, cls).install(mh)
-
-        cls.client = cls.clients[0]
         cls.replica1 = cls.replicas[0]
         cls.replica2 = cls.replicas[1]
 
@@ -103,19 +101,19 @@ class TestServerDel(ServerDelBase):
         #                    \
         #   replica1------- replica2
 
-        tasks.create_segment(cls.client, cls.replica1, cls.replica2)
-        tasks.create_segment(cls.client, cls.replica1, cls.replica2,
+        tasks.create_segment(cls.master, cls.replica1, cls.replica2)
+        tasks.create_segment(cls.master, cls.replica1, cls.replica2,
                              suffix=CA_SUFFIX_NAME)
 
         # try to delete all relevant segment connecting master and replica1/2
         segment_name_fmt = '{p[0].hostname}-to-{p[1].hostname}'
         for domain_pair in permutations((cls.master, cls.replica2)):
             tasks.destroy_segment(
-                cls.client, segment_name_fmt.format(p=domain_pair))
+                cls.master, segment_name_fmt.format(p=domain_pair))
 
         for ca_pair in permutations((cls.master, cls.replica1)):
             tasks.destroy_segment(
-                cls.client, segment_name_fmt.format(p=ca_pair),
+                cls.master, segment_name_fmt.format(p=ca_pair),
                 suffix=CA_SUFFIX_NAME)
 
     def test_removal_of_nonexistent_master_raises_error(self):
@@ -125,7 +123,7 @@ class TestServerDel(ServerDelBase):
         hostname = u'bogus-master.bogus.domain'
         err_message = "{}: server not found".format(hostname)
         tasks.assert_error(
-            tasks.run_server_del(self.client, hostname),
+            tasks.run_server_del(self.master, hostname),
             err_message,
             returncode=2
         )
@@ -136,7 +134,7 @@ class TestServerDel(ServerDelBase):
         an error
         """
         hostname = u'bogus-master.bogus.domain'
-        result = tasks.run_server_del(self.client, hostname, force=True)
+        result = tasks.run_server_del(self.master, hostname, force=True)
         assert result.returncode == 0
         assert ('Deleted IPA server "{}"'.format(hostname) in
                 result.stdout_text)
@@ -150,7 +148,7 @@ class TestServerDel(ServerDelBase):
         """
 
         check_removal_disconnects_topology(
-            self.client,
+            self.master,
             self.replica1.hostname,
             affected_suffixes=(DOMAIN_SUFFIX_NAME,)
         )
@@ -162,7 +160,7 @@ class TestServerDel(ServerDelBase):
         """
 
         check_removal_disconnects_topology(
-            self.client,
+            self.master,
             self.replica2.hostname,
             affected_suffixes=(CA_SUFFIX_NAME,)
         )
@@ -173,7 +171,7 @@ class TestServerDel(ServerDelBase):
         destroys master for good
         """
         check_master_removal(
-            self.client,
+            self.master,
             self.replica1.hostname,
             ignore_topology_disconnect=True
         )
@@ -188,7 +186,7 @@ class TestServerDel(ServerDelBase):
         destroys master for good
         """
         check_master_removal(
-            self.client,
+            self.master,
             self.replica2.hostname,
             ignore_topology_disconnect=True
         )
@@ -202,7 +200,7 @@ class TestServerDel(ServerDelBase):
         tests that master removal will now raise errors in both suffixes.
         """
         check_removal_disconnects_topology(
-            self.client,
+            self.master,
             self.master.hostname,
             affected_suffixes=(CA_SUFFIX_NAME, DOMAIN_SUFFIX_NAME)
         )
@@ -212,7 +210,7 @@ class TestServerDel(ServerDelBase):
         tests the removal of replica1 which should now pass without errors
         """
         check_master_removal(
-            self.client,
+            self.master,
             self.replica1.hostname
         )
 
@@ -221,7 +219,7 @@ class TestServerDel(ServerDelBase):
         tests the removal of replica2 which should now pass without errors
         """
         check_master_removal(
-            self.client,
+            self.master,
             self.replica2.hostname
         )
 


### PR DESCRIPTION
TestLastServices suite was fixed in PR #1913 . This PR completes ticket https://pagure.io/freeipa/issue/7517

The first patch does a bit of optimization so that this suite can be run on smaller topology, e.g. https://github.com/freeipa/freeipa-pr-ci/pull/165

Second fixes test_removal_of_replica1_disconnects_domain_topology, test_removal_of_replica2_disconnects_ca_topology. Details in commit message.

Third fixes test_removal_of_master_disconnects_both_topologies. Details in commit message.

Temp commit will be removed on successful run.

I think that the suite is still bit unstable as test_ignore_topology_disconnect_replica{1,2} reinstall master in disconnected topology so bad things might in theory happen. It might not be hit though, so let's try if it will work as is. 
