### PR TITLE
ipa vault-archive overwrites an existing value without warning

### DIFF
--- a/ipaserver/plugins/vault.py
+++ b/ipaserver/plugins/vault.py
@@ -55,7 +55,10 @@ Vaults
 """) + _("""
 Manage vaults.
 """) + _("""
-Vault is a secure place to store a secret.
+Vault is a secure place to store a secret. One vault can only
+store one secret. Contents of vault would be overwritten if
+at all present.
+
 """) + _("""
 Based on the ownership there are three vault categories:
 * user/private vault

--- a/ipatests/test_integration/test_advise.py
+++ b/ipatests/test_integration/test_advise.py
@@ -56,17 +56,6 @@ class TestAdvice(IntegrationTest):
         run_advice(self.master, advice_id, advice_regex, raiseerr)
 
 
-    def test_advice_FedoraAuthconfig(self):
-        advice_id = 'config-fedora-authconfig'
-        advice_regex = "\#\!\/bin\/sh.*" \
-                       "authconfig[\s]+\-\-enableldap[\s]+" \
-                       "\-\-ldapserver\=.*[\s]+\-\-enablerfc2307bis[\s]+" \
-                       "\-\-enablekrb5"
-        raiseerr = True
-
-        run_advice(self.master, advice_id, advice_regex, raiseerr)
-
-
     def test_advice_FreeBSDNSSPAM(self):
         advice_id = 'config-freebsd-nss-pam-ldapd'
         advice_regex = "\#\!\/bin\/sh.*" \


### PR DESCRIPTION
Upstream ticket was raised for issuing an warning message
whenever data in ipa vault is overwritten.

In Bugzilla(1339129) its agreed upon that Current behavior is consistent
with other IPA commands. None of ipa mod commands asks for confirmation
and therefore it should be the same here.
But to document, that vault can contain only one value in ipa help vault.

This PR addresses the changes agreed in Bugzilla.

Resolves: https://pagure.io/freeipa/issue/5922