### PR TITLE
pylint3: workaround false positives reported for W1662

### DIFF
--- a/ipaclient/csrgen.py
+++ b/ipaclient/csrgen.py
@@ -144,8 +144,8 @@ class Formatter(object):
                 for rule in field_mapping.data_rules]
 
             data_sources = []
-            for rule in field_mapping.data_rules:
-                data_source = rule.options.get('data_source')
+            for xrule in field_mapping.data_rules:
+                data_source = xrule.options.get('data_source')
                 if data_source:
                     data_sources.append(data_source)
 

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -638,7 +638,7 @@ class API(ReadOnly):
 
         logger.debug("importing all plugin modules in %s...", package_name)
         modules = getattr(package, 'modules', find_modules_in_dir(package_dir))
-        modules = ['.'.join((package_name, name)) for name in modules]
+        modules = ['.'.join((package_name, mname)) for mname in modules]
 
         for name in modules:
             logger.debug("importing plugin module %s", name)

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -1226,7 +1226,7 @@ class LDAPClient(object):
 
         assert isinstance(filters, (list, tuple))
 
-        filters = [f for f in filters if f]
+        filters = [fx for fx in filters if fx]
         if filters and rules == cls.MATCH_NONE:  # unary operator
             return '(%s%s)' % (cls.MATCH_NONE,
                                cls.combine_filters(filters, cls.MATCH_ANY))

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -496,7 +496,7 @@ def run(args, stdin=None, raiseonerr=True, nolog=(), env=None,
             pent = pwd.getpwnam(runas)
 
             suplementary_gids = [
-                grp.getgrnam(group).gr_gid for group in suplementary_groups
+                grp.getgrnam(sgroup).gr_gid for sgroup in suplementary_groups
             ]
 
             logger.debug('runas=%s (UID %d, GID %s)', runas,


### PR DESCRIPTION
Pylint3 falsely reports warning W1662: using a variable that was bound
inside a comprehension for the cases where the same name is reused for a
loop after the comprehension in question.

Rename the variable in a loop to avoid it.

If the code looks like the following:

  arr = [f for f in filters if callable(f)]
  for f in arr:
      result = result + f()

pylint3 would consider 'f' used outside of comprehension. Clearly, this
is a false-positive warning as the second 'f' use is completely
independent of the comprehension's use of 'f'.