### PR TITLE
[Backport][ipa-4-6] Fix test_server_del::TestLastServices

### DIFF
--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -523,16 +523,13 @@ class server_del(LDAPDelete):
                       "leave your installation without a CA."),
                     ignore_last_of_role)
 
+            # change the renewal master if there is other master with CA
             if ca_renewal_master == hostname:
                 other_cas = [ca for ca in ca_servers if ca != hostname]
 
-                # if this is the last CA there is no other server to become
-                # renewal master
-                if not other_cas:
-                    return
-
-                self.api.Command.config_mod(
-                    ca_renewal_master_server=other_cas[0])
+                if other_cas:
+                    self.api.Command.config_mod(
+                        ca_renewal_master_server=other_cas[0])
 
         if ignore_last_of_role:
             self.add_message(

--- a/ipatests/test_integration/test_server_del.py
+++ b/ipatests/test_integration/test_server_del.py
@@ -241,23 +241,6 @@ class TestLastServices(ServerDelBase):
             cls.topology, cls.master, cls.replicas, [],
             domain_level=cls.domain_level, setup_replica_cas=False)
 
-    def test_removal_of_master_raises_error_about_last_ca(self):
-        """
-        test that removal of master fails on the last
-        """
-        tasks.assert_error(
-            tasks.run_server_del(self.replicas[0], self.master.hostname),
-            "Deleting this server is not allowed as it would leave your "
-            "installation without a CA.",
-            1
-        )
-
-    def test_install_ca_on_replica1(self):
-        """
-        Install CA on replica so that we can test DNS-related checks
-        """
-        tasks.install_ca(self.replicas[0], domain_level=self.domain_level)
-
     def test_removal_of_master_raises_error_about_last_dns(self):
         """
         Now server-del should complain about the removal of last DNS server
@@ -288,6 +271,32 @@ class TestLastServices(ServerDelBase):
             "Replica is active DNSSEC key master. Uninstall "
             "could break your DNS system. Please disable or replace "
             "DNSSEC key master first.",
+            1
+        )
+
+    def test_disable_dnssec_on_master(self):
+        """
+        Disable DNSSec master so that it is not tested anymore. Normal way
+        would be to move the DNSSec master to replica, but that is tested in
+        DNSSec tests.
+        """
+        args = [
+            "ipa-dns-install",
+            "--disable-dnssec-master",
+            "--forwarder", self.master.config.dns_forwarder,
+            "--force",
+            "-U",
+        ]
+        self.master.run_command(args)
+
+    def test_removal_of_master_raises_error_about_last_ca(self):
+        """
+        test that removal of master fails on the last
+        """
+        tasks.assert_error(
+            tasks.run_server_del(self.replicas[0], self.master.hostname),
+            "Deleting this server is not allowed as it would leave your "
+            "installation without a CA.",
             1
         )
 


### PR DESCRIPTION
This PR was opened manually because PR #1913 was pushed to master and backport to ipa-4-6 is required.