### PR TITLE
ipa vault-archive overwrites an existing value without warning

### DIFF
--- a/ipaserver/plugins/vault.py
+++ b/ipaserver/plugins/vault.py
@@ -55,7 +55,9 @@ Vaults
 """) + _("""
 Manage vaults.
 """) + _("""
-Vault is a secure place to store a secret.
+Vault is a secure place to store a secret. One vault can only
+store one secret. When archiving a secret in a vault, the
+existing secret (if any) is overwritten.
 """) + _("""
 Based on the ownership there are three vault categories:
 * user/private vault


### PR DESCRIPTION
Upstream ticket was raised for issuing an warning message
whenever data in ipa vault is overwritten.

In Bugzilla(1339129) its agreed upon that Current behavior is consistent
with other IPA commands. None of ipa mod commands asks for confirmation
and therefore it should be the same here.
But to document, that vault can contain only one value in ipa help vault.

This PR addresses the changes agreed in Bugzilla.

Resolves: https://pagure.io/freeipa/issue/5922