### PR TITLE
Cosmetic changes for ipa pwpolicy command

### DIFF
--- a/ipalib/errors.py
+++ b/ipalib/errors.py
@@ -1519,11 +1519,11 @@ class EmptyModlist(ExecutionError):
     >>> raise EmptyModlist()
     Traceback (most recent call last):
       ...
-    EmptyModlist: no modifications to be performed
+    EmptyModlist: Stored value is same as provided
     """
 
     errno = 4202
-    format = _('no modifications to be performed')
+    format = _('Stored value is same as provided')
 
 
 class DatabaseError(ExecutionError):


### PR DESCRIPTION
If you try to change the value of the password policy to the
same value as it already has then you will get an error:

ipa: ERROR: no modifications to be performed.

PR changes this error message to:
ipa: ERROR: Stored value is same as provided

https://pagure.io/freeipa/issue/362