### PR TITLE
ipa-server-install: publish complete cert chain in /usr/share/ipa/html/ca.crt

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -61,7 +61,7 @@ jobs:
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
         template: *ci-master-f28
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-28/test_topologies:
     requires: [fedora-28/build]

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -432,7 +432,7 @@ class HTTPInstance(service.Service):
             raise RuntimeError("HTTPD cert was issued by an unknown CA.")
         # at this time we can assume any CA cert will be valid since this is
         # only run during installation
-        x509.write_certificate(ca_certs[0], paths.CA_CRT)
+        x509.write_certificate_list(certlist, paths.CA_CRT)
 
     def is_kdcproxy_configured(self):
         """Check if KDC proxy has already been configured in the past"""


### PR DESCRIPTION
When IPA is installed with an externally signed CA, the master installer does not publish the whole cert chain in /usr/share/ipa/html/ca.crt (but /etc/ipa/ca.crt contains the full chain).

If a client is installed with a One-Time Password and without the --ca-cert-file option, the client installer downloads the cert chain from http://master.example.com/ipa/config/ca.crt (=/usr/share/ipa/html/ca.crt). The client installation then fails. Note that when the client is installed by providing admin/password, installation succeeds because the cert chain is read from the LDAP server.

Implements the fix and associated integration test.

https://pagure.io/freeipa/issue/7526