### PR TITLE
[Backport][ipa-4-6] ipa vault-archive overwrites an existing value without warning

### DIFF
--- a/ipaserver/plugins/vault.py
+++ b/ipaserver/plugins/vault.py
@@ -55,7 +55,9 @@ Vaults
 """) + _("""
 Manage vaults.
 """) + _("""
-Vault is a secure place to store a secret.
+Vault is a secure place to store a secret. One vault can only
+store one secret. When archiving a secret in a vault, the
+existing secret (if any) is overwritten.
 """) + _("""
 Based on the ownership there are three vault categories:
 * user/private vault


### PR DESCRIPTION
This PR was opened automatically because PR #1948 was pushed to master and backport to ipa-4-6 is required.