### PR TITLE
Don't try to set Kerberos extradata when there is no principal

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -87,14 +87,14 @@ jobs:
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-28/test_ipa_cli:
+  fedora-28/test_commands:
     requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_ipa_cli.py
+        test_suite: test_integration/test_commands.py
         template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipa_pwd_extop.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipa_pwd_extop.c
@@ -595,7 +595,8 @@ parse_req_done:
     } else {
         principal = slapi_ch_smprintf("root/admin@%s", krbcfg->realm);
     }
-    ipapwd_set_extradata(pwdata.dn, principal, pwdata.timeNow);
+    if (principal)
+        ipapwd_set_extradata(pwdata.dn, principal, pwdata.timeNow);
 
 	/* Free anything that we allocated above */
 free_and_return:

--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1376,6 +1376,18 @@ def ldappasswd_user_change(user, oldpw, newpw, master):
     master.run_command(args)
 
 
+def ldappasswd_sysaccount_change(user, oldpw, newpw, master):
+    container_sysaccounts = dict(DEFAULT_CONFIG)['container_sysaccounts']
+    basedn = master.domain.basedn
+
+    userdn = "uid={},{},{}".format(user, container_sysaccounts, basedn)
+    master_ldap_uri = "ldap://{}".format(master.external_hostname)
+
+    args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
+            '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
+    master.run_command(args)
+
+
 def add_dns_zone(master, zone, skip_overlap_check=False,
                  dynamic_update=False, add_a_record_hosts=None):
     """


### PR DESCRIPTION
This was causing ns-slapd to segfault in the password plugin.

https://pagure.io/freeipa/issue/7561

Signed-off-by: Rob Crittenden <rcritten@redhat.com>