### PR TITLE
Travis: ignore 'line break after binary operator'

### DIFF
--- a/.travis_run_task.sh
+++ b/.travis_run_task.sh
@@ -38,8 +38,9 @@ if [[ "$TASK_TO_RUN" == "lint" ]]
 then
     if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]
     then
-        git diff origin/$TRAVIS_BRANCH -U0 | pycodestyle --diff &> $PEP8_ERROR_LOG ||:
-    fi 
+        git diff origin/$TRAVIS_BRANCH -U0 | \
+            pycodestyle --ignore=W504 --diff &> $PEP8_ERROR_LOG ||:
+    fi
 fi
 
 if [[ -n "$TESTS_TO_RUN" ]]


### PR DESCRIPTION
We started seeing the error `line break after binary operator` but when fixed, error of `line break before binary operator` appears. Ignore one of these. Worked for https://github.com/freeipa/freeipa/pull/1563