### PR TITLE
Require python-ldap with fix for ref counting bug

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -72,13 +72,14 @@
 # Use python3-pyldap to be compatible with old python3-pyldap 2.x and new
 # python3-ldap 3.0. The python3-ldap package also provides python3-pyldap.
 %if 0%{?fedora} >= 28
-# https://pagure.io/freeipa/issue/7257 DNSSEC daemons on Python 3
-%global python2_ldap_version 3.0.0-0.4.b4
-%global python3_ldap_version 3.0.0-0.4.b4
+# fix for segfault in python-ldap, https://pagure.io/freeipa/issue/7324
+%global python2_ldap_version 3.1.0-1
+%global python3_ldap_version 3.1.0-1
 %else
 # syncrepl fix, https://pagure.io/freeipa/issue/7240
 %global python2_ldap_version 2.4.25-9
-%global python3_ldap_version 2.4.35.1-2
+# fix for segfault in python-ldap, https://pagure.io/freeipa/issue/7324
+%global python3_ldap_version 2.4.37-4
 %endif
 
 %endif


### PR DESCRIPTION
python-ldap 3.1.0 and python3-pyldap 2.4.37-4 fix a segfault caused by
a reference counting bug.

See: https://pagure.io/freeipa/issue/7324
Signed-off-by: Christian Heimes <cheimes@redhat.com>