### PR TITLE
[Backport][ipa-4-5] Don't try to set Kerberos extradata when there is no principal

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipa_pwd_extop.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipa_pwd_extop.c
@@ -595,7 +595,8 @@ parse_req_done:
     } else {
         principal = slapi_ch_smprintf("root/admin@%s", krbcfg->realm);
     }
-    ipapwd_set_extradata(pwdata.dn, principal, pwdata.timeNow);
+    if (principal)
+        ipapwd_set_extradata(pwdata.dn, principal, pwdata.timeNow);
 
 	/* Free anything that we allocated above */
 free_and_return:


### PR DESCRIPTION
This was causing ns-slapd to segfault in the password plugin.

https://pagure.io/freeipa/issue/7561

Signed-off-by: Rob Crittenden <rcritten@redhat.com>