### PR TITLE
[Backport][ipa-4-6] Add test case for allow-retrieve-keytab

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -22,8 +22,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-f27
-          name: freeipa/ci-master-f27
-          version: 1.0.2
+          name: freeipa/ci-ipa-4-6-f27
+          version: 1.0.0
         timeout: 1800
         topology: *build
 

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -69,17 +69,10 @@
 %global selinux_policy_version 3.13.1-283.24
 %global slapi_nis_version 0.56.1
 
-# Use python3-pyldap to be compatible with old python3-pyldap 2.x and new
-# python3-ldap 3.0. The python3-ldap package also provides python3-pyldap.
-%if 0%{?fedora} >= 28
-# https://pagure.io/freeipa/issue/7257 DNSSEC daemons on Python 3
-%global python2_ldap_version 3.0.0-0.4.b4
-%global python3_ldap_version 3.0.0-0.4.b4
-%else
 # syncrepl fix, https://pagure.io/freeipa/issue/7240
 %global python2_ldap_version 2.4.25-9
-%global python3_ldap_version 2.4.35.1-2
-%endif
+# fix for segfault in python-ldap, https://pagure.io/freeipa/issue/7324
+%global python3_ldap_version 2.4.37-4
 
 %endif
 
@@ -290,6 +283,7 @@ BuildRequires:  python3-netaddr
 BuildRequires:  python3-pyasn1
 BuildRequires:  python3-pyasn1-modules
 BuildRequires:  python3-pyldap >= %{python3_ldap_version}
+BuildConflicts: python3-ldap < 3.1.0
 %endif # with_python3
 %endif # with_lint
 
@@ -321,6 +315,7 @@ Requires: %{name}-common = %{version}-%{release}
 %if 0%{?with_python3}
 Requires: python3-ipaserver = %{version}-%{release}
 Requires: python3-pyldap >= %{python3_ldap_version}
+Conflicts: python3-ldap < 3.1.0
 %else
 Requires: python2-ipaserver = %{version}-%{release}
 Requires: python2-ldap >= %{python2_ldap_version}
@@ -462,6 +457,7 @@ Requires: python3-ipaclient = %{version}-%{release}
 Requires: python3-custodia >= 0.3.1
 # we need pre-requires since earlier versions may break upgrade
 Requires(pre): python3-pyldap >= %{python3_ldap_version}
+Conflicts: python3-ldap < 3.1.0
 Requires: python3-lxml
 Requires: python3-gssapi >= 1.2.0
 Requires: python3-sssdconfig
@@ -581,6 +577,7 @@ Requires: %{name}-common = %{version}-%{release}
 Requires: python3-gssapi >= 1.2.0-5
 Requires: python3-ipaclient = %{version}-%{release}
 Requires: python3-pyldap >= %{python3_ldap_version}
+Conflicts: python3-ldap < 3.1.0
 Requires: python3-sssdconfig
 %else
 Requires: python2-gssapi >= 1.2.0-5
@@ -816,6 +813,7 @@ Requires: python3-jwcrypto >= 0.4.2
 Requires: python3-cffi
 # we need pre-requires since earlier versions may break upgrade
 Requires(pre): python3-pyldap >= %{python3_ldap_version}
+Conflicts: python3-ldap < 3.1.0
 Requires: python3-requests
 Requires: python3-dns >= 1.15
 Requires: python3-netifaces >= 0.10.4

--- a/ipatests/test_xmlrpc/test_service_plugin.py
+++ b/ipatests/test_xmlrpc/test_service_plugin.py
@@ -280,6 +280,60 @@ class test_service(Declarative):
             ),
         ),
 
+        dict(
+            desc='Allow admin to create keytab for %r' % service1,
+            command=('service_allow_create_keytab', [service1],
+                     dict(user=u'admin'),
+                     ),
+            expected=dict(
+                completed=1,
+                failed=dict(
+                    ipaallowedtoperform_write_keys=dict(
+                        group=[],
+                        host=[],
+                        hostgroup=[],
+                        user=[]
+                    )
+                ),
+                result=dict(
+                    dn=service1dn,
+                    ipaallowedtoperform_write_keys_user=[u'admin'],
+                    krbprincipalname=[service1],
+                    krbcanonicalname=[service1],
+                    managedby_host=[fqdn1],
+                ),
+            ),
+        ),
+
+        dict(
+            desc='Retrieve %r with all=True and keytab allowed' % service1,
+            command=('service_show', [service1], dict(all=True)),
+            expected=dict(
+                value=service1,
+                summary=None,
+                result=dict(
+                    dn=service1dn,
+                    ipaallowedtoperform_write_keys_user=[u'admin'],
+                    krbprincipalname=[service1],
+                    ipakrbprincipalalias=[service1],
+                    krbcanonicalname=[service1],
+                    objectclass=objectclasses.service + [
+                        u'ipaallowedoperations'
+                    ],
+                    ipauniqueid=[fuzzy_uuid],
+                    managedby_host=[fqdn1],
+                    has_keytab=False,
+                    ipakrbrequirespreauth=True,
+                    ipakrbokasdelegate=False,
+                    ipakrboktoauthasdelegate=False,
+                    krbpwdpolicyreference=[DN(
+                        u'cn=Default Service Password Policy',
+                        api.env.container_service,
+                        api.env.basedn,
+                    )],
+                ),
+            ),
+        ),
 
         dict(
             desc='Search for %r with members' % service1,
@@ -291,6 +345,7 @@ class test_service(Declarative):
                 result=[
                     dict(
                         dn=service1dn,
+                        ipaallowedtoperform_write_keys_user=[u'admin'],
                         krbprincipalname=[service1],
                         krbcanonicalname=[service1],
                         managedby_host=[fqdn1],
@@ -300,6 +355,30 @@ class test_service(Declarative):
             ),
         ),
 
+        dict(
+            desc='Disallow admin to create keytab for %r' % service1,
+            command=(
+                'service_disallow_create_keytab', [service1],
+                dict(user=u'admin'),
+            ),
+            expected=dict(
+                completed=1,
+                failed=dict(
+                    ipaallowedtoperform_write_keys=dict(
+                        group=[],
+                        host=[],
+                        hostgroup=[],
+                        user=[]
+                    )
+                ),
+                result=dict(
+                    dn=service1dn,
+                    krbprincipalname=[service1],
+                    krbcanonicalname=[service1],
+                    managedby_host=[fqdn1],
+                ),
+            ),
+        ),
 
         dict(
             desc='Search for %r' % service1,
@@ -333,7 +412,9 @@ class test_service(Declarative):
                         krbprincipalname=[service1],
                         ipakrbprincipalalias=[service1],
                         krbcanonicalname=[service1],
-                        objectclass=objectclasses.service,
+                        objectclass=objectclasses.service + [
+                            u'ipaallowedoperations'
+                        ],
                         ipauniqueid=[fuzzy_uuid],
                         has_keytab=False,
                         managedby_host=[fqdn1],


### PR DESCRIPTION
This PR was opened automatically because PR #1964 was pushed to master and backport to ipa-4-6 is required.