### PR TITLE
Print version string in installer

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -61,6 +61,7 @@ from ipapython.ipautil import (
     user_input,
 )
 from ipapython.ssh import SSHPublicKey
+from ipapython import version
 
 from . import automount, ipadiscovery, timeconf, sssd
 from .ipachangeconf import IPAChangeConf
@@ -2014,6 +2015,10 @@ def install_check(options):
     global cli_kdc
     global client_domain
     global cli_basedn
+
+    print("This program will set up FreeIPA client.")
+    print("Version {}".format(version.VERSION))
+    print("")
 
     cli_domain_source = 'Unknown source'
     cli_server_source = 'Unknown source'

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -19,7 +19,7 @@ import six
 from ipaclient.install.client import check_ldap_conf
 from ipaclient.install.ipachangeconf import IPAChangeConf
 from ipalib.install import certmonger, sysrestore
-from ipapython import ipautil
+from ipapython import ipautil, version
 from ipapython.ipautil import (
     ipa_generate_password, run, user_input)
 from ipapython.admintool import ScriptError
@@ -382,6 +382,7 @@ def install_check(installer):
     print("======================================="
           "=======================================")
     print("This program will set up the FreeIPA Server.")
+    print("Version {}".format(version.VERSION))
     print("")
     print("This includes:")
     if setup_ca:

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -27,7 +27,7 @@ from ipaclient.install.ipachangeconf import IPAChangeConf
 import ipaclient.install.timeconf
 from ipalib.install import certstore, sysrestore
 from ipalib.install.kinit import kinit_keytab
-from ipapython import ipaldap, ipautil
+from ipapython import ipaldap, ipautil, version
 from ipapython.certdb import IPA_CA_TRUST_FLAGS, EXTERNAL_CA_TRUST_FLAGS
 from ipapython.dn import DN
 from ipapython.admintool import ScriptError
@@ -681,6 +681,10 @@ def install_check(installer):
     options = installer
     filename = installer.replica_file
     installer._enrollment_performed = False
+
+    print("This program will set up FreeIPA replica.")
+    print("Version {}".format(version.VERSION))
+    print("")
 
     if tasks.is_fips_enabled():
         raise RuntimeError(


### PR DESCRIPTION
The server, replica, and client installer now print the current version
number on the console, before the actual installer starts. It makes it
easier to debug problems with failed installations. Users typically post
the console output in a ticket.

Signed-off-by: Christian Heimes <cheimes@redhat.com>