### PR TITLE
Handle compressed responses from Dogtag

### DIFF
--- a/ipapython/dogtag.py
+++ b/ipapython/dogtag.py
@@ -19,6 +19,7 @@
 
 import collections
 import gzip
+import io
 import logging
 import xml.dom.minidom
 import zlib
@@ -61,6 +62,15 @@ INCLUDED_PROFILES = {
 
 DEFAULT_PROFILE = u'caIPAserviceCert'
 KDC_PROFILE = u'KDCs_PKINIT_Certs'
+
+
+if six.PY3:
+    gzip_decompress = gzip.decompress  # pylint: disable=no-member
+else:
+    # note: gzip.decompress available in Python >= 3.2
+    def gzip_decompress(data):
+        with gzip.GzipFile(fileobj=io.BytesIO(data)) as f:
+            return f.read()
 
 
 def error_from_xml(doc, message_template):
@@ -232,8 +242,7 @@ def _httplib_request(
 
     encoding = res.getheader('Content-Encoding')
     if encoding == 'gzip':
-        # note: gzip.decompress available in Python >= 3.2
-        http_body = gzip.decompress(http_body)  # pylint: disable=no-member
+        http_body = gzip_decompress(http_body)
     elif encoding == 'deflate':
         http_body = zlib.decompress(http_body)
 


### PR DESCRIPTION
We currently accept compressed responses for some Dogtag resources,
via an 'Accept: gzip, deflate' header.  But we don't decompress the
received data.  Inspect the response Content-Encoding header and
decompress the response body according to its value.

The `gzip.decompress` function is only available on Python 3.2 or
later.  In earlier versions, it is necessary to use StringIO and
treat the compressed data as a file.  This commit avoids this
complexity.  Therefore it should only be included in Python 3 based
releases.

Fixes: https://pagure.io/freeipa/issue/7563