### PR TITLE
Start to deprecate Python 2 support

### DIFF
--- a/ipaplatform/fedora/__init__.py
+++ b/ipaplatform/fedora/__init__.py
@@ -20,4 +20,14 @@
 '''
 This module contains Fedora specific platform files.
 '''
+import sys
+import warnings
+
 NAME = 'fedora'
+
+if sys.version_info < (3, 6):
+    warnings.warn(
+        "Support for Python 2.7 and 3.5 is deprecated. Python version "
+        "3.6 or newer will be required in the next major release.",
+        category=DeprecationWarning
+    )

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -97,7 +97,7 @@ common_args = dict(
     url="https://www.freeipa.org/",
     download_url="https://www.freeipa.org/page/Downloads",
     platforms=["Linux"],
-    python_requires=">=2.7.5,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
+    python_requires=">=2.7.5,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: System Administrators",
@@ -107,7 +107,6 @@ common_args = dict(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
         "Operating System :: POSIX",


### PR DESCRIPTION
Python 2 will reach EOL in 18 months. Start to issue deprecation
warnings on Python 2.

No longer claim support for Python 3.5. Python 3.5 is untested.

Fixes: https://pagure.io/freeipa/issue/7568
Signed-off-by: Christian Heimes <cheimes@redhat.com>