### PR TITLE
Uninstall fix for named-pkcs11

### DIFF
--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -1211,9 +1211,13 @@ class BindInstance(service.Service):
         # disabled by default, by ldap_enable()
         if enabled:
             self.enable()
+        else:
+            self.disable()
 
         if running:
             self.restart()
+        else:
+            self.stop()
 
         self.named_regular.unmask()
         if named_regular_enabled:

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -177,8 +177,6 @@ class TestBackupAndRestore(IntegrationTest):
 
     def test_full_backup_and_restore_with_removed_users(self):
         """regression test for https://fedorahosted.org/freeipa/ticket/3866"""
-        tasks.uninstall_master(self.master)
-        tasks.install_master(self.master)
         with restore_checker(self.master):
             backup_path = backup(self.master)
 
@@ -202,8 +200,6 @@ class TestBackupAndRestore(IntegrationTest):
 
     def test_full_backup_and_restore_with_selinux_booleans_off(self):
         """regression test for https://fedorahosted.org/freeipa/ticket/4157"""
-        tasks.uninstall_master(self.master)
-        tasks.install_master(self.master)
         with restore_checker(self.master):
             backup_path = backup(self.master)
 


### PR DESCRIPTION
Sometimes named-pkcs11 is not being stopped or reloaded during
uninstall and it causes a lot of problems while testing, for example,
backup and restore tests are failing because of ipa-server-install
fails on checking DNS step.

Also reverting 415578a19 as it's not needed anymore and additional
uninstall/install take a lot of time.

Fixes backup/restore tests runs. Maybe something else.