### PR TITLE
Add test for  --external-cert-file points to a non-existing file or invalid file.

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -27,6 +27,18 @@ jobs:
         timeout: 1800
         topology: *build
 
+  fedora-28/simple_replication:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_simple_replication.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-28/caless:
     requires: [fedora-28/build]
     priority: 50
@@ -34,7 +46,164 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_caless.py::TestReplicaInstall
+        test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
         template: *ci-master-f28
-        timeout: 6600
+        timeout: 3600
         topology: *master_1repl
+
+  fedora-28/external_ca:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-28/test_topologies:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_topologies.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_sudo:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_sudo.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-28/test_commands:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_commands.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_kerberos_flags:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_kerberos_flags.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-28/test_http_kdc_proxy:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_http_kdc_proxy.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-28/test_forced_client_enrolment:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_forced_client_reenrollment.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-28/test_advise:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_advise.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_testconfig:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_testconfig.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_service_permissions:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_service_permissions.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_netgroup:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_netgroup.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_vault:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_vault.py
+        template: *ci-master-f28
+        timeout: 4500
+        topology: *master_1repl
+
+  fedora-28/test_authconfig:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_authselect.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl_1client
+

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -1181,24 +1181,6 @@ class TestReplicaInstall(CALessBase):
         if self.domain_level > DOMAIN_LEVEL_0:
             self.verify_installation()
 
-    @replica_install_teardown
-    def test_install_ca_replica(self):
-        # related to https://pagure.io/freeipa/issue/6985
-        replica = self.replicas[0]
-
-        # install ca on replica with non-existing cert
-        tasks.install_ca(replica, external_ca=True, cert_files='abc.crt')
-
-        # install ca with invalid cert
-        contents = (
-            '-----BEGIN CERTIFICATE-----\n'
-            'sdnmsdkfbsdifbsdbasdsdSDDDasdmnd\n'
-            '-----END CERTIFICATE-----')
-
-        cert1 = tempfile.mkdtemp(suffix='abc.crt', dir=paths.TMP)
-        replica.put_file_contents(cert1, contents)
-        tasks.install_ca(replica, external_ca=True, cert_files=cert1)
-
 
 class TestClientInstall(CALessBase):
     num_clients = 1


### PR DESCRIPTION
Reverts freeipa/freeipa#1978