### PR TITLE
Use replace instead of add to set new default ipaSELinuxUserMapOrder

### DIFF
--- a/install/updates/50-ipaconfig.update
+++ b/install/updates/50-ipaconfig.update
@@ -1,5 +1,5 @@
 dn: cn=ipaConfig,cn=etc,$SUFFIX
-add:ipaSELinuxUserMapOrder: guest_u:s0$$xguest_u:s0$$user_u:s0$$staff_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023
+replace: ipaSELinuxUserMapOrder: guest_u:s0$$xguest_u:s0$$user_u:s0-s0:c0.c1023$$staff_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023::ipaSELinuxUserMapOrder: guest_u:s0$$xguest_u:s0$$user_u:s0$$staff_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023
 add:ipaSELinuxUserMapDefault: unconfined_u:s0-s0:c0.c1023
 add:ipaUserObjectClasses: ipasshuser
 remove:ipaConfigString:AllowLMhash


### PR DESCRIPTION
The add was in effect replacing whatever data was already there
causing any custom order to be lost on each run of
ipa-server-upgrade.

https://pagure.io/freeipa/issue/6610

Signed-off-by: Rob Crittenden <rcritten@redhat.com>