### PR TITLE
Fix API Browser commands description

### DIFF
--- a/ipaclient/plugins/dns.py
+++ b/ipaclient/plugins/dns.py
@@ -134,6 +134,7 @@ class dnszone_mod(DNSZoneMethodOverride):
 # Do not add anything new here!
 @register(no_fail=True)
 class dnsrecord_split_parts(Command):
+    __doc__ = _('Split DNS record to parts')
     NO_CLI = True
 
     takes_args = (

--- a/ipaserver/plugins/aci.py
+++ b/ipaserver/plugins/aci.py
@@ -17,7 +17,23 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
+
+from copy import deepcopy
+import logging
+
+import six
+
+from ipalib import api, crud, errors
+from ipalib import Object
+from ipalib import Flag, Str, StrEnum, DNParam
+from ipalib.aci import ACI
+from ipalib import output
+from ipalib import _, ngettext
+from ipalib.plugable import Registry
+from .baseldap import gen_pkey_only_option, pkey_to_value
+from ipapython.dn import DN
+
+__doc__ = _("""
 Directory Server Access Control Instructions (ACIs)
 
 ACIs are used to allow or deny access to information. This module is
@@ -115,22 +131,7 @@ The show command shows the raw 389-ds ACI.
 IMPORTANT: When modifying the target attributes of an existing ACI you
 must include all existing attributes as well. When doing an aci-mod the
 targetattr REPLACES the current attributes, it does not add to them.
-
-"""
-from copy import deepcopy
-import logging
-
-import six
-
-from ipalib import api, crud, errors
-from ipalib import Object
-from ipalib import Flag, Str, StrEnum, DNParam
-from ipalib.aci import ACI
-from ipalib import output
-from ipalib import _, ngettext
-from ipalib.plugable import Registry
-from .baseldap import gen_pkey_only_option, pkey_to_value
-from ipapython.dn import DN
+""")
 
 if six.PY3:
     unicode = str
@@ -432,9 +433,7 @@ _prefix_option = StrEnum('aciprefix',
 
 @register()
 class aci(Object):
-    """
-    ACI object.
-    """
+    __doc__ = _('ACI object.')
     NO_CLI = True
 
     label = _('ACIs')
@@ -519,9 +518,7 @@ class aci(Object):
 
 @register()
 class aci_add(crud.Create):
-    """
-    Create new ACI.
-    """
+    __doc__ = _('Create new ACI.')
     NO_CLI = True
     msg_summary = _('Created ACI "%(value)s"')
 
@@ -573,9 +570,7 @@ class aci_add(crud.Create):
 
 @register()
 class aci_del(crud.Delete):
-    """
-    Delete ACI.
-    """
+    __doc__ = _('Delete ACI.')
     NO_CLI = True
     has_output = output.standard_boolean
     msg_summary = _('Deleted ACI "%(value)s"')
@@ -614,9 +609,7 @@ class aci_del(crud.Delete):
 
 @register()
 class aci_mod(crud.Update):
-    """
-    Modify ACI.
-    """
+    __doc__ = _('Modify ACI.')
     NO_CLI = True
 
     takes_options = (_prefix_option,)
@@ -677,8 +670,8 @@ class aci_mod(crud.Update):
 
 @register()
 class aci_find(crud.Search):
-    """
-    Search for ACIs.
+    __doc__ = _("""
+Search for ACIs.
 
     Returns a list of ACIs
 
@@ -695,7 +688,7 @@ class aci_find(crud.Search):
     For example, searching on memberof=ipausers will find all ACIs that
     have ipausers as a memberof. There may be other ACIs that apply to
     members of that group indirectly.
-    """
+    """)
     NO_CLI = True
     msg_summary = ngettext('%(count)d ACI matched', '%(count)d ACIs matched', 0)
 
@@ -883,9 +876,7 @@ class aci_find(crud.Search):
 
 @register()
 class aci_show(crud.Retrieve):
-    """
-    Display a single ACI given an ACI name.
-    """
+    __doc__ = _('Display a single ACI given an ACI name.')
     NO_CLI = True
 
     takes_options = (
@@ -924,9 +915,7 @@ class aci_show(crud.Retrieve):
 
 @register()
 class aci_rename(crud.Update):
-    """
-    Rename an ACI.
-    """
+    __doc__ = _('Rename an ACI.')
     NO_CLI = True
 
     takes_options = (

--- a/ipaserver/plugins/batch.py
+++ b/ipaserver/plugins/batch.py
@@ -18,7 +18,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
+import logging
+
+import six
+
+from ipalib import api, errors
+from ipalib import Command
+from ipalib.frontend import Local
+from ipalib.parameters import Str, Dict
+from ipalib.output import Output
+from ipalib.text import _
+from ipalib.request import context
+from ipalib.plugable import Registry
+from ipapython.version import API_VERSION
+
+__doc__ = _("""
 Plugin to make multiple ipa calls via one remote procedure call
 
 To run this code in the lite-server
@@ -43,21 +57,7 @@ The format of the response is nested the same way.  At the top you will see
 
 And then a nested response for each IPA command method sent in the request
 
-"""
-
-import logging
-
-import six
-
-from ipalib import api, errors
-from ipalib import Command
-from ipalib.frontend import Local
-from ipalib.parameters import Str, Dict
-from ipalib.output import Output
-from ipalib.text import _
-from ipalib.request import context
-from ipalib.plugable import Registry
-from ipapython.version import API_VERSION
+""")
 
 if six.PY3:
     unicode = str
@@ -68,6 +68,7 @@ register = Registry()
 
 @register()
 class batch(Command):
+    __doc__ = _('Make multiple ipa calls via one remote procedure call')
     NO_CLI = True
 
     takes_args = (

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1709,9 +1709,7 @@ class cert_find(Search, CertMethod):
 
 @register()
 class ca_is_enabled(Command):
-    """
-    Checks if any of the servers has the CA service enabled.
-    """
+    __doc__ = _('Checks if any of the servers has the CA service enabled.')
     NO_CLI = True
     has_output = output.standard_value
 

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -3838,9 +3838,7 @@ class dnsrecord_mod(LDAPUpdate):
 
 @register()
 class dnsrecord_delentry(LDAPDelete):
-    """
-    Delete DNS record entry.
-    """
+    __doc__ = _('Delete DNS record entry.')
     msg_summary = _('Deleted record "%(value)s"')
     NO_CLI = True
 
@@ -4067,9 +4065,7 @@ class dns_resolve(Command):
 
 @register()
 class dns_is_enabled(Command):
-    """
-    Checks if any of the servers has the DNS service enabled.
-    """
+    __doc__ = _('Checks if any of the servers has the DNS service enabled.')
     NO_CLI = True
     has_output = output.standard_value
 

--- a/ipaserver/plugins/hbacrule.py
+++ b/ipaserver/plugins/hbacrule.py
@@ -563,6 +563,7 @@ class hbacrule_remove_host(LDAPRemoveMember):
 
 @register()
 class hbacrule_add_sourcehost(LDAPAddMember):
+    __doc__ = _('Add source hosts and hostgroups to an HBAC rule.')
     NO_CLI = True
 
     member_attributes = ['sourcehost']
@@ -575,6 +576,7 @@ class hbacrule_add_sourcehost(LDAPAddMember):
 
 @register()
 class hbacrule_remove_sourcehost(LDAPRemoveMember):
+    __doc__ = _('Remove source hosts and hostgroups from an HBAC rule.')
     NO_CLI = True
 
     member_attributes = ['sourcehost']

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -34,9 +34,7 @@ register = Registry()
 
 @register()
 class json_metadata(Command):
-    """
-    Export plugin meta-data for the webUI.
-    """
+    __doc__ = _('Export plugin meta-data for the webUI.')
     NO_CLI = True
 
 
@@ -149,6 +147,7 @@ class json_metadata(Command):
 
 @register()
 class i18n_messages(Command):
+    __doc__ = _('Internationalization messages')
     NO_CLI = True
 
     messages = {

--- a/ipaserver/plugins/join.py
+++ b/ipaserver/plugins/join.py
@@ -51,7 +51,7 @@ def validate_host(ugettext, cn):
 
 @register()
 class join(Command):
-    """Join an IPA domain"""
+    __doc__ = _('Join an IPA domain')
 
     NO_CLI = True
 

--- a/ipaserver/plugins/permission.py
+++ b/ipaserver/plugins/permission.py
@@ -1390,7 +1390,7 @@ class permission_show(baseldap.LDAPRetrieve):
 
 @register()
 class permission_add_member(baseldap.LDAPAddMember):
-    """Add members to a permission."""
+    __doc__ = _('Add members to a permission.')
     NO_CLI = True
 
     def pre_callback(self, ldap, dn, member_dns, failed, *keys, **options):
@@ -1402,5 +1402,5 @@ class permission_add_member(baseldap.LDAPAddMember):
 
 @register()
 class permission_remove_member(baseldap.LDAPRemoveMember):
-    """Remove members from a permission."""
+    __doc__ = _('Remove members from a permission.')
     NO_CLI = True

--- a/ipaserver/plugins/privilege.py
+++ b/ipaserver/plugins/privilege.py
@@ -192,9 +192,7 @@ class privilege_add_member(LDAPAddMember):
 
 @register()
 class privilege_remove_member(LDAPRemoveMember):
-    """
-    Remove members from a privilege
-    """
+    __doc__ = _('Remove members from a privilege')
     NO_CLI=True
 
 

--- a/ipaserver/plugins/pwpolicy.py
+++ b/ipaserver/plugins/pwpolicy.py
@@ -89,9 +89,8 @@ register = Registry()
 
 @register()
 class cosentry(LDAPObject):
-    """
-    Class of Service object used for linking policies with groups
-    """
+    __doc__ = _('Class of Service object used for linking policies with'
+                ' groups')
     NO_CLI = True
 
     container_dn = DN(('cn', 'costemplates'), api.env.container_accounts)
@@ -169,6 +168,7 @@ class cosentry(LDAPObject):
 
 @register()
 class cosentry_add(LDAPCreate):
+    __doc__ = _('Add Class of Service entry')
     NO_CLI = True
 
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys, **options):
@@ -191,11 +191,13 @@ class cosentry_add(LDAPCreate):
 
 @register()
 class cosentry_del(LDAPDelete):
+    __doc__ = _('Delete Class of Service entry')
     NO_CLI = True
 
 
 @register()
 class cosentry_mod(LDAPUpdate):
+    __doc__ = _('Modify Class of Service entry')
     NO_CLI = True
 
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys, **options):
@@ -213,11 +215,13 @@ class cosentry_mod(LDAPUpdate):
 
 @register()
 class cosentry_show(LDAPRetrieve):
+    __doc__ = _('Display Class of Service entry')
     NO_CLI = True
 
 
 @register()
 class cosentry_find(LDAPSearch):
+    __doc__ = _('Search for Class of Service entry')
     NO_CLI = True
 
 

--- a/ipaserver/plugins/schema.py
+++ b/ipaserver/plugins/schema.py
@@ -283,6 +283,7 @@ class command_find(metaobject_find):
 
 @register()
 class command_defaults(PKQuery):
+    __doc__ = _('Return command defaults')
     NO_CLI = True
 
     takes_options = (
@@ -772,6 +773,7 @@ class output_find(BaseParamSearch):
 
 @register()
 class schema(Command):
+    __doc__ = _('Store and provide schema for commands and topics')
     NO_CLI = True
 
     takes_options = (

--- a/ipaserver/plugins/session.py
+++ b/ipaserver/plugins/session.py
@@ -7,6 +7,7 @@ import logging
 from ipalib import Command
 from ipalib.request import context
 from ipalib.plugable import Registry
+from ipalib.text import _
 
 logger = logging.getLogger(__name__)
 
@@ -15,9 +16,8 @@ register = Registry()
 
 @register()
 class session_logout(Command):
-    '''
-    RPC command used to log the current user out of their session.
-    '''
+    __doc__ = _('RPC command used to log the current user out of their'
+                ' session.')
     NO_CLI = True
 
     def execute(self, *args, **options):

--- a/ipaserver/plugins/vault.py
+++ b/ipaserver/plugins/vault.py
@@ -768,6 +768,7 @@ class vault(LDAPObject):
 
 @register()
 class vault_add_internal(LDAPCreate):
+    __doc__ = _('Add a vault.')
 
     NO_CLI = True
 
@@ -916,6 +917,7 @@ class vault_find(LDAPSearch):
 
 @register()
 class vault_mod_internal(LDAPUpdate):
+    __doc__ = _('Modify a vault.')
 
     NO_CLI = True
 
@@ -1011,6 +1013,7 @@ class vaultconfig_show(Retrieve):
 
 @register()
 class vault_archive_internal(PKQuery):
+    __doc__ = _('Archive data into a vault.')
 
     NO_CLI = True
 
@@ -1087,6 +1090,7 @@ class vault_archive_internal(PKQuery):
 
 @register()
 class vault_retrieve_internal(PKQuery):
+    __doc__ = _('Retrieve data from a vault.')
 
     NO_CLI = True
 
@@ -1215,6 +1219,7 @@ class vault_remove_member(VaultModMember, LDAPRemoveMember):
 
 @register()
 class kra_is_enabled(Command):
+    __doc__ = _('Checks if any of the servers has the KRA service enabled')
     NO_CLI = True
 
     has_output = output.standard_value


### PR DESCRIPTION
On Web UI API Browser some commands have no translated description or have no description at all.
To get list of such:

1) by curl receive JSON reply to json_metadata request with 'Accept-Language:ru'
2) jq '.result.commands | keys[] as $k | "\($k), \(.[$k] | .doc)"' json-reply | grep -P '(, null|^[^а-яА-Я]*$)'

Result:
```
batch
command_defaults
cosentry_add
cosentry_del
cosentry_find
cosentry_mod
cosentry_show
dnsrecord_split_parts
hbacrule_add_sourcehost
hbacrule_remove_sourcehost
i18n_messages
kra_is_enabled
schema
vault_add_internal
vault_archive_internal
vault_mod_internal
vault_retrieve_internal
aci_add
aci_del
aci_find
aci_mod
aci_rename
aci_show
ca_is_enabled
dns_is_enabled
dnsrecord_delentry
idrange_add
idrange_mod
join
json_metadata
permission_add_member
permission_remove_member
privilege_remove_member
session_logout
```
Cause: the command description is taken from python docstring. Thus
commands should have them and should include the callings of gettext to be translated.

This patch fix it.
