### PR TITLE
Fix translation of python brace formatted messages

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -1270,7 +1270,7 @@ class TrustDomainInstance(object):
                 ttype = trust_type_string(
                     res.info_ex.trust_type, res.info_ex.trust_attributes
                 )
-                err = unicode(msg).format(
+                err = msg.format(
                     ipa_domain=another_domain.info['dns_domain'],
                     trust_type=ttype)
 

--- a/ipaserver/plugins/domainlevel.py
+++ b/ipaserver/plugins/domainlevel.py
@@ -67,7 +67,7 @@ def check_conflict_entries(ldap, api, desired_value):
             scope=ldap.SCOPE_SUBTREE)
         message = _("Domain Level cannot be raised to {0}, "
                     "existing replication conflicts have to be resolved."
-                    .format(desired_value))
+                    ).format(desired_value)
         raise errors.InvalidDomainLevelError(reason=message)
     except errors.NotFound:
         pass
@@ -152,7 +152,7 @@ class domainlevel_set(Command):
             if supported.min > desired_value or supported.max < desired_value:
                 message = _("Domain Level cannot be raised to {0}, server {1} "
                             "does not support it."
-                            .format(desired_value, master['cn'][0]))
+                            ).format(desired_value, master['cn'][0])
                 raise errors.InvalidDomainLevelError(reason=message)
 
         # Check if conflict entries exist in topology subtree

--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -39,7 +39,7 @@ else:
     _dcerpc_bindings_installed = False
 
 
-ID_RANGE_VS_DNA_WARNING = """=======
+ID_RANGE_VS_DNA_WARNING = _("""=======
 WARNING:
 
 DNA plugin in 389-ds will allocate IDs based on the ranges configured for the
@@ -51,7 +51,7 @@ the new local range. Specifically, The dnaNextRange attribute of 'cn=Posix
 IDs,cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config' has to be
 modified to match the new range.
 =======
-"""
+""")
 
 __doc__ = _("""
 ID ranges
@@ -161,8 +161,7 @@ this domain has the SID S-1-5-21-123-456-789-1010 then 1010 id the RID of the
 user. RIDs are unique in a domain, 32bit values and are used for users and
 groups.
 
-{0}
-""".format(ID_RANGE_VS_DNA_WARNING))
+""") + ID_RANGE_VS_DNA_WARNING
 
 register = Registry()
 
@@ -243,8 +242,7 @@ class idrange(LDAPObject):
         StrEnum('iparangetype?',
                 label=_('Range type'),
                 cli_name='type',
-                doc=(_('ID range type, one of {vals}'
-                     .format(vals=', '.join(sorted(range_types))))),
+                doc=_('ID range type, one of allowed values'),
                 values=sorted(range_types),
                 flags=['no_update'],
                 )
@@ -400,8 +398,7 @@ class idrange_add(LDAPCreate):
 
     must be given to add a new range for a trusted AD domain.
 
-{0}
-""".format(ID_RANGE_VS_DNA_WARNING))
+""") + ID_RANGE_VS_DNA_WARNING
 
     msg_summary = _('Added ID range "%(value)s"')
 
@@ -615,8 +612,7 @@ class idrange_show(LDAPRetrieve):
 class idrange_mod(LDAPUpdate):
     __doc__ = _("""Modify ID range.
 
-{0}
-""".format(ID_RANGE_VS_DNA_WARNING))
+""") + ID_RANGE_VS_DNA_WARNING
 
     msg_summary = _('Modified ID range "%(value)s"')
 

--- a/ipaserver/plugins/serverroles.py
+++ b/ipaserver/plugins/serverroles.py
@@ -79,7 +79,7 @@ class serverroles(Backend):
             return self.role_names[key]
         except KeyError:
             raise errors.NotFound(
-                reason=_("{role}: role not found".format(role=role_name)))
+                reason=_("{role}: role not found").format(role=role_name))
 
     def _get_enabled_masters(self, role_name):
         result = {}
@@ -164,4 +164,4 @@ class serverroles(Backend):
                 self.attributes[attr].set(self.api, value)
             except KeyError:
                 raise errors.NotFound(
-                    reason=_('{attr}: no such attribute'.format(attr=attr)))
+                    reason=_('{attr}: no such attribute').format(attr=attr))

--- a/ipaserver/plugins/topology.py
+++ b/ipaserver/plugins/topology.py
@@ -86,7 +86,7 @@ def validate_domain_level(api):
     if current < DOMAIN_LEVEL_1:
         raise errors.InvalidDomainLevelError(
             reason=_('Topology management requires minimum domain level {0} '
-                   .format(DOMAIN_LEVEL_1))
+                     ).format(DOMAIN_LEVEL_1)
         )
 
 
@@ -256,7 +256,7 @@ class topologysegment(LDAPObject):
                 name='leftnode',
                 error=_("left node ({host}) does not support "
                         "suffix '{suff}'"
-                        .format(host=leftnode, suff=suffix))
+                        ).format(host=leftnode, suff=suffix)
             )
 
         if rightnode not in suffix_m_hostnames:
@@ -264,7 +264,7 @@ class topologysegment(LDAPObject):
                 name='rightnode',
                 error=_("right node ({host}) does not support "
                         "suffix '{suff}'"
-                        .format(host=rightnode, suff=suffix))
+                        ).format(host=rightnode, suff=suffix)
             )
 
 

--- a/ipaserver/plugins/trust.py
+++ b/ipaserver/plugins/trust.py
@@ -559,7 +559,7 @@ class trust(LDAPObject):
                 continue
             for value in values:
                 if not ipaserver.dcerpc.is_sid_valid(value):
-                    err = unicode(_("invalid SID: {SID}")).format(SID=value)
+                    err = _("invalid SID: {SID}").format(SID=value)
                     raise errors.ValidationError(name=attr, error=err)
 
     def get_dn(self, *keys, **kwargs):
@@ -685,8 +685,8 @@ ipa idrange-del before retrying the command with the desired range type.
         StrEnum('range_type?',
                 label=_('Range type'),
                 cli_name='range_type',
-                doc=(_('Type of trusted domain ID range, one of {vals}'
-                     .format(vals=', '.join(sorted(range_types))))),
+                doc=_('Type of trusted domain ID range, one of allowed ' +
+                      'values'),
                 values=sorted(range_types),
                 ),
         Bool('bidirectional?',
@@ -992,9 +992,9 @@ ipa idrange-del before retrying the command with the desired range type.
                     trust_type
                 )
             except errors.NotFound:
-                _message = _("Unable to resolve domain controller for "
-                             "{domain} domain. ")
-                error_message = unicode(_message).format(domain=keys[-1])
+                error_message = _("Unable to resolve domain controller for "
+                                  "{domain} domain. "
+                                  ).format(domain=keys[-1])
                 instructions = []
 
                 if dns_container_exists(self.obj.backend):
@@ -1020,7 +1020,7 @@ ipa idrange-del before retrying the command with the desired range type.
                             "found in the documentation. "
                         )
                         instructions.append(
-                            unicode(_instruction).format(domain=keys[-1])
+                            _instruction.format(domain=keys[-1])
                         )
                 else:
                     _instruction = _(
@@ -1029,7 +1029,7 @@ ipa idrange-del before retrying the command with the desired range type.
                         "domain from IPA hosts and back."
                     )
                     instructions.append(
-                        unicode(_instruction).format(domain=keys[-1])
+                        _instruction.format(domain=keys[-1])
                     )
                 raise errors.NotFound(
                     reason=error_message,

--- a/ipatests/test_ipalib/test_text.py
+++ b/ipatests/test_ipalib/test_text.py
@@ -201,6 +201,12 @@ class test_Gettext(object):
         inst = self.klass('hello %(adj)s nurse', 'foo', 'bar')
         assert inst % dict(adj='tall', stuff='junk') == 'hello tall nurse'
 
+    def test_format(self):
+        inst = self.klass('{0} {adj} nurse', 'foo', 'bar')
+        posargs = ('hello', 'bye')
+        knownargs = {'adj': 'caring', 'stuff': 'junk'}
+        assert inst.format(*posargs, **knownargs) == 'hello caring nurse'
+
     def test_eq(self):
         inst1 = self.klass('what up?', 'foo', 'bar')
         inst2 = self.klass('what up?', 'foo', 'bar')
@@ -263,6 +269,21 @@ class test_NGettext(object):
         assert inst % dict(count=0, dish='frown') == '0 geese make a frown'
         assert inst % dict(count=1, dish='stew') == '1 goose makes a stew'
         assert inst % dict(count=2, dish='pie') == '2 geese make a pie'
+
+    def test_format(self):
+        singular = '{count} goose makes a {0} {dish}'
+        plural = '{count} geese make a {0} {dish}'
+        inst = self.klass(singular, plural, 'foo', 'bar')
+        posargs = ('tasty', 'disgusting')
+        knownargs0 = {'count': 0, 'dish': 'frown', 'stuff': 'junk'}
+        knownargs1 = {'count': 1, 'dish': 'stew', 'stuff': 'junk'}
+        knownargs2 = {'count': 2, 'dish': 'pie', 'stuff': 'junk'}
+        expected_str0 = '0 geese make a tasty frown'
+        expected_str1 = '1 goose makes a tasty stew'
+        expected_str2 = '2 geese make a tasty pie'
+        assert inst.format(*posargs, **knownargs0) == expected_str0
+        assert inst.format(*posargs, **knownargs1) == expected_str1
+        assert inst.format(*posargs, **knownargs2) == expected_str2
 
     def test_eq(self):
         inst1 = self.klass(singular, plural, 'foo', 'bar')
@@ -386,6 +407,12 @@ class test_ConcatenatedText(object):
     def test_mod(self):
         inst = self.klass('[', text.Gettext('%(color)s', 'foo', 'bar'), ']')
         assert inst % dict(color='red', stuff='junk') == '[red]'
+
+    def test_format(self):
+        inst = self.klass('{0}', text.Gettext('{color}', 'foo', 'bar'), ']')
+        posargs = ('[', '(')
+        knownargs = {'color': 'red', 'stuff': 'junk'}
+        assert inst.format(*posargs, **knownargs) == '[red]'
 
     def test_add(self):
         inst = (text.Gettext('pale ', 'foo', 'bar') +


### PR DESCRIPTION
Some of the messages cannot be translated because of a broken python brace formatting.

Simple reproducer:

Take a translatable message string from ipaserver/plugins/topology.py ```Topology management requires minimum domain level {0} ``` and put it on a test script with original formatting:
```python
#!/usr/bin/python

from ipalib.text import _
import os

os.environ['LC_ALL']='fr'
desired_value = '1'
msgtest = _('Topology management requires minimum domain level {0} '.format(desired_value))
import pdb;pdb.set_trace()
print msgtest
```

Out: 
```python
(Pdb) msgtest
Gettext('Topology management requires minimum domain level 1 ', domain='ipa', localedir=None)
(Pdb) print msgtest
Topology management requires minimum domain level 1
```
But French was expected.

Cause: The 'format' method should be called after a gettext one
to follow 'python-brace-format' rule:

```python
msgtest = unicode(_('Topology management requires minimum domain level {0} ')).format(desired_value)
```

with correct out:
```
(Pdb) msgtest
u'La gestion de la topologie n\xe9cessite le niveau de domaine minimal 1'
```


List of affected:
```
ipaserver/plugins/idrange.py:56
ipaserver/plugins/idrange.py:246
ipaserver/plugins/idrange.py:383
ipaserver/plugins/idrange.py:616
ipaserver/plugins/trust.py:688
ipaserver/plugins/topology.py:88
ipaserver/plugins/topology.py:257
ipaserver/plugins/topology.py:265
ipaserver/plugins/serverroles.py:82
ipaserver/plugins/serverroles.py:167
ipaserver/plugins/domainlevel.py:68
ipaserver/plugins/domainlevel.py:153
```

This patch should fix it.
