### PR TITLE
Test: when non responding forwarder is used, wrong error message is reported.

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -60,7 +60,7 @@ jobs:
         build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
         template: *ci-master-f28
-        timeout: 3600
+        timeout: 4200
         topology: *master_1repl_1client
 
   fedora-28/test_topologies:
@@ -206,4 +206,16 @@ jobs:
         template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl_1client
+
+  fedora-28/test_installtion:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterNoForwarder
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
 


### PR DESCRIPTION
related : https://pagure.io/freeipa/issue/6989