### PR TITLE
Use one Custodia peer to retrieve all secrets

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -60,7 +60,7 @@ jobs:
         build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
         template: *ci-master-f28
-        timeout: 3600
+        timeout: 4200
         topology: *master_1repl_1client
 
   fedora-28/test_topologies:

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -280,7 +280,6 @@ def install_step_0(standalone, replica_config, options, custodia):
         cafile = os.path.join(replica_config.dir, 'cacert.p12')
         if options.promote:
             custodia.get_ca_keys(
-                replica_config.ca_host_name,
                 cafile,
                 replica_config.dirman_password)
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -763,7 +763,7 @@ class CAInstance(DogtagInstance):
         self.configure_agent_renewal()
 
     def __import_ra_key(self):
-        self._custodia.import_ra_key(self.master_host)
+        self._custodia.import_ra_key()
         self.__set_ra_cert_perms()
 
         self.configure_agent_renewal()

--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -93,7 +93,6 @@ def install(api, replica_config, options, custodia):
                     paths.KRB5_KEYTAB,
                     ccache)
                 custodia.get_kra_keys(
-                    replica_config.kra_host_name,
                     krafile,
                     replica_config.dirman_password)
         else:

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1113,9 +1113,9 @@ def uninstall(installer):
     dsinstance.DsInstance(fstore=fstore).uninstall()
     if _server_trust_ad_installed:
         adtrustinstance.ADTRUSTInstance(fstore).uninstall()
-    # ldap_uri isn't used, but IPAKEMKeys parses /etc/ipa/default.conf
+    # realm isn't used, but IPAKEMKeys parses /etc/ipa/default.conf
     # otherwise, see https://pagure.io/freeipa/issue/7474 .
-    custodiainstance.CustodiaInstance(ldap_uri='ldapi://invalid').uninstall()
+    custodiainstance.CustodiaInstance(realm='REALM.INVALID').uninstall()
     otpdinstance.OtpdInstance().uninstall()
     tasks.restore_hostname(fstore, sstore)
     fstore.restore_all_files()

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1515,7 +1515,7 @@ def install(installer):
     krb.restart()
 
     if promote:
-        custodia.import_dm_password(config.master_host_name)
+        custodia.import_dm_password()
         promote_sssd(config.host_name)
         promote_openldap_conf(config.host_name, config.master_host_name)
 


### PR DESCRIPTION
Fix 994f71ac8a1bb7ba6bc9caf0f6e4f59af44ad9c4 was incomplete. Under some
circumstancs the DM hash and CA keys were still retrieved from two different
machines.

Custodia client now uses a single remote to upload keys and download all
secrets.

Signed-off-by: Christian Heimes <cheimes@redhat.com>