### PR TITLE
[Backport][ipa-4-6] ui_tests: fixes for issues with sending key and focus on element

### DIFF
--- a/ipatests/test_webui/test_service.py
+++ b/ipatests/test_webui/test_service.py
@@ -592,6 +592,7 @@ class test_service(sevice_tasks):
         pkey = self.get_service_pkey('smtp')
         self.add_service('smtp', confirm=False)
         actions = ActionChains(self.driver)
+        actions.click()
         actions.send_keys(Keys.ENTER).perform()
         self.wait(1)
         assert self.has_record(pkey)

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -1689,6 +1689,7 @@ class UI_driver(object):
         expand.click()
         action_link = self.find("li[data-name=%s] a" % name, By.CSS_SELECTOR,
                                 context, strict=True)
+        self.move_to_element_in_page(action_link)
         action_link.click()
         if confirm:
             self.wait(0.5)  # wait for dialog


### PR DESCRIPTION
This PR was opened automatically because PR #1999 was pushed to master and backport to ipa-4-6 is required.