### PR TITLE
 [Backport][ipa-4-6] Use replace instead of add to set new default ipaSELinuxUserMapOrder

### DIFF
--- a/install/updates/50-ipaconfig.update
+++ b/install/updates/50-ipaconfig.update
@@ -1,5 +1,5 @@
 dn: cn=ipaConfig,cn=etc,$SUFFIX
-add:ipaSELinuxUserMapOrder: guest_u:s0$$xguest_u:s0$$user_u:s0$$staff_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023
+replace: ipaSELinuxUserMapOrder: guest_u:s0$$xguest_u:s0$$user_u:s0-s0:c0.c1023$$staff_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023::ipaSELinuxUserMapOrder: guest_u:s0$$xguest_u:s0$$user_u:s0$$staff_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023
 add:ipaSELinuxUserMapDefault: unconfined_u:s0-s0:c0.c1023
 add:ipaUserObjectClasses: ipasshuser
 remove:ipaConfigString:AllowLMhash

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+#
+"""Misc test for 'ipa' CLI regressions
+"""
+from __future__ import absolute_import
+
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestIPACommand(IntegrationTest):
+    """
+    A lot of commands can be executed against a single IPA installation
+    so provide a generic class to execute one-off commands that need to be
+    tested without having to fire up a full server to run one command.
+    """
+    topology = 'line'
+
+    def test_change_selinuxusermaporder(self):
+        """
+        An update file meant to ensure a more sane default was
+        overriding any customization done to the order.
+        """
+        maporder = "unconfined_u:s0-s0:c0.c1023"
+
+        # set a new default
+        result = self.master.run_command(
+            ["ipa", "config-mod",
+             "--ipaselinuxusermaporder={}".format(maporder)],
+            raiseonerr=False
+        )
+        assert result.returncode == 0
+
+        # apply the update
+        result = self.master.run_command(
+            ["ipa-server-upgrade"],
+            raiseonerr=False
+        )
+        assert result.returncode == 0
+
+        # ensure result is the same
+        result = self.master.run_command(
+            ["ipa", "config-show"],
+            raiseonerr=False
+        )
+        assert result.returncode == 0
+        assert "SELinux user map order: {}".format(
+            maporder) in result.stdout_text


### PR DESCRIPTION
The add was in effect replacing whatever data was already there
causing any custom order to be lost on each run of
ipa-server-upgrade.

https://pagure.io/freeipa/issue/6610

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
Reviewed-By: Florence Blanc-Renaud <frenaud@redhat.com>