### PR TITLE
Suppress missing cn=schema compat on installation

### DIFF
--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -239,7 +239,15 @@ class IPAUpgrade(service.Service):
         ldif_outfile = "%s.modified.out" % self.filename
         with open(ldif_outfile, "w") as out_file:
             with open(self.filename, "r") as in_file:
+                parser = GetEntryFromLDIF(in_file, entries_dn=[COMPAT_DN])
+                parser.parse()
+                try:
+                    compat_entry = parser.get_results()[COMPAT_DN]
+                except KeyError:
+                    return
                 parser = installutils.ModifyLDIF(in_file, out_file)
+                if not compat_entry.get('nsslapd-pluginEnabled'):
+                    return
                 parser.remove_value(COMPAT_DN, "nsslapd-pluginEnabled")
                 parser.remove_value(COMPAT_DN, "nsslapd-pluginenabled")
                 parser.add_value(COMPAT_DN, "nsslapd-pluginEnabled",


### PR DESCRIPTION
The schema compat plugin is disabled on upgrades but it is
possible that it is not configured at all and this will
produce a rather nasty looking error message.

Check to see if it is configured at all before trying to
disable it.

https://pagure.io/freeipa/issue/6610