### PR TITLE
Fedora 29 renamed fedora-domainname.service

### DIFF
--- a/ipaplatform/fedora/services.py
+++ b/ipaplatform/fedora/services.py
@@ -24,14 +24,23 @@ Contains Fedora-specific service class implementations.
 
 from __future__ import absolute_import
 
+import os
+
 from ipaplatform.redhat import services as redhat_services
 
 # Mappings from service names as FreeIPA code references to these services
 # to their actual systemd service names
 fedora_system_units = redhat_services.redhat_system_units.copy()
 
-# Service that sets domainname on Fedora is called fedora-domainname.service
-fedora_system_units['domainname'] = 'fedora-domainname.service'
+# Fedora 28 and earlier have fedora-domainname.service. Starting from
+# Fedora 29, the service is called nis-domainname.service as defined in
+# ipaplatform.redhat.services.
+HAS_FEDORA_DOMAINNAME_SERVICE = os.path.isfile(
+    "/usr/lib/systemd/system/fedora-domainname.service"
+)
+
+if HAS_FEDORA_DOMAINNAME_SERVICE:
+    fedora_system_units['domainname'] = 'fedora-domainname.service'
 
 
 # Service classes that implement Fedora-specific behaviour
@@ -44,7 +53,7 @@ class FedoraService(redhat_services.RedHatService):
 # of specified name
 
 def fedora_service_class_factory(name, api=None):
-    if name == 'domainname':
+    if HAS_FEDORA_DOMAINNAME_SERVICE and name == 'domainname':
         return FedoraService(name, api)
     return redhat_services.redhat_service_class_factory(name, api)
 

--- a/ipaplatform/redhat/services.py
+++ b/ipaplatform/redhat/services.py
@@ -47,6 +47,7 @@ redhat_system_units = dict((x, "%s.service" % x)
 
 redhat_system_units['rpcgssd'] = 'nfs-secure.service'
 redhat_system_units['rpcidmapd'] = 'nfs-idmap.service'
+redhat_system_units['domainname'] = 'nis-domainname.service'
 
 # Rewrite dirsrv and pki-tomcatd services as they support instances via separate
 # service generator. To make this working, one needs to have both foo@.servic


### PR DESCRIPTION
In Fedora 29, the fedora-domainname.service has been renamed to
nis-domainname.service like on RHEL. The ipaplatform service module for
Fedora now only renames the service, when it detects the presence of
fedora-domainname.service.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1588192
Fixes: https://pagure.io/freeipa/issue/7582
Signed-off-by: Christian Heimes <cheimes@redhat.com>