### PR TITLE
[Backport][ipa-4-6] Uninstall fix for named-pkcs11

### DIFF
--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -1183,9 +1183,13 @@ class BindInstance(service.Service):
         # disabled by default, by ldap_enable()
         if enabled:
             self.enable()
+        else:
+            self.disable()
 
         if running:
             self.restart()
+        else:
+            self.stop()
 
         self.named_regular.unmask()
         if named_regular_enabled:

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -166,8 +166,6 @@ class TestBackupAndRestore(IntegrationTest):
 
     def test_full_backup_and_restore_with_removed_users(self):
         """regression test for https://fedorahosted.org/freeipa/ticket/3866"""
-        tasks.uninstall_master(self.master)
-        tasks.install_master(self.master)
         with restore_checker(self.master):
             backup_path = backup(self.master)
 
@@ -191,8 +189,6 @@ class TestBackupAndRestore(IntegrationTest):
 
     def test_full_backup_and_restore_with_selinux_booleans_off(self):
         """regression test for https://fedorahosted.org/freeipa/ticket/4157"""
-        tasks.uninstall_master(self.master)
-        tasks.install_master(self.master)
         with restore_checker(self.master):
             backup_path = backup(self.master)
 


### PR DESCRIPTION
This PR was opened automatically because PR #1987 was pushed to master and backport to ipa-4-6 is required.