### PR TITLE
Use python3-lesscpy 0.13.0

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -159,8 +159,9 @@ BuildRequires:  libsss_nss_idmap-devel >= 1.15.3
 BuildRequires:  rhino
 BuildRequires:  libverto-devel
 BuildRequires:  libunistring-devel
-# /usr/bin/lesscpy is provided by Python 2 package
-BuildRequires:  python2-lesscpy
+# 0.13.0: https://bugzilla.redhat.com/show_bug.cgi?id=1584773
+# 0.13.0-2: fix for missing dependency on python-six
+BuildRequires:  python3-lesscpy >= 0.13.0-2
 %endif # ONLY_CLIENT
 
 #

--- a/install/ui/util/make-css.sh
+++ b/install/ui/util/make-css.sh
@@ -22,5 +22,5 @@ set -o errexit
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-lesscpy -x $DIR/../less/ipa.less > $DIR/../css/ipa.css
+py3-lesscpy -x $DIR/../less/ipa.less > $DIR/../css/ipa.css
 exit $?


### PR DESCRIPTION
Require python-lesscpy 0.13. with Python 3 fix and use py3-lesscpy to
compile ipa.css.

python2-lesscpy was the last Python 2 dependency.

Fixes: https://pagure.io/freeipa/issue/7585
Signed-off-by: Christian Heimes <cheimes@redhat.com>