### PR TITLE
[Backport][ipa-4-6] Test coverage for multiservers for radius proxy

### DIFF
--- a/ipatests/test_xmlrpc/test_radiusproxy_plugin.py
+++ b/ipatests/test_xmlrpc/test_radiusproxy_plugin.py
@@ -73,6 +73,19 @@ class test_raduisproxy(Declarative):
 
 
         dict(
+            desc='Try to add multiple radius proxy server %r' % radius1,
+            command=('radiusproxy_add', [radius1],
+                     dict(
+                     ipatokenradiusserver=radius1_fqdn,
+                     addattr=u'ipatokenradiusserver=radius1_fqdn',
+                     ipatokenradiussecret=password1,
+                     ),
+                     ),
+            expected=errors.OnlyOneValueAllowed(attr='ipatokenradiusserver')
+        ),
+
+
+        dict(
             desc='Create %r' % radius1,
             command=('radiusproxy_add', [radius1],
                 dict(


### PR DESCRIPTION
This PR was opened automatically because PR #2005 was pushed to master and backport to ipa-4-6 is required.