### PR TITLE
Increase WSGI process count to 5 on 64bit

### DIFF
--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -41,7 +41,7 @@ WSGISocketPrefix $WSGI_PREFIX_DIR
 
 
 # Configure mod_wsgi handler for /ipa
-WSGIDaemonProcess ipa processes=2 threads=1 maximum-requests=500 \
+WSGIDaemonProcess ipa processes=$WSGI_PROCESSES threads=1 maximum-requests=500 \
   user=ipaapi group=ipaapi display-name=%{GROUP} socket-timeout=2147483647 \
   lang=C.UTF-8 locale=C.UTF-8
 WSGIImportScript /usr/share/ipa/wsgi.py process-group=ipa application-group=ipa

--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -5,9 +5,11 @@
 '''
 This base platform module exports platform dependant constants.
 '''
+import sys
 
 
 class BaseConstantsNamespace(object):
+    IS_64BITS = sys.maxsize > 2 ** 32
     DS_USER = 'dirsrv'
     DS_GROUP = 'dirsrv'
     HTTPD_USER = "apache"
@@ -42,6 +44,9 @@ class BaseConstantsNamespace(object):
     # WSGI module override, only used on Fedora
     MOD_WSGI_PYTHON2 = None
     MOD_WSGI_PYTHON3 = None
+    # WSGIDaemonProcess process count. On 64bit platforms, each process
+    # consumes about 110 MB RSS, from which are about 35 MB shared.
+    WSGI_PROCESSES = 5 if IS_64BITS else 2
     # high ciphers without RC4, MD5, TripleDES, pre-shared key, secure
     # remote password, and DSA cert authentication.
     TLS_HIGH_CIPHERS = "HIGH:!aNULL:!eNULL:!MD5:!RC4:!3DES:!PSK:!SRP:!aDSS"

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -108,6 +108,7 @@ class HTTPInstance(service.Service):
             IPA_CUSTODIA_SOCKET=paths.IPA_CUSTODIA_SOCKET,
             IPA_CCACHES=paths.IPA_CCACHES,
             WSGI_PREFIX_DIR=paths.WSGI_PREFIX_DIR,
+            WSGI_PROCESSES=constants.WSGI_PROCESSES,
         )
         self.ca_file = ca_file
         if ca_is_configured is not None:

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1734,6 +1734,7 @@ def upgrade_configuration():
         DOGTAG_PORT=8009,
         CLONE='#',
         WSGI_PREFIX_DIR=paths.WSGI_PREFIX_DIR,
+        WSGI_PROCESSES=constants.WSGI_PROCESSES,
         GSSAPI_SESSION_KEY=paths.GSSAPI_SESSION_KEY,
         FONTS_DIR=paths.FONTS_DIR,
         IPA_CCACHES=paths.IPA_CCACHES,


### PR DESCRIPTION
Increase the WSGI daemon worker process count from 2 processes to 5
processes. This allows IPA RPC to handle more parallel requests. The
additional processes increase memory consumption by approximante 250 MB
in total.

Since memory is scarce on 32bit platforms, only 64bit platforms are
bumped to 5 workers.

Fixes: https://pagure.io/freeipa/issue/7587
Signed-off-by: Christian Heimes <cheimes@redhat.com>