### PR TITLE
[Backport][ipa-4-5] Increase WSGI process count to 5 on 64bit

### DIFF
--- a/install/conf/ipa.conf
+++ b/install/conf/ipa.conf
@@ -51,7 +51,7 @@ WSGISocketPrefix /run/httpd/wsgi
 
 
 # Configure mod_wsgi handler for /ipa
-WSGIDaemonProcess ipa processes=2 threads=1 maximum-requests=500 \
+WSGIDaemonProcess ipa processes=$WSGI_PROCESSES threads=1 maximum-requests=500 \
  user=ipaapi group=ipaapi display-name=%{GROUP} socket-timeout=2147483647
 WSGIImportScript /usr/share/ipa/wsgi.py process-group=ipa application-group=ipa
 WSGIScriptAlias /ipa /usr/share/ipa/wsgi.py

--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -32,4 +32,4 @@ class BaseConstantsNamespace(object):
     SSSD_USER = "sssd"
     # WSGIDaemonProcess process count. On 64bit platforms, each process
     # consumes about 110 MB RSS, from which are about 35 MB shared.
-    WSGI_PROCESSES = 5 if IS_64BITS else 2
+    WSGI_PROCESSES = 4 if IS_64BITS else 2

--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -5,9 +5,11 @@
 '''
 This base platform module exports platform dependant constants.
 '''
+import sys
 
 
 class BaseConstantsNamespace(object):
+    IS_64BITS = sys.maxsize > 2 ** 32
     DS_USER = 'dirsrv'
     DS_GROUP = 'dirsrv'
     HTTPD_USER = "apache"
@@ -28,3 +30,6 @@ class BaseConstantsNamespace(object):
     # nfsd init variable used to enable kerberized NFS
     SECURE_NFS_VAR = "SECURE_NFS"
     SSSD_USER = "sssd"
+    # WSGIDaemonProcess process count. On 64bit platforms, each process
+    # consumes about 110 MB RSS, from which are about 35 MB shared.
+    WSGI_PROCESSES = 5 if IS_64BITS else 2

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -152,6 +152,7 @@ class HTTPInstance(service.Service):
             DOMAIN=self.domain,
             AUTOREDIR='' if auto_redirect else '#',
             CRL_PUBLISH_PATH=paths.PKI_CA_PUBLISH_DIR,
+            WSGI_PROCESSES=constants.WSGI_PROCESSES,
         )
         self.ca_file = ca_file
         if ca_is_configured is not None:

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1611,7 +1611,8 @@ def upgrade_configuration():
         AUTOREDIR='' if auto_redirect else '#',
         CRL_PUBLISH_PATH=paths.PKI_CA_PUBLISH_DIR,
         DOGTAG_PORT=8009,
-        CLONE='#'
+        CLONE='#',
+        WSGI_PROCESSES=constants.WSGI_PROCESSES,
     )
 
     subject_base = find_subject_base()


### PR DESCRIPTION
Increase the WSGI daemon worker process count from 2 processes to 5
processes. This allows IPA RPC to handle more parallel requests. The
additional processes increase memory consumption by approximante 250 MB
in total.

Since memory is scarce on 32bit platforms, only 64bit platforms are
bumped to 5 workers.

PR was ACKed manually because this is backport of PR #2028.

Fixes: https://pagure.io/freeipa/issue/7587
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Alexander Bokovoy <abokovoy@redhat.com>