### PR TITLE
Installer: configure authselect with-sudo

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2962,7 +2962,8 @@ def _install(options):
         tasks.modify_nsswitch_pam_stack(
             sssd=options.sssd,
             mkhomedir=options.mkhomedir,
-            statestore=statestore
+            statestore=statestore,
+            sudo=options.conf_sudo
         )
 
         logger.info("%s enabled", "SSSD" if options.sssd else "LDAP")

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -133,7 +133,8 @@ class BaseTaskNamespace(object):
 
         raise NotImplementedError()
 
-    def modify_nsswitch_pam_stack(self, sssd, mkhomedir, statestore):
+    def modify_nsswitch_pam_stack(self, sssd, mkhomedir, statestore,
+                                  sudo=True):
         """
         If sssd flag is true, configure pam and nsswitch so that SSSD is used
         for retrieving user information and authentication.

--- a/ipaplatform/debian/tasks.py
+++ b/ipaplatform/debian/tasks.py
@@ -31,7 +31,7 @@ class DebianTaskNamespace(RedHatTaskNamespace):
         return True
 
     @staticmethod
-    def modify_nsswitch_pam_stack(sssd, mkhomedir, statestore):
+    def modify_nsswitch_pam_stack(sssd, mkhomedir, statestore, sudo=True):
         if mkhomedir:
             try:
                 ipautil.run(["pam-auth-update",

--- a/ipaplatform/redhat/authconfig.py
+++ b/ipaplatform/redhat/authconfig.py
@@ -41,7 +41,7 @@ def get_auth_tool():
 class RedHatAuthToolBase(object):
 
     @abc.abstractmethod
-    def configure(self, sssd, mkhomedir, statestore):
+    def configure(self, sssd, mkhomedir, statestore, sudo=True):
         pass
 
     @abc.abstractmethod
@@ -102,11 +102,11 @@ class RedHatAuthSelect(RedHatAuthToolBase):
         features = output_items[1:]
         return profile, features
 
-    def configure(self, sssd, mkhomedir, statestore):
+    def configure(self, sssd, mkhomedir, statestore, sudo=True):
         # In the statestore, the following keys are used for the
         # 'authselect' module:
         # profile: name of the profile configured pre-installation
-        # features_list: lsit of features configured pre-installation
+        # features_list: list of features configured pre-installation
         # mkhomedir: True if installation was called with --mkhomedir
         # profile and features_list are used when reverting to the
         # pre-install state
@@ -132,6 +132,8 @@ class RedHatAuthSelect(RedHatAuthToolBase):
         if mkhomedir:
             cmd.append("with-mkhomedir")
             statestore.backup_state('authselect', 'mkhomedir', True)
+        if sudo:
+            cmd.append("with-sudo")
         cmd.append("--force")
 
         ipautil.run(cmd)
@@ -275,7 +277,7 @@ class RedHatAuthConfig(RedHatAuthToolBase):
         except ipautil.CalledProcessError:
             raise ScriptError("Failed to execute authconfig command")
 
-    def configure(self, sssd, mkhomedir, statestore):
+    def configure(self, sssd, mkhomedir, statestore, sudo=True):
         if sssd:
             statestore.backup_state('authconfig', 'sssd', True)
             statestore.backup_state('authconfig', 'sssdauth', True)

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -207,9 +207,10 @@ class RedHatTaskNamespace(BaseTaskNamespace):
         with open(paths.SYSCONF_NETWORK, 'w') as f:
             f.writelines(content)
 
-    def modify_nsswitch_pam_stack(self, sssd, mkhomedir, statestore):
+    def modify_nsswitch_pam_stack(self, sssd, mkhomedir, statestore,
+                                  sudo=True):
         auth_config = get_auth_tool()
-        auth_config.configure(sssd, mkhomedir, statestore)
+        auth_config.configure(sssd, mkhomedir, statestore, sudo)
 
     def is_nosssd_supported(self):
         # The flag --no-sssd is not supported any more for rhel-based distros
@@ -232,7 +233,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
         mkhomedir = statestore.get_state('authconfig', 'mkhomedir')
 
         # Force authselect 'sssd' profile
-        authselect_cmd = [paths.AUTHSELECT, "select", "sssd"]
+        authselect_cmd = [paths.AUTHSELECT, "select", "sssd", "with-sudo"]
         if mkhomedir:
             authselect_cmd.append("with-mkhomedir")
         authselect_cmd.append("--force")

--- a/ipatests/test_integration/test_authselect.py
+++ b/ipatests/test_integration/test_authselect.py
@@ -51,7 +51,7 @@ class TestClientInstallation(IntegrationTest):
     Tests the client installation with authselect profile.
 
     When the system is a fresh installation, authselect tool is available
-    and the default profile 'sssd' without any option is set be default.
+    and the default profile 'sssd' without any option is set by default.
     But when the system has been upgraded from older version, even though
     authselect tool is available, no profile is set (authselect current would
     return 'No existing configuration detected').
@@ -121,7 +121,8 @@ class TestClientInstallation(IntegrationTest):
         assert result.returncode == 0
         assert self.msg_warn_install in result.stderr_text
         # Client installation must configure the 'sssd' profile
-        check_authselect_profile(self.client, default_profile)
+        # with sudo
+        check_authselect_profile(self.client, default_profile, ('with-sudo',))
 
     def test_uninstall_client_no_preconfigured_profile(self):
         """
@@ -149,8 +150,10 @@ class TestClientInstallation(IntegrationTest):
         result = self._install_client(extraargs=['-f', '--mkhomedir'])
         assert result.returncode == 0
         assert self.msg_warn_install not in result.stderr_text
+        # Client installation must configure the 'sssd' profile
+        # with mkhomedir (because of extraargs) and with sudo
         check_authselect_profile(
-            self.client, default_profile, ('with-mkhomedir',))
+            self.client, default_profile, ('with-mkhomedir', 'with-sudo'))
 
     def test_uninstall_client_preconfigured_profile(self):
         """
@@ -163,6 +166,17 @@ class TestClientInstallation(IntegrationTest):
         assert self.msg_warn_uninstall not in result.stderr_text
         check_authselect_profile(
             self.client, preconfigured_profile, preconfigured_options)
+
+    def test_install_client_no_sudo(self):
+        """
+        Test client installation with --no-sudo option
+        """
+        result = self._install_client(extraargs=['-f', '--no-sudo'])
+        assert result.returncode == 0
+        assert self.msg_warn_install not in result.stderr_text
+        # Client installation must configure the 'sssd' profile
+        # but not with sudo (because of extraargs)
+        check_authselect_profile(self.client, default_profile, ())
 
     @classmethod
     def uninstall(cls, mh):
@@ -179,7 +193,7 @@ class TestServerInstallation(IntegrationTest):
     Tests the server installation with authselect profile.
 
     When the system is a fresh installation, authselect tool is available
-    and the default profile 'sssd' without any option is set be default.
+    and the default profile 'sssd' without any option is set by default.
     But when the system has been upgraded from older version, even though
     authselect tool is available, no profile is set (authselect current would
     return 'No existing configuration detected').
@@ -200,7 +214,7 @@ class TestServerInstallation(IntegrationTest):
         apply_authselect_profile(
             self.master, preconfigured_profile, preconfigured_options)
         tasks.install_master(self.master, setup_dns=False)
-        check_authselect_profile(self.master, default_profile)
+        check_authselect_profile(self.master, default_profile, ('with-sudo',))
 
     def test_uninstall(self):
         """


### PR DESCRIPTION
authselect needs to be configured with the 'with-sudo' feature (except
when ipa-client-install is called with the option --no-sudo).

https://pagure.io/freeipa/issue/7562