### PR TITLE
ipaserver config plugin: Increase search records minimum limit

### DIFF
--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -85,6 +85,18 @@ EXAMPLES:
 
 register = Registry()
 
+
+def validate_search_records_limit(ugettext, value):
+    """Check if value is greater than a realistic minimum.
+
+    Values 0 and -1 are valid, as they represent unlimited.
+    """
+    if value in {-1, 0}:
+        return
+    if value < 10:
+        return _('must be at least 10')
+
+
 @register()
 class config(LDAPObject):
     """
@@ -161,10 +173,10 @@ class config(LDAPObject):
             minvalue=-1,
         ),
         Int('ipasearchrecordslimit',
+            validate_search_records_limit,
             cli_name='searchrecordslimit',
             label=_('Search size limit'),
             doc=_('Maximum number of records to search (-1 or 0 is unlimited)'),
-            minvalue=-1,
         ),
         IA5Str('ipausersearchfields',
             cli_name='usersearch',

--- a/ipatests/test_xmlrpc/test_config_plugin.py
+++ b/ipatests/test_xmlrpc/test_config_plugin.py
@@ -227,4 +227,80 @@ class test_config(Declarative):
                         sl_domain),
             ),
         ),
+        dict(
+            desc='Set the number of search records to -1 (unlimited)',
+            command=(
+                'config_mod', [], {
+                    'ipasearchrecordslimit': u'-1',
+                },
+            ),
+            expected={
+                'result': lambda d: d['ipasearchrecordslimit'] == (u'-1',),
+                'summary': None,
+                'value': None,
+            },
+        ),
+        dict(
+            desc='Set the number of search records to greater than 10',
+            command=(
+                'config_mod', [], {
+                    'ipasearchrecordslimit': u'100',
+                },
+            ),
+            expected={
+                'result': lambda d: d['ipasearchrecordslimit'] == (u'100',),
+                'summary': None,
+                'value': None,
+            },
+        ),
+        dict(
+            desc='Set the number of search records to lower than -1',
+            command=(
+                'config_mod', [], {
+                    'ipasearchrecordslimit': u'-10',
+                },
+            ),
+            expected=errors.ValidationError(
+                name=u'searchrecordslimit',
+                error=u'must be at least 10',
+            ),
+        ),
+        dict(
+            desc='Set the number of search records to lower than 10',
+            command=(
+                'config_mod', [], {
+                    'ipasearchrecordslimit': u'1',
+                },
+            ),
+            expected=errors.ValidationError(
+                name=u'searchrecordslimit',
+                error=u'must be at least 10',
+            ),
+        ),
+        dict(
+            desc='Set the number of search records to zero (unlimited)',
+            command=(
+                'config_mod', [], {
+                    'ipasearchrecordslimit': u'0',
+                },
+            ),
+            expected={
+                'result': lambda d: d['ipasearchrecordslimit'] == (u'-1',),
+                'summary': None,
+                'value': None,
+            },
+        ),
+        dict(
+            desc='Set the number of search records back to 100',
+            command=(
+                'config_mod', [], {
+                    'ipasearchrecordslimit': u'100',
+                },
+            ),
+            expected={
+                'result': lambda d: d['ipasearchrecordslimit'] == (u'100',),
+                'summary': None,
+                'value': None,
+            },
+        ),
     ]


### PR DESCRIPTION
Issue: https://pagure.io/freeipa/issue/6617

Check if the given search records value is greater than an arbitrary number that is not so close to zero.

The number 10 is arbitrary, I'm open for discussion.

The last test also works as a clean-up task, returning the setting back to _unlimited_.