### PR TITLE
Test for :  ipa-client-install should not use hardcoded admin principal

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -431,7 +431,8 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
     return result
 
 
-def install_client(master, client, extra_args=()):
+def install_client(master, client, extra_args=(),
+                   user=None, password=None):
     client.collect_log(paths.IPACLIENT_INSTALL_LOG)
 
     apply_common_fixes(client)
@@ -443,12 +444,16 @@ def install_client(master, client, extra_args=()):
     if not error:
         master.run_command(["ipa", "dnszone-mod", zone,
                             "--dynamic-update=TRUE"])
+    if user is None:
+        user = client.config.admin_name
+    if password is None:
+        password = client.config.admin_password
 
     client.run_command(['ipa-client-install', '-U',
                         '--domain', client.domain.name,
                         '--realm', client.domain.realm,
-                        '-p', client.config.admin_name,
-                        '-w', client.config.admin_password,
+                        '-p', user,
+                        '-w', password,
                         '--server', master.hostname]
                        + list(extra_args))
 

--- a/ipatests/test_integration/test_user_permissions.py
+++ b/ipatests/test_integration/test_user_permissions.py
@@ -2,6 +2,10 @@
 # Copyright (C) 2018  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
+
+from ipaplatform.paths import paths
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_plugins.integration import tasks
 
@@ -93,3 +97,55 @@ class TestUserPermissions(IntegrationTest):
         # the field Kerberos Keys available must contain True
         result = self.master.run_command(['ipa', 'stageuser-show', stageuser])
         assert 'Kerberos keys available: True' in result.stdout_text
+
+
+class TestInstallClientNoAdmin(IntegrationTest):
+    num_clients = 1
+
+    def test_installclient_as_user_admin(self):
+        """ipa-client-install should not use hardcoded admin for principal
+
+        In ipaclient-install.log it should use the username that was entered
+        earlier in the install process at the prompt.
+        Related to : https://pagure.io/freeipa/issue/5406
+        """
+        client = self.clients[0]
+        tasks.install_master(self.master)
+        tasks.kinit_admin(self.master)
+        username = 'testuser1'
+        password = 'userSecretPassword123'
+        password_confirmation = "%s\n%s\n" % (password,
+                                              password)
+
+        self.master.run_command(['ipa', 'user-add', username,
+                                 '--first', username,
+                                 '--last', username,
+                                 '--password'],
+                                stdin_text=password_confirmation)
+
+        role_add = ['ipa', 'role-add', 'useradmin']
+        self.master.run_command(role_add)
+        self.master.run_command(['ipa', 'privilege-add', 'Add Hosts'])
+        self.master.run_command(['ipa', 'privilege-add-permission',
+                                 '--permissions', 'System: Add Hosts',
+                                 'Add Hosts'])
+
+        self.master.run_command(['ipa', 'role-add-privilege', 'useradmin',
+                                 '--privileges', 'Host Enrollment'])
+
+        self.master.run_command(['ipa', 'role-add-privilege', 'useradmin',
+                                 '--privileges', 'Add Hosts'])
+
+        role_member_add = ['ipa', 'role-add-member', 'useradmin',
+                           '--users={}'.format(username)]
+        self.master.run_command(role_member_add)
+        user_kinit = "%s\n%s\n%s\n" % (password, password, password)
+        self.master.run_command(['kinit', username],
+                                stdin_text=user_kinit)
+        tasks.install_client(self.master, client, user=username,
+                             password=password)
+        msg = "args=['/usr/bin/getent', 'passwd', '%s@%s']" % \
+              (username, client.domain.name)
+        install_log = client.get_file_contents(paths.IPACLIENT_INSTALL_LOG,
+                                               encoding='utf-8')
+        assert msg in install_log


### PR DESCRIPTION
Related to : https://pagure.io/freeipa/issue/5406
