### PR TITLE
[Fedora29]: fix dependency for *-domainname.service file

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -576,7 +576,11 @@ Requires: krb5-workstation >= %{krb5_version}
 Requires: authselect >= 0.4-2
 Requires: curl
 # NIS domain name config: /usr/lib/systemd/system/*-domainname.service
+%if 0%{?fedora} >= 29
+Requires: hostname
+%else
 Requires: initscripts
+%endif
 Requires: libcurl >= 7.21.7-2
 Requires: xmlrpc-c >= 1.27.4
 Requires: sssd >= 1.14.0


### PR DESCRIPTION
FreeIPA has a dependency on /usr/lib/systemd/system/*-domainname.service
file. In fedora <=28, this is provided by package 'initscripts'
but in fedora >= 29, this is provided by package 'hostname'.

Fixes:
https://pagure.io/freeipa/issue/7591