### PR TITLE
Apply validate_doc() to NO_CLI commands

### DIFF
--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -3550,6 +3550,7 @@ for param in _dns_records:
 
 @register()
 class dnsrecord_split_parts(Command):
+    __doc__ = _('Split DNS record to parts')
     NO_CLI = True
 
     takes_args = (

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -19,9 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Plugins not accessible directly through the CLI, commands used internally
-"""
 from ipalib import Command
 from ipalib import Str
 from ipalib.frontend import Local
@@ -29,6 +26,10 @@ from ipalib.output import Output
 from ipalib.text import _
 from ipalib.util import json_serialize
 from ipalib.plugable import Registry
+
+__doc__ = _("""
+Plugins not accessible directly through the CLI, commands used internally
+""")
 
 register = Registry()
 

--- a/ipaserver/plugins/join.py
+++ b/ipaserver/plugins/join.py
@@ -17,10 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Joining an IPA domain
-"""
-
 import logging
 
 import six
@@ -30,6 +26,10 @@ from ipalib import Command, Str
 from ipalib import errors
 from ipalib import _
 from ipaserver.install import installutils
+
+__doc__ = _("""
+Joining an IPA domain
+""")
 
 if six.PY3:
     unicode = str

--- a/ipaserver/plugins/session.py
+++ b/ipaserver/plugins/session.py
@@ -9,6 +9,10 @@ from ipalib.request import context
 from ipalib.plugable import Registry
 from ipalib.text import _
 
+__doc__ = _("""
+Session Support for IPA
+""")
+
 logger = logging.getLogger(__name__)
 
 register = Registry()

--- a/makeapi
+++ b/makeapi
@@ -166,10 +166,6 @@ def validate_doc():
     for cmd in api.Command():
         cmd_class = cmd.__class__
 
-        # Skip commands marked as NO_CLI
-        if getattr(cmd, 'NO_CLI', False):
-            continue
-
         # Have we processed this module yet?
         topic = cmd.topic
         while topic is not None:


### PR DESCRIPTION
For now validate_doc() checks NO_CLI commands only.

From validate_doc:
```
 * Every command must have documentation
and it must be marked for international translation

* Every module hosting a command must have documentation
and it must be marked for international translation

* Every module topic must be marked for international translation
```

So, to prevent from NO_CLI commands have no translatable
description or have no one at all in Web UI API Browser 
validation of ```__doc__``` is required.

https://pagure.io/freeipa/issue/7592
Additionally, 
```
1 commands without doc, 0 commands whose doc is not i18n
1 modules without doc, 2 modules whose doc is not i18n
```
are fixed.
