### PR TITLE
Always set ca_host when installing replica

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -241,11 +241,9 @@ def create_ipa_conf(fstore, config, ca_enabled, master=None):
         gopts.extend([
             ipaconf.setOption('enable_ra', 'True'),
             ipaconf.setOption('ra_plugin', 'dogtag'),
-            ipaconf.setOption('dogtag_version', '10')
+            ipaconf.setOption('dogtag_version', '10'),
+            ipaconf.setOption('ca_host', config.ca_host_name)
         ])
-
-        if not config.setup_ca:
-            gopts.append(ipaconf.setOption('ca_host', config.ca_host_name))
     else:
         gopts.extend([
             ipaconf.setOption('enable_ra', 'False'),


### PR DESCRIPTION
ipa-replica-install only set ca_host in its temporary
/etc/ipa/default.conf, when it wasn't installing a replica with CA. As a
consequence, the replica installer was picking a random CA server from
LDAP.

Always set the replication peer as ca_host. This will ensure that the
installer uses the same replication peer for CA. In case the replication
peer is not a CA master, the installer will automatically pick another
host later.

See: https://pagure.io/freeipa/issue/7566
Signed-off-by: Christian Heimes <cheimes@redhat.com>