### PR TITLE
[Backport ipa-4-5] Always set ca_host when installing replica

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -236,11 +236,9 @@ def create_ipa_conf(fstore, config, ca_enabled, master=None):
         gopts.extend([
             ipaconf.setOption('enable_ra', 'True'),
             ipaconf.setOption('ra_plugin', 'dogtag'),
-            ipaconf.setOption('dogtag_version', '10')
+            ipaconf.setOption('dogtag_version', '10'),
+            ipaconf.setOption('ca_host', config.ca_host_name)
         ])
-
-        if not config.setup_ca:
-            gopts.append(ipaconf.setOption('ca_host', config.ca_host_name))
     else:
         gopts.extend([
             ipaconf.setOption('enable_ra', 'False'),


### PR DESCRIPTION
This PR was opened automatically because PR #2054 was pushed to ipa-4-6 and backport to ipa-4-5 is required.