### PR TITLE
Ensure that public cert and CA bundle are readable

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1879,7 +1879,7 @@ def get_ca_certs(fstore, options, server, basedn, realm):
 
     if ca_certs is not None:
         try:
-            x509.write_certificate_list(ca_certs, ca_file)
+            x509.write_certificate_list(ca_certs, ca_file, mode=0o644)
         except Exception as e:
             if os.path.exists(ca_file):
                 try:
@@ -2874,10 +2874,14 @@ def _install(options):
 
     x509.write_certificate_list(
         [c for c, n, t, u in ca_certs if t is not False],
-        paths.KDC_CA_BUNDLE_PEM)
+        paths.KDC_CA_BUNDLE_PEM,
+        mode=0o644
+    )
     x509.write_certificate_list(
         [c for c, n, t, u in ca_certs if t is not False],
-        paths.CA_BUNDLE_PEM)
+        paths.CA_BUNDLE_PEM,
+        mode=0o644
+    )
 
     # Add the CA certificates to the IPA NSS database
     logger.debug("Adding CA certificates to the IPA NSS database.")

--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -186,10 +186,10 @@ def update_server(certs):
     update_file(paths.CACERT_PEM, certs)
 
 
-def update_file(filename, certs, mode=0o444):
+def update_file(filename, certs, mode=0o644):
     certs = (c[0] for c in certs if c[2] is not False)
     try:
-        x509.write_certificate_list(certs, filename)
+        x509.write_certificate_list(certs, filename, mode=mode)
     except Exception as e:
         logger.error("failed to update %s: %s", filename, e)
 

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -553,7 +553,7 @@ def write_certificate(cert, filename):
         raise errors.FileError(reason=str(e))
 
 
-def write_certificate_list(certs, filename):
+def write_certificate_list(certs, filename, mode=None):
     """
     Write a list of certificates to a file in PEM format.
 
@@ -563,6 +563,8 @@ def write_certificate_list(certs, filename):
 
     try:
         with open(filename, 'wb') as f:
+            if mode is not None:
+                os.fchmod(f.fileno(), mode)
             for cert in certs:
                 f.write(cert.public_bytes(Encoding.PEM))
     except (IOError, OSError) as e:

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -280,6 +280,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
 
         try:
             f = open(new_cacert_path, 'w')
+            os.fchmod(f.fileno(), 0o644)
         except IOError as e:
             logger.info("Failed to open %s: %s", new_cacert_path, e)
             return False

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -849,7 +849,7 @@ class CAInstance(DogtagInstance):
         for path in [paths.IPA_CA_CRT,
                      paths.KDC_CA_BUNDLE_PEM,
                      paths.CA_BUNDLE_PEM]:
-            x509.write_certificate_list(certlist, path)
+            x509.write_certificate_list(certlist, path, mode=0o644)
 
     def __request_ra_certificate(self):
         """

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -181,7 +181,8 @@ class HTTPInstance(service.Service):
         session_dir = os.path.dirname(self.sub_dict['GSSAPI_SESSION_KEY'])
         if not os.path.isdir(session_dir):
             os.makedirs(session_dir)
-            os.chmod(session_dir, 0o755)
+        # Must be world-readable / executable
+        os.chmod(session_dir, 0o755)
 
         target_fname = paths.HTTPD_IPA_CONF
         http_txt = ipautil.template_file(

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -432,7 +432,7 @@ class HTTPInstance(service.Service):
             raise RuntimeError("HTTPD cert was issued by an unknown CA.")
         # at this time we can assume any CA cert will be valid since this is
         # only run during installation
-        x509.write_certificate_list(certlist, paths.CA_CRT)
+        x509.write_certificate_list(certlist, paths.CA_CRT, mode=0o644)
 
     def is_kdcproxy_configured(self):
         """Check if KDC proxy has already been configured in the past"""

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1104,7 +1104,11 @@ def load_external_cert(files, ca_subject):
     cert_file.flush()
 
     ca_file = tempfile.NamedTemporaryFile()
-    x509.write_certificate_list(ca_cert_chain[1:], ca_file.name)
+    x509.write_certificate_list(
+        ca_cert_chain[1:],
+        ca_file.name,
+        mode=0o644
+    )
     ca_file.flush()
 
     return cert_file, ca_file

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -505,7 +505,7 @@ class KrbInstance(service.Service):
                                           self.api.env.realm,
                                           False)
         ca_certs = [c for c, _n, t, _u in ca_certs if t is not False]
-        x509.write_certificate_list(ca_certs, paths.CACERT_PEM)
+        x509.write_certificate_list(ca_certs, paths.CACERT_PEM, mode=0o644)
 
     def issue_selfsigned_pkinit_certs(self):
         self._call_certmonger(certmonger_ca="SelfSign")

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -145,7 +145,7 @@ def install_ca_cert(ldap, base_dn, realm, cafile, destfile=paths.IPA_CA_CRT):
                 pass
         else:
             certs = [c[0] for c in certs if c[2] is not False]
-            x509.write_certificate_list(certs, destfile)
+            x509.write_certificate_list(certs, destfile, mode=0o644)
     except Exception as e:
         raise ScriptError("error copying files: " + str(e))
     return destfile


### PR DESCRIPTION
In CIS hardened mode, the process umask is 027. This results in some
files not being world readable. Ensure that write_certificate_list()
calls in client installer, server installer, and upgrader create cert
bundles with permission bits 0644.

Make CA bundles, certs, and cert directories world-accessible in
upgrader.

Fixes: pagure.io/freeipa/issue/7594