### PR TITLE
[Backport][ipa-4-5] Check if issuer DN is updated after self-signed > external-ca

### DIFF
--- a/ipatests/pytest_plugins/integration/create_external_ca.py
+++ b/ipatests/pytest_plugins/integration/create_external_ca.py
@@ -25,12 +25,17 @@ from cryptography.hazmat.primitives import serialization
 import datetime
 import six
 
+ISSUER_CN = 'example.test'
 
 class ExternalCA(object):
     """
     Provide external CA for testing
     """
-    def create_ca(self, cn='example.test'):
+    def __init__(self, days=365):
+        self.now = datetime.datetime.utcnow()
+        self.delta = datetime.timedelta(days=days)
+
+    def create_ca(self, cn=ISSUER_CN):
         """Create root CA.
 
         :returns: bytes -- Root CA in PEM format.

--- a/ipatests/test_integration/test_external_ca.py
+++ b/ipatests/test_integration/test_external_ca.py
@@ -23,6 +23,7 @@ from ipatests.test_integration.base import IntegrationTest
 from ipaplatform.paths import paths
 
 from itertools import chain, repeat
+from ipatests.pytest_plugins.integration.create_external_ca import ISSUER_CN
 
 IPA_CA = 'ipa_ca.crt'
 ROOT_CA = 'root_ca.crt'
@@ -32,7 +33,7 @@ PKI_START_STR = 'Started pki_tomcatd'
 
 
 def check_CA_flag(host, nssdb=paths.PKI_TOMCAT_ALIAS_DIR,
-                  cn='example.test'):
+                  cn=ISSUER_CN):
     """
     Check if external CA (by default 'example.test' in our test env) has
     CA flag in nssdb.
@@ -160,6 +161,15 @@ class TestSelfExternalSelf(IntegrationTest):
         # Check if external CA have "C" flag after the switch
         result = check_CA_flag(self.master)
         assert bool(result), ('External CA does not have "C" flag')
+
+    def test_issuerDN_after_renew_to_external(self):
+        """ Check if issuer DN is updated after self-signed > external-ca
+
+        This test checks if issuer DN is updated properly after CA is
+        renewed from self-signed to external-ca
+        """
+        result = self.master.run_command(['ipa', 'ca-show', 'ipa'])
+        assert "Issuer DN: CN={}".format(ISSUER_CN) in result.stdout_text
 
     def test_switch_back_to_self_signed(self):
 


### PR DESCRIPTION
This test checks if issuer DN is updated properly after CA is
renewed from self-signed to external-ca

related ticket: https://pagure.io/freeipa/issue/7316

Signed-off-by: Mohammad Rizwan Yusuf <myusuf@redhat.com>

Replaced hardcoded issuer CN for external ca with constant

Signed-off-by: Mohammad Rizwan Yusuf <myusuf@redhat.com>
Reviewed-By: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Florence Blanc-Renaud <frenaud@redhat.com>