### PR TITLE
[Backport][ipa-4-6] Use 4 WSGI workers on 64bit systems

### DIFF
--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -46,7 +46,7 @@ class BaseConstantsNamespace(object):
     MOD_WSGI_PYTHON3 = None
     # WSGIDaemonProcess process count. On 64bit platforms, each process
     # consumes about 110 MB RSS, from which are about 35 MB shared.
-    WSGI_PROCESSES = 5 if IS_64BITS else 2
+    WSGI_PROCESSES = 4 if IS_64BITS else 2
 
 
 constants = BaseConstantsNamespace()


### PR DESCRIPTION
Commit f1d5ab3a03191dbb02e5f95308cf8c4f1971cdcf increases WSGI worker
count to five. This turned out to be a bit much for our test systems.
Four workers are good enough and still double the old amount.

See: https://pagure.io/freeipa/issue/7587
Signed-off-by: Christian Heimes <cheimes@redhat.com>

Manual backport of PR #2062