### PR TITLE
Prevent the creation on users and groups with numeric characters only

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -288,7 +288,9 @@ RENEWAL_REUSE_CA_NAME = 'dogtag-ipa-ca-renew-agent-reuse'
 CA_DBUS_TIMEOUT = 120
 
 # regexp definitions
-PATTERN_GROUPUSER_NAME = '^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$'
+PATTERN_GROUPUSER_NAME = (
+    '(?!^[0-9]+$)^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?$'
+)
 
 # Kerberos Anonymous principal name
 ANON_USER = 'WELLKNOWN/ANONYMOUS'

--- a/ipatests/test_xmlrpc/test_group_plugin.py
+++ b/ipatests/test_xmlrpc/test_group_plugin.py
@@ -169,6 +169,26 @@ class TestGroup(XMLRPC_test):
                 error=u'may only include letters, numbers, _, -, . and $')):
             command()
 
+    def test_create_with_name_starting_with_numeric(self):
+        """Successfully create a group with name starting with numeric chars"""
+        testgroup = GroupTracker(
+            name=u'1234group',
+            description=u'Group name starting with numeric chars',
+        )
+        testgroup.create()
+        testgroup.delete()
+
+    def test_create_with_numeric_only_group_name(self):
+        """Try to create a group with name only contains numeric chars"""
+        testgroup = GroupTracker(
+            name=u'1234', description=u'Numeric only group name',
+        )
+        with raises_exact(errors.ValidationError(
+            name='group_name',
+            error=u'may only include letters, numbers, _, -, . and $',
+        )):
+            testgroup.create()
+
 
 @pytest.mark.tier1
 class TestFindGroup(XMLRPC_test):

--- a/ipatests/test_xmlrpc/test_user_plugin.py
+++ b/ipatests/test_xmlrpc/test_user_plugin.py
@@ -644,6 +644,25 @@ class TestCreate(XMLRPC_test):
         with raises_exact(errors.ManagedGroupExistsError(group=group.cn)):
             command()
 
+    def test_create_with_username_starting_with_numeric(self):
+        """Successfully create a user with name starting with numeric chars"""
+        testuser = UserTracker(
+            name=u'1234user', givenname=u'First1234', sn=u'Surname1234',
+        )
+        testuser.create()
+        testuser.delete()
+
+    def test_create_with_numeric_only_username(self):
+        """Try to create a user with name only contains numeric chars"""
+        testuser = UserTracker(
+            name=u'1234', givenname=u'NumFirst1234', sn=u'NumSurname1234',
+        )
+        with raises_exact(errors.ValidationError(
+                name=u'login',
+                error=u'may only include letters, numbers, _, -, . and $',
+        )):
+            testuser.create()
+
 
 @pytest.mark.tier1
 class TestUserWithGroup(XMLRPC_test):


### PR DESCRIPTION
Update regular expression validator to prevent user and group creation.

Issue: https://pagure.io/freeipa/issue/7572

The expression updated by this PR was changed only twice [since the beginging on project](https://github.com/freeipa/freeipa/blob/d1691eee88c5462ef1d015617fd5b65eec0319b9/ipalib/plugins/baseuser.py#L212):
- [first change](https://github.com/freeipa/freeipa/commit/37200806118d39ef8afe84ad5887a294d54e2659) removed the lenght limit
- [second change](https://github.com/freeipa/freeipa/commit/8f8e3d008f1de91337a83ea6d271662432209767) unified the expression used by user and group in the `constants.py` file

This PR doesn't prevent the creation of user or groups starting with a number. Related info: https://access.redhat.com/solutions/3103631

Also, I haven't updated the error message, should I do it? If so, possible wording:
```
may only include letters, numbers, _, -, ., $ and must contain a letter
```

It seems that _systemd_ has a [stricter set of rules](https://github.com/systemd/systemd/blob/master/src/basic/user-util.c#L569-L581), which I think it could affect FreeIPA in the future:
> - We don't allow any dots (this would break chown syntax which permits dots as user/group name separator)
> - We require that names fit into the appropriate utmp field
> - We don't allow empty user names
