### PR TITLE
Check if user permssions and umask 0022 is set when executing ipa-restore

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,36 @@
-ipatests/prci_definitions/gating.yaml
+topologies:
+  build: &build
+    name: build
+    cpu: 2
+    memory: 3800
+  master_1repl: &master_1repl
+    name: master_1repl
+    cpu: 4
+    memory: 5750
+
+jobs:
+  fedora-28/build:
+    requires: []
+    priority: 100
+    job:
+      class: Build
+      args:
+        git_repo: '{git_repo}'
+        git_refspec: '{git_refspec}'
+        template: &ci-master-f28
+          name: freeipa/ci-master-f28
+          version: 0.1.5
+        timeout: 1800
+        topology: *build
+
+  fedora-28/backup_restore:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestUserrootFilesOwnershipPermission
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -23,7 +23,11 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f28
           name: freeipa/ci-master-f28
+<<<<<<< HEAD
           version: 0.1.7
+=======
+          version: 0.1.6
+>>>>>>> Making nigthly test definition editable by FreeIPA's contributors
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_master
+++ b/ipatests/prci_definitions/nightly_master
@@ -35,7 +35,11 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f28
           name: freeipa/ci-master-f28
+<<<<<<< HEAD
           version: 0.1.7
+=======
+          version: 0.1.6
+>>>>>>> Making nigthly test definition editable by FreeIPA's contributors
         timeout: 1800
         topology: *build
 
@@ -229,8 +233,12 @@ jobs:
         test_suite: test_integration/test_caless.py::TestClientInstall
         template: *ci-master-f28
         timeout: 5400
+<<<<<<< HEAD
         # actually master_1client
         topology: *master_1repl_1client
+=======
+        topology: *master_1repl
+>>>>>>> Making nigthly test definition editable by FreeIPA's contributors
 
   fedora-28/test_caless_TestIPACommands:
     requires: [fedora-28/build]
@@ -410,7 +418,11 @@ jobs:
         test_suite: test_integration/test_replica_promotion.py::TestKRAInstall
         template: *ci-master-f28
         timeout: 7200
+<<<<<<< HEAD
         topology: *master_2repl_1client
+=======
+        topology: *master_1repl
+>>>>>>> Making nigthly test definition editable by FreeIPA's contributors
 
   fedora-28/test_replica_promotion_TestCAInstall:
     requires: [fedora-28/build]
@@ -422,7 +434,11 @@ jobs:
         test_suite: test_integration/test_replica_promotion.py::TestCAInstall
         template: *ci-master-f28
         timeout: 7200
+<<<<<<< HEAD
         topology: *master_2repl_1client
+=======
+        topology: *master_1repl
+>>>>>>> Making nigthly test definition editable by FreeIPA's contributors
 
   fedora-28/test_replica_promotion_TestReplicaPromotionLevel1:
     requires: [fedora-28/build]
@@ -446,7 +462,11 @@ jobs:
         test_suite: test_integration/test_replica_promotion.py::TestReplicaManageCommands
         template: *ci-master-f28
         timeout: 7200
+<<<<<<< HEAD
         topology: *master_2repl_1client
+=======
+        topology: *master_1repl
+>>>>>>> Making nigthly test definition editable by FreeIPA's contributors
 
   fedora-28/test_replica_promotion_TestUnprivilegedUserPermissions:
     requires: [fedora-28/build]
@@ -470,7 +490,11 @@ jobs:
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
         template: *ci-master-f28
         timeout: 7200
+<<<<<<< HEAD
         topology: *master_2repl_1client
+=======
+        topology: *master_1repl
+>>>>>>> Making nigthly test definition editable by FreeIPA's contributors
 
   fedora-28/test_replica_promotion_TestOldReplicaWorksAfterDomainUpgrade:
     requires: [fedora-28/build]

--- a/ipatests/prci_definitions/nightly_rawhide
+++ b/ipatests/prci_definitions/nightly_rawhide
@@ -229,8 +229,12 @@ jobs:
         test_suite: test_integration/test_caless.py::TestClientInstall
         template: *ci-master-frawhide
         timeout: 5400
+<<<<<<< HEAD
         # actually master_1client
         topology: *master_1repl_1client
+=======
+        topology: *master_1repl
+>>>>>>> Making nigthly test definition editable by FreeIPA's contributors
 
   fedora-rawhide/test_caless_TestIPACommands:
     requires: [fedora-rawhide/build]
@@ -410,7 +414,11 @@ jobs:
         test_suite: test_integration/test_replica_promotion.py::TestKRAInstall
         template: *ci-master-frawhide
         timeout: 7200
+<<<<<<< HEAD
         topology: *master_2repl_1client
+=======
+        topology: *master_1repl
+>>>>>>> Making nigthly test definition editable by FreeIPA's contributors
 
   fedora-rawhide/test_replica_promotion_TestCAInstall:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
This test checks if the access rights for user/group
is set to 644 on /var/lib/dirsrv/slapd-TESTRELM-TEST/ldif/*
and umask 0022 set while restoring.

related ticket: https://pagure.io/freeipa/issue/6844

Signed-off-by: Mohammad Rizwan Yusuf <myusuf@redhat.com>