### PR TITLE
ui_tests - stabilization fixes + test_config fix

### DIFF
--- a/ipatests/test_webui/test_config.py
+++ b/ipatests/test_webui/test_config.py
@@ -145,8 +145,11 @@ class test_config(UI_driver):
                                    'Must be an integer')
 
         # test field with negative value
-        self.assert_field_negative(size_limit_s, '-10',
-                                   'Minimum value is -1')
+        self.assert_field_negative(
+            size_limit_s, '-10',
+            "invalid 'searchrecordslimit': must be at least 10",
+            dialog=True,
+        )
 
         # test field with space
         self.assert_field_negative(size_limit_s, ' 11',

--- a/ipatests/test_webui/test_user.py
+++ b/ipatests/test_webui/test_user.py
@@ -237,6 +237,8 @@ class test_user(user_tasks):
         cert_widget_sel = "div.certificate-widget"
 
         self.add_record(user.ENTITY, user.DATA)
+        self.wait()
+        self.close_notifications()
         self.navigate_to_record(user.PKEY)
 
         # cert request
@@ -539,6 +541,8 @@ class test_user(user_tasks):
         first_mail = self.create_email_addr(user.DATA.get('pkey'))
 
         self.add_record(user.ENTITY, user.DATA)
+        self.wait()
+        self.close_notifications()
         self.navigate_to_record(user.DATA.get('pkey'))
 
         # add a new mail (without save) and reset
@@ -574,6 +578,7 @@ class test_user(user_tasks):
         # cleanup
         self.delete(user.ENTITY, [user.DATA])
 
+    @screenshot
     def test_user_misc(self):
         """
         Test various miscellaneous test cases under one roof to save init time

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -1734,6 +1734,8 @@ class UI_driver(object):
         self.action_list_action('disable')
         self.wait_for_request(n=2)
         self.assert_no_error_dialog()
+        self.close_notifications()
+        self.move_to_element_in_page(title)
         self.assert_class(title, 'disabled')
 
     def delete_action(self, entity, pkey, action='delete', facet='search'):


### PR DESCRIPTION
    This patch aims to fix the following tests which seems to be quite
    unstable recently:
    
    test_user::test_actions - closing notification and moving to element
    to have screenshot of current place.
    
    test_user::certificates - add wait() / close_notification
    
    test_config::test_size_limits - add wait() to fill_input()