### PR TITLE
Catch ACIError instead of invalid credentials

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -472,7 +472,8 @@ class DogtagInstance(service.Service):
             time.sleep(1)
             try:
                 master_conn.simple_bind(self.admin_dn, self.admin_password)
-            except ldap.INVALID_CREDENTIALS:
+            except errors.ACIError:
+                # user not replicated yet
                 pass
             else:
                 logger.debug("Successfully logged in as %s", self.admin_dn)


### PR DESCRIPTION
ipaldap's LDAPClient client turns INVALID_CREDENTIAL error into
ACIError. Catch the ACIError and wait until the user has been
replicated.

Apparently no manual or automated test ran into the timeout during
testing.

Fixes: Fixes: https://pagure.io/freeipa/issue/7593
Signed-off-by: Christian Heimes <cheimes@redhat.com>