### PR TITLE
[Backport][ipa-4-6] Catch ACIError instead of invalid credentials

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -471,7 +471,8 @@ class DogtagInstance(service.Service):
             time.sleep(1)
             try:
                 master_conn.simple_bind(self.admin_dn, self.admin_password)
-            except ldap.INVALID_CREDENTIALS:
+            except errors.ACIError:
+                # user not replicated yet
                 pass
             else:
                 logger.debug("Successfully logged in as %s", self.admin_dn)


### PR DESCRIPTION
This PR was opened automatically because PR #2084 was pushed to master and backport to ipa-4-6 is required.