### PR TITLE
[Backport][ipa-4-5] Catch ACIError instead of invalid credentials

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -468,7 +468,8 @@ class DogtagInstance(service.Service):
             time.sleep(1)
             try:
                 master_conn.simple_bind(self.admin_dn, self.admin_password)
-            except ldap.INVALID_CREDENTIALS:
+            except errors.ACIError:
+                # user not replicated yet
                 pass
             else:
                 self.log.debug("Successfully logged in as %s", self.admin_dn)


### PR DESCRIPTION
ipaldap's LDAPClient client turns INVALID_CREDENTIAL error into
ACIError. Catch the ACIError and wait until the user has been
replicated.

Apparently no manual or automated test ran into the timeout during
testing.

Fixes: Fixes: https://pagure.io/freeipa/issue/7593
Signed-off-by: Christian Heimes <cheimes@redhat.com>

Manual backport of PR #2084 to 4.5