### PR TITLE
[RFE] DNS package check should be called earlier in installation routine

### DIFF
--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -471,6 +471,15 @@ def install_check(installer):
 
     domain_name = domain_name.lower()
 
+    if options.setup_dns:
+        api.env.domain = domain_name
+        dns.install_check(False, api, False, options, host_name)
+        ip_addresses = dns.ip_addresses
+    else:
+        ip_addresses = get_server_ip_address(host_name,
+                                             not installer.interactive, False,
+                                             options.ip_addresses)
+
     if not options.realm_name:
         realm_name = read_realm_name(domain_name, not installer.interactive)
         logger.debug("read realm_name: %s\n", realm_name)
@@ -634,14 +643,6 @@ def install_check(installer):
         ca.install_check(False, None, options)
     if options.setup_kra:
         kra.install_check(api, None, options)
-
-    if options.setup_dns:
-        dns.install_check(False, api, False, options, host_name)
-        ip_addresses = dns.ip_addresses
-    else:
-        ip_addresses = get_server_ip_address(host_name,
-                                             not installer.interactive, False,
-                                             options.ip_addresses)
 
         # check addresses here, dns module is doing own check
         no_matching_interface_for_ip_address_warning(ip_addresses)


### PR DESCRIPTION
In case the integrated DNS service should be used for IdM, either by using the
non-interactive '--setup-dns' option or by answering 'yes' to the interactive
'Do you want to configure integrated DNS (BIND)?' question, the check whether
the 'ipa-server-dns' package is installed, only comes after a lot of other information
have been evaluated ([server|dns|realm] name, DM and admin password).

This PR check, whether the 'ipa-server-dns' package is installed or not,
earlier in the installation routine.

Resolves: https://pagure.io/freeipa/issue/7577