### PR TITLE
[Backport][ipa-4-6] Improve Custodia key distribution handling, by ensuring that upon replica installation the keys are  successfully shared with the peer systems.

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -644,3 +644,33 @@ class TestSubCAkeyReplication(IntegrationTest):
         ssl_cmd = ['openssl', 'x509', '-text', '-in', TEST_CRT_FILE]
         ssl = replica.run_command(ssl_cmd)
         assert 'Issuer: CN = {}'.format(self.SUBCA) in ssl.stdout_text
+
+
+class TestReplicaInstallCustodia(IntegrationTest):
+    """
+    Pagure Reference: https://pagure.io/freeipa/issue/7518
+    """
+
+    topology = 'line'
+    num_replicas = 2
+    domain_level = DOMAIN_LEVEL_1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, domain_level=cls.domain_level)
+
+    def test_replica_install_for_custodia(self):
+        master = self.master
+        replica1 = self.replicas[0]
+        replica2 = self.replicas[1]
+
+        # Install Replica1 without CA and stop ipa-custodia
+        tasks.install_replica(master, replica1, setup_ca=False)
+        replica1.run_command(['ipactl', 'status'])
+        replica1.run_command(['systemctl', 'stop', 'ipa-custodia'])
+        replica1.run_command(['ipactl', 'status'])
+
+        # Install Replica2 with CA with source as Replica1.
+        tasks.install_replica(replica1, replica2, setup_ca=True)
+        result = replica2.run_command(['ipactl', 'status'])
+        assert 'ipa-custodia Service: RUNNING' in result.stdout_text


### PR DESCRIPTION
This PR was opened automatically because PR #2027 was pushed to master and backport to ipa-4-6 is required.