### PR TITLE
[py37] Import ABCs from collections.abc

### DIFF
--- a/ipaclient/remote_plugins/__init__.py
+++ b/ipaclient/remote_plugins/__init__.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
 
-import collections
 import errno
 import json
 import locale
@@ -10,16 +9,25 @@ import logging
 import os
 import time
 
+import six
+
 from . import compat
 from . import schema
 from ipaclient.plugins.rpcclient import rpcclient
 from ipalib.constants import USER_CACHE_PATH
 from ipapython.dnsutil import DNSName
 
+# pylint: disable=no-name-in-module, import-error
+if six.PY3:
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
+# pylint: enable=no-name-in-module, import-error
+
 logger = logging.getLogger(__name__)
 
 
-class ServerInfo(collections.MutableMapping):
+class ServerInfo(MutableMapping):
     _DIR = os.path.join(USER_CACHE_PATH, 'ipa', 'servers')
 
     def __init__(self, api):

--- a/ipaclient/remote_plugins/schema.py
+++ b/ipaclient/remote_plugins/schema.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
 
-import collections
 import errno
 import json
 import logging
@@ -27,6 +26,13 @@ from ipapython.ipautil import fsdecode
 from ipapython.dn import DN
 from ipapython.dnsutil import DNSName
 
+# pylint: disable=no-name-in-module, import-error
+if six.PY3:
+    from collections.abc import Mapping, Sequence
+else:
+    from collections import Mapping, Sequence
+# pylint: enable=no-name-in-module, import-error
+
 logger = logging.getLogger(__name__)
 
 FORMAT = '1'
@@ -39,7 +45,7 @@ _TYPES = {
     'DNSName': DNSName,
     'Principal': unicode,
     'NoneType': type(None),
-    'Sequence': collections.Sequence,
+    'Sequence': Sequence,
     'bool': bool,
     'dict': dict,
     'int': int,
@@ -315,7 +321,7 @@ class _SchemaObjectPlugin(_SchemaPlugin):
     schema_key = 'classes'
 
 
-class _SchemaNameSpace(collections.Mapping):
+class _SchemaNameSpace(Mapping):
 
     def __init__(self, schema, name):
         self.name = name

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -51,6 +51,13 @@ from ipapython.ipa_log_manager import (
     LOGGING_FORMAT_STDERR)
 from ipapython.version import VERSION, API_VERSION, DEFAULT_PLUGINS
 
+# pylint: disable=no-name-in-module, import-error
+if six.PY3:
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
+# pylint: enable=no-name-in-module, import-error
+
 if six.PY3:
     unicode = str
 
@@ -282,7 +289,7 @@ class Plugin(ReadOnly):
         )
 
 
-class APINameSpace(collections.Mapping):
+class APINameSpace(Mapping):
     def __init__(self, api, base):
         self.__api = api
         self.__base = base

--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -28,7 +28,6 @@ from __future__ import absolute_import
 import os
 import json
 import time
-import collections
 import logging
 import warnings
 
@@ -37,6 +36,12 @@ import six
 from ipapython import ipautil
 from ipaplatform.paths import paths
 
+# pylint: disable=no-name-in-module, import-error
+if six.PY3:
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
+# pylint: enable=no-name-in-module, import-error
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +67,7 @@ wellknownports = {
 SERVICE_POLL_INTERVAL = 0.1 # seconds
 
 
-class KnownServices(collections.Mapping):
+class KnownServices(Mapping):
     """
     KnownServices is an abstract class factory that should give out instances
     of well-known platform services. Actual implementation must create these

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -27,7 +27,6 @@ import datetime
 from decimal import Decimal
 from copy import deepcopy
 import contextlib
-import collections
 import os
 import pwd
 import warnings
@@ -52,6 +51,13 @@ from ipapython.ipautil import format_netloc, CIDict
 from ipapython.dn import DN
 from ipapython.dnsutil import DNSName
 from ipapython.kerberos import Principal
+
+# pylint: disable=no-name-in-module, import-error
+if six.PY3:
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
+# pylint: enable=no-name-in-module, import-error
 
 if six.PY3:
     unicode = str
@@ -213,7 +219,7 @@ class SchemaCache(object):
 schema_cache = SchemaCache()
 
 
-class LDAPEntry(collections.MutableMapping):
+class LDAPEntry(MutableMapping):
     __slots__ = ('_conn', '_dn', '_names', '_nice', '_raw', '_sync',
                  '_not_list', '_orig_raw', '_raw_view',
                  '_single_value_view')
@@ -577,7 +583,7 @@ class LDAPEntry(collections.MutableMapping):
         return iter(self._nice)
 
 
-class LDAPEntryView(collections.MutableMapping):
+class LDAPEntryView(MutableMapping):
     __slots__ = ('_entry',)
 
     def __init__(self, entry):

--- a/ipaserver/dnssec/ldapkeydb.py
+++ b/ipaserver/dnssec/ldapkeydb.py
@@ -5,9 +5,10 @@
 from __future__ import print_function, absolute_import
 
 from binascii import hexlify
-import collections
 import logging
 from pprint import pprint
+
+import six
 
 import ipalib
 from ipaplatform.paths import paths
@@ -22,6 +23,13 @@ from ipaserver.dnssec.abshsm import (
     populate_pkcs11_metadata)
 from ipaserver import p11helper as _ipap11helper
 import uuid
+
+# pylint: disable=no-name-in-module, import-error
+if six.PY3:
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
+# pylint: enable=no-name-in-module, import-error
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +130,7 @@ def str_hexlify(data):
     return out
 
 
-class Key(collections.MutableMapping):
+class Key(MutableMapping):
     """abstraction to hide LDAP entry weirdnesses:
         - non-normalized attribute names
         - boolean attributes returned as strings

--- a/ipaserver/dnssec/localhsm.py
+++ b/ipaserver/dnssec/localhsm.py
@@ -5,9 +5,10 @@
 
 from __future__ import print_function, absolute_import
 
-import collections
 import os
 from pprint import pprint
+
+import six
 
 from ipalib.constants import SOFTHSM_DNSSEC_TOKEN_LABEL
 from ipaplatform.paths import paths
@@ -16,6 +17,13 @@ from ipaserver.dnssec.abshsm import (attrs_name2id, attrs_id2name, AbstractHSM,
                                      keytype_id2name, keytype_name2id,
                                      ldap2p11helper_api_params)
 from ipaserver.dnssec.ldapkeydb import str_hexlify
+
+# pylint: disable=no-name-in-module, import-error
+if six.PY3:
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
+# pylint: enable=no-name-in-module, import-error
 
 
 private_key_api_params = set(["label", "id", "data", "unwrapping_key",
@@ -28,7 +36,8 @@ public_key_api_params = set(["label", "id", "data", "cka_copyable",
     "cka_derive", "cka_encrypt", "cka_modifiable", "cka_private",
     "cka_trusted", "cka_verify", "cka_verify_recover", "cka_wrap"])
 
-class Key(collections.MutableMapping):
+
+class Key(MutableMapping):
     def __init__(self, p11, handle):
         self.p11 = p11
         self.handle = handle

--- a/ipatests/test_xmlrpc/xmlrpc_test.py
+++ b/ipatests/test_xmlrpc/xmlrpc_test.py
@@ -22,7 +22,6 @@ Base class for all XML-RPC tests
 """
 from __future__ import print_function
 
-import collections
 import datetime
 import inspect
 import unittest
@@ -34,6 +33,12 @@ from ipatests.util import assert_deepequal, Fuzzy
 from ipalib import api, request, errors
 from ipapython.version import API_VERSION
 
+# pylint: disable=no-name-in-module, import-error
+if six.PY3:
+    from collections.abc import Sequence
+else:
+    from collections import Sequence
+# pylint: enable=no-name-in-module, import-error
 
 # Matches a gidnumber like '1391016742'
 # FIXME: Does it make more sense to return gidnumber, uidnumber, etc. as `int`
@@ -57,7 +62,7 @@ fuzzy_base64 = Fuzzy('^[0-9A-Za-z/+]+={0,2}$')
 def fuzzy_sequence_of(fuzzy):
     """Construct a Fuzzy for a Sequence of values matching the given Fuzzy."""
     def test(xs):
-        if not isinstance(xs, collections.Sequence):
+        if not isinstance(xs, Sequence):
             return False
         else:
             return all(fuzzy == x for x in xs)


### PR DESCRIPTION
Python 3 has moved all collection abstract base classes to
collections.abc. Python 3.7 started to deprecate the old aliases.

The whole import block needs to be protected with import-error and
no-name-in-module, because Python 2 doesn't have collections.abc module and
collections.abc.Mapping, while Python 3 doesn't have collections.Mapping.

Fixes: https://pagure.io/freeipa/issue/7609
Signed-off-by: Christian Heimes <cheimes@redhat.com>