### PR TITLE
ipa_tests: ipa-replica-prepare stuck on user input

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -379,7 +379,7 @@ def replica_prepare(master, replica, extra_args=(),
             '-p', replica.config.dirman_password,
             replica.hostname]
     if master_authoritative_for_client_domain(master, replica):
-        args.extend(['--ip-address', replica.ip])
+        args.extend(['--ip-address', replica.ip, '--auto-reverse'])
     args.extend(extra_args)
     result = master.run_command(args, raiseonerr=raiseonerr,
                                 stdin_text=stdin_text)


### PR DESCRIPTION
TestOldReplicaWorksAfterDomainUpgrade is getting stuck while
    running "ipa-replica-prepare" as it is asking for user input:
    "Do you want to search for missing reverse zones?". Adding
    "--auto-reverse" in order to continue.