### PR TITLE
ipa-server-install: fix zonemgr argument validator

### DIFF
--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -476,7 +476,11 @@ class DNSInstallInterface(hostname.HostNameInstallInterface):
             encoding = getattr(sys.stdin, 'encoding', None)
             if encoding is None:
                 encoding = 'utf-8'
-            value = value.decode(encoding)
+
+            # value is string in py2 and py3
+            if not isinstance(value, unicode):
+                value = value.decode(encoding)
+
             bindinstance.validate_zonemgr_str(value)
         except ValueError as e:
             # FIXME we can do this in better way

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -410,7 +410,11 @@ class TestInstallMasterDNS(IntegrationTest):
         pass
 
     def test_install_master(self):
-        tasks.install_master(self.master, setup_dns=True)
+        tasks.install_master(
+            self.master,
+            setup_dns=True,
+            extra_args=['--zonemgr', 'me@example.org'],
+        )
 
     def test_install_kra(self):
         tasks.install_kra(self.master, first_instance=True)


### PR DESCRIPTION
Fix `ERROR 'str' object has no attribute 'decode'` when `--zonemgr` is
passed to ipa-server-install.

Solution copied from commit 75d26e1, function `ipaserver.install.bindinstance.zonemgr_callback` duplicates the behavior of the method affected by this patch.

Issue: https://pagure.io/freeipa/issue/7612