### PR TITLE
Delay enablement of services and DNS SRV entries

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -4425,9 +4425,10 @@ output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
 command: server_role_find/1
-args: 1,8,4
+args: 1,9,4
 arg: Str('criteria?')
 option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('include_master', autofill=True, default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Str('role_servrole?', autofill=False, cli_name='role')
 option: Str('server_server?', autofill=False, cli_name='server')

--- a/install/tools/ipa-adtrust-install
+++ b/install/tools/ipa-adtrust-install
@@ -32,7 +32,7 @@ import six
 from optparse import SUPPRESS_HELP  # pylint: disable=deprecated-module
 
 from ipalib.install import sysrestore
-from ipaserver.install import adtrust
+from ipaserver.install import adtrust, service
 from ipaserver.install.installutils import (
     read_password,
     check_server_configuration,
@@ -211,6 +211,10 @@ def main():
 
     adtrust.install_check(True, options, api)
     adtrust.install(True, options, fstore, api)
+
+    # Enable configured services and update DNS SRV records
+    service.enable_services(api.env.host)
+    api.Command.dns_update_system_records()
 
     print("""
 =============================================================================

--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -342,18 +342,26 @@ def main():
     )
     api.finalize()
     api.Backend.ldap2.connect()
-
     domain_level = dsinstance.get_domain_level(api)
+
     if domain_level > DOMAIN_LEVEL_0:
         promote(safe_options, options, filename)
     else:
         install(safe_options, options, filename)
 
+    # pki-spawn restarts 389-DS, reconnect
+    api.Backend.ldap2.close()
+    api.Backend.ldap2.connect()
+
+    # Enable configured services and update DNS SRV records
+    service.enable_services(api.env.host)
+    api.Command.dns_update_system_records()
+    api.Backend.ldap2.disconnect()
+
     # execute ipactl to refresh services status
     ipautil.run([paths.IPACTL, 'start', '--ignore-service-failures'],
                 raiseonerr=False)
 
-    api.Backend.ldap2.disconnect()
 
 fail_message = '''
 Your system may be partly configured.

--- a/install/tools/ipa-dns-install
+++ b/install/tools/ipa-dns-install
@@ -35,6 +35,7 @@ from ipapython.config import IPAOptionParser
 from ipapython.ipa_log_manager import standard_logging_setup
 
 from ipaserver.install import dns as dns_installer
+from ipaserver.install import service
 
 logger = logging.getLogger(os.path.basename(__file__))
 
@@ -141,6 +142,9 @@ def main():
 
     dns_installer.install_check(True, api, False, options, hostname=api.env.host)
     dns_installer.install(True, False, options)
+    # Enable configured services and update DNS SRV records
+    service.enable_services(api.env.host)
+    api.Command.dns_update_system_records()
 
     # execute ipactl to refresh services status
     ipautil.run([paths.IPACTL, 'start', '--ignore-service-failures'],

--- a/ipaserver/dns_data_management.py
+++ b/ipaserver/dns_data_management.py
@@ -96,7 +96,9 @@ class IPASystemRecords(object):
         self.servers_data = {}
 
         servers_result = self.api_instance.Command.server_find(
-            no_members=False)['result']
+            no_members=False,
+            servrole=u"IPA master",  # only active, fully installed masters
+        )['result']
         for s in servers_result:
             weight, location, roles = self.__get_server_attrs(s)
             self.servers_data[s['cn'][0]] = {
@@ -348,7 +350,9 @@ class IPASystemRecords(object):
         zone_obj = zone.Zone(self.domain_abs, relativize=False)
         if servers is None:
             servers_result = self.api_instance.Command.server_find(
-                pkey_only=True)['result']
+                pkey_only=True,
+                servrole=u"IPA master",  # only fully installed masters
+            )['result']
             servers = [s['cn'][0] for s in servers_result]
 
         locations_result = self.api_instance.Command.location_find()['result']

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -583,7 +583,7 @@ class ADTRUSTInstance(service.Service):
             self.print_msg(err_msg)
             self.print_msg("Add the following service records to your DNS " \
                            "server for DNS zone %s: " % zone)
-            system_records = IPASystemRecords(api)
+            system_records = IPASystemRecords(api, all_servers=True)
             adtrust_records = system_records.get_base_records(
                 [self.fqdn], ["AD trust controller"],
                 include_master_role=False, include_kerberos_realm=False)
@@ -738,12 +738,12 @@ class ADTRUSTInstance(service.Service):
         # Note that self.dm_password is None for ADTrustInstance because
         # we ensure to be called as root and using ldapi to use autobind
         try:
-            self.ldap_enable('ADTRUST', self.fqdn, None, self.suffix)
+            self.ldap_configure('ADTRUST', self.fqdn, None, self.suffix)
         except (ldap.ALREADY_EXISTS, errors.DuplicateEntry):
             logger.info("ADTRUST Service startup entry already exists.")
 
         try:
-            self.ldap_enable('EXTID', self.fqdn, None, self.suffix)
+            self.ldap_configure('EXTID', self.fqdn, None, self.suffix)
         except (ldap.ALREADY_EXISTS, errors.DuplicateEntry):
             logger.info("EXTID Service startup entry already exists.")
 

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -688,7 +688,7 @@ class BindInstance(service.Service):
         return normalize_zone(self.host_domain) == normalize_zone(self.domain)
 
     def create_file_with_system_records(self):
-        system_records = IPASystemRecords(self.api)
+        system_records = IPASystemRecords(self.api, all_servers=True)
         text = u'\n'.join(
             IPASystemRecords.records_list_from_zone(
                 system_records.get_base_records()
@@ -765,7 +765,7 @@ class BindInstance(service.Service):
         # Instead we reply on the IPA init script to start only enabled
         # components as found in our LDAP configuration tree
         try:
-            self.ldap_enable('DNS', self.fqdn, None, self.suffix)
+            self.ldap_configure('DNS', self.fqdn, None, self.suffix)
         except errors.DuplicateEntry:
             # service already exists (forced DNS reinstall)
             # don't crash, just report error
@@ -1210,7 +1210,7 @@ class BindInstance(service.Service):
 
         installutils.rmtree(paths.BIND_LDAP_DNS_IPA_WORKDIR)
 
-        # disabled by default, by ldap_enable()
+        # disabled by default, by ldap_configure()
         if enabled:
             self.enable()
         else:

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1266,7 +1266,7 @@ class CAInstance(DogtagInstance):
             config = ['caRenewalMaster']
         else:
             config = []
-        self.ldap_enable('CA', self.fqdn, None, basedn, config)
+        self.ldap_configure('CA', self.fqdn, None, basedn, config)
 
     def setup_lightweight_ca_key_retrieval(self):
         if sysupgrade.get_upgrade_state('dogtag', 'setup_lwca_key_retrieval'):

--- a/ipaserver/install/dnskeysyncinstance.py
+++ b/ipaserver/install/dnskeysyncinstance.py
@@ -383,8 +383,8 @@ class DNSKeySyncInstance(service.Service):
 
     def __enable(self):
         try:
-            self.ldap_enable('DNSKeySync', self.fqdn, None,
-                             self.suffix, self.extra_config)
+            self.ldap_configure('DNSKeySync', self.fqdn, None,
+                                self.suffix, self.extra_config)
         except errors.DuplicateEntry:
             logger.error("DNSKeySync service already exists")
 

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -156,7 +156,7 @@ class HTTPInstance(service.Service):
         # We do not let the system start IPA components on its own,
         # Instead we reply on the IPA init script to start only enabled
         # components as found in our LDAP configuration tree
-        self.ldap_enable('HTTP', self.fqdn, None, self.suffix)
+        self.ldap_configure('HTTP', self.fqdn, None, self.suffix)
 
     def configure_selinux_for_httpd(self):
         try:
@@ -566,7 +566,7 @@ class HTTPInstance(service.Service):
         if running:
             self.restart()
 
-        # disabled by default, by ldap_enable()
+        # disabled by default, by ldap_configure()
         if enabled:
             self.enable()
 

--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -226,4 +226,11 @@ class KRAInstaller(KRAInstall):
             logger.error('%s', dedent(self.FAIL_MESSAGE))
             raise
 
+        # pki-spawn restarts 389-DS, reconnect
+        api.Backend.ldap2.close()
+        api.Backend.ldap2.connect()
+
+        # Enable configured services and update DNS SRV records
+        service.enable_services(api.env.host)
+        api.Command.dns_update_system_records()
         api.Backend.ldap2.disconnect()

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -393,4 +393,4 @@ class KRAInstance(DogtagInstance):
                 directives[nickname], cert)
 
     def __enable_instance(self):
-        self.ldap_enable('KRA', self.fqdn, None, self.suffix)
+        self.ldap_configure('KRA', self.fqdn, None, self.suffix)

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -242,7 +242,7 @@ class KrbInstance(service.Service):
         # We do not let the system start IPA components on its own,
         # Instead we reply on the IPA init script to start only enabled
         # components as found in our LDAP configuration tree
-        self.ldap_enable('KDC', self.fqdn, None, self.suffix)
+        self.ldap_configure('KDC', self.fqdn, None, self.suffix)
 
     def __start_instance(self):
         try:
@@ -619,7 +619,7 @@ class KrbInstance(service.Service):
             except ValueError as error:
                 logger.debug("%s", error)
 
-        # disabled by default, by ldap_enable()
+        # disabled by default, by ldap_configure()
         if enabled:
             self.enable()
 

--- a/ipaserver/install/odsexporterinstance.py
+++ b/ipaserver/install/odsexporterinstance.py
@@ -74,8 +74,8 @@ class ODSExporterInstance(service.Service):
     def __enable(self):
 
         try:
-            self.ldap_enable('DNSKeyExporter', self.fqdn, None,
-                             self.suffix)
+            self.ldap_configure('DNSKeyExporter', self.fqdn, None,
+                                self.suffix)
         except errors.DuplicateEntry:
             logger.error("DNSKeyExporter service already exists")
 

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -140,8 +140,8 @@ class OpenDNSSECInstance(service.Service):
 
     def __enable(self):
         try:
-            self.ldap_enable('DNSSEC', self.fqdn, None,
-                             self.suffix, self.extra_config)
+            self.ldap_configure('DNSSEC', self.fqdn, None,
+                                self.suffix, self.extra_config)
         except errors.DuplicateEntry:
             logger.error("DNSSEC service already exists")
 
@@ -372,7 +372,7 @@ class OpenDNSSECInstance(service.Service):
 
         self.restore_state("kasp_db_configured")  # just eat state
 
-        # disabled by default, by ldap_enable()
+        # disabled by default, by ldap_configure()
         if enabled:
             self.enable()
 

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1519,14 +1519,11 @@ def install(installer):
 
     if options.setup_dns:
         dns.install(False, True, options, api)
-    else:
-        api.Command.dns_update_system_records()
 
     if options.setup_adtrust:
         adtrust.install(False, options, fstore, api)
 
     ca_servers = service.find_providing_servers('CA', api.Backend.ldap2, api)
-    api.Backend.ldap2.disconnect()
 
     if not promote:
         # Call client install script
@@ -1554,6 +1551,11 @@ def install(installer):
 
         # remove the extracted replica file
         remove_replica_info_dir(installer)
+
+    # Enable configured services and update DNS SRV records
+    service.enable_services(config.host_name)
+    api.Command.dns_update_system_records()
+    api.Backend.ldap2.disconnect()
 
     # Everything installed properly, activate ipa service.
     services.knownservices.ipa.enable()

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -27,6 +27,7 @@ import socket
 import time
 import traceback
 import tempfile
+import warnings
 
 import six
 
@@ -60,6 +61,10 @@ SERVICE_LIST = {
     'DNSSEC': ('ods-enforcerd', 100),
     'DNSKeySync': ('ipa-dnskeysyncd', 110),
 }
+
+CONFIGURED_SERVICE = u'configuredService'
+ENABLED_SERVICE = 'enabledService'
+
 
 def print_msg(message, output_fd=sys.stdout):
     logger.debug("%s", message)
@@ -122,7 +127,7 @@ def find_providing_servers(svcname, conn, api):
     """
     dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
     query_filter = conn.make_filter({'objectClass': 'ipaConfigObject',
-                                     'ipaConfigString': 'enabledService',
+                                     'ipaConfigString': ENABLED_SERVICE,
                                      'cn': svcname}, rules='&')
     try:
         entries, _trunc = conn.find_entries(filter=query_filter, base_dn=dn)
@@ -229,6 +234,51 @@ def set_service_entry_config(name, fqdn, config_values,
     except (errors.DuplicateEntry) as e:
         logger.debug("failed to add service entry %s", name)
         raise e
+
+
+def enable_services(fqdn):
+    """Change all configured services to enabled
+
+    Server.ldap_configure() only marks a service as configured. Services
+    are enabled at the very end of installation.
+
+    Note: DNS records must be updated with dns_update_system_records, too.
+
+    :param fqdn: hostname of server
+    """
+    ldap2 = api.Backend.ldap2
+    search_base = DN(('cn', fqdn), api.env.container_masters, api.env.basedn)
+    search_filter = ldap2.make_filter(
+        {
+            'objectClass': 'ipaConfigObject',
+            'ipaConfigString': CONFIGURED_SERVICE
+        },
+        rules='&'
+    )
+    entries = ldap2.get_entries(
+        search_base,
+        filter=search_filter,
+        scope=api.Backend.ldap2.SCOPE_ONELEVEL,
+        attrs_list=['cn', 'ipaConfigString']
+    )
+    for entry in entries:
+        name = entry['cn']
+        cfgstrings = entry.setdefault('ipaConfigString', [])
+        for value in list(cfgstrings):
+            if value.lower() == CONFIGURED_SERVICE.lower():
+                cfgstrings.remove(value)
+        if not case_insensitive_attr_has_value(cfgstrings, ENABLED_SERVICE):
+            cfgstrings.append(ENABLED_SERVICE)
+
+        try:
+            ldap2.update_entry(entry)
+        except errors.EmptyModlist:
+            logger.debug("Nothing to do for service %s", name)
+        except Exception:
+            logger.exception("failed to set service %s config values", name)
+            raise
+        else:
+            logger.debug("Enabled service %s for %s", name, fqdn)
 
 
 class Service(object):
@@ -578,7 +628,35 @@ class Service(object):
         self.steps = []
 
     def ldap_enable(self, name, fqdn, dm_password=None, ldap_suffix='',
-                    config=[]):
+                    config=()):
+        """Legacy function, all services should use ldap_configure()
+        """
+        warnings.warn(
+            "ldap_enable is deprecated, use ldap_configure instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        self._ldap_enable(ENABLED_SERVICE, name, fqdn, ldap_suffix, config)
+
+    def ldap_configure(self, name, fqdn, dm_password=None, ldap_suffix='',
+                       config=()):
+        """Create or modify service entry in cn=masters,cn=ipa,cn=etc
+
+        Contrary to ldap_enable(), the method only sets
+        ipaConfigString=configuredService. ipaConfigString=enabledService
+        is set at the very end of the installation process, to ensure that
+        other machines see this master/replica after it is fully installed.
+
+        To switch all configured services to enabled, use::
+
+            ipaserver.install.service.enable_services(api.env.host)
+            api.Command.dns_update_system_records()
+        """
+        self._ldap_enable(
+            CONFIGURED_SERVICE, name, fqdn, ldap_suffix, config
+        )
+
+    def _ldap_enable(self, value, name, fqdn, ldap_suffix, config):
         extra_config_opts = [
             ' '.join([u'startOrder', unicode(SERVICE_LIST[name][1])])
         ]
@@ -589,7 +667,7 @@ class Service(object):
         set_service_entry_config(
             name,
             fqdn,
-            [u'enabledService'],
+            [value],
             ldap_suffix=ldap_suffix,
             post_add_config=extra_config_opts)
 
@@ -615,7 +693,7 @@ class Service(object):
 
         # case insensitive
         for value in entry.get('ipaConfigString', []):
-            if value.lower() == u'enabledservice':
+            if value.lower() == ENABLED_SERVICE:
                 entry['ipaConfigString'].remove(value)
                 break
 
@@ -728,7 +806,7 @@ class SimpleServiceInstance(Service):
         if self.gensvc_name == None:
             self.enable()
         else:
-            self.ldap_enable(self.gensvc_name, self.fqdn, None, self.suffix)
+            self.ldap_configure(self.gensvc_name, self.fqdn, None, self.suffix)
 
     def is_installed(self):
         return self.service.is_installed()

--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -205,7 +205,10 @@ class server(LDAPObject):
             return
 
         enabled_roles = self.api.Command.server_role_find(
-            server_server=entry_attrs['cn'][0], status=ENABLED)['result']
+            server_server=entry_attrs['cn'][0],
+            status=ENABLED,
+            include_master=True,
+        )['result']
 
         enabled_role_names = [r[u'role_servrole'] for r in enabled_roles]
 
@@ -339,7 +342,9 @@ class server_find(LDAPSearch):
             role_status = self.api.Command.server_role_find(
                 server_server=None,
                 role_servrole=role,
-                status=ENABLED)['result']
+                status=ENABLED,
+                include_master=True,
+            )['result']
 
             return set(
                 r[u'server_server'] for r in role_status)

--- a/ipaserver/plugins/serverrole.py
+++ b/ipaserver/plugins/serverrole.py
@@ -15,16 +15,21 @@ IPA server roles
 """) + _("""
 Get status of roles (DNS server, CA, etc.) provided by IPA masters.
 """) + _("""
+The status of a role is either enabled, configured, or absent.
+""") + _("""
 EXAMPLES:
 """) + _("""
   Show status of 'DNS server' role on a server:
     ipa server-role-show ipa.example.com "DNS server"
 """) + _("""
   Show status of all roles containing 'AD' on a server:
-    ipa server-role-find --server ipa.example.com --role='AD'
+    ipa server-role-find --server ipa.example.com --role="AD trust controller"
 """) + _("""
   Show status of all configured roles on a server:
     ipa server-role-find ipa.example.com
+""") + _("""
+  Show implicit IPA master role:
+    ipa server-role-find --include-master
 """)
 
 

--- a/ipaserver/plugins/serverrole.py
+++ b/ipaserver/plugins/serverrole.py
@@ -5,7 +5,7 @@
 from ipalib.crud import Retrieve, Search
 from ipalib.errors import NotFound
 from ipalib.frontend import Object
-from ipalib.parameters import Int, Str, StrEnum
+from ipalib.parameters import Flag, Int, Str, StrEnum
 from ipalib.plugable import Registry
 from ipalib import _, ngettext
 
@@ -129,6 +129,10 @@ class server_role_find(Search):
             minvalue=0,
             autofill=False,
         ),
+        Flag(
+            'include_master',
+            doc=_('Include IPA master entries'),
+        )
     )
 
     def execute(self, *keys, **options):
@@ -151,8 +155,16 @@ class server_role_find(Search):
             role_servrole=role_name,
             status=status)
 
-        result = [
-            r for r in role_status if r[u'role_servrole'] != "IPA master"]
+        # Don't display "IPA master" information unless the role is
+        # requested explicitly. All servers are considered IPA masters,
+        # except for replicas during installation.
+        if options.get('include_master') or role_name == "IPA master":
+            result = role_status
+        else:
+            result = [
+                r for r in role_status
+                if r[u'role_servrole'] != "IPA master"
+            ]
         return dict(
             result=result,
             count=len(result),


### PR DESCRIPTION
### Query for server role IPA master

server_find and server_role plugin were hiding IPA master role
information. It's now possible to fetch IPA master role information and
to filter by IPA master role, e.g. to ignore servers that have some
services configured but not (yet) enabled.

### Only create DNS SRV records for ready server

When installing multiple replicas in parallel, one replica may create
SRV entries for other replicas, although the replicas aren't fully
installed yet. This may cause some services to connect to a server, that
isn't ready to serve requests.

The DNS IPASystemRecords framework now skips all servers that aren't
ready IPA masters.

### Delay enabling services until end of installer

Service entries in cn=FQDN,cn=masters,cn=ipa,cn=etc are no longer
created as enabled. Instead they are flagged as configuredService. At
the very end of the installer, the service entries are switched from
configured to enabled service.

- SRV records are created at the very end of the installer.
- Dogtag installer only picks fully installed servers
- Certmonger ignores all configured but not yet enabled servers.

Fixes: pagure.io/freeipa/issue/7566