### PR TITLE
ipa-pwd-extop: don't check password policy for non-Kerberos account set by DM or a passsync manager

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
@@ -286,8 +286,8 @@ free_and_error:
  * slapi_pblock_destroy(pb)
  */
 static int pwd_get_values(const Slapi_Entry *ent, const char *attrname,
-			  Slapi_ValueSet** results, char** actual_type_name,
-			  int *buffer_flags)
+                          Slapi_ValueSet** results, char** actual_type_name,
+                          int *buffer_flags)
 {
     int flags=0;
     int type_name_disposition = 0;
@@ -560,7 +560,7 @@ int ipapwd_CheckPolicy(struct ipapwd_data *data)
                 LOG_TRACE("No password policy, use defaults");
             }
             break;
-	case IPA_CHANGETYPE_ADMIN:
+        case IPA_CHANGETYPE_ADMIN:
             /* The expiration date needs to be older than the current time
              * otherwise the KDC may not immediately register the password
              * as expired. The last password change needs to match the
@@ -636,7 +636,7 @@ int ipapwd_CheckPolicy(struct ipapwd_data *data)
 }
 
 /* Searches the dn in directory,
- *  If found	 : fills in slapi_entry structure and returns 0
+ *  If found     : fills in slapi_entry structure and returns 0
  *  If NOT found : returns the search result as LDAP_NO_SUCH_OBJECT
  */
 int ipapwd_getEntry(const char *dn, Slapi_Entry **e2, char **attrlist)
@@ -795,22 +795,21 @@ int ipapwd_SetPassword(struct ipapwd_krbcfg *krbcfg,
         slapi_mods_add_mod_values(smods, LDAP_MOD_REPLACE,
                                   "krbPrincipalKey", svals);
 
-		/* krbLastPwdChange is used to tell whether a host entry has a
-		 * keytab so don't set it on hosts.
-		 */
+        /* krbLastPwdChange is used to tell whether a host entry has a
+         * keytab so don't set it on hosts. */
         if (!is_host) {
-	    /* change Last Password Change field with the current date */
+            /* change Last Password Change field with the current date */
             ret = ipapwd_setdate(data->target, smods, "krbLastPwdChange",
                                  data->timeNow, false);
             if (ret != LDAP_SUCCESS)
                 goto free_and_return;
 
-	    /* set Password Expiration date */
+            /* set Password Expiration date */
             ret = ipapwd_setdate(data->target, smods, "krbPasswordExpiration",
                                  data->expireTime, (data->expireTime == 0));
             if (ret != LDAP_SUCCESS)
                 goto free_and_return;
-	}
+        }
     }
 
     if (nt && is_smb) {

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
@@ -888,8 +888,8 @@ int ipapwd_SetPassword(struct ipapwd_krbcfg *krbcfg,
     slapi_mods_add_string(smods, LDAP_MOD_REPLACE,
                           "userPassword", data->password);
 
-    /* set password history */
-    if (data->policy.history_length > 0) {
+    /* set password history if a Kerberos object */
+    if (data->policy.history_length > 0 && is_krb) {
         pwvals = ipapwd_setPasswordHistory(smods, data);
         if (pwvals) {
             slapi_mods_add_mod_values(smods, LDAP_MOD_REPLACE,

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipa_pwd_extop.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipa_pwd_extop.c
@@ -398,15 +398,18 @@ parse_req_done:
 		}
 	}
 
-	 /* Now we have the DN, look for the entry */
-	 ret = ipapwd_getEntry(dn, &targetEntry, attrlist);
-	 /* If we can't find the entry, then that's an error */
-	 if (ret) {
-	 	/* Couldn't find the entry, fail */
-		errMesg = "No such Entry exists.\n" ;
-		rc = LDAP_NO_SUCH_OBJECT;
-		goto free_and_return;
-	 }
+        /* Now we have the DN, look for the entry */
+        target_sdn = slapi_sdn_new_dn_byval(dn);
+        ret = ipapwd_getEntry(target_sdn, &targetEntry, attrlist);
+        slapi_sdn_free(&target_sdn);
+
+        /* If we can't find the entry, then that's an error */
+        if (ret) {
+            /* Couldn't find the entry, fail */
+            errMesg = "No such Entry exists.\n" ;
+            rc = LDAP_NO_SUCH_OBJECT;
+            goto free_and_return;
+        }
 
     if (dn) {
         Slapi_DN *bind_sdn;
@@ -1848,7 +1851,7 @@ static int ipapwd_start( Slapi_PBlock *pb )
     krb5_context krbctx = NULL;
     krb5_error_code krberr;
     char *realm = NULL;
-    char *config_dn;
+    Slapi_DN *config_sdn = NULL;
     Slapi_Entry *config_entry = NULL;
     int ret;
 
@@ -1861,13 +1864,13 @@ static int ipapwd_start( Slapi_PBlock *pb )
         return LDAP_SUCCESS;
     }
 
-    if (slapi_pblock_get(pb, SLAPI_TARGET_DN, &config_dn) != 0) {
+    if (slapi_pblock_get(pb, SLAPI_TARGET_SDN, &config_sdn) != 0) {
         LOG_FATAL("No config DN?\n");
         ret = LDAP_OPERATIONS_ERROR;
         goto done;
     }
 
-    if (ipapwd_getEntry(config_dn, &config_entry, NULL) != LDAP_SUCCESS) {
+    if (ipapwd_getEntry(config_sdn, &config_entry, NULL) != LDAP_SUCCESS) {
         LOG_FATAL("No config Entry extop?\n");
         ret = LDAP_SUCCESS;
         goto done;
@@ -1896,7 +1899,7 @@ static int ipapwd_start( Slapi_PBlock *pb )
         goto done;
     }
 
-    ipa_pwd_config_dn = slapi_ch_strdup(config_dn);
+    ipa_pwd_config_dn = slapi_ch_strdup(slapi_sdn_get_dn(config_sdn));
     if (!ipa_pwd_config_dn) {
         LOG_OOM();
         ret = LDAP_OPERATIONS_ERROR;

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipa_pwd_extop.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipa_pwd_extop.c
@@ -222,7 +222,7 @@ static int ipapwd_chpwop(Slapi_PBlock *pb, struct ipapwd_krbcfg *krbcfg)
 	Slapi_Value *objectclass=NULL;
 	char *attrlist[] = {"*", "passwordHistory", NULL };
 	struct ipapwd_data pwdata;
-	int is_krb, is_smb, is_ipant;
+	int is_krb, is_smb, is_ipant, is_memberof;
 	char *principal = NULL;
 	Slapi_PBlock *chpwop_pb = NULL;
 	Slapi_DN     *target_sdn = NULL;
@@ -348,7 +348,7 @@ parse_req_done:
 	/* Determine the target DN for this operation */
 	slapi_pblock_get(pb, SLAPI_TARGET_SDN, &target_sdn);
 	if (target_sdn != NULL) {
-		/* If there is a TARGET_DN we are consuming it */
+		/* If there is a TARGET_SDN we are consuming it */
 		slapi_pblock_set(pb, SLAPI_TARGET_SDN, NULL);
 		target_dn = slapi_sdn_get_ndn(target_sdn);
 	}
@@ -372,11 +372,11 @@ parse_req_done:
 	}
 	slapi_sdn_free(&target_sdn);
 
-	 if (slapi_pblock_set( pb, SLAPI_ORIGINAL_TARGET, dn )) {
-		LOG_FATAL("slapi_pblock_set failed!\n");
-		rc = LDAP_OPERATIONS_ERROR;
-		goto free_and_return;
-	 }
+        if (slapi_pblock_set( pb, SLAPI_ORIGINAL_TARGET, dn )) {
+            LOG_FATAL("slapi_pblock_set failed!\n");
+            rc = LDAP_OPERATIONS_ERROR;
+            goto free_and_return;
+        }
 
 	if (usetxn) {
                 Slapi_DN *sdn = slapi_sdn_new_dn_byref(dn);
@@ -485,6 +485,7 @@ parse_req_done:
 
 	 rc = ipapwd_entry_checks(pb, targetEntry,
 				&is_root, &is_krb, &is_smb, &is_ipant,
+				&is_memberof,
 				SLAPI_USERPWD_ATTR, SLAPI_ACL_WRITE);
 	 if (rc) {
 		goto free_and_return;
@@ -580,16 +581,21 @@ parse_req_done:
 	/* check the policy */
 	ret = ipapwd_CheckPolicy(&pwdata);
 	if (ret) {
-		errMesg = ipapwd_error2string(ret);
 		if (ret == IPAPWD_POLICY_ERROR) {
 			errMesg = "Internal error";
 			rc = ret;
-		} else {
+			goto free_and_return;
+		}
+		/* ipapwd_CheckPolicy happily will try to apply a policy
+		 * even if it doesn't need to be applied for Directory Manager
+		 * or passsync managers, filter that error out */
+		if (pwdata.changetype != IPA_CHANGETYPE_DSMGR) {
+			errMesg = ipapwd_error2string(ret);
 			ret = ipapwd_to_ldap_pwpolicy_error(ret);
 			slapi_pwpolicy_make_response_control(pb, -1, -1, ret);
 			rc = LDAP_CONSTRAINT_VIOLATION;
+			goto free_and_return;
 		}
-		goto free_and_return;
 	}
 
 	/* Now we're ready to set the kerberos key material */

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipapwd.h
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipapwd.h
@@ -90,6 +90,7 @@ struct ipapwd_operation {
     struct ipapwd_data pwdata;
     int pwd_op;
     int is_krb;
+    int is_memberof;
     int skip_keys;
     int skip_history;
 };
@@ -113,6 +114,7 @@ struct ipapwd_krbcfg {
 
 int ipapwd_entry_checks(Slapi_PBlock *pb, struct slapi_entry *e,
                         int *is_root, int *is_krb, int *is_smb, int *is_ipant,
+			int *is_memberof,
                         char *attr, int access);
 int ipapwd_gen_checks(Slapi_PBlock *pb, char **errMesg,
                       struct ipapwd_krbcfg **config, int check_flags);

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipapwd.h
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipapwd.h
@@ -117,7 +117,7 @@ int ipapwd_entry_checks(Slapi_PBlock *pb, struct slapi_entry *e,
 int ipapwd_gen_checks(Slapi_PBlock *pb, char **errMesg,
                       struct ipapwd_krbcfg **config, int check_flags);
 int ipapwd_CheckPolicy(struct ipapwd_data *data);
-int ipapwd_getEntry(const char *dn, Slapi_Entry **e2, char **attrlist);
+int ipapwd_getEntry(Slapi_DN *sdn, Slapi_Entry **e2, char **attrlist);
 int ipapwd_get_cur_kvno(Slapi_Entry *target);
 int ipapwd_setdate(Slapi_Entry *source, Slapi_Mods *smods, const char *attr,
                    time_t date, bool remove);

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -129,6 +129,7 @@ static char *ipapwd_getIpaConfigAttr(const char *attr)
     const char *attrs_list[] = {attr, 0};
     char *value = NULL;
     char *dn = NULL;
+    Slapi_DN *sdn = NULL;
     int ret;
 
     dn = slapi_ch_smprintf("cn=ipaconfig,cn=etc,%s", ipa_realm_tree);
@@ -137,9 +138,12 @@ static char *ipapwd_getIpaConfigAttr(const char *attr)
         goto done;
     }
 
-    ret = ipapwd_getEntry(dn, &entry, (char **) attrs_list);
+    /* _byref() will take ownership of the dn */
+    sdn = slapi_sdn_new_dn_byref(dn);
+
+    ret = ipapwd_getEntry(sdn, &entry, (char **) attrs_list);
     if (ret) {
-        LOG("failed to retrieve config entry: %s\n", dn);
+        LOG("failed to retrieve config entry: %s\n", slapi_sdn_get_dn(sdn));
         goto done;
     }
 
@@ -147,7 +151,7 @@ static char *ipapwd_getIpaConfigAttr(const char *attr)
 
 done:
     slapi_entry_free(entry);
-    slapi_ch_free_string(&dn);
+    slapi_sdn_free(&sdn);
     return value;
 }
 
@@ -210,7 +214,7 @@ static int ipapwd_pre_add(Slapi_PBlock *pb)
     char *errMesg = "Internal operations error\n";
     struct slapi_entry *e = NULL;
     char *userpw = NULL;
-    char *dn = NULL;
+    Slapi_DN *sdn = NULL;
     struct ipapwd_operation *pwdop = NULL;
     void *op;
     int is_repl_op, is_root, is_krb, is_smb, is_ipant;
@@ -292,8 +296,10 @@ static int ipapwd_pre_add(Slapi_PBlock *pb)
                  * a valid krbPrincipalKey
                  */
                 if (has_krbprincipalkey(e)) {
-                    slapi_pblock_get(pb, SLAPI_TARGET_DN, &dn);
-                    LOG("User Life Cycle: %s is a activated stage user (with prehashed password and krb keys)\n", dn ? dn : "unknown");
+                    slapi_pblock_get(pb, SLAPI_TARGET_SDN, &sdn);
+                    LOG("User Life Cycle: %s is a activated stage user "
+                        "(with prehashed password and krb keys)\n",
+                        sdn ? slapi_sdn_get_dn(sdn) : "unknown");
                     return 0;
                 }
 
@@ -317,7 +323,7 @@ static int ipapwd_pre_add(Slapi_PBlock *pb)
     }
 
     /* Get target DN */
-    ret = slapi_pblock_get(pb, SLAPI_TARGET_DN, &dn);
+    ret = slapi_pblock_get(pb, SLAPI_TARGET_SDN, &sdn);
     if (ret) {
         rc = LDAP_OPERATIONS_ERROR;
         goto done;
@@ -441,7 +447,7 @@ done:
 #define NTHASH_REGEN_VAL "MagicRegen"
 #define NTHASH_REGEN_LEN sizeof(NTHASH_REGEN_VAL)
 static int ipapwd_regen_nthash(Slapi_PBlock *pb, Slapi_Mods *smods,
-                               char *dn, struct slapi_entry *entry,
+                               const char *dn, struct slapi_entry *entry,
                                struct ipapwd_krbcfg *krbcfg);
 
 /* PRE MOD Operation:
@@ -463,8 +469,8 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
     Slapi_Mods *smods = NULL;
     char *userpw = NULL;
     char *unhashedpw = NULL;
-    char *dn = NULL;
-    Slapi_DN *tmp_dn;
+    Slapi_DN *sdn = NULL;
+    Slapi_DN *tmp_sdn;
     struct slapi_entry *e = NULL;
     struct ipapwd_operation *pwdop = NULL;
     void *op;
@@ -571,14 +577,14 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
      * pre-requisites */
 
     /* Get target DN */
-    ret = slapi_pblock_get(pb, SLAPI_TARGET_DN, &dn);
+    ret = slapi_pblock_get(pb, SLAPI_TARGET_SDN, &sdn);
     if (ret) {
         rc = LDAP_OPERATIONS_ERROR;
         goto done;
     }
 
-    tmp_dn = slapi_sdn_new_dn_byref(dn);
-    if (tmp_dn) {
+    tmp_sdn = slapi_sdn_dup(sdn);
+    if (tmp_sdn) {
         /* xxxPAR: Ideally SLAPI_MODIFY_EXISTING_ENTRY should be
          * available but it turns out that is only true if you are
          * a dbm backend pre-op plugin - lucky dbm backend pre-op
@@ -590,8 +596,8 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
          *
          slapi_pblock_get( pb, SLAPI_MODIFY_EXISTING_ENTRY, &e);
          */
-        ret = slapi_search_internal_get_entry(tmp_dn, 0, &e, ipapwd_plugin_id);
-        slapi_sdn_free(&tmp_dn);
+        ret = slapi_search_internal_get_entry(tmp_sdn, 0, &e, ipapwd_plugin_id);
+        slapi_sdn_free(&tmp_sdn);
         if (ret != LDAP_SUCCESS) {
             LOG("Failed to retrieve entry?!\n");
            rc = LDAP_NO_SUCH_OBJECT;
@@ -618,7 +624,7 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
             /* Make sense to call only if this entry has krb keys to source
              * the nthash from */
             if (is_krb) {
-                rc = ipapwd_regen_nthash(pb, smods, dn, e, krbcfg);
+                rc = ipapwd_regen_nthash(pb, smods, slapi_sdn_get_dn(sdn), e, krbcfg);
             } else {
                 rc = LDAP_UNWILLING_TO_PERFORM;
             }
@@ -819,7 +825,7 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
         /* Check Bind DN */
         slapi_pblock_get(pb, SLAPI_CONN_DN, &binddn);
         bdn = slapi_sdn_new_dn_byref(binddn);
-        tdn = slapi_sdn_new_dn_byref(dn);
+        tdn = slapi_sdn_dup(sdn);
 
         /* if the change is performed by someone else,
          * it is an admin change that will require a new
@@ -842,7 +848,7 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
 
     }
 
-    pwdop->pwdata.dn = slapi_ch_strdup(dn);
+    pwdop->pwdata.dn = slapi_ch_strdup(slapi_sdn_get_dn(sdn));
     pwdop->pwdata.timeNow = time(NULL);
     pwdop->pwdata.target = e;
 
@@ -933,7 +939,7 @@ done:
 }
 
 static int ipapwd_regen_nthash(Slapi_PBlock *pb, Slapi_Mods *smods,
-                               char *dn, struct slapi_entry *entry,
+                               const char *dn, struct slapi_entry *entry,
                                struct ipapwd_krbcfg *krbcfg)
 {
     Slapi_Attr *attr;
@@ -1391,7 +1397,9 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
     };
     struct berval *credentials = NULL;
     Slapi_Entry *entry = NULL;
-    char *dn = NULL;
+    Slapi_DN *target_sdn = NULL;
+    Slapi_DN *sdn = NULL;
+    const char *dn = NULL;
     int method = 0;
     bool syncreq;
     bool otpreq;
@@ -1402,7 +1410,7 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
     struct tm expire_tm;
 
     /* get BIND parameters */
-    ret |= slapi_pblock_get(pb, SLAPI_BIND_TARGET, &dn);
+    ret |= slapi_pblock_get(pb, SLAPI_BIND_TARGET_SDN, &target_sdn);
     ret |= slapi_pblock_get(pb, SLAPI_BIND_METHOD, &method);
     ret |= slapi_pblock_get(pb, SLAPI_BIND_CREDENTIALS, &credentials);
     if (ret) {
@@ -1415,7 +1423,9 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
         return 0;
 
     /* Retrieve the user's entry. */
-    ret = ipapwd_getEntry(dn, &entry, (char **) attrs_list);
+    sdn = slapi_sdn_dup(target_sdn);
+    dn = slapi_sdn_get_dn(sdn);
+    ret = ipapwd_getEntry(sdn, &entry, (char **) attrs_list);
     if (ret) {
         LOG("failed to retrieve user entry: %s\n", dn);
         return 0;
@@ -1472,13 +1482,15 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
         goto invalid_creds;
 
     /* Attempt to write out kerberos keys for the user. */
-    ipapwd_write_krb_keys(pb, dn, entry, credentials);
+    ipapwd_write_krb_keys(pb, discard_const(dn), entry, credentials);
 
     slapi_entry_free(entry);
+    slapi_sdn_free(&sdn);
     return 0;
 
 invalid_creds:
     slapi_entry_free(entry);
+    slapi_sdn_free(&sdn);
     slapi_send_ldap_result(pb, LDAP_INVALID_CREDENTIALS,
                            NULL, NULL, 0, NULL);
     return 1;

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -80,6 +80,8 @@ struct ipapwd_op_ext {
     int object_type;     /* handle to the extended object */
     int handle;          /* extension handle              */
 };
+
+
 /*****************************************************************************
  * pre/post operations to intercept writes to userPassword
  ****************************************************************************/
@@ -217,7 +219,7 @@ static int ipapwd_pre_add(Slapi_PBlock *pb)
     Slapi_DN *sdn = NULL;
     struct ipapwd_operation *pwdop = NULL;
     void *op;
-    int is_repl_op, is_root, is_krb, is_smb, is_ipant;
+    int is_repl_op, is_root, is_krb, is_smb, is_ipant, is_memberof;
     int ret;
     int rc = LDAP_SUCCESS;
 
@@ -242,8 +244,8 @@ static int ipapwd_pre_add(Slapi_PBlock *pb)
     /* check this is something interesting for us first */
     userpw = slapi_entry_attr_get_charptr(e, SLAPI_USERPWD_ATTR);
     if (!userpw) {
-	/* nothing interesting here */
-	return 0;
+        /* nothing interesting here */
+        return 0;
     }
 
     /* Ok this is interesting,
@@ -312,6 +314,7 @@ static int ipapwd_pre_add(Slapi_PBlock *pb)
 
     rc = ipapwd_entry_checks(pb, e,
                              &is_root, &is_krb, &is_smb, &is_ipant,
+                             &is_memberof,
                              NULL, SLAPI_ACL_ADD);
     if (rc != LDAP_SUCCESS) {
         goto done;
@@ -346,6 +349,7 @@ static int ipapwd_pre_add(Slapi_PBlock *pb)
 
     pwdop->pwd_op = IPAPWD_OP_ADD;
     pwdop->pwdata.password = slapi_ch_strdup(userpw);
+    pwdop->is_memberof = is_memberof;
 
     if (is_root) {
         pwdop->pwdata.changetype = IPA_CHANGETYPE_DSMGR;
@@ -367,12 +371,15 @@ static int ipapwd_pre_add(Slapi_PBlock *pb)
         }
     }
 
-    pwdop->pwdata.dn = slapi_ch_strdup(dn);
+    pwdop->pwdata.dn = slapi_ch_strdup(slapi_sdn_get_dn(sdn));
     pwdop->pwdata.timeNow = time(NULL);
     pwdop->pwdata.target = e;
 
     ret = ipapwd_CheckPolicy(&pwdop->pwdata);
-    if (ret) {
+    /* For accounts created by cn=Directory Manager or a passsync
+     * managers, ignore result of a policy check */
+    if ((pwdop->pwdata.changetype != IPA_CHANGETYPE_DSMGR) &&
+        (ret != 0) ) {
         errMesg = ipapwd_error2string(ret);
         rc = LDAP_CONSTRAINT_VIOLATION;
         goto done;
@@ -474,7 +481,7 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
     struct slapi_entry *e = NULL;
     struct ipapwd_operation *pwdop = NULL;
     void *op;
-    int is_repl_op, is_pwd_op, is_root, is_krb, is_smb, is_ipant;
+    int is_repl_op, is_pwd_op, is_root, is_krb, is_smb, is_ipant, is_memberof;
     int has_krb_keys = 0;
     int has_history = 0;
     int gen_krb_keys = 0;
@@ -607,6 +614,7 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
 
     rc = ipapwd_entry_checks(pb, e,
                              &is_root, &is_krb, &is_smb, &is_ipant,
+                             &is_memberof,
                              is_pwd_op ? SLAPI_USERPWD_ATTR : "ipaNTHash",
                              SLAPI_ACL_WRITE);
     if (rc) {
@@ -809,6 +817,7 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
     }
 
     pwdop->is_krb = is_krb;
+    pwdop->is_memberof = is_memberof;
     pwdop->pwd_op = IPAPWD_OP_MOD;
     pwdop->pwdata.password = slapi_ch_strdup(unhashedpw);
     pwdop->pwdata.changetype = IPA_CHANGETYPE_NORMAL;
@@ -853,11 +862,13 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
     pwdop->pwdata.target = e;
 
     /* if krb keys are being set by an external agent we assume password
-     * policies have been properly checked already, so we check them only
-     * if no krb keys are available */
+     * policies have been properly checked already. We check them only if no
+     * krb keys are available and raise error if the change is not done by a
+     * cn=Directory Manager or one of passsync managers */
     if (has_krb_keys == 0) {
         ret = ipapwd_CheckPolicy(&pwdop->pwdata);
-        if (ret) {
+        if ((pwdop->pwdata.changetype != IPA_CHANGETYPE_DSMGR) &&
+            (ret != 0)) {
             errMesg = ipapwd_error2string(ret);
             rc = LDAP_CONSTRAINT_VIOLATION;
             goto done;
@@ -1069,7 +1080,7 @@ static int ipapwd_post_modadd(Slapi_PBlock *pb)
     if (IPAPWD_OP_NULL == pwdop->pwd_op)
         return 0;
 
-    if ( ! (pwdop->is_krb)) {
+    if ( !pwdop->is_krb || pwdop->is_memberof) {
         LOG("Not a kerberos user, ignore krb attributes\n");
         return 0;
     }
@@ -1428,6 +1439,7 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
     ret = ipapwd_getEntry(sdn, &entry, (char **) attrs_list);
     if (ret) {
         LOG("failed to retrieve user entry: %s\n", dn);
+        slapi_sdn_free(&sdn);
         return 0;
     }
 
@@ -1452,6 +1464,7 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
             if (current_time > expire_time && expire_time > 0) {
                 LOG_FATAL("kerberos principal in %s is expired\n", dn);
                 slapi_entry_free(entry);
+                slapi_sdn_free(&sdn);
                 slapi_send_ldap_result(pb, LDAP_UNWILLING_TO_PERFORM, NULL,
                                        "Account (Kerberos principal) is expired",
                                         0, NULL);
@@ -1474,6 +1487,7 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
     ret = ipapwd_authenticate(dn, entry, credentials);
     if (ret) {
         slapi_entry_free(entry);
+        slapi_sdn_free(&sdn);
         return 0;
     }
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_commands.py
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1780,15 +1780,23 @@ def ldappasswd_user_change(user, oldpw, newpw, master):
     master.run_command(args)
 
 
-def ldappasswd_sysaccount_change(user, oldpw, newpw, master):
+def ldappasswd_sysaccount_change(user, oldpw, newpw, master, use_dirman=False):
     container_sysaccounts = dict(DEFAULT_CONFIG)['container_sysaccounts']
     basedn = master.domain.basedn
 
     userdn = "uid={},{},{}".format(user, container_sysaccounts, basedn)
     master_ldap_uri = "ldap://{}".format(master.hostname)
 
-    args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
-            '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
+    if use_dirman:
+        args = [paths.LDAPPASSWD, '-D',
+                str(master.config.dirman_dn),  # pylint: disable=no-member
+                '-w', master.config.dirman_password,
+                '-a', oldpw,
+                '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri,
+                userdn]
+    else:
+        args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
+                '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
     master.run_command(args)
 
 

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1768,15 +1768,21 @@ def get_host_ip_with_hostmask(host):
         return None
 
 
-def ldappasswd_user_change(user, oldpw, newpw, master):
+def ldappasswd_user_change(user, oldpw, newpw, master, use_dirman=False):
     container_user = dict(DEFAULT_CONFIG)['container_user']
     basedn = master.domain.basedn
 
     userdn = "uid={},{},{}".format(user, container_user, basedn)
     master_ldap_uri = "ldap://{}".format(master.hostname)
 
-    args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
-            '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
+    if use_dirman:
+        args = [paths.LDAPPASSWD, '-D',
+                str(master.config.dirman_dn),  # pylint: disable=no-member
+                '-w', master.config.dirman_password,
+                '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri, userdn]
+    else:
+        args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
+                '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
     master.run_command(args)
 
 

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -16,6 +16,7 @@ import textwrap
 import time
 import paramiko
 import pytest
+from subprocess import CalledProcessError
 
 from cryptography.hazmat.backends import default_backend
 from cryptography import x509
@@ -29,6 +30,7 @@ from ipapython.dn import DN
 from ipapython.certdb import get_ca_nickname
 
 from ipatests.test_integration.base import IntegrationTest
+
 from ipatests.pytest_ipa.integration import tasks
 from ipaplatform.tasks import tasks as platform_tasks
 from ipatests.create_external_ca import ExternalCA
@@ -229,17 +231,18 @@ class TestIPACommand(IntegrationTest):
 
         base_dn = str(master.domain.basedn)
         entry_ldif = textwrap.dedent("""
-            dn: uid=system,cn=sysaccounts,cn=etc,{base_dn}
+            dn: uid={sysuser},cn=sysaccounts,cn=etc,{base_dn}
             changetype: add
             objectclass: account
             objectclass: simplesecurityobject
-            uid: system
+            uid: {sysuser}
             userPassword: {original_passwd}
             passwordExpirationTime: 20380119031407Z
             nsIdleTimeout: 0
         """).format(
             base_dn=base_dn,
-            original_passwd=original_passwd)
+            original_passwd=original_passwd,
+            sysuser=sysuser)
         tasks.ldapmodify_dm(master, entry_ldif)
 
         tasks.ldappasswd_sysaccount_change(sysuser, original_passwd,
@@ -330,6 +333,88 @@ class TestIPACommand(IntegrationTest):
         newkrblastpwdchange2, newkrbexp2 = self.get_krbinfo(user)
         assert newkrblastpwdchange != newkrblastpwdchange2
         assert newkrbexp != newkrbexp2
+
+    def test_change_sysaccount_password_issue7181(self):
+        """
+        Test how a password change performed by a cn=Directory Manager
+        works against a non-Kerberos account with a policy preventing
+        re-use of previously used passwords
+        """
+        sysuser = 'forcedpolicy'
+        policy_group = 'forcedpolicy'
+        original_passwd = 'Secret123'
+        new_passwd = 'userPasswd123'
+
+        master = self.master
+
+        # Add a group with a custom password policy
+        tasks.kinit_admin(self.master)
+        result = master.run_command(
+            ["ipa", "group-add", policy_group]
+        )
+        assert 'Added group "{}"'.format(policy_group) in result.stdout_text
+
+        result = master.run_command(
+            ["ipa", "pwpolicy-add", policy_group,
+                "--history=5", "--priority=1"],
+        )
+        assert 'History size: 5' in result.stdout_text
+
+        # Add a system account and add it to a group managed by the policy
+        base_dn = str(master.domain.basedn)  # pylint: disable=no-member
+        entry_ldif = textwrap.dedent("""
+            dn: uid={account_name},cn=sysaccounts,cn=etc,{base_dn}
+            changetype: add
+            objectclass: account
+            objectclass: simplesecurityobject
+            objectclass: nsMemberOf
+            objectclass: krbPrincipalAux
+            uid: {account_name}
+            userPassword: {original_passwd}
+            passwordExpirationTime: 20380119031407Z
+            nsIdleTimeout: 0
+            memberOf: cn={group_name},cn=groups,cn=accounts,{base_dn}
+        """).format(
+            account_name=sysuser,
+            group_name=policy_group,
+            base_dn=base_dn,
+            original_passwd=original_passwd)
+
+        tasks.ldapmodify_dm(master, entry_ldif)
+
+        # For an LDAP object not managed by IPA we have to use
+        # --addattr to add it as a member of a group
+        value = "member=uid={account_name},cn=sysaccounts,cn=etc,{base_dn}"
+        result = master.run_command(
+            ["ipa", "group-mod", policy_group,
+                "--addattr={value}".format(
+                    value=value.format(
+                        account_name=sysuser,
+                        base_dn=base_dn
+                    )
+                )],
+        )
+        assert 'Modified group "{}"'.format(policy_group) in result.stdout_text
+
+        # Now try to change password thrice:
+        # as a user, as a cn=Directory Manager, and as a user again
+        # If ticket 7181 is not fixed, the second change will fail
+        # Third one must fail as we are reusing the password as non-DM
+        tasks.ldappasswd_sysaccount_change(sysuser, original_passwd,
+                                           new_passwd, master,
+                                           use_dirman=False)
+        tasks.ldappasswd_sysaccount_change(sysuser, new_passwd,
+                                           new_passwd, master,
+                                           use_dirman=True)
+        try:
+            tasks.ldappasswd_sysaccount_change(sysuser, new_passwd,
+                                               original_passwd, master,
+                                               use_dirman=False)
+        except CalledProcessError as e:
+            if e.returncode != 1:
+                raise
+        else:
+            pytest.fail("Password change violating policy did not fail")
 
     def test_change_selinuxusermaporder(self):
         """


### PR DESCRIPTION
Password changes performed by cn=Directory Manager are excluded from
password policy checks according to [1]. This is correctly handled by
ipa-pwd-extop in case of a normal Kerberos principal in IPA. However,
non-kerberos accounts were not excluded from the check.

As result, password updates for PKI CA admin account in o=ipaca were
failing if a password policy does not allow a password reuse. We are
re-setting the password for PKI CA admin in ipa-replica-prepare in case
the original directory manager's password was updated since creation of
`cacert.p12`.

Do password policy check for non-Kerberos accounts only if it was set by
a regular user or admin. Changes performed by a cn=Directory Manager and
passsync managers should be excluded from the policy check.

Fixes: https://pagure.io/freeipa/issue/7181
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>

[1] https://access.redhat.com/documentation/en-us/red_hat_directory_server/10/html/administration_guide/user_account_management-managing_the_password_policy