### PR TITLE
ipa client uninstall: clean the state store when restoring hostname

### DIFF
--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -392,7 +392,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
         statestore.backup_state('network', 'hostname', old_hostname)
 
     def restore_hostname(self, fstore, statestore):
-        old_hostname = statestore.get_state('network', 'hostname')
+        old_hostname = statestore.restore_state('network', 'hostname')
 
         if old_hostname is not None:
             try:


### PR DESCRIPTION
When ipa client was installed with the --hostname= option, it stores
[network]
hostname = (current hostname)
in /var/lib/ipa-client/sysrestore/sysrestore.state and changes the hostname
from (current hostname) to the value provided in --hostname.

During uninstall, the previous hostname is restored but the entry does
not get removed from sysrestore.state. As the uninstaller checks if all
entries from sysrestore.state have been restored, it warns that some
state has not been restored.

The fix calls statestore.restore_state() instead of statestore.get_state()
as this method also clears the entry.

https://pagure.io/freeipa/issue/7620