### PR TITLE
Fix CA topology warning

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1523,8 +1523,6 @@ def install(installer):
     if options.setup_adtrust:
         adtrust.install(False, options, fstore, api)
 
-    ca_servers = service.find_providing_servers('CA', api.Backend.ldap2, api)
-
     if not promote:
         # Call client install script
         service.print_msg("Configuring client side components")
@@ -1555,6 +1553,7 @@ def install(installer):
     # Enable configured services and update DNS SRV records
     service.enable_services(config.host_name)
     api.Command.dns_update_system_records()
+    ca_servers = service.find_providing_servers('CA', api.Backend.ldap2, api)
     api.Backend.ldap2.disconnect()
 
     # Everything installed properly, activate ipa service.

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -63,7 +63,7 @@ SERVICE_LIST = {
 }
 
 CONFIGURED_SERVICE = u'configuredService'
-ENABLED_SERVICE = 'enabledService'
+ENABLED_SERVICE = u'enabledService'
 
 
 def print_msg(message, output_fd=sys.stdout):
@@ -676,7 +676,7 @@ class Service(object):
 
         entry_dn = DN(('cn', name), ('cn', fqdn), ('cn', 'masters'),
                         ('cn', 'ipa'), ('cn', 'etc'), ldap_suffix)
-        search_kw = {'ipaConfigString': u'enabledService'}
+        search_kw = {'ipaConfigString': ENABLED_SERVICE}
         filter = api.Backend.ldap2.make_filter(search_kw)
         try:
             entries, _truncated = api.Backend.ldap2.find_entries(


### PR DESCRIPTION
Commit 7284097eedef70dd556270732e6ab8e23501ce09 kept
find_providing_servers('CA') call before enable_services(). Therefore the
list of known CA servers did not contain the current replica.
ipa-replica-install on the first replica with --setup-ca still printed
the CA topology warning.

See: https://pagure.io/freeipa/issue/7566
Signed-off-by: Christian Heimes <cheimes@redhat.com>