### PR TITLE
[Backport][ipa-4-5] replica improvements

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -61,4 +61,4 @@ jobs:
         test_suite: test_integration/test_external_ca.py::TestExternalCA
         template: *ci-ipa-4-5-f26
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -771,6 +771,7 @@ def configure_certmonger(
     cmonger = services.knownservices.certmonger
     try:
         cmonger.enable()
+        cmonger.start()
     except Exception as e:
         root_logger.error(
             "Failed to configure automatic startup of the %s daemon: %s",
@@ -782,14 +783,24 @@ def configure_certmonger(
     subject = str(DN(('CN', hostname), subject_base))
     passwd_fname = os.path.join(paths.IPA_NSSDB_DIR, 'pwdfile.txt')
     try:
-        certmonger.request_cert(
+        certmonger.request_and_wait_for_cert(
             certpath=paths.IPA_NSSDB_DIR,
-            nickname='Local IPA host', subject=subject, dns=[hostname],
-            principal=principal, passwd_fname=passwd_fname)
-    except Exception as ex:
-        root_logger.error(
-            "%s request for host certificate failed: %s",
-            cmonger.service_name, ex)
+            storage='NSSDB',
+            nickname='Local IPA host',
+            subject=subject,
+            dns=[hostname],
+            principal=principal,
+            passwd_fname=passwd_fname,
+            resubmit_timeout=120,
+        )
+    except Exception as e:
+        root_logger.exception("certmonger request failed")
+        raise ScriptError(
+            "{} request for host certificate failed: {}".format(
+                cmonger.service_name, e
+            ),
+            rval=CLIENT_INSTALL_ERROR
+        )
 
 
 def configure_sssd_conf(

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -302,20 +302,56 @@ def add_subject(request_id, subject):
 def request_and_wait_for_cert(
         certpath, subject, principal, nickname=None, passwd_fname=None,
         dns=None, ca='IPA', profile=None,
-        pre_command=None, post_command=None, storage='NSSDB', perms=None):
-    """
-    Execute certmonger to request a server certificate.
+        pre_command=None, post_command=None, storage='NSSDB', perms=None,
+        resubmit_timeout=0):
+    """Request certificate, wait and possibly resubmit failing requests
 
-    The method also waits for the certificate to be available.
+    Submit a cert request to certmonger and wait until the request has
+    finished.
+
+    With timeout, a failed request is resubmitted. During parallel replica
+    installation, a request sometimes fails with CA_REJECTED or
+    CA_UNREACHABLE. The error occurs when the master is either busy or some
+    information haven't been replicated yet. Even a stuck request can be
+    recovered, e.g. when permission and group information have been
+    replicated.
     """
-    reqId = request_cert(certpath, subject, principal, nickname,
-                         passwd_fname, dns, ca, profile,
-                         pre_command, post_command, storage, perms)
-    state = wait_for_request(reqId, api.env.startup_timeout)
-    ca_error = get_request_value(reqId, 'ca-error')
-    if state != 'MONITORING' or ca_error:
-        raise RuntimeError("Certificate issuance failed ({})".format(state))
-    return reqId
+    req_id = request_cert(
+        certpath, subject, principal, nickname, passwd_fname, dns, ca,
+        profile, pre_command, post_command, storage, perms
+    )
+
+    deadline = time.time() + resubmit_timeout
+    while True:  # until success, timeout, or error
+        state = wait_for_request(req_id, api.env.replication_wait_timeout)
+        ca_error = get_request_value(req_id, 'ca-error')
+        if state == 'MONITORING' and ca_error is None:
+            # we got a winner, exiting
+            root_logger.debug("Cert request %s was successful", req_id)
+            return req_id
+
+        root_logger.debug(
+            "Cert request %s failed: %s (%s)", req_id, state, ca_error
+        )
+        if state not in {'CA_REJECTED', 'CA_UNREACHABLE'}:
+            # probably unrecoverable error
+            root_logger.debug("Giving up on cert request %s", req_id)
+            break
+        elif not resubmit_timeout:
+            # no resubmit
+            break
+        elif time.time() > deadline:
+            root_logger.debug("Request %s reached resubmit dead line", req_id)
+            break
+        else:
+            # sleep and resubmit
+            root_logger.debug("Sleep and resubmit cert request %s", req_id)
+            time.sleep(10)
+            resubmit_request(req_id)
+
+    raise RuntimeError(
+        "Certificate issuance failed ({}: {})".format(state, ca_error)
+    )
 
 
 def request_cert(

--- a/ipaserver/dns_data_management.py
+++ b/ipaserver/dns_data_management.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 import six
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from dns import (
     rdata,
     rdataclass,
@@ -68,7 +68,7 @@ class IPASystemRecords(object):
     def __init__(self, api_instance, all_servers=False):
         self.api_instance = api_instance
         self.domain_abs = DNSName(self.api_instance.env.domain).make_absolute()
-        self.servers_data = {}
+        self.servers_data = OrderedDict()
         self.__init_data(all_servers=all_servers)
 
     def reload_data(self):
@@ -90,7 +90,7 @@ class IPASystemRecords(object):
         return location + DNSName('_locations') + self.domain_abs
 
     def __init_data(self, all_servers=False):
-        self.servers_data = {}
+        self.servers_data.clear()
 
         kwargs = dict(no_members=False)
         if not all_servers:
@@ -325,7 +325,7 @@ class IPASystemRecords(object):
 
         zone_obj = zone.Zone(self.domain_abs, relativize=False)
         if servers is None:
-            servers = self.servers_data.keys()
+            servers = list(self.servers_data)
 
         for server in servers:
             self._add_base_dns_records_for_server(zone_obj, server,
@@ -348,11 +348,7 @@ class IPASystemRecords(object):
         """
         zone_obj = zone.Zone(self.domain_abs, relativize=False)
         if servers is None:
-            servers_result = self.api_instance.Command.server_find(
-                pkey_only=True,
-                servrole=u"IPA master",  # only fully installed masters
-            )['result']
-            servers = [s['cn'][0] for s in servers_result]
+            servers = list(self.servers_data)
 
         locations_result = self.api_instance.Command.location_find()['result']
         locations = [l['idnsname'][0] for l in locations_result]

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -389,8 +389,13 @@ class CAInstance(DogtagInstance):
             self.step("set up CRL publishing", self.__enable_crl_publish)
             self.step("enable PKIX certificate path discovery and validation", self.enable_pkix)
             if promote:
-                self.step("destroying installation admin user", self.teardown_admin)
-            self.step("starting certificate server instance", self.start_instance)
+                self.step("destroying installation admin user",
+                          self.teardown_admin)
+            self.step("starting certificate server instance",
+                      self.start_instance)
+            if promote:
+                self.step("Finalize replication settings",
+                          self.finalize_replica_config)
         # Step 1 of external is getting a CSR so we don't need to do these
         # steps until we get a cert back from the external CA.
         if self.external != 1:
@@ -1197,12 +1202,15 @@ class CAInstance(DogtagInstance):
         api.Backend.ldap2.add_entry(entry)
 
     def __setup_replication(self):
-
         repl = replication.CAReplicationManager(self.realm, self.fqdn)
         repl.setup_cs_replication(self.master_host)
 
         # Activate Topology for o=ipaca segments
         self.__update_topology()
+
+    def finalize_replica_config(self):
+        repl = replication.CAReplicationManager(self.realm, self.fqdn)
+        repl.finalize_replica_config(self.master_host)
 
     def __enable_instance(self):
         basedn = ipautil.realm_to_suffix(self.realm)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -863,7 +863,9 @@ class CAInstance(DogtagInstance):
                 profile='caServerCert',
                 pre_command='renew_ra_cert_pre',
                 post_command='renew_ra_cert',
-                storage="FILE")
+                storage="FILE",
+                resubmit_timeout=api.env.replication_wait_timeout
+            )
             self.__set_ra_cert_perms()
 
             self.requestId = str(reqId)

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -663,12 +663,19 @@ class CertDB(object):
     def export_pem_cert(self, nickname, location):
         return self.nssdb.export_pem_cert(nickname, location)
 
-    def request_service_cert(self, nickname, principal, host):
-        certmonger.request_and_wait_for_cert(certpath=self.secdir,
-                                             nickname=nickname,
-                                             principal=principal,
-                                             subject=host,
-                                             passwd_fname=self.passwd_fname)
+    def request_service_cert(self, nickname, principal, host,
+                             resubmit_timeout=None):
+        if resubmit_timeout is None:
+            resubmit_timeout = api.env.replication_wait_timeout
+        return certmonger.request_and_wait_for_cert(
+            certpath=self.secdir,
+            storage='NSSDB',
+            nickname=nickname,
+            principal=principal,
+            subject=host,
+            passwd_fname=self.passwd_fname,
+            resubmit_timeout=resubmit_timeout
+        )
 
     def is_ipa_issued_cert(self, api, nickname):
         """

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -417,6 +417,20 @@ class DsInstance(service.Service):
 
         self.start_creation(runtime=30)
 
+    def _get_replication_manager(self):
+        # Always connect to self over ldapi
+        ldap_uri = ipaldap.get_ldap_uri(protocol='ldapi', realm=self.realm)
+        conn = ipaldap.LDAPClient(ldap_uri)
+        conn.external_bind()
+        repl = replication.ReplicationManager(
+            self.realm, self.fqdn, self.dm_password, conn=conn
+        )
+        if self.dm_password is not None and not self.promote:
+            bind_dn = DN(('cn', 'Directory Manager'))
+            bind_pw = self.dm_password
+        else:
+            bind_dn = bind_pw = None
+        return repl, bind_dn, bind_pw
 
     def __setup_replica(self):
         """
@@ -433,25 +447,23 @@ class DsInstance(service.Service):
             self.realm,
             self.dm_password)
 
-        # Always connect to self over ldapi
-        ldap_uri = ipaldap.get_ldap_uri(protocol='ldapi', realm=self.realm)
-        conn = ipaldap.LDAPClient(ldap_uri)
-        conn.external_bind()
-        repl = replication.ReplicationManager(self.realm,
-                                              self.fqdn,
-                                              self.dm_password, conn=conn)
-
-        if self.dm_password is not None and not self.promote:
-            bind_dn = DN(('cn', 'Directory Manager'))
-            bind_pw = self.dm_password
-        else:
-            bind_dn = bind_pw = None
-
-        repl.setup_promote_replication(self.master_fqdn,
-                                       r_binddn=bind_dn,
-                                       r_bindpw=bind_pw,
-                                       cacert=self.ca_file)
+        repl, bind_dn, bind_pw = self._get_replication_manager()
+        repl.setup_promote_replication(
+            self.master_fqdn,
+            r_binddn=bind_dn,
+            r_bindpw=bind_pw,
+            cacert=self.ca_file
+        )
         self.run_init_memberof = repl.needs_memberof_fixup()
+
+    def finalize_replica_config(self):
+        repl, bind_dn, bind_pw = self._get_replication_manager()
+        repl.finalize_replica_config(
+            self.master_fqdn,
+            r_binddn=bind_dn,
+            r_bindpw=bind_pw,
+            cacert=self.ca_file
+        )
 
     def __configure_sasl_mappings(self):
         # we need to remove any existing SASL mappings in the directory as otherwise they

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -847,7 +847,9 @@ class DsInstance(service.Service):
                     ca='IPA',
                     profile=dogtag.DEFAULT_PROFILE,
                     dns=[self.fqdn],
-                    post_command=cmd)
+                    post_command=cmd,
+                    resubmit_timeout=api.env.replication_wait_timeout
+                )
             finally:
                 if prev_helper is not None:
                     certmonger.modify_ca_helper('IPA', prev_helper)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -450,7 +450,10 @@ class HTTPInstance(service.Service):
                     ca='IPA',
                     profile=dogtag.DEFAULT_PROFILE,
                     dns=[self.fqdn],
-                    post_command='restart_httpd')
+                    post_command='restart_httpd',
+                    storage='NSSDB',
+                    resubmit_timeout=api.env.replication_wait_timeout
+                )
             finally:
                 if prev_helper is not None:
                     certmonger.modify_ca_helper('IPA', prev_helper)

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -437,7 +437,9 @@ class KrbInstance(service.Service):
                 storage='FILE',
                 profile=KDC_PROFILE,
                 post_command='renew_kdc_cert',
-                perms=(0o644, 0o600))
+                perms=(0o644, 0o600),
+                resubmit_timeout=api.env.replication_wait_timeout
+            )
         except dbus.DBusException as e:
             # if the certificate is already tracked, ignore the error
             name = e.get_dbus_name()

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -71,6 +71,20 @@ STRIP_ATTRS = ('modifiersName',
                'internalModifiersName',
                'internalModifyTimestamp')
 
+# settings for cn=replica,cn=$DB,cn=mapping tree,cn=config
+# during replica installation
+REPLICA_CREATION_SETTINGS = {
+    "nsds5ReplicaReleaseTimeout": ["20"],
+    "nsds5ReplicaBackoffMax": ["3"],
+    "nsDS5ReplicaBindDnGroupCheckInterval": ["2"]
+}
+# after replica installation
+REPLICA_FINAL_SETTINGS = {
+    "nsds5ReplicaReleaseTimeout": ["60"],
+    "nsds5ReplicaBackoffMax": ["300"],  # default
+    "nsDS5ReplicaBindDnGroupCheckInterval": ["60"]
+}
+
 
 def replica_conn_check(master_host, host_name, realm, check_ca,
                        dogtag_master_ds_port, admin_password=None,
@@ -197,9 +211,13 @@ def wait_for_entry(connection, dn, timeout, attr=None, attrvalue='*',
 
 
 class ReplicationManager(object):
-    """Manage replication agreements between DS servers, and sync
-    agreements with Windows servers"""
-    def __init__(self, realm, hostname, dirman_passwd, port=PORT, starttls=False, conn=None):
+    """Manage replication agreements
+
+    between DS servers, and sync  agreements with Windows servers
+    """
+
+    def __init__(self, realm, hostname, dirman_passwd=None, port=PORT,
+                 starttls=False, conn=None):
         self.hostname = hostname
         self.port = port
         self.dirman_passwd = dirman_passwd
@@ -476,22 +494,16 @@ class ReplicationManager(object):
         except errors.NotFound:
             pass
         else:
-            managers = {DN(m) for m in entry.get('nsDS5ReplicaBindDN', [])}
-
-            mods = []
-            if replica_binddn not in managers:
+            binddns = entry.setdefault('nsDS5ReplicaBindDN', [])
+            if replica_binddn not in {DN(m) for m in binddns}:
                 # Add the new replication manager
-                mods.append(
-                    (ldap.MOD_ADD, 'nsDS5ReplicaBindDN', replica_binddn)
-                )
-            if 'nsds5replicareleasetimeout' not in entry:
-                # See https://pagure.io/freeipa/issue/7488
-                mods.append(
-                    (ldap.MOD_ADD, 'nsds5replicareleasetimeout', ['60'])
-                )
-
-            if mods:
-                conn.modify_s(dn, mods)
+                binddns.append(replica_binddn)
+            for key, value in REPLICA_CREATION_SETTINGS.items():
+                entry[key] = value
+            try:
+                conn.update_entry(entry)
+            except errors.EmptyModlist:
+                pass
 
             self.set_replica_binddngroup(conn, entry)
 
@@ -510,9 +522,8 @@ class ReplicationManager(object):
             nsds5flags=["1"],
             nsds5replicabinddn=[replica_binddn],
             nsds5replicabinddngroup=[self.repl_man_group_dn],
-            nsds5replicabinddngroupcheckinterval=["60"],
-            nsds5replicareleasetimeout=["60"],
             nsds5replicalegacyconsumer=["off"],
+            **REPLICA_CREATION_SETTINGS
         )
         conn.add_entry(entry)
 
@@ -537,6 +548,47 @@ class ReplicationManager(object):
             conn.add_entry(entry)
         except errors.DuplicateEntry:
             return
+
+    def _finalize_replica_settings(self, conn):
+        """Change replica settings to final values
+
+        During replica installation, some settings are configured for faster
+        replication.
+        """
+        dn = self.replica_dn()
+        entry = conn.get_entry(dn)
+        for key, value in REPLICA_FINAL_SETTINGS.items():
+            entry[key] = value
+        try:
+            conn.update_entry(entry)
+        except errors.EmptyModlist:
+            pass
+
+    def finalize_replica_config(self, r_hostname, r_binddn=None,
+                                r_bindpw=None, cacert=paths.IPA_CA_CRT):
+        """Apply final cn=replica settings
+
+        replica_config() sets several attribute to fast cache invalidation
+        and fast reconnects to optimize replicat installation. For
+        production, longer timeouts and less aggressive cache invalidation
+        is sufficient. finalize_replica_config() sets the values on new
+        replica and the master.
+
+        When installing multiple replicas in parallel, one replica may
+        finalize the values while another is still installing.
+
+        See https://pagure.io/freeipa/issue/7617
+        """
+        self._finalize_replica_settings(self.conn)
+
+        ldap_uri = ipaldap.get_ldap_uri(r_hostname)
+        r_conn = ipaldap.LDAPClient(ldap_uri, cacert=cacert)
+        if r_bindpw:
+            r_conn.simple_bind(r_binddn, r_bindpw)
+        else:
+            r_conn.gssapi_bind()
+        self._finalize_replica_settings(r_conn)
+        r_conn.close()
 
     def setup_chaining_backend(self, conn):
         chaindn = DN(('cn', 'chaining database'), ('cn', 'plugins'), ('cn', 'config'))

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1502,6 +1502,8 @@ def install(installer):
     # Apply any LDAP updates. Needs to be done after the replica is synced-up
     service.print_msg("Applying LDAP updates")
     ds.apply_updates()
+    service.print_msg("Finalize replication settings")
+    ds.finalize_replica_config()
 
     if kra_enabled:
         kra.install(api, config, options, custodia=custodia)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1444,15 +1444,12 @@ def install(installer):
         pkcs12_info=pkinit_pkcs12_info,
         promote=promote)
 
-    # we now need to enable ssl on the ds
-    ds.enable_ssl()
-
     if promote:
         # We need to point to the master when certmonger asks for
-        # HTTP certificate.
-        # During http installation, the HTTP/hostname principal is created
-        # locally then the installer waits for the entry to appear on the
-        # master selected for the installation.
+        # a DS or HTTP certificate.
+        # During http installation, the <service>/hostname principal is
+        # created locally then the installer waits for the entry to appear
+        # on the master selected for the installation.
         # In a later step, the installer requests a SSL certificate through
         # Certmonger (and the op adds the principal if it does not exist yet).
         # If xmlrpc_uri points to the soon-to-be replica,
@@ -1465,6 +1462,9 @@ def install(installer):
         # setting xmlrpc_uri
         create_ipa_conf(fstore, config, ca_enabled,
                         master=config.master_host_name)
+
+    # we now need to enable ssl on the ds
+    ds.enable_ssl()
 
     install_http(
         config,

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -50,6 +50,7 @@ from ipaserver.install import dnskeysyncinstance
 from ipaserver.install import dogtaginstance
 from ipaserver.install import krbinstance
 from ipaserver.install import adtrustinstance
+from ipaserver.install import replication
 from ipaserver.install.upgradeinstance import IPAUpgrade
 from ipaserver.install.ldapupdate import BadSyntax
 
@@ -1575,11 +1576,14 @@ def update_replica_config(db_suffix):
     except ipalib.errors.NotFound:
         return  # entry does not exist until a replica is installed
 
-    if 'nsds5replicareleasetimeout' not in entry:
-        # See https://pagure.io/freeipa/issue/7488
-        root_logger.info("Adding nsds5replicaReleaseTimeout=60 to %s", dn)
-        entry['nsds5replicareleasetimeout'] = '60'
+    for key, value in replication.REPLICA_FINAL_SETTINGS.items():
+        entry[key] = value
+    try:
         api.Backend.ldap2.update_entry(entry)
+    except ipalib.errors.EmptyModlist:
+        pass
+    else:
+        root_logger.info("Updated entry %s", dn)
 
 
 def upgrade_configuration():


### PR DESCRIPTION
Manual backport of three PRs to 4.5 branch

### replicainstall: DS SSL replica install pick right certmonger host, 
- [x] PR #2115

Extend fix 0f31564b35aac250456233f98730811560eda664 to also move
the DS SSL setup so that the xmlrpc_uri is configured to point
to the remote master we are configuring against.

https://pagure.io/freeipa/issue/7566

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

### Tune DS replication settings
- [x] PR #2111

Tune 389-DS replication settings to improve performance and avoid
timeouts. During installation of a replica, the value of
nsDS5ReplicaBindDnGroupCheckInterval is reduced to 2 seconds. At the end
of the installation, the value is increased sensible production
settings. This avoids long delays during replication.

See: https://pagure.io/freeipa/issue/7617
Signed-off-by: Christian Heimes <cheimes@redhat.com>

### Auto-retry failed certmonger requests
- [x] PR #2122 
  
During parallel replica installation, a request sometimes fails with
CA_REJECTED or CA_UNREACHABLE. The error occur when the master is
either busy or some information haven't been replicated yet. Even
a stuck request can be recovered, e.g. when permission and group
information have been replicated.

A new function request_and_retry_cert() automatically resubmits failing
requests until it times out.

Fixes: https://pagure.io/freeipa/issue/7623
Signed-off-by: Christian Heimes <cheimes@redhat.com>

### Fix race condition in get_locations_records()
- [x] PR #2120

The method IPASystemRecords.get_locations_records() has a race condition.
The IPASystemRecords object creates a mapping of server names to server
data. get_locations_records() uses server_find() again to get a list of
servers, but then operates on the cached dict of server names.

In parallel replication case, the second server_find() call in
get_locations_records() can return additional servers. Since the rest of
the code operates on the cached data, the method then fails with a KeyError.

server_data is now an OrderedDict to keep same sorting as with
server_find().

Fixes: pagure.io/freeipa/issue/7566
Signed-off-by: Christian Heimes <cheimes@redhat.com>

### Note

**Fix CA topology warning**, PR #2114 does not apply to 4.5 branch. 4.5 doesn't have the code to print a warning.