### PR TITLE
[Backport][ipa-4-6] Tune DS replication settings

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -410,6 +410,9 @@ class CAInstance(DogtagInstance):
                           self.teardown_admin)
             self.step("starting certificate server instance",
                       self.start_instance)
+            if promote:
+                self.step("Finalize replication settings",
+                          self.finalize_replica_config)
         # Step 1 of external is getting a CSR so we don't need to do these
         # steps until we get a cert back from the external CA.
         if self.external != 1:
@@ -1245,12 +1248,15 @@ class CAInstance(DogtagInstance):
         api.Backend.ldap2.add_entry(entry)
 
     def __setup_replication(self):
-
         repl = replication.CAReplicationManager(self.realm, self.fqdn)
         repl.setup_cs_replication(self.master_host)
 
         # Activate Topology for o=ipaca segments
         self.__update_topology()
+
+    def finalize_replica_config(self):
+        repl = replication.CAReplicationManager(self.realm, self.fqdn)
+        repl.finalize_replica_config(self.master_host)
 
     def __enable_instance(self):
         basedn = ipautil.realm_to_suffix(self.realm)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1506,6 +1506,8 @@ def install(installer):
     # Apply any LDAP updates. Needs to be done after the replica is synced-up
     service.print_msg("Applying LDAP updates")
     ds.apply_updates()
+    service.print_msg("Finalize replication settings")
+    ds.finalize_replica_config()
 
     if kra_enabled:
         kra.install(api, config, options, custodia=custodia)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -47,6 +47,7 @@ from ipaserver.install import dnskeysyncinstance
 from ipaserver.install import dogtaginstance
 from ipaserver.install import krbinstance
 from ipaserver.install import adtrustinstance
+from ipaserver.install import replication
 from ipaserver.install.upgradeinstance import IPAUpgrade
 from ipaserver.install.ldapupdate import BadSyntax
 
@@ -1647,11 +1648,14 @@ def update_replica_config(db_suffix):
     except ipalib.errors.NotFound:
         return  # entry does not exist until a replica is installed
 
-    if 'nsds5replicareleasetimeout' not in entry:
-        # See https://pagure.io/freeipa/issue/7488
-        logger.info("Adding nsds5replicaReleaseTimeout=60 to %s", dn)
-        entry['nsds5replicareleasetimeout'] = '60'
+    for key, value in replication.REPLICA_FINAL_SETTINGS.items():
+        entry[key] = value
+    try:
         api.Backend.ldap2.update_entry(entry)
+    except ipalib.errors.EmptyModlist:
+        pass
+    else:
+        logger.info("Updated entry %s", dn)
 
 
 def fix_permissions():


### PR DESCRIPTION
Manual backport of PR #2111 to 4.6 branch

Tune 389-DS replication settings to improve performance and avoid
timeouts. During installation of a replica, the value of
nsDS5ReplicaBindDnGroupCheckInterval is reduced to 2 seconds. At the end
of the installation, the value is increased sensible production
settings. This avoids long delays during replication.

See: https://pagure.io/freeipa/issue/7617
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Tibor Dudlak <tdudlak@redhat.com>