### PR TITLE
Fix DNSSEC install regression

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -230,3 +230,15 @@ jobs:
         template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
+
+  fedora-28/dnssec:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl

--- a/install/tools/ipa-dns-install
+++ b/install/tools/ipa-dns-install
@@ -35,7 +35,6 @@ from ipapython.config import IPAOptionParser
 from ipapython.ipa_log_manager import standard_logging_setup
 
 from ipaserver.install import dns as dns_installer
-from ipaserver.install import service
 
 logger = logging.getLogger(os.path.basename(__file__))
 
@@ -142,9 +141,7 @@ def main():
 
     dns_installer.install_check(True, api, False, options, hostname=api.env.host)
     dns_installer.install(True, False, options)
-    # Enable configured services and update DNS SRV records
-    service.enable_services(api.env.host)
-    api.Command.dns_update_system_records()
+    # Services are enabled in dns_installer.install()
 
     # execute ipactl to refresh services status
     ipautil.run([paths.IPACTL, 'start', '--ignore-service-failures'],

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -44,6 +44,7 @@ from ipaserver.install import bindinstance
 from ipaserver.install import dnskeysyncinstance
 from ipaserver.install import odsexporterinstance
 from ipaserver.install import opendnssecinstance
+from ipaserver.install import service
 
 if six.PY3:
     unicode = str
@@ -355,6 +356,10 @@ def install(standalone, replica, options, api=api):
 
     dnskeysyncd.start_dnskeysyncd()
     bind.start_named()
+
+    # Enable configured services for standalone check_global_configuration()
+    if standalone:
+        service.enable_services(api.env.host)
 
     # this must be done when bind is started and operational
     bind.update_system_records()


### PR DESCRIPTION
7284097eedef70dd556270732e6ab8e23501ce09 introduced a regression in
DNSSEC master installation. For standalone and replica installation,
services have to be enabled before checking bind config.

Fixes: https://pagure.io/freeipa/issue/7635
See: https://pagure.io/freeipa/issue/7566
Signed-off-by: Christian Heimes <cheimes@redhat.com>