### PR TITLE
[Backport][ipa-4-6] Fix DNSSEC install regression

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -75,3 +75,14 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-27/dnssec:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl

--- a/install/tools/ipa-dns-install
+++ b/install/tools/ipa-dns-install
@@ -37,7 +37,6 @@ from ipapython.config import IPAOptionParser
 from ipapython.ipa_log_manager import standard_logging_setup
 
 from ipaserver.install import dns as dns_installer
-from ipaserver.install import service
 
 logger = logging.getLogger(os.path.basename(__file__))
 
@@ -149,9 +148,7 @@ def main():
 
     dns_installer.install_check(True, api, False, options, hostname=api.env.host)
     dns_installer.install(True, False, options)
-    # Enable configured services and update DNS SRV records
-    service.enable_services(api.env.host)
-    api.Command.dns_update_system_records()
+    # Services are enabled in dns_installer.install()
 
     # execute ipactl to refresh services status
     ipautil.run(['ipactl', 'start', '--ignore-service-failures'],

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -44,6 +44,7 @@ from ipaserver.install import bindinstance
 from ipaserver.install import dnskeysyncinstance
 from ipaserver.install import odsexporterinstance
 from ipaserver.install import opendnssecinstance
+from ipaserver.install import service
 
 if six.PY3:
     unicode = str
@@ -356,6 +357,10 @@ def install(standalone, replica, options, api=api):
 
     dnskeysyncd.start_dnskeysyncd()
     bind.start_named()
+
+    # Enable configured services for standalone check_global_configuration()
+    if standalone:
+        service.enable_services(api.env.host)
 
     # this must be done when bind is started and operational
     bind.update_system_records()


### PR DESCRIPTION
This PR was opened and then ACKed automatically because backport of PR #2128 was required. Wait for CI to finish before pushing. In case of questions or problems contact @tiran who is author of the original PR.