### PR TITLE
Fix pylint 2.0 return-related violations

### DIFF
--- a/ipaclient/install/ipadiscovery.py
+++ b/ipaclient/install/ipadiscovery.py
@@ -549,6 +549,7 @@ class IPADiscovery(object):
                     continue
                 if realm:
                     return realm
+        return None
 
     def ipadnssearchkrbkdc(self, domain=None):
         kdc = None

--- a/ipalib/frontend.py
+++ b/ipalib/frontend.py
@@ -1160,7 +1160,7 @@ class Command(HasParam):
         cls.register_callback('interactive_prompt', callback, first)
 
     def interactive_prompt_callback(self, kw):
-        return
+        pass
 
 
 class LocalOrRemote(Command):

--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -2005,7 +2005,6 @@ class AccessTime(Str):
             raise ValidationError(
                 name=self.get_param_name(), error=ugettext('incomplete time value')
             )
-        return None
 
 
 class DNParam(Param):

--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -140,8 +140,6 @@ class PlatformService(object):
         with open(paths.SVC_LIST_FILE, 'w') as f:
             json.dump(svc_list, f)
 
-        return
-
     def stop(self, instance_name="", capture_output=True,
              update_service_list=True):
         """
@@ -163,14 +161,12 @@ class PlatformService(object):
         with open(paths.SVC_LIST_FILE, 'w') as f:
             json.dump(svc_list, f)
 
-        return
-
     def reload_or_restart(self, instance_name="", capture_output=True,
                           wait=True):
-        return
+        pass
 
     def restart(self, instance_name="", capture_output=True, wait=True):
-        return
+        pass
 
     def is_running(self, instance_name="", wait=True):
         return False
@@ -185,22 +181,22 @@ class PlatformService(object):
         return False
 
     def enable(self, instance_name=""):
-        return
+        pass
 
     def disable(self, instance_name=""):
-        return
+        pass
 
     def mask(self, instance_name=""):
-        return
+        pass
 
     def unmask(self, instance_name=""):
-        return
+        pass
 
     def install(self, instance_name=""):
-        return
+        pass
 
     def remove(self, instance_name=""):
-        return
+        pass
 
 
 class SystemdService(PlatformService):

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -177,7 +177,7 @@ class BaseTaskNamespace(object):
         """
         Migrate pam stack configuration to authselect.
         """
-        return
+        pass
 
     def set_selinux_booleans(self, required_settings, backup_func=None):
         """Set the specified SELinux booleans

--- a/ipapython/install/core.py
+++ b/ipapython/install/core.py
@@ -275,8 +275,6 @@ class Configurable(six.with_metaclass(abc.ABCMeta, object)):
     def group(cls):
         assert not hasattr(super(Configurable, cls), 'group')
 
-        return None
-
     def __init__(self, **kwargs):
         """
         Initialize the configurable.
@@ -339,7 +337,7 @@ class Configurable(six.with_metaclass(abc.ABCMeta, object)):
         raise TypeError("{0} is not composite".format(self))
 
     def _get_fallback(self):
-        return None
+        pass
 
     @abc.abstractmethod
     def _configure(self):
@@ -362,6 +360,7 @@ class Configurable(six.with_metaclass(abc.ABCMeta, object)):
         self.validate()
         if self.__state == _EXECUTE_PENDING:
             return self.execute()
+        return None
 
     def validate(self):
         """

--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -746,6 +746,7 @@ class DomainValidator(object):
                         logger.warning('%s', msg)
 
                 return entries
+        return None
 
     def __retrieve_trusted_domain_gc_list(self, domain):
         """
@@ -1048,7 +1049,7 @@ class TrustDomainInstance(object):
         Only top level name and top level name exclusions are handled here.
         """
         if not another_domain.ftinfo_records:
-            return
+            return None
 
         ftinfo_records = []
         info = lsa.ForestTrustInformation()

--- a/ipaserver/dnssec/syncrepl.py
+++ b/ipaserver/dnssec/syncrepl.py
@@ -42,6 +42,7 @@ class SyncReplConsumer(ReconnectLDAPObject, SyncreplConsumer):
             return cookie
         else:
             logger.debug('Current cookie is: None (not received yet)')
+            return None
 
     def syncrepl_set_cookie(self, cookie):
         logger.debug('New cookie is: %s', cookie)

--- a/ipaserver/install/adtrust.py
+++ b/ipaserver/install/adtrust.py
@@ -262,7 +262,7 @@ def retrieve_potential_adtrust_agents(api):
     except (errors.DatabaseError, errors.NetworkError) as e:
         logger.error(
             "Could not retrieve a list of existing IPA masters: %s", e)
-        return
+        return None
 
     try:
         # search for existing AD trust agents
@@ -270,7 +270,7 @@ def retrieve_potential_adtrust_agents(api):
             servrole=u'AD trust agent', all=True)['result']
     except (errors.DatabaseError, errors.NetworkError) as e:
         logger.error("Could not retrieve a list of adtrust agents: %s", e)
-        return
+        return None
 
     dl_enabled_master_cns = {m['cn'][0] for m in dl_enabled_masters}
     adtrust_agents_cns = {m['cn'][0] for m in adtrust_agents}

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -141,6 +141,7 @@ def named_conf_get_directive(name, section=NAMED_SECTION_IPA, str_val=True):
 
                 if match and name == match.group('name'):
                     return match.group('value')
+    return None
 
 
 def named_conf_set_directive(name, value, section=NAMED_SECTION_IPA,

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -174,6 +174,7 @@ def find_substring(data, value):
     for d in data:
         if d.startswith(value):
             return get_value(d)
+    return None
 
 
 def get_defList(data):

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -126,6 +126,8 @@ class CACertManage(admintool.AdminTool):
                 return self.renew()
             elif command == 'install':
                 return self.install()
+            else:
+                raise NotImplementedError
         finally:
             api.Backend.ldap2.disconnect()
 

--- a/ipaserver/install/ipa_server_certinstall.py
+++ b/ipaserver/install/ipa_server_certinstall.py
@@ -246,6 +246,7 @@ class ServerCertInstall(admintool.AdminTool):
                     return req_id
         except RuntimeError as e:
             raise admintool.ScriptError(str(e))
+        return None
 
     def check_chain(self, pkcs12_filename, pkcs12_pin, nssdb):
         # create a temp nssdb

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -63,7 +63,7 @@ def get_pkinit_request_ca():
         {'cert-file': paths.KDC_CERT})
 
     if pkinit_request_id is None:
-        return
+        return None
 
     return certmonger.get_request_value(pkinit_request_id, 'ca-name')
 

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -110,7 +110,7 @@ def safe_output(attr, values):
             return 'XXXXXXXX'
 
     if values is None:
-        return
+        return None
 
     is_list = type(values) in (tuple, list)
 

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1216,6 +1216,7 @@ def find_subject_base():
 
     logger.error('Unable to determine certificate subject base. '
                  'certmap.conf will not be updated.')
+    return None
 
 
 def uninstall_selfsign(ds, http):

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -319,7 +319,7 @@ class Service(object):
     def principal(self):
         if any(attr is None for attr in (self.realm, self.fqdn,
                                          self.service_prefix)):
-            return
+            return None
 
         return unicode(
             kerberos.Principal(

--- a/ipaserver/p11helper.py
+++ b/ipaserver/p11helper.py
@@ -929,6 +929,7 @@ class P11_Helper(object):
             if self.token_label == char_array_to_unicode(
                     token_info_ptr[0].label, 32).rstrip():
                 return slot
+        return None
 
     def finalize(self):
         """

--- a/ipaserver/plugins/aci.py
+++ b/ipaserver/plugins/aci.py
@@ -412,6 +412,7 @@ def validate_permissions(ugettext, perm):
     perm = perm.strip().lower()
     if perm not in _valid_permissions_values:
         return '"%s" is not a valid permission' % perm
+    return None
 
 
 def _normalize_permissions(perm):

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -319,6 +319,7 @@ def validate_externalhost(ugettext, hostname):
         validate_hostname(hostname, check_fqdn=False, allow_underscore=True)
     except ValueError as e:
         return unicode(e)
+    return None
 
 
 external_host_param = Str('externalhost*', validate_externalhost,

--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -92,10 +92,10 @@ def validate_search_records_limit(ugettext, value):
     Values 0 and -1 are valid, as they represent unlimited.
     """
     if value in {-1, 0}:
-        return
+        return None
     if value < 10:
         return _('must be at least 10')
-
+    return None
 
 @register()
 class config(LDAPObject):

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -401,7 +401,7 @@ def _validate_ipnet(ugettext, ipnet):
 
 def _validate_bind_aci(ugettext, bind_acis):
     if not bind_acis:
-        return
+        return None
 
     bind_acis = bind_acis.split(';')
     if bind_acis[-1]:
@@ -422,10 +422,11 @@ def _validate_bind_aci(ugettext, bind_acis):
             return unicode(e)
         except UnboundLocalError:
             return _(u"invalid address format")
+    return None
 
 def _normalize_bind_aci(bind_acis):
     if not bind_acis:
-        return
+        return None
     bind_acis = bind_acis.split(';')
     normalized = []
     for bind_aci in bind_acis:
@@ -729,7 +730,7 @@ class DNSRecord(Str):
         vals = tuple(kw.get(part_name) for part_name in part_names)
 
         if all(val is None for val in vals):
-             return
+            return None
 
         if raise_on_none:
             for val_id,val in enumerate(vals):
@@ -789,17 +790,17 @@ class DNSRecord(Str):
 
     def _rule_validatedns(self, _, value):
         if not self.validatedns:
-            return
+            return None
 
         if value is None:
-            return
+            return None
 
         if not self.supported:
             return _('DNS RR type "%s" is not supported by bind-dyndb-ldap plugin') \
                      % self.rrtype
 
         if self.parts is None:
-            return
+            return None
 
         # validate record format
         values = self._get_part_values(value)
@@ -1282,6 +1283,8 @@ def _validate_naptr_flags(ugettext, flags):
     for flag in flags:
         if flag not in allowed_flags:
             return _('flags must be one of "S", "A", "U", or "P"')
+    return None
+
 
 class NAPTRRecord(DNSRecord):
     rrtype = 'NAPTR'
@@ -1370,6 +1373,7 @@ def _sig_time_validator(ugettext, value):
         time.strptime(value, time_format)
     except ValueError:
         return _('the value does not follow "YYYYMMDDHHMMSS" time format')
+    return None
 
 
 class SIGRecord(UnsupportedDNSRecord):
@@ -1460,7 +1464,7 @@ def _normalize_uri_target(uri_target):
     # RFC 7553 section 4.4: The Target MUST NOT be an empty URI ("").
     # minlength in param will detect this
     if not uri_target:
-        return
+        return None
     return u'"{0}"'.format(uri_target)
 
 

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1284,7 +1284,7 @@ class RestClient(Backend):
     def __enter__(self):
         """Log into the REST API"""
         if self.cookie is not None:
-            return
+            return None
 
         # Refresh the ca_host property
         object.__setattr__(self, '_ca_host', None)

--- a/ipaserver/plugins/hbacrule.py
+++ b/ipaserver/plugins/hbacrule.py
@@ -118,8 +118,7 @@ def is_all(options, attribute):
             value = options[attribute].lower()
         if value == 'all':
             return True
-    else:
-        return False
+    return False
 
 
 @register()

--- a/ipaserver/plugins/permission.py
+++ b/ipaserver/plugins/permission.py
@@ -127,6 +127,7 @@ def strip_ldap_prefix(uri):
 def prevalidate_filter(ugettext, value):
     if not value.startswith('(') or not value.endswith(')'):
         return _('must be enclosed in parentheses')
+    return None
 
 
 class DNOrURL(DNParam):
@@ -148,6 +149,7 @@ def validate_type(ugettext, typestr):
         return _('"%s" is not an object type') % typestr
     if not getattr(obj, 'permission_filter_objectclasses', None):
         return _('"%s" is not a valid permission type') % typestr
+    return None
 
 
 def _disallow_colon(option):
@@ -903,6 +905,8 @@ class permission(baseldap.LDAPObject):
         elif filter_ops['add']:
             options['ipapermtargetfilter'] = list(options.get(
                 'ipapermtargetfilter') or []) + filter_ops['add']
+
+        return None
 
     def validate_permission(self, entry):
         ldap = self.Backend.ldap2

--- a/ipaserver/plugins/realmdomains.py
+++ b/ipaserver/plugins/realmdomains.py
@@ -72,6 +72,7 @@ def _domain_name_validator(ugettext, value):
         validate_domain_name(value, allow_slash=False)
     except ValueError as e:
         return unicode(e)
+    return None
 
 
 @register()

--- a/ipaserver/plugins/selinuxusermap.py
+++ b/ipaserver/plugins/selinuxusermap.py
@@ -140,8 +140,6 @@ def validate_selinuxuser_inlist(ldap, user):
             reason=_('SELinux user %(user)s not found in '
                      'ordering list (in config)') % dict(user=user))
 
-    return
-
 
 @register()
 class selinuxusermap(LDAPObject):

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -196,7 +196,7 @@ def read_input(environ):
     try:
         length = int(environ.get('CONTENT_LENGTH'))
     except (ValueError, TypeError):
-        return
+        return None
     return environ['wsgi.input'].read(length).decode('utf-8')
 
 
@@ -613,13 +613,13 @@ class KerberosSession(HTTP_Status):
         ccache_name = environ.get('KRB5CCNAME')
         if ccache_name is None:
             logger.debug('no ccache, need login')
-            return
+            return None
 
         # ... make sure we have a name ...
         principal = environ.get('GSS_NAME')
         if principal is None:
             logger.debug('no Principal Name, need login')
-            return
+            return None
 
         # ... and use it to resolve the ccache name (Issue: 6972 )
         gss_name = gssapi.Name(principal, gssapi.NameType.kerberos_principal)
@@ -630,7 +630,7 @@ class KerberosSession(HTTP_Status):
         if not creds:
             logger.debug(
                 'ccache expired or invalid, deleting session, need login')
-            return
+            return None
 
         return ccache_name
 

--- a/ipaserver/secrets/client.py
+++ b/ipaserver/secrets/client.py
@@ -114,3 +114,5 @@ class CustodiaClient(object):
             self.keystore.set('keys/%s' % keyname, value)
         else:
             return value
+
+        return None


### PR DESCRIPTION
Aiming to support pylint 2.0 some functions and methods must have their
return statements updated in order to fix two new violations:

- `useless-return` (R1711):
  Useless return at end of function or method Emitted when a single
  "return" or "return None" statement is found at the end of function
  or method definition. This statement can safely be removed because
  Python will implicitly return None

- `inconsistent-return-statements` (R1710):
  Either all return statements in a function should return an
  expression, or none of them should. According to PEP8, if any return
  statement returns an expression, any return statements where no value
  is returned should explicitly state this as return None, and an
  explicit return statement should be present at the end of the
  function (if reachable)

Issue: https://pagure.io/freeipa/issue/7614

Signed-off-by: Armando Neto <abiagion@redhat.com>