### PR TITLE
pylint 2.0: node.path is a list

### DIFF
--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -364,6 +364,11 @@ class IPAChecker(BaseChecker):
 
     def _get_forbidden_import_rule(self, node):
         path = node.path
+        if path and isinstance(path, list):
+            # In pylint 2.0, path is a list with one element. Namespace
+            # packages may contain more than one element, but we can safely
+            # ignore them, as they don't contain code.
+            path = path[0]
         if path:
             path = os.path.abspath(path)
             while path.startswith(self._dir):


### PR DESCRIPTION
In pylint 2.0 and astroid 2.0, node.path has become a list. It's usually
a list of one element unless namespace packages are involved.

See https://github.com/PyCQA/astroid/commit/7f46f9341cc54bbe6763409c4ca7ea3adfec098a#diff-f0ac879524bcb98964f7d8738a084820

See: https://pagure.io/freeipa/issue/7614
Signed-off-by: Christian Heimes <cheimes@redhat.com>