### PR TITLE
Add tab completion and history to ipa console

### DIFF
--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -992,12 +992,18 @@ class console(frontend.Command):
         )
         if filename:
             try:
-                script = open(filename)
+                with open(filename) as f:
+                    source = f.read()
             except IOError as e:
                 sys.exit("%s: %s" % (e.filename, e.strerror))
             try:
-                with script:
-                    exec(script, globals(), local)
+                compiled = compile(
+                    source,
+                    filename,
+                    'exec',
+                    flags=print_function.compiler_flag
+                )
+                exec(compiled, globals(), local)
             except Exception:
                 traceback.print_exc()
                 sys.exit(1)

--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -1313,6 +1313,20 @@ def run_certutil(host, args, reqdir, dbtype=None,
                             stdin_text=stdin)
 
 
+def upload_temp_contents(host, contents, encoding='utf-8'):
+    """Upload contents to a temporary file
+
+    :param host: Remote host instance
+    :param contents: file content (str, bytes)
+    :param encoding: file encoding
+    :return: Temporary file name
+    """
+    result = host.run_command(['mktemp'])
+    tmpname = result.stdout_text.strip()
+    host.put_file_contents(tmpname, contents, encoding=encoding)
+    return tmpname
+
+
 def assert_error(result, stderr_text, returncode=None):
     "Assert that `result` command failed and its stderr contains `stderr_text`"
     assert stderr_text in result.stderr_text, result.stderr_text

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -164,3 +164,19 @@ class TestIPACommand(IntegrationTest):
         assert result.returncode == 0
         assert "SELinux user map order: {}".format(
             maporder) in result.stdout_text
+
+    def test_ipa_console(self):
+        result = self.master.run_command(
+            ["ipa", "console"],
+            stdin_text="api.env"
+        )
+        assert "ipalib.config.Env" in result.stdout_text
+
+        filename = tasks.upload_temp_contents(
+            self.master,
+            "print(api.env)\n"
+        )
+        result = self.master.run_command(
+            ["ipa", "console", filename],
+        )
+        assert "ipalib.config.Env" in result.stdout_text


### PR DESCRIPTION
ipa console is a useful tool to use FreeIPA's API in an interactive
Python console. The patch adds readline tab completion and history
support.

The PR also fixes a bug in ``ipa console filename`` case and adds a test case.

Signed-off-by: Christian Heimes <cheimes@redhat.com>