### PR TITLE
Fix pylint 2.0 conditional-related violations

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2081,7 +2081,7 @@ def install_check(options):
             rval=CLIENT_INSTALL_ERROR
         )
 
-    if (hostname == 'localhost') or (hostname == 'localhost.localdomain'):
+    if hostname in ('localhost', 'localhost.localdomain'):
         raise ScriptError(
             "Invalid hostname, '{}' must not be used.".format(hostname),
             rval=CLIENT_INSTALL_ERROR)

--- a/ipalib/aci.py
+++ b/ipalib/aci.py
@@ -113,10 +113,10 @@ class ACI(object):
             if token == "(":
                 var = next(lexer).strip()
                 operator = next(lexer)
-                if operator != "=" and operator != "!=":
+                if operator not in ("=", "!="):
                     # Peek at the next char before giving up
                     operator = operator + next(lexer)
-                    if operator != "=" and operator != "!=":
+                    if operator not in ("=", "!="):
                         raise SyntaxError("No operator in target, got '%s'" % operator)
                 op = operator
                 val = next(lexer).strip()

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -676,7 +676,7 @@ class textui(backend.Backend):
                 return -1
             try:
                 selection = int(resp) - 1
-                if (selection >= 0 and selection < counter):
+                if (counter > selection >= 0):
                     break
             except Exception:
                 # fall through to the error msg

--- a/ipapython/graph.py
+++ b/ipapython/graph.py
@@ -55,7 +55,7 @@ class Graph(object):
 
         # delete edges
         self.edges = [
-            e for e in self.edges if e[0] != vertex and e[1] != vertex
+            e for e in self.edges if vertex not in (e[0], e[1])
         ]
 
     def get_tails(self, head):

--- a/ipaserver/dnssec/bindmgr.py
+++ b/ipaserver/dnssec/bindmgr.py
@@ -90,7 +90,7 @@ class BINDMgr(object):
 
         Change is only recorded to memory.
         self.sync() has to be called to synchronize change to BIND."""
-        assert op == 'add' or op == 'del' or op == 'mod'
+        assert op in ('add', 'del', 'mod')
         zone = self.dn2zone_name(attrs['dn'])
         self.modified_zones.add(zone)
         zone_keys = self.ldap_keys.setdefault(zone, {})

--- a/ipaserver/dnssec/odsmgr.py
+++ b/ipaserver/dnssec/odsmgr.py
@@ -106,7 +106,7 @@ class LDAPZoneListReader(ZoneListReader):
         super(LDAPZoneListReader, self).__init__()
 
     def process_ipa_zone(self, op, uuid, zone_ldap):
-        assert (op == 'add' or op == 'del'), 'unsupported op %s' % op
+        assert (op in ['add', 'del']), 'unsupported op %s' % op
         assert uuid is not None
         assert 'idnsname' in zone_ldap, \
             'LDAP zone UUID %s without idnsName' % uuid
@@ -177,7 +177,7 @@ class ODSMgr(object):
 
         Change is only recorded to memory.
         self.sync() have to be called to synchronize change to ODS."""
-        assert op == 'add' or op == 'del'
+        assert op in ('add', 'del')
         self.zl_ldap.process_ipa_zone(op, uuid, attrs)
         logger.debug("LDAP zones: %s", self.zl_ldap.mapping)
 

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -209,7 +209,7 @@ def verify_fqdn(host_name, no_host_dns=False, local_hostname=True):
         address = a[4][0]
         if address in verified:
             continue
-        if address == '127.0.0.1' or address == '::1':
+        if address in ('127.0.0.1', '::1'):
             raise HostForwardLookupError("The IPA Server hostname must not resolve to localhost (%s). A routable IP address must be used. Check /etc/hosts to see if %s is an alias for %s" % (address, host_name, address))
         try:
             logger.debug('Check reverse address of %s', address)

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1692,7 +1692,7 @@ class cert_find(Search, CertMethod):
                     self.obj._fill_owners(obj)
 
         result = list(six.itervalues(result))
-        if sizelimit > 0 and len(result) > sizelimit:
+        if (len(result) > sizelimit > 0):
             if not truncated:
                 self.add_message(messages.SearchResultTruncated(
                         reason=errors.SizeLimitExceeded()))

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -339,9 +339,9 @@ def parse_and_set_boolean_xml(node, response, response_name):
     - off
     '''
     value = node.text.strip().lower()
-    if value == 'true' or value == 'yes':
+    if value in ('true', 'yes'):
         value = True
-    elif value == 'false' or value == 'no':
+    elif value in ('false', 'no'):
         value = False
     else:
         raise ValueError('expected true|false|yes|no|on|off for "%s", but got "%s"' % \


### PR DESCRIPTION
In order to support pylint 2.0 the following violations must be fixed:

- `chained-comparison` (R1716):
  Simplify chained comparison between the operands This message is
  emitted when pylint encounters boolean operation like
  "a < b and b < c", suggesting instead to refactor it to "a < b < c".

- `consider-using-in` (R1714):
  Consider merging these comparisons with "in" to %r To check if a
  variable is equal to one of many values,combine the values into a
  tuple and check if the variable is contained "in" it instead of
  checking for equality against each of the values.This is faster
  and less verbose.

Issue: https://pagure.io/freeipa/issue/7614

Signed-off-by: Armando Neto <abiagion@redhat.com>