### PR TITLE
Add a skeleton kdcpolicy plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -231,6 +231,9 @@ AM_COND_IF([BUILD_IPA_CERTAUTH_PLUGIN], [
                [AC_MSG_WARN([Cannot build IPA KDB certauth plugin])])
 ])
 
+AM_CONDITIONAL([BUILD_IPA_KDCPOLICY_PLUGIN],
+               [test x$have_kdcpolicy_plugin = xyes])
+
 dnl ---------------------------------------------------------------------------
 dnl - Check for program paths
 dnl ---------------------------------------------------------------------------

--- a/daemons/ipa-kdb/Makefile.am
+++ b/daemons/ipa-kdb/Makefile.am
@@ -46,6 +46,10 @@ if BUILD_IPA_CERTAUTH_PLUGIN
 ipadb_la_SOURCES += ipa_kdb_certauth.c
 endif
 
+if BUILD_IPA_KDCPOLICY_PLUGIN
+ipadb_la_SOURCES += ipa_kdb_kdcpolicy.c
+endif
+
 ipadb_la_LDFLAGS = 		\
 	-avoid-version 		\
 	-module			\
@@ -83,6 +87,10 @@ ipa_kdb_tests_SOURCES =        \
 
 if BUILD_IPA_CERTAUTH_PLUGIN
 ipa_kdb_tests_SOURCES += ipa_kdb_certauth.c
+endif
+
+if BUILD_IPA_KDCPOLICY_PLUGIN
+ipa_kdb_tests_SOURCES += ipa_kdb_kdcpolicy.c
 endif
 
 ipa_kdb_tests_CFLAGS = $(CMOCKA_CFLAGS)

--- a/daemons/ipa-kdb/ipa_kdb.exports
+++ b/daemons/ipa-kdb/ipa_kdb.exports
@@ -4,6 +4,7 @@ EXPORTED {
 	global:
 		kdb_function_table;
 		certauth_ipakdb_initvt;
+		kdcpolicy_ipakdb_initvt;
 
 	# everything else is local
 	local:

--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+ */
+
+#include <errno.h>
+#include <syslog.h>
+#include <krb5/kdcpolicy_plugin.h>
+
+#include "ipa_krb5.h"
+#include "ipa_kdb.h"
+
+struct krb5_kdcpolicy_moddata_st {
+    /* Storage struct for kdcpolicy callback state */
+    ;
+};
+
+static krb5_error_code ipa_kdcpolicy_init(krb5_context context,
+                                          krb5_kdcpolicy_moddata *data_out)
+{
+    struct krb5_kdcpolicy_moddata_st *data = calloc(1, sizeof(*data));
+    if (data == NULL) {
+        return ENOMEM;
+    }
+
+    krb5_klog_syslog(LOG_INFO, "IPA kdcpolicy plugin loaded.");
+    *data_out = data;
+    return 0;
+}
+
+static krb5_error_code ipa_kdcpolicy_fini(krb5_context context,
+                                          krb5_kdcpolicy_moddata moddata)
+{
+    free(moddata);
+    krb5_klog_syslog(LOG_INFO, "IPA kdcpolicy plugin unloaded.");
+    return 0;
+}
+
+static krb5_error_code
+ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
+                       const krb5_kdc_req *request,
+                       const krb5_db_entry *client,
+                       const krb5_db_entry *server,
+                       const char *const *auth_indicators,
+                       const char **status, krb5_deltat *lifetime_out,
+                       krb5_deltat *renew_lifetime_out)
+{
+    *status = NULL;
+    *lifetime_out = 0;
+    *renew_lifetime_out = 0;
+
+    krb5_klog_syslog(LOG_INFO, "IPA kdcpolicy: checking AS-REQ.");
+
+    return 0;
+}
+
+static krb5_error_code
+ipa_kdcpolicy_check_tgs(krb5_context context, krb5_kdcpolicy_moddata moddata,
+                        const krb5_kdc_req *request,
+                        const krb5_db_entry *server,
+                        const krb5_ticket *ticket,
+                        const char *const *auth_indicators,
+                        const char **status, krb5_deltat *lifetime_out,
+                        krb5_deltat *renew_lifetime_out)
+{
+    *status = NULL;
+    *lifetime_out = 0;
+    *renew_lifetime_out = 0;
+
+    krb5_klog_syslog(LOG_INFO, "IPA kdcpolicy: checking TGS-REQ.");
+
+    return 0;
+}
+
+krb5_error_code kdcpolicy_ipakdb_initvt(krb5_context context,
+                                        int maj_ver, int min_ver,
+                                        krb5_plugin_vtable vtable)
+{
+    krb5_kdcpolicy_vtable vt;
+
+    if (maj_ver != 1)
+        return KRB5_PLUGIN_VER_NOTSUPP;
+
+    vt = (krb5_kdcpolicy_vtable)vtable;
+    vt->name = "ipakdb";
+    vt->init = ipa_kdcpolicy_init;
+    vt->fini = ipa_kdcpolicy_fini;
+    vt->check_as = ipa_kdcpolicy_check_as;
+    vt->check_tgs = ipa_kdcpolicy_check_tgs;
+    return 0;
+}

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -930,6 +930,8 @@ if [ $1 -gt 1 ] ; then
             cp /etc/ipa/ca.crt /var/lib/ipa-client/pki/kdc-ca-bundle.pem
             cp /etc/ipa/ca.crt /var/lib/ipa-client/pki/ca-bundle.pem
         fi
+
+        %{__python3} -c 'from ipaclient.install.client import configure_krb5_snippet; configure_krb5_snippet()' >>/var/log/ipaupgrade.log 2>&1
     fi
 
     if [ $restore -ge 2 ]; then

--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -51,6 +51,7 @@ dist_app_DATA =				\
 	kdc_extensions.template		\
 	kdc_req.conf.template		\
 	krb5.conf.template		\
+	freeipa-server.template		\
 	krb5.ini.template		\
 	krb.con.template		\
 	krbrealm.con.template		\

--- a/install/share/freeipa-server.template
+++ b/install/share/freeipa-server.template
@@ -1,0 +1,5 @@
+[plugins]
+    certauth = {
+        module = ipakdb:kdb/ipadb.so
+        enable_only = ipakdb
+    }

--- a/install/share/freeipa-server.template
+++ b/install/share/freeipa-server.template
@@ -3,3 +3,7 @@
         module = ipakdb:kdb/ipadb.so
         enable_only = ipakdb
     }
+    kdcpolicy = {
+        module = ipakdb:kdb/ipadb.so
+        enable_only = ipakdb
+    }

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -662,19 +662,23 @@ def hardcode_ldap_server(cli_server):
         "hardcoded server name: %s", cli_server[0])
 
 
-def configure_krb5_conf(
-        cli_realm, cli_domain, cli_server, cli_kdc, dnsok,
-        filename, client_domain, client_hostname, force=False,
-        configure_sssd=True):
-
-    # First, write a snippet to krb5.conf.d.  Currently this doesn't support
-    # templating, but that could be changed in the future.
+# Currently this doesn't support templating, but that could be changed in the
+# future.  Note that this function is also called from %post.
+def configure_krb5_snippet():
     template = os.path.join(
         paths.USR_SHARE_IPA_CLIENT_DIR,
         os.path.basename(paths.KRB5_FREEIPA) + ".template"
     )
     shutil.copy(template, paths.KRB5_FREEIPA)
     os.chmod(paths.KRB5_FREEIPA, 0o644)
+
+
+def configure_krb5_conf(
+        cli_realm, cli_domain, cli_server, cli_kdc, dnsok,
+        filename, client_domain, client_hostname, force=False,
+        configure_sssd=True):
+    # First, write a snippet to krb5.conf.d.
+    configure_krb5_snippet()
 
     # Then, perform the rest of our configuration into krb5.conf itself.
     krbconf = IPAChangeConf("IPA Installer")

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -74,6 +74,7 @@ class BasePathNamespace:
     COMMON_KRB5_CONF_DIR = "/etc/krb5.conf.d/"
     KRB5_CONF = "/etc/krb5.conf"
     KRB5_FREEIPA = COMMON_KRB5_CONF_DIR + "freeipa"
+    KRB5_FREEIPA_SERVER = COMMON_KRB5_CONF_DIR + "freeipa-server"
     KRB5_KEYTAB = "/etc/krb5.keytab"
     LDAP_CONF = "/etc/ldap.conf"
     LIBNSS_LDAP_CONF = "/etc/libnss-ldap.conf"

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -348,6 +348,7 @@ class KrbInstance(service.Service):
     def __configure_instance(self):
         self.__template_file(paths.KRB5KDC_KDC_CONF, chmod=None)
         self.__template_file(paths.KRB5_CONF)
+        self.__template_file(paths.KRB5_FREEIPA_SERVER)
         self.__template_file(paths.KRB5_FREEIPA, client_template=True)
         self.__template_file(paths.HTML_KRB5_INI)
         self.__template_file(paths.KRB_CON)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1628,36 +1628,16 @@ def setup_spake(krb):
         aug.close()
 
 
-def enable_certauth(krb):
-    logger.info("[Enable certauth]")
+# Currently, this doesn't support templating.
+def enable_server_snippet():
+    logger.info("[Enable server krb5.conf snippet]")
 
-    aug = Augeas(flags=Augeas.NO_LOAD | Augeas.NO_MODL_AUTOLOAD,
-                 loadpath=paths.USR_SHARE_IPA_DIR)
-    try:
-        aug.transform('IPAKrb5', paths.KRB5_CONF)
-        aug.load()
-
-        path = '/files{}/plugins/certauth'.format(paths.KRB5_CONF)
-        modified = False
-
-        if not aug.match(path):
-            aug.set('{}/module'.format(path), 'ipakdb:kdb/ipadb.so')
-            aug.set('{}/enable_only'.format(path), 'ipakdb')
-            modified = True
-
-        if modified:
-            try:
-                aug.save()
-            except IOError:
-                for error_path in aug.match('/augeas//error'):
-                    logger.error('augeas: %s', aug.get(error_path))
-                raise
-
-            if krb.is_running():
-                krb.stop()
-            krb.start()
-    finally:
-        aug.close()
+    template = os.path.join(
+        paths.USR_SHARE_IPA_CLIENT_DIR,
+        os.path.basename(paths.KRB5_FREEIPA_SERVER) + ".template"
+    )
+    shutil.copy(template, paths.KRB5_FREEIPA)
+    os.chmod(paths.KRB5_FREEIPA, 0o644)
 
 
 def ntpd_cleanup(fqdn, fstore):
@@ -2112,7 +2092,7 @@ def upgrade_configuration():
     krb.add_anonymous_principal()
     setup_spake(krb)
     setup_pkinit(krb)
-    enable_certauth(krb)
+    enable_server_snippet()
 
     if not ds_running:
         ds.stop(ds.serverid)

--- a/server.m4
+++ b/server.m4
@@ -53,6 +53,11 @@ AC_CHECK_HEADER([krb5/certauth_plugin.h],
                 [have_certauth_plugin=yes],
                 [have_certauth_plugin=no])
 
+dnl -- Check if we can build the kdcpolicy plugin
+AC_CHECK_HEADER([krb5/kdcpolicy_plugin.h],
+                [have_kdcpolicy_plugin=yes],
+                [have_kdcpolicy_plugin=no])
+
 dnl ---------------------------------------------------------------------------
 dnl - Check for KRB5 krad
 dnl ---------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Robbie Harwood <rharwood@redhat.com>

Back in krb5-1.16 (and in RHEL-7.5), I added the [kdcpolicy plugin](http://web.mit.edu/kerberos/krb5-devel/doc/plugindev/kdcpolicy.html) to krb5.  This interface allows a module to hook all AS and TGS requests, potentially reject them, and manipulate ticket lifetimes.  This PR is a basic implementation of the interface, with all the plumbing IPA needs to get it loaded and installed.

There are ~~two~~ three use cases I had in mind, though of course many more are possible (this is a very powerful place to have a hook into the KDC):

- Reduced ticket lifetimes based on [auth indicator](http://web.mit.edu/kerberos/krb5-devel/doc/admin/auth_indicator.html)
- Adding (well, subtracting) random jitter from certain principal lifetimes to reduce contention from groups of tickets all needing renewal simultaneously
- Time-based access control to hosts/services

Since presumably we don't want any of that to be hardcoded behavior, the difficult part is now making it all configurable.  (As well as figuring out any behavior we want to control at the moment).  Per IRC conversation, I'm opening this PR so that we have something to look at while we discuss that.

BACKPORT NOTE: there's a spec file change in this PR.