### PR TITLE
Fix Pylint 2.0 violations

### DIFF
--- a/ipaclient/plugins/automember.py
+++ b/ipaclient/plugins/automember.py
@@ -28,8 +28,9 @@ register = Registry()
 @register(override=True, no_fail=True)
 class automember_add_condition(MethodOverride):
     has_output_params = (
-        Str('failed',
-        label=_('Failed to add'),
-        flags=['suppress_empty'],
+        Str(
+            'failed',
+            label=_('Failed to add'),
+            flags=['suppress_empty'],
         ),
     )

--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -669,9 +669,8 @@ class ModVaultData(Local):
 
         name = self.name + '_internal'
         try:
+            # ipalib.errors.NotFound exception can be propagated
             return self.api.Command[name](*args, **options)
-        except errors.NotFound:
-            raise
         except (errors.InternalError,
                 errors.ExecutionError,
                 errors.GenericError):

--- a/ipalib/backend.py
+++ b/ipalib/backend.py
@@ -139,7 +139,7 @@ class Executioner(Backend):
             if _name not in self.Command:
                 raise CommandError(name=_name)
             return self.Command[_name](*args, **options)
-        except PublicError:
+        except PublicError:  # pylint: disable=try-except-raise
             raise
         except Exception as e:
             logger.exception(

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -1071,9 +1071,11 @@ class RPCClient(Connectible):
                             )
                     # We don't care about the response, just that we got one
                     return serverproxy
+                # pylint: disable=try-except-raise
                 except errors.KerberosError:
                     # kerberos error on one server is likely on all
                     raise
+                # pylint: enable=try-except-raise
                 except ProtocolError as e:
                     if hasattr(context, 'session_cookie') and e.errcode == 401:
                         # Unauthorized. Remove the session and try again.

--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -367,7 +367,7 @@ class SystemdService(PlatformService):
                 return False
             else:
                 svar = self.parse_variables(result.output)
-                if not self.service_instance("") in svar:
+                if self.service_instance("") not in svar:
                     # systemd doesn't show the service
                     return False
         except ipautil.CalledProcessError:

--- a/ipapython/install/core.py
+++ b/ipapython/install/core.py
@@ -310,8 +310,6 @@ class Configurable(six.with_metaclass(abc.ABCMeta, object)):
             prop = prop_cls(self)
             try:
                 prop.validate(value)
-            except KnobValueError:
-                raise
             except ValueError as e:
                 raise KnobValueError(name, str(e))
 

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -208,11 +208,10 @@ class SchemaCache(object):
             info = e.args[0].get('info', '').strip()
             raise errors.DatabaseError(desc = u'uri=%s' % url,
                                 info = u'Unable to retrieve LDAP schema: %s: %s' % (desc, info))
-        except IndexError:
-            # no 'cn=schema' entry in LDAP? some servers use 'cn=subschema'
-            # TODO: DS uses 'cn=schema', support for other server?
-            #       raise a more appropriate exception
-            raise
+
+        # no 'cn=schema' entry in LDAP? some servers use 'cn=subschema'
+        # TODO: DS uses 'cn=schema', support for other server?
+        #       raise a more appropriate exception
 
         return ldap.schema.SubSchema(schema_entry[1])
 

--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -68,7 +68,7 @@ from time import sleep
 try:
     from ldap.controls import RequestControl as LDAPControl
 except ImportError:
-    from ldap.controls import LDAPControl as LDAPControl
+    from ldap.controls import LDAPControl
 
 if six.PY3:
     unicode = str
@@ -1726,8 +1726,8 @@ class TrustDomainJoins(object):
         self.local_domain.establish_trust(self.remote_domain,
                                           trustdom_passwd,
                                           trust_type, trust_external)
-        return dict(
-                    local=self.local_domain,
-                    remote=self.remote_domain,
-                    verified=False
-                   )
+        return {
+            'local': self.local_domain,
+            'remote': self.remote_domain,
+            'verified': False,
+        }

--- a/ipaserver/p11helper.py
+++ b/ipaserver/p11helper.py
@@ -467,16 +467,11 @@ p11_kit_uri_free = _libp11_kit.p11_kit_uri_free
 def loadLibrary(module):
     """Load the PKCS#11 library"""
     # Load PKCS #11 library
-    try:
-        if module:
-            # pylint: disable=no-member
-            pDynLib = _ffi.dlopen(module, _ffi.RTLD_NOW | _ffi.RTLD_LOCAL)
-        else:
-            raise Exception()
-
-    except Exception:
-        # Failed to load the PKCS #11 library
-        raise
+    if module:
+        # pylint: disable=no-member
+        pDynLib = _ffi.dlopen(module, _ffi.RTLD_NOW | _ffi.RTLD_LOCAL)
+    else:
+        raise Exception()
 
     # Retrieve the entry point for C_GetFunctionList
     pGetFunctionList = pDynLib.C_GetFunctionList

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -1073,7 +1073,9 @@ last, after all sets and adds."""),
                 entry_attrs[attr] = value
             else:
                 # unknown attribute: remove duplicite and invalid values
-                entry_attrs[attr] = list(set([val for val in entry_attrs[attr] if val]))
+                entry_attrs[attr] = list(
+                    {val for val in entry_attrs[attr] if val}
+                )
                 if not entry_attrs[attr]:
                     entry_attrs[attr] = None
                 elif isinstance(entry_attrs[attr], (tuple, list)) and len(entry_attrs[attr]) == 1:
@@ -2343,7 +2345,9 @@ class BaseLDAPModAttribute(LDAPQuery):
         return arg.clone(required=True, attribute=attribute, alwaysask=True)
 
     def _update_attrs(self, update, entry_attrs):
-        raise NotImplementedError("%s.update_attrs()", self.__class__.__name__)
+        raise NotImplementedError(
+            "%s.update_attrs()" % self.__class__.__name__
+        )
 
     def execute(self, *keys, **options):
         ldap = self.obj.backend

--- a/ipaserver/plugins/krbtpolicy.py
+++ b/ipaserver/plugins/krbtpolicy.py
@@ -226,7 +226,7 @@ class krbtpolicy_reset(baseldap.LDAPQuery):
         else:
             def_values = _default_values
 
-        entry = ldap.get_entry(dn, def_values.keys())
+        entry = ldap.get_entry(dn, list(def_values))
         entry.update(def_values)
         try:
             ldap.update_entry(entry)

--- a/ipaserver/plugins/privilege.py
+++ b/ipaserver/plugins/privilege.py
@@ -242,7 +242,8 @@ class privilege_remove_permission(LDAPRemoveReverseMember):
             type=dict,
             doc=_('Members that could not be added'),
         ),
-        output.Output('completed',
+        output.Output(
+            'completed',
             type=int,
             doc=_('Number of permissions removed'),
         ),

--- a/ipaserver/plugins/role.py
+++ b/ipaserver/plugins/role.py
@@ -240,11 +240,13 @@ class role_remove_privilege(LDAPRemoveReverseMember):
 
     has_output = (
         output.Entry('result'),
-        output.Output('failed',
+        output.Output(
+            'failed',
             type=dict,
             doc=_('Members that could not be added'),
         ),
-        output.Output('completed',
+        output.Output(
+            'completed',
             type=int,
             doc=_('Number of privileges removed'),
         ),

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -832,8 +832,9 @@ class user_find(baseuser_find):
                 DN(self.obj.active_container_dn, self.api.env.basedn),
                 DN(self.obj.delete_container_dn, self.api.env.basedn),
             )
-            entries[:] = [e for e in entries
-                          if any(e.dn.endswith(bd) for bd in base_dns)]
+            entries[:] = list(
+                e for e in entries if any(e.dn.endswith(bd) for bd in base_dns)
+            )
 
         self.post_common_callback(ldap, entries, lockout=False, **options)
         for entry in entries:

--- a/pylintrc
+++ b/pylintrc
@@ -92,6 +92,7 @@ disable=
     useless-super-delegation,  # new in pylint 1.7
     redefined-argument-from-local,  # new in pylint 1.7
     consider-merging-isinstance,  # new in pylint 1.7
+    bad-option-value,  # required to support upgrade to pylint 2.0
 
 
 [REPORTS]


### PR DESCRIPTION
Fix the following violations aiming to support Pylint 2.0

- `unneeded-not` (C0113):
  Consider changing "not item in items" to "item not in items" used
  when a boolean expression contains an unneeded negation.

- `useless-import-alias` (C0414):
  Import alias does not rename original package Used when an import
  alias is same as original package.e.g using import numpy as numpy
  instead of import numpy as np

- `raising-format-tuple` (W0715):
  Exception arguments suggest string formatting might be intended Used
  when passing multiple arguments to an exception constructor, the
  first of them a string literal containing what appears to be
  placeholders intended for formatting

- `bad-continuation` (C0330):
  This was already included on the disable list, although with current
  version of pylint (2.0.0.dev2) violations at the end of the files
  are not being ignored.
  See: PyCQA/pylint#2278

- `try-except-raise` (E0705):
  The except handler raises immediately Used when an except handler
  uses raise as its first or only operator. This is useless because it
  raises back the exception immediately. Remove the raise operator or
  the entire try-except-raise block!

- `consider-using-set-comprehension` (R1718):
  Consider using a set comprehension Although there is nothing
  syntactically wrong with this code, it is hard to read and can be
  simplified to a set comprehension.Also it is faster since you don't
  need to create another transient list

- `dict-keys-not-iterating` (W1655):
  dict.keys referenced when not iterating Used when dict.keys is
  referenced in a non-iterating context (returns an iterator in
  Python 3)

- `comprehension-escape` (W1662):
  Using a variable that was bound inside a comprehension Emitted when
  using a variable, that was bound in a comprehension handler, outside
  of the comprehension itself. On Python 3 these variables will be
  deleted outside of the comprehension.

Issue: https://pagure.io/freeipa/issue/7614

Signed-off-by: Armando Neto <abiagion@redhat.com>