### PR TITLE
Disable Pylint 2.0 violations

### DIFF
--- a/ipapython/install/util.py
+++ b/ipapython/install/util.py
@@ -83,11 +83,11 @@ def run_generator_with_yield_from(gen):
 
 class InnerClassMeta(type):
     # pylint: disable=no-value-for-parameter
-    def __new__(mcs, name, bases, class_dict):
+    def __new__(cls, name, bases, class_dict):
         class_dict.pop('__outer_class__', None)
         class_dict.pop('__outer_name__', None)
 
-        return super(InnerClassMeta, mcs).__new__(mcs, name, bases, class_dict)
+        return super(InnerClassMeta, cls).__new__(cls, name, bases, class_dict)
 
     def __get__(cls, obj, obj_type):
         outer_class, outer_name = cls.__bind(obj_type)

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -513,6 +513,7 @@ def run(args, stdin=None, raiseonerr=True, nolog=(), env=None,
             os.umask(umask)
 
     try:
+        # pylint: disable=subprocess-popen-preexec-fn
         p = subprocess.Popen(args, stdin=p_in, stdout=p_out, stderr=p_err,
                              close_fds=True, env=env, cwd=cwd,
                              preexec_fn=preexec_fn)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1990,10 +1990,12 @@ class ExternalCAProfile(object):
             _oid = univ.ObjectIdentifier(parts[0])
 
             # It is; construct a V2 template
+            # pylint: disable=too-many-function-args
             return MSCSTemplateV2.__new__(MSCSTemplateV2, s)
 
         except pyasn1.error.PyAsn1Error:
             # It is not an OID; treat as a template name
+            # pylint: disable=too-many-function-args
             return MSCSTemplateV1.__new__(MSCSTemplateV1, s)
 
     def __getstate__(self):

--- a/ipaserver/plugins/automember.py
+++ b/ipaserver/plugins/automember.py
@@ -451,10 +451,7 @@ class automember_remove_condition(LDAPUpdate):
 
         # Define container key
         type_attr_default = {'group': 'manager', 'hostgroup': 'fqdn'}
-        if 'key' in options:
-            key = options['key']
-        else:
-            key = type_attr_default[options['type']]
+        key = options.get('key', type_attr_default[options['type']])
 
         key = '%s=' % key
         completed = 0

--- a/ipaserver/plugins/permission.py
+++ b/ipaserver/plugins/permission.py
@@ -1299,10 +1299,9 @@ class permission_find(baseldap.LDAPSearch):
                 self.obj.upgrade_permission(entry, output_only=True)
 
         if not truncated:
-            if 'sizelimit' in options:
-                max_entries = options['sizelimit']
-            else:
-                max_entries = self.api.Backend.ldap2.size_limit
+            max_entries = options.get(
+                'sizelimit', self.api.Backend.ldap2.size_limit
+            )
 
             if max_entries > 0:
                 # should we get more entries than current sizelimit, fail

--- a/pylintrc
+++ b/pylintrc
@@ -18,6 +18,11 @@ extension-pkg-whitelist=
     gssapi,
     netifaces
 
+[CLASSES]
+
+# List of valid names for the first argument in a metaclass class method.
+# This can be removed after upgrading to pylint 2.0
+valid-metaclass-classmethod-first-arg=cls
 
 [MESSAGES CONTROL]
 
@@ -93,7 +98,9 @@ disable=
     redefined-argument-from-local,  # new in pylint 1.7
     consider-merging-isinstance,  # new in pylint 1.7
     bad-option-value,  # required to support upgrade to pylint 2.0
-
+    assignment-from-no-return,  # new in pylint 2.0
+    keyword-arg-before-vararg,  # pylint 2.0, remove after dropping Python 2
+    useless-object-inheritance, # pylint 2.0, remove after dropping Python 2
 
 [REPORTS]
 


### PR DESCRIPTION
Opening this Pull Request to discuss if this violations should be ignored or addressed any other way.

Specifically `bad-mcs-classmethod-argument` (C0204) seems to be caused by a bug in the current version of Pylint (2.0.0.dev2), setting `valid-metaclass-classmethod-first-arg` to its default value (`mcs`) fixed the issue.

Globally disabling the following violations:

- `consider-using-get` (R1715):
  Consider using dict.get for getting values from a dict if a key is
  present or a default if not Using the builtin dict.get for getting a
  value from a dictionary if a key is present or a default if not, is
  simpler and considered more idiomatic, although sometimes a bit slower

- `assignment-from-no-return` (E1111):
  Assigning to function call which doesn't return. Used when an
  assignment is done on a function call but the inferred function
  doesn't return anything.

Locally disabling the following:

- `subprocess-popen-preexec-fn` (W1509):
  Using preexec_fn keyword which may be unsafe in the presence of
  threads The preexec_fn parameter is not safe to use in the presence
  of threads in your application. The child process could deadlock
  before exec is called. If you must use it, keep it trivial! Minimize
  the number of libraries you call into.
  https://docs.python.org/3/library/subprocess.html#popen-constructor

- `missing-format-attribute` (W1306):
  Missing format attribute %r in format specifier %r Used when a
  PEP 3101 format string uses an attribute specifier ({0.length}),
  but the argument passed for formatting doesn't have that attribute.
  This message can't be emitted when using Python < 2.7.

- `consider-using-set-comprehension` (R1718):
  Consider using a set comprehension Although there is nothing
  syntactically wrong with this code, it is hard to read and can be
  simplified to a set comprehension.Also it is faster since you don't
  need to create another transient list

- `keyword-arg-before-vararg` (W1113):
  Keyword argument before variable positional arguments list in the
  definition of %s function When defining a keyword argument before
  variable positional arguments, one can end up in having multiple
  values passed for the aforementioned parameter in case the method is
  called with keyword arguments.

- `dict-keys-not-iterating` (W1655):
  dict.keys referenced when not iterating Used when dict.keys is
  referenced in a non-iterating context (returns an iterator in
  Python 3)

- `comprehension-escape` (W1662):
  Using a variable that was bound inside a comprehension Emitted when
  using a variable, that was bound in a comprehension handler, outside
  of the comprehension itself. On Python 3 these variables will be
  deleted outside of the comprehension.

Issue: https://pagure.io/freeipa/issue/7614

Signed-off-by: Armando Neto <abiagion@redhat.com>