### PR TITLE
[Backport][ipa-4-6] Disable Pylint 2.0 violations

### DIFF
--- a/ipapython/install/util.py
+++ b/ipapython/install/util.py
@@ -83,11 +83,11 @@ def run_generator_with_yield_from(gen):
 
 class InnerClassMeta(type):
     # pylint: disable=no-value-for-parameter
-    def __new__(mcs, name, bases, class_dict):
+    def __new__(cls, name, bases, class_dict):
         class_dict.pop('__outer_class__', None)
         class_dict.pop('__outer_name__', None)
 
-        return super(InnerClassMeta, mcs).__new__(mcs, name, bases, class_dict)
+        return super(InnerClassMeta, cls).__new__(cls, name, bases, class_dict)
 
     def __get__(cls, obj, obj_type):
         outer_class, outer_name = cls.__bind(obj_type)

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -503,6 +503,7 @@ def run(args, stdin=None, raiseonerr=True, nolog=(), env=None,
             os.umask(umask)
 
     try:
+        # pylint: disable=subprocess-popen-preexec-fn
         p = subprocess.Popen(args, stdin=p_in, stdout=p_out, stderr=p_err,
                              close_fds=True, env=env, cwd=cwd,
                              preexec_fn=preexec_fn)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1982,10 +1982,12 @@ class ExternalCAProfile(object):
             _oid = univ.ObjectIdentifier(parts[0])
 
             # It is; construct a V2 template
+            # pylint: disable=too-many-function-args
             return MSCSTemplateV2.__new__(MSCSTemplateV2, s)
 
         except pyasn1.error.PyAsn1Error:
             # It is not an OID; treat as a template name
+            # pylint: disable=too-many-function-args
             return MSCSTemplateV1.__new__(MSCSTemplateV1, s)
 
     def __getstate__(self):

--- a/ipaserver/plugins/automember.py
+++ b/ipaserver/plugins/automember.py
@@ -451,10 +451,7 @@ class automember_remove_condition(LDAPUpdate):
 
         # Define container key
         type_attr_default = {'group': 'manager', 'hostgroup': 'fqdn'}
-        if 'key' in options:
-            key = options['key']
-        else:
-            key = type_attr_default[options['type']]
+        key = options.get('key', type_attr_default[options['type']])
 
         key = '%s=' % key
         completed = 0

--- a/ipaserver/plugins/permission.py
+++ b/ipaserver/plugins/permission.py
@@ -1299,10 +1299,9 @@ class permission_find(baseldap.LDAPSearch):
                 self.obj.upgrade_permission(entry, output_only=True)
 
         if not truncated:
-            if 'sizelimit' in options:
-                max_entries = options['sizelimit']
-            else:
-                max_entries = self.api.Backend.ldap2.size_limit
+            max_entries = options.get(
+                'sizelimit', self.api.Backend.ldap2.size_limit
+            )
 
             if max_entries > 0:
                 # should we get more entries than current sizelimit, fail

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -30,17 +30,17 @@ def _warning_already_exists(cls, member):
 
 
 def fake_class(name_or_class_obj, members=()):
-    if isinstance(name_or_class_obj, scoped_nodes.Class):
+    if isinstance(name_or_class_obj, scoped_nodes.ClassDef):
         cl = name_or_class_obj
     else:
-        cl = scoped_nodes.Class(name_or_class_obj, None)
+        cl = scoped_nodes.ClassDef(name_or_class_obj, None)
 
     for m in members:
         if isinstance(m, str):
             if m in cl.locals:
                 _warning_already_exists(cl, m)
             else:
-                cl.locals[m] = [scoped_nodes.Class(m, None)]
+                cl.locals[m] = [scoped_nodes.ClassDef(m, None)]
         elif isinstance(m, dict):
             for key, val in m.items():
                 assert isinstance(key, str), "key must be string"
@@ -224,7 +224,7 @@ def fix_ipa_classes(cls):
     if class_name_with_module in ipa_class_members:
         fake_class(cls, ipa_class_members[class_name_with_module])
 
-MANAGER.register_transform(scoped_nodes.Class, fix_ipa_classes)
+MANAGER.register_transform(scoped_nodes.ClassDef, fix_ipa_classes)
 
 
 def pytest_config_transform():

--- a/pylintrc
+++ b/pylintrc
@@ -18,6 +18,11 @@ extension-pkg-whitelist=
     gssapi,
     netifaces
 
+[CLASSES]
+
+# List of valid names for the first argument in a metaclass class method.
+# This can be removed after upgrading to pylint 2.0
+valid-metaclass-classmethod-first-arg=cls
 
 [MESSAGES CONTROL]
 
@@ -93,7 +98,9 @@ disable=
     redefined-argument-from-local,  # new in pylint 1.7
     consider-merging-isinstance,  # new in pylint 1.7
     bad-option-value,  # required to support upgrade to pylint 2.0
-
+    assignment-from-no-return,  # new in pylint 2.0
+    keyword-arg-before-vararg,  # pylint 2.0, remove after dropping Python 2
+    useless-object-inheritance, # pylint 2.0, remove after dropping Python 2
 
 [REPORTS]
 


### PR DESCRIPTION
This PR was opened automatically because PR #2150 was pushed to master and backport to ipa-4-6 is required.