### PR TITLE
Fix KRA replica installation from CA master

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1485,7 +1485,10 @@ def install(installer):
     otpd.create_instance('OTPD', config.host_name,
                          ipautil.realm_to_suffix(config.realm_name))
 
-    if ca_enabled:
+    if kra_enabled:
+        # A KRA peer always provides a CA, too.
+        mode = custodiainstance.CustodiaModes.KRA_PEER
+    elif ca_enabled:
         mode = custodiainstance.CustodiaModes.CA_PEER
     else:
         mode = custodiainstance.CustodiaModes.MASTER_PEER


### PR DESCRIPTION
ipa-replica-install --kra-install can fail when the topology already has
a KRA, but replica is installed from a master with just CA. In that
case, Custodia may pick a machine that doesn't have the KRA auditing and
signing certs in its NSSDB.

Example:
 * master with CA
 * replica1 with CA and KRA
 * new replica gets installed from master

The replica installer now always picks a KRA peer.

The change fixes test scenario TestInstallWithCA1::()::test_replica2_ipa_dns_install

Fixes: https://pagure.io/freeipa/issue/7518
Signed-off-by: Christian Heimes <cheimes@redhat.com>