### PR TITLE
Mark DL0 TestReplicaManageDel tests as xfail

### DIFF
--- a/ipatests/test_integration/test_topology.py
+++ b/ipatests/test_integration/test_topology.py
@@ -249,6 +249,7 @@ class TestCASpecificRUVs(IntegrationTest):
             "Replica RUVs were not clean during replica uninstallation")
 
 
+@pytest.mark.xfail(reason="Ticket N 7622", strict=True)
 class TestReplicaManageDel(IntegrationTest):
     domain_level = 0
     topology = 'star'


### PR DESCRIPTION
Mark failing DL0 TestReplicaManageDel tests as xfail until
issue 7622 is fixed.

https://pagure.io/freeipa/issue/7622