### PR TITLE
[Backport][ipa-4-6] Fix regression: Handle unicode where str is expected

### DIFF
--- a/ipaclient/remote_plugins/schema.py
+++ b/ipaclient/remote_plugins/schema.py
@@ -608,7 +608,7 @@ def get_package(server_info, client):
             s = topic['topic_topic']
             if isinstance(s, bytes):
                 s = s.decode('utf-8')
-            module.topic = s.partition('/')[0]
+            module.topic = str(s).partition('/')[0]
         else:
             module.topic = None
 

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -152,3 +152,10 @@ class TestIPACommand(IntegrationTest):
             ["ipa", "console", filename],
         )
         assert "ipalib.config.Env" in result.stdout_text
+
+    def test_list_help_topics(self):
+        result = self.master.run_command(
+            ["ipa", "help", "topics"],
+            raiseonerr=False
+        )
+        assert result.returncode == 0


### PR DESCRIPTION
This PR was opened automatically because PR #2165 was pushed to master and backport to ipa-4-6 is required.