### PR TITLE
[Backport][ipa-4-7] Fix $-style format string in ipa_ldap_init (util/ipa_ldap.c)

### DIFF
--- a/util/ipa_ldap.c
+++ b/util/ipa_ldap.c
@@ -39,7 +39,7 @@ int ipa_ldap_init(LDAP **ld, const char *ldap_uri)
     if (ret != LDAP_SUCCESS) {
         fprintf(
             stderr,
-            _("Unable to initialize connection to ldap server %1$s: %1$s\n"),
+            _("Unable to initialize connection to ldap server %1$s: %2$s\n"),
             ldap_uri,
             ldap_err2string(ret)
         );


### PR DESCRIPTION
This PR was opened automatically because PR #2173 was pushed to master and backport to ipa-4-7 is required.