### PR TITLE
[Backport][ipa-4-6] [Tests] Test for removal server with verbose option

### DIFF
--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -706,7 +706,7 @@ def kinit_admin(host, raiseonerr=True):
 
 
 def uninstall_master(host, ignore_topology_disconnect=True,
-                     ignore_last_of_role=True, clean=True):
+                     ignore_last_of_role=True, clean=True, verbose=False):
     host.collect_log(paths.IPASERVER_UNINSTALL_LOG)
     uninstall_cmd = ['ipa-server-install', '--uninstall', '-U']
 
@@ -718,7 +718,12 @@ def uninstall_master(host, ignore_topology_disconnect=True,
     if ignore_last_of_role and host_domain_level != DOMAIN_LEVEL_0:
         uninstall_cmd.append('--ignore-last-of-role')
 
-    host.run_command(uninstall_cmd)
+    if verbose and host_domain_level != DOMAIN_LEVEL_0:
+        uninstall_cmd.append('-v')
+
+    result = host.run_command(uninstall_cmd)
+    assert "Traceback" not in result.stdout_text
+
     host.run_command(['pkidestroy', '-s', 'CA', '-i', 'pki-tomcat'],
                      raiseonerr=False)
     host.run_command(['rm', '-rf',

--- a/ipatests/test_integration/test_server_del.py
+++ b/ipatests/test_integration/test_server_del.py
@@ -185,7 +185,7 @@ class TestServerDel(ServerDelBase):
     def test_ignore_topology_disconnect_replica2(self):
         """
         tests that removal of replica2 with '--ignore-topology-disconnect'
-        destroys master for good
+        destroys master for good with verbose option for uninstallation
         """
         check_master_removal(
             self.client,
@@ -194,7 +194,7 @@ class TestServerDel(ServerDelBase):
         )
 
         # reinstall the replica
-        tasks.uninstall_master(self.replica2)
+        tasks.uninstall_master(self.replica2, verbose=True)
         tasks.install_replica(self.master, self.replica2, setup_ca=True)
 
     def test_removal_of_master_disconnects_both_topologies(self):


### PR DESCRIPTION
This PR was opened automatically because PR #2004 was pushed to master and backport to ipa-4-6 is required.