### PR TITLE
webui: fix indentation on multiple places

### DIFF
--- a/install/ui/src/freeipa/_base/debug.js
+++ b/install/ui/src/freeipa/_base/debug.js
@@ -19,23 +19,23 @@
  */
 define([], function() {
 
-	/**
-	 * Debug module
-	 *
-	 * One can set flags to enable console output of various messages.
-	 *
-	 * """
-	 * var debug = require('freeipa._base.debug');
-	 * debug.provider_missing_value = true;
-	 * """
-	 *
-	 * Currently used flags
-	 *
-	 * - provider_missing_value
-	 *
-	 * @class _base.debug
-	 */
-	return {
-		provider_missing_value: false
-	};
+    /**
+     * Debug module
+     *
+     * One can set flags to enable console output of various messages.
+     *
+     * """
+     * var debug = require('freeipa._base.debug');
+     * debug.provider_missing_value = true;
+     * """
+     *
+     * Currently used flags
+     *
+     * - provider_missing_value
+     *
+     * @class _base.debug
+     */
+    return {
+        provider_missing_value: false
+    };
 });

--- a/install/ui/src/freeipa/widgets/App.js
+++ b/install/ui/src/freeipa/widgets/App.js
@@ -260,13 +260,13 @@ define(['dojo/_base/declare',
                     {
                         name: 'profile',
                         label: text.get('@i18n:profile-menu.profile',
-			    'Profile'),
+                                        'Profile'),
                         icon: 'fa-user'
                     },
                     {
                         name: 'password_reset',
                         label: text.get('@i18n:profile-menu.password_reset',
-			    'Change password'),
+                                        'Change password'),
                         icon: 'fa-key'
                     },
                     {
@@ -275,7 +275,7 @@ define(['dojo/_base/declare',
                     {
                         name: 'configuration',
                         label: text.get('@i18n:profile-menu.configuration',
-			    'Customization'),
+                                        'Customization'),
                         icon: 'fa-gear'
                     },
                     {
@@ -289,7 +289,7 @@ define(['dojo/_base/declare',
                     {
                         name: 'logout',
                         label: text.get('@i18n:profile-menu.logout',
-			    'Log out'),
+                                        'Log out'),
                         icon: 'fa-sign-out'
                     }
                 ]

--- a/install/ui/src/freeipa/widgets/LoginScreen.js
+++ b/install/ui/src/freeipa/widgets/LoginScreen.js
@@ -97,7 +97,7 @@ define(['dojo/_base/declare',
 
             this.cert_btn_node = IPA.button({
                 name: 'cert_auth',
-		title: text.get('@i18n:login.login_certificate_desc',
+                title: text.get('@i18n:login.login_certificate_desc',
                     'Log in using personal certificate'),
                 label: text.get('@i18n:login.login_certificate',
                     'Log In Using Certificate'),


### PR DESCRIPTION
## webui: change indentation of freeipa/_base/debug.js

Change to use spaces for indentation as it was the the only file
which uses tabs and not spaces.

## webui: remove mixed indentation in App and LoginScreen

Only spaces should be used for indentation.

It was introduced in commits:

* 7f9f59b
* 5d8fde0

Related to: https://pagure.io/freeipa/issue/7559