### PR TITLE
ipaserver/plugins/cert.py: Added reason to raise of errors.NotFound

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -301,7 +301,7 @@ def ca_kdc_check(api_instance, hostname):
         ipaconfigstring = {val.lower() for val in kdc_entry['ipaConfigString']}
 
         if 'enabledservice' not in ipaconfigstring:
-            raise errors.NotFound()
+            raise errors.NotFound(reason="enabledService not in ipaConfigString kdc entry")
 
     except errors.NotFound:
         raise errors.ACIError(

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -301,7 +301,8 @@ def ca_kdc_check(api_instance, hostname):
         ipaconfigstring = {val.lower() for val in kdc_entry['ipaConfigString']}
 
         if 'enabledservice' not in ipaconfigstring:
-            raise errors.NotFound(reason="enabledService not in ipaConfigString kdc entry")
+            raise errors.NotFound(
+                reason=_("enabledService not in ipaConfigString kdc entry"))
 
     except errors.NotFound:
         raise errors.ACIError(


### PR DESCRIPTION
In the case that enabledService is not found ipaConfigString kdc entry, a
NotFound error was raised without setting the reason. This resulted in a
traceback.