### PR TITLE
ipaclient-install: chmod needs octal permissions

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -673,7 +673,7 @@ def configure_krb5_conf(
         os.path.basename(paths.KRB5_FREEIPA) + ".template"
     )
     shutil.copy(template, paths.KRB5_FREEIPA)
-    os.chmod(paths.KRB5_FREEIPA, 0x644)
+    os.chmod(paths.KRB5_FREEIPA, 0o644)
 
     # Then, perform the rest of our configuration into krb5.conf itself.
     krbconf = IPAChangeConf("IPA Installer")


### PR DESCRIPTION
With freeipa-client-4.6.90.pre2-3.fc28.x86_64 I ended up with:
```
---x--Sr-T. 1 root root 54 Jul 24 13:24 /etc/krb5.conf.d/freeipa*
```