### PR TITLE
Do not set ca_host when --setup-ca is used.

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -241,9 +241,12 @@ def create_ipa_conf(fstore, config, ca_enabled, master=None):
         gopts.extend([
             ipaconf.setOption('enable_ra', 'True'),
             ipaconf.setOption('ra_plugin', 'dogtag'),
-            ipaconf.setOption('dogtag_version', '10'),
-            ipaconf.setOption('ca_host', config.ca_host_name)
+            ipaconf.setOption('dogtag_version', '10')
         ])
+
+        if not config.setup_ca:
+            gopts.append(ipaconf.setOption('ca_host', config.ca_host_name))
+
     else:
         gopts.extend([
             ipaconf.setOption('enable_ra', 'False'),


### PR DESCRIPTION
Setting ca_host caused replication failures on DL0
because it was trying to connect to wrong CA host.
Trying to avoid corner-case in ipaserver/plugins/dogtag.py
when api.env.host nor api.env.ca_host had not CA configured
and there was ca_host set to api.env.ca_host variable.

Reverts: https://github.com/freeipa/freeipa/pull/2048
See: https://pagure.io/freeipa/issue/7566
Resolves: https://pagure.io/freeipa/issue/7629