### PR TITLE
Convert members into types in sudorule-*-option

### DIFF
--- a/ipaserver/plugins/sudorule.py
+++ b/ipaserver/plugins/sudorule.py
@@ -949,6 +949,9 @@ class sudorule_add_option(LDAPQuery):
         attrs_list = self.obj.default_attributes
         entry_attrs = ldap.get_entry(dn, attrs_list)
 
+        self.obj.get_indirect_members(entry_attrs, attrs_list)
+        self.obj.convert_attribute_members(entry_attrs, [cn], **options)
+
         entry_attrs = entry_to_dict(entry_attrs, **options)
 
         return dict(result=entry_attrs, value=pkey_to_value(cn, options))
@@ -998,6 +1001,9 @@ class sudorule_remove_option(LDAPQuery):
 
         attrs_list = self.obj.default_attributes
         entry_attrs = ldap.get_entry(dn, attrs_list)
+
+        self.obj.get_indirect_members(entry_attrs, attrs_list)
+        self.obj.convert_attribute_members(entry_attrs, [cn], **options)
 
         entry_attrs = entry_to_dict(entry_attrs, **options)
 

--- a/ipatests/test_xmlrpc/test_sudorule_plugin.py
+++ b/ipatests/test_xmlrpc/test_sudorule_plugin.py
@@ -393,11 +393,19 @@ class test_sudorule(XMLRPC_test):
         Test adding an option to Sudo rule using
         `xmlrpc.sudorule_add_option`.
         """
+        # Add a user and group to the sudorule so we can test that
+        # membership is properly translated in add_option.
+        ret = api.Command['sudorule_add_user'](
+            self.rule_name, user=self.test_user, group=self.test_group
+        )
+        assert ret['completed'] == 2
         ret = api.Command['sudorule_add_option'](
             self.rule_name, ipasudoopt=self.test_option
         )
         entry = ret['result']
         assert_attr_equal(entry, 'ipasudoopt', self.test_option)
+        assert_attr_equal(entry, 'memberuser_user', self.test_user)
+        assert_attr_equal(entry, 'memberuser_group', self.test_group)
 
     def test_b_sudorule_remove_option(self):
         """
@@ -409,6 +417,14 @@ class test_sudorule(XMLRPC_test):
         )
         entry = ret['result']
         assert 'ipasudoopt' not in entry
+        # Verify that membership is properly converted in remove_option
+        assert_attr_equal(entry, 'memberuser_user', self.test_user)
+        assert_attr_equal(entry, 'memberuser_group', self.test_group)
+        # Clean up by removing the user and group added in add_option
+        ret = api.Command['sudorule_remove_user'](
+            self.rule_name, user=self.test_user, group=self.test_group
+        )
+        assert ret['completed'] == 2
 
     def test_a_sudorule_add_host(self):
         """


### PR DESCRIPTION
The indirect members need to be calculated and the member
attributes converted. This is normally done in
baseldap::LDAPRetrieve but these methods provide their
own execute() in order to handle the option values.

Update sudorule_add|remove_option tests to include check
that converted user/group exists in the proper format.

https://pagure.io/freeipa/issue/7649

Signed-off-by: Rob Crittenden <rcritten@redhat.com>