### PR TITLE
[Backport][ipa-4-7] ipaserver/plugins/cert.py: Added reason to raise of errors.NotFound

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -301,7 +301,8 @@ def ca_kdc_check(api_instance, hostname):
         ipaconfigstring = {val.lower() for val in kdc_entry['ipaConfigString']}
 
         if 'enabledservice' not in ipaconfigstring:
-            raise errors.NotFound()
+            raise errors.NotFound(
+                reason=_("enabledService not in ipaConfigString kdc entry"))
 
     except errors.NotFound:
         raise errors.ACIError(


### PR DESCRIPTION
This PR is manual backport of https://github.com/freeipa/freeipa/pull/2187 please wait for CI before pushing and do not forget about backport to branches specified with labels.
In case of questions or problems contact @t-woerner who is author of the original PR.