### PR TITLE
Restore SELinux context of session_dir /etc/httpd/alias and template_dir /var/log/dirsrv/slapd-X

### DIFF
--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -183,6 +183,9 @@ class HTTPInstance(service.Service):
             os.makedirs(session_dir)
         # Must be world-readable / executable
         os.chmod(session_dir, 0o755)
+        # Restore SELinux context of session_dir /etc/httpd/alias, see
+        # https://pagure.io/freeipa/issue/7662
+        tasks.restore_context(session_dir)
 
         target_fname = paths.HTTPD_IPA_CONF
         http_txt = ipautil.template_file(

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -607,10 +607,13 @@ class Restore(admintool.AdminTool):
             logger.info("Waiting for LDIF to finish")
             wait_for_task(conn, dn)
         else:
+            template_dir = paths.VAR_LOG_DIRSRV_INSTANCE_TEMPLATE % instance
             try:
-                os.makedirs(paths.VAR_LOG_DIRSRV_INSTANCE_TEMPLATE % instance)
+                os.makedirs(template_dir)
             except OSError as e:
                 pass
+            # Restore SELinux context of template_dir
+            tasks.restore_context(template_dir)
 
             args = [paths.LDIF2DB,
                     '-Z', instance,


### PR DESCRIPTION
## Restore SELinux context of session_dir /etc/httpd/alias and template_dir /var/log/dirsrv/slapd-X:

### httpinstance: Restore SELinux context of session_dir /etc/httpd/alias
    
The session directory /etc/httpd/alias/ could be created with the wrong SELinux context. Therefore httpd was not able to write to this directory.
    
Fixes: https://pagure.io/freeipa/issue/7662
    
Related-to: 49b4a057f1b0459331bcec2c8d760627d00e4571 (Create missing /etc/httpd/alias for ipasession.key)

### ipa_restore: Restore SELinux context of template_dir /var/log/dirsrv/slapd-X
    
The template directory /var/log/dirsrv/slapd-X could be created with the wrong SELinux context.
    
Related to: https://pagure.io/freeipa/issue/7662
