### PR TITLE
Generate CSR dynamically for UI tests

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -27,218 +27,50 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-28/simple_replication:
+  fedora-28/test_host:
     requires: [fedora-28/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_simple_replication.py
+        test_suite: test_webui/test_host.py
         template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/caless:
+  fedora-28/test_cert:
     requires: [fedora-28/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
+        test_suite: test_webui/test_cert.py
         template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/external_ca_1:
+  fedora-28/test_service:
     requires: [fedora-28/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_external_ca.py::TestExternalCA
-        template: *ci-master-f28
-        timeout: 4800
-        topology: *master_1repl_1client
-
-  fedora-28/external_ca_2:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
+        test_suite: test_webui/test_service.py
         template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/test_topologies:
+  fedora-28/test_users:
     requires: [fedora-28/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_topologies.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_sudo:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_sudo.py
-        template: *ci-master-f28
-        timeout: 4800
-        topology: *master_1repl_1client
-
-  fedora-28/test_commands:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_commands.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_kerberos_flags:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_kerberos_flags.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl_1client
-
-  fedora-28/test_http_kdc_proxy:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_http_kdc_proxy.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl_1client
-
-  fedora-28/test_forced_client_enrolment:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *ci-master-f28
-        timeout: 4800
-        topology: *master_1repl_1client
-
-  fedora-28/test_advise:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_advise.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_testconfig:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_testconfig.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_service_permissions:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_service_permissions.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_netgroup:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_netgroup.py
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/test_vault:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_vault.py
-        template: *ci-master-f28
-        timeout: 6300
-        topology: *master_1repl
-
-  fedora-28/test_authconfig:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_authselect.py
-        template: *ci-master-f28
-        timeout: 4800
-        topology: *master_1repl_1client
-
-  fedora-28/replica_promotion:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-28/dnssec:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
+        test_suite: test_webui/test_user.py
         template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl

--- a/ipatests/test_webui/test_cert.py
+++ b/ipatests/test_webui/test_cert.py
@@ -25,25 +25,9 @@ from ipatests.test_webui.ui_driver import UI_driver
 from ipatests.test_webui.ui_driver import screenshot
 from datetime import date, timedelta
 import pytest
+from tempfile import NamedTemporaryFile
 
 ENTITY = 'cert'
-
-CERT_CSR = ("""-----BEGIN NEW CERTIFICATE REQUEST-----
-MIICcjCCAVoCAQAwLTERMA8GA1UEChMISVBBLlRFU1QxGDAWBgNVBAMTD21hc3Rl
-ci5pcGEudGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK9xZ/OT
-PC9vlwP78ACCYTOGy8C+Ho4OUF4p4PYPkns4Zdov6N/f0MlUcxY7cpAlKlAZT53b
-OphSKamc7nlNgUAzV1S6JTm1YXiTzG6mAOWWK/i3O25rNfiz0D+srlqS0ADsGPwG
-4vxuWJYwUEKcV4YgCYCJj78dD+yxoz5anVrNosN4tVGg6jfaPI9uu1T+FhsNM/AC
-EN7pa50bgeV7iBZs/pdZEXEsk18NO4W55yPAKQp5JFCL6eeBJcHTU/IuEb/YPCSr
-e873Iwzw4ZqW8dHbE10Za3VzdKPDUbtJp93rvU6imRavvifIAa3GgBuLYbpEXXcG
-B6MLHdWOApwPBoMCAwEAAaAAMA0GCSqGSIb3DQEBCwUAA4IBAQClXDGZoGUSetZP
-lwx//vSN6P6y30dpiHDQiY4hCLYplpoB7V6wXXVMyuKpJjRMQ2mSdyuFge14Lvwr
-y1pE8Vg0+D99PW09tGTp54egPCKeyXptJ/1xi/Quo70OfSSI01vSczMDGTa4OfAB
-VPzE2xey1qL0a0UHqwBaSqnt6D0Xmid79YP0XkVEqZeHZvprtXzeA4dNc1GrZrjb
-7bazcPXbd7PXQaEFvmhqbDMFvu3xMBm5HJd4WkYKvBFDw4NHfT6jw/yRZXkWwJ/F
-EI0h2e9yxrSKgOEpWmeCdETZhMCljx5C2rLNqLAWJIJQ293UuVRCg4Rn6fdIefhF
-yKHlBerZ
------END NEW CERTIFICATE REQUEST-----""")
 
 ERR_SPACE = "invalid '{}': Leading and trailing spaces are not allowed"
 ERR_MUST_INTEGER = "invalid '{}': must be an integer"
@@ -180,7 +164,11 @@ class test_cert(UI_driver):
 
         # add a new cert
         hostname = self.config.get('ipa_server')
-        record = add_cert(self, 'HTTP/{}'.format(hostname), CERT_CSR)
+        tf = NamedTemporaryFile()
+        csr_file = tf.name
+        self.generate_csr(hostname, csr_file)
+        csr_contents = open(csr_file, 'r').read()
+        record = add_cert(self, 'HTTP/{}'.format(hostname), csr_contents)
 
         # revoke added cert
         revoke_cert(self, record, '1')

--- a/ipatests/test_webui/test_host.py
+++ b/ipatests/test_webui/test_host.py
@@ -160,7 +160,8 @@ class test_host(host_tasks):
             self.skip('CSR file is not configured')
 
         self.init_app()
-        # ENHANCEMENT: generate csr dynamically
+        hostname = self.config.get('ipa_server')
+        self.generate_csr(hostname, csr_path)
         csr = self.load_file(csr_path)
         cert_widget_sel = "div.certificate-widget"
 

--- a/ipatests/test_webui/test_service.py
+++ b/ipatests/test_webui/test_service.py
@@ -56,7 +56,8 @@ class sevice_tasks(UI_driver):
         }
 
     def load_file(self, path):
-        # ENHANCEMENT: generate csr dynamically
+        hostname = self.config.get('ipa_server')
+        self.generate_csr(hostname, path)
         with open(path, 'r') as file_d:
             content = file_d.read()
         return content

--- a/ipatests/test_webui/test_user.py
+++ b/ipatests/test_webui/test_user.py
@@ -232,7 +232,8 @@ class test_user(user_tasks):
             self.skip('CSR file is not configured')
 
         self.init_app()
-        # ENHANCEMENT: generate csr dynamically
+        hostname = self.config.get('ipa_server')
+        self.generate_csr(hostname, csr_path)
         csr = self.load_file(csr_path)
         cert_widget_sel = "div.certificate-widget"
 


### PR DESCRIPTION
There were hardcoded csr in test_cert.py. 'host_csr_path'
and 'service_csr_path' needs to be generated before executing
UI tests. This fix removes the hardcoded values as well as need
of generating csr before executing UI testsuit.

Signed-off-by: Mohammad Rizwan Yusuf <myusuf@redhat.com>