### PR TITLE
[ipa-4-5] Test: fix definition of template for dnssec

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -71,6 +71,6 @@ jobs:
       args:
         build_url: '{fedora-26/build_url}'
         test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
-        template: *ci-master-f26
+        template: *ci-ipa-4-5-f26
         timeout: 3600
         topology: *master_1repl

--- a/ipatests/pytest_plugins/integration/tasks.py
+++ b/ipatests/pytest_plugins/integration/tasks.py
@@ -265,6 +265,18 @@ def enable_replication_debugging(host):
                      stdin_text=logging_ldif)
 
 
+def set_default_ttl_for_ipa_dns_zone(host, raiseonerr=True):
+    args = [
+        'ipa', 'dnszone-mod', host.domain.name,
+        '--default-ttl', '1',
+        '--ttl', '1'
+    ]
+    result = host.run_command(args, raiseonerr=raiseonerr, stdin_text=None)
+    if result.returncode != 0:
+        log.info('Failed to set TTL and default TTL for DNS zone %s to 1',
+                    host.domain.name)
+
+
 def install_master(host, setup_dns=True, setup_kra=False, setup_adtrust=False,
                    extra_args=(), domain_level=None, unattended=True,
                    stdin_text=None, raiseonerr=True):
@@ -303,6 +315,10 @@ def install_master(host, setup_dns=True, setup_kra=False, setup_adtrust=False,
         enable_replication_debugging(host)
         setup_sssd_debugging(host)
         kinit_admin(host)
+        if setup_dns:
+            # fixup DNS zone default TTL for IPA DNS zone
+            # For tests we should not wait too long
+            set_default_ttl_for_ipa_dns_zone(host, raiseonerr=raiseonerr)
     return result
 
 


### PR DESCRIPTION
The template used for dnssec does not exist, the test
should use ci-ipa-4-5-f26 instead of ci-master-f26