### PR TITLE
PRCI: extend timeouts for gating

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -60,7 +60,7 @@ jobs:
         build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCA
         template: *ci-master-f28
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-28/external_ca_2:
@@ -96,7 +96,7 @@ jobs:
         build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_sudo.py
         template: *ci-master-f28
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-28/test_commands:
@@ -144,7 +144,7 @@ jobs:
         build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_forced_client_reenrollment.py
         template: *ci-master-f28
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-28/test_advise:
@@ -204,7 +204,7 @@ jobs:
         build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_vault.py
         template: *ci-master-f28
-        timeout: 4500
+        timeout: 6300
         topology: *master_1repl
 
   fedora-28/test_authconfig:
@@ -216,7 +216,7 @@ jobs:
         build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_authselect.py
         template: *ci-master-f28
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-28/replica_promotion:


### PR DESCRIPTION
Some tests have been identified as frequently failing on timeouts. While
we are investigating PRCI potential issues, increase the timeouts to
make PRCI usable. The rule is to add 30min if the test involves CA/KRA
installation or 20min otherwise for the most problematic tests.

test_forced_client_enrolment: from 1h to 1h20
test_vault: from 1h15 to 1h45
external_ca_1: from 1h to 1h20
test_sudo: from 1h to 1h20
test_authconfig: from 1h to 1h20