### PR TITLE
[Backport][ipa-4-6] PRCI: extend timeouts for gating

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -60,7 +60,7 @@ jobs:
         build_url: '{fedora-27/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCA
         template: *ci-master-f27
-        timeout: 4200
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-27/test_ipa_commands:


### PR DESCRIPTION
This PR was opened manually because PR #2227 was pushed to master and backport to ipa-4-6 is required.

Some tests have been identified as frequently failing on timeouts. While
we are investigating PRCI potential issues, increase the timeouts to
make PRCI usable. The rule is to add 30min if the test involves CA/KRA
installation or 20min otherwise for the most problematic tests.

external_ca: from 1h to 1h20

Reviewed-By: Tibor Dudlak <tdudlak@redhat.com>