### PR TITLE
Disable DL0 specific tests

### DIFF
--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -265,6 +265,7 @@ class CALessBase(IntegrationTest):
 
         if domain_level is None:
             domain_level = tasks.domainlevel(master)
+        tasks.check_domain_level(domain_level)
         files_to_copy = ['root.pem']
         if http_pkcs12_exists:
             files_to_copy.append(http_pkcs12)
@@ -1072,8 +1073,7 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='server.p12',
                                       dirsrv_pkcs12='server.p12')
         assert result.returncode == 0
-        if self.domain_level > DOMAIN_LEVEL_0:
-            self.verify_installation()
+        self.verify_installation()
 
     @replica_install_teardown
     def test_wildcard_http(self):
@@ -1085,8 +1085,7 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='http.p12',
                                       dirsrv_pkcs12='dirsrv.p12')
         assert result.returncode == 0
-        if self.domain_level > DOMAIN_LEVEL_0:
-            self.verify_installation()
+        self.verify_installation()
 
     @replica_install_teardown
     def test_wildcard_ds(self):
@@ -1098,8 +1097,7 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='http.p12',
                                       dirsrv_pkcs12='dirsrv.p12')
         assert result.returncode == 0
-        if self.domain_level > DOMAIN_LEVEL_0:
-            self.verify_installation()
+        self.verify_installation()
 
     @replica_install_teardown
     def test_http_san(self):
@@ -1111,8 +1109,7 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='http.p12',
                                       dirsrv_pkcs12='dirsrv.p12')
         assert result.returncode == 0
-        if self.domain_level > DOMAIN_LEVEL_0:
-            self.verify_installation()
+        self.verify_installation()
 
     @replica_install_teardown
     def test_ds_san(self):
@@ -1124,8 +1121,7 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pkcs12='http.p12',
                                       dirsrv_pkcs12='dirsrv.p12')
         assert result.returncode == 0
-        if self.domain_level > DOMAIN_LEVEL_0:
-            self.verify_installation()
+        self.verify_installation()
 
     @replica_install_teardown
     def test_interactive_missing_http_pkcs_password(self):
@@ -1139,8 +1135,7 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(http_pin=None, unattended=False,
                                       stdin_text=stdin_text)
         assert result.returncode == 0
-        if self.domain_level > DOMAIN_LEVEL_0:
-            self.verify_installation()
+        self.verify_installation()
 
     @replica_install_teardown
     def test_interactive_missing_ds_pkcs_password(self):
@@ -1154,8 +1149,7 @@ class TestReplicaInstall(CALessBase):
         result = self.prepare_replica(dirsrv_pin=None, unattended=False,
                                       stdin_text=stdin_text)
         assert result.returncode == 0
-        if self.domain_level > DOMAIN_LEVEL_0:
-            self.verify_installation()
+        self.verify_installation()
 
     @replica_install_teardown
     def test_no_http_password(self):
@@ -1168,8 +1162,7 @@ class TestReplicaInstall(CALessBase):
                                       dirsrv_pkcs12='dirsrv.p12',
                                       http_pin='')
         assert result.returncode == 0
-        if self.domain_level > DOMAIN_LEVEL_0:
-            self.verify_installation()
+        self.verify_installation()
 
     @replica_install_teardown
     def test_no_ds_password(self):
@@ -1182,8 +1175,7 @@ class TestReplicaInstall(CALessBase):
                                       dirsrv_pkcs12='dirsrv.p12',
                                       dirsrv_pin='')
         assert result.returncode == 0
-        if self.domain_level > DOMAIN_LEVEL_0:
-            self.verify_installation()
+        self.verify_installation()
 
     @replica_install_teardown
     def test_certs_with_no_password(self):
@@ -1198,8 +1190,7 @@ class TestReplicaInstall(CALessBase):
         self.prepare_replica(http_pkcs12='http.p12',
                              dirsrv_pkcs12='dirsrv.p12',
                              http_pin='', dirsrv_pin='')
-        if self.domain_level > DOMAIN_LEVEL_0:
-            self.verify_installation()
+        self.verify_installation()
 
     @replica_install_teardown
     def test_certs_with_no_password_interactive(self):
@@ -1217,8 +1208,7 @@ class TestReplicaInstall(CALessBase):
                                       http_pin=None, dirsrv_pin=None,
                                       unattended=False, stdin_text=stdin_text)
         assert result.returncode == 0
-        if self.domain_level > DOMAIN_LEVEL_0:
-            self.verify_installation()
+        self.verify_installation()
 
 
 class TestClientInstall(CALessBase):

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -40,12 +40,14 @@ class ReplicaPromotionBase(IntegrationTest):
         assert(found > 0), result2.stdout_text
 
 
+@pytest.mark.skip(reason="Domain level 0 is not supported anymore")
 class TestReplicaPromotionLevel0(ReplicaPromotionBase):
 
     topology = 'star'
     num_replicas = 1
     domain_level = DOMAIN_LEVEL_0
 
+    @pytest.mark.skip(reason="Domain level 0 is not supported anymore")
     @replicas_cleanup
     def test_promotion_disabled(self):
         """
@@ -87,6 +89,7 @@ class TestReplicaPromotionLevel0(ReplicaPromotionBase):
         assert(found2 > 0), result2.stdout_text
 
 
+@pytest.mark.skip(reason="Domain level 0 is not supported anymore")
 @pytest.mark.xfail(reason="Ticket N 6274", strict=True)
 class TestKRAInstall(IntegrationTest):
     """
@@ -126,6 +129,7 @@ class TestKRAInstall(IntegrationTest):
         tasks.install_kra(replica2)
 
 
+@pytest.mark.skip(reason="Domain level 0 is not supported anymore")
 @pytest.mark.xfail(reason="Ticket N 6274", strict=True)
 class TestCAInstall(IntegrationTest):
     topology = 'star'
@@ -178,6 +182,7 @@ class TestReplicaPromotionLevel1(ReplicaPromotionBase):
     num_replicas = 1
     domain_level = DOMAIN_LEVEL_1
 
+    @pytest.mark.skip(reason="Domain level 0 is not supported anymore")
     @replicas_cleanup
     def test_replica_prepare_disabled(self):
         replica = self.replicas[0]
@@ -205,6 +210,7 @@ class TestReplicaPromotionLevel1(ReplicaPromotionBase):
                                      '-U'])
 
 
+@pytest.mark.skip(reason="Domain level 0 is not supported anymore")
 @pytest.mark.xfail(reason="Ticket N 6274", strict=True)
 class TestReplicaManageCommands(IntegrationTest):
     topology = "star"
@@ -372,6 +378,7 @@ class TestProhibitReplicaUninstallation(IntegrationTest):
                                       '-U', '--ignore-topology-disconnect'])
 
 
+@pytest.mark.skip(reason="Domain level 0 is not supported anymore")
 @pytest.mark.xfail(reason="Ticket N 6274", strict=True)
 class TestOldReplicaWorksAfterDomainUpgrade(IntegrationTest):
     topology = 'star'


### PR DESCRIPTION
Disable tests that use domain level 0. Fail early to catch additional
tests that depend on DL0.

See: https://pagure.io/freeipa/issue/7669
Signed-off-by: Christian Heimes <cheimes@redhat.com>