### PR TITLE
ipaclient: Remove --no-sssd and --noac options

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3709,11 +3709,7 @@ class ClientInstall(ClientInstallInterface,
     def prompt_password(self):
         return self.interactive
 
-    no_ac = knob(
-        None,
-        description="do not modify the nsswitch.conf and PAM configuration",
-        cli_names='--noac',
-    )
+    no_ac = False
 
     force = knob(
         None,

--- a/ipaclient/install/sssd.py
+++ b/ipaclient/install/sssd.py
@@ -43,11 +43,4 @@ class SSSDInstallInterface(service.ServiceInstallInterface):
     )
     preserve_sssd = enroll_only(preserve_sssd)
 
-    no_sssd = knob(
-        None,
-        deprecated=True,
-        description="Do not configure the client to use SSSD for "
-                    "authentication",
-        cli_names=[None, '-S'],
-    )
-    no_sssd = enroll_only(no_sssd)
+    no_sssd = False

--- a/ipatests/test_integration/test_authselect.py
+++ b/ipatests/test_integration/test_authselect.py
@@ -88,6 +88,7 @@ class TestClientInstallation(IntegrationTest):
             ['ipa-client-install', '--uninstall', '-U'],
             raiseonerr=False)
 
+    @pytest.mark.skip(reason="Option --no-sssd has been removed")
     def test_install_client_no_sssd(self):
         """
         Test client installation with --no-sssd option.
@@ -98,6 +99,7 @@ class TestClientInstallation(IntegrationTest):
         msg = "Option '--no-sssd' is incompatible with the 'authselect' tool"
         assert msg in result.stderr_text
 
+    @pytest.mark.skip(reason="Option --noac has been removed")
     def test_install_client_no_ac(self):
         """
         Test client installation with --noac option.


### PR DESCRIPTION
Client installation with --no-sssd option has already beeen deprecated
with https://pagure.io/freeipa/issue/5860. Authconfig support has been
removed, therefore --no-ac option can be removed also.

ipatests/test_integration/test_authselect.py: Skip no_sssd and no_ac tests.

See: https://pagure.io/freeipa/issue/7671
Signed-off-by: Thomas Woerner <twoerner@redhat.com>