### PR TITLE
[Backport][ipa-4-7] do not use RC4 in FIPS mode

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
@@ -46,7 +46,6 @@
 /* Type of connection for this operation;*/
 #define LDAP_EXTOP_PASSMOD_CONN_SECURE
 
-#define PROC_SYS_FIPS "/proc/sys/crypto/fips_enabled"
 
 /* Uncomment the following #undef FOR TESTING:
  * allows non-SSL connections to use the password change extended op */
@@ -63,27 +62,6 @@ static const char *ipapwd_def_encsalts[] = {
     "aes128-cts:special",
     NULL
 };
-
-static bool fips_enabled(void)
-{
-    int fd;
-    ssize_t len;
-    char buf[8];
-
-    fd = open(PROC_SYS_FIPS, O_RDONLY);
-    if (fd != -1) {
-        len = read(fd, buf, sizeof(buf));
-        close(fd);
-        /* Assume FIPS in enabled if PROC_SYS_FIPS contains a non-0 value
-         * similar to the is_fips_enabled() check in
-         * ipaplatform/redhat/tasks.py */
-        if (!(len == 2 && buf[0] == '0' && buf[1] == '\n')) {
-            return true;
-        }
-    }
-
-    return false;
-}
 
 static struct ipapwd_krbcfg *ipapwd_getConfig(void)
 {
@@ -255,7 +233,7 @@ static struct ipapwd_krbcfg *ipapwd_getConfig(void)
 
     /* get the ipa etc/ipaConfig entry */
     config->allow_nt_hash = false;
-    if (fips_enabled()) {
+    if (ipapwd_fips_enabled()) {
         LOG("FIPS mode is enabled, NT hashes are not allowed.\n");
     } else {
         ret = ipapwd_getEntry(ipa_etc_config_dn, &config_entry, NULL);

--- a/util/ipa_pwd.h
+++ b/util/ipa_pwd.h
@@ -77,3 +77,5 @@ int ipapwd_generate_new_history(char *password,
                                 int *new_pwd_hlen);
 
 int encode_nt_key(char *newPasswd, uint8_t *nt_key);
+
+bool ipapwd_fips_enabled(void);


### PR DESCRIPTION
This PR was opened automatically because PR #2228 was pushed to master and backport to ipa-4-7 is required.