### PR TITLE
[Backport][ipa-4-5] Check if replication agreement exist before enable/disable it

### DIFF
--- a/install/tools/ipa-replica-manage
+++ b/install/tools/ipa-replica-manage
@@ -1200,8 +1200,11 @@ def re_initialize(realm, thishost, fromhost, dirman_passwd, nolookup=False):
         repl = replication.ReplicationManager(realm, fromhost, dirman_passwd)
         agreement = repl.get_replication_agreement(thishost)
 
-        thisrepl.enable_agreement(fromhost)
-        repl.enable_agreement(thishost)
+        try:
+            thisrepl.enable_agreement(fromhost)
+            repl.enable_agreement(thishost)
+        except errors.NotFound as e:
+            sys.exit(e)
 
         repl.force_sync(repl.conn, thishost)
 

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -33,6 +33,7 @@ import ldap
 from ipalib import api, errors
 from ipalib.cli import textui
 from ipapython.ipa_log_manager import root_logger
+from ipalib.text import _
 from ipapython import ipautil, ipaldap
 from ipapython.admintool import ScriptError
 from ipapython.dn import DN
@@ -1625,6 +1626,11 @@ class ReplicationManager(object):
         Disable the replication agreement to hostname.
         """
         entry = self.get_replication_agreement(hostname)
+        if not entry:
+            raise errors.NotFound(reason=_(
+                "Replication agreement for %(hostname)s not found") % {
+                    'hostname': hostname
+                })
         entry['nsds5ReplicaEnabled'] = 'off'
 
         try:
@@ -1639,6 +1645,11 @@ class ReplicationManager(object):
         Note: for replication to work it needs to be enabled both ways.
         """
         entry = self.get_replication_agreement(hostname)
+        if not entry:
+            raise errors.NotFound(reason=_(
+                "Replication agreement for %(hostname)s not found") % {
+                    'hostname': hostname
+                })
         entry['nsds5ReplicaEnabled'] = 'on'
 
         try:


### PR DESCRIPTION
If the replication agreement does not exist, a custom exception is
raised explaining the problem.

https://pagure.io/freeipa/issue/7201

Reviewed-By: Rob Crittenden <rcritten@redhat.com>