### PR TITLE
[Backport][ipa-4-6] Re-open the ldif file to prevent error message

### DIFF
--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -237,17 +237,22 @@ class IPAUpgrade(service.Service):
 
     def __disable_schema_compat(self):
         ldif_outfile = "%s.modified.out" % self.filename
+
+        with open(self.filename, "r") as in_file:
+            parser = GetEntryFromLDIF(in_file, entries_dn=[COMPAT_DN])
+            parser.parse()
+
+        try:
+            compat_entry = parser.get_results()[COMPAT_DN]
+        except KeyError:
+            return
+
+        if not compat_entry.get('nsslapd-pluginEnabled'):
+            return
+
         with open(ldif_outfile, "w") as out_file:
             with open(self.filename, "r") as in_file:
-                parser = GetEntryFromLDIF(in_file, entries_dn=[COMPAT_DN])
-                parser.parse()
-                try:
-                    compat_entry = parser.get_results()[COMPAT_DN]
-                except KeyError:
-                    return
                 parser = installutils.ModifyLDIF(in_file, out_file)
-                if not compat_entry.get('nsslapd-pluginEnabled'):
-                    return
                 parser.remove_value(COMPAT_DN, "nsslapd-pluginEnabled")
                 parser.remove_value(COMPAT_DN, "nsslapd-pluginenabled")
                 parser.add_value(COMPAT_DN, "nsslapd-pluginEnabled",

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -18,4 +18,6 @@ class TestUpgrade(IntegrationTest):
     def test_invoke_upgrader(self):
         cmd = self.master.run_command(['ipa-server-upgrade'],
                                       raiseonerr=False)
+        assert ("DN: cn=Schema Compatibility,cn=plugins,cn=config does not \
+                exists or haven't been updated" not in cmd.stdout_text)
         assert cmd.returncode == 0


### PR DESCRIPTION
This PR was opened automatically because PR #2222 was pushed to master and backport to ipa-4-6 is required.