### PR TITLE
[Backport][ipa-4-7] Check if user permssions and umask 0022 is set after ipa-restore

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -25,6 +25,7 @@ import re
 import contextlib
 from tempfile import NamedTemporaryFile
 
+from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipapython import ipautil
@@ -36,7 +37,6 @@ from ipatests.util import assert_deepequal
 from ldap.dn import escape_dn_chars
 
 logger = logging.getLogger(__name__)
-
 
 def assert_entries_equal(a, b):
     assert_deepequal(a.dn, b.dn)
@@ -50,6 +50,7 @@ def assert_results_equal(a, b):
             'stderr': r.stderr_text,
             'returncode': r.returncode,
         }
+
     assert_deepequal(to_dict(a), to_dict(b))
 
 
@@ -246,7 +247,6 @@ class BaseBackupAndRestoreWithDNS(IntegrationTest):
     def _full_backup_restore_with_DNS_zone(self, reinstall=False):
         """backup, uninstall, restore"""
         with restore_checker(self.master):
-
             self.master.run_command([
                 'ipa', 'dnszone-add',
                 self.example_test_zone,
@@ -312,7 +312,6 @@ class BaseBackupAndRestoreWithDNSSEC(IntegrationTest):
 
     def _full_backup_and_restore_with_DNSSEC_zone(self, reinstall=False):
         with restore_checker(self.master):
-
             self.master.run_command([
                 'ipa', 'dnszone-add',
                 self.example_test_zone,
@@ -494,7 +493,7 @@ class TestBackupAndRestoreWithReplica(IntegrationTest):
         check_replication(self.master, replica, "testuser1")
 
 
-class TestUserrootFilesOwnership(IntegrationTest):
+class TestUserRootFilesOwnershipPermission(IntegrationTest):
     """Test to check if userroot.ldif have proper ownership.
 
     Before the fix, when ipa-backup was called for the first time,
@@ -511,9 +510,19 @@ class TestUserrootFilesOwnership(IntegrationTest):
     fail
 
     related ticket: https://pagure.io/freeipa/issue/7010
+
+    This test also checks if the access rights for user/group
+    are set and umask 0022 set while restoring.
+
+    related ticket: https://pagure.io/freeipa/issue/6844
     """
 
-    def test_userroot_ldif_files_ownership(self):
+    @classmethod
+    def install(cls, mh):
+        super(TestUserRootFilesOwnershipPermission, cls).install(mh)
+        cls.bashrc_file = cls.master.get_file_contents('/root/.bashrc')
+
+    def test_userroot_ldif_files_ownership_and_permission(self):
         """backup, uninstall, restore, backup"""
         tasks.install_master(self.master)
         backup_path = backup(self.master)
@@ -522,28 +531,57 @@ class TestUserrootFilesOwnership(IntegrationTest):
                                  '--uninstall',
                                  '-U'])
 
+        # set umask to 077 just to check if restore success.
+        self.master.run_command('echo "umask 0077" >> /root/.bashrc')
+        result = self.master.run_command(['umask'])
+        assert '0077' in result.stdout_text
+
         dirman_password = self.master.config.dirman_password
-        self.master.run_command(['ipa-restore', backup_path],
-                                stdin_text=dirman_password + '\nyes')
+        result = self.master.run_command(['ipa-restore', backup_path],
+                                         stdin_text=dirman_password + '\nyes')
+        assert 'Temporary setting umask to 022' in result.stderr_text
+
+        # check if umask reset to 077 after restore.
+        result = self.master.run_command(['umask'])
+        assert '0077' in result.stdout_text
 
         # check if files have proper owner and group.
         dashed_domain = self.master.domain.realm.replace(".", '-')
         arg = ['stat',
-               '-c', '%U%G',
-               '/var/lib/dirsrv/slapd-' + dashed_domain + '/ldif']
+               '-c', '%U:%G',
+               '{}/ldif/'.format(
+                   paths.VAR_LIB_SLAPD_INSTANCE_DIR_TEMPLATE %
+                   dashed_domain)]
         cmd = self.master.run_command(arg)
-        assert 'dirsrvdirsrv' in cmd.stdout_text
+        expected = '{}:{}'.format(constants.DS_USER, constants.DS_GROUP)
+        assert expected in cmd.stdout_text
+
+        # also check of access rights are set to 644.
+        arg = ['stat',
+               '-c', '%U:%G:%a',
+               '{}/ldif/{}-ipaca.ldif'.format(
+                   paths.VAR_LIB_SLAPD_INSTANCE_DIR_TEMPLATE %
+                   dashed_domain, dashed_domain)]
+        cmd = self.master.run_command(arg)
+        assert '{}:644'.format(expected) in cmd.stdout_text
 
         arg = ['stat',
-               '-c', '%U%G',
-               '/var/lib/dirsrv/slapd-' + dashed_domain + '/ldif/']
+               '-c', '%U:%G:%a',
+               '{}/ldif/{}-userRoot.ldif'.format(
+                   paths.VAR_LIB_SLAPD_INSTANCE_DIR_TEMPLATE %
+                   dashed_domain, dashed_domain)]
         cmd = self.master.run_command(arg)
-        assert 'dirsrvdirsrv' in cmd.stdout_text
+        assert '{}:644'.format(expected) in cmd.stdout_text
 
         cmd = self.master.run_command(['ipa-backup', '-d'])
         unexp_str = "CRITICAL: db2ldif failed:"
         assert cmd.returncode == 0
         assert unexp_str not in cmd.stdout_text
+
+    def test_files_ownership_and_permission_teardown(self):
+        """ Method to restore the default bashrc contents"""
+        if self.bashrc_file is not None:
+            self.master.put_file_contents('/root/.bashrc', self.bashrc_file)
 
 
 class TestBackupAndRestoreDMPassword(IntegrationTest):


### PR DESCRIPTION
This PR was opened automatically because PR #2194 was pushed to master and backport to ipa-4-7 is required.