### PR TITLE
Simple doc string additions

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -173,6 +173,11 @@ def unparse_trust_flags(trust_flags):
 
 
 def verify_kdc_cert_validity(kdc_cert, ca_certs, realm):
+    """
+    Verifies the validity of a kdc_cert, ensuring it is trusted by
+    the ca_certs chain, has a PKINIT_KDC extended key usage support,
+    and verify it applies to the given realm.
+    """
     with NamedTemporaryFile() as kdc_file, NamedTemporaryFile() as ca_file:
         kdc_file.write(kdc_cert.public_bytes(x509.Encoding.PEM))
         kdc_file.flush()

--- a/ipapython/kernel_keyring.py
+++ b/ipapython/kernel_keyring.py
@@ -60,6 +60,12 @@ def get_real_key(key):
 
 
 def get_persistent_key(key):
+    """
+    Fetches the value of a persistent key from storage, trimming trailing
+    any tailing whitespace.
+
+    Assert when key is not a string-type.
+    """
     assert isinstance(key, six.string_types)
     result = run([paths.KEYCTL, 'get_persistent', KEYRING, key],
                  raiseonerr=False, capture_output=True)
@@ -69,6 +75,9 @@ def get_persistent_key(key):
 
 
 def is_persistent_keyring_supported():
+    """
+    Returns True if the kernel persistent keyring is supported.
+    """
     uid = os.geteuid()
     try:
         get_persistent_key(str(uid))


### PR DESCRIPTION
This is my first PR to FreeIPA; I think I need to create an issue associated with this in Pagure, but I'm not entirely sure. Perhaps we could go without for these changes, as they affect documentation only?

Feedback on process much appreciated. :)

I've added docstrings for three functions in `ipapython`:

 - `verify_kdc_cert_validity`
 - `get_persistent_key`
 - `is_persistent_keyring_supported`