### PR TITLE
uninstall -v: remove Tracebacks

### DIFF
--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -491,20 +491,21 @@ def run(args, stdin=None, raiseonerr=True, nolog=(), env=None,
     logger.debug('Starting external process')
     logger.debug('args=%s', arg_string)
 
+    if runas is not None:
+        pent = pwd.getpwnam(runas)
+
+        suplementary_gids = [
+            grp.getgrnam(sgroup).gr_gid for sgroup in suplementary_groups
+        ]
+
+        logger.debug('runas=%s (UID %d, GID %s)', runas,
+                     pent.pw_uid, pent.pw_gid)
+        if suplementary_groups:
+            for group, gid in zip(suplementary_groups, suplementary_gids):
+                logger.debug('suplementary_group=%s (GID %d)', group, gid)
+
     def preexec_fn():
         if runas is not None:
-            pent = pwd.getpwnam(runas)
-
-            suplementary_gids = [
-                grp.getgrnam(sgroup).gr_gid for sgroup in suplementary_groups
-            ]
-
-            logger.debug('runas=%s (UID %d, GID %s)', runas,
-                         pent.pw_uid, pent.pw_gid)
-            if suplementary_groups:
-                for group, gid in zip(suplementary_groups, suplementary_gids):
-                    logger.debug('suplementary_group=%s (GID %d)', group, gid)
-
             os.setgroups(suplementary_gids)
             os.setregid(pent.pw_gid, pent.pw_gid)
             os.setreuid(pent.pw_uid, pent.pw_uid)


### PR DESCRIPTION
ipa-server-install --uninstall -v -U prints Traceback in its log file.
This issue happens because it calls subprocess.Popen with close_fds=True
(which closes all file descriptors in the child process)
but it is trying to use the file logger in the child process
(preexec_fn is called in the child just before the child is executed).
The fix is using the logger only in the parent process.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1480502