### PR TITLE
ipa commands: print 'IPA is not configured' when ipa is not setup

### DIFF
--- a/install/tools/ipa-compat-manage
+++ b/install/tools/ipa-compat-manage
@@ -82,6 +82,8 @@ def main():
     retval = 0
     files = [paths.SCHEMA_COMPAT_ULDIF]
 
+    installutils.check_server_configuration()
+
     options, args = parse_options()
 
     if len(args) != 1:

--- a/install/tools/ipa-csreplica-manage
+++ b/install/tools/ipa-csreplica-manage
@@ -32,6 +32,7 @@ from ipaserver.install import (replication, installutils, bindinstance,
 from ipalib import api, errors
 from ipalib.util import has_managed_topology
 from ipapython import ipautil, ipaldap, version
+from ipapython.admintool import ScriptError
 from ipapython.dn import DN
 
 logger = logging.getLogger(os.path.basename(__file__))
@@ -408,6 +409,7 @@ def exit_on_managed_topology(what, hint="topologysegment"):
 
 
 def main():
+    installutils.check_server_configuration()
     options, args = parse_options()
 
     # Just initialize the environment. This is so the installer can have
@@ -496,7 +498,7 @@ try:
     main()
 except KeyboardInterrupt:
     sys.exit(1)
-except SystemExit as e:
+except (SystemExit, ScriptError) as e:
     sys.exit(e)
 except Exception as e:
     sys.exit("unexpected error: %s" % e)

--- a/ipaserver/advise/base.py
+++ b/ipaserver/advise/base.py
@@ -30,6 +30,7 @@ from ipalib.errors import ValidationError
 from ipaplatform.paths import paths
 from ipapython import admintool
 from ipapython.ipa_log_manager import Filter
+from ipaserver.install import installutils
 
 
 """
@@ -418,6 +419,7 @@ class IpaAdvise(admintool.AdminTool):
 
     def validate_options(self):
         super(IpaAdvise, self).validate_options(needs_root=False)
+        installutils.check_server_configuration()
 
         if len(self.args) > 1:
             raise self.option_parser.error("You can only provide one "

--- a/ipaserver/install/ipa_pkinit_manage.py
+++ b/ipaserver/install/ipa_pkinit_manage.py
@@ -9,6 +9,7 @@ import logging
 from ipalib import api
 from ipaplatform.paths import paths
 from ipapython.admintool import AdminTool
+from ipaserver.install import installutils
 from ipaserver.install.krbinstance import KrbInstance, is_pkinit_enabled
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ class PKINITManage(AdminTool):
 
     def validate_options(self):
         super(PKINITManage, self).validate_options(needs_root=True)
+        installutils.check_server_configuration()
 
         option_parser = self.option_parser
 

--- a/ipaserver/install/ipa_server_upgrade.py
+++ b/ipaserver/install/ipa_server_upgrade.py
@@ -35,6 +35,8 @@ class ServerUpgrade(admintool.AdminTool):
     def validate_options(self):
         super(ServerUpgrade, self).validate_options(needs_root=True)
 
+        installutils.check_server_configuration()
+
         if self.options.force:
             self.options.skip_version_check = True
 

--- a/ipaserver/install/ipa_winsync_migrate.py
+++ b/ipaserver/install/ipa_winsync_migrate.py
@@ -350,7 +350,7 @@ class WinsyncMigrate(admintool.AdminTool):
         # Check if the IPA server is configured before attempting to migrate
         try:
             installutils.check_server_configuration()
-        except RuntimeError as e:
+        except admintool.ScriptError as e:
             sys.exit(e)
 
         # Finalize API


### PR DESCRIPTION
Some commands print tracebacks or unclear error message when they are called on a machine where ipa packages are installed but IPA is not configured.
Consistently report 'IPA is not configured on this system' in this case.

Also add a test.
    
Related to https://pagure.io/freeipa/issue/6261
