### PR TITLE
Fix js error on reset view

### DIFF
--- a/install/ui/src/libs/jquery.ordered-map.js
+++ b/install/ui/src/libs/jquery.ordered-map.js
@@ -125,7 +125,11 @@ jQuery.ordered_map = jQuery.fn.ordered_map = function(map) {
     };
 
     that.get_key_index = function(key) {
-        return that._key_indicies[key];
+        var index = that._key_indicies[key];
+        if (index !== undefined) {
+            return index;
+        }
+        return -1;
     };
 
     that.get_key_by_index = function(index) {

--- a/install/ui/src/libs/jquery.ordered-map.js
+++ b/install/ui/src/libs/jquery.ordered-map.js
@@ -112,6 +112,11 @@ jQuery.ordered_map = jQuery.fn.ordered_map = function(map) {
         that.keys.splice(i, 1);
         that.values.splice(i, 1);
         delete that._key_indicies[key];
+
+        // reindex
+        for (var j=i; j<that.keys.length; j++) {
+            that._key_indicies[that.keys[j]]=j;
+        }
         that.length = that.keys.length;
         return value;
     };


### PR DESCRIPTION
Fix for https://pagure.io/freeipa/issue/7678 :
1) "get_key_index" returns -1 in mismatching case;
2) reindex "key_indicies" after item remove.