### PR TITLE
Fix render validation items on keypress event at login form

### DIFF
--- a/install/ui/src/freeipa/widgets/LoginScreenBase.js
+++ b/install/ui/src/freeipa/widgets/LoginScreenBase.js
@@ -285,13 +285,17 @@ define(['dojo/_base/declare',
          */
         display_caps_warning: function(display) {
 
-            this.caps_warning = display;
             var val_summary = this.get_widget('validation');
             if (display) {
-                val_summary.add_warning('caps', this.caps_warning_msg);
+                if (!this.caps_warning) {
+                    val_summary.add_warning('caps', this.caps_warning_msg);
+                }
             } else {
-                val_summary.remove('caps');
+                if (this.caps_warning) {
+                    val_summary.remove('caps');
+                }
             }
+            this.caps_warning = display;
         },
 
         bind_validation: function(summary, field) {


### PR DESCRIPTION
There are many no needed render callings which are performed
on each "keypress" event at login form. It is enough to update
validation items on "CapsLock" state change.

Fixes: https://pagure.io/freeipa/issue/7679