### PR TITLE
[Backport][ipa-4-7] uninstall -v: remove Tracebacks

### DIFF
--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -491,20 +491,21 @@ def run(args, stdin=None, raiseonerr=True, nolog=(), env=None,
     logger.debug('Starting external process')
     logger.debug('args=%s', arg_string)
 
+    if runas is not None:
+        pent = pwd.getpwnam(runas)
+
+        suplementary_gids = [
+            grp.getgrnam(sgroup).gr_gid for sgroup in suplementary_groups
+        ]
+
+        logger.debug('runas=%s (UID %d, GID %s)', runas,
+                     pent.pw_uid, pent.pw_gid)
+        if suplementary_groups:
+            for group, gid in zip(suplementary_groups, suplementary_gids):
+                logger.debug('suplementary_group=%s (GID %d)', group, gid)
+
     def preexec_fn():
         if runas is not None:
-            pent = pwd.getpwnam(runas)
-
-            suplementary_gids = [
-                grp.getgrnam(sgroup).gr_gid for sgroup in suplementary_groups
-            ]
-
-            logger.debug('runas=%s (UID %d, GID %s)', runas,
-                         pent.pw_uid, pent.pw_gid)
-            if suplementary_groups:
-                for group, gid in zip(suplementary_groups, suplementary_gids):
-                    logger.debug('suplementary_group=%s (GID %d)', group, gid)
-
             os.setgroups(suplementary_gids)
             os.setregid(pent.pw_gid, pent.pw_gid)
             os.setreuid(pent.pw_uid, pent.pw_uid)


### PR DESCRIPTION
This PR was opened automatically because PR #2265 was pushed to master and backport to ipa-4-7 is required.