### PR TITLE
[Backport][ipa-4-6] ipa commands: print 'IPA is not configured' when ipa is not setup

### DIFF
--- a/install/tools/ipa-compat-manage
+++ b/install/tools/ipa-compat-manage
@@ -82,6 +82,8 @@ def main():
     retval = 0
     files = [paths.SCHEMA_COMPAT_ULDIF]
 
+    installutils.check_server_configuration()
+
     options, args = parse_options()
 
     if len(args) != 1:

--- a/install/tools/ipa-csreplica-manage
+++ b/install/tools/ipa-csreplica-manage
@@ -32,6 +32,7 @@ from ipaserver.install import (replication, installutils, bindinstance,
 from ipalib import api, errors
 from ipalib.util import has_managed_topology
 from ipapython import ipautil, ipaldap, version
+from ipapython.admintool import ScriptError
 from ipapython.dn import DN
 
 logger = logging.getLogger(os.path.basename(__file__))
@@ -408,6 +409,7 @@ def exit_on_managed_topology(what, hint="topologysegment"):
 
 
 def main():
+    installutils.check_server_configuration()
     options, args = parse_options()
 
     # Just initialize the environment. This is so the installer can have
@@ -496,7 +498,7 @@ try:
     main()
 except KeyboardInterrupt:
     sys.exit(1)
-except SystemExit as e:
+except (SystemExit, ScriptError) as e:
     sys.exit(e)
 except Exception as e:
     sys.exit("unexpected error: %s" % e)

--- a/install/tools/man/ipa-backup.1
+++ b/install/tools/man/ipa-backup.1
@@ -69,6 +69,8 @@ Log to the given file
 0 if the command was successful
 
 1 if an error occurred
+
+2 if IPA is not configured
 .SH "FILES"
 .PP
 \fI/var/lib/ipa/backup\fR

--- a/ipapython/admintool.py
+++ b/ipapython/admintool.py
@@ -32,6 +32,10 @@ from ipapython import version
 from ipapython import config
 from ipapython.ipa_log_manager import standard_logging_setup
 
+SUCCESS = 0
+SERVER_INSTALL_ERROR = 1
+SERVER_NOT_CONFIGURED = 2
+
 logger = logging.getLogger(__name__)
 
 
@@ -301,7 +305,9 @@ class AdminTool(object):
         if error_message:
             logger.error('%s', error_message)
         message = "The %s command failed." % self.command_name
-        if self.log_file_name:
+        if self.log_file_name and return_value != 2:
+            # magic value because this is common between server and client
+            # but imports are not straigthforward
             message += " See %s for more information" % self.log_file_name
         logger.error('%s', message)
 

--- a/ipaserver/advise/base.py
+++ b/ipaserver/advise/base.py
@@ -30,6 +30,7 @@ from ipalib.errors import ValidationError
 from ipaplatform.paths import paths
 from ipapython import admintool
 from ipapython.ipa_log_manager import Filter
+from ipaserver.install import installutils
 
 
 """
@@ -418,6 +419,7 @@ class IpaAdvise(admintool.AdminTool):
 
     def validate_options(self):
         super(IpaAdvise, self).validate_options(needs_root=False)
+        installutils.check_server_configuration()
 
         if len(self.args) > 1:
             raise self.option_parser.error("You can only provide one "

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -56,7 +56,7 @@ from ipalib.install import sysrestore
 from ipalib.install.kinit import kinit_password
 import ipaplatform
 from ipapython import ipautil, admintool, version
-from ipapython.admintool import ScriptError
+from ipapython.admintool import ScriptError, SERVER_NOT_CONFIGURED  # noqa: E402
 from ipapython.certdb import EXTERNAL_CA_TRUST_FLAGS
 from ipapython.ipaldap import DIRMAN_DN, LDAPClient
 from ipalib.util import validate_hostname
@@ -934,7 +934,8 @@ def check_server_configuration():
     """
     server_fstore = sysrestore.FileStore(paths.SYSRESTORE)
     if not server_fstore.has_files():
-        raise RuntimeError("IPA is not configured on this system.")
+        raise ScriptError("IPA is not configured on this system.",
+                          rval=SERVER_NOT_CONFIGURED)
 
 
 def remove_file(filename):

--- a/ipaserver/install/ipa_pkinit_manage.py
+++ b/ipaserver/install/ipa_pkinit_manage.py
@@ -9,6 +9,7 @@ import logging
 from ipalib import api
 from ipaplatform.paths import paths
 from ipapython.admintool import AdminTool
+from ipaserver.install import installutils
 from ipaserver.install.krbinstance import KrbInstance, is_pkinit_enabled
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ class PKINITManage(AdminTool):
 
     def validate_options(self):
         super(PKINITManage, self).validate_options(needs_root=True)
+        installutils.check_server_configuration()
 
         option_parser = self.option_parser
 

--- a/ipaserver/install/ipa_server_upgrade.py
+++ b/ipaserver/install/ipa_server_upgrade.py
@@ -35,6 +35,8 @@ class ServerUpgrade(admintool.AdminTool):
     def validate_options(self):
         super(ServerUpgrade, self).validate_options(needs_root=True)
 
+        installutils.check_server_configuration()
+
         if self.options.force:
             self.options.skip_version_check = True
 

--- a/ipaserver/install/ipa_winsync_migrate.py
+++ b/ipaserver/install/ipa_winsync_migrate.py
@@ -350,7 +350,7 @@ class WinsyncMigrate(admintool.AdminTool):
         # Check if the IPA server is configured before attempting to migrate
         try:
             installutils.check_server_configuration()
-        except RuntimeError as e:
+        except admintool.ScriptError as e:
             sys.exit(e)
 
         # Finalize API


### PR DESCRIPTION
This PR was opened automatically because PR #2268 was pushed to master and backport to ipa-4-6 is required.