### PR TITLE
[Backport][ipa-4-5] ipa commands: print 'IPA is not configured' when ipa is not setup

### DIFF
--- a/install/tools/ipa-compat-manage
+++ b/install/tools/ipa-compat-manage
@@ -82,6 +82,8 @@ def main():
     retval = 0
     files = [paths.SCHEMA_COMPAT_ULDIF]
 
+    installutils.check_server_configuration()
+
     options, args = parse_options()
 
     if len(args) != 1:

--- a/install/tools/ipa-csreplica-manage
+++ b/install/tools/ipa-csreplica-manage
@@ -404,6 +404,7 @@ def exit_on_managed_topology(what, hint="topologysegment"):
 
 
 def main():
+    installutils.check_server_configuration()
     options, args = parse_options()
 
     # Just initialize the environment. This is so the installer can have
@@ -492,7 +493,7 @@ try:
     main()
 except KeyboardInterrupt:
     sys.exit(1)
-except SystemExit as e:
+except (SystemExit, RuntimeError) as e:
     sys.exit(e)
 except Exception as e:
     sys.exit("unexpected error: %s" % e)

--- a/ipaserver/advise/base.py
+++ b/ipaserver/advise/base.py
@@ -29,6 +29,7 @@ from ipalib.errors import ValidationError
 from ipaplatform.paths import paths
 from ipapython import admintool
 from ipapython.ipa_log_manager import log_mgr
+from ipaserver.install import installutils
 
 
 """
@@ -417,6 +418,7 @@ class IpaAdvise(admintool.AdminTool):
 
     def validate_options(self):
         super(IpaAdvise, self).validate_options(needs_root=False)
+        installutils.check_server_configuration()
 
         if len(self.args) > 1:
             raise self.option_parser.error("You can only provide one "

--- a/ipaserver/install/ipa_pkinit_manage.py
+++ b/ipaserver/install/ipa_pkinit_manage.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 from ipalib import api
 from ipaplatform.paths import paths
 from ipapython.admintool import AdminTool
+from ipaserver.install import installutils
 from ipaserver.install.krbinstance import KrbInstance, is_pkinit_enabled
 
 
@@ -17,6 +18,7 @@ class PKINITManage(AdminTool):
 
     def validate_options(self):
         super(PKINITManage, self).validate_options(needs_root=True)
+        installutils.check_server_configuration()
 
         option_parser = self.option_parser
 

--- a/ipaserver/install/ipa_server_upgrade.py
+++ b/ipaserver/install/ipa_server_upgrade.py
@@ -29,6 +29,8 @@ class ServerUpgrade(admintool.AdminTool):
     def validate_options(self):
         super(ServerUpgrade, self).validate_options(needs_root=True)
 
+        installutils.check_server_configuration()
+
         if self.options.force:
             self.options.skip_version_check = True
 

--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -1,4 +1,6 @@
+import os
 import shlex
+import subprocess
 import sys
 import contextlib
 
@@ -305,3 +307,56 @@ class TestCLIParsing(object):
 
         if not adtrust_is_enabled:
             mockldap.del_entry(adtrust_dn)
+
+
+IPA_NOT_CONFIGURED = b'IPA is not configured on this system'
+IPA_CLIENT_NOT_CONFIGURED = b'IPA client is not configured on this system'
+
+
+@pytest.mark.needs_ipaapi
+@pytest.mark.skipif(
+    os.geteuid() != 0 or os.path.isfile('/etc/ipa/default.conf'),
+    reason="Must have root privileges to run this test "
+           "and IPA must not be installed")
+@pytest.mark.parametrize(
+    "args, retcode, error",
+    [
+        # Commands delivered by the client pkg
+        (['ipa'], 1, IPA_CLIENT_NOT_CONFIGURED),
+        (['ipa-certupdate'], 1, IPA_CLIENT_NOT_CONFIGURED),
+        (['ipa-client-automount'], 1, IPA_CLIENT_NOT_CONFIGURED),
+        # Commands delivered by the server pkg
+        (['ipa-adtrust-install'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-advise'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-backup'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-cacert-manage'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-ca-install'], 1,
+         b'IPA server is not configured on this system'),
+        (['ipa-compat-manage'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-csreplica-manage'], 1, IPA_NOT_CONFIGURED),
+        (['ipactl', 'status'], 4, b'IPA is not configured'),
+        (['ipa-dns-install'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-kra-install'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-ldap-updater',
+          '/usr/share/ipa/updates/05-pre_upgrade_plugins.update'],
+         1, IPA_NOT_CONFIGURED),
+        (['ipa-managed-entries'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-nis-manage'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-pkinit-manage'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-replica-manage', 'list'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-server-certinstall'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-server-upgrade'], 1, IPA_NOT_CONFIGURED),
+        (['ipa-winsync-migrate'], 1, IPA_NOT_CONFIGURED)
+    ])
+def test_command_ipa_not_installed(args, retcode, error):
+    """
+    Test that the commands properly return that IPA client|server is not
+    configured on this system.
+    Launch the command specified in args.
+    Check that the exit code is as expected and that stderr
+    contains the expected strings.
+    """
+    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    res = p.communicate()
+    assert retcode == p.returncode
+    assert error in res[1]


### PR DESCRIPTION
This is a manual backport of PR #2268 to ipa-4-5.