### PR TITLE
[Backport][ipa-4-6] Test for ipa-replica-install fails with PIN error for CA-less env.

### DIFF
--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -1146,6 +1146,41 @@ class TestReplicaInstall(CALessBase):
         if self.domain_level > DOMAIN_LEVEL_0:
             self.verify_installation()
 
+    @replica_install_teardown
+    def test_certs_with_no_password(self):
+        # related to https://pagure.io/freeipa/issue/7274
+
+        self.create_pkcs12('ca1/replica', filename='http.p12',
+                           password='')
+        self.create_pkcs12('ca1/replica', filename='dirsrv.p12',
+                           password='')
+        self.prepare_cacert('ca1')
+
+        self.prepare_replica(http_pkcs12='http.p12',
+                             dirsrv_pkcs12='dirsrv.p12',
+                             http_pin='', dirsrv_pin='')
+        if self.domain_level > DOMAIN_LEVEL_0:
+            self.verify_installation()
+
+    @replica_install_teardown
+    def test_certs_with_no_password_interactive(self):
+        # related to https://pagure.io/freeipa/issue/7274
+
+        self.create_pkcs12('ca1/replica', filename='http.p12',
+                           password='')
+        self.create_pkcs12('ca1/replica', filename='dirsrv.p12',
+                           password='')
+        self.prepare_cacert('ca1')
+        stdin_text = '\n\nyes'
+
+        result = self.prepare_replica(http_pkcs12='http.p12',
+                                      dirsrv_pkcs12='dirsrv.p12',
+                                      http_pin=None, dirsrv_pin=None,
+                                      unattended=False, stdin_text=stdin_text)
+        assert result.returncode == 0
+        if self.domain_level > DOMAIN_LEVEL_0:
+            self.verify_installation()
+
 
 class TestClientInstall(CALessBase):
     num_clients = 1


### PR DESCRIPTION
Signed-off-by: Anuja More <amore@redhat.com>
Reviewed-By: Florence Blanc-Renaud <frenaud@redhat.com>
Reviewed-By: Aleksei Slaikovskii <aslaikov@redhat.com>
Reviewed-By: Stanislav Laznicka <slaznick@redhat.com>