### PR TITLE
[Backport][ipa-4-6] Do not set ca_host when --setup-ca is used.

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -452,6 +452,11 @@ class CAInstance(DogtagInstance):
                 self.step("updating IPA configuration", update_ipa_conf)
                 self.step("enabling CA instance", self.__enable_instance)
                 if not promote:
+                    if self.clone:
+                        # DL0 workaround; see docstring of __expose_ca_in_ldap
+                        self.step("exposing CA instance on LDAP",
+                                  self.__expose_ca_in_ldap)
+
                     self.step("migrating certificate profiles to LDAP",
                               migrate_profiles_to_ldap)
                     self.step("importing IPA certificate profiles",
@@ -1268,6 +1273,25 @@ class CAInstance(DogtagInstance):
         else:
             config = []
         self.ldap_configure('CA', self.fqdn, None, basedn, config)
+
+    def __expose_ca_in_ldap(self):
+        """
+        In a case when replica is created on DL0 we need to make
+        sure that query for CA service record of this replica in
+        ldap will succeed in time of installation.
+        This method is needed for sucessfull replica installation
+        on DL0 and should be removed alongside with code for DL0.
+
+        To suppress deprecation warning message this method is
+        not invoking ldap_enable() but _ldap_enable() method.
+        """
+
+        basedn = ipautil.realm_to_suffix(self.realm)
+        if not self.clone:
+            config = ['caRenewalMaster']
+        else:
+            config = []
+        self._ldap_enable(u'enabledService', "CA", self.fqdn, basedn, config)
 
     def setup_lightweight_ca_key_retrieval(self):
         if sysupgrade.get_upgrade_state('dogtag', 'setup_lwca_key_retrieval'):

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -241,9 +241,12 @@ def create_ipa_conf(fstore, config, ca_enabled, master=None):
         gopts.extend([
             ipaconf.setOption('enable_ra', 'True'),
             ipaconf.setOption('ra_plugin', 'dogtag'),
-            ipaconf.setOption('dogtag_version', '10'),
-            ipaconf.setOption('ca_host', config.ca_host_name)
+            ipaconf.setOption('dogtag_version', '10')
         ])
+
+        if not config.setup_ca:
+            gopts.append(ipaconf.setOption('ca_host', config.ca_host_name))
+
     else:
         gopts.extend([
             ipaconf.setOption('enable_ra', 'False'),


### PR DESCRIPTION
This PR was opened automatically because PR #2185 was pushed to master and backport to ipa-4-6 is required.