### PR TITLE
[Backport][ipa-4-6] Fix ipa-replica-install when key not protected by PIN

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1057,7 +1057,7 @@ def promote_check(installer):
         if options.http_pin is None:
             options.http_pin = installutils.read_password(
                 "Enter Apache Server private key unlock",
-                confirm=False, validate=False)
+                confirm=False, validate=False, retry=False)
             if options.http_pin is None:
                 raise ScriptError(
                     "Apache Server private key unlock password required")
@@ -1073,7 +1073,7 @@ def promote_check(installer):
         if options.dirsrv_pin is None:
             options.dirsrv_pin = installutils.read_password(
                 "Enter Directory Server private key unlock",
-                confirm=False, validate=False)
+                confirm=False, validate=False, retry=False)
             if options.dirsrv_pin is None:
                 raise ScriptError(
                     "Directory Server private key unlock password required")
@@ -1089,7 +1089,7 @@ def promote_check(installer):
         if options.pkinit_pin is None:
             options.pkinit_pin = installutils.read_password(
                 "Enter Kerberos KDC private key unlock",
-                confirm=False, validate=False)
+                confirm=False, validate=False, retry=False)
             if options.pkinit_pin is None:
                 raise ScriptError(
                     "Kerberos KDC private key unlock password required")


### PR DESCRIPTION
Manual backport because PR #1315  was pushed to master and backport to ipa-4-6 is required.