### PR TITLE
Fix external CA next step example output

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -674,7 +674,7 @@ class CAInstance(DogtagInstance):
 
         if self.external == 1:
             print("The next step is to get %s signed by your CA and re-run %s as:" % (self.csr_file, sys.argv[0]))
-            print("%s --external-cert-file=/path/to/signed_certificate --external-cert-file=/path/to/external_ca_certificate" % sys.argv[0])
+            print("%s --external_cert_file=/path/to/signed_certificate --external_ca_file=/path/to/external_ca_certificate" % sys.argv[0])
             sys.exit(0)
         else:
             shutil.move(paths.CA_BACKUP_KEYS_P12,


### PR DESCRIPTION
Currently it displays the option `--external-cert-file` twice.
The option should be `--external_cert_file` but only once and the second option should be `--external_ca_file`.