### PR TITLE
Delete empty keytab during client installation

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2126,6 +2126,16 @@ def install_check(options):
         logger.warning("Option 'force-join' has no additional effect "
                        "when used with together with option 'keytab'.")
 
+    # Remove invalid keytab file
+    try:
+        gssapi.Credentials(
+            store={'keytab': paths.KRB5_KEYTAB},
+            usage='accept',
+        )
+    except gssapi.exceptions.GSSError:
+        logger.debug("Deleting invalid keytab: '%s'.", paths.KRB5_KEYTAB)
+        remove_file(paths.KRB5_KEYTAB)
+
     # Check if old certificate exist and show warning
     if (
         not options.ca_cert_file and


### PR DESCRIPTION
Client installation fails if '/etc/krb5.keytab' exists as a zero-length file. Deleting empty keytab before proceeding with the installation fixes the problem.

https://pagure.io/freeipa/issue/7625

Signed-off-by: Armando Neto <abiagion@redhat.com>

**Note to reviewers:**
Function implemented instead of an in-place solution, so it could be easily tested, if this solution is overkill I don't mind to remove the test case and move the check-and-delete procedure to where the function is being called.
