### PR TITLE
ipa-server-install: do not perform forwarder validation with --no-dnssec-validation

### DIFF
--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -292,8 +292,8 @@ def install_check(standalone, api, replica, options, hostname):
 
     # test DNSSEC forwarders
     if options.forwarders:
-        if (not bindinstance.check_forwarders(options.forwarders)
-                and not options.no_dnssec_validation):
+        if not options.no_dnssec_validation \
+                and not bindinstance.check_forwarders(options.forwarders):
             options.no_dnssec_validation = True
             print("WARNING: DNSSEC validation will be disabled")
 


### PR DESCRIPTION
When ipa-server-install is called -with --forwarder, it checks if the forwarder supports DNSSEC and:
- exits if the forwarder is not reachable or does not answer to a query for . SOA
- prints a warning if the forwarder does not support DNSSEC.

When the --no-dnssec-validation option is provided, the installer should not perform the check.

The commit also adds a test that simulates a non-responding forwarder. It would have been too complex to setup a forwarder without DNSSEC support (i.e. a machine with BIND service and /etc/named.conf containing `dnssec-enable no; dnssec-validation no;`).

Fixes: https://pagure.io/freeipa/issue/7666
