### PR TITLE
[Backport][ipa-4-7] Add "389-ds-base-legacy-tools" to requires.

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -329,6 +329,7 @@ Requires: python2-ipaserver = %{version}-%{release}
 Requires: python2-ldap >= %{python_ldap_version}
 %endif
 Requires: 389-ds-base >= %{ds_version}
+Requires: 389-ds-base-legacy-tools >= %{ds_version}
 Requires: openldap-clients > 2.4.35-4
 Requires: nss >= %{nss_version}
 Requires: nss-tools >= %{nss_version}


### PR DESCRIPTION
This PR was opened automatically because PR #2309 was pushed to master and backport to ipa-4-7 is required.