### PR TITLE
[Backport][ipa-4-6] Prevent installation with single label domains

### DIFF
--- a/ipalib/install/service.py
+++ b/ipalib/install/service.py
@@ -129,6 +129,10 @@ class ServiceInstallInterface(common.Installable,
         cli_names='--realm',
     )
 
+    @realm_name.validator
+    def realm_name(self, value):
+        validate_domain_name(value, entity="realm")
+
     host_name = knob(
         str, None,
         description="The hostname of this machine (FQDN). If specified, the "

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -402,11 +402,18 @@ def validate_dns_label(dns_label, allow_underscore=False, allow_slash=False):
                            % dict(chars=chars, chars2=chars2))
 
 
-def validate_domain_name(domain_name, allow_underscore=False, allow_slash=False):
+def validate_domain_name(
+    domain_name, allow_underscore=False,
+    allow_slash=False, entity='domain'
+):
     if domain_name.endswith('.'):
         domain_name = domain_name[:-1]
 
     domain_name = domain_name.split(".")
+
+    if len(domain_name) < 2:
+        raise ValueError(_(
+            'single label {}s are not supported'.format(entity)))
 
     # apply DNS name validator to every name part
     for label in domain_name:

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -473,6 +473,11 @@ def install_check(installer):
     if not options.realm_name:
         realm_name = read_realm_name(domain_name, not installer.interactive)
         logger.debug("read realm_name: %s\n", realm_name)
+
+        try:
+            validate_domain_name(realm_name, entity="realm")
+        except ValueError as e:
+            raise ScriptError("Invalid realm name: {}".format(unicode(e)))
     else:
         realm_name = options.realm_name.upper()
 

--- a/ipatests/test_xmlrpc/test_config_plugin.py
+++ b/ipatests/test_xmlrpc/test_config_plugin.py
@@ -22,10 +22,12 @@
 Test the `ipaserver/plugins/config.py` module.
 """
 
-from ipalib import errors
+from ipalib import api, errors
 from ipatests.test_xmlrpc.xmlrpc_test import Declarative
 import pytest
 
+domain = api.env.domain
+sl_domain = 'singlelabeldomain'
 
 @pytest.mark.tier1
 class test_config(Declarative):
@@ -286,5 +288,19 @@ class test_config(Declarative):
                 'summary': None,
                 'value': None,
             },
+        ),
+        dict(
+            desc='Check if domain resolution order does not accept SLD',
+            command=(
+                'config_mod', [], {
+                    'ipadomainresolutionorder': u'{domain}:{sl_domain}'.format(
+                        domain=domain, sl_domain=sl_domain)}),
+            expected=errors.ValidationError(
+                name=u'ipadomainresolutionorder',
+                error=(
+                    u"Invalid domain name '{}': "
+                    "single label domains are not supported").format(
+                        sl_domain),
+            ),
         ),
     ]

--- a/ipatests/test_xmlrpc/test_realmdomains_plugin.py
+++ b/ipatests/test_xmlrpc/test_realmdomains_plugin.py
@@ -33,6 +33,7 @@ our_domain = api.env.domain
 new_domain_1 = u'example1.com'
 new_domain_2 = u'example2.com'
 bad_domain = u'doesnotexist.test'
+sl_domain = u'singlelabeldomain'
 
 
 @pytest.mark.tier1
@@ -280,4 +281,12 @@ class test_realmdomains(Declarative):
                 ),
             ),
         ),
+        dict(
+            desc='Add a single label domain {}'.format(sl_domain),
+            command=('realmdomains_mod', [], {'add_domain': sl_domain}),
+            expected=errors.ValidationError(
+                name='add_domain',
+                error='single label domains are not supported'
+            ),
+        )
     ]


### PR DESCRIPTION
Adds validation to prevent user to install ipa with single label
domain.

https://pagure.io/freeipa/issue/7207

Reviewed-By: Florence Blanc-Renaud <frenaud@redhat.com>