### PR TITLE
[Backport][ipa-4-7] bump PRCI template version to 0.1.8

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -23,7 +23,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f28
           name: freeipa/ci-master-f28
-          version: 0.1.7
+          version: 0.1.8
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -35,7 +35,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f28
           name: freeipa/ci-master-f28
-          version: 0.1.7
+          version: 0.1.8
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -29,7 +29,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f28
           name: freeipa/ci-master-f28
-          version: 0.1.7
+          version: 0.1.8
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
This PR was opened automatically because PR #2314 was pushed to master and backport to ipa-4-7 is required.