### PR TITLE
[Backport][ipa-4-7] ipa-server-install: do not perform forwarder validation with --no-dnssec-validation

### DIFF
--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -292,8 +292,8 @@ def install_check(standalone, api, replica, options, hostname):
 
     # test DNSSEC forwarders
     if options.forwarders:
-        if (not bindinstance.check_forwarders(options.forwarders)
-                and not options.no_dnssec_validation):
+        if not options.no_dnssec_validation \
+                and not bindinstance.check_forwarders(options.forwarders):
             options.no_dnssec_validation = True
             print("WARNING: DNSSEC validation will be disabled")
 


### PR DESCRIPTION
This PR was opened automatically because PR #2310 was pushed to master and backport to ipa-4-7 is required.