### PR TITLE
[Backport][ipa-4-6] ipa-server-install: do not perform forwarder validation with --no-dnssec-validation

### DIFF
--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -293,8 +293,8 @@ def install_check(standalone, api, replica, options, hostname):
 
     # test DNSSEC forwarders
     if options.forwarders:
-        if (not bindinstance.check_forwarders(options.forwarders)
-                and not options.no_dnssec_validation):
+        if not options.no_dnssec_validation \
+                and not bindinstance.check_forwarders(options.forwarders):
             options.no_dnssec_validation = True
             print("WARNING: DNSSEC validation will be disabled")
 

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -570,3 +570,47 @@ class TestMigrateDNSSECMaster(IntegrationTest):
             self.master.ip, example3_test_zone, timeout=200
         ), ("Zone %s is not signed (master)"
             % example3_test_zone)
+
+
+class TestInstallNoDnssecValidation(IntegrationTest):
+    """test installation of the master with
+    --no-dnssec-validation
+
+    Test for issue 7666: ipa-server-install --setup-dns is failing
+    if using --no-dnssec-validation and --forwarder, when the
+    specified forwarder does not support DNSSEC.
+    The forwarder should not be checked for DNSSEC support when
+    --no-dnssec-validation argument is specified.
+    In order to reproduce the conditions, the test is using a dummy
+    IP address for the forwarder (i.e. there is no BIND service available
+    at this IP address). To make sure of that, the test is using the IP of
+    a replica (that is not yet setup).
+    """
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        cls.install_args = [
+            'ipa-server-install',
+            '-n', cls.master.domain.name,
+            '-r', cls.master.domain.realm,
+            '-p', cls.master.config.dirman_password,
+            '-a', cls.master.config.admin_password,
+            '-U',
+            '--setup-dns',
+            '--forwarder', cls.replicas[0].ip,
+            '--auto-reverse'
+        ]
+
+    def test_install_withDnssecValidation(self):
+        cmd = self.master.run_command(self.install_args, raiseonerr=False)
+        # The installer checks that the forwarder supports DNSSEC
+        # but the forwarder does not answer => expect failure
+        assert cmd.returncode != 0
+
+    def test_install_noDnssecValidation(self):
+        # With the --no-dnssec-validation, the installer does not check
+        # whether the forwarder supports DNSSEC => success even if the
+        # forwarder is not reachable
+        self.master.run_command(
+            self.install_args + ['--no-dnssec-validation'])


### PR DESCRIPTION
This PR was opened automatically because PR #2310 was pushed to master and backport to ipa-4-6 is required.