### PR TITLE
ipa-replica-install: fix pkinit setup 

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -300,9 +300,11 @@ def ca_kdc_check(api_instance, hostname):
 
         ipaconfigstring = {val.lower() for val in kdc_entry['ipaConfigString']}
 
-        if 'enabledservice' not in ipaconfigstring:
+        if 'enabledservice' not in ipaconfigstring \
+                and 'configuredservice' not in ipaconfigstring:
             raise errors.NotFound(
-                reason=_("enabledService not in ipaConfigString kdc entry"))
+                reason=_("enabledService/configuredService not in "
+                         "ipaConfigString kdc entry"))
 
     except errors.NotFound:
         raise errors.ACIError(

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -208,6 +208,9 @@ class TestReplicaPromotionLevel1(ReplicaPromotionBase):
                                      '-r', self.master.domain.realm,
                                      '--server', self.master.hostname,
                                      '-U'])
+        # Ensure that pkinit is properly configured, test for 7566
+        result = self.replicas[0].run_command(['ipa-pkinit-manage', 'status'])
+        assert "PKINIT is enabled" in result.stdout_text
 
 
 @pytest.mark.skip(reason="Domain level 0 is not supported anymore")


### PR DESCRIPTION
### ipa-replica-install: fix pkinit setup
commit 7284097 (Delay enabling services until end of installer)
introduced a regression in replica installation.
When the replica requests a cert for PKINIT, a check is done
to ensure that the hostname corresponds to a machine with a
KDC service enabled (ipaconfigstring attribute of
cn=KDC,cn=<hostname>,cn=masters,cn=ipa,cn=etc,$BASEDN must contain
'enabledService').
With the commit mentioned above, the service is set to enabled only
at the end of the installation.

The fix makes a less strict check, ensuring that 'enabledService'
or 'configuredService' is in ipaconfigstring.

Fixes: https://pagure.io/freeipa/issue/7566

### Tests: test successful PKINIT install on replica

Add a test checking that ipa-replica-install successfully configures
PKINIT on the replica