### PR TITLE
Fix certificate type error when exporting to file

### DIFF
--- a/ipaclient/plugins/ca.py
+++ b/ipaclient/plugins/ca.py
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
+import base64
 
 from ipaclient.frontend import MethodOverride
 from ipalib import errors, util, x509, Str
@@ -34,13 +35,11 @@ class WithCertOutArgs(MethodOverride):
         result = super(WithCertOutArgs, self).forward(*keys, **options)
         if filename:
             if options.get('chain', False):
-                certs = (x509.load_der_x509_certificate(c)
-                         for c in result['result']['certificate_chain'])
+                certs = result['result']['certificate_chain']
             else:
-                certs = [
-                    x509.load_der_x509_certificate(
-                        result['result']['certificate'])
-                ]
+                certs = [result['result']['certificate']]
+            certs = (x509.load_der_x509_certificate(base64.b64decode(cert))
+                     for cert in certs)
             x509.write_certificate_list(certs, filename)
 
         return result

--- a/ipatests/test_xmlrpc/test_ca_plugin.py
+++ b/ipatests/test_xmlrpc/test_ca_plugin.py
@@ -97,6 +97,13 @@ class TestCAbasicCRUD(XMLRPC_test):
     def test_retrieve_all(self, crud_subca):
         crud_subca.retrieve(all=True)
 
+    def test_export_ca(self, tmpdir, crud_subca):
+        exported_ca = tmpdir.join('exported_ca')
+        command = crud_subca.make_retrieve_command(
+            certificate_out=u'%s' % exported_ca,
+        )
+        command()
+
     def test_delete(self, crud_subca):
         crud_subca.delete()
 

--- a/ipatests/test_xmlrpc/tracker/ca_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/ca_plugin.py
@@ -91,9 +91,10 @@ class CATracker(Tracker):
             result=dict(failed=[])
         ), result)
 
-    def make_retrieve_command(self, all=False, raw=False):
+    def make_retrieve_command(self, all=False, raw=False, **options):
         """Make function that retrieves the entry using ${CMD}_show"""
-        return self.make_command('ca_show', self.name, all=all, raw=raw)
+        return self.make_command('ca_show', self.name, all=all, raw=raw,
+                                 **options)
 
     def check_retrieve(self, result, all=False, raw=False):
         """Check the plugin's `show` command result"""


### PR DESCRIPTION
Commands `ipa ca-show` and `ipa cert-show` share the same code, this commit updates the former, closing the gap between them.

Reflecting the changes done in 5a44ca6.

https://pagure.io/freeipa/issue/7628

Signed-off-by: Armando Neto <abiagion@redhat.com>

To be more specific, `ipa cert-show` code is: https://github.com/freeipa/freeipa/blob/5a44ca638310913ab6b0c239374f4b0ddeeedeb3/ipaclient/plugins/cert.py#L51-L73