### PR TITLE
Add client uninstallation tests to nightly

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -688,6 +688,18 @@ jobs:
         timeout: 7200
         topology: *master_3repl_1client
 
+  fedora-28/test_client_uninstallation:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_uninstallation.py
+        template: *ci-master-f28
+        timeout: 7200
+        topology: *master_1repl
+
   fedora-28/test_webui:
     requires: [fedora-28/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -664,6 +664,18 @@ jobs:
         timeout: 7200
         topology: *master_3repl_1client
 
+  fedora-rawhide/test_client_uninstallation:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_uninstallation.py
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_1repl
+
   fedora-rawhide/test_webui:
     requires: [fedora-rawhide/build]
     priority: 50

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -40,7 +40,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_uninstallation.py::TestUninstallBase::test_failed_uninstall
         template: *ci-master-f28
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *master_1repl


### PR DESCRIPTION
This PR adds the client uninstallation tests (back) to nightly PR-CI list.