### PR TITLE
 ipa-replica-install: properly use the file store 

### DIFF
--- a/ipatests/test_integration/test_uninstallation.py
+++ b/ipatests/test_integration/test_uninstallation.py
@@ -49,6 +49,18 @@ class TestUninstallBase(IntegrationTest):
             ['ls', restore_state_path], raiseonerr=False)
         assert 'No such file or directory' in result.stderr_text
 
+    def test_install_uninstall_replica(self):
+        # Test that the sequence install replica / uninstall replica
+        # properly removes the line
+        # Include /etc/httpd/conf.d/ipa-rewrite.conf
+        # from ssl.conf on the replica
+        tasks.install_replica(self.master, self.replicas[0],
+                              extra_args=['--force-join'])
+        tasks.uninstall_replica(self.master, self.replicas[0])
+        errline = b'Include /etc/httpd/conf.d/ipa-rewrite.conf'
+        ssl_conf = self.replicas[0].get_file_contents(paths.HTTPD_SSL_CONF)
+        assert errline not in ssl_conf
+
     def test_failed_uninstall(self):
         self.master.run_command(['ipactl', 'stop'])
 


### PR DESCRIPTION
### ipa-replica-install: properly use the file store
In ipa-replica-install, many components use their own instance of the FileStore to backup configuration files to the pre-install state. This causes issues when the calls are mixed, like for instance:
ds.do_task1_that_backups_file (using ds.filestore)
http.do_task2_that_backups_file (using http.filestore)
ds.do_task3_that_backups_file (using ds.filestore)

because the list of files managed by ds.filestore does not include the files managed by http.filestore, and the 3rd call would remove any file added on 2nd call.

The symptom of this bug is that ipa-replica-install does not save /etc/httpd/conf.d/ssl.conf and subsequent uninstallation does not restore the file, leading to a line referring to ipa-rewrite.conf
that prevents httpd startup.

The installer should consistently use the same filestore.

Fixes https://pagure.io/freeipa/issue/7684

### Test: scenario replica install/uninstall should restore ssl.conf

Test that the scenario ipa-replica-install/ uninstall correctly restores the file /etc/httpd/conf.d/ssl.conf

Related to https://pagure.io/freeipa/issue/7684