### PR TITLE
Add test for client installation with empty keytab file

### DIFF
--- a/ipatests/test_integration/test_forced_client_reenrollment.py
+++ b/ipatests/test_integration/test_forced_client_reenrollment.py
@@ -160,6 +160,19 @@ class TestForcedClientReenrollment(IntegrationTest):
         self.clients[0].run_command(['touch', EMPTY_KEYTAB])
         self.reenroll_client(keytab=EMPTY_KEYTAB, expect_fail=True)
 
+    def test_try_to_reenroll_with_empty_keytab(self, client):
+        """
+        Client re-enrollment with invalid (empty) client keytab file
+        """
+        self.restore_client()
+        self.check_client_host_entry()
+        try:
+            os.remove(CLIENT_KEYTAB)
+        except OSError:
+            pass
+        self.clients[0].run_command(['touch', CLIENT_KEYTAB])
+        self.reenroll_client(force_join=True)
+
     def uninstall_client(self):
         self.clients[0].run_command(
             ['ipa-client-install', '--uninstall', '-U'],


### PR DESCRIPTION
Missing test case for cf1301fb064fc230c780c4bc5eeccb723899f7b6.

https://pagure.io/freeipa/issue/7625

Signed-off-by: Armando Neto <abiagion@redhat.com>

Related Pull requests: #2308 and #2330.