### PR TITLE
Incompatible IPA versions, pausing replication

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -444,9 +444,8 @@ class DsInstance(service.Service):
               is used (we do not have access to masters' DM password in this
               stage)
         """
-        replication.enable_replication_version_checking(
-            self.realm,
-            self.dm_password)
+        serverid = "-".join(self.realm.split("."))
+        installutils.restart_dirsrv(serverid)
 
         repl, bind_dn, bind_pw = self._get_replication_manager()
         repl.setup_promote_replication(


### PR DESCRIPTION
Bug Description:
	The bug is not systematic. Symptoms are replication broken and this message
	ERR - repl_version_plugin_recv_acquire_cb - [file ipa_repl_version.c, line 119]: Incompatible IPA versions, pausing replication
	IPA Version Replication is a plugin that checks replication version (payload).
	It does the checking in the early phase of replication protocol (acquire_replica).
	The plugin must be enabled on both side, or disabled on both side.
	If we have a mixed setting (i.e. disabled on Master and enabled on Replica), there is
	a risk that the Master sends an incomplete payload. The incomplete payload will be rejected
	by the Replica and replication in both direction will fail.
	The risk is that on the master, the plugin got initialized but not started.
	Initialization of the plugin registers a broker API that allows a plugin (replication) to call
	a callback even if the plugin is not started.
	The problem is that to build valid payload the 'IPA Version Replication' needs to be started
	(data_version to be initialized).

Fix Description:
	The fix consist in:
		- define data_version during plugin initialization
		- Make plugin callback as noop if the plugin is not started. This is just for perf.
		- Prevent to enable the 'IPA Version Replication' when a replica is created.

https://pagure.io/freeipa/issue/7690