### PR TITLE
[Backport][ipa-4-7] Update required version of dogtag to detect when FIPS is available

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -94,9 +94,9 @@
 
 %endif  # Fedora
 
-# Require Dogtag PKI 10.6.1 with Python 3 and SQL NSSDB fixes for external
-# CA support, https://bugzilla.redhat.com/show_bug.cgi?id=1573094
-%global pki_version 10.6.1
+# Require Dogtag PKI 10.6.6 to detect when fips is available,
+# https://pagure.io/freeipa/issue/7608
+%global pki_version 10.6.6
 
 # NSS release with fix for CKA_LABEL import bug in shared SQL database.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1568271


### PR DESCRIPTION
This PR was opened automatically because PR #2345 was pushed to master and backport to ipa-4-7 is required.