### PR TITLE
authselect: harden uninstallation of ipa client

### DIFF
--- a/ipaplatform/redhat/authconfig.py
+++ b/ipaplatform/redhat/authconfig.py
@@ -162,8 +162,10 @@ class RedHatAuthSelect(RedHatAuthToolBase):
             profile = 'sssd'
             features = ''
         else:
-            profile = statestore.restore_state('authselect', 'profile')
-            features = statestore.restore_state('authselect', 'features_list')
+            profile = \
+                statestore.restore_state('authselect', 'profile') or 'sssd'
+            features = \
+                statestore.restore_state('authselect', 'features_list') or ''
             statestore.delete_state('authselect', 'mkhomedir')
 
         cmd = [paths.AUTHSELECT, "select", profile, features, "--force"]


### PR DESCRIPTION
When ipa client is uninstalled, the content of sysrestore.state is read to restore the previous authselect profile and features.
The code should properly handle the case where sysrestore.state contains the header for the authselect section, but the key=value for profile and features are missing.

The PR also adds an integration test.

Fixes https://pagure.io/freeipa/issue/7657