### PR TITLE
Fix translation of 'Remove' dialog for 'association_table' widget

### DIFF
--- a/install/ui/src/freeipa/association.js
+++ b/install/ui/src/freeipa/association.js
@@ -735,14 +735,10 @@ IPA.association_table_widget = function (spec) {
             return;
         }
 
-        var entity_label = that.entity.metadata.label_singular;
         var pkey = that.facet.get_pkey();
-        var other_entity_label = that.other_entity.metadata.label;
 
         var title = that.remove_title;
-        title = title.replace('${entity}', entity_label);
         title = title.replace('${primary_key}', pkey);
-        title = title.replace('${other_entity}', other_entity_label);
 
         var dialog = IPA.association_deleter_dialog({
             title: title,

--- a/install/ui/src/freeipa/automember.js
+++ b/install/ui/src/freeipa/automember.js
@@ -295,7 +295,10 @@ IPA.automember.rule_details_facet = function(spec) {
                                 required: true
                             }
                         ]
-                    }
+                    },
+                    deleter_dialog: {
+                        title: '@i18n:objects.automember.remove_inc_conditions',
+                    },
                 }
             ]
         },
@@ -325,7 +328,10 @@ IPA.automember.rule_details_facet = function(spec) {
                                 required: true
                             }
                         ]
-                    }
+                    },
+                    deleter_dialog: {
+                        title: '@i18n:objects.automember.remove_exc_conditions',
+                    },
                 }
             ]
         }

--- a/install/ui/src/freeipa/hbac.js
+++ b/install/ui/src/freeipa/hbac.js
@@ -327,7 +327,7 @@ var add_hbacrule_details_facet_widgets = function (spec) {
                             add_method: 'add_user',
                             remove_method: 'remove_user',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.hbacrule.remove_users',
                         },
                         {
                             $type: 'rule_association_table',
@@ -336,7 +336,7 @@ var add_hbacrule_details_facet_widgets = function (spec) {
                             add_method: 'add_user',
                             remove_method: 'remove_user',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.hbacrule.remove_groups',
                         }
                     ]
                 }
@@ -400,7 +400,7 @@ var add_hbacrule_details_facet_widgets = function (spec) {
                             add_method: 'add_host',
                             remove_method: 'remove_host',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.hbacrule.remove_hosts',
                         },
                         {
                             $type: 'rule_association_table',
@@ -409,7 +409,7 @@ var add_hbacrule_details_facet_widgets = function (spec) {
                             add_method: 'add_host',
                             remove_method: 'remove_host',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.hbacrule.remove_hostgroups',
                         }
                     ]
                 }
@@ -467,7 +467,7 @@ var add_hbacrule_details_facet_widgets = function (spec) {
                             add_method: 'add_service',
                             remove_method: 'remove_service',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.hbacrule.remove_services',
                         },
                         {
                             $type: 'rule_association_table',
@@ -476,7 +476,7 @@ var add_hbacrule_details_facet_widgets = function (spec) {
                             add_method: 'add_service',
                             remove_method: 'remove_service',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.hbacrule.remove_servicegroups',
                         }
                     ]
                 }

--- a/install/ui/src/freeipa/host.js
+++ b/install/ui/src/freeipa/host.js
@@ -927,8 +927,6 @@ IPA.host_unprovision_dialog = function(spec) {
     var that = IPA.dialog(spec);
     that.facet = spec.facet;
 
-    that.title = that.title.replace('${entity}', that.entity.metadata.label_singular);
-
     that.create_content = function() {
         that.container.append(text.get('@i18n:objects.host.unprovision_confirmation'));
     };

--- a/install/ui/src/freeipa/host.js
+++ b/install/ui/src/freeipa/host.js
@@ -202,7 +202,7 @@ return {
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
                             add_title: '@i18n:keytab.add_retrive',
-                            remove_title: '@i18n:keytab.remove_retrieve',
+                            remove_title: '@i18n:keytab.remove_users_retrieve',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_read_keys_user',
@@ -219,7 +219,7 @@ return {
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
                             add_title: '@i18n:keytab.add_retrive',
-                            remove_title: '@i18n:keytab.remove_retrieve',
+                            remove_title: '@i18n:keytab.remove_groups_retrieve',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_read_keys_group',
@@ -236,7 +236,7 @@ return {
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
                             add_title: '@i18n:keytab.add_retrive',
-                            remove_title: '@i18n:keytab.remove_retrieve',
+                            remove_title: '@i18n:keytab.remove_hosts_retrieve',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_read_keys_host',
@@ -253,7 +253,7 @@ return {
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
                             add_title: '@i18n:keytab.add_retrive',
-                            remove_title: '@i18n:keytab.remove_retrieve',
+                            remove_title: '@i18n:keytab.remove_hostgroups_retrieve',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_read_keys_hostgroup',
@@ -277,7 +277,7 @@ return {
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
                             add_title: '@i18n:keytab.add_create',
-                            remove_title: '@i18n:keytab.remove_create',
+                            remove_title: '@i18n:keytab.remove_users_create',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_write_keys_user',
@@ -294,7 +294,7 @@ return {
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
                             add_title: '@i18n:keytab.add_create',
-                            remove_title: '@i18n:keytab.remove_create',
+                            remove_title: '@i18n:keytab.remove_groups_create',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_write_keys_group',
@@ -311,7 +311,7 @@ return {
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
                             add_title: '@i18n:keytab.add_create',
-                            remove_title: '@i18n:keytab.remove_create',
+                            remove_title: '@i18n:keytab.remove_hosts_create',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_write_keys_host',
@@ -328,7 +328,7 @@ return {
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
                             add_title: '@i18n:keytab.add_create',
-                            remove_title: '@i18n:keytab.remove_create',
+                            remove_title: '@i18n:keytab.remove_hostgroups_create',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_write_keys_hostgroup',

--- a/install/ui/src/freeipa/netgroup.js
+++ b/install/ui/src/freeipa/netgroup.js
@@ -188,7 +188,7 @@ var add_netgroup_details_facet_widgets = function (spec) {
                             add_method: 'add_member',
                             remove_method: 'remove_member',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member',
+                            remove_title: '@i18n:objects.netgroup.remove_users',
                             columns: [
                                 {
                                     name: 'memberuser_user',
@@ -204,7 +204,7 @@ var add_netgroup_details_facet_widgets = function (spec) {
                             add_method: 'add_member',
                             remove_method: 'remove_member',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member',
+                            remove_title: '@i18n:objects.netgroup.remove_groups',
                             columns: [
                                 {
                                     name: 'memberuser_group',
@@ -277,7 +277,7 @@ var add_netgroup_details_facet_widgets = function (spec) {
                             remove_method: 'remove_member',
                             external: 'externalhost',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member',
+                            remove_title: '@i18n:objects.netgroup.remove_hosts',
                             columns: [
                                 {
                                     name: 'memberhost_host',
@@ -299,7 +299,7 @@ var add_netgroup_details_facet_widgets = function (spec) {
                             add_method: 'add_member',
                             remove_method: 'remove_member',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member',
+                            remove_title: '@i18n:objects.netgroup.remove_hostgroups',
                             columns: [
                                 {
                                     name: 'memberhost_hostgroup',

--- a/install/ui/src/freeipa/plugins/caacl.js
+++ b/install/ui/src/freeipa/plugins/caacl.js
@@ -197,7 +197,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             add_method: 'add_profile',
                             remove_method: 'remove_profile',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.caacl.remove_profiles',
                         }
                     ]
                 }
@@ -302,7 +302,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             add_method: 'add_user',
                             remove_method: 'remove_user',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.caacl.remove_users',
                         },
                         {
                             $type: 'rule_association_table',
@@ -311,7 +311,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             add_method: 'add_user',
                             remove_method: 'remove_user',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.caacl.remove_groups',
                         }
                     ]
                 },
@@ -341,7 +341,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             add_method: 'add_host',
                             remove_method: 'remove_host',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.caacl.remove_hosts',
                         },
                         {
                             $type: 'rule_association_table',
@@ -350,7 +350,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             add_method: 'add_host',
                             remove_method: 'remove_host',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.caacl.remove_hostgroups',
                         }
                     ]
                 },
@@ -373,7 +373,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             add_method: 'add_service',
                             remove_method: 'remove_service',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.caacl.remove_services',
                         }
                     ]
                 },
@@ -397,7 +397,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             add_method: 'add_ca',
                             remove_method: 'remove_ca',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.caacl.remove_ca',
                         }
                     ]
                 }

--- a/install/ui/src/freeipa/selinux.js
+++ b/install/ui/src/freeipa/selinux.js
@@ -221,7 +221,7 @@ var add_selinux_details_facet_widgets = function (spec) {
                             add_method: 'add_user',
                             remove_method: 'remove_user',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.selinuxusermap.remove_users',
                         },
                         {
                             $type: 'rule_association_table',
@@ -230,7 +230,7 @@ var add_selinux_details_facet_widgets = function (spec) {
                             add_method: 'add_user',
                             remove_method: 'remove_user',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.selinuxusermap.remove_groups',
                         }
                     ]
                 }
@@ -294,7 +294,7 @@ var add_selinux_details_facet_widgets = function (spec) {
                             add_method: 'add_host',
                             remove_method: 'remove_host',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.selinuxusermap.remove_hosts',
                         },
                         {
                             $type: 'rule_association_table',
@@ -303,7 +303,7 @@ var add_selinux_details_facet_widgets = function (spec) {
                             add_method: 'add_host',
                             remove_method: 'remove_host',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.selinuxusermap.remove_hostgroups',
                         }
                     ]
                 }

--- a/install/ui/src/freeipa/service.js
+++ b/install/ui/src/freeipa/service.js
@@ -654,9 +654,6 @@ IPA.service.unprovision_dialog = function(spec) {
     var that = IPA.dialog(spec);
     that.facet = spec.facet;
 
-    var entity_singular = that.entity.metadata.label_singular;
-    that.title = that.title.replace('${entity}', entity_singular);
-
     that.create_content = function() {
         that.container.append(text.get('@i18n:objects.service.unprovision_confirmation'));
     };

--- a/install/ui/src/freeipa/service.js
+++ b/install/ui/src/freeipa/service.js
@@ -205,7 +205,7 @@ return {
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
                             add_title: '@i18n:keytab.add_retrive',
-                            remove_title: '@i18n:keytab.remove_retrieve',
+                            remove_title: '@i18n:keytab.remove_users_retrieve',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_read_keys_user',
@@ -222,7 +222,7 @@ return {
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
                             add_title: '@i18n:keytab.add_retrive',
-                            remove_title: '@i18n:keytab.remove_retrieve',
+                            remove_title: '@i18n:keytab.remove_groups_retrieve',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_read_keys_group',
@@ -239,7 +239,7 @@ return {
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
                             add_title: '@i18n:keytab.add_retrive',
-                            remove_title: '@i18n:keytab.remove_retrieve',
+                            remove_title: '@i18n:keytab.remove_hosts_retrieve',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_read_keys_host',
@@ -256,7 +256,7 @@ return {
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
                             add_title: '@i18n:keytab.add_retrive',
-                            remove_title: '@i18n:keytab.remove_retrieve',
+                            remove_title: '@i18n:keytab.remove_hostgroups_retrieve',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_read_keys_hostgroup',
@@ -280,7 +280,7 @@ return {
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
                             add_title: '@i18n:keytab.add_create',
-                            remove_title: '@i18n:keytab.remove_create',
+                            remove_title: '@i18n:keytab.remove_users_create',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_write_keys_user',
@@ -297,7 +297,7 @@ return {
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
                             add_title: '@i18n:keytab.add_create',
-                            remove_title: '@i18n:keytab.remove_create',
+                            remove_title: '@i18n:keytab.remove_groups_create',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_write_keys_group',
@@ -314,7 +314,7 @@ return {
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
                             add_title: '@i18n:keytab.add_create',
-                            remove_title: '@i18n:keytab.remove_create',
+                            remove_title: '@i18n:keytab.remove_hosts_create',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_write_keys_host',
@@ -331,7 +331,7 @@ return {
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
                             add_title: '@i18n:keytab.add_create',
-                            remove_title: '@i18n:keytab.remove_create',
+                            remove_title: '@i18n:keytab.remove_hostgroups_create',
                             columns: [
                                 {
                                     name: 'ipaallowedtoperform_write_keys_hostgroup',

--- a/install/ui/src/freeipa/sudo.js
+++ b/install/ui/src/freeipa/sudo.js
@@ -359,7 +359,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             remove_method: 'remove_user',
                             external: 'externaluser',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.sudorule.remove_users',
                         },
                         {
                             $type: 'rule_association_table',
@@ -368,7 +368,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             add_method: 'add_user',
                             remove_method: 'remove_user',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.sudorule.remove_groups',
                         }
                     ]
                 }
@@ -434,7 +434,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             remove_method: 'remove_host',
                             external: 'externalhost',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.sudorule.remove_hosts',
                         },
                         {
                             $type: 'rule_association_table',
@@ -443,7 +443,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             add_method: 'add_host',
                             remove_method: 'remove_host',
                             add_title: '@i18n:association.add.member',
-                            remove_title: '@i18n:association.remove.member'
+                            remove_title: '@i18n:objects.sudorule.remove_hostgroups',
                         }
                     ]
                 }
@@ -527,7 +527,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             add_method: 'add_allow_command',
                             remove_method: 'remove_allow_command',
                             add_title: '@i18n:association.add.memberallowcmd',
-                            remove_title: '@i18n:association.remove.memberallowcmd'
+                            remove_title: '@i18n:objects.sudorule.remove_allow_cmds',
                         },
                         {
                             $type: 'rule_association_table',
@@ -536,7 +536,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             add_method: 'add_allow_command',
                             remove_method: 'remove_allow_command',
                             add_title: '@i18n:association.add.memberallowcmd',
-                            remove_title: '@i18n:association.remove.memberallowcmd'
+                            remove_title: '@i18n:objects.sudorule.remove_allow_cmdgroups',
                         },
                         {
                             $factory: IPA.header_widget,
@@ -551,7 +551,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             add_method: 'add_deny_command',
                             remove_method: 'remove_deny_command',
                             add_title: '@i18n:association.add.memberdenycmd',
-                            remove_title: '@i18n:association.remove.memberdenycmd'
+                            remove_title: '@i18n:objects.sudorule.remove_deny_cmds',
                         },
                         {
                             $type: 'rule_association_table',
@@ -560,7 +560,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             add_method: 'add_deny_command',
                             remove_method: 'remove_deny_command',
                             add_title: '@i18n:association.add.memberdenycmd',
-                            remove_title: '@i18n:association.remove.memberdenycmd'
+                            remove_title: '@i18n:objects.sudorule.remove_deny_cmdgroups',
                         }
                     ]
                 }
@@ -632,7 +632,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             add_method: 'add_runasuser',
                             remove_method: 'remove_runasuser',
                             add_title: '@i18n:association.add.ipasudorunas',
-                            remove_title: '@i18n:association.remove.ipasudorunas'
+                            remove_title: '@i18n:objects.sudorule.remove_runas_users',
                         },
                         {
                             $type: 'rule_association_table',
@@ -641,7 +641,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             add_method: 'add_runasuser',
                             remove_method: 'remove_runasuser',
                             add_title: '@i18n:association.add.ipasudorunas',
-                            remove_title: '@i18n:association.remove.ipasudorunas'
+                            remove_title: '@i18n:objects.sudorule.remove_runas_usergroups',
                         }
                     ]
                 },
@@ -664,7 +664,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                         add_method: 'add_runasgroup',
                         remove_method: 'remove_runasgroup',
                         add_title: '@i18n:association.add.ipasudorunasgroup',
-                        remove_title: '@i18n:association.remove.ipasudorunasgroup'
+                        remove_title: '@i18n:objects.sudorule.remove_runas_groups',
                     }]
                 }
             ]

--- a/install/ui/src/freeipa/topology.js
+++ b/install/ui/src/freeipa/topology.js
@@ -448,7 +448,8 @@ return {
                                 {
                                     name: 'service_relative_weight'
                                 }
-                            ]
+                            ],
+                            remove_title: '@i18n:objects.topologylocation.remove_servers',
                         }
                     ]
                 }

--- a/install/ui/src/freeipa/vault.js
+++ b/install/ui/src/freeipa/vault.js
@@ -88,7 +88,8 @@ var make_vaults_details_page_spec = function() {
                                 name: 'member_user',
                                 label: '@i18n:objects.vault.user'
                             }
-                        ]
+                        ],
+                        remove_title: '@i18n:objects.vault.remove_member_users',
                     },
                     {
                         $type: 'association_table',
@@ -101,7 +102,8 @@ var make_vaults_details_page_spec = function() {
                                 name: 'member_group',
                                 label: '@i18n:objects.vault.group'
                             }
-                        ]
+                        ],
+                        remove_title: '@i18n:objects.vault.remove_member_groups',
                     },
                     {
                         $type: 'association_table',
@@ -115,7 +117,8 @@ var make_vaults_details_page_spec = function() {
                                 name: 'member_service',
                                 label: '@i18n:objects.vault.service'
                             }
-                        ]
+                        ],
+                        remove_title: '@i18n:objects.vault.remove_member_services',
                     }
                 ]
             },
@@ -137,7 +140,8 @@ var make_vaults_details_page_spec = function() {
                                 name: 'owner_user',
                                 label: '@i18n:objects.vault.user'
                             }
-                        ]
+                        ],
+                        remove_title: '@i18n:objects.vault.remove_owner_users',
                     },
                     {
                         $type: 'association_table',
@@ -152,7 +156,8 @@ var make_vaults_details_page_spec = function() {
                                 name: 'owner_group',
                                 label: '@i18n:objects.vault.group'
                             }
-                        ]
+                        ],
+                        remove_title: '@i18n:objects.vault.remove_owner_groups',
                     },
                     {
                         $type: 'association_table',
@@ -168,7 +173,8 @@ var make_vaults_details_page_spec = function() {
                                 name: 'owner_service',
                                 label: '@i18n:objects.vault.service'
                             }
-                        ]
+                        ],
+                        remove_title: '@i18n:objects.vault.remove_owner_services',
                     }
                 ]
             }
@@ -225,7 +231,8 @@ var make_my_vault_spec = function() {
             // in case that table on each facet gather more columns with these names.
             // I.e. facet with user vaults get column with name 'service', then
             // the value of 'service' column will be also added to command options.
-            additional_table_attrs: ['username', 'service', 'shared']
+            additional_table_attrs: ['username', 'service', 'shared'],
+            title: '@i18n:objects.vault.remove',
         }
     };
 

--- a/install/ui/src/freeipa/widget.js
+++ b/install/ui/src/freeipa/widget.js
@@ -4188,6 +4188,7 @@ IPA.attribute_table_widget = function(spec) {
 
     that.attribute_name = spec.attribute_name || that.name;
     that.adder_dialog_spec = spec.adder_dialog;
+    that.deleter_dialog_spec = spec.deleter_dialog;
     that.css_class = spec.css_class;
 
     that.add_command = spec.add_command;
@@ -4335,9 +4336,17 @@ IPA.attribute_table_widget = function(spec) {
             return null;
         }
 
+        var title;
+        if (that.deleter_dialog_spec) {
+            var pkey = that.facet.get_pkey();
+            title = text.get(that.deleter_dialog_spec.title);
+            title = title.replace('${primary_key}', pkey);
+        }
+
         var dialog = IPA.deleter_dialog({
             entity: that.entity,
-            values: selected_values
+            values: selected_values,
+            title: title,
         });
 
         dialog.execute = function() {

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1167,6 +1167,9 @@ class i18n_messages(Command):
             },
             "topologylocation": {
                 "remove": _("Remove IPA locations"),
+                "remove_servers": _(
+                    "Remove IPA servers from IPA location '${primary_key}'"
+                ),
             },
             "topologysegment": {
                 "remove": _("Remove topology segments"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -837,7 +837,7 @@ class i18n_messages(Command):
                 "status": _("Status"),
                 "unprovision": _("Unprovision"),
                 "unprovision_confirmation": _("Are you sure you want to unprovision this host?"),
-                "unprovision_title": _("Unprovisioning ${entity}"),
+                "unprovision_title": _("Unprovisioning host"),
                 "unprovisioned": _("Host unprovisioned"),
             },
             "hostgroup": {
@@ -1051,7 +1051,7 @@ class i18n_messages(Command):
                 "status": _("Status"),
                 "unprovision": _("Unprovision"),
                 "unprovision_confirmation": _("Are you sure you want to unprovision this service?"),
-                "unprovision_title": _("Unprovisioning ${entity}"),
+                "unprovision_title": _("Unprovisioning service"),
                 "unprovisioned": _("Service unprovisioned"),
                 "valid": _("Kerberos Key Present, Service Provisioned"),
             },

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -718,6 +718,25 @@ class i18n_messages(Command):
                 "host": _("Accessing"),
                 "ipaenabledflag": _("Rule status"),
                 "remove": _("Remove HBAC rules"),
+                "remove_groups": _(
+                    "Remove user groups from HBAC rule '${primary_key}'"
+                ),
+                "remove_hostgroups": _(
+                    "Remove host groups from HBAC rule '${primary_key}'"
+                ),
+                "remove_hosts": _(
+                    "Remove hosts from HBAC rule '${primary_key}'"
+                ),
+                "remove_servicegroups": _(
+                    "Remove HBAC service groups from HBAC rule "
+                    "'${primary_key}'"
+                ),
+                "remove_services": _(
+                    "Remove HBAC services from HBAC rule '${primary_key}'"
+                ),
+                "remove_users": _(
+                    "Remove users from HBAC rule '${primary_key}'"
+                ),
                 "service": _("Via Service"),
                 "specified_hosts": _("Specified Hosts and Groups"),
                 "specified_services": _("Specified Services and Groups"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1245,6 +1245,25 @@ class i18n_messages(Command):
                 "members": _("Members"),
                 "my_vaults_title": _("My User Vaults"),
                 "owners": _("Owners"),
+                "remove": _("Remove vaults"),
+                "remove_member_groups": _(
+                    "Remove user groups from members of vault '${primary_key}'"
+                ),
+                "remove_member_services": _(
+                    "Remove services from members of vault '${primary_key}'"
+                ),
+                "remove_member_users": _(
+                    "Remove users from members of vault '${primary_key}'"
+                ),
+                "remove_owner_groups": _(
+                    "Remove user groups from owners of vault '${primary_key}'"
+                ),
+                "remove_owner_services": _(
+                    "Remove services from owners of vault '${primary_key}'"
+                ),
+                "remove_owner_users": _(
+                    "Remove users from owners of vault '${primary_key}'"
+                ),
                 "service": _("Service"),
                 "service_vaults_title": _("Service Vaults"),
                 "shared": _("Shared"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -862,11 +862,23 @@ class i18n_messages(Command):
                 "identity": _("Netgroup Settings"),
                 "netgroups": _("Netgroups"),
                 "remove": _("Remove netgroups"),
+                "remove_from_netgroups": _(
+                    "Remove netgroup '${primary_key}' from netgroups"
+                ),
+                "remove_groups": _(
+                    "Remove user groups from netgroup '${primary_key}'"
+                ),
+                "remove_hosts": _(
+                    "Remove hosts from netgroup '${primary_key}'"
+                ),
+                "remove_hostgroups": _(
+                    "Remove host groups from netgroup '${primary_key}'"
+                ),
                 "remove_netgroups": _(
                     "Remove netgroups from netgroup '${primary_key}'"
                 ),
-                "remove_from_netgroups": _(
-                    "Remove netgroup '${primary_key}' from netgroups"
+                "remove_users": _(
+                    "Remove users from netgroup '${primary_key}'"
                 ),
                 "specified_hosts": _("Specified Hosts and Groups"),
                 "specified_users": _("Specified Users and Groups"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -318,8 +318,30 @@ class i18n_messages(Command):
             "add_retrive": _("Allow ${other_entity} to retrieve keytab of ${primary_key}"),
             "allowed_to_create": _("Allowed to create keytab"),
             "allowed_to_retrieve": _("Allowed to retrieve keytab"),
-            "remove_create": _("Disallow ${other_entity} to create keytab of ${primary_key}"),
-            "remove_retrieve": _("Disallow ${other_entity} to retrieve keytab of ${primary_key}"),
+            "remove_groups_create": _(
+                "Disallow user groups to create keytab of '${primary_key}'"
+            ),
+            "remove_groups_retrieve": _(
+                "Disallow user groups to retrieve keytab of '${primary_key}'"
+            ),
+            "remove_hostgroups_create": _(
+                "Disallow host groups to create keytab of '${primary_key}'"
+            ),
+            "remove_hostgroups_retrieve": _(
+                "Disallow host groups to retrieve keytab of '${primary_key}'"
+            ),
+            "remove_hosts_create": _(
+                "Disallow hosts to create keytab of '${primary_key}'"
+            ),
+            "remove_hosts_retrieve": _(
+                "Disallow hosts to retrieve keytab of '${primary_key}'"
+            ),
+            "remove_users_create": _(
+                "Disallow users to create keytab of '${primary_key}'"
+            ),
+            "remove_users_retrieve": _(
+                "Disallow users to retrieve keytab of '${primary_key}'"
+            ),
         },
         "krbaliases": {
             "adder_title": _("Add Kerberos Principal Alias"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -476,6 +476,12 @@ class i18n_messages(Command):
                 "hostgrouprules": _("Host group rules"),
                 "inclusive": _("Inclusive"),
                 "remove": _("Remove auto membership rules"),
+                "remove_exc_conditions": _(
+                    "Remove exclusive conditions from rule '${primary_key}'"
+                ),
+                "remove_inc_conditions": _(
+                    "Remove inclusive conditions from rule '${primary_key}'"
+                ),
                 "usergrouprule": _("User group rule"),
                 "usergrouprules": _("User group rules"),
             },

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1078,6 +1078,43 @@ class i18n_messages(Command):
                 "option_removed": _("${count} option(s) removed"),
                 "options": _("Options"),
                 "remove": _("Remove sudo rules"),
+                "remove_allow_cmds": _(
+                    "Remove allow sudo commands from sudo rule "
+                    "'${primary_key}'"
+                ),
+                "remove_allow_cmdgroups": _(
+                    "Remove allow sudo command groups from sudo rule "
+                    "'${primary_key}'"
+                ),
+                "remove_deny_cmds": _(
+                    "Remove deny sudo commands from sudo rule "
+                    "'${primary_key}'"
+                ),
+                "remove_deny_cmdgroups": _(
+                    "Remove deny sudo command groups from sudo rule "
+                    "'${primary_key}'"
+                ),
+                "remove_groups": _(
+                    "Remove user groups from sudo rule '${primary_key}'"
+                ),
+                "remove_hostgroups": _(
+                    "Remove host groups from sudo rule '${primary_key}'"
+                ),
+                "remove_hosts": _(
+                    "Remove hosts from sudo rule '${primary_key}'"
+                ),
+                "remove_runas_users": _(
+                    "Remove RunAs users from sudo rule '${primary_key}'"
+                ),
+                "remove_runas_usergroups": _(
+                    "Remove RunAs user groups from sudo rule '${primary_key}'"
+                ),
+                "remove_runas_groups": _(
+                    "Remove RunAs groups from sudo rule '${primary_key}'"
+                ),
+                "remove_users": _(
+                    "Remove users from sudo rule '${primary_key}'"
+                ),
                 "runas": _("As Whom"),
                 "specified_commands": _("Specified Commands and Groups"),
                 "specified_groups": _("Specified Groups"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -985,6 +985,18 @@ class i18n_messages(Command):
                 "anyone": _("Anyone"),
                 "host": _("Host"),
                 "remove": _("Remove selinux user maps"),
+                "remove_groups": _(
+                    "Remove user groups from SELinux user map '${primary_key}'"
+                ),
+                "remove_hostgroups": _(
+                    "Remove host groups from SELinux user map '${primary_key}'"
+                ),
+                "remove_hosts": _(
+                    "Remove hosts from SELinux user map '${primary_key}'"
+                ),
+                "remove_users": _(
+                    "Remove users from SELinux user map '${primary_key}'"
+                ),
                 "specified_hosts": _("Specified Hosts and Groups"),
                 "specified_users": _("Specified Users and Groups"),
                 "user": _("User"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -674,6 +674,7 @@ class i18n_messages(Command):
                 "ptr_redir_zones": _("Fetching DNS zones."),
                 "ptr_redir_zones_err": _("An error occurred while fetching dns zones."),
                 "redirection_dnszone": _("You will be redirected to DNS Zone."),
+                "remove": _("Remove DNS resource records"),
                 "standard": _("Standard Record Types"),
                 "title": _("Records for DNS Zone"),
                 "type": _("Record Type"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -512,6 +512,28 @@ class i18n_messages(Command):
                 "no_ca_msg": _("If no CAs are specified, requests to the default CA are allowed."),
                 "profile": _("Profiles"),
                 "remove": _("Remove CA ACLs"),
+                "remove_ca": _(
+                    "Remove Certificate Authorities from CA ACL "
+                    "'${primary_key}'"
+                ),
+                "remove_groups": _(
+                    "Remove user groups from CA ACL '${primary_key}'"
+                ),
+                "remove_hostgroups": _(
+                    "Remove host groups from CA ACL '${primary_key}'"
+                ),
+                "remove_hosts": _(
+                    "Remove hosts from CA ACL '${primary_key}'"
+                ),
+                "remove_profiles": _(
+                    "Remove certificate profiles from CA ACL '${primary_key}'"
+                ),
+                "remove_services": _(
+                    "Remove services from CA ACL '${primary_key}'"
+                ),
+                "remove_users": _(
+                    "Remove users from CA ACL '${primary_key}'"
+                ),
                 "specified_cas": _("Specified CAs"),
                 "specified_hosts": _("Specified Hosts and Groups"),
                 "specified_profiles": _("Specified Profiles"),


### PR DESCRIPTION
As for now the default title of remove dialogs, which are initialized from 'association_table' widget, is set to something like
```
Remove ${other_entity} from ${entity} ${primary_key}
```
where 'other_entity' and 'entity' are also translatable texts.
This construction is used via the method 'show_remove_dialog' of 'association_table' widget for the all 'Delete' actions within the details of entities. Such concatenation leads to a bad quality translation and should be changed to an entire sentence.

From now a mentioned title is taken from a spec and should be specified explicitly.

Fixes: https://pagure.io/freeipa/issue/7704

This PR depends on #2371.