### PR TITLE
Support Samba 4.9

### DIFF
--- a/install/updates/90-post_upgrade_plugins.update
+++ b/install/updates/90-post_upgrade_plugins.update
@@ -19,6 +19,7 @@ plugin: update_fix_duplicate_cacrt_in_ldap
 plugin: update_upload_cacrt
 # update_ra_cert_store has to be executed after update_ca_renewal_master
 plugin: update_ra_cert_store
+plugin: update_mapping_Guests_to_nobody
 
 # last
 # DNS version 1

--- a/ipaserver/install/plugins/adtrust.py
+++ b/ipaserver/install/plugins/adtrust.py
@@ -23,7 +23,8 @@ from ipalib import Registry, errors
 from ipalib import Updater
 from ipapython.dn import DN
 from ipaserver.install import sysupgrade
-from ipaserver.install.adtrustinstance import ADTRUSTInstance
+from ipaserver.install.adtrustinstance import (
+    ADTRUSTInstance, map_Guests_to_nobody)
 
 logger = logging.getLogger(__name__)
 
@@ -382,3 +383,20 @@ class update_tdo_gidnumber(Updater):
             return False, ()
 
         return False, ()
+
+
+@register()
+class update_mapping_Guests_to_nobody(Updater):
+    """
+    Map BUILTIN\\Guests group to nobody
+
+    Samba 4.9 became more strict on availability of builtin Guests group
+    """
+    def execute(self, **options):
+        # First, see if trusts are enabled on the server
+        if not self.api.Command.adtrust_is_enabled()['result']:
+            logger.debug('AD Trusts are not enabled on this server')
+            return False, []
+
+        map_Guests_to_nobody()
+        return False, []


### PR DESCRIPTION
Samba 4.9 became a bit more strict about creating a local NT token and a
failure to resolve or create BUILTIN\Guests group will cause a rejection
of the connection for a successfully authenticated one.

Add a default mapping of the nobody group to BUILTIN\Guests.

BUILTIN\Guests is a special group SID that is added to the NT token for
authenticated users.

For real guests there is 'guest account' option in smb.conf which
defaults to 'nobody' user.

This was implicit behavior before as 'guest account = nobody' by
default would pick up 'nobody' group as well.

Fixes: https://pagure.io/freeipa/issue/7705