### PR TITLE
ipatests: mark known failures as xfail

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -122,6 +122,7 @@ class InstallTestBase2(IntegrationTest):
     def test_replica2_ipa_ca_install(self):
         tasks.install_ca(self.replicas[2])
 
+    @pytest.mark.xfail(reason='Ticket 7654', strict=True)
     def test_replica2_ipa_kra_install(self):
         tasks.install_kra(self.replicas[2])
 


### PR DESCRIPTION
The tests in test_integration/test_installation.py
that inherit from InstallTestBase2 all fail in
test_replica2_ipa_kra_install because of ticket
7654: ipa-kra-install fails on DL1

This is an issue linked to dogtag (see
https://pagure.io/dogtagpki/issue/3055), where the
installation of a KRA clone creates a range depletion
when multiple clones are created from the same master.

Marking the tests as known failure, waiting for dogtag's
fix.

Related to https://pagure.io/freeipa/issue/7654