### PR TITLE
[ipa-4-6] ipa-advise: fix script for smart card preparation

### DIFF
--- a/ipaserver/advise/plugins/smart_card_auth.py
+++ b/ipaserver/advise/plugins/smart_card_auth.py
@@ -184,10 +184,11 @@ class config_server_for_smart_card_auth(common_smart_card_auth_config):
         self.log.command(
             self._interpolate_nssnickname_directive_file_into_command(
                 "http_cert_nick=$(grep '{directive}' {filename} |"
-                " cut -f 2 -d ' ')"))
+                " cut -f 2- -d ' ' | sed \"s/^'\(.*\)'$/\\1/\")"))
 
         self.log.exit_on_failed_command(
-            'certutil -M -n $http_cert_nick -d "{}" -f {} -t "Pu,u,u"'.format(
+            'certutil -M -n "$http_cert_nick" -d "{}" -f {} '
+            '-t "Pu,u,u"'.format(
                 paths.HTTPD_ALIAS_DIR,
                 httpd_nss_database_pwd_file),
             ['Can not set trust flags on HTTP certificate'])


### PR DESCRIPTION
The script has 2 issues:
- if the http nickname contains spaces (like `"CN=host,O=Example Org"`, which can happen when the http cert is provided by an external CA), the extraction of the nick from /etc/httpd/conf.d/nss.conf fails.
The nick name is build using
`grep NSSNickname /etc/httpd/conf.d/nss.conf | cut -f 2 -d ' '`
which results in `"CN=host,O=Example`
(note the end is missing).
The script should rather use `cut -f 2- -d ' '` in order to extract the whole nickname.

- when the http nickname is enclosed in single quote, the script should remove them, otherwise the shell tries to escape them and fails to find the cert in /etc/httpd/alias.

The fix is using `sed "s/^'\(.*\)'$/\1/"` in order to remove leading and trailing single quote, if present.

Fixes: https://pagure.io/freeipa/issue/7706

**Important note**: ipa-4-7 and master use mod_ssl instead of mod_nss and do not see this issue. The fix is required on ipa-4-6 branch only.