### PR TITLE
[Backport][ipa-4-7] ipatests: mark known failures as xfail

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -122,6 +122,7 @@ class InstallTestBase2(IntegrationTest):
     def test_replica2_ipa_ca_install(self):
         tasks.install_ca(self.replicas[2])
 
+    @pytest.mark.xfail(reason='Ticket 7654', strict=True)
     def test_replica2_ipa_kra_install(self):
         tasks.install_kra(self.replicas[2])
 


### PR DESCRIPTION
This PR was opened automatically because PR #2375 was pushed to master and backport to ipa-4-7 is required.