### PR TITLE
[Backport][ipa-4-7] Tests: remove dl0 tests from nightly definition

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -388,42 +388,6 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-28/test_replica_promotion_TestReplicaPromotionLevel0:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel0
-        template: *ci-master-f28
-        timeout: 7200
-        topology: *master_1repl
-
-  fedora-28/test_replica_promotion_TestKRAInstall:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_replica_promotion.py::TestKRAInstall
-        template: *ci-master-f28
-        timeout: 7200
-        topology: *master_2repl_1client
-
-  fedora-28/test_replica_promotion_TestCAInstall:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_replica_promotion.py::TestCAInstall
-        template: *ci-master-f28
-        timeout: 7200
-        topology: *master_2repl_1client
-
   fedora-28/test_replica_promotion_TestReplicaPromotionLevel1:
     requires: [fedora-28/build]
     priority: 50
@@ -435,18 +399,6 @@ jobs:
         template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
-
-  fedora-28/test_replica_promotion_TestReplicaManageCommands:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_replica_promotion.py::TestReplicaManageCommands
-        template: *ci-master-f28
-        timeout: 7200
-        topology: *master_2repl_1client
 
   fedora-28/test_replica_promotion_TestUnprivilegedUserPermissions:
     requires: [fedora-28/build]
@@ -471,18 +423,6 @@ jobs:
         template: *ci-master-f28
         timeout: 7200
         topology: *master_2repl_1client
-
-  fedora-28/test_replica_promotion_TestOldReplicaWorksAfterDomainUpgrade:
-    requires: [fedora-28/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_replica_promotion.py::TestOldReplicaWorksAfterDomainUpgrade
-        template: *ci-master-f28
-        timeout: 7200
-        topology: *master_1repl
 
   fedora-28/test_replica_promotion_TestWrongClientDomain:
     requires: [fedora-28/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -388,42 +388,6 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-rawhide/test_replica_promotion_TestReplicaPromotionLevel0:
-    requires: [fedora-rawhide/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-rawhide/build_url}'
-        test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel0
-        template: *ci-master-frawhide
-        timeout: 7200
-        topology: *master_1repl
-
-  fedora-rawhide/test_replica_promotion_TestKRAInstall:
-    requires: [fedora-rawhide/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-rawhide/build_url}'
-        test_suite: test_integration/test_replica_promotion.py::TestKRAInstall
-        template: *ci-master-frawhide
-        timeout: 7200
-        topology: *master_2repl_1client
-
-  fedora-rawhide/test_replica_promotion_TestCAInstall:
-    requires: [fedora-rawhide/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-rawhide/build_url}'
-        test_suite: test_integration/test_replica_promotion.py::TestCAInstall
-        template: *ci-master-frawhide
-        timeout: 7200
-        topology: *master_1repl
-
   fedora-rawhide/test_replica_promotion_TestReplicaPromotionLevel1:
     requires: [fedora-rawhide/build]
     priority: 50
@@ -432,18 +396,6 @@ jobs:
       args:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *ci-master-frawhide
-        timeout: 7200
-        topology: *master_1repl
-
-  fedora-rawhide/test_replica_promotion_TestReplicaManageCommands:
-    requires: [fedora-rawhide/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-rawhide/build_url}'
-        test_suite: test_integration/test_replica_promotion.py::TestReplicaManageCommands
         template: *ci-master-frawhide
         timeout: 7200
         topology: *master_1repl
@@ -468,18 +420,6 @@ jobs:
       args:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
-        template: *ci-master-frawhide
-        timeout: 7200
-        topology: *master_1repl
-
-  fedora-rawhide/test_replica_promotion_TestOldReplicaWorksAfterDomainUpgrade:
-    requires: [fedora-rawhide/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-rawhide/build_url}'
-        test_suite: test_integration/test_replica_promotion.py::TestOldReplicaWorksAfterDomainUpgrade
         template: *ci-master-frawhide
         timeout: 7200
         topology: *master_1repl


### PR DESCRIPTION
This PR was opened manually because PR #2370 was pushed to master and backport to ipa-4-7, which is required, failed  because the planet earth was spinning at lower speed at the moment .

Commit fca1167af48651c3454c33c77ef28ec333220040 removed the following tests
from ipatests/test_integration/test_replica_promotion.py:
TestReplicaPromotionLevel0
TestKRAInstall
TestCAInstall
TestReplicaManageCommands
TestOldReplicaWorksAfterDomainUpgrade
but the nightly definition was not updated accordingly.
The fix removes the unexisting tests from nightly.

Related to https://pagure.io/freeipa/issue/7689