### PR TITLE
Fix loading 'freeipa/text' at production mode

### DIFF
--- a/install/html/ssbrowser.html
+++ b/install/html/ssbrowser.html
@@ -25,20 +25,26 @@
             ]
         };
         (function() {
+            var icons = [
+                '../ui/favicon.ico',
+            ];
             var styles = [
                 '../ui/css/patternfly.css',
                 '../ui/css/ipa.css'
             ];
             var scripts = [
                 '../ui/js/libs/jquery.js',
-                '../ui/js/dojo/dojo.js'
+                '../ui/js/libs/jquery.ordered-map.js',
+                '../ui/js/dojo/dojo.js',
             ];
             ipa_loader.scripts(scripts, function() {
                 require([
                     'dojo/dom',
-                    'freeipa/text',
-                    'dojo/domReady!'],
-                    function(dom, text) {
+                    'freeipa/core',
+                    'dojo/domReady!',
+                    ],
+                    function(dom) {
+                        var text = require('freeipa/text');
                         msg = "".concat(
                             text.get('@i18n:ssbrowser-page.header'),
                             text.get('@i18n:ssbrowser-page.firefox-header'),
@@ -53,6 +59,7 @@
                     });
             });
             ipa_loader.styles(styles);
+            ipa_loader.icons(icons);
         })();
     </script>
 

--- a/install/html/unauthorized.html
+++ b/install/html/unauthorized.html
@@ -25,27 +25,34 @@
             ]
         };
         (function() {
+            var icons = [
+                '../ui/favicon.ico',
+            ];
             var styles = [
                 '../ui/css/patternfly.css',
                 '../ui/css/ipa.css'
             ];
             var scripts = [
                 '../ui/js/libs/jquery.js',
-                '../ui/js/dojo/dojo.js'
+                '../ui/js/libs/jquery.ordered-map.js',
+                '../ui/js/dojo/dojo.js',
             ];
 
             ipa_loader.scripts(scripts, function() {
                 require([
                     'dojo/dom',
-                    'freeipa/text',
-                    'dojo/domReady!'],
-                    function(dom, text) {
+                    'freeipa/core',
+                    'dojo/domReady!',
+                    ],
+                    function(dom) {
+                        var text = require('freeipa/text');
                         if (msg = text.get('@i18n:unauthorized-page')) {
                             dom.byId('unauthorized-msg').innerHTML=msg;
                         }
                     });
             });
             ipa_loader.styles(styles);
+            ipa_loader.icons(icons);
         })();
     </script>
 </head>


### PR DESCRIPTION
As for now 'ssbrowser.html' and 'unauthorized.html' pages are
loaded without JS error at development mode only.

There is no standalone 'freeipa/text' module as a source at
production mode. Thus 'core' one has to be loaded first and
then 'text'.

Related issue: https://pagure.io/freeipa/issue/7703