### PR TITLE
Fix translation of 'add' dialog's title for association_table widget

### DIFF
--- a/install/ui/src/freeipa/association.js
+++ b/install/ui/src/freeipa/association.js
@@ -184,7 +184,7 @@ IPA.attribute_adder_dialog = function(spec) {
             required: true
         }
     ];
-    spec.title = spec.title || text.get('@i18n:dialogs.add_title').replace('${entity}', metadata.label);
+    spec.title = spec.title || text.get('@i18n:dialogs.add_title_default');
     spec.subject = metadata.label;
 
     var that = IPA.entity_adder_dialog(spec);
@@ -638,14 +638,10 @@ IPA.association_table_widget = function (spec) {
 
     that.create_add_dialog = function() {
 
-        var entity_label = that.entity.metadata.label_singular;
         var pkey = that.facet.get_pkey();
-        var other_entity_label = that.other_entity.metadata.label;
 
         var title = that.add_title;
-        title = title.replace('${entity}', entity_label);
         title = title.replace('${primary_key}', pkey);
-        title = title.replace('${other_entity}', other_entity_label);
 
         return IPA.association_adder_dialog({
             title: title,

--- a/install/ui/src/freeipa/hbac.js
+++ b/install/ui/src/freeipa/hbac.js
@@ -329,7 +329,7 @@ var add_hbacrule_details_facet_widgets = function (spec) {
                             name: 'memberuser_user',
                             add_method: 'add_user',
                             remove_method: 'remove_user',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.hbacrule.add_users',
                             remove_title: '@i18n:objects.hbacrule.remove_users'
                         },
                         {
@@ -338,7 +338,7 @@ var add_hbacrule_details_facet_widgets = function (spec) {
                             name: 'memberuser_group',
                             add_method: 'add_user',
                             remove_method: 'remove_user',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.hbacrule.add_groups',
                             remove_title: '@i18n:objects.hbacrule.remove_groups'
                         }
                     ]
@@ -402,7 +402,7 @@ var add_hbacrule_details_facet_widgets = function (spec) {
                             name: 'memberhost_host',
                             add_method: 'add_host',
                             remove_method: 'remove_host',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.hbacrule.add_hosts',
                             remove_title: '@i18n:objects.hbacrule.remove_hosts'
                         },
                         {
@@ -411,7 +411,7 @@ var add_hbacrule_details_facet_widgets = function (spec) {
                             name: 'memberhost_hostgroup',
                             add_method: 'add_host',
                             remove_method: 'remove_host',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.hbacrule.add_hostgroups',
                             remove_title: '@i18n:objects.hbacrule.remove_hostgroups'
                         }
                     ]
@@ -469,7 +469,7 @@ var add_hbacrule_details_facet_widgets = function (spec) {
                             name: 'memberservice_hbacsvc',
                             add_method: 'add_service',
                             remove_method: 'remove_service',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.hbacrule.add_services',
                             remove_title: '@i18n:objects.hbacrule.remove_services'
                         },
                         {
@@ -478,7 +478,7 @@ var add_hbacrule_details_facet_widgets = function (spec) {
                             name: 'memberservice_hbacsvcgroup',
                             add_method: 'add_service',
                             remove_method: 'remove_service',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.hbacrule.add_servicegroups',
                             remove_title: '@i18n:objects.hbacrule.remove_servicegroups'
                         }
                     ]

--- a/install/ui/src/freeipa/host.js
+++ b/install/ui/src/freeipa/host.js
@@ -201,7 +201,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
-                            add_title: '@i18n:keytab.add_retrive',
+                            add_title: '@i18n:keytab.add_users_retrieve',
                             remove_title: '@i18n:keytab.remove_users_retrieve',
                             columns: [
                                 {
@@ -218,7 +218,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
-                            add_title: '@i18n:keytab.add_retrive',
+                            add_title: '@i18n:keytab.add_groups_retrieve',
                             remove_title: '@i18n:keytab.remove_groups_retrieve',
                             columns: [
                                 {
@@ -235,7 +235,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
-                            add_title: '@i18n:keytab.add_retrive',
+                            add_title: '@i18n:keytab.add_hosts_retrieve',
                             remove_title: '@i18n:keytab.remove_hosts_retrieve',
                             columns: [
                                 {
@@ -252,7 +252,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
-                            add_title: '@i18n:keytab.add_retrive',
+                            add_title: '@i18n:keytab.add_hostgroups_retrieve',
                             remove_title: '@i18n:keytab.remove_hostgroups_retrieve',
                             columns: [
                                 {
@@ -276,7 +276,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
-                            add_title: '@i18n:keytab.add_create',
+                            add_title: '@i18n:keytab.add_users_create',
                             remove_title: '@i18n:keytab.remove_users_create',
                             columns: [
                                 {
@@ -293,7 +293,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
-                            add_title: '@i18n:keytab.add_create',
+                            add_title: '@i18n:keytab.add_groups_create',
                             remove_title: '@i18n:keytab.remove_groups_create',
                             columns: [
                                 {
@@ -310,7 +310,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
-                            add_title: '@i18n:keytab.add_create',
+                            add_title: '@i18n:keytab.add_hosts_create',
                             remove_title: '@i18n:keytab.remove_hosts_create',
                             columns: [
                                 {
@@ -327,7 +327,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
-                            add_title: '@i18n:keytab.add_create',
+                            add_title: '@i18n:keytab.add_hostgroups_create',
                             remove_title: '@i18n:keytab.remove_hostgroups_create',
                             columns: [
                                 {

--- a/install/ui/src/freeipa/netgroup.js
+++ b/install/ui/src/freeipa/netgroup.js
@@ -188,7 +188,7 @@ var add_netgroup_details_facet_widgets = function (spec) {
                             name: 'memberuser_user',
                             add_method: 'add_member',
                             remove_method: 'remove_member',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.netgroup.add_users',
                             remove_title: '@i18n:objects.netgroup.remove_users',
                             columns: [
                                 {
@@ -204,7 +204,7 @@ var add_netgroup_details_facet_widgets = function (spec) {
                             name: 'memberuser_group',
                             add_method: 'add_member',
                             remove_method: 'remove_member',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.netgroup.add_groups',
                             remove_title: '@i18n:objects.netgroup.remove_groups',
                             columns: [
                                 {
@@ -277,7 +277,7 @@ var add_netgroup_details_facet_widgets = function (spec) {
                             add_method: 'add_member',
                             remove_method: 'remove_member',
                             external: 'externalhost',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.netgroup.add_hosts',
                             remove_title: '@i18n:objects.netgroup.remove_hosts',
                             columns: [
                                 {
@@ -299,7 +299,7 @@ var add_netgroup_details_facet_widgets = function (spec) {
                             name: 'memberhost_hostgroup',
                             add_method: 'add_member',
                             remove_method: 'remove_member',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.netgroup.add_hostgroups',
                             remove_title: '@i18n:objects.netgroup.remove_hostgroups',
                             columns: [
                                 {

--- a/install/ui/src/freeipa/plugins/caacl.js
+++ b/install/ui/src/freeipa/plugins/caacl.js
@@ -197,7 +197,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             name: 'ipamembercertprofile_certprofile',
                             add_method: 'add_profile',
                             remove_method: 'remove_profile',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.caacl.add_profiles',
                             remove_title: '@i18n:objects.caacl.remove_profiles'
                         }
                     ]
@@ -302,7 +302,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             name: 'memberuser_user',
                             add_method: 'add_user',
                             remove_method: 'remove_user',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.caacl.add_users',
                             remove_title: '@i18n:objects.caacl.remove_users'
                         },
                         {
@@ -311,7 +311,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             name: 'memberuser_group',
                             add_method: 'add_user',
                             remove_method: 'remove_user',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.caacl.add_groups',
                             remove_title: '@i18n:objects.caacl.remove_groups'
                         }
                     ]
@@ -341,7 +341,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             name: 'memberhost_host',
                             add_method: 'add_host',
                             remove_method: 'remove_host',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.caacl.add_hosts',
                             remove_title: '@i18n:objects.caacl.remove_hosts'
                         },
                         {
@@ -350,7 +350,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             name: 'memberhost_hostgroup',
                             add_method: 'add_host',
                             remove_method: 'remove_host',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.caacl.add_hostgroups',
                             remove_title: '@i18n:objects.caacl.remove_hostgroups'
                         }
                     ]
@@ -373,7 +373,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             name: 'memberservice_service',
                             add_method: 'add_service',
                             remove_method: 'remove_service',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.caacl.add_services',
                             remove_title: '@i18n:objects.caacl.remove_services'
                         }
                     ]
@@ -397,7 +397,7 @@ var add_caacl_details_facet_widgets = function (spec) {
                             name: 'ipamemberca_ca',
                             add_method: 'add_ca',
                             remove_method: 'remove_ca',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.caacl.add_ca',
                             remove_title: '@i18n:objects.caacl.remove_ca'
                         }
                     ]

--- a/install/ui/src/freeipa/rule.js
+++ b/install/ui/src/freeipa/rule.js
@@ -153,14 +153,10 @@ IPA.rule_association_table_widget = function(spec) {
 
     that.create_add_dialog = function() {
 
-        var entity_label = that.entity.metadata.label_singular;
         var pkey = that.facet.get_pkey();
-        var other_entity_label = that.other_entity.metadata.label;
 
         var title = that.add_title;
-        title = title.replace('${entity}', entity_label);
         title = title.replace('${primary_key}', pkey);
-        title = title.replace('${other_entity}', other_entity_label);
 
         var exclude = that.values;
         if (that.external) {

--- a/install/ui/src/freeipa/selinux.js
+++ b/install/ui/src/freeipa/selinux.js
@@ -221,7 +221,7 @@ var add_selinux_details_facet_widgets = function (spec) {
                             name: 'memberuser_user',
                             add_method: 'add_user',
                             remove_method: 'remove_user',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.selinuxusermap.add_users',
                             remove_title: '@i18n:objects.selinuxusermap.remove_users'
                         },
                         {
@@ -230,7 +230,7 @@ var add_selinux_details_facet_widgets = function (spec) {
                             name: 'memberuser_group',
                             add_method: 'add_user',
                             remove_method: 'remove_user',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.selinuxusermap.add_groups',
                             remove_title: '@i18n:objects.selinuxusermap.remove_groups'
                         }
                     ]
@@ -294,7 +294,7 @@ var add_selinux_details_facet_widgets = function (spec) {
                             name: 'memberhost_host',
                             add_method: 'add_host',
                             remove_method: 'remove_host',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.selinuxusermap.add_hosts',
                             remove_title: '@i18n:objects.selinuxusermap.remove_hosts'
                         },
                         {
@@ -303,7 +303,7 @@ var add_selinux_details_facet_widgets = function (spec) {
                             name: 'memberhost_hostgroup',
                             add_method: 'add_host',
                             remove_method: 'remove_host',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.selinuxusermap.add_hostgroups',
                             remove_title: '@i18n:objects.selinuxusermap.remove_hostgroups'
                         }
                     ]

--- a/install/ui/src/freeipa/service.js
+++ b/install/ui/src/freeipa/service.js
@@ -204,7 +204,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
-                            add_title: '@i18n:keytab.add_retrive',
+                            add_title: '@i18n:keytab.add_users_retrieve',
                             remove_title: '@i18n:keytab.remove_users_retrieve',
                             columns: [
                                 {
@@ -221,7 +221,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
-                            add_title: '@i18n:keytab.add_retrive',
+                            add_title: '@i18n:keytab.add_groups_retrieve',
                             remove_title: '@i18n:keytab.remove_groups_retrieve',
                             columns: [
                                 {
@@ -238,7 +238,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
-                            add_title: '@i18n:keytab.add_retrive',
+                            add_title: '@i18n:keytab.add_hosts_retrieve',
                             remove_title: '@i18n:keytab.remove_hosts_retrieve',
                             columns: [
                                 {
@@ -255,7 +255,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_retrieve_keytab',
                             remove_method: 'disallow_retrieve_keytab',
-                            add_title: '@i18n:keytab.add_retrive',
+                            add_title: '@i18n:keytab.add_hostgroups_retrieve',
                             remove_title: '@i18n:keytab.remove_hostgroups_retrieve',
                             columns: [
                                 {
@@ -279,7 +279,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
-                            add_title: '@i18n:keytab.add_create',
+                            add_title: '@i18n:keytab.add_users_create',
                             remove_title: '@i18n:keytab.remove_users_create',
                             columns: [
                                 {
@@ -296,7 +296,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
-                            add_title: '@i18n:keytab.add_create',
+                            add_title: '@i18n:keytab.add_groups_create',
                             remove_title: '@i18n:keytab.remove_groups_create',
                             columns: [
                                 {
@@ -313,7 +313,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
-                            add_title: '@i18n:keytab.add_create',
+                            add_title: '@i18n:keytab.add_hosts_create',
                             remove_title: '@i18n:keytab.remove_hosts_create',
                             columns: [
                                 {
@@ -330,7 +330,7 @@ return {
                             flags: ['w_if_no_aci'],
                             add_method: 'allow_create_keytab',
                             remove_method: 'disallow_create_keytab',
-                            add_title: '@i18n:keytab.add_create',
+                            add_title: '@i18n:keytab.add_hostgroups_create',
                             remove_title: '@i18n:keytab.remove_hostgroups_create',
                             columns: [
                                 {

--- a/install/ui/src/freeipa/sudo.js
+++ b/install/ui/src/freeipa/sudo.js
@@ -361,7 +361,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             add_method: 'add_user',
                             remove_method: 'remove_user',
                             external: 'externaluser',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.sudorule.add_users',
                             remove_title: '@i18n:objects.sudorule.remove_users'
                         },
                         {
@@ -370,7 +370,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             name: 'memberuser_group',
                             add_method: 'add_user',
                             remove_method: 'remove_user',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.sudorule.add_groups',
                             remove_title: '@i18n:objects.sudorule.remove_groups'
                         }
                     ]
@@ -436,7 +436,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             add_method: 'add_host',
                             remove_method: 'remove_host',
                             external: 'externalhost',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.sudorule.add_hosts',
                             remove_title: '@i18n:objects.sudorule.remove_hosts'
                         },
                         {
@@ -445,7 +445,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             name: 'memberhost_hostgroup',
                             add_method: 'add_host',
                             remove_method: 'remove_host',
-                            add_title: '@i18n:association.add.member',
+                            add_title: '@i18n:objects.sudorule.add_hostgroups',
                             remove_title: '@i18n:objects.sudorule.remove_hostgroups'
                         }
                     ]
@@ -529,7 +529,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             name: 'memberallowcmd_sudocmd',
                             add_method: 'add_allow_command',
                             remove_method: 'remove_allow_command',
-                            add_title: '@i18n:association.add.memberallowcmd',
+                            add_title: '@i18n:objects.sudorule.add_allow_cmds',
                             remove_title: '@i18n:objects.sudorule.remove_allow_cmds'
                         },
                         {
@@ -538,7 +538,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             name: 'memberallowcmd_sudocmdgroup',
                             add_method: 'add_allow_command',
                             remove_method: 'remove_allow_command',
-                            add_title: '@i18n:association.add.memberallowcmd',
+                            add_title: '@i18n:objects.sudorule.add_allow_cmdgroups',
                             remove_title: '@i18n:objects.sudorule.remove_allow_cmdgroups'
                         },
                         {
@@ -553,7 +553,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             name: 'memberdenycmd_sudocmd',
                             add_method: 'add_deny_command',
                             remove_method: 'remove_deny_command',
-                            add_title: '@i18n:association.add.memberdenycmd',
+                            add_title: '@i18n:objects.sudorule.add_deny_cmds',
                             remove_title: '@i18n:objects.sudorule.remove_deny_cmds'
                         },
                         {
@@ -562,7 +562,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             name: 'memberdenycmd_sudocmdgroup',
                             add_method: 'add_deny_command',
                             remove_method: 'remove_deny_command',
-                            add_title: '@i18n:association.add.memberdenycmd',
+                            add_title: '@i18n:objects.sudorule.add_deny_cmdgroups',
                             remove_title: '@i18n:objects.sudorule.remove_deny_cmdgroups'
                         }
                     ]
@@ -634,7 +634,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             external: 'ipasudorunasextuser',
                             add_method: 'add_runasuser',
                             remove_method: 'remove_runasuser',
-                            add_title: '@i18n:association.add.ipasudorunas',
+                            add_title: '@i18n:objects.sudorule.add_runas_users',
                             remove_title: '@i18n:objects.sudorule.remove_runas_users'
                         },
                         {
@@ -643,7 +643,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                             name: 'ipasudorunas_group',
                             add_method: 'add_runasuser',
                             remove_method: 'remove_runasuser',
-                            add_title: '@i18n:association.add.ipasudorunas',
+                            add_title: '@i18n:objects.sudorule.add_runas_usergroups',
                             remove_title: '@i18n:objects.sudorule.remove_runas_usergroups'
                         }
                     ]
@@ -666,7 +666,7 @@ var add_sudorule_details_facet_widgets = function (spec) {
                         external: 'ipasudorunasextgroup',
                         add_method: 'add_runasgroup',
                         remove_method: 'remove_runasgroup',
-                        add_title: '@i18n:association.add.ipasudorunasgroup',
+                        add_title: '@i18n:objects.sudorule.add_runas_groups',
                         remove_title: '@i18n:objects.sudorule.remove_runas_groups'
                     }]
                 }

--- a/install/ui/src/freeipa/topology.js
+++ b/install/ui/src/freeipa/topology.js
@@ -170,6 +170,7 @@ return {
         }
     ],
     adder_dialog: {
+        title: '@i18n:objects.topologysegment.add',
         fields: [
             {
                 name: 'cn',
@@ -449,6 +450,7 @@ return {
                                     name: 'service_relative_weight'
                                 }
                             ],
+                            add_title: '@i18n:objects.topologylocation.add_server',
                             remove_title: '@i18n:objects.topologylocation.remove_servers'
                         }
                     ]
@@ -714,14 +716,10 @@ topology.location_association_table_widget = function(spec) {
 
     that.create_add_dialog = function() {
 
-        var entity_label = that.entity.metadata.label_singular;
         var pkey = that.facet.get_pkey();
-        var other_entity_label = that.other_entity.metadata.label_singular;
 
         var title = that.add_title;
-        title = title.replace('${entity}', entity_label);
         title = title.replace('${primary_key}', pkey);
-        title = title.replace('${other_entity}', other_entity_label);
 
         return topology.location_server_adder_dialog({
             title: title,

--- a/install/ui/src/freeipa/vault.js
+++ b/install/ui/src/freeipa/vault.js
@@ -89,6 +89,7 @@ var make_vaults_details_page_spec = function() {
                                 label: '@i18n:objects.vault.user'
                             }
                         ],
+                        add_title: '@i18n:objects.vault.add_member_users',
                         remove_title: '@i18n:objects.vault.remove_member_users'
                     },
                     {
@@ -103,6 +104,7 @@ var make_vaults_details_page_spec = function() {
                                 label: '@i18n:objects.vault.group'
                             }
                         ],
+                        add_title: '@i18n:objects.vault.add_member_groups',
                         remove_title: '@i18n:objects.vault.remove_member_groups'
                     },
                     {
@@ -118,6 +120,7 @@ var make_vaults_details_page_spec = function() {
                                 label: '@i18n:objects.vault.service'
                             }
                         ],
+                        add_title: '@i18n:objects.vault.add_member_services',
                         remove_title: '@i18n:objects.vault.remove_member_services'
                     }
                 ]
@@ -141,6 +144,7 @@ var make_vaults_details_page_spec = function() {
                                 label: '@i18n:objects.vault.user'
                             }
                         ],
+                        add_title: '@i18n:objects.vault.add_owner_users',
                         remove_title: '@i18n:objects.vault.remove_owner_users'
                     },
                     {
@@ -157,6 +161,7 @@ var make_vaults_details_page_spec = function() {
                                 label: '@i18n:objects.vault.group'
                             }
                         ],
+                        add_title: '@i18n:objects.vault.add_owner_groups',
                         remove_title: '@i18n:objects.vault.remove_owner_groups'
                     },
                     {
@@ -174,6 +179,7 @@ var make_vaults_details_page_spec = function() {
                                 label: '@i18n:objects.vault.service'
                             }
                         ],
+                        add_title: '@i18n:objects.vault.add_owner_services',
                         remove_title: '@i18n:objects.vault.remove_owner_services'
                     }
                 ]

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -778,6 +778,25 @@ class i18n_messages(Command):
             },
             "hbacrule": {
                 "add": _("Add HBAC rule"),
+                "add_groups": _(
+                    "Add user groups into HBAC rule '${primary_key}'"
+                ),
+                "add_hostgroups": _(
+                    "Add host groups into HBAC rule '${primary_key}'"
+                ),
+                "add_hosts": _(
+                    "Add hosts into HBAC rule '${primary_key}'"
+                ),
+                "add_servicegroups": _(
+                    "Add HBAC service groups into HBAC rule "
+                    "'${primary_key}'"
+                ),
+                "add_services": _(
+                    "Add HBAC services into HBAC rule '${primary_key}'"
+                ),
+                "add_users": _(
+                    "Add users into HBAC rule '${primary_key}'"
+                ),
                 "any_host": _("Any Host"),
                 "any_service": _("Any Service"),
                 "anyone": _("Anyone"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -314,8 +314,30 @@ class i18n_messages(Command):
         },
         "false": _("False"),
         "keytab": {
-            "add_create": _("Allow ${other_entity} to create keytab of ${primary_key}"),
-            "add_retrive": _("Allow ${other_entity} to retrieve keytab of ${primary_key}"),
+            "add_groups_create": _(
+                "Allow user groups to create keytab of '${primary_key}'"
+            ),
+            "add_groups_retrieve": _(
+                "Allow user groups to retrieve keytab of '${primary_key}'"
+            ),
+            "add_hostgroups_create": _(
+                "Allow host groups to create keytab of '${primary_key}'"
+            ),
+            "add_hostgroups_retrieve": _(
+                "Allow host groups to retrieve keytab of '${primary_key}'"
+            ),
+            "add_hosts_create": _(
+                "Allow hosts to create keytab of '${primary_key}'"
+            ),
+            "add_hosts_retrieve": _(
+                "Allow hosts to retrieve keytab of '${primary_key}'"
+            ),
+            "add_users_create": _(
+                "Allow users to create keytab of '${primary_key}'"
+            ),
+            "add_users_retrieve": _(
+                "Allow users to retrieve keytab of '${primary_key}'"
+            ),
             "allowed_to_create": _("Allowed to create keytab"),
             "allowed_to_retrieve": _("Allowed to retrieve keytab"),
             "remove_groups_create": _(

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1331,6 +1331,9 @@ class i18n_messages(Command):
             },
             "topologylocation": {
                 "add": _("Add IPA location"),
+                "add_server": _(
+                    "Add IPA server into IPA location '${primary_key}'"
+                ),
                 "remove": _("Remove IPA locations"),
                 "remove_servers": _(
                     "Remove IPA servers from IPA location '${primary_key}'"

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1090,6 +1090,18 @@ class i18n_messages(Command):
             },
             "selinuxusermap": {
                 "add": _("Add SELinux user map"),
+                "add_groups": _(
+                    "Add user groups into SELinux user map '${primary_key}'"
+                ),
+                "add_hostgroups": _(
+                    "Add host groups into SELinux user map '${primary_key}'"
+                ),
+                "add_hosts": _(
+                    "Add hosts into SELinux user map '${primary_key}'"
+                ),
+                "add_users": _(
+                    "Add users into SELinux user map '${primary_key}'"
+                ),
                 "any_host": _("Any Host"),
                 "anyone": _("Anyone"),
                 "host": _("Host"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1191,6 +1191,43 @@ class i18n_messages(Command):
             "sudorule": {
                 "add": _("Add sudo rule"),
                 "add_option": _("Add sudo option"),
+                "add_allow_cmds": _(
+                    "Add allow sudo commands into sudo rule "
+                    "'${primary_key}'"
+                ),
+                "add_allow_cmdgroups": _(
+                    "Add allow sudo command groups into sudo rule "
+                    "'${primary_key}'"
+                ),
+                "add_deny_cmds": _(
+                    "Add deny sudo commands into sudo rule "
+                    "'${primary_key}'"
+                ),
+                "add_deny_cmdgroups": _(
+                    "Add deny sudo command groups into sudo rule "
+                    "'${primary_key}'"
+                ),
+                "add_groups": _(
+                    "Add user groups into sudo rule '${primary_key}'"
+                ),
+                "add_hostgroups": _(
+                    "Add host groups into sudo rule '${primary_key}'"
+                ),
+                "add_hosts": _(
+                    "Add hosts into sudo rule '${primary_key}'"
+                ),
+                "add_runas_users": _(
+                    "Add RunAs users into sudo rule '${primary_key}'"
+                ),
+                "add_runas_usergroups": _(
+                    "Add RunAs user groups into sudo rule '${primary_key}'"
+                ),
+                "add_runas_groups": _(
+                    "Add RunAs groups into sudo rule '${primary_key}'"
+                ),
+                "add_users": _(
+                    "Add users into sudo rule '${primary_key}'"
+                ),
                 "allow": _("Allow"),
                 "any_command": _("Any Command"),
                 "any_group": _("Any Group"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -539,6 +539,28 @@ class i18n_messages(Command):
             },
             "caacl": {
                 "add": _("Add CA ACL"),
+                "add_ca": _(
+                    "Add Certificate Authorities into CA ACL "
+                    "'${primary_key}'"
+                ),
+                "add_groups": _(
+                    "Add user groups into CA ACL '${primary_key}'"
+                ),
+                "add_hostgroups": _(
+                    "Add host groups into CA ACL '${primary_key}'"
+                ),
+                "add_hosts": _(
+                    "Add hosts into CA ACL '${primary_key}'"
+                ),
+                "add_profiles": _(
+                    "Add certificate profiles into CA ACL '${primary_key}'"
+                ),
+                "add_services": _(
+                    "Add services into CA ACL '${primary_key}'"
+                ),
+                "add_users": _(
+                    "Add users into CA ACL '${primary_key}'"
+                ),
                 "all": _("All"),
                 "any_ca": _("Any CA"),
                 "any_host": _("Any Host"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1400,6 +1400,24 @@ class i18n_messages(Command):
             },
             "vault": {
                 "add": _("Add vault"),
+                "add_member_groups": _(
+                    "Add user groups into members of vault '${primary_key}'"
+                ),
+                "add_member_services": _(
+                    "Add services into members of vault '${primary_key}'"
+                ),
+                "add_member_users": _(
+                    "Add users into members of vault '${primary_key}'"
+                ),
+                "add_owner_groups": _(
+                    "Add user groups into owners of vault '${primary_key}'"
+                ),
+                "add_owner_services": _(
+                    "Add services into owners of vault '${primary_key}'"
+                ),
+                "add_owner_users": _(
+                    "Add users into owners of vault '${primary_key}'"
+                ),
                 "add_warn_arch_ret": _(
                     "Secrets can be added/retrieved to vault only by using "
                     "vault-archive and vault-retrieve from CLI."

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -952,6 +952,18 @@ class i18n_messages(Command):
             },
             "netgroup": {
                 "add": _("Add netgroup"),
+                "add_groups": _(
+                    "Add user groups into netgroup '${primary_key}'"
+                ),
+                "add_hosts": _(
+                    "Add hosts into netgroup '${primary_key}'"
+                ),
+                "add_hostgroups": _(
+                    "Add host groups into netgroup '${primary_key}'"
+                ),
+                "add_users": _(
+                    "Add users into netgroup '${primary_key}'"
+                ),
                 "any_host": _("Any Host"),
                 "anyone": _("Anyone"),
                 "external": _("External"),


### PR DESCRIPTION
As for now the default title of add dialogs, which are initialized from 'association_table' widget, is set to something like:
```python
 'Add ${other_entity} into ${entity} ${primary_key}'
```

where 'other_entity' and 'entity' are also translatable texts. This construction is used via 'create_add_dialog' method of 'association_table' widget for the all 'Add' actions within
the details of entities.
    
Such concatenation leads to a bad quality translation and should be replaced with an entire sentence.
    
From now a mentioned title is taken from a spec and should be specified explicitly.
    
Fixes: https://pagure.io/freeipa/issue/7714