### PR TITLE
Py3: Remove subclassing from object

### DIFF
--- a/contrib/lite-server.py
+++ b/contrib/lite-server.py
@@ -106,7 +106,7 @@ def get_ccname():
     return krb5_unparse_ccache(scheme, location)
 
 
-class KRBCheater(object):
+class KRBCheater:
     """Add KRB5CCNAME to WSGI environ
     """
     def __init__(self, app, ccname):

--- a/install/tools/ipa-custodia-check.in
+++ b/install/tools/ipa-custodia-check.in
@@ -89,7 +89,7 @@ parser.add_argument(
 )
 
 
-class IPACustodiaTester(object):
+class IPACustodiaTester:
     files = [
         paths.IPA_DEFAULT_CONF,
         paths.KRB5_KEYTAB,

--- a/install/tools/ipa-httpd-kdcproxy.in
+++ b/install/tools/ipa-httpd-kdcproxy.in
@@ -63,7 +63,7 @@ class FatalError(Error):
     """
 
 
-class KDCProxyConfig(object):
+class KDCProxyConfig:
     ipaconfig_flag = 'ipaKDCProxyEnabled'
 
     def __init__(self, time_limit=TIME_LIMIT):

--- a/install/tools/ipa-replica-conncheck.in
+++ b/install/tools/ipa-replica-conncheck.in
@@ -57,7 +57,7 @@ CCACHE_FILE = None
 KRB5_CONFIG = None
 
 
-class SshExec(object):
+class SshExec:
     def __init__(self, user, addr):
         self.user = user
         self.addr = addr
@@ -95,7 +95,7 @@ class SshExec(object):
                            capture_output=True, capture_error=True)
 
 
-class CheckedPort(object):
+class CheckedPort:
     def __init__(self, port, port_type, description):
         self.port = port
         self.port_type = port_type

--- a/ipaclient/csrgen.py
+++ b/ipaclient/csrgen.py
@@ -75,7 +75,7 @@ class IPAExtension(jinja2.ext.Extension):
         return data
 
 
-class Formatter(object):
+class Formatter:
     """
     Class for processing a set of CSR generation rules into a template.
 
@@ -258,7 +258,7 @@ class OpenSSLFormatter(Formatter):
         return self.SyntaxRule(prepared_template, is_extension)
 
 
-class FieldMapping(object):
+class FieldMapping:
     """Representation of the rules needed to construct a complete cert field.
 
     Attributes:
@@ -276,7 +276,7 @@ class FieldMapping(object):
         self.data_rules = data_rules
 
 
-class Rule(object):
+class Rule:
     __slots__ = ['name', 'template', 'options']
 
     def __init__(self, name, template, options):
@@ -285,7 +285,7 @@ class Rule(object):
         self.options = options
 
 
-class RuleProvider(object):
+class RuleProvider:
     def rules_for_profile(self, profile_id):
         """
         Return the rules needed to build a CSR using the given profile.
@@ -368,7 +368,7 @@ class FileRuleProvider(RuleProvider):
         return field_mappings
 
 
-class CSRGenerator(object):
+class CSRGenerator:
     def __init__(self, rule_provider, formatter_class=OpenSSLFormatter):
         self.rule_provider = rule_provider
         self.formatter = formatter_class()
@@ -389,7 +389,7 @@ class CSRGenerator(object):
         return config
 
 
-class CSRLibraryAdaptor(object):
+class CSRLibraryAdaptor:
     def get_subject_public_key_info(self):
         raise NotImplementedError('Use a subclass of CSRLibraryAdaptor')
 
@@ -401,7 +401,7 @@ class CSRLibraryAdaptor(object):
         raise NotImplementedError('Use a subclass of CSRLibraryAdaptor')
 
 
-class OpenSSLAdaptor(object):
+class OpenSSLAdaptor:
     def __init__(self, key=None, key_filename=None, password_filename=None):
         """
         Must provide either ``key_filename`` or ``key``.
@@ -458,7 +458,7 @@ class OpenSSLAdaptor(object):
         return encoder.encode(csr)
 
 
-class NSSAdaptor(object):
+class NSSAdaptor:
     def __init__(self, database, password_filename):
         self.database = database
         self.password_filename = password_filename

--- a/ipaclient/install/ipachangeconf.py
+++ b/ipaclient/install/ipachangeconf.py
@@ -51,7 +51,7 @@ def openLocked(filename, perms):
     #TODO: put section delimiters as separating element of the list
     #      so that we can process multiple sections in one go
     #TODO: add a comment all but provided options as a section option
-class IPAChangeConf(object):
+class IPAChangeConf:
     def __init__(self, name):
         self.progname = name
         self.indent = ("", "", "")

--- a/ipaclient/install/ipadiscovery.py
+++ b/ipaclient/install/ipadiscovery.py
@@ -99,7 +99,7 @@ def get_ipa_basedn(conn):
     return None
 
 
-class IPADiscovery(object):
+class IPADiscovery:
 
     def __init__(self):
         self.realm = None

--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -546,7 +546,7 @@ class vault_mod(Local):
         return response
 
 
-class _TransportCertCache(object):
+class _TransportCertCache:
     def __init__(self):
         self._dirname = os.path.join(
                 USER_CACHE_PATH, 'ipa', 'kra-transport-certs'

--- a/ipaclient/remote_plugins/schema.py
+++ b/ipaclient/remote_plugins/schema.py
@@ -95,7 +95,7 @@ class _SchemaObject(Object):
     pass
 
 
-class _SchemaPlugin(object):
+class _SchemaPlugin:
     bases = None
     schema_key = None
 
@@ -352,7 +352,7 @@ class NotAvailable(Exception):
     pass
 
 
-class Schema(object):
+class Schema:
     """
     Store and provide schema for commands and topics
 

--- a/ipalib/aci.py
+++ b/ipalib/aci.py
@@ -41,7 +41,7 @@ PERMISSIONS = ["read", "write", "add", "delete", "search", "compare",
                "selfwrite", "proxy", "all"]
 
 
-class ACI(object):
+class ACI:
     """
     Holds the basic data for an ACI entry, as stored in the cn=accounts
     entry in LDAP.  Has methods to parse an ACI string and export to an

--- a/ipalib/base.py
+++ b/ipalib/base.py
@@ -29,7 +29,7 @@ from ipalib.constants import NAME_REGEX, NAME_ERROR
 from ipalib.constants import TYPE_ERROR, SET_ERROR, DEL_ERROR, OVERRIDE_ERROR
 
 
-class ReadOnly(object):
+class ReadOnly:
     """
     Base class for classes that can be locked into a read-only state.
 
@@ -269,7 +269,7 @@ class NameSpace(ReadOnly):
     through a dictionary interface.  For example, say we create a `NameSpace`
     instance from a list containing a single member, like this:
 
-    >>> class my_member(object):
+    >>> class my_member:
     ...     name = 'my_name'
     ...
     >>> namespace = NameSpace([my_member])
@@ -287,7 +287,7 @@ class NameSpace(ReadOnly):
     For a more detailed example, say we create a `NameSpace` instance from a
     generator like this:
 
-    >>> class Member(object):
+    >>> class Member:
     ...     def __init__(self, i):
     ...         self.i = i
     ...         self.name = self.__name__ = 'member%d' % i

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -704,7 +704,7 @@ class help(frontend.Local):
     """
     Display help for a command or topic.
     """
-    class Writer(object):
+    class Writer:
         """
         Writer abstraction
         """
@@ -1082,7 +1082,7 @@ cli_application_commands = (
 )
 
 
-class Collector(object):
+class Collector:
     def __init__(self):
         object.__setattr__(self, '_Collector__options', {})
 

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -53,7 +53,8 @@ from ipalib import errors
 if six.PY3:
     unicode = str
 
-class Env(object):
+
+class Env:
     """
     Store and retrieve environment variables.
 

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -47,7 +47,7 @@ DBUS_CM_CA_IF = 'org.fedorahosted.certmonger.ca'
 DBUS_PROPERTY_IF = 'org.freedesktop.DBus.Properties'
 
 
-class _cm_dbus_object(object):
+class _cm_dbus_object:
     """
     Auxiliary class for convenient DBus object handling.
     """

--- a/ipalib/install/sysrestore.py
+++ b/ipalib/install/sysrestore.py
@@ -55,7 +55,7 @@ SYSRESTORE_INDEXFILE = "sysrestore.index"
 SYSRESTORE_STATEFILE = "sysrestore.state"
 
 
-class FileStore(object):
+class FileStore:
     """Class for handling backup and restore of files"""
 
     def __init__(self, path = SYSRESTORE_PATH, index_file = SYSRESTORE_INDEXFILE):
@@ -307,7 +307,7 @@ class FileStore(object):
         return True
 
 
-class StateFile(object):
+class StateFile:
     """A metadata file for recording system state which can
     be backed up and later restored.
     StateFile gets reloaded every time to prevent loss of information

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -89,7 +89,7 @@ def find_modules_in_dir(src_dir):
         yield module
 
 
-class Registry(object):
+class Registry:
     """A decorator that makes plugins available to the API
 
     Usage::
@@ -240,7 +240,7 @@ class Plugin(ReadOnly):
             if not self.__finalized:
                 self.finalize()
 
-    class finalize_attr(object):
+    class finalize_attr:
         """
         Create a stub object for plugin attribute that isn't set until the
         finalization of the plugin initialization.

--- a/ipalib/request.py
+++ b/ipalib/request.py
@@ -33,7 +33,7 @@ from ipalib.constants import CALLABLE_ERROR
 context = threading.local()
 
 
-class _FrameContext(object):
+class _FrameContext:
     pass
 
 

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -491,7 +491,7 @@ def xml_loads(data, encoding='UTF-8'):
         raise decode_fault(e)
 
 
-class DummyParser(object):
+class DummyParser:
     def __init__(self):
         self.data = []
 
@@ -1203,7 +1203,7 @@ class xmlclient(RPCClient):
         return xml_unwrap(result)
 
 
-class JSONServerProxy(object):
+class JSONServerProxy:
     def __init__(self, uri, transport, encoding, verbose, allow_none):
         split_uri = urllib.parse.urlsplit(uri)
         if split_uri.scheme not in ("http", "https"):

--- a/ipalib/text.py
+++ b/ipalib/text.py
@@ -154,7 +154,7 @@ def create_translation(key):
     return translation
 
 
-class LazyText(object):
+class LazyText:
     """
     Base class for deferred translation.
 
@@ -319,7 +319,7 @@ class FixMe(Gettext):
     creates conspicuous looking UI labels that remind the programmer to
     "fix-me!".  For example, the typical usage would be something like this:
 
-    >>> class Plugin(object):
+    >>> class Plugin:
     ...     label = None
     ...     def __init__(self):
     ...         self.name = self.__class__.__name__
@@ -485,7 +485,7 @@ class NGettext(LazyText):
 
 
 @six.python_2_unicode_compatible
-class ConcatenatedLazyText(object):
+class ConcatenatedLazyText:
     """Concatenation of multiple strings, or any objects convertible to unicode
 
     Used to concatenate several LazyTexts together.
@@ -525,7 +525,7 @@ class ConcatenatedLazyText(object):
             return ConcatenatedLazyText(*[other] + self.components)
 
 
-class GettextFactory(object):
+class GettextFactory:
     """
     Factory for creating ``_()`` functions.
 

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -994,7 +994,7 @@ def has_managed_topology(api):
     return domainlevel > DOMAIN_LEVEL_0
 
 
-class classproperty(object):
+class classproperty:
     __slots__ = ('__doc__', 'fget')
 
     def __init__(self, fget=None, doc=None):

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -83,7 +83,7 @@ SAN_KRB5PRINCIPALNAME = '1.3.6.1.5.2.2'
 
 
 @crypto_utils.register_interface(crypto_x509.Certificate)
-class IPACertificate(object):
+class IPACertificate:
     """
     A proxy class wrapping a python-cryptography certificate representation for
     FreeIPA purposes

--- a/ipaplatform/_importhook.py
+++ b/ipaplatform/_importhook.py
@@ -10,7 +10,7 @@ import sys
 from ipaplatform.osinfo import osinfo
 
 
-class IpaMetaImporter(object):
+class IpaMetaImporter:
     modules = {
         'ipaplatform.constants',
         'ipaplatform.paths',

--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -8,7 +8,7 @@ This base platform module exports platform dependant constants.
 import sys
 
 
-class BaseConstantsNamespace(object):
+class BaseConstantsNamespace:
     IS_64BITS = sys.maxsize > 2 ** 32
     DS_USER = 'dirsrv'
     DS_GROUP = 'dirsrv'

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -22,7 +22,7 @@ This base platform module exports default filesystem paths.
 '''
 
 
-class BasePathNamespace(object):
+class BasePathNamespace:
     BASH = "/bin/bash"
     BIN_HOSTNAMECTL = "/bin/hostnamectl"
     ECHO = "/bin/echo"

--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -96,7 +96,7 @@ class KnownServices(Mapping):
             raise AttributeError(name)
 
 
-class PlatformService(object):
+class PlatformService:
     """
     PlatformService abstracts out external process running on the system
     which is possible to administer (start, stop, check status, etc).

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -34,7 +34,7 @@ from ipapython import ipautil
 logger = logging.getLogger(__name__)
 
 
-class BaseTaskNamespace(object):
+class BaseTaskNamespace:
 
     def restore_context(self, filepath, force=False):
         """Restore SELinux security context on the given filepath.

--- a/ipaplatform/redhat/authconfig.py
+++ b/ipaplatform/redhat/authconfig.py
@@ -38,7 +38,7 @@ def get_auth_tool():
 
 
 @six.add_metaclass(abc.ABCMeta)
-class RedHatAuthToolBase(object):
+class RedHatAuthToolBase:
 
     @abc.abstractmethod
     def configure(self, sssd, mkhomedir, statestore, sudo=True):

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -69,7 +69,7 @@ def selinux_enabled():
 
 
 @total_ordering
-class IPAVersion(object):
+class IPAVersion:
     _rpmvercmp_func = None
 
     @classmethod

--- a/ipapython/admintool.py
+++ b/ipapython/admintool.py
@@ -53,7 +53,7 @@ class ScriptError(Exception):
         return str(self)
 
 
-class AdminTool(object):
+class AdminTool:
     """Base class for command-line admin tools
 
     To run the tool, call the main() classmethod with a list of command-line

--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -221,7 +221,7 @@ KEY_RE = re.compile(
 )
 
 
-class NSSDatabase(object):
+class NSSDatabase:
     """A general-purpose wrapper around a NSS cert database
 
     For permanent NSS databases, pass the cert DB directory to __init__

--- a/ipapython/config.py
+++ b/ipapython/config.py
@@ -152,7 +152,7 @@ def verify_args(parser, args, needed_args = None):
         parser.error("no %s specified" % needed_list[len_have])
 
 
-class IPAConfig(object):
+class IPAConfig:
     def __init__(self):
         self.default_realm = None
         self.default_server = []

--- a/ipapython/cookie.py
+++ b/ipapython/cookie.py
@@ -66,7 +66,8 @@ escaping and unescapin.
 
 #-------------------------------------------------------------------------------
 
-class Cookie(object):
+
+class Cookie:
     '''
     A Cookie object has the following attributes:
 

--- a/ipapython/directivesetter.py
+++ b/ipapython/directivesetter.py
@@ -15,7 +15,7 @@ from ipapython.ipautil import unescape_seq, escape_seq
 _SENTINEL = object()
 
 
-class DirectiveSetter(object):
+class DirectiveSetter:
     """Safe directive setter
 
     with DirectiveSetter('/path/to/conf') as ds:

--- a/ipapython/dn.py
+++ b/ipapython/dn.py
@@ -557,7 +557,7 @@ else:
 
 
 @functools.total_ordering
-class AVA(object):
+class AVA:
     '''
     AVA(arg0, ...)
 
@@ -706,7 +706,7 @@ class AVA(object):
 
 
 @functools.total_ordering
-class RDN(object):
+class RDN:
     '''
     RDN(arg0, ...)
 
@@ -951,7 +951,7 @@ class RDN(object):
 
 
 @functools.total_ordering
-class DN(object):
+class DN:
     '''
     DN(arg0, ...)
 

--- a/ipapython/graph.py
+++ b/ipapython/graph.py
@@ -4,7 +4,7 @@
 from collections import deque
 
 
-class Graph(object):
+class Graph:
     """
     Simple oriented graph structure
 

--- a/ipapython/install/util.py
+++ b/ipapython/install/util.py
@@ -11,7 +11,7 @@ import sys
 import six
 
 
-class from_(object):
+class from_:
     """
     Wrapper for delegating to a subgenerator.
 

--- a/ipapython/ipa_log_manager.py
+++ b/ipapython/ipa_log_manager.py
@@ -57,7 +57,7 @@ LOGGING_FORMAT_STANDARD_CONSOLE = '%(name)-12s: %(levelname)-8s %(message)s'
 LOGGING_FORMAT_STANDARD_FILE = '%(asctime)s %(levelname)s %(message)s'
 
 
-class _DeprecatedLogger(object):
+class _DeprecatedLogger:
     def __init__(self, logger, name):
         self._logger = logger
         self._name = name
@@ -133,7 +133,7 @@ def get_logger(who, bind_logger_names=False):
     return logger
 
 
-class Filter(object):
+class Filter:
     def __init__(self, regexp, level):
         self.regexp = re.compile(regexp)
         self.level = level

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -126,7 +126,7 @@ def ldap_initialize(uri, cacertfile=None):
     return conn
 
 
-class _ServerSchema(object):
+class _ServerSchema:
     '''
     Properties of a schema retrieved from an LDAP server.
     '''
@@ -137,7 +137,7 @@ class _ServerSchema(object):
         self.retrieve_timestamp = time.time()
 
 
-class SchemaCache(object):
+class SchemaCache:
     '''
     Cache the schema's from individual LDAP servers.
     '''
@@ -635,7 +635,7 @@ class SingleValueLDAPEntryView(LDAPEntryView):
             self._entry[name] = [value]
 
 
-class LDAPClient(object):
+class LDAPClient:
     """LDAP backend class
 
     This class abstracts a LDAP connection, providing methods that work with

--- a/ipapython/kerberos.py
+++ b/ipapython/kerberos.py
@@ -61,7 +61,7 @@ def split_principal_name(principal_name):
 
 
 @six.python_2_unicode_compatible
-class Principal(object):
+class Principal:
     """
     Container for the principal name and realm according to RFC 1510
     """

--- a/ipapython/ssh.py
+++ b/ipapython/ssh.py
@@ -38,7 +38,8 @@ __all__ = ['SSHPublicKey']
 OPENSSH_BASE_REGEX = re.compile(r'^[\t ]*(?P<keytype>[^\x00\n\r]+?) [\t ]*(?P<key>[^\x00\n\r]+?)(?:[\t ]+(?P<comment>[^\x00\n\r]*?)[\t ]*)?$')
 OPENSSH_OPTIONS_REGEX = re.compile(r'(?P<name>[-0-9A-Za-z]+)(?:="(?P<value>(?:\\"|[^\x00\n\r"])*)")?')
 
-class SSHPublicKey(object):
+
+class SSHPublicKey:
     """
     SSH public key object.
     """

--- a/ipaserver/advise/base.py
+++ b/ipaserver/advise/base.py
@@ -81,7 +81,7 @@ As a result, you can redirect the advice's output directly to a script file.
 DEFAULT_INDENTATION_INCREMENT = 2
 
 
-class _IndentationTracker(object):
+class _IndentationTracker:
     """
     A simple wrapper that tracks the indentation level of the generated bash
     commands
@@ -130,7 +130,7 @@ class _IndentationTracker(object):
         self._recompute_indentation_level()
 
 
-class CompoundStatement(object):
+class CompoundStatement:
     """
     Wrapper around indented blocks of Bash statements.
 
@@ -221,7 +221,7 @@ class ForLoop(CompoundStatement):
         self.advice_output.command('done')
 
 
-class _AdviceOutput(object):
+class _AdviceOutput:
 
     def __init__(self):
         self.content = []

--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -193,7 +193,7 @@ class ExtendedDNControl(LDAPControl):
         )
 
 
-class DomainValidator(object):
+class DomainValidator:
     ATTR_FLATNAME = 'ipantflatname'
     ATTR_SID = 'ipantsecurityidentifier'
     ATTR_TRUSTED_SID = 'ipanttrusteddomainsid'
@@ -824,7 +824,7 @@ def string_to_array(what):
     return [ord(v) for v in what]
 
 
-class TrustDomainInstance(object):
+class TrustDomainInstance:
 
     def __init__(self, hostname, creds=None):
         self.parm = param.LoadParm()
@@ -1569,7 +1569,7 @@ def retrieve_remote_domain(hostname, local_flatname,
     return rd
 
 
-class TrustDomainJoins(object):
+class TrustDomainJoins:
     def __init__(self, api):
         self.api = api
         self.local_domain = None

--- a/ipaserver/dns_data_management.py
+++ b/ipaserver/dns_data_management.py
@@ -62,7 +62,7 @@ class IPADomainIsNotManagedByIPAError(Exception):
     pass
 
 
-class IPASystemRecords(object):
+class IPASystemRecords:
 
     # fixme do it configurable
     PRIORITY_HIGH = 0

--- a/ipaserver/dnssec/abshsm.py
+++ b/ipaserver/dnssec/abshsm.py
@@ -174,7 +174,7 @@ def ldap2p11helper_api_params(ldap_key):
     return unwrap_params
 
 
-class AbstractHSM(object):
+class AbstractHSM:
     def _filter_replica_keys(self, all_keys):
         replica_keys = {}
         for key_id, key in all_keys.items():

--- a/ipaserver/dnssec/bindmgr.py
+++ b/ipaserver/dnssec/bindmgr.py
@@ -31,7 +31,8 @@ time_bindfmt = '%Y%m%d%H%M%S'
 FILE_PERM = (stat.S_IRUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IWUSR)
 DIR_PERM = (stat.S_IRWXU | stat.S_IRWXG)
 
-class BINDMgr(object):
+
+class BINDMgr:
     """BIND key manager. It does LDAP->BIND key files synchronization.
 
     One LDAP object with idnsSecKey object class will produce

--- a/ipaserver/dnssec/odsmgr.py
+++ b/ipaserver/dnssec/odsmgr.py
@@ -19,7 +19,7 @@ ENTRYUUID_PREFIX = "/var/lib/ipa/dns/zone/entryUUID/"
 ENTRYUUID_PREFIX_LEN = len(ENTRYUUID_PREFIX)
 
 
-class ZoneListReader(object):
+class ZoneListReader:
     def __init__(self):
         self.names = set()  # dns.name
         self.uuids = set()  # UUID strings
@@ -119,7 +119,7 @@ class LDAPZoneListReader(ZoneListReader):
             self._del_zone(zone_ldap['idnsname'][0], uuid)
 
 
-class ODSMgr(object):
+class ODSMgr:
     """OpenDNSSEC zone manager. It does LDAP->ODS synchronization.
 
     Zones with idnsSecInlineSigning attribute = TRUE in LDAP are added

--- a/ipaserver/dnssec/temp.py
+++ b/ipaserver/dnssec/temp.py
@@ -6,7 +6,8 @@ import errno
 import shutil
 import tempfile
 
-class TemporaryDirectory(object):
+
+class TemporaryDirectory:
     def __init__(self, root):
         self.root = root
 

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -579,7 +579,7 @@ def ensure_dnsserver_container_exists(ldap, api_instance, logger=logger):
         logger.debug('cn=servers,cn=dns container already exists')
 
 
-class DnsBackup(object):
+class DnsBackup:
     def __init__(self, service):
         self.service = service
         self.zones = {}

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1937,7 +1937,7 @@ def update_ipa_conf():
         parser.write(f)
 
 
-class ExternalCAProfile(object):
+class ExternalCAProfile:
     """
     An external CA profile configuration.  Currently the only
     subclasses are for Microsoft CAs, for providing data in the

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -136,7 +136,7 @@ def is_ipa_issued_cert(api, cert):
     return DN(cert.issuer) == cacert_subject
 
 
-class CertDB(object):
+class CertDB:
     """An IPA-server-specific wrapper around NSS
 
     This class knows IPA-specific details such as nssdir location, or the
@@ -711,7 +711,7 @@ class CertDB(object):
         self.nssdb.convert_db()
 
 
-class _CrossProcessLock(object):
+class _CrossProcessLock:
     _DATETIME_FORMAT = '%Y%m%d%H%M%S%f'
 
     def __init__(self, filename):

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -111,7 +111,7 @@ class UpgradeMissingVersionError(UpgradeVersionError):
     pass
 
 
-class ReplicaConfig(object):
+class ReplicaConfig:
     def __init__(self, top_dir=None):
         self.realm_name = ""
         self.domain_name = ""

--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -238,7 +238,7 @@ def convertKeyDerivation(value):
     }.get(value.lower(), None)
 
 
-class XMLDecryptor(object):
+class XMLDecryptor:
     """This decrypts values from XML as specified in:
         * http://www.w3.org/TR/xmlenc-core/
         * RFC 6931"""
@@ -285,7 +285,7 @@ class XMLDecryptor(object):
         return out
 
 
-class PSKCKeyPackage(object):
+class PSKCKeyPackage:
     _XML = {
         'pskc:DeviceInfo': {
             'pskc:IssueNo/text()':      ('issueno',      unicode),
@@ -451,7 +451,7 @@ class PSKCKeyPackage(object):
             out['ipatoken' + key] = unicode(reducer(dates).strftime("%Y%m%d%H%M%SZ"))
 
 
-class PSKCDocument(object):
+class PSKCDocument:
     @property
     def keyname(self):
         return self.__keyname

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -133,7 +133,7 @@ def safe_output(attr, values):
     return values
 
 
-class LDAPUpdate(object):
+class LDAPUpdate:
     action_keywords = ["default", "add", "remove", "only", "onlyifexist", "deleteentry", "replace", "addifnew", "addifexist"]
 
     def __init__(self, dm_password=None, sub_dict={},

--- a/ipaserver/install/plugins/rename_managed.py
+++ b/ipaserver/install/plugins/rename_managed.py
@@ -53,7 +53,7 @@ def entry_to_update(entry):
     return update
 
 
-class GenerateUpdateMixin(object):
+class GenerateUpdateMixin:
     def _dn_suffix_replace(self, dn, old_suffix, new_suffix):
         """Replace all occurences of "old" AVAs in a DN by "new"
 

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -215,7 +215,7 @@ def wait_for_entry(connection, dn, timeout, attr=None, attrvalue='*',
             time.sleep(1)
 
 
-class ReplicationManager(object):
+class ReplicationManager:
     """Manage replication agreements
 
     between DS servers, and sync  agreements with Windows servers

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -281,7 +281,7 @@ def enable_services(fqdn):
             logger.debug("Enabled service %s for %s", name, fqdn)
 
 
-class Service(object):
+class Service:
     def __init__(self, service_name, service_desc=None, sstore=None,
                  fstore=None, api=api, realm_name=None,
                  service_user=None, service_prefix=None,

--- a/ipaserver/p11helper.py
+++ b/ipaserver/p11helper.py
@@ -705,7 +705,7 @@ def _set_wrapping_mech_parameters(mech_type, mech):
 ########################################################################
 # P11_Helper object
 #
-class P11_Helper(object):
+class P11_Helper:
     @property
     def p11(self):
         return self.p11_ptr[0]

--- a/ipaserver/plugins/certmap.py
+++ b/ipaserver/plugins/certmap.py
@@ -402,7 +402,7 @@ DBUS_SSSD_USERS_IF = 'org.freedesktop.sssd.infopipe.Users'
 DBUS_SSSD_USER_IF = 'org.freedesktop.sssd.infopipe.Users.User'
 
 
-class _sssd(object):
+class _sssd:
     """
     Auxiliary class for SSSD infopipe DBus.
     """

--- a/ipaserver/secrets/client.py
+++ b/ipaserver/secrets/client.py
@@ -17,7 +17,7 @@ import urllib3
 import requests
 
 
-class CustodiaClient(object):
+class CustodiaClient:
 
     def _client_keys(self):
         return self.ikk.server_keys

--- a/ipaserver/secrets/common.py
+++ b/ipaserver/secrets/common.py
@@ -7,7 +7,7 @@ import ldap.filter
 from ipapython.ipaldap import ldap_initialize
 
 
-class iSecLdap(object):
+class iSecLdap:
 
     def __init__(self, uri, auth_type=None):
         self.uri = uri

--- a/ipaserver/secrets/store.py
+++ b/ipaserver/secrets/store.py
@@ -19,7 +19,7 @@ class UnknownKeyName(Exception):
     pass
 
 
-class DBMAPHandler(object):
+class DBMAPHandler:
 
     def __init__(self, config, dbmap, nickname):
         raise NotImplementedError

--- a/ipaserver/servroles.py
+++ b/ipaserver/servroles.py
@@ -91,7 +91,7 @@ ABSENT = u'absent'
 
 
 @six.add_metaclass(abc.ABCMeta)
-class LDAPBasedProperty(object):
+class LDAPBasedProperty:
     """
     base class for all master properties defined by LDAP content
     :param attr_name: attribute name

--- a/ipaserver/topology.py
+++ b/ipaserver/topology.py
@@ -128,7 +128,7 @@ def _format_topology_errors(topo_errors):
     return "\n".join(msg_lines)
 
 
-class TopologyConnectivity(object):
+class TopologyConnectivity:
     """
     a simple class abstracting the replication connectivity in managed topology
     """

--- a/ipatests/create_external_ca.py
+++ b/ipatests/create_external_ca.py
@@ -30,7 +30,8 @@ import six
 
 ISSUER_CN = 'example.test'
 
-class ExternalCA(object):
+
+class ExternalCA:
     """
     Provide external CA for testing
     """

--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -25,7 +25,7 @@ BASE_DIR = os.path.abspath(os.path.join(HERE, os.pardir, os.pardir))
 
 @pytest.mark.tier0
 @pytest.mark.needs_ipaapi
-class TestCLIParsing(object):
+class TestCLIParsing:
     """Tests that commandlines are correctly parsed to Command keyword args
     """
     def check_command(self, commandline, expected_command_name, **kw_expected):

--- a/ipatests/test_cmdline/test_help.py
+++ b/ipatests/test_cmdline/test_help.py
@@ -37,7 +37,7 @@ pytestmark = pytest.mark.needs_ipaapi
 
 
 @pytest.mark.tier0
-class CLITestContext(object):
+class CLITestContext:
     """Context manager that replaces stdout & stderr, and catches SystemExit
 
     Whatever was printed to the streams is available in ``stdout`` and

--- a/ipatests/test_integration/base.py
+++ b/ipatests/test_integration/base.py
@@ -28,7 +28,7 @@ from pytest_sourceorder import ordered
 @ordered
 @pytest.mark.usefixtures('mh')
 @pytest.mark.usefixtures('integration_logs')
-class IntegrationTest(object):
+class IntegrationTest:
     num_replicas = 0
     num_clients = 0
     num_ad_domains = 0

--- a/ipatests/test_integration/test_legacy_clients.py
+++ b/ipatests/test_integration/test_legacy_clients.py
@@ -35,7 +35,7 @@ from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration import test_trust as trust_tests
 
 
-class BaseTestLegacyClient(object):
+class BaseTestLegacyClient:
     """
     Tests legacy client support.
     """
@@ -470,14 +470,14 @@ class BaseTestLegacyClient(object):
 
 # Base classes with attributes that are specific for each legacy client test
 
-class BaseTestLegacySSSDBefore19RedHat(object):
+class BaseTestLegacySSSDBefore19RedHat:
 
     advice_id = 'config-redhat-sssd-before-1-9'
     required_extra_roles = ['legacy_client_sssd_redhat']
     optional_extra_roles = ['ad_subdomain', 'ad_treedomain']
 
 
-class BaseTestLegacyNssPamLdapdRedHat(object):
+class BaseTestLegacyNssPamLdapdRedHat:
 
     advice_id = 'config-redhat-nss-pam-ldapd'
     required_extra_roles = ['legacy_client_nss_pam_ldapd_redhat']
@@ -487,7 +487,7 @@ class BaseTestLegacyNssPamLdapdRedHat(object):
         tasks.clear_sssd_cache(self.master)
 
 
-class BaseTestLegacyNssLdapRedHat(object):
+class BaseTestLegacyNssLdapRedHat:
 
     advice_id = 'config-redhat-nss-ldap'
     required_extra_roles = ['legacy_client_nss_ldap_redhat']
@@ -529,7 +529,7 @@ class BaseTestLegacyClientNonPosix(BaseTestLegacyClient,
         pass
 
 
-class BaseTestSSSDMixin(object):
+class BaseTestSSSDMixin:
 
     def test_apply_advice(self):
         super(BaseTestSSSDMixin, self).test_apply_advice()

--- a/ipatests/test_integration/test_ordering.py
+++ b/ipatests/test_integration/test_ordering.py
@@ -29,7 +29,7 @@ from pytest_sourceorder import ordered
 
 
 @ordered
-class TestBase(object):
+class TestBase:
     @classmethod
     def setup_class(cls):
         cls.value = 'unchanged'

--- a/ipatests/test_integration/test_testconfig.py
+++ b/ipatests/test_integration/test_testconfig.py
@@ -82,7 +82,7 @@ def extend_dict(defaults, *others, **kwargs):
     return copy.deepcopy(result)
 
 
-class CheckConfig(object):
+class CheckConfig:
     def check_config(self, conf):
         pass
 

--- a/ipatests/test_ipaclient/test_csrgen.py
+++ b/ipatests/test_ipaclient/test_csrgen.py
@@ -54,7 +54,7 @@ class IdentityFormatter(csrgen.Formatter):
         return {'options': syntax_rules}
 
 
-class test_Formatter(object):
+class test_Formatter:
     def test_prepare_data_rule_with_data_source(self, formatter):
         data_rule = csrgen.Rule('uid', '{{subject.uid.0}}',
                                 {'data_source': 'subject.uid.0'})
@@ -135,7 +135,7 @@ class test_Formatter(object):
         assert prepared == 'rule1,rule2'
 
 
-class test_FileRuleProvider(object):
+class test_FileRuleProvider:
     def test_rule_basic(self, rule_provider):
         rule_name = 'basic'
 
@@ -168,7 +168,7 @@ class test_FileRuleProvider(object):
             rule_provider.rules_for_profile('nosuchprofile')
 
 
-class test_CSRGenerator(object):
+class test_CSRGenerator:
     def test_userCert_OpenSSL(self, generator):
         principal = {
             'uid': ['testuser'],
@@ -264,7 +264,7 @@ class test_CSRGenerator(object):
                 config.encode('utf-8'), adaptor.get_subject_public_key_info())
 
 
-class test_rule_handling(object):
+class test_rule_handling:
     def test_optionalAttributeMissing(self, generator):
         principal = {'uid': 'testuser'}
         rule_provider = StubRuleProvider()

--- a/ipatests/test_ipalib/test_backend.py
+++ b/ipatests/test_ipalib/test_backend.py
@@ -49,7 +49,7 @@ class test_Backend(ClassChecker):
         assert self.cls.__bases__ == (plugable.Plugin,)
 
 
-class Disconnect(object):
+class Disconnect:
     called = False
 
     def __init__(self, id=None):

--- a/ipatests/test_ipalib/test_base.py
+++ b/ipatests/test_ipalib/test_base.py
@@ -108,7 +108,7 @@ def test_lock():
     assert str(e) == 'already locked: %r' % o
 
     # Test with another class implemented locking protocol:
-    class Lockable(object):
+    class Lockable:
         __locked = False
         def __lock__(self):
             self.__locked = True
@@ -122,7 +122,7 @@ def test_lock():
     assert str(e) == 'already locked: %r' % o
 
     # Test with a class incorrectly implementing the locking protocol:
-    class Broken(object):
+    class Broken:
         def __lock__(self):
             pass
         def __islocked__(self):
@@ -145,7 +145,7 @@ def test_islocked():
     assert f(o) is True
 
     # Test with another class implemented locking protocol:
-    class Lockable(object):
+    class Lockable:
         __locked = False
         def __lock__(self):
             self.__locked = True
@@ -157,7 +157,7 @@ def test_islocked():
     assert f(o) is True
 
     # Test with a class incorrectly implementing the locking protocol:
-    class Broken(object):
+    class Broken:
         __lock__ = False
         def __islocked__(self):
             return False
@@ -207,7 +207,7 @@ def membername(i):
     return 'member%03d' % i
 
 
-class DummyMember(object):
+class DummyMember:
     def __init__(self, i):
         self.i = i
         self.name = self.__name__ = membername(i)

--- a/ipatests/test_ipalib/test_cli.py
+++ b/ipatests/test_ipalib/test_cli.py
@@ -76,7 +76,7 @@ def get_cmd_name(i):
     return 'cmd_%d' % i
 
 
-class DummyCommand(object):
+class DummyCommand:
     def __init__(self, name):
         self.__name = name
 
@@ -85,7 +85,7 @@ class DummyCommand(object):
     name = property(__get_name)
 
 
-class DummyAPI(object):
+class DummyAPI:
     def __init__(self, cnt):
         self.__cmd = plugable.APINameSpace(self.__cmd_iter(cnt), DummyCommand)
 

--- a/ipatests/test_ipalib/test_errors.py
+++ b/ipatests/test_ipalib/test_errors.py
@@ -41,7 +41,7 @@ if six.PY3:
 pytestmark = pytest.mark.tier0
 
 
-class PrivateExceptionTester(object):
+class PrivateExceptionTester:
     _klass = None
     __klass = None
 
@@ -193,7 +193,7 @@ class test_PluginMissingOverrideError(PrivateExceptionTester):
 ##############################################################################
 # Unit tests for public errors:
 
-class PublicExceptionTester(object):
+class PublicExceptionTester:
     _klass = None
     __klass = None
 
@@ -338,7 +338,7 @@ class test_PublicError(PublicExceptionTester):
         assert_equal(list(inst_match),list(instructions))
 
 
-class BaseMessagesTest(object):
+class BaseMessagesTest:
     """Generic test for all of a module's errors or messages
     """
     def test_public_messages(self):
@@ -367,7 +367,7 @@ class BaseMessagesTest(object):
         pass
 
 
-class test_PublicErrors(object):
+class test_PublicErrors:
     message_list = errors.public_errors
     errno_range = list(range(900, 5999))
     required_classes = (Exception, errors.PublicError)

--- a/ipatests/test_ipalib/test_frontend.py
+++ b/ipatests/test_ipalib/test_frontend.py
@@ -71,7 +71,7 @@ def test_is_rule():
     is_rule = frontend.is_rule
     flag = frontend.RULE_FLAG
 
-    class no_call(object):
+    class no_call:
         def __init__(self, value):
             if value is not None:
                 assert value in (True, False)
@@ -199,7 +199,7 @@ class test_Command(ClassChecker):
         """
         Return a standard subclass of `ipalib.frontend.Command`.
         """
-        class Rule(object):
+        class Rule:
             def __init__(self, name):
                 self.name = name
 
@@ -230,7 +230,7 @@ class test_Command(ClassChecker):
         """
         Helper method used to test args and options.
         """
-        class api(object):
+        class api:
             @staticmethod
             def is_production_mode():
                 return False
@@ -276,7 +276,7 @@ class test_Command(ClassChecker):
         """
         Test the ``ipalib.frontend.Command.args`` instance attribute.
         """
-        class api(object):
+        class api:
             @staticmethod
             def is_production_mode():
                 return False
@@ -333,7 +333,7 @@ class test_Command(ClassChecker):
         """
         Test the ``ipalib.frontend.Command.options`` instance attribute.
         """
-        class api(object):
+        class api:
             @staticmethod
             def is_production_mode():
                 return False
@@ -357,7 +357,7 @@ class test_Command(ClassChecker):
         """
         Test the ``ipalib.frontend.Command.output`` instance attribute.
         """
-        class api(object):
+        class api:
             @staticmethod
             def is_production_mode():
                 return False
@@ -405,7 +405,7 @@ class test_Command(ClassChecker):
         """
         Test the `ipalib.frontend.Command.convert` method.
         """
-        class api(object):
+        class api:
             @staticmethod
             def is_production_mode():
                 return False
@@ -422,7 +422,7 @@ class test_Command(ClassChecker):
         """
         Test the `ipalib.frontend.Command.normalize` method.
         """
-        class api(object):
+        class api:
             @staticmethod
             def is_production_mode():
                 return False
@@ -470,7 +470,7 @@ class test_Command(ClassChecker):
         """
         Test the `ipalib.frontend.Command.validate` method.
         """
-        class api(object):
+        class api:
             env = config.Env(context='cli')
             @staticmethod
             def is_production_mode():
@@ -689,7 +689,7 @@ class test_Command(ClassChecker):
         """
         Test the `ipalib.frontend.Command.validate_output` method.
         """
-        class api(object):
+        class api:
             @staticmethod
             def is_production_mode():
                 return False
@@ -731,7 +731,7 @@ class test_Command(ClassChecker):
         """
         Test `ipalib.frontend.Command.validate_output` per-type validation.
         """
-        class api(object):
+        class api:
             @staticmethod
             def is_production_mode():
                 return False
@@ -760,7 +760,7 @@ class test_Command(ClassChecker):
         """
         Test `ipalib.frontend.Command.validate_output` nested validation.
         """
-        class api(object):
+        class api:
             @staticmethod
             def is_production_mode():
                 return False
@@ -795,7 +795,7 @@ class test_Command(ClassChecker):
         """
         Test the `ipalib.frontend.Command.get_output_params` method.
         """
-        class api(object):
+        class api:
             @staticmethod
             def is_production_mode():
                 return False
@@ -831,7 +831,7 @@ class test_LocalOrRemote(ClassChecker):
         """
         Test the `ipalib.frontend.LocalOrRemote.__init__` method.
         """
-        class api(object):
+        class api:
             @staticmethod
             def is_production_mode():
                 return False
@@ -914,7 +914,7 @@ class test_Object(ClassChecker):
         Test the `ipalib.frontend.Object.__init__` method.
         """
         # Setup for test:
-        class DummyAttribute(object):
+        class DummyAttribute:
             def __init__(self, obj_name, attr_name, name=None):
                 self.obj_name = obj_name
                 self.attr_name = attr_name
@@ -942,7 +942,7 @@ class test_Object(ClassChecker):
         cnt = 10
         methods_format = 'method_%d'
 
-        class FakeAPI(object):
+        class FakeAPI:
             def __init__(self):
                 self._API__plugins = get_attributes(cnt, methods_format)
                 self._API__default_map = {}
@@ -1111,13 +1111,16 @@ class test_Attribute(ClassChecker):
         Test the `ipalib.frontend.Attribute.__init__` method.
         """
         user_obj = 'The user frontend.Object instance'
-        class api(object):
+
+        class api:
             Object = {("user", "1"): user_obj}
             @staticmethod
             def is_production_mode():
                 return False
+
         class user_add(self.cls):
             pass
+
         o = user_add(api)
         assert read_only(o, 'api') is api
         assert read_only(o, 'obj') is user_obj

--- a/ipatests/test_ipalib/test_parameters.py
+++ b/ipatests/test_ipalib/test_parameters.py
@@ -173,7 +173,7 @@ def test_parse_param_spec():
     assert str(e) == TYPE_ERROR % ('spec', str, bad_value, type(bad_value))
 
 
-class DummyRule(object):
+class DummyRule:
     def __init__(self, error=None):
         assert error is None or type(error) is unicode
         self.error = error
@@ -581,7 +581,7 @@ class test_Param(ClassChecker):
         """
         Test the `ipalib.parameters.Param.get_default` method.
         """
-        class PassThrough(object):
+        class PassThrough:
             value = None
 
             def __call__(self, value):

--- a/ipatests/test_ipalib/test_plugable.py
+++ b/ipatests/test_ipalib/test_plugable.py
@@ -35,6 +35,7 @@ import pytest
 
 pytestmark = pytest.mark.tier0
 
+
 class test_Plugin(ClassChecker):
     """
     Test the `ipalib.plugable.Plugin` class.
@@ -88,7 +89,7 @@ class test_Plugin(ClassChecker):
         """
         Test the `ipalib.plugable.Plugin.finalize` method.
         """
-        class api(object):
+        class api:
             @staticmethod
             def is_production_mode():
                 return False
@@ -102,14 +103,15 @@ def test_Registry():
     """
     Test the `ipalib.plugable.Registry` class
     """
-    class Base1(object):
-        pass
-    class Base2(object):
+    class Base1:
         pass
 
+    class Base2:
+        pass
 
     class plugin1(Base1):
         pass
+
     class plugin2(Base2):
         pass
 

--- a/ipatests/test_ipalib/test_rpc.py
+++ b/ipatests/test_ipalib/test_rpc.py
@@ -262,7 +262,7 @@ class test_xmlclient(PluginTester):
 
 @pytest.mark.skip_ipaclient_unittest
 @pytest.mark.needs_ipaapi
-class test_xml_introspection(object):
+class test_xml_introspection:
     @classmethod
     def setup_class(cls):
         try:

--- a/ipatests/test_ipalib/test_text.py
+++ b/ipatests/test_ipalib/test_text.py
@@ -50,7 +50,7 @@ def test_create_translation():
     assert context.__dict__[key] is t
 
 
-class test_TestLang(object):
+class test_TestLang:
     lang_env_vars = {'LC_ALL', 'LC_MESSAGES', 'LANGUAGE', 'LANG'}
 
     def setup_lang(self):
@@ -148,7 +148,8 @@ class test_TestLang(object):
         result = self.po_file_iterate(self.po_file, get_msgstr, get_msgstr_plural)
         assert result == 0
 
-class test_LazyText(object):
+
+class test_LazyText:
 
     klass = text.LazyText
 
@@ -159,7 +160,7 @@ class test_LazyText(object):
         assert inst.key == ('foo', 'bar')
 
 
-class test_FixMe(object):
+class test_FixMe:
     klass = text.FixMe
 
     def test_init(self):
@@ -178,7 +179,7 @@ class test_FixMe(object):
         assert type(unicode(inst)) is unicode
 
 
-class test_Gettext(object):
+class test_Gettext:
 
     klass = text.Gettext
 
@@ -240,7 +241,7 @@ class test_Gettext(object):
         assert (inst4 != inst1) is True
 
 
-class test_NGettext(object):
+class test_NGettext:
 
     klass = text.NGettext
 
@@ -318,7 +319,7 @@ class test_NGettext(object):
         assert (inst4 != inst1) is True
 
 
-class test_GettextFactory(object):
+class test_GettextFactory:
 
     klass = text.GettextFactory
 
@@ -351,7 +352,7 @@ class test_GettextFactory(object):
         assert g.localedir == 'bar'
 
 
-class test_NGettextFactory(object):
+class test_NGettextFactory:
 
     klass = text.NGettextFactory
 
@@ -385,7 +386,7 @@ class test_NGettextFactory(object):
         assert ng.localedir == 'bar'
 
 
-class test_ConcatenatedText(object):
+class test_ConcatenatedText:
 
     klass = text.ConcatenatedLazyText
 

--- a/ipatests/test_ipalib/test_x509.py
+++ b/ipatests/test_ipalib/test_x509.py
@@ -160,7 +160,8 @@ QUs1Hx1wL7mL4U8fKCFDKA+ds2B2xWgoZg==
 -----END CERTIFICATE-----
 '''
 
-class test_x509(object):
+
+class test_x509:
     """
     Test `ipalib.x509`
 

--- a/ipatests/test_ipapython/test_directivesetter.py
+++ b/ipatests/test_ipapython/test_directivesetter.py
@@ -33,7 +33,7 @@ def tempdir(request):
     return tempdir
 
 
-class test_set_directive_lines(object):
+class test_set_directive_lines:
     def test_remove_directive(self):
         lines = directivesetter.set_directive_lines(
             False, '=', 'foo', None, EXAMPLE_CONFIG, comment="#")
@@ -50,7 +50,7 @@ class test_set_directive_lines(object):
         assert list(lines) == ['foo=3\n', 'foobar=2\n']
 
 
-class test_set_directive_lines_whitespace(object):
+class test_set_directive_lines_whitespace:
     def test_remove_directive(self):
         lines = directivesetter.set_directive_lines(
             False, ' ', 'foo', None, WHITESPACE_CONFIG, comment="#")
@@ -72,7 +72,7 @@ class test_set_directive_lines_whitespace(object):
         assert list(lines) == ['foo 1\n', 'foobar 6\n']
 
 
-class test_set_directive(object):
+class test_set_directive:
     def test_set_directive(self):
         """Check that set_directive writes the new data and preserves mode."""
         fd, filename = tempfile.mkstemp()
@@ -100,7 +100,7 @@ class test_set_directive(object):
             os.remove(filename)
 
 
-class test_get_directive(object):
+class test_get_directive:
     def test_get_directive(self, tmpdir):
         configfile = tmpdir.join('config')
         configfile.write(''.join(EXAMPLE_CONFIG))
@@ -113,7 +113,7 @@ class test_get_directive(object):
                                                     separator='=')
 
 
-class test_get_directive_whitespace(object):
+class test_get_directive_whitespace:
     def test_get_directive(self, tmpdir):
         configfile = tmpdir.join('config')
         configfile.write(''.join(WHITESPACE_CONFIG))

--- a/ipatests/test_ipapython/test_dnsutil.py
+++ b/ipatests/test_ipapython/test_dnsutil.py
@@ -33,7 +33,7 @@ def mkuri(priority, weight, target):
     )
 
 
-class TestSortSRV(object):
+class TestSortSRV:
     def test_empty(self):
         assert dnsutil.sort_prio_weight([]) == []
 
@@ -96,7 +96,7 @@ class TestSortSRV(object):
         assert len(dnsutil.sort_prio_weight(records)) == len(records)
 
 
-class TestSortURI(object):
+class TestSortURI:
     def test_prio(self):
         h1 = mkuri(1, 0, u"https://host1/api")
         h2 = mkuri(2, 0, u"https://host2/api")

--- a/ipatests/test_ipapython/test_ipautil.py
+++ b/ipatests/test_ipapython/test_ipautil.py
@@ -84,7 +84,7 @@ def test_ip_address(addr, words, prefixlen):
         assert ip.prefixlen == prefixlen
 
 
-class TestCIDict(object):
+class TestCIDict:
     def setup(self):
         self.cidict = ipautil.CIDict()
         self.cidict["Key1"] = "val1"
@@ -333,7 +333,7 @@ class TestCIDict(object):
         assert list(dct.values()) == [None] * 3
 
 
-class TestTimeParser(object):
+class TestTimeParser:
     def test_simple(self):
         timestr = "20070803"
 

--- a/ipatests/test_ipapython/test_keyring.py
+++ b/ipatests/test_ipapython/test_keyring.py
@@ -35,7 +35,8 @@ SIZE_256 = 'abcdefgh' * 32
 SIZE_512 = 'abcdefgh' * 64
 SIZE_1024 = 'abcdefgh' * 128
 
-class test_keyring(object):
+
+class test_keyring:
     """
     Test the kernel keyring interface
     """

--- a/ipatests/test_ipapython/test_session_storage.py
+++ b/ipatests/test_ipapython/test_session_storage.py
@@ -12,7 +12,7 @@ from ipapython import session_storage
 
 @pytest.mark.skip_ipaclient_unittest
 @pytest.mark.needs_ipaapi
-class test_session_storage(object):
+class test_session_storage:
     """
     Test the session storage interface
     """

--- a/ipatests/test_ipaserver/httptest.py
+++ b/ipatests/test_ipaserver/httptest.py
@@ -24,7 +24,8 @@ from six.moves import urllib
 
 from ipalib import api, util
 
-class Unauthorized_HTTP_test(object):
+
+class Unauthorized_HTTP_test:
     """
     Base class for simple HTTP request tests executed against URI
     with no required authorization

--- a/ipatests/test_ipaserver/test_install/test_adtrustinstance.py
+++ b/ipatests/test_ipaserver/test_install/test_adtrustinstance.py
@@ -29,7 +29,7 @@ if six.PY3:
 
 
 @pytest.mark.tier0
-class test_adtrustinstance(object):
+class test_adtrustinstance:
     """
     Test `adtrustinstance`.
     """

--- a/ipatests/test_ipaserver/test_install/test_cainstance.py
+++ b/ipatests/test_ipaserver/test_install/test_cainstance.py
@@ -14,7 +14,7 @@ from ipaserver.install import cainstance
 pytestmark = pytest.mark.tier0
 
 
-class test_ExternalCAProfile(object):
+class test_ExternalCAProfile:
     def test_MSCSTemplateV1_good(self):
         o = cainstance.MSCSTemplateV1("MySubCA")
         assert hexlify(o.get_ext_data()) == b'1e0e004d007900530075006200430041'

--- a/ipatests/test_ipaserver/test_ipap11helper.py
+++ b/ipatests/test_ipaserver/test_ipap11helper.py
@@ -91,7 +91,7 @@ def p11(request, token_path):
     return p11
 
 
-class test_p11helper(object):
+class test_p11helper:
     def test_generate_master_key(self, p11):
         assert p11.generate_master_key(master_key_label, master_key_id,
                                        key_length=16, cka_wrap=True,

--- a/ipatests/test_ipaserver/test_kadmin.py
+++ b/ipatests/test_ipaserver/test_kadmin.py
@@ -80,7 +80,7 @@ def service(request):
 
 @pytest.mark.skipif(
     os.getuid() != 0, reason="kadmin.local is accesible only to root")
-class TestKadmin(object):
+class TestKadmin:
     def assert_success(self, command, *args):
         """
         Since kadmin.local returns 0 also when internal errors occur, we have

--- a/ipatests/test_ipaserver/test_ldap.py
+++ b/ipatests/test_ipaserver/test_ldap.py
@@ -45,7 +45,7 @@ if six.PY3:
 
 @pytest.mark.tier0
 @pytest.mark.needs_ipaapi
-class test_ldap(object):
+class test_ldap:
     """
     Test various LDAP client bind methods.
     """
@@ -142,7 +142,7 @@ class test_ldap(object):
 
 @pytest.mark.tier0
 @pytest.mark.needs_ipaapi
-class test_LDAPEntry(object):
+class test_LDAPEntry:
     """
     Test the LDAPEntry class
     """

--- a/ipatests/test_ipaserver/test_otptoken_import.py
+++ b/ipatests/test_ipaserver/test_otptoken_import.py
@@ -27,7 +27,7 @@ from ipaserver.install.ipa_otptoken_import import convertHashName
 basename = os.path.join(os.path.dirname(__file__), "data")
 
 @pytest.mark.tier1
-class test_otptoken_import(object):
+class test_otptoken_import:
     def test_figure3(self):
         doc = PSKCDocument(os.path.join(basename, "pskc-figure3.xml"))
         assert doc.keyname is None

--- a/ipatests/test_ipaserver/test_rpcserver.py
+++ b/ipatests/test_ipaserver/test_rpcserver.py
@@ -35,7 +35,8 @@ if six.PY3:
 
 pytestmark = pytest.mark.tier0
 
-class StartResponse(object):
+
+class StartResponse:
     def __init__(self):
         self.reset()
 
@@ -135,7 +136,7 @@ def test_params_2_args_options():
     assert f([args, options]) == (args, options)
 
 
-class test_session(object):
+class test_session:
     klass = rpcserver.wsgi_dispatch
 
     def test_route(self):

--- a/ipatests/test_ipaserver/test_serverroles.py
+++ b/ipatests/test_ipaserver/test_serverroles.py
@@ -218,7 +218,7 @@ master_data = {
 }
 
 
-class MockMasterTopology(object):
+class MockMasterTopology:
     """
     object that will set up and tear down entries in LDAP backend to mimic
     a presence of real IPA masters with services running on them.
@@ -587,7 +587,7 @@ def dns_server(request):
     return request.param
 
 
-class TestServerRoleStatusRetrieval(object):
+class TestServerRoleStatusRetrieval:
     def retrieve_role(self, master, role, mock_api, mock_masters):
         fqdn = mock_masters.get_fqdn(master)
         return mock_api.Backend.serverroles.server_role_retrieve(
@@ -683,7 +683,7 @@ class TestServerRoleStatusRetrieval(object):
                                    'ca-dns-dnssec-keymaster-pkinit-server'))
 
 
-class TestServerAttributes(object):
+class TestServerAttributes:
     def config_retrieve(self, assoc_role_name, mock_api):
         return mock_api.Backend.serverroles.config_retrieve(
             assoc_role_name)

--- a/ipatests/test_ipaserver/test_topology_plugin.py
+++ b/ipatests/test_ipaserver/test_topology_plugin.py
@@ -11,7 +11,7 @@ import pytest
 
 
 @pytest.mark.tier1
-class TestTopologyPlugin(object):
+class TestTopologyPlugin:
     """
     Test Topology plugin from the DS point of view
     Testcase: http://www.freeipa.org/page/V4/Manage_replication_topology/

--- a/ipatests/test_ipaserver/test_version_comparison.py
+++ b/ipatests/test_ipaserver/test_version_comparison.py
@@ -33,7 +33,8 @@ version_strings = [
 def versions(request):
     return request.param
 
-class TestVersionComparsion(object):
+
+class TestVersionComparsion:
 
     def test_versions(self, versions):
         version_string1, version_string2, expected_comparison = versions

--- a/ipatests/test_util.py
+++ b/ipatests/test_util.py
@@ -49,7 +49,7 @@ else:
 pattern_type = type(re.compile(""))
 
 
-class Prop(object):
+class Prop:
     def __init__(self, *ops):
         self.__ops = frozenset(ops)
         self.__prop = 'prop value'
@@ -72,7 +72,7 @@ class Prop(object):
     prop = property(__get_prop, __set_prop, __del_prop)
 
 
-class test_Fuzzy(object):
+class test_Fuzzy:
     klass = util.Fuzzy
 
     def test_init(self):

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -112,7 +112,7 @@ def screenshot(fn):
     return screenshot_wrapper
 
 
-class UI_driver(object):
+class UI_driver:
     """
     Base class for all UI integration tests
     """

--- a/ipatests/test_xmlrpc/test_baseldap_plugin.py
+++ b/ipatests/test_xmlrpc/test_baseldap_plugin.py
@@ -89,7 +89,7 @@ def test_callback_registration():
         messages.append(('Base registered callback', param))
     callbacktest_base.register_callback('test', registered_callback)
 
-    class SomeClass(object):
+    class SomeClass:
         def registered_callback(self, command, param):
             messages.append(('Registered callback from another class', param))
     callbacktest_base.register_callback('test', SomeClass().registered_callback)
@@ -179,12 +179,12 @@ def test_exc_callback_registration():
 
 @pytest.mark.tier0
 def test_entry_to_dict():
-    class FakeAttributeType(object):
+    class FakeAttributeType:
         def __init__(self, name, syntax):
             self.names = (name,)
             self.syntax = syntax
 
-    class FakeSchema(object):
+    class FakeSchema:
         def get_obj(self, type, name):
             if type != ldap.schema.AttributeType:
                 return

--- a/ipatests/test_xmlrpc/test_certmap_plugin.py
+++ b/ipatests/test_xmlrpc/test_certmap_plugin.py
@@ -202,7 +202,7 @@ class TestAddRemoveCertmap(XMLRPC_test):
         certmap_user.remove_certmap(ipacertmapdata=u'rawdata')
 
 
-class EWE(object):
+class EWE:
     """
     Context manager that checks the outcome of wrapped statement executed
     under specified user against specified expected outcome based on permission

--- a/ipatests/test_xmlrpc/tracker/base.py
+++ b/ipatests/test_xmlrpc/tracker/base.py
@@ -15,7 +15,7 @@ from ipapython.version import API_VERSION
 from ipatests.util import Fuzzy
 
 
-class BaseTracker(object):
+class BaseTracker:
     _override_me_msg = "This method needs to be overridden in a subclass"
 
     def __init__(self, default_version=None):

--- a/ipatests/test_xmlrpc/tracker/certmapdata.py
+++ b/ipatests/test_xmlrpc/tracker/certmapdata.py
@@ -12,7 +12,7 @@ from ipapython.dn import DN
 from ipatests.util import assert_deepequal
 
 
-class CertmapdataMixin(object):
+class CertmapdataMixin:
     certmapdata_options = {u'issuer', u'subject', u'certificate',
                            u'ipacertmapdata'}
 

--- a/ipatests/test_xmlrpc/tracker/kerberos_aliases.py
+++ b/ipatests/test_xmlrpc/tracker/kerberos_aliases.py
@@ -22,7 +22,7 @@ class KerberosAliasError(Exception):
     pass
 
 
-class KerberosAliasMixin(object):
+class KerberosAliasMixin:
     """KerberosAliasMixin"""
 
     def _make_add_alias_cmd(self):

--- a/ipatests/test_xmlrpc/xmlrpc_test.py
+++ b/ipatests/test_xmlrpc/xmlrpc_test.py
@@ -205,7 +205,7 @@ def assert_is_member(entry, value, key='member'):
 # has already been called we continue gracefully. Other errors will be
 # raised.
 
-class XMLRPC_test(object):
+class XMLRPC_test:
     """
     Base class for all XML-RPC plugin tests
     """

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -93,7 +93,7 @@ def check_no_ipaapi(reason="Skip tests that needs an IPA API"):
             raise pytest.skip(reason)
 
 
-class TempDir(object):
+class TempDir:
     def __init__(self):
         self.__path = tempfile.mkdtemp(prefix='ipa.tests.')
         assert self.path == self.__path
@@ -183,7 +183,7 @@ def assert_not_equal(val1, val2):
     assert val1 != val2, '%r == %r' % (val1, val2)
 
 
-class Fuzzy(object):
+class Fuzzy:
     """
     Perform a fuzzy (non-strict) equality tests.
 
@@ -521,7 +521,7 @@ def is_prop(prop):
     return type(prop) is property
 
 
-class ClassChecker(object):
+class ClassChecker:
     __cls = None
     __subcls = None
 
@@ -582,7 +582,7 @@ def create_test_api(**kw):
     return (api, home)
 
 
-class PluginTester(object):
+class PluginTester:
     __plugin = None
 
     def __get_plugin(self):
@@ -624,7 +624,7 @@ class PluginTester(object):
         context.__dict__.clear()
 
 
-class dummy_ugettext(object):
+class dummy_ugettext:
     __called = False
 
     def __init__(self, translation=None):
@@ -653,7 +653,7 @@ class dummy_ugettext(object):
         self.__called = False
 
 
-class dummy_ungettext(object):
+class dummy_ungettext:
     __called = False
 
     def __init__(self):
@@ -674,7 +674,7 @@ class dummy_ungettext(object):
         return self.translation_plural
 
 
-class DummyMethod(object):
+class DummyMethod:
     def __init__(self, callback, name):
         self.__callback = callback
         self.__name = name
@@ -683,7 +683,7 @@ class DummyMethod(object):
         return self.__callback(self.__name, args, kw)
 
 
-class DummyClass(object):
+class DummyClass:
     def __init__(self, *calls):
         self.__calls = calls
         self.__i = 0
@@ -727,7 +727,7 @@ class DummyClass(object):
         return self.__i == len(self.__calls)
 
 
-class MockLDAP(object):
+class MockLDAP:
     def __init__(self):
         self.connection = ldap_initialize(
             'ldap://{host}'.format(host=ipalib.api.env.host)

--- a/pylintrc
+++ b/pylintrc
@@ -100,7 +100,6 @@ disable=
     bad-option-value,  # required to support upgrade to pylint 2.0
     assignment-from-no-return,  # new in pylint 2.0
     keyword-arg-before-vararg,  # pylint 2.0, remove after dropping Python 2
-    useless-object-inheritance, # pylint 2.0, remove after dropping Python 2
 
 [REPORTS]
 


### PR DESCRIPTION
Python 2 had old style and new style classes. Python 3 has only new
style classes. There is no point to subclass from object any more.

See: https://pagure.io/freeipa/issue/7715
Signed-off-by: Christian Heimes <cheimes@redhat.com>