### PR TITLE
Py3: Replace six types with actual Python 3 types

### DIFF
--- a/ipalib/aci.py
+++ b/ipalib/aci.py
@@ -165,7 +165,7 @@ class ACI:
                 raise SyntaxError("invalid permission: '%s'" % p)
         if not self.name:
             raise SyntaxError("name must be set")
-        if not isinstance(self.name, six.string_types):
+        if not isinstance(self.name, str):
             raise SyntaxError("name must be a string")
         if not isinstance(self.target, dict) or len(self.target) == 0:
             raise SyntaxError("target must be a non-empty dictionary")

--- a/ipalib/base.py
+++ b/ipalib/base.py
@@ -23,8 +23,6 @@ Foundational classes and functions.
 
 import re
 
-import six
-
 from ipalib.constants import NAME_REGEX, NAME_ERROR
 from ipalib.constants import TYPE_ERROR, SET_ERROR, DEL_ERROR, OVERRIDE_ERROR
 
@@ -468,7 +466,7 @@ class NameSpace(ReadOnly):
         :param key: The name or index of a member, or a slice object.
         """
         key = getattr(key, '__name__',  key)
-        if isinstance(key, six.string_types):
+        if isinstance(key, str):
             return self.__map[key]
         if type(key) in (int, slice):
             return self.__members[key]

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -311,7 +311,7 @@ class textui(backend.Backend):
           objectClass: top
           objectClass: someClass
         """
-        assert isinstance(attr, six.string_types)
+        assert isinstance(attr, str)
         if not isinstance(value, (list, tuple)):
             # single-value attribute
             self.print_indented(format % (attr, self.encode_binary(value)), indent)
@@ -450,7 +450,7 @@ class textui(backend.Backend):
         ------------------
         Only dashed above.
         """
-        assert isinstance(dash, six.string_types)
+        assert isinstance(dash, str)
         assert len(dash) == 1
         dashes = dash * len(string)
         if above:

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -253,7 +253,7 @@ class Env:
             )
         # pylint: enable=no-member
         assert not hasattr(self, key)
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             value = value.strip()
             if isinstance(value, bytes):
                 value = value.decode('utf-8')

--- a/ipalib/messages.py
+++ b/ipalib/messages.py
@@ -71,7 +71,7 @@ def process_message_arguments(obj, format=None, message=None, **kw):
             obj.format = format
         obj.forwarded = False
         obj.msg = obj.format % kw
-        if isinstance(obj.format, six.string_types):
+        if isinstance(obj.format, str):
             obj.strerror = ugettext(obj.format) % kw
         else:
             obj.strerror = obj.format % kw

--- a/ipalib/messages.py
+++ b/ipalib/messages.py
@@ -50,7 +50,7 @@ def add_message(version, result, message):
 
 def process_message_arguments(obj, format=None, message=None, **kw):
     for key, value in kw.items():
-        if not isinstance(value, six.integer_types):
+        if not isinstance(value, int):
             try:
                 kw[key] = unicode(value)
             except UnicodeError:

--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -415,8 +415,8 @@ class Param(ReadOnly):
         ('cli_name', str, None),
         ('cli_short_name', str, None),
         ('deprecated_cli_aliases', frozenset, frozenset()),
-        ('label', (six.string_types, Gettext), None),
-        ('doc', (six.string_types, Gettext), None),
+        ('label', (str, Gettext), None),
+        ('doc', (str, Gettext), None),
         ('required', bool, True),
         ('multivalue', bool, False),
         ('primary_key', bool, False),
@@ -1007,7 +1007,7 @@ class Bool(Param):
         """
         if type(value) in self.allowed_types:
             return value
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             value = value.lower()
         if value in self.truths:
             return True
@@ -1188,7 +1188,7 @@ class Decimal(Number):
             value = kw.get(kwparam)
             if value is None:
                 continue
-            if isinstance(value, (six.string_types, float)):
+            if isinstance(value, (str, float)):
                 try:
                     value = decimal.Decimal(value)
                 except Exception as e:
@@ -1282,7 +1282,7 @@ class Decimal(Number):
         return value
 
     def _convert_scalar(self, value, index=None):
-        if isinstance(value, (six.string_types, float)):
+        if isinstance(value, (str, float)):
             try:
                 value = decimal.Decimal(value)
             except decimal.DecimalException as e:
@@ -1313,7 +1313,7 @@ class Data(Param):
         ('minlength', int, None),
         ('maxlength', int, None),
         ('length', int, None),
-        ('pattern_errmsg', (six.string_types,), None),
+        ('pattern_errmsg', (str,), None),
     )
 
     re = None
@@ -1542,7 +1542,7 @@ class Str(Data):
     """
 
     kwargs = Data.kwargs + (
-        ('pattern', (six.string_types,), None),
+        ('pattern', (str,), None),
         ('noextrawhitespace', bool, True),
     )
 
@@ -1630,7 +1630,7 @@ class IA5Str(Str):
         super(IA5Str, self).__init__(name, *rules, **kw)
 
     def _convert_scalar(self, value, index=None):
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             for char in value:
                 if ord(char) > 127:
                     raise ConversionError(name=self.get_param_name(),
@@ -1805,7 +1805,7 @@ class DateTime(Param):
     type_error = _('must be datetime value')
 
     def _convert_scalar(self, value, index=None):
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             if value == u'now':
                 time = datetime.datetime.utcnow()
                 return time

--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -132,7 +132,7 @@ from ipapython.dnsutil import DNSName
 def _is_null(value):
     if value:
         return False
-    elif isinstance(value, six.integer_types + (float, decimal.Decimal)):
+    elif isinstance(value, (int, float, decimal.Decimal)):
         # 0 is not NULL
         return False
     else:
@@ -597,7 +597,7 @@ class Param(ReadOnly):
             value = self.__kw[key]
             if callable(value) and hasattr(value, '__name__'):
                 value = value.__name__
-            elif isinstance(value, six.integer_types):
+            elif isinstance(value, int):
                 value = str(value)
             elif isinstance(value, (tuple, set, frozenset)):
                 value = apirepr(list(value))
@@ -1072,7 +1072,7 @@ class Number(Param):
         """
         if type(value) in self.allowed_types:
             return value
-        if type(value) in (unicode, float) + six.integer_types:
+        if type(value) in (unicode, float, int):
             try:
                 return self.type(value)
             except ValueError:
@@ -1089,12 +1089,12 @@ class Int(Number):
     """
 
     type = int
-    allowed_types = six.integer_types
+    allowed_types = (int,)
     type_error = _('must be an integer')
 
     kwargs = Param.kwargs + (
-        ('minvalue', six.integer_types, int(MININT)),
-        ('maxvalue', six.integer_types, int(MAXINT)),
+        ('minvalue', int, int(MININT)),
+        ('maxvalue', int, int(MAXINT)),
     )
 
     @staticmethod
@@ -1138,7 +1138,7 @@ class Int(Number):
         """
         Check min constraint.
         """
-        assert type(value) in six.integer_types
+        assert isinstance(value, int)
         if value < self.minvalue:
             return _('must be at least %(minvalue)d') % dict(
                 minvalue=self.minvalue,
@@ -1150,7 +1150,7 @@ class Int(Number):
         """
         Check max constraint.
         """
-        assert type(value) in six.integer_types
+        assert isinstance(value, int)
         if value > self.maxvalue:
             return _('can be at most %(maxvalue)d') % dict(
                 maxvalue=self.maxvalue,
@@ -1563,7 +1563,7 @@ class Str(Data):
         """
         if type(value) in self.allowed_types:
             return value
-        if type(value) in (float, decimal.Decimal) + six.integer_types:
+        if type(value) in (int, float, decimal.Decimal):
             return self.type(value)
         if type(value) in (tuple, list):
             raise ConversionError(name=self.name,
@@ -1721,7 +1721,7 @@ class IntEnum(Enum):
     """
 
     type = int
-    allowed_types = six.integer_types
+    allowed_types = (int,)
     type_error = Int.type_error
 
     def _convert_scalar(self, value, index=None):

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -171,7 +171,7 @@ def xml_wrap(value, version):
     if type(value) is Decimal:
         # transfer Decimal as a string
         return unicode(value)
-    if isinstance(value, six.integer_types) and (value < MININT or value > MAXINT):
+    if isinstance(value, int) and (value < MININT or value > MAXINT):
         return unicode(value)
     if isinstance(value, DN):
         return str(value)
@@ -200,7 +200,7 @@ def xml_wrap(value, version):
         return base64.b64encode(
             value.public_bytes(x509_Encoding.DER)).decode('ascii')
 
-    assert type(value) in (unicode, float, bool, type(None)) + six.integer_types
+    assert type(value) in (unicode, float, int, bool, type(None))
     return value
 
 
@@ -320,6 +320,7 @@ class _JSONPrimer(dict):
         self.update({
             unicode: _identity,
             bool: _identity,
+            int: _identity,
             type(None): _identity,
             float: _identity,
             Decimal: unicode,
@@ -334,9 +335,6 @@ class _JSONPrimer(dict):
             crypto_x509.Certificate: self._enc_certificate,
             crypto_x509.CertificateSigningRequest: self._enc_certificate,
         })
-        # int, long
-        for t in six.integer_types:
-            self[t] = _identity
 
     def __missing__(self, typ):
         # walk MRO to find best match

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -86,7 +86,7 @@ def json_serialize(obj):
         return [json_serialize(o) for o in obj]
     if isinstance(obj, dict):
         return {k: json_serialize(v) for (k, v) in obj.items()}
-    if isinstance(obj, (bool, float, unicode, type(None), six.integer_types)):
+    if isinstance(obj, (int, bool, float, unicode, type(None))):
         return obj
     if isinstance(obj, str):
         return obj.decode('utf-8')

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -214,7 +214,7 @@ def check_writable_file(filename):
         raise errors.FileError(reason=str(e))
 
 def normalize_zonemgr(zonemgr):
-    if not zonemgr or not isinstance(zonemgr, six.string_types):
+    if not zonemgr or not isinstance(zonemgr, str):
         return zonemgr
     if '@' in zonemgr:
         # local-part needs to be normalized
@@ -763,8 +763,8 @@ def _resolve_record(owner, rtype, nameserver_ip=None, edns0=False,
     :param flag_cd: requires dnssec=True, adds flag CD
     :raise DNSException: if error occurs
     """
-    assert isinstance(nameserver_ip, six.string_types) or nameserver_ip is None
-    assert isinstance(rtype, six.string_types)
+    assert isinstance(nameserver_ip, str) or nameserver_ip is None
+    assert isinstance(rtype, str)
 
     res = dns.resolver.Resolver()
     if nameserver_ip:

--- a/ipapython/cookie.py
+++ b/ipapython/cookie.py
@@ -394,7 +394,7 @@ class Cookie:
             self._timestamp = value
         elif isinstance(value, (six.integer_types, float)):
             self._timestamp = datetime.datetime.utcfromtimestamp(value)
-        elif isinstance(value, six.string_types):
+        elif isinstance(value, str):
             self._timestamp = Cookie.parse_datetime(value)
         else:
             raise TypeError('value must be datetime, int, long, float, basestring or None, not %s' % \
@@ -420,7 +420,7 @@ class Cookie:
             self._expires = value
         elif isinstance(value, (six.integer_types, float)):
             self._expires = datetime.datetime.utcfromtimestamp(value)
-        elif isinstance(value, six.string_types):
+        elif isinstance(value, str):
             self._expires = Cookie.parse_datetime(value)
         else:
             raise TypeError('value must be datetime, int, long, float, basestring or None, not %s' % \

--- a/ipapython/cookie.py
+++ b/ipapython/cookie.py
@@ -22,7 +22,6 @@ import datetime
 import email.utils
 from calendar import timegm
 
-import six
 # pylint: disable=import-error
 from six.moves.urllib.parse import urlparse
 # pylint: enable=import-error
@@ -392,7 +391,7 @@ class Cookie:
             self._timestamp = None
         elif isinstance(value, datetime.datetime):
             self._timestamp = value
-        elif isinstance(value, (six.integer_types, float)):
+        elif isinstance(value, (int, float)):
             self._timestamp = datetime.datetime.utcfromtimestamp(value)
         elif isinstance(value, str):
             self._timestamp = Cookie.parse_datetime(value)
@@ -418,7 +417,7 @@ class Cookie:
             self._expires = None
         elif isinstance(value, datetime.datetime):
             self._expires = value
-        elif isinstance(value, (six.integer_types, float)):
+        elif isinstance(value, (int, float)):
             self._expires = datetime.datetime.utcfromtimestamp(value)
         elif isinstance(value, str):
             self._expires = Cookie.parse_datetime(value)

--- a/ipapython/directivesetter.py
+++ b/ipapython/directivesetter.py
@@ -2,8 +2,6 @@
 # Copyright (C) 2018 FreeIPA Contributors see COPYING for license
 #
 
-import six
-
 import io
 import os
 import re
@@ -47,7 +45,7 @@ class DirectiveSetter:
         fd, name = tempfile.mkstemp(prefix=prefix, dir=directory, text=True)
         with io.open(fd, mode='w', closefd=True) as f:
             for line in self.lines:
-                if not isinstance(line, six.text_type):
+                if not isinstance(line, str):
                     line = line.decode('utf-8')
                 f.write(line)
             self.lines = None

--- a/ipapython/dn.py
+++ b/ipapython/dn.py
@@ -454,7 +454,7 @@ def _normalize_ava_input(val):
     if six.PY3 and isinstance(val, bytes):
         raise TypeError('expected str, got bytes: %r' % val)
     elif not isinstance(val, str):
-        val = val_encode(six.text_type(val))
+        val = val_encode(str(val))
     elif six.PY2 and isinstance(val, unicode):
         val = val.encode('utf-8')
     return val
@@ -882,7 +882,7 @@ class RDN:
         if len(self._avas) == 0:
             raise IndexError("No AVA's in this RDN")
 
-        self._avas[0][0] = val_encode(six.text_type(new_attr))
+        self._avas[0][0] = val_encode(str(new_attr))
 
     attr  = property(_get_attr)
 
@@ -894,7 +894,7 @@ class RDN:
     def _set_value(self, new_value):
         if len(self._avas) == 0:
             raise IndexError("No AVA's in this RDN")
-        self._avas[0][1] = val_encode(six.text_type(new_value))
+        self._avas[0][1] = val_encode(str(new_value))
 
     value = property(_get_value)
 
@@ -1114,7 +1114,7 @@ class DN:
     def _rdns_from_value(self, value):
         if isinstance(value, str):
             try:
-                if isinstance(value, six.text_type):
+                if isinstance(value, str):
                     value = val_encode(value)
                 rdns = str2dn(value)
             except DECODING_ERROR:

--- a/ipapython/dn.py
+++ b/ipapython/dn.py
@@ -453,7 +453,7 @@ def _adjust_indices(start, end, length):
 def _normalize_ava_input(val):
     if six.PY3 and isinstance(val, bytes):
         raise TypeError('expected str, got bytes: %r' % val)
-    elif not isinstance(val, six.string_types):
+    elif not isinstance(val, str):
         val = val_encode(six.text_type(val))
     elif six.PY2 and isinstance(val, unicode):
         val = val.encode('utf-8')
@@ -500,7 +500,7 @@ def get_ava(*args):
             if len(arg) != 2:
                 raise ValueError("tuple or list must be 2-valued, not \"%s\"" % (arg))
             ava = [_normalize_ava_input(arg[0]), _normalize_ava_input(arg[1]), 0]
-        elif isinstance(arg, six.string_types):
+        elif isinstance(arg, str):
             rdn = str2rdn(arg)
             if len(rdn) > 1:
                 raise TypeError("multiple AVA's specified by \"%s\"" % (arg))
@@ -679,7 +679,7 @@ class AVA:
         caseIgnoreMatch.
         '''
         # Try coercing string to AVA, if successful compare to coerced object
-        if isinstance(other, six.string_types):
+        if isinstance(other, str):
             try:
                 other_ava = AVA(other)
                 return self.__eq__(other_ava)
@@ -824,7 +824,7 @@ class RDN:
 
         if raw:  # fast raw mode
             avas = args
-        elif ava_count == 1 and isinstance(args[0], six.string_types):
+        elif ava_count == 1 and isinstance(args[0], str):
             avas = str2rdn(args[0])
             sort = 1
         elif ava_count == 1 and isinstance(args[0], RDN):
@@ -864,7 +864,7 @@ class RDN:
             return self._get_ava(self._avas[key])
         if isinstance(key, slice):
             return [self._get_ava(ava) for ava in self._avas[key]]
-        elif isinstance(key, six.string_types):
+        elif isinstance(key, str):
             for ava in self._avas:
                 if key == val_decode(ava[0]):
                     return val_decode(ava[1])
@@ -909,7 +909,7 @@ class RDN:
 
     def __eq__(self, other):
         # Try coercing string to RDN, if successful compare to coerced object
-        if isinstance(other, six.string_types):
+        if isinstance(other, str):
             try:
                 other_rdn = RDN(other)
                 return self.__eq__(other_rdn)
@@ -939,7 +939,7 @@ class RDN:
                 result._avas.append((ava[0], ava[1], ava[2]))
         elif isinstance(other, AVA):
             result._avas.append(other.to_openldap())
-        elif isinstance(other, six.string_types):
+        elif isinstance(other, str):
             rdn = self.__class__(other)
             for ava in rdn._avas:
                 result._avas.append((ava[0], ava[1], ava[2]))
@@ -1112,7 +1112,7 @@ class DN:
         return [[list(a) for a in rdn] for rdn in rdns]
 
     def _rdns_from_value(self, value):
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             try:
                 if isinstance(value, six.text_type):
                     value = val_encode(value)
@@ -1185,7 +1185,7 @@ class DN:
             new_dn = cls.__new__(cls)
             new_dn.rdns = self.rdns[key]
             return new_dn
-        elif isinstance(key, six.string_types):
+        elif isinstance(key, str):
             for rdn in self.rdns:
                 for ava in rdn:
                     if key == val_decode(ava[0]):
@@ -1212,7 +1212,7 @@ class DN:
 
     def __eq__(self, other):
         # Try coercing to DN, if successful compare to coerced object
-        if isinstance(other, (six.string_types, RDN, AVA)):
+        if isinstance(other, (str, RDN, AVA)):
             try:
                 other_dn = DN(other)
                 return self.__eq__(other_dn)

--- a/ipapython/dn.py
+++ b/ipapython/dn.py
@@ -860,7 +860,7 @@ class RDN:
         return len(self._avas)
 
     def __getitem__(self, key):
-        if isinstance(key, six.integer_types):
+        if isinstance(key, int):
             return self._get_ava(self._avas[key])
         if isinstance(key, slice):
             return [self._get_ava(ava) for ava in self._avas[key]]
@@ -1178,7 +1178,7 @@ class DN:
         return len(self.rdns)
 
     def __getitem__(self, key):
-        if isinstance(key, six.integer_types):
+        if isinstance(key, int):
             return self._get_rdn(self.rdns[key])
         if isinstance(key, slice):
             cls = self.__class__

--- a/ipapython/dnsutil.py
+++ b/ipapython/dnsutil.py
@@ -49,7 +49,7 @@ class DNSName(dns.name.Name):
 
     def __init__(self, labels, origin=None):
         try:
-            if isinstance(labels, six.string_types):
+            if isinstance(labels, str):
                 #pylint: disable=E1101
                 labels = dns.name.from_text(unicode(labels), origin).labels
             elif isinstance(labels, dns.name.Name):

--- a/ipapython/ipa_log_manager.py
+++ b/ipapython/ipa_log_manager.py
@@ -23,8 +23,6 @@ import time
 import warnings
 import sys
 
-import six
-
 # Module exports
 __all__ = ['log_mgr', 'root_logger', 'standard_logging_setup',
            'ISO8601_UTC_DATETIME_FMT',
@@ -93,7 +91,7 @@ class _DeprecatedLogger:
 
 
 def get_logger(who, bind_logger_names=False):
-    if isinstance(who, six.string_types):
+    if isinstance(who, str):
         warnings.warn(
             "{}.log_mgr.get_logger is deprecated, use "
             "logging.getLogger".format(__name__),
@@ -109,7 +107,7 @@ def get_logger(who, bind_logger_names=False):
 
     logger = logging.getLogger(logger_name)
 
-    if not isinstance(who, six.string_types):
+    if not isinstance(who, str):
         obj_name = '%s.%s' % (who.__module__, who.__class__.__name__)
         logger = _DeprecatedLogger(logger, obj_name)
 

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -372,7 +372,7 @@ class LDAPEntry(MutableMapping):
             self._not_list.discard(name)
 
     def _attr_name(self, name):
-        if not isinstance(name, six.string_types):
+        if not isinstance(name, str):
             raise TypeError(
                 "attribute name must be unicode or str, got %s object %r" % (
                     name.__class__.__name__, name))

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -910,7 +910,7 @@ class LDAPClient:
             else:
                 return b'FALSE'
         elif isinstance(val, (unicode, int, Decimal, DN, Principal)):
-            return six.text_type(val).encode('utf-8')
+            return str(val).encode('utf-8')
         elif isinstance(val, DNSName):
             return val.to_text().encode('ascii')
         elif isinstance(val, bytes):
@@ -1295,7 +1295,7 @@ class LDAPClient:
                 value = u'\\'.join(
                     value[i:i+2] for i in six.moves.range(-2, len(value), 2))
             else:
-                value = six.text_type(value)
+                value = str(value)
                 value = ldap.filter.escape_filter_chars(value)
 
             if not exact:

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -909,8 +909,7 @@ class LDAPClient:
                 return b'TRUE'
             else:
                 return b'FALSE'
-        elif isinstance(val, (unicode, six.integer_types, Decimal, DN,
-                              Principal)):
+        elif isinstance(val, (unicode, int, Decimal, DN, Principal)):
             return six.text_type(val).encode('utf-8')
         elif isinstance(val, DNSName):
             return val.to_text().encode('ascii')

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -447,7 +447,7 @@ def run(args, stdin=None, raiseonerr=True, nolog=(), env=None,
     p_out = None
     p_err = None
 
-    if isinstance(nolog, six.string_types):
+    if isinstance(nolog, str):
         # We expect a tuple (or list, or other iterable) of nolog strings.
         # Passing just a single string is bad: strings are iterable, so this
         # would result in every individual character of that string being
@@ -585,7 +585,7 @@ def run(args, stdin=None, raiseonerr=True, nolog=(), env=None,
 def nolog_replace(string, nolog):
     """Replace occurences of strings given in `nolog` with XXXXXXXX"""
     for value in nolog:
-        if not value or not isinstance(value, six.string_types):
+        if not value or not isinstance(value, str):
             continue
 
         quoted = urllib.parse.quote(value)
@@ -954,7 +954,7 @@ def user_input(prompt, default = None, allow_empty = True):
                     return ''
                 raise RuntimeError("Failed to get user input")
 
-    if isinstance(default, six.string_types):
+    if isinstance(default, str):
         while True:
             try:
                 ret = input("%s [%s]: " % (prompt, default))

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -1441,12 +1441,12 @@ if six.PY2:
         """
         if isinstance(value, six.binary_type):
             return value.decode(sys.getfilesystemencoding())
-        elif isinstance(value, six.text_type):
+        elif isinstance(value, str):
             return value
         else:
             raise TypeError("expect {0} or {1}, not {2}".format(
                 six.binary_type.__name__,
-                six.text_type.__name__,
+                str.__name__,
                 type(value).__name__))
 else:
     fsdecode = os.fsdecode  #pylint: disable=no-member
@@ -1522,7 +1522,7 @@ def decode_json(data):
         # default
         return 'utf-8'
 
-    if isinstance(data, six.text_type):
+    if isinstance(data, str):
         return data
 
     return data.decode(detect_encoding(data), 'surrogatepass')

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -1439,13 +1439,13 @@ if six.PY2:
         Decode argument using the file system encoding, as returned by
         `sys.getfilesystemencoding()`.
         """
-        if isinstance(value, six.binary_type):
+        if isinstance(value, bytes):
             return value.decode(sys.getfilesystemencoding())
         elif isinstance(value, str):
             return value
         else:
             raise TypeError("expect {0} or {1}, not {2}".format(
-                six.binary_type.__name__,
+                bytes.__name__,
                 str.__name__,
                 type(value).__name__))
 else:

--- a/ipapython/kerberos.py
+++ b/ipapython/kerberos.py
@@ -71,7 +71,7 @@ class Principal:
                 "Cannot create a principal object from bytes: {!r}".format(
                     components)
             )
-        elif isinstance(components, six.string_types):
+        elif isinstance(components, str):
             # parse principal components from realm
             self.components, self.realm = self._parse_from_text(
                 components, realm)

--- a/ipapython/kerberos.py
+++ b/ipapython/kerberos.py
@@ -66,7 +66,7 @@ class Principal:
     Container for the principal name and realm according to RFC 1510
     """
     def __init__(self, components, realm=None):
-        if isinstance(components, six.binary_type):
+        if isinstance(components, bytes):
             raise TypeError(
                 "Cannot create a principal object from bytes: {!r}".format(
                     components)

--- a/ipapython/kernel_keyring.py
+++ b/ipapython/kernel_keyring.py
@@ -20,7 +20,6 @@
 from __future__ import absolute_import
 
 import os
-import six
 
 from ipapython.ipautil import run
 from ipaplatform.paths import paths
@@ -51,7 +50,7 @@ def get_real_key(key):
     One cannot request a key based on the description it was created with
     so find the one we're looking for.
     """
-    assert isinstance(key, six.string_types)
+    assert isinstance(key, str)
     result = run([paths.KEYCTL, 'search', KEYRING, KEYTYPE, key],
                  raiseonerr=False, capture_output=True)
     if result.returncode:
@@ -66,7 +65,7 @@ def get_persistent_key(key):
 
     Assert when key is not a string-type.
     """
-    assert isinstance(key, six.string_types)
+    assert isinstance(key, str)
     result = run([paths.KEYCTL, 'get_persistent', KEYRING, key],
                  raiseonerr=False, capture_output=True)
     if result.returncode:
@@ -91,7 +90,7 @@ def has_key(key):
     """
     Returns True/False whether the key exists in the keyring.
     """
-    assert isinstance(key, six.string_types)
+    assert isinstance(key, str)
     try:
         get_real_key(key)
         return True
@@ -105,7 +104,7 @@ def read_key(key):
 
     Use pipe instead of print here to ensure we always get the raw data.
     """
-    assert isinstance(key, six.string_types)
+    assert isinstance(key, str)
     real_key = get_real_key(key)
     result = run([paths.KEYCTL, 'pipe', real_key], raiseonerr=False,
                  capture_output=True)
@@ -119,7 +118,7 @@ def update_key(key, value):
     """
     Update the keyring data. If they key doesn't exist it is created.
     """
-    assert isinstance(key, six.string_types)
+    assert isinstance(key, str)
     assert isinstance(value, bytes)
     if has_key(key):
         real_key = get_real_key(key)
@@ -135,7 +134,7 @@ def add_key(key, value):
     """
     Add a key to the kernel keyring.
     """
-    assert isinstance(key, six.string_types)
+    assert isinstance(key, str)
     assert isinstance(value, bytes)
     if has_key(key):
         raise ValueError('key %s already exists' % key)
@@ -149,7 +148,7 @@ def del_key(key):
     """
     Remove a key from the keyring
     """
-    assert isinstance(key, six.string_types)
+    assert isinstance(key, str)
     real_key = get_real_key(key)
     result = run([paths.KEYCTL, 'unlink', real_key, KEYRING],
                  raiseonerr=False)

--- a/ipaserver/dcerpc_common.py
+++ b/ipaserver/dcerpc_common.py
@@ -1,7 +1,7 @@
 import six
 from ipalib import _
 if six.PY3:
-    unicode = six.text_type
+    unicode = str
 
 # Both constants can be used as masks against trust direction
 # because bi-directional has two lower bits set.

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -201,7 +201,7 @@ def named_conf_set_directive(name, value, section=NAMED_SECTION_IPA,
                     if name == match.group('name'):
                         matched = True
                         if value is not None:
-                            if not isinstance(value, six.string_types):
+                            if not isinstance(value, str):
                                 value = str(value)
                             new_conf = named_conf_arg_template \
                                     % dict(indent=last_indent,

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -84,7 +84,7 @@ def lookup_ca_subject(api, subject_base):
         # installutils.default_ca_subject_dn is NOT used here in
         # case the default changes in the future.
         ca_subject = DN(('CN', 'Certificate Authority'), subject_base)
-    return six.text_type(ca_subject)
+    return str(ca_subject)
 
 
 def set_subject_base_in_config(subject_base):
@@ -130,7 +130,7 @@ def install_check(standalone, replica_config, options):
         _api = api if standalone else options._remote_api
 
         # for replica-install the knobs cannot be written, hence leading '_'
-        options._subject_base = six.text_type(replica_config.subject_base)
+        options._subject_base = str(replica_config.subject_base)
         options._ca_subject = lookup_ca_subject(_api, options._subject_base)
 
     if replica_config is not None and not replica_config.setup_ca:

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -38,7 +38,6 @@ import syslog
 import time
 import tempfile
 
-import six
 # pylint: disable=import-error
 from six.moves.configparser import RawConfigParser
 # pylint: enable=import-error
@@ -548,7 +547,7 @@ class CAInstance(DogtagInstance):
         # Directory server
         config.set("CA", "pki_ds_ldap_port", "389")
         config.set("CA", "pki_ds_password", self.dm_password)
-        config.set("CA", "pki_ds_base_dn", six.text_type(self.basedn))
+        config.set("CA", "pki_ds_base_dn", str(self.basedn))
         config.set("CA", "pki_ds_database", "ipaca")
 
         if self.use_ldaps:
@@ -2038,7 +2037,7 @@ class MSCSTemplateV1(MSCSTemplate):
         if len(parts) > 1:
             raise ValueError(
                 "Cannot specify certificate template version when using name.")
-        self.asn1obj = char.BMPString(six.text_type(parts[0]))
+        self.asn1obj = char.BMPString(str(parts[0]))
 
 
 class MSCSTemplateV2(MSCSTemplate):

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -143,7 +143,7 @@ def install_check(standalone, api, replica, options, hostname):
             dnsutil.check_zone_overlap(reverse_zone)
         except ValueError as e:
             if options.force or options.allow_zone_overlap:
-                logger.warning('%s', six.text_type(e))
+                logger.warning('%s', str(e))
             else:
                 raise e
 

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -26,7 +26,6 @@ import shutil
 import tempfile
 import base64
 
-import six
 # pylint: disable=import-error
 from six.moves.configparser import RawConfigParser
 # pylint: enable=import-error
@@ -203,7 +202,7 @@ class KRAInstance(DogtagInstance):
         # Directory server
         config.set("KRA", "pki_ds_ldap_port", "389")
         config.set("KRA", "pki_ds_password", self.dm_password)
-        config.set("KRA", "pki_ds_base_dn", six.text_type(self.basedn))
+        config.set("KRA", "pki_ds_base_dn", str(self.basedn))
         config.set("KRA", "pki_ds_database", "ipaca")
         config.set("KRA", "pki_ds_create_new_db", "False")
 

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -830,7 +830,7 @@ def _check_single_value_attrs(params, entry_attrs):
 # required, make sure we enforce that.
 def _check_empty_attrs(params, entry_attrs):
     for (a, v) in entry_attrs.items():
-        if v is None or (isinstance(v, six.string_types) and len(v) == 0):
+        if v is None or (isinstance(v, str) and len(v) == 0):
             if a in params and params[a].required:
                 raise errors.RequirementError(name=a)
 
@@ -1973,7 +1973,7 @@ class LDAPSearch(BaseLDAPCommand, crud.Search):
             config_attrs = config.get(
                 self.obj.search_attributes_config, [])
             if len(config_attrs) == 1 and (
-              isinstance(config_attrs[0], six.string_types)):
+                    isinstance(config_attrs[0], str)):
                 search_attrs = config_attrs[0].split(',')
 
         search_kw = {}

--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -80,7 +80,7 @@ def validate_nsaccountlock(entry_attrs):
     if 'nsaccountlock' in entry_attrs:
         nsaccountlock = entry_attrs['nsaccountlock']
         if not isinstance(nsaccountlock, (bool, Bool)):
-            if not isinstance(nsaccountlock, six.string_types):
+            if not isinstance(nsaccountlock, str):
                 raise errors.OnlyOneValueAllowed(attr='nsaccountlock')
             if nsaccountlock.lower() not in ('true', 'false'):
                 raise errors.ValidationError(name='nsaccountlock',
@@ -391,7 +391,7 @@ class baseuser(LDAPObject):
             if not isinstance(email, (list, tuple)):
                 email = [email]
             for m in email:
-                if isinstance(m, six.string_types):
+                if isinstance(m, str):
                     if '@' not in m and defaultdomain:
                         m = m + u'@' + defaultdomain
                     if not Email(m):

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -173,12 +173,12 @@ def _acl_make_request(principal_type, principal, ca_id, profile_id):
     groups = []
     if principal_type == 'user':
         user_obj = api.Command.user_show(
-            six.text_type(principal.username))['result']
+            str(principal.username))['result']
         groups = user_obj.get('memberof_group', [])
         groups += user_obj.get('memberofindirect_group', [])
     elif principal_type == 'host':
         host_obj = api.Command.host_show(
-            six.text_type(principal.hostname))['result']
+            str(principal.hostname))['result']
         groups = host_obj.get('memberof_hostgroup', [])
         groups += host_obj.get('memberofindirect_hostgroup', [])
     req.user.groups = sorted(set(groups))
@@ -957,7 +957,7 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
             if add:
                 if principal.is_service and not principal.is_host:
                     self.api.Command.service_add(
-                        six.text_type(principal), all=True, force=True)
+                        str(principal), all=True, force=True)
                     return self.lookup_principal(principal)  # we want an LDAPEntry
                 else:
                     if principal.is_user:

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -2165,7 +2165,7 @@ class DNSZoneBase_add(LDAPCreate):
             try:
                 check_zone_overlap(keys[-1], raise_on_error=False)
             except ValueError as e:
-                raise errors.InvocationError(six.text_type(e))
+                raise errors.InvocationError(str(e))
 
         return dn
 

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -1687,7 +1687,7 @@ def _create_idn_filter(cmd, ldap, term=None, **options):
         config = ldap.get_ipa_config()
         config_attrs = config.get(cmd.obj.search_attributes_config, [])
         if len(config_attrs) == 1 and (isinstance(config_attrs[0],
-                                                  six.string_types)):
+                                                  str)):
             search_attrs = config_attrs[0].split(',')
 
     search_kw['objectclass'] = cmd.obj.object_class

--- a/ipaserver/plugins/group.py
+++ b/ipaserver/plugins/group.py
@@ -521,7 +521,7 @@ class group_find(LDAPSearch):
             search_kw = {}
             config = ldap.get_ipa_config()
             attrs = config.get(self.obj.search_attributes_config, [])
-            if len(attrs) == 1 and isinstance(attrs[0], six.string_types):
+            if len(attrs) == 1 and isinstance(attrs[0], str):
                 search_attrs = attrs[0].split(',')
                 for a in search_attrs:
                     search_kw[a] = criteria

--- a/ipaserver/plugins/permission.py
+++ b/ipaserver/plugins/permission.py
@@ -137,7 +137,7 @@ class DNOrURL(DNParam):
     """
 
     def _convert_scalar(self, value, index=None):
-        if isinstance(value, six.string_types) and value.startswith('ldap:///'):
+        if isinstance(value, str) and value.startswith('ldap:///'):
             value = strip_ldap_prefix(value)
         return super(DNOrURL, self)._convert_scalar(value)
 

--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -546,7 +546,7 @@ class service(LDAPObject):
 
     def get_dn(self, *keys, **kwargs):
         key = keys[0]
-        if isinstance(key, six.text_type):
+        if isinstance(key, str):
             key = kerberos.Principal(key)
 
         key = unicode(normalize_principal(key))

--- a/ipatests/create_external_ca.py
+++ b/ipatests/create_external_ca.py
@@ -26,7 +26,6 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
 import datetime
-import six
 
 ISSUER_CN = 'example.test'
 
@@ -53,7 +52,7 @@ class ExternalCA:
         self.ca_public_key = self.ca_key.public_key()
 
         subject = self.issuer = x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, six.text_type(cn)),
+            x509.NameAttribute(NameOID.COMMON_NAME, str(cn)),
         ])
 
         builder = x509.CertificateBuilder()

--- a/ipatests/pytest_ipa/integration/env_config.py
+++ b/ipatests/pytest_ipa/integration/env_config.py
@@ -28,8 +28,6 @@ import os
 import json
 import collections
 
-import six
-
 from ipapython import ipautil
 from ipatests.pytest_ipa.integration.config import Config, Domain
 from ipalib.constants import MAX_DOMAIN_LEVEL
@@ -134,7 +132,7 @@ def config_from_env(env):
     kwargs['domains'] = []
 
     # $IPv6SETUP needs to be 'TRUE' to enable ipv6
-    if isinstance(kwargs['ipv6'], six.string_types):
+    if isinstance(kwargs['ipv6'], str):
         kwargs['ipv6'] = (kwargs['ipv6'].upper() == 'TRUE')
 
     config = Config(**kwargs)

--- a/ipatests/test_integration/test_dns_locations.py
+++ b/ipatests/test_integration/test_dns_locations.py
@@ -4,7 +4,6 @@
 import logging
 import time
 import pytest
-import six
 import dns.resolver
 import dns.rrset
 import dns.rdatatype
@@ -39,7 +38,7 @@ IPA_DEFAULT_ADTRUST_SRV_REC = (
 )
 
 IPA_CA_A_REC = (
-    (DNSName(six.text_type(IPA_CA_RECORD))),
+    (DNSName(str(IPA_CA_RECORD))),
 )
 
 

--- a/ipatests/test_ipalib/test_parameters.py
+++ b/ipatests/test_ipalib/test_parameters.py
@@ -1243,7 +1243,7 @@ class test_Int(ClassChecker):
         # Test with no kwargs:
         o = self.cls('my_number')
         assert o.type == int
-        assert o.allowed_types == six.integer_types
+        assert o.allowed_types == (int,)
         assert isinstance(o, parameters.Int)
         assert o.minvalue == int(MININT)
         assert o.maxvalue == int(MAXINT)

--- a/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
@@ -66,11 +66,11 @@ class StageUserTracker(KerberosAliasMixin, Tracker):
         """ Check for non-empty unicode string for the required attributes
         in the init method """
 
-        if not (isinstance(givenname, six.string_types) and givenname):
+        if not (isinstance(givenname, str) and givenname):
             raise ValueError(
                 "Invalid first name provided: {!r}".format(givenname)
                 )
-        if not (isinstance(sn, six.string_types) and sn):
+        if not (isinstance(sn, str) and sn):
             raise ValueError("Invalid second name provided: {!r}".format(sn))
 
         super(StageUserTracker, self).__init__(default_version=None)

--- a/ipatests/test_xmlrpc/tracker/user_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/user_plugin.py
@@ -67,11 +67,11 @@ class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
         """ Check for non-empty unicode string for the required attributes
         in the init method """
 
-        if not (isinstance(givenname, six.string_types) and givenname):
+        if not (isinstance(givenname, str) and givenname):
             raise ValueError(
                 "Invalid first name provided: {!r}".format(givenname)
                 )
-        if not (isinstance(sn, six.string_types) and sn):
+        if not (isinstance(sn, str) and sn):
             raise ValueError("Invalid second name provided: {!r}".format(sn))
 
         super(UserTracker, self).__init__(default_version=None)

--- a/ipatests/test_xmlrpc/xmlrpc_test.py
+++ b/ipatests/test_xmlrpc/xmlrpc_test.py
@@ -43,7 +43,7 @@ else:
 # Matches a gidnumber like '1391016742'
 # FIXME: Does it make more sense to return gidnumber, uidnumber, etc. as `int`
 # or `long`?  If not, we still need to return them as `unicode` instead of `str`.
-fuzzy_digits = Fuzzy(r'^\d+$', type=six.string_types)
+fuzzy_digits = Fuzzy(r'^\d+$', type=str)
 
 uuid_re = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 
@@ -109,18 +109,16 @@ fuzzy_caid = fuzzy_uuid
 fuzzy_ipauniqueid = Fuzzy('(?i)ipauniqueid=%s' % uuid_re)
 
 # Matches a hash signature, not enforcing length
-fuzzy_hash = Fuzzy(
-    r'^([a-f0-9][a-f0-9]:)+[a-f0-9][a-f0-9]$', type=six.string_types
-)
+fuzzy_hash = Fuzzy(r'^([a-f0-9][a-f0-9]:)+[a-f0-9][a-f0-9]$', type=str)
 
 # Matches a date, like Tue Apr 26 17:45:35 2016 UTC
 fuzzy_date = Fuzzy(
     r'^[a-zA-Z]{3} [a-zA-Z]{3} \d{2} \d{2}:\d{2}:\d{2} \d{4} UTC$'
 )
 
-fuzzy_issuer = Fuzzy(type=six.string_types)
+fuzzy_issuer = Fuzzy(type=str)
 
-fuzzy_hex = Fuzzy(r'^0x[0-9a-fA-F]+$', type=six.string_types)
+fuzzy_hex = Fuzzy(r'^0x[0-9a-fA-F]+$', type=str)
 
 # Matches password - password consists of all printable characters without
 # whitespaces. The only exception is space, but space cannot be at the
@@ -131,7 +129,7 @@ fuzzy_password = Fuzzy(r'^\S([\S ]*\S)*$')
 fuzzy_dergeneralizedtime = Fuzzy(type=datetime.datetime)
 
 # match any string
-fuzzy_string = Fuzzy(type=six.string_types)
+fuzzy_string = Fuzzy(type=str)
 
 fuzzy_bytes = Fuzzy(type=bytes)
 

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -278,7 +278,7 @@ class Fuzzy:
         :param test: A callable used to perform equality test, e.g.
             ``lambda other: other >= 18``
         """
-        assert regex is None or isinstance(regex, six.string_types)
+        assert regex is None or isinstance(regex, str)
         assert test is None or callable(test)
         if regex is None:
             self.re = None
@@ -286,7 +286,7 @@ class Fuzzy:
             self.re = re.compile(regex)
             if type is None:
                 type = unicode
-            assert type in (unicode, bytes, six.string_types)
+            assert type in (unicode, bytes, str)
         self.regex = regex
         self.type = type
         self.test = test
@@ -398,7 +398,7 @@ def assert_deepequal(expected, got, doc='', stack=tuple()):
     if isinstance(got, tuple):
         got = list(got)
     if isinstance(expected, DN):
-        if isinstance(got, six.string_types):
+        if isinstance(got, str):
             got = DN(got)
     if (
         not (isinstance(expected, Fuzzy)

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -210,7 +210,7 @@ class Fuzzy:
     Use of a regular expression by default implies the ``unicode`` type, so
     comparing with an ``str`` instance will evaluate to ``False``:
 
-    >>> phone.type is six.text_type
+    >>> phone.type is str
     True
     >>> b'123-456-7890' == phone
     False


### PR DESCRIPTION
Slowly get rid of Python 2 and six backwards compatibility code. Replace

* ``six.string_types`` with ``str``
* ``six.string_type`` with ``str``
* ``six.integer_types`` with ``int``
* ``six.bytes_type`` with ``bytes``

See: https://pagure.io/freeipa/issue/7715
