### PR TITLE
ipatests: mark known failure for  installation_TestInstallWithCA2

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -104,6 +104,7 @@ class InstallTestBase2(IntegrationTest):
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=False)
 
+    @pytest.mark.xfail(reason='Ticket 7651', strict=True)
     def test_replica0_with_ca_kra_dns_install(self):
         tasks.install_replica(self.master, self.replicas[0], setup_ca=True,
                               setup_kra=True, setup_dns=True)


### PR DESCRIPTION
The test TestInstallWithCA2 and TestInstallWithCA_DNS2 fail in
test_replica0_with_ca_kra_dns_install because they both try to
install a (first instance of) KRA.

This is a known issue, thus marking as xfail.

Related to https://pagure.io/freeipa/issue/7651