### PR TITLE
Add jslint check to PR CI tests

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -55,7 +55,7 @@ steps:
   - sed -ri "s/mode = production/mode = development/" /etc/ipa/default.conf
   - systemctl restart httpd.service
   lint:
-  - make V=0 pylint
+  - make V=0 lint
   webui_unit:
   - dnf install -y npm
   - cd ${container_working_dir}/install/ui/js/libs && make

--- a/Makefile.am
+++ b/Makefile.am
@@ -185,7 +185,7 @@ endif
 	@ # just tests, aci, api and pylint on Python 3
 	PYTHONPATH=$(abspath $(top_srcdir)) $(PYTHON) ipatests/ipa-run-tests \
 	    --ipaclient-unittests
-	$(MAKE) $(AM_MAKEFLAGS) acilint apilint polint pylint
+	$(MAKE) $(AM_MAKEFLAGS) acilint apilint polint pylint jslint check
 	@echo "All tests passed."
 
 .PHONY: fastcheck fasttest fastlint


### PR DESCRIPTION
For now, from all possible lint checks, pylint applies only.
jslint can prevent JavaScript errors at WebUI.

Fixes: https://pagure.io/freeipa/issue/7717