### PR TITLE
Py3: Replace six.moves imports

### DIFF
--- a/daemons/ipa-otpd/test.py
+++ b/daemons/ipa-otpd/test.py
@@ -19,11 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from io import StringIO
 import struct
 import subprocess
 import sys
-
-from six import StringIO
 
 try:
     from pyrad import packet

--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -23,16 +23,13 @@ from __future__ import print_function
 import logging
 import sys
 import os
-
 import re
-import ldap
 import socket
 import traceback
+from urllib.parse import urlparse
+from xmlrpc.client import MAXINT
 
-# pylint: disable=import-error
-from six.moves.urllib.parse import urlparse
-from six.moves.xmlrpc_client import MAXINT
-# pylint: enable=import-error
+import ldap
 
 from ipaclient.install import ipadiscovery
 from ipapython import ipautil

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -29,10 +29,8 @@ import tempfile
 import time
 import traceback
 
-# pylint: disable=import-error
-from six.moves.configparser import RawConfigParser
-from six.moves.urllib.parse import urlparse, urlunparse
-# pylint: enable=import-error
+from configparser import RawConfigParser
+from urllib.parse import urlparse, urlunparse
 
 from ipalib import api, errors, x509
 from ipalib.install import certmonger, certstore, service, sysrestore

--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -24,9 +24,7 @@ import os
 import tempfile
 import shutil
 
-# pylint: disable=import-error
-from six.moves.urllib.parse import urlsplit
-# pylint: enable=import-error
+from urllib.parse import urlsplit
 
 from ipalib.install import certmonger, certstore, sysrestore
 from ipalib.install.kinit import kinit_keytab

--- a/ipaclient/plugins/otptoken.py
+++ b/ipaclient/plugins/otptoken.py
@@ -33,8 +33,8 @@ import locale
 import qrcode
 
 import six
-from six import StringIO
-from six.moves import urllib
+from io import StringIO
+import urllib
 
 if six.PY3:
     unicode = str

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -23,6 +23,7 @@ Functionality for Command Line Interface.
 from __future__ import print_function
 
 import atexit
+import builtins
 import importlib
 import logging
 import textwrap
@@ -53,9 +54,6 @@ from ipalib.util import (
 
 if six.PY3:
     unicode = str
-    import builtins  # pylint: disable=import-error
-else:
-    import __builtin__ as builtins  # pylint: disable=import-error
 
 if six.PY2:
     reload(sys)  # pylint: disable=reload-builtin, undefined-variable

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -33,12 +33,10 @@ from __future__ import absolute_import
 import os
 from os import path
 import sys
+from urllib.parse import urlparse, urlunparse
+from configparser import RawConfigParser, ParsingError
 
 import six
-# pylint: disable=import-error
-from six.moves.urllib.parse import urlparse, urlunparse
-from six.moves.configparser import RawConfigParser, ParsingError
-# pylint: enable=import-error
 
 from ipaplatform.tasks import tasks
 from ipapython.dn import DN

--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -103,11 +103,9 @@ import re
 import decimal
 import base64
 import datetime
+from xmlrpc.client import MAXINT, MININT
 
 import six
-# pylint: disable=import-error
-from six.moves.xmlrpc_client import MAXINT, MININT
-# pylint: enable=import-error
 from cryptography import x509 as crypto_x509
 
 from ipalib.text import _ as ugettext

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -42,13 +42,13 @@ import json
 import re
 import socket
 import gzip
-from cryptography import x509 as crypto_x509
+import urllib
+from ssl import SSLError
 
+from cryptography import x509 as crypto_x509
 import gssapi
 from dns.exception import DNSException
-from ssl import SSLError
 import six
-from six.moves import urllib
 
 from ipalib.backend import Connectible
 from ipalib.constants import LDAP_GENERALIZED_TIME_FORMAT

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -31,6 +31,7 @@ import os
 import socket
 import traceback
 import errno
+import urllib
 import sys
 
 from ctypes.util import find_library
@@ -38,7 +39,6 @@ from functools import total_ordering
 from subprocess import CalledProcessError
 
 from pyasn1.error import PyAsn1Error
-from six.moves import urllib
 
 from ipapython import directivesetter
 from ipapython import ipautil

--- a/ipapython/config.py
+++ b/ipapython/config.py
@@ -23,15 +23,13 @@ from optparse import (
     Option, Values, OptionParser, IndentedHelpFormatter, OptionValueError)
 # pylint: enable=deprecated-module
 from copy import copy
+from configparser import SafeConfigParser
+from urllib.parse import urlsplit
 import socket
 import functools
 
 from dns.exception import DNSException
 import dns.name
-# pylint: disable=import-error
-from six.moves.configparser import SafeConfigParser
-from six.moves.urllib.parse import urlsplit
-# pylint: enable=import-error
 
 from ipaplatform.paths import paths
 from ipapython.dn import DN

--- a/ipapython/cookie.py
+++ b/ipapython/cookie.py
@@ -21,10 +21,8 @@ import re
 import datetime
 import email.utils
 from calendar import timegm
+from urllib.parse import urlparse
 
-# pylint: disable=import-error
-from six.moves.urllib.parse import urlparse
-# pylint: enable=import-error
 
 '''
 Core Python has two cookie libraries, Cookie.py targeted to server

--- a/ipapython/dogtag.py
+++ b/ipapython/dogtag.py
@@ -21,13 +21,11 @@ import collections
 import gzip
 import io
 import logging
+from urllib.parse import urlencode
 import xml.dom.minidom
 import zlib
 
 import six
-# pylint: disable=import-error
-from six.moves.urllib.parse import urlencode
-# pylint: enable=import-error
 
 # pylint: disable=ipa-forbidden-import
 from ipalib import api, errors

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -29,11 +29,8 @@ from copy import deepcopy
 import contextlib
 import os
 import pwd
+from urllib.parse import urlparse
 import warnings
-
-# pylint: disable=import-error
-from six.moves.urllib.parse import urlparse
-# pylint: enable=import-error
 
 from cryptography import x509 as crypto_x509
 

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -41,13 +41,13 @@ import grp
 from contextlib import contextmanager
 import locale
 import collections
+import urllib
 
 from dns import resolver, reversename
 from dns.exception import DNSException
 
 import six
 from six.moves import input
-from six.moves import urllib
 
 from ipapython.dn import DN
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -37,10 +37,8 @@ import sys
 import syslog
 import time
 import tempfile
+from configparser import RawConfigParser
 
-# pylint: disable=import-error
-from six.moves.configparser import RawConfigParser
-# pylint: enable=import-error
 from pyasn1.codec.der import encoder
 from pyasn1.type import char, univ, namedtype
 import pyasn1.error

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -19,6 +19,7 @@
 
 from __future__ import absolute_import
 
+import configparser
 import logging
 import os
 import stat
@@ -34,7 +35,6 @@ import time
 import datetime
 
 import six
-from six.moves import configparser
 
 from ipalib.install import certmonger, sysrestore
 from ipapython import dogtag

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -35,20 +35,14 @@ import shutil
 import traceback
 import textwrap
 from contextlib import contextmanager
+from configparser import ConfigParser as SafeConfigParser
+from configparser import NoOptionError
 
 from dns import resolver, rdatatype
 from dns.exception import DNSException
 import ldap
 import ldapurl
 import six
-# pylint: disable=import-error
-if six.PY3:
-    # The SafeConfigParser class has been renamed to ConfigParser in Py3
-    from configparser import ConfigParser as SafeConfigParser
-else:
-    from ConfigParser import SafeConfigParser
-from six.moves.configparser import NoOptionError
-# pylint: enable=import-error
 
 from ipalib.install import sysrestore
 from ipalib.install.kinit import kinit_password

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -25,10 +25,7 @@ import pwd
 import shutil
 import tempfile
 import base64
-
-# pylint: disable=import-error
-from six.moves.configparser import RawConfigParser
-# pylint: enable=import-error
+from configparser import RawConfigParser
 
 from ipalib import api
 from ipalib import x509

--- a/ipaserver/plugins/otptoken.py
+++ b/ipaserver/plugins/otptoken.py
@@ -30,11 +30,11 @@ from ipalib.request import context
 from ipapython.dn import DN
 
 import base64
+import urllib
 import uuid
 import os
 
 import six
-from six.moves import urllib
 
 if six.PY3:
     unicode = str

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -29,6 +29,9 @@ import logging
 from xml.sax.saxutils import escape
 import os
 import traceback
+from io import BytesIO
+from urllib.parse import parse_qs
+from xmlrpc.client import Fault
 
 import gssapi
 import requests
@@ -37,11 +40,6 @@ import ldap.controls
 from pyasn1.type import univ, namedtype
 from pyasn1.codec.ber import encoder
 import six
-# pylint: disable=import-error
-from six.moves.urllib.parse import parse_qs
-from six.moves.xmlrpc_client import Fault
-# pylint: enable=import-error
-from six import BytesIO
 
 from ipalib import plugable, errors
 from ipalib.capabilities import VERSION_WITHOUT_CAPABILITIES

--- a/ipaserver/secrets/kem.py
+++ b/ipaserver/secrets/kem.py
@@ -5,9 +5,7 @@ from __future__ import print_function, absolute_import
 import errno
 import os
 
-# pylint: disable=import-error
-from six.moves.configparser import ConfigParser
-# pylint: enable=import-error
+from configparser import ConfigParser
 
 from ipaplatform.paths import paths
 from ipapython.dn import DN

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 import logging
 import os
+from io import StringIO
 import textwrap
 import re
 import collections
@@ -34,7 +35,6 @@ import dns
 from ldif import LDIFWriter
 import pytest
 from SSSDConfig import SSSDConfig
-from six import StringIO
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend

--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+from io import StringIO
 import shlex
 import subprocess
 import sys
@@ -7,7 +8,6 @@ import tempfile
 import unittest
 
 import six
-from six import StringIO
 
 from ipatests import util
 from ipatests.test_ipalib.test_x509 import goodcert_headers

--- a/ipatests/test_cmdline/test_help.py
+++ b/ipatests/test_cmdline/test_help.py
@@ -19,11 +19,11 @@
 
 import sys
 import os
+from io import StringIO
 import shutil
 import errno
 
 import six
-from six import StringIO
 
 from ipalib import api, errors
 from ipaserver.plugins.user import user_add

--- a/ipatests/test_ipalib/test_parameters.py
+++ b/ipatests/test_ipalib/test_parameters.py
@@ -31,12 +31,11 @@ import re
 import sys
 from decimal import Decimal
 from inspect import isclass
+from xmlrpc.client import MAXINT, MININT
+
 import pytest
 
 import six
-# pylint: disable=import-error
-from six.moves.xmlrpc_client import MAXINT, MININT
-# pylint: enable=import-error
 from cryptography import x509 as crypto_x509
 from cryptography.hazmat.backends import default_backend
 

--- a/ipatests/test_ipalib/test_rpc.py
+++ b/ipatests/test_ipalib/test_rpc.py
@@ -23,13 +23,11 @@ Test the `ipalib.rpc` module.
 from __future__ import print_function
 
 import unittest
+from xmlrpc.client import Binary, Fault, dumps, loads
+import urllib
 
 import pytest
 import six
-# pylint: disable=import-error
-from six.moves.xmlrpc_client import Binary, Fault, dumps, loads
-# pylint: enable=import-error
-from six.moves import urllib
 
 from ipatests.util import raises, assert_equal, PluginTester, DummyClass
 from ipatests.util import Fuzzy

--- a/ipatests/test_ipaserver/httptest.py
+++ b/ipatests/test_ipaserver/httptest.py
@@ -20,7 +20,7 @@
 Base class for HTTP request tests
 """
 
-from six.moves import urllib
+import urllib
 
 from ipalib import api, util
 

--- a/ipatests/test_ipaserver/test_install/test_cainstance.py
+++ b/ipatests/test_ipaserver/test_install/test_cainstance.py
@@ -3,11 +3,9 @@
 #
 
 from binascii import hexlify
+from io import StringIO
 import pickle
-# pylint: disable=import-error
-from six.moves.configparser import RawConfigParser
-# pylint: enable=import-error
-from six import StringIO
+from configparser import RawConfigParser
 import pytest
 from ipaserver.install import cainstance
 

--- a/ipatests/test_webui/test_loginscreen.py
+++ b/ipatests/test_webui/test_loginscreen.py
@@ -5,6 +5,7 @@
 """
 Test LoginScreen widget and all it's views
 """
+import urllib
 
 from ipatests.test_webui.ui_driver import UI_driver
 from ipatests.test_webui.ui_driver import screenshot
@@ -18,7 +19,6 @@ except ImportError:
     pass
 
 import pytest
-from six.moves import urllib
 
 
 @pytest.mark.tier1

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -30,11 +30,10 @@ import re
 import os
 from functools import wraps
 import unittest
+from urllib.error import URLError
+
 import paramiko
 
-# pylint: disable=import-error
-from six.moves.urllib.error import URLError
-# pylint: enable=import-error
 
 try:
     from selenium import webdriver


### PR DESCRIPTION
Replace six.moves and six.StringIO/BytesIO imports with cannonical
Python 3 packages.

Note: six.moves.input behaves differently than builtin input function.
Therefore I left six.moves.input for now.

See: https://pagure.io/freeipa/issue/7715
Signed-off-by: Christian Heimes <cheimes@redhat.com>