### PR TITLE
Fix writing certificate chain to file

### DIFF
--- a/ipaclient/plugins/ca.py
+++ b/ipaclient/plugins/ca.py
@@ -37,9 +37,8 @@ class WithCertOutArgs(MethodOverride):
             if options.get('chain', False):
                 certs = result['result']['certificate_chain']
             else:
-                certs = [result['result']['certificate']]
-            certs = (x509.load_der_x509_certificate(base64.b64decode(cert))
-                     for cert in certs)
+                certs = [base64.b64decode(result['result']['certificate'])]
+            certs = (x509.load_der_x509_certificate(cert) for cert in certs)
             x509.write_certificate_list(certs, filename)
 
         return result

--- a/ipaclient/plugins/cert.py
+++ b/ipaclient/plugins/cert.py
@@ -64,9 +64,8 @@ class CertRetrieveOverride(MethodOverride):
             if options.get('chain', False):
                 certs = result['result']['certificate_chain']
             else:
-                certs = [result['result']['certificate']]
-            certs = (x509.load_der_x509_certificate(base64.b64decode(cert))
-                     for cert in certs)
+                certs = [base64.b64decode(result['result']['certificate'])]
+            certs = (x509.load_der_x509_certificate(cert) for cert in certs)
             x509.write_certificate_list(certs, certificate_out)
 
         return result


### PR DESCRIPTION
An client-side error occurs when cert commands are instructed to
write the certificate chain (--chain option) to a file
(--certificate-out option).  This regression was introduced in the
'cert' plugin in commit 5a44ca638310913ab6b0c239374f4b0ddeeedeb3,
and reflected in the 'ca' plugin in commit
c7064494e5801d5fd4670e6aab1e07c65d7a0731.

The server behaviour did not change; rather the client did not
correctly handle the DER-encoded certificates in the
'certificate_chain' response field.  Fix the issue by treating the
'certificate' field as base-64 encoded DER, and the
'certificate_chain' field as an array of raw DER certificates.

Fixes: https://pagure.io/freeipa/issue/7700