### PR TITLE
Find orphan automember rules

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -186,6 +186,20 @@ output: Output('count', type=[<type 'int'>])
 output: ListOfEntries('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: Output('truncated', type=[<type 'bool'>])
+command: automember_find_orphans/1
+args: 1,7,4
+arg: Str('criteria?')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Str('description?', autofill=False, cli_name='desc')
+option: Flag('pkey_only?', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Flag('remove?', autofill=True, default=False)
+option: StrEnum('type', values=[u'group', u'hostgroup'])
+option: Str('version?')
+output: Output('count', type=[<type 'int'>])
+output: ListOfEntries('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: Output('truncated', type=[<type 'bool'>])
 command: automember_mod/1
 args: 1,9,3
 arg: Str('cn', cli_name='automember_rule')
@@ -6503,6 +6517,7 @@ default: automember_default_group_set/1
 default: automember_default_group_show/1
 default: automember_del/1
 default: automember_find/1
+default: automember_find_orphans/1
 default: automember_mod/1
 default: automember_rebuild/1
 default: automember_remove_condition/1

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -83,8 +83,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-define(IPA_API_VERSION_MINOR, 229)
-# Last change: Added the Certificate parameter
+define(IPA_API_VERSION_MINOR, 230)
+# Last change: Added `automember-find-orphans' command
 
 
 ########################################################


### PR DESCRIPTION
If groups or hostgroups have been removed after automember rules have been
created using them, then automember-rebuild, automember-add, host-add and
more commands could fail.

A new command has been added to the ipa tool:

  ipa automember-find-orphans --type={hostgroup,group} [--remove]

This command retuns the list of orphan automember rules in the same way as
automember-find. With the --remove option the orphan rules are also removed.

Using ideas from a patch by: Rob Crittenden <rcritten@redhat.com>

See: https://pagure.io/freeipa/issue/6476
Signed-off-by: Thomas Woerner <twoerner@redhat.com>