### PR TITLE
certdb: provide meaningful err msg for wrong PIN

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -221,6 +221,24 @@ KEY_RE = re.compile(
 )
 
 
+class Pkcs12ImportIncorrectPasswordError(RuntimeError):
+    """ Raised when import_pkcs12 fails because of a wrong password.
+    """
+    pass
+
+
+class Pkcs12ImportOpenError(RuntimeError):
+    """ Raised when import_pkcs12 fails trying to open the file.
+    """
+    pass
+
+
+class Pkcs12ImportUnknownError(RuntimeError):
+    """ Raised when import_pkcs12 fails because of an unknown error.
+    """
+    pass
+
+
 class NSSDatabase:
     """A general-purpose wrapper around a NSS cert database
 
@@ -578,13 +596,15 @@ class NSSDatabase:
         try:
             self.run_pk12util(args)
         except ipautil.CalledProcessError as e:
-            if e.returncode == 17:
-                raise RuntimeError("incorrect password for pkcs#12 file %s" %
-                    pkcs12_filename)
+            if e.returncode == 17 or e.returncode == 18:
+                raise Pkcs12ImportIncorrectPasswordError(
+                    "incorrect password for pkcs#12 file %s" % pkcs12_filename)
             elif e.returncode == 10:
-                raise RuntimeError("Failed to open %s" % pkcs12_filename)
+                raise Pkcs12ImportOpenError(
+                    "Failed to open %s" % pkcs12_filename)
             else:
-                raise RuntimeError("unknown error import pkcs#12 file %s" %
+                raise Pkcs12ImportUnknownError(
+                    "unknown error import pkcs#12 file %s" %
                     pkcs12_filename)
         finally:
             if pkcs12_password_file is not None:
@@ -722,8 +742,13 @@ class NSSDatabase:
             if import_keys:
                 try:
                     self.import_pkcs12(filename, key_password)
-                except RuntimeError:
+                except Pkcs12ImportUnknownError:
+                    # the file may not be a PKCS#12 file,
+                    # go to the generic error about unrecognized format
                     pass
+                except RuntimeError as e:
+                    raise RuntimeError("Failed to load %s: %s" %
+                                       (filename, str(e)))
                 else:
                     if key_file:
                         raise RuntimeError(
@@ -749,7 +774,9 @@ class NSSDatabase:
 
                     continue
 
-            raise RuntimeError("Failed to load %s" % filename)
+            # Supported formats were tried but none succeeded
+            raise RuntimeError("Failed to load %s: unrecognized format" %
+                               filename)
 
         if import_keys and not key_file:
             raise RuntimeError(

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -509,7 +509,6 @@ class TestServerInstall(CALessBase):
                      'ipa-server-install: error: You must specify '
                      '--dirsrv-pin with --dirsrv-cert-file')
 
-    @pytest.mark.xfail(reason='freeipa ticket 5378', strict=True)
     @server_install_teardown
     def test_incorect_http_pin(self):
         "IPA server install with incorrect HTTP PKCS#12 password"
@@ -520,7 +519,6 @@ class TestServerInstall(CALessBase):
         result = self.install_server(http_pin='bad<pin>')
         assert_error(result, 'incorrect password for pkcs#12 file server.p12')
 
-    @pytest.mark.xfail(reason='freeipa ticket 5378', strict=True)
     @server_install_teardown
     def test_incorect_ds_pin(self):
         "IPA server install with incorrect DS PKCS#12 password"
@@ -863,7 +861,6 @@ class TestReplicaInstall(CALessBase):
         assert_error(result, 'Failed to open %s/does_not_exist' %
                      self.master.config.test_dir)
 
-    @pytest.mark.xfail(reason='freeipa ticket 5378', strict=True)
     @replica_install_teardown
     def test_incorect_http_pin(self):
         "IPA replica install with incorrect HTTP PKCS#12 password"
@@ -874,7 +871,6 @@ class TestReplicaInstall(CALessBase):
         assert result.returncode > 0
         assert_error(result, 'incorrect password for pkcs#12 file replica.p12')
 
-    @pytest.mark.xfail(reason='freeipa ticket 5378', strict=True)
     @replica_install_teardown
     def test_incorect_ds_pin(self):
         "IPA replica install with incorrect DS PKCS#12 password"
@@ -1359,7 +1355,6 @@ class TestCertInstall(CALessBase):
                                   cert_exists=False)
         assert_error(result, 'Failed to open does_not_exist')
 
-    @pytest.mark.xfail(reason='freeipa ticket 5378', strict=True)
     def test_incorect_http_pin(self):
         "Install new HTTP certificate with incorrect PKCS#12 password"
 
@@ -1367,7 +1362,6 @@ class TestCertInstall(CALessBase):
         assert_error(result,
                      'incorrect password for pkcs#12 file server.p12')
 
-    @pytest.mark.xfail(reason='freeipa ticket 5378', strict=True)
     def test_incorect_dirsrv_pin(self):
         "Install new DS certificate with incorrect PKCS#12 password"
 


### PR DESCRIPTION
ipa-server-install or ipa-replica-install do not provide a meaningful error message in CA-less mode when the install fails because of a wrong PIN.
Update the err msg so that it provides a hint to the user.

Update the associated tests with the correct message and remove the pytest.mark.xfail annotation.

Fixes https://pagure.io/freeipa/issue/5378