### PR TITLE
Bump requires 389-ds-base

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -48,7 +48,9 @@
 %global selinux_policy_version 3.14.1-14
 %global slapi_nis_version 0.56.1-4
 %global python_ldap_version 3.1.0-1
-%global ds_version 1.4.0.8-1
+# Fix for "Installation fails: Replica Busy"
+# https://bugzilla.redhat.com/show_bug.cgi?id=1598478
+%global ds_version 1.3.8.4-15
 %else
 # Fedora
 %global package_name freeipa
@@ -68,7 +70,9 @@
 
 # Fix for "Crash when failing to read from SASL connection"
 # https://pagure.io/389-ds-base/issue/49639
-%global ds_version 1.4.0.8-1
+# Fix for "Installation fails: Replica Busy"
+# https://pagure.io/389-ds-base/issue/49818
+%global ds_version 1.4.0.16-1
 
 %endif  # Fedora
 


### PR DESCRIPTION
ipa-replica-install sometimes fails with
```
[28/41]: setting up initial replication
Starting replication, please wait until this has completed.
[ldap://master.ipa.test:389] reports: Replica Busy! Status: [Error (1) Replication error acquiring replica: replica busy]
 [error] RuntimeError: Failed to start replication
```
which is caused by a 389-ds issue
(https://pagure.io/389-ds-base/issue/49818)
Bump requires to include the fix.

Fixes: https://pagure.io/freeipa/issue/7642