### PR TITLE
ipatests: mark known failures as xfail 

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -104,7 +104,6 @@ class InstallTestBase2(IntegrationTest):
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=False)
 
-    @pytest.mark.xfail(reason='Ticket 7651', strict=True)
     def test_replica0_with_ca_kra_dns_install(self):
         tasks.install_replica(self.master, self.replicas[0], setup_ca=True,
                               setup_kra=True, setup_dns=True)
@@ -185,6 +184,7 @@ class TestInstallWithCA2(InstallTestBase2):
 
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
+    @pytest.mark.xfail(reason='Ticket 7651', strict=True)
     def test_replica0_with_ca_kra_dns_install(self):
         super(TestInstallWithCA2, self).test_replica0_with_ca_kra_dns_install()
 
@@ -247,6 +247,7 @@ class TestInstallWithCA_DNS2(InstallTestBase2):
 
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
+    @pytest.mark.xfail(reason='Ticket 7651', strict=True)
     def test_replica0_with_ca_kra_dns_install(self):
         super(
             TestInstallWithCA_DNS2, self


### PR DESCRIPTION
Commit 5dbcc1a marked the base class method `test_replica0_with_ca_kra_dns_install` as known failure, but this does not work with inherited classes. The child class methods need to be marked
themselves as known failures with `@pytest.mark.xfail`.

Furthermore, `TestInstallWithCA_KRA2` and `TestInstallWithCA_KRA_DNS2` tests should succeed because the master is installed with KRA (issue 7651 is related to replica install with --setup-kra
when it is the first KRA instance).

Related to https://pagure.io/freeipa/issue/7651