### PR TITLE
Fix misleading errors during client install rollback

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3282,13 +3282,14 @@ def uninstall(options):
     remove_file(paths.SSSD_MC_GROUP)
     remove_file(paths.SSSD_MC_PASSWD)
 
-    try:
-        run([paths.SSSCTL, "cache-remove", "-o", "--stop", "--start"])
-    except Exception:
-        logger.info(
-            "An error occurred while removing SSSD's cache."
-            "Please remove the cache manually by executing "
-            "sssctl cache-remove -o.")
+    if was_sssd_installed:
+        try:
+            run([paths.SSSCTL, "cache-remove", "-o", "--stop", "--start"])
+        except Exception:
+            logger.info(
+                "An error occurred while removing SSSD's cache."
+                "Please remove the cache manually by executing "
+                "sssctl cache-remove -o.")
 
     if ipa_domain:
         sssd_domain_ldb = "cache_" + ipa_domain + ".ldb"
@@ -3352,7 +3353,8 @@ def uninstall(options):
 
     # SSSD was not installed before our installation, and no other domains
     # than IPA are configured in sssd.conf - make sure config file is removed
-    elif not was_sssd_installed and not was_sssd_configured:
+    elif not was_sssd_installed and not was_sssd_configured \
+            and os.path.exists(paths.SSSD_CONF):
         try:
             os.rename(paths.SSSD_CONF, paths.SSSD_CONF_DELETED)
         except OSError:

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -1125,11 +1125,14 @@ def ensure_krbcanonicalname_set(ldap, entry_attrs):
 def check_client_configuration():
     """
     Check if IPA client is configured on the system.
+
+    Hardcode return code to avoid recursive imports
     """
     if (not os.path.isfile(paths.IPA_DEFAULT_CONF) or
             not os.path.isdir(paths.IPA_CLIENT_SYSRESTORE) or
             not os.listdir(paths.IPA_CLIENT_SYSRESTORE)):
-        raise ScriptError('IPA client is not configured on this system')
+        raise ScriptError('IPA client is not configured on this system',
+                          2)  # CLIENT_NOT_CONFIGURED
 
 
 def check_principal_realm_in_trust_namespace(api_instance, *keys):

--- a/ipaplatform/redhat/authconfig.py
+++ b/ipaplatform/redhat/authconfig.py
@@ -141,7 +141,7 @@ class RedHatAuthSelect(RedHatAuthToolBase):
     def unconfigure(
         self, fstore, statestore, was_sssd_installed, was_sssd_configured
     ):
-        if not statestore.has_state('authselect'):
+        if not statestore.has_state('authselect') and was_sssd_installed:
             logger.warning(
                 "WARNING: Unable to revert to the pre-installation state "
                 "('authconfig' tool has been deprecated in favor of "

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -69,11 +69,12 @@ def setup_server_logs_collecting(host):
 
     # IPA install logs
     host.collect_log(paths.IPASERVER_INSTALL_LOG)
+    host.collect_log(paths.IPASERVER_UNINSTALL_LOG)
     host.collect_log(paths.IPACLIENT_INSTALL_LOG)
+    host.collect_log(paths.IPACLIENT_UNINSTALL_LOG)
     host.collect_log(paths.IPAREPLICA_INSTALL_LOG)
     host.collect_log(paths.IPAREPLICA_CONNCHECK_LOG)
     host.collect_log(paths.IPAREPLICA_CA_INSTALL_LOG)
-    host.collect_log(paths.IPACLIENT_INSTALL_LOG)
     host.collect_log(paths.IPASERVER_KRA_INSTALL_LOG)
     host.collect_log(paths.IPA_CUSTODIA_AUDIT_LOG)
 

--- a/ipatests/test_integration/test_authselect.py
+++ b/ipatests/test_integration/test_authselect.py
@@ -136,7 +136,6 @@ class TestClientInstallation(IntegrationTest):
         # by default
         result = self._uninstall_client()
         assert result.returncode == 0
-        assert self.msg_warn_uninstall in result.stderr_text
         check_authselect_profile(self.client, default_profile)
 
     def test_install_client_preconfigured_profile(self):

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -207,6 +207,36 @@ class TestWrongClientDomain(IntegrationTest):
         assert(result1.returncode == 0), (
             'Failed to promote the client installed with the upcase domain name')
 
+    def test_client_rollback(self):
+        """Test that bogus error msgs are not in output on rollback.
+
+           FIXME: including in this suite to avoid setting up a
+                  master just to test a client install failure. If
+                  a pure client install suite is added this can be
+                  moved.
+
+           Ticket https://pagure.io/freeipa/issue/7729
+        """
+        client = self.replicas[0]
+
+        # Cleanup previous run
+        client.run_command(['ipa-server-install',
+                            '--uninstall', '-U'], raiseonerr=False)
+
+        result = client.run_command(['ipa-client-install', '-U',
+                                     '--server', self.master.hostname,
+                                     '--domain', client.domain.name,
+                                     '-w', 'foo'], raiseonerr=False)
+
+        assert(result.returncode == 1)
+
+        assert("Unconfigured automount client failed" not in
+               result.stdout_text)
+
+        assert("WARNING: Unable to revert" not in result.stdout_text)
+
+        assert("An error occurred while removing SSSD" not in
+               result.stdout_text)
 
 class TestRenewalMaster(IntegrationTest):
 


### PR DESCRIPTION
Some incorrect errors are possible if a client installation
fails and a configuration rollback is required.

These include:

1. Unconfigured automount client failed: CalledProcessError(Command
['/usr/sbin/ipa-client-automount', '--uninstall', '--debug']
returned non-zero exit status 1: '')

Caused by check_client_configuration() not returning the correct
return value (2).

2. WARNING: Unable to revert to the pre-installation state ('authconfig'
tool has been deprecated in favor of 'authselect'). The default sssd
profile will be used instead.
The authconfig arguments would have been: authconfig --disableldap
--disablekrb5 --disablesssdauth --disablemkhomedir

If installation fails before SSSD is configured there is no state
to roll back to. Detect this condition.

3. An error occurred while removing SSSD's cache.Please remove the
cache manually by executing sssctl cache-remove -o.

Again, if SSSD is not configured yet then there is no cache to
remove. Also correct the missing space after the period.

https://pagure.io/freeipa/issue/7729
