### PR TITLE
Handle NTP configuration in a replica server installation

### DIFF
--- a/install/tools/man/ipa-replica-install.1
+++ b/install/tools/man/ipa-replica-install.1
@@ -14,7 +14,7 @@ Domain level 0 is not supported anymore.
 
 To create a replica, the machine only needs to be enrolled in the FreeIPA domain first. This process of turning the IPA client into a replica is also referred to as replica promotion.
 
-If you're starting with an existing IPA client, simply run ipa\-replica\-install to have it promoted into a replica.
+If you're starting with an existing IPA client, simply run ipa\-replica\-install to have it promoted into a replica. The NTP configuration cannot be updated during client promotion. 
 
 To promote a blank machine into a replica, you have two options, you can either run ipa\-client\-install in a separate step, or pass the enrollment related options to the ipa\-replica\-install (see CLIENT ENROLLMENT OPTIONS). In the latter case, ipa\-replica\-install will join the machine to the IPA realm automatically and will proceed with the promotion step.
 

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -717,6 +717,11 @@ def ensure_enrolled(installer):
         for ip in installer.ip_addresses:
             # installer.ip_addresses is of type [CheckedIPAddress]
             args.extend(("--ip-address", str(ip)))
+    if installer.ntp_servers:
+        for server in installer.ntp_servers:
+            args.extend(("--ntp-server", server))
+    if installer.ntp_pool:
+        args.extend(("--ntp-pool", installer.ntp_pool))
 
     try:
         # Call client install script
@@ -773,6 +778,11 @@ def promote_check(installer):
             print("IPA client is already configured on this system, ignoring "
                   "the --domain, --server, --realm, --hostname, --password "
                   "and --keytab options.")
+
+        # The NTP configuration can not be touched on pre-installed client:
+        if options.no_ntp or options.ntp_servers or options.ntp_pool:
+                raise ScriptError(
+                    "NTP configuration cannot be updated during promotion")
 
     sstore = sysrestore.StateFile(paths.SYSRESTORE)
 


### PR DESCRIPTION
There were two separate issues:

1. If not enrolling on a pre-configured client then the ntp-server and
   ntp-pool options are not being passed down to the client installer
   invocation.
2. If the client is already enrolled then the ntp options are ignored
   altogether.

So basically reverse those. Detect the ntp options and add them to
the ipa-client-install invocation if the client is not pre-enrolled.

If it is pre-enrolled then call out to the time configuration
methods to setup the servers or pool. The changes will be recorded
in the client sysrestore.

https://pagure.io/freeipa/issue/7723

Signed-off-by: Rob Crittenden <rcritten@redhat.com>