### PR TITLE
[Backport][ipa-4-7] Move ipa's systemd tmpfiles from /var/run to /run

### DIFF
--- a/init/tmpfilesd/Makefile.am
+++ b/init/tmpfilesd/Makefile.am
@@ -7,4 +7,4 @@ systemdtmpfiles_DATA =         \
 CLEANFILES = $(systemdtmpfiles_DATA)
 
 %: %.in Makefile
-	sed -e 's|@localstatedir[@]|$(localstatedir)|g' '$(srcdir)/$@.in' >$@
+	cp '$(srcdir)/$@.in' $@

--- a/init/tmpfilesd/ipa.conf.in
+++ b/init/tmpfilesd/ipa.conf.in
@@ -1,2 +1,2 @@
-d @localstatedir@/run/ipa 0711 root root
-d @localstatedir@/run/ipa/ccaches 0770 ipaapi ipaapi
+d /run/ipa 0711 root root
+d /run/ipa/ccaches 0770 ipaapi ipaapi

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -350,7 +350,7 @@ class BasePathNamespace(object):
     OPENDNSSEC_KASP_DB = "/var/opendnssec/kasp.db"
     IPA_ODS_EXPORTER_CCACHE = "/var/opendnssec/tmp/ipa-ods-exporter.ccache"
     VAR_RUN_DIRSRV_DIR = "/var/run/dirsrv"
-    IPA_CCACHES = "/var/run/ipa/ccaches"
+    IPA_CCACHES = "/run/ipa/ccaches"
     HTTP_CCACHE = "/var/lib/ipa/gssproxy/http.ccache"
     CA_BUNDLE_PEM = "/var/lib/ipa-client/pki/ca-bundle.pem"
     KDC_CA_BUNDLE_PEM = "/var/lib/ipa-client/pki/kdc-ca-bundle.pem"


### PR DESCRIPTION
This PR was opened automatically because PR #2450 was pushed to master and backport to ipa-4-7 is required.