### PR TITLE
[Backport][ipa-4-7] Bump requires 389-ds-base

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -70,7 +70,9 @@
 %global selinux_policy_version 3.14.1-14
 %global slapi_nis_version 0.56.1-4
 %global python_ldap_version 3.1.0-1
-%global ds_version 1.4.0.8-1
+# Fix for "Installation fails: Replica Busy"
+# https://bugzilla.redhat.com/show_bug.cgi?id=1598478
+%global ds_version 1.3.8.4-15
 %else
 # Fedora
 %global package_name freeipa
@@ -90,7 +92,9 @@
 
 # Fix for "Crash when failing to read from SASL connection"
 # https://pagure.io/389-ds-base/issue/49639
-%global ds_version 1.4.0.8-1
+# Fix for "Installation fails: Replica Busy"
+# https://pagure.io/389-ds-base/issue/49818
+%global ds_version 1.4.0.16-1
 
 %endif  # Fedora
 


### PR DESCRIPTION
This PR was opened automatically because PR #2433 was pushed to master and backport to ipa-4-7 is required.