### PR TITLE
[Backport][ipa-4-6] Bump requires 389-ds-base

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -82,7 +82,7 @@
 %global pki_version 10.5.12
 # Fix for "Installation fails: Replica Busy"
 # https://pagure.io/389-ds-base/issue/49818
-%global ds_version 1.4.0.16-1
+%global ds_version 1.3.8.8
 
 %endif
 
@@ -152,7 +152,7 @@ BuildRequires:  libini_config-devel
 BuildRequires:  cyrus-sasl-devel
 %if ! %{ONLY_CLIENT}
 # 1.3.3.9: DS_Sleep (https://fedorahosted.org/389/ticket/48005)
-BuildRequires:  389-ds-base-devel >= 1.3.3.9
+BuildRequires:  389-ds-base-devel >= %{ds_version}
 BuildRequires:  svrcore-devel
 %if 0%{?rhel}
 BuildRequires:  samba-devel >= 4.0.0
@@ -333,7 +333,7 @@ Requires: python2-ldap >= %{python2_ldap_version}
 # 1.3.7.9-1: https://bugzilla.redhat.com/show_bug.cgi?id=1459946
 #            https://bugzilla.redhat.com/show_bug.cgi?id=1511462
 #            https://bugzilla.redhat.com/show_bug.cgi?id=1514033
-Requires: 389-ds-base >= 1.3.7.9-1
+Requires: 389-ds-base >= %{ds_version}
 Requires: openldap-clients > 2.4.35-4
 Requires: nss >= 3.14.3-12.0
 Requires: nss-tools >= 3.14.3-12.0
@@ -381,7 +381,7 @@ Requires(pre): certmonger >= 0.79.5-1
 # 1.3.7.9-1: https://bugzilla.redhat.com/show_bug.cgi?id=1459946
 #            https://bugzilla.redhat.com/show_bug.cgi?id=1511462
 #            https://bugzilla.redhat.com/show_bug.cgi?id=1514033
-Requires(pre): 389-ds-base >= 1.3.7.9-1
+Requires(pre): 389-ds-base >= %{ds_version}
 Requires: fontawesome-fonts
 Requires: open-sans-fonts
 Requires: openssl

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -60,6 +60,9 @@
 %global python2_ldap_version 2.4.15
 # 10.5.9-5: https://bugzilla.redhat.com/show_bug.cgi?id=1596629
 %global pki_version 10.5.9-5
+# Fix for "Installation fails: Replica Busy"
+# https://bugzilla.redhat.com/show_bug.cgi?id=1598478
+%global ds_version 1.3.8.4-15
 %else
 # 1.15.1-7: certauth (http://krbdev.mit.edu/rt/Ticket/Display.html?id=8561)
 %global krb5_version 1.15.1-7
@@ -77,6 +80,9 @@
 %global python3_ldap_version 2.4.37-4
 # 10.5.12: https://pagure.io/dogtagpki/issue/3043
 %global pki_version 10.5.12
+# Fix for "Installation fails: Replica Busy"
+# https://pagure.io/389-ds-base/issue/49818
+%global ds_version 1.4.0.16-1
 
 %endif
 


### PR DESCRIPTION
Manual backport of #2433

ipa-replica-install sometimes fails with
--
[28/41]: setting up initial replication
Starting replication, please wait until this has completed.
[ldap://master.ipa.test:389] reports: Replica Busy! Status: [Error (1) Replication error acquiring replica: replica busy]
 [error] RuntimeError: Failed to start replication
--
which is caused by a 389-ds issue
(https://pagure.io/389-ds-base/issue/49818)
Bump requires to include the fix.

Fixes: https://pagure.io/freeipa/issue/7642
Reviewed-By: Christian Heimes <cheimes@redhat.com>