### PR TITLE
Support interactive prompt for ntp options

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2470,18 +2470,21 @@ def sync_time(options, fstore, statestore):
     # disable other time&date services first
     timeconf.force_chrony(statestore)
 
-    logger.info('Synchronizing time')
-
-    if not options.ntp_servers:
+    if not options.ntp_servers and not options.ntp_pool:
         ds = discovery.IPADiscovery()
         ntp_servers = ds.ipadns_search_srv(cli_domain, '_ntp._udp',
                                            None, break_on_first=False)
-    else:
-        ntp_servers = options.ntp_servers
+        if not ntp_servers and not options.unattended:
+            options.ntp_servers, options.ntp_pool = timeconf.get_time_source()
+        else:
+            options.ntp_servers = ntp_servers
+
+    logger.info('Synchronizing time')
 
     configured = False
-    if ntp_servers or options.ntp_pool:
-        configured = timeconf.configure_chrony(ntp_servers, options.ntp_pool,
+    if options.ntp_servers or options.ntp_pool:
+        configured = timeconf.configure_chrony(options.ntp_servers,
+                                               options.ntp_pool,
                                                fstore, statestore)
     else:
         logger.warning("No SRV records of NTP servers found and no NTP server "


### PR DESCRIPTION
As the FreeIPA server is no longer a NTP service
providing instance its clients and replicas
configuration of time service can not be handled
as it was before change to chrony. Configuration
using master FQDN or autodiscovery for DNS record
would make no difference because every FreeIPA
instance is only chrony client now and does not
update DNS _ntp._udp record.

FreeIPA now asks user for NTP source server
or pool address in interactive mode if there is
no server nor pool specified and autodiscovery
has not found any NTP source in DNS records.

Resolves: https://pagure.io/freeipa/issue/7747