### PR TITLE
Fix C issues found by coverity and others

### DIFF
--- a/client/config.c
+++ b/client/config.c
@@ -123,17 +123,18 @@ get_config_entry(char * in_data, const char *section, const char *key)
             line++;
             p = strchr(line, ']');
             if (p) {
-                tmp = strndup(line, p - line);
                 if (in_section) {
                     /* We exited the matching section without a match */
                     free(data);
                     return NULL;
                 }
+                tmp = strndup(line, p - line);
                 if (strcmp(section, tmp) == 0) {
                     free(tmp);
                     in_section = 1;
                     continue;
                 }
+                free(tmp);
             }
         } /* [ */
 

--- a/daemons/ipa-slapi-plugins/ipa-cldap/ipa_cldap_netlogon.c
+++ b/daemons/ipa-slapi-plugins/ipa-cldap/ipa_cldap_netlogon.c
@@ -260,6 +260,10 @@ int ipa_cldap_netlogon(struct ipa_cldap_ctx *ctx,
             if (req->kvps.pairs[i].value.bv_val[len-1] == '.') {
                 len--;
             }
+            if (domain != NULL) {
+                free(domain);
+                domain = NULL;
+            }
             domain = strndup(req->kvps.pairs[i].value.bv_val, len);
             if (!domain) {
                 ret = ENOMEM;


### PR DESCRIPTION
Two issues have been addressed:

    Fix ressource leak in daemons/ipa-slapi-plugins/ipa-cldap/ipa_cldap_netlogon.c ipa_cldap_netlogon
    
    The leak happens due to using strndup in a for loop to create a temporary
    string without freeing it in all cases.

and

    Fix ressource leak in client/config.c get_config_entry
    
    The leak happens due to using strndup to create a temporary string without
    freeing it afterwards.
