### PR TITLE
Update annobin to fix continuous-integration/travis-ci/pr issues

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -30,6 +30,7 @@ steps:
   - "dnf makecache || :"
   - dnf builddep -y ${builddep_opts} -D "with_wheels 1" --spec freeipa.spec.in --best --allowerasing --setopt=install_weak_deps=False
   - dnf install -y gdb
+  - dnf update -y annobin
   cleanup:
   - chown -R ${uid}:${gid} ${container_working_dir}
   - journalctl -b --no-pager > systemd_journal.log


### PR DESCRIPTION
gcc is updated with the dnf builddep line, but annobin is not. Therefore
configure fails with "C compiler cannot create executables".

This is related to https://bugzilla.redhat.com/show_bug.cgi?id=1574478

See: https://pagure.io/freeipa/issue/7740
Signed-off-by: Thomas Woerner <twoerner@redhat.com>