### PR TITLE
[Backport][ipa-4-7] Update annobin to fix continuous-integration/travis-ci/pr issues

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -30,6 +30,7 @@ steps:
   - "dnf makecache || :"
   - dnf builddep -y ${builddep_opts} -D "with_wheels 1" --spec freeipa.spec.in --best --allowerasing --setopt=install_weak_deps=False
   - dnf install -y gdb
+  - dnf update -y annobin
   cleanup:
   - chown -R ${uid}:${gid} ${container_working_dir}
   - journalctl -b --no-pager > systemd_journal.log

--- a/.test_runner_config_py3_temp.yaml
+++ b/.test_runner_config_py3_temp.yaml
@@ -32,6 +32,7 @@ steps:
   - "dnf makecache || :"
   - dnf builddep -y ${builddep_opts} --spec freeipa.spec.in --best --allowerasing --setopt=install_weak_deps=False
   - dnf install -y gdb
+  - dnf update -y annobin
   cleanup:
   - chown -R ${uid}:${gid} ${container_working_dir}
   - >


### PR DESCRIPTION
This PR was opened automatically because PR #2474 was pushed to master and backport to ipa-4-7 is required.