### PR TITLE
[Backport][ipa-4-6] ipa-replica-install --setup-adtrust: check for package ipa-server-tru…

### DIFF
--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -15,6 +15,7 @@ class BaseConstantsNamespace(object):
     HTTPD_USER = "apache"
     HTTPD_GROUP = "apache"
     GSSPROXY_USER = "root"
+    IPA_ADTRUST_PACKAGE_NAME = "freeipa-server-trust-ad"
     IPA_DNS_PACKAGE_NAME = "freeipa-server-dns"
     KDCPROXY_USER = "kdcproxy"
     NAMED_USER = "named"

--- a/ipaplatform/rhel/constants.py
+++ b/ipaplatform/rhel/constants.py
@@ -13,6 +13,7 @@ from ipaplatform.redhat.constants import RedHatConstantsNamespace
 
 
 class RHELConstantsNamespace(RedHatConstantsNamespace):
+    IPA_ADTRUST_PACKAGE_NAME = "ipa-server-trust-ad"
     IPA_DNS_PACKAGE_NAME = "ipa-server-dns"
 
 constants = RHELConstantsNamespace()

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -72,6 +72,15 @@ def check_inst():
                   "start the installation again")
             return False
 
+    # Check that ipa-server-trust-ad package is installed,
+    # by looking for the file /usr/share/ipa/smb.conf.empty
+    if not os.path.exists(os.path.join(paths.USR_SHARE_IPA_DIR,
+                                       "smb.conf.empty")):
+        print("AD Trust requires the '%s' package" %
+              constants.IPA_ADTRUST_PACKAGE_NAME)
+        print("Please install the package and start the installation again")
+        return False
+
     #TODO: Add check for needed samba4 libraries
 
     return True


### PR DESCRIPTION
This PR was opened automatically because PR #2471 was pushed to master and backport to ipa-4-6 is required.