### PR TITLE
Improve Python configuration for LGTM

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -22,6 +22,7 @@ path_classifiers:
   install:
     - install
 extraction:
+  # https://lgtm.com/help/lgtm/cpp-extraction
   cpp:
     prepare:
       packages:
@@ -31,13 +32,16 @@ extraction:
         - autopoint
         - libtool
         - gettext
-        - python-all-dev
+        - git
+        - python3-dev
         - python3-distutils
-        - python3-setutools
         - python3-lesscpy
+        - python3-setuptools
+        - python3-wheel
         - nodejs
         - uglifyjs
         - systemd
+        - 389-ds-base-dev
         - libssl-dev
         - libsasl2-dev
         - libldap2-dev
@@ -58,3 +62,87 @@ extraction:
     index:
       build_command:
         - make -j2 -s
+  # https://lgtm.com/help/lgtm/python-extraction
+  python:
+    prepare:
+      packages:
+        - build-essential
+        - autoconf
+        - automake
+        - autopoint
+        - libtool
+        - gettext
+        - git
+        - python3-dev
+        - python3-distutils
+        - python3-lesscpy
+        - python3-setuptools
+        - python3-wheel
+        - nodejs
+        - uglifyjs
+        - systemd
+        - 389-ds-base-dev
+        - libssl-dev
+        - libsasl2-dev
+        - libldap2-dev
+        - libkrb5-dev
+        - libkrad-dev
+        - libini-config-dev
+        - libnss3-dev
+        - libsss-certmap-dev
+        - libsss-idmap-dev
+        - libsss-nss-idmap-dev
+        - libunistring-dev
+        - libxmlrpc-core-c3-dev
+        - samba-dev
+        - uuid-dev
+        # extra dependencies for Python packages
+        - libaugeas-dev
+        - augeas-lenses
+        - libdbus-1-dev
+        - libffi-dev
+        - libxslt1-dev
+        - python3-libsss-nss-idmap
+        - python3-sss
+    after_prepare:
+      - ./autogen.sh --with-ipaplatform=debian
+    python_setup:
+      version: 3
+      setup_py: false
+      requirements:
+        - cffi
+        - cryptography
+        - custodia
+        - dbus-python
+        - dnspython
+        - jinja2
+        - jwcrypto
+        - lxml
+        - gssapi
+        - netaddr
+        - netifaces
+        - polib
+        - requests
+        - python-augeas
+        - pyasn1
+        - pyasn1-modules
+        - pytest
+        - pytest_multihost
+        - python-ldap
+        - python-yubico
+        - pyusb
+        - pyyaml
+        - qrcode
+        - six
+    before_index:
+      # Let LGTM pick up our packages
+      - export PYTHONPATH=$LGTM_SRC
+    index:
+      exclude:
+        # auto-generated files
+        - ipaclient/remote_plugins/2_114
+        - ipaclient/remote_plugins/2_156
+        - ipaclient/remote_plugins/2_164
+        - ipaclient/remote_plugins/2_49
+        # packaging helpers
+        - pypi

--- a/contrib/lgtm_container.py
+++ b/contrib/lgtm_container.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+"""Helper script to test LGTM config
+
+$ contrib/lgtm_container.py > Dockerfile
+$ docker build -t lgtm .
+"""
+import os
+import yaml
+
+LGTM_YML = os.path.join(os.path.dirname(__file__), '..', '.lgtm.yml')
+
+
+def main():
+    with open(LGTM_YML) as f:
+        cfg = yaml.safe_load(f)
+
+    python = cfg['extraction']['python']
+
+    print("""\
+    FROM ubuntu:bionic
+    RUN apt-get update && \
+        apt-get install -y {dpkg} python3-venv && \
+        apt-get clean
+    RUN python3 -m venv /venv
+    RUN /venv/bin/pip install wheel
+    RUN /venv/bin/pip install {pypkg}
+    ADD . /freeipa
+    RUN cd /freeipa && ./autogen.sh --with-ipaplatform=debian
+    """.format(
+        dpkg=' '.join(python['prepare']['packages']),
+        pypkg=' '.join(python['python_setup']['requirements'])
+    ))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
LGTM is no longer able to analyse all Python code without importing it.
Define OS and Python package dependencies and build the project for
Python, too.

Signed-off-by: Christian Heimes <cheimes@redhat.com>