### PR TITLE
Require Dogtag 10.6.7 with KRA DL1 fix

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -76,9 +76,9 @@
 
 %endif  # Fedora
 
-# Require Dogtag PKI 10.6.6 to detect when fips is available,
-# https://pagure.io/freeipa/issue/7608
-%global pki_version 10.6.6
+# Require Dogtag PKI 10.6.7 with fix for KRA installer
+# https://pagure.io/freeipa/issue/7654
+%global pki_version 10.6.7
 
 # NSS release with fix for CKA_LABEL import bug in shared SQL database.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1568271

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -118,7 +118,6 @@ class InstallTestBase2(IntegrationTest):
     def test_replica2_ipa_ca_install(self):
         tasks.install_ca(self.replicas[2])
 
-    @pytest.mark.xfail(reason='Ticket 7654', strict=True)
     def test_replica2_ipa_kra_install(self):
         tasks.install_kra(self.replicas[2])
 


### PR DESCRIPTION
Dogtag PKI >= 10.6.7 comes with a fix for number range depletion when
multiple clones created from same master.

pki-ca-10.6.7 updates are pending. For the time being, FreeIPA's master
COPR has builds.

See: https://pagure.io/freeipa/issue/7654
See: https://pagure.io/dogtagpki/issue/3055
Signed-off-by: Christian Heimes <cheimes@redhat.com>