### PR TITLE
ipa-backup: restart services before compressing the backup

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -147,6 +147,12 @@ def backup(host):
     """Run backup on host, return the path to the backup directory"""
     result = host.run_command(['ipa-backup', '-v'])
 
+    # Test for ticket 7632: check that services are restarted
+    # before the backup is compressed
+    pattern = r'.*gzip.*Starting IPA service.*'
+    if (re.match(pattern, result.stderr_text, re.DOTALL)):
+        raise AssertionError('IPA Services are started after compression')
+
     # Get the backup location from the command's output
     for line in result.stderr_text.splitlines():
         prefix = 'ipaserver.install.ipa_backup: INFO: Backed up to '


### PR DESCRIPTION
## ipa-backup: restart services before compressing the backup

ipa-backup gathers all the files needed for the backup, then compresses
the file and finally restarts the IPA services. When the backup is a
large file, the compression may take time and widen the unavailabity
window.
    
This fix restarts the services as soon as all the required files are
gathered, and compresses after services are restarted.
    
Fixes: https://pagure.io/freeipa/issue/7632

## ipatest: add functional test for ipa-backup
    
The test ensures that ipa-backup compresses the files after the
IPA services are restarted.
