### PR TITLE
[Backport][ipa-4-6] ipa-backup: restart services before compressing the backup

### DIFF
--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -292,6 +292,7 @@ class Backup(admintool.AdminTool):
         os.mkdir(self.dir)
         os.chmod(self.dir, 0o750)
         os.chown(self.dir, pent.pw_uid, pent.pw_gid)
+        self.tarfile = None
 
         self.header = os.path.join(self.top_dir, 'header')
 
@@ -328,7 +329,6 @@ class Backup(admintool.AdminTool):
                 auth_backup_path = os.path.join(paths.VAR_LIB_IPA, 'auth_backup')
                 tasks.backup_auth_configuration(auth_backup_path)
                 self.file_backup(options)
-            self.finalize_backup(options.data_only, options.gpg, options.gpg_keyring)
 
             if options.data_only:
                 if not options.online:
@@ -337,6 +337,14 @@ class Backup(admintool.AdminTool):
             else:
                 logger.info('Starting IPA service')
                 run(['ipactl', 'start'])
+
+            # Compress after services are restarted to minimize
+            # the unavailability window
+            if not options.data_only:
+                self.compress_file_backup()
+
+            self.finalize_backup(options.data_only, options.gpg,
+                                 options.gpg_keyring)
 
         finally:
             try:
@@ -491,7 +499,7 @@ class Backup(admintool.AdminTool):
         def verify_directories(dirs):
             return [s for s in dirs if os.path.exists(s)]
 
-        tarfile = os.path.join(self.dir, 'files.tar')
+        self.tarfile = os.path.join(self.dir, 'files.tar')
 
         logger.info("Backing up files")
         args = ['tar',
@@ -499,7 +507,7 @@ class Backup(admintool.AdminTool):
                 '--xattrs',
                 '--selinux',
                 '-cf',
-                tarfile
+                self.tarfile
                ]
 
         args.extend(verify_directories(self.dirs))
@@ -525,7 +533,7 @@ class Backup(admintool.AdminTool):
                     '--selinux',
                     '--no-recursion',
                     '-rf',  # -r appends to an existing archive
-                    tarfile,
+                    self.tarfile,
                    ]
             args.extend(missing_directories)
 
@@ -536,17 +544,20 @@ class Backup(admintool.AdminTool):
                     'when adding directory structure: %s' %
                     (result.returncode, result.error_log))
 
+    def compress_file_backup(self):
+
         # Compress the archive. This is done separately, since 'tar' cannot
         # append to a compressed archive.
-        result = run(['gzip', tarfile], raiseonerr=False)
-        if result.returncode != 0:
-            raise admintool.ScriptError(
-                'gzip returned non-zero code %d '
-                'when compressing the backup: %s' %
-                (result.returncode, result.error_log))
+        if self.tarfile:
+            result = run(['gzip', self.tarfile], raiseonerr=False)
+            if result.returncode != 0:
+                raise admintool.ScriptError(
+                    'gzip returned non-zero code %d '
+                    'when compressing the backup: %s' %
+                    (result.returncode, result.error_log))
 
-        # Rename the archive back to files.tar to preserve compatibility
-        os.rename(os.path.join(self.dir, 'files.tar.gz'), tarfile)
+            # Rename the archive back to files.tar to preserve compatibility
+            os.rename(os.path.join(self.dir, 'files.tar.gz'), self.tarfile)
 
 
     def create_header(self, data_only):

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -139,6 +139,12 @@ def backup(host):
     """Run backup on host, return the path to the backup directory"""
     result = host.run_command(['ipa-backup', '-v'])
 
+    # Test for ticket 7632: check that services are restarted
+    # before the backup is compressed
+    pattern = r'.*gzip.*Starting IPA service.*'
+    if (re.match(pattern, result.stderr_text, re.DOTALL)):
+        raise AssertionError('IPA Services are started after compression')
+
     # Get the backup location from the command's output
     for line in result.stderr_text.splitlines():
         prefix = 'ipaserver.install.ipa_backup: INFO: Backed up to '


### PR DESCRIPTION
Manual PR because PR #2492 was pushed to master and backport to ipa-4-6 is required.