### PR TITLE
 Keep Dogtag's client db in external CA step 1

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -480,7 +480,12 @@ class CAInstance(DogtagInstance):
         try:
             self.start_creation(runtime=runtime)
         finally:
-            self.clean_pkispawn_files()
+            if self.external == 1:
+                # Don't remove client DB in external CA step 1
+                # https://pagure.io/freeipa/issue/7742
+                logger.debug("Keep pkispawn files for step 2")
+            else:
+                self.clean_pkispawn_files()
 
     def __spawn_instance(self):
         """

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -167,11 +167,13 @@ class DogtagInstance(service.Service):
 
     def clean_pkispawn_files(self):
         if self.tmp_agent_db is not None:
+            logger.debug("Removing %s", self.tmp_agent_db)
             shutil.rmtree(self.tmp_agent_db, ignore_errors=True)
 
-        shutil.rmtree('/root/.dogtag/pki-tomcat/{subsystem}/'
-                      .format(subsystem=self.subsystem.lower()),
-                      ignore_errors=True)
+        client_dir = os.path.join(
+            '/root/.dogtag/pki-tomcat/', self.subsystem.lower())
+        logger.debug("Removing %s", client_dir)
+        shutil.rmtree(client_dir, ignore_errors=True)
 
     def restart_instance(self):
         self.restart('pki-tomcat')

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -292,7 +292,7 @@ def set_default_ttl_for_ipa_dns_zone(host, raiseonerr=True):
 
 def install_master(host, setup_dns=True, setup_kra=False, setup_adtrust=False,
                    extra_args=(), domain_level=None, unattended=True,
-                   stdin_text=None, raiseonerr=True):
+                   external_ca=False, stdin_text=None, raiseonerr=True):
     if domain_level is None:
         domain_level = host.config.domain_level
     check_domain_level(domain_level)
@@ -321,11 +321,14 @@ def install_master(host, setup_dns=True, setup_kra=False, setup_adtrust=False,
         args.append('--setup-kra')
     if setup_adtrust:
         args.append('--setup-adtrust')
+    if external_ca:
+        args.append('--external-ca')
 
     args.extend(extra_args)
     result = host.run_command(args, raiseonerr=raiseonerr,
                               stdin_text=stdin_text)
-    if result.returncode == 0:
+    if result.returncode == 0 and not external_ca:
+        # external CA step 1 doesn't have DS and KDC fully configured, yet
         enable_replication_debugging(host)
         setup_sssd_debugging(host)
         kinit_admin(host)

--- a/ipatests/test_integration/test_external_ca.py
+++ b/ipatests/test_integration/test_external_ca.py
@@ -70,24 +70,12 @@ def match_in_journal(host, string, since='today', services=('certmonger',)):
 
 
 def install_server_external_ca_step1(host):
-    """funtion for step 1 to install the ipa server with external ca"""
-
-    args = ['ipa-server-install', '-U',
-            '-a', host.config.admin_password,
-            '-p', host.config.dirman_password,
-            '--setup-dns', '--no-forwarders',
-            '-n', host.domain.name,
-            '-r', host.domain.realm,
-            '--domain-level=%i' % host.config.domain_level,
-            '--external-ca']
-
-    cmd = host.run_command(args)
-    return cmd
+    """Step 1 to install the ipa server with external ca"""
+    return tasks.install_master(host, external_ca=True)
 
 
 def install_server_external_ca_step2(host, ipa_ca_cert, root_ca_cert):
-    """funtion for step 2 to install the ipa server with external ca"""
-
+    """Step 2 to install the ipa server with external ca"""
     args = ['ipa-server-install',
             '-a', host.config.admin_password,
             '-p', host.config.dirman_password,


### PR DESCRIPTION
* Keep Dogtag's client db in external CA step 1
* Use tasks.install_master() in external_ca tests

Fixes: https://pagure.io/freeipa/issue/7742