### PR TITLE
Check omitted tests

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -639,3 +639,27 @@ jobs:
         template: *ci-master-f28
         timeout: 19600
         topology: *ipaserver
+
+  fedora-28/customized_ds_config_install:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_customized_ds_config_install.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/dns_locations:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_dns_locations.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_2repl_1client

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -627,3 +627,27 @@ jobs:
         template: *ci-master-frawhide
         timeout: 7200
         topology: *ipaserver
+
+  fedora-rawhide/customized_ds_config_install:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_customized_ds_config_install.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/dns_locations:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_dns_locations.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_2repl_1client

--- a/ipatests/test_integration/test_customized_ds_config_install.py
+++ b/ipatests/test_integration/test_customized_ds_config_install.py
@@ -47,26 +47,8 @@ nsslapd-dbcachesize: 10000001
 CONFIG_LDIF_PATH = "/root/dirsrv-config-mod.ldif"
 
 
-class TestCustomInstallMaster(IntegrationTest):
-    """
-    Install master with customized DS config
-    """
-    topology = 'star'
-
-    @classmethod
-    def install(cls, mh):
-        # just prepare LDIF file on both master and replica
-        cls.master.put_file_contents(CONFIG_LDIF_PATH, DIRSRV_CONFIG_MODS)
-
-    def test_customized_ds_install_master(self):
-        tasks.install_master(self.master, setup_dns=False, extra_args=[
-            '--dirsrv-config-file', CONFIG_LDIF_PATH
-        ])
-
-
-class TestCustomInstallReplica(IntegrationTest):
-    """
-    Install replica with customized DS config
+class TestCustomDSConfigInstall(IntegrationTest):
+    """Install master and replica with custom DS config
     """
     topology = 'star'
     num_replicas = 1
@@ -74,8 +56,14 @@ class TestCustomInstallReplica(IntegrationTest):
     @classmethod
     def install(cls, mh):
         # just prepare LDIF file on both master and replica
-        cls.replicas[0].put_file_contents(CONFIG_LDIF_PATH, DIRSRV_CONFIG_MODS)
-        tasks.install_master(cls.master)
+        cls.master.put_file_contents(CONFIG_LDIF_PATH, DIRSRV_CONFIG_MODS)
+        cls.replicas[0].put_file_contents(CONFIG_LDIF_PATH,
+                                          DIRSRV_CONFIG_MODS)
+
+    def test_customized_ds_install_master(self):
+        tasks.install_master(self.master, setup_dns=False, extra_args=[
+            '--dirsrv-config-file', CONFIG_LDIF_PATH
+        ])
 
     def test_customized_ds_install_replica(self):
         tasks.install_replica(


### PR DESCRIPTION
## Add missing tests to nighly runs
    
Run test_customized_ds_config_install and test_dns_locations in nightly
runs.

## Speed up test_customized_ds_config_install
    
Reuse master instance when installing replica with custom DS config.
This avoids one extra ipa-server-install and also tests replica
installation from a master with custom DS config.


See: https://pagure.io/freeipa/issue/7743
Signed-off-by: Christian Heimes <cheimes@redhat.com>