### PR TITLE
Fixes for more issues found by coverity

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -2586,6 +2586,12 @@ krb5_error_code ipadb_mspac_get_trusted_domains(struct ipadb_context *ipactx)
         }
 
         /* We should have a single AVA in the domain RDN */
+        if (rdn == NULL) {
+            ldap_dnfree(dn);
+            ret = EINVAL;
+            goto done;
+        }
+
         t[n].parent_name = strndup(rdn[0]->la_value.bv_val, rdn[0]->la_value.bv_len);
 
         ldap_dnfree(dn);

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -176,7 +176,11 @@ static bool has_krbprincipalkey(Slapi_Entry *entry) {
 
             if (rc || (num_keys <= 0)) {
                 /* this one is not valid, ignore it */
-                if (keys) ipa_krb5_free_key_data(keys, num_keys);
+                if (keys) {
+                    ipa_krb5_free_key_data(keys, num_keys);
+                    keys = NULL;
+                    num_keys = 0;
+                }
             } else {
                 /* It exists at least this one that is valid, no need to continue */
                 if (keys) ipa_krb5_free_key_data(keys, num_keys);

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -766,7 +766,7 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
     /* Check this is a clear text password, or refuse operation (only if we need
      * to comput other hashes */
     if (! unhashedpw && (gen_krb_keys || is_smb || is_ipant)) {
-        if ('{' == userpw[0]) {
+        if ((userpw != NULL) && ('{' == userpw[0])) {
             if (0 == strncasecmp(userpw, "{CLEAR}", strlen("{CLEAR}"))) {
                 unhashedpw = slapi_ch_strdup(&userpw[strlen("{CLEAR}")]);
                 if (NULL == unhashedpw) {


### PR DESCRIPTION
* has_krbprincipalkey: avoid double free
* ipadb_mspac_get_trusted_domains: NULL ptr deref 
* ipapwd_pre_mod: NULL ptr deref 

See https://pagure.io/freeipa/issue/7738