### PR TITLE
[Backport][ipa-4-7] Display succesful install message when ipa-replica-install completes

### DIFF
--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -213,8 +213,8 @@ class CustodiaInstance(SimpleServiceInstance):
     def _wait_keys(self):
         timeout = api.env.replication_wait_timeout
         deadline = int(time.time()) + timeout
-        logger.info("Waiting up to %s seconds to see our keys "
-                    "appear on host %s", timeout, self.ldap_uri)
+        logger.debug("Waiting up to %s seconds to see our keys "
+                     "appear on host %s", timeout, self.ldap_uri)
 
         konn = KEMLdap(self.ldap_uri)
         saved_e = None

--- a/ipaserver/install/ipa_replica_install.py
+++ b/ipaserver/install/ipa_replica_install.py
@@ -81,7 +81,9 @@ ReplicaInstall = cli.install_tool(
     CompatServerReplicaInstall,
     command_name='ipa-replica-install',
     log_file_name=paths.IPAREPLICA_INSTALL_LOG,
+    console_format='%(message)s',
     debug_option=True,
+    verbose=True,
 )
 
 

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -181,7 +181,7 @@ def install_dns_records(config, options, remote_api, fstore=None):
             reverse_zone = bindinstance.find_reverse_zone(ip, remote_api)
 
             bind.add_master_dns_records(config.host_name,
-                                        str(ip),
+                                        [str(ip)],
                                         config.realm_name,
                                         config.domain_name,
                                         reverse_zone)


### PR DESCRIPTION
This PR was opened automatically because PR #2503 was pushed to master and backport to ipa-4-7 is required.