### PR TITLE
compatablity with http2.4

### DIFF
--- a/install/share/ipa-kdc-proxy.conf.template
+++ b/install/share/ipa-kdc-proxy.conf.template
@@ -1,3 +1,6 @@
+#
+# VERSION 2 - DO NOT REMOVE THIS LINE
+#
 # Kerberos over HTTP / MS-KKDCP support (Kerberos KDC Proxy)
 #
 # The symlink from /etc/ipa/kdcproxy/ to /etc/httpd/conf.d/ is maintained
@@ -23,8 +26,7 @@ WSGIScriptReloading Off
 
 <Location "/KdcProxy">
   Satisfy Any
-  Order Deny,Allow
-  Allow from all
+  Require all granted
   WSGIProcessGroup kdcproxy
   WSGIApplicationGroup kdcproxy
 </Location>

--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 29 - DO NOT REMOVE THIS LINE
+# VERSION 30 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -108,8 +108,7 @@ Alias /ipa/session/cookie "/usr/share/ipa/gssapi.login"
 # Turn off Apache authentication for password/token based login pages
 <Location "/ipa/session/login_password">
   Satisfy Any
-  Order Deny,Allow
-  Allow from all
+  Require all granted
 </Location>
 
 # Login with user certificate/smartcard configuration
@@ -138,14 +137,12 @@ Alias /ipa/session/cookie "/usr/share/ipa/gssapi.login"
 
 <Location "/ipa/session/change_password">
   Satisfy Any
-  Order Deny,Allow
-  Allow from all
+  Require all granted
 </Location>
 
 <Location "/ipa/session/sync_token">
   Satisfy Any
-  Order Deny,Allow
-  Allow from all
+  Require all granted
 </Location>
 
 # Custodia stuff is redirected to the custodia daemon

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1774,7 +1774,8 @@ def upgrade_configuration():
         GSSAPI_SESSION_KEY=paths.GSSAPI_SESSION_KEY,
         FONTS_DIR=paths.FONTS_DIR,
         IPA_CCACHES=paths.IPA_CCACHES,
-        IPA_CUSTODIA_SOCKET=paths.IPA_CUSTODIA_SOCKET
+        IPA_CUSTODIA_SOCKET=paths.IPA_CUSTODIA_SOCKET,
+        KDCPROXY_CONFIG=paths.KDCPROXY_CONFIG,
     )
 
     subject_base = find_subject_base()
@@ -1814,6 +1815,9 @@ def upgrade_configuration():
         upgrade_file(sub_dict, paths.HTTPD_IPA_REWRITE_CONF,
                      os.path.join(paths.USR_SHARE_IPA_DIR,
                                   "ipa-rewrite.conf.template"))
+        upgrade_file(sub_dict, paths.HTTPD_IPA_KDCPROXY_CONF,
+                     os.path.join(paths.USR_SHARE_IPA_DIR,
+                                  "ipa-kdc-proxy.conf.template"))
         if ca.is_configured():
             upgrade_file(
                 sub_dict,


### PR DESCRIPTION
IPA server running httpd-2.4 and using the following old directives (Order, Allow or Deny) which have been deprecated

Changes commited "Require all granted"