### PR TITLE
rpc: always read response

### DIFF
--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -710,8 +710,15 @@ class KerbTransport(SSLTransport):
                     response = h.getresponse()
 
                 if response.status != 200:
-                    if (response.getheader("content-length", 0)):
-                        response.read()
+                    # Must read response (even if it is empty)
+                    # before sending another request.
+                    #
+                    # https://docs.python.org/3/library/http.client.html
+                    #   #http.client.HTTPConnection.getresponse
+                    #
+                    # https://pagure.io/freeipa/issue/7752
+                    #
+                    response.read()
 
                     if response.status == 401:
                         if not self._auth_complete(response):


### PR DESCRIPTION
If the server responds 401 and the response body is empty, the
client raises ResponseNotReady.  This occurs because:

1. For a non-200 response, the response read only if the
   Content-Length header occurs.

2. The response must be read before another request (e.g. the
   follow-up request with WWW-Authenticate header set), and this
   condition was not met.  For details see
   https://github.com/python/cpython/blob/v3.6.7/Lib/http/client.py#L1305-L1321.

This situation should not arise in regular use, because the client
either has a session cookie, or, knowing the details of the server
it is contacting, it establishes the GSS-API context and includes
the WWW-Authenticate header in the initial request.

Nevertheless, this problem has been observed in the wild.  I do not
know its ordinary cause(s), but one can force the issue by removing
an authenticated user's session cache from /run/ipa/ccaches, then
performing a request.

Resolve the issue by always reading the response.  It is safe to
call response.read() regardless of whether the Content-Length header
appears, or whether the body is empty.

Fixes: https://pagure.io/freeipa/issue/7752