### PR TITLE
[Backport][ipa-4-7]  Restore KRA clone installation integration test

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -98,9 +98,9 @@
 
 %endif  # Fedora
 
-# Require Dogtag PKI 10.6.6 to detect when fips is available,
-# https://pagure.io/freeipa/issue/7608
-%global pki_version 10.6.6
+# Require Dogtag PKI 10.6.7 which fixes UpdateNumberRange clone
+# installation issue; https://pagure.io/freeipa/issue/7654
+%global pki_version 10.6.7
 
 # NSS release with fix for CKA_LABEL import bug in shared SQL database.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1568271

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -98,9 +98,10 @@
 
 %endif  # Fedora
 
-# Require Dogtag PKI 10.6.7 which fixes UpdateNumberRange clone
+# Require Dogtag PKI 10.6.7-3 which fixes UpdateNumberRange clone
 # installation issue; https://pagure.io/freeipa/issue/7654
-%global pki_version 10.6.7
+# and https://pagure.io/dogtagpki/issue/3073
+%global pki_version 10.6.7-3
 
 # NSS release with fix for CKA_LABEL import bug in shared SQL database.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1568271

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -122,7 +122,6 @@ class InstallTestBase2(IntegrationTest):
     def test_replica2_ipa_ca_install(self):
         tasks.install_ca(self.replicas[2])
 
-    @pytest.mark.xfail(reason='Ticket 7654', strict=True)
     def test_replica2_ipa_kra_install(self):
         tasks.install_kra(self.replicas[2])
 


### PR DESCRIPTION
Manual backport of PR #2436

* Restore KRA clone installation integration test
* Require Dogtag 10.6.7-3

Travis CI on 4.7 is failing with Dogtag 10.6.6.