### PR TITLE
Fix test_cli_fsencoding on Python 3.7

### DIFF
--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -340,8 +340,14 @@ def test_cli_fsencoding():
         env=env,
     )
     out, err = p.communicate()
-    assert p.returncode > 0, (out, err)
-    assert b'System encoding must be UTF-8' in err, (out, err)
+
+    if sys.version_info >= (3, 7):
+        # Python 3.7+ has PEP 538: Legacy C Locale Coercion
+        assert p.returncode == 0, (out, err)
+    else:
+        # Python 3.6 does not support UTF-8 fs encoding with non-UTF LC
+        assert p.returncode != 0, (out, err)
+        assert b'System encoding must be UTF-8' in err, (out, err)
 
 
 IPA_NOT_CONFIGURED = b'IPA is not configured on this system'


### PR DESCRIPTION
Starting with Python 3.7, PEP 538 addresses the locale issue. Python now
supports UTF-8 file system encoding with non-UTF-8 C locale.

See: https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep538
See: https://pagure.io/freeipa/issue/5887
Signed-off-by: Christian Heimes <cheimes@redhat.com>