### PR TITLE
Increase memory size for ipaserver topology (nightly-master.yaml)

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -13,8 +13,8 @@ topologies:
     memory: 6700
   ipaserver: &ipaserver
     name: ipaserver
-    cpu: 1
-    memory: 2400
+    cpu: 2
+    memory: 4800
   master_2repl_1client: &master_2repl_1client
     name: master_2repl_1client
     cpu: 5

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -13,8 +13,8 @@ topologies:
     memory: 6700
   ipaserver: &ipaserver
     name: ipaserver
-    cpu: 1
-    memory: 2400
+    cpu: 2
+    memory: 4800
   master_2repl_1client: &master_2repl_1client
     name: master_2repl_1client
     cpu: 5


### PR DESCRIPTION
Trying to fix "Cannot allocate memory" error for Web UI tests