### PR TITLE
[Backport][ipa-4-6] Allow ipaapi user to access SSSD's info pipe

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -33,6 +33,7 @@ from six.moves.urllib.parse import urlparse, urlunparse
 # pylint: enable=import-error
 
 from ipalib import api, errors, x509
+from ipalib.constants import IPAAPI_USER
 from ipalib.install import certmonger, certstore, service, sysrestore
 from ipalib.install import hostname as hostname_
 from ipalib.install.kinit import kinit_keytab, kinit_password
@@ -866,7 +867,7 @@ def configure_sssd_conf(
         domain = sssdconfig.new_domain(cli_domain)
 
     if options.on_master:
-        sssd_enable_service(sssdconfig, 'ifp')
+        sssd_enable_ifp(sssdconfig)
 
     if (
         (options.conf_ssh and os.path.isfile(paths.SSH_CONFIG)) or
@@ -970,21 +971,47 @@ def configure_sssd_conf(
     return 0
 
 
-def sssd_enable_service(sssdconfig, service):
+def sssd_enable_service(sssdconfig, name):
     try:
-        sssdconfig.new_service(service)
+        sssdconfig.new_service(name)
     except SSSDConfig.ServiceAlreadyExists:
         pass
     except SSSDConfig.ServiceNotRecognizedError:
         logger.error(
-            "Unable to activate the %s service in SSSD config.", service)
+            "Unable to activate the '%s' service in SSSD config.", name)
         logger.info(
             "Please make sure you have SSSD built with %s support "
-            "installed.", service)
+            "installed.", name)
         logger.info(
-            "Configure %s support manually in /etc/sssd/sssd.conf.", service)
+            "Configure %s support manually in /etc/sssd/sssd.conf.", name)
+        return None
 
-    sssdconfig.activate_service(service)
+    sssdconfig.activate_service(name)
+    return sssdconfig.get_service(name)
+
+
+def sssd_enable_ifp(sssdconfig):
+    """Enable and configure libsss_simpleifp plugin
+    """
+    service = sssd_enable_service(sssdconfig, 'ifp')
+    if service is None:
+        # unrecognized service
+        return
+
+    try:
+        uids = service.get_option('allowed_uids')
+    except SSSDConfig.NoOptionError:
+        uids = set()
+    else:
+        uids = {s.strip() for s in uids.split(',') if s.strip()}
+    # SSSD supports numeric and string UIDs
+    # ensure that root is allowed to access IFP, might be 0 or root
+    if uids.isdisjoint({'0', 'root'}):
+        uids.add('root')
+    # allow IPA API to access IFP
+    uids.add(IPAAPI_USER)
+    service.set_option('allowed_uids', ', '.join(sorted(uids)))
+    sssdconfig.save_service(service)
 
 
 def change_ssh_config(filename, changes, sections):

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -20,6 +20,8 @@ import pytest
 from cryptography.hazmat.backends import default_backend
 from cryptography import x509
 
+from ipalib.constants import IPAAPI_USER
+
 from ipaplatform.paths import paths
 
 from ipatests.test_integration.base import IntegrationTest
@@ -27,6 +29,7 @@ from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.create_external_ca import ExternalCA
 
 logger = logging.getLogger(__name__)
+
 
 class TestIPACommand(IntegrationTest):
     """
@@ -401,3 +404,31 @@ class TestIPACommand(IntegrationTest):
             x509.load_pem_x509_certificate(data, backend=default_backend())
 
             self.master.run_command(['rm', '-f', filename])
+
+    def test_sssd_ifp_access_ipaapi(self):
+        # check that ipaapi is allowed to access sssd-ifp for smartcard auth
+        # https://pagure.io/freeipa/issue/7751
+        username = 'admin'
+        # get UID for user
+        result = self.master.run_command(['ipa', 'user-show', username])
+        mo = re.search(r'UID: (\d+)', result.stdout_text)
+        assert mo is not None, result.stdout_text
+        uid = mo.group(1)
+
+        cmd = [
+            'dbus-send',
+            '--print-reply', '--system',
+            '--dest=org.freedesktop.sssd.infopipe',
+            '/org/freedesktop/sssd/infopipe/Users',
+            'org.freedesktop.sssd.infopipe.Users.FindByName',
+            'string:{}'.format(username)
+        ]
+        # test IFP as root
+        result = self.master.run_command(cmd)
+        assert uid in result.stdout_text
+
+        # test IFP as ipaapi
+        result = self.master.run_command(
+            ['sudo', '-u', IPAAPI_USER, '--'] + cmd
+        )
+        assert uid in result.stdout_text


### PR DESCRIPTION
Manual backport of PR #2515 

For smart card authentication, ipaapi must be able to access to sss-ifp.
During installation and upgrade, the ipaapi user is now added to
[ifp]allowed_uids.

The commit also fixes two related issues:

* The server upgrade code now enables ifp service in sssd.conf. The
  existing code modified sssd.conf but never wrote the changes to disk.
* sssd_enable_service() no longer fails after it has detected an
  unrecognized service.

Fixes: https://pagure.io/freeipa/issue/7751
Signed-off-by: Christian Heimes <cheimes@redhat.com>