### PR TITLE
Copy-paste error in permssions plugin, CID 323649

### DIFF
--- a/ipaserver/plugins/permission.py
+++ b/ipaserver/plugins/permission.py
@@ -486,7 +486,7 @@ class permission(baseldap.LDAPObject):
 
             if old_client:
                 for old_name, new_name in _DEPRECATED_OPTION_ALIASES.items():
-                    if new_name in entry:
+                    if new_name in rights:
                         rights[old_name] = rights[new_name]
                         del rights[new_name]
 

--- a/ipatests/test_xmlrpc/test_old_permission_plugin.py
+++ b/ipatests/test_xmlrpc/test_old_permission_plugin.py
@@ -73,8 +73,8 @@ permission3_attributelevelrights = {
                                      'ipapermbindruletype': u'rscwo',
                                      'ipapermdefaultattr': u'rscwo',
                                      'ipapermexcludedattr': u'rscwo',
-                                     'ipapermlocation': u'rscwo',
-                                     'ipapermright': u'rscwo',
+                                     'subtree': u'rscwo',  # old
+                                     'permissions': u'rscwo',  # old
                                      'ipapermtarget': u'rscwo',
                                      'ipapermtargetfilter': u'rscwo',
                                      'ipapermtargetto': u'rscwo',


### PR DESCRIPTION
Address a bug in the code block for attributeLevelRights for old clients.
The backward compatibility code for deprecated options was not triggered,
because the new name was checked against wrong dict.

Coverity Scan issue 323649, Copy-paste error

   The copied code will not have its intended effect.
   In postprocess_result: A copied piece of code is inconsistent with the
   original (CWE-398)

See: Fixes: https://pagure.io/freeipa/issue/7753
Signed-off-by: Christian Heimes <cheimes@redhat.com>