### PR TITLE
Nightly test definition: remove redundant and add missing tests

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -628,6 +628,18 @@ jobs:
         timeout: 7200
         topology: *master_1repl_1client
 
+  fedora-28/test_user_permissions:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_user_permissions.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl_1client
+
   fedora-28/test_webui:
     requires: [fedora-28/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -616,6 +616,18 @@ jobs:
         timeout: 7200
         topology: *master_1repl_1client
 
+  fedora-rawhide/test_user_permissions:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_user_permissions.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl_1client
+
   fedora-rawhide/test_webui:
     requires: [fedora-rawhide/build]
     priority: 50


### PR DESCRIPTION
## Nightly tests: remove tests already executed in gating
Remove tests from nightly_master and nightly_rawhide as they are already executed in gating:
- test_caless.py::TestServerReplicaCALessToCAFull
- test_replica_promotion.py::TestSubCAkeyReplication

## Nightly tests: add test_user_permissions.py
Run the above test in the nightly test suites
    
Related to https://pagure.io/freeipa/issue/7743


