### PR TITLE
[Backport][ipa-4-7] Replace messagebus with modern name dbus

### DIFF
--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 # should make them available through knownservices.<name> and take care of
 # re-mapping internally, if needed
 wellknownservices = ['certmonger', 'dirsrv', 'httpd', 'ipa', 'krb5kdc',
-                     'messagebus', 'nslcd', 'nscd', 'ntpd', 'portmap',
+                     'dbus', 'nslcd', 'nscd', 'ntpd', 'portmap',
                      'rpcbind', 'kadmin', 'sshd', 'autofs', 'rpcgssd',
                      'rpcidmapd', 'pki_tomcatd', 'chronyd', 'domainname',
                      'named', 'ods_enforcerd', 'ods_signerd', 'gssproxy']

--- a/ipaplatform/debian/services.py
+++ b/ipaplatform/debian/services.py
@@ -153,8 +153,6 @@ def debian_service_class_factory(name, api=None):
         return DebianNoService(name, api)
     if name == 'ipa':
         return redhat_services.RedHatIPAService(name, api)
-    if name == 'messagebus':
-        return DebianNoService(name, api)
     if name == 'ntpd':
         return DebianSysvService("ntp", api)
     return DebianService(name, api)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1049,7 +1049,7 @@ class CAInstance(DogtagInstance):
         # cause files to have a new owner.
         self.restore_state("user_exists")
 
-        services.knownservices.messagebus.start()
+        services.knownservices.dbus.start()
         cmonger = services.knownservices.certmonger
         cmonger.start()
 

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -266,7 +266,7 @@ class DogtagInstance(service.Service):
         """
         cmonger = services.knownservices.certmonger
         cmonger.enable()
-        services.knownservices.messagebus.start()
+        services.knownservices.dbus.start()
         cmonger.start()
 
         bus = dbus.SystemBus()
@@ -338,7 +338,7 @@ class DogtagInstance(service.Service):
             "for %s", self.subsystem)
 
         cmonger = services.knownservices.certmonger
-        services.knownservices.messagebus.start()
+        services.knownservices.dbus.start()
         cmonger.start()
 
         nicknames = list(self.tracking_reqs)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -361,11 +361,11 @@ def check_dns_resolution(host_name, dns_servers):
 
 
 def configure_certmonger():
-    messagebus = services.knownservices.messagebus
+    dbus = services.knownservices.dbus
     try:
-        messagebus.start()
+        dbus.start()
     except Exception as e:
-        raise ScriptError("Messagebus service unavailable: %s" % str(e),
+        raise ScriptError("dbus service unavailable: %s" % str(e),
                           rval=3)
 
     # Ensure that certmonger has been started at least once to generate the


### PR DESCRIPTION
This PR was opened automatically because PR #2531 was pushed to master and backport to ipa-4-7 is required.