### PR TITLE
Fedora 29: Fix pylint 2.1.1 violations 

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -215,7 +215,12 @@ BuildRequires:  python3-polib
 BuildRequires:  python3-pyasn1
 BuildRequires:  python3-pyasn1-modules
 BuildRequires:  python3-pycodestyle
+%if 0%{?fedora} >= 29
+# https://bugzilla.redhat.com/show_bug.cgi?id=1648299
+BuildRequires:  python3-pylint >= 2.1.1-2
+%else
 BuildRequires:  python3-pylint >= 1.7
+%endif
 BuildRequires:  python3-pytest-multihost
 BuildRequires:  python3-pytest-sourceorder
 BuildRequires:  python3-qrcode-core >= 5.0.0

--- a/install/share/wsgi.py
+++ b/install/share/wsgi.py
@@ -60,3 +60,4 @@ else:
         else:
             logger.error("IPA does not work with the threaded MPM, "
                          "use the pre-fork MPM")
+            raise RuntimeError('threaded MPM detected')

--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -77,7 +77,7 @@ def get_custodia_instance(config, mode):
     elif mode == CustodiaModes.FIRST_MASTER:
         custodia_peer = None
     else:
-        raise RuntimeError("Unknown custodia mode %s", mode)
+        raise RuntimeError("Unknown custodia mode %s" % mode)
 
     if custodia_peer is None:
         # use ldapi with local dirsrv instance

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -52,6 +52,7 @@ class build_py(setuptools_build_py):
                 os.unlink(outfile)
             except OSError:
                 pass
+            return None
         else:
             return setuptools_build_py.build_module(self, module,
                                                     module_file, package)

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1377,12 +1377,10 @@ def run_repeatedly(host, command, assert_zero_rc=True, test=None,
 
 
 def get_host_ip_with_hostmask(host):
-    """
-    Detects the IP of the host including the hostmask.
+    """Detects the IP of the host including the hostmask
 
     Returns None if the IP could not be detected.
     """
-
     ip = host.ip
     result = host.run_command(['ip', 'addr'])
     full_ip_regex = r'(?P<full_ip>%s/\d{1,2}) ' % re.escape(ip)
@@ -1390,6 +1388,8 @@ def get_host_ip_with_hostmask(host):
 
     if match:
         return match.group('full_ip')
+    else:
+        return None
 
 
 def ldappasswd_user_change(user, oldpw, newpw, master):

--- a/ipatests/test_cmdline/test_help.py
+++ b/ipatests/test_cmdline/test_help.py
@@ -66,6 +66,8 @@ class CLITestContext:
                 return False
             self.exception = exc_value
             return True
+        else:
+            return None
 
 
 def test_ipa_help():

--- a/ipatests/test_integration/test_topologies.py
+++ b/ipatests/test_integration/test_topologies.py
@@ -22,7 +22,7 @@ from ipatests.pytest_ipa.integration import tasks
 
 def test_topology_star():
     topo = tasks.get_topo('star')
-    assert topo == tasks.star_topo
+    assert topo is tasks.star_topo
     assert list(topo('M', [1, 2, 3, 4, 5])) == [
         ('M', 1),
         ('M', 2),
@@ -35,7 +35,7 @@ def test_topology_star():
 
 def test_topology_line():
     topo = tasks.get_topo('line')
-    assert topo == tasks.line_topo
+    assert topo is tasks.line_topo
     assert list(topo('M', [1, 2, 3, 4, 5])) == [
         ('M', 1),
         (1, 2),
@@ -48,7 +48,7 @@ def test_topology_line():
 
 def test_topology_tree():
     topo = tasks.get_topo('tree')
-    assert topo == tasks.tree_topo
+    assert topo is tasks.tree_topo
     assert list(topo('M', [1, 2, 3, 4, 5])) == [
         ('M', 1),
         ('M', 2),
@@ -73,7 +73,7 @@ def test_topology_tree():
 
 def test_topology_tree2():
     topo = tasks.get_topo('tree2')
-    assert topo == tasks.tree2_topo
+    assert topo is tasks.tree2_topo
     assert list(topo('M', [1, 2, 3, 4, 5])) == [
         ('M', 1),
         ('M', 2),
@@ -86,7 +86,7 @@ def test_topology_tree2():
 
 def test_topology_complete():
     topo = tasks.get_topo('complete')
-    assert topo == tasks.complete_topo
+    assert topo is tasks.complete_topo
     assert list(topo('M', [1, 2, 3])) == [
         ('M', 1),
         ('M', 2),
@@ -100,7 +100,7 @@ def test_topology_complete():
 
 def test_topology_two_connected():
     topo = tasks.get_topo('2-connected')
-    assert topo == tasks.two_connected_topo
+    assert topo is tasks.two_connected_topo
     assert list(topo('M', [1, 2, 3, 4, 5, 6, 7, 8])) == [
         ('M', 1),
         ('M', 2),
@@ -120,7 +120,7 @@ def test_topology_two_connected():
 
 def test_topology_double_circle_topo():
     topo = tasks.get_topo('double-circle')
-    assert topo == tasks.double_circle_topo
+    assert topo is tasks.double_circle_topo
     assert list(topo('M', list(range(1, 30)))) == [
         ('M', 1),
         (1, 6),

--- a/ipatests/test_integration/test_topology.py
+++ b/ipatests/test_integration/test_topology.py
@@ -25,6 +25,7 @@ def find_segment(master, replica):
     for segment in allsegments:
         if master.hostname in segment and replica.hostname in segment:
             return '-to-'.join(segment)
+    return None
 
 
 @pytest.mark.skipif(config.domain_level == 0, reason=reasoning)

--- a/ipatests/test_ipalib/test_frontend.py
+++ b/ipatests/test_ipalib/test_frontend.py
@@ -206,6 +206,8 @@ class test_Command(ClassChecker):
             def __call__(self, _, value):
                 if value != self.name:
                     return _('must equal %r') % self.name
+                else:
+                    return None
 
         default_from = parameters.DefaultFrom(
                 lambda arg: arg,

--- a/ipatests/test_ipalib/test_text.py
+++ b/ipatests/test_ipalib/test_text.py
@@ -214,6 +214,7 @@ class test_Gettext:
         inst3 = self.klass('Hello world', 'foo', 'bar')
         inst4 = self.klass('what up?', 'foo', 'baz')
 
+        # pylint: disable=comparison-with-itself
         assert (inst1 == inst1) is True
         assert (inst1 == inst2) is True
         assert (inst1 == inst3) is False
@@ -292,6 +293,7 @@ class test_NGettext:
         inst3 = self.klass(singular, '%(count)d thingies', 'foo', 'bar')
         inst4 = self.klass(singular, plural, 'foo', 'baz')
 
+        # pylint: disable=comparison-with-itself
         assert (inst1 == inst1) is True
         assert (inst1 == inst2) is True
         assert (inst1 == inst3) is False

--- a/ipatests/test_ipaplatform/test_tasks.py
+++ b/ipatests/test_ipaplatform/test_tasks.py
@@ -19,6 +19,7 @@ def test_ipa_version():
     if hasattr(v4, '_rpmvercmp'):
         assert v4._rpmvercmp_func is not None
 
+    # pylint: disable=comparison-with-itself
     assert v3 < v4
     assert v3 <= v4
     assert v3 <= v3

--- a/ipatests/test_ipapython/test_dn.py
+++ b/ipatests/test_ipapython/test_dn.py
@@ -913,6 +913,7 @@ class TestDN(unittest.TestCase):
 
         # Test "in" membership
         self.assertTrue(self.container_rdn1 in container_dn)
+        # pylint: disable=comparison-with-itself
         self.assertTrue(container_dn in container_dn)
         self.assertFalse(self.base_rdn1 in container_dn)
 

--- a/ipatests/test_ipapython/test_ipautil.py
+++ b/ipatests/test_ipapython/test_ipautil.py
@@ -182,7 +182,8 @@ class TestCIDict:
         assert ("Key1", "val1") in items_set
         assert ("key2", "val2") in items_set
         assert ("KEY3", "VAL3") in items_set
-
+        # pylint: disable=dict-iter-method
+        # pylint: disable=dict-keys-not-iterating, dict-values-not-iterating
         assert list(self.cidict.items()) == list(self.cidict.iteritems()) == list(zip(
             self.cidict.keys(), self.cidict.values()))
 
@@ -192,8 +193,9 @@ class TestCIDict:
 
     def test_iteritems(self):
         items = []
-        for (k,v) in self.cidict.iteritems():
-            items.append((k,v))
+        # pylint: disable=dict-iter-method
+        for k, v in self.cidict.iteritems():
+            items.append((k, v))
         assert_equal(3, len(items))
         items_set = set(items)
         assert ("Key1", "val1") in items_set
@@ -202,6 +204,7 @@ class TestCIDict:
 
     def test_iterkeys(self):
         keys = []
+        # pylint: disable=dict-iter-method
         for k in self.cidict.iterkeys():
             keys.append(k)
         assert_equal(3, len(keys))
@@ -212,6 +215,7 @@ class TestCIDict:
 
     def test_itervalues(self):
         values = []
+        # pylint: disable=dict-iter-method
         for k in self.cidict.itervalues():
             values.append(k)
         assert_equal(3, len(values))
@@ -227,7 +231,7 @@ class TestCIDict:
         assert "Key1" in keys_set
         assert "key2" in keys_set
         assert "KEY3" in keys_set
-
+        # pylint: disable=dict-iter-method
         assert list(self.cidict.keys()) == list(self.cidict.iterkeys())
 
     def test_values(self):
@@ -237,7 +241,7 @@ class TestCIDict:
         assert "val1" in values_set
         assert "val2" in values_set
         assert "VAL3" in values_set
-
+        # pylint: disable=dict-iter-method
         assert list(self.cidict.values()) == list(self.cidict.itervalues())
 
     def test_update(self):

--- a/ipatests/test_webui/test_selfservice.py
+++ b/ipatests/test_webui/test_selfservice.py
@@ -23,7 +23,7 @@ Selfservice tests
 
 from ipatests.test_webui.ui_driver import UI_driver
 from ipatests.test_webui.ui_driver import screenshot
-import ipatests.test_webui.data_selfservice as data_selfservice
+from ipatests.test_webui import data_selfservice
 import ipatests.test_webui.data_user as user
 import pytest
 

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -215,7 +215,7 @@ class UI_driver:
                 )
         else:
             try:
-                if browser == 'chrome' or browser == 'chromium':
+                if browser in {'chrome', 'chromium'}:
                     driver = webdriver.Chrome(chrome_options=options)
                 elif browser == 'ie':
                     driver = webdriver.Ie()

--- a/ipatests/test_xmlrpc/test_baseldap_plugin.py
+++ b/ipatests/test_xmlrpc/test_baseldap_plugin.py
@@ -187,13 +187,15 @@ def test_entry_to_dict():
     class FakeSchema:
         def get_obj(self, type, name):
             if type != ldap.schema.AttributeType:
-                return
+                return None
             if name == 'binaryattr':
                 return FakeAttributeType(name, '1.3.6.1.4.1.1466.115.121.1.40')
             elif name == 'textattr':
                 return FakeAttributeType(name, '1.3.6.1.4.1.1466.115.121.1.15')
             elif name == 'dnattr':
                 return FakeAttributeType(name, '1.3.6.1.4.1.1466.115.121.1.12')
+            else:
+                return None
 
     class FakeLDAPClient(ipaldap.LDAPClient):
         def __init__(self):

--- a/ipatests/test_xmlrpc/test_certmap_plugin.py
+++ b/ipatests/test_xmlrpc/test_certmap_plugin.py
@@ -272,9 +272,10 @@ class EWE:
             if self.expected and self.returned:
                 assert_deepequal(self.expected, self.value)
             elif self.expected:
-                assert False, "Value expected but not provided"
+                raise AssertionError("Value expected but not provided")
             elif self.returned:
-                assert False, "Value provided but not expected"
+                raise AssertionError("Value provided but not expected")
+            return None
 
 
 def permissions_idfn(perms):

--- a/ipatests/test_xmlrpc/test_certmap_plugin.py
+++ b/ipatests/test_xmlrpc/test_certmap_plugin.py
@@ -109,7 +109,7 @@ class TestCRUD(XMLRPC_test):
     @pytest.mark.parametrize('update', [
             dict(u) for l in range(1, len(certmaprule_update_params)+1)
             for u in itertools.combinations(
-                certmaprule_update_params.items(), l)
+                list(certmaprule_update_params.items()), l)
         ],
         ids=update_idfn,
     )
@@ -187,7 +187,7 @@ class TestAddRemoveCertmap(XMLRPC_test):
         'options', [
             dict(o) for l in range(len(certmapdata_create_params)+1)
             for o in itertools.combinations(
-                certmapdata_create_params.items(), l)
+                list(certmapdata_create_params.items()), l)
         ],
         ids=addcertmap_id,
     )
@@ -313,10 +313,10 @@ def bindtype_permission(request):
 
 @pytest.fixture(
     scope='class',
-    params=itertools.chain(*[
-            itertools.combinations(certmaprule_permissions.values(), l)
-            for l in range(len(certmaprule_permissions.values())+1)
-    ]),
+    params=itertools.chain(
+        *[itertools.combinations(list(certmaprule_permissions.values()), l)
+          for l in range(len(list(certmaprule_permissions.values())) + 1)]
+    ),
     ids=permissions_idfn,
 )
 def certmap_user_permissions(request, bindtype_permission):

--- a/ipatests/test_xmlrpc/test_dns_realmdomains_integration.py
+++ b/ipatests/test_xmlrpc/test_dns_realmdomains_integration.py
@@ -87,6 +87,8 @@ def assert_realmdomain_and_txt_record_not_present(response):
         api.Command['dnsrecord_show'](zone, u'_kerberos')
     except errors.NotFound:
         return True
+    else:
+        return False
 
 
 @pytest.mark.tier1

--- a/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
@@ -160,7 +160,7 @@ class StageUserTracker(KerberosAliasMixin, Tracker):
             elif key == u'ipasshpubkey':
                 self.attrs[u'sshpubkeyfp'] = [sshpubkeyfp]
                 self.attrs[key] = [self.kwargs[key]]
-            elif key == u'random' or key == u'userpassword':
+            elif key in {u'random', u'userpassword'}:
                 self.attrs[u'krbextradata'] = [Fuzzy(type=bytes)]
                 self.attrs[u'krbpasswordexpiration'] = [
                     fuzzy_dergeneralizedtime]

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -71,7 +71,8 @@ PYTEST_VERSION = tuple(int(v) for v in pytest.__version__.split('.'))
 def check_ipaclient_unittests(reason="Skip in ipaclient unittest mode"):
     """Call this in a package to skip the package in ipaclient-unittest mode
     """
-    if pytest.config.getoption('ipaclient_unittests', False):
+    config = pytest.config  # pylint: disable=no-member
+    if config.getoption('ipaclient_unittests', False):
         if PYTEST_VERSION[0] >= 3:
             # pytest 3+ does no longer allow pytest.skip() on module level
             # pylint: disable=unexpected-keyword-arg
@@ -84,7 +85,8 @@ def check_ipaclient_unittests(reason="Skip in ipaclient unittest mode"):
 def check_no_ipaapi(reason="Skip tests that needs an IPA API"):
     """Call this in a package to skip the package in no-ipaapi mode
     """
-    if pytest.config.getoption('skip_ipaapi', False):
+    config = pytest.config  # pylint: disable=no-member
+    if config.getoption('skip_ipaapi', False):
         if PYTEST_VERSION[0] >= 3:
             # pylint: disable=unexpected-keyword-arg
             raise pytest.skip.Exception(reason, allow_module_level=True)

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -504,6 +504,10 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.interactive = True
     api.env.ipalib = ''  # object
     api.env.kinit_lifetime = None
+    api.env.lite_pem = ''
+    api.env.lite_profiler = ''
+    api.env.lite_host = ''
+    api.env.lite_port = 0
     api.env.log = ''  # object
     api.env.logdir = ''  # object
     api.env.mode = ''

--- a/pylintrc
+++ b/pylintrc
@@ -100,6 +100,7 @@ disable=
     bad-option-value,  # required to support upgrade to pylint 2.0
     assignment-from-no-return,  # new in pylint 2.0
     keyword-arg-before-vararg,  # pylint 2.0, remove after dropping Python 2
+    consider-using-enumerate,  # pylint 2.1, clean up tests later
 
 [REPORTS]
 

--- a/tox.ini
+++ b/tox.ini
@@ -50,5 +50,6 @@ commands=
 
 [pycodestyle]
 # E402 module level import not at top of file
-ignore = E402
+# W504 line break after binary operator
+ignore = E402, W504
 


### PR DESCRIPTION
* Ignore W504 code style like in travis config
* Address pylint violations in lite-server
* Address inconsistent-return-statements
* Ignore consider-using-enumerate for now
* Address consider-using-in
* Fix comparison-with-callable
* Fix useless-import-alias
* Fix Module 'pytest' has no 'config' member
* Fix various dict related pylint warnings
* Fix raising-format-tuple
* Silence comparison-with-itself in tests
* Require pylint 2.1.1-2

See: https://pagure.io/freeipa/issue/7758
See: https://bugzilla.redhat.com/show_bug.cgi?id=1648299
