### PR TITLE
Add sysadm_r to default SELinux user map order

### DIFF
--- a/install/share/bootstrap-template.ldif
+++ b/install/share/bootstrap-template.ldif
@@ -411,7 +411,7 @@ ipaDefaultEmailDomain: $DOMAIN
 ipaMigrationEnabled: FALSE
 ipaConfigString: AllowNThash
 ipaConfigString: KDC:Disable Last Success
-ipaSELinuxUserMapOrder: guest_u:s0$$xguest_u:s0$$user_u:s0$$staff_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023
+ipaSELinuxUserMapOrder: guest_u:s0$$xguest_u:s0$$user_u:s0$$staff_u:s0-s0:c0.c1023$$sysadm_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023
 ipaSELinuxUserMapDefault: unconfined_u:s0-s0:c0.c1023
 
 dn: cn=cosTemplates,cn=accounts,$SUFFIX

--- a/install/ui/test/data/ipa_init.json
+++ b/install/ui/test/data/ipa_init.json
@@ -36,7 +36,7 @@
                   "ipausers"
                ],
                "ipaselinuxusermaporder" : [
-                  "guest_u:s0$xguest_u:s0$user_u:s0$staff_u:s0-s0:c0.c1023$unconfined_u:s0-s0:c0.c1023"
+                  "guest_u:s0$xguest_u:s0$user_u:s0$staff_u:s0-s0:c0.c1023$sysadm_u:s0-s0:c0.c1023$unconfined_u:s0-s0:c0.c1023"
                ],
                "ca_renewal_master_server" : [
                   "vm.example.com"

--- a/ipatests/test_xmlrpc/test_config_plugin.py
+++ b/ipatests/test_xmlrpc/test_config_plugin.py
@@ -148,8 +148,12 @@ class test_config(Declarative):
 
         dict(
             desc='Try to set new selinux order and invalid default user',
-            command=('config_mod', [],
-                dict(ipaselinuxusermaporder=u'xguest_u:s0$guest_u:s0$user_u:s0-s0:c0.c1023$staff_u:s0-s0:c0.c1023$unconfined_u:s0-s0:c0.c1023',
+            command=(
+                'config_mod', [],
+                dict(
+                    ipaselinuxusermaporder=u'xguest_u:s0$guest_u:s0'
+                    u'$user_u:s0-s0:c0.c1023$staff_u:s0-s0:c0.c1023'
+                    u'$sysadm_u:s0-s0:c0.c1023$unconfined_u:s0-s0:c0.c1023',
                     ipaselinuxusermapdefault=u'unknown_u:s0')),
             expected=errors.ValidationError(name='ipaselinuxusermapdefault',
                 error='SELinux user map default user not in order list'),


### PR DESCRIPTION
It is a standard SELinux user role included in RHEL (like
user_r, staff_r, guest_r) and used quite often.

See: https://pagure.io/freeipa/issue/7658

So far the upgrade process is not covered, only new install.
I suppose a file like ./install/updates/50-ipaconfig.update has to be created for upgrades to be covered.

Without the change to the ldif:
  SELinux user map order:
guest_u:s0$xguest_u:s0$user_u:s0$staff_u:s0-s0:c0.c1023$unconfined_u:s0-s0:c0.c1023
New install with the change to the ldif:
  SELinux user map order:
guest_u:s0$xguest_u:s0$user_u:s0$staff_u:s0-s0:c0.c1023$sysadm_u:s0-s0:c0.c1023$unconfined_u:s0-s0:c0.c1023
