### PR TITLE
ipatests: update tests for ipa-server-certinstall

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -242,3 +242,15 @@ jobs:
         template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
+
+  fedora-28/test_caless_TestCertInstall:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_caless.py::TestCertInstall
+        template: *ci-master-f28
+        timeout: 5400
+        topology: *master_1repl

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -1447,18 +1447,24 @@ class TestCertInstall(CALessBase):
 
         assert result.returncode > 0
 
+    @pytest.mark.xfail(reason='freeipa ticket 7759', strict=True)
     def test_http_intermediate_ca(self):
         "Install new HTTP certificate issued by intermediate CA"
 
         result = self.certinstall('w', 'ca1/subca/server')
-        assert result.returncode == 0, result.stderr_text
+        # As the intermediate CA is not trusted, command must fail
+        assert_error(result,
+                     "Peer's certificate issuer is not trusted")
 
-    @pytest.mark.xfail(reason='freeipa ticket 6959', strict=True)
     def test_ds_intermediate_ca(self):
         "Install new DS certificate issued by intermediate CA"
 
         result = self.certinstall('d', 'ca1/subca/server')
-        assert result.returncode == 0, result.stderr_text
+        # As the intermediate CA is not trusted, command must fail
+        assert_error(result,
+                     "Peer's certificate issuer is not trusted "
+                     "(certutil: certificate is invalid: Peer's Certificate "
+                     "issuer is not recognized.")
 
     def test_self_signed(self):
         "Install new self-signed certificate"


### PR DESCRIPTION
1. The test test_http_intermediate_ca was expecting success when it should expect a failure. Scenario:
- install IPA ca-less with certs signed by rootCA
- call ipa-server-certinstall with a cert signed by a subCA to replace http cert.
In this case, the command should refuse changing the cert (otherwise the clients won't be able any more to use ipa * commands as the subca is not installed in /etc/ipa/nssdb or in /etc/ipa/ca.crt).

The commit fixes the test expectation and marks the test as xfail (see ticket 7759).
    
2. The test test_ds_intermediate_ca was expecting success when it should expect a failure. Same scenario as above, but for the ldap server cert.

The commit fixes the test expectation and removes the xfail (ticket 6959 was closed as invalid).

Note:
The behavior differs for ldap and http cert because LDAP server is using a NSSDB and http server is using openssl, hence ipa-server-certinstall follows 2 different code paths when changing the server cert.
    
Related to https://pagure.io/freeipa/issue/7759
Related to https://pagure.io/freeipa/issue/6959
