### PR TITLE
certdb: ensure non-empty Subject Key Identifier

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -924,10 +924,13 @@ class NSSDatabase:
             raise ValueError("not a CA certificate")
 
         try:
-            cert.extensions.get_extension_for_class(
+            ski = cert.extensions.get_extension_for_class(
                     cryptography.x509.SubjectKeyIdentifier)
         except cryptography.x509.ExtensionNotFound:
             raise ValueError("missing subject key identifier extension")
+        else:
+            if len(ski.value.digest) == 0:
+                raise ValueError("subject key identifier must not be empty")
 
         try:
             self.run_certutil(['-V', '-n', nickname, '-u', 'L'],


### PR DESCRIPTION
Installation or IPA CA renewal with externally-signed CA accepts an
IPA CA certificate with empty Subject Key Identifier. This is
technically legal in X.509, but is an operational issue.
Furthermore, due to an extant bug in Dogtag
(https://pagure.io/dogtagpki/issue/3079) it will cause Dogtag
startup failure.

Reject CA certificates with empty Subject Key Identifier.

Fixes: https://pagure.io/freeipa/issue/7762