### PR TITLE
[Backport][ipa-4-7] certdb: ensure non-empty Subject Key Identifier

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -919,10 +919,13 @@ class NSSDatabase(object):
             raise ValueError("not a CA certificate")
 
         try:
-            cert.extensions.get_extension_for_class(
+            ski = cert.extensions.get_extension_for_class(
                     cryptography.x509.SubjectKeyIdentifier)
         except cryptography.x509.ExtensionNotFound:
             raise ValueError("missing subject key identifier extension")
+        else:
+            if len(ski.value.digest) == 0:
+                raise ValueError("subject key identifier must not be empty")
 
         try:
             self.run_certutil(['-V', '-n', nickname, '-u', 'L'],


### PR DESCRIPTION
This PR was opened automatically because PR #2548 was pushed to master and backport to ipa-4-7 is required.