### PR TITLE
ipatests: add missing tests in test_backup_and_restore.py

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -400,6 +400,42 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
+  fedora-28/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
+        template: *ci-master-f28
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-28/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
+        template: *ci-master-f28
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-28/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
+        template: *ci-master-f28
+        timeout: 7200
+        topology: *master_2repl_1client
+
   fedora-28/test_dnssec:
     requires: [fedora-28/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -304,14 +304,14 @@ jobs:
         timeout: 5400
         topology: *master_1repl
 
-  fedora-rawhide/test_backup_and_restore_TestUserrootFilesOwnership:
+  fedora-rawhide/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
     requires: [fedora-rawhide/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-rawhide/build_url}'
-        test_suite: test_integration/test_backup_and_restore.py::TestUserrootFilesOwnership
+        test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
         template: *ci-master-frawhide
         timeout: 7200
         topology: *master_1repl
@@ -399,6 +399,42 @@ jobs:
         template: *ci-master-frawhide
         timeout: 7200
         topology: *master_1repl
+
+  fedora-rawhide/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-rawhide/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-rawhide/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_2repl_1client
 
   fedora-rawhide/test_dnssec:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
3 tests were missing from this test file in the nightly tests:
- TestBackupAndRestoreWithReplica
- TestBackupAndRestoreDMPassword
- TestReplicaInstallAfterRestore

one test was having the wrong name in nightly_rawhide:
- TestUserRootFilesOwnershipPermission

Related to https://pagure.io/freeipa/issue/7743