### PR TITLE
ipatests: add missing tests for test_caless

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -280,6 +280,30 @@ jobs:
         timeout: 5400
         topology: *master_1repl
 
+  fedora-28/test_caless_TestReplicaCALessToCAFull:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
+        template: *ci-master-f28
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-28/test_caless_TestServerCALessToExternalCA:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
+        template: *ci-master-f28
+        timeout: 5400
+        topology: *master_1repl
+
   fedora-28/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
     requires: [fedora-28/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -280,6 +280,30 @@ jobs:
         timeout: 5400
         topology: *master_1repl
 
+  fedora-rawhide/test_caless_TestReplicaCALessToCAFull:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
+        template: *ci-master-frawhide
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-rawhide/test_caless_TestServerCALessToExternalCA:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
+        template: *ci-master-frawhide
+        timeout: 5400
+        topology: *master_1repl
+
   fedora-rawhide/test_backup_and_restore_TestUserrootFilesOwnership:
     requires: [fedora-rawhide/build]
     priority: 50


### PR DESCRIPTION
Two tests were missing from nightly definition:
- test_caless.py::TestReplicaCALessToCAFull
- test_caless.py::TestServerCALessToExternalCA
    
Related to https://pagure.io/freeipa/issue/7743
