### PR TITLE
Fix "ipa vault-retrieve --shared $vault" does not work if IPA host is not a KRA (issue 7691)

### DIFF
--- a/install/updates/20-aci.update
+++ b/install/updates/20-aci.update
@@ -36,6 +36,10 @@ remove:aci:(targetfilter="(objectclass=nsContainer)")(version 3.0; acl "Deny rea
 dn: cn=masters,cn=ipa,cn=etc,$SUFFIX
 add:aci:(targetfilter="(objectclass=nsContainer)")(targetattr="objectclass || cn")(version 3.0; acl "Read access to masters"; allow(read, search, compare) userdn = "ldap:///all";)
 
+# Allow users to discover enabled services
+dn: cn=masters,cn=ipa,cn=etc,$SUFFIX
+add:aci:(targetfilter = "(ipaConfigString=enabledService)")(targetattrs = "ipaConfigString")(version 3.0; acl "Find enabled services"; allow(read, search, compare) userdn = "ldap:///all";)
+
 # Allow hosts to read masters service configuration
 dn: cn=masters,cn=ipa,cn=etc,$SUFFIX
 add:aci:(targetfilter = "(objectclass=nsContainer)")(targetattr = "ipaConfigString")(version 3.0; acl "Allow hosts to read masters service configuration"; allow(read, search, compare) userdn = "ldap:///fqdn=*,cn=computers,cn=accounts,$SUFFIX";)

--- a/ipatests/test_integration/test_vault.py
+++ b/ipatests/test_integration/test_vault.py
@@ -20,13 +20,16 @@ class TestInstallKRA(IntegrationTest):
 
     vault_password = "password"
     vault_data = "SSBsb3ZlIENJIHRlc3RzCg=="
+    vault_user = "vault_user"
+    vault_user_password = "vault_user_password"
     vault_name_master = "ci_test_vault_master"
     vault_name_master2 = "ci_test_vault_master2"
     vault_name_master3 = "ci_test_vault_master3"
     vault_name_replica_without_KRA = "ci_test_vault_replica_without_kra"
+    shared_vault_name_replica_without_KRA = ("ci_test_shared"
+                                             "_vault_replica_without_kra")
     vault_name_replica_with_KRA = "ci_test_vault_replica_with_kra"
     vault_name_replica_KRA_uninstalled = "ci_test_vault_replica_KRA_uninstalled"
-
 
     @classmethod
     def install(cls, mh):
@@ -88,6 +91,66 @@ class TestInstallKRA(IntegrationTest):
         time.sleep(WAIT_AFTER_ARCHIVE)
 
         self._retrieve_secret([self.vault_name_replica_without_KRA])
+
+    def test_create_and_retrieve_shared_vault_replica_without_kra(self):
+        # create vault
+        self.replicas[0].run_command([
+            "ipa", "vault-add",
+            self.shared_vault_name_replica_without_KRA,
+            "--shared",
+            "--type", "standard",
+        ])
+
+        # archive secret
+        self.replicas[0].run_command([
+            "ipa", "vault-archive",
+            self.shared_vault_name_replica_without_KRA,
+            "--shared",
+            "--data", self.vault_data,
+        ])
+        time.sleep(WAIT_AFTER_ARCHIVE)
+
+        # add non-admin user
+        self.replicas[0].run_command([
+            'ipa', 'user-add', self.vault_user,
+            '--first', self.vault_user,
+            '--last', self.vault_user,
+            '--password'],
+            stdin_text=self.vault_user_password)
+
+        # add it to vault
+        self.replicas[0].run_command([
+            "ipa", "vault-add-member",
+            self.shared_vault_name_replica_without_KRA,
+            "--shared",
+            "--users", self.vault_user,
+        ])
+
+        self.replicas[0].run_command([
+            'kdestroy', '-A'])
+
+        user_kinit = "%s\n%s\n%s\n" % (self.vault_user_password,
+                                       self.vault_user_password,
+                                       self.vault_user_password)
+
+        self.replicas[0].run_command([
+            'kinit', self.vault_user],
+            stdin_text=user_kinit)
+
+        # TODO: possibly refactor with:
+        # self._retrieve_secret([self.vault_name_replica_without_KRA])
+
+        self.replicas[0].run_command([
+            "ipa", "vault-retrieve",
+            "--shared",
+            self.shared_vault_name_replica_without_KRA,
+            "--out=test.txt"])
+
+        self.replicas[0].run_command([
+            'kdestroy', '-A'])
+
+        tasks.kinit_admin(self.replicas[0])
+
 
     def test_create_and_retrieve_vault_replica_with_kra(self):
 


### PR DESCRIPTION
Standard users cannot determine services like KRA.
Using ldapsearch with (ipaConfigString=enabledService)
always fails.
Catch that.

Note that this is not the definitive fix for https://pagure.io/freeipa/issue/7691 (yet)
