### PR TITLE
certdb: validate certificate signatures

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -933,8 +933,15 @@ class NSSDatabase:
                 raise ValueError("subject key identifier must not be empty")
 
         try:
-            self.run_certutil(['-V', '-n', nickname, '-u', 'L'],
-                              capture_output=True)
+            self.run_certutil(
+                [
+                    '-V',       # check validity of cert and attrs
+                    '-n', nickname,
+                    '-u', 'L',  # usage; 'L' means "SSL CA"
+                    '-e',       # check signature(s); this checks
+                                # key sizes, sig algorithm, etc.
+                ],
+                capture_output=True)
         except ipautil.CalledProcessError as e:
             # certutil output in case of error is
             # 'certutil: certificate is invalid: <ERROR_STRING>\n'

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1043,6 +1043,7 @@ def load_external_cert(files, ca_subject):
             try:
                 nssdb.verify_ca_cert_validity(nickname)
             except ValueError as e:
+                cert, subject, issuer = cache[nickname]
                 raise ScriptError(
                     "CA certificate %s in %s is not valid: %s" %
                     (subject, ", ".join(files), e))


### PR DESCRIPTION
When verifying a CA certificate, validate its signature.  This causes
FreeIPA to reject certificate chains with bad signatures, signatures using
unacceptable algorithms, or certificates with unacceptable key sizes.  The
'-e' option to 'certutil -V' was the missing ingredient.

An an example of a problem prevented by this change, a certifiate signed by
a 1024-bit intermediate CA, would previously have been imported by
ipa-cacert-manage, but would cause Dogtag startup failure due to failing
self-test.  With this change, ipa-cacert-manage will reject the
certificate:

 \# ipa-cacert-manage renew --external-cert-file /tmp/ipa.p7
 Importing the renewed CA certificate, please wait
 CA certificate CN=Certificate Authority,O=IPA.LOCAL 201809261455
 in /tmp/ipa.p7 is not valid: certutil: certificate is invalid: The
 certificate was signed using a signature algorithm that is
 disabled because it is not secure.

Fixes: https://pagure.io/freeipa/issue/7761