### PR TITLE
certdb: validate server cert signature

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -896,8 +896,15 @@ class NSSDatabase:
         cert = self.get_cert(nickname)
 
         try:
-            self.run_certutil(['-V', '-n', nickname, '-u', 'V'],
-                              capture_output=True)
+            self.run_certutil(
+                [
+                    '-V',  # check validity of cert and attrs
+                    '-n', nickname,
+                    '-u', 'V',  # usage; 'V' means "SSL server"
+                    '-e',  # check signature(s); this checks
+                    # key sizes, sig algorithm, etc.
+                ],
+                capture_output=True)
         except ipautil.CalledProcessError as e:
             # certutil output in case of error is
             # 'certutil: certificate is invalid: <ERROR_STRING>\n'


### PR DESCRIPTION
PR https://github.com/freeipa/freeipa/pull/2554 added the '-e' option for CA
cert validation. Let's also verify signature, key size, and signing algorithm
of server certs. With the '-e' option, the installer and other
tools will catch weak certs early.

Fixes: pagure.io/freeipa/issue/7761
Signed-off-by: Christian Heimes <cheimes@redhat.com>