### PR TITLE
ipatests: add missing nightly tests for replica_promotion installation and external_ca

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -556,6 +556,18 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
+  fedora-28/test_replica_promotion_TestReplicaInstallCustodia:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
+        template: *ci-master-f28
+        timeout: 7200
+        topology: *master_2repl_1client
+
   fedora-28/test_upgrade:
     requires: [fedora-28/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -123,6 +123,30 @@ jobs:
         timeout: 10800
         topology: *master_3repl_1client
 
+  fedora-28/test_installation_TestInstallWithCA_DNS3:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_installation_TestInstallWithCA_DNS4:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-28/test_installation_TestInstallWithCA_KRA_DNS1:
     requires: [fedora-28/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -858,3 +858,39 @@ jobs:
         template: *ci-master-f28
         timeout: 3600
         topology: *master_2repl_1client
+
+  fedora-28/external_ca_TestExternalCAdirsrvStop:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/external_ca_TestExternalCAInvalidCert:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/external_ca_TestMultipleExternalCA:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -846,3 +846,39 @@ jobs:
         template: *ci-master-frawhide
         timeout: 3600
         topology: *master_2repl_1client
+
+  fedora-rawhide/external_ca_TestExternalCAdirsrvStop:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/external_ca_TestExternalCAInvalidCert:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/external_ca_TestMultipleExternalCA:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -556,6 +556,18 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
+  fedora-rawhide/test_replica_promotion_TestReplicaInstallCustodia:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_2repl_1client
+
   fedora-rawhide/test_upgrade:
     requires: [fedora-rawhide/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -123,6 +123,30 @@ jobs:
         timeout: 10800
         topology: *master_3repl_1client
 
+  fedora-rawhide/test_installation_TestInstallWithCA_DNS3:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/test_installation_TestInstallWithCA_DNS4:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-rawhide/test_installation_TestInstallWithCA_KRA_DNS1:
     requires: [fedora-rawhide/build]
     priority: 50


### PR DESCRIPTION
## ipatests: add missing tests for test_installation.py

Some tests were missing in the nightly:
- test_installation.py::TestInstallWithCA_DNS3
- test_installation.py::TestInstallWithCA_DNS4

## ipatests: add missing tests for test_replica_promotion.py
    
The following test was missing from nightly:
test_replica_promotion.py::TestReplicaInstallCustodia

## ipatests: add missing tests for test_external_ca.py

Some tests were missing from nightly definition:
- test_external_ca.py::TestExternalCAdirsrvStop
- test_external_ca.py::TestExternalCAInvalidCert
- test_external_ca.py::TestMultipleExternalCA

Related to https://pagure.io/freeipa/issue/7743