### PR TITLE
Fix nightly PR CI configuration for Web UI tests

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -719,7 +719,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_loginscreen.py
           test_webui/test_misc_cases.py
           test_webui/test_navigation.py
@@ -735,7 +735,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_host.py
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
@@ -751,7 +751,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
         template: *ci-master-f28
@@ -765,7 +765,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_automount.py
           test_webui/test_dns.py
           test_webui/test_vault.py
@@ -780,7 +780,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_hbac.py
           test_webui/test_krbtpolicy.py
           test_webui/test_pwpolicy.py
@@ -797,7 +797,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_delegation.py
           test_webui/test_rbac.py
           test_webui/test_selfservice.py
@@ -812,7 +812,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
@@ -828,7 +828,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_group.py
           test_webui/test_user.py
         template: *ci-master-f28

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -707,7 +707,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-rawhide/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_loginscreen.py
           test_webui/test_misc_cases.py
           test_webui/test_navigation.py
@@ -723,7 +723,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-rawhide/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_host.py
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
@@ -739,7 +739,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-rawhide/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
         template: *ci-master-frawhide
@@ -753,7 +753,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-rawhide/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_automount.py
           test_webui/test_dns.py
           test_webui/test_vault.py
@@ -768,7 +768,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-rawhide/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_hbac.py
           test_webui/test_krbtpolicy.py
           test_webui/test_pwpolicy.py
@@ -785,7 +785,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-rawhide/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_delegation.py
           test_webui/test_rbac.py
           test_webui/test_selfservice.py
@@ -800,7 +800,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-rawhide/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
@@ -816,7 +816,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-rawhide/build_url}'
-        test_suite: >
+        test_suite: >-
           test_webui/test_group.py
           test_webui/test_user.py
         template: *ci-master-frawhide


### PR DESCRIPTION
Add strip operator for test_suite definitions (in nightly_*.yaml) to prevent inserting line breaks.

https://pagure.io/freeipa/issue/7756