### PR TITLE
Fix pytest deprecation warning

### DIFF
--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -130,7 +130,7 @@ def pytest_cmdline_main(config):
 
 
 def pytest_runtest_setup(item):
-    if isinstance(item, item.Function):
+    if isinstance(item, pytest.Function):
         if item.get_marker('skip_ipaclient_unittest'):
             # pylint: disable=no-member
             if pytest.config.option.ipaclient_unittests:


### PR DESCRIPTION
conftest uses the Function attribute of a pytest.Function object. Latest
pytest has deprecated the attribute:

  _pytest.warning_types.RemovedInPytest4Warning: usage of Function.Function
   is deprecated, please use pytest.Function instead

Signed-off-by: Christian Heimes <cheimes@redhat.com>