### PR TITLE
[Backport][ipa-4-6] Fix pytest deprecation warning

### DIFF
--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -125,7 +125,7 @@ def pytest_cmdline_main(config):
 
 
 def pytest_runtest_setup(item):
-    if isinstance(item, item.Function):
+    if isinstance(item, pytest.Function):
         if item.get_marker('skip_ipaclient_unittest'):
             # pylint: disable=no-member
             if pytest.config.option.ipaclient_unittests:


### PR DESCRIPTION
This PR was opened automatically because PR #2569 was pushed to master and backport to ipa-4-6 is required.