### PR TITLE
[Backport][ipa-4-7] freeipa.spec.in: add BuildRequires for python3-lib389

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -282,6 +282,7 @@ BuildRequires:  python3-jinja2
 BuildRequires:  python3-jwcrypto >= 0.4.2
 BuildRequires:  python3-ldap >= %{python_ldap_version}
 BuildRequires:  python3-ldap >= %{python_ldap_version}
+BuildRequires:  python3-lib389 >= %{ds_version}
 BuildRequires:  python3-libipa_hbac
 BuildRequires:  python3-libsss_nss_idmap
 BuildRequires:  python3-lxml


### PR DESCRIPTION
This PR was opened automatically because PR #2565 was pushed to master and backport to ipa-4-7 is required.