### PR TITLE
ipa-kdb: reduce LDAP operations timeout to 30 seconds

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_common.c
+++ b/daemons/ipa-kdb/ipa_kdb_common.c
@@ -23,7 +23,7 @@
 #include "ipa_kdb.h"
 #include <unicase.h>
 
-static struct timeval std_timeout = {300, 0};
+static struct timeval std_timeout = {30, 0};
 
 char *ipadb_filter_escape(const char *input, bool star)
 {


### PR DESCRIPTION
Since LDAP operations used by ipa-kdb driver are synchronous, the
timeout specified here is blocking entire KDC. It is worth reducing the
timeout and since AS REQ processing timeout in KDC is 1 minute, reducing
the timeout for LDAP operations down to 30 seconds allows KDC to
respond promptly in worst case scenario as well.

Fixes: https://pagure.io/freeipa/issue/7217