### PR TITLE
[Backport][ipa-4-6] ipa-kdb: reduce LDAP operations timeout to 30 seconds

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_common.c
+++ b/daemons/ipa-kdb/ipa_kdb_common.c
@@ -23,7 +23,7 @@
 #include "ipa_kdb.h"
 #include <unicase.h>
 
-static struct timeval std_timeout = {300, 0};
+static struct timeval std_timeout = {30, 0};
 
 char *ipadb_filter_escape(const char *input, bool star)
 {


### PR DESCRIPTION
This PR was opened automatically because PR #2575 was pushed to master and backport to ipa-4-6 is required.