### PR TITLE
Issue #7744: Use api.env.server for config.ca_host_name

### DIFF
--- a/install/tools/ipa-ca-install.in
+++ b/install/tools/ipa-ca-install.in
@@ -165,7 +165,7 @@ def install_replica(safe_options, options):
     api.Backend.ldap2.connect()
 
     config = ReplicaConfig()
-    config.ca_host_name = None
+    config.ca_host_name = api.env.server
     config.realm_name = api.env.realm
     config.host_name = api.env.host
     config.domain_name = api.env.domain


### PR DESCRIPTION
Bug: https://pagure.io/freeipa/issue/7744

This is a really quick attempt to fix this bug. Currently, the CA server is always chosen from LDAP. As a result, when installing the CA but, passing in `--server`, the replica install will use the server passed in but the CA install can replicate from another. This leads to lots of confusion when reviewing the replication topology and can lead to replicating the entire CA domain from a high latency link. 

This really bites us in production where new replicas will replicate initially from a server on the other side of the world and that link has high latency causing failures midway through the install. 

I think this change will work and am happy to test it out. I'd love to see this back ported to 4.5.4 but, understand if that's not possible. 