### PR TITLE
ipa-pwd-extop: don't check password policy for non-Kerberos account set by DM or a passsync manager

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
@@ -286,8 +286,8 @@ free_and_error:
  * slapi_pblock_destroy(pb)
  */
 static int pwd_get_values(const Slapi_Entry *ent, const char *attrname,
-			  Slapi_ValueSet** results, char** actual_type_name,
-			  int *buffer_flags)
+                          Slapi_ValueSet** results, char** actual_type_name,
+                          int *buffer_flags)
 {
     int flags=0;
     int type_name_disposition = 0;
@@ -443,6 +443,23 @@ int ipapwd_entry_checks(Slapi_PBlock *pb, struct slapi_entry *e,
     *is_krb = slapi_entry_attr_has_syntax_value(e, SLAPI_ATTR_OBJECTCLASS, sval);
     slapi_value_free(&sval);
 
+    /* If entry has krbPrincipalAux object class but lacks krbPrincipalName and
+     * memberOf attributes consider this not a Kerberos principal object. In
+     * FreeIPA krbPrincipalAux allows to store krbPwdPolicyReference attribute
+     * which is added by a CoS plugin configuration based on a memberOf
+     * attribute value.
+     * Note that slapi_entry_attr_find() returns 0 if attr exists, -1 for absence
+     */
+    if (*is_krb) {
+        Slapi_Attr *attr_prname = NULL;
+        Slapi_Attr *attr_memberof = NULL;
+        int has_prname = slapi_entry_attr_find(e, "krbPrincipalName", &attr_prname);
+        int has_memberOf = slapi_entry_attr_find(e, "memberOf", &attr_memberof);
+        if ((has_prname == -1) && (has_memberOf == 0)) {
+            *is_krb = 0;
+        }
+    }
+
     sval = slapi_value_new_string("sambaSamAccount");
     if (!sval) {
         rc = LDAP_OPERATIONS_ERROR;
@@ -560,7 +577,7 @@ int ipapwd_CheckPolicy(struct ipapwd_data *data)
                 LOG_TRACE("No password policy, use defaults");
             }
             break;
-	case IPA_CHANGETYPE_ADMIN:
+        case IPA_CHANGETYPE_ADMIN:
             /* The expiration date needs to be older than the current time
              * otherwise the KDC may not immediately register the password
              * as expired. The last password change needs to match the
@@ -636,7 +653,7 @@ int ipapwd_CheckPolicy(struct ipapwd_data *data)
 }
 
 /* Searches the dn in directory,
- *  If found	 : fills in slapi_entry structure and returns 0
+ *  If found     : fills in slapi_entry structure and returns 0
  *  If NOT found : returns the search result as LDAP_NO_SUCH_OBJECT
  */
 int ipapwd_getEntry(const char *dn, Slapi_Entry **e2, char **attrlist)
@@ -795,22 +812,21 @@ int ipapwd_SetPassword(struct ipapwd_krbcfg *krbcfg,
         slapi_mods_add_mod_values(smods, LDAP_MOD_REPLACE,
                                   "krbPrincipalKey", svals);
 
-		/* krbLastPwdChange is used to tell whether a host entry has a
-		 * keytab so don't set it on hosts.
-		 */
+        /* krbLastPwdChange is used to tell whether a host entry has a
+         * keytab so don't set it on hosts. */
         if (!is_host) {
-	    /* change Last Password Change field with the current date */
+            /* change Last Password Change field with the current date */
             ret = ipapwd_setdate(data->target, smods, "krbLastPwdChange",
                                  data->timeNow, false);
             if (ret != LDAP_SUCCESS)
                 goto free_and_return;
 
-	    /* set Password Expiration date */
+            /* set Password Expiration date */
             ret = ipapwd_setdate(data->target, smods, "krbPasswordExpiration",
                                  data->expireTime, (data->expireTime == 0));
             if (ret != LDAP_SUCCESS)
                 goto free_and_return;
-	}
+        }
     }
 
     if (nt && is_smb) {

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1421,15 +1421,23 @@ def ldappasswd_user_change(user, oldpw, newpw, master):
     master.run_command(args)
 
 
-def ldappasswd_sysaccount_change(user, oldpw, newpw, master):
+def ldappasswd_sysaccount_change(user, oldpw, newpw, master, use_dirman=False):
     container_sysaccounts = dict(DEFAULT_CONFIG)['container_sysaccounts']
     basedn = master.domain.basedn
 
     userdn = "uid={},{},{}".format(user, container_sysaccounts, basedn)
     master_ldap_uri = "ldap://{}".format(master.external_hostname)
 
-    args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
-            '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
+    if use_dirman:
+        args = [paths.LDAPPASSWD, '-D',
+                str(master.config.dirman_dn),  # pylint: disable=no-member
+                '-w', master.config.dirman_password,
+                '-a', oldpw,
+                '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri,
+                userdn]
+    else:
+        args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
+                '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
     master.run_command(args)
 
 

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1421,7 +1421,8 @@ def ldappasswd_user_change(user, oldpw, newpw, master):
     master.run_command(args)
 
 
-def ldappasswd_sysaccount_change(user, oldpw, newpw, master, use_dirman=False):
+def ldappasswd_sysaccount_change(user, oldpw, newpw, master,
+                                 use_dirman=False, raiseonerr=True):
     container_sysaccounts = dict(DEFAULT_CONFIG)['container_sysaccounts']
     basedn = master.domain.basedn
 
@@ -1429,16 +1430,25 @@ def ldappasswd_sysaccount_change(user, oldpw, newpw, master, use_dirman=False):
     master_ldap_uri = "ldap://{}".format(master.external_hostname)
 
     if use_dirman:
-        args = [paths.LDAPPASSWD, '-D',
-                str(master.config.dirman_dn),  # pylint: disable=no-member
-                '-w', master.config.dirman_password,
-                '-a', oldpw,
-                '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri,
-                userdn]
+        args = [
+            paths.LDAPPASSWD, '-D',
+            str(master.config.dirman_dn),  # pylint: disable=no-member
+            '-w', master.config.dirman_password,
+            '-a', oldpw,
+            '-s', newpw,
+            '-x', '-ZZ', '-H', master_ldap_uri,
+            userdn
+        ]
     else:
-        args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
-                '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
-    master.run_command(args)
+        args = [
+            paths.LDAPPASSWD,
+            '-D', userdn,
+            '-w', oldpw,
+            '-a', oldpw,
+            '-s', newpw,
+            '-x', '-ZZ', '-H', master_ldap_uri
+        ]
+    return master.run_command(args, raiseonerr=raiseonerr)
 
 
 def add_dns_zone(master, zone, skip_overlap_check=False,

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -10,7 +10,6 @@ import re
 import os
 import logging
 import ssl
-from tempfile import NamedTemporaryFile
 from itertools import chain, repeat
 import textwrap
 import time
@@ -124,21 +123,21 @@ class TestIPACommand(IntegrationTest):
         master = self.master
 
         base_dn = str(master.domain.basedn)  # pylint: disable=no-member
-        tf = NamedTemporaryFile()
-        ldif_file = tf.name
         entry_ldif = textwrap.dedent("""
-            dn: uid=system,cn=sysaccounts,cn=etc,{base_dn}
+            dn: uid={sysuser},cn=sysaccounts,cn=etc,{base_dn}
             changetype: add
             objectclass: account
             objectclass: simplesecurityobject
-            uid: system
+            uid: {sysuser}
             userPassword: {original_passwd}
             passwordExpirationTime: 20380119031407Z
             nsIdleTimeout: 0
         """).format(
             base_dn=base_dn,
-            original_passwd=original_passwd)
-        master.put_file_contents(ldif_file, entry_ldif)
+            original_passwd=original_passwd,
+            sysuser=sysuser)
+
+        ldif_file = tasks.upload_temp_contents(master, entry_ldif)
         arg = ['ldapmodify',
                '-h', master.hostname,
                '-p', '389', '-D',
@@ -195,8 +194,6 @@ class TestIPACommand(IntegrationTest):
         # a 1s precision)
         time.sleep(1)
         # perform ldapmodify on userpassword as dir mgr
-        mod = NamedTemporaryFile()
-        ldif_file = mod.name
         entry_ldif = textwrap.dedent("""
             dn: uid={user},cn=users,cn=accounts,{base_dn}
             changetype: modify
@@ -206,7 +203,7 @@ class TestIPACommand(IntegrationTest):
             user=user,
             base_dn=base_dn,
             new_passwd=new_passwd)
-        master.put_file_contents(ldif_file, entry_ldif)
+        ldif_file = tasks.upload_temp_contents(master, entry_ldif)
         arg = ['ldapmodify',
                '-h', master.hostname,
                '-p', '389', '-D',
@@ -251,6 +248,89 @@ class TestIPACommand(IntegrationTest):
         # both should have changed
         assert newkrblastpwdchange != newkrblastpwdchange2
         assert newkrbexp != newkrbexp2
+
+    def test_change_sysaccount_password_issue7181(self):
+        """
+        Test how a password change performed by a cn=Directory Manager
+        works against a non-Kerberos account with a policy preventing
+        re-use of previously used passwords
+        """
+        sysuser = 'forcedpolicy'
+        policy_group = 'forcedpolicy'
+        original_passwd = 'Secret123'
+        new_passwd = 'userPasswd123'
+        master = self.master
+
+        # Add a group with a custom password policy
+        tasks.kinit_admin(master)
+        result = master.run_command(
+            ["ipa", "group-add", policy_group]
+        )
+        assert 'Added group "{}"'.format(policy_group) in result.stdout_text
+
+        result = master.run_command(
+            ["ipa", "pwpolicy-add", policy_group,
+             "--history=5", "--priority=1"],
+        )
+        assert 'History size: 5' in result.stdout_text
+
+        # Add a system account and add it to a group managed by the policy
+        base_dn = str(master.domain.basedn)  # pylint: disable=no-member
+        entry_ldif = textwrap.dedent("""
+            dn: uid={account_name},cn=sysaccounts,cn=etc,{base_dn}
+            changetype: add
+            objectclass: account
+            objectclass: simplesecurityobject
+            objectclass: nsMemberOf
+            objectclass: krbPrincipalAux
+            uid: {account_name}
+            userPassword: {original_passwd}
+            passwordExpirationTime: 20380119031407Z
+            nsIdleTimeout: 0
+            memberOf: cn={group_name},cn=groups,cn=accounts,{base_dn}
+        """).format(
+            account_name=sysuser,
+            group_name=policy_group,
+            base_dn=base_dn,
+            original_passwd=original_passwd)
+
+        ldif_file = tasks.upload_temp_contents(master, entry_ldif)
+        arg = [
+            'ldapmodify',
+            '-h', master.hostname,
+            '-p', '389',
+            '-D', str(master.config.dirman_dn),   # pylint: disable=no-member
+            '-w', master.config.dirman_password,
+            '-f', ldif_file
+        ]
+        master.run_command(arg)
+
+        # For an LDAP object not managed by IPA we have to use
+        # --addattr to add it as a member of a group
+        value = "member=uid={},cn=sysaccounts,cn=etc,{}".format(
+            sysuser, base_dn
+        )
+        result = master.run_command(
+            ["ipa", "group-mod", policy_group, "--addattr={}".format(value)]
+        )
+        expected = 'Modified group "{}"'.format(policy_group)
+        assert expected in result.stdout_text
+
+        # Now try to change password thrice:
+        # as a user, as a cn=Directory Manager, and as a user again
+        # If ticket 7181 is not fixed, the second change will fail
+        # Third one must fail as we are reusing the password as non-DM
+        tasks.ldappasswd_sysaccount_change(
+            sysuser, original_passwd, new_passwd, master, use_dirman=False
+        )
+        tasks.ldappasswd_sysaccount_change(
+            sysuser, new_passwd, new_passwd, master, use_dirman=True
+        )
+        result = tasks.ldappasswd_sysaccount_change(
+            sysuser, new_passwd, new_passwd, master,
+            use_dirman=False, raiseonerr=False
+        )
+        assert result.returncode == 1
 
     def test_change_selinuxusermaporder(self):
         """


### PR DESCRIPTION
The PR was originally PR @abbra's PR https://github.com/freeipa/freeipa/pull/2106. PR-CI was broken for that PR. I also squashed some intermediate commits.

## Original PR message

Password changes performed by cn=Directory Manager are excluded from
password policy checks according to [1]. This is correctly handled by
ipa-pwd-extop in case of a normal Kerberos principal in IPA. However,
non-kerberos accounts were not excluded from the check.

As result, password updates for PKI CA admin account in o=ipaca were
failing if a password policy does not allow a password reuse. We are
re-setting the password for PKI CA admin in ipa-replica-prepare in case
the original directory manager's password was updated since creation of
`cacert.p12`.

Do password policy check for non-Kerberos accounts only if it was set by
a regular user or admin. Changes performed by a cn=Directory Manager and
passsync managers should be excluded from the policy check.

Fixes: https://pagure.io/freeipa/issue/7181
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>

[1] https://access.redhat.com/documentation/en-us/red_hat_directory_server/10/html/administration_guide/user_account_management-managing_the_password_policy