### PR TITLE
ipa-replica-install: password and admin-password options mutually exclusive

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -771,6 +771,10 @@ def promote_check(installer):
 
     client_fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
     if not client_fstore.has_files():
+        # One-step replica installation
+        if options.password and options.admin_password:
+            raise ScriptError("--password and --admin-password options are "
+                              "mutually exclusive")
         ensure_enrolled(installer)
     else:
         if (options.domain_name or options.server or options.realm_name or

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -50,6 +50,26 @@ class TestReplicaPromotionLevel1(ReplicaPromotionBase):
     domain_level = DOMAIN_LEVEL_1
 
     @replicas_cleanup
+    def test_one_step_install_pwd_and_admin_pwd(self):
+        """--password and --admin-password options are mutually exclusive
+
+        Test for ticket 6353
+        """
+        expected_err = "--password and --admin-password options are " \
+                       "mutually exclusive"
+        result = self.replicas[0].run_command([
+            'ipa-replica-install', '-w',
+            self.master.config.admin_password,
+            '-p', 'OTPpwd',
+            '-n', self.master.domain.name,
+            '-r', self.master.domain.realm,
+            '--server', self.master.hostname,
+            '-U'],
+            raiseonerr=False)
+        assert result.returncode == 1
+        assert expected_err in result.stderr_text
+
+    @replicas_cleanup
     def test_one_command_installation(self):
         """
         TestCase:


### PR DESCRIPTION
## ipa-replica-install: make password and admin-password options mutually exclusive
Currently it is possible to run ipa-replica-install in one step, and provide --password and --admin-password simultaneously.
This is confusing as --password is intended for one-time pwd when the ipa-replica-install command is delegated to a user who doesn't know the admin password.

The fix makes --password and --admin-password options mutually exclusive.
    
Fixes https://pagure.io/freeipa/issue/6353

## ipatests: add test for ipa-replica-install options
Add a test checking that --password and --admin-password options are mutually exclusive.

