### PR TITLE
[Backport][ipa-4-6] ipatests: fix test_replica_uninstall_deletes_ruvs

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1140,6 +1140,40 @@ def wait_for_replication(ldap, timeout=30):
         logger.error('Giving up wait for replication to finish')
 
 
+def wait_for_cleanallruv_tasks(ldap, timeout=30):
+    """Wait until cleanallruv tasks are finished
+    """
+    logger.debug('Waiting for cleanallruv tasks to finish')
+    success_status = 'Successfully cleaned rid'
+    for i in range(timeout):
+        status_attr = 'nstaskstatus'
+        try:
+            entries = ldap.get_entries(
+                DN(('cn', 'cleanallruv'), ('cn', 'tasks'), ('cn', 'config')),
+                scope=ldap.SCOPE_ONELEVEL,
+                attrs_list=[status_attr])
+        except errors.EmptyResult:
+            logger.debug("No cleanallruv tasks")
+            break
+        # Check status
+        if all(
+            e.single_value[status_attr].startswith(success_status)
+            for e in entries
+        ):
+            logger.debug("All cleanallruv tasks finished successfully")
+            break
+        else:
+            logger.debug("cleanallruv task in progress, (waited %s/%ss)",
+                         i, timeout)
+        time.sleep(1)
+    else:
+        logger.error('Giving up waiting for cleanallruv to finish')
+        for e in entries:
+            stat_str = e.single_value[status_attr]
+            if not stat_str.startswith(success_status):
+                logger.debug('%s status: %s', e.dn, stat_str)
+
+
 def add_a_records_for_hosts_in_master_domain(master):
     for host in master.domain.hosts:
         # We don't need to take care of the zone creation since it is master

--- a/ipatests/test_integration/test_topology.py
+++ b/ipatests/test_integration/test_topology.py
@@ -6,6 +6,7 @@ import re
 
 import pytest
 
+
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.env_config import get_global_config
@@ -260,6 +261,10 @@ class TestCASpecificRUVs(IntegrationTest):
             "Did not find proper number of replica hostname (%s) occurrencies"
             " in the command output: %s" % (replica.hostname, res1))
         tasks.uninstall_master(replica)
+        # ipa-replica-manage del launches a clean-ruv task which is
+        # ASYNCHRONOUS
+        # wait for the task to finish before checking list-ruv
+        tasks.wait_for_cleanallruv_tasks(self.master.ldap_connect())
         res2 = master.run_command(['ipa-replica-manage', 'list-ruv', '-p',
                                   master.config.dirman_password]).stdout_text
         assert(replica.hostname not in res2), (


### PR DESCRIPTION
This PR was opened because PR #2574 was pushed to master and backport to ipa-4-6 is required.