### PR TITLE
[Backport][ipa-4-6] ipa-replica-install: password and admin-password options mutually exclusive

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1006,6 +1006,10 @@ def promote_check(installer):
 
     client_fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
     if not client_fstore.has_files():
+        # One-step replica installation
+        if options.password and options.admin_password:
+            raise ScriptError("--password and --admin-password options are "
+                              "mutually exclusive")
         ensure_enrolled(installer)
     else:
         if (options.domain_name or options.server or options.realm_name or

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -190,6 +190,26 @@ class TestReplicaPromotionLevel1(ReplicaPromotionBase):
                              "is supported only in 0-level IPA domain", 1)
 
     @replicas_cleanup
+    def test_one_step_install_pwd_and_admin_pwd(self):
+        """--password and --admin-password options are mutually exclusive
+
+        Test for ticket 6353
+        """
+        expected_err = "--password and --admin-password options are " \
+                       "mutually exclusive"
+        result = self.replicas[0].run_command([
+            'ipa-replica-install', '-w',
+            self.master.config.admin_password,
+            '-p', 'OTPpwd',
+            '-n', self.master.domain.name,
+            '-r', self.master.domain.realm,
+            '--server', self.master.hostname,
+            '-U'],
+            raiseonerr=False)
+        assert result.returncode == 1
+        assert expected_err in result.stderr_text
+
+    @replicas_cleanup
     def test_one_command_installation(self):
         """
         TestCase:


### PR DESCRIPTION
This PR was opened manually because PR #2585 was pushed to master and backport to ipa-4-6 is required.