### PR TITLE
TestBackupAndRestoreWithReplica needs 2 replicas

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -434,7 +434,7 @@ jobs:
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
         template: *ci-master-f28
         timeout: 7200
-        topology: *master_1repl
+        topology: *master_2repl_1client
 
   fedora-28/test_backup_and_restore_TestBackupAndRestoreDMPassword:
     requires: [fedora-28/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -434,7 +434,7 @@ jobs:
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
         template: *ci-master-frawhide
         timeout: 7200
-        topology: *master_1repl
+        topology: *master_2repl_1client
 
   fedora-rawhide/test_backup_and_restore_TestBackupAndRestoreDMPassword:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
The test case TestBackupAndRestoreWithReplica needs two replicas but
PR-CI just had topology: *master_1repl.

Fixes: https://pagure.io/freeipa/issue/7691
Signed-off-by: Christian Heimes <cheimes@redhat.com>