### PR TITLE
Fix ipa user-find --certificate

### DIFF
--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -33,6 +33,7 @@ from urllib.parse import urlparse
 import warnings
 
 from cryptography import x509 as crypto_x509
+from cryptography.hazmat.primitives import serialization
 
 import ldap
 import ldap.sasl
@@ -1289,6 +1290,8 @@ class LDAPClient:
             ]
             return cls.combine_filters(flts, rules)
         elif value is not None:
+            if isinstance(value, crypto_x509.Certificate):
+                value = value.public_bytes(serialization.Encoding.DER)
             if isinstance(value, bytes):
                 value = binascii.hexlify(value).decode('ascii')
                 # value[-2:0] is empty string for the initial '\\'

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -251,6 +251,11 @@ class TestCRUD(XMLRPC_test):
                         valid_not_after=fuzzy_date,
                     ))
         host.retrieve()
+        # test host-find with --certificate
+        command = host.make_find_command(
+            fqdn=host.fqdn, usercertificate=host_cert)
+        res = command()['result']
+        assert len(res) == 1
 
     def test_try_rename(self, host):
         host.ensure_exists()

--- a/ipatests/test_xmlrpc/test_user_plugin.py
+++ b/ipatests/test_xmlrpc/test_user_plugin.py
@@ -25,6 +25,7 @@ Test the `ipaserver/plugins/user.py` module.
 """
 
 import pytest
+import base64
 import datetime
 import ldap
 import re
@@ -231,6 +232,36 @@ class TestUser(XMLRPC_test):
             'user_mod', user.uid, **dict(userclass=u'')
         )
         user.check_update(result)
+        user.delete()
+
+    def test_find_cert(self, user):
+        """ Add a usercertificate and perform a user-find --certificate """
+        user_cert = (
+            u"MIICszCCAZugAwIBAgICM24wDQYJKoZIhvcNAQELBQAwIzEUMBIGA1UEChML\r\n"
+            "RVhBTVBMRS5PUkcxCzAJBgNVBAMTAkNBMB4XDTE3MDExOTEwMjUyOVoXDTE3M\r\n"
+            "DQxOTEwMjUyOVowFjEUMBIGA1UEAxMLc3RhZ2V1c2VyLTEwggEiMA0GCSqGSI\r\n"
+            "b3DQEBAQUAA4IBDwAwggEKAoIBAQCq03FRQQBvq4HwYMKP8USLZuOkKzuIs2V\r\n"
+            "Pt8k/+nO1dADrzMogKDiUDjCwYoG2UM/sj6P+PJUUCNDLh5eRRI+aR5VE5y2a\r\n"
+            "K95iCsj1ByDWrugAUXgr8GUUr+UbaGc0XxHCMnQBkYhzbXY3u91KYRRh5l3lx\r\n"
+            "RSICcVeJFJ/tiMS14Vsor1DWykHGz1wm0Zjwg1XDV3oea+uwrSz5Pa6RNPlgC\r\n"
+            "+GGW6B7+8qC2XdSSEwvY7y1SAGgqyOxN/FLwvqqMDNU0uX7fww587uZ57IfYz\r\n"
+            "b8Xn5DAprRFNk40FDc46rMlkPBT+Tij1I0jedD8h2e6WEa7JRU6SGToYDbRm4\r\n"
+            "RL9xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHqm1jXzYer9oSjYs9qh1jWpM\r\n"
+            "vTcN+0/z1uuX++Wezh3lG7IzYtypbZNxlXDECyrkUh+9oxzMJqdlZ562ko2br\r\n"
+            "uK6X5csbbM9uVsUva8NCsPPfZXDhrYaMKFvQGFY4pO3uhFGhccob037VN5Ifm\r\n"
+            "aKGM8aJ40cw2PQh38QPDdemizyVCThQ9Pcr+WgWKiG+t2Gd9NldJRLEhky0bW\r\n"
+            "2fc4zWZVbGq5nFXy1k+d/bgkHbVzf255eFZOKKy0NgZwig+uSlhVWPJjS4Z1w\r\n"
+            "LbpBKxTZp/xD0yEARs0u1ZcCELO/BkgQM50EDKmahIM4mdCs/7j1B/DdWs2i3\r\n"
+            "5lnbjxYYiUiyA=")
+        user.ensure_exists()
+        user.update(dict(usercertificate=user_cert),
+                    expected_updates=dict(
+                        usercertificate=[base64.b64decode(user_cert)])
+                    )
+        command = user.make_find_command(uid=user.name,
+                                         usercertificate=user_cert)
+        res = command()['result']
+        assert len(res) == 1
         user.delete()
 
 


### PR DESCRIPTION
## ipaldap.py: fix method creating a ldap filter for IPACertificate
    
`ipa user-find --certificate` and `ipa host-find --certificate` fail to return matching entries, because the method transforming the attribute into a LDAP filter does not properly handle IPACertificate objects.
Directory Server logs show a filter with `(usercertificate=ipalib.x509.IPACertificate object at 0x7fc0a5575b90>)`

When the attribute contains a IPACertificate, the method needs to extract the public bytes instead of calling str(value).

Fixes https://pagure.io/freeipa/issue/7770

## ipatests: add xmlrpc test for user|host-find --certificate
    
There were no xmlrpc tests for `ipa user-find --certificate` or `ipa host-find --certificate`. The commit adds tests for these commands.

Related to https://pagure.io/freeipa/issue/7770

