### PR TITLE
Fix crashing WebUI identity tests in Nightly PR

### DIFF
--- a/ipatests/test_webui/test_automember.py
+++ b/ipatests/test_webui/test_automember.py
@@ -595,6 +595,10 @@ class TestAutomember(UI_driver):
         self.switch_to_facet('memberof_group')
         self.assert_record(pkey)
 
+        # Clear default user group
+        self.navigate_by_menu('identity/automember/amgroup')
+        self.select_combobox('automemberdefaultgroup', '')
+
         self.delete_users(user_pkey)
         self.delete_user_groups(pkey)
 
@@ -617,6 +621,10 @@ class TestAutomember(UI_driver):
         self.navigate_to_record(host_data['pkey'])
         self.switch_to_facet('memberof_hostgroup')
         self.assert_record(pkey)
+
+        # Clear default host group
+        self.navigate_by_menu('identity/automember/amhostgroup')
+        self.select_combobox('automemberdefaultgroup', '')
 
         self.delete('host', [{'pkey': host_data['pkey']}])
         self.delete_host_groups(pkey)

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -965,7 +965,8 @@ class UI_driver:
         self.wait_for_request()
 
         list_cnt = self.find('.combobox-widget-list', By.CSS_SELECTOR, cb, strict=True)
-        opt_s = "select[name=list] option[value='%s']" % value
+        opt_s = 'select[name=list] option'
+        opt_s += "[value='%s']" % value if value else ':not([value])'
         option = self.find(opt_s, By.CSS_SELECTOR, cb)
 
         if combobox_input:


### PR DESCRIPTION
Clear default user/host group before deleting it in "Automember" tests.