### PR TITLE
Add gating tests to nightly

### DIFF
--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -10,7 +10,7 @@ topologies:
   master_1repl_1client: &master_1repl_1client
     name: master_1repl_1client
     cpu: 4
-    memory: 6700
+    memory: 7400
   ipaserver: &ipaserver
     name: ipaserver
     cpu: 2
@@ -38,6 +38,186 @@ jobs:
           version: 0.2.0
         timeout: 1800
         topology: *build
+        
+  fedora-28/simple_replication:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_simple_replication.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/external_ca_1:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCA
+        template: *ci-master-f28
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-28/external_ca_2:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_topologies:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_topologies.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_sudo:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_sudo.py
+        template: *ci-master-f28
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-28/test_commands:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_commands.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_kerberos_flags:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_kerberos_flags.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-28/test_http_kdc_proxy:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_http_kdc_proxy.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-28/test_forced_client_enrolment:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_forced_client_reenrollment.py
+        template: *ci-master-f28
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-28/test_advise:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_advise.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_testconfig:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_testconfig.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_service_permissions:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_service_permissions.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_netgroup:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_netgroup.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-28/test_vault:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_vault.py
+        template: *ci-master-f28
+        timeout: 6300
+        topology: *master_1repl
+
+  fedora-28/test_authconfig:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_authselect.py
+        template: *ci-master-f28
+        timeout: 4800
+        topology: *master_1repl_1client
 
   fedora-28/test_server_del:
     requires: [fedora-28/build]
@@ -930,6 +1110,18 @@ jobs:
         template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
+
+  fedora-28/test_ntp_options:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_ntp_options.py::TestNTPoptions
+        template: *ci-master-f28
+        timeout: 7200
+        topology: *master_1repl_1client
 
   fedora-28/test_pkinit_manage:
     requires: [fedora-28/build]

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -38,6 +38,186 @@ jobs:
           version: 0.2.0
         timeout: 1800
         topology: *build
+        
+  fedora-29/simple_replication:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_simple_replication.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/external_ca_1:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCA
+        template: *ci-master-f29
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-29/external_ca_2:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_topologies:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_topologies.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_sudo:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_sudo.py
+        template: *ci-master-f29
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-29/test_commands:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_commands.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_kerberos_flags:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_kerberos_flags.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-29/test_http_kdc_proxy:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_http_kdc_proxy.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-29/test_forced_client_enrolment:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_forced_client_reenrollment.py
+        template: *ci-master-f29
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-29/test_advise:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_advise.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_testconfig:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_testconfig.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_service_permissions:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_service_permissions.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_netgroup:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_netgroup.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_vault:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_vault.py
+        template: *ci-master-f29
+        timeout: 6300
+        topology: *master_1repl
+
+  fedora-29/test_authconfig:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_authselect.py
+        template: *ci-master-f29
+        timeout: 4800
+        topology: *master_1repl_1client
 
   fedora-29/test_server_del:
     requires: [fedora-29/build]
@@ -931,7 +1111,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/test_ntp_options:
+  fedora-29/test_ntp_options:
     requires: [fedora-29/build]
     priority: 50
     job:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -38,6 +38,186 @@ jobs:
           version: 0.0.4
         timeout: 1800
         topology: *build
+        
+  fedora-rawhide/simple_replication:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_simple_replication.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/external_ca_1:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCA
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-rawhide/external_ca_2:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/test_topologies:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_topologies.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/test_sudo:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_sudo.py
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-rawhide/test_commands:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_commands.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/test_kerberos_flags:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_kerberos_flags.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-rawhide/test_http_kdc_proxy:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_http_kdc_proxy.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-rawhide/test_forced_client_enrolment:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_forced_client_reenrollment.py
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-rawhide/test_advise:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_advise.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/test_testconfig:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_testconfig.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/test_service_permissions:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_service_permissions.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/test_netgroup:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_netgroup.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/test_vault:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_vault.py
+        template: *ci-master-frawhide
+        timeout: 6300
+        topology: *master_1repl
+
+  fedora-rawhide/test_authconfig:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_authselect.py
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl_1client
 
   fedora-rawhide/test_server_del:
     requires: [fedora-rawhide/build]
@@ -48,7 +228,7 @@ jobs:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_server_del.py
         template: *ci-master-frawhide
-        timeout: 8000
+        timeout: 10800
         topology: *master_2repl_1client
 
   fedora-rawhide/test_installation_TestInstallWithCA1:
@@ -469,7 +649,7 @@ jobs:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_dnssec.py
         template: *ci-master-frawhide
-        timeout: 7200
+        timeout: 10800
         topology: *master_2repl_1client
 
   fedora-rawhide/test_replica_promotion_TestReplicaPromotionLevel1:
@@ -506,7 +686,7 @@ jobs:
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
         template: *ci-master-frawhide
         timeout: 7200
-        topology: *master_1repl
+        topology: *master_2repl_1client
 
   fedora-rawhide/test_replica_promotion_TestWrongClientDomain:
     requires: [fedora-rawhide/build]
@@ -580,14 +760,26 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
-  fedora-rawhide/test_topology:
+  fedora-rawhide/test_topology_TestCASpecificRUVs:
     requires: [fedora-rawhide/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-rawhide/build_url}'
-        test_suite: test_integration/test_topology.py
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-rawhide/test_topology_TestTopologyOptions:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_topology.py::TestTopologyOptions
         template: *ci-master-frawhide
         timeout: 7200
         topology: *master_3repl_1client
@@ -613,7 +805,7 @@ jobs:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
         template: *ci-master-frawhide
-        timeout: 7200
+        timeout: 10800
         topology: *master_3repl_1client
 
   fedora-rawhide/test_replication_layouts_TestLineTopologyWithCAKRA:
@@ -625,7 +817,7 @@ jobs:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
         template: *ci-master-frawhide
-        timeout: 7200
+        timeout: 10800
         topology: *master_3repl_1client
 
   fedora-rawhide/test_replication_layouts.py_TestStarTopologyWithoutCA:
@@ -661,7 +853,7 @@ jobs:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
         template: *ci-master-frawhide
-        timeout: 7200
+        timeout: 10800
         topology: *master_3repl_1client
 
   fedora-rawhide/test_replication_layouts_TestCompleteTopologyWithoutCA:


### PR DESCRIPTION
The objective of this change is to address the problem mentioned in this
thread: https://lists.fedorahosted.org/archives/list/freeipa-devel@lists.fedorahosted.org/message/FIOWT53LJMAZQYHOTT4BEAJX5Q6422LB/

Since the concept of nightly is being a superset of gating, the gating
tests are incorporated in nightly in this commit.

Signed-off-by: Diogo Nunes <diogo.hap@gmail.com>