### PR TITLE
Update gating/nightly tests to Fedora 29

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -13,7 +13,7 @@ topologies:
     memory: 7400
 
 jobs:
-  fedora-28/build:
+  fedora-29/build:
     requires: []
     priority: 100
     job:
@@ -21,224 +21,225 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-f28
-          name: freeipa/ci-master-f28
-          version: 0.1.9
+        template: &ci-master-f29
+          name: freeipa/ci-master-f29
+          version: 0.2.0
         timeout: 1800
         topology: *build
 
-  fedora-28/simple_replication:
-    requires: [fedora-28/build]
+  fedora-29/simple_replication:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_simple_replication.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/caless:
-    requires: [fedora-28/build]
+  fedora-29/caless:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/external_ca_1:
-    requires: [fedora-28/build]
+  fedora-29/external_ca_1:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCA
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-28/external_ca_2:
-    requires: [fedora-28/build]
+  fedora-29/external_ca_2:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/test_topologies:
-    requires: [fedora-28/build]
+  fedora-29/test_topologies:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_topologies.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/test_sudo:
-    requires: [fedora-28/build]
+  fedora-29/test_sudo:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_sudo.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-28/test_commands:
-    requires: [fedora-28/build]
+  fedora-29/test_commands:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_commands.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/test_kerberos_flags:
-    requires: [fedora-28/build]
+  fedora-29/test_kerberos_flags:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_kerberos_flags.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-28/test_http_kdc_proxy:
-    requires: [fedora-28/build]
+  fedora-29/test_http_kdc_proxy:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_http_kdc_proxy.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-28/test_forced_client_enrolment:
-    requires: [fedora-28/build]
+  fedora-29/test_forced_client_enrolment:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-28/test_advise:
-    requires: [fedora-28/build]
+  fedora-29/test_advise:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_advise.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/test_testconfig:
-    requires: [fedora-28/build]
+  fedora-29/test_testconfig:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_testconfig.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/test_service_permissions:
-    requires: [fedora-28/build]
+  fedora-29/test_service_permissions:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_service_permissions.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/test_netgroup:
-    requires: [fedora-28/build]
+  fedora-29/test_netgroup:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_netgroup.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/test_vault:
-    requires: [fedora-28/build]
+  fedora-29/test_vault:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_vault.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 6300
         topology: *master_1repl
 
-  fedora-28/test_authconfig:
-    requires: [fedora-28/build]
+  fedora-29/test_authconfig:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_authselect.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-28/replica_promotion:
-    requires: [fedora-28/build]
+  fedora-29/replica_promotion:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-28/dnssec:
-    requires: [fedora-28/build]
+  fedora-29/dnssec:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
+

--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -10,7 +10,7 @@ topologies:
   master_1repl_1client: &master_1repl_1client
     name: master_1repl_1client
     cpu: 4
-    memory: 7400
+    memory: 6700
   ipaserver: &ipaserver
     name: ipaserver
     cpu: 2
@@ -25,7 +25,7 @@ topologies:
     memory: 12900
 
 jobs:
-  fedora-29/build:
+  fedora-28/build:
     requires: []
     priority: 100
     job:
@@ -33,900 +33,900 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-f29
-          name: freeipa/ci-master-f29
+        template: &ci-master-f28
+          name: freeipa/ci-master-f28
           version: 0.2.0
         timeout: 1800
         topology: *build
 
-  fedora-29/test_server_del:
-    requires: [fedora-29/build]
+  fedora-28/test_server_del:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_server_del.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA1:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallWithCA1:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA2:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallWithCA2:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA_KRA1:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallWithCA_KRA1:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA_KRA2:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallWithCA_KRA2:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA_DNS1:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallWithCA_DNS1:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA_DNS2:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallWithCA_DNS2:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA_DNS3:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallWithCA_DNS3:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_installation_TestInstallWithCA_DNS4:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallWithCA_DNS4:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_installation_TestInstallWithCA_KRA_DNS1:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallWithCA_KRA_DNS1:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA_KRA_DNS2:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallWithCA_KRA_DNS2:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallMaster:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallMaster:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMaster
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_1repl
 
-  fedora-29/test_installation_TestInstallMasterKRA:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallMasterKRA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_1repl
 
-  fedora-29/test_installation_TestInstallMasterDNS:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallMasterDNS:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_1repl
 
-  fedora-29/test_installation_TestInstallMasterReservedIPasForwarder:
-    requires: [fedora-29/build]
+  fedora-28/test_installation_TestInstallMasterReservedIPasForwarder:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_1repl
 
-  fedora-29/test_caless_TestServerInstall:
-    requires: [fedora-29/build]
+  fedora-28/test_caless_TestServerInstall:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_caless.py::TestServerInstall
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 12000
         topology: *master_1repl
 
-  fedora-29/test_caless_TestReplicaInstall:
-    requires: [fedora-29/build]
+  fedora-28/test_caless_TestReplicaInstall:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_caless_TestClientInstall:
-    requires: [fedora-29/build]
+  fedora-28/test_caless_TestClientInstall:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_caless.py::TestClientInstall
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 5400
         # actually master_1client
         topology: *master_1repl_1client
 
-  fedora-29/test_caless_TestIPACommands:
-    requires: [fedora-29/build]
+  fedora-28/test_caless_TestIPACommands:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_caless.py::TestIPACommands
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_caless_TestCertInstall:
-    requires: [fedora-29/build]
+  fedora-28/test_caless_TestCertInstall:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_caless.py::TestCertInstall
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_caless_TestPKINIT:
-    requires: [fedora-29/build]
+  fedora-28/test_caless_TestPKINIT:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_caless.py::TestPKINIT
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_caless_TestServerReplicaCALessToCAFull:
-    requires: [fedora-29/build]
+  fedora-28/test_caless_TestServerReplicaCALessToCAFull:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_caless_TestReplicaCALessToCAFull:
-    requires: [fedora-29/build]
+  fedora-28/test_caless_TestReplicaCALessToCAFull:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_caless_TestServerCALessToExternalCA:
-    requires: [fedora-29/build]
+  fedora-28/test_caless_TestServerCALessToExternalCA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
-    requires: [fedora-29/build]
+  fedora-28/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupAndRestore:
-    requires: [fedora-29/build]
+  fedora-28/test_backup_and_restore_TestBackupAndRestore:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
-    requires: [fedora-29/build]
+  fedora-28/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
-    requires: [fedora-29/build]
+  fedora-28/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithDNS:
-    requires: [fedora-29/build]
+  fedora-28/test_backup_and_restore_TestBackupAndRestoreWithDNS:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
-    requires: [fedora-29/build]
+  fedora-28/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithKRA:
-    requires: [fedora-29/build]
+  fedora-28/test_backup_and_restore_TestBackupAndRestoreWithKRA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
-    requires: [fedora-29/build]
+  fedora-28/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithReplica:
-    requires: [fedora-29/build]
+  fedora-28/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-29/test_backup_and_restore_TestBackupAndRestoreDMPassword:
-    requires: [fedora-29/build]
+  fedora-28/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestReplicaInstallAfterRestore:
-    requires: [fedora-29/build]
+  fedora-28/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-29/test_dnssec:
-    requires: [fedora-29/build]
+  fedora-28/test_dnssec:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_dnssec.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-29/test_replica_promotion_TestReplicaPromotionLevel1:
-    requires: [fedora-29/build]
+  fedora-28/test_replica_promotion_TestReplicaPromotionLevel1:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestUnprivilegedUserPermissions:
-    requires: [fedora-29/build]
+  fedora-28/test_replica_promotion_TestUnprivilegedUserPermissions:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestProhibitReplicaUninstallation:
-    requires: [fedora-29/build]
+  fedora-28/test_replica_promotion_TestProhibitReplicaUninstallation:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-29/test_replica_promotion_TestWrongClientDomain:
-    requires: [fedora-29/build]
+  fedora-28/test_replica_promotion_TestWrongClientDomain:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestWrongClientDomain
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestRenewalMaster:
-    requires: [fedora-29/build]
+  fedora-28/test_replica_promotion_TestRenewalMaster:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestReplicaInstallWithExistingEntry:
-    requires: [fedora-29/build]
+  fedora-28/test_replica_promotion_TestReplicaInstallWithExistingEntry:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallWithExistingEntry
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestSubCAkeyReplication:
-    requires: [fedora-29/build]
+  fedora-28/test_replica_promotion_TestSubCAkeyReplication:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestReplicaInstallCustodia:
-    requires: [fedora-29/build]
+  fedora-28/test_replica_promotion_TestReplicaInstallCustodia:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-29/test_upgrade:
-    requires: [fedora-29/build]
+  fedora-28/test_upgrade:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_upgrade.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_topology_TestCASpecificRUVs:
-    requires: [fedora-29/build]
+  fedora-28/test_topology_TestCASpecificRUVs:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_topology_TestTopologyOptions:
-    requires: [fedora-29/build]
+  fedora-28/test_topology_TestTopologyOptions:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_topology.py::TestTopologyOptions
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestLineTopologyWithoutCA:
-    requires: [fedora-29/build]
+  fedora-28/test_replication_layouts_TestLineTopologyWithoutCA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestLineTopologyWithCA:
-    requires: [fedora-29/build]
+  fedora-28/test_replication_layouts_TestLineTopologyWithCA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestLineTopologyWithCAKRA:
-    requires: [fedora-29/build]
+  fedora-28/test_replication_layouts_TestLineTopologyWithCAKRA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts.py_TestStarTopologyWithoutCA:
-    requires: [fedora-29/build]
+  fedora-28/test_replication_layouts.py_TestStarTopologyWithoutCA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestStarTopologyWithCA:
-    requires: [fedora-29/build]
+  fedora-28/test_replication_layouts_TestStarTopologyWithCA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestStarTopologyWithCAKRA:
-    requires: [fedora-29/build]
+  fedora-28/test_replication_layouts_TestStarTopologyWithCAKRA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestCompleteTopologyWithoutCA:
-    requires: [fedora-29/build]
+  fedora-28/test_replication_layouts_TestCompleteTopologyWithoutCA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestCompleteTopologyWithCA:
-    requires: [fedora-29/build]
+  fedora-28/test_replication_layouts_TestCompleteTopologyWithCA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestCompleteTopologyWithCAKRA:
-    requires: [fedora-29/build]
+  fedora-28/test_replication_layouts_TestCompleteTopologyWithCAKRA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_client_uninstallation:
-    requires: [fedora-29/build]
+  fedora-28/test_client_uninstallation:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_uninstallation.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 7200
         topology: *master_1repl_1client
 
-  fedora-29/test_user_permissions:
-    requires: [fedora-29/build]
+  fedora-28/test_user_permissions:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_user_permissions.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-29/test_webui_cert:
-    requires: [fedora-29/build]
+  fedora-28/test_webui_cert:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_webui/test_cert.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 1800
         topology: *ipaserver
 
-  fedora-29/test_webui_general:
-    requires: [fedora-29/build]
+  fedora-28/test_webui_general:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: >-
           test_webui/test_loginscreen.py
           test_webui/test_misc_cases.py
           test_webui/test_navigation.py
           test_webui/test_translation.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_hosts:
-    requires: [fedora-29/build]
+  fedora-28/test_webui_hosts:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: >-
           test_webui/test_host.py
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
           test_webui/test_service.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_identity:
-    requires: [fedora-29/build]
+  fedora-28/test_webui_identity:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_network:
-    requires: [fedora-29/build]
+  fedora-28/test_webui_network:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: >-
           test_webui/test_automount.py
           test_webui/test_dns.py
           test_webui/test_vault.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_policy:
-    requires: [fedora-29/build]
+  fedora-28/test_webui_policy:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: >-
           test_webui/test_hbac.py
           test_webui/test_krbtpolicy.py
           test_webui/test_pwpolicy.py
           test_webui/test_selinuxusermap.py
           test_webui/test_sudo.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_rbac:
-    requires: [fedora-29/build]
+  fedora-28/test_webui_rbac:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: >-
           test_webui/test_delegation.py
           test_webui/test_rbac.py
           test_webui/test_selfservice.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_server:
-    requires: [fedora-29/build]
+  fedora-28/test_webui_server:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: >-
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
           test_webui/test_trust.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_users:
-    requires: [fedora-29/build]
+  fedora-28/test_webui_users:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: >-
           test_webui/test_group.py
           test_webui/test_user.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/customized_ds_config_install:
-    requires: [fedora-29/build]
+  fedora-28/customized_ds_config_install:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_customized_ds_config_install.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/dns_locations:
-    requires: [fedora-29/build]
+  fedora-28/dns_locations:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_dns_locations.py
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *master_2repl_1client
 
-  fedora-29/external_ca_TestExternalCAdirsrvStop:
-    requires: [fedora-29/build]
+  fedora-28/external_ca_TestExternalCAdirsrvStop:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/external_ca_TestExternalCAInvalidCert:
-    requires: [fedora-29/build]
+  fedora-28/external_ca_TestExternalCAInvalidCert:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/external_ca_TestMultipleExternalCA:
-    requires: [fedora-29/build]
+  fedora-28/external_ca_TestMultipleExternalCA:
+    requires: [fedora-28/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
-        template: *ci-master-f29
+        template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl


### PR DESCRIPTION
Testing new Fedora 29 Vagrant template box with gating tests.