### PR TITLE
[Backport][ipa-4-7] prci_definitions: update vagrant memory topology requirements

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -6,11 +6,11 @@ topologies:
   master_1repl: &master_1repl
     name: master_1repl
     cpu: 4
-    memory: 5750
+    memory: 6450
   master_1repl_1client: &master_1repl_1client
     name: master_1repl_1client
     cpu: 4
-    memory: 6700
+    memory: 7400
 
 jobs:
   fedora-28/build:

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -6,23 +6,23 @@ topologies:
   master_1repl: &master_1repl
     name: master_1repl
     cpu: 4
-    memory: 5750
+    memory: 6450
   master_1repl_1client: &master_1repl_1client
     name: master_1repl_1client
     cpu: 4
-    memory: 6700
+    memory: 7400
   ipaserver: &ipaserver
     name: ipaserver
-    cpu: 1
+    cpu: 2
     memory: 2400
   master_2repl_1client: &master_2repl_1client
     name: master_2repl_1client
     cpu: 5
-    memory: 9100
+    memory: 10150
   master_3repl_1client: &master_3repl_1client
     name: master_3repl_1client
     cpu: 6
-    memory: 11500
+    memory: 12900
 
 jobs:
   fedora-28/build:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -6,23 +6,23 @@ topologies:
   master_1repl: &master_1repl
     name: master_1repl
     cpu: 4
-    memory: 5750
+    memory: 6450
   master_1repl_1client: &master_1repl_1client
     name: master_1repl_1client
     cpu: 4
-    memory: 6700
+    memory: 7400
   ipaserver: &ipaserver
     name: ipaserver
-    cpu: 1
+    cpu: 2
     memory: 2400
   master_2repl_1client: &master_2repl_1client
     name: master_2repl_1client
     cpu: 5
-    memory: 9100
+    memory: 10150
   master_3repl_1client: &master_3repl_1client
     name: master_3repl_1client
     cpu: 6
-    memory: 11500
+    memory: 12900
 
 jobs:
   fedora-rawhide/build:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -12,11 +12,11 @@ topologies:
   master_1repl: &master_1repl
     name: master_1repl
     cpu: 4
-    memory: 5750
+    memory: 6450
   master_1repl_1client: &master_1repl_1client
     name: master_1repl_1client
     cpu: 4
-    memory: 6700
+    memory: 7400
 
 jobs:
   fedora-28/build:


### PR DESCRIPTION
Manual backport of PR #2609 to `ipa-4-7` branch. 

Original author: @f-trivino 