### PR TITLE
[Backport][ipa-4-6] prci_definitions: update vagrant memory topology requirements

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -6,11 +6,11 @@ topologies:
   master_1repl: &master_1repl
     name: master_1repl
     cpu: 4
-    memory: 5750
+    memory: 6450
   master_1repl_1client: &master_1repl_1client
     name: master_1repl_1client
     cpu: 4
-    memory: 6700
+    memory: 7400
 
 jobs:
   fedora-27/build:


### PR DESCRIPTION
Manual backport of PR #2609 to `ipa-4-6` branch.

Original author: @f-trivino