### PR TITLE
Update temp commit template to F29

### DIFF
--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -17,9 +17,21 @@ topologies:
     name: master_1repl_1client
     cpu: 4
     memory: 7400
+  ipaserver: &ipaserver
+    name: ipaserver
+    cpu: 2
+    memory: 2400
+  master_2repl_1client: &master_2repl_1client
+    name: master_2repl_1client
+    cpu: 5
+    memory: 10150
+  master_3repl_1client: &master_3repl_1client
+    name: master_3repl_1client
+    cpu: 6
+    memory: 12900
 
 jobs:
-  fedora-28/build:
+  fedora-29/build:
     requires: []
     priority: 100
     job:
@@ -27,20 +39,20 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-f28
-          name: freeipa/ci-master-f28
-          version: 0.1.9
+        template: &ci-master-f29
+          name: freeipa/ci-master-f29
+          version: 0.2.0
         timeout: 1800
         topology: *build
 
-  fedora-28/temp_commit:
-    requires: [fedora-28/build]
+  fedora-29/temp_commit:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-28/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_REPLACEME.py
-        template: *ci-master-f28
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl_1client


### PR DESCRIPTION
The temp_commit.yaml template now uses F29 as well. It also contains all
topology configurations from the nightly jobs.

Fixes: https://pagure.io/freeipa/issue/7779
Signed-off-by: Christian Heimes <cheimes@redhat.com>