### PR TITLE
[Backport][ipa-4-6] ipa upgrade: handle double-encoded certificates

### DIFF
--- a/ipaserver/install/plugins/upload_cacrt.py
+++ b/ipaserver/install/plugins/upload_cacrt.py
@@ -115,7 +115,18 @@ class update_upload_cacrt(Updater):
                 entry.single_value['cACertificate;binary'] = ca_cert
                 ldap.add_entry(entry)
             else:
-                if b'' in entry['cACertificate;binary']:
+                force_write = False
+                try:
+                    _cert_bin = entry['cACertificate;binary']
+                except ValueError:
+                    # BZ 1644874
+                    # sometimes the cert is badly stored, twice encoded
+                    # force write to fix the value
+                    logger.debug('Fixing the value of cACertificate;binary '
+                                 'in entry %s', entry.dn)
+                    force_write = True
+
+                if force_write or b'' in entry['cACertificate;binary']:
                     entry.single_value['cACertificate;binary'] = ca_cert
                     ldap.update_entry(entry)
 

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -6,6 +6,9 @@
 Module provides tests to verify that the upgrade script works.
 """
 
+import base64
+from cryptography.hazmat.primitives import serialization
+from ipapython.dn import DN
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 
@@ -21,3 +24,35 @@ class TestUpgrade(IntegrationTest):
         assert ("DN: cn=Schema Compatibility,cn=plugins,cn=config does not \
                 exists or haven't been updated" not in cmd.stdout_text)
         assert cmd.returncode == 0
+
+    def test_double_encoded_cacert(self):
+        """Test for BZ 1644874
+
+        In old IPA version, the entry cn=CAcert,cn=ipa,cn=etc,$basedn
+        could contain a double-encoded cert, which leads to ipa-server-upgrade
+        failure.
+        Force a double-encoded value then call upgrade to check the fix.
+        """
+        # Read the current entry from LDAP
+        ldap = self.master.ldap_connect()
+        basedn = self.master.domain.basedn  # pylint: disable=no-member
+        dn = DN(('cn', 'CAcert'), ('cn', 'ipa'), ('cn', 'etc'), basedn)
+        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        # Extract the certificate as DER then double-encode
+        cacert = entry['cacertificate;binary'][0]
+        cacert_der = cacert.public_bytes(serialization.Encoding.DER)
+        cacert_b64 = base64.b64encode(cacert_der)
+        # overwrite the value with double-encoded cert
+        entry.single_value['cACertificate;binary'] = cacert_b64
+        ldap.update_entry(entry)  # pylint: disable=no-member
+
+        # try the upgrade
+        self.master.run_command(['ipa-server-upgrade'])
+
+        # read the value after upgrade, should be fixed
+        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        try:
+            _cacert = entry['cacertificate;binary']
+        except ValueError:
+            raise AssertionError('%s contains a double-encoded cert'
+                                 % entry.dn)


### PR DESCRIPTION
This PR was opened automatically because PR #2618 was pushed to master and backport to ipa-4-6 is required.