### PR TITLE
ipatests integration/tasks.py: Honor clean for firewall in uninstall_master

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -793,8 +793,9 @@ def uninstall_master(host, ignore_topology_disconnect=True,
 
     result = host.run_command(uninstall_cmd)
     assert "Traceback" not in result.stdout_text
-    Firewall(host).disable_services(["freeipa-ldap", "freeipa-ldaps",
-                                     "freeipa-trust", "dns"])
+    if clean:
+        Firewall(host).disable_services(["freeipa-ldap", "freeipa-ldaps",
+                                         "freeipa-trust", "dns"])
 
     host.run_command(['pkidestroy', '-s', 'CA', '-i', 'pki-tomcat'],
                      raiseonerr=False)

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -814,7 +814,7 @@ class TestReplicaInstallAfterRestore(IntegrationTest):
         master.run_command(arg)
 
         # uninstall master.
-        tasks.uninstall_master(master)
+        tasks.uninstall_master(master, clean=False)
 
         # master restore.
         dirman_password = master.config.dirman_password

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -56,6 +56,9 @@ class TestReplicaPromotionLevel1(ReplicaPromotionBase):
 
         Test for ticket 6353
         """
+        # Configure firewall first
+        Firewall(self.replicas[0]).enable_services(["freeipa-ldap",
+                                                    "freeipa-ldaps"])
         expected_err = "--password and --admin-password options are " \
                        "mutually exclusive"
         result = self.replicas[0].run_command([
@@ -69,8 +72,6 @@ class TestReplicaPromotionLevel1(ReplicaPromotionBase):
             raiseonerr=False)
         assert result.returncode == 1
         assert expected_err in result.stderr_text
-        Firewall(self.replicas[0]).enable_services(["freeipa-ldap",
-                                                    "freeipa-ldaps"])
 
     @replicas_cleanup
     def test_one_command_installation(self):
@@ -79,14 +80,15 @@ class TestReplicaPromotionLevel1(ReplicaPromotionBase):
         http://www.freeipa.org/page/V4/Replica_Promotion/Test_plan
         #Test_case:_Replica_can_be_installed_using_one_command
         """
+        # Configure firewall first
+        Firewall(self.replicas[0]).enable_services(["freeipa-ldap",
+                                                    "freeipa-ldaps"])
         self.replicas[0].run_command(['ipa-replica-install', '-w',
                                      self.master.config.admin_password,
                                      '-n', self.master.domain.name,
                                      '-r', self.master.domain.realm,
                                      '--server', self.master.hostname,
                                      '-U'])
-        Firewall(self.replicas[0]).enable_services(["freeipa-ldap",
-                                                    "freeipa-ldaps"])
         # Ensure that pkinit is properly configured, test for 7566
         result = self.replicas[0].run_command(['ipa-pkinit-manage', 'status'])
         assert "PKINIT is enabled" in result.stdout_text
@@ -136,6 +138,9 @@ class TestUnprivilegedUserPermissions(IntegrationTest):
     def test_replica_promotion_by_unprivileged_user(self):
         replica = self.replicas[0]
         tasks.install_client(self.master, replica)
+        # Configure firewall first
+        Firewall(replica).enable_services(["freeipa-ldap",
+                                           "freeipa-ldaps"])
         result2 = replica.run_command(['ipa-replica-install',
                                        '-P', self.username,
                                        '-p', self.new_password,
@@ -149,14 +154,15 @@ class TestUnprivilegedUserPermissions(IntegrationTest):
         self.master.run_command(['ipa', 'group-add-member', 'admins',
                                  '--users=%s' % self.username])
 
+        # Configure firewall first
+        Firewall(self.replicas[0]).enable_services(["freeipa-ldap",
+                                                    "freeipa-ldaps"])
         self.replicas[0].run_command(['ipa-replica-install',
                                       '-P', self.username,
                                       '-p', self.new_password,
                                       '-n', self.master.domain.name,
                                       '-r', self.master.domain.realm,
                                       '-U'])
-        Firewall(self.replicas[0]).enable_services(["freeipa-ldap",
-                                                    "freeipa-ldaps"])
 
 
 class TestProhibitReplicaUninstallation(IntegrationTest):
@@ -212,6 +218,9 @@ class TestWrongClientDomain(IntegrationTest):
                             '-w', self.master.config.admin_password,
                             '--server', self.master.hostname,
                             '--force-join'])
+        # Configure firewall first
+        Firewall(client).enable_services(["freeipa-ldap",
+                                          "freeipa-ldaps"])
         result = client.run_command(['ipa-replica-install', '-U', '-w',
                                      self.master.config.dirman_password],
                                     raiseonerr=False)
@@ -230,6 +239,9 @@ class TestWrongClientDomain(IntegrationTest):
                                      '--force-join'], raiseonerr=False)
         assert(result.returncode == 0), (
             'Failed to setup client with the upcase domain name')
+        # Configure firewall first
+        Firewall(self.replicas[0]).enable_services(["freeipa-ldap",
+                                                    "freeipa-ldaps"])
         result1 = client.run_command(['ipa-replica-install', '-U', '-w',
                                       self.master.config.dirman_password],
                                      raiseonerr=False)

--- a/ipatests/test_integration/test_server_del.py
+++ b/ipatests/test_integration/test_server_del.py
@@ -6,6 +6,7 @@ from itertools import permutations
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
+from ipatests.pytest_ipa.integration.firewall import Firewall
 from ipalib.constants import DOMAIN_LEVEL_1, DOMAIN_SUFFIX_NAME, CA_SUFFIX_NAME
 
 REMOVAL_ERR_TEMPLATE = ("Removal of '{hostname}' leads to disconnected "
@@ -264,6 +265,7 @@ class TestLastServices(ServerDelBase):
             "-U",
         ]
         self.master.run_command(args)
+        Firewall(self.master).enable_service("dns")
 
     def test_removal_of_master_raises_error_about_dnssec(self):
         tasks.assert_error(


### PR DESCRIPTION
This fix will make sure that the firewall services are only cleaned up if
the clean flag is True for example for backup and restore tests where the
clean flag is set to False for the server uninstall.

See: https://pagure.io/freeipa/issue/7755
Signed-off-by: Thomas Woerner <twoerner@redhat.com>