### PR TITLE
ipatests: fix TestUpgrade::test_double_encoded_cacert

### DIFF
--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -49,6 +49,8 @@ class TestUpgrade(IntegrationTest):
         # try the upgrade
         self.master.run_command(['ipa-server-upgrade'])
 
+        # reconnect to the master (upgrade stops 389-ds)
+        ldap = self.master.ldap_connect()
         # read the value after upgrade, should be fixed
         entry = ldap.get_entry(dn)  # pylint: disable=no-member
         try:


### PR DESCRIPTION
The test is using a stale ldap connection to the master
(obtained before calling upgrade, and the upgrade stops
and starts 389-ds, breaking the connection).
    
The fix re-connects before using the ldap handle.
    
Related to https://pagure.io/freeipa/issue/7775
