### PR TITLE
Require Dogtag PKI 10.6.8-3

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -76,10 +76,11 @@
 
 %endif  # Fedora
 
-# Require Dogtag PKI 10.6.7-3 which fixes UpdateNumberRange clone
-# installation issue; https://pagure.io/freeipa/issue/7654
+# Require Dogtag PKI 10.6.8-3 (10.6.7 was never pushed to stable)
+# 10.6.7 fixes UpdateNumberRange clone installation issue
+# https://pagure.io/freeipa/issue/7654 and empty token issue
 # and https://pagure.io/dogtagpki/issue/3073
-%global pki_version 10.6.7-3
+%global pki_version 10.6.8-3
 
 # NSS release with fix for CKA_LABEL import bug in shared SQL database.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1568271
@@ -289,10 +290,6 @@ Requires(post): systemd-units
 Requires: selinux-policy >= %{selinux_policy_version}
 Requires(post): selinux-policy-base >= %{selinux_policy_version}
 Requires: slapi-nis >= %{slapi_nis_version}
-# jss is an indirect dependency. 4.4.5 fixes sub CA replication bug,
-# see https://pagure.io/freeipa/issue/7536
-# see https://pagure.io/freeipa/issue/7590
-Requires: jss >= 4.4.5-1
 Requires: pki-ca >= %{pki_version}
 Requires: pki-kra >= %{pki_version}
 Requires(preun): systemd-units


### PR DESCRIPTION
pki-core 10.6.7 was unpushed and never landed in Fedora stable. The
latest release is 10.6.8-3 with additional fixes. The new versions are
in testing and FreeIPA's master COPR.

Also remove dependency on JSS. The dependency was originally added as a
workaround. The pki-core package already requires a newer version of JSS.

Fixes: https://pagure.io/freeipa/issue/7654
Signed-off-by: Christian Heimes <cheimes@redhat.com>