### PR TITLE
[Backport][ipa-4-7] ipatests: fix TestUpgrade::test_double_encoded_cacert

### DIFF
--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -49,6 +49,8 @@ class TestUpgrade(IntegrationTest):
         # try the upgrade
         self.master.run_command(['ipa-server-upgrade'])
 
+        # reconnect to the master (upgrade stops 389-ds)
+        ldap = self.master.ldap_connect()
         # read the value after upgrade, should be fixed
         entry = ldap.get_entry(dn)  # pylint: disable=no-member
         try:


### PR DESCRIPTION
This PR was opened automatically because PR #2639 was pushed to master and backport to ipa-4-7 is required.