### PR TITLE
[Backport][ipa-4-7] Require Dogtag PKI 10.6.8-3

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -98,10 +98,11 @@
 
 %endif  # Fedora
 
-# Require Dogtag PKI 10.6.7-3 which fixes UpdateNumberRange clone
-# installation issue; https://pagure.io/freeipa/issue/7654
+# Require Dogtag PKI 10.6.8-3 (10.6.7 was never pushed to stable)
+# 10.6.7 fixes UpdateNumberRange clone installation issue
+# https://pagure.io/freeipa/issue/7654 and empty token issue
 # and https://pagure.io/dogtagpki/issue/3073
-%global pki_version 10.6.7-3
+%global pki_version 10.6.8-3
 
 # NSS release with fix for CKA_LABEL import bug in shared SQL database.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1568271
@@ -381,10 +382,6 @@ Requires(post): systemd-units
 Requires: selinux-policy >= %{selinux_policy_version}
 Requires(post): selinux-policy-base >= %{selinux_policy_version}
 Requires: slapi-nis >= %{slapi_nis_version}
-# jss is an indirect dependency. 4.4.5 fixes sub CA replication bug,
-# see https://pagure.io/freeipa/issue/7536
-# see https://pagure.io/freeipa/issue/7590
-Requires: jss >= 4.4.5-1
 Requires: pki-ca >= %{pki_version}
 Requires: pki-kra >= %{pki_version}
 Requires(preun): systemd-units


### PR DESCRIPTION
This PR was opened automatically because PR #2641 was pushed to master and backport to ipa-4-7 is required.