### PR TITLE
Fix support for gssproxy non-privileged user

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1170,7 +1170,7 @@ fi
 %{_usr}/share/ipa/updates/*
 %dir %{_localstatedir}/lib/ipa
 %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/backup
-%attr(700,root,root) %dir %{_localstatedir}/lib/ipa/gssproxy
+%ghost %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/gssproxy
 %attr(711,root,root) %dir %{_localstatedir}/lib/ipa/sysrestore
 %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/sysupgrade
 %attr(755,root,root) %dir %{_localstatedir}/lib/ipa/pki-ca

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -238,6 +238,9 @@ class BaseTaskNamespace:
     def configure_http_gssproxy_conf(self, ipauser):
         raise NotImplementedError()
 
+    def configure_ipa_gssproxy_dir(self):
+        raise NotImplementedError()
+
     def remove_httpd_service_ipa_conf(self):
         """Remove configuration of httpd service of IPA"""
         raise NotImplementedError()

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -35,6 +35,7 @@ import urllib
 import subprocess
 import sys
 import textwrap
+import pwd
 
 from ctypes.util import find_library
 from functools import total_ordering
@@ -537,8 +538,30 @@ class RedHatTaskNamespace(BaseTaskNamespace):
             )
         )
 
-        os.chmod(paths.GSSPROXY_CONF, 0o600)
+        pent = pwd.getpwnam(constants.GSSPROXY_USER)
+        if pent.pw_uid == 0:
+            # by default gssproxy user is root
+            mod = 0o600
+        else:
+            # gssproxy user is non-privileged
+            mod = 0o640
+        os.chmod(paths.GSSPROXY_CONF, mod)
+        os.chown(paths.GSSPROXY_CONF, 0, pent.pw_gid)
         self.restore_context(paths.GSSPROXY_CONF)
+
+    def configure_ipa_gssproxy_dir(self):
+        ipa_gssproxy_dir = os.path.dirname(paths.HTTP_KEYTAB)
+        pent = pwd.getpwnam(constants.GSSPROXY_USER)
+        if pent.pw_uid == 0:
+            # by default gssproxy user is root
+            mod = 0o700
+        else:
+            # gssproxy user is non-privileged
+            mod = 0o770
+        if not os.path.isdir(ipa_gssproxy_dir):
+            os.mkdir(ipa_gssproxy_dir)
+        os.chmod(ipa_gssproxy_dir, mod)
+        os.chown(ipa_gssproxy_dir, 0, pent.pw_gid)
 
     def configure_httpd_wsgi_conf(self):
         """Configure WSGI for correct Python version (Fedora)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -213,6 +213,7 @@ class HTTPInstance(service.Service):
 
     def configure_gssproxy(self):
         tasks.configure_http_gssproxy_conf(IPAAPI_USER)
+        tasks.configure_ipa_gssproxy_dir()
         services.knownservices.gssproxy.restart()
 
     def get_mod_nss_nickname(self):
@@ -602,6 +603,9 @@ class HTTPInstance(service.Service):
                          "issued by IPA", cert.subject)
 
     def request_service_keytab(self):
+        ipa_gssproxy_dir = os.path.dirname(paths.HTTP_KEYTAB)
+        if not os.path.isdir(ipa_gssproxy_dir):
+            os.mkdir(ipa_gssproxy_dir)
         super(HTTPInstance, self).request_service_keytab()
 
         if self.master_fqdn is not None:

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -2004,6 +2004,7 @@ def upgrade_configuration():
     update_ipa_httpd_service_conf(http)
     update_ipa_http_wsgi_conf(http)
     migrate_to_mod_ssl(http)
+    tasks.configure_ipa_gssproxy_dir()
     update_http_keytab(http)
     http.configure_gssproxy()
     http.start()

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -735,7 +735,7 @@ class Service:
         if keytab is None:
             keytab = self.keytab
         if owner is None:
-            owner = self.service_user
+            owner = self.keytab_user
 
         pent = pwd.getpwnam(owner)
         os.chown(keytab, pent.pw_uid, pent.pw_gid)


### PR DESCRIPTION
* Fix an owner of HTTP service keytab ( apache user -> gssproxy user ).
* Fix permissions to /var/lib/ipa/gssproxy directory to allow gssproxy non-privileged user write to.
* Fix permissions to /etc/gssproxy/10-ipa.conf file to allow gssproxy non-privileged user read from.
* Add test.

For default gssproxy user (root) nothing changes.

Fixes: https://pagure.io/freeipa/issue/7798