### PR TITLE
[Backport][ipa-4-6] Resolve user/group names in idoverride*-find ack

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1537,3 +1537,21 @@ def strip_cert_header(pem):
         return s.group(1)
     else:
         return pem
+
+
+def user_add(host, login, first='test', last='user', extra_args=()):
+    cmd = [
+        "ipa", "user-add", login,
+        "--first", first,
+        "--last", last
+    ]
+    cmd.extend(extra_args)
+    return host.run_command(cmd)
+
+
+def group_add(host, groupname, extra_args=()):
+    cmd = [
+        "ipa", "group-add", groupname,
+    ]
+    cmd.extend(extra_args)
+    return host.run_command(cmd)

--- a/ipatests/test_integration/test_idviews.py
+++ b/ipatests/test_integration/test_idviews.py
@@ -165,6 +165,7 @@ class TestRulesWithServicePrincipals(IntegrationTest):
 
     topology = 'star'
     num_replicas = 0
+    num_clients = 0
     service_certprofile = 'caIPAserviceCert'
     caacl = 'test_caacl'
     keytab = "replica.keytab"
@@ -238,3 +239,133 @@ EOF
                                          raiseonerr=False)
         assert(result.returncode == 0), (
             'Failed to add a cert to custom certprofile')
+
+
+class TestIDViews(IntegrationTest):
+    topology = 'star'
+    num_replicas = 0
+    num_clients = 1
+
+    user1 = 'testuser1'
+    user1_uid = 10001
+    user1_gid = 10001
+    user1_uid_override = 5001
+    user1_gid_override = 6001
+
+    user2 = 'testuser2'
+    user2_uid = 10002
+    user2_gid = 10002
+
+    group1 = 'testgroup1'
+    group1_gid = 11001
+    group1_gid_override = 7001
+
+    idview = 'testview'
+
+    @classmethod
+    def install(cls, mh):
+        super(TestIDViews, cls).install(mh)
+        master = cls.master
+        client = cls.clients[0]
+        tasks.kinit_admin(master)
+
+        tasks.user_add(
+            master, cls.user1, first='Test1',
+            extra_args=[
+                '--uid', str(cls.user1_uid),
+                '--gidnumber', str(cls.user1_gid),
+            ]
+        )
+        tasks.user_add(
+            master, cls.user2, first='Test2',
+            extra_args=[
+                '--uid', str(cls.user2_uid),
+                '--gidnumber', str(cls.user2_gid),
+            ]
+        )
+        tasks.group_add(
+            master, cls.group1, extra_args=['--gid', str(cls.group1_gid)]
+        )
+
+        master.run_command(['ipa', 'idview-add', cls.idview])
+
+        # add overrides for user1 and its default user group
+        master.run_command([
+            'ipa', 'idoverrideuser-add', cls.idview, cls.user1,
+            '--uid', str(cls.user1_uid_override),
+            '--gid', str(cls.user1_gid_override),
+            '--homedir', '/special-home/{}'.format(cls.user1),
+            '--shell', '/bin/special'
+        ])
+        master.run_command([
+            'ipa', 'idoverridegroup-add', cls.idview, cls.group1,
+            '--gid', str(cls.group1_gid_override),
+        ])
+
+        # ID view overrides don't work on IPA masters
+        master.run_command([
+            'ipa', 'idview-apply', cls.idview,
+            '--hosts', client.hostname
+        ])
+        # finally restart SSSD to materialize idviews
+        client.run_command(['systemctl', 'restart', 'sssd.service'])
+
+    def test_useroverride(self):
+        result = self.clients[0].run_command(['id', self.user1])
+        assert 'uid={}'.format(self.user1_uid_override) in result.stdout_text
+        assert 'gid={}'.format(self.user1_gid_override) in result.stdout_text
+
+        result = self.clients[0].run_command(
+            ['getent', 'passwd', str(self.user1_uid_override)]
+        )
+        expected = '{}:*:{}:{}'.format(
+            self.user1, self.user1_uid_override, self.user1_gid_override
+        )
+        assert expected in result.stdout_text
+
+        result = self.master.run_command(['id', self.user1])
+        assert 'uid={}'.format(self.user1_uid) in result.stdout_text
+        assert 'gid={}'.format(self.user1_gid) in result.stdout_text
+
+    def test_useroverride_original_uid(self):
+        # It's still possible to request the user with its original UID. In
+        # this case the getent command returns the user with override uid.
+        result = self.clients[0].run_command(
+            ['getent', 'passwd', str(self.user1_uid)]
+        )
+        expected = '{}:*:{}:{}'.format(
+            self.user1, self.user1_uid_override, self.user1_gid_override
+        )
+        assert expected in result.stdout_text
+
+    def test_anchor_username(self):
+        result = self.master.run_command([
+            'ipa', 'idoverrideuser-find', self.idview, '--anchor', self.user1
+        ])
+        expected = "Anchor to override: {}".format(self.user1)
+        assert expected in result.stdout_text
+
+    def test_groupoverride(self):
+        result = self.clients[0].run_command(['getent', 'group', self.group1])
+        assert ':{}:'.format(self.group1_gid_override) in result.stdout_text
+
+        result = self.master.run_command(['getent', 'group', self.group1])
+        assert ':{}:'.format(self.group1_gid) in result.stdout_text
+
+    def test_groupoverride_system_objects(self):
+        # group override for user group should fail
+        result = self.master.run_command(
+            ['ipa', 'idoverridegroup-add', self.idview, self.user1,
+             '--gid', str(self.user1_gid_override)],
+            raiseonerr=False
+        )
+        assert result.returncode == 1
+        assert "cannot be overridden" in result.stderr_text
+
+    def test_anchor_groupname(self):
+        result = self.master.run_command([
+            'ipa', 'idoverridegroup-find', self.idview,
+            '--anchor', self.group1
+        ])
+        expected = "Anchor to override: {}".format(self.group1)
+        assert expected in result.stdout_text


### PR DESCRIPTION
Manual backport of #2648 to IPA 4.6 branch. I'm Auto-ACK this PR because it was only a trivial merge conflict.

## Resolve user/group names in idoverride*-find

ipa idoverrideuser-find and ...group-find have an --anchor argument. The
anchor argument used to support only anchor UUIDs like
':IPA:domain:UUID' or ':SID:S-sid'. The find commands now detect regular
user or group names and translate them to anchors.

## Add integration tests for idviews

Add several tests to verify new anchor override and general idview
override functionality.

## Run idviews integration tests in nightly 

Fixes: pagure.io/freeipa/issue/6594