### PR TITLE
ipatests: fix test_full_backup_and_restore

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -418,7 +418,7 @@ def master_authoritative_for_client_domain(master, client):
     return result.returncode == 0
 
 
-def _config_replica_resolvconf_with_master_data(master, replica):
+def config_replica_resolvconf_with_master_data(master, replica):
     """
     Configure replica /etc/resolv.conf to use master as DNS server
     """

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -489,6 +489,15 @@ class TestBackupAndRestoreWithReplica(IntegrationTest):
             domain_level = cls.master.config.domain_level
         else:
             domain_level = cls.domain_level
+        # Configure /etc/resolv.conf on each replica to use the master as DNS
+        # Otherwise ipa-replica-manage re-initialize is unable to
+        # resolve the master name
+        tasks.config_replica_resolvconf_with_master_data(
+            cls.master,
+            cls.replica1)
+        tasks.config_replica_resolvconf_with_master_data(
+            cls.master,
+            cls.replica2)
         # Configure only master and one replica.
         # Replica is configured without CA
         tasks.install_topo(


### PR DESCRIPTION
The test is failing when calling (on the replica) `ipa-replica-manage re-initialize --from <master>` because the tool needs to resolve master.
The test does not set `/etc/resolv.conf` on the replica, as a consequence it relies on whatever DNS server is configured in your test environment prior to launching the test, and makes the test unreliable.
In PR-CI env, `/etc/resolv.conf` points to the machine hosting the replica vm, which is unable to resolve master.ipa.test.

The fix is modifying the replica's /etc/resolv.conf to use the master as DNS.

Fixes https://pagure.io/freeipa/issue/7778