### PR TITLE
[Backport][ipa-4-7] Fix f52e0e3 typo in tests label definition

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -195,7 +195,7 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
-  fedora-28/test_idviews:
+  fedora-29/test_idviews:
     requires: [fedora-29/build]
     priority: 50
     job:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -195,7 +195,7 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
-  fedora-28/test_idviews:
+  fedora-rawhide/test_idviews:
     requires: [fedora-rawhide/build]
     priority: 50
     job:


### PR DESCRIPTION
This PR was opened automatically because PR #2656 was pushed to master and backport to ipa-4-7 is required.