### PR TITLE
Add index and container for RFC 2307 IP services

### DIFF
--- a/install/share/bootstrap-template.ldif
+++ b/install/share/bootstrap-template.ldif
@@ -34,6 +34,12 @@ objectClass: top
 objectClass: nsContainer
 cn: hostgroups
 
+dn: cn=ipservices,cn=accounts,$SUFFIX
+changetype: add
+objectClass: top
+objectClass: nsContainer
+cn: ipservices
+
 dn: cn=alt,$SUFFIX
 changetype: add
 objectClass: nsContainer

--- a/install/share/indices.ldif
+++ b/install/share/indices.ldif
@@ -333,3 +333,13 @@ objectClass: nsindex
 nssystemindex: false
 nsindextype: eq
 nsindextype: sub
+
+# NOTE: There is no index on ipServiceProtocol because the index would have
+# poor selectivity. An ipService entry has either 'tcp' or 'udp' as protocol.
+dn: cn=ipServicePort,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: ipServicePort
+objectClass: top
+objectClass: nsIndex
+nsSystemIndex: false
+nsIndexType: eq

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -308,3 +308,10 @@ default: objectclass: nsindex
 default: nssystemindex: false
 default: nsindextype: eq
 default: nsindextype: sub
+
+dn: cn=ipServicePort,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: ipServicePort
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: eq

--- a/install/updates/30-ipservices.update
+++ b/install/updates/30-ipservices.update
@@ -1,0 +1,6 @@
+# container for RFC 2307 IP services
+
+dn: cn=ipservices,cn=accounts,$SUFFIX
+default: objectClass: top
+default: objectClass: nsContainer
+default: cn: ipservices


### PR DESCRIPTION
IPA doesn't officially support RFC 2307 IP services. However SSSD has a
nsswitch plugin to provide service lookups. The subtree search for
(&(ipserviceport=$PORT)(ipserviceprotocol=$SRV)(objectclass=ipservice)) in
cn=accounts,$SUFFIX has caused performance issues on large
installations.

This patch introduced a dedicated container
cn=ipservices,cn=accounts,$SUFFIX for IP services for future use or 3rd
party extensions. SSSD will be change its search base in an upcoming
release, too.

A new ipServicePort index is added to optimize searches for an IP
service by port. There is no index on ipServiceProtocol because the index
would have poor selectivity. An ipService entry has either 'tcp' or 'udp'
as protocol.

Fixes: https://pagure.io/freeipa/issue/7797
See: https://pagure.io/freeipa/issue/7786
Signed-off-by: Christian Heimes <cheimes@redhat.com>

Also see #2649