### PR TITLE
Always collect test logs

### DIFF
--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -253,12 +253,16 @@ def mh(request, class_integration_logs):
     setup_class(cls, mh)
     mh._pytestmh_request.addfinalizer(lambda: teardown_class(cls))
 
-    yield mh.install()
-
-    for host in cls.get_all_hosts():
-        host.remove_log_collector(collect_log)
-
-    collect_test_logs(request.node, class_integration_logs, request.config)
+    try:
+        yield mh.install()
+    finally:
+        hosts = list(cls.get_all_hosts())
+        for host in hosts:
+            host.remove_log_collector(collect_log)
+        collect_test_logs(
+            request.node, class_integration_logs, request.config
+        )
+        collect_systemd_journal(request.node, hosts, request.config)
 
 
 def setup_class(cls, mh):


### PR DESCRIPTION
mh.install() is the default multi host installer. Most integration test
classes use it to install master, replicas, and clients. In case of a
failed installation, the test collector step is skipped.

Guard log collection with a try/finally block so logs are always
collected.

Signed-off-by: Christian Heimes <cheimes@redhat.com>