### PR TITLE
[Backport][ipa-4-7] ipatests: fix test_full_backup_and_restore

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -411,7 +411,7 @@ def master_authoritative_for_client_domain(master, client):
     return result.returncode == 0
 
 
-def _config_replica_resolvconf_with_master_data(master, replica):
+def config_replica_resolvconf_with_master_data(master, replica):
     """
     Configure replica /etc/resolv.conf to use master as DNS server
     """

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -489,6 +489,15 @@ class TestBackupAndRestoreWithReplica(IntegrationTest):
             domain_level = cls.master.config.domain_level
         else:
             domain_level = cls.domain_level
+        # Configure /etc/resolv.conf on each replica to use the master as DNS
+        # Otherwise ipa-replica-manage re-initialize is unable to
+        # resolve the master name
+        tasks.config_replica_resolvconf_with_master_data(
+            cls.master,
+            cls.replica1)
+        tasks.config_replica_resolvconf_with_master_data(
+            cls.master,
+            cls.replica2)
         # Configure only master and one replica.
         # Replica is configured without CA
         tasks.install_topo(


### PR DESCRIPTION
This PR was opened automatically because PR #2659 was pushed to master and backport to ipa-4-7 is required.