### PR TITLE
[Backport][ipa-4-7] Add index and container for RFC 2307 IP services

### DIFF
--- a/install/share/bootstrap-template.ldif
+++ b/install/share/bootstrap-template.ldif
@@ -34,6 +34,12 @@ objectClass: top
 objectClass: nsContainer
 cn: hostgroups
 
+dn: cn=ipservices,cn=accounts,$SUFFIX
+changetype: add
+objectClass: top
+objectClass: nsContainer
+cn: ipservices
+
 dn: cn=alt,$SUFFIX
 changetype: add
 objectClass: nsContainer

--- a/install/share/indices.ldif
+++ b/install/share/indices.ldif
@@ -333,3 +333,13 @@ objectClass: nsindex
 nssystemindex: false
 nsindextype: eq
 nsindextype: sub
+
+# NOTE: There is no index on ipServiceProtocol because the index would have
+# poor selectivity. An ipService entry has either 'tcp' or 'udp' as protocol.
+dn: cn=ipServicePort,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: ipServicePort
+objectClass: top
+objectClass: nsIndex
+nsSystemIndex: false
+nsIndexType: eq

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -308,3 +308,10 @@ default: objectclass: nsindex
 default: nssystemindex: false
 default: nsindextype: eq
 default: nsindextype: sub
+
+dn: cn=ipServicePort,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: ipServicePort
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: eq

--- a/install/updates/30-ipservices.update
+++ b/install/updates/30-ipservices.update
@@ -1,0 +1,6 @@
+# container for RFC 2307 IP services
+
+dn: cn=ipservices,cn=accounts,$SUFFIX
+default: objectClass: top
+default: objectClass: nsContainer
+default: cn: ipservices


### PR DESCRIPTION
This PR was opened automatically because PR #2661 was pushed to master and backport to ipa-4-7 is required.