### PR TITLE
Add index on idnsName

### DIFF
--- a/install/share/indices.ldif
+++ b/install/share/indices.ldif
@@ -393,3 +393,11 @@ objectClass:top
 objectClass:nsIndex
 nsSystemIndex: false
 nsIndexType: eq
+
+dn: cn=idnsName,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: idnsName
+objectClass: top
+objectClass: nsIndex
+nsSystemIndex: false
+nsIndexType: eq

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -359,3 +359,10 @@ default: objectClass:top
 default: objectClass:nsIndex
 default: nsSystemIndex: false
 default: nsIndexType: eq
+
+dn: cn=idnsName,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: idnsName
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: eq


### PR DESCRIPTION
The data structures for the internal DNS server use the attribute idnsName
instead of cn in the DN. It's also used to search for entries when entries
are added, modified, or removed.

The new index speeds up dnsrecord and dnszone related commands as well
as commands like host-add and host-del --updatedns.

Fixes: https://pagure.io/freeipa/issue/7803
Signed-off-by: Christian Heimes <cheimes@redhat.com>

Note, this PR contain changes from https://github.com/freeipa/freeipa/pull/2649 to a avoid merge conflict.