### PR TITLE
Replace nss.conf with zero-length file instead of removing

### DIFF
--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -226,7 +226,9 @@ class HTTPInstance(service.Service):
 
     def disable_nss_conf(self):
         """
-        Backs up and removes the original nss.conf file.
+        Backs up the original nss.conf file and replace it with the empty one.
+        Empty file avoids recreation of nss.conf in case the package is
+        reinstalled.
 
         There is no safe way to co-exist since there is no safe port
         to make mod_nss use, disable it completely.
@@ -236,7 +238,8 @@ class HTTPInstance(service.Service):
             # (mod_nss -> mod_ssl upgrade scenario)
             if not self.fstore.has_file(paths.HTTPD_NSS_CONF):
                 self.fstore.backup_file(paths.HTTPD_NSS_CONF)
-            installutils.remove_file(paths.HTTPD_NSS_CONF)
+
+        open(paths.HTTPD_NSS_CONF, 'w').close()
 
     def set_mod_ssl_protocol(self):
         directivesetter.set_directive(paths.HTTPD_SSL_CONF,


### PR DESCRIPTION
Empty nss.conf avoids recreation of nss.conf in case `mod_nss` package is reinstalled. It is needed because by default (e.g. recreated) nss.conf has `Listen 8443` while this port is also used by dogtag. 

Fixes: https://pagure.io/freeipa/issue/7745