### PR TITLE
[WIP] Move docker pull call to before_install block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_install:
     - ls /proc/net
     - cat /proc/net/if_inet6
 #    - ip addr show dev lo | grep -q inet6 || (echo "No IPv6 address found"; exit 1)
+    - docker pull $TEST_RUNNER_IMAGE
 
 install:
     - pip3 install --upgrade pip

--- a/.travis_run_task.sh
+++ b/.travis_run_task.sh
@@ -45,8 +45,6 @@ then
     popd
 fi
 
-docker pull $TEST_RUNNER_IMAGE
-
 ipa-docker-test-runner -l $CI_RESULTS_LOG \
     -c $TEST_RUNNER_CONFIG \
     $developer_mode_opt \


### PR DESCRIPTION
Travis seems to be failing to pull the Docker image from Docker Hub. I'm following Travis guide to test if this could fix it.

More info: https://docs.travis-ci.com/user/docker/