### PR TITLE
ipa-getkeytab: resolve symlink

### DIFF
--- a/ipatests/test_cmdline/test_ipagetkeytab.py
+++ b/ipatests/test_cmdline/test_ipagetkeytab.py
@@ -190,6 +190,23 @@ class test_ipagetkeytab(KeytabRetrievalTest):
         except Exception as errmsg:
             assert('Unable to bind to LDAP. Error initializing principal' in str(errmsg))
 
+    def test_dangling_symlink(self, test_service):
+        # see https://pagure.io/freeipa/issue/4607
+        test_service.ensure_exists()
+
+        fd, symlink_target = tempfile.mkstemp()
+        os.close(fd)
+        os.unlink(symlink_target)
+        # create dangling symlink
+        os.symlink(self.keytabname, symlink_target)
+
+        try:
+            self.assert_success(test_service.name, raiseonerr=True)
+            assert os.path.isfile(symlink_target)
+            assert os.path.samefile(self.keytabname, symlink_target)
+        finally:
+            os.unlink(symlink_target)
+
 
 class TestBindMethods(KeytabRetrievalTest):
     """


### PR DESCRIPTION
Resolve one level of symbolic links to support a dangling symlink as
keytab target. To prevent symlink attacks, only resolve symlink when the
symlink is owned by the current effective user and group.

Fixes: https://pagure.io/freeipa/issue/4607
Signed-off-by: Christian Heimes <cheimes@redhat.com>