### PR TITLE
[Backport][ipa-4-7] Disable nss-p11-kit crypto policy for tests

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -50,6 +50,8 @@ steps:
   install_packages:
   - sed -i 's/%_install_langs \(.*\)/\0:fr/g' /etc/rpm/macros.image-language-conf
   - dnf install -y ${container_working_dir}/dist/rpms/*.rpm --best --allowerasing
+  # nss-p11-kit causes OpenLDAP's TLSMC patch to block
+  - rm -f /etc/crypto-policies/local.d/nss-p11-kit.config && update-crypto-policies
   install_server:
   - ipa-server-install -U --domain ${server_domain} --realm ${server_realm} -p ${server_password}
     -a ${server_password} --setup-dns --setup-kra --auto-forwarders

--- a/.test_runner_config_py3_temp.yaml
+++ b/.test_runner_config_py3_temp.yaml
@@ -51,6 +51,8 @@ steps:
   - sed -i 's/%_install_langs \(.*\)/\0:fr/g' /etc/rpm/macros.image-language-conf
   - dnf install -y ${container_working_dir}/dist/rpms/*.rpm --best --allowerasing
   - dnf install -y python3-mod_wsgi --best --allowerasing  # Py3 temporary
+  # nss-p11-kit causes OpenLDAP's TLSMC patch to block
+  - rm -f /etc/crypto-policies/local.d/nss-p11-kit.config && update-crypto-policies
   install_server:
   - ipa-server-install -U --domain ${server_domain} --realm ${server_realm} -p ${server_password}
     -a ${server_password} --setup-dns --auto-forwarders


### PR DESCRIPTION
Manual backport of PR #2679 

NSS 3.40 and 3.41 enable p11-kit proxy. The PKCS#11 proxy loads all
PKCS#11 providers including the default SoftHSM2 token. On Fedora 28
OpenLDAP is patched to use Mozilla NSS. Because the SoftHSM2 token is
protected, the OpenLDAP function tlsmc_extract_cacerts() blocks because
it is waiting for PIN.

Delete the p11-kit policy and regenerate crypto policy.

OpenLDAP debug output:

```
ldap_url_parse_ext(ldap://master.ipa.test:389/)
TLSMC: MozNSS compatibility interception begins.
tlsmc_intercept_initialization: INFO: entry options follow:
tlsmc_intercept_initialization: INFO: cacertdir = `/etc/dirsrv/slapd-IPA-TEST'
tlsmc_intercept_initialization: INFO: certfile = `(null)'
tlsmc_intercept_initialization: INFO: keyfile = `(null)'
tlsmc_convert: INFO: trying to open NSS DB with CACertDir = `/etc/dirsrv/slapd-IPA-TEST'.
tlsmc_open_nssdb: INFO: trying to initialize moznss using security dir `/etc/dirsrv/slapd-IPA-TEST` prefix ``.
tlsmc_open_nssdb: INFO: initialized MozNSS context.
tlsmc_convert: INFO: trying with PEM dir = `/tmp/openldap-tlsmc-slapd-IPA-TEST--CFD75CD2496FD947611EE486C199DB7DE06AF86D5CD28715BAD24414827D1987'.
tlsmc_convert: WARN: will try to create PEM dir.
tlsmc_prepare_dir: INFO: preparing PEM directory `/tmp/openldap-tlsmc-slapd-IPA-TEST--CFD75CD2496FD947611EE486C199DB7DE06AF86D5CD28715BAD24414827D1987'.
tlsmc_prepare_dir: INFO: creating a subdirectory `cacerts'.
tlsmc_prepare_dir: INFO: successfully created PEM directory structure.
   ***NSS 3.40 BLOCKS HERE***
tlsmc_extract_cacerts: INFO: found cert nick=`Server-Cert', _not_ a trusted CA, skipping.
tlsmc_extract_cacerts: INFO: found cert nick=`Self-Signed-CA', a trusted CA.
```

Signed-off-by: Christian Heimes <cheimes@redhat.com>