### PR TITLE
[Backport][ipa-4-7] Add more LDAP indices

### DIFF
--- a/install/share/indices.ldif
+++ b/install/share/indices.ldif
@@ -216,6 +216,40 @@ ObjectClass: top
 ObjectClass: nsIndex
 nsSystemIndex: false
 nsIndexType: eq
+nsIndexType: pres
+
+dn: cn=automountMapName,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: automountMapName
+ObjectClass: top
+ObjectClass: nsIndex
+nsSystemIndex: false
+nsIndexType: eq
+
+dn: cn=ipaConfigString,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: ipaConfigString
+objectClass:top
+objectClass:nsIndex
+nsSystemIndex: false
+nsIndexType: eq
+
+dn: cn=ipaEnabledFlag,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: ipaEnabledFlag
+objectClass:top
+objectClass:nsIndex
+nsSystemIndex: false
+nsIndexType: eq
+
+dn: cn=ipaKrbAuthzData,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: ipaKrbAuthzData
+objectClass: top
+objectClass: nsIndex
+nsSystemIndex: false
+nsIndexType: eq
+nsIndexType: sub
 
 dn: cn=ipakrbprincipalalias,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 changetype: add
@@ -341,5 +375,21 @@ changetype: add
 cn: ipServicePort
 objectClass: top
 objectClass: nsIndex
+nsSystemIndex: false
+nsIndexType: eq
+
+dn: cn=accessRuleType,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: accessRuleType
+objectClass:top
+objectClass:nsIndex
+nsSystemIndex: false
+nsIndexType: eq
+
+dn: cn=hostCategory,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: hostCategory
+objectClass:top
+objectClass:nsIndex
 nsSystemIndex: false
 nsIndexType: eq

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -151,6 +151,36 @@ default:ObjectClass: top
 default:ObjectClass: nsIndex
 default:nsSystemIndex: false
 default:nsIndexType: eq
+add:nsIndexType: pres
+
+dn: cn=automountMapName,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: automountMapName
+default: ObjectClass: top
+default: ObjectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: eq
+
+dn: cn=ipaConfigString,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: ipaConfigString
+default: objectClass:top
+default: objectClass:nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: eq
+
+dn: cn=ipaEnabledFlag,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: ipaEnabledFlag
+default: objectClass:top
+default: objectClass:nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: eq
+
+dn: cn=ipaKrbAuthzData,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: ipaKrbAuthzData
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: eq
+default: nsIndexType: sub
 
 dn: cn=ipakrbprincipalalias,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 default:cn: ipakrbprincipalalias
@@ -313,5 +343,19 @@ dn: cn=ipServicePort,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 default: cn: ipServicePort
 default: objectClass: top
 default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: eq
+
+dn: cn=accessRuleType,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: accessRuleType
+default: objectClass:top
+default: objectClass:nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: eq
+
+dn: cn=hostCategory,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: hostCategory
+default: objectClass:top
+default: objectClass:nsIndex
 default: nsSystemIndex: false
 default: nsIndexType: eq

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -405,6 +405,7 @@ class CAInstance(DogtagInstance):
                 self.step("creating installation admin user", self.setup_admin)
             self.step("configuring certificate server instance",
                       self.__spawn_instance)
+            self.step("reindex attributes", self.reindex_task)
             self.step("exporting Dogtag certificate store pin",
                       self.create_certstore_passwdfile)
             self.step("stopping certificate server instance to update CS.cfg",

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -43,6 +43,7 @@ from ipapython import ipaldap
 from ipapython import ipautil
 from ipapython.dn import DN
 from ipaserver.install import service
+from ipaserver.install import sysupgrade
 from ipaserver.install import replication
 from ipaserver.install.installutils import stopped_service
 
@@ -537,3 +538,48 @@ class DogtagInstance(service.Service):
         # shutil.copy() doesn't copy owner
         s = os.stat(config)
         os.chown(bak, s.st_uid, s.st_gid)
+
+    def reindex_task(self, force=False):
+        """Reindex ipaca entries
+
+        pkispawn sometimes does not run its indextasks. This leads to slow
+        unindexed filters on attributes such as description, which is used
+        to log in with a certificate. Explicitly reindex attribute that
+        should have been reindexed by CA's indextasks.ldif.
+
+        See https://pagure.io/dogtagpki/issue/3083
+        """
+        state_name = 'reindex_task'
+        if not force and sysupgrade.get_upgrade_state('dogtag', state_name):
+            return
+
+        cn = "indextask_ipaca_{}".format(int(time.time()))
+        dn = DN(
+            ('cn', cn), ('cn', 'index'), ('cn', 'tasks'), ('cn', 'config')
+        )
+        entry = api.Backend.ldap2.make_entry(
+            dn,
+            objectClass=['top', 'extensibleObject'],
+            cn=[cn],
+            nsInstance=['ipaca'],  # Dogtag PKI database
+            nsIndexAttribute=[
+                # from pki/base/ca/shared/conf/indextasks.ldif
+                'archivedBy', 'certstatus', 'clientId', 'dataType',
+                'dateOfCreate', 'description', 'duration', 'extension',
+                'issuedby', 'issuername', 'metaInfo', 'notafter',
+                'notbefore', 'ownername', 'publicKeyData', 'requestid',
+                'requestowner', 'requestsourceid', 'requeststate',
+                'requesttype', 'revInfo', 'revokedOn', 'revokedby',
+                'serialno', 'status', 'subjectname',
+            ],
+            ttl=[10],
+        )
+        logger.debug('Creating ipaca reindex task %s', dn)
+        api.Backend.ldap2.add_entry(entry)
+        logger.debug('Waiting for task...')
+        exitcode = replication.wait_for_task(api.Backend.ldap2, dn)
+        logger.debug(
+            'Task %s has finished with exit code %i',
+            dn, exitcode
+        )
+        sysupgrade.set_upgrade_state('dogtag', state_name, True)

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -543,7 +543,7 @@ class LDAPUpdate(object):
             nsIndexAttribute=list(attributes),
         )
 
-        logger.info(
+        logger.debug(
             "Creating task %s to index attributes: %s",
             dn, ', '.join(attributes)
         )
@@ -581,7 +581,7 @@ class LDAPUpdate(object):
                 continue
 
             if "finished" in status.lower():
-                logger.info("Indexing finished")
+                logger.debug("Indexing finished")
                 break
 
             logger.debug("Indexing in progress")

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -134,7 +134,14 @@ def safe_output(attr, values):
 
 
 class LDAPUpdate(object):
-    action_keywords = ["default", "add", "remove", "only", "onlyifexist", "deleteentry", "replace", "addifnew", "addifexist"]
+    action_keywords = [
+        "default", "add", "remove", "only", "onlyifexist", "deleteentry",
+        "replace", "addifnew", "addifexist"
+    ]
+    index_suffix = DN(
+        ('cn', 'index'), ('cn', 'userRoot'), ('cn', 'ldbm database'),
+        ('cn', 'plugins'), ('cn', 'config')
+    )
 
     def __init__(self, dm_password=None, sub_dict={},
                  online=True, ldapi=False):
@@ -515,8 +522,8 @@ class LDAPUpdate(object):
 
         return all_updates
 
-    def create_index_task(self, attribute):
-        """Create a task to update an index for an attribute"""
+    def create_index_task(self, *attributes):
+        """Create a task to update an index for attributes"""
 
         # Sleep a bit to ensure previous operations are complete
         time.sleep(5)
@@ -525,7 +532,7 @@ class LDAPUpdate(object):
         # cn_uuid.time is in nanoseconds, but other users of LDAPUpdate expect
         # seconds in 'TIME' so scale the value down
         self.sub_dict['TIME'] = int(cn_uuid.time/1e9)
-        cn = "indextask_%s_%s_%s" % (attribute, cn_uuid.time, cn_uuid.clock_seq)
+        cn = "indextask_%s_%s" % (cn_uuid.time, cn_uuid.clock_seq)
         dn = DN(('cn', cn), ('cn', 'index'), ('cn', 'tasks'), ('cn', 'config'))
 
         e = self.conn.make_entry(
@@ -533,11 +540,13 @@ class LDAPUpdate(object):
             objectClass=['top', 'extensibleObject'],
             cn=[cn],
             nsInstance=['userRoot'],
-            nsIndexAttribute=[attribute],
+            nsIndexAttribute=list(attributes),
         )
 
-        logger.debug("Creating task to index attribute: %s", attribute)
-        logger.debug("Task id: %s", dn)
+        logger.info(
+            "Creating task %s to index attributes: %s",
+            dn, ', '.join(attributes)
+        )
 
         self.conn.add_entry(e)
 
@@ -571,8 +580,8 @@ class LDAPUpdate(object):
                 time.sleep(1)
                 continue
 
-            if status.lower().find("finished") > -1:
-                logger.debug("Indexing finished")
+            if "finished" in status.lower():
+                logger.info("Indexing finished")
                 break
 
             logger.debug("Indexing in progress")
@@ -792,7 +801,7 @@ class LDAPUpdate(object):
         entry = self._apply_update_disposition(update.get('updates'), entry)
         if entry is None:
             # It might be None if it is just deleting an entry
-            return
+            return None, False
 
         self.print_entity(entry, "Final value after applying updates")
 
@@ -811,7 +820,7 @@ class LDAPUpdate(object):
                         # this may not be an error (e.g. entries in NIS container)
                         logger.error("Parent DN of %s may not exist, cannot "
                                      "create the entry", entry.dn)
-                        return
+                        return entry, False
                 added = True
                 self.modified = True
             except Exception as e:
@@ -846,12 +855,7 @@ class LDAPUpdate(object):
             if updated:
                 self.modified = True
 
-        if entry.dn.endswith(DN(('cn', 'index'), ('cn', 'userRoot'),
-                                ('cn', 'ldbm database'), ('cn', 'plugins'),
-                                ('cn', 'config'))) and (added or updated):
-            taskid = self.create_index_task(entry.single_value['cn'])
-            self.monitor_index_task(taskid)
-        return
+        return entry, added or updated
 
     def _delete_record(self, updates):
         """
@@ -903,13 +907,24 @@ class LDAPUpdate(object):
             raise RuntimeError("Offline updates are not supported.")
 
     def _run_updates(self, all_updates):
+        index_attributes = set()
         for update in all_updates:
             if 'deleteentry' in update:
                 self._delete_record(update)
             elif 'plugin' in update:
                 self._run_update_plugin(update['plugin'])
             else:
-                self._update_record(update)
+                entry, modified = self._update_record(update)
+                if modified and entry.dn.endswith(self.index_suffix):
+                    index_attributes.add(entry.single_value['cn'])
+
+        if index_attributes:
+            # The LDAPUpdate framework now keeps record of all changed/added
+            # indices and batches all changed attribute in a single index
+            # task. This makes updates much faster when multiple indices are
+            # added or modified.
+            task_dn = self.create_index_task(*sorted(index_attributes))
+            self.monitor_index_task(task_dn)
 
     def update(self, files, ordered=True):
         """Execute the update. files is a list of the update files to use.

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -2032,6 +2032,7 @@ def upgrade_configuration():
     add_default_caacl(ca)
 
     if ca.is_configured():
+        ca.reindex_task()
         cainstance.repair_profile_caIPAserviceCert()
         ca.setup_lightweight_ca_key_retrieval()
         cainstance.ensure_ipa_authority_entry()


### PR DESCRIPTION
Manual backport of PR #2649 

## Add more LDAP indices

An index is used to optimize an LDAP operation. Without an index, 389-DS
has to perform a partial or even full table scan. A full database scan can
easily take 10 seconds or more in a large installation.

* automountMapKey: eq, pres (was: eq)
* autoMountMapName: eq
* ipaConfigString: eq
* ipaEnabledFlag: eq
* ipaKrbAuthzData: eq, sub
* accessRuleType: eq
* hostCategory: eq

automountMapKey and autoMountMapName filters are used for automount.

Installation and service discovery (CA, KRA) use ipaConfigString to find
active services and CA renewal master.

SSSD filters with ipaEnabledFlag, accessRuleType, and hostCategory to
find and cache HBAC rules for each host.

ipaKrbAuthzData is used by ipa host-del. The framework performs a
``*arg*`` query, therefore a sub index is required, too.

Fixes: https://pagure.io/freeipa/issue/7786
Fixes: https://pagure.io/freeipa/issue/7787
Fixes: https://pagure.io/freeipa/issue/7790
Fixes: https://pagure.io/freeipa/issue/7792


## LDAPUpdate: Batch index tasks

The LDAPUpdate framework now keeps record of all changed/added indices
and batches all changed attribute in a single index task. It makes
updates much faster when multiple indices are added or modified.

##  Create reindex task for ipaca DB

pkispawn sometimes does not run its indextasks. This leads to slow
unindexed filters on attributes such as description, which is used
to log in with a certificate. Explicitly reindex attribute that
should have been reindexed by CA's indextasks.ldif.

See: https://pagure.io/dogtagpki/issue/3083

# NOTE

IP service performance issue is now tracked in ticket https://pagure.io/freeipa/issue/7797