### PR TITLE
[Backport][ipa-4-7] [NFS] ipa-client-automount and NFS unit name changes

### DIFF
--- a/client/ipa-client-automount.in
+++ b/client/ipa-client-automount.in
@@ -314,23 +314,21 @@ def uninstall(fstore, statestore):
                 print('Unable to restore SSSD configuration: %s' % str(e))
                 logger.debug('Unable to restore SSSD configuration: %s',
                              str(e))
+ 
+    # rpcidmapd and rpcgssd are static units now
     if statestore.has_state('rpcidmapd'):
-        enabled = statestore.restore_state('rpcidmapd', 'enabled')
-        running = statestore.restore_state('rpcidmapd', 'running')
-        rpcidmapd = services.knownservices.rpcidmapd
-        if not enabled:
-            rpcidmapd.disable()
-        if not running:
-            rpcidmapd.stop()
+        statestore.delete_state('rpcidmapd','enabled')
+        statestore.delete_state('rpcidmapd','running')
     if statestore.has_state('rpcgssd'):
-        enabled = statestore.restore_state('rpcgssd', 'enabled')
-        running = statestore.restore_state('rpcgssd', 'running')
-        rpcgssd = services.knownservices.rpcgssd
-        if not enabled:
-            rpcgssd.disable()
-        if not running:
-            rpcgssd.stop()
+        statestore.delete_state('rpcgssd','enabled')
+        statestore.delete_state('rpcgssd','running')
 
+    nfsutils = services.knownservices['nfs-utils']
+    try:
+        nfsutils.restart()
+    except Exception as e:
+        logger.error("Failed to restart nfs client services (%s)" % str(e))
+        return 1
     return 0
 
 def configure_nfs(fstore, statestore):
@@ -365,35 +363,18 @@ def configure_nfs(fstore, statestore):
 
     print("Configured %s" % paths.IDMAPD_CONF)
 
-    rpcidmapd = services.knownservices.rpcidmapd
-    statestore.backup_state('rpcidmapd', 'enabled', rpcidmapd.is_enabled())
-    statestore.backup_state('rpcidmapd', 'running', rpcidmapd.is_running())
-    try:
-        rpcidmapd.restart()
-        print("Started %s" % rpcidmapd.service_name)
-    except Exception as e:
-        logger.error("%s failed to restart: %s", rpcidmapd.service_name, e)
-    try:
-        rpcidmapd.enable()
-    except Exception as e:
-        print("Failed to configure automatic startup of the %s daemon" % (rpcidmapd.service_name))
-        logger.error("Failed to enable automatic startup of the %s daemon: %s",
-                     rpcidmapd.service_name, str(e))
-
     rpcgssd = services.knownservices.rpcgssd
-    statestore.backup_state('rpcgssd', 'enabled', rpcgssd.is_enabled())
-    statestore.backup_state('rpcgssd', 'running', rpcgssd.is_running())
     try:
         rpcgssd.restart()
-        print("Started %s" % rpcgssd.service_name)
     except Exception as e:
-        logger.error("%s failed to restart: %s", rpcgssd.service_name, e)
+        logger.error("Failed to restart rpc-gssd (%s)" % str(e))
+        return 1
+    nfsutils = services.knownservices['nfs-utils']
     try:
-        rpcgssd.enable()
+        nfsutils.restart()
     except Exception as e:
-        print("Failed to configure automatic startup of the %s daemon" % (rpcgssd.service_name))
-        logger.error("Failed to enable automatic startup of the %s daemon: %s",
-                     rpcgssd.service_name, str(e))
+        logger.error("Failed to restart nfs client services (%s)" % str(e))
+        return 1
 
 def main():
     try:

--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -53,7 +53,8 @@ wellknownservices = ['certmonger', 'dirsrv', 'httpd', 'ipa', 'krb5kdc',
                      'dbus', 'nslcd', 'nscd', 'ntpd', 'portmap',
                      'rpcbind', 'kadmin', 'sshd', 'autofs', 'rpcgssd',
                      'rpcidmapd', 'pki_tomcatd', 'chronyd', 'domainname',
-                     'named', 'ods_enforcerd', 'ods_signerd', 'gssproxy']
+                     'named', 'ods_enforcerd', 'ods_signerd', 'gssproxy',
+                     'nfs-utils']
 
 # The common ports for these services. This is used to wait for the
 # service to become available.

--- a/ipaplatform/redhat/services.py
+++ b/ipaplatform/redhat/services.py
@@ -45,8 +45,8 @@ logger = logging.getLogger(__name__)
 redhat_system_units = dict((x, "%s.service" % x)
                            for x in base_services.wellknownservices)
 
-redhat_system_units['rpcgssd'] = 'nfs-secure.service'
-redhat_system_units['rpcidmapd'] = 'nfs-idmap.service'
+redhat_system_units['rpcgssd'] = 'rpc-gssd.service'
+redhat_system_units['rpcidmapd'] = 'nfs-idmapd.service'
 redhat_system_units['domainname'] = 'nis-domainname.service'
 
 # Rewrite dirsrv and pki-tomcatd services as they support instances via separate

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -663,3 +663,15 @@ jobs:
         template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
+
+  fedora-29/test_automount_locations:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_automount_locations.py
+        template: *ci-master-f29
+        timeout: 6300
+        topology: *master_1repl

--- a/ipatests/test_integration/test_automount_locations.py
+++ b/ipatests/test_integration/test_automount_locations.py
@@ -1,0 +1,84 @@
+#
+# Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+#
+
+"""This module provides tests for the automount location feature.
+"""
+
+from __future__ import absolute_import
+
+import time
+import re
+
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_ipa.integration import tasks
+
+# give some time for units to stabilize
+# otherwise we get transient errors
+WAIT_AFTER_INSTALL = 5
+WAIT_AFTER_UNINSTALL = WAIT_AFTER_INSTALL
+
+
+class TestAutomountInstallUninstall(IntegrationTest):
+    """
+    Test if ipa-client-automount behaves as expected
+    """
+
+    num_replicas = 1
+    topology = 'star'
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=False)
+        client = cls.replicas[0]
+        tasks.install_client(cls.master, client)
+
+    def test_use_automount_location(self):
+
+        client = self.replicas[0]
+
+        self.master.run_command([
+            "ipa", "automountlocation-add", "baltimore"
+        ])
+
+        self.master.run_command([
+            "ipa", "host-mod", client.hostname,
+            "--location", "baltimore"
+        ])
+
+        # systemctl non-fatal errors will only be displayed
+        # if ipa-client-automount is launched with --debug
+        result1 = client.run_command([
+            'ipa-client-automount', '--location', 'baltimore',
+            '-U', '--debug'
+        ])
+
+        # systemctl non-fatal errors will show up like this:
+        # stderr=Failed to restart nfs-secure.service: \
+        #        Unit nfs-secure.service not found.
+        # normal output:
+        # stderr=
+        m1 = re.search(r'(?<=stderr\=Failed).+', result1.stderr_text)
+        # maybe re-use m1.group(0) if it exists.
+        assert m1 is None
+
+        time.sleep(WAIT_AFTER_INSTALL)
+
+        result2 = client.run_command([
+            'ipa-client-automount', '--uninstall',
+            '-U', '--debug'
+        ])
+
+        m2 = re.search(r'(?<=stderr\=Failed).+', result2.stderr_text)
+        assert m2 is None
+
+        time.sleep(WAIT_AFTER_UNINSTALL)
+
+        self.master.run_command([
+            "ipa", "host-mod", client.hostname,
+            "--location", "''"
+        ])
+
+        self.master.run_command([
+            "ipa", "automountlocation-del", "baltimore"
+        ])


### PR DESCRIPTION
This PR was opened automatically because PR #2657 was pushed to master and backport to ipa-4-7 is required.