### PR TITLE
Fix test_advise in nightly runs

### DIFF
--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -157,7 +157,7 @@ jobs:
         test_suite: test_integration/test_advise.py
         template: *ci-master-f28
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-28/test_testconfig:
     requires: [fedora-28/build]

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -157,7 +157,7 @@ jobs:
         test_suite: test_integration/test_advise.py
         template: *ci-master-f29
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-29/test_testconfig:
     requires: [fedora-29/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -157,7 +157,7 @@ jobs:
         test_suite: test_integration/test_advise.py
         template: *ci-master-frawhide
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-rawhide/test_testconfig:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
test_advise now needs one client, too.

See: https://pagure.io/freeipa/issue/7751
Signed-off-by: Christian Heimes <cheimes@redhat.com>