### PR TITLE
[Backport][ipa-4-7] ipa-sidgen: make internal fetch_attr helper really internal

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-sidgen/ipa_sidgen_task.c
+++ b/daemons/ipa-slapi-plugins/ipa-sidgen/ipa_sidgen_task.c
@@ -63,7 +63,7 @@ struct worker_ctx {
     struct range_info **ranges;
 };
 
-static const char *fetch_attr(Slapi_Entry *e, const char *attrname,
+static const char *ipa_sidgen_fetch_attr(Slapi_Entry *e, const char *attrname,
                                               const char *default_val)
 {
     Slapi_Attr *attr;
@@ -242,7 +242,7 @@ int sidgen_task_add(Slapi_PBlock *pb, Slapi_Entry *e,
 
     worker_ctx->plugin_id = global_sidgen_plugin_id;
 
-    str = fetch_attr(e, "delay", NULL);
+    str = ipa_sidgen_fetch_attr(e, "delay", NULL);
     if (str != NULL) {
         errno = 0;
         worker_ctx->delay = strtol(str, &endptr, 10);
@@ -255,7 +255,7 @@ int sidgen_task_add(Slapi_PBlock *pb, Slapi_Entry *e,
     }
     LOG("delay is [%li].\n", worker_ctx->delay);
 
-    str = fetch_attr(e, "nsslapd-basedn", NULL);
+    str = ipa_sidgen_fetch_attr(e, "nsslapd-basedn", NULL);
     if (str == NULL) {
         LOG_FATAL("Missing nsslapd-basedn!\n");
         *returncode = LDAP_CONSTRAINT_VIOLATION;


### PR DESCRIPTION
This PR was opened automatically because PR #2693 was pushed to master and backport to ipa-4-7 is required.