### PR TITLE
replica install: set the same master as preferred source for domain a…

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -812,7 +812,8 @@ def promote_check(installer):
     config.host_name = api.env.host
     config.domain_name = api.env.domain
     config.master_host_name = api.env.server
-    config.ca_host_name = api.env.ca_host
+    # Try to use same master for CA install
+    config.ca_host_name = api.env.server
     config.kra_host_name = config.ca_host_name
     config.ca_ds_port = 389
     config.setup_ca = options.setup_ca


### PR DESCRIPTION
…nd CA

During ipa-replica-install, the installer creates a ReplicaConfig
object that contains a config.ca_host_name attribute, built from
api.env.ca_host.
This attribute is used as preferred source when asking the DNS for a CA
master from which to initialize the CA instance
(see commit 8decef33 for master selection and preferred host).

In most of the cases, /etc/ipa/default.conf does not contain any
definition for ca_host. In this case, api.env.ca_host is set to
the local hostname.
As a consequence, replica install is trying to use the local host
as preferred source (which does not have any CA yet), and the method
to find the CA source randomly picks the CA in the DNS.

With the fix, the master picked for domain replication is also used as
preferred source for CA/KRA.