### PR TITLE
Require 3.41.0-3 on Fedora 28

### DIFF
--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -50,8 +50,6 @@ steps:
   install_packages:
   - sed -i 's/%_install_langs \(.*\)/\0:fr/g' /etc/rpm/macros.image-language-conf
   - dnf install -y ${container_working_dir}/dist/rpms/*.rpm --best --allowerasing
-  # nss-p11-kit causes OpenLDAP's TLSMC patch to block
-  - rm -f /etc/crypto-policies/local.d/nss-p11-kit.config && update-crypto-policies
   install_server:
   - ipa-server-install -U --domain ${server_domain} --realm ${server_realm} -p ${server_password}
     -a ${server_password} --setup-dns --setup-kra --auto-forwarders

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -82,9 +82,13 @@
 # and https://pagure.io/dogtagpki/issue/3073
 %global pki_version 10.6.8-3
 
-# NSS release with fix for CKA_LABEL import bug in shared SQL database.
-# https://bugzilla.redhat.com/show_bug.cgi?id=1568271
-%global nss_version 3.36.1-1.1
+# NSS release with fix for p11-kit-proxy issue, affects F28
+# https://pagure.io/freeipa/issue/7810
+%if 0%{?fedora} == 28
+%global nss_version 3.41.0-3
+%else
+%global nss_version 3.41.0-1
+%endif
 
 # One-Way Trust authenticated by trust secret
 # https://bugzilla.redhat.com/show_bug.cgi?id=1345975#c20


### PR DESCRIPTION
nss-3.41.0-3.fc28 fixes an issue with p11-kit crypto policy that caused
OpenLDAP to fail when SoftHSM2 is installed. The build is available in
Fedora updates-testing and @freeipa/freeipa-master COPR.

nss-3.41.0-1.fc29 is available in F29 stable.

See: https://pagure.io/freeipa/issue/7810
Signed-off-by: Christian Heimes <cheimes@redhat.com>