### PR TITLE
pkinit enable: use local dogtag only if host has CA

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -45,6 +45,7 @@ from ipaserver.install import replication
 from ipaserver.install import ldapupdate
 
 from ipaserver.install import certs
+from ipaserver.masters import find_providing_servers
 from ipaplatform.constants import constants
 from ipaplatform.tasks import tasks
 from ipaplatform.paths import paths
@@ -428,10 +429,13 @@ class KrbInstance(service.Service):
             prev_helper = None
             # on the first CA-ful master without '--no-pkinit', we issue the
             # certificate by contacting Dogtag directly
+            localhost_has_ca = self.fqdn in find_providing_servers(
+                'CA', conn=self.api.Backend.ldap2, api=self.api)
             use_dogtag_submit = all(
                 [self.master_fqdn is None,
                  self.pkcs12_info is None,
-                 self.config_pkinit])
+                 self.config_pkinit,
+                 localhost_has_ca])
 
             if use_dogtag_submit:
                 ca_args = [


### PR DESCRIPTION
## pkinit enable: use local dogtag only if host has CA

`ipa-pkinit-manage enable` is failing if called on a master that does not have a CA instance, because it is trying to contact dogtag on the localhost.
The command should rather use certmonger in this case, and let certmonger contact the right master to request the KDC certificate.

Fixes: https://pagure.io/freeipa/issue/7795

## ipatests: add integration test for pkinit enable on replica

`ipa-pkinit-manage` enable was failing when run on a replica without a CA instance.
Add a test with the following scenario:
- install a replica with `--no-pkinit`
- check that the KDC cert is self signed
- call `ipa-pkinit-manage enable`
- check that the KDC cert is signed by IPA CA

Related to https://pagure.io/freeipa/issue/7795