### PR TITLE
[FileStore] Add support for the stacked backup

### DIFF
--- a/install/tools/ipa-adtrust-install.in
+++ b/install/tools/ipa-adtrust-install.in
@@ -135,7 +135,7 @@ def main():
 
     check_server_configuration()
 
-    fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    fstore = sysrestore.FileStore()
 
     print("================================================================"
           "==============")

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3183,7 +3183,7 @@ def uninstall_check(options):
             "IPA client is not configured on this system.",
             rval=rval)
 
-    server_fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    server_fstore = sysrestore.FileStore()
     if server_fstore.has_files() and not options.on_master:
         logger.error(
             "IPA client is configured as a part of IPA server on this system.")

--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -104,7 +104,7 @@ def run_with_args(api):
             os.environ['KRB5CCNAME'] = old_krb5ccname
         shutil.rmtree(tmpdir)
 
-    server_fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    server_fstore = sysrestore.FileStore()
     if server_fstore.has_files():
         update_server(certs)
         try:

--- a/ipalib/install/sysrestore.py
+++ b/ipalib/install/sysrestore.py
@@ -64,7 +64,7 @@ SYSRESTORE_STATEFILE = "sysrestore.state"
 class FileStore:
     """Class for handling backup and restore of files"""
 
-    def __init__(self, path = SYSRESTORE_PATH, index_file = SYSRESTORE_INDEXFILE):
+    def __init__(self, path=SYSRESTORE_PATH, index_file=SYSRESTORE_INDEXFILE):
         """Create a _StoreFiles object, that uses @path as the
         base directory.
 
@@ -165,7 +165,7 @@ class FileStore:
             cont_hash = sha256(f.read()).hexdigest()
 
         filename = "{hexhash}-{bcppath}".format(
-                hexhash=cont_hash, bcppath=backupfile)
+            hexhash=cont_hash, bcppath=backupfile)
 
         backup_path = os.path.join(self._path, filename)
         if os.path.isfile(backup_path):
@@ -196,7 +196,7 @@ class FileStore:
                 break
         return result
 
-    def restore_file(self, path, new_path = None):
+    def restore_file(self, path, new_path=None):
         """Restore the copy of a file at @path to its original
         location and delete the copy.
 
@@ -360,7 +360,7 @@ class StateFile:
     enabled=False
     """
 
-    def __init__(self, path = SYSRESTORE_PATH, state_file = SYSRESTORE_STATEFILE):
+    def __init__(self, path=SYSRESTORE_PATH, state_file=SYSRESTORE_STATEFILE):
         """Create a StateFile object, loading from @path.
 
         The dictionary @modules, a member of the returned object,
@@ -431,7 +431,9 @@ class StateFile:
         a string or boolean.
         """
         if not isinstance(value, (str, bool, unicode)):
-            raise ValueError("Only strings, booleans or unicode strings are supported")
+            raise ValueError(
+                "Only strings, booleans or unicode strings are supported"
+            )
 
         self._load()
 

--- a/ipalib/install/sysrestore.py
+++ b/ipalib/install/sysrestore.py
@@ -118,7 +118,7 @@ class FileStore:
         if len(self.files) == 0:
             logger.debug("  -> no files, removing file")
             if os.path.exists(self._index):
-                os.remove(self._index)
+                os.unlink(self._index)
             return
 
         p = SafeConfigParser()
@@ -247,7 +247,7 @@ class FileStore:
             path = new_path
 
         shutil.copy(backup_path, path)  # SELinux needs copy
-        os.remove(backup_path)
+        os.unlink(backup_path)
 
         os.chown(path, int(uid), int(gid))
         os.chmod(path, int(mode))
@@ -281,7 +281,7 @@ class FileStore:
                 continue
 
             shutil.copy(backup_path, path)  # SELinux needs copy
-            os.remove(backup_path)
+            os.unlink(backup_path)
 
             os.chown(path, int(uid), int(gid))
             os.chmod(path, int(mode))
@@ -411,7 +411,7 @@ class StateFile:
         if len(self.modules) == 0:
             logger.debug("  -> no modules, removing file")
             if os.path.exists(self._path):
-                os.remove(self._path)
+                os.unlink(self._path)
             return
 
         p = SafeConfigParser()

--- a/ipalib/install/sysrestore.py
+++ b/ipalib/install/sysrestore.py
@@ -29,7 +29,6 @@ import collections
 import logging
 import os
 import os.path
-import random
 import shutil
 import stat
 from hashlib import sha256
@@ -81,8 +80,6 @@ class FileStore:
 
         self._path = path
         self._index = os.path.join(self._path, index_file)
-
-        self.random = random.Random()
 
         self.files = collections.OrderedDict()
         self._load()

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -200,7 +200,7 @@ class CertDB:
         if fstore:
             self.fstore = fstore
         else:
-            self.fstore = sysrestore.FileStore(paths.SYSRESTORE)
+            self.fstore = sysrestore.FileStore()
 
     ca_subject = ipautil.dn_attribute_property('_ca_subject')
     subject_base = ipautil.dn_attribute_property('_subject_base')

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -77,7 +77,7 @@ def _is_master():
 
 
 def _disable_dnssec():
-    fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    fstore = sysrestore.FileStore()
 
     ods = opendnssecinstance.OpenDNSSECInstance(fstore)
     ods.realm = api.env.realm
@@ -114,7 +114,7 @@ def _disable_dnssec():
 def install_check(standalone, api, replica, options, hostname):
     global ip_addresses
     global reverse_zones
-    fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    fstore = sysrestore.FileStore()
 
     if not os.path.isfile(paths.IPA_DNS_INSTALL):
         raise RuntimeError("Integrated DNS requires '%s' package" %
@@ -319,7 +319,7 @@ def install_check(standalone, api, replica, options, hostname):
 
 
 def install(standalone, replica, options, api=api):
-    fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    fstore = sysrestore.FileStore()
 
     if standalone:
         # otherwise this is done by server/replica installer
@@ -396,7 +396,7 @@ def uninstall_check(options):
 
 
 def uninstall():
-    fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    fstore = sysrestore.FileStore()
     ods = opendnssecinstance.OpenDNSSECInstance(fstore)
     if ods.is_configured():
         ods.uninstall()

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -670,7 +670,7 @@ def check_server_configuration():
     Most convenient use case for the function is in install tools that require
     configured IPA for its function.
     """
-    server_fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    server_fstore = sysrestore.FileStore()
     if not server_fstore.has_files():
         raise ScriptError("IPA is not configured on this system.",
                           rval=SERVER_NOT_CONFIGURED)
@@ -705,8 +705,8 @@ def is_ipa_configured():
     """
     installed = False
 
-    sstore = sysrestore.StateFile(paths.SYSRESTORE)
-    fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    sstore = sysrestore.StateFile()
+    fstore = sysrestore.FileStore()
 
     for module in IPA_MODULES:
         if sstore.has_state(module):

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -84,7 +84,7 @@ class OpenDNSSECInstance(service.Service):
         if fstore:
             self.fstore = fstore
         else:
-            self.fstore = sysrestore.FileStore(paths.SYSRESTORE)
+            self.fstore = sysrestore.FileStore()
 
     suffix = ipautil.dn_attribute_property('_suffix')
 

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -354,8 +354,8 @@ def install_check(installer):
             "Please uninstall it before configuring the IPA server, "
             "using 'ipa-client-install --uninstall'")
 
-    fstore = sysrestore.FileStore(SYSRESTORE_DIR_PATH)
-    sstore = sysrestore.StateFile(SYSRESTORE_DIR_PATH)
+    fstore = sysrestore.FileStore()
+    sstore = sysrestore.StateFile()
 
     # This will override any settings passed in on the cmdline
     if os.path.isfile(paths.ROOT_IPA_CACHE):
@@ -1027,8 +1027,8 @@ def uninstall_check(installer):
               "If you want to install the\nIPA server, please install "
               "it using 'ipa-server-install'.")
 
-    fstore = sysrestore.FileStore(SYSRESTORE_DIR_PATH)
-    sstore = sysrestore.StateFile(SYSRESTORE_DIR_PATH)
+    fstore = sysrestore.FileStore()
+    sstore = sysrestore.StateFile()
 
     # Configuration for ipalib, we will bootstrap and finalize later, after
     # we are sure we have the configuration file ready.

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -795,9 +795,9 @@ def promote_check(installer):
                 raise ScriptError(
                     "NTP configuration cannot be updated during promotion")
 
-    sstore = sysrestore.StateFile(paths.SYSRESTORE)
+    sstore = sysrestore.StateFile()
 
-    fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    fstore = sysrestore.FileStore()
 
     env = Env()
     env._bootstrap(context='installer', confdir=paths.ETC_IPA, log=None)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1293,7 +1293,7 @@ def uninstall_dogtag_9(ds, http):
     with open(paths.IPA_DEFAULT_CONF, 'w') as f:
         p.write(f)
 
-    sstore = sysrestore.StateFile(paths.SYSRESTORE)
+    sstore = sysrestore.StateFile()
     sstore.restore_state('pkids', 'enabled')
     sstore.restore_state('pkids', 'running')
     sstore.restore_state('pkids', 'user_exists')
@@ -1680,7 +1680,7 @@ def enable_certauth(krb):
 
 
 def ntpd_cleanup(fqdn, fstore):
-    sstore = sysrestore.StateFile(paths.SYSRESTORE)
+    sstore = sysrestore.StateFile()
     timeconf.restore_forced_timeservices(sstore, 'ntpd')
     if sstore.has_state('ntp'):
         instance = services.service('ntpd', api)
@@ -1826,7 +1826,7 @@ def upgrade_configuration():
 
     logger.debug('IPA version %s', version.VENDOR_VERSION)
 
-    fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    fstore = sysrestore.FileStore()
 
     fqdn = api.env.host
 

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -295,12 +295,12 @@ class Service:
         if sstore:
             self.sstore = sstore
         else:
-            self.sstore = sysrestore.StateFile(paths.SYSRESTORE)
+            self.sstore = sysrestore.StateFile()
 
         if fstore:
             self.fstore = fstore
         else:
-            self.fstore = sysrestore.FileStore(paths.SYSRESTORE)
+            self.fstore = sysrestore.FileStore()
 
         self.realm = realm_name
         self.suffix = DN()

--- a/ipatests/test_install/test_filestore.py
+++ b/ipatests/test_install/test_filestore.py
@@ -1,0 +1,958 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Module provides unit tests to verify that the FileStore code works.
+"""
+
+from __future__ import absolute_import
+
+import collections
+import filecmp
+import os
+import shutil
+from hashlib import sha256
+
+import pytest
+import six
+
+# pylint: disable=import-error
+if six.PY3:
+    # The SafeConfigParser class has been renamed to ConfigParser in Py3
+    from configparser import ConfigParser as SafeConfigParser
+    from configparser import MissingSectionHeaderError
+else:
+    from ConfigParser import SafeConfigParser
+    from ConfigParser import MissingSectionHeaderError
+# pylint: enable=import-error
+
+from ipalib.install import sysrestore
+from ipalib.install.sysrestore import SYSRESTORE_SEP as SEP
+from ipaplatform.paths import paths
+
+
+TESTDATA = {
+    "test_create": [
+        {},
+        {"path": "notdefault_storedir"},
+        {"path": "notdefault_storedir", "index_file": "notdefault_indexfile"},
+        {"index_file": "notdefault_indexfile"},
+    ],
+    "test_restore": [
+        {"path": "/oldpath"},
+        {"new_path": "newpath", "path": "/oldpath"},
+    ],
+}
+
+
+# helpers
+def backuped_name(path):
+    """
+    Return an expected internal name of a file being backuped to filestore
+    """
+    backupfile = os.path.basename(path)
+    with open(path, "rb") as f:
+        cont_hash = sha256(f.read()).hexdigest()
+    return "{hexhash}-{bcppath}".format(
+        hexhash=cont_hash, bcppath=backupfile
+    )
+
+
+def mkfile_source(sourcedir, sourcefile="sourcepath", content="content"):
+    """
+    Prepare an arbitrary source file
+    """
+    sourcepath = os.path.join(sourcedir, sourcefile)
+    with open(sourcepath, "w") as f:
+        f.write(content)
+    return sourcepath
+
+
+def index_path(index_dict):
+    """
+    Build an expected path (string) of index file from a given dict
+    """
+    indexdir = index_dict.get("path", sysrestore.SYSRESTORE_PATH)
+    indexfile = index_dict.get("index_file", sysrestore.SYSRESTORE_INDEXFILE)
+    return os.path.join(indexdir, indexfile)
+
+
+def idf(val):
+    """
+    Improve readability of parameterization
+    """
+    if not val:
+        return "@default"
+    else:
+        return "@" + str(val)
+
+
+@pytest.fixture
+def sysrestore_dirs(request, tmpdir):
+    """
+    Prepare sysrestore dirs for tests.
+    Monkeypatch paths.SYSRESTORE to override the default one
+    to prevent damage installed IPA.
+    """
+    sysrest_orig = paths.SYSRESTORE
+    paths.SYSRESTORE = str(tmpdir.mkdir("default_store"))
+
+    import importlib
+    importlib.reload(sysrestore)
+
+    def fin():
+        paths.SYSRESTORE = sysrest_orig
+        importlib.reload(sysrestore)
+
+    request.addfinalizer(fin)
+
+    store_dir = str(tmpdir.mkdir("sysrestore"))
+    source_dir = str(tmpdir.mkdir("sourcedir"))
+    return {"store_dir": store_dir, "source_dir": source_dir}
+
+
+@pytest.fixture
+def fstore(sysrestore_dirs):
+    """
+    Create a FileStore in specified location
+    """
+    fstore = sysrestore.FileStore(path=sysrestore_dirs["store_dir"])
+    return fstore
+
+
+@pytest.mark.parametrize("testdata", TESTDATA["test_create"], ids=idf)
+def test_create_new(testdata, sysrestore_dirs):
+    """
+    Condition: new (not existing before) filestore.
+    Expected result: there should be no files within the store.
+    """
+    if "path" in testdata.keys():
+        testdata["path"] = sysrestore_dirs["store_dir"]
+    fstore = sysrestore.FileStore(**testdata)
+    assert not fstore.files
+
+
+@pytest.mark.parametrize("testdata", TESTDATA["test_create"], ids=idf)
+def test_create_empty_existing(testdata, sysrestore_dirs):
+    """
+    Condition: existing but empty filestore.
+    Expected result: there should be no files within the store.
+    """
+    if "path" in testdata.keys():
+        testdata["path"] = sysrestore_dirs["store_dir"]
+    with open(index_path(testdata), "w") as f:
+        f.write("")
+    fstore = sysrestore.FileStore(**testdata)
+    assert not fstore.files
+
+
+@pytest.mark.parametrize("testdata", TESTDATA["test_create"], ids=idf)
+def test_create_no_headers(testdata, sysrestore_dirs):
+    """
+    Condition: existing filestore but having no headers.
+    Expected result: there should be an exception.
+    """
+    if "path" in testdata.keys():
+        testdata["path"] = sysrestore_dirs["store_dir"]
+    fstore = None
+    with open(index_path(testdata), "w") as f:
+        f.write("noheaders")
+
+    with pytest.raises(MissingSectionHeaderError):
+        fstore = sysrestore.FileStore(**testdata)
+        pytest.fail("Attempting to parse a config file which has"
+                    "no section headers should raise an exception")
+
+    assert fstore is None
+
+
+@pytest.mark.parametrize(
+    "testdata", [
+        {"index_file": ""},
+        {"index_file": "/some/path"},
+    ],
+    ids=idf,
+)
+def test_create_non_indexfile(testdata, sysrestore_dirs):
+    """
+    Condition: create filestore with index file having name with leading dirs.
+    Expected result: there should be an exception.
+    """
+    fstore = None
+    if "path" in testdata.keys():
+        testdata["path"] = sysrestore_dirs["store_dir"]
+    with pytest.raises(ValueError):
+        fstore = sysrestore.FileStore(**testdata)
+        pytest.fail("Attempting to create a filestore with empty "
+                    "index or with index file having name with "
+                    "leading dirs should raise an exception")
+
+    assert fstore is None
+
+
+@pytest.mark.parametrize("testdata", TESTDATA["test_create"], ids=idf)
+def test_create_wrong_header(testdata, sysrestore_dirs):
+    """
+    Condition: existing filestore, but having wrong headers.
+    Expected result: there should be no files within the store.
+    """
+    if "path" in testdata.keys():
+        testdata["path"] = sysrestore_dirs["store_dir"]
+    p = SafeConfigParser()
+    p.read_dict(
+        collections.OrderedDict([
+            ("wrongheader",
+             collections.OrderedDict([
+                 ("key", "value"),
+             ])),
+        ])
+    )
+    with open(index_path(testdata), "w") as f:
+        p.write(f)
+    fstore = sysrestore.FileStore(**testdata)
+    assert not fstore.files
+
+
+@pytest.mark.parametrize("testdata", TESTDATA["test_create"], ids=idf)
+def test_create_broken_store(testdata, sysrestore_dirs):
+    """
+    Condition: existing filestore, but having broken state.
+    Expected result: there should be an exception.
+    """
+    if "path" in testdata.keys():
+        testdata["path"] = sysrestore_dirs["store_dir"]
+    p = SafeConfigParser()
+    # make key name case sensitive
+    p.optionxform = str
+
+    expected_files = collections.OrderedDict([
+        ("key", SEP * (sysrestore.SYSRESTORE_MAX_INDEX - 1)),
+    ])
+    p.read_dict(
+        collections.OrderedDict([
+            (sysrestore.SYSRESTORE_SECTION, expected_files),
+        ])
+    )
+
+    with open(index_path(testdata), "w") as f:
+        p.write(f)
+
+    fstore = None
+    with pytest.raises(ValueError) as error:
+        fstore = sysrestore.FileStore(**testdata)
+        pytest.fail("Attempting to load FileStore with broken value"
+                    " should raise exception")
+    assert str(error.value) == "Broken store {0}".format(
+        index_path(testdata)
+    )
+    assert fstore is None
+
+
+@pytest.mark.parametrize("testdata", TESTDATA["test_create"], ids=idf)
+def test_create(testdata, sysrestore_dirs):
+    """
+    Condition: existing filestore with files within.
+    Expected result: successful creation of filestore.
+    """
+    if "path" in testdata.keys():
+        testdata["path"] = sysrestore_dirs["store_dir"]
+    p = SafeConfigParser()
+    # make key name case sensitive
+    p.optionxform = str
+
+    expected_files = collections.OrderedDict([
+        ("key", SEP * sysrestore.SYSRESTORE_MAX_INDEX),
+    ])
+    p.read_dict(
+        collections.OrderedDict([
+            (sysrestore.SYSRESTORE_SECTION, expected_files),
+        ])
+    )
+
+    with open(index_path(testdata), "w") as f:
+        p.write(f)
+
+    fstore = sysrestore.FileStore(**testdata)
+    assert fstore.files == expected_files
+
+
+def test_save_empty(fstore):
+    """
+    Condition: cleared filestore.
+    Expected result: lack of store index.
+    """
+    fstore.files.clear()
+    # if files is an empty dict then store should be removed
+    fstore.save()
+    assert not os.path.isfile(fstore._index)
+
+
+def test_save_broken_store(fstore):
+    """
+    Condition: filestore with broken state.
+    Expected result: there should be an exception.
+    """
+    fstore.files = collections.OrderedDict([
+        ("key", SEP * (sysrestore.SYSRESTORE_MAX_INDEX - 1)),
+    ])
+
+    with pytest.raises(ValueError) as error:
+        fstore.save()
+        pytest.fail("Attempting to save FileStore with broken value"
+                    " should raise ValueError exception")
+    assert str(error.value) == "Broken store {0}".format(fstore._index)
+    assert not os.path.isfile(fstore._index)
+
+
+def test_save(fstore):
+    """
+    Condition: filestore with files within.
+    Expected result: successful saving to store index.
+    """
+    fstore.files = collections.OrderedDict([
+        ("key", SEP * sysrestore.SYSRESTORE_MAX_INDEX),
+    ])
+    fstore.save()
+
+    p = SafeConfigParser()
+    p.optionxform = str
+    p.read(fstore._index)
+
+    expected_files = collections.OrderedDict()
+    for section in p.sections():
+        for (key, value) in p.items(section):
+            expected_files[key] = value
+
+    assert fstore.files == expected_files
+
+
+@pytest.mark.parametrize("nonabs_path", ["", "../relative/"], ids=idf)
+def test_backup_not_abs(nonabs_path, fstore, sysrestore_dirs):
+    """
+    Condition: path to be backuped is empty or non-absolute.
+    Expected result: there should be an exception.
+    """
+    with pytest.raises(ValueError) as error:
+        fstore.backup_file(nonabs_path)
+        pytest.fail("Attempting to backup empty or relative "
+                    "path should raise an exception")
+    assert str(error.value) == "Absolute path required"
+    assert not os.listdir(sysrestore_dirs["store_dir"])
+
+
+def test_backup_file_not_exist(fstore, sysrestore_dirs):
+    """
+    Condition: path to be backuped does not exist.
+    Expected result: there should be no file in the store.
+    """
+    fstore.backup_file("/notexisted")
+    assert not os.listdir(sysrestore_dirs["store_dir"])
+
+
+def test_backup_dir(fstore, sysrestore_dirs):
+    """
+    Condition: path to be backuped is directory.
+    Expected result: there should be an exception.
+    """
+    with pytest.raises(ValueError) as error:
+        fstore.backup_file(sysrestore_dirs["source_dir"])
+        pytest.fail("Attempting to backup a non-regular file "
+                    "should raise an exception")
+    assert str(error.value) == "Regular file required"
+    assert not os.listdir(sysrestore_dirs["store_dir"])
+
+
+def test_backup_broken_store(fstore, sysrestore_dirs):
+    """
+    Condition: filestore with broken state.
+    Expected result: there should be an exception.
+    """
+    sourcepath = mkfile_source(sysrestore_dirs["source_dir"])
+    fstore.files = collections.OrderedDict([
+        ("key", SEP * (sysrestore.SYSRESTORE_MAX_INDEX - 1)),
+    ])
+
+    with pytest.raises(ValueError) as error:
+        fstore.backup_file(sourcepath)
+        pytest.fail("Attempting to backup file into broken "
+                    "store should raise an exception")
+    assert str(error.value) == "Broken store {0}".format(fstore._index)
+    assert not os.listdir(sysrestore_dirs["store_dir"])
+
+
+def test_backup(fstore, sysrestore_dirs):
+    """
+    Condition: new filestore.
+    Expected result: successful backup of file.
+    """
+    sourcepath = mkfile_source(sysrestore_dirs["source_dir"])
+    expected_stat = os.lstat(sourcepath)
+    expected_mode = expected_stat.st_mode
+
+    template = "{stats.st_mode},{stats.st_uid},{stats.st_gid},{path}"
+    value = template.format(stats=expected_stat, path=sourcepath)
+    expected_files = collections.OrderedDict()
+    expected_files[backuped_name(sourcepath)] = value
+
+    fstore.backup_file(sourcepath)
+    assert fstore.files == expected_files
+
+    backupfile = os.path.join(sysrestore_dirs["store_dir"],
+                              backuped_name(sourcepath))
+    actual_stat = os.lstat(backupfile)
+    actual_mode = actual_stat.st_mode
+    assert oct(actual_mode) == oct(expected_mode)
+    # check content
+    assert filecmp.cmp(sourcepath, backupfile, shallow=False)
+
+
+def test_backup_same_file(fstore, sysrestore_dirs):
+    """
+    Condition: new filestore with the same file within.
+    Expected result: no backup of file, no store changes.
+    """
+    sourcepath = mkfile_source(sysrestore_dirs["source_dir"])
+    fstore.backup_file(sourcepath)
+    backupfile = os.path.join(sysrestore_dirs["store_dir"],
+                              backuped_name(sourcepath))
+    expected_stat = os.lstat(backupfile)
+    expected_mode = expected_stat.st_mode
+    expected_files = collections.OrderedDict(fstore.files)
+
+    # repeat backup
+    fstore.backup_file(sourcepath)
+    actual_stat = os.lstat(backupfile)
+    actual_mode = actual_stat.st_mode
+    assert oct(actual_mode) == oct(expected_mode)
+    assert fstore.files == expected_files
+
+
+def test_backup_same_filename(fstore, sysrestore_dirs):
+    """
+    Condition: source file has been already backuped, but the content
+    is different. Updated file should be appended to the filestore.
+    Expected result: successful backup; ordered store.
+    """
+    sourcepath = mkfile_source(sysrestore_dirs["source_dir"])
+    expected_stat = os.lstat(sourcepath)
+    template = "{stats.st_mode},{stats.st_uid},{stats.st_gid},{path}"
+    value = template.format(stats=expected_stat, path=sourcepath)
+    expected_files = collections.OrderedDict()
+    expected_files[backuped_name(sourcepath)] = value
+
+    fstore.backup_file(sourcepath)
+
+    # overwrite source
+    sourcepath = mkfile_source(sysrestore_dirs["source_dir"],
+                               content="overwrite_content")
+    expected_stat = os.lstat(sourcepath)
+    expected_mode = expected_stat.st_mode
+    value = template.format(stats=expected_stat, path=sourcepath)
+    expected_files[backuped_name(sourcepath)] = value
+
+    fstore.backup_file(sourcepath)
+    # check an internal state of store
+    assert len(fstore.files) == 2
+    assert fstore.files == expected_files
+
+    backupfile = os.path.join(sysrestore_dirs["store_dir"],
+                              backuped_name(sourcepath))
+    actual_stat = os.lstat(backupfile)
+    actual_mode = actual_stat.st_mode
+    assert oct(actual_mode) == oct(expected_mode)
+    # check content
+    assert filecmp.cmp(sourcepath, backupfile, shallow=False)
+
+
+def test_has_file_empty_store(fstore):
+    """
+    Condition: new filestore without files within.
+    Expected result: filestore has no file.
+    """
+    fstore.files = collections.OrderedDict([
+        ("key", SEP * sysrestore.SYSRESTORE_MAX_INDEX),
+    ])
+    assert not fstore.has_file("testpath")
+
+
+def test_has_file_broken_store(fstore):
+    """
+    Condition: new filestore with broken state.
+    Expected result: there should be an exception.
+    """
+    fstore.files = collections.OrderedDict([
+        ("key", SEP * (sysrestore.SYSRESTORE_MAX_INDEX - 1)),
+    ])
+    with pytest.raises(ValueError) as error:
+        fstore.has_file("testpath")
+        pytest.fail("Attempting to read from broken store "
+                    "should raise an exception")
+    assert str(error.value) == "Broken store {0}".format(fstore._index)
+
+
+def test_has_file_no_file(fstore):
+    """
+    Condition: filestore with files within, but has not a given one.
+    Expected result: filestore has no file.
+    """
+    fstore.files = collections.OrderedDict([
+        ("key", SEP * sysrestore.SYSRESTORE_MAX_INDEX),
+    ])
+    assert not fstore.has_file("testpath")
+
+
+def test_has_file(fstore):
+    """
+    Condition: filestore with files within.
+    Expected result: filestore has file.
+    """
+    value = SEP * sysrestore.SYSRESTORE_MAX_INDEX
+    parts = value.split(SEP)
+    parts[sysrestore.SYSRESTORE_PATH_INDEX] = "testpath"
+    value = SEP.join(parts)
+    fstore.files = collections.OrderedDict([
+        ("key", value),
+    ])
+    assert fstore.has_file("testpath")
+
+
+@pytest.mark.parametrize("nonabs_path", ["", "../relative/"], ids=idf)
+def test_restore_not_abs(nonabs_path, fstore, sysrestore_dirs):
+    """
+    Condition: path to be restored is empty or relative.
+    Expected result: there should be an exception.
+    """
+    with pytest.raises(ValueError) as error:
+        fstore.restore_file(nonabs_path)
+        pytest.fail("Attempting to restore empty or non-absolute "
+                    "path should raise an exception")
+    assert str(error.value) == "Absolute path required"
+    assert not os.listdir(sysrestore_dirs["source_dir"])
+
+
+@pytest.mark.parametrize("nonabs_path", ["", "../relative/"], ids=idf)
+def test_restore_not_abs_new(nonabs_path, fstore, sysrestore_dirs):
+    """
+    Condition: new path to be restored to is empty or relative.
+    Expected result: there should be an exception.
+    """
+    with pytest.raises(ValueError) as error:
+        fstore.restore_file(path="/oldpath", new_path=nonabs_path)
+        pytest.fail("Attempting to restore to a non-absolute "
+                    "path should raise an exception")
+    assert str(error.value) == "Absolute new path required"
+    assert not os.listdir(sysrestore_dirs["source_dir"])
+
+
+@pytest.mark.parametrize("testdata", TESTDATA["test_restore"], ids=idf)
+def test_restore_broken_store(testdata, fstore, sysrestore_dirs):
+    """
+    Condition: filestore with a broken state.
+    Expected result: there should be an exception.
+    """
+    if "new_path" in testdata.keys():
+        testdata["new_path"] = os.path.join(sysrestore_dirs["source_dir"],
+                                            testdata["new_path"])
+    fstore.files = collections.OrderedDict([
+        ("key", SEP * (sysrestore.SYSRESTORE_MAX_INDEX - 1)),
+    ])
+    with pytest.raises(ValueError) as error:
+        fstore.restore_file(**testdata)
+        pytest.fail("Attempting to restore from broken store "
+                    "should raise an exception")
+    assert str(error.value) == "Broken store {0}".format(fstore._index)
+    assert not os.listdir(sysrestore_dirs["source_dir"])
+
+
+@pytest.mark.parametrize("testdata", TESTDATA["test_restore"], ids=idf)
+def test_restore_no_filename(testdata, fstore, sysrestore_dirs):
+    """
+    Condition: filestore with empty key.
+    Expected result: there should be an exception.
+    """
+    if "new_path" in testdata.keys():
+        testdata["new_path"] = os.path.join(sysrestore_dirs["source_dir"],
+                                            testdata["new_path"])
+    value = SEP * sysrestore.SYSRESTORE_MAX_INDEX
+    parts = value.split(SEP)
+    parts[sysrestore.SYSRESTORE_PATH_INDEX] = testdata["path"]
+    value = SEP.join(parts)
+    fstore.files = collections.OrderedDict([
+        ("", value),
+    ])
+    with pytest.raises(ValueError) as error:
+        fstore.restore_file(**testdata)
+        pytest.fail("Attempting to restore a file "
+                    "without name should raise an exception")
+    assert str(error.value) == "No such file name in the index"
+    assert not os.listdir(sysrestore_dirs["source_dir"])
+
+
+@pytest.mark.parametrize("testdata", TESTDATA["test_restore"], ids=idf)
+def test_restore_no_filepath(testdata, fstore, sysrestore_dirs):
+    """
+    Condition: filestore with empty file path.
+    Expected result: there should be an exception.
+    """
+    if "new_path" in testdata.keys():
+        testdata["new_path"] = os.path.join(sysrestore_dirs["source_dir"],
+                                            testdata["new_path"])
+    value = SEP * sysrestore.SYSRESTORE_MAX_INDEX
+    parts = value.split(SEP)
+    parts[sysrestore.SYSRESTORE_PATH_INDEX] = "nopath"
+    value = SEP.join(parts)
+    fstore.files = collections.OrderedDict([
+        ("key", value),
+    ])
+    with pytest.raises(ValueError) as error:
+        fstore.restore_file(**testdata)
+        pytest.fail("Attempting to restore a file "
+                    "without path should raise an exception")
+    assert str(error.value) == "No such file name in the index"
+    assert not os.listdir(sysrestore_dirs["source_dir"])
+
+
+@pytest.mark.parametrize("testdata", TESTDATA["test_restore"], ids=idf)
+def test_restore_no_backup(testdata, fstore, sysrestore_dirs):
+    """
+    Condition: filestore with missing file.
+    Expected result: restoration should fail.
+    """
+    if "new_path" in testdata.keys():
+        testdata["new_path"] = os.path.join(sysrestore_dirs["source_dir"],
+                                            testdata["new_path"])
+    value = SEP * sysrestore.SYSRESTORE_MAX_INDEX
+    parts = value.split(SEP)
+    parts[sysrestore.SYSRESTORE_PATH_INDEX] = testdata["path"]
+    value = SEP.join(parts)
+    fstore.files = collections.OrderedDict([
+        ("/notexisted", value),
+    ])
+    assert not fstore.restore_file(**testdata)
+    assert not os.listdir(sysrestore_dirs["source_dir"])
+
+
+@pytest.mark.parametrize("testdata", TESTDATA["test_restore"], ids=idf)
+def test_restore_file(testdata, fstore, sysrestore_dirs):
+    """
+    Condition: filestore with backuped file within.
+    Expected result: successful restoration of file.
+    """
+    if "new_path" in testdata.keys():
+        testdata["new_path"] = os.path.join(sysrestore_dirs["source_dir"],
+                                            testdata["new_path"])
+    sourcepath = mkfile_source(sysrestore_dirs["source_dir"])
+    testdata["path"] = sourcepath
+    restorepath = testdata.get("new_path")
+    if restorepath is None:
+        restorepath = sourcepath
+
+    expected_stat = os.lstat(sourcepath)
+    expected_mode = expected_stat.st_mode
+
+    bkwargs = dict(testdata)
+    try:
+        del bkwargs["new_path"]
+    except KeyError:
+        pass
+    fstore.backup_file(**bkwargs)
+    # do not remove because it is used for content compare
+    bakfile = sourcepath + ".bak"
+    os.rename(sourcepath, bakfile)
+    assert fstore.restore_file(**testdata)
+    assert not fstore.files
+
+    actual_stat = os.lstat(restorepath)
+    actual_mode = actual_stat.st_mode
+    assert oct(actual_mode) == oct(expected_mode)
+    assert actual_stat.st_uid == expected_stat.st_uid
+    assert actual_stat.st_gid == expected_stat.st_gid
+    # check content
+    assert filecmp.cmp(restorepath, bakfile, shallow=False)
+
+    assert not os.listdir(sysrestore_dirs["store_dir"])
+
+
+@pytest.mark.parametrize("newpath", ["", "newpath"], ids=idf)
+def test_restore_stacked_backup(newpath, fstore, sysrestore_dirs):
+    """
+    Condition: filestore with backuped n-times file within.
+    Expected result: successful restoration of file.
+    """
+    NUM_ITERS = 10
+    kwargs = {}
+    backups = []
+
+    if newpath:
+        newpath = os.path.join(sysrestore_dirs["source_dir"], newpath)
+        kwargs["new_path"] = newpath
+
+    sourcepath = mkfile_source(sysrestore_dirs["source_dir"])
+    kwargs["path"] = sourcepath
+    bkwargs = dict(kwargs)
+    try:
+        del bkwargs["new_path"]
+    except KeyError:
+        pass
+
+    # create stack of backups for file with same name
+    for num in range(NUM_ITERS):
+        sourcepath = mkfile_source(sysrestore_dirs["source_dir"],
+                                   content="content" + str(num))
+        kwargs["path"] = sourcepath
+
+        expected_stat = os.lstat(sourcepath)
+
+        fstore.backup_file(**bkwargs)
+        # do not remove because it is used for content compare
+        backups.append([backuped_name(sourcepath), expected_stat])
+        bakfile = sourcepath + ".bak" + str(num)
+        os.rename(sourcepath, bakfile)
+
+    # restore stack of backups
+    for num in reversed(range(NUM_ITERS)):
+        (expected_backupfile, expected_stat) = backups[num]
+        expected_path = os.path.join(sysrestore_dirs["store_dir"],
+                                     expected_backupfile)
+        assert fstore.restore_file(**kwargs)
+        assert expected_backupfile not in fstore.files
+        assert not os.path.exists(expected_path)
+
+        expected_mode = expected_stat.st_mode
+        if newpath:
+            restorepath = kwargs["new_path"]
+        else:
+            restorepath = sourcepath
+        actual_stat = os.lstat(restorepath)
+        actual_mode = actual_stat.st_mode
+        assert oct(actual_mode) == oct(expected_mode)
+        assert actual_stat.st_uid == expected_stat.st_uid
+        assert actual_stat.st_gid == expected_stat.st_gid
+        # check content
+        bakfile = sourcepath + ".bak" + str(num)
+        assert filecmp.cmp(restorepath, bakfile, shallow=False)
+
+    assert not fstore.files
+    assert not os.listdir(sysrestore_dirs["store_dir"])
+
+
+def test_restoreall_no_files(fstore):
+    """
+    Condition: empty filestore.
+    Expected result: restoration should fail.
+    """
+    fstore.files.clear()
+    assert not fstore.restore_all_files()
+
+
+def test_restoreall_files(fstore, sysrestore_dirs):
+    """
+    Condition: filestore with n different files
+    Expected result: successful restoration of files
+    """
+    NUM_BACKUPS = 10
+    backups = []
+
+    # create backups
+    for num in range(NUM_BACKUPS):
+        sourcefile = "sourcefile" + str(num)
+        sourcepath = mkfile_source(sysrestore_dirs["source_dir"], sourcefile,
+                                   content="content" + str(num))
+        expected_stat = os.lstat(sourcepath)
+
+        fstore.backup_file(path=sourcepath)
+        # do not remove because it is used for content compare
+        backups.append([sourcepath, expected_stat])
+        bakfile = sourcepath + ".bak"
+        os.rename(sourcepath, bakfile)
+
+    assert fstore.restore_all_files()
+    assert not fstore.files
+    assert not os.listdir(sysrestore_dirs["store_dir"])
+
+    for (sourcepath, expected_stat) in backups:
+        expected_mode = expected_stat.st_mode
+        restorepath = sourcepath
+        actual_stat = os.lstat(restorepath)
+        actual_mode = actual_stat.st_mode
+        assert oct(actual_mode) == oct(expected_mode)
+        assert actual_stat.st_uid == expected_stat.st_uid
+        assert actual_stat.st_gid == expected_stat.st_gid
+        # check content
+        bakfile = sourcepath + ".bak"
+        assert filecmp.cmp(restorepath, bakfile, shallow=False)
+
+
+def test_restoreall_file(fstore, sysrestore_dirs):
+    """
+    Condition: filestore with backuped n-times file within.
+    Expected result: successful restoration of file.
+    """
+    NUM_BACKUPS = 10
+    sourcepath = mkfile_source(sysrestore_dirs["source_dir"])
+    expected_stat = os.lstat(sourcepath)
+    expected_mode = expected_stat.st_mode
+    bakfile = sourcepath + ".bak"
+    shutil.copy2(sourcepath, bakfile)
+    fstore.backup_file(sourcepath)
+
+    # create backups
+    for num in range(NUM_BACKUPS):
+        mkfile_source(sysrestore_dirs["source_dir"],
+                      content="content" + str(num))
+        fstore.backup_file(sourcepath)
+
+    fstore.restore_all_files()
+    assert not fstore.files
+    assert not os.listdir(sysrestore_dirs["store_dir"])
+
+    actual_stat = os.lstat(sourcepath)
+    actual_mode = actual_stat.st_mode
+    assert oct(actual_mode) == oct(expected_mode)
+    assert actual_stat.st_uid == expected_stat.st_uid
+    assert actual_stat.st_gid == expected_stat.st_gid
+    # check content
+    assert filecmp.cmp(sourcepath, bakfile, shallow=False)
+
+
+def test_has_files_no_files(fstore):
+    """
+    Condition: empty filestore.
+    Expected result: has not files.
+    """
+    fstore.files.clear()
+    assert not fstore.has_files()
+
+
+def test_has_files(fstore):
+    """
+    Condition: filestore with files within.
+    Expected result: has files.
+    """
+    fstore.files.clear()
+    value = SEP * sysrestore.SYSRESTORE_MAX_INDEX
+    fstore.files = collections.OrderedDict([
+        ("key", value),
+    ])
+    assert fstore.has_files()
+
+
+@pytest.mark.parametrize("nonabs_path", ["", "../relative/"], ids=idf)
+def test_untrack_file_not_abs(nonabs_path, fstore):
+    """
+    Condition: path to be untracked is empty or relative.
+    Expected result: there should be an exception.
+    """
+    with pytest.raises(ValueError) as error:
+        fstore.untrack_file(nonabs_path)
+        pytest.fail("Attempting to untrack file with relative "
+                    "path should raise an exception")
+    assert str(error.value) == "Absolute path required"
+
+
+def test_untrack_broken_store(fstore):
+    """
+    Condition: filestore with broken state.
+    Expected result: there should be an exception.
+    """
+    fstore.files = collections.OrderedDict([
+        ("key", SEP * (sysrestore.SYSRESTORE_MAX_INDEX - 1)),
+    ])
+
+    with pytest.raises(ValueError) as error:
+        fstore.untrack_file("/somepath")
+        pytest.fail("Attempting to untrack file from broken "
+                    "store should raise an exception")
+    assert str(error.value) == "Broken store {0}".format(fstore._index)
+
+
+def test_untrack_no_filename(fstore):
+    """
+    Condition: filestore without filename.
+    Expected result: there should be an exception.
+    """
+    value = SEP * sysrestore.SYSRESTORE_MAX_INDEX
+    parts = value.split(SEP)
+    parts[sysrestore.SYSRESTORE_PATH_INDEX] = "/somepath"
+    value = SEP.join(parts)
+    fstore.files = collections.OrderedDict([
+        ("", value),
+    ])
+    with pytest.raises(ValueError) as error:
+        fstore.untrack_file("/somepath")
+        pytest.fail("Attempting to untrack a file "
+                    "without name should raise an exception")
+    assert str(error.value) == "No such file name in the index"
+
+
+def test_untrack_no_filepath(fstore):
+    """
+    Condition: filestore without filepath.
+    Expected result: there should be an exception.
+    """
+    value = SEP * sysrestore.SYSRESTORE_MAX_INDEX
+    parts = value.split(SEP)
+    parts[sysrestore.SYSRESTORE_PATH_INDEX] = "nopath"
+    value = SEP.join(parts)
+    fstore.files = collections.OrderedDict([
+        ("key", value),
+    ])
+    with pytest.raises(ValueError) as error:
+        fstore.untrack_file("/somepath")
+        pytest.fail("Attempting to untrack a file "
+                    "without path should raise an exception")
+    assert str(error.value) == "No such file name in the index"
+
+
+def test_untrack_no_backup(fstore):
+    """
+    Condition: filestore without backup.
+    Expected result: untracking should fail.
+    """
+    value = SEP * sysrestore.SYSRESTORE_MAX_INDEX
+    parts = value.split(SEP)
+    parts[sysrestore.SYSRESTORE_PATH_INDEX] = "/somepath"
+    value = SEP.join(parts)
+    fstore.files = collections.OrderedDict([
+        ("/notexisted", value),
+    ])
+    assert not fstore.untrack_file("/somepath")
+
+
+def test_untrack(fstore, sysrestore_dirs):
+    """
+    Condition: filestore with files within.
+    Expected result: successful untracking.
+    """
+    sourcepath = mkfile_source(sysrestore_dirs["source_dir"])
+    fstore.backup_file(sourcepath)
+    assert fstore.untrack_file(sourcepath)
+    assert not fstore.files
+    assert not os.listdir(sysrestore_dirs["store_dir"])
+
+
+def test_untrack_stacked_backup(fstore, sysrestore_dirs):
+    """
+    Condition: filestore with stacked backup of file.
+    Expected result: successful untracking.
+    """
+    NUM_ITERS = 10
+    backups = []
+
+    sourcepath = mkfile_source(sysrestore_dirs["source_dir"])
+    for num in range(NUM_ITERS):
+        mkfile_source(sysrestore_dirs["source_dir"],
+                      content="content" + str(num))
+        fstore.backup_file(sourcepath)
+        backups.append(os.path.join(sysrestore_dirs["store_dir"],
+                       backuped_name(sourcepath)))
+
+    # untrack stack of backups
+    for num in reversed(range(NUM_ITERS)):
+        expected_backupfile = backups[num]
+        assert fstore.untrack_file(sourcepath)
+        assert not os.path.exists(expected_backupfile)
+
+    assert not fstore.files
+    assert not os.listdir(sysrestore_dirs["store_dir"])


### PR DESCRIPTION
The current implementation doesn't ensure the order of backup/restoration. There are use cases requiring the multiple backups of a file with same name but different content. And for these situations, FileStore is not predictable.
    
* to ensure the order usual dict storage is replaced with OrderedDict one
* all search operations are performed in a reversed order
* add tests
* fix pylint errors
    
Fixes: https://pagure.io/freeipa/issue/7820