### PR TITLE
Remove 389-ds templates now that lib389 is used for installs

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -72,23 +72,6 @@ from ipaserver.masters import ENABLED_SERVICE
 
 logger = logging.getLogger(__name__)
 
-# We need to reset the template because the CA uses the regular boot
-# information
-INF_TEMPLATE = """
-[General]
-FullMachineName=   $FQDN
-SuiteSpotUserID=   $USER
-SuiteSpotGroup=    $GROUP
-ServerRoot=    $SERVER_ROOT
-[slapd]
-ServerPort=   $DSPORT
-ServerIdentifier=   $SERVERID
-Suffix=   $SUFFIX
-RootDN=   cn=Directory Manager
-RootDNPwd= $PASSWORD
-ConfigFile = /usr/share/pki/ca/conf/database.ldif
-"""
-
 
 ADMIN_GROUPS = [
     'Enterprise CA Administrators',

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -186,32 +186,6 @@ def get_all_external_schema_files(root):
     return sorted(f)
 
 
-INF_TEMPLATE = """
-[General]
-FullMachineName=   $FQDN
-SuiteSpotUserID=   $USER
-SuiteSpotGroup=    $GROUP
-ServerRoot=    $SERVER_ROOT
-[slapd]
-ServerPort=   389
-ServerIdentifier=   $SERVERID
-Suffix=   $SUFFIX
-RootDN=   cn=Directory Manager
-RootDNPwd= $PASSWORD
-InstallLdifFile= /var/lib/dirsrv/boot.ldif
-inst_dir=   /var/lib/dirsrv/scripts-$SERVERID
-"""
-
-BASE_TEMPLATE = """
-dn: $SUFFIX
-objectClass: top
-objectClass: domain
-objectClass: pilotObject
-dc: $BASEDC
-info: IPA V2.0
-"""
-
-
 class DsInstance(service.Service):
     def __init__(self, realm_name=None, domain_name=None, fstore=None,
                  domainlevel=None, config_ldif=None):


### PR DESCRIPTION
The templates created the inf files for calling the 389-ds
installer setup-ds.pl. Now that lib389 is being used for installation
these are no longer necessary.

Related: https://pagure.io/freeipa/issue/4491

Signed-off-by: Rob Crittenden <rcritten@redhat.com>