### PR TITLE
[Backport][ipa-4-7] pkinit enable: use local dogtag only if host has CA

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -428,10 +428,13 @@ class KrbInstance(service.Service):
             prev_helper = None
             # on the first CA-ful master without '--no-pkinit', we issue the
             # certificate by contacting Dogtag directly
+            localhost_has_ca = self.fqdn in service.find_providing_servers(
+                'CA', conn=self.api.Backend.ldap2, api=self.api)
             use_dogtag_submit = all(
                 [self.master_fqdn is None,
                  self.pkcs12_info is None,
-                 self.config_pkinit])
+                 self.config_pkinit,
+                 localhost_has_ca])
 
             if use_dogtag_submit:
                 ca_args = [


### PR DESCRIPTION
This PR was opened automatically because PR #2706 was pushed to master and backport to ipa-4-7 is required.