### PR TITLE
Require krb5 with fix for CVE-2018-20217

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -57,7 +57,8 @@
 # Fedora
 %global package_name freeipa
 %global alt_name ipa
-%global krb5_version 1.16.1
+# Fix for CVE-2018-20217
+%global krb5_version 1.16.1-24
 %global krb5_kdb_version 7.0
 # 0.7.16: https://github.com/drkjam/netaddr/issues/71
 %global python_netaddr_version 0.7.16


### PR DESCRIPTION
A Reachable Assertion issue was discovered in the KDC in MIT Kerberos 5
(aka krb5) before 1.17. If an attacker can obtain a krbtgt ticket using
an older encryption type (single-DES, triple-DES, or RC4), the attacker
can crash the KDC by making an S4U2Self request.

1.16.1-24 comes without Fix-bugs-with-concurrent-use-of-MEMORY-ccaches,
which caused a regression with IPA.

See: https://nvd.nist.gov/vuln/detail/CVE-2018-20217
Signed-off-by: Christian Heimes <cheimes@redhat.com>

The new version is already in F29 and is scheduled for stable for F28. Travis CI may still fail for a couple of hours.