### PR TITLE
[Backport][ipa-4-6] Dcerpc fix collision detection

### DIFF
--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -1454,7 +1454,7 @@ def run(api):
         (_options, argv) = api.bootstrap_with_global_options(context='cli')
 
         try:
-            check_client_configuration()
+            check_client_configuration(env=api.env)
         except ScriptError as e:
             sys.exit(e)
 

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -1121,14 +1121,18 @@ def ensure_krbcanonicalname_set(ldap, entry_attrs):
     entry_attrs.update(old_entry)
 
 
-def check_client_configuration():
+def check_client_configuration(env=None):
     """
     Check if IPA client is configured on the system.
+
+    Hardcode return code to avoid recursive imports
     """
-    if (not os.path.isfile(paths.IPA_DEFAULT_CONF) or
+    if ((env is not None and not os.path.isfile(env.conf_default)) or
+       (not os.path.isfile(paths.IPA_DEFAULT_CONF) or
             not os.path.isdir(paths.IPA_CLIENT_SYSRESTORE) or
-            not os.listdir(paths.IPA_CLIENT_SYSRESTORE)):
-        raise ScriptError('IPA client is not configured on this system')
+            not os.listdir(paths.IPA_CLIENT_SYSRESTORE))):
+        raise ScriptError('IPA client is not configured on this system',
+                          2)  # CLIENT_NOT_CONFIGURED
 
 
 def check_principal_realm_in_trust_namespace(api_instance, *keys):


### PR DESCRIPTION
Manual backport of PR#2732

Because commit e59ee6099f065c2155e3be13025459108daf7900 was not backported to 4.6, I had to update the patch to incorporate part of it to ipa-4-6. The result is the same for `check_client_configuration()`.