### PR TITLE
Don't use Python dependency generator yet

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -96,6 +96,11 @@
 # https://pagure.io/389-ds-base/issue/49818
 %global ds_version 1.4.0.16-1
 
+# Don't use Fedora's Python dependency generator on Fedora 30/rawhide yet.
+# Some packages don't provide new dist aliases.
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/
+%{?python_disable_dependency_generator}
+
 %endif  # Fedora
 
 # Require Dogtag PKI 10.6.8-3 (10.6.7 was never pushed to stable)


### PR DESCRIPTION
Manual backport of PR #2729 

Fedora 30 started to have python_enable_dependency_generator by default.
Some packages like python3-dbus don't have the new dist names yet. This
fix enables testing on rawhide.

https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/

Signed-off-by: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Alexander Bokovoy <abokovoy@redhat.com>