### PR TITLE
[WebUI] Don't use cross-origin request

### DIFF
--- a/install/ui/src/freeipa/widgets/LoginScreen.js
+++ b/install/ui/src/freeipa/widgets/LoginScreen.js
@@ -60,7 +60,7 @@ define(['dojo/_base/declare',
         kerberos_msg: "<i class=\"fa fa-info-circle\"></i> To log in with " +
             "<strong>Kerberos</strong>, please make sure you" +
             " have valid tickets (obtainable via kinit) and <a href=" +
-            "'http://${host}/ipa/config/ssbrowser.html'>configured</a>" +
+            "'${protocol}//${host}/ipa/config/ssbrowser.html'>configured</a>" +
             " the browser correctly, then click Login. ",
         cert_msg: "<i class=\"fa fa-info-circle\"></i> To log in with " +
             "<strong>certificate</strong>, please make sure you have valid " +
@@ -582,9 +582,9 @@ define(['dojo/_base/declare',
                 this.continue_msg
             );
 
-            this.kerberos_msg = this.kerberos_msg.replace(
-                '${host}', window.location.hostname
-            );
+            this.kerberos_msg = this.kerberos_msg
+                .replace('${protocol}', window.location.protocol)
+                .replace('${host}', window.location.hostname);
 
             this.password_change_complete = text.get(
                 spec.password_change_complete ||

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -389,9 +389,9 @@ class i18n_messages(Command):
             "krb_auth_msg": _(
                 "<i class=\"fa fa-info-circle\"></i> To log in with "
                 "<strong>Kerberos</strong>, please make sure you have valid "
-                "tickets (obtainable via kinit) and <a href='http://${host}/"
-                "ipa/config/ssbrowser.html'>configured</a> the browser "
-                "correctly, then click 'Log in'."),
+                "tickets (obtainable via kinit) and <a href='${protocol}//"
+                "${host}/ipa/config/ssbrowser.html'>configured</a> the browser"
+                " correctly, then click 'Log in'."),
             "loading": _("Loading"),
             "krbprincipal_expired": _(
                 "Kerberos Principal you entered is expired"),


### PR DESCRIPTION
'Origin' for IPA login page is 'httpS://xxx'. But 'configured' link
has URL like 'http://xxx/ssbrowser.html'.

Since IPA web server doesn't use any kind of Access-Control-Allow-Origin
rules Mozilla Firefox blocks Cross-Origin request due to the Same Origin
policy violation.

So, just follow the Same Origin policy.

Fixes: https://pagure.io/freeipa/issue/7832