### PR TITLE
Create systemd-user HBAC service and rule

### DIFF
--- a/install/share/bootstrap-template.ldif
+++ b/install/share/bootstrap-template.ldif
@@ -346,6 +346,14 @@ cn: sudo-i
 description: sudo-i
 ipauniqueid:autogenerate
 
+dn: cn=systemd-user,cn=hbacservices,cn=hbac,$SUFFIX
+changetype: add
+objectclass: ipahbacservice
+objectclass: ipaobject
+cn: systemd-user
+description: pam_systemd and systemd user@.service
+ipauniqueid:autogenerate
+
 dn: cn=gdm,cn=hbacservices,cn=hbac,$SUFFIX
 changetype: add
 objectclass: ipahbacservice

--- a/install/share/default-hbac.ldif
+++ b/install/share/default-hbac.ldif
@@ -12,3 +12,16 @@ ipaenabledflag: TRUE
 description: Allow all users to access any host from any host
 ipauniqueid: autogenerate
 
+# default HBAC policy for pam_systemd
+dn: ipauniqueid=autogenerate,cn=hbac,$SUFFIX
+changetype: add
+objectclass: ipaassociation
+objectclass: ipahbacrule
+cn: allow_systemd-user
+accessruletype: allow
+usercategory: all
+hostcategory: all
+servicecategory: systemd-user
+ipaenabledflag: TRUE
+description: Allow pam_systemd to run user@.service to create a system user session
+ipauniqueid: autogenerate


### PR DESCRIPTION
authselect changed pam_systemd session from optional to required. When
the HBAC rule allow_all is disabled and replaced with more fine grained
rules, loginsi now to fail, because systemd's user@.service is able to
create a systemd session.

Add systemd-user HBAC service and a HBAC rule that allows systemd-user
to run on all hosts for all users by default. ipa-server-upgrade creates
the service and rule, too. In case the service already exists, no
attempt is made to create the rule. This allows admins to delete the
rule permanently.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1643928
Fixes: https://pagure.io/freeipa/issue/7831
Signed-off-by: Christian Heimes <cheimes@redhat.com>