### PR TITLE
[Backport][ipa-4-7] Require krb5 with fix for CVE-2018-20217

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -77,7 +77,8 @@
 # Fedora
 %global package_name freeipa
 %global alt_name ipa
-%global krb5_version 1.16.1
+# Fix for CVE-2018-20217
+%global krb5_version 1.16.1-24
 %global krb5_kdb_version 7.0
 # 0.7.16: https://github.com/drkjam/netaddr/issues/71
 %global python_netaddr_version 0.7.16


### PR DESCRIPTION
This PR was opened automatically because PR #2737 was pushed to master and backport to ipa-4-7 is required.