### PR TITLE
[Backport][ipa-4-6] Create systemd-user HBAC service and rule

### DIFF
--- a/install/share/bootstrap-template.ldif
+++ b/install/share/bootstrap-template.ldif
@@ -346,6 +346,14 @@ cn: sudo-i
 description: sudo-i
 ipauniqueid:autogenerate
 
+dn: cn=systemd-user,cn=hbacservices,cn=hbac,$SUFFIX
+changetype: add
+objectclass: ipahbacservice
+objectclass: ipaobject
+cn: systemd-user
+description: pam_systemd and systemd user@.service
+ipauniqueid:autogenerate
+
 dn: cn=gdm,cn=hbacservices,cn=hbac,$SUFFIX
 changetype: add
 objectclass: ipahbacservice

--- a/install/share/default-hbac.ldif
+++ b/install/share/default-hbac.ldif
@@ -12,3 +12,16 @@ ipaenabledflag: TRUE
 description: Allow all users to access any host from any host
 ipauniqueid: autogenerate
 
+# default HBAC policy for pam_systemd
+dn: ipauniqueid=autogenerate,cn=hbac,$SUFFIX
+changetype: add
+objectclass: ipaassociation
+objectclass: ipahbacrule
+cn: allow_systemd-user
+accessruletype: allow
+usercategory: all
+hostcategory: all
+servicecategory: systemd-user
+ipaenabledflag: TRUE
+description: Allow pam_systemd to run user@.service to create a system user session
+ipauniqueid: autogenerate

--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -126,11 +126,17 @@ def pytest_cmdline_main(config):
 
 def pytest_runtest_setup(item):
     if isinstance(item, pytest.Function):
-        if item.get_marker('skip_ipaclient_unittest'):
+        # pytest 3.6 has deprecated get_marker in 3.6. The method was
+        # removed in 4.x and replaced with get_closest_marker.
+        if hasattr(item, 'get_closest_marker'):
+            get_marker = item.get_closest_marker  # pylint: disable=no-member
+        else:
+            get_marker = item.get_marker  # pylint: disable=no-member
+        if get_marker('skip_ipaclient_unittest'):
             # pylint: disable=no-member
             if pytest.config.option.ipaclient_unittests:
                 pytest.skip("Skip in ipaclient unittest mode")
-        if item.get_marker('needs_ipaapi'):
+        if get_marker('needs_ipaapi'):
             # pylint: disable=no-member
             if pytest.config.option.skip_ipaapi:
                 pytest.skip("Skip tests that needs an IPA API")

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -432,3 +432,62 @@ class TestIPACommand(IntegrationTest):
             ['sudo', '-u', IPAAPI_USER, '--'] + cmd
         )
         assert uid in result.stdout_text
+
+    def test_hbac_systemd_user(self):
+        # https://pagure.io/freeipa/issue/7831
+        tasks.kinit_admin(self.master)
+        # check for presence
+        self.master.run_command(
+            ['ipa', 'hbacrule-show', 'allow_systemd-user']
+        )
+        self.master.run_command(
+            ['ipa', 'hbacsvc-show', 'systemd-user']
+        )
+
+        # delete both
+        self.master.run_command(
+            ['ipa', 'hbacrule-del', 'allow_systemd-user']
+        )
+        self.master.run_command(
+            ['ipa', 'hbacsvc-del', 'systemd-user']
+        )
+
+        # run upgrade
+        result = self.master.run_command(['ipa-server-upgrade'])
+        assert 'Created hbacsvc systemd-user' in result.stderr_text
+        assert 'Created hbac rule allow_systemd-user' in result.stderr_text
+
+        # check for presence
+        result = self.master.run_command(
+            ['ipa', 'hbacrule-show', 'allow_systemd-user', '--all']
+        )
+        lines = set(l.strip() for l in result.stdout_text.split('\n'))
+        assert 'User category: all' in lines
+        assert 'Host category: all' in lines
+        assert 'Enabled: TRUE' in lines
+        assert 'Services: systemd-user' in lines
+        assert 'accessruletype: allow' in lines
+
+        self.master.run_command(
+            ['ipa', 'hbacsvc-show', 'systemd-user']
+        )
+
+        # only delete rule
+        self.master.run_command(
+            ['ipa', 'hbacrule-del', 'allow_systemd-user']
+        )
+
+        # run upgrade
+        result = self.master.run_command(['ipa-server-upgrade'])
+        assert (
+            'hbac service systemd-user already exists' in result.stderr_text
+        )
+        assert (
+            'Created hbac rule allow_systemd-user' not in result.stderr_text
+        )
+        result = self.master.run_command(
+            ['ipa', 'hbacrule-show', 'allow_systemd-user'],
+            raiseonerr=False
+        )
+        assert result.returncode != 0
+        assert 'HBAC rule not found' in result.stderr_text


### PR DESCRIPTION
Manual backport of PR #2746 

authselect changed pam_systemd session from optional to required. When
the HBAC rule allow_all is disabled and replaced with more fine grained
rules, loginsi now to fail, because systemd's user@.service is able to
create a systemd session.

Add systemd-user HBAC service and a HBAC rule that allows systemd-user
to run on all hosts for all users by default. ipa-server-upgrade creates
the service and rule, too. In case the service already exists, no
attempt is made to create the rule. This allows admins to delete the
rule permanently.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1643928
Fixes: https://pagure.io/freeipa/issue/7831
Signed-off-by: Christian Heimes <cheimes@redhat.com>