### PR TITLE
Use expanduser instead of HOME env var

### DIFF
--- a/ipalib/__init__.py
+++ b/ipalib/__init__.py
@@ -722,7 +722,7 @@ Key            Example value                  Description
 =============  =============================  =======================
 bin            '/usr/bin'                     Dir. containing script
 dot_ipa        '/home/jderose/.ipa'           User config directory
-home           os.environ['HOME']             User home dir.
+home           os.path.expanduser('~')        User home dir.
 ipalib         '.../site-packages/ipalib'     Dir. of ipalib package
 mode           'unit_test'                    The mode ipalib is in
 script         sys.argv[0]                    Path of script

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -450,7 +450,8 @@ class Env:
         self.site_packages = path.dirname(self.ipalib)
         self.script = path.abspath(sys.argv[0])
         self.bin = path.dirname(self.script)
-        self.home = os.environ.get('HOME', None)
+        home = os.path.expanduser('~')
+        self.home = home if not home.startswith('~') else None
         self.fips_mode = tasks.is_fips_enabled()
 
         # Merge in overrides:

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -225,7 +225,7 @@ DEFAULT_CONFIG = (
     ('site_packages', object),  # The directory contaning ipalib
     ('script', object),  # sys.argv[0]
     ('bin', object),  # The directory containing the script
-    ('home', object),  # $HOME
+    ('home', object),  # os.path.expanduser('~')
 
     # Vars set in Env._bootstrap():
     ('in_tree', object),  # Whether or not running in-tree (bool)
@@ -313,13 +313,7 @@ TLS_VERSION_MINIMAL = "tls1.0"
 # Use cache path
 USER_CACHE_PATH = (
     os.environ.get('XDG_CACHE_HOME') or
-    os.path.join(
-        os.environ.get(
-            'HOME',
-            os.path.expanduser('~')
-        ),
-        '.cache'
-    )
+    os.path.expanduser('~/.cache')
 )
 
 SOFTHSM_DNSSEC_TOKEN_LABEL = u'ipaDNSSEC'

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -552,6 +552,10 @@ class DsInstance(service.Service):
         self.backup_state("serverid", self.serverid)
         self.fstore.backup_file(paths.SYSCONFIG_DIRSRV)
 
+        # workaround for https://pagure.io/389-ds-base/issue/50152
+        if 'HOME' not in os.environ:
+            os.environ['HOME'] = api.env.home
+
         # The new installer is api driven. We can pass it a log function
         # and it will use it. Because of this, we can pass verbose true,
         # and allow our logger to control the display based on level.


### PR DESCRIPTION
The HOME directory may not be available in containers. It's also the
wrong variable on some platforms. Use os.path.expanduser() instead of
HOME.

Also adds a workaround for lib389 bug https://pagure.io/389-ds-base/issue/50152

Fixes: https://pagure.io/freeipa/issue/7837
Signed-off-by: Christian Heimes <cheimes@redhat.com>