### PR TITLE
Fix systemd-user HBAC rule

### DIFF
--- a/install/share/default-hbac.ldif
+++ b/install/share/default-hbac.ldif
@@ -21,7 +21,7 @@ cn: allow_systemd-user
 accessruletype: allow
 usercategory: all
 hostcategory: all
-servicecategory: systemd-user
+memberService: cn=systemd-user,cn=hbacservices,cn=hbac,$SUFFIX
 ipaenabledflag: TRUE
 description: Allow pam_systemd to run user@.service to create a system user session
 ipauniqueid: autogenerate

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -501,11 +501,17 @@ class TestIPACommand(IntegrationTest):
         tasks.kinit_admin(self.master)
         # check for presence
         self.master.run_command(
-            ['ipa', 'hbacrule-show', 'allow_systemd-user']
-        )
-        self.master.run_command(
             ['ipa', 'hbacsvc-show', 'systemd-user']
         )
+        result = self.master.run_command(
+            ['ipa', 'hbacrule-show', 'allow_systemd-user', '--all']
+        )
+        lines = set(l.strip() for l in result.stdout_text.split('\n'))
+        assert 'User category: all' in lines
+        assert 'Host category: all' in lines
+        assert 'Enabled: TRUE' in lines
+        assert 'Services: systemd-user' in lines
+        assert 'accessruletype: allow' in lines
 
         # delete both
         self.master.run_command(


### PR DESCRIPTION
2ef6e14c5a87724a3b37dd5f0817af48c4411e03 added an invalid HBAC rule that
encoded the service wrongly.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1643928
Fixes: https://pagure.io/freeipa/issue/7831
Signed-off-by: Christian Heimes <cheimes@redhat.com>