### PR TITLE
replica installation: add master record only if in managed zone

### DIFF
--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -38,7 +38,7 @@ jobs:
           version: 0.2.0
         timeout: 1800
         topology: *build
-        
+
   fedora-28/simple_replication:
     requires: [fedora-28/build]
     priority: 50
@@ -759,6 +759,18 @@ jobs:
         template: *ci-master-f28
         timeout: 7200
         topology: *master_2repl_1client
+
+  fedora-28/test_replica_promotion_TestReplicaInForwardZone:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaInForwardZone
+        template: *ci-master-f28
+        timeout: 7200
+        topology: *master_1repl
 
   fedora-28/test_upgrade:
     requires: [fedora-28/build]

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -38,7 +38,7 @@ jobs:
           version: 0.2.0
         timeout: 1800
         topology: *build
-        
+
   fedora-29/simple_replication:
     requires: [fedora-29/build]
     priority: 50
@@ -759,6 +759,18 @@ jobs:
         template: *ci-master-f29
         timeout: 7200
         topology: *master_2repl_1client
+
+  fedora-29/test_replica_promotion_TestReplicaInForwardZone:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaInForwardZone
+        template: *ci-master-f29
+        timeout: 7200
+        topology: *master_1repl
 
   fedora-29/test_upgrade:
     requires: [fedora-29/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -38,7 +38,7 @@ jobs:
           version: 0.0.4
         timeout: 1800
         topology: *build
-        
+
   fedora-rawhide/simple_replication:
     requires: [fedora-rawhide/build]
     priority: 50
@@ -760,6 +760,18 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  fedora-rawhide/test_replica_promotion_TestReplicaInForwardZone:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaInForwardZone
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_1repl
+
   fedora-rawhide/test_upgrade:
     requires: [fedora-rawhide/build]
     priority: 50
@@ -1129,7 +1141,7 @@ jobs:
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-rawhide/build_url}'          
+        build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
         template: *ci-master-frawhide
         timeout: 7200


### PR DESCRIPTION
### replica installation: add master record only if in managed zone

Scenario: install a replica with DNS, whose IP address is part of a forward zone.
Currently, the replica installation fails because the installer is trying to add a A/AAAA record for the replica in the zone when setting up the bind instance, and addition of records in a forward zone is forbidden.

The bind installer should check if the IP address is in a master zone (i.e. a DNS zone managed by IdM, not a forward zone), and avoid creating the record if it's not the case.

During uninstallation, perform the same check before removing the DNS record (if in a forward zone, no need to call dnsrecord-del).

Fixes: https://pagure.io/freeipa/issue/7369

### ipatests: add test for replica in forward zone

Scenario: install a replica with DNS, with the replica part of a forward zone.
The replica installation should proceed successfully and avoid trying to add a DNS record for the replica in the forward zone, as the forward zone is not managed by IPA DNS.

Test added to nightly definitions.

Related to https://pagure.io/freeipa/issue/7369