### PR TITLE
Split test_webui_hosts PRCI tests

### DIFF
--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -956,7 +956,19 @@ jobs:
         timeout: 3600
         topology: *ipaserver
 
-  fedora-28/test_webui_hosts:
+  fedora-28/test_webui_host:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_webui/test_host.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-28/test_webui_host_net_groups:
     requires: [fedora-28/build]
     priority: 50
     job:
@@ -964,10 +976,8 @@ jobs:
       args:
         build_url: '{fedora-28/build_url}'
         test_suite: >-
-          test_webui/test_host.py
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
-          test_webui/test_service.py
         template: *ci-master-f28
         timeout: 3600
         topology: *ipaserver
@@ -1047,6 +1057,18 @@ jobs:
           test_webui/test_trust.py
         template: *ci-master-f28
         timeout: 3600
+        topology: *ipaserver
+
+  fedora-28/test_webui_service:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_webui/test_service.py
+        template: *ci-master-f28
+        timeout: 1800
         topology: *ipaserver
 
   fedora-28/test_webui_users:

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -956,7 +956,19 @@ jobs:
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_hosts:
+  fedora-29/test_webui_host:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_webui/test_host.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-29/test_webui_host_net_groups:
     requires: [fedora-29/build]
     priority: 50
     job:
@@ -964,10 +976,8 @@ jobs:
       args:
         build_url: '{fedora-29/build_url}'
         test_suite: >-
-          test_webui/test_host.py
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
-          test_webui/test_service.py
         template: *ci-master-f29
         timeout: 3600
         topology: *ipaserver
@@ -1047,6 +1057,18 @@ jobs:
           test_webui/test_trust.py
         template: *ci-master-f29
         timeout: 3600
+        topology: *ipaserver
+
+  fedora-29/test_webui_service:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_webui/test_service.py
+        template: *ci-master-f29
+        timeout: 1800
         topology: *ipaserver
 
   fedora-29/test_webui_users:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -956,7 +956,19 @@ jobs:
         timeout: 3600
         topology: *ipaserver
 
-  fedora-rawhide/test_webui_hosts:
+  fedora-rawhide/test_webui_host:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_webui/test_host.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-rawhide/test_webui_host_net_groups:
     requires: [fedora-rawhide/build]
     priority: 50
     job:
@@ -964,10 +976,8 @@ jobs:
       args:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: >-
-          test_webui/test_host.py
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
-          test_webui/test_service.py
         template: *ci-master-frawhide
         timeout: 3600
         topology: *ipaserver
@@ -1047,6 +1057,18 @@ jobs:
           test_webui/test_trust.py
         template: *ci-master-frawhide
         timeout: 3600
+        topology: *ipaserver
+
+  fedora-rawhide/test_webui_service:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_webui/test_service.py
+        template: *ci-master-frawhide
+        timeout: 1800
         topology: *ipaserver
 
   fedora-rawhide/test_webui_users:


### PR DESCRIPTION
Web UI test_host is too heavy and causes timeout errors during night runs, so it is moved to separate configuration.