### PR TITLE
 [Backport][ipa-4-6] replica installation: add master record only if in managed zone

### DIFF
--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -845,10 +845,13 @@ class BindInstance(service.Service):
 
         # Add forward and reverse records to self
         for addr in addrs:
-            try:
+            # Check first if the zone is a master zone
+            # (if it is a forward zone, dns_zone_exists will return False)
+            if dns_zone_exists(zone, api=self.api):
                 add_fwd_rr(zone, host, addr, self.api)
-            except errors.NotFound:
-                pass
+            else:
+                logger.debug("Skip adding record %s to a zone %s "
+                             "not managed by IPA", addr, zone)
 
             reverse_zone = find_reverse_zone(addr, self.api)
             if reverse_zone:
@@ -1063,6 +1066,10 @@ class BindInstance(service.Service):
         self.host = host
         self.fqdn = fqdn
         self.domain = domain_name
+
+        if not dns_zone_exists(zone, api=self.api):
+            # Zone may be a forward zone, skip update
+            return
 
         areclist = get_fwd_rr(zone, host, api=self.api)
         for rdata in areclist:

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -697,3 +697,101 @@ class TestReplicaInstallCustodia(IntegrationTest):
         tasks.install_replica(replica1, replica2, setup_ca=True)
         result = replica2.run_command(['ipactl', 'status'])
         assert 'ipa-custodia Service: RUNNING' in result.stdout_text
+
+
+def update_etc_hosts(host, ip, old_hostname, new_hostname):
+    '''Adds or update /etc/hosts
+
+    If /etc/hosts contains an entry for old_hostname, replace it with
+    new_hostname.
+    If /etc/hosts did not contain the entry, create one for new_hostname with
+    the provided ip.
+    The function makes a backup in /etc/hosts.sav
+
+    :param host the machine on which /etc/hosts needs to be update_dns_records
+    :param ip the ip address for the new record
+    :param old_hostname the hostname to replace
+    :param new_hostname the new hostname to put in /etc/hosts
+    '''
+    # Make a backup
+    host.run_command(['/usr/bin/cp',
+                      paths.HOSTS,
+                      '%s.sav' % paths.HOSTS])
+    contents = host.get_file_contents(paths.HOSTS, encoding='utf-8')
+    # If /etc/hosts already contains old_hostname, simply replace
+    pattern = r'^(.*\s){}(\s)'.format(old_hostname)
+    new_contents, mods = re.subn(pattern, r'\1{}\2'.format(new_hostname),
+                                 contents, flags=re.MULTILINE)
+    # If it didn't contain any entry for old_hostname, just add new_hostname
+    if mods == 0:
+        short = new_hostname.split(".", 1)[0]
+        new_contents = new_contents + "\n{}\t{} {}\n".format(ip,
+                                                             new_hostname,
+                                                             short)
+    host.put_file_contents(paths.HOSTS, new_contents)
+
+
+def restore_etc_hosts(host):
+    '''Restores /etc/hosts.sav into /etc/hosts
+    '''
+    host.run_command(['/usr/bin/mv',
+                      '%s.sav' % paths.HOSTS,
+                      paths.HOSTS],
+                     raiseonerr=False)
+
+
+class TestReplicaInForwardZone(IntegrationTest):
+    """
+    Pagure Reference: https://pagure.io/freeipa/issue/7369
+
+    Scenario: install a replica whose name is in a forwarded zone
+    """
+
+    forwardzone = 'forward.test'
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=True)
+
+    def test_replica_install_in_forward_zone(self):
+        master = self.master
+        replica = self.replicas[0]
+
+        # Create a forward zone on the master
+        master.run_command(['ipa', 'dnsforwardzone-add', self.forwardzone,
+                            '--skip-overlap-check',
+                            '--forwarder', master.config.dns_forwarder])
+
+        # Configure the client with a name in the forwardzone
+        r_shortname = replica.hostname.split(".", 1)[0]
+        r_new_hostname = '{}.{}'.format(r_shortname,
+                                        self.forwardzone)
+
+        # Update /etc/hosts on the master with an entry for the replica
+        # otherwise replica conncheck would fail
+        update_etc_hosts(master, replica.ip, replica.hostname,
+                         r_new_hostname)
+        # Remove the replica previous hostname from /etc/hosts
+        # and add the replica new hostname
+        # otherwise replica install will complain because
+        # hostname does not match
+        update_etc_hosts(replica, replica.ip, replica.hostname,
+                         r_new_hostname)
+
+        try:
+            # install client with a hostname in the forward zone
+            tasks.install_client(self.master, replica,
+                                 extra_args=['--hostname', r_new_hostname])
+
+            replica.run_command(['ipa-replica-install',
+                                 '--principal', replica.config.admin_name,
+                                 '--admin-password',
+                                 replica.config.admin_password,
+                                 '--setup-dns',
+                                 '--forwarder', master.config.dns_forwarder,
+                                 '-U'])
+        finally:
+            # Restore /etc/hosts on master and replica
+            restore_etc_hosts(master)
+            restore_etc_hosts(replica)


### PR DESCRIPTION
This is a manual backport of #2767 to ipa-4-6 branch.
The backport differs because ipa-4-6 does not use Firewall in the PRCI tests, and there is no nightly definition.