### PR TITLE
Add workaround for slow host/service del

### DIFF
--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -899,7 +899,9 @@ class host_mod(LDAPUpdate):
             old_certs = entry_attrs_old.get('usercertificate', [])
             removed_certs = set(old_certs) - set(certs)
             for cert in removed_certs:
-                rm_certs = api.Command.cert_find(certificate=cert)['result']
+                rm_certs = api.Command.cert_find(
+                    certificate=cert,
+                    host=keys)['result']
                 revoke_certs(rm_certs)
 
         if certs:
@@ -1335,7 +1337,9 @@ class host_remove_cert(LDAPRemoveAttributeViaOption):
         assert isinstance(dn, DN)
 
         for cert in options.get('usercertificate', []):
-            revoke_certs(api.Command.cert_find(certificate=cert)['result'])
+            revoke_certs(api.Command.cert_find(
+                certificate=cert,
+                host=keys)['result'])
 
         return dn
 

--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -713,7 +713,8 @@ class service_mod(LDAPUpdate):
             removed_certs = set(old_certs) - set(certs)
             for cert in removed_certs:
                 rm_certs = api.Command.cert_find(
-                    certificate=cert.public_bytes(x509.Encoding.DER))['result']
+                    certificate=cert.public_bytes(x509.Encoding.DER),
+                    service=keys)['result']
                 revoke_certs(rm_certs)
 
         if certs:
@@ -993,7 +994,9 @@ class service_remove_cert(LDAPRemoveAttributeViaOption):
         assert isinstance(dn, DN)
 
         for cert in options.get('usercertificate', []):
-            revoke_certs(api.Command.cert_find(certificate=cert)['result'])
+            revoke_certs(api.Command.cert_find(
+                certificate=cert,
+                service=keys)['result'])
 
         return dn
 


### PR DESCRIPTION
host-del and service-del are slow because cert revokation is implemented
inefficiently. The internal cert_find() call retrieves all certificates
from Dogtag.

The workaround special cases service and host find without additional RA
search options. A search for service and host certs limits the scope to
certificate with matching subject common name.
 
See: https://pagure.io/freeipa/issue/7835
See: https://bugzilla.redhat.com/show_bug.cgi?id=1669012
