### PR TITLE
[Backport][ipa-4-7] Use expanduser instead of HOME env var

### DIFF
--- a/ipalib/__init__.py
+++ b/ipalib/__init__.py
@@ -722,7 +722,7 @@ Key            Example value                  Description
 =============  =============================  =======================
 bin            '/usr/bin'                     Dir. containing script
 dot_ipa        '/home/jderose/.ipa'           User config directory
-home           os.environ['HOME']             User home dir.
+home           os.path.expanduser('~')        User home dir.
 ipalib         '.../site-packages/ipalib'     Dir. of ipalib package
 mode           'unit_test'                    The mode ipalib is in
 script         sys.argv[0]                    Path of script

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -451,7 +451,8 @@ class Env(object):
         self.site_packages = path.dirname(self.ipalib)
         self.script = path.abspath(sys.argv[0])
         self.bin = path.dirname(self.script)
-        self.home = os.environ.get('HOME', None)
+        home = os.path.expanduser('~')
+        self.home = home if not home.startswith('~') else None
         self.fips_mode = tasks.is_fips_enabled()
 
         # Merge in overrides:

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -225,7 +225,7 @@ DEFAULT_CONFIG = (
     ('site_packages', object),  # The directory contaning ipalib
     ('script', object),  # sys.argv[0]
     ('bin', object),  # The directory containing the script
-    ('home', object),  # $HOME
+    ('home', object),  # os.path.expanduser('~')
 
     # Vars set in Env._bootstrap():
     ('in_tree', object),  # Whether or not running in-tree (bool)
@@ -313,13 +313,7 @@ TLS_VERSION_MINIMAL = "tls1.0"
 # Use cache path
 USER_CACHE_PATH = (
     os.environ.get('XDG_CACHE_HOME') or
-    os.path.join(
-        os.environ.get(
-            'HOME',
-            os.path.expanduser('~')
-        ),
-        '.cache'
-    )
+    os.path.expanduser('~/.cache')
 )
 
 SOFTHSM_DNSSEC_TOKEN_LABEL = u'ipaDNSSEC'


### PR DESCRIPTION
Manual backport of first commit from PR #2755 

The HOME directory may not be available in containers. It's also the
wrong variable on some platforms. Use os.path.expanduser() instead of
HOME.

Fixes: https://pagure.io/freeipa/issue/7837
Signed-off-by: Christian Heimes <cheimes@redhat.com>