### PR TITLE
[Backport][ipa-4-6] Add workaround for slow host/service del

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1470,6 +1470,22 @@ class cert_find(Search, CertMethod):
         result = collections.OrderedDict()
         complete = bool(ra_options)
 
+        # workaround for RHBZ#1669012
+        # Improve performance for service and host case by also searching
+        # for subject. This limits the amount of certificate retrieved from
+        # Dogtag. The special case is only used, when no ra_options are set
+        # and exactly one service or host is supplied.
+        # The complete flag is left to False.
+        if not ra_options:
+            services = options.get('service', ())
+            hosts = options.get('host', ())
+            if len(services) == 1 and not hosts:
+                principal = kerberos.Principal(options['service'][0])
+                if principal.is_service:
+                    ra_options['subject'] = principal.hostname
+            elif len(hosts) == 1 and not services:
+                ra_options['subject'] = options['host'][0]
+
         try:
             ca_enabled_check(self.api)
         except errors.NotFound:

--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -899,7 +899,9 @@ class host_mod(LDAPUpdate):
             old_certs = entry_attrs_old.get('usercertificate', [])
             removed_certs = set(old_certs) - set(certs)
             for cert in removed_certs:
-                rm_certs = api.Command.cert_find(certificate=cert)['result']
+                rm_certs = api.Command.cert_find(
+                    certificate=cert,
+                    host=keys)['result']
                 revoke_certs(rm_certs)
 
         if certs:
@@ -1335,7 +1337,9 @@ class host_remove_cert(LDAPRemoveAttributeViaOption):
         assert isinstance(dn, DN)
 
         for cert in options.get('usercertificate', []):
-            revoke_certs(api.Command.cert_find(certificate=cert)['result'])
+            revoke_certs(api.Command.cert_find(
+                certificate=cert,
+                host=keys)['result'])
 
         return dn
 

--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -703,7 +703,8 @@ class service_mod(LDAPUpdate):
             removed_certs = set(old_certs) - set(certs)
             for cert in removed_certs:
                 rm_certs = api.Command.cert_find(
-                    certificate=cert.public_bytes(x509.Encoding.DER))['result']
+                    certificate=cert.public_bytes(x509.Encoding.DER),
+                    service=keys)['result']
                 revoke_certs(rm_certs)
 
         if certs:
@@ -983,7 +984,9 @@ class service_remove_cert(LDAPRemoveAttributeViaOption):
         assert isinstance(dn, DN)
 
         for cert in options.get('usercertificate', []):
-            revoke_certs(api.Command.cert_find(certificate=cert)['result'])
+            revoke_certs(api.Command.cert_find(
+                certificate=cert,
+                service=keys)['result'])
 
         return dn
 


### PR DESCRIPTION
This PR was opened automatically because PR #2785 was pushed to master and backport to ipa-4-6 is required.