### PR TITLE
[Backport][ipa-4-7] Split Web UI test suite in nightly PR CI configuration (IPA 4.7)

### DIFF
--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -640,16 +640,161 @@ jobs:
         timeout: 7200
         topology: *master_1repl_1client
 
-  fedora-28/test_webui:
+  fedora-28/test_webui_cert:
     requires: [fedora-28/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: test_webui/
+        test_suite: test_webui/test_cert.py
         template: *ci-master-f28
-        timeout: 16000
+        timeout: 1800
+        topology: *ipaserver
+
+  fedora-28/test_webui_general:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: >-
+          test_webui/test_loginscreen.py
+          test_webui/test_misc_cases.py
+          test_webui/test_navigation.py
+          test_webui/test_translation.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-28/test_webui_host:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_webui/test_host.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-28/test_webui_host_net_groups:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: >-
+          test_webui/test_hostgroup.py
+          test_webui/test_netgroup.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-28/test_webui_identity:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: >-
+          test_webui/test_automember.py
+          test_webui/test_idviews.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-28/test_webui_network:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: >-
+          test_webui/test_automount.py
+          test_webui/test_dns.py
+          test_webui/test_vault.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-28/test_webui_policy:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: >-
+          test_webui/test_hbac.py
+          test_webui/test_krbtpolicy.py
+          test_webui/test_pwpolicy.py
+          test_webui/test_selinuxusermap.py
+          test_webui/test_sudo.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-28/test_webui_rbac:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: >-
+          test_webui/test_delegation.py
+          test_webui/test_rbac.py
+          test_webui/test_selfservice.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-28/test_webui_server:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: >-
+          test_webui/test_config.py
+          test_webui/test_range.py
+          test_webui/test_realmdomains.py
+          test_webui/test_trust.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-28/test_webui_service:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_webui/test_service.py
+        template: *ci-master-f28
+        timeout: 1800
+        topology: *ipaserver
+
+  fedora-28/test_webui_users:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: >-
+          test_webui/test_group.py
+          test_webui/test_user.py
+        template: *ci-master-f28
+        timeout: 3600
         topology: *ipaserver
 
   fedora-28/test_pkinit_manage:

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -640,16 +640,161 @@ jobs:
         timeout: 7200
         topology: *master_1repl_1client
 
-  fedora-29/test_webui:
+  fedora-29/test_webui_cert:
     requires: [fedora-29/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
         build_url: '{fedora-29/build_url}'
-        test_suite: test_webui/
+        test_suite: test_webui/test_cert.py
         template: *ci-master-f29
-        timeout: 16000
+        timeout: 1800
+        topology: *ipaserver
+
+  fedora-29/test_webui_general:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: >-
+          test_webui/test_loginscreen.py
+          test_webui/test_misc_cases.py
+          test_webui/test_navigation.py
+          test_webui/test_translation.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-29/test_webui_host:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_webui/test_host.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-29/test_webui_host_net_groups:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: >-
+          test_webui/test_hostgroup.py
+          test_webui/test_netgroup.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-29/test_webui_identity:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: >-
+          test_webui/test_automember.py
+          test_webui/test_idviews.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-29/test_webui_network:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: >-
+          test_webui/test_automount.py
+          test_webui/test_dns.py
+          test_webui/test_vault.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-29/test_webui_policy:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: >-
+          test_webui/test_hbac.py
+          test_webui/test_krbtpolicy.py
+          test_webui/test_pwpolicy.py
+          test_webui/test_selinuxusermap.py
+          test_webui/test_sudo.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-29/test_webui_rbac:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: >-
+          test_webui/test_delegation.py
+          test_webui/test_rbac.py
+          test_webui/test_selfservice.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-29/test_webui_server:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: >-
+          test_webui/test_config.py
+          test_webui/test_range.py
+          test_webui/test_realmdomains.py
+          test_webui/test_trust.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-29/test_webui_service:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_webui/test_service.py
+        template: *ci-master-f29
+        timeout: 1800
+        topology: *ipaserver
+
+  fedora-29/test_webui_users:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: >-
+          test_webui/test_group.py
+          test_webui/test_user.py
+        template: *ci-master-f29
+        timeout: 3600
         topology: *ipaserver
 
   fedora-29/test_pkinit_manage:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -628,16 +628,161 @@ jobs:
         timeout: 7200
         topology: *master_1repl_1client
 
-  fedora-rawhide/test_webui:
+  fedora-rawhide/test_webui_cert:
     requires: [fedora-rawhide/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
         build_url: '{fedora-rawhide/build_url}'
-        test_suite: test_webui/
+        test_suite: test_webui/test_cert.py
         template: *ci-master-frawhide
-        timeout: 7200
+        timeout: 1800
+        topology: *ipaserver
+
+  fedora-rawhide/test_webui_general:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: >-
+          test_webui/test_loginscreen.py
+          test_webui/test_misc_cases.py
+          test_webui/test_navigation.py
+          test_webui/test_translation.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-rawhide/test_webui_host:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_webui/test_host.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-rawhide/test_webui_host_net_groups:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: >-
+          test_webui/test_hostgroup.py
+          test_webui/test_netgroup.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-rawhide/test_webui_identity:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: >-
+          test_webui/test_automember.py
+          test_webui/test_idviews.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-rawhide/test_webui_network:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: >-
+          test_webui/test_automount.py
+          test_webui/test_dns.py
+          test_webui/test_vault.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-rawhide/test_webui_policy:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: >-
+          test_webui/test_hbac.py
+          test_webui/test_krbtpolicy.py
+          test_webui/test_pwpolicy.py
+          test_webui/test_selinuxusermap.py
+          test_webui/test_sudo.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-rawhide/test_webui_rbac:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: >-
+          test_webui/test_delegation.py
+          test_webui/test_rbac.py
+          test_webui/test_selfservice.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-rawhide/test_webui_server:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: >-
+          test_webui/test_config.py
+          test_webui/test_range.py
+          test_webui/test_realmdomains.py
+          test_webui/test_trust.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-rawhide/test_webui_service:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_webui/test_service.py
+        template: *ci-master-frawhide
+        timeout: 1800
+        topology: *ipaserver
+
+  fedora-rawhide/test_webui_users:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: >-
+          test_webui/test_group.py
+          test_webui/test_user.py
+        template: *ci-master-frawhide
+        timeout: 3600
         topology: *ipaserver
 
   fedora-rawhide/test_pkinit_manage:


### PR DESCRIPTION
**Manually** apply changes from PRs:
https://github.com/freeipa/freeipa/pull/2538
https://github.com/freeipa/freeipa/pull/2774

WebUI test suite configuration is split to 11 bunches of tests to avoid unexpected timeouts.
test_webui/test_host.py runs standalone because it is unstable and heaviest one.

Original task: https://pagure.io/freeipa/issue/7756