### PR TITLE
prci_definitions: Add nightly flow for pki dependency testing

### DIFF
--- a/ipatests/prci_definitions/nightly_master_pki.yaml
+++ b/ipatests/prci_definitions/nightly_master_pki.yaml
@@ -1,0 +1,703 @@
+topologies:
+  build: &build
+    name: build
+    cpu: 2
+    memory: 3800
+  master_1repl: &master_1repl
+    name: master_1repl
+    cpu: 4
+    memory: 6450
+  master_1repl_1client: &master_1repl_1client
+    name: master_1repl_1client
+    cpu: 4
+    memory: 7400
+  ipaserver: &ipaserver
+    name: ipaserver
+    cpu: 2
+    memory: 2400
+  master_2repl_1client: &master_2repl_1client
+    name: master_2repl_1client
+    cpu: 5
+    memory: 10150
+  master_3repl_1client: &master_3repl_1client
+    name: master_3repl_1client
+    cpu: 6
+    memory: 12900
+
+jobs:
+  fedora-29/build:
+    requires: []
+    priority: 100
+    job:
+      class: Build
+      args:
+        git_repo: '{git_repo}'
+        git_refspec: '{git_refspec}'
+        template: &pki-master-f29
+          name: freeipa/pki-master-f29
+          version: 0.0.1
+        timeout: 1800
+        topology: *build
+
+  fedora-29/simple_replication:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_simple_replication.py
+        template: *pki-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/external_ca_1:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCA
+        template: *pki-master-f29
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-29/external_ca_2:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
+        template: *pki-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_vault:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_vault.py
+        template: *pki-master-f29
+        timeout: 6300
+        topology: *master_1repl
+
+  fedora-29/test_forced_client_enrolment:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_forced_client_reenrollment.py
+        template: *pki-master-f29
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-29/test_installation_TestInstallWithCA1:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA1
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-29/test_installation_TestInstallWithCA2:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA2
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-29/test_installation_TestInstallWithCA_KRA1:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-29/test_installation_TestInstallWithCA_KRA2:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-29/test_installation_TestInstallWithCA_DNS1:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-29/test_installation_TestInstallWithCA_DNS2:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-29/test_installation_TestInstallWithCA_DNS3:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
+        template: *pki-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_installation_TestInstallWithCA_DNS4:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
+        template: *pki-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_installation_TestInstallWithCA_KRA_DNS1:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-29/test_installation_TestInstallWithCA_KRA_DNS2:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-29/test_installation_TestInstallMaster:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMaster
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_1repl
+
+  fedora-29/test_installation_TestInstallMasterKRA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterKRA
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_1repl
+
+  fedora-29/test_installation_TestInstallMasterDNS:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterDNS
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_1repl
+
+  fedora-29/test_installation_TestInstallMasterReservedIPasForwarder:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_1repl
+
+  fedora-29/test_caless_TestServerInstall:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_caless.py::TestServerInstall
+        template: *pki-master-f29
+        timeout: 12000
+        topology: *master_1repl
+
+  fedora-29/test_caless_TestReplicaInstall:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_caless.py::TestReplicaInstall
+        template: *pki-master-f29
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-29/test_caless_TestClientInstall:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_caless.py::TestClientInstall
+        template: *pki-master-f29
+        timeout: 5400
+        # actually master_1client
+        topology: *master_1repl_1client
+
+  fedora-29/test_caless_TestIPACommands:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_caless.py::TestIPACommands
+        template: *pki-master-f29
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-29/test_caless_TestCertInstall:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_caless.py::TestCertInstall
+        template: *pki-master-f29
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-29/test_caless_TestPKINIT:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_caless.py::TestPKINIT
+        template: *pki-master-f29
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-29/test_caless_TestServerReplicaCALessToCAFull:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
+        template: *pki-master-f29
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-29/test_caless_TestReplicaCALessToCAFull:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
+        template: *pki-master-f29
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-29/test_caless_TestServerCALessToExternalCA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
+        template: *pki-master-f29
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithKRA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-29/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  fedora-29/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  fedora-29/test_replica_promotion_TestReplicaPromotionLevel1:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-29/test_replica_promotion_TestRenewalMaster:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-29/test_replica_promotion_TestSubCAkeyReplication:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-29/test_replica_promotion_TestReplicaInstallCustodia:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  fedora-29/test_upgrade:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_upgrade.py
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-29/test_topology_TestCASpecificRUVs:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-29/test_replication_layouts_TestLineTopologyWithoutCA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-29/test_replication_layouts_TestLineTopologyWithCA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-29/test_replication_layouts_TestLineTopologyWithCAKRA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-29/test_replication_layouts.py_TestStarTopologyWithoutCA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-29/test_replication_layouts_TestStarTopologyWithCA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-29/test_replication_layouts_TestStarTopologyWithCAKRA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
+        template: *pki-master-f29
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-29/test_replication_layouts_TestCompleteTopologyWithoutCA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-29/test_replication_layouts_TestCompleteTopologyWithCA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-29/test_replication_layouts_TestCompleteTopologyWithCAKRA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-29/test_client_uninstallation:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_uninstallation.py
+        template: *pki-master-f29
+        timeout: 7200
+        topology: *master_1repl_1client
+
+  fedora-29/test_webui_cert:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_webui/test_cert.py
+        template: *pki-master-f29
+        timeout: 1800
+        topology: *ipaserver
+
+  fedora-29/test_webui_identity:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: >-
+          test_webui/test_automember.py
+          test_webui/test_idviews.py
+        template: *pki-master-f29
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-29/dns_locations:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_dns_locations.py
+        template: *pki-master-f29
+        timeout: 3600
+        topology: *master_2repl_1client
+
+  fedora-29/external_ca_TestExternalCAdirsrvStop:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
+        template: *pki-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/external_ca_TestExternalCAInvalidCert:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert
+        template: *pki-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/external_ca_TestMultipleExternalCA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
+        template: *pki-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_pkinit_manage:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_pkinit_manage.py
+        template: *pki-master-f29
+        timeout: 3600
+        topology: *master_1repl


### PR DESCRIPTION
This commit adds PKI nightly flow definition. It executes relevant
freeipa tests in order to catch PKI regressions.