### PR TITLE
tests: Don't provide explicit hostname to ldapmodify

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -306,7 +306,7 @@ def enable_replication_debugging(host, log_level=0):
     host.run_command(['ldapmodify', '-x',
                       '-D', str(host.config.dirman_dn),
                       '-w', host.config.dirman_password,
-                      '-h', host.hostname],
+                      ],
                      stdin_text=logging_ldif)
 
 


### PR DESCRIPTION
Manual revert of bbac233b5ee487ab0e035cf0b861144769a0b738

The assumption was that ldap.conf was hosed and it couldn't
tell what hostname to use so one was hardcoded. This code
doesn't explicitly test that ldap.conf is sane but it is
a nice side-effect I suppose.

https://pagure.io/freeipa/issue/5880
Signed-off-by: Rob Crittenden <rcritten@redhat.com>