### PR TITLE
[Backport][ipa-4-7] PRCI failures fix

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -167,13 +167,11 @@ class TestInstallWithCA1(InstallTestBase1):
     def test_replica1_ipa_kra_install(self):
         super(TestInstallWithCA1, self).test_replica1_ipa_kra_install()
 
-    @pytest.mark.xfail(reason="FreeIPA ticket 7008", strict=True)
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
     def test_replica2_with_ca_kra_install(self):
         super(TestInstallWithCA1, self).test_replica2_with_ca_kra_install()
 
-    @pytest.mark.xfail(reason="FreeIPA ticket 7008", strict=True)
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
     def test_replica2_ipa_dns_install(self):
@@ -213,7 +211,6 @@ class TestInstallWithCA2(InstallTestBase2):
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=False)
 
-    @pytest.mark.xfail(reason="FreeIPA ticket 7008", strict=True)
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
     def test_replica0_with_ca_kra_dns_install(self):
@@ -258,13 +255,11 @@ class TestInstallWithCA_DNS1(InstallTestBase1):
     def test_replica1_ipa_kra_install(self):
         super(TestInstallWithCA_DNS1, self).test_replica1_ipa_kra_install()
 
-    @pytest.mark.xfail(reason="FreeIPA ticket 7008", strict=True)
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
     def test_replica2_with_ca_kra_install(self):
         super(TestInstallWithCA_DNS1, self).test_replica2_with_ca_kra_install()
 
-    @pytest.mark.xfail(reason="FreeIPA ticket 7008", strict=True)
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
     def test_replica2_ipa_dns_install(self):
@@ -277,7 +272,6 @@ class TestInstallWithCA_DNS2(InstallTestBase2):
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=True)
 
-    @pytest.mark.xfail(reason="FreeIPA ticket 7008", strict=True)
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
     def test_replica0_with_ca_kra_dns_install(self):


### PR DESCRIPTION
This is a manual backport of #2180, which seems does not have a corresponding Pagure issue

test_installation.py
- ticket 7008 closed so removing xfail
  - TestInstallWithCA1
  - TestInstallWithCA
  - TestInstallWithCA_DNS1
  - TestInstallWithCA_DNS2

nightly_master
- test_backup_and_restore_TestUser[r>R]ootFilesOwnership[Permission]

Signed-off-by: Pavel Picka <ppicka@redhat.com>
Reviewed-By: Michal Reznik <mreznik@redhat.com>