### PR TITLE
[Backport][ipa-4-7] tests: Don't provide explicit hostname to ldapmodify

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -305,7 +305,7 @@ def enable_replication_debugging(host, log_level=0):
     host.run_command(['ldapmodify', '-x',
                       '-D', str(host.config.dirman_dn),
                       '-w', host.config.dirman_password,
-                      '-h', host.hostname],
+                      ],
                      stdin_text=logging_ldif)
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #2798 was pushed to master and backport to ipa-4-7 is required.