### PR TITLE
Require secure-binds for password login

### DIFF
--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -81,6 +81,7 @@ dist_app_DATA =				\
 	replica-automember.ldif		\
 	sasl-mapping-fallback.ldif	\
 	schema-update.ldif		\
+	secure-binds.ldif		\
 	vault.ldif			\
 	kdcproxy-enable.uldif		\
 	kdcproxy-disable.uldif		\

--- a/install/share/secure-binds.ldif
+++ b/install/share/secure-binds.ldif
@@ -1,0 +1,6 @@
+# config
+dn: cn=config
+changetype: modify
+replace: nsslapd-require-secure-binds
+nsslapd-require-secure-binds: on
+

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -326,6 +326,7 @@ class DsInstance(service.Service):
                       self.__import_ca_certs)
         # set min SSF after DS is configured for TLS
         self.step("require minimal SSF", self.__min_ssf)
+        self.step("require secure binds", self.__secure_binds)
         self.step("restarting directory server", self.__restart_instance)
 
         self.start_creation()
@@ -1245,6 +1246,9 @@ class DsInstance(service.Service):
 
     def __min_ssf(self):
         self._ldap_mod("min-ssf.ldif")
+
+    def __secure_binds(self):
+        self._ldap_mod("secure-binds.ldif")
 
     def __add_sudo_binduser(self):
         self._ldap_mod("sudobind.ldif", self.sub_dict)


### PR DESCRIPTION
nsslapd-require-secure-binds restricts password based simple binds to
secure connections. It does not prevent a careless user from
transmitting a password in plain text. But it makes it obvious that he
did something bad. Password based bind attempts over an insecure
connections are refused with:

  Confidentiality required: Operation requires a secure connection

Secure connections are:

* LDAP connections on port 389 with STARTTLS
* LDAPS connections in port 636
* LDAPI connections to a local Unix sockets

Anonymous bind (simple_bind with empty DN and password) and GSSAPI
bind operations are not affected.

nsslapd-require-secure-binds is enabled after 389-DS is configured for
TLS/SSL.

Signed-off-by: Christian Heimes <cheimes@redhat.com>

**NOTE** The change may cause compatibility issues with applications that don't perform secure binds.