### PR TITLE
Tests: fix option name for dsctl

### DIFF
--- a/ipatests/test_integration/test_uninstallation.py
+++ b/ipatests/test_integration/test_uninstallation.py
@@ -115,5 +115,5 @@ class TestUninstallBase(IntegrationTest):
             ])
 
             self.master.run_command([
-                paths.DSCTL, serverid, 'remove', '--doit'
+                paths.DSCTL, serverid, 'remove', '--do-it'
             ])


### PR DESCRIPTION
389-ds-base has modified one option name in dsctl, and our test `test_uninstallation.py::TestUninstallBase::()::test_failed_uninstall` is still using the old option (--doit) instead of the new one (--do-it).

Fixes: https://pagure.io/freeipa/issue/7856