### PR TITLE
Compile IPA modules with C11 extensions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,14 +18,20 @@ AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([foreign 1.9 tar-pax])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES])
 
+dnl enable C11 extensions for features like memset_s()
+CFLAGS+=" -D__STDC_WANT_LIB_EXT1__=1"
+dnl enable features like htole16()
+CFLAGS+=" -D_DEFAULT_SOURCE=1"
+dnl Enable features like strndup()
+CFLAGS+=" -D_POSIX_C_SOURCE=200809L"
+dnl fail hard when includes statements are missing
+CFLAGS+=" -Werror=implicit-function-declaration"
+
 AC_PROG_CC_C99
 AC_DISABLE_STATIC
 LT_INIT
 
 AC_HEADER_STDC
-
-dnl fail hard when includes statements are missing
-CFLAGS+=" -Werror=implicit-function-declaration"
 
 PKG_PROG_PKG_CONFIG
 

--- a/daemons/ipa-slapi-plugins/libotp/otp_config.c
+++ b/daemons/ipa-slapi-plugins/libotp/otp_config.c
@@ -217,7 +217,7 @@ struct otp_config *otp_config_init(Slapi_ComponentId *plugin_id)
     void *node = NULL;
     int search_result = 0;
 
-    cfg = (typeof(cfg)) slapi_ch_calloc(1, sizeof(*cfg));
+    cfg = (struct otp_config *) slapi_ch_calloc(1, sizeof(*cfg));
     cfg->plugin_id = plugin_id;
 
     /* Build the config table. */
@@ -229,7 +229,7 @@ struct otp_config *otp_config_init(Slapi_ComponentId *plugin_id)
             struct record *rec;
 
             /* Create the config entry. */
-            rec = (typeof(rec)) slapi_ch_calloc(1, sizeof(*rec));
+            rec = (struct record *) slapi_ch_calloc(1, sizeof(*rec));
             rec->spec = specs[i];
             rec->sdn = make_sdn(rec->spec->prefix, sfx);
 

--- a/util/ipa_krb5.h
+++ b/util/ipa_krb5.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <time.h>
 #include <lber.h>
 #include <krb5/krb5.h>
 #include <kdb.h>


### PR DESCRIPTION
- define ``__STDC_WANT_LIB_EXT1__`` to get C11 extensions like ``memset_s()`` for
  Samba's ``ZERO_STRUCT()`` macro, see
  https://en.cppreference.com/w/c/string/byte/memset
- ``_DEFAULT_SOURCE`` enables features like htole16() from endian.h, see
  http://man7.org/linux/man-pages/man3/endian.3.html
- ``_POSIX_C_SOURCE >= 200809`` enables features like ``strndup()`` from ``string.h``,
  see http://man7.org/linux/man-pages/man3/strndup.3.html
- ``time_t`` is no longer implicitly defined, include ``time.h``
- ``typeof()`` is only available as GNU extension. Use explicit types
  instead of generic ``__typeof__()``.

Fixes: https://pagure.io/freeipa/issue/7858
Signed-off-by: Christian Heimes <cheimes@redhat.com>