### PR TITLE
Update build requirements on twine

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -195,7 +195,11 @@ BuildRequires:  python3-six
 BuildRequires:  dbus-glib-devel
 BuildRequires:  libffi-devel
 BuildRequires:  python3-tox
+%if 0%{?fedora} <= 28
 BuildRequires:  python3-twine
+%else
+BuildRequires:  twine
+%endif
 BuildRequires:  python3-wheel
 %endif # with_wheels
 


### PR DESCRIPTION
On Fedora >= 29 the command 'twine' is provied by the twine package. On
F28 it's in python3-twine. F30 no longer has python3-twine.

Signed-off-by: Christian Heimes <cheimes@redhat.com>