### PR TITLE
Remove ZERO_STRUCT() call

### DIFF
--- a/daemons/ipa-sam/ipa_sam.c
+++ b/daemons/ipa-sam/ipa_sam.c
@@ -2179,7 +2179,6 @@ static bool fill_pdb_trusted_domain(TALLOC_CTX *mem_ctx,
 	if (dummy == NULL) {
 		DEBUG(9, ("Attribute %s not present.\n",
 			  LDAP_ATTRIBUTE_TRUST_SID));
-		ZERO_STRUCT(td->security_identifier);
 	} else {
 		err = sss_idmap_sid_to_smb_sid(ipasam_state->idmap_ctx,
 					       dummy, &sid);


### PR DESCRIPTION
ipa_sam uses Samba's macro ZERO_STRUCT() to safely zero out a block in
memory. On F30 ZERO_STRUCT() is currently broken, because it uses the
undefined C11 function memset_s().

During investigation of the bug, it turned out that
ZERO_STRUCT(td->security_identifier) is not needed. The whole td struct
is allocated with talloc_zero(), so td->security_identifier is already
zeroed.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1672231
Signed-off-by: Christian Heimes <cheimes@redhat.com>