### PR TITLE
[Backport][ipa-4-7] Update build requirements on twine

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -230,7 +230,11 @@ BuildRequires:  python2-six
 BuildRequires:  dbus-glib-devel
 BuildRequires:  libffi-devel
 BuildRequires:  python3-tox
+%if 0%{?fedora} <= 28
 BuildRequires:  python3-twine
+%else
+BuildRequires:  twine
+%endif
 BuildRequires:  python3-wheel
 %endif # with_wheels
 


### PR DESCRIPTION
This PR was opened automatically because PR #2819 was pushed to master and backport to ipa-4-7 is required.