### PR TITLE
[Backport][ipa-4-7] Remove ZERO_STRUCT() call

### DIFF
--- a/daemons/ipa-sam/ipa_sam.c
+++ b/daemons/ipa-sam/ipa_sam.c
@@ -2179,7 +2179,6 @@ static bool fill_pdb_trusted_domain(TALLOC_CTX *mem_ctx,
 	if (dummy == NULL) {
 		DEBUG(9, ("Attribute %s not present.\n",
 			  LDAP_ATTRIBUTE_TRUST_SID));
-		ZERO_STRUCT(td->security_identifier);
 	} else {
 		err = sss_idmap_sid_to_smb_sid(ipasam_state->idmap_ctx,
 					       dummy, &sid);


### PR DESCRIPTION
This PR was opened automatically because PR #2820 was pushed to master and backport to ipa-4-7 is required.