### PR TITLE
Disable dependency on dogtag-pki PyPI package

### DIFF
--- a/ipaserver/setup.py
+++ b/ipaserver/setup.py
@@ -48,7 +48,9 @@ if __name__ == '__main__':
             "custodia",
             "dbus-python",
             "dnspython",
-            "dogtag-pki",
+            # dogtag-pki is just the client package on PyPI. ipaserver
+            # requires the full pki package.
+            # "dogtag-pki",
             "ipaclient",
             "ipalib",
             "ipaplatform",


### PR DESCRIPTION
The dependency on 'dogtag-pki' PyPI package causes problems.

For one it's not the full pki package. It only provides the client part,
but ipaserver also needs the pki.server subpackage with pkispawn command.

The Fedora package dependency generator turns the requirement into a
package requirement, but python3-pki does not provide the package name
python3.7dist(dogtag-pki).

Signed-off-by: Christian Heimes <cheimes@redhat.com>