### PR TITLE
[Backport][ipa-4-7] Disable dependency on dogtag-pki PyPI package

### DIFF
--- a/ipaserver/setup.py
+++ b/ipaserver/setup.py
@@ -48,7 +48,9 @@ if __name__ == '__main__':
             "custodia",
             "dbus-python",
             "dnspython",
-            "dogtag-pki",
+            # dogtag-pki is just the client package on PyPI. ipaserver
+            # requires the full pki package.
+            # "dogtag-pki",
             "ipaclient",
             "ipalib",
             "ipaplatform",


### PR DESCRIPTION
This PR was opened automatically because PR #2828 was pushed to master and backport to ipa-4-7 is required.