### PR TITLE
[Backport][ipa-4-7] ipatests: add test for correct modlist when value encoding differs

### DIFF
--- a/ipatests/test_ipaserver/test_ldap.py
+++ b/ipatests/test_ipaserver/test_ldap.py
@@ -317,3 +317,21 @@ class test_LDAPEntry(object):
 
         e.raw['test'].append(b'second')
         assert e['test'] == ['not list', u'second']
+
+    def test_modlist_with_varying_encodings(self):
+        """
+        Test modlist is correct when only encoding of new value differs
+
+        See: https://bugzilla.redhat.com/show_bug.cgi?id=1658302
+        """
+        dn_ipa_encoded = b'O=Red Hat\\, Inc.'
+        dn_389ds_encoded = b'O=Red Hat\\2C Inc.'
+        entry = self.entry
+        entry.raw['distinguishedName'] = [dn_389ds_encoded]
+        # This is to make entry believe that that value was part of the
+        # original data we received from LDAP
+        entry.reset_modlist()
+        entry['distinguishedName'] = [entry['distinguishedName'][0]]
+        assert entry.generate_modlist() == [
+            (1, 'distinguishedName', [dn_389ds_encoded]),
+            (0, 'distinguishedName', [dn_ipa_encoded])]


### PR DESCRIPTION
This is a manual backport of #2827 
Adding ACk as  it is a backport

See: https://pagure.io/freeipa/issue/7750
Reviewed-By: Alexander Bokovoy <abokovoy@redhat.com>