### PR TITLE
[Backport][ipa-4-6] Fix "Configured size limit exceeded" warning on Web UI

### DIFF
--- a/install/ui/src/freeipa/rpc.js
+++ b/install/ui/src/freeipa/rpc.js
@@ -1105,5 +1105,14 @@ rpc.extract_objects = function(values) {
     return values;
 };
 
+/**
+ * Server side error/warning codes
+ *
+ * Add new errors from ipalib.messages only if necessary.
+ */
+rpc.errors = {
+    search_result_truncated: 13017
+};
+
 return rpc;
 });

--- a/install/ui/src/freeipa/search.js
+++ b/install/ui/src/freeipa/search.js
@@ -293,7 +293,8 @@ IPA.search_facet = function(spec, no_init) {
             name: that.get_search_command_name(),
             entity: that.managed_entity.name,
             method: 'find',
-            args: args
+            args: args,
+            suppress_warnings: [rpc.errors.search_result_truncated]
         });
 
         command.set_options(that.get_refresh_command_options());

--- a/install/ui/src/freeipa/widget.js
+++ b/install/ui/src/freeipa/widget.js
@@ -5013,7 +5013,7 @@ IPA.entity_select_widget = function(spec) {
             method: 'find',
             args: [filter],
             options: that.filter_options,
-            suppress_warnings: [13017]
+            suppress_warnings: [rpc.errors.search_result_truncated]
         });
         var no_members = metadata.get('@mc-opt:' + cmd.get_command() + ':no_members');
         if (no_members) {

--- a/ipatests/test_webui/test_config.py
+++ b/ipatests/test_webui/test_config.py
@@ -165,6 +165,33 @@ class test_config(UI_driver):
         self.facet_button_click('save')
 
     @screenshot
+    def test_size_limit_notification(self):
+        """
+        Test if no notification is shown when size limit exceeded
+        """
+        self.init_app()
+        self.navigate_to_entity(config_data.ENTITY)
+
+        size_limit_s = 'ipasearchrecordslimit'
+        def_val = self.get_field_value(size_limit_s)
+
+        self.fill_input(size_limit_s, '10')
+        self.facet_button_click('save')
+
+        self.navigate_to_entity('cert')
+        # wait for a half sec for notification to appear
+        self.wait(0.5)
+        warning = self.find('div.notification-area .alert-warning',
+                            By.CSS_SELECTOR)
+        try:
+            assert not warning, "Warning present: {}".format(warning.text)
+        finally:
+            # restore previous value
+            self.navigate_to_entity(config_data.ENTITY)
+            self.fill_input(size_limit_s, def_val)
+            self.facet_button_click('save')
+
+    @screenshot
     def test_time_limits(self):
         """
         Test "Search time limit" field


### PR DESCRIPTION
Suppress size limit warning in 'refresh' command.

Manual backport for #2739.

Ticket: https://pagure.io/freeipa/issue/7603
Reviewed-By: Alexander Bokovoy <abokovoy@redhat.com>