### PR TITLE
tests: mark xfail for test_selinux_user_optimized on fed<=28

### DIFF
--- a/ipatests/test_integration/test_user_permissions.py
+++ b/ipatests/test_integration/test_user_permissions.py
@@ -4,10 +4,13 @@
 
 from __future__ import absolute_import
 
+import paramiko
+import pytest
+
+from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
-import paramiko
 
 class TestUserPermissions(IntegrationTest):
     topology = 'star'
@@ -67,6 +70,8 @@ class TestUserPermissions(IntegrationTest):
         # call ipa user-del --preserve
         self.master.run_command(['ipa', 'user-del', '--preserve', testuser])
 
+    @pytest.mark.xfail(osinfo.id == 'fedora' and int(osinfo.version_id) <= 28,
+                       reason='sssd ticket 3819', strict=True)
     def test_selinux_user_optimized(self):
         """
         Check that SELinux login context is set on first login for the


### PR DESCRIPTION
The test TestUserPermissions::test_selinux_user_optimized is
testing the fix for SSSD issue 3819, but the fix is not
available in fedora 28. Hence mark the test as xfail when
executed on fedora <=28 (our nightly tests also run on fed 28).

For full ref: fixed in sssd 1.16.4, Fedora 28 provides
1.16.3-2.fc28 only, while Fedora 29 provides 2.0.0-3.fc29.

related ticket : https://pagure.io/SSSD/sssd/issue/3819