### PR TITLE
Chown pki-tomcat's deployment.cfg to pkiuser after writing it.

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -483,7 +483,6 @@ class CAInstance(DogtagInstance):
         (cfg_fd, cfg_file) = tempfile.mkstemp()
         os.close(cfg_fd)
         pent = pwd.getpwnam(self.service_user)
-        os.chown(cfg_file, pent.pw_uid, pent.pw_gid)
 
         # Create CA configuration
         config = RawConfigParser()
@@ -646,6 +645,9 @@ class CAInstance(DogtagInstance):
         # Generate configuration file
         with open(cfg_file, "w") as f:
             config.write(f)
+
+        # Finally chown the config file (rhbz#1677027)
+        os.chown(cfg_file, pent.pw_uid, pent.pw_gid)
 
         self.backup_state('installed', True)
         try:


### PR DESCRIPTION
This fixes ipa-server-install when fs.protected_regular=1
Fedora bug: https://bugzilla.redhat.com/show_bug.cgi?id=1677027

Fixes: https://pagure.io/freeipa/issue/7866
Signed-off-by: François Cami <fcami@redhat.com>