### PR TITLE
[Backport][ipa-4-7] Chown pki-tomcat's deployment.cfg to pkiuser after writing it.

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -502,7 +502,6 @@ class CAInstance(DogtagInstance):
         (cfg_fd, cfg_file) = tempfile.mkstemp()
         os.close(cfg_fd)
         pent = pwd.getpwnam(self.service_user)
-        os.chown(cfg_file, pent.pw_uid, pent.pw_gid)
 
         # Create CA configuration
         config = RawConfigParser()
@@ -665,6 +664,9 @@ class CAInstance(DogtagInstance):
         # Generate configuration file
         with open(cfg_file, "w") as f:
             config.write(f)
+
+        # Finally chown the config file (rhbz#1677027)
+        os.chown(cfg_file, pent.pw_uid, pent.pw_gid)
 
         self.backup_state('installed', True)
         try:


### PR DESCRIPTION
This PR was opened automatically because PR #2843 was pushed to master and backport to ipa-4-7 is required.