### PR TITLE
ipa_sam: remove dependency to talloc_strackframe.h

### DIFF
--- a/daemons/ipa-sam/ipa_sam.c
+++ b/daemons/ipa-sam/ipa_sam.c
@@ -19,7 +19,6 @@
 #include <util/data_blob.h>
 #include <util/time.h>
 #include <util/debug.h>
-#include <util/talloc_stack.h>
 
 #ifndef _SAMBA_UTIL_H_
 bool trim_string(char *s, const char *front, const char *back);
@@ -880,8 +879,12 @@ static bool ipasam_uid_to_sid(struct pdb_methods *methods, uid_t uid,
 	struct dom_sid *user_sid = NULL;
 	int rc;
 	enum idmap_error_code err;
-	TALLOC_CTX *tmp_ctx = talloc_stackframe();
 	struct unixid id;
+
+	TALLOC_CTX *tmp_ctx = talloc_new(priv);
+	if (tmp_ctx == NULL) {
+		goto done;
+	}
 
 	/* Fast fail if we get a request for uidNumber=0 because it currently
 	 * will never exist in the directory
@@ -967,8 +970,12 @@ static bool ipasam_gid_to_sid(struct pdb_methods *methods, gid_t gid,
 	size_t c;
 	int rc;
 	enum idmap_error_code err;
-	TALLOC_CTX *tmp_ctx = talloc_stackframe();
 	struct unixid id;
+
+	TALLOC_CTX *tmp_ctx = talloc_new(priv);
+	if (tmp_ctx == NULL) {
+		goto done;
+	}
 
 	filter = talloc_asprintf(tmp_ctx,
 				 "(|(&(gidNumber=%u)"
@@ -3620,7 +3627,8 @@ static void ipasam_free_private_data(void **vp)
 		(*ipasam_state)->result = NULL;
 	}
 	if ((*ipasam_state)->domain_dn != NULL) {
-		SAFE_FREE((*ipasam_state)->domain_dn);
+		free((*ipasam_state)->domain_dn);
+		(*ipasam_state)->domain_dn = NULL;
 	}
 
 	*ipasam_state = NULL;


### PR DESCRIPTION
Recent Samba versions removed some header files which did include
non-public APIs. As a result talloc_strackframe.h and memory.h (for
SAFE_FREE) are not available anymore. This patch replaces the use of the
non-public APIs with public ones.