### PR TITLE
pkinit setup: fix regression on master install

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -429,13 +429,14 @@ class KrbInstance(service.Service):
             prev_helper = None
             # on the first CA-ful master without '--no-pkinit', we issue the
             # certificate by contacting Dogtag directly
-            localhost_has_ca = self.fqdn in find_providing_servers(
+            ca_instances = find_providing_servers(
                 'CA', conn=self.api.Backend.ldap2, api=self.api)
+
             use_dogtag_submit = all(
                 [self.master_fqdn is None,
                  self.pkcs12_info is None,
                  self.config_pkinit,
-                 localhost_has_ca])
+                 len(ca_instances) == 0])
 
             if use_dogtag_submit:
                 ca_args = [

--- a/ipatests/test_integration/test_pkinit_manage.py
+++ b/ipatests/test_integration/test_pkinit_manage.py
@@ -126,3 +126,20 @@ class TestPkinitManage(IntegrationTest):
 
         self.replicas[0].run_command(['ipa-pkinit-manage', 'enable'])
         check_pkinit(self.replicas[0], enabled=True)
+
+
+class TestPkinitInstall(IntegrationTest):
+    """Tests that ipa-server-install properly configures pkinit.
+
+    Non-regression test for issue 7795.
+    """
+    num_replicas = 0
+
+    @classmethod
+    def install(cls, mh):
+        # Install the master
+        tasks.install_master(cls.master)
+
+    def test_pkinit(self):
+        # Ensure that pkinit is properly configured
+        check_pkinit(self.master, enabled=True)


### PR DESCRIPTION
## pkinit setup: fix regression on master install
The commit 7785210 intended to fix ipa-pkinit-manage enable on a replica without any CA but introduced a regression: ipa-server-install fails to configure pkinit with the fix.

This commit provides a proper fix without the regression: pkinit needs to contact Dogtag directly only in case there is no CA instance yet (for ex. because we are installing the first master).

Fixes: https://pagure.io/freeipa/issue/7795

## test: add non-reg test checking pkinit after server install
Add a test with the following scenario:
ipa-server-install (with ca and pkinit enabled)
check that pkinit is properly enabled:
ipa-pkinit-manage status must return "enabled"
the KDC cert must be signed by IPA CA

Related to: https://pagure.io/freeipa/issue/7795
