### PR TITLE
[Backport][ipa-4-7] Web UI: Increase timeouts for UI tests in Nightly PR configuration

### DIFF
--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -661,7 +661,7 @@ jobs:
         build_url: '{fedora-28/build_url}'
         test_suite: test_webui/test_cert.py
         template: *ci-master-f28
-        timeout: 1800
+        timeout: 2400
         topology: *ipaserver
 
   fedora-28/test_webui_general:
@@ -792,7 +792,7 @@ jobs:
         build_url: '{fedora-28/build_url}'
         test_suite: test_webui/test_service.py
         template: *ci-master-f28
-        timeout: 1800
+        timeout: 2400
         topology: *ipaserver
 
   fedora-28/test_webui_users:
@@ -806,7 +806,7 @@ jobs:
           test_webui/test_group.py
           test_webui/test_user.py
         template: *ci-master-f28
-        timeout: 3600
+        timeout: 4800
         topology: *ipaserver
 
   fedora-28/test_pkinit_manage:

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -661,7 +661,7 @@ jobs:
         build_url: '{fedora-29/build_url}'
         test_suite: test_webui/test_cert.py
         template: *ci-master-f29
-        timeout: 1800
+        timeout: 2400
         topology: *ipaserver
 
   fedora-29/test_webui_general:
@@ -792,7 +792,7 @@ jobs:
         build_url: '{fedora-29/build_url}'
         test_suite: test_webui/test_service.py
         template: *ci-master-f29
-        timeout: 1800
+        timeout: 2400
         topology: *ipaserver
 
   fedora-29/test_webui_users:
@@ -806,7 +806,7 @@ jobs:
           test_webui/test_group.py
           test_webui/test_user.py
         template: *ci-master-f29
-        timeout: 3600
+        timeout: 4800
         topology: *ipaserver
 
   fedora-29/test_pkinit_manage:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -649,7 +649,7 @@ jobs:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_webui/test_cert.py
         template: *ci-master-frawhide
-        timeout: 1800
+        timeout: 2400
         topology: *ipaserver
 
   fedora-rawhide/test_webui_general:
@@ -780,7 +780,7 @@ jobs:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_webui/test_service.py
         template: *ci-master-frawhide
-        timeout: 1800
+        timeout: 2400
         topology: *ipaserver
 
   fedora-rawhide/test_webui_users:
@@ -794,7 +794,7 @@ jobs:
           test_webui/test_group.py
           test_webui/test_user.py
         template: *ci-master-frawhide
-        timeout: 3600
+        timeout: 4800
         topology: *ipaserver
 
   fedora-rawhide/test_pkinit_manage:


### PR DESCRIPTION
Manual backport of #2838 

Some test suites for WebUI in Nightly PR configuration have timeouts without any reserve.
So these tests fails randomly.

Timeout values for these test was increased to {real duration} + ~30%

https://pagure.io/freeipa/issue/7864