### PR TITLE
[Backport][ipa-4-7] pkinit setup: fix regression on master install

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -428,13 +428,14 @@ class KrbInstance(service.Service):
             prev_helper = None
             # on the first CA-ful master without '--no-pkinit', we issue the
             # certificate by contacting Dogtag directly
-            localhost_has_ca = self.fqdn in service.find_providing_servers(
+            ca_instances = service.find_providing_servers(
                 'CA', conn=self.api.Backend.ldap2, api=self.api)
+
             use_dogtag_submit = all(
                 [self.master_fqdn is None,
                  self.pkcs12_info is None,
                  self.config_pkinit,
-                 localhost_has_ca])
+                 len(ca_instances) == 0])
 
             if use_dogtag_submit:
                 ca_args = [

--- a/ipatests/test_integration/test_pkinit_manage.py
+++ b/ipatests/test_integration/test_pkinit_manage.py
@@ -126,3 +126,20 @@ class TestPkinitManage(IntegrationTest):
 
         self.replicas[0].run_command(['ipa-pkinit-manage', 'enable'])
         check_pkinit(self.replicas[0], enabled=True)
+
+
+class TestPkinitInstall(IntegrationTest):
+    """Tests that ipa-server-install properly configures pkinit.
+
+    Non-regression test for issue 7795.
+    """
+    num_replicas = 0
+
+    @classmethod
+    def install(cls, mh):
+        # Install the master
+        tasks.install_master(cls.master)
+
+    def test_pkinit(self):
+        # Ensure that pkinit is properly configured
+        check_pkinit(self.master, enabled=True)


### PR DESCRIPTION
This PR was opened manually (cherry-picked) because PR #2847 was pushed to master and backport to ipa-4-7 is required. Automatic backport of #2847 failed, hence the cherry-pick.