### PR TITLE
Fix installation when CA subject DN has escapes

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -91,6 +91,9 @@
 # and https://pagure.io/dogtagpki/issue/3073
 %global pki_version 10.6.8-3
 
+# https://pagure.io/certmonger/issue/90
+%global certmonger_version 0.79.7-1
+
 # NSS release with fix for p11-kit-proxy issue, affects F28
 # https://pagure.io/freeipa/issue/7810
 %if 0%{?fedora} == 28
@@ -313,7 +316,7 @@ Requires(preun): systemd-units
 Requires(postun): systemd-units
 Requires: policycoreutils >= 2.1.12-5
 Requires: tar
-Requires(pre): certmonger >= 0.79.5-1
+Requires(pre): certmonger >= %{certmonger_version}
 Requires(pre): 389-ds-base >= %{ds_version}
 Requires: fontawesome-fonts
 Requires: open-sans-fonts
@@ -487,7 +490,7 @@ Requires: initscripts
 Requires: libcurl >= 7.21.7-2
 Requires: xmlrpc-c >= 1.27.4
 Requires: sssd-ipa >= %{sssd_version}
-Requires: certmonger >= 0.79.5-1
+Requires: certmonger >= %{certmonger_version}
 Requires: nss-tools >= %{nss_version}
 Requires: bind-utils
 Requires: oddjob-mkhomedir


### PR DESCRIPTION
There were several bugs across several projects preventing
installation when the CA subject DN contains characters that need
escaping in the string representation, e.g.

    CN=Certificate Authority,O=Acme\, Inc.,ST=Massachusetts,C=US

The package versions containing relevant fixes are:

- 389-ds-base 1.4.0.20 (we already require >= 1.4.0.21)
- pki-core 10.5.5 (we already require >= 10.6.8)
- certmonger 0.79.7 (this commit bumps the dependency)

With this change, installation will now work.  Integration tests are
left for a subsequent commit.

Fixes: https://pagure.io/freeipa/issue/7347