### PR TITLE
[Backport][ipa-4-6] Processing of server roles should ignore errors.EmptyResult

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1782,6 +1782,8 @@ def upgrade_configuration():
         DOGTAG_PORT=8009,
         CLONE='#',
         WSGI_PROCESSES=constants.WSGI_PROCESSES,
+        IPA_CCACHES=paths.IPA_CCACHES,
+        IPA_CUSTODIA_SOCKET=paths.IPA_CUSTODIA_SOCKET
     )
 
     subject_base = find_subject_base()

--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -288,9 +288,20 @@ class config(LDAPObject):
     def update_entry_with_role_config(self, role_name, entry_attrs):
         backend = self.api.Backend.serverroles
 
-        role_config = backend.config_retrieve(role_name)
+        try:
+            role_config = backend.config_retrieve(role_name)
+        except errors.EmptyResult:
+            # No role config means current user identity
+            # has no rights to see it, return with no action
+            return
+
         for key, value in role_config.items():
-            entry_attrs.update({key: value})
+            try:
+                entry_attrs.update({key: value})
+            except errors.EmptyResult:
+                # An update that doesn't change an entry is fine here
+                # Just ignore and move to the next key pair
+                pass
 
 
     def show_servroles_attributes(self, entry_attrs, *roles, **options):


### PR DESCRIPTION
MANUAL BACKPORT.

This was not backported when the original PR was pushed. The milestone was pushed back afterward.

ipa-4-6 still defines:
WSGI_PROCESSES=constants.WSGI_PROCESSES,

---------
When non-admin user issues a command that utilizes
api.Object.config.show_servroles_attributes(), some server roles might
return errors.EmptyResult, indicating that a role is not visible to this
identity.

Most of the callers to api.Object.config.show_servroles_attributes() do
not process errors.EmptyResult so it goes up to an API caller. In case
of Web UI it breaks retrieval of the initial configuration due to ipa
config-show failing completely rather than avoiding to show available
server roles.

Fixes: https://pagure.io/freeipa/issue/7452
Signed-off-by: Alexander Bokovoy abokovoy@redhat.com