### PR TITLE
CRL generation master: new utility to enable|disable

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -997,6 +997,7 @@ fi
 %{_sbindir}/ipa-cacert-manage
 %{_sbindir}/ipa-winsync-migrate
 %{_sbindir}/ipa-pkinit-manage
+%{_sbindir}/ipa-crlgen-manage
 %{_libexecdir}/certmonger/dogtag-ipa-ca-renew-agent-submit
 %{_libexecdir}/certmonger/ipa-server-guard
 %dir %{_libexecdir}/ipa
@@ -1055,6 +1056,7 @@ fi
 %{_mandir}/man1/ipa-cacert-manage.1*
 %{_mandir}/man1/ipa-winsync-migrate.1*
 %{_mandir}/man1/ipa-pkinit-manage.1*
+%{_mandir}/man1/ipa-crlgen-manage.1*
 
 
 %files -n python3-ipaserver

--- a/install/tools/Makefile.am
+++ b/install/tools/Makefile.am
@@ -28,6 +28,7 @@ dist_noinst_DATA =		\
 	ipa-cacert-manage.in	\
 	ipa-winsync-migrate.in	\
 	ipa-pkinit-manage.in	\
+	ipa-crlgen-manage.in	\
 	ipa-custodia.in		\
 	ipa-custodia-check.in	\
 	ipa-httpd-kdcproxy.in	\
@@ -58,6 +59,7 @@ nodist_sbin_SCRIPTS =		\
 	ipa-cacert-manage	\
 	ipa-winsync-migrate	\
 	ipa-pkinit-manage	\
+	ipa-crlgen-manage	\
 	$(NULL)
 
 appdir = $(libexecdir)/ipa/

--- a/install/tools/ipa-crlgen-manage.in
+++ b/install/tools/ipa-crlgen-manage.in
@@ -1,0 +1,8 @@
+@PYTHONSHEBANG@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+from ipaserver.install.ipa_crlgen_manage import CRLGenManage
+
+CRLGenManage.run_cli()

--- a/install/tools/man/Makefile.am
+++ b/install/tools/man/Makefile.am
@@ -27,6 +27,7 @@ dist_man1_MANS = 			\
 	ipa-cacert-manage.1		\
 	ipa-winsync-migrate.1		\
 	ipa-pkinit-manage.1		\
+	ipa-crlgen-manage.1		\
         $(NULL)
 
 dist_man8_MANS =			\

--- a/install/tools/man/ipa-crlgen-manage.1
+++ b/install/tools/man/ipa-crlgen-manage.1
@@ -1,0 +1,47 @@
+.\"
+.\" Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+.\"
+.TH "ipa-crlgen-manage" "1" "Feb 12 2019" "FreeIPA" "FreeIPA Manual Pages"
+.SH "NAME"
+ipa\-crlgen\-manage \- Enables or disables CRL generation
+.SH "SYNOPSIS"
+ipa\-crlgen\-manage [options] <enable|disable|status>
+.SH "DESCRIPTION"
+Run the command with the \fBenable\fR option to enable CRL generation on the
+local host. This requires that the IPA server is already installed and
+configured, including a CA. The command will restart Dogtag and Apache.
+
+Run the command with the \fBdisable\fR option to disable CRL generation on the
+local host. The command will restart Dogtag and Apache.
+
+Run the command with the \fBstatus\fR option to determine the current status
+of CRL generation. If the local host is configured for CRL generation, the
+command also prints the last CRL generation date and number.
+
+Important: the administrator must ensure that there is only one IPA server
+generating CRLs. In order to transfer the CRL generation from one server to
+another, please run \fBipa-crlgen-manage disable\fR on the current CRL
+generation master, followed by \fBipa-crlgen-manage enable\fR on the new
+CRL generation master.
+.SH "OPTIONS"
+.TP
+\fB\-\-version\fR
+Show the program's version and exit.
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Show the help for this program.
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Print debugging information.
+.TP
+\fB\-q\fR, \fB\-\-quiet\fR
+Output only errors.
+.TP
+\fB\-\-log\-file\fR=\fIFILE\fR
+Log to the given file.
+.SH "EXIT STATUS"
+0 if the command was successful
+
+1 if an error occurred
+
+2 if the local host is not an IPA server

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -31,7 +31,7 @@ from ipaserver.install.replication import replica_conn_check
 from ipalib import api, errors
 from ipapython.dn import DN
 
-from . import conncheck, dogtag
+from . import conncheck, dogtag, cainstance
 
 if six.PY3:
     unicode = str
@@ -113,6 +113,37 @@ def print_ca_configuration(options):
     else:
         chaining = "self-signed"
     print("Chaining:     {}".format(chaining))
+
+
+def uninstall_check(options):
+    """Check if the host is CRL generation master"""
+    # Skip the checks if the host is not a CA instance
+    ca = cainstance.CAInstance(api.env.realm)
+    if not (api.Command.ca_is_enabled()['result'] and
+       cainstance.is_ca_installed_locally()):
+        return
+
+    # skip the checks if the host is the last master
+    ipa_config = api.Command.config_show()['result']
+    ipa_masters = ipa_config['ipa_master_server']
+    if len(ipa_masters) <= 1:
+        return
+
+    try:
+        crlgen_enabled = ca.is_crlgen_enabled()
+    except cainstance.InconsistentCRLGenConfigException:
+        # If config is inconsistent, let's be safe and act as if
+        # crl gen was enabled
+        crlgen_enabled = True
+
+    if crlgen_enabled:
+        print("Deleting this server will leave your installation "
+              "without a CRL generation master.")
+        if (options.unattended and not options.ignore_last_of_role) or \
+           not (options.unattended or ipautil.user_input(
+                "Are you sure you want to continue with the uninstall "
+                "procedure?", False)):
+            raise ScriptError("Aborting uninstall operation.")
 
 
 def install_check(standalone, replica_config, options):

--- a/ipaserver/install/ipa_crlgen_manage.py
+++ b/ipaserver/install/ipa_crlgen_manage.py
@@ -1,0 +1,118 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+from __future__ import print_function, absolute_import
+
+import os
+import logging
+from cryptography.hazmat.backends import default_backend
+from cryptography import x509
+
+from ipalib import api
+from ipalib.errors import NetworkError
+from ipaplatform.paths import paths
+from ipapython.admintool import AdminTool
+from ipaserver.install import cainstance
+from ipaserver.install import installutils
+
+logger = logging.getLogger(__name__)
+
+
+class CRLGenManage(AdminTool):
+    command_name = "ipa-crlgen-manage"
+    usage = "%prog <enable|disable|status>"
+    description = "Manage CRL Generation Master."
+
+    def validate_options(self):
+        super(CRLGenManage, self).validate_options(needs_root=True)
+        installutils.check_server_configuration()
+
+        option_parser = self.option_parser
+
+        if not self.args:
+            option_parser.error("action not specified")
+        elif len(self.args) > 1:
+            option_parser.error("too many arguments")
+
+        action = self.args[0]
+        if action not in {'enable', 'disable', 'status'}:
+            option_parser.error("unrecognized action '{}'".format(action))
+
+    def run(self):
+        api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
+        api.finalize()
+
+        try:
+            api.Backend.ldap2.connect()
+        except NetworkError as e:
+            logger.debug("Unable to connect to the local instance: %s", e)
+            raise RuntimeError("IPA must be running, please run ipactl start")
+        ca = cainstance.CAInstance(api.env.realm)
+
+        try:
+            action = self.args[0]
+            if action == 'enable':
+                self.enable(ca)
+            elif action == 'disable':
+                self.disable(ca)
+            elif action == 'status':
+                self.status(ca)
+        finally:
+            api.Backend.ldap2.disconnect()
+
+        return 0
+
+    def check_local_ca_instance(self, raiseOnErr=False):
+        if not api.Command.ca_is_enabled()['result'] or \
+           not cainstance.is_ca_installed_locally():
+            if raiseOnErr:
+                raise RuntimeError("Dogtag CA is not installed. "
+                                   "Please install a CA first with the "
+                                   "`ipa-ca-install` command.")
+            else:
+                logger.warning(
+                    "Warning: Dogtag CA is not installed on this server.")
+                return False
+        return True
+
+    def enable(self, ca):
+        # When the local node is not a CA, raise an Exception
+        self.check_local_ca_instance(raiseOnErr=True)
+        ca.setup_crlgen(True)
+        logger.info("CRL generation enabled on the local host. "
+                    "Please make sure to have only a single CRL generation "
+                    "master.")
+
+    def disable(self, ca):
+        # When the local node is not a CA, nothing to do
+        if not self.check_local_ca_instance():
+            return
+        ca.setup_crlgen(False)
+        logger.info("CRL generation disabled on the local host. "
+                    "Please make sure to configure CRL generation on another "
+                    "master with %s enable", self.command_name)
+
+    def status(self, ca):
+        # When the local node is not a CA, return "disabled"
+        if not self.check_local_ca_instance():
+            print("CRL generation: disabled")
+            return
+
+        # Local node is a CA, check its configuration
+        if ca.is_crlgen_enabled():
+            print("CRL generation: enabled")
+            try:
+                crl_filename = os.path.join(paths.PKI_CA_PUBLISH_DIR,
+                                            'MasterCRL.bin')
+                with open(crl_filename, 'rb') as f:
+                    crl = x509.load_der_x509_crl(f.read(), default_backend())
+                    print("Last CRL update: {}".format(crl.last_update))
+                    for ext in crl.extensions:
+                        if ext.oid == x509.oid.ExtensionOID.CRL_NUMBER:
+                            print("Last CRL Number: {}".format(
+                                ext.value.crl_number))
+            except IOError:
+                logger.error("Unable to find last CRL")
+        else:
+            print("CRL generation: disabled")

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1046,6 +1046,8 @@ def uninstall_check(installer):
     else:
         dns.uninstall_check(options)
 
+        ca.uninstall_check(options)
+
         if domain_level == DOMAIN_LEVEL_0:
             rm = replication.ReplicationManager(
                 realm=api.env.realm,

--- a/ipaserver/plugins/rabase.py
+++ b/ipaserver/plugins/rabase.py
@@ -123,3 +123,12 @@ class rabase(Backend):
         :param options: dictionary of search options
         """
         raise errors.NotImplementedError(name='%s.find' % self.name)
+
+    def updateCRL(self, wait='false'):
+        """
+        Force update of the CRL
+
+        :param wait: if true, the call will be synchronous and return only
+                     when the CRL has been generated
+        """
+        raise errors.NotImplementedError(name='%s.updateCRL' % self.name)

--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -377,6 +377,7 @@ IPA_CLIENT_NOT_CONFIGURED = b'IPA client is not configured on this system'
         (['ipa-ca-install'], 1, None,
          b'IPA server is not configured on this system'),
         (['ipa-compat-manage'], 2, None, IPA_NOT_CONFIGURED),
+        (['ipa-crlgen-manage'], 2, None, IPA_NOT_CONFIGURED),
         (['ipa-csreplica-manage'], 1, None, IPA_NOT_CONFIGURED),
         (['ipactl', 'status'], 4, None, b'IPA is not configured'),
         (['ipa-dns-install'], 2, None, IPA_NOT_CONFIGURED),

--- a/ipatests/test_integration/test_crlgen_manage.py
+++ b/ipatests/test_integration/test_crlgen_manage.py
@@ -1,0 +1,304 @@
+#
+# Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Module provides tests for the ipa-crlgen-manage command.
+"""
+
+from __future__ import absolute_import
+
+import os
+from cryptography.hazmat.backends import default_backend
+from cryptography import x509
+
+from ipaplatform.paths import paths
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+CRLGEN_STATUS_ENABLED = 'enabled'
+CRLGEN_STATUS_DISABLED = 'disabled'
+CRL_FILENAME = os.path.join(paths.PKI_CA_PUBLISH_DIR, 'MasterCRL.bin')
+
+
+def check_crlgen_status(host, rc=0, msg=None, enabled=True, check_crl=False):
+    """Checks that CRLGen is configured as expected
+
+    :param host: The host where ;ipa-crlgen-manage status' command is run
+    :param rc: the expected result code
+    :param msg: the expected msg in stderr
+    :param enabled: the expected status
+    :param check_crl: if True we expect a Master.bin CRL file
+
+    If enabled:
+    ipa-crlgen-manage status must return 'CRL generation: enabled'
+    and print the last CRL update date and number if crl_present=True.
+    If disabled:
+    ipa-crlgen-manage status must return 'CRL generation: disabled'
+    """
+    result = host.run_command(['ipa-crlgen-manage', 'status'],
+                              raiseonerr=False)
+
+    assert result.returncode == rc
+    if msg:
+        assert msg in result.stderr_text
+
+    if rc == 0:
+        status = CRLGEN_STATUS_ENABLED if enabled else CRLGEN_STATUS_DISABLED
+        assert 'CRL generation: {}'.format(status) in result.stdout_text
+
+        if check_crl and enabled:
+            # We expect CRL generation to be enabled and need to check for
+            # MasterCRL.bin
+            crl_content = host.get_file_contents(CRL_FILENAME)
+            crl = x509.load_der_x509_crl(crl_content, default_backend())
+            last_update_msg = 'Last CRL update: {}'.format(crl.last_update)
+            assert last_update_msg in result.stdout_text
+
+            for ext in crl.extensions:
+                if ext.oid == x509.oid.ExtensionOID.CRL_NUMBER:
+                    number_msg = "Last CRL Number: {}".format(
+                        ext.value.crl_number)
+                    assert number_msg in result.stdout_text
+
+
+def check_crlgen_enable(host, rc=0, msg=None, check_crl=False):
+    """Check ipa-crlgen-manage enable command
+
+    Launch ipa-crlgen-manage command and check the result code and output
+    """
+    result = host.run_command(['ipa-crlgen-manage', 'enable'],
+                              raiseonerr=False)
+    assert result.returncode == rc
+    if msg:
+        assert msg in result.stderr_text
+    if rc == 0:
+        # check ipa-crlgen-manage status is consistent
+        check_crlgen_status(host, enabled=True, check_crl=check_crl)
+
+
+def check_crlgen_disable(host, rc=0, msg=None):
+    """Check ipa-crlgen-manage disable command
+
+    Launch ipa-crlgen-manage command and check the result code and output
+    """
+    result = host.run_command(['ipa-crlgen-manage', 'disable'],
+                              raiseonerr=False)
+    assert result.returncode == rc
+    if msg:
+        assert msg in result.stderr_text
+    if rc == 0:
+        # check ipa-crlgen-manage status is consistent
+        check_crlgen_status(host, enabled=False)
+
+
+def break_crlgen_with_rewriterule(host):
+    """Create an inconsistent configuration on a CRL master
+
+    In the file /etc/httpd/conf.d/ipa-pki-proxy.conf, add a RewriteRule that
+    should be present only on non-CRL master"""
+    content = host.get_file_contents(paths.HTTPD_IPA_PKI_PROXY_CONF,
+                                     encoding='utf-8')
+    new_content = content + "\nRewriteRule ^/ipa/crl/MasterCRL.bin " \
+        "https://{}/ca/ee/ca/getCRL?op=getCRL&crlIssuingPoint=MasterCRL " \
+        "[L,R=301,NC]".format(host.hostname)
+    host.put_file_contents(paths.HTTPD_IPA_PKI_PROXY_CONF, new_content)
+
+    check_crlgen_status(host, rc=1, msg="Configuration is inconsistent")
+
+
+def break_crlgen_with_CS_cfg(host):
+    """Create an inconsistent configuration on a CRL master
+
+    Add a enableCRLUpdates=false directive that should be present only on
+    non-CRL master"""
+    content = host.get_file_contents(paths.CA_CS_CFG_PATH,
+                                     encoding='utf-8')
+    new_lines = []
+    for line in content.split('\n'):
+        if line.startswith('ca.crl.MasterCRL.enableCRLCache'):
+            new_lines.append("ca.crl.MasterCRL.enableCRLCache=false")
+        else:
+            new_lines.append(line)
+    host.put_file_contents(paths.CA_CS_CFG_PATH, '\n'.join(new_lines))
+
+    check_crlgen_status(host, rc=1, msg="Configuration is inconsistent")
+
+
+class TestCRLGenManage(IntegrationTest):
+    """Tests the ipa-crlgen-manage command.
+
+    ipa-crlgen-manage can be used to enable, disable or check
+    the status of CRL generation.
+    """
+
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        # Install a master and check CRL status (=enabled)
+        tasks.install_master(cls.master)
+        # We don't check for MasterCRL.bin presence because it may not
+        # be generated right after the install
+        check_crlgen_status(cls.master, enabled=True)
+
+    def test_master_enable_crlgen_already_enabled(self):
+        """Test ipa-crlgen-manage enable on an already enabled instance"""
+        # We don't check for MasterCRL.bin presence because it may not
+        # be generated right after the install
+        check_crlgen_enable(
+            self.master, rc=0,
+            msg="Nothing to do, CRL generation already enabled")
+
+    def test_master_disable_crlgen(self):
+        """Test ipa-crlgen-manage disable on an enabled instance"""
+        check_crlgen_disable(
+            self.master, rc=0,
+            msg="make sure to configure CRL generation on another master")
+
+    def test_master_disable_crlgen_already_disabled(self):
+        """Test ipa-crlgen-manage disable on an enabled instance"""
+        check_crlgen_disable(
+            self.master, rc=0,
+            msg="Nothing to do, CRL generation already disabled")
+
+    def test_master_enable_crlgen(self):
+        """Test ipa-crlgen-manage enable on a disabled instance"""
+        # This time we check that MasterCRL.bin is present
+        check_crlgen_enable(
+            self.master, rc=0,
+            msg="make sure to have only a single CRL generation master",
+            check_crl=True)
+
+    def test_crlgen_status_on_replica(self):
+        """Test crlgen status on a replica without CA
+
+        Install a replica without CA
+        then call ipa-crlgen-manage status.
+        """
+        tasks.install_replica(self.master, self.replicas[0], setup_ca=False)
+        check_crlgen_status(self.replicas[0], enabled=False)
+
+    def test_crlgen_disable_on_caless_replica(self):
+        """Test crlgen disable on a replica without CA"""
+        check_crlgen_disable(
+            self.replicas[0], rc=0,
+            msg="Warning: Dogtag CA is not installed on this server")
+
+    def test_crlgen_enable_on_caless_replica(self):
+        """Test crlgen enable on a replica without CA"""
+        check_crlgen_enable(
+            self.replicas[0], rc=1,
+            msg="Dogtag CA is not installed. Please install a CA first")
+
+    def test_crlgen_enable_on_ca_replica(self):
+        """Test crlgen enable on a replica with CA
+
+        Install a CA clone and enable CRLgen"""
+        tasks.install_ca(self.replicas[0])
+        check_crlgen_enable(
+            self.replicas[0], rc=0,
+            msg="make sure to have only a single CRL generation master",
+            check_crl=True)
+
+    def test_crlgen_enable_on_broken_master(self):
+        """Test crlgen enable on master with inconsistent config
+
+        Break the (enabled) master config by setting the rewriterule
+        and call enable"""
+        # Make sure the config is enabled
+        check_crlgen_enable(self.master)
+        # Break the config with RewriteRule
+        break_crlgen_with_rewriterule(self.master)
+        # Call enable to repair
+        check_crlgen_enable(
+            self.master, rc=0,
+            msg="CRL generation is partially enabled, repairing...",
+            check_crl=True)
+
+    def test_crlgen_disable_on_broken_master(self):
+        """Test crlgen disable on master with inconsistent config
+
+        Break the (enabled) master config by setting the rewriterule
+        and call disable"""
+        # Make sure the config is enabled
+        check_crlgen_enable(self.master)
+        # Break the config with RewriteRule
+        break_crlgen_with_rewriterule(self.master)
+        # Call disable to repair
+        check_crlgen_disable(
+            self.master, rc=0,
+            msg="CRL generation is partially enabled, repairing...")
+
+    def test_crlgen_enable_on_broken_replica(self):
+        """Test crlgen enable on replica with inconsistent config
+
+        Break the (enabled) replica config by setting enableCRLUpdates=false
+        and call enable"""
+        # Make sure the config is enabled
+        check_crlgen_enable(self.replicas[0])
+        # Break the config with RewriteRule
+        break_crlgen_with_CS_cfg(self.replicas[0])
+        # Call enable to repair
+        check_crlgen_enable(
+            self.replicas[0], rc=0,
+            msg="CRL generation is partially enabled, repairing...",
+            check_crl=True)
+
+    def test_crlgen_disable_on_broken_replica(self):
+        """Test crlgen disable on replica with inconsistent config
+
+        Break the (enabled) replica config by setting enableCRLUpdates=false
+        and call disable"""
+        # Make sure the config is enabled
+        check_crlgen_enable(self.replicas[0])
+        # Break the config with RewriteRule
+        break_crlgen_with_CS_cfg(self.replicas[0])
+        # Call disable to repair
+        check_crlgen_disable(
+            self.replicas[0], rc=0,
+            msg="CRL generation is partially enabled, repairing...")
+
+    def test_uninstall_without_ignore_last_of_role(self):
+        """Test uninstallation of the CRL generation master
+
+        If --ignore-last-of-role is not provided, uninstall prints a msg
+        and exits on error.
+        """
+        # Make sure CRL gen is enabled on the master
+        check_crlgen_enable(self.master)
+        # call uninstall without --ignore-last-of-role, should be refused
+        result = self.master.run_command(
+            ['ipa-server-install', '--uninstall', '-U'], raiseonerr=False)
+        assert result.returncode == 1
+        expected_msg = "Deleting this server will leave your installation " \
+                       "without a CRL generation master"
+        assert expected_msg in result.stdout_text
+
+    def test_uninstall_with_ignore_last_of_role(self):
+        """Test uninstallation of the CRL generation master
+
+        When --ignore-last-of-role is provided, uninstall prints a msg but
+        gets executed.
+        """
+        # Make sure CRL gen is enabled on the master
+        check_crlgen_enable(self.master)
+        # call uninstall with --ignore-last-of-role, should be OK
+        result = self.master.run_command(
+            ['ipa-server-install', '--uninstall', '-U',
+             '--ignore-last-of-role'])
+        expected_msg = "Deleting this server will leave your installation " \
+                       "without a CRL generation master"
+        assert expected_msg in result.stdout_text
+
+    def test_uninstall_last_master_does_not_require_ignore_last_of_role(self):
+        """Test uninstallation of the last master
+
+        Even if the host is CRL generation master, uninstall must proceed
+        even without --ignore-last-of-role because we are removing the last
+        master.
+        """
+        # Make sure CRL gen is enabled on the replica
+        check_crlgen_enable(self.replicas[0])
+        # call uninstall without --ignore-last-of-role, should be OK
+        self.master.run_command(['ipa-server-install', '--uninstall', '-U'])


### PR DESCRIPTION
### CRL generation master: new utility to enable|disable
Implement a new command ipa-clrgen-manage to enable, disable, or check the status of CRL generation on the localhost.
The command automates the manual steps described in the wiki https://www.freeipa.org/page/Howto/Promote_CA_to_Renewal_and_CRL_Master

Fixes: https://pagure.io/freeipa/issue/5803

### Test: add new tests for ipa-crlgen-manage
Add new integration tests for the new command ipa-crlgen-manage, and test_cmdline tests.

Related to: https://pagure.io/freeipa/issue/5803
