### PR TITLE
ipa-client-automount: handle NFS configuration file changes

### DIFF
--- a/client/ipa-client-automount.in
+++ b/client/ipa-client-automount.in
@@ -335,14 +335,16 @@ def configure_nfs(fstore, statestore):
     """
     Configure secure NFS
     """
-    replacevars = {
-        constants.SECURE_NFS_VAR: 'yes',
-    }
-    ipautil.backup_config_and_replace_variables(fstore,
-        paths.SYSCONFIG_NFS, replacevars=replacevars)
-    tasks.restore_context(paths.SYSCONFIG_NFS)
-
-    print("Configured %s" % paths.SYSCONFIG_NFS)
+    # Newer Fedora releases ship /etc/nfs.conf instead of /etc/sysconfig/nfs
+    # and do not require changes there. On these, SECURE_NFS_VAR == None
+    if constants.SECURE_NFS_VAR:
+        replacevars = {
+            constants.SECURE_NFS_VAR: 'yes',
+        }
+        ipautil.backup_config_and_replace_variables(fstore,
+            paths.SYSCONFIG_NFS, replacevars=replacevars)
+        tasks.restore_context(paths.SYSCONFIG_NFS)
+        print("Configured %s" % paths.SYSCONFIG_NFS)
 
     # Prepare the changes
     # We need to use IPAChangeConf as simple regexp substitution

--- a/ipaplatform/fedora/constants.py
+++ b/ipaplatform/fedora/constants.py
@@ -10,6 +10,12 @@ This Fedora base platform module exports platform related constants.
 from __future__ import absolute_import
 
 from ipaplatform.redhat.constants import RedHatConstantsNamespace
+from ipaplatform.osinfo import osinfo
+
+# Fedora 28 and earlier use /etc/sysconfig/nfs
+# Fedora 30 and later use /etc/nfs.conf
+# Fedora 29 has both
+HAS_NFS_CONF = osinfo.version_number >= (30,)
 
 
 class FedoraConstantsNamespace(RedHatConstantsNamespace):
@@ -22,6 +28,7 @@ class FedoraConstantsNamespace(RedHatConstantsNamespace):
     # secure remote password, and DSA cert authentication.
     # see https://fedoraproject.org/wiki/Changes/CryptoPolicy
     TLS_HIGH_CIPHERS = "PROFILE=SYSTEM:!3DES:!PSK:!SRP:!aDSS"
-
+    if HAS_NFS_CONF:
+        SECURE_NFS_VAR = None
 
 constants = FedoraConstantsNamespace()

--- a/ipaplatform/fedora/paths.py
+++ b/ipaplatform/fedora/paths.py
@@ -26,6 +26,7 @@ in Fedora-based systems.
 from __future__ import absolute_import
 
 from ipaplatform.redhat.paths import RedHatPathNamespace
+from ipaplatform.fedora.constants import HAS_NFS_CONF
 
 
 class FedoraPathNamespace(RedHatPathNamespace):
@@ -33,6 +34,8 @@ class FedoraPathNamespace(RedHatPathNamespace):
         "/etc/httpd/conf.modules.d/02-ipa-wsgi.conf"
     )
     NAMED_CRYPTO_POLICY_FILE = "/etc/crypto-policies/back-ends/bind.config"
+    if HAS_NFS_CONF:
+        SYSCONFIG_NFS = '/etc/nfs.conf'
 
 
 paths = FedoraPathNamespace()

--- a/ipaplatform/fedora/services.py
+++ b/ipaplatform/fedora/services.py
@@ -34,7 +34,7 @@ fedora_system_units = redhat_services.redhat_system_units.copy()
 # Fedora 28 and earlier have fedora-domainname.service. Starting from
 # Fedora 29, the service is called nis-domainname.service as defined in
 # ipaplatform.redhat.services.
-HAS_FEDORA_DOMAINNAME_SERVICE = int(osinfo.version_id) <= 28
+HAS_FEDORA_DOMAINNAME_SERVICE = osinfo.version_number <= (28,)
 
 if HAS_FEDORA_DOMAINNAME_SERVICE:
     fedora_system_units['domainname'] = 'fedora-domainname.service'

--- a/ipaplatform/osinfo.py
+++ b/ipaplatform/osinfo.py
@@ -178,6 +178,15 @@ class OSInfo(Mapping):
         return self._info.get('VERSION_ID')
 
     @property
+    def version_number(self):
+        """Version number tuple based on version_id
+        """
+        version_id = self._info.get('VERSION_ID')
+        if not version_id:
+            return ()
+        return tuple(int(p) for p in version_id.split('.'))
+
+    @property
     def platform_ids(self):
         """Ordered tuple of detected platforms (including override)
         """

--- a/ipaplatform/rhel/constants.py
+++ b/ipaplatform/rhel/constants.py
@@ -10,10 +10,17 @@ This RHEL base platform module exports platform related constants.
 from __future__ import absolute_import
 
 from ipaplatform.redhat.constants import RedHatConstantsNamespace
+from ipaplatform.osinfo import osinfo
+
+# RHEL 7 and earlier use /etc/sysconfig/nfs
+# RHEL 8 uses /etc/nfs.conf
+HAS_NFS_CONF = osinfo.version_number >= (8,)
 
 
 class RHELConstantsNamespace(RedHatConstantsNamespace):
     IPA_ADTRUST_PACKAGE_NAME = "ipa-server-trust-ad"
     IPA_DNS_PACKAGE_NAME = "ipa-server-dns"
+    if HAS_NFS_CONF:
+        SECURE_NFS_VAR = None
 
 constants = RHELConstantsNamespace()

--- a/ipaplatform/rhel/paths.py
+++ b/ipaplatform/rhel/paths.py
@@ -26,10 +26,12 @@ in RHEL-based systems.
 from __future__ import absolute_import
 
 from ipaplatform.redhat.paths import RedHatPathNamespace
+from ipaplatform.rhel.constants import HAS_NFS_CONF
 
 
 class RHELPathNamespace(RedHatPathNamespace):
-    pass
+    if HAS_NFS_CONF:
+        SYSCONFIG_NFS = '/etc/nfs.conf'
 
 
 paths = RHELPathNamespace()


### PR DESCRIPTION
nfs-utils in Fedora 30 and later switched its configuration
file from /etc/sysconfig/nfs to /etc/nfs.conf, providing a
conversion service (nfs-convert.service) for upgrades.
However, for new installs the original configuration file
is missing. This change:
* detects the new nfs-utils behavior
* avoids backing up the new NFS configuration file as we do
  not have to modify it.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1676981

Fixes: https://pagure.io/freeipa/issue/7868
Signed-off-by: François Cami <fcami@redhat.com>