### PR TITLE
ipatests: remove all occurrences of osinfo.version_id

### DIFF
--- a/ipaplatform/osinfo.py
+++ b/ipaplatform/osinfo.py
@@ -172,12 +172,6 @@ class OSInfo(Mapping):
         return self._info.get('VERSION')
 
     @property
-    def version_id(self):
-        """Version identifier
-        """
-        return self._info.get('VERSION_ID')
-
-    @property
     def version_number(self):
         """Version number tuple based on version_id
         """

--- a/ipatests/test_integration/test_user_permissions.py
+++ b/ipatests/test_integration/test_user_permissions.py
@@ -70,8 +70,9 @@ class TestUserPermissions(IntegrationTest):
         # call ipa user-del --preserve
         self.master.run_command(['ipa', 'user-del', '--preserve', testuser])
 
-    @pytest.mark.xfail(osinfo.id == 'fedora' and int(osinfo.version_id) <= 28,
-                       reason='sssd ticket 3819', strict=True)
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora' and osinfo.version_number <= (28,),
+        reason='sssd ticket 3819', strict=True)
     def test_selinux_user_optimized(self):
         """
         Check that SELinux login context is set on first login for the

--- a/ipatests/test_ipapython/test_certdb.py
+++ b/ipatests/test_ipapython/test_certdb.py
@@ -10,7 +10,7 @@ from ipaplatform.osinfo import osinfo
 CERTNICK = 'testcert'
 
 if osinfo.id == 'fedora':
-    if int(osinfo.version_id) >= 28:
+    if osinfo.version_number >= (28,):
         NSS_DEFAULT = 'sql'
     else:
         NSS_DEFAULT = 'dbm'


### PR DESCRIPTION
The fix for https://pagure.io/freeipa/issue/7868 introduced
a tuple-based OS version management method (osinfo.version_number)
by Christian Heimes.
Convert all occurrences of osinfo.version_id in ipatests to
osinfo.version_number then remove osinfo.version_id.

Related to: https://pagure.io/freeipa/issue/7873
Signed-off-by: François Cami <fcami@redhat.com>