### PR TITLE
tox.ini: ignore R1720 no-else-raise errors

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -101,6 +101,7 @@ disable=
     assignment-from-no-return,  # new in pylint 2.0
     keyword-arg-before-vararg,  # pylint 2.0, remove after dropping Python 2
     consider-using-enumerate,  # pylint 2.1, clean up tests later
+    no-else-raise, # python 2.4.0
 
 [REPORTS]
 


### PR DESCRIPTION
Newer pylint trips on unnecessary else/elif after raise.
Ignore that error for now as it breaks our build.

Signed-off-by: François Cami <fcami@redhat.com>