### PR TITLE
[Backport][ipa-4-7] pylintrc: ignore R1720 no-else-raise errors

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -102,6 +102,7 @@ disable=
     keyword-arg-before-vararg,  # pylint 2.0, remove after dropping Python 2
     useless-object-inheritance, # pylint 2.0, remove after dropping Python 2
     consider-using-enumerate,  # pylint 2.1, clean up tests later
+    no-else-raise, # python 2.4.0
 
 [REPORTS]
 


### PR DESCRIPTION
MANUAL BACKPORT

Newer pylint trips on unnecessary else/elif after raise.
Ignore that error for now as it breaks our build.

Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Christian Heimes <cheimes@redhat.com>