### PR TITLE
ipatests: fix host name for ssh connection from controller to master

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -289,7 +289,8 @@ class TestIPACommand(IntegrationTest):
         """
 
         test_user = 'test-ssh'
-        master = self.master.hostname
+        external_master_hostname = \
+            self.master.external_hostname  # pylint: disable=no-member
 
         pub_keys = []
 
@@ -319,13 +320,13 @@ class TestIPACommand(IntegrationTest):
         # first connection attempt is a workaround for
         # https://pagure.io/SSSD/sssd/issue/3669
         try:
-            sshcon.connect(master, username=test_user,
+            sshcon.connect(external_master_hostname, username=test_user,
                            key_filename=first_priv_key_path, timeout=1)
         except (paramiko.AuthenticationException, paramiko.SSHException):
             pass
 
         try:
-            sshcon.connect(master, username=test_user,
+            sshcon.connect(external_master_hostname, username=test_user,
                            key_filename=first_priv_key_path, timeout=1)
         except (paramiko.AuthenticationException,
                 paramiko.SSHException) as e:


### PR DESCRIPTION
Use master.external_hostname instead of master.hostname for ssh connection
from controller machine to master. If hostname and external_hostname in
test_config.yml do no match then trying to establish ssh connection
was failing with "[Errno -2] Name or service not known".

Fixes https://pagure.io/freeipa/issue/7874