### PR TITLE
[Backport][ipa-4-7] ipatests: remove all occurrences of osinfo.version_id

### DIFF
--- a/ipaplatform/osinfo.py
+++ b/ipaplatform/osinfo.py
@@ -172,12 +172,6 @@ class OSInfo(Mapping):
         return self._info.get('VERSION')
 
     @property
-    def version_id(self):
-        """Version identifier
-        """
-        return self._info.get('VERSION_ID')
-
-    @property
     def version_number(self):
         """Version number tuple based on version_id
         """

--- a/ipatests/test_ipapython/test_certdb.py
+++ b/ipatests/test_ipapython/test_certdb.py
@@ -10,7 +10,7 @@ from ipaplatform.osinfo import osinfo
 CERTNICK = 'testcert'
 
 if osinfo.id == 'fedora':
-    if int(osinfo.version_id) >= 28:
+    if osinfo.version_number >= (28,):
         NSS_DEFAULT = 'sql'
     else:
         NSS_DEFAULT = 'dbm'


### PR DESCRIPTION
MANUAL BACKPORT of PR #2867 

The fix for https://pagure.io/freeipa/issue/7868 introduced
a tuple-based OS version management method (osinfo.version_number)
by Christian Heimes.
Convert all occurrences of osinfo.version_id in ipatests to
osinfo.version_number then remove osinfo.version_id.

Related to: https://pagure.io/freeipa/issue/7873
Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Christian Heimes <cheimes@redhat.com>