### PR TITLE
[Backport][ipa-4-7] ipa-client-automount: fix PEP8 issues

### DIFF
--- a/client/ipa-client-automount.in
+++ b/client/ipa-client-automount.in
@@ -312,9 +312,9 @@ def uninstall(fstore, statestore):
                 wait_for_sssd()
             except Exception as e:
                 print('Unable to restore SSSD configuration: %s' % str(e))
-                logger.debug('Unable to restore SSSD configuration: %s',
-                             str(e))
- 
+                logger.debug(
+                    'Unable to restore SSSD configuration: %s', str(e))
+
     # rpcidmapd and rpcgssd are static units now
     if statestore.has_state('rpcidmapd'):
         statestore.delete_state('rpcidmapd','enabled')
@@ -327,7 +327,7 @@ def uninstall(fstore, statestore):
     try:
         nfsutils.restart()
     except Exception as e:
-        logger.error("Failed to restart nfs client services (%s)" % str(e))
+        logger.error("Failed to restart nfs client services (%s)", str(e))
         return 1
     return 0
 
@@ -369,14 +369,12 @@ def configure_nfs(fstore, statestore):
     try:
         rpcgssd.restart()
     except Exception as e:
-        logger.error("Failed to restart rpc-gssd (%s)" % str(e))
-        return 1
+        logger.error("Failed to restart rpc-gssd (%s)", str(e))
     nfsutils = services.knownservices['nfs-utils']
     try:
         nfsutils.restart()
     except Exception as e:
-        logger.error("Failed to restart nfs client services (%s)" % str(e))
-        return 1
+        logger.error("Failed to restart nfs client services (%s)", str(e))
 
 def main():
     try:


### PR DESCRIPTION
This PR was opened automatically because PR #2880 was pushed to master and backport to ipa-4-7 is required.