### PR TITLE
[ipa-4-7] Add missing nightly test definitions from master

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -39,6 +39,186 @@ jobs:
         timeout: 1800
         topology: *build
 
+  fedora-29/simple_replication:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_simple_replication.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/external_ca_1:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCA
+        template: *ci-master-f29
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-29/external_ca_2:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_topologies:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_topologies.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_sudo:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_sudo.py
+        template: *ci-master-f29
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-29/test_commands:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_commands.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_kerberos_flags:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_kerberos_flags.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-29/test_http_kdc_proxy:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_http_kdc_proxy.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-29/test_forced_client_enrolment:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_forced_client_reenrollment.py
+        template: *ci-master-f29
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-29/test_advise:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_advise.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-29/test_testconfig:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_testconfig.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_service_permissions:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_service_permissions.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_netgroup:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_netgroup.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_vault:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_vault.py
+        template: *ci-master-f29
+        timeout: 6300
+        topology: *master_1repl
+
+  fedora-29/test_authconfig:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_authselect.py
+        template: *ci-master-f29
+        timeout: 4800
+        topology: *master_1repl_1client
+
   fedora-29/test_server_del:
     requires: [fedora-29/build]
     priority: 50
@@ -48,7 +228,7 @@ jobs:
         build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_server_del.py
         template: *ci-master-f29
-        timeout: 8000
+        timeout: 10800
         topology: *master_2repl_1client
 
   fedora-29/test_installation_TestInstallWithCA1:
@@ -122,6 +302,30 @@ jobs:
         template: *ci-master-f29
         timeout: 10800
         topology: *master_3repl_1client
+
+  fedora-29/test_installation_TestInstallWithCA_DNS3:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_installation_TestInstallWithCA_DNS4:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
 
   fedora-29/test_installation_TestInstallWithCA_KRA_DNS1:
     requires: [fedora-29/build]
@@ -292,14 +496,38 @@ jobs:
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestUserrootFilesOwnership:
+  fedora-29/test_caless_TestReplicaCALessToCAFull:
     requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_backup_and_restore.py::TestUserrootFilesOwnership
+        test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
+        template: *ci-master-f29
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-29/test_caless_TestServerCALessToExternalCA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
+        template: *ci-master-f29
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-29/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
         template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
@@ -388,6 +616,42 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
+  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
+        template: *ci-master-f29
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  fedora-29/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
+        template: *ci-master-f29
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-29/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
+        template: *ci-master-f29
+        timeout: 7200
+        topology: *master_2repl_1client
+
   fedora-29/test_dnssec:
     requires: [fedora-29/build]
     priority: 50
@@ -397,7 +661,7 @@ jobs:
         build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_dnssec.py
         template: *ci-master-f29
-        timeout: 7200
+        timeout: 10800
         topology: *master_2repl_1client
 
   fedora-29/test_replica_promotion_TestReplicaPromotionLevel1:
@@ -484,6 +748,18 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
+  fedora-29/test_replica_promotion_TestReplicaInstallCustodia:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
+        template: *ci-master-f29
+        timeout: 7200
+        topology: *master_2repl_1client
+
   fedora-29/test_replica_promotion_TestReplicaInForwardZone:
     requires: [fedora-29/build]
     priority: 50
@@ -553,7 +829,7 @@ jobs:
         build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
         template: *ci-master-f29
-        timeout: 7200
+        timeout: 10800
         topology: *master_3repl_1client
 
   fedora-29/test_replication_layouts_TestLineTopologyWithCAKRA:
@@ -565,7 +841,7 @@ jobs:
         build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
         template: *ci-master-f29
-        timeout: 7200
+        timeout: 10800
         topology: *master_3repl_1client
 
   fedora-29/test_replication_layouts.py_TestStarTopologyWithoutCA:
@@ -601,7 +877,7 @@ jobs:
         build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
         template: *ci-master-f29
-        timeout: 7200
+        timeout: 10800
         topology: *master_3repl_1client
 
   fedora-29/test_replication_layouts_TestCompleteTopologyWithoutCA:
@@ -650,6 +926,18 @@ jobs:
         test_suite: test_integration/test_uninstallation.py
         template: *ci-master-f29
         timeout: 7200
+        topology: *master_1repl_1client
+
+  fedora-29/test_user_permissions:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_user_permissions.py
+        template: *ci-master-f29
+        timeout: 3600
         topology: *master_1repl_1client
 
   fedora-29/test_webui_cert:
@@ -808,6 +1096,66 @@ jobs:
         template: *ci-master-f29
         timeout: 4800
         topology: *ipaserver
+
+  fedora-29/customized_ds_config_install:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_customized_ds_config_install.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/dns_locations:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_dns_locations.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_2repl_1client
+
+  fedora-29/external_ca_TestExternalCAdirsrvStop:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/external_ca_TestExternalCAInvalidCert:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/external_ca_TestMultipleExternalCA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
 
   fedora-29/test_pkinit_manage:
     requires: [fedora-29/build]


### PR DESCRIPTION
Copy current test definitions from `master` branch to `ipa-4-7`.

Test case `fedora-29/test_ntp_options` was not copied because its
associated test suite is not available in the `ipa-4-7` branch.

Is it necessary to create a Pagure issue to track this change?