### PR TITLE
[ipa-4-7] too-restrictive mask checks

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1387,3 +1387,14 @@ def default_subject_base(realm_name):
 
 def default_ca_subject_dn(subject_base):
     return DN(('CN', 'Certificate Authority'), subject_base)
+
+
+def validate_mask():
+    try:
+        mask = os.umask(0)
+    finally:
+        os.umask(mask)
+    mask_str = None
+    if mask & 0b111101101 > 0:
+        mask_str = "{:04o}".format(mask)
+    return mask_str

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -41,7 +41,7 @@ from ipaserver.install import (
 from ipaserver.install.installutils import (
     IPA_MODULES, BadHostError, get_fqdn, get_server_ip_address,
     is_ipa_configured, load_pkcs12, read_password, verify_fqdn,
-    update_hosts_file)
+    update_hosts_file, validate_mask)
 
 if six.PY3:
     unicode = str
@@ -314,6 +314,16 @@ def install_check(installer):
     tasks.check_ipv6_stack_enabled()
     tasks.check_selinux_status()
     check_ldap_conf()
+
+    mask_str = validate_mask()
+    if mask_str:
+        print("Unexpected system mask: %s, expected 0022" % mask_str)
+        if installer.interactive:
+            if not user_input("Do you want to continue anyway?", True):
+                raise ScriptError(
+                    "Unexpected system mask: %s" % mask_str)
+        else:
+            raise ScriptError("Unexpected system mask: %s" % mask_str)
 
     if options.master_password:
         msg = ("WARNING:\noption '-P/--master-password' is deprecated. "

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -41,7 +41,7 @@ from ipaserver.install import (
     adtrust, bindinstance, ca, dns, dsinstance, httpinstance,
     installutils, kra, krbinstance, otpdinstance, custodiainstance, service)
 from ipaserver.install.installutils import (
-    ReplicaConfig, load_pkcs12, is_ipa_configured)
+    ReplicaConfig, load_pkcs12, is_ipa_configured, validate_mask)
 from ipaserver.install.replication import (
     ReplicationManager, replica_conn_check)
 import SSSDConfig
@@ -569,6 +569,11 @@ def common_check(no_ntp):
     tasks.check_ipv6_stack_enabled()
     tasks.check_selinux_status()
     check_ldap_conf()
+
+    mask_str = validate_mask()
+    if mask_str:
+        raise ScriptError(
+            "Unexpected system mask: %s, expected 0022" % mask_str)
 
     if is_ipa_configured():
         raise ScriptError(

--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -820,3 +820,15 @@ jobs:
         template: *ci-master-f28
         timeout: 3600
         topology: *master_1repl
+
+  fedora-28/mask:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_installation.py::TestMaskInstall
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *ipaserver

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1180,3 +1180,15 @@ jobs:
         template: *ci-master-f29
         timeout: 6300
         topology: *master_1repl
+
+  fedora-29/mask:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestMaskInstall
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *ipaserver

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -808,3 +808,15 @@ jobs:
         template: *ci-master-frawhide
         timeout: 3600
         topology: *master_1repl
+
+  fedora-rawhide/mask:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_installation.py::TestMaskInstall
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *ipaserver

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -567,3 +567,49 @@ class TestKRAinstallAfterCertRenew(IntegrationTest):
         self.master.run_command(['kinit', 'admin'], stdin_text=passwd)
         cmd = self.master.run_command(['ipa-kra-install', '-p', dm_pass, '-U'])
         self.master.run_command(['systemctl', 'start', 'chronyd'])
+
+
+class TestMaskInstall(IntegrationTest):
+    """ Test master and replica installation with wrong mask
+
+    This test checks that master/replica installation fails (expectedly) if
+    mask > 022.
+
+    related ticket: https://pagure.io/freeipa/issue/7193
+    """
+
+    num_replicas = 0
+
+    @classmethod
+    def install(cls, mh):
+        super(TestMaskInstall, cls).install(mh)
+        cls.bashrc_file = cls.master.get_file_contents('/root/.bashrc')
+
+    def test_install_master(self):
+        self.master.run_command('echo "umask 0027" >> /root/.bashrc')
+        result = self.master.run_command(['umask'])
+        assert '0027' in result.stdout_text
+
+        cmd = tasks.install_master(
+            self.master, setup_dns=False, raiseonerr=False
+        )
+        exp_str = ("Unexpected system mask")
+        assert (exp_str in cmd.stderr_text and cmd.returncode != 0)
+
+    def test_install_replica(self):
+        result = self.master.run_command(['umask'])
+        assert '0027' in result.stdout_text
+
+        cmd = self.master.run_command([
+            'ipa-replica-install', '-w', self.master.config.admin_password,
+            '-n', self.master.domain.name, '-r', self.master.domain.realm,
+            '--server', 'dummy_master.%s' % self.master.domain.name,
+            '-U'], raiseonerr=False
+        )
+        exp_str = ("Unexpected system mask")
+        assert (exp_str in cmd.stderr_text and cmd.returncode != 0)
+
+    def test_files_ownership_and_permission_teardown(self):
+        """ Method to restore the default bashrc contents"""
+        if self.bashrc_file is not None:
+            self.master.put_file_contents('/root/.bashrc', self.bashrc_file)


### PR DESCRIPTION
MANUAL BACKPORT

ipatests: add too-restritive mask tests
ipa-{server,replica}-install: add too-restritive mask detection

If the mask used during the installation is "too restrictive", ie.0027,
installing FreeIPA results in a broken server or replica.
Check for too-restrictive mask at install time and error out.

Fixes: https://pagure.io/freeipa/issue/7193
Signed-off-by: François Cami fcami@redhat.com