### PR TITLE
[ipa-4-6] too-restrictive mask checks

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1642,3 +1642,14 @@ def default_subject_base(realm_name):
 
 def default_ca_subject_dn(subject_base):
     return DN(('CN', 'Certificate Authority'), subject_base)
+
+
+def validate_mask():
+    try:
+        mask = os.umask(0)
+    finally:
+        os.umask(mask)
+    mask_str = None
+    if mask & 0b111101101 > 0:
+        mask_str = "{:04o}".format(mask)
+    return mask_str

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -38,7 +38,7 @@ from ipaserver.install import (
 from ipaserver.install.installutils import (
     IPA_MODULES, BadHostError, get_fqdn, get_server_ip_address,
     is_ipa_configured, load_pkcs12, read_password, verify_fqdn,
-    update_hosts_file)
+    update_hosts_file, validate_mask)
 
 if six.PY3:
     unicode = str
@@ -310,6 +310,16 @@ def install_check(installer):
 
     tasks.check_ipv6_stack_enabled()
     tasks.check_selinux_status()
+
+    mask_str = validate_mask()
+    if mask_str:
+        print("Unexpected system mask: %s, expected 0022" % mask_str)
+        if installer.interactive:
+            if not user_input("Do you want to continue anyway?", True):
+                raise ScriptError(
+                    "Unexpected system mask: %s" % mask_str)
+        else:
+            raise ScriptError("Unexpected system mask: %s" % mask_str)
 
     if options.master_password:
         msg = ("WARNING:\noption '-P/--master-password' is deprecated. "

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -42,7 +42,8 @@ from ipaserver.install import (
     installutils, kra, krbinstance,
     ntpinstance, otpdinstance, custodiainstance, service)
 from ipaserver.install.installutils import (
-    create_replica_config, ReplicaConfig, load_pkcs12, is_ipa_configured)
+    create_replica_config, ReplicaConfig, load_pkcs12, is_ipa_configured,
+    validate_mask)
 from ipaserver.install.replication import (
     ReplicationManager, replica_conn_check)
 import SSSDConfig
@@ -574,6 +575,11 @@ def check_remote_version(client, local_version):
 def common_check(no_ntp):
     tasks.check_ipv6_stack_enabled()
     tasks.check_selinux_status()
+
+    mask_str = validate_mask()
+    if mask_str:
+        raise ScriptError(
+            "Unexpected system mask: %s, expected 0022" % mask_str)
 
     if is_ipa_configured():
         raise ScriptError(


### PR DESCRIPTION
MANUAL BACKPORT

ipatests: add too-restritive mask tests
ipa-{server,replica}-install: add too-restritive mask detection

If the mask used during the installation is "too restrictive", ie.0027,
installing FreeIPA results in a broken server or replica.
Check for too-restrictive mask at install time and error out.

Fixes: https://pagure.io/freeipa/issue/7193
Signed-off-by: François Cami fcami@redhat.com