### PR TITLE
[Backport][ipa-4-6] CRL generation master: new utility to enable|disable

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -996,6 +996,7 @@ install/tools/ipa-backup
 install/tools/ipa-ca-install
 install/tools/ipa-cacert-manage
 install/tools/ipa-compat-manage
+install/tools/ipa-crlgen-manage
 install/tools/ipa-csreplica-manage
 install/tools/ipa-custodia
 install/tools/ipa-custodia-check
@@ -1381,6 +1382,7 @@ fi
 %{_sbindir}/ipa-cacert-manage
 %{_sbindir}/ipa-winsync-migrate
 %{_sbindir}/ipa-pkinit-manage
+%{_sbindir}/ipa-crlgen-manage
 %{_libexecdir}/certmonger/dogtag-ipa-ca-renew-agent-submit
 %{_libexecdir}/certmonger/ipa-server-guard
 %dir %{_libexecdir}/ipa
@@ -1445,6 +1447,7 @@ fi
 %{_mandir}/man1/ipa-cacert-manage.1*
 %{_mandir}/man1/ipa-winsync-migrate.1*
 %{_mandir}/man1/ipa-pkinit-manage.1*
+%{_mandir}/man1/ipa-crlgen-manage.1*
 
 
 %files -n python2-ipaserver

--- a/install/tools/Makefile.am
+++ b/install/tools/Makefile.am
@@ -29,6 +29,7 @@ dist_sbin_SCRIPTS =		\
 	ipa-cacert-manage	\
 	ipa-winsync-migrate	\
 	ipa-pkinit-manage	\
+	ipa-crlgen-manage	\
 	$(NULL)
 
 appdir = $(libexecdir)/ipa/

--- a/install/tools/ipa-crlgen-manage
+++ b/install/tools/ipa-crlgen-manage
@@ -1,0 +1,8 @@
+#! /usr/bin/python2 -E
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+from ipaserver.install.ipa_crlgen_manage import CRLGenManage
+
+CRLGenManage.run_cli()

--- a/install/tools/man/Makefile.am
+++ b/install/tools/man/Makefile.am
@@ -28,6 +28,7 @@ dist_man1_MANS = 			\
 	ipa-cacert-manage.1		\
 	ipa-winsync-migrate.1		\
 	ipa-pkinit-manage.1		\
+	ipa-crlgen-manage.1		\
         $(NULL)
 
 dist_man8_MANS =			\

--- a/install/tools/man/ipa-crlgen-manage.1
+++ b/install/tools/man/ipa-crlgen-manage.1
@@ -1,0 +1,47 @@
+.\"
+.\" Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+.\"
+.TH "ipa-crlgen-manage" "1" "Feb 12 2019" "FreeIPA" "FreeIPA Manual Pages"
+.SH "NAME"
+ipa\-crlgen\-manage \- Enables or disables CRL generation
+.SH "SYNOPSIS"
+ipa\-crlgen\-manage [options] <enable|disable|status>
+.SH "DESCRIPTION"
+Run the command with the \fBenable\fR option to enable CRL generation on the
+local host. This requires that the IPA server is already installed and
+configured, including a CA. The command will restart Dogtag and Apache.
+
+Run the command with the \fBdisable\fR option to disable CRL generation on the
+local host. The command will restart Dogtag and Apache.
+
+Run the command with the \fBstatus\fR option to determine the current status
+of CRL generation. If the local host is configured for CRL generation, the
+command also prints the last CRL generation date and number.
+
+Important: the administrator must ensure that there is only one IPA server
+generating CRLs. In order to transfer the CRL generation from one server to
+another, please run \fBipa-crlgen-manage disable\fR on the current CRL
+generation master, followed by \fBipa-crlgen-manage enable\fR on the new
+CRL generation master.
+.SH "OPTIONS"
+.TP
+\fB\-\-version\fR
+Show the program's version and exit.
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Show the help for this program.
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Print debugging information.
+.TP
+\fB\-q\fR, \fB\-\-quiet\fR
+Output only errors.
+.TP
+\fB\-\-log\-file\fR=\fIFILE\fR
+Log to the given file.
+.SH "EXIT STATUS"
+0 if the command was successful
+
+1 if an error occurred
+
+2 if the local host is not an IPA server

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -274,6 +274,10 @@ def is_ca_installed_locally():
     return os.path.exists(paths.CA_CS_CFG_PATH)
 
 
+class InconsistentCRLGenConfigException(Exception):
+    pass
+
+
 class CAInstance(DogtagInstance):
     """
     When using a dogtag CA the DS database contains just the
@@ -296,6 +300,14 @@ class CAInstance(DogtagInstance):
                      'subsystemCert cert-pki-ca',
                      'caSigningCert cert-pki-ca')
     server_cert_name = 'Server-Cert cert-pki-ca'
+    # The following must be aligned with the RewriteRule defined in
+    # install/share/ipa-pki-proxy.conf.template
+    crl_rewrite_pattern = r"^\s*(RewriteRule\s+\^/ipa/crl/MasterCRL.bin\s.*)$"
+    crl_rewrite_comment = r"^#\s*RewriteRule\s+\^/ipa/crl/MasterCRL.bin\s.*$"
+    crl_rewriterule = "\nRewriteRule ^/ipa/crl/MasterCRL.bin " \
+        "http://{}/ca/ee/ca/getCRL?" \
+        "op=getCRL&crlIssuingPoint=MasterCRL " \
+        "[L,R=301,NC]"
 
     def __init__(self, realm=None, host_name=None, custodia=None):
         super(CAInstance, self).__init__(
@@ -1388,6 +1400,155 @@ class CAInstance(DogtagInstance):
                                 '50-dogtag10-migration.update')]
                   )
 
+    def is_crlgen_enabled(self):
+        """Check if the local CA instance is generating CRL
+
+        Three conditions must be met to consider that the local CA is CRL
+        generation master:
+        - in CS.cfg ca.crl.MasterCRL.enableCRLCache=true
+        - in CS.cfg ca.crl.MasterCRL.enableCRLUpdates=true
+        - in /etc/httpd/conf.d/ipa-pki-proxy.conf the RewriteRule
+        ^/ipa/crl/MasterCRL.bin is disabled (commented or removed)
+
+        If the values are inconsistent, an exception is raised
+        :returns: True/False
+        :raises: InconsistentCRLGenConfigException if the config is
+                 inconsistent
+        """
+        try:
+            cache = installutils.get_directive(
+                self.config, 'ca.crl.MasterCRL.enableCRLCache', '=')
+            enableCRLCache = cache.lower() == 'true'
+            updates = installutils.get_directive(
+                self.config, 'ca.crl.MasterCRL.enableCRLUpdates', '=')
+            enableCRLUpdates = updates.lower() == 'true'
+
+            # If the values are different, the config is inconsistent
+            if enableCRLCache != enableCRLUpdates:
+                raise InconsistentCRLGenConfigException(
+                    "Configuration is inconsistent, please check "
+                    "ca.crl.MasterCRL.enableCRLCache and "
+                    "ca.crl.MasterCRL.enableCRLUpdates in {} and "
+                    "run ipa-crlgen-manage [enable|disable] to repair".format(
+                        self.config))
+        except IOError:
+            raise RuntimeError(
+                "Unable to read {}".format(self.config))
+
+        # At this point enableCRLCache and enableCRLUpdates have the same value
+        try:
+            rewriteRuleDisabled = True
+            p = re.compile(self.crl_rewrite_pattern)
+            with open(paths.HTTPD_IPA_PKI_PROXY_CONF) as f:
+                for line in f.readlines():
+                    if p.search(line):
+                        rewriteRuleDisabled = False
+                        break
+        except IOError:
+            raise RuntimeError(
+                "Unable to read {}".format(paths.HTTPD_IPA_PKI_PROXY_CONF))
+
+        # if enableCRLUpdates and rewriteRuleDisabled are different, the config
+        # is inconsistent
+        if enableCRLUpdates != rewriteRuleDisabled:
+            raise InconsistentCRLGenConfigException(
+                "Configuration is inconsistent, please check "
+                "ca.crl.MasterCRL.enableCRLCache in {} and the "
+                "RewriteRule ^/ipa/crl/MasterCRL.bin in {} and "
+                "run ipa-crlgen-manage [enable|disable] to repair".format(
+                    self.config, paths.HTTPD_IPA_PKI_PROXY_CONF))
+        return enableCRLUpdates
+
+    def setup_crlgen(self, setup_crlgen):
+        """Configure the local host for CRL generation
+
+        :param setup_crlgen: if True enable CRL generation, if False, disable
+        """
+        try:
+            crlgen_enabled = self.is_crlgen_enabled()
+            if crlgen_enabled == setup_crlgen:
+                logger.info(
+                    "Nothing to do, CRL generation already %s",
+                    "enabled" if crlgen_enabled else "disabled")
+                return
+        except InconsistentCRLGenConfigException:
+            logger.warning("CRL generation is partially enabled, repairing...")
+
+        # Stop PKI
+        logger.info("Stopping %s", self.service_name)
+        self.stop_instance()
+        logger.debug("%s successfully stopped", self.service_name)
+
+        # Edit the CS.cfg directives
+        logger.info("Editing %s", self.config)
+        with installutils.DirectiveSetter(
+                self.config, quotes=False, separator='=') as ds:
+            # Convert the bool setup_crlgen to a lowercase string
+            str_value = str(setup_crlgen).lower()
+            ds.set('ca.crl.MasterCRL.enableCRLCache', str_value)
+            ds.set('ca.crl.MasterCRL.enableCRLUpdates', str_value)
+
+        # Start pki-tomcat
+        logger.info("Starting %s", self.service_name)
+        self.start_instance()
+        logger.debug("%s successfully started", self.service_name)
+
+        # Edit the RewriteRule
+        def comment_rewriterule():
+            logger.info("Editing %s", paths.HTTPD_IPA_PKI_PROXY_CONF)
+            # look for the pattern RewriteRule ^/ipa/crl/MasterCRL.bin ..
+            # and comment out
+            p = re.compile(self.crl_rewrite_pattern, re.MULTILINE)
+            with open(paths.HTTPD_IPA_PKI_PROXY_CONF) as f:
+                content = f.read()
+            new_content = p.sub(r"#\1", content)
+            with open(paths.HTTPD_IPA_PKI_PROXY_CONF, 'w') as f:
+                f.write(new_content)
+
+        def uncomment_rewriterule():
+            logger.info("Editing %s", paths.HTTPD_IPA_PKI_PROXY_CONF)
+            # check if the pattern RewriteRule ^/ipa/crl/MasterCRL.bin ..
+            # is already present
+            present = False
+            p = re.compile(self.crl_rewrite_pattern, re.MULTILINE)
+            with open(paths.HTTPD_IPA_PKI_PROXY_CONF) as f:
+                content = f.read()
+            present = p.search(content)
+            # Remove the comment
+            p_comment = re.compile(self.crl_rewrite_comment, re.MULTILINE)
+            new_content = p_comment.sub("", content)
+            # If not already present, add RewriteRule
+            if not present:
+                new_content += self.crl_rewriterule.format(api.env.host)
+            # Finally write the file
+            with open(paths.HTTPD_IPA_PKI_PROXY_CONF, 'w') as f:
+                f.write(new_content)
+
+        try:
+            if setup_crlgen:
+                comment_rewriterule()
+            else:
+                uncomment_rewriterule()
+
+        except IOError:
+            raise RuntimeError(
+                "Unable to access {}".format(paths.HTTPD_IPA_PKI_PROXY_CONF))
+
+        # Restart httpd
+        http_service = services.knownservices.httpd
+        logger.info("Restarting %s", http_service.service_name)
+        http_service.restart()
+        logger.debug("%s successfully restarted", http_service.service_name)
+
+        # make sure a CRL is generated if setup_crl is True
+        if setup_crlgen:
+            logger.info("Forcing CRL update")
+            api.Backend.ra.override_port = 8443
+            result = api.Backend.ra.updateCRL(wait='true')
+            if result.get('crlUpdate', 'Failure') == 'Success':
+                logger.debug("Successfully updated CRL")
+            api.Backend.ra.override_port = None
+
 
 def replica_ca_install_check(config, promote):
     if promote:
@@ -1502,7 +1663,6 @@ def __update_entry_from_cert(make_filter, make_entry, cert):
         return False
 
     return True
-
 
 def update_people_entry(cert):
     """

--- a/ipaserver/install/ipa_crlgen_manage.py
+++ b/ipaserver/install/ipa_crlgen_manage.py
@@ -1,0 +1,118 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+from __future__ import print_function, absolute_import
+
+import os
+import logging
+from cryptography.hazmat.backends import default_backend
+from cryptography import x509
+
+from ipalib import api
+from ipalib.errors import NetworkError
+from ipaplatform.paths import paths
+from ipapython.admintool import AdminTool
+from ipaserver.install import cainstance
+from ipaserver.install import installutils
+
+logger = logging.getLogger(__name__)
+
+
+class CRLGenManage(AdminTool):
+    command_name = "ipa-crlgen-manage"
+    usage = "%prog <enable|disable|status>"
+    description = "Manage CRL Generation Master."
+
+    def validate_options(self):
+        super(CRLGenManage, self).validate_options(needs_root=True)
+        installutils.check_server_configuration()
+
+        option_parser = self.option_parser
+
+        if not self.args:
+            option_parser.error("action not specified")
+        elif len(self.args) > 1:
+            option_parser.error("too many arguments")
+
+        action = self.args[0]
+        if action not in {'enable', 'disable', 'status'}:
+            option_parser.error("unrecognized action '{}'".format(action))
+
+    def run(self):
+        api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
+        api.finalize()
+
+        try:
+            api.Backend.ldap2.connect()
+        except NetworkError as e:
+            logger.debug("Unable to connect to the local instance: %s", e)
+            raise RuntimeError("IPA must be running, please run ipactl start")
+        ca = cainstance.CAInstance(api.env.realm)
+
+        try:
+            action = self.args[0]
+            if action == 'enable':
+                self.enable(ca)
+            elif action == 'disable':
+                self.disable(ca)
+            elif action == 'status':
+                self.status(ca)
+        finally:
+            api.Backend.ldap2.disconnect()
+
+        return 0
+
+    def check_local_ca_instance(self, raiseOnErr=False):
+        if not api.Command.ca_is_enabled()['result'] or \
+           not cainstance.is_ca_installed_locally():
+            if raiseOnErr:
+                raise RuntimeError("Dogtag CA is not installed. "
+                                   "Please install a CA first with the "
+                                   "`ipa-ca-install` command.")
+            else:
+                logger.warning(
+                    "Warning: Dogtag CA is not installed on this server.")
+                return False
+        return True
+
+    def enable(self, ca):
+        # When the local node is not a CA, raise an Exception
+        self.check_local_ca_instance(raiseOnErr=True)
+        ca.setup_crlgen(True)
+        logger.info("CRL generation enabled on the local host. "
+                    "Please make sure to have only a single CRL generation "
+                    "master.")
+
+    def disable(self, ca):
+        # When the local node is not a CA, nothing to do
+        if not self.check_local_ca_instance():
+            return
+        ca.setup_crlgen(False)
+        logger.info("CRL generation disabled on the local host. "
+                    "Please make sure to configure CRL generation on another "
+                    "master with %s enable", self.command_name)
+
+    def status(self, ca):
+        # When the local node is not a CA, return "disabled"
+        if not self.check_local_ca_instance():
+            print("CRL generation: disabled")
+            return
+
+        # Local node is a CA, check its configuration
+        if ca.is_crlgen_enabled():
+            print("CRL generation: enabled")
+            try:
+                crl_filename = os.path.join(paths.PKI_CA_PUBLISH_DIR,
+                                            'MasterCRL.bin')
+                with open(crl_filename, 'rb') as f:
+                    crl = x509.load_der_x509_crl(f.read(), default_backend())
+                    print("Last CRL update: {}".format(crl.last_update))
+                    for ext in crl.extensions:
+                        if ext.oid == x509.oid.ExtensionOID.CRL_NUMBER:
+                            print("Last CRL Number: {}".format(
+                                ext.value.crl_number))
+            except IOError:
+                logger.error("Unable to find last CRL")
+        else:
+            print("CRL generation: disabled")

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1017,6 +1017,8 @@ def uninstall_check(installer):
     else:
         dns.uninstall_check(options)
 
+        ca.uninstall_check(options)
+
         if domain_level == DOMAIN_LEVEL_0:
             rm = replication.ReplicationManager(
                 realm=api.env.realm,

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1147,6 +1147,67 @@ def parse_unrevoke_cert_xml(doc):
     return response
 
 
+def parse_updateCRL_xml(doc):
+    '''
+    :param doc: The root node of the xml document to parse
+    :returns:   result dict
+    :except ValueError:
+
+    After parsing the results are returned in a result dict. The following
+    table illustrates the mapping from the CMS data item to what may be found
+    in the result dict. If a CMS data item is absent it will also be absent in
+    the result dict.
+
+    If the requestStatus is not SUCCESS then the response dict will have the
+    contents described in `parse_error_template_xml`.
+
+    +-----------------+-------------+-----------------------+---------------+
+    |cms name         |cms type     |result name            |result type    |
+    +=================+=============+=======================+===============+
+    |crlIssuingPoint  |string       |crl_issuing_point      |unicode        |
+    +-----------------+-------------+-----------------------+---------------+
+    |crlUpdate        |string       |crl_update [1]         |unicode        |
+    +-----------------+-------------+-----------------------+---------------+
+
+    .. [1] crlUpdate may be one of:
+
+           - "Success"
+           - "Failure"
+           - "missingParameters"
+           - "testingNotEnabled"
+           - "testingInProgress"
+           - "Scheduled"
+           - "inProgress"
+           - "disabled"
+           - "notInitialized"
+
+    '''
+
+    request_status = get_request_status_xml(doc)
+
+    if request_status != CMS_STATUS_SUCCESS:
+        response = parse_error_template_xml(doc)
+        return response
+
+    response = {}
+    response['request_status'] = request_status
+
+    crl_issuing_point = doc.xpath('//xml/header/crlIssuingPoint[1]')
+    if len(crl_issuing_point) == 1:
+        crl_issuing_point = etree.tostring(
+            crl_issuing_point[0], method='text',
+            encoding=unicode).strip()
+        response['crl_issuing_point'] = crl_issuing_point
+
+    crl_update = doc.xpath('//xml/header/crlUpdate[1]')
+    if len(crl_update) == 1:
+        crl_update = etree.tostring(crl_update[0], method='text',
+                                    encoding=unicode).strip()
+        response['crl_update'] = crl_update
+
+    return response
+
+
 def host_has_service(host, ldap2, service='CA'):
     """
     :param host: A host which might be a master for a service.
@@ -1970,6 +2031,47 @@ class ra(rabase.rabase, RestClient):
             results.append(response_request)
 
         return results
+
+    def updateCRL(self, wait='false'):
+        """
+        Force update of the CRL
+
+        :param wait: if true, the call will be synchronous and return only
+                     when the CRL has been generated
+        """
+        logger.debug('%s.updateCRL()', type(self).__name__)
+        # Call CMS
+        http_status, _http_headers, http_body = (
+            self._sslget('/ca/agent/ca/updateCRL',
+                         self.override_port or self.env.ca_agent_port,
+                         crlIssuingPoint='MasterCRL',
+                         waitForUpdate=wait,
+                         xml='true')
+        )
+
+        # Parse and handle errors
+        if http_status != 200:
+            self.raise_certificate_operation_error('updateCRL',
+                                                   detail=http_status)
+
+        parse_result = self.get_parse_result_xml(http_body,
+                                                 parse_updateCRL_xml)
+        request_status = parse_result['request_status']
+        if request_status != CMS_STATUS_SUCCESS:
+            self.raise_certificate_operation_error(
+                'updateCRL',
+                cms_request_status_to_string(request_status),
+                parse_result.get('error_string'))
+
+        # Return command result
+        cmd_result = {}
+
+        if 'crl_issuing_point' in parse_result:
+            cmd_result['crlIssuingPoint'] = parse_result['crl_issuing_point']
+        if 'crl_update' in parse_result:
+            cmd_result['crlUpdate'] = parse_result['crl_update']
+
+        return cmd_result
 
 
 # ----------------------------------------------------------------------------

--- a/ipaserver/plugins/rabase.py
+++ b/ipaserver/plugins/rabase.py
@@ -123,3 +123,12 @@ class rabase(Backend):
         :param options: dictionary of search options
         """
         raise errors.NotImplementedError(name='%s.find' % self.name)
+
+    def updateCRL(self, wait='false'):
+        """
+        Force update of the CRL
+
+        :param wait: if true, the call will be synchronous and return only
+                     when the CRL has been generated
+        """
+        raise errors.NotImplementedError(name='%s.updateCRL' % self.name)

--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -368,6 +368,7 @@ IPA_CLIENT_NOT_CONFIGURED = b'IPA client is not configured on this system'
         (['ipa-ca-install'], 1, None,
          b'IPA server is not configured on this system'),
         (['ipa-compat-manage'], 2, None, IPA_NOT_CONFIGURED),
+        (['ipa-crlgen-manage'], 2, None, IPA_NOT_CONFIGURED),
         (['ipa-csreplica-manage'], 1, None, IPA_NOT_CONFIGURED),
         (['ipactl', 'status'], 4, None, b'IPA is not configured'),
         (['ipa-dns-install'], 2, None, IPA_NOT_CONFIGURED),

--- a/ipatests/test_integration/test_crlgen_manage.py
+++ b/ipatests/test_integration/test_crlgen_manage.py
@@ -1,0 +1,304 @@
+#
+# Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Module provides tests for the ipa-crlgen-manage command.
+"""
+
+from __future__ import absolute_import
+
+import os
+from cryptography.hazmat.backends import default_backend
+from cryptography import x509
+
+from ipaplatform.paths import paths
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+CRLGEN_STATUS_ENABLED = 'enabled'
+CRLGEN_STATUS_DISABLED = 'disabled'
+CRL_FILENAME = os.path.join(paths.PKI_CA_PUBLISH_DIR, 'MasterCRL.bin')
+
+
+def check_crlgen_status(host, rc=0, msg=None, enabled=True, check_crl=False):
+    """Checks that CRLGen is configured as expected
+
+    :param host: The host where ;ipa-crlgen-manage status' command is run
+    :param rc: the expected result code
+    :param msg: the expected msg in stderr
+    :param enabled: the expected status
+    :param check_crl: if True we expect a Master.bin CRL file
+
+    If enabled:
+    ipa-crlgen-manage status must return 'CRL generation: enabled'
+    and print the last CRL update date and number if crl_present=True.
+    If disabled:
+    ipa-crlgen-manage status must return 'CRL generation: disabled'
+    """
+    result = host.run_command(['ipa-crlgen-manage', 'status'],
+                              raiseonerr=False)
+
+    assert result.returncode == rc
+    if msg:
+        assert msg in result.stderr_text
+
+    if rc == 0:
+        status = CRLGEN_STATUS_ENABLED if enabled else CRLGEN_STATUS_DISABLED
+        assert 'CRL generation: {}'.format(status) in result.stdout_text
+
+        if check_crl and enabled:
+            # We expect CRL generation to be enabled and need to check for
+            # MasterCRL.bin
+            crl_content = host.get_file_contents(CRL_FILENAME)
+            crl = x509.load_der_x509_crl(crl_content, default_backend())
+            last_update_msg = 'Last CRL update: {}'.format(crl.last_update)
+            assert last_update_msg in result.stdout_text
+
+            for ext in crl.extensions:
+                if ext.oid == x509.oid.ExtensionOID.CRL_NUMBER:
+                    number_msg = "Last CRL Number: {}".format(
+                        ext.value.crl_number)
+                    assert number_msg in result.stdout_text
+
+
+def check_crlgen_enable(host, rc=0, msg=None, check_crl=False):
+    """Check ipa-crlgen-manage enable command
+
+    Launch ipa-crlgen-manage command and check the result code and output
+    """
+    result = host.run_command(['ipa-crlgen-manage', 'enable'],
+                              raiseonerr=False)
+    assert result.returncode == rc
+    if msg:
+        assert msg in result.stderr_text
+    if rc == 0:
+        # check ipa-crlgen-manage status is consistent
+        check_crlgen_status(host, enabled=True, check_crl=check_crl)
+
+
+def check_crlgen_disable(host, rc=0, msg=None):
+    """Check ipa-crlgen-manage disable command
+
+    Launch ipa-crlgen-manage command and check the result code and output
+    """
+    result = host.run_command(['ipa-crlgen-manage', 'disable'],
+                              raiseonerr=False)
+    assert result.returncode == rc
+    if msg:
+        assert msg in result.stderr_text
+    if rc == 0:
+        # check ipa-crlgen-manage status is consistent
+        check_crlgen_status(host, enabled=False)
+
+
+def break_crlgen_with_rewriterule(host):
+    """Create an inconsistent configuration on a CRL master
+
+    In the file /etc/httpd/conf.d/ipa-pki-proxy.conf, add a RewriteRule that
+    should be present only on non-CRL master"""
+    content = host.get_file_contents(paths.HTTPD_IPA_PKI_PROXY_CONF,
+                                     encoding='utf-8')
+    new_content = content + "\nRewriteRule ^/ipa/crl/MasterCRL.bin " \
+        "https://{}/ca/ee/ca/getCRL?op=getCRL&crlIssuingPoint=MasterCRL " \
+        "[L,R=301,NC]".format(host.hostname)
+    host.put_file_contents(paths.HTTPD_IPA_PKI_PROXY_CONF, new_content)
+
+    check_crlgen_status(host, rc=1, msg="Configuration is inconsistent")
+
+
+def break_crlgen_with_CS_cfg(host):
+    """Create an inconsistent configuration on a CRL master
+
+    Add a enableCRLUpdates=false directive that should be present only on
+    non-CRL master"""
+    content = host.get_file_contents(paths.CA_CS_CFG_PATH,
+                                     encoding='utf-8')
+    new_lines = []
+    for line in content.split('\n'):
+        if line.startswith('ca.crl.MasterCRL.enableCRLCache'):
+            new_lines.append("ca.crl.MasterCRL.enableCRLCache=false")
+        else:
+            new_lines.append(line)
+    host.put_file_contents(paths.CA_CS_CFG_PATH, '\n'.join(new_lines))
+
+    check_crlgen_status(host, rc=1, msg="Configuration is inconsistent")
+
+
+class TestCRLGenManage(IntegrationTest):
+    """Tests the ipa-crlgen-manage command.
+
+    ipa-crlgen-manage can be used to enable, disable or check
+    the status of CRL generation.
+    """
+
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        # Install a master and check CRL status (=enabled)
+        tasks.install_master(cls.master)
+        # We don't check for MasterCRL.bin presence because it may not
+        # be generated right after the install
+        check_crlgen_status(cls.master, enabled=True)
+
+    def test_master_enable_crlgen_already_enabled(self):
+        """Test ipa-crlgen-manage enable on an already enabled instance"""
+        # We don't check for MasterCRL.bin presence because it may not
+        # be generated right after the install
+        check_crlgen_enable(
+            self.master, rc=0,
+            msg="Nothing to do, CRL generation already enabled")
+
+    def test_master_disable_crlgen(self):
+        """Test ipa-crlgen-manage disable on an enabled instance"""
+        check_crlgen_disable(
+            self.master, rc=0,
+            msg="make sure to configure CRL generation on another master")
+
+    def test_master_disable_crlgen_already_disabled(self):
+        """Test ipa-crlgen-manage disable on an enabled instance"""
+        check_crlgen_disable(
+            self.master, rc=0,
+            msg="Nothing to do, CRL generation already disabled")
+
+    def test_master_enable_crlgen(self):
+        """Test ipa-crlgen-manage enable on a disabled instance"""
+        # This time we check that MasterCRL.bin is present
+        check_crlgen_enable(
+            self.master, rc=0,
+            msg="make sure to have only a single CRL generation master",
+            check_crl=True)
+
+    def test_crlgen_status_on_replica(self):
+        """Test crlgen status on a replica without CA
+
+        Install a replica without CA
+        then call ipa-crlgen-manage status.
+        """
+        tasks.install_replica(self.master, self.replicas[0], setup_ca=False)
+        check_crlgen_status(self.replicas[0], enabled=False)
+
+    def test_crlgen_disable_on_caless_replica(self):
+        """Test crlgen disable on a replica without CA"""
+        check_crlgen_disable(
+            self.replicas[0], rc=0,
+            msg="Warning: Dogtag CA is not installed on this server")
+
+    def test_crlgen_enable_on_caless_replica(self):
+        """Test crlgen enable on a replica without CA"""
+        check_crlgen_enable(
+            self.replicas[0], rc=1,
+            msg="Dogtag CA is not installed. Please install a CA first")
+
+    def test_crlgen_enable_on_ca_replica(self):
+        """Test crlgen enable on a replica with CA
+
+        Install a CA clone and enable CRLgen"""
+        tasks.install_ca(self.replicas[0])
+        check_crlgen_enable(
+            self.replicas[0], rc=0,
+            msg="make sure to have only a single CRL generation master",
+            check_crl=True)
+
+    def test_crlgen_enable_on_broken_master(self):
+        """Test crlgen enable on master with inconsistent config
+
+        Break the (enabled) master config by setting the rewriterule
+        and call enable"""
+        # Make sure the config is enabled
+        check_crlgen_enable(self.master)
+        # Break the config with RewriteRule
+        break_crlgen_with_rewriterule(self.master)
+        # Call enable to repair
+        check_crlgen_enable(
+            self.master, rc=0,
+            msg="CRL generation is partially enabled, repairing...",
+            check_crl=True)
+
+    def test_crlgen_disable_on_broken_master(self):
+        """Test crlgen disable on master with inconsistent config
+
+        Break the (enabled) master config by setting the rewriterule
+        and call disable"""
+        # Make sure the config is enabled
+        check_crlgen_enable(self.master)
+        # Break the config with RewriteRule
+        break_crlgen_with_rewriterule(self.master)
+        # Call disable to repair
+        check_crlgen_disable(
+            self.master, rc=0,
+            msg="CRL generation is partially enabled, repairing...")
+
+    def test_crlgen_enable_on_broken_replica(self):
+        """Test crlgen enable on replica with inconsistent config
+
+        Break the (enabled) replica config by setting enableCRLUpdates=false
+        and call enable"""
+        # Make sure the config is enabled
+        check_crlgen_enable(self.replicas[0])
+        # Break the config with RewriteRule
+        break_crlgen_with_CS_cfg(self.replicas[0])
+        # Call enable to repair
+        check_crlgen_enable(
+            self.replicas[0], rc=0,
+            msg="CRL generation is partially enabled, repairing...",
+            check_crl=True)
+
+    def test_crlgen_disable_on_broken_replica(self):
+        """Test crlgen disable on replica with inconsistent config
+
+        Break the (enabled) replica config by setting enableCRLUpdates=false
+        and call disable"""
+        # Make sure the config is enabled
+        check_crlgen_enable(self.replicas[0])
+        # Break the config with RewriteRule
+        break_crlgen_with_CS_cfg(self.replicas[0])
+        # Call disable to repair
+        check_crlgen_disable(
+            self.replicas[0], rc=0,
+            msg="CRL generation is partially enabled, repairing...")
+
+    def test_uninstall_without_ignore_last_of_role(self):
+        """Test uninstallation of the CRL generation master
+
+        If --ignore-last-of-role is not provided, uninstall prints a msg
+        and exits on error.
+        """
+        # Make sure CRL gen is enabled on the master
+        check_crlgen_enable(self.master)
+        # call uninstall without --ignore-last-of-role, should be refused
+        result = self.master.run_command(
+            ['ipa-server-install', '--uninstall', '-U'], raiseonerr=False)
+        assert result.returncode == 1
+        expected_msg = "Deleting this server will leave your installation " \
+                       "without a CRL generation master"
+        assert expected_msg in result.stdout_text
+
+    def test_uninstall_with_ignore_last_of_role(self):
+        """Test uninstallation of the CRL generation master
+
+        When --ignore-last-of-role is provided, uninstall prints a msg but
+        gets executed.
+        """
+        # Make sure CRL gen is enabled on the master
+        check_crlgen_enable(self.master)
+        # call uninstall with --ignore-last-of-role, should be OK
+        result = self.master.run_command(
+            ['ipa-server-install', '--uninstall', '-U',
+             '--ignore-last-of-role'])
+        expected_msg = "Deleting this server will leave your installation " \
+                       "without a CRL generation master"
+        assert expected_msg in result.stdout_text
+
+    def test_uninstall_last_master_does_not_require_ignore_last_of_role(self):
+        """Test uninstallation of the last master
+
+        Even if the host is CRL generation master, uninstall must proceed
+        even without --ignore-last-of-role because we are removing the last
+        master.
+        """
+        # Make sure CRL gen is enabled on the replica
+        check_crlgen_enable(self.replicas[0])
+        # call uninstall without --ignore-last-of-role, should be OK
+        self.master.run_command(['ipa-server-install', '--uninstall', '-U'])


### PR DESCRIPTION
This is a manual backport of PR #2859 to ipa-4-6 branch.

There were a few merge conflicts:

- in ipa-4-6 branch the build mechanism does not use `ipa-crlgen-manage.in` template script to generate `ipa-crlgen-manage` script. This mechanism was introduced later. The final `ipa-crlgen-manage` script is used instead, and the python2 shebang gets replaced for python3 during the build.
- in ipa-4-6 branch, the `get|set_directives` are provided by `installutils` instead of `directivesetter`.