### PR TITLE
Send only the path and not the full URI to httplib.request

### DIFF
--- a/ipapython/dogtag.py
+++ b/ipapython/dogtag.py
@@ -227,7 +227,7 @@ def _httplib_request(
 
     try:
         conn = connection_factory(host, port, **connection_options)
-        conn.request(method, uri, body=request_body, headers=headers)
+        conn.request(method, path, body=request_body, headers=headers)
         res = conn.getresponse()
 
         http_status = res.status


### PR DESCRIPTION
1. 

Sending the full uri was causing httplib to send requests as:

POST http://ipa.example.com/ca/admin/ca/getStatus HTTP/1.1

https://pagure.io/freeipa/issue/7883

Signed-off-by: Rob Crittenden <rcritten@redhat.com>