### PR TITLE
[Backport][ipa-4-6] Send only the path and not the full URI to httplib.request

### DIFF
--- a/ipapython/dogtag.py
+++ b/ipapython/dogtag.py
@@ -217,7 +217,7 @@ def _httplib_request(
 
     try:
         conn = connection_factory(host, port, **connection_options)
-        conn.request(method, uri, body=request_body, headers=headers)
+        conn.request(method, path, body=request_body, headers=headers)
         res = conn.getresponse()
 
         http_status = res.status


### PR DESCRIPTION
This PR was opened automatically because PR #2906 was pushed to master and backport to ipa-4-6 is required.