### PR TITLE
Coverity: fix issue in ipa_extdom_extop.c

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_extop.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_extop.c
@@ -118,7 +118,7 @@ static int ipa_get_threadnumber(Slapi_ComponentId *plugin_id, size_t *threadnumb
     *threadnumber = slapi_entry_attr_get_uint(search_entries[0],
                                               NSSLAPD_THREADNUMBER);
 
-    if (threadnumber <= 0) {
+    if (*threadnumber <= 0) {
         LOG_FATAL("No thread number found.\n");
         ret = LDAP_OPERATIONS_ERROR;
         goto done;


### PR DESCRIPTION
Coverity found the following issue:
Error: BAD_COMPARE (CWE-697): [#def1]
freeipa-4.6.5/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_extop.c:121: null_misuse: Comparing pointer "threadnumber" against "NULL" using anything besides "==" or "!=" is likely to be incorrect.

The comparison is using the pointer while it should use the pointed value.

Fixes: https://pagure.io/freeipa/issue/7884