### PR TITLE
Fix assign instead of compare

### DIFF
--- a/client/ipa-getkeytab.c
+++ b/client/ipa-getkeytab.c
@@ -687,7 +687,7 @@ static int resolve_ktname(const char *keytab, char **ktname, char **err_msg)
      * root. For simplicity, only one level if indirection is resolved.
      */
     if ((stat(keytab, &st) == -1) &&
-            (errno = ENOENT) &&
+            (errno == ENOENT) &&
             (lstat(keytab, &lst) == 0) &&
             (S_ISLNK(lst.st_mode))) {
         /* keytab is a dangling symlink. */


### PR DESCRIPTION
Commit 53e0b2255d92c9c21c19306cf37cc8de0476dc9c introduced a minor bug.
Instead of comparing errno to ENOENT, the check assigned ENOENT to
errno.

Coverity: CID 337082
See: https://pagure.io/freeipa/issue/4607
Signed-off-by: Christian Heimes <cheimes@redhat.com>