### PR TITLE
[Backport][ipa-4-7] Coverity: fix issue in ipa_extdom_extop.c

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_extop.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_extop.c
@@ -118,7 +118,7 @@ static int ipa_get_threadnumber(Slapi_ComponentId *plugin_id, size_t *threadnumb
     *threadnumber = slapi_entry_attr_get_uint(search_entries[0],
                                               NSSLAPD_THREADNUMBER);
 
-    if (threadnumber <= 0) {
+    if (*threadnumber <= 0) {
         LOG_FATAL("No thread number found.\n");
         ret = LDAP_OPERATIONS_ERROR;
         goto done;


### PR DESCRIPTION
This PR was opened automatically because PR #2913 was pushed to master and backport to ipa-4-7 is required.