### PR TITLE
Completely drop /var/cache/ipa/sessions

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -253,7 +253,6 @@ class BasePathNamespace:
     IPA_JS_PLUGINS_DIR = "/usr/share/ipa/ui/js/plugins"
     UPDATES_DIR = "/usr/share/ipa/updates/"
     DICT_WORDS = "/usr/share/dict/words"
-    CACHE_IPA_SESSIONS = "/var/cache/ipa/sessions"
     VAR_KERBEROS_KRB5KDC_DIR = "/var/kerberos/krb5kdc/"
     VAR_KRB5KDC_K5_REALM = "/var/kerberos/krb5kdc/.k5."
     CACERT_PEM = "/var/kerberos/krb5kdc/cacert.pem"

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -889,7 +889,6 @@ def install(installer):
             subject_base=options.subject_base,
             auto_redirect=not options.no_ui_redirect,
             ca_is_configured=setup_ca)
-    tasks.restore_context(paths.CACHE_IPA_SESSIONS)
 
     ca.set_subject_base_in_config(options.subject_base)
 


### PR DESCRIPTION
This directory has been already dropped in 6d66e826c,
but not entirely.