### PR TITLE
[Backport][ipa-4-7] GIT: ignore ipa-crlgen-manage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ install/tools/ipa-ca-install
 install/tools/ipa-compat-manage
 install/tools/ipa-csreplica-manage
 install/tools/ipactl
+install/tools/ipa-crlgen-manage
 install/tools/ipa-custodia
 install/tools/ipa-custodia-check
 install/tools/ipa-dns-install


### PR DESCRIPTION
This PR was opened automatically because PR #2922 was pushed to master and backport to ipa-4-7 is required.