### PR TITLE
ipa-replica-manage: fix force-sync

### DIFF
--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -1241,7 +1241,7 @@ def force_sync(realm, thishost, fromhost, dirman_passwd, nolookup=False):
         repl = replication.ReplicationManager(realm, fromhost, dirman_passwd)
         repl.force_sync(repl.conn, thishost)
         agreement = repl.get_replication_agreement(thishost)
-        repl.wait_for_repl_init(repl.conn, agreement.dn)
+        repl.wait_for_repl_update(repl.conn, agreement.dn)
         ds.replica_manage_time_skew(prevent=True)
 
 def show_DNA_ranges(hostname, master, realm, dirman_passwd, nextrange=False,


### PR DESCRIPTION
ipa-replica-manage force-sync --from <server> is performing a wrong check
that may result in the tool looping on "No status yet".

force-sync is adding a nsds5replicaupdateschedule attribute to the
replication agreement in order to force replication to wake up. Note that
this is not a re-initialization (re init drops the current db and reloads
the entire db).

In a second step, force-sync is checking the replication agreement by reading
nsds5BeginReplicaRefresh, nsds5ReplicaLastInitStatus,
nsds5ReplicaLastInitStart and nsds5ReplicaLastInitEnd. This is a wrong
test as force-sync is not an init operation and does not touch these
attributes.

The tool should call wait_for_repl_update rather than wait_for_repl_init.
This way, the check is done on the replication agreement attributes
nsds5replicaUpdateInProgress, nsds5ReplicaLastUpdateStatus,
nsds5ReplicaLastUpdateStart and nsds5ReplicaLastUpdateEnd.

Fixes: https://pagure.io/freeipa/issue/7886