### PR TITLE
Hidden replica test

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -772,6 +772,18 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
+  fedora-28/test_replica_promotion_TestHiddenReplicaPromotion:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
+        template: *ci-master-f28
+        timeout: 7200
+        topology: *master_1repl
+
   fedora-28/test_upgrade:
     requires: [fedora-28/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -772,6 +772,18 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
+   fedora-29/test_replica_promotion_TestHiddenReplicaPromotion:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
+        template: *ci-master-f29
+        timeout: 7200
+        topology: *master_1repl
+
   fedora-29/test_upgrade:
     requires: [fedora-29/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -772,7 +772,7 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
-   fedora-29/test_replica_promotion_TestHiddenReplicaPromotion:
+  fedora-29/test_replica_promotion_TestHiddenReplicaPromotion:
     requires: [fedora-29/build]
     priority: 50
     job:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -772,6 +772,18 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
+   fedora-rawhide/test_replica_promotion_TestHiddenReplicaPromotion:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_1repl
+
   fedora-rawhide/test_upgrade:
     requires: [fedora-rawhide/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -772,7 +772,7 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
-   fedora-rawhide/test_replica_promotion_TestHiddenReplicaPromotion:
+  fedora-rawhide/test_replica_promotion_TestHiddenReplicaPromotion:
     requires: [fedora-rawhide/build]
     priority: 50
     job:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -45,14 +45,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-29/temp_commit:
+  fedora-29/test_replica_promotion_TestHiddenReplicaPromotion:
     requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
         template: *ci-master-f29
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *master_1repl


### PR DESCRIPTION
Depends on https://github.com/freeipa/freeipa/pull/2923

ipatests: Exercise hidden replica feature
    
A hidden replica is a replica that does not advertise its services via
DNS SRV records, ipa-ca DNS entry, or LDAP. Clients do not auto-select a
hidden replica, but are still free to explicitly connect to it.

Signed-off-by: Francois Cami <fcami@redhat.com>
