### PR TITLE
[Backport][ipa-4-7] ipa-replica-manage: fix force-sync

### DIFF
--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -1246,7 +1246,7 @@ def force_sync(realm, thishost, fromhost, dirman_passwd, nolookup=False):
         repl = replication.ReplicationManager(realm, fromhost, dirman_passwd)
         repl.force_sync(repl.conn, thishost)
         agreement = repl.get_replication_agreement(thishost)
-        repl.wait_for_repl_init(repl.conn, agreement.dn)
+        repl.wait_for_repl_update(repl.conn, agreement.dn)
         ds.replica_manage_time_skew(prevent=True)
 
 def show_DNA_ranges(hostname, master, realm, dirman_passwd, nextrange=False,


### PR DESCRIPTION
This PR was opened automatically because PR #2925 was pushed to master and backport to ipa-4-7 is required.