### PR TITLE
[Backport][ipa-4-6] domainlevel_get: return errors.NotFound when domain level is missing

### DIFF
--- a/ipaserver/plugins/domainlevel.py
+++ b/ipaserver/plugins/domainlevel.py
@@ -10,6 +10,7 @@ from ipalib import errors
 from ipalib import output
 from ipalib.parameters import Int
 from ipalib.plugable import Registry
+from ipalib.constants import DOMAIN_LEVEL_0, MIN_DOMAIN_LEVEL
 
 from ipapython.dn import DN
 
@@ -45,7 +46,7 @@ def get_domainlevel_range(master_entry):
             int(master_entry['ipaMaxDomainLevel'][0])
         )
     except KeyError:
-        return DomainLevelRange(0, 0)
+        return DomainLevelRange(DOMAIN_LEVEL_0, DOMAIN_LEVEL_0)
 
 
 def check_conflict_entries(ldap, api, desired_value):
@@ -102,12 +103,20 @@ class domainlevel_get(Command):
 
     def execute(self, *args, **options):
         ldap = self.api.Backend.ldap2
-        entry = ldap.get_entry(
+        entry = ldap.get_entries(
             get_domainlevel_dn(self.api),
-            ['ipaDomainLevel']
-        )
+            scope=ldap.SCOPE_BASE,
+            filter='(objectclass=ipadomainlevelconfig)',
+            attrs_list=['ipaDomainLevel']
+        )[0]
 
-        return {'result': int(entry.single_value['ipaDomainLevel'])}
+        try:
+            value = int(entry.single_value['ipaDomainLevel'])
+            return {'result': value}
+        except KeyError:
+            raise errors.NotFound(
+                reason=_(
+                    'Server does not support domain level functionality'))
 
 
 @register()
@@ -120,7 +129,7 @@ class domainlevel_set(Command):
         Int('ipadomainlevel',
             cli_name='level',
             label=_('Domain Level'),
-            minvalue=0,
+            minvalue=MIN_DOMAIN_LEVEL,
         ),
     )
 

--- a/ipaserver/plugins/topology.py
+++ b/ipaserver/plugins/topology.py
@@ -12,7 +12,7 @@ from .baseldap import (
     LDAPRetrieve)
 from ipalib import _, ngettext
 from ipalib import output
-from ipalib.constants import DOMAIN_LEVEL_1
+from ipalib.constants import MIN_DOMAIN_LEVEL, DOMAIN_LEVEL_1
 from ipaserver.topology import (
     create_topology_graph, get_topology_connection_errors,
     map_masters_to_suffixes)
@@ -82,7 +82,11 @@ register = Registry()
 
 
 def validate_domain_level(api):
-    current = int(api.Command.domainlevel_get()['result'])
+    try:
+        current = int(api.Command.domainlevel_get()['result'])
+    except errors.NotFound:
+        current = MIN_DOMAIN_LEVEL
+
     if current < DOMAIN_LEVEL_1:
         raise errors.InvalidDomainLevelError(
             reason=_('Topology management requires minimum domain level {0} '


### PR DESCRIPTION
This PR was opened automatically because PR #2878 was pushed to master and backport to ipa-4-6 is required.