### PR TITLE
[Backport][ipa-4-7] Fix assign instead of compare

### DIFF
--- a/client/ipa-getkeytab.c
+++ b/client/ipa-getkeytab.c
@@ -687,7 +687,7 @@ static int resolve_ktname(const char *keytab, char **ktname, char **err_msg)
      * root. For simplicity, only one level if indirection is resolved.
      */
     if ((stat(keytab, &st) == -1) &&
-            (errno = ENOENT) &&
+            (errno == ENOENT) &&
             (lstat(keytab, &lst) == 0) &&
             (S_ISLNK(lst.st_mode))) {
         /* keytab is a dangling symlink. */


### PR DESCRIPTION
This PR was opened automatically because PR #2914 was pushed to master and backport to ipa-4-7 is required.