### PR TITLE
[Backport][ipa-4-6] ipa-replica-manage: fix force-sync

### DIFF
--- a/install/tools/ipa-replica-manage
+++ b/install/tools/ipa-replica-manage
@@ -1246,7 +1246,7 @@ def force_sync(realm, thishost, fromhost, dirman_passwd, nolookup=False):
         repl = replication.ReplicationManager(realm, fromhost, dirman_passwd)
         repl.force_sync(repl.conn, thishost)
         agreement = repl.get_replication_agreement(thishost)
-        repl.wait_for_repl_init(repl.conn, agreement.dn)
+        repl.wait_for_repl_update(repl.conn, agreement.dn)
         ds.replica_manage_time_skew(prevent=True)
 
 def show_DNA_ranges(hostname, master, realm, dirman_passwd, nextrange=False,


### PR DESCRIPTION
This is a manual backport of PR #2925 to ipa-4-6.
The only difference is the name of the script: in the master branch, the code is in ` install/tools/ipa-replica-manage.in` and ipa-replica-manage script is generated from the `.in` file during the build.
In ipa-4-6 branch, the code is directly in `install/tools/ipa-replica-manage`.