### PR TITLE
Refactor container_masters queries

### DIFF
--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -40,6 +40,7 @@ from ipaserver.dns_data_management import (
 from ipaserver.install import installutils
 from ipaserver.install import service
 from ipaserver.install import sysupgrade
+from ipaserver.masters import get_masters
 from ipapython import ipaldap
 from ipapython import ipautil
 from ipapython import dnsutil
@@ -1073,13 +1074,8 @@ class BindInstance(service.Service):
             cname_fqdn[cname] = fqdn
 
         # get FQDNs of all IPA masters
-        ldap = self.api.Backend.ldap2
         try:
-            entries = ldap.get_entries(
-                DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                   self.api.env.basedn),
-                ldap.SCOPE_ONELEVEL, None, ['cn'])
-            masters = set(e['cn'][0] for e in entries)
+            masters = set(get_masters(self.api.Backend.ldap2))
         except errors.NotFound:
             masters = set()
 

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -898,8 +898,7 @@ class BindInstance(service.Service):
 
     def __add_others(self):
         entries = api.Backend.ldap2.get_entries(
-            DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-               self.suffix),
+            DN(api.env.container_masters, self.suffix),
             api.Backend.ldap2.SCOPE_ONELEVEL, None, ['dn'])
 
         for entry in entries:

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1167,8 +1167,8 @@ class CAInstance(DogtagInstance):
         if fqdn is None:
             fqdn = api.env.host
 
-        dn = DN(('cn', 'CA'), ('cn', fqdn), ('cn', 'masters'), ('cn', 'ipa'),
-                ('cn', 'etc'), api.env.basedn)
+        dn = DN(('cn', 'CA'), ('cn', fqdn), api.env.container_masters,
+                api.env.basedn)
         renewal_filter = '(ipaConfigString=caRenewalMaster)'
         try:
             api.Backend.ldap2.get_entries(base_dn=dn, filter=renewal_filter,
@@ -1182,8 +1182,7 @@ class CAInstance(DogtagInstance):
         if fqdn is None:
             fqdn = api.env.host
 
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                     api.env.basedn)
+        base_dn = DN(api.env.container_masters, api.env.basedn)
         filter = '(&(cn=CA)(ipaConfigString=caRenewalMaster))'
         try:
             entries = api.Backend.ldap2.get_entries(

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -98,8 +98,8 @@ def _disable_dnssec():
                                                api.env.basedn)
 
     conn = api.Backend.ldap2
-    dn = DN(('cn', 'DNSSEC'), ('cn', api.env.host), ('cn', 'masters'),
-            ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+    dn = DN(('cn', 'DNSSEC'), ('cn', api.env.host),
+            api.env.container_masters, api.env.basedn)
     try:
         entry = conn.get_entry(dn)
     except errors.NotFound:

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -583,7 +583,8 @@ class Backup(admintool.AdminTool):
         config.set('ipa', 'ipa_version', str(version.VERSION))
         config.set('ipa', 'version', '1')
 
-        dn = DN(('cn', api.env.host), ('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+        dn = DN(('cn', api.env.host), api.env.container_masters,
+                api.env.basedn)
         services_cns = []
         try:
             conn = self.get_connection()

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -519,7 +519,8 @@ class Restore(admintool.AdminTool):
                                 master, e)
                 continue
 
-            master_dn = DN(('cn', master), ('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+            master_dn = DN(('cn', master), api.env.container_masters,
+                           api.env.basedn)
             try:
                 services = repl.conn.get_entries(master_dn,
                                                  repl.conn.SCOPE_ONELEVEL)

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -43,6 +43,7 @@ from ipaserver.install.replication import (wait_for_task, ReplicationManager,
                                            get_cs_replication_manager)
 from ipaserver.install import installutils
 from ipaserver.install import dsinstance, httpinstance, cainstance, krbinstance
+from ipaserver.masters import get_masters
 from ipapython import ipaldap
 import ipapython.errors
 from ipaplatform.constants import constants
@@ -497,16 +498,7 @@ class Restore(admintool.AdminTool):
             logger.error('Unable to get connection, skipping disabling '
                          'agreements: %s', e)
             return
-        masters = []
-        dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
-        try:
-            entries = conn.get_entries(dn, conn.SCOPE_ONELEVEL)
-        except Exception as e:
-            raise admintool.ScriptError(
-                "Failed to read master data: %s" % e)
-        else:
-            masters = [ent.single_value['cn'] for ent in entries]
-
+        masters = get_masters(conn)
         for master in masters:
             if master == api.env.host:
                 continue

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -486,11 +486,7 @@ class KrbInstance(service.Service):
         unadvertise enabled PKINIT feature in master's KDC entry in LDAP
         """
         ldap = api.Backend.ldap2
-        dn = DN(('cn', 'KDC'),
-                ('cn', self.fqdn),
-                ('cn', 'masters'),
-                ('cn', 'ipa'),
-                ('cn', 'etc'),
+        dn = DN(('cn', 'KDC'), ('cn', self.fqdn), api.env.container_masters,
                 self.suffix)
 
         entry = ldap.get_entry(dn, ['ipaConfigString'])

--- a/ipaserver/install/plugins/ca_renewal_master.py
+++ b/ipaserver/install/plugins/ca_renewal_master.py
@@ -47,8 +47,7 @@ class update_ca_renewal_master(Updater):
             return False, []
 
         ldap = self.api.Backend.ldap2
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                     self.api.env.basedn)
+        base_dn = DN(self.api.env.container_masters, self.api.env.basedn)
         dn = DN(('cn', 'CA'), ('cn', self.api.env.host), base_dn)
         filter = '(&(cn=CA)(ipaConfigString=caRenewalMaster))'
         try:

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1408,8 +1408,7 @@ class ReplicationManager:
 
         # delete master entry with all active services
         try:
-            dn = DN(('cn', replica), ('cn', 'masters'), ('cn', 'ipa'),
-                    ('cn', 'etc'), self.suffix)
+            dn = DN(('cn', replica), api.env.container_masters, self.suffix)
             entries = self.conn.get_entries(dn, ldap.SCOPE_SUBTREE)
             if entries:
                 entries.sort(key=lambda x: len(x.dn), reverse=True)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1261,8 +1261,8 @@ def uninstall_dogtag_9(ds, http):
         logger.debug('Dogtag is version 10 or above')
         return
 
-    dn = DN(('cn', 'CA'), ('cn', api.env.host), ('cn', 'masters'),
-            ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+    dn = DN(('cn', 'CA'), ('cn', api.env.host), api.env.container_masters,
+            api.env.basedn)
     try:
         api.Backend.ldap2.delete_entry(dn)
     except ipalib.errors.PublicError as e:

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -134,8 +134,7 @@ def set_service_entry_config(name, fqdn, config_values,
     assert isinstance(ldap_suffix, DN)
 
     entry_name = DN(
-        ('cn', name), ('cn', fqdn), ('cn', 'masters'),
-        ('cn', 'ipa'), ('cn', 'etc'), ldap_suffix)
+        ('cn', name), ('cn', fqdn), api.env.container_masters, ldap_suffix)
 
     # enable disabled service
     try:
@@ -618,8 +617,8 @@ class Service:
     def ldap_disable(self, name, fqdn, ldap_suffix):
         assert isinstance(ldap_suffix, DN)
 
-        entry_dn = DN(('cn', name), ('cn', fqdn), ('cn', 'masters'),
-                        ('cn', 'ipa'), ('cn', 'etc'), ldap_suffix)
+        entry_dn = DN(('cn', name), ('cn', fqdn), api.env.container_masters,
+                      ldap_suffix)
         search_kw = {'ipaConfigString': ENABLED_SERVICE}
         filter = api.Backend.ldap2.make_filter(search_kw)
         try:
@@ -652,8 +651,8 @@ class Service:
         logger.debug("service %s startup entry disabled", name)
 
     def ldap_remove_service_container(self, name, fqdn, ldap_suffix):
-        entry_dn = DN(('cn', name), ('cn', fqdn), ('cn', 'masters'),
-                        ('cn', 'ipa'), ('cn', 'etc'), ldap_suffix)
+        entry_dn = DN(('cn', name), ('cn', fqdn),
+                      self.api.env.container_masters, ldap_suffix)
         try:
             api.Backend.ldap2.delete_entry(entry_dn)
         except errors.NotFound:

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -497,7 +497,7 @@ def host_is_master(ldap, fqdn):
 
     Raises an exception if a master, otherwise returns nothing.
     """
-    master_dn = DN(('cn', fqdn), ('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+    master_dn = DN(('cn', fqdn), api.env.container_masters, api.env.basedn)
     try:
         ldap.get_entry(master_dn, ['objectclass'])
         raise errors.ValidationError(name='hostname', error=_('An IPA master host cannot be deleted or disabled'))

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -53,7 +53,9 @@ from ipalib import output
 from ipapython import dnsutil, kerberos
 from ipapython.dn import DN
 from ipaserver.plugins.service import normalize_principal, validate_realm
-from ipaserver.masters import ENABLED_SERVICE, CONFIGURED_SERVICE
+from ipaserver.masters import (
+    ENABLED_SERVICE, CONFIGURED_SERVICE, is_service_enabled
+)
 
 try:
     import pyhbac
@@ -1904,14 +1906,5 @@ class ca_is_enabled(Command):
     has_output = output.standard_value
 
     def execute(self, *args, **options):
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                     self.api.env.basedn)
-        filter = '(&(objectClass=ipaConfigObject)(cn=CA))'
-        try:
-            self.api.Backend.ldap2.find_entries(
-                base_dn=base_dn, filter=filter, attrs_list=[])
-        except errors.NotFound:
-            result = False
-        else:
-            result = True
+        result = is_service_enabled('CA', conn=self.api.Backend.ldap2)
         return dict(result=result, value=pkey_to_value(None, options))

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -86,6 +86,7 @@ from ipaserver.dns_data_management import (
     IPASystemRecords,
     IPADomainIsNotManagedByIPAError,
 )
+from ipaserver.masters import find_providing_servers, is_service_enabled
 
 if six.PY3:
     unicode = str
@@ -1593,19 +1594,7 @@ def dnssec_installed(ldap):
     :param ldap: ldap connection
     :return: True if DNSSEC was installed, otherwise False
     """
-    dn = DN(api.env.container_masters, api.env.basedn)
-
-    filter_attrs = {
-        u'cn': u'DNSSEC',
-        u'objectclass': u'ipaConfigObject',
-    }
-    only_masters_f = ldap.make_filter(filter_attrs, rules=ldap.MATCH_ALL)
-
-    try:
-        ldap.find_entries(filter=only_masters_f, base_dn=dn)
-    except errors.NotFound:
-        return False
-    return True
+    return is_service_enabled('DNSSEC', conn=ldap)
 
 
 def default_zone_update_policy(zone):
@@ -3191,24 +3180,9 @@ class dnsrecord(LDAPObject):
         return cliname
 
     def get_dns_masters(self):
-        ldap = self.api.Backend.ldap2
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), self.api.env.basedn)
-        ldap_filter = '(&(objectClass=ipaConfigObject)(cn=DNS))'
-        dns_masters = []
-
-        try:
-            entries = ldap.find_entries(filter=ldap_filter, base_dn=base_dn)[0]
-
-            for entry in entries:
-                try:
-                    master = entry.dn[1]['cn']
-                    dns_masters.append(master)
-                except (IndexError, KeyError):
-                    pass
-        except errors.NotFound:
-            return []
-
-        return dns_masters
+        return find_providing_servers(
+            'DNS', self.api.Backend.ldap2, preferred_hosts=[api.env.host]
+        )
 
     def get_record_entry_attrs(self, entry_attrs):
         entry_attrs = entry_attrs.copy()
@@ -4074,19 +4048,8 @@ class dns_is_enabled(Command):
     NO_CLI = True
     has_output = output.standard_value
 
-    base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
-    filter = '(&(objectClass=ipaConfigObject)(cn=DNS))'
-
     def execute(self, *args, **options):
-        ldap = self.api.Backend.ldap2
-        dns_enabled = False
-
-        try:
-            ldap.find_entries(filter=self.filter, base_dn=self.base_dn)
-            dns_enabled = True
-        except errors.EmptyResult:
-            dns_enabled = False
-
+        dns_enabled = is_service_enabled('DNS', conn=self.api.Backend.ldap2)
         return dict(result=dns_enabled, value=pkey_to_value(None, options))
 
 

--- a/ipaserver/plugins/domainlevel.py
+++ b/ipaserver/plugins/domainlevel.py
@@ -73,25 +73,18 @@ def check_conflict_entries(ldap, api, desired_value):
     except errors.NotFound:
         pass
 
+
 def get_master_entries(ldap, api):
     """
     Returns list of LDAPEntries representing IPA masters.
     """
-
-    container_masters = DN(
-        ('cn', 'masters'),
-        ('cn', 'ipa'),
-        ('cn', 'etc'),
-        api.env.basedn
-    )
-
+    dn = DN(api.env.container_masters, api.env.basedn)
     masters, _dummy = ldap.find_entries(
         filter="(cn=*)",
-        base_dn=container_masters,
+        base_dn=dn,
         scope=ldap.SCOPE_ONELEVEL,
         paged_search=True,  # we need to make sure to get all of them
     )
-
     return masters
 
 

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -69,6 +69,7 @@ from ipapython.dn import DN
 from ipapython.ipaldap import LDAPClient
 from ipapython.ipautil import ipa_generate_password, TMP_PWD_ENTROPY_BITS
 from ipalib.capabilities import client_has_capability
+from ipaserver.masters import get_masters
 
 if six.PY3:
     unicode = str
@@ -1105,21 +1106,11 @@ class user_status(LDAPQuery):
         attr_list = ['krbloginfailedcount', 'krblastsuccessfulauth', 'krblastfailedauth', 'nsaccountlock']
 
         disabled = False
-        masters = []
-        # Get list of masters
-        try:
-            masters, _truncated = ldap.find_entries(
-                None, ['*'], DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn),
-                ldap.SCOPE_ONELEVEL
-            )
-        except errors.NotFound:
-            # If this happens we have some pretty serious problems
-            logger.error('No IPA masters found!')
+        masters = get_masters(ldap)
 
         entries = []
         count = 0
-        for master in masters:
-            host = master['cn'][0]
+        for host in masters:
             if host == api.env.host:
                 other_ldap = self.obj.backend
             else:

--- a/ipaserver/plugins/vault.py
+++ b/ipaserver/plugins/vault.py
@@ -34,6 +34,7 @@ from .service import normalize_principal, validate_realm
 from ipalib import _, ngettext
 from ipapython import kerberos
 from ipapython.dn import DN
+from ipaserver.masters import is_service_enabled
 
 if api.env.in_server:
     import pki.account
@@ -1225,14 +1226,5 @@ class kra_is_enabled(Command):
     has_output = output.standard_value
 
     def execute(self, *args, **options):
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                     self.api.env.basedn)
-        filter = '(&(objectClass=ipaConfigObject)(cn=KRA))'
-        try:
-            self.api.Backend.ldap2.find_entries(
-                base_dn=base_dn, filter=filter, attrs_list=[])
-        except errors.NotFound:
-            result = False
-        else:
-            result = True
+        result = is_service_enabled('KRA', conn=self.api.Backend.ldap2)
         return dict(result=result, value=pkey_to_value(None, options))


### PR DESCRIPTION
Refactor for hidden replica PR #2927. All APIs that look for masters and services are now going through a set of well-defined APIs and use ``api.env.container_masters``.

## Use api.env.container_masters

Replace occurences of ``('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc')``     with ``api.env.container_masters``.

## Consolidate container_masters queries


Replace manual queries of ``container_masters`` with new APIs ``get_masters()`` and `is_service_enabled()``.