### PR TITLE
replica install: acknowledge ca_host override

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -816,8 +816,12 @@ def promote_check(installer):
     config.host_name = api.env.host
     config.domain_name = api.env.domain
     config.master_host_name = api.env.server
-    # Try to use same master for CA install
-    config.ca_host_name = api.env.server
+    if not api.env.ca_host or api.env.ca_host == api.env.host:
+        # ca_host has not been configured explicitly, prefer source master
+        config.ca_host_name = api.env.server
+    else:
+        # default to ca_host from IPA config
+        config.ca_host_name = api.env.ca_host
     config.kra_host_name = config.ca_host_name
     config.ca_ds_port = 389
     config.setup_ca = options.setup_ca


### PR DESCRIPTION
Fixup for commit c0fd5e39c726ef4dc12e87a2f9c08ebb32ed27fe. Only set
ca_host to source master hostname if ca_host points to the local host.
This permits users to override ca_host in /etc/ipa/default.conf when
installing a replica.

Signed-off-by: Christian Heimes <cheimes@redhat.com>

Backport this PR together with commit from PR #2698