### PR TITLE
[Backport] [ipa-4-6] replica install: acknowledge ca_host override

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1037,7 +1037,12 @@ def promote_check(installer):
     config.host_name = api.env.host
     config.domain_name = api.env.domain
     config.master_host_name = api.env.server
-    config.ca_host_name = api.env.ca_host
+    if not api.env.ca_host or api.env.ca_host == api.env.host:
+        # ca_host has not been configured explicitly, prefer source master
+        config.ca_host_name = api.env.server
+    else:
+        # default to ca_host from IPA config
+        config.ca_host_name = api.env.ca_host
     config.kra_host_name = config.ca_host_name
     config.ca_ds_port = 389
     config.setup_ca = options.setup_ca


### PR DESCRIPTION
This PR is manual backport of https://github.com/freeipa/freeipa/pull/2939 please wait for CI before pushing.
In case of questions or problems contact @tiran who is author of the original PR.

Fixup for commit c0fd5e39c726ef4dc12e87a2f9c08ebb32ed27fe. Only set
ca_host to source master hostname if ca_host points to the local host.
This permits users to override ca_host in /etc/ipa/default.conf when
installing a replica.

Related: https://pagure.io/freeipa/issue/7744
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Alexander Bokovoy <abokovoy@redhat.com>
Reviewed-By: Tibor Dudlak <tdudlak@redhat.com>