### PR TITLE
Show a notification that sssd needs restarting after idrange-mod using

### DIFF
--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -54,7 +54,7 @@ wellknownservices = ['certmonger', 'dirsrv', 'httpd', 'ipa', 'krb5kdc',
                      'rpcbind', 'kadmin', 'sshd', 'autofs', 'rpcgssd',
                      'rpcidmapd', 'pki_tomcatd', 'chronyd', 'domainname',
                      'named', 'ods_enforcerd', 'ods_signerd', 'gssproxy',
-                     'nfs-utils']
+                     'nfs-utils', 'sssd']
 
 # The common ports for these services. This is used to wait for the
 # service to become available.

--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -22,8 +22,9 @@ import six
 from ipalib.plugable import Registry
 from .baseldap import (LDAPObject, LDAPCreate, LDAPDelete,
                                      LDAPRetrieve, LDAPSearch, LDAPUpdate)
-from ipalib import api, Int, Str, StrEnum, _, ngettext
+from ipalib import api, Int, Str, StrEnum, _, ngettext, messages
 from ipalib import errors
+from ipaplatform import services
 from ipapython.dn import DN
 
 if six.PY3:
@@ -764,4 +765,10 @@ class idrange_mod(LDAPUpdate):
         assert isinstance(dn, DN)
         self.obj.handle_ipabaserid(entry_attrs, options)
         self.obj.handle_iparangetype(entry_attrs, options)
+        self.add_message(
+            messages.ServiceRestartRequired(
+                service=services.knownservices['sssd'].systemd_name,
+                server=keys[0]
+            )
+        )
         return dn

--- a/ipatests/test_xmlrpc/test_range_plugin.py
+++ b/ipatests/test_xmlrpc/test_range_plugin.py
@@ -23,7 +23,8 @@ Test the `ipaserver/plugins/idrange.py` module, and XML-RPC in general.
 
 import six
 
-from ipalib import api, errors
+from ipalib import api, errors, messages
+from ipaplatform import services
 from ipatests.test_xmlrpc.xmlrpc_test import Declarative, fuzzy_uuid
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.util import MockLDAP
@@ -786,6 +787,12 @@ class test_range(Declarative):
             command=('idrange_mod', [domain3range2],
                      dict(ipabaseid=domain3range1_base_id)),
             expected=dict(
+                messages=(
+                    messages.ServiceRestartRequired(
+                        service=services.knownservices['sssd'].systemd_name,
+                        server=domain3range2
+                    ).to_dict(),
+                ),
                 result=dict(
                     cn=[domain3range2],
                     ipabaseid=[unicode(domain3range1_base_id)],
@@ -851,6 +858,12 @@ class test_range(Declarative):
             command=('idrange_mod', [domain2range1],
                      dict(ipabaserid=domain5range1_base_rid)),
             expected=dict(
+                messages=(
+                    messages.ServiceRestartRequired(
+                        service=services.knownservices['sssd'].systemd_name,
+                        server=domain2range1
+                    ).to_dict(),
+                ),
                 result=dict(
                     cn=[domain2range1],
                     ipabaseid=[unicode(domain2range1_base_id)],


### PR DESCRIPTION
If the `ipa idrange-mod` command has been used show a notification that sssd.service needs restarting. It's needed for applying changes. E.g. after setup AD trust with a domain with more than 200000 objects (the highest RID > idm's default value, 200000) users with RIDs > 200000 are not able to login, the size needs to be increased via idrange-mod, but it makes an effect only after sssd restarting.

Fixes: https://pagure.io/freeipa/issue/7708