### PR TITLE
[Backport][ipa-4-7] Consolidate container_masters queries 

### DIFF
--- a/install/tools/ipa-ca-install.in
+++ b/install/tools/ipa-ca-install.in
@@ -35,6 +35,7 @@ from ipaserver.install.installutils import check_creds, ReplicaConfig
 from ipaserver.install import dsinstance, ca
 from ipaserver.install import cainstance, service
 from ipaserver.install import custodiainstance
+from ipaserver.masters import find_providing_server
 from ipapython import version
 from ipalib import api
 from ipalib.constants import DOMAIN_LEVEL_1
@@ -183,8 +184,9 @@ def install_replica(safe_options, options):
         config.subject_base = attrs.get('ipacertificatesubjectbase')[0]
 
     if config.ca_host_name is None:
-        config.ca_host_name = \
-            service.find_providing_server('CA', api.Backend.ldap2, api.env.ca_host)
+        config.ca_host_name = find_providing_server(
+            'CA', api.Backend.ldap2, [api.env.ca_host]
+        )
 
     options.realm_name = config.realm_name
     options.domain_name = config.domain_name
@@ -258,7 +260,8 @@ def install(safe_options, options):
             paths.KRB5_KEYTAB,
             ccache)
 
-        ca_host = service.find_providing_server('CA', api.Backend.ldap2)
+        ca_host = find_providing_server('CA', api.Backend.ldap2)
+
         if ca_host is None:
             install_master(safe_options, options)
         else:

--- a/install/tools/ipactl.in
+++ b/install/tools/ipactl.in
@@ -224,9 +224,9 @@ def get_config(dirsrv):
         svc_list.append([order, name])
 
     ordered_list = []
-    for (order, svc) in sorted(svc_list):
+    for order, svc in sorted(svc_list):
         if svc in service.SERVICE_LIST:
-            ordered_list.append(service.SERVICE_LIST[svc][0])
+            ordered_list.append(service.SERVICE_LIST[svc].systemd_name)
     return ordered_list
 
 def get_config_from_file():

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -897,8 +897,7 @@ class BindInstance(service.Service):
 
     def __add_others(self):
         entries = api.Backend.ldap2.get_entries(
-            DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-               self.suffix),
+            DN(api.env.container_masters, self.suffix),
             api.Backend.ldap2.SCOPE_ONELEVEL, None, ['dn'])
 
         for entry in entries:

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -40,6 +40,7 @@ from ipaserver.dns_data_management import (
 from ipaserver.install import installutils
 from ipaserver.install import service
 from ipaserver.install import sysupgrade
+from ipaserver.masters import get_masters
 from ipapython import ipautil
 from ipapython import dnsutil
 from ipapython.dnsutil import DNSName
@@ -1072,13 +1073,8 @@ class BindInstance(service.Service):
             cname_fqdn[cname] = fqdn
 
         # get FQDNs of all IPA masters
-        ldap = self.api.Backend.ldap2
         try:
-            entries = ldap.get_entries(
-                DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                   self.api.env.basedn),
-                ldap.SCOPE_ONELEVEL, None, ['cn'])
-            masters = set(e['cn'][0] for e in entries)
+            masters = set(get_masters(self.api.Backend.ldap2))
         except errors.NotFound:
             masters = set()
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1187,8 +1187,8 @@ class CAInstance(DogtagInstance):
         if fqdn is None:
             fqdn = api.env.host
 
-        dn = DN(('cn', 'CA'), ('cn', fqdn), ('cn', 'masters'), ('cn', 'ipa'),
-                ('cn', 'etc'), api.env.basedn)
+        dn = DN(('cn', 'CA'), ('cn', fqdn), api.env.container_masters,
+                api.env.basedn)
         renewal_filter = '(ipaConfigString=caRenewalMaster)'
         try:
             api.Backend.ldap2.get_entries(base_dn=dn, filter=renewal_filter,
@@ -1202,8 +1202,7 @@ class CAInstance(DogtagInstance):
         if fqdn is None:
             fqdn = api.env.host
 
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                     api.env.basedn)
+        base_dn = DN(api.env.container_masters, api.env.basedn)
         filter = '(&(cn=CA)(ipaConfigString=caRenewalMaster))'
         try:
             entries = api.Backend.ldap2.get_entries(

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -71,6 +71,7 @@ from ipaserver.install import replication
 from ipaserver.install import sysupgrade
 from ipaserver.install.dogtaginstance import DogtagInstance
 from ipaserver.plugins import ldap2
+from ipaserver.masters import ENABLED_SERVICE
 
 logger = logging.getLogger(__name__)
 
@@ -1318,7 +1319,7 @@ class CAInstance(DogtagInstance):
             config = ['caRenewalMaster']
         else:
             config = []
-        self._ldap_enable(u'enabledService', "CA", self.fqdn, basedn, config)
+        self._ldap_enable(ENABLED_SERVICE, "CA", self.fqdn, basedn, config)
 
     def setup_lightweight_ca_key_retrieval(self):
         # Important: there is a typo in the below string, which is known

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -98,8 +98,8 @@ def _disable_dnssec():
                                                api.env.basedn)
 
     conn = api.Backend.ldap2
-    dn = DN(('cn', 'DNSSEC'), ('cn', api.env.host), ('cn', 'masters'),
-            ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+    dn = DN(('cn', 'DNSSEC'), ('cn', api.env.host),
+            api.env.container_masters, api.env.basedn)
     try:
         entry = conn.get_entry(dn)
     except errors.NotFound:

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -584,7 +584,8 @@ class Backup(admintool.AdminTool):
         config.set('ipa', 'ipa_version', str(version.VERSION))
         config.set('ipa', 'version', '1')
 
-        dn = DN(('cn', api.env.host), ('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+        dn = DN(('cn', api.env.host), api.env.container_masters,
+                api.env.basedn)
         services_cns = []
         try:
             conn = self.get_connection()

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -43,6 +43,7 @@ from ipaserver.install.replication import (wait_for_task, ReplicationManager,
                                            get_cs_replication_manager)
 from ipaserver.install import installutils
 from ipaserver.install import dsinstance, httpinstance, cainstance, krbinstance
+from ipaserver.masters import get_masters
 from ipapython import ipaldap
 import ipapython.errors
 from ipaplatform.constants import constants
@@ -498,16 +499,7 @@ class Restore(admintool.AdminTool):
             logger.error('Unable to get connection, skipping disabling '
                          'agreements: %s', e)
             return
-        masters = []
-        dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
-        try:
-            entries = conn.get_entries(dn, conn.SCOPE_ONELEVEL)
-        except Exception as e:
-            raise admintool.ScriptError(
-                "Failed to read master data: %s" % e)
-        else:
-            masters = [ent.single_value['cn'] for ent in entries]
-
+        masters = get_masters(conn)
         for master in masters:
             if master == api.env.host:
                 continue

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -520,7 +520,8 @@ class Restore(admintool.AdminTool):
                                 master, e)
                 continue
 
-            master_dn = DN(('cn', master), ('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+            master_dn = DN(('cn', master), api.env.container_masters,
+                           api.env.basedn)
             try:
                 services = repl.conn.get_entries(master_dn,
                                                  repl.conn.SCOPE_ONELEVEL)

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -43,6 +43,7 @@ from ipapython.dogtag import KDC_PROFILE
 
 from ipaserver.install import replication
 from ipaserver.install import ldapupdate
+from ipaserver.masters import find_providing_servers
 
 from ipaserver.install import certs
 from ipaplatform.constants import constants
@@ -428,7 +429,7 @@ class KrbInstance(service.Service):
             prev_helper = None
             # on the first CA-ful master without '--no-pkinit', we issue the
             # certificate by contacting Dogtag directly
-            ca_instances = service.find_providing_servers(
+            ca_instances = find_providing_servers(
                 'CA', conn=self.api.Backend.ldap2, api=self.api)
 
             use_dogtag_submit = all(

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -486,11 +486,7 @@ class KrbInstance(service.Service):
         unadvertise enabled PKINIT feature in master's KDC entry in LDAP
         """
         ldap = api.Backend.ldap2
-        dn = DN(('cn', 'KDC'),
-                ('cn', self.fqdn),
-                ('cn', 'masters'),
-                ('cn', 'ipa'),
-                ('cn', 'etc'),
+        dn = DN(('cn', 'KDC'), ('cn', self.fqdn), api.env.container_masters,
                 self.suffix)
 
         entry = ldap.get_entry(dn, ['ipaConfigString'])

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -14,6 +14,7 @@ from subprocess import CalledProcessError
 
 from ipalib.install import sysrestore
 from ipaserver.install import service
+from ipaserver.masters import ENABLED_SERVICE
 from ipapython.dn import DN
 from ipapython import directivesetter
 from ipapython import ipautil
@@ -45,7 +46,7 @@ def get_dnssec_key_masters(conn):
     filter_attrs = {
         u'cn': u'DNSSEC',
         u'objectclass': u'ipaConfigObject',
-        u'ipaConfigString': [KEYMASTER, u'enabledService'],
+        u'ipaConfigString': [KEYMASTER, ENABLED_SERVICE],
     }
     only_masters_f = conn.make_filter(filter_attrs, rules=conn.MATCH_ALL)
 

--- a/ipaserver/install/plugins/ca_renewal_master.py
+++ b/ipaserver/install/plugins/ca_renewal_master.py
@@ -47,8 +47,7 @@ class update_ca_renewal_master(Updater):
             return False, []
 
         ldap = self.api.Backend.ldap2
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                     self.api.env.basedn)
+        base_dn = DN(self.api.env.container_masters, self.api.env.basedn)
         dn = DN(('cn', 'CA'), ('cn', self.api.env.host), base_dn)
         filter = '(&(cn=CA)(ipaConfigString=caRenewalMaster))'
         try:

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1419,8 +1419,7 @@ class ReplicationManager(object):
 
         # delete master entry with all active services
         try:
-            dn = DN(('cn', replica), ('cn', 'masters'), ('cn', 'ipa'),
-                    ('cn', 'etc'), self.suffix)
+            dn = DN(('cn', replica), api.env.container_masters, self.suffix)
             entries = self.conn.get_entries(dn, ldap.SCOPE_SUBTREE)
             if entries:
                 entries.sort(key=lambda x: len(x.dn), reverse=True)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -44,6 +44,7 @@ from ipaserver.install.installutils import (
     ReplicaConfig, load_pkcs12, is_ipa_configured, validate_mask)
 from ipaserver.install.replication import (
     ReplicationManager, replica_conn_check)
+from ipaserver.masters import find_providing_servers, find_providing_server
 import SSSDConfig
 from subprocess import CalledProcessError
 
@@ -1035,9 +1036,10 @@ def promote_check(installer):
         if subject_base is not None:
             config.subject_base = DN(subject_base)
 
-        # Find if any server has a CA
-        ca_host = service.find_providing_server(
-                'CA', conn, config.ca_host_name)
+        # Find any server with a CA
+        ca_host = find_providing_server(
+            'CA', conn, [config.ca_host_name]
+        )
         if ca_host is not None:
             config.ca_host_name = ca_host
             ca_enabled = True
@@ -1058,14 +1060,16 @@ def promote_check(installer):
                              "custom certificates.")
                 raise ScriptError(rval=3)
 
-        kra_host = service.find_providing_server(
-                'KRA', conn, config.kra_host_name)
+        # Find any server with a KRA
+        kra_host = find_providing_server(
+            'KRA', conn, [config.kra_host_name]
+        )
         if kra_host is not None:
             config.kra_host_name = kra_host
             kra_enabled = True
         else:
             if options.setup_kra:
-                logger.error("There is no KRA server in the domain, "
+                logger.error("There is no active KRA server in the domain, "
                              "can't setup a KRA clone")
                 raise ScriptError(rval=3)
             kra_enabled = False
@@ -1299,7 +1303,7 @@ def install(installer):
     # Enable configured services and update DNS SRV records
     service.enable_services(config.host_name)
     api.Command.dns_update_system_records()
-    ca_servers = service.find_providing_servers('CA', api.Backend.ldap2, api)
+    ca_servers = find_providing_servers('CA', api.Backend.ldap2, api=api)
     api.Backend.ldap2.disconnect()
 
     # Everything installed properly, activate ipa service.

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1259,8 +1259,8 @@ def uninstall_dogtag_9(ds, http):
         logger.debug('Dogtag is version 10 or above')
         return
 
-    dn = DN(('cn', 'CA'), ('cn', api.env.host), ('cn', 'masters'),
-            ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+    dn = DN(('cn', 'CA'), ('cn', api.env.host), api.env.container_masters,
+            api.env.basedn)
     try:
         api.Backend.ldap2.delete_entry(dn)
     except ipalib.errors.PublicError as e:

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -134,8 +134,7 @@ def set_service_entry_config(name, fqdn, config_values,
     assert isinstance(ldap_suffix, DN)
 
     entry_name = DN(
-        ('cn', name), ('cn', fqdn), ('cn', 'masters'),
-        ('cn', 'ipa'), ('cn', 'etc'), ldap_suffix)
+        ('cn', name), ('cn', fqdn), api.env.container_masters, ldap_suffix)
 
     # enable disabled service
     try:
@@ -618,8 +617,8 @@ class Service(object):
     def ldap_disable(self, name, fqdn, ldap_suffix):
         assert isinstance(ldap_suffix, DN)
 
-        entry_dn = DN(('cn', name), ('cn', fqdn), ('cn', 'masters'),
-                        ('cn', 'ipa'), ('cn', 'etc'), ldap_suffix)
+        entry_dn = DN(('cn', name), ('cn', fqdn), api.env.container_masters,
+                      ldap_suffix)
         search_kw = {'ipaConfigString': ENABLED_SERVICE}
         filter = api.Backend.ldap2.make_filter(search_kw)
         try:
@@ -652,8 +651,8 @@ class Service(object):
         logger.debug("service %s startup entry disabled", name)
 
     def ldap_remove_service_container(self, name, fqdn, ldap_suffix):
-        entry_dn = DN(('cn', name), ('cn', fqdn), ('cn', 'masters'),
-                        ('cn', 'ipa'), ('cn', 'etc'), ldap_suffix)
+        entry_dn = DN(('cn', name), ('cn', fqdn),
+                      self.api.env.container_masters, ldap_suffix)
         try:
             api.Backend.ldap2.delete_entry(entry_dn)
         except errors.NotFound:

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -38,32 +38,14 @@ from ipapython import kerberos
 from ipalib import api, errors, x509
 from ipaplatform import services
 from ipaplatform.paths import paths
+from ipaserver.masters import (
+    CONFIGURED_SERVICE, ENABLED_SERVICE, SERVICE_LIST
+)
 
 logger = logging.getLogger(__name__)
 
 if six.PY3:
     unicode = str
-
-# The service name as stored in cn=masters,cn=ipa,cn=etc. In the tuple
-# the first value is the *nix service name, the second the start order.
-SERVICE_LIST = {
-    'KDC': ('krb5kdc', 10),
-    'KPASSWD': ('kadmin', 20),
-    'DNS': ('named', 30),
-    'HTTP': ('httpd', 40),
-    'KEYS': ('ipa-custodia', 41),
-    'CA': ('pki-tomcatd', 50),
-    'KRA': ('pki-tomcatd', 51),
-    'ADTRUST': ('smb', 60),
-    'EXTID': ('winbind', 70),
-    'OTPD': ('ipa-otpd', 80),
-    'DNSKeyExporter': ('ipa-ods-exporter', 90),
-    'DNSSEC': ('ods-enforcerd', 100),
-    'DNSKeySync': ('ipa-dnskeysyncd', 110),
-}
-
-CONFIGURED_SERVICE = u'configuredService'
-ENABLED_SERVICE = u'enabledService'
 
 
 def print_msg(message, output_fd=sys.stdout):
@@ -115,44 +97,6 @@ def add_principals_to_group(admin_conn, group, member_attr, principals):
         # If there are no changes just pass
         pass
 
-
-def find_providing_servers(svcname, conn, api):
-    """
-    Find servers that provide the given service.
-
-    :param svcname: The service to find
-    :param conn: a connection to the LDAP server
-    :return: list of host names (possibly empty)
-
-    """
-    dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
-    query_filter = conn.make_filter({'objectClass': 'ipaConfigObject',
-                                     'ipaConfigString': ENABLED_SERVICE,
-                                     'cn': svcname}, rules='&')
-    try:
-        entries, _trunc = conn.find_entries(filter=query_filter, base_dn=dn)
-    except errors.NotFound:
-        return []
-    else:
-        return [entry.dn[1].value for entry in entries]
-
-
-def find_providing_server(svcname, conn, host_name=None, api=api):
-    """
-    Find a server that provides the given service.
-
-    :param svcname: The service to find
-    :param conn: a connection to the LDAP server
-    :param host_name: the preferred server
-    :return: the selected host name
-
-    """
-    servers = find_providing_servers(svcname, conn, api)
-    if len(servers) == 0:
-        return None
-    if host_name in servers:
-        return host_name
-    return servers[0]
 
 
 def case_insensitive_attr_has_value(attr, value):
@@ -658,7 +602,7 @@ class Service(object):
 
     def _ldap_enable(self, value, name, fqdn, ldap_suffix, config):
         extra_config_opts = [
-            ' '.join([u'startOrder', unicode(SERVICE_LIST[name][1])])
+            u'startOrder {}'.format(SERVICE_LIST[name].startorder),
         ]
         extra_config_opts.extend(config)
 

--- a/ipaserver/masters.py
+++ b/ipaserver/masters.py
@@ -1,0 +1,122 @@
+#
+# Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+#
+"""Helpers services in for cn=masters,cn=ipa,cn=etc
+"""
+
+from __future__ import absolute_import
+
+import collections
+import logging
+import random
+
+from ipapython.dn import DN
+from ipalib import api
+from ipalib import errors
+
+logger = logging.getLogger(__name__)
+
+# constants for ipaConfigString
+CONFIGURED_SERVICE = u'configuredService'
+ENABLED_SERVICE = u'enabledService'
+
+# The service name as stored in cn=masters,cn=ipa,cn=etc. The values are:
+# 0: systemd service name
+# 1: start order for system service
+# 2: LDAP server entry CN, also used as SERVICE_LIST key
+service_definition = collections.namedtuple(
+    "service_definition",
+    "systemd_name startorder service_entry"
+)
+
+SERVICES = [
+    service_definition('krb5kdc', 10, 'KDC'),
+    service_definition('kadmin', 20, 'KPASSWD'),
+    service_definition('named', 30, 'DNS'),
+    service_definition('httpd', 40, 'HTTP'),
+    service_definition('ipa-custodia', 41, 'KEYS'),
+    service_definition('pki-tomcatd', 50, 'CA'),
+    service_definition('pki-tomcatd', 51, 'KRA'),
+    service_definition('smb', 60, 'ADTRUST'),
+    service_definition('winbind', 70, 'EXTID'),
+    service_definition('ipa-otpd', 80, 'OTPD'),
+    service_definition('ipa-ods-exporter', 90, 'DNSKeyExporter'),
+    service_definition('ods-enforcerd', 100, 'DNSSEC'),
+    service_definition('ipa-dnskeysyncd', 110, 'DNSKeySync'),
+]
+
+SERVICE_LIST = {s.service_entry: s for s in SERVICES}
+
+
+def find_providing_servers(svcname, conn=None, preferred_hosts=(), api=api):
+    """Find servers that provide the given service.
+
+    :param svcname: The service to find
+    :param preferred_hosts: preferred servers
+    :param conn: a connection to the LDAP server
+    :param api: ipalib.API instance
+    :return: list of host names in randomized order (possibly empty)
+
+    Preferred servers are moved to the front of the list if and only if they
+    are found as providing servers.
+    """
+    assert isinstance(preferred_hosts, (tuple, list))
+    if svcname not in SERVICE_LIST:
+        raise ValueError("Unknown service '{}'.".format(svcname))
+    if conn is None:
+        conn = api.Backend.ldap2
+
+    dn = DN(api.env.container_masters, api.env.basedn)
+    query_filter = conn.make_filter(
+        {
+            'objectClass': 'ipaConfigObject',
+            'ipaConfigString': ENABLED_SERVICE,
+            'cn': svcname
+        },
+        rules='&'
+    )
+    try:
+        entries, _trunc = conn.find_entries(
+            filter=query_filter,
+            attrs_list=[],
+            base_dn=dn
+        )
+    except errors.NotFound:
+        return []
+
+    # unique list of host names, DNS is case insensitive
+    servers = list(set(entry.dn[1].value.lower() for entry in entries))
+    # shuffle the list like DNS SRV would randomize it
+    random.shuffle(servers)
+    # Move preferred hosts to front
+    for host_name in reversed(preferred_hosts):
+        host_name = host_name.lower()
+        try:
+            servers.remove(host_name)
+        except ValueError:
+            # preferred server not found, log and ignore
+            logger.warning(
+                "Lookup failed: Preferred host %s does not provide %s.",
+                host_name, svcname
+            )
+        else:
+            servers.insert(0, host_name)
+    return servers
+
+
+def find_providing_server(svcname, conn=None, preferred_hosts=(), api=api):
+    """Find a server that provides the given service.
+
+    :param svcname: The service to find
+    :param conn: a connection to the LDAP server
+    :param host_name: the preferred server
+    :param api: ipalib.API instance
+    :return: the selected host name or None
+    """
+    servers = find_providing_servers(
+        svcname, conn=conn, preferred_hosts=preferred_hosts, api=api
+    )
+    if not servers:
+        return None
+    else:
+        return servers[0]

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -497,7 +497,7 @@ def host_is_master(ldap, fqdn):
 
     Raises an exception if a master, otherwise returns nothing.
     """
-    master_dn = DN(('cn', fqdn), ('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+    master_dn = DN(('cn', fqdn), api.env.container_masters, api.env.basedn)
     try:
         ldap.get_entry(master_dn, ['objectclass'])
         raise errors.ValidationError(name='hostname', error=_('An IPA master host cannot be deleted or disabled'))

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -55,7 +55,9 @@ from ipalib import output
 from ipapython import dnsutil, kerberos
 from ipapython.dn import DN
 from ipaserver.plugins.service import normalize_principal, validate_realm
-from ipaserver.masters import ENABLED_SERVICE, CONFIGURED_SERVICE
+from ipaserver.masters import (
+    ENABLED_SERVICE, CONFIGURED_SERVICE, is_service_enabled
+)
 
 try:
     import pyhbac
@@ -1906,14 +1908,5 @@ class ca_is_enabled(Command):
     has_output = output.standard_value
 
     def execute(self, *args, **options):
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                     self.api.env.basedn)
-        filter = '(&(objectClass=ipaConfigObject)(cn=CA))'
-        try:
-            self.api.Backend.ldap2.find_entries(
-                base_dn=base_dn, filter=filter, attrs_list=[])
-        except errors.NotFound:
-            result = False
-        else:
-            result = True
+        result = is_service_enabled('CA', conn=self.api.Backend.ldap2)
         return dict(result=result, value=pkey_to_value(None, options))

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -55,6 +55,7 @@ from ipalib import output
 from ipapython import dnsutil, kerberos
 from ipapython.dn import DN
 from ipaserver.plugins.service import normalize_principal, validate_realm
+from ipaserver.masters import ENABLED_SERVICE, CONFIGURED_SERVICE
 
 try:
     import pyhbac
@@ -297,19 +298,14 @@ def caacl_check(principal, ca, profile_id):
 def ca_kdc_check(api_instance, hostname):
     master_dn = api_instance.Object.server.get_dn(unicode(hostname))
     kdc_dn = DN(('cn', 'KDC'), master_dn)
-
+    wanted = {ENABLED_SERVICE, CONFIGURED_SERVICE}
     try:
         kdc_entry = api_instance.Backend.ldap2.get_entry(
             kdc_dn, ['ipaConfigString'])
-
-        ipaconfigstring = {val.lower() for val in kdc_entry['ipaConfigString']}
-
-        if 'enabledservice' not in ipaconfigstring \
-                and 'configuredservice' not in ipaconfigstring:
+        if not wanted.intersection(kdc_entry['ipaConfigString']):
             raise errors.NotFound(
                 reason=_("enabledService/configuredService not in "
                          "ipaConfigString kdc entry"))
-
     except errors.NotFound:
         raise errors.ACIError(
             info=_("Host '%(hostname)s' is not an active KDC")

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -86,6 +86,7 @@ from ipaserver.dns_data_management import (
     IPASystemRecords,
     IPADomainIsNotManagedByIPAError,
 )
+from ipaserver.masters import find_providing_servers, is_service_enabled
 
 if six.PY3:
     unicode = str
@@ -1593,19 +1594,7 @@ def dnssec_installed(ldap):
     :param ldap: ldap connection
     :return: True if DNSSEC was installed, otherwise False
     """
-    dn = DN(api.env.container_masters, api.env.basedn)
-
-    filter_attrs = {
-        u'cn': u'DNSSEC',
-        u'objectclass': u'ipaConfigObject',
-    }
-    only_masters_f = ldap.make_filter(filter_attrs, rules=ldap.MATCH_ALL)
-
-    try:
-        ldap.find_entries(filter=only_masters_f, base_dn=dn)
-    except errors.NotFound:
-        return False
-    return True
+    return is_service_enabled('DNSSEC', conn=ldap)
 
 
 def default_zone_update_policy(zone):
@@ -3191,24 +3180,9 @@ class dnsrecord(LDAPObject):
         return cliname
 
     def get_dns_masters(self):
-        ldap = self.api.Backend.ldap2
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), self.api.env.basedn)
-        ldap_filter = '(&(objectClass=ipaConfigObject)(cn=DNS))'
-        dns_masters = []
-
-        try:
-            entries = ldap.find_entries(filter=ldap_filter, base_dn=base_dn)[0]
-
-            for entry in entries:
-                try:
-                    master = entry.dn[1]['cn']
-                    dns_masters.append(master)
-                except (IndexError, KeyError):
-                    pass
-        except errors.NotFound:
-            return []
-
-        return dns_masters
+        return find_providing_servers(
+            'DNS', self.api.Backend.ldap2, preferred_hosts=[api.env.host]
+        )
 
     def get_record_entry_attrs(self, entry_attrs):
         entry_attrs = entry_attrs.copy()
@@ -4074,19 +4048,8 @@ class dns_is_enabled(Command):
     NO_CLI = True
     has_output = output.standard_value
 
-    base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
-    filter = '(&(objectClass=ipaConfigObject)(cn=DNS))'
-
     def execute(self, *args, **options):
-        ldap = self.api.Backend.ldap2
-        dns_enabled = False
-
-        try:
-            ldap.find_entries(filter=self.filter, base_dn=self.base_dn)
-            dns_enabled = True
-        except errors.EmptyResult:
-            dns_enabled = False
-
+        dns_enabled = is_service_enabled('DNS', conn=self.api.Backend.ldap2)
         return dict(result=dns_enabled, value=pkey_to_value(None, options))
 
 

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -255,6 +255,7 @@ from ipalib import Backend, api
 from ipapython.dn import DN
 import ipapython.cookie
 from ipapython import dogtag, ipautil, certdb
+from ipaserver.masters import find_providing_server
 
 if api.env.in_server:
     import pki
@@ -1207,57 +1208,6 @@ def parse_updateCRL_xml(doc):
 
     return response
 
-
-def host_has_service(host, ldap2, service='CA'):
-    """
-    :param host: A host which might be a master for a service.
-    :param ldap2: connection to the local database
-    :param service: The service for which the host might be a master.
-    :return:   (true, false)
-
-    Check if a specified host is a master for a specified service.
-    """
-    base_dn = DN(('cn', host), ('cn', 'masters'), ('cn', 'ipa'),
-                 ('cn', 'etc'), api.env.basedn)
-    filter_attrs = {
-        'objectClass': 'ipaConfigObject',
-        'cn': service,
-        'ipaConfigString': 'enabledService',
-        }
-    query_filter = ldap2.make_filter(filter_attrs, rules='&')
-    try:
-        ent, _trunc = ldap2.find_entries(filter=query_filter, base_dn=base_dn)
-        if len(ent):
-            return True
-    except Exception:
-        pass
-    return False
-
-
-def select_any_master(ldap2, service='CA'):
-    """
-    :param ldap2: connection to the local database
-    :param service: The service for which we're looking for a master.
-    :return:   host as str
-
-    Select any host which is a master for a specified service.
-    """
-    base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                  api.env.basedn)
-    filter_attrs = {
-         'objectClass': 'ipaConfigObject',
-         'cn': service,
-         'ipaConfigString': 'enabledService',}
-    query_filter = ldap2.make_filter(filter_attrs, rules='&')
-    try:
-        ent, _trunc = ldap2.find_entries(filter=query_filter, base_dn=base_dn)
-        if len(ent):
-            entry = random.choice(ent)
-            return entry.dn[1].value
-    except Exception:
-        pass
-    return None
-
 #-------------------------------------------------------------------------------
 
 from ipalib import Registry, errors, SkipPluginModule
@@ -1265,7 +1215,6 @@ if api.env.ra_plugin != 'dogtag':
     # In this case, abort loading this plugin module...
     raise SkipPluginModule(reason='dogtag not selected as RA plugin')
 import os
-import random
 from ipaserver.plugins import rabase
 from ipalib.constants import TYPE_ERROR
 from ipalib import _
@@ -1330,17 +1279,19 @@ class RestClient(Backend):
         if self._ca_host is not None:
             return self._ca_host
 
-        ldap2 = self.api.Backend.ldap2
-        if host_has_service(api.env.ca_host, ldap2, "CA"):
-            object.__setattr__(self, '_ca_host', api.env.ca_host)
-        elif api.env.host != api.env.ca_host:
-            if host_has_service(api.env.host, ldap2, "CA"):
-                object.__setattr__(self, '_ca_host', api.env.host)
-        else:
-            object.__setattr__(self, '_ca_host', select_any_master(ldap2))
-        if self._ca_host is None:
-            object.__setattr__(self, '_ca_host', api.env.ca_host)
-        return self._ca_host
+        preferred = [api.env.ca_host]
+        if api.env.host != api.env.ca_host:
+            preferred.append(api.env.host)
+        ca_host = find_providing_server(
+            'CA', conn=self.api.Backend.ldap2, preferred_hosts=preferred,
+            api=self.api
+        )
+        if ca_host is None:
+            # TODO: need during installation, CA is not yet set as enabled
+            ca_host = api.env.ca_host
+        # object is locked, need to use __setattr__()
+        object.__setattr__(self, '_ca_host', ca_host)
+        return ca_host
 
     def __enter__(self):
         """Log into the REST API"""
@@ -2082,9 +2033,7 @@ class kra(Backend):
     """
 
     def __init__(self, api, kra_port=443):
-
         self.kra_port = kra_port
-
         super(kra, self).__init__(api)
 
     @property
@@ -2095,17 +2044,18 @@ class kra(Backend):
 
         Select our KRA host.
         """
-        ldap2 = self.api.Backend.ldap2
-        if host_has_service(api.env.ca_host, ldap2, "KRA"):
-            return api.env.ca_host
+        preferred = [api.env.ca_host]
         if api.env.host != api.env.ca_host:
-            if host_has_service(api.env.host, ldap2, "KRA"):
-                return api.env.host
-        host = select_any_master(ldap2, "KRA")
-        if host:
-            return host
-        else:
-            return api.env.ca_host
+            preferred.append(api.env.host)
+
+        kra_host = find_providing_server(
+            'KRA', self.api.Backend.ldap2, preferred_hosts=preferred,
+            api=self.api
+        )
+        if kra_host is None:
+            # TODO: need during installation, KRA is not yet set as enabled
+            kra_host = api.env.ca_host
+        return kra_host
 
     @contextlib.contextmanager
     def get_client(self):

--- a/ipaserver/plugins/domainlevel.py
+++ b/ipaserver/plugins/domainlevel.py
@@ -73,25 +73,18 @@ def check_conflict_entries(ldap, api, desired_value):
     except errors.NotFound:
         pass
 
+
 def get_master_entries(ldap, api):
     """
     Returns list of LDAPEntries representing IPA masters.
     """
-
-    container_masters = DN(
-        ('cn', 'masters'),
-        ('cn', 'ipa'),
-        ('cn', 'etc'),
-        api.env.basedn
-    )
-
+    dn = DN(api.env.container_masters, api.env.basedn)
     masters, _dummy = ldap.find_entries(
         filter="(cn=*)",
-        base_dn=container_masters,
+        base_dn=dn,
         scope=ldap.SCOPE_ONELEVEL,
         paged_search=True,  # we need to make sure to get all of them
     )
-
     return masters
 
 

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -69,6 +69,7 @@ from ipapython.dn import DN
 from ipapython.ipaldap import LDAPClient
 from ipapython.ipautil import ipa_generate_password, TMP_PWD_ENTROPY_BITS
 from ipalib.capabilities import client_has_capability
+from ipaserver.masters import get_masters
 
 if six.PY3:
     unicode = str
@@ -1105,21 +1106,11 @@ class user_status(LDAPQuery):
         attr_list = ['krbloginfailedcount', 'krblastsuccessfulauth', 'krblastfailedauth', 'nsaccountlock']
 
         disabled = False
-        masters = []
-        # Get list of masters
-        try:
-            masters, _truncated = ldap.find_entries(
-                None, ['*'], DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn),
-                ldap.SCOPE_ONELEVEL
-            )
-        except errors.NotFound:
-            # If this happens we have some pretty serious problems
-            logger.error('No IPA masters found!')
+        masters = get_masters(ldap)
 
         entries = []
         count = 0
-        for master in masters:
-            host = master['cn'][0]
+        for host in masters:
             if host == api.env.host:
                 other_ldap = self.obj.backend
             else:

--- a/ipaserver/plugins/vault.py
+++ b/ipaserver/plugins/vault.py
@@ -34,6 +34,7 @@ from .service import normalize_principal, validate_realm
 from ipalib import _, ngettext
 from ipapython import kerberos
 from ipapython.dn import DN
+from ipaserver.masters import is_service_enabled
 
 if api.env.in_server:
     import pki.account
@@ -1225,14 +1226,5 @@ class kra_is_enabled(Command):
     has_output = output.standard_value
 
     def execute(self, *args, **options):
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                     self.api.env.basedn)
-        filter = '(&(objectClass=ipaConfigObject)(cn=KRA))'
-        try:
-            self.api.Backend.ldap2.find_entries(
-                base_dn=base_dn, filter=filter, attrs_list=[])
-        except errors.NotFound:
-            result = False
-        else:
-            result = True
+        result = is_service_enabled('KRA', conn=self.api.Backend.ldap2)
         return dict(result=result, value=pkey_to_value(None, options))

--- a/ipaserver/servroles.py
+++ b/ipaserver/servroles.py
@@ -79,7 +79,7 @@ import six
 
 from ipalib import _, errors
 from ipapython.dn import DN
-
+from ipaserver.masters import ENABLED_SERVICE
 
 if six.PY3:
     unicode = str
@@ -483,11 +483,8 @@ class ServiceBasedRole(BaseServerRole):
         :param entry: LDAPEntry of the service
         :returns: True if the service entry is enabled, False otherwise
         """
-        enabled_value = 'enabledservice'
-        ipaconfigstring_values = set(
-            e.lower() for e in entry.get('ipaConfigString', []))
-
-        return enabled_value in ipaconfigstring_values
+        ipaconfigstring_values = set(entry.get('ipaConfigString', []))
+        return ENABLED_SERVICE in ipaconfigstring_values
 
     def _get_services_by_masters(self, entries):
         """

--- a/ipatests/test_ipaserver/test_serverroles.py
+++ b/ipatests/test_ipaserver/test_serverroles.py
@@ -16,6 +16,7 @@ import pytest
 from ipaplatform.paths import paths
 from ipalib import api, create_api, errors
 from ipapython.dn import DN
+from ipaserver.masters import ENABLED_SERVICE
 
 pytestmark = pytest.mark.needs_ipaapi
 
@@ -25,7 +26,7 @@ def _make_service_entry(ldap_backend, dn, enabled=True, other_config=None):
         'objectClass': ['top', 'nsContainer', 'ipaConfigObject'],
     }
     if enabled:
-        mods.update({'ipaConfigString': ['enabledService']})
+        mods.update({'ipaConfigString': [ENABLED_SERVICE]})
 
     if other_config is not None:
         mods.setdefault('ipaConfigString', [])


### PR DESCRIPTION
Manual backport of PRs #2938 and #2144

The backports are required for PR #2923. The hidden replica feature is build on top of the find_providing_server(s) API and related improvements in ``ipaserver/masters.py``.