### PR TITLE
[Backport][ipa-4-6] Consolidate container_masters queries 

### DIFF
--- a/install/tools/ipa-ca-install
+++ b/install/tools/ipa-ca-install
@@ -34,6 +34,7 @@ from ipaserver.install.installutils import check_creds, ReplicaConfig
 from ipaserver.install import dsinstance, ca
 from ipaserver.install import cainstance, service
 from ipaserver.install import custodiainstance
+from ipaserver.masters import find_providing_server
 from ipapython import version
 from ipalib import api
 from ipalib.constants import DOMAIN_LEVEL_0
@@ -211,8 +212,9 @@ def install_replica(safe_options, options, filename):
         config.subject_base = attrs.get('ipacertificatesubjectbase')[0]
 
     if config.ca_host_name is None:
-        config.ca_host_name = \
-            service.find_providing_server('CA', api.Backend.ldap2, api.env.ca_host)
+        config.ca_host_name = find_providing_server(
+            'CA', api.Backend.ldap2, [api.env.ca_host]
+        )
 
     options.realm_name = config.realm_name
     options.domain_name = config.domain_name
@@ -299,7 +301,8 @@ def promote(safe_options, options, filename):
             paths.KRB5_KEYTAB,
             ccache)
 
-        ca_host = service.find_providing_server('CA', api.Backend.ldap2)
+        ca_host = find_providing_server('CA', api.Backend.ldap2)
+
         if ca_host is None:
             install_master(safe_options, options)
         else:

--- a/install/tools/ipactl
+++ b/install/tools/ipactl
@@ -224,9 +224,9 @@ def get_config(dirsrv):
         svc_list.append([order, name])
 
     ordered_list = []
-    for (order, svc) in sorted(svc_list):
+    for order, svc in sorted(svc_list):
         if svc in service.SERVICE_LIST:
-            ordered_list.append(service.SERVICE_LIST[svc][0])
+            ordered_list.append(service.SERVICE_LIST[svc].systemd_name)
     return ordered_list
 
 def get_config_from_file():

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -40,6 +40,7 @@ from ipaserver.dns_data_management import (
 from ipaserver.install import installutils
 from ipaserver.install import service
 from ipaserver.install import sysupgrade
+from ipaserver.masters import get_masters
 from ipapython import ipautil
 from ipapython import dnsutil
 from ipapython.dnsutil import DNSName
@@ -1037,13 +1038,8 @@ class BindInstance(service.Service):
             cname_fqdn[cname] = fqdn
 
         # get FQDNs of all IPA masters
-        ldap = self.api.Backend.ldap2
         try:
-            entries = ldap.get_entries(
-                DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                   self.api.env.basedn),
-                ldap.SCOPE_ONELEVEL, None, ['cn'])
-            masters = set(e['cn'][0] for e in entries)
+            masters = set(get_masters(self.api.Backend.ldap2))
         except errors.NotFound:
             masters = set()
 

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -862,8 +862,7 @@ class BindInstance(service.Service):
 
     def __add_others(self):
         entries = api.Backend.ldap2.get_entries(
-            DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-               self.suffix),
+            DN(api.env.container_masters, self.suffix),
             api.Backend.ldap2.SCOPE_ONELEVEL, None, ['dn'])
 
         for entry in entries:

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -71,6 +71,7 @@ from ipaserver.install import replication
 from ipaserver.install import sysupgrade
 from ipaserver.install.dogtaginstance import DogtagInstance
 from ipaserver.plugins import ldap2
+from ipaserver.masters import ENABLED_SERVICE
 
 logger = logging.getLogger(__name__)
 
@@ -1304,7 +1305,7 @@ class CAInstance(DogtagInstance):
             config = ['caRenewalMaster']
         else:
             config = []
-        self._ldap_enable(u'enabledService', "CA", self.fqdn, basedn, config)
+        self._ldap_enable(ENABLED_SERVICE, "CA", self.fqdn, basedn, config)
 
     def setup_lightweight_ca_key_retrieval(self):
         if sysupgrade.get_upgrade_state('dogtag', 'setup_lwca_key_retrieval'):

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1173,8 +1173,8 @@ class CAInstance(DogtagInstance):
         if fqdn is None:
             fqdn = api.env.host
 
-        dn = DN(('cn', 'CA'), ('cn', fqdn), ('cn', 'masters'), ('cn', 'ipa'),
-                ('cn', 'etc'), api.env.basedn)
+        dn = DN(('cn', 'CA'), ('cn', fqdn), api.env.container_masters,
+                api.env.basedn)
         renewal_filter = '(ipaConfigString=caRenewalMaster)'
         try:
             api.Backend.ldap2.get_entries(base_dn=dn, filter=renewal_filter,
@@ -1188,8 +1188,7 @@ class CAInstance(DogtagInstance):
         if fqdn is None:
             fqdn = api.env.host
 
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                     api.env.basedn)
+        base_dn = DN(api.env.container_masters, api.env.basedn)
         filter = '(&(cn=CA)(ipaConfigString=caRenewalMaster))'
         try:
             entries = api.Backend.ldap2.get_entries(

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -98,8 +98,8 @@ def _disable_dnssec():
                                                api.env.basedn)
 
     conn = api.Backend.ldap2
-    dn = DN(('cn', 'DNSSEC'), ('cn', api.env.host), ('cn', 'masters'),
-            ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+    dn = DN(('cn', 'DNSSEC'), ('cn', api.env.host),
+            api.env.container_masters, api.env.basedn)
     try:
         entry = conn.get_entry(dn)
     except errors.NotFound:

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -576,7 +576,8 @@ class Backup(admintool.AdminTool):
         config.set('ipa', 'ipa_version', str(version.VERSION))
         config.set('ipa', 'version', '1')
 
-        dn = DN(('cn', api.env.host), ('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+        dn = DN(('cn', api.env.host), api.env.container_masters,
+                api.env.basedn)
         services_cns = []
         try:
             conn = self.get_connection()

--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -41,6 +41,7 @@ from ipaserver.install.installutils import create_replica_config
 from ipaserver.install import dogtaginstance
 from ipaserver.install import kra
 from ipaserver.install.installutils import ReplicaConfig
+from ipaserver.masters import find_providing_server
 
 logger = logging.getLogger(__name__)
 
@@ -206,8 +207,14 @@ class KRAInstaller(KRAInstall):
                 config.subject_base = attrs.get('ipacertificatesubjectbase')[0]
 
             if config.kra_host_name is None:
-                config.kra_host_name = service.find_providing_server(
-                    'KRA', api.Backend.ldap2, api.env.ca_host)
+                config.kra_host_name = find_providing_server(
+                    'KRA', api.Backend.ldap2, [api.env.ca_host]
+                )
+                if config.kra_host_name is None:
+                    # all CA/KRA servers are down or unreachable.
+                    raise admintool.ScriptError(
+                        "Failed to find an active KRA server!"
+                    )
             custodia = custodiainstance.get_custodia_instance(
                 config, custodiainstance.CustodiaModes.KRA_PEER)
         else:

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -507,7 +507,8 @@ class Restore(admintool.AdminTool):
                                 master, e)
                 continue
 
-            master_dn = DN(('cn', master), ('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+            master_dn = DN(('cn', master), api.env.container_masters,
+                           api.env.basedn)
             try:
                 services = repl.conn.get_entries(master_dn,
                                                  repl.conn.SCOPE_ONELEVEL)

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -41,6 +41,7 @@ from ipaserver.install.replication import (wait_for_task, ReplicationManager,
                                            get_cs_replication_manager)
 from ipaserver.install import installutils
 from ipaserver.install import dsinstance, httpinstance, cainstance, krbinstance
+from ipaserver.masters import get_masters
 from ipapython import ipaldap
 import ipapython.errors
 from ipaplatform.constants import constants
@@ -485,16 +486,7 @@ class Restore(admintool.AdminTool):
             logger.error('Unable to get connection, skipping disabling '
                          'agreements: %s', e)
             return
-        masters = []
-        dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
-        try:
-            entries = conn.get_entries(dn, conn.SCOPE_ONELEVEL)
-        except Exception as e:
-            raise admintool.ScriptError(
-                "Failed to read master data: %s" % e)
-        else:
-            masters = [ent.single_value['cn'] for ent in entries]
-
+        masters = get_masters(conn)
         for master in masters:
             if master == api.env.host:
                 continue

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -470,11 +470,7 @@ class KrbInstance(service.Service):
         unadvertise enabled PKINIT feature in master's KDC entry in LDAP
         """
         ldap = api.Backend.ldap2
-        dn = DN(('cn', 'KDC'),
-                ('cn', self.fqdn),
-                ('cn', 'masters'),
-                ('cn', 'ipa'),
-                ('cn', 'etc'),
+        dn = DN(('cn', 'KDC'), ('cn', self.fqdn), api.env.container_masters,
                 self.suffix)
 
         entry = ldap.get_entry(dn, ['ipaConfigString'])

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -15,6 +15,7 @@ from subprocess import CalledProcessError
 from ipalib.install import sysrestore
 from ipaserver.install import service
 from ipaserver.install import installutils
+from ipaserver.masters import ENABLED_SERVICE
 from ipapython.dn import DN
 from ipapython import ipautil
 from ipaplatform import services
@@ -45,7 +46,7 @@ def get_dnssec_key_masters(conn):
     filter_attrs = {
         u'cn': u'DNSSEC',
         u'objectclass': u'ipaConfigObject',
-        u'ipaConfigString': [KEYMASTER, u'enabledService'],
+        u'ipaConfigString': [KEYMASTER, ENABLED_SERVICE],
     }
     only_masters_f = conn.make_filter(filter_attrs, rules=conn.MATCH_ALL)
 

--- a/ipaserver/install/plugins/ca_renewal_master.py
+++ b/ipaserver/install/plugins/ca_renewal_master.py
@@ -46,8 +46,7 @@ class update_ca_renewal_master(Updater):
             return False, []
 
         ldap = self.api.Backend.ldap2
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                     self.api.env.basedn)
+        base_dn = DN(self.api.env.container_masters, self.api.env.basedn)
         dn = DN(('cn', 'CA'), ('cn', self.api.env.host), base_dn)
         filter = '(&(cn=CA)(ipaConfigString=caRenewalMaster))'
         try:

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1419,8 +1419,7 @@ class ReplicationManager(object):
 
         # delete master entry with all active services
         try:
-            dn = DN(('cn', replica), ('cn', 'masters'), ('cn', 'ipa'),
-                    ('cn', 'etc'), self.suffix)
+            dn = DN(('cn', replica), api.env.container_masters, self.suffix)
             entries = self.conn.get_entries(dn, ldap.SCOPE_SUBTREE)
             if entries:
                 entries.sort(key=lambda x: len(x.dn), reverse=True)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -46,6 +46,7 @@ from ipaserver.install.installutils import (
     validate_mask)
 from ipaserver.install.replication import (
     ReplicationManager, replica_conn_check)
+from ipaserver.masters import find_providing_servers, find_providing_server
 import SSSDConfig
 from subprocess import CalledProcessError
 
@@ -1262,9 +1263,10 @@ def promote_check(installer):
         if subject_base is not None:
             config.subject_base = DN(subject_base)
 
-        # Find if any server has a CA
-        ca_host = service.find_providing_server(
-                'CA', conn, config.ca_host_name)
+        # Find any server with a CA
+        ca_host = find_providing_server(
+            'CA', conn, [config.ca_host_name]
+        )
         if ca_host is not None:
             config.ca_host_name = ca_host
             ca_enabled = True
@@ -1285,14 +1287,16 @@ def promote_check(installer):
                              "custom certificates.")
                 raise ScriptError(rval=3)
 
-        kra_host = service.find_providing_server(
-                'KRA', conn, config.kra_host_name)
+        # Find any server with a KRA
+        kra_host = find_providing_server(
+            'KRA', conn, [config.kra_host_name]
+        )
         if kra_host is not None:
             config.kra_host_name = kra_host
             kra_enabled = True
         else:
             if options.setup_kra:
-                logger.error("There is no KRA server in the domain, "
+                logger.error("There is no active KRA server in the domain, "
                              "can't setup a KRA clone")
                 raise ScriptError(rval=3)
             kra_enabled = False
@@ -1582,7 +1586,7 @@ def install(installer):
     # Enable configured services and update DNS SRV records
     service.enable_services(config.host_name)
     api.Command.dns_update_system_records()
-    ca_servers = service.find_providing_servers('CA', api.Backend.ldap2, api)
+    ca_servers = find_providing_servers('CA', api.Backend.ldap2, api=api)
     api.Backend.ldap2.disconnect()
 
     # Everything installed properly, activate ipa service.

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1244,8 +1244,8 @@ def uninstall_dogtag_9(ds, http):
         logger.debug('Dogtag is version 10 or above')
         return
 
-    dn = DN(('cn', 'CA'), ('cn', api.env.host), ('cn', 'masters'),
-            ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+    dn = DN(('cn', 'CA'), ('cn', api.env.host), api.env.container_masters,
+            api.env.basedn)
     try:
         api.Backend.ldap2.delete_entry(dn)
     except ipalib.errors.PublicError as e:

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -134,8 +134,7 @@ def set_service_entry_config(name, fqdn, config_values,
     assert isinstance(ldap_suffix, DN)
 
     entry_name = DN(
-        ('cn', name), ('cn', fqdn), ('cn', 'masters'),
-        ('cn', 'ipa'), ('cn', 'etc'), ldap_suffix)
+        ('cn', name), ('cn', fqdn), api.env.container_masters, ldap_suffix)
 
     # enable disabled service
     try:
@@ -577,8 +576,8 @@ class Service(object):
     def ldap_disable(self, name, fqdn, ldap_suffix):
         assert isinstance(ldap_suffix, DN)
 
-        entry_dn = DN(('cn', name), ('cn', fqdn), ('cn', 'masters'),
-                        ('cn', 'ipa'), ('cn', 'etc'), ldap_suffix)
+        entry_dn = DN(('cn', name), ('cn', fqdn), api.env.container_masters,
+                      ldap_suffix)
         search_kw = {'ipaConfigString': ENABLED_SERVICE}
         filter = api.Backend.ldap2.make_filter(search_kw)
         try:
@@ -611,8 +610,8 @@ class Service(object):
         logger.debug("service %s startup entry disabled", name)
 
     def ldap_remove_service_container(self, name, fqdn, ldap_suffix):
-        entry_dn = DN(('cn', name), ('cn', fqdn), ('cn', 'masters'),
-                        ('cn', 'ipa'), ('cn', 'etc'), ldap_suffix)
+        entry_dn = DN(('cn', name), ('cn', fqdn),
+                      self.api.env.container_masters, ldap_suffix)
         try:
             api.Backend.ldap2.delete_entry(entry_dn)
         except errors.NotFound:

--- a/ipaserver/masters.py
+++ b/ipaserver/masters.py
@@ -1,0 +1,123 @@
+#
+# Copyright (C) 2018  FreeIPA Contributors see COPYING for license
+#
+"""Helpers services in for cn=masters,cn=ipa,cn=etc
+"""
+
+from __future__ import absolute_import
+
+import collections
+import logging
+import random
+
+from ipapython.dn import DN
+from ipalib import api
+from ipalib import errors
+
+logger = logging.getLogger(__name__)
+
+# constants for ipaConfigString
+CONFIGURED_SERVICE = u'configuredService'
+ENABLED_SERVICE = u'enabledService'
+
+# The service name as stored in cn=masters,cn=ipa,cn=etc. The values are:
+# 0: systemd service name
+# 1: start order for system service
+# 2: LDAP server entry CN, also used as SERVICE_LIST key
+service_definition = collections.namedtuple(
+    "service_definition",
+    "systemd_name startorder service_entry"
+)
+
+SERVICES = [
+    service_definition('krb5kdc', 10, 'KDC'),
+    service_definition('kadmin', 20, 'KPASSWD'),
+    service_definition('named', 30, 'DNS'),
+    service_definition('httpd', 40, 'HTTP'),
+    service_definition('ipa-custodia', 41, 'KEYS'),
+    service_definition('ntpd', 45, 'NTP'),
+    service_definition('pki-tomcatd', 50, 'CA'),
+    service_definition('pki-tomcatd', 51, 'KRA'),
+    service_definition('smb', 60, 'ADTRUST'),
+    service_definition('winbind', 70, 'EXTID'),
+    service_definition('ipa-otpd', 80, 'OTPD'),
+    service_definition('ipa-ods-exporter', 90, 'DNSKeyExporter'),
+    service_definition('ods-enforcerd', 100, 'DNSSEC'),
+    service_definition('ipa-dnskeysyncd', 110, 'DNSKeySync'),
+]
+
+SERVICE_LIST = {s.service_entry: s for s in SERVICES}
+
+
+def find_providing_servers(svcname, conn=None, preferred_hosts=(), api=api):
+    """Find servers that provide the given service.
+
+    :param svcname: The service to find
+    :param preferred_hosts: preferred servers
+    :param conn: a connection to the LDAP server
+    :param api: ipalib.API instance
+    :return: list of host names in randomized order (possibly empty)
+
+    Preferred servers are moved to the front of the list if and only if they
+    are found as providing servers.
+    """
+    assert isinstance(preferred_hosts, (tuple, list))
+    if svcname not in SERVICE_LIST:
+        raise ValueError("Unknown service '{}'.".format(svcname))
+    if conn is None:
+        conn = api.Backend.ldap2
+
+    dn = DN(api.env.container_masters, api.env.basedn)
+    query_filter = conn.make_filter(
+        {
+            'objectClass': 'ipaConfigObject',
+            'ipaConfigString': ENABLED_SERVICE,
+            'cn': svcname
+        },
+        rules='&'
+    )
+    try:
+        entries, _trunc = conn.find_entries(
+            filter=query_filter,
+            attrs_list=[],
+            base_dn=dn
+        )
+    except errors.NotFound:
+        return []
+
+    # unique list of host names, DNS is case insensitive
+    servers = list(set(entry.dn[1].value.lower() for entry in entries))
+    # shuffle the list like DNS SRV would randomize it
+    random.shuffle(servers)
+    # Move preferred hosts to front
+    for host_name in reversed(preferred_hosts):
+        host_name = host_name.lower()
+        try:
+            servers.remove(host_name)
+        except ValueError:
+            # preferred server not found, log and ignore
+            logger.warning(
+                "Lookup failed: Preferred host %s does not provide %s.",
+                host_name, svcname
+            )
+        else:
+            servers.insert(0, host_name)
+    return servers
+
+
+def find_providing_server(svcname, conn=None, preferred_hosts=(), api=api):
+    """Find a server that provides the given service.
+
+    :param svcname: The service to find
+    :param conn: a connection to the LDAP server
+    :param host_name: the preferred server
+    :param api: ipalib.API instance
+    :return: the selected host name or None
+    """
+    servers = find_providing_servers(
+        svcname, conn=conn, preferred_hosts=preferred_hosts, api=api
+    )
+    if not servers:
+        return None
+    else:
+        return servers[0]

--- a/ipaserver/masters.py
+++ b/ipaserver/masters.py
@@ -121,3 +121,54 @@ def find_providing_server(svcname, conn=None, preferred_hosts=(), api=api):
         return None
     else:
         return servers[0]
+
+
+def get_masters(conn=None, api=api):
+    """Get all master hostnames
+
+    :param conn: a connection to the LDAP server
+    :param api: ipalib.API instance
+    :return: list of hostnames
+    """
+    if conn is None:
+        conn = api.Backend.ldap2
+
+    dn = DN(api.env.container_masters, api.env.basedn)
+    entries = conn.get_entries(dn, conn.SCOPE_ONELEVEL, None, ['cn'])
+    return list(e['cn'][0] for e in entries)
+
+
+def is_service_enabled(svcname, conn=None, api=api):
+    """Check if service is enabled on any master
+
+    The check function only looks for presence of service entries. It
+    ignores enabled/hidden flags.
+
+    :param svcname: The service to find
+    :param conn: a connection to the LDAP server
+    :param api: ipalib.API instance
+    :return: True/False
+    """
+    if svcname not in SERVICE_LIST:
+        raise ValueError("Unknown service '{}'.".format(svcname))
+    if conn is None:
+        conn = api.Backend.ldap2
+
+    dn = DN(api.env.container_masters, api.env.basedn)
+    query_filter = conn.make_filter(
+        {
+            'objectClass': 'ipaConfigObject',
+            'cn': svcname
+        },
+        rules='&'
+    )
+    try:
+        conn.find_entries(
+            filter=query_filter,
+            attrs_list=[],
+            base_dn=dn
+        )
+    except errors.NotFound:
+        return False
+    else:
+        return True

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -497,7 +497,7 @@ def host_is_master(ldap, fqdn):
 
     Raises an exception if a master, otherwise returns nothing.
     """
-    master_dn = DN(('cn', fqdn), ('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+    master_dn = DN(('cn', fqdn), api.env.container_masters, api.env.basedn)
     try:
         ldap.get_entry(master_dn, ['objectclass'])
         raise errors.ValidationError(name='hostname', error=_('An IPA master host cannot be deleted or disabled'))

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -55,7 +55,9 @@ from ipalib import output
 from ipapython import dnsutil, kerberos
 from ipapython.dn import DN
 from ipaserver.plugins.service import normalize_principal, validate_realm
-from ipaserver.masters import ENABLED_SERVICE, CONFIGURED_SERVICE
+from ipaserver.masters import (
+    ENABLED_SERVICE, CONFIGURED_SERVICE, is_service_enabled
+)
 
 try:
     import pyhbac
@@ -1908,14 +1910,5 @@ class ca_is_enabled(Command):
     has_output = output.standard_value
 
     def execute(self, *args, **options):
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                     self.api.env.basedn)
-        filter = '(&(objectClass=ipaConfigObject)(cn=CA))'
-        try:
-            self.api.Backend.ldap2.find_entries(
-                base_dn=base_dn, filter=filter, attrs_list=[])
-        except errors.NotFound:
-            result = False
-        else:
-            result = True
+        result = is_service_enabled('CA', conn=self.api.Backend.ldap2)
         return dict(result=result, value=pkey_to_value(None, options))

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -55,6 +55,7 @@ from ipalib import output
 from ipapython import dnsutil, kerberos
 from ipapython.dn import DN
 from ipaserver.plugins.service import normalize_principal, validate_realm
+from ipaserver.masters import ENABLED_SERVICE, CONFIGURED_SERVICE
 
 try:
     import pyhbac
@@ -297,19 +298,14 @@ def caacl_check(principal, ca, profile_id):
 def ca_kdc_check(api_instance, hostname):
     master_dn = api_instance.Object.server.get_dn(unicode(hostname))
     kdc_dn = DN(('cn', 'KDC'), master_dn)
-
+    wanted = {ENABLED_SERVICE, CONFIGURED_SERVICE}
     try:
         kdc_entry = api_instance.Backend.ldap2.get_entry(
             kdc_dn, ['ipaConfigString'])
-
-        ipaconfigstring = {val.lower() for val in kdc_entry['ipaConfigString']}
-
-        if 'enabledservice' not in ipaconfigstring \
-                and 'configuredservice' not in ipaconfigstring:
+        if not wanted.intersection(kdc_entry['ipaConfigString']):
             raise errors.NotFound(
                 reason=_("enabledService/configuredService not in "
                          "ipaConfigString kdc entry"))
-
     except errors.NotFound:
         raise errors.ACIError(
             info=_("Host '%(hostname)s' is not an active KDC")

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -255,6 +255,7 @@ from ipalib import Backend, api
 from ipapython.dn import DN
 import ipapython.cookie
 from ipapython import dogtag, ipautil, certdb
+from ipaserver.masters import find_providing_server
 
 if api.env.in_server:
     import pki
@@ -1208,56 +1209,6 @@ def parse_updateCRL_xml(doc):
     return response
 
 
-def host_has_service(host, ldap2, service='CA'):
-    """
-    :param host: A host which might be a master for a service.
-    :param ldap2: connection to the local database
-    :param service: The service for which the host might be a master.
-    :return:   (true, false)
-
-    Check if a specified host is a master for a specified service.
-    """
-    base_dn = DN(('cn', host), ('cn', 'masters'), ('cn', 'ipa'),
-                 ('cn', 'etc'), api.env.basedn)
-    filter_attrs = {
-        'objectClass': 'ipaConfigObject',
-        'cn': service,
-        'ipaConfigString': 'enabledService',
-        }
-    query_filter = ldap2.make_filter(filter_attrs, rules='&')
-    try:
-        ent, _trunc = ldap2.find_entries(filter=query_filter, base_dn=base_dn)
-        if len(ent):
-            return True
-    except Exception:
-        pass
-    return False
-
-
-def select_any_master(ldap2, service='CA'):
-    """
-    :param ldap2: connection to the local database
-    :param service: The service for which we're looking for a master.
-    :return:   host as str
-
-    Select any host which is a master for a specified service.
-    """
-    base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                  api.env.basedn)
-    filter_attrs = {
-         'objectClass': 'ipaConfigObject',
-         'cn': service,
-         'ipaConfigString': 'enabledService',}
-    query_filter = ldap2.make_filter(filter_attrs, rules='&')
-    try:
-        ent, _trunc = ldap2.find_entries(filter=query_filter, base_dn=base_dn)
-        if len(ent):
-            entry = random.choice(ent)
-            return entry.dn[1].value
-    except Exception:
-        pass
-    return None
-
 #-------------------------------------------------------------------------------
 
 from ipalib import Registry, errors, SkipPluginModule
@@ -1265,7 +1216,6 @@ if api.env.ra_plugin != 'dogtag':
     # In this case, abort loading this plugin module...
     raise SkipPluginModule(reason='dogtag not selected as RA plugin')
 import os
-import random
 from ipaserver.plugins import rabase
 from ipalib.constants import TYPE_ERROR
 from ipalib import _
@@ -1330,17 +1280,19 @@ class RestClient(Backend):
         if self._ca_host is not None:
             return self._ca_host
 
-        ldap2 = self.api.Backend.ldap2
-        if host_has_service(api.env.ca_host, ldap2, "CA"):
-            object.__setattr__(self, '_ca_host', api.env.ca_host)
-        elif api.env.host != api.env.ca_host:
-            if host_has_service(api.env.host, ldap2, "CA"):
-                object.__setattr__(self, '_ca_host', api.env.host)
-        else:
-            object.__setattr__(self, '_ca_host', select_any_master(ldap2))
-        if self._ca_host is None:
-            object.__setattr__(self, '_ca_host', api.env.ca_host)
-        return self._ca_host
+        preferred = [api.env.ca_host]
+        if api.env.host != api.env.ca_host:
+            preferred.append(api.env.host)
+        ca_host = find_providing_server(
+            'CA', conn=self.api.Backend.ldap2, preferred_hosts=preferred,
+            api=self.api
+        )
+        if ca_host is None:
+            # TODO: need during installation, CA is not yet set as enabled
+            ca_host = api.env.ca_host
+        # object is locked, need to use __setattr__()
+        object.__setattr__(self, '_ca_host', ca_host)
+        return ca_host
 
     def __enter__(self):
         """Log into the REST API"""
@@ -2082,9 +2034,7 @@ class kra(Backend):
     """
 
     def __init__(self, api, kra_port=443):
-
         self.kra_port = kra_port
-
         super(kra, self).__init__(api)
 
     @property
@@ -2095,17 +2045,18 @@ class kra(Backend):
 
         Select our KRA host.
         """
-        ldap2 = self.api.Backend.ldap2
-        if host_has_service(api.env.ca_host, ldap2, "KRA"):
-            return api.env.ca_host
+        preferred = [api.env.ca_host]
         if api.env.host != api.env.ca_host:
-            if host_has_service(api.env.host, ldap2, "KRA"):
-                return api.env.host
-        host = select_any_master(ldap2, "KRA")
-        if host:
-            return host
-        else:
-            return api.env.ca_host
+            preferred.append(api.env.host)
+
+        kra_host = find_providing_server(
+            'KRA', self.api.Backend.ldap2, preferred_hosts=preferred,
+            api=self.api
+        )
+        if kra_host is None:
+            # TODO: need during installation, KRA is not yet set as enabled
+            kra_host = api.env.ca_host
+        return kra_host
 
     @contextlib.contextmanager
     def get_client(self):

--- a/ipaserver/plugins/domainlevel.py
+++ b/ipaserver/plugins/domainlevel.py
@@ -73,25 +73,18 @@ def check_conflict_entries(ldap, api, desired_value):
     except errors.NotFound:
         pass
 
+
 def get_master_entries(ldap, api):
     """
     Returns list of LDAPEntries representing IPA masters.
     """
-
-    container_masters = DN(
-        ('cn', 'masters'),
-        ('cn', 'ipa'),
-        ('cn', 'etc'),
-        api.env.basedn
-    )
-
+    dn = DN(api.env.container_masters, api.env.basedn)
     masters, _dummy = ldap.find_entries(
         filter="(cn=*)",
-        base_dn=container_masters,
+        base_dn=dn,
         scope=ldap.SCOPE_ONELEVEL,
         paged_search=True,  # we need to make sure to get all of them
     )
-
     return masters
 
 

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -69,6 +69,7 @@ from ipapython.dn import DN
 from ipapython.ipaldap import LDAPClient
 from ipapython.ipautil import ipa_generate_password, TMP_PWD_ENTROPY_BITS
 from ipalib.capabilities import client_has_capability
+from ipaserver.masters import get_masters
 
 if six.PY3:
     unicode = str
@@ -1105,21 +1106,11 @@ class user_status(LDAPQuery):
         attr_list = ['krbloginfailedcount', 'krblastsuccessfulauth', 'krblastfailedauth', 'nsaccountlock']
 
         disabled = False
-        masters = []
-        # Get list of masters
-        try:
-            masters, _truncated = ldap.find_entries(
-                None, ['*'], DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn),
-                ldap.SCOPE_ONELEVEL
-            )
-        except errors.NotFound:
-            # If this happens we have some pretty serious problems
-            logger.error('No IPA masters found!')
+        masters = get_masters(ldap)
 
         entries = []
         count = 0
-        for master in masters:
-            host = master['cn'][0]
+        for host in masters:
             if host == api.env.host:
                 other_ldap = self.obj.backend
             else:

--- a/ipaserver/plugins/vault.py
+++ b/ipaserver/plugins/vault.py
@@ -34,6 +34,7 @@ from .service import normalize_principal, validate_realm
 from ipalib import _, ngettext
 from ipapython import kerberos
 from ipapython.dn import DN
+from ipaserver.masters import is_service_enabled
 
 if api.env.in_server:
     import pki.account
@@ -1220,14 +1221,5 @@ class kra_is_enabled(Command):
     has_output = output.standard_value
 
     def execute(self, *args, **options):
-        base_dn = DN(('cn', 'masters'), ('cn', 'ipa'), ('cn', 'etc'),
-                     self.api.env.basedn)
-        filter = '(&(objectClass=ipaConfigObject)(cn=KRA))'
-        try:
-            self.api.Backend.ldap2.find_entries(
-                base_dn=base_dn, filter=filter, attrs_list=[])
-        except errors.NotFound:
-            result = False
-        else:
-            result = True
+        result = is_service_enabled('KRA', conn=self.api.Backend.ldap2)
         return dict(result=result, value=pkey_to_value(None, options))

--- a/ipaserver/servroles.py
+++ b/ipaserver/servroles.py
@@ -79,7 +79,7 @@ import six
 
 from ipalib import _, errors
 from ipapython.dn import DN
-
+from ipaserver.masters import ENABLED_SERVICE
 
 if six.PY3:
     unicode = str
@@ -483,11 +483,8 @@ class ServiceBasedRole(BaseServerRole):
         :param entry: LDAPEntry of the service
         :returns: True if the service entry is enabled, False otherwise
         """
-        enabled_value = 'enabledservice'
-        ipaconfigstring_values = set(
-            e.lower() for e in entry.get('ipaConfigString', []))
-
-        return enabled_value in ipaconfigstring_values
+        ipaconfigstring_values = set(entry.get('ipaConfigString', []))
+        return ENABLED_SERVICE in ipaconfigstring_values
 
     def _get_services_by_masters(self, entries):
         """

--- a/ipatests/test_ipaserver/test_serverroles.py
+++ b/ipatests/test_ipaserver/test_serverroles.py
@@ -16,6 +16,7 @@ import pytest
 from ipaplatform.paths import paths
 from ipalib import api, create_api, errors
 from ipapython.dn import DN
+from ipaserver.masters import ENABLED_SERVICE
 
 pytestmark = pytest.mark.needs_ipaapi
 
@@ -25,7 +26,7 @@ def _make_service_entry(ldap_backend, dn, enabled=True, other_config=None):
         'objectClass': ['top', 'nsContainer', 'ipaConfigObject'],
     }
     if enabled:
-        mods.update({'ipaConfigString': ['enabledService']})
+        mods.update({'ipaConfigString': [ENABLED_SERVICE]})
 
     if other_config is not None:
         mods.setdefault('ipaConfigString', [])


### PR DESCRIPTION
Manual backport of PRs #2938 and #2144 

The backports are required for PR #2923. The hidden replica feature is build on top of the find_providing_server(s) API and related improvements in ``ipaserver/masters.py``.