### PR TITLE
Extend test for orphan automember rules (issue/6476)

### DIFF
--- a/ipatests/test_xmlrpc/test_automember_plugin.py
+++ b/ipatests/test_xmlrpc/test_automember_plugin.py
@@ -837,6 +837,15 @@ class TestAutomemberFindOrphans(XMLRPC_test):
 
         hostgroup1.ensure_missing()
 
+        # Test rebuild (is failing)
+        try:
+            api.Command['automember_rebuild'](type=u'hostgroup')
+        except errors.DatabaseError:
+            pass
+        else:
+            pytest.fail("automember_rebuild was not failing with "
+                        "an orphan automember rule")
+
         # Find obsolete automember rules
         result = api.Command['automember_find_orphans'](type=u'hostgroup')
         assert result['count'] == 1
@@ -849,6 +858,12 @@ class TestAutomemberFindOrphans(XMLRPC_test):
         # Find obsolete automember rules
         result = api.Command['automember_find_orphans'](type=u'hostgroup')
         assert result['count'] == 0
+
+        # Test rebuild (may not be failing)
+        try:
+            api.Command['automember_rebuild'](type=u'hostgroup')
+        except errors.DatabaseError:
+            assert False
 
         # Final cleanup of automember rule if it still exists
         with raises_exact(errors.NotFound(


### PR DESCRIPTION
The test was not executing ipa automember-rebuild --type hostgroup.

The test has been extended to execute it twice: Once when it needs to fail
because there is an orphan automember rule. Also after this orphan
automember rule has been removed. Here the test needs to succeed.

Fixes: https://pagure.io/freeipa/issue/7891
Signed-off-by: Thomas Woerner <twoerner@redhat.com>