### PR TITLE
[Backport][ipa-4-6] Add uniqueness constraint on CA ACL name

### DIFF
--- a/install/updates/10-uniqueness.update
+++ b/install/updates/10-uniqueness.update
@@ -92,3 +92,20 @@ add:uniqueness-across-all-subtrees: on
 dn: cn=ipaUniqueID uniqueness,cn=plugins,cn=config
 add:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
 add:uniqueness-across-all-subtrees: on
+
+dn: cn=caacl name uniqueness,cn=plugins,cn=config
+default:objectClass: top
+default:objectClass: nsSlapdPlugin
+default:objectClass: extensibleObject
+default:cn: caacl name uniqueness
+default:nsslapd-pluginDescription: Enforce unique attribute values
+default:nsslapd-pluginPath: libattr-unique-plugin
+default:nsslapd-pluginInitfunc: NSUniqueAttr_Init
+default:nsslapd-pluginType: preoperation
+default:nsslapd-pluginEnabled: on
+default:uniqueness-attribute-name: cn
+default:uniqueness-subtrees: cn=caacls,cn=ca,$SUFFIX
+default:nsslapd-plugin-depends-on-type: database
+default:nsslapd-pluginId: NSUniqueAttr
+default:nsslapd-pluginVersion: 1.1.0
+default:nsslapd-pluginVendor: Fedora Project


### PR DESCRIPTION
This is a manual backport of PR #1365 to ipa-4-6 branch. The cherry-pick applied cleanly.