### PR TITLE
[Backport][ipa-4-6] Extend test for orphan automember rules (issue/6476)

### DIFF
--- a/ipatests/test_xmlrpc/test_automember_plugin.py
+++ b/ipatests/test_xmlrpc/test_automember_plugin.py
@@ -746,6 +746,15 @@ class TestAutomemberFindOrphans(XMLRPC_test):
 
         hostgroup1.ensure_missing()
 
+        # Test rebuild (is failing)
+        try:
+            api.Command['automember_rebuild'](type=u'hostgroup')
+        except errors.DatabaseError:
+            pass
+        else:
+            pytest.fail("automember_rebuild was not failing with "
+                        "an orphan automember rule")
+
         # Find obsolete automember rules
         result = api.Command['automember_find_orphans'](type=u'hostgroup')
         assert result['count'] == 1
@@ -758,6 +767,12 @@ class TestAutomemberFindOrphans(XMLRPC_test):
         # Find obsolete automember rules
         result = api.Command['automember_find_orphans'](type=u'hostgroup')
         assert result['count'] == 0
+
+        # Test rebuild (may not be failing)
+        try:
+            api.Command['automember_rebuild'](type=u'hostgroup')
+        except errors.DatabaseError:
+            assert False
 
         # Final cleanup of automember rule if it still exists
         with raises_exact(errors.NotFound(


### PR DESCRIPTION
This PR was opened automatically because PR #2951 was pushed to master and backport to ipa-4-6 is required.