### PR TITLE
ipa-setup-kra: fix python2 parameter

### DIFF
--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -213,7 +213,7 @@ def sync_services_state(fqdn):
     """
     result = api.Command.server_role_find(
         server_server=fqdn,
-        role_servrole='IPA master',
+        role_servrole=u'IPA master',
         status=HIDDEN
     )
     if result['count']:


### PR DESCRIPTION
ipa-setup-kra is failing in python2 with
invalid 'role_servrole': must be Unicode text
because of a unicode conversion error.

The method api.Command.server_role_find is called with the parameter
role_servrole='IPA master' but it should rather be
role_servrole=u'IPA master'

Fixes: https://pagure.io/freeipa/issue/7897