### PR TITLE
Disable flaky hidden replica backup test

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -925,4 +925,3 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         # FIXME: restore turns hidden replica into enabled replica
         self._check_config([self.master, self.replicas[0]])
         self._check_server_role(self.replicas[0], 'enabled')
-        self._check_dnsrecords([self.master, self.replicas[0]])


### PR DESCRIPTION
The test case for hidden replica restore is flaky and sometimes fails.
The general issues is covered by upstream bug 7894.

See: https://pagure.io/freeipa/issue/7894
Signed-off-by: Christian Heimes <cheimes@redhat.com>