### PR TITLE
[Backport][ipa-4-6] ipa-setup-kra: fix python2 parameter

### DIFF
--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -213,7 +213,7 @@ def sync_services_state(fqdn):
     """
     result = api.Command.server_role_find(
         server_server=fqdn,
-        role_servrole='IPA master',
+        role_servrole=u'IPA master',
         status=HIDDEN
     )
     if result['count']:


### PR DESCRIPTION
This PR was opened automatically because PR #2968 was pushed to master and backport to ipa-4-6 is required.