### PR TITLE
Add PKI config override option

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1082,6 +1082,7 @@ fi
 # END
 %{_usr}/share/ipa/wsgi.py*
 %{_usr}/share/ipa/kdcproxy.wsgi
+%{_usr}/share/ipa/ipaca*.ini
 %{_usr}/share/ipa/*.ldif
 %{_usr}/share/ipa/*.uldif
 %{_usr}/share/ipa/*.template

--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -96,6 +96,8 @@ dist_app_DATA =				\
 	ipa-rewrite.conf.template	\
 	min-ssf.ldif			\
 	ipaca_default.ini		\
+	ipaca_customize.ini		\
+	ipaca_softhsm2.ini		\
 	$(NULL)
 
 kdcproxyconfdir = $(IPA_SYSCONF_DIR)/kdcproxy

--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -95,6 +95,7 @@ dist_app_DATA =				\
 	ipa-pki-proxy.conf.template	\
 	ipa-rewrite.conf.template	\
 	min-ssf.ldif			\
+	ipaca_default.ini		\
 	$(NULL)
 
 kdcproxyconfdir = $(IPA_SYSCONF_DIR)/kdcproxy

--- a/install/share/ipaca_customize.ini
+++ b/install/share/ipaca_customize.ini
@@ -1,0 +1,123 @@
+#
+# Dogtag PKI configuration file
+#
+# Notes:
+#  - "%" must be quoted as "%%".
+#  - options in the [CA] and [KRA] section cannot be overriden from options
+#    in the [DEFAULT] section
+#  - pki_*_token options are hard-coded to pki_token_name
+#  - pki_sslserver_token is hard-coded to 'internal'
+#  - pki_backup_keys is automatically disabled when HSM support is enabled,
+#    as HSM backup is not possible with the default mechanism.
+#
+# Predefined variables
+#  - ipa_ca_subject
+#  - ipa_ds_base_dn
+#  - ipa_fqdn
+#  - ipa_subject_base
+#  - pki_admin_password
+#  - pki_dns_domainname
+#  - softhsm2_so
+
+
+[DEFAULT]
+# default algorithms for all certificates
+ipa_key_algorithm=SHA256withRSA
+ipa_key_size=2048
+ipa_key_type=rsa
+ipa_signing_algorithm=SHA256withRSA
+
+# Used for IPA CA
+# signing algorithm can be overriden on command line
+ipa_ca_signing_algorithm=%(ipa_key_algorithm)s
+ipa_ca_key_size=%(ipa_key_size)s
+ipa_ca_key_type=%(ipa_key_type)s
+
+# HSM support
+pki_hsm_enable=False
+pki_hsm_libfile=
+pki_hsm_modulename=
+pki_token_name=internal
+# backup is automatically disabled when HSM support is enabled
+pki_backup_keys=True
+pki_backup_password=%(pki_admin_password)s
+
+pki_admin_email=root@localhost
+
+## auditSigningCert cert-pki-ca / auditSigningCert cert-pki-kra
+pki_audit_signing_key_algorithm=%(ipa_key_algorithm)s
+pki_audit_signing_key_size=%(ipa_key_size)s
+pki_audit_signing_key_type=%(ipa_key_type)s
+pki_audit_signing_signing_algorithm=%(ipa_signing_algorithm)s
+pki_audit_signing_token=%(pki_token_name)s
+
+# Configures the status request timeout, i.e. the connect/data
+# timeout on the HTTP request to get the status of Dogtag.
+#
+# This configuration is needed in "multiple IP address" scenarios
+# where this server's hostname has multiple IP addresses but the
+# HTTP server is only listening on one of them.  Without a timeout,
+# if a "wrong" IP address is tried first, it will take a long time
+# to timeout, exceeding the overall timeout hence the request will
+# not be re-tried.  Setting a shorter timeout allows the request
+# to be re-tried.
+#
+# Note that HSMs cause different behaviour so this value might
+# not be suitable for when we implement HSM support.  It is
+# known that a value of 5s is too short in HSM environment.
+#
+pki_status_request_timeout=15
+
+# for supporting server cert SAN injection
+pki_san_inject=False
+pki_san_for_server_cert=
+
+## Server-Cert cert-pki-ca
+pki_sslserver_key_algorithm=%(ipa_key_algorithm)s
+pki_sslserver_key_size=%(ipa_key_size)s
+pki_sslserver_key_type=%(ipa_key_type)s
+
+## subsystemCert cert-pki-ca
+pki_subsystem_key_algorithm=%(ipa_key_algorithm)s
+pki_subsystem_key_size=%(ipa_key_size)s
+pki_subsystem_key_type=%(ipa_key_type)s
+pki_subsystem_token=%(pki_token_name)s
+
+[CA]
+pki_random_serial_numbers_enable=False
+
+## caSigningCert cert-pki-ca
+pki_ca_signing_key_algorithm=%(ipa_ca_signing_algorithm)s
+pki_ca_signing_key_size=%(ipa_ca_key_size)s
+pki_ca_signing_key_type=%(ipa_ca_key_type)s
+pki_ca_signing_signing_algorithm=%(ipa_ca_signing_algorithm)s
+pki_ca_signing_token=%(pki_token_name)s
+
+# MS subca request ext data
+pki_req_ext_oid=1.3.6.1.4.1.311.20.2
+pki_req_ext_critical=False
+pki_req_ext_data=1E0A00530075006200430041
+
+## ocspSigningCert cert-pki-ca
+pki_ocsp_signing_key_algorithm=%(ipa_key_algorithm)s
+pki_ocsp_signing_key_size=%(ipa_key_size)s
+pki_ocsp_signing_key_type=%(ipa_key_type)s
+pki_ocsp_signing_signing_algorithm=%(ipa_signing_algorithm)s
+pki_ocsp_signing_token=%(pki_token_name)s
+
+[KRA]
+pki_kra_ephemeral_requests=True
+
+## storageCert cert-pki-kra
+pki_storage_key_algorithm=%(ipa_key_algorithm)s
+pki_storage_key_size=%(ipa_key_size)s
+pki_storage_key_type=%(ipa_key_type)s
+pki_storage_signing_algorithm=%(ipa_signing_algorithm)s
+pki_storage_token=%(pki_token_name)s
+
+## transportCert cert-pki-kra
+pki_transport_key_algorithm=%(ipa_key_algorithm)s
+pki_transport_key_size=%(ipa_key_size)s
+pki_transport_key_type=%(ipa_key_type)s
+pki_transport_signing_algorithm=%(ipa_signing_algorithm)s
+pki_transport_token=%(pki_token_name)s

--- a/install/share/ipaca_customize.ini
+++ b/install/share/ipaca_customize.ini
@@ -12,7 +12,6 @@
 #
 # Predefined variables
 #  - ipa_ca_subject
-#  - ipa_ds_base_dn
 #  - ipa_fqdn
 #  - ipa_subject_base
 #  - pki_admin_password

--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -8,15 +8,10 @@
 #
 
 [DEFAULT]
-# hard-coded IPA default settings
-ipa_security_domain_name=IPA
-ipa_ds_database=ipaca
-ipa_admin_nickname=ipa-ca-agent
 ipa_ca_pem_file=/etc/ipa/ca.crt
 
 ## dynamic values
 # ipa_ca_subject=
-# ipa_ds_base_dn=
 # ipa_subject_base=
 # ipa_fqdn=
 # ipa_ocsp_uri=
@@ -36,8 +31,8 @@ pki_admin_cert_file=%(pki_client_dir)s/ca_admin.cert
 pki_admin_cert_request_type=pkcs10
 pki_admin_dualkey=False
 pki_admin_name=%(ipa_admin_user)s
-pki_admin_nickname=%(ipa_admin_nickname)s
-pki_admin_subject_dn=cn=%(ipa_admin_nickname)s,%(ipa_subject_base)s
+pki_admin_nickname=ipa-ca-agent
+pki_admin_subject_dn=cn=ipa-ca-agent,%(ipa_subject_base)s
 pki_admin_uid=%(ipa_admin_user)s
 
 pki_ca_hostname=%(pki_security_domain_hostname)s
@@ -55,6 +50,10 @@ pki_client_pkcs12_password=%(pki_admin_password)s
 pki_ds_bind_dn=cn=Directory Manager
 pki_ds_ldap_port=389
 pki_ds_ldaps_port=636
+# CA: o=ipaca, KRA: o=kra,o=ipaca
+pki_ds_base_dn=o=ipaca
+pki_ds_database=ipaca
+pki_ds_hostname=%(ipa_fqdn)s
 pki_ds_remove_data=True
 pki_ds_secure_connection=False
 pki_ds_secure_connection_ca_nickname=Directory Server CA certificate
@@ -70,7 +69,7 @@ pki_enable_proxy=True
 pki_restart_configured_instance=False
 pki_security_domain_hostname=%(ipa_fqdn)s
 pki_security_domain_https_port=443
-pki_security_domain_name=%(ipa_security_domain_name)s
+pki_security_domain_name=IPA
 pki_security_domain_password=%(pki_admin_password)s
 pki_security_domain_user=%(ipa_admin_user)s
 pki_self_signed_token=internal
@@ -81,6 +80,7 @@ pki_skip_installation=False
 pki_skip_sd_verify=False
 
 pki_sslserver_token=internal
+pki_ssl_server_token=%(pki_sslserver_token)s
 pki_sslserver_nickname=Server-Cert cert-pki-ca
 pki_sslserver_subject_dn=cn=%(ipa_fqdn)s,%(ipa_subject_base)s
 
@@ -101,27 +101,15 @@ pki_cert_chain_nickname=caSigningCert External CA
 pki_pkcs12_path=
 pki_pkcs12_password=
 
-pki_ds_base_dn=%(ipa_ds_base_dn)s
-pki_ds_database=%(ipa_ds_database)s
-pki_ds_hostname=%(ipa_fqdn)s
-
 
 [CA]
+pki_ds_base_dn=o=ipaca
+
 pki_ca_signing_record_create=True
 pki_ca_signing_serial_number=1
 pki_ca_signing_subject_dn=%(ipa_ca_subject)s
 
 pki_ca_signing_csr_path=/root/ipa.csr
-
-# pki_ocsp_signing_csr_path=
-# pki_audit_signing_csr_path=
-# pki_sslserver_csr_path=
-# pki_subsystem_csr_path=
-
-# pki_ocsp_signing_cert_path=
-# pki_audit_signing_cert_path=
-# pki_sslserver_cert_path=
-# pki_subsystem_cert_path=
 
 pki_ca_starting_crl_number=0
 
@@ -139,7 +127,6 @@ pki_ocsp_signing_subject_dn=cn=OCSP Subsystem,%(ipa_subject_base)s
 pki_profiles_in_ldap=True
 pki_subordinate=False
 pki_subordinate_create_new_security_domain=False
-### pki_subordinate_security_domain_name=%(pki_dns_domainname)s Subordinate Security Domain
 
 pki_audit_signing_nickname=auditSigningCert cert-pki-ca
 pki_audit_signing_subject_dn=cn=CA Audit,%(ipa_subject_base)s
@@ -158,25 +145,14 @@ pki_replica_number_range_end=100
 
 
 [KRA]
+pki_ds_base_dn=o=kra,o=ipaca
+pki_ds_create_new_db=False
+pki_ds_secure_connection=True
+
 pki_import_admin_cert=True
 pki_standalone=False
-pki_ds_create_new_db=False
-
-# pki_admin_csr_path=
-# pki_audit_signing_csr_path=
-# pki_sslserver_csr_path=
-# pki_storage_csr_path=
-# pki_subsystem_csr_path=
-# pki_transport_csr_path=
 
 pki_external_step_two=False
-
-# pki_admin_cert_path=
-# pki_audit_signing_cert_path=
-# pki_sslserver_cert_path=
-# pki_storage_cert_path=
-# pki_subsystem_cert_path=
-# pki_transport_cert_path=
 
 pki_storage_nickname=storageCert cert-pki-kra
 pki_storage_subject_dn=cn=KRA Storage Certificate,%(ipa_subject_base)s
@@ -190,4 +166,4 @@ pki_audit_signing_subject_dn=cn=KRA Audit,%(ipa_subject_base)s
 # Needed because CA and KRA share the same database
 # We will use the dbuser created for the CA.
 pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(ipa_ds_database)s
+pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=ipaca

--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -1,0 +1,644 @@
+###############################################################################
+##  Default Configuration:                                                   ##
+##                                                                           ##
+##  Values in this section are common to more than one PKI subsystem, and    ##
+##  contain required information which MAY be overridden by users as         ##
+##  necessary.                                                               ##
+##                                                                           ##
+##  There are also some meta-parameters that determine how the PKI           ##
+##  configuratiion should work.                                              ##
+##                                                                           ##
+###############################################################################
+[DEFAULT]
+
+JAVA_HOME=%(java_home)s
+
+# The sensitive_parameters contains a list of parameters which may contain
+# sensitive information which must not be displayed to the console nor stored
+# in log files for security reasons.
+sensitive_parameters=
+    pki_admin_password
+    pki_backup_password
+    pki_client_database_password
+    pki_client_pin
+    pki_client_pkcs12_password
+    pki_clone_pkcs12_password
+    pki_ds_password
+    pki_external_pkcs12_password
+    pki_pkcs12_password
+    pki_one_time_pin
+    pki_pin
+    pki_replication_password
+    pki_security_domain_password
+    pki_server_pkcs12_password
+    pki_token_password
+
+# The spawn_scriplets contains a list of scriplets to be executed by pkispawn.
+spawn_scriplets=
+    initialization
+    infrastructure_layout
+    instance_layout
+    subsystem_layout
+    webapp_deployment
+    slot_substitution
+    security_databases
+    selinux_setup
+    configuration
+    finalization
+
+# The destroy_scriplets contains a list of scriplets to be executed by pkidestroy.
+destroy_scriplets=
+    initialization
+    configuration
+    webapp_deployment
+    subsystem_layout
+    security_databases
+    instance_layout
+    selinux_setup
+    infrastructure_layout
+    finalization
+
+# By default, the following parameters will be set for Tomcat instances.
+# There is no reason to uncomment these.  They are provided for reference in 
+# case someone wants to override them in their config file.
+#
+# Tomcat instances:
+# pki_instance_name=pki-tomcat
+# pki_https_port=8443
+# pki_http_port=8080
+
+pki_admin_cert_file=%(pki_client_dir)s/ca_admin.cert
+pki_admin_cert_request_type=pkcs10
+pki_admin_dualkey=False
+pki_admin_key_algorithm=SHA256withRSA
+# DEPRECATED: Use 'pki_admin_key_size' instead.
+pki_admin_keysize=2048
+pki_admin_key_size=%(pki_admin_keysize)s
+pki_admin_key_type=rsa
+pki_admin_password=
+
+pki_audit_group=pkiaudit
+
+pki_audit_signing_key_algorithm=SHA256withRSA
+pki_audit_signing_key_size=2048
+pki_audit_signing_key_type=rsa
+pki_audit_signing_signing_algorithm=SHA256withRSA
+pki_audit_signing_token=
+
+pki_backup_keys=False
+pki_backup_password=
+pki_ca_hostname=%(pki_security_domain_hostname)s
+pki_ca_port=%(pki_security_domain_https_port)s
+
+pki_ca_signing_nickname=caSigningCert cert-%(pki_instance_name)s CA
+
+# DEPRECATED: Use 'pki_ca_signing_cert_path' instead.
+pki_external_ca_cert_path=%(pki_instance_configuration_path)s/external_ca.cert
+pki_ca_signing_cert_path=%(pki_external_ca_cert_path)s
+
+pki_client_admin_cert_p12=%(pki_client_dir)s/%(pki_subsystem_type)s_admin_cert.p12
+pki_client_database_password=
+pki_client_database_purge=True
+pki_client_dir=%(home_dir)s/.dogtag/%(pki_instance_name)s
+pki_client_pkcs12_password=
+pki_ds_bind_dn=cn=Directory Manager
+pki_ds_create_new_db=True
+pki_ds_ldap_port=389
+pki_ds_ldaps_port=636
+pki_ds_password=
+pki_ds_remove_data=True
+pki_ds_secure_connection=False
+pki_ds_secure_connection_ca_nickname=Directory Server CA certificate
+pki_ds_secure_connection_ca_pem_file=
+pki_group=pkiuser
+pki_hsm_enable=False
+pki_hsm_libfile=
+pki_hsm_modulename=
+pki_issuing_ca_hostname=%(pki_security_domain_hostname)s
+pki_issuing_ca_https_port=%(pki_security_domain_https_port)s
+pki_issuing_ca_uri=https://%(pki_issuing_ca_hostname)s:%(pki_issuing_ca_https_port)s
+pki_issuing_ca=%(pki_issuing_ca_uri)s
+pki_replication_password=
+pki_status_request_timeout=
+pki_restart_configured_instance=True
+pki_security_domain_hostname=%(pki_hostname)s
+pki_security_domain_https_port=8443
+pki_security_domain_name=%(pki_dns_domainname)s Security Domain
+pki_security_domain_password=
+pki_security_domain_user=caadmin
+pki_self_signed_token=internal
+#for supporting server cert SAN injection
+pki_san_inject=False
+pki_san_for_server_cert=
+pki_skip_configuration=False
+pki_skip_ds_verify=False
+pki_skip_installation=False
+pki_skip_sd_verify=False
+
+# DEPRECATED
+# Use 'pki_sslserver_*' instead.
+pki_ssl_server_key_algorithm=SHA256withRSA
+pki_ssl_server_key_size=2048
+pki_ssl_server_key_type=rsa
+pki_ssl_server_nickname=Server-Cert cert-%(pki_instance_name)s
+pki_ssl_server_subject_dn=cn=%(pki_hostname)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_ssl_server_token=
+
+pki_sslserver_key_algorithm=%(pki_ssl_server_key_algorithm)s
+pki_sslserver_key_size=%(pki_ssl_server_key_size)s
+pki_sslserver_key_type=%(pki_ssl_server_key_type)s
+pki_sslserver_nickname=%(pki_ssl_server_nickname)s
+pki_sslserver_subject_dn=%(pki_ssl_server_subject_dn)s
+pki_sslserver_token=%(pki_ssl_server_token)s
+
+pki_subsystem_key_algorithm=SHA256withRSA
+pki_subsystem_key_size=2048
+pki_subsystem_key_type=rsa
+pki_subsystem_nickname=subsystemCert cert-%(pki_instance_name)s
+pki_subsystem_subject_dn=cn=Subsystem Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_subsystem_token=
+
+pki_theme_enable=True
+pki_theme_server_dir=/usr/share/pki/common-ui
+pki_token_name=internal
+pki_token_password=
+pki_user=pkiuser
+pki_existing=False
+
+# DEPRECATED: Use 'pki_cert_chain_path' instead.
+pki_external_ca_cert_chain_path=%(pki_instance_configuration_path)s/external_ca_chain.cert
+pki_cert_chain_path=%(pki_external_ca_cert_chain_path)s
+
+# DEPRECATED: Use 'pki_cert_chain_nickname' instead.
+pki_external_ca_cert_chain_nickname=caSigningCert External CA
+pki_cert_chain_nickname=%(pki_external_ca_cert_chain_nickname)s
+
+pki_pkcs12_path=
+pki_pkcs12_password=
+
+# Paths:
+# These are used in the processing of pkispawn and are not supposed
+# to be overwritten by user configuration files.
+#
+pki_client_database_dir=%(pki_client_subsystem_dir)s/alias
+pki_client_subsystem_dir=%(pki_client_dir)s/%(pki_subsystem_type)s
+pki_client_password_conf=%(pki_client_subsystem_dir)s/password.conf
+pki_client_pkcs12_password_conf=%(pki_client_subsystem_dir)s/pkcs12_password.conf
+pki_client_admin_cert=%(pki_client_dir)s/%(pki_subsystem_type)s_admin.cert
+pki_source_conf_path=/usr/share/pki/%(pki_subsystem_type)s/conf
+pki_source_setup_path=/usr/share/pki/setup
+pki_source_server_path=/usr/share/pki/server/conf
+pki_source_cs_cfg=/usr/share/pki/%(pki_subsystem_type)s/conf/CS.cfg
+pki_source_registry=/usr/share/pki/setup/pkidaemon_registry
+pki_source_subsystem_path=/usr/share/pki/%(pki_subsystem_type)s
+pki_path=/var/lib/pki
+pki_log_path=/var/log/pki
+pki_configuration_path=/etc/pki
+pki_registry_path=/etc/sysconfig/pki
+pki_instance_path=%(pki_path)s/%(pki_instance_name)s
+pki_instance_log_path=%(pki_log_path)s/%(pki_instance_name)s
+pki_instance_configuration_path=%(pki_configuration_path)s/%(pki_instance_name)s
+pki_database_path=%(pki_instance_configuration_path)s/alias
+pki_instance_database_link=%(pki_instance_path)s/alias
+pki_instance_conf_link=%(pki_instance_path)s/conf
+pki_instance_logs_link=%(pki_instance_path)s/logs
+pki_subsystem_path=%(pki_instance_path)s/%(pki_subsystem_type)s
+pki_subsystem_log_path=%(pki_instance_log_path)s/%(pki_subsystem_type)s
+pki_subsystem_archive_log_path=%(pki_subsystem_log_path)s/archive
+pki_subsystem_configuration_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s
+pki_subsystem_database_link=%(pki_subsystem_path)s/alias
+pki_subsystem_conf_link=%(pki_subsystem_path)s/conf
+pki_subsystem_logs_link=%(pki_subsystem_path)s/logs
+pki_subsystem_registry_link=%(pki_subsystem_path)s/registry
+
+ 
+###############################################################################
+##  Tomcat Configuration:                                                    ##
+##                                                                           ##
+##  Values in this section are common to PKI subsystems that run             ##
+##  as an instance of 'Tomcat' (CA, KRA, OCSP, TKS, and TPS subsystems       ##
+##  including 'Clones', 'Subordinate CAs', and 'External CAs'), and contain  ##
+##  required information which MAY be overridden by users as necessary.      ##
+##                                                                           ##
+##  PKI CLONES:  To specify a 'CA Clone', a 'KRA Clone', an 'OCSP Clone',    ##
+##               a 'TKS Clone', or a 'TPS Clone', change the value of        ##
+##               'pki_clone' from 'False' to 'True'.                         ##
+##                                                                           ##
+##    REMINDER:  PKI CA Clones, Subordinate CAs, and External CAs            ##
+##               are MUTUALLY EXCLUSIVE entities!!!                          ##
+###############################################################################
+[Tomcat]
+pki_ajp_host=localhost
+pki_ajp_port=8009
+pki_server_pkcs12_path=
+pki_server_pkcs12_password=
+pki_server_external_certs_path=
+pki_clone=False
+pki_clone_pkcs12_password=
+pki_clone_pkcs12_path=
+pki_clone_replicate_schema=True
+pki_clone_replication_master_port=
+pki_clone_replication_clone_port=
+pki_clone_replication_security=None
+pki_clone_setup_replication=True
+pki_clone_reindex_data=False
+pki_master_hostname=%(pki_security_domain_hostname)s
+pki_master_https_port=%(pki_security_domain_https_port)s
+pki_clone_uri=https://%(pki_master_hostname)s:%(pki_master_https_port)s
+pki_enable_access_log=True
+pki_enable_java_debugger=False
+pki_enable_on_system_boot=True
+pki_enable_proxy=False
+pki_proxy_http_port=80
+pki_proxy_https_port=443
+pki_security_manager=true
+pki_tomcat_server_port=8005
+
+# Paths
+# These are used in the processing of pkispawn and are not supposed
+# to be overwritten by user configuration files.
+#
+pki_systemd_service=/lib/systemd/system/pki-tomcatd@.service
+pki_systemd_target=/lib/systemd/system/pki-tomcatd.target
+pki_systemd_target_wants=/etc/systemd/system/pki-tomcatd.target.wants
+pki_systemd_service_link=%(pki_systemd_target_wants)s/pki-tomcatd@%(pki_instance_name)s.service
+pki_cgroup_systemd_service_path=/sys/fs/cgroup/systemd/system/%(pki_systemd_service)s
+pki_cgroup_systemd_service=%(pki_cgroup_systemd_service_path)s/%(pki_instance_name)s
+pki_cgroup_cpu_systemd_service_path=/sys/fs/cgroup/cpu\,cpuacct/system/%(pki_systemd_service)s
+pki_cgroup_cpu_systemd_service=%(pki_cgroup_cpu_systemd_service_path)s/%(pki_systemd_service)s
+
+CATALINA_HOME=/usr/share/tomcat
+pki_tomcat_bin_path=%(CATALINA_HOME)s/bin
+pki_tomcat_lib_path=%(CATALINA_HOME)s/lib
+
+pki_tomcat_systemd=/usr/sbin/tomcat
+pki_source_server_xml=%(pki_source_server_path)s/server.xml
+pki_source_context_xml=%(pki_source_server_path)s/context.xml
+pki_source_tomcat_conf=%(pki_source_server_path)s/tomcat.conf
+pki_instance_type=Tomcat
+pki_tomcat_common_path=%(pki_instance_path)s/common
+pki_tomcat_common_lib_path=%(pki_tomcat_common_path)s/lib
+pki_tomcat_tmpdir_path=%(pki_instance_path)s/temp
+pki_tomcat_webapps_path=%(pki_instance_path)s/webapps
+pki_tomcat_common_webapps_path=%(pki_instance_path)s/common/webapps
+pki_tomcat_work_path=%(pki_instance_path)s/work
+pki_tomcat_work_catalina_path=%(pki_tomcat_work_path)s/Catalina
+pki_tomcat_work_catalina_host_path=%(pki_tomcat_work_catalina_path)s/localhost
+pki_tomcat_work_catalina_host_run_path=%(pki_tomcat_work_catalina_host_path)s/_
+pki_tomcat_work_catalina_host_subsystem_path=%(pki_tomcat_work_catalina_host_path)s/%(pki_subsystem_type)s
+pki_instance_conf_log4j_properties=%(pki_instance_configuration_path)s/log4j.properties
+pki_instance_type_registry_path=%(pki_registry_path)s/tomcat
+pki_instance_registry_path=%(pki_instance_type_registry_path)s/%(pki_instance_name)s
+pki_subsystem_registry_path=%(pki_instance_registry_path)s/%(pki_subsystem_type)s
+pki_tomcat_bin_link=%(pki_instance_path)s/bin
+pki_instance_lib=%(pki_instance_path)s/lib
+pki_instance_lib_log4j_properties=%(pki_instance_lib)s/log4j.properties
+pki_instance_systemd_link=%(pki_instance_path)s/%(pki_instance_name)s
+pki_subsystem_signed_audit_log_path=%(pki_subsystem_log_path)s/signedAudit
+pki_tomcat_subsystem_webapps_path=%(pki_subsystem_path)s/webapps
+pki_tomcat_webapps_subsystem_path=%(pki_tomcat_subsystem_webapps_path)s/%(pki_subsystem_type)s
+pki_tomcat_webapps_subsystem_webinf_classes_path=%(pki_tomcat_webapps_subsystem_path)s/WEB-INF/classes
+pki_tomcat_webapps_subsystem_webinf_lib_path=%(pki_tomcat_webapps_subsystem_path)s/WEB-INF/lib
+
+
+###############################################################################
+##  CA Configuration:                                                        ##
+##                                                                           ##
+##  Values in this section are common to CA subsystems including 'PKI CAs',  ##
+##  'Cloned CAs', 'Subordinate CAs', and 'External CAs', and contain         ##
+##  required information which MAY be overridden by users as necessary.      ##
+##                                                                           ##
+##     EXTERNAL CAs:  To specify an 'External CA', change the value          ##
+##                    of 'pki_external' from 'False' to 'True'.              ##
+##                                                                           ##
+##  SUBORDINATE CAs:  To specify a 'Subordinate CA', change the value        ##
+##                    of 'pki_subordinate' from 'False' to 'True'.           ##
+##                                                                           ##
+##         REMINDER:  PKI CA Clones, Subordinate CAs, and External CAs       ##
+##                    are MUTUALLY EXCLUSIVE entities!!!                     ##
+###############################################################################
+[CA]
+pki_ca_signing_key_algorithm=SHA256withRSA
+pki_ca_signing_key_size=2048
+pki_ca_signing_key_type=rsa
+pki_ca_signing_record_create=True
+pki_ca_signing_serial_number=1
+pki_ca_signing_signing_algorithm=SHA256withRSA
+pki_ca_signing_subject_dn=cn=CA Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_ca_signing_token=
+
+# DEPRECATED: Use 'pki_ca_signing_csr_path' instead.
+pki_external_csr_path=
+pki_ca_signing_csr_path=%(pki_external_csr_path)s
+
+pki_ocsp_signing_csr_path=
+pki_audit_signing_csr_path=
+pki_sslserver_csr_path=
+pki_subsystem_csr_path=
+
+pki_ocsp_signing_cert_path=
+pki_audit_signing_cert_path=
+pki_sslserver_cert_path=
+pki_subsystem_cert_path=
+
+pki_ca_starting_crl_number=0
+pki_external=False
+pki_req_ext_add=False
+# MS subca request ext data
+pki_req_ext_oid=1.3.6.1.4.1.311.20.2
+pki_req_ext_critical=False
+pki_req_ext_data=1E0A00530075006200430041
+pki_external_step_two=False
+
+pki_external_pkcs12_path=%(pki_pkcs12_path)s
+pki_external_pkcs12_password=%(pki_pkcs12_password)s
+pki_import_admin_cert=False
+
+pki_ocsp_signing_key_algorithm=SHA256withRSA
+pki_ocsp_signing_key_size=2048
+pki_ocsp_signing_key_type=rsa
+pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s CA
+pki_ocsp_signing_signing_algorithm=SHA256withRSA
+pki_ocsp_signing_subject_dn=cn=CA OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_ocsp_signing_token=
+
+pki_profiles_in_ldap=False
+pki_random_serial_numbers_enable=False
+pki_subordinate=False
+pki_subordinate_create_new_security_domain=False
+pki_subordinate_security_domain_name=%(pki_dns_domainname)s Subordinate Security Domain
+
+pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
+pki_admin_name=%(pki_admin_uid)s
+pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
+pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_admin_uid=caadmin
+
+pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s CA
+pki_audit_signing_subject_dn=cn=CA Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+
+pki_ds_base_dn=o=%(pki_instance_name)s-CA
+pki_ds_database=%(pki_instance_name)s-CA
+pki_ds_hostname=%(pki_hostname)s
+pki_subsystem_name=CA %(pki_hostname)s %(pki_https_port)s
+pki_share_db=False
+pki_master_crl_enable=True
+
+# Default OCSP URI added by AuthInfoAccessExtDefault if the profile
+# config is blank.  If both are blank, the value is constructed
+# based on the CMS hostname and port.
+pki_default_ocsp_uri=
+
+# Paths
+# These are used in the processing of pkispawn and are not supposed
+# to be overwritten by user configuration files.
+#
+pki_source_emails=/usr/share/pki/ca/emails
+pki_source_flatfile_txt=%(pki_source_conf_path)s/flatfile.txt
+pki_source_profiles=/usr/share/pki/ca/profiles
+pki_source_proxy_conf=%(pki_source_conf_path)s/proxy.conf
+pki_source_registry_cfg=%(pki_source_conf_path)s/registry.cfg
+pki_source_admincert_profile=%(pki_source_conf_path)s/%(pki_admin_key_type)sAdminCert.profile
+pki_source_caauditsigningcert_profile=%(pki_source_conf_path)s/caAuditSigningCert.profile
+pki_source_cacert_profile=%(pki_source_conf_path)s/caCert.profile
+pki_source_caocspcert_profile=%(pki_source_conf_path)s/caOCSPCert.profile
+pki_source_servercert_profile=%(pki_source_conf_path)s/%(pki_sslserver_key_type)sServerCert.profile
+pki_source_subsystemcert_profile=%(pki_source_conf_path)s/%(pki_subsystem_key_type)sSubsystemCert.profile
+pki_subsystem_emails_path=%(pki_subsystem_path)s/emails
+pki_subsystem_profiles_path=%(pki_subsystem_path)s/profiles
+
+pki_serial_number_range_start=1
+pki_serial_number_range_end=10000000
+pki_request_number_range_start=1
+pki_request_number_range_end=10000000
+pki_replica_number_range_start=1
+pki_replica_number_range_end=100
+
+
+###############################################################################
+##  KRA Configuration:                                                       ##
+##                                                                           ##
+##  Values in this section are common to KRA subsystems                      ##
+##  including 'PKI KRAs', 'Cloned KRAs', and 'Stand-alone KRAs' and contain  ##
+##  required information which MAY be overridden by users as necessary.      ##
+##                                                                           ##
+##      STAND-ALONE KRAs:  To specify a 'Stand-alone KRA', change the value  ##
+##                         of 'pki_standalone' from 'False' to 'True', and   ##
+##                         specify the various 'pki_external' parameters     ##
+##                         as appropriate.                                   ##
+##                                                                           ##
+###############################################################################
+[KRA]
+pki_import_admin_cert=True
+pki_standalone=False
+pki_kra_ephemeral_requests=False
+
+# DEPRECATED
+# Use 'pki_*_csr_path' instead.
+pki_external_admin_csr_path=
+pki_external_audit_signing_csr_path=
+pki_external_sslserver_csr_path=
+pki_external_storage_csr_path=
+pki_external_subsystem_csr_path=
+pki_external_transport_csr_path=
+
+pki_admin_csr_path=%(pki_external_admin_csr_path)s
+pki_audit_signing_csr_path=%(pki_external_audit_signing_csr_path)s
+pki_sslserver_csr_path=%(pki_external_sslserver_csr_path)s
+pki_storage_csr_path=%(pki_external_storage_csr_path)s
+pki_subsystem_csr_path=%(pki_external_subsystem_csr_path)s
+pki_transport_csr_path=%(pki_external_transport_csr_path)s
+
+pki_external_step_two=False
+
+# DEPRECATED
+# Use 'pki_*_cert_path' instead.
+pki_external_admin_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_admin.cert
+pki_external_audit_signing_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_audit_signing.cert
+pki_external_sslserver_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_sslserver.cert
+pki_external_storage_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_storage.cert
+pki_external_subsystem_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_subsystem.cert
+pki_external_transport_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_transport.cert
+
+pki_admin_cert_path=%(pki_external_admin_cert_path)s
+pki_audit_signing_cert_path=%(pki_external_audit_signing_cert_path)s
+pki_sslserver_cert_path=%(pki_external_sslserver_cert_path)s
+pki_storage_cert_path=%(pki_external_storage_cert_path)s
+pki_subsystem_cert_path=%(pki_external_subsystem_cert_path)s
+pki_transport_cert_path=%(pki_external_transport_cert_path)s
+
+pki_storage_key_algorithm=SHA256withRSA
+pki_storage_key_size=2048
+pki_storage_key_type=rsa
+pki_storage_nickname=storageCert cert-%(pki_instance_name)s KRA
+pki_storage_signing_algorithm=SHA256withRSA
+pki_storage_subject_dn=cn=DRM Storage Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_storage_token=
+
+pki_transport_key_algorithm=SHA256withRSA
+pki_transport_key_size=2048
+pki_transport_key_type=rsa
+pki_transport_nickname=transportCert cert-%(pki_instance_name)s KRA
+pki_transport_signing_algorithm=SHA256withRSA
+pki_transport_subject_dn=cn=DRM Transport Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_transport_token=
+
+pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
+pki_admin_name=%(pki_admin_uid)s
+pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
+pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_admin_uid=kraadmin
+
+pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s KRA
+pki_audit_signing_subject_dn=cn=KRA Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+
+pki_ds_base_dn=o=%(pki_instance_name)s-KRA
+pki_ds_database=%(pki_instance_name)s-KRA
+pki_ds_hostname=%(pki_hostname)s
+pki_subsystem_name=KRA %(pki_hostname)s %(pki_https_port)s
+pki_share_db=True
+pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
+
+###############################################################################
+##  OCSP Configuration:                                                      ##
+##                                                                           ##
+##  Values in this section are common to OCSP subsystems                     ##
+##  including 'PKI OCSPs', 'Cloned OCSPs', and 'Stand-alone OCSPs' and       ##
+##  contain required information which MAY be overridden by users as         ##
+##  necessary.                                                               ##
+##                                                                           ##
+##      STAND-ALONE OCSPs:  To specify a 'Stand-alone OCSP', change the      ##
+##                          value of 'pki_standalone' from 'False' to        ##
+##                          'True', and specify the various 'pki_external'   ##
+##                          parameters as appropriate.                       ##
+##                          (NOTE:  Stand-alone OCSP is not yet supported!)  ##
+##                                                                           ##
+###############################################################################
+[OCSP]
+pki_import_admin_cert=True
+pki_standalone=False
+
+# DEPRECATED
+# Use 'pki_*_csr_path' instead.
+pki_external_admin_csr_path=
+pki_external_audit_signing_csr_path=
+pki_external_signing_csr_path=
+pki_external_sslserver_csr_path=
+pki_external_subsystem_csr_path=
+
+pki_admin_csr_path=%(pki_external_admin_csr_path)s
+pki_audit_signing_csr_path=%(pki_external_audit_signing_csr_path)s
+pki_ocsp_signing_csr_path =%(pki_external_signing_csr_path)s
+pki_sslserver_csr_path=%(pki_external_sslserver_csr_path)s
+pki_subsystem_csr_path=%(pki_external_subsystem_csr_path)s
+
+pki_external_step_two=False
+
+# DEPRECATED
+# Use 'pki_*_cert_path' instead.
+pki_external_admin_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_admin.cert
+pki_external_audit_signing_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_audit_signing.cert
+pki_external_signing_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_signing.cert
+pki_external_sslserver_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_sslserver.cert
+pki_external_subsystem_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_subsystem.cert
+
+pki_admin_cert_path=%(pki_external_admin_cert_path)s
+pki_audit_signing_cert_path=%(pki_external_audit_signing_cert_path)s
+pki_ocsp_signing_cert_path=%(pki_external_signing_cert_path)s
+pki_sslserver_cert_path=%(pki_external_sslserver_cert_path)s
+pki_subsystem_cert_path=%(pki_external_subsystem_cert_path)s
+
+pki_ocsp_signing_key_algorithm=SHA256withRSA
+pki_ocsp_signing_key_size=2048
+pki_ocsp_signing_key_type=rsa
+pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s OCSP
+pki_ocsp_signing_signing_algorithm=SHA256withRSA
+pki_ocsp_signing_subject_dn=cn=OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_ocsp_signing_token=
+
+pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
+pki_admin_name=%(pki_admin_uid)s
+pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
+pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_admin_uid=ocspadmin
+
+pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s OCSP
+pki_audit_signing_subject_dn=cn=OCSP Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+
+pki_ds_base_dn=o=%(pki_instance_name)s-OCSP
+pki_ds_database=%(pki_instance_name)s-OCSP
+pki_ds_hostname=%(pki_hostname)s
+pki_subsystem_name=OCSP %(pki_hostname)s %(pki_https_port)s
+pki_share_db=True
+pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
+
+
+###############################################################################
+##  RA Configuration:                                                        ##
+##                                                                           ##
+##  Values in this section are common to PKI RA subsystems, and contain      ##
+##  required information which MAY be overridden by users as necessary.      ##
+###############################################################################
+[RA]
+
+###############################################################################
+##  TKS Configuration:                                                       ##
+##                                                                           ##
+##  Values in this section are common to TKS subsystems                      ##
+##  including 'PKI TKSs' and 'Cloned TKSs', and contain                      ##
+##  required information which MAY be overridden by users as necessary.      ##
+###############################################################################
+[TKS]
+pki_import_admin_cert=True
+pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
+pki_admin_name=%(pki_admin_uid)s
+pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
+pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_admin_uid=tksadmin
+pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s TKS
+pki_audit_signing_subject_dn=cn=TKS Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_ds_base_dn=o=%(pki_instance_name)s-TKS
+pki_ds_database=%(pki_instance_name)s-TKS
+pki_ds_hostname=%(pki_hostname)s
+pki_subsystem_name=TKS %(pki_hostname)s %(pki_https_port)s
+pki_share_db=True
+pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
+
+###############################################################################
+##  TPS Configuration:                                                       ##
+##                                                                           ##
+##  Values in this section are common to PKI TPS subsystems, and contain     ##
+##  required information which MAY be overridden by users as necessary.      ##
+###############################################################################
+[TPS]
+pki_import_admin_cert=True
+pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
+pki_admin_name=%(pki_admin_uid)s
+pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
+pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_admin_uid=tpsadmin
+pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s TPS
+pki_audit_signing_subject_dn=cn=TPS Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_ds_base_dn=o=%(pki_instance_name)s-TPS
+pki_ds_database=%(pki_instance_name)s-TPS
+pki_ds_hostname=%(pki_hostname)s
+pki_subsystem_name=TPS %(pki_hostname)s %(pki_https_port)s
+pki_authdb_hostname=%(pki_hostname)s
+pki_authdb_port=389
+pki_authdb_secure_conn=False
+pki_ca_uri=https://%(pki_hostname)s:%(pki_https_port)s
+pki_kra_uri=https://%(pki_hostname)s:%(pki_https_port)s
+pki_tks_uri=https://%(pki_hostname)s:%(pki_https_port)s
+pki_enable_server_side_keygen=False
+pki_import_shared_secret=False
+pki_share_db=True
+pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
+pki_source_phone_home_xml=/usr/share/pki/%(pki_subsystem_type)s/conf/phoneHome.xml
+pki_source_registry_cfg=%(pki_source_conf_path)s/registry.cfg
+
+# Paths
+# These are used in the processing of pkispawn and are not supposed
+# to be overwritten by user configuration files.
+#
+pki_subsystem_signed_audit_log_path=%(pki_subsystem_log_path)s/signedAudit
+

--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -1,37 +1,88 @@
+#
+# Dogtag PKI configuration file
+#
+# Note: "%" must be quoted as "%%".
+#
+
 [DEFAULT]
+ipa_admin_email=root@localhost
+# default algorithms for all certificates
+ipa_key_algorithm=SHA256withRSA
+ipa_key_size=2048
+ipa_key_type=rsa
+ipa_signing_algorithm=SHA256withRSA
+
+# Used for IPA CA
+# signing algorithm can be overriden on command line
+ipa_ca_signing_algorithm=%(ipa_key_algorithm)s
+ipa_ca_key_size=%(ipa_key_size)s
+ipa_ca_key_type=%(ipa_key_type)s
+
+# hard-coded IPA default settings
+ipa_security_domain_name=IPA
+ipa_ds_database=ipaca
+ipa_ds_base_dn=o=%(ipa_ds_database)s
+ipa_admin_user=admin
+ipa_admin_nickname=ipa-ca-agent
+ipa_ca_pem_file=/etc/ipa/ca.crt
+
+# dynamic values
+ipa_ca_subject=
+ipa_subject_base=
+ipa_fqdn=
+ipa_ocsp_uri=
+ipa_admin_cert_p12=
+ipa_master_host=
+ipa_clone_uri=
+
+# sensitive dynamic values
+pki_admin_password=
+pki_ds_password=
+pki_token_password=
+
+# HSM support
+ipa_backup_keys=True
+ipa_hsm_enable=False
+ipa_hsm_libfile=
+ipa_hsm_modulename=
+ipa_token_name=internal
+
+# Dogtag defaults
+pki_instance_name=pki-tomcat
+pki_configuration_path=/etc/pki
+pki_instance_configuration_path=%(pki_configuration_path)s/%(pki_instance_name)s
+
 pki_admin_cert_file=%(pki_client_dir)s/ca_admin.cert
 pki_admin_cert_request_type=pkcs10
 pki_admin_dualkey=False
-pki_admin_key_algorithm=SHA256withRSA
-pki_admin_key_size=2048
-pki_admin_key_type=rsa
-pki_admin_password=
+pki_admin_key_algorithm=%(ipa_key_algorithm)s
+pki_admin_key_size=%(ipa_key_size)s
+pki_admin_key_type=%(ipa_key_type)s
 
 pki_audit_group=pkiaudit
-pki_audit_signing_key_algorithm=SHA256withRSA
-pki_audit_signing_key_size=2048
-pki_audit_signing_key_type=rsa
-pki_audit_signing_signing_algorithm=SHA256withRSA
-pki_audit_signing_token=
+pki_audit_signing_key_algorithm=%(ipa_key_algorithm)s
+pki_audit_signing_key_size=%(ipa_key_size)s
+pki_audit_signing_key_type=%(ipa_key_type)s
+pki_audit_signing_signing_algorithm=%(ipa_signing_algorithm)s
+pki_audit_signing_token=%(ipa_token_name)s
 
-pki_backup_keys=False
-pki_backup_password=
+pki_backup_keys=True
+pki_backup_password=%(pki_admin_password)s
 pki_ca_hostname=%(pki_security_domain_hostname)s
 pki_ca_port=%(pki_security_domain_https_port)s
 
-pki_ca_signing_nickname=caSigningCert cert-%(pki_instance_name)s CA
+# nickname and subject are hard-coded
+pki_ca_signing_nickname=caSigningCert cert-pki-ca
 pki_ca_signing_cert_path=%(pki_instance_configuration_path)s/external_ca.cert
 
-pki_client_admin_cert_p12=%(pki_client_dir)s/%(pki_subsystem_type)s_admin_cert.p12
+pki_client_admin_cert_p12=%(ipa_admin_cert_p12)s
 pki_client_database_password=
 pki_client_database_purge=True
 pki_client_dir=%(home_dir)s/.dogtag/%(pki_instance_name)s
-pki_client_pkcs12_password=
+pki_client_pkcs12_password=%(pki_admin_password)s
 pki_ds_bind_dn=cn=Directory Manager
-pki_ds_create_new_db=True
 pki_ds_ldap_port=389
 pki_ds_ldaps_port=636
-pki_ds_password=
 pki_ds_remove_data=True
 pki_ds_secure_connection=False
 pki_ds_secure_connection_ca_nickname=Directory Server CA certificate
@@ -42,16 +93,34 @@ pki_hsm_libfile=
 pki_hsm_modulename=
 pki_issuing_ca_hostname=%(pki_security_domain_hostname)s
 pki_issuing_ca_https_port=%(pki_security_domain_https_port)s
-pki_issuing_ca_uri=https://%(pki_issuing_ca_hostname)s:%(pki_issuing_ca_https_port)s
+pki_issuing_ca_uri=https://%(ipa_fqdn)s:443
 pki_issuing_ca=%(pki_issuing_ca_uri)s
 pki_replication_password=
-pki_status_request_timeout=
-pki_restart_configured_instance=True
-pki_security_domain_hostname=%(pki_hostname)s
-pki_security_domain_https_port=8443
-pki_security_domain_name=%(pki_dns_domainname)s Security Domain
-pki_security_domain_password=
-pki_security_domain_user=caadmin
+
+# Configures the status request timeout, i.e. the connect/data
+# timeout on the HTTP request to get the status of Dogtag.
+#
+# This configuration is needed in "multiple IP address" scenarios
+# where this server's hostname has multiple IP addresses but the
+# HTTP server is only listening on one of them.  Without a timeout,
+# if a "wrong" IP address is tried first, it will take a long time
+# to timeout, exceeding the overall timeout hence the request will
+# not be re-tried.  Setting a shorter timeout allows the request
+# to be re-tried.
+#
+# Note that HSMs cause different behaviour so this value might
+# not be suitable for when we implement HSM support.  It is
+# known that a value of 5s is too short in HSM environment.
+#
+pki_status_request_timeout=15
+
+pki_enable_proxy=True
+pki_restart_configured_instance=False
+pki_security_domain_hostname=%(ipa_fqdn)s
+pki_security_domain_https_port=443
+pki_security_domain_name=%(ipa_security_domain_name)s
+pki_security_domain_password=%(pki_admin_password)s
+pki_security_domain_user=%(ipa_admin_user)s
 pki_self_signed_token=internal
 
 # for supporting server cert SAN injection
@@ -62,24 +131,26 @@ pki_skip_ds_verify=False
 pki_skip_installation=False
 pki_skip_sd_verify=False
 
-pki_sslserver_key_algorithm=SHA256withRSA
-pki_sslserver_key_size=2048
-pki_sslserver_key_type=rsa
-pki_sslserver_nickname=Server-Cert cert-%(pki_instance_name)s
-pki_sslserver_subject_dn=cn=%(pki_hostname)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_sslserver_token=
+pki_sslserver_key_algorithm=%(ipa_key_algorithm)s
+pki_sslserver_key_size=%(ipa_key_size)s
+pki_sslserver_key_type=%(ipa_key_type)s
+pki_sslserver_token=internal
+# nickname and subject are hard-coded
+pki_sslserver_nickname=Server-Cert cert-pki-ca
+pki_sslserver_subject_dn=cn=%(ipa_fqdn)s,%(ipa_subject_base)s
 
-pki_subsystem_key_algorithm=SHA256withRSA
-pki_subsystem_key_size=2048
-pki_subsystem_key_type=rsa
-pki_subsystem_nickname=subsystemCert cert-%(pki_instance_name)s
-pki_subsystem_subject_dn=cn=Subsystem Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_subsystem_token=
+pki_subsystem_key_algorithm=%(ipa_key_algorithm)s
+pki_subsystem_key_size=%(ipa_key_size)s
+pki_subsystem_key_type=%(ipa_key_type)s
+pki_subsystem_token=%(ipa_token_name)s
+# nickname and subject are hard-coded
+pki_subsystem_nickname=subsystemCert cert-pki-ca
+pki_subsystem_subject_dn=cn=CA Subsystem,%(ipa_subject_base)s
 
 pki_theme_enable=True
 pki_theme_server_dir=/usr/share/pki/common-ui
-pki_token_name=internal
-pki_token_password=
+pki_token_name=%(ipa_token_name)s
+# pki_token_password
 pki_user=pkiuser
 pki_existing=False
 
@@ -89,18 +160,21 @@ pki_cert_chain_nickname=caSigningCert External CA
 pki_pkcs12_path=
 pki_pkcs12_password=
 
+pki_ds_base_dn=%(ipa_ds_base_dn)s
+pki_ds_database=%(ipa_ds_database)s
+pki_ds_hostname=%(ipa_fqdn)s
+
 
 [CA]
-pki_ca_signing_key_algorithm=SHA256withRSA
-pki_ca_signing_key_size=2048
-pki_ca_signing_key_type=rsa
+pki_ca_signing_key_algorithm=%(ipa_ca_signing_algorithm)s
+pki_ca_signing_key_size=%(ipa_ca_key_size)s
+pki_ca_signing_key_type=%(ipa_ca_key_type)s
 pki_ca_signing_record_create=True
 pki_ca_signing_serial_number=1
-pki_ca_signing_signing_algorithm=SHA256withRSA
-pki_ca_signing_subject_dn=cn=CA Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_ca_signing_token=
+pki_ca_signing_signing_algorithm=%(ipa_ca_signing_algorithm)s
+pki_ca_signing_subject_dn=%(ipa_ca_subject)s
+pki_ca_signing_token=%(ipa_token_name)s
 
-# DEPRECATED: Use 'pki_ca_signing_csr_path' instead.
 pki_ca_signing_csr_path=%(pki_instance_configuration_path)s/external_ca.csr
 
 pki_ocsp_signing_csr_path=
@@ -126,37 +200,35 @@ pki_external_pkcs12_path=%(pki_pkcs12_path)s
 pki_external_pkcs12_password=%(pki_pkcs12_password)s
 pki_import_admin_cert=False
 
-pki_ocsp_signing_key_algorithm=SHA256withRSA
-pki_ocsp_signing_key_size=2048
-pki_ocsp_signing_key_type=rsa
-pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s CA
-pki_ocsp_signing_signing_algorithm=SHA256withRSA
-pki_ocsp_signing_subject_dn=cn=CA OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_ocsp_signing_token=
+pki_ocsp_signing_key_algorithm=%(ipa_key_algorithm)s
+pki_ocsp_signing_key_size=%(ipa_key_size)s
+pki_ocsp_signing_key_type=%(ipa_key_type)s
+pki_ocsp_signing_signing_algorithm=%(ipa_signing_algorithm)s
+pki_ocsp_signing_token=%(ipa_token_name)s
+# nickname and subject are hard-coded
+pki_ocsp_signing_nickname=ocspSigningCert cert-pki-ca
+pki_ocsp_signing_subject_dn=cn=OCSP Subsystem,%(ipa_subject_base)s
 
-pki_profiles_in_ldap=False
+pki_profiles_in_ldap=True
 pki_random_serial_numbers_enable=False
 pki_subordinate=False
 pki_subordinate_create_new_security_domain=False
 pki_subordinate_security_domain_name=%(pki_dns_domainname)s Subordinate Security Domain
 
-pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
-pki_admin_name=%(pki_admin_uid)s
-pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
-pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_admin_uid=caadmin
+pki_admin_email=%(ipa_admin_email)s
+pki_admin_name=%(ipa_admin_user)s
+pki_admin_nickname=%(ipa_admin_nickname)s
+pki_admin_subject_dn=cn=%(ipa_admin_nickname)s,%(ipa_subject_base)s
+pki_admin_uid=%(ipa_admin_user)s
 
-pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s CA
-pki_audit_signing_subject_dn=cn=CA Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+# nickname and subject are hard-coded
+pki_audit_signing_nickname=auditSigningCert cert-pki-ca
+pki_audit_signing_subject_dn=cn=CA Audit,%(ipa_subject_base)s
 
-pki_ds_base_dn=o=%(pki_instance_name)s-CA
-pki_ds_database=%(pki_instance_name)s-CA
-pki_ds_hostname=%(pki_hostname)s
-pki_subsystem_name=CA %(pki_hostname)s %(pki_https_port)s
 pki_share_db=False
 pki_master_crl_enable=True
 
-pki_default_ocsp_uri=
+pki_default_ocsp_uri=%(ipa_ocsp_uri)s
 
 pki_serial_number_range_start=1
 pki_serial_number_range_end=10000000
@@ -169,52 +241,49 @@ pki_replica_number_range_end=100
 [KRA]
 pki_import_admin_cert=True
 pki_standalone=False
-pki_kra_ephemeral_requests=False
+pki_kra_ephemeral_requests=True
+pki_ds_create_new_db=True
 
-pki_admin_csr_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_admin.csr
-pki_audit_signing_csr_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_audit_signing.csr
-pki_sslserver_csr_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_sslserver.csr
-pki_storage_csr_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_storage.csr
-pki_subsystem_csr_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_subsystem.csr
-pki_transport_csr_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_transport.csr
+# pki_admin_csr_path=
+# pki_audit_signing_csr_path=
+# pki_sslserver_csr_path=
+# pki_storage_csr_path=
+# pki_subsystem_csr_path=
+# pki_transport_csr_path=
 
 pki_external_step_two=False
 
-pki_admin_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_admin.cert
-pki_audit_signing_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_audit_signing.cert
-pki_sslserver_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_sslserver.cert
-pki_storage_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_storage.cert
-pki_subsystem_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_subsystem.cert
-pki_transport_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_transport.cert
+# pki_admin_cert_path=
+# pki_audit_signing_cert_path=
+# pki_sslserver_cert_path=
+# pki_storage_cert_path=
+# pki_subsystem_cert_path=
+# pki_transport_cert_path=
 
-pki_storage_key_algorithm=SHA256withRSA
-pki_storage_key_size=2048
-pki_storage_key_type=rsa
-pki_storage_nickname=storageCert cert-%(pki_instance_name)s KRA
+pki_storage_key_algorithm=%(ipa_key_algorithm)s
+pki_storage_key_size=%(ipa_key_size)s
+pki_storage_key_type=%(ipa_key_type)s
+pki_storage_nickname=storageCert cert-pki-kra
 pki_storage_signing_algorithm=SHA256withRSA
-pki_storage_subject_dn=cn=DRM Storage Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_storage_token=
+pki_storage_subject_dn=cn=KRA Storage Certificate,%(ipa_subject_base)s
+pki_storage_token=%(ipa_token_name)s
 
-pki_transport_key_algorithm=SHA256withRSA
-pki_transport_key_size=2048
-pki_transport_key_type=rsa
-pki_transport_nickname=transportCert cert-%(pki_instance_name)s KRA
+pki_transport_key_algorithm=%(ipa_key_algorithm)s
+pki_transport_key_size=%(ipa_key_size)s
+pki_transport_key_type=%(ipa_key_type)s
+pki_transport_nickname=transportCert cert-pki-kra
 pki_transport_signing_algorithm=SHA256withRSA
-pki_transport_subject_dn=cn=DRM Transport Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_transport_token=
+pki_transport_subject_dn=cn=KRA Transport Certificate,%(ipa_subject_base)s
+pki_transport_token=%(ipa_token_name)s
 
-pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
-pki_admin_name=%(pki_admin_uid)s
-pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
-pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_admin_uid=kraadmin
+pki_admin_email=%(ipa_admin_email)s
+pki_admin_name=%(ipa_admin_user)s
+pki_admin_nickname=%(ipa_admin_nickname)s
+pki_admin_subject_dn=cn=%(ipa_admin_nickname)s,%(ipa_subject_base)s
+pki_admin_uid=%(ipa_admin_user)s
 
-pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s KRA
-pki_audit_signing_subject_dn=cn=KRA Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_audit_signing_nickname=auditSigningCert cert-pki-kra
+pki_audit_signing_subject_dn=cn=KRA Audit,%(ipa_subject_base)s
 
-pki_ds_base_dn=o=%(pki_instance_name)s-KRA
-pki_ds_database=%(pki_instance_name)s-KRA
-pki_ds_hostname=%(pki_hostname)s
-pki_subsystem_name=KRA %(pki_hostname)s %(pki_https_port)s
 pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
+pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(ipa_ds_database)s

--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -1,28 +1,16 @@
 #
 # Dogtag PKI configuration file
 #
+# The ipaca_default.ini contains hard-coded defaults that cannot be modified
+# by a user without breaking FreeIPA internals.
+#
 # Note: "%" must be quoted as "%%".
 #
 
 [DEFAULT]
-ipa_admin_email=root@localhost
-
-# default algorithms for all certificates
-ipa_key_algorithm=SHA256withRSA
-ipa_key_size=2048
-ipa_key_type=rsa
-ipa_signing_algorithm=SHA256withRSA
-
-# Used for IPA CA
-# signing algorithm can be overriden on command line
-ipa_ca_signing_algorithm=%(ipa_key_algorithm)s
-ipa_ca_key_size=%(ipa_key_size)s
-ipa_ca_key_type=%(ipa_key_type)s
-
 # hard-coded IPA default settings
 ipa_security_domain_name=IPA
 ipa_ds_database=ipaca
-ipa_admin_user=admin
 ipa_admin_nickname=ipa-ca-agent
 ipa_ca_pem_file=/etc/ipa/ca.crt
 
@@ -33,20 +21,11 @@ ipa_ca_pem_file=/etc/ipa/ca.crt
 # ipa_fqdn=
 # ipa_ocsp_uri=
 # ipa_admin_cert_p12=
+# ipa_admin_user=
 
 # sensitive dynamic values
 # pki_admin_password=
 # pki_ds_password=
-# pki_token_password=
-
-# HSM support
-pki_hsm_enable=False
-pki_hsm_libfile=
-pki_hsm_modulename=
-pki_token_name=internal
-# backup is automatically disabled when HSM support is enabled
-pki_backup_keys=True
-pki_backup_password=%(pki_admin_password)s
 
 # Dogtag defaults
 pki_instance_name=pki-tomcat
@@ -56,16 +35,10 @@ pki_instance_configuration_path=%(pki_configuration_path)s/%(pki_instance_name)s
 pki_admin_cert_file=%(pki_client_dir)s/ca_admin.cert
 pki_admin_cert_request_type=pkcs10
 pki_admin_dualkey=False
-pki_admin_key_algorithm=%(ipa_key_algorithm)s
-pki_admin_key_size=%(ipa_key_size)s
-pki_admin_key_type=%(ipa_key_type)s
-
-pki_audit_group=pkiaudit
-pki_audit_signing_key_algorithm=%(ipa_key_algorithm)s
-pki_audit_signing_key_size=%(ipa_key_size)s
-pki_audit_signing_key_type=%(ipa_key_type)s
-pki_audit_signing_signing_algorithm=%(ipa_signing_algorithm)s
-pki_audit_signing_token=%(pki_token_name)s
+pki_admin_name=%(ipa_admin_user)s
+pki_admin_nickname=%(ipa_admin_nickname)s
+pki_admin_subject_dn=cn=%(ipa_admin_nickname)s,%(ipa_subject_base)s
+pki_admin_uid=%(ipa_admin_user)s
 
 pki_ca_hostname=%(pki_security_domain_hostname)s
 pki_ca_port=%(pki_security_domain_https_port)s
@@ -86,30 +59,12 @@ pki_ds_remove_data=True
 pki_ds_secure_connection=False
 pki_ds_secure_connection_ca_nickname=Directory Server CA certificate
 pki_ds_secure_connection_ca_pem_file=%(ipa_ca_pem_file)s
-pki_group=pkiuser
 
 pki_issuing_ca_hostname=%(pki_security_domain_hostname)s
 pki_issuing_ca_https_port=%(pki_security_domain_https_port)s
 pki_issuing_ca_uri=https://%(ipa_fqdn)s:443
 pki_issuing_ca=%(pki_issuing_ca_uri)s
 pki_replication_password=
-
-# Configures the status request timeout, i.e. the connect/data
-# timeout on the HTTP request to get the status of Dogtag.
-#
-# This configuration is needed in "multiple IP address" scenarios
-# where this server's hostname has multiple IP addresses but the
-# HTTP server is only listening on one of them.  Without a timeout,
-# if a "wrong" IP address is tried first, it will take a long time
-# to timeout, exceeding the overall timeout hence the request will
-# not be re-tried.  Setting a shorter timeout allows the request
-# to be re-tried.
-#
-# Note that HSMs cause different behaviour so this value might
-# not be suitable for when we implement HSM support.  It is
-# known that a value of 5s is too short in HSM environment.
-#
-pki_status_request_timeout=15
 
 pki_enable_proxy=True
 pki_restart_configured_instance=False
@@ -120,32 +75,23 @@ pki_security_domain_password=%(pki_admin_password)s
 pki_security_domain_user=%(ipa_admin_user)s
 pki_self_signed_token=internal
 
-# for supporting server cert SAN injection
-pki_san_inject=False
-pki_san_for_server_cert=
 pki_skip_configuration=False
 pki_skip_ds_verify=False
 pki_skip_installation=False
 pki_skip_sd_verify=False
 
-pki_sslserver_key_algorithm=%(ipa_key_algorithm)s
-pki_sslserver_key_size=%(ipa_key_size)s
-pki_sslserver_key_type=%(ipa_key_type)s
 pki_sslserver_token=internal
-# nickname and subject are hard-coded
 pki_sslserver_nickname=Server-Cert cert-pki-ca
 pki_sslserver_subject_dn=cn=%(ipa_fqdn)s,%(ipa_subject_base)s
 
-pki_subsystem_key_algorithm=%(ipa_key_algorithm)s
-pki_subsystem_key_size=%(ipa_key_size)s
-pki_subsystem_key_type=%(ipa_key_type)s
-pki_subsystem_token=%(pki_token_name)s
 # nickname and subject are hard-coded
 pki_subsystem_nickname=subsystemCert cert-pki-ca
 pki_subsystem_subject_dn=cn=CA Subsystem,%(ipa_subject_base)s
 
 pki_theme_enable=True
 pki_theme_server_dir=/usr/share/pki/common-ui
+pki_audit_group=pkiaudit
+pki_group=pkiuser
 pki_user=pkiuser
 pki_existing=False
 
@@ -161,14 +107,9 @@ pki_ds_hostname=%(ipa_fqdn)s
 
 
 [CA]
-pki_ca_signing_key_algorithm=%(ipa_ca_signing_algorithm)s
-pki_ca_signing_key_size=%(ipa_ca_key_size)s
-pki_ca_signing_key_type=%(ipa_ca_key_type)s
 pki_ca_signing_record_create=True
 pki_ca_signing_serial_number=1
-pki_ca_signing_signing_algorithm=%(ipa_ca_signing_algorithm)s
 pki_ca_signing_subject_dn=%(ipa_ca_subject)s
-pki_ca_signing_token=%(pki_token_name)s
 
 pki_ca_signing_csr_path=/root/ipa.csr
 
@@ -183,40 +124,23 @@ pki_ca_signing_csr_path=/root/ipa.csr
 # pki_subsystem_cert_path=
 
 pki_ca_starting_crl_number=0
+
 pki_external=False
 pki_external_step_two=False
 pki_req_ext_add=False
-# MS subca request ext data
-pki_req_ext_oid=1.3.6.1.4.1.311.20.2
-pki_req_ext_critical=False
-pki_req_ext_data=1E0A00530075006200430041
 
 pki_external_pkcs12_path=%(pki_pkcs12_path)s
 pki_external_pkcs12_password=%(pki_pkcs12_password)s
 pki_import_admin_cert=False
 
-pki_ocsp_signing_key_algorithm=%(ipa_key_algorithm)s
-pki_ocsp_signing_key_size=%(ipa_key_size)s
-pki_ocsp_signing_key_type=%(ipa_key_type)s
-pki_ocsp_signing_signing_algorithm=%(ipa_signing_algorithm)s
-pki_ocsp_signing_token=%(pki_token_name)s
-# nickname and subject are hard-coded
 pki_ocsp_signing_nickname=ocspSigningCert cert-pki-ca
 pki_ocsp_signing_subject_dn=cn=OCSP Subsystem,%(ipa_subject_base)s
 
 pki_profiles_in_ldap=True
-pki_random_serial_numbers_enable=False
 pki_subordinate=False
 pki_subordinate_create_new_security_domain=False
 ### pki_subordinate_security_domain_name=%(pki_dns_domainname)s Subordinate Security Domain
 
-pki_admin_email=%(ipa_admin_email)s
-pki_admin_name=%(ipa_admin_user)s
-pki_admin_nickname=%(ipa_admin_nickname)s
-pki_admin_subject_dn=cn=%(ipa_admin_nickname)s,%(ipa_subject_base)s
-pki_admin_uid=%(ipa_admin_user)s
-
-# nickname and subject are hard-coded
 pki_audit_signing_nickname=auditSigningCert cert-pki-ca
 pki_audit_signing_subject_dn=cn=CA Audit,%(ipa_subject_base)s
 
@@ -236,7 +160,6 @@ pki_replica_number_range_end=100
 [KRA]
 pki_import_admin_cert=True
 pki_standalone=False
-pki_kra_ephemeral_requests=True
 pki_ds_create_new_db=False
 
 # pki_admin_csr_path=
@@ -255,27 +178,11 @@ pki_external_step_two=False
 # pki_subsystem_cert_path=
 # pki_transport_cert_path=
 
-pki_storage_key_algorithm=%(ipa_key_algorithm)s
-pki_storage_key_size=%(ipa_key_size)s
-pki_storage_key_type=%(ipa_key_type)s
 pki_storage_nickname=storageCert cert-pki-kra
-pki_storage_signing_algorithm=SHA256withRSA
 pki_storage_subject_dn=cn=KRA Storage Certificate,%(ipa_subject_base)s
-pki_storage_token=%(pki_token_name)s
 
-pki_transport_key_algorithm=%(ipa_key_algorithm)s
-pki_transport_key_size=%(ipa_key_size)s
-pki_transport_key_type=%(ipa_key_type)s
 pki_transport_nickname=transportCert cert-pki-kra
-pki_transport_signing_algorithm=SHA256withRSA
 pki_transport_subject_dn=cn=KRA Transport Certificate,%(ipa_subject_base)s
-pki_transport_token=%(pki_token_name)s
-
-pki_admin_email=%(ipa_admin_email)s
-pki_admin_name=%(ipa_admin_user)s
-pki_admin_nickname=%(ipa_admin_nickname)s
-pki_admin_subject_dn=cn=%(ipa_admin_nickname)s,%(ipa_subject_base)s
-pki_admin_uid=%(ipa_admin_user)s
 
 pki_audit_signing_nickname=auditSigningCert cert-pki-kra
 pki_audit_signing_subject_dn=cn=KRA Audit,%(ipa_subject_base)s

--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -6,6 +6,7 @@
 
 [DEFAULT]
 ipa_admin_email=root@localhost
+
 # default algorithms for all certificates
 ipa_key_algorithm=SHA256withRSA
 ipa_key_size=2048
@@ -21,31 +22,31 @@ ipa_ca_key_type=%(ipa_key_type)s
 # hard-coded IPA default settings
 ipa_security_domain_name=IPA
 ipa_ds_database=ipaca
-ipa_ds_base_dn=o=%(ipa_ds_database)s
 ipa_admin_user=admin
 ipa_admin_nickname=ipa-ca-agent
 ipa_ca_pem_file=/etc/ipa/ca.crt
 
-# dynamic values
-ipa_ca_subject=
-ipa_subject_base=
-ipa_fqdn=
-ipa_ocsp_uri=
-ipa_admin_cert_p12=
-ipa_master_host=
-ipa_clone_uri=
+## dynamic values
+# ipa_ca_subject=
+# ipa_ds_base_dn=
+# ipa_subject_base=
+# ipa_fqdn=
+# ipa_ocsp_uri=
+# ipa_admin_cert_p12=
 
 # sensitive dynamic values
-pki_admin_password=
-pki_ds_password=
-pki_token_password=
+# pki_admin_password=
+# pki_ds_password=
+# pki_token_password=
 
 # HSM support
-ipa_backup_keys=True
-ipa_hsm_enable=False
-ipa_hsm_libfile=
-ipa_hsm_modulename=
-ipa_token_name=internal
+pki_hsm_enable=False
+pki_hsm_libfile=
+pki_hsm_modulename=
+pki_token_name=internal
+# backup is automatically disabled when HSM support is enabled
+pki_backup_keys=True
+pki_backup_password=%(pki_admin_password)s
 
 # Dogtag defaults
 pki_instance_name=pki-tomcat
@@ -64,10 +65,8 @@ pki_audit_signing_key_algorithm=%(ipa_key_algorithm)s
 pki_audit_signing_key_size=%(ipa_key_size)s
 pki_audit_signing_key_type=%(ipa_key_type)s
 pki_audit_signing_signing_algorithm=%(ipa_signing_algorithm)s
-pki_audit_signing_token=%(ipa_token_name)s
+pki_audit_signing_token=%(pki_token_name)s
 
-pki_backup_keys=True
-pki_backup_password=%(pki_admin_password)s
 pki_ca_hostname=%(pki_security_domain_hostname)s
 pki_ca_port=%(pki_security_domain_https_port)s
 
@@ -86,11 +85,9 @@ pki_ds_ldaps_port=636
 pki_ds_remove_data=True
 pki_ds_secure_connection=False
 pki_ds_secure_connection_ca_nickname=Directory Server CA certificate
-pki_ds_secure_connection_ca_pem_file=
+pki_ds_secure_connection_ca_pem_file=%(ipa_ca_pem_file)s
 pki_group=pkiuser
-pki_hsm_enable=False
-pki_hsm_libfile=
-pki_hsm_modulename=
+
 pki_issuing_ca_hostname=%(pki_security_domain_hostname)s
 pki_issuing_ca_https_port=%(pki_security_domain_https_port)s
 pki_issuing_ca_uri=https://%(ipa_fqdn)s:443
@@ -142,15 +139,13 @@ pki_sslserver_subject_dn=cn=%(ipa_fqdn)s,%(ipa_subject_base)s
 pki_subsystem_key_algorithm=%(ipa_key_algorithm)s
 pki_subsystem_key_size=%(ipa_key_size)s
 pki_subsystem_key_type=%(ipa_key_type)s
-pki_subsystem_token=%(ipa_token_name)s
+pki_subsystem_token=%(pki_token_name)s
 # nickname and subject are hard-coded
 pki_subsystem_nickname=subsystemCert cert-pki-ca
 pki_subsystem_subject_dn=cn=CA Subsystem,%(ipa_subject_base)s
 
 pki_theme_enable=True
 pki_theme_server_dir=/usr/share/pki/common-ui
-pki_token_name=%(ipa_token_name)s
-# pki_token_password
 pki_user=pkiuser
 pki_existing=False
 
@@ -173,28 +168,28 @@ pki_ca_signing_record_create=True
 pki_ca_signing_serial_number=1
 pki_ca_signing_signing_algorithm=%(ipa_ca_signing_algorithm)s
 pki_ca_signing_subject_dn=%(ipa_ca_subject)s
-pki_ca_signing_token=%(ipa_token_name)s
+pki_ca_signing_token=%(pki_token_name)s
 
-pki_ca_signing_csr_path=%(pki_instance_configuration_path)s/external_ca.csr
+pki_ca_signing_csr_path=/root/ipa.csr
 
-pki_ocsp_signing_csr_path=
-pki_audit_signing_csr_path=
-pki_sslserver_csr_path=
-pki_subsystem_csr_path=
+# pki_ocsp_signing_csr_path=
+# pki_audit_signing_csr_path=
+# pki_sslserver_csr_path=
+# pki_subsystem_csr_path=
 
-pki_ocsp_signing_cert_path=
-pki_audit_signing_cert_path=
-pki_sslserver_cert_path=
-pki_subsystem_cert_path=
+# pki_ocsp_signing_cert_path=
+# pki_audit_signing_cert_path=
+# pki_sslserver_cert_path=
+# pki_subsystem_cert_path=
 
 pki_ca_starting_crl_number=0
 pki_external=False
+pki_external_step_two=False
 pki_req_ext_add=False
 # MS subca request ext data
 pki_req_ext_oid=1.3.6.1.4.1.311.20.2
 pki_req_ext_critical=False
 pki_req_ext_data=1E0A00530075006200430041
-pki_external_step_two=False
 
 pki_external_pkcs12_path=%(pki_pkcs12_path)s
 pki_external_pkcs12_password=%(pki_pkcs12_password)s
@@ -204,7 +199,7 @@ pki_ocsp_signing_key_algorithm=%(ipa_key_algorithm)s
 pki_ocsp_signing_key_size=%(ipa_key_size)s
 pki_ocsp_signing_key_type=%(ipa_key_type)s
 pki_ocsp_signing_signing_algorithm=%(ipa_signing_algorithm)s
-pki_ocsp_signing_token=%(ipa_token_name)s
+pki_ocsp_signing_token=%(pki_token_name)s
 # nickname and subject are hard-coded
 pki_ocsp_signing_nickname=ocspSigningCert cert-pki-ca
 pki_ocsp_signing_subject_dn=cn=OCSP Subsystem,%(ipa_subject_base)s
@@ -213,7 +208,7 @@ pki_profiles_in_ldap=True
 pki_random_serial_numbers_enable=False
 pki_subordinate=False
 pki_subordinate_create_new_security_domain=False
-pki_subordinate_security_domain_name=%(pki_dns_domainname)s Subordinate Security Domain
+### pki_subordinate_security_domain_name=%(pki_dns_domainname)s Subordinate Security Domain
 
 pki_admin_email=%(ipa_admin_email)s
 pki_admin_name=%(ipa_admin_user)s
@@ -242,7 +237,7 @@ pki_replica_number_range_end=100
 pki_import_admin_cert=True
 pki_standalone=False
 pki_kra_ephemeral_requests=True
-pki_ds_create_new_db=True
+pki_ds_create_new_db=False
 
 # pki_admin_csr_path=
 # pki_audit_signing_csr_path=
@@ -266,7 +261,7 @@ pki_storage_key_type=%(ipa_key_type)s
 pki_storage_nickname=storageCert cert-pki-kra
 pki_storage_signing_algorithm=SHA256withRSA
 pki_storage_subject_dn=cn=KRA Storage Certificate,%(ipa_subject_base)s
-pki_storage_token=%(ipa_token_name)s
+pki_storage_token=%(pki_token_name)s
 
 pki_transport_key_algorithm=%(ipa_key_algorithm)s
 pki_transport_key_size=%(ipa_key_size)s
@@ -274,7 +269,7 @@ pki_transport_key_type=%(ipa_key_type)s
 pki_transport_nickname=transportCert cert-pki-kra
 pki_transport_signing_algorithm=SHA256withRSA
 pki_transport_subject_dn=cn=KRA Transport Certificate,%(ipa_subject_base)s
-pki_transport_token=%(ipa_token_name)s
+pki_transport_token=%(pki_token_name)s
 
 pki_admin_email=%(ipa_admin_email)s
 pki_admin_name=%(ipa_admin_user)s
@@ -285,5 +280,7 @@ pki_admin_uid=%(ipa_admin_user)s
 pki_audit_signing_nickname=auditSigningCert cert-pki-kra
 pki_audit_signing_subject_dn=cn=KRA Audit,%(ipa_subject_base)s
 
+# Needed because CA and KRA share the same database
+# We will use the dbuser created for the CA.
 pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(ipa_ds_database)s

--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -1,84 +1,13 @@
-###############################################################################
-##  Default Configuration:                                                   ##
-##                                                                           ##
-##  Values in this section are common to more than one PKI subsystem, and    ##
-##  contain required information which MAY be overridden by users as         ##
-##  necessary.                                                               ##
-##                                                                           ##
-##  There are also some meta-parameters that determine how the PKI           ##
-##  configuratiion should work.                                              ##
-##                                                                           ##
-###############################################################################
 [DEFAULT]
-
-JAVA_HOME=%(java_home)s
-
-# The sensitive_parameters contains a list of parameters which may contain
-# sensitive information which must not be displayed to the console nor stored
-# in log files for security reasons.
-sensitive_parameters=
-    pki_admin_password
-    pki_backup_password
-    pki_client_database_password
-    pki_client_pin
-    pki_client_pkcs12_password
-    pki_clone_pkcs12_password
-    pki_ds_password
-    pki_external_pkcs12_password
-    pki_pkcs12_password
-    pki_one_time_pin
-    pki_pin
-    pki_replication_password
-    pki_security_domain_password
-    pki_server_pkcs12_password
-    pki_token_password
-
-# The spawn_scriplets contains a list of scriplets to be executed by pkispawn.
-spawn_scriplets=
-    initialization
-    infrastructure_layout
-    instance_layout
-    subsystem_layout
-    webapp_deployment
-    slot_substitution
-    security_databases
-    selinux_setup
-    configuration
-    finalization
-
-# The destroy_scriplets contains a list of scriplets to be executed by pkidestroy.
-destroy_scriplets=
-    initialization
-    configuration
-    webapp_deployment
-    subsystem_layout
-    security_databases
-    instance_layout
-    selinux_setup
-    infrastructure_layout
-    finalization
-
-# By default, the following parameters will be set for Tomcat instances.
-# There is no reason to uncomment these.  They are provided for reference in 
-# case someone wants to override them in their config file.
-#
-# Tomcat instances:
-# pki_instance_name=pki-tomcat
-# pki_https_port=8443
-# pki_http_port=8080
-
 pki_admin_cert_file=%(pki_client_dir)s/ca_admin.cert
 pki_admin_cert_request_type=pkcs10
 pki_admin_dualkey=False
 pki_admin_key_algorithm=SHA256withRSA
-# DEPRECATED: Use 'pki_admin_key_size' instead.
-pki_admin_keysize=2048
-pki_admin_key_size=%(pki_admin_keysize)s
+pki_admin_key_size=2048
 pki_admin_key_type=rsa
 pki_admin_password=
 
 pki_audit_group=pkiaudit
-
 pki_audit_signing_key_algorithm=SHA256withRSA
 pki_audit_signing_key_size=2048
 pki_audit_signing_key_type=rsa
@@ -91,10 +20,7 @@ pki_ca_hostname=%(pki_security_domain_hostname)s
 pki_ca_port=%(pki_security_domain_https_port)s
 
 pki_ca_signing_nickname=caSigningCert cert-%(pki_instance_name)s CA
-
-# DEPRECATED: Use 'pki_ca_signing_cert_path' instead.
-pki_external_ca_cert_path=%(pki_instance_configuration_path)s/external_ca.cert
-pki_ca_signing_cert_path=%(pki_external_ca_cert_path)s
+pki_ca_signing_cert_path=%(pki_instance_configuration_path)s/external_ca.cert
 
 pki_client_admin_cert_p12=%(pki_client_dir)s/%(pki_subsystem_type)s_admin_cert.p12
 pki_client_database_password=
@@ -127,7 +53,8 @@ pki_security_domain_name=%(pki_dns_domainname)s Security Domain
 pki_security_domain_password=
 pki_security_domain_user=caadmin
 pki_self_signed_token=internal
-#for supporting server cert SAN injection
+
+# for supporting server cert SAN injection
 pki_san_inject=False
 pki_san_for_server_cert=
 pki_skip_configuration=False
@@ -135,21 +62,12 @@ pki_skip_ds_verify=False
 pki_skip_installation=False
 pki_skip_sd_verify=False
 
-# DEPRECATED
-# Use 'pki_sslserver_*' instead.
-pki_ssl_server_key_algorithm=SHA256withRSA
-pki_ssl_server_key_size=2048
-pki_ssl_server_key_type=rsa
-pki_ssl_server_nickname=Server-Cert cert-%(pki_instance_name)s
-pki_ssl_server_subject_dn=cn=%(pki_hostname)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_ssl_server_token=
-
-pki_sslserver_key_algorithm=%(pki_ssl_server_key_algorithm)s
-pki_sslserver_key_size=%(pki_ssl_server_key_size)s
-pki_sslserver_key_type=%(pki_ssl_server_key_type)s
-pki_sslserver_nickname=%(pki_ssl_server_nickname)s
-pki_sslserver_subject_dn=%(pki_ssl_server_subject_dn)s
-pki_sslserver_token=%(pki_ssl_server_token)s
+pki_sslserver_key_algorithm=SHA256withRSA
+pki_sslserver_key_size=2048
+pki_sslserver_key_type=rsa
+pki_sslserver_nickname=Server-Cert cert-%(pki_instance_name)s
+pki_sslserver_subject_dn=cn=%(pki_hostname)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+pki_sslserver_token=
 
 pki_subsystem_key_algorithm=SHA256withRSA
 pki_subsystem_key_size=2048
@@ -165,158 +83,13 @@ pki_token_password=
 pki_user=pkiuser
 pki_existing=False
 
-# DEPRECATED: Use 'pki_cert_chain_path' instead.
-pki_external_ca_cert_chain_path=%(pki_instance_configuration_path)s/external_ca_chain.cert
-pki_cert_chain_path=%(pki_external_ca_cert_chain_path)s
-
-# DEPRECATED: Use 'pki_cert_chain_nickname' instead.
-pki_external_ca_cert_chain_nickname=caSigningCert External CA
-pki_cert_chain_nickname=%(pki_external_ca_cert_chain_nickname)s
+pki_cert_chain_path=%(pki_instance_configuration_path)s/external_ca_chain.cert
+pki_cert_chain_nickname=caSigningCert External CA
 
 pki_pkcs12_path=
 pki_pkcs12_password=
 
-# Paths:
-# These are used in the processing of pkispawn and are not supposed
-# to be overwritten by user configuration files.
-#
-pki_client_database_dir=%(pki_client_subsystem_dir)s/alias
-pki_client_subsystem_dir=%(pki_client_dir)s/%(pki_subsystem_type)s
-pki_client_password_conf=%(pki_client_subsystem_dir)s/password.conf
-pki_client_pkcs12_password_conf=%(pki_client_subsystem_dir)s/pkcs12_password.conf
-pki_client_admin_cert=%(pki_client_dir)s/%(pki_subsystem_type)s_admin.cert
-pki_source_conf_path=/usr/share/pki/%(pki_subsystem_type)s/conf
-pki_source_setup_path=/usr/share/pki/setup
-pki_source_server_path=/usr/share/pki/server/conf
-pki_source_cs_cfg=/usr/share/pki/%(pki_subsystem_type)s/conf/CS.cfg
-pki_source_registry=/usr/share/pki/setup/pkidaemon_registry
-pki_source_subsystem_path=/usr/share/pki/%(pki_subsystem_type)s
-pki_path=/var/lib/pki
-pki_log_path=/var/log/pki
-pki_configuration_path=/etc/pki
-pki_registry_path=/etc/sysconfig/pki
-pki_instance_path=%(pki_path)s/%(pki_instance_name)s
-pki_instance_log_path=%(pki_log_path)s/%(pki_instance_name)s
-pki_instance_configuration_path=%(pki_configuration_path)s/%(pki_instance_name)s
-pki_database_path=%(pki_instance_configuration_path)s/alias
-pki_instance_database_link=%(pki_instance_path)s/alias
-pki_instance_conf_link=%(pki_instance_path)s/conf
-pki_instance_logs_link=%(pki_instance_path)s/logs
-pki_subsystem_path=%(pki_instance_path)s/%(pki_subsystem_type)s
-pki_subsystem_log_path=%(pki_instance_log_path)s/%(pki_subsystem_type)s
-pki_subsystem_archive_log_path=%(pki_subsystem_log_path)s/archive
-pki_subsystem_configuration_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s
-pki_subsystem_database_link=%(pki_subsystem_path)s/alias
-pki_subsystem_conf_link=%(pki_subsystem_path)s/conf
-pki_subsystem_logs_link=%(pki_subsystem_path)s/logs
-pki_subsystem_registry_link=%(pki_subsystem_path)s/registry
 
- 
-###############################################################################
-##  Tomcat Configuration:                                                    ##
-##                                                                           ##
-##  Values in this section are common to PKI subsystems that run             ##
-##  as an instance of 'Tomcat' (CA, KRA, OCSP, TKS, and TPS subsystems       ##
-##  including 'Clones', 'Subordinate CAs', and 'External CAs'), and contain  ##
-##  required information which MAY be overridden by users as necessary.      ##
-##                                                                           ##
-##  PKI CLONES:  To specify a 'CA Clone', a 'KRA Clone', an 'OCSP Clone',    ##
-##               a 'TKS Clone', or a 'TPS Clone', change the value of        ##
-##               'pki_clone' from 'False' to 'True'.                         ##
-##                                                                           ##
-##    REMINDER:  PKI CA Clones, Subordinate CAs, and External CAs            ##
-##               are MUTUALLY EXCLUSIVE entities!!!                          ##
-###############################################################################
-[Tomcat]
-pki_ajp_host=localhost
-pki_ajp_port=8009
-pki_server_pkcs12_path=
-pki_server_pkcs12_password=
-pki_server_external_certs_path=
-pki_clone=False
-pki_clone_pkcs12_password=
-pki_clone_pkcs12_path=
-pki_clone_replicate_schema=True
-pki_clone_replication_master_port=
-pki_clone_replication_clone_port=
-pki_clone_replication_security=None
-pki_clone_setup_replication=True
-pki_clone_reindex_data=False
-pki_master_hostname=%(pki_security_domain_hostname)s
-pki_master_https_port=%(pki_security_domain_https_port)s
-pki_clone_uri=https://%(pki_master_hostname)s:%(pki_master_https_port)s
-pki_enable_access_log=True
-pki_enable_java_debugger=False
-pki_enable_on_system_boot=True
-pki_enable_proxy=False
-pki_proxy_http_port=80
-pki_proxy_https_port=443
-pki_security_manager=true
-pki_tomcat_server_port=8005
-
-# Paths
-# These are used in the processing of pkispawn and are not supposed
-# to be overwritten by user configuration files.
-#
-pki_systemd_service=/lib/systemd/system/pki-tomcatd@.service
-pki_systemd_target=/lib/systemd/system/pki-tomcatd.target
-pki_systemd_target_wants=/etc/systemd/system/pki-tomcatd.target.wants
-pki_systemd_service_link=%(pki_systemd_target_wants)s/pki-tomcatd@%(pki_instance_name)s.service
-pki_cgroup_systemd_service_path=/sys/fs/cgroup/systemd/system/%(pki_systemd_service)s
-pki_cgroup_systemd_service=%(pki_cgroup_systemd_service_path)s/%(pki_instance_name)s
-pki_cgroup_cpu_systemd_service_path=/sys/fs/cgroup/cpu\,cpuacct/system/%(pki_systemd_service)s
-pki_cgroup_cpu_systemd_service=%(pki_cgroup_cpu_systemd_service_path)s/%(pki_systemd_service)s
-
-CATALINA_HOME=/usr/share/tomcat
-pki_tomcat_bin_path=%(CATALINA_HOME)s/bin
-pki_tomcat_lib_path=%(CATALINA_HOME)s/lib
-
-pki_tomcat_systemd=/usr/sbin/tomcat
-pki_source_server_xml=%(pki_source_server_path)s/server.xml
-pki_source_context_xml=%(pki_source_server_path)s/context.xml
-pki_source_tomcat_conf=%(pki_source_server_path)s/tomcat.conf
-pki_instance_type=Tomcat
-pki_tomcat_common_path=%(pki_instance_path)s/common
-pki_tomcat_common_lib_path=%(pki_tomcat_common_path)s/lib
-pki_tomcat_tmpdir_path=%(pki_instance_path)s/temp
-pki_tomcat_webapps_path=%(pki_instance_path)s/webapps
-pki_tomcat_common_webapps_path=%(pki_instance_path)s/common/webapps
-pki_tomcat_work_path=%(pki_instance_path)s/work
-pki_tomcat_work_catalina_path=%(pki_tomcat_work_path)s/Catalina
-pki_tomcat_work_catalina_host_path=%(pki_tomcat_work_catalina_path)s/localhost
-pki_tomcat_work_catalina_host_run_path=%(pki_tomcat_work_catalina_host_path)s/_
-pki_tomcat_work_catalina_host_subsystem_path=%(pki_tomcat_work_catalina_host_path)s/%(pki_subsystem_type)s
-pki_instance_conf_log4j_properties=%(pki_instance_configuration_path)s/log4j.properties
-pki_instance_type_registry_path=%(pki_registry_path)s/tomcat
-pki_instance_registry_path=%(pki_instance_type_registry_path)s/%(pki_instance_name)s
-pki_subsystem_registry_path=%(pki_instance_registry_path)s/%(pki_subsystem_type)s
-pki_tomcat_bin_link=%(pki_instance_path)s/bin
-pki_instance_lib=%(pki_instance_path)s/lib
-pki_instance_lib_log4j_properties=%(pki_instance_lib)s/log4j.properties
-pki_instance_systemd_link=%(pki_instance_path)s/%(pki_instance_name)s
-pki_subsystem_signed_audit_log_path=%(pki_subsystem_log_path)s/signedAudit
-pki_tomcat_subsystem_webapps_path=%(pki_subsystem_path)s/webapps
-pki_tomcat_webapps_subsystem_path=%(pki_tomcat_subsystem_webapps_path)s/%(pki_subsystem_type)s
-pki_tomcat_webapps_subsystem_webinf_classes_path=%(pki_tomcat_webapps_subsystem_path)s/WEB-INF/classes
-pki_tomcat_webapps_subsystem_webinf_lib_path=%(pki_tomcat_webapps_subsystem_path)s/WEB-INF/lib
-
-
-###############################################################################
-##  CA Configuration:                                                        ##
-##                                                                           ##
-##  Values in this section are common to CA subsystems including 'PKI CAs',  ##
-##  'Cloned CAs', 'Subordinate CAs', and 'External CAs', and contain         ##
-##  required information which MAY be overridden by users as necessary.      ##
-##                                                                           ##
-##     EXTERNAL CAs:  To specify an 'External CA', change the value          ##
-##                    of 'pki_external' from 'False' to 'True'.              ##
-##                                                                           ##
-##  SUBORDINATE CAs:  To specify a 'Subordinate CA', change the value        ##
-##                    of 'pki_subordinate' from 'False' to 'True'.           ##
-##                                                                           ##
-##         REMINDER:  PKI CA Clones, Subordinate CAs, and External CAs       ##
-##                    are MUTUALLY EXCLUSIVE entities!!!                     ##
-###############################################################################
 [CA]
 pki_ca_signing_key_algorithm=SHA256withRSA
 pki_ca_signing_key_size=2048
@@ -328,8 +101,7 @@ pki_ca_signing_subject_dn=cn=CA Signing Certificate,ou=%(pki_instance_name)s,o=%
 pki_ca_signing_token=
 
 # DEPRECATED: Use 'pki_ca_signing_csr_path' instead.
-pki_external_csr_path=
-pki_ca_signing_csr_path=%(pki_external_csr_path)s
+pki_ca_signing_csr_path=%(pki_instance_configuration_path)s/external_ca.csr
 
 pki_ocsp_signing_csr_path=
 pki_audit_signing_csr_path=
@@ -384,28 +156,7 @@ pki_subsystem_name=CA %(pki_hostname)s %(pki_https_port)s
 pki_share_db=False
 pki_master_crl_enable=True
 
-# Default OCSP URI added by AuthInfoAccessExtDefault if the profile
-# config is blank.  If both are blank, the value is constructed
-# based on the CMS hostname and port.
 pki_default_ocsp_uri=
-
-# Paths
-# These are used in the processing of pkispawn and are not supposed
-# to be overwritten by user configuration files.
-#
-pki_source_emails=/usr/share/pki/ca/emails
-pki_source_flatfile_txt=%(pki_source_conf_path)s/flatfile.txt
-pki_source_profiles=/usr/share/pki/ca/profiles
-pki_source_proxy_conf=%(pki_source_conf_path)s/proxy.conf
-pki_source_registry_cfg=%(pki_source_conf_path)s/registry.cfg
-pki_source_admincert_profile=%(pki_source_conf_path)s/%(pki_admin_key_type)sAdminCert.profile
-pki_source_caauditsigningcert_profile=%(pki_source_conf_path)s/caAuditSigningCert.profile
-pki_source_cacert_profile=%(pki_source_conf_path)s/caCert.profile
-pki_source_caocspcert_profile=%(pki_source_conf_path)s/caOCSPCert.profile
-pki_source_servercert_profile=%(pki_source_conf_path)s/%(pki_sslserver_key_type)sServerCert.profile
-pki_source_subsystemcert_profile=%(pki_source_conf_path)s/%(pki_subsystem_key_type)sSubsystemCert.profile
-pki_subsystem_emails_path=%(pki_subsystem_path)s/emails
-pki_subsystem_profiles_path=%(pki_subsystem_path)s/profiles
 
 pki_serial_number_range_start=1
 pki_serial_number_range_end=10000000
@@ -415,57 +166,26 @@ pki_replica_number_range_start=1
 pki_replica_number_range_end=100
 
 
-###############################################################################
-##  KRA Configuration:                                                       ##
-##                                                                           ##
-##  Values in this section are common to KRA subsystems                      ##
-##  including 'PKI KRAs', 'Cloned KRAs', and 'Stand-alone KRAs' and contain  ##
-##  required information which MAY be overridden by users as necessary.      ##
-##                                                                           ##
-##      STAND-ALONE KRAs:  To specify a 'Stand-alone KRA', change the value  ##
-##                         of 'pki_standalone' from 'False' to 'True', and   ##
-##                         specify the various 'pki_external' parameters     ##
-##                         as appropriate.                                   ##
-##                                                                           ##
-###############################################################################
 [KRA]
 pki_import_admin_cert=True
 pki_standalone=False
 pki_kra_ephemeral_requests=False
 
-# DEPRECATED
-# Use 'pki_*_csr_path' instead.
-pki_external_admin_csr_path=
-pki_external_audit_signing_csr_path=
-pki_external_sslserver_csr_path=
-pki_external_storage_csr_path=
-pki_external_subsystem_csr_path=
-pki_external_transport_csr_path=
-
-pki_admin_csr_path=%(pki_external_admin_csr_path)s
-pki_audit_signing_csr_path=%(pki_external_audit_signing_csr_path)s
-pki_sslserver_csr_path=%(pki_external_sslserver_csr_path)s
-pki_storage_csr_path=%(pki_external_storage_csr_path)s
-pki_subsystem_csr_path=%(pki_external_subsystem_csr_path)s
-pki_transport_csr_path=%(pki_external_transport_csr_path)s
+pki_admin_csr_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_admin.csr
+pki_audit_signing_csr_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_audit_signing.csr
+pki_sslserver_csr_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_sslserver.csr
+pki_storage_csr_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_storage.csr
+pki_subsystem_csr_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_subsystem.csr
+pki_transport_csr_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_transport.csr
 
 pki_external_step_two=False
 
-# DEPRECATED
-# Use 'pki_*_cert_path' instead.
-pki_external_admin_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_admin.cert
-pki_external_audit_signing_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_audit_signing.cert
-pki_external_sslserver_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_sslserver.cert
-pki_external_storage_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_storage.cert
-pki_external_subsystem_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_subsystem.cert
-pki_external_transport_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_transport.cert
-
-pki_admin_cert_path=%(pki_external_admin_cert_path)s
-pki_audit_signing_cert_path=%(pki_external_audit_signing_cert_path)s
-pki_sslserver_cert_path=%(pki_external_sslserver_cert_path)s
-pki_storage_cert_path=%(pki_external_storage_cert_path)s
-pki_subsystem_cert_path=%(pki_external_subsystem_cert_path)s
-pki_transport_cert_path=%(pki_external_transport_cert_path)s
+pki_admin_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_admin.cert
+pki_audit_signing_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_audit_signing.cert
+pki_sslserver_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_sslserver.cert
+pki_storage_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_storage.cert
+pki_subsystem_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_subsystem.cert
+pki_transport_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_transport.cert
 
 pki_storage_key_algorithm=SHA256withRSA
 pki_storage_key_size=2048
@@ -498,147 +218,3 @@ pki_ds_hostname=%(pki_hostname)s
 pki_subsystem_name=KRA %(pki_hostname)s %(pki_https_port)s
 pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
-
-###############################################################################
-##  OCSP Configuration:                                                      ##
-##                                                                           ##
-##  Values in this section are common to OCSP subsystems                     ##
-##  including 'PKI OCSPs', 'Cloned OCSPs', and 'Stand-alone OCSPs' and       ##
-##  contain required information which MAY be overridden by users as         ##
-##  necessary.                                                               ##
-##                                                                           ##
-##      STAND-ALONE OCSPs:  To specify a 'Stand-alone OCSP', change the      ##
-##                          value of 'pki_standalone' from 'False' to        ##
-##                          'True', and specify the various 'pki_external'   ##
-##                          parameters as appropriate.                       ##
-##                          (NOTE:  Stand-alone OCSP is not yet supported!)  ##
-##                                                                           ##
-###############################################################################
-[OCSP]
-pki_import_admin_cert=True
-pki_standalone=False
-
-# DEPRECATED
-# Use 'pki_*_csr_path' instead.
-pki_external_admin_csr_path=
-pki_external_audit_signing_csr_path=
-pki_external_signing_csr_path=
-pki_external_sslserver_csr_path=
-pki_external_subsystem_csr_path=
-
-pki_admin_csr_path=%(pki_external_admin_csr_path)s
-pki_audit_signing_csr_path=%(pki_external_audit_signing_csr_path)s
-pki_ocsp_signing_csr_path =%(pki_external_signing_csr_path)s
-pki_sslserver_csr_path=%(pki_external_sslserver_csr_path)s
-pki_subsystem_csr_path=%(pki_external_subsystem_csr_path)s
-
-pki_external_step_two=False
-
-# DEPRECATED
-# Use 'pki_*_cert_path' instead.
-pki_external_admin_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_admin.cert
-pki_external_audit_signing_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_audit_signing.cert
-pki_external_signing_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_signing.cert
-pki_external_sslserver_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_sslserver.cert
-pki_external_subsystem_cert_path=%(pki_instance_configuration_path)s/%(pki_subsystem_type)s_subsystem.cert
-
-pki_admin_cert_path=%(pki_external_admin_cert_path)s
-pki_audit_signing_cert_path=%(pki_external_audit_signing_cert_path)s
-pki_ocsp_signing_cert_path=%(pki_external_signing_cert_path)s
-pki_sslserver_cert_path=%(pki_external_sslserver_cert_path)s
-pki_subsystem_cert_path=%(pki_external_subsystem_cert_path)s
-
-pki_ocsp_signing_key_algorithm=SHA256withRSA
-pki_ocsp_signing_key_size=2048
-pki_ocsp_signing_key_type=rsa
-pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s OCSP
-pki_ocsp_signing_signing_algorithm=SHA256withRSA
-pki_ocsp_signing_subject_dn=cn=OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_ocsp_signing_token=
-
-pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
-pki_admin_name=%(pki_admin_uid)s
-pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
-pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_admin_uid=ocspadmin
-
-pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s OCSP
-pki_audit_signing_subject_dn=cn=OCSP Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-
-pki_ds_base_dn=o=%(pki_instance_name)s-OCSP
-pki_ds_database=%(pki_instance_name)s-OCSP
-pki_ds_hostname=%(pki_hostname)s
-pki_subsystem_name=OCSP %(pki_hostname)s %(pki_https_port)s
-pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
-
-
-###############################################################################
-##  RA Configuration:                                                        ##
-##                                                                           ##
-##  Values in this section are common to PKI RA subsystems, and contain      ##
-##  required information which MAY be overridden by users as necessary.      ##
-###############################################################################
-[RA]
-
-###############################################################################
-##  TKS Configuration:                                                       ##
-##                                                                           ##
-##  Values in this section are common to TKS subsystems                      ##
-##  including 'PKI TKSs' and 'Cloned TKSs', and contain                      ##
-##  required information which MAY be overridden by users as necessary.      ##
-###############################################################################
-[TKS]
-pki_import_admin_cert=True
-pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
-pki_admin_name=%(pki_admin_uid)s
-pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
-pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_admin_uid=tksadmin
-pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s TKS
-pki_audit_signing_subject_dn=cn=TKS Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_ds_base_dn=o=%(pki_instance_name)s-TKS
-pki_ds_database=%(pki_instance_name)s-TKS
-pki_ds_hostname=%(pki_hostname)s
-pki_subsystem_name=TKS %(pki_hostname)s %(pki_https_port)s
-pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
-
-###############################################################################
-##  TPS Configuration:                                                       ##
-##                                                                           ##
-##  Values in this section are common to PKI TPS subsystems, and contain     ##
-##  required information which MAY be overridden by users as necessary.      ##
-###############################################################################
-[TPS]
-pki_import_admin_cert=True
-pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
-pki_admin_name=%(pki_admin_uid)s
-pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
-pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_admin_uid=tpsadmin
-pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s TPS
-pki_audit_signing_subject_dn=cn=TPS Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
-pki_ds_base_dn=o=%(pki_instance_name)s-TPS
-pki_ds_database=%(pki_instance_name)s-TPS
-pki_ds_hostname=%(pki_hostname)s
-pki_subsystem_name=TPS %(pki_hostname)s %(pki_https_port)s
-pki_authdb_hostname=%(pki_hostname)s
-pki_authdb_port=389
-pki_authdb_secure_conn=False
-pki_ca_uri=https://%(pki_hostname)s:%(pki_https_port)s
-pki_kra_uri=https://%(pki_hostname)s:%(pki_https_port)s
-pki_tks_uri=https://%(pki_hostname)s:%(pki_https_port)s
-pki_enable_server_side_keygen=False
-pki_import_shared_secret=False
-pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
-pki_source_phone_home_xml=/usr/share/pki/%(pki_subsystem_type)s/conf/phoneHome.xml
-pki_source_registry_cfg=%(pki_source_conf_path)s/registry.cfg
-
-# Paths
-# These are used in the processing of pkispawn and are not supposed
-# to be overwritten by user configuration files.
-#
-pki_subsystem_signed_audit_log_path=%(pki_subsystem_log_path)s/signedAudit
-

--- a/install/share/ipaca_softhsm2.ini
+++ b/install/share/ipaca_softhsm2.ini
@@ -1,0 +1,9 @@
+#
+# Example config for softhsm2
+#
+
+[DEFAULT]
+pki_hsm_enable=True
+pki_hsm_libfile=%(softhsm2_so)s
+pki_hsm_modulename=softhsm2
+pki_token_name=softhsm_token

--- a/install/tools/ipa-ca-install.in
+++ b/install/tools/ipa-ca-install.in
@@ -86,6 +86,7 @@ def parse_options():
                       type="choice", choices=ca_algos,
                       metavar="{{{0}}}".format(",".join(ca_algos)),
                       help="Signing algorithm of the IPA CA certificate")
+
     parser.add_option("-P", "--principal", dest="principal", sensitive=True,
                       default=None, help="User allowed to manage replicas")
     parser.add_option("--subject-base", dest="subject_base",
@@ -100,6 +101,10 @@ def parse_options():
                           "The CA certificate subject DN "
                           "(default CN=Certificate Authority,O=<realm-name>). "
                           "RDNs are in LDAP order (most specific RDN first)."))
+
+    parser.add_option("--pki-config-override", dest="pki_config_override",
+                      default=None,
+                      help="Path to ini file with config overrides.")
 
     options, args = parser.parse_args()
     safe_options = parser.get_safe_opts(options)

--- a/install/tools/man/ipa-ca-install.1
+++ b/install/tools/man/ipa-ca-install.1
@@ -73,6 +73,9 @@ The CA certificate subject DN (default CN=Certificate Authority,O=REALM.NAME).  
 \fB\-\-subject\-base\fR=\fISUBJECT\fR
 The subject base for certificates issued by IPA (default O=REALM.NAME).  RDNs are in LDAP order (most specific RDN first).
 .TP
+\fB\-\-pki\-config\-override\fR=\fIFILE\fR
+File containing overrides for CA installation.
+.TP
 \fB\-\-ca\-signing\-algorithm\fR=\fIALGORITHM\fR
 Signing algorithm of the IPA CA certificate. Possible values are SHA1withRSA, SHA256withRSA, SHA512withRSA. Default value is SHA256withRSA. Use this option with --external-ca if the external CA does not support the default signing algorithm.
 .TP

--- a/install/tools/man/ipa-kra-install.1
+++ b/install/tools/man/ipa-kra-install.1
@@ -51,6 +51,9 @@ Output only errors
 .TP
 \fB\-\-log-file\fR=\fRFILE\fR
 Log to the given file
+.TP
+\fB\-\-pki\-config\-override\fR=\fIFILE\fR
+File containing overrides for KRA installation.
 .SH "EXIT STATUS"
 0 if the command was successful
 

--- a/install/tools/man/ipa-replica-install.1
+++ b/install/tools/man/ipa-replica-install.1
@@ -140,6 +140,9 @@ Name of the Apache Server SSL certificate to install
 \fB\-\-pkinit\-cert\-name\fR=NAME
 Name of the Kerberos KDC SSL certificate to install
 .TP
+\fB\-\-pki\-config\-override\fR=\fIFILE\fR
+File containing overrides for CA and KRA installation.
+.TP
 \fB\-\-skip\-schema\-check\fR
 Skip check for updated CA DS schema on the remote master
 

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -152,6 +152,9 @@ Name of the Kerberos KDC SSL certificate to install.
 \fB\-\-ca\-cert\-file\fR=\fIFILE\fR
 File containing the CA certificate of the CA which issued the Directory Server, Apache Server and Kerberos KDC certificates. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times. Use this option if the CA certificate is not present in the certificate files.
 .TP
+\fB\-\-pki\-config\-override\fR=\fIFILE\fR
+File containing overrides for CA and KRA installation.
+.TP
 \fB\-\-ca\-subject\fR=\fISUBJECT\fR
 The CA certificate subject DN (default CN=Certificate Authority,O=REALM.NAME). RDNs are in LDAP order (most specific RDN first).
 .TP

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -336,22 +336,25 @@ def install_step_0(standalone, replica_config, options, custodia):
     ca = cainstance.CAInstance(
         realm=realm_name, host_name=host_name, custodia=custodia
     )
-    ca.configure_instance(host_name, dm_password, dm_password,
-                          subject_base=subject_base,
-                          ca_subject=ca_subject,
-                          ca_signing_algorithm=ca_signing_algorithm,
-                          ca_type=ca_type,
-                          external_ca_profile=external_ca_profile,
-                          csr_file=csr_file,
-                          cert_file=cert_file,
-                          cert_chain_file=cert_chain_file,
-                          pkcs12_info=pkcs12_info,
-                          master_host=master_host,
-                          master_replication_port=master_replication_port,
-                          ra_p12=ra_p12,
-                          ra_only=ra_only,
-                          promote=promote,
-                          use_ldaps=use_ldaps)
+    ca.configure_instance(
+        host_name, dm_password, dm_password,
+        subject_base=subject_base,
+        ca_subject=ca_subject,
+        ca_signing_algorithm=ca_signing_algorithm,
+        ca_type=ca_type,
+        external_ca_profile=external_ca_profile,
+        csr_file=csr_file,
+        cert_file=cert_file,
+        cert_chain_file=cert_chain_file,
+        pkcs12_info=pkcs12_info,
+        master_host=master_host,
+        master_replication_port=master_replication_port,
+        ra_p12=ra_p12,
+        ra_only=ra_only,
+        promote=promote,
+        use_ldaps=use_ldaps,
+        pki_config_override=options.pki_config_override,
+    )
 
 
 def install_step_1(standalone, replica_config, options, custodia):

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -306,6 +306,7 @@ class CAInstance(DogtagInstance):
         self.csr_file = None
         self.cert_file = None
         self.cert_chain_file = None
+        self.basedn = DN(('o', 'ipaca'))
 
         if realm is not None:
             self.canickname = get_ca_nickname(realm)
@@ -327,7 +328,8 @@ class CAInstance(DogtagInstance):
                            ca_signing_algorithm=None,
                            ca_type=None, external_ca_profile=None,
                            ra_p12=None, ra_only=False,
-                           promote=False, use_ldaps=False):
+                           promote=False, use_ldaps=False,
+                           pki_config_override=None):
         """Create a CA instance.
 
            To create a clone, pass in pkcs12_info.
@@ -370,6 +372,7 @@ class CAInstance(DogtagInstance):
 
         self.no_db_setup = promote
         self.use_ldaps = use_ldaps
+        self.pki_config_override = pki_config_override
 
         # Determine if we are installing as an externally-signed CA and
         # what stage we're in.
@@ -569,6 +572,8 @@ class CAInstance(DogtagInstance):
                 pki_external_step_two=True,
             )
 
+        nolog_list = [self.dm_password, self.admin_password, pki_pin]
+
         config = self._create_spawn_config(cfg)
         pent = pwd.getpwnam(self.service_user)
         with tempfile.NamedTemporaryFile('w') as f:
@@ -580,7 +585,7 @@ class CAInstance(DogtagInstance):
 
             DogtagInstance.spawn_instance(
                 self, f.name,
-                nolog_list=(self.dm_password, self.admin_password, pki_pin)
+                nolog_list=nolog_list
             )
 
         if self.external == 1:

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -501,7 +501,7 @@ class CAInstance(DogtagInstance):
                 os.path.isfile(paths.PKI_TOMCAT_PASSWORD_CONF)):
             # generate pin which we know can be used for FIPS NSS database
             pki_pin = ipautil.ipa_generate_password()
-            cfg['pki_pin'] = pki_pin
+            cfg['pki_server_database_password'] = pki_pin
         else:
             pki_pin = None
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -322,7 +322,7 @@ class CAInstance(DogtagInstance):
     def configure_instance(self, host_name, dm_password, admin_password,
                            pkcs12_info=None, master_host=None, csr_file=None,
                            cert_file=None, cert_chain_file=None,
-                           master_replication_port=None,
+                           master_replication_port=389,
                            subject_base=None, ca_subject=None,
                            ca_signing_algorithm=None,
                            ca_type=None, external_ca_profile=None,
@@ -361,10 +361,7 @@ class CAInstance(DogtagInstance):
         self.ca_subject = \
             ca_subject or installutils.default_ca_subject_dn(self.subject_base)
 
-        if ca_signing_algorithm is None:
-            self.ca_signing_algorithm = 'SHA256withRSA'
-        else:
-            self.ca_signing_algorithm = ca_signing_algorithm
+        self.ca_signing_algorithm = ca_signing_algorithm
         if ca_type is not None:
             self.ca_type = ca_type
         else:
@@ -490,131 +487,46 @@ class CAInstance(DogtagInstance):
         Creates the config file with IPA specific parameters
         and passes it to the base class to call pkispawn
         """
+        cfg = dict(
+            pki_ds_secure_connection=self.use_ldaps
+        )
 
-        # Create an empty and secured file
-        (cfg_fd, cfg_file) = tempfile.mkstemp()
-        os.close(cfg_fd)
-        pent = pwd.getpwnam(self.service_user)
-
-        # Create CA configuration
-        config = RawConfigParser()
-        config.optionxform = str
-        config.add_section("CA")
-
-        # Server
-        config.set("CA", "pki_security_domain_name", self.security_domain_name)
-        config.set("CA", "pki_enable_proxy", "True")
-        config.set("CA", "pki_restart_configured_instance", "False")
-        config.set("CA", "pki_backup_keys", "True")
-        config.set("CA", "pki_backup_password", self.admin_password)
-        config.set("CA", "pki_profiles_in_ldap", "True")
-        config.set("CA", "pki_default_ocsp_uri",
-            "http://{}.{}/ca/ocsp".format(
-                ipalib.constants.IPA_CA_RECORD,
-                ipautil.format_netloc(api.env.domain)))
-
-        # Configures the status request timeout, i.e. the connect/data
-        # timeout on the HTTP request to get the status of Dogtag.
-        #
-        # This configuration is needed in "multiple IP address" scenarios
-        # where this server's hostname has multiple IP addresses but the
-        # HTTP server is only listening on one of them.  Without a timeout,
-        # if a "wrong" IP address is tried first, it will take a long time
-        # to timeout, exceeding the overall timeout hence the request will
-        # not be re-tried.  Setting a shorter timeout allows the request
-        # to be re-tried.
-        #
-        # Note that HSMs cause different behaviour so this value might
-        # not be suitable for when we implement HSM support.  It is
-        # known that a value of 5s is too short in HSM environment.
-        #
-        config.set("CA", "pki_status_request_timeout", "15")  # 15 seconds
-
-        # Client security database
-        config.set("CA", "pki_client_pkcs12_password", self.admin_password)
-
-        # Administrator
-        config.set("CA", "pki_admin_name", self.admin_user)
-        config.set("CA", "pki_admin_uid", self.admin_user)
-        config.set("CA", "pki_admin_email", "root@localhost")
-        config.set("CA", "pki_admin_password", self.admin_password)
-        config.set("CA", "pki_admin_nickname", "ipa-ca-agent")
-        config.set("CA", "pki_admin_subject_dn",
-            str(DN(('cn', 'ipa-ca-agent'), self.subject_base)))
-        config.set("CA", "pki_client_admin_cert_p12", paths.DOGTAG_ADMIN_P12)
-
-        # Directory server
-        config.set("CA", "pki_ds_ldap_port", "389")
-        config.set("CA", "pki_ds_password", self.dm_password)
-        config.set("CA", "pki_ds_base_dn", str(self.basedn))
-        config.set("CA", "pki_ds_database", "ipaca")
-
-        if self.use_ldaps:
-            self._use_ldaps_during_spawn(config)
-
-        # Certificate subject DN's
-        config.set("CA", "pki_subsystem_subject_dn",
-            str(DN(('cn', 'CA Subsystem'), self.subject_base)))
-        config.set("CA", "pki_ocsp_signing_subject_dn",
-            str(DN(('cn', 'OCSP Subsystem'), self.subject_base)))
-        config.set("CA", "pki_sslserver_subject_dn",
-            str(DN(('cn', self.fqdn), self.subject_base)))
-        config.set("CA", "pki_audit_signing_subject_dn",
-            str(DN(('cn', 'CA Audit'), self.subject_base)))
-        config.set(
-            "CA", "pki_ca_signing_subject_dn",
-            str(self.ca_subject))
-
-        # Certificate nicknames
-        config.set("CA", "pki_subsystem_nickname", "subsystemCert cert-pki-ca")
-        config.set("CA", "pki_ocsp_signing_nickname", "ocspSigningCert cert-pki-ca")
-        config.set("CA", "pki_sslserver_nickname", "Server-Cert cert-pki-ca")
-        config.set("CA", "pki_audit_signing_nickname", "auditSigningCert cert-pki-ca")
-        config.set("CA", "pki_ca_signing_nickname", "caSigningCert cert-pki-ca")
-
-        # CA key algorithm
-        config.set("CA", "pki_ca_signing_key_algorithm", self.ca_signing_algorithm)
+        if self.ca_signing_algorithm is not None:
+            cfg['ipa_ca_signing_algorithm'] = self.ca_signing_algorithm
 
         if not (os.path.isdir(paths.PKI_TOMCAT_ALIAS_DIR) and
                 os.path.isfile(paths.PKI_TOMCAT_PASSWORD_CONF)):
             # generate pin which we know can be used for FIPS NSS database
             pki_pin = ipautil.ipa_generate_password()
-            config.set("CA", "pki_pin", pki_pin)
+            cfg['pki_pin'] = pki_pin
         else:
             pki_pin = None
 
         if self.clone:
-
             if self.no_db_setup:
-                config.set("CA", "pki_ds_create_new_db", "False")
-                config.set("CA", "pki_clone_setup_replication", "False")
-                config.set("CA", "pki_clone_reindex_data", "True")
+                cfg.update(
+                    pki_ds_create_new_db=False,
+                    pki_clone_setup_replication=False,
+                    pki_clone_reindex_data=True,
+                )
 
             cafile = self.pkcs12_info[0]
             shutil.copy(cafile, paths.TMP_CA_P12)
             pent = pwd.getpwnam(self.service_user)
             os.chown(paths.TMP_CA_P12, pent.pw_uid, pent.pw_gid)
 
-            # Security domain registration
-            config.set("CA", "pki_security_domain_hostname", self.master_host)
-            config.set("CA", "pki_security_domain_https_port", "443")
-            config.set("CA", "pki_security_domain_user", self.admin_user)
-            config.set("CA", "pki_security_domain_password", self.admin_password)
-
-            # Clone
-            config.set("CA", "pki_clone", "True")
-            config.set("CA", "pki_clone_pkcs12_path", paths.TMP_CA_P12)
-            config.set("CA", "pki_clone_pkcs12_password", self.dm_password)
-            config.set("CA", "pki_clone_replication_security", "TLS")
-            config.set("CA", "pki_clone_replication_master_port", str(self.master_replication_port))
-            config.set("CA", "pki_clone_replication_clone_port", "389")
-            config.set("CA", "pki_clone_replicate_schema", "False")
-            config.set("CA", "pki_clone_uri", "https://%s" % ipautil.format_netloc(self.master_host, 443))
+            self._configure_clone(
+                cfg,
+                security_domain_hostname=self.master_host,
+                clone_pkcs12_path=paths.TMP_CA_P12,
+            )
 
         # External CA
         if self.external == 1:
-            config.set("CA", "pki_external", "True")
-            config.set("CA", "pki_external_csr_path", self.csr_file)
+            cfg.update(
+                pki_external=True,
+                pki_ca_signing_csr_path=self.csr_file,
+            )
 
             if self.ca_type == ExternalCAType.MS_CS.value:
                 # Include MS template name extension in the CSR
@@ -624,11 +536,12 @@ class CAInstance(DogtagInstance):
                     template = MSCSTemplateV1(u"SubCA")
 
                 ext_data = binascii.hexlify(template.get_ext_data())
-                config.set("CA", "pki_req_ext_add", "True")
-                config.set("CA", "pki_req_ext_oid", template.ext_oid)
-                config.set("CA", "pki_req_ext_critical", "False")
-                config.set("CA", "pki_req_ext_data", ext_data.decode('ascii'))
-
+                cfg.update(
+                    pki_req_ext_add=True,
+                    pki_req_ext_oid=template.ext_oid,
+                    pki_req_ext_critical=False,
+                    pki_req_ext_data=ext_data.decode('ascii'),
+                )
         elif self.external == 2:
             cert_file = tempfile.NamedTemporaryFile()
             with open(self.cert_file, 'rb') as f:
@@ -649,28 +562,26 @@ class CAInstance(DogtagInstance):
                 cert_chain, re.DOTALL).group(0)
             cert_chain_file = ipautil.write_tmp_file(cert_chain)
 
-            config.set("CA", "pki_external", "True")
-            config.set("CA", "pki_external_ca_cert_path", cert_file.name)
-            config.set("CA", "pki_external_ca_cert_chain_path", cert_chain_file.name)
-            config.set("CA", "pki_external_step_two", "True")
-
-        # Generate configuration file
-        with open(cfg_file, "w") as f:
-            config.write(f)
-
-        # Finally chown the config file (rhbz#1677027)
-        os.chown(cfg_file, pent.pw_uid, pent.pw_gid)
-
-        self.backup_state('installed', True)
-        try:
-            DogtagInstance.spawn_instance(
-                self, cfg_file,
-                nolog_list=(self.dm_password,
-                            self.admin_password,
-                            pki_pin)
+            cfg.update(
+                pki_external=True,
+                pki_ca_signing_cert_path=cert_file.name,
+                pki_cert_chain_path=cert_chain_file.name,
+                pki_external_step_two=True,
             )
-        finally:
-            os.remove(cfg_file)
+
+        config = self._create_spawn_config(cfg)
+        pent = pwd.getpwnam(self.service_user)
+        with tempfile.NamedTemporaryFile('w') as f:
+            config.write(f)
+            f.flush()
+            os.fchown(f.fileno(), pent.pw_uid, pent.pw_gid)
+
+            self.backup_state('installed', True)
+
+            DogtagInstance.spawn_instance(
+                self, f.name,
+                nolog_list=(self.dm_password, self.admin_password, pki_pin)
+            )
 
         if self.external == 1:
             print("The next step is to get %s signed by your CA and re-run %s as:" % (self.csr_file, sys.argv[0]))

--- a/ipaserver/install/dogtag.py
+++ b/ipaserver/install/dogtag.py
@@ -5,6 +5,12 @@
 """
 Dogtag-based service installer module
 """
+import os
+
+# pylint: disable=import-error
+from six.moves.configparser import RawConfigParser
+# pylint: enable=import-error
+
 
 from ipalib.install import service
 from ipalib.install.service import prepare_only, replica_install_only
@@ -23,3 +29,24 @@ class DogtagInstallInterface(service.ServiceInstallInterface):
     )
     ca_file = prepare_only(ca_file)
     ca_file = replica_install_only(ca_file)
+
+    pki_config_override = knob(
+        str, None,
+        cli_names='--pki-config-override',
+        description="Path to ini file with config overrides.",
+    )
+
+    @pki_config_override.validator
+    def pki_config_override(self, value):
+        if value is None:
+            return
+        if not os.path.isabs(value):
+            raise ValueError("must use an absolute path")
+        try:
+            cfg = RawConfigParser()
+            with open(value) as f:
+                cfg.readfp(f)  # pylint: disable=deprecated-method
+        except Exception as e:
+            raise ValueError(
+                "Invalid config '{}': {}".format(value, e)
+            )

--- a/ipaserver/install/dogtag.py
+++ b/ipaserver/install/dogtag.py
@@ -5,16 +5,11 @@
 """
 Dogtag-based service installer module
 """
-import os
-
-# pylint: disable=import-error
-from six.moves.configparser import RawConfigParser
-# pylint: enable=import-error
-
 
 from ipalib.install import service
 from ipalib.install.service import prepare_only, replica_install_only
 from ipapython.install.core import knob
+from ipaserver.install.dogtaginstance import PKIIniLoader
 
 
 class DogtagInstallInterface(service.ServiceInstallInterface):
@@ -38,15 +33,5 @@ class DogtagInstallInterface(service.ServiceInstallInterface):
 
     @pki_config_override.validator
     def pki_config_override(self, value):
-        if value is None:
-            return
-        if not os.path.isabs(value):
-            raise ValueError("must use an absolute path")
-        try:
-            cfg = RawConfigParser()
-            with open(value) as f:
-                cfg.readfp(f)  # pylint: disable=deprecated-method
-        except Exception as e:
-            raise ValueError(
-                "Invalid config '{}': {}".format(value, e)
-            )
+        if value is not None:
+            PKIIniLoader.verify_pki_config_override(value)

--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -75,6 +75,11 @@ class KRAInstall(admintool.AdminTool):
             dest="uninstall", action="store_true", default=False,
             help=SUPPRESS_HELP)
 
+        parser.add_option(
+            "--pki-config-override", dest="pki_config_override",
+            default=None,
+            help="Path to ini file with config overrides.")
+
     def validate_options(self, needs_root=True):
         super(KRAInstall, self).validate_options(needs_root=True)
 

--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -87,11 +87,14 @@ def install(api, replica_config, options, custodia):
         promote = True
 
     kra = krainstance.KRAInstance(realm_name)
-    kra.configure_instance(realm_name, host_name, dm_password, dm_password,
-                           subject_base=subject_base,
-                           pkcs12_info=pkcs12_info,
-                           master_host=master_host,
-                           promote=promote)
+    kra.configure_instance(
+        realm_name, host_name, dm_password, dm_password,
+        subject_base=subject_base,
+        pkcs12_info=pkcs12_info,
+        master_host=master_host,
+        promote=promote,
+        pki_config_override=options.pki_config_override,
+    )
 
     _service.print_msg("Restarting the directory server")
     ds = dsinstance.DsInstance()

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -169,15 +169,13 @@ class KRAInstance(DogtagInstance):
             pki_client_pkcs12_password=self.admin_password,
             pki_import_admin_cert=False,
             pki_client_admin_cert_p12=admin_p12_file,
-            pki_ds_secure_connection=True,  # always LDAPS
-            pki_ds_create_new_db=False,
         )
 
         if not (os.path.isdir(paths.PKI_TOMCAT_ALIAS_DIR) and
                 os.path.isfile(paths.PKI_TOMCAT_PASSWORD_CONF)):
             # generate pin which we know can be used for FIPS NSS database
             pki_pin = ipautil.ipa_generate_password()
-            cfg['pki_pin'] = pki_pin
+            cfg['pki_server_database_password'] = pki_pin
         else:
             pki_pin = None
 

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -77,7 +77,7 @@ class KRAInstance(DogtagInstance):
     def configure_instance(self, realm_name, host_name, dm_password,
                            admin_password, pkcs12_info=None, master_host=None,
                            subject_base=None, subject=None,
-                           promote=False):
+                           promote=False, pki_config_override=None):
         """Create a KRA instance.
 
            To create a clone, pass in pkcs12_info.
@@ -90,6 +90,7 @@ class KRAInstance(DogtagInstance):
         if self.pkcs12_info is not None or promote:
             self.clone = True
         self.master_host = master_host
+        self.pki_config_override = pki_config_override
 
         self.subject_base = \
             subject_base or installutils.default_subject_base(realm_name)
@@ -213,13 +214,14 @@ class KRAInstance(DogtagInstance):
         with open(cfg_file, "w") as f:
             config.write(f)
 
+        nolog_list = [
+            self.dm_password, self.admin_password, pki_pin, tmp_agent_pwd
+        ]
+
         try:
             DogtagInstance.spawn_instance(
                 self, cfg_file,
-                nolog_list=(self.dm_password,
-                            self.admin_password,
-                            pki_pin,
-                            tmp_agent_pwd)
+                nolog_list=nolog_list
             )
         finally:
             os.remove(p12_tmpfile_name)

--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -1193,6 +1193,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-28/test_pki_config_override:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_pki_config_override.py
+        template: *ci-master-f28
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-28/mask:
     requires: [fedora-28/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1193,6 +1193,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-29/test_pki_config_override:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_pki_config_override.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-29/test_automount_locations:
     requires: [fedora-29/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1193,6 +1193,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-rawhide/test_pki_config_override:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_pki_config_override.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-rawhide/mask:
     requires: [fedora-rawhide/build]
     priority: 50

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -39,7 +39,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
 
-
+from ipapython import certdb
 from ipapython import ipautil
 from ipaplatform.paths import paths
 from ipapython.dn import DN
@@ -1494,6 +1494,32 @@ def run_certutil(host, args, reqdir, dbtype=None,
     new_args.extend(args)
     return host.run_command(new_args, raiseonerr=raiseonerr,
                             stdin_text=stdin)
+
+
+def certutil_certs_keys(host, reqdir, pwd_file, token_name=None):
+    """Run certutils and get mappings of cert and key files
+    """
+    base_args = ['-f', pwd_file]
+    if token_name is not None:
+        base_args.extend(['-h', token_name])
+    cert_args = base_args + ['-L']
+    key_args = base_args + ['-K']
+
+    result = run_certutil(host, cert_args, reqdir)
+    certs = {}
+    for line in result.stdout_text.splitlines():
+        mo = certdb.CERT_RE.match(line)
+        if mo:
+            certs[mo.group('nick')] = mo.group('flags')
+
+    result = run_certutil(host, key_args, reqdir)
+    assert 'orphan' not in result.stdout_text
+    keys = {}
+    for line in result.stdout_text.splitlines():
+        mo = certdb.KEY_RE.match(line)
+        if mo:
+            keys[mo.group('nick')] = mo.group('keyid')
+    return certs, keys
 
 
 def upload_temp_contents(host, contents, encoding='utf-8'):

--- a/ipatests/test_integration/test_pki_config_override.py
+++ b/ipatests/test_integration/test_pki_config_override.py
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+"""Test cases for PKI config overrides
+"""
+from __future__ import absolute_import
+
+from ipalib.x509 import load_pem_x509_certificate
+from ipaplatform.paths import paths
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_ipa.integration import tasks
+
+
+KEY_OVERRIDE = """
+[DEFAULT]
+ipa_key_size=4096
+"""
+
+
+class TestPKIConfigOverride(IntegrationTest):
+    @classmethod
+    def install(cls, mh):
+        pki_ini = tasks.upload_temp_contents(cls.master, KEY_OVERRIDE)
+        extra_args = [
+            '--pki-config-override', pki_ini,
+        ]
+        tasks.install_master(
+            cls.master, setup_dns=False, extra_args=extra_args
+        )
+        cls.master.run_command(['rm', '-f', pki_ini])
+
+    def test_cert_rsa4096(self):
+        ca_pem = self.master.get_file_contents(
+            paths.IPA_CA_CRT, encoding=None
+        )
+        cert = load_pem_x509_certificate(ca_pem)
+        assert cert.public_key().key_size == 4096


### PR DESCRIPTION
Add an option to override CA and KRA settings passed to pkispawn. The feature allows users to change key size, signature algorithm, and other parameters. It's a prerequisite for HSM support.

The patchset also simplifies and improves how IPA creates the pki.ini files that gets passed to pkispawn.

See https://pagure.io/freeipa/issue/5608

Split of PR #2307