### PR TITLE
Move DS's Kerberos env vars to unit file

### DIFF
--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -39,6 +39,7 @@ dist_app_DATA =				\
 	replica-acis.ldif		\
 	replica-prevent-time-skew.ldif  \
 	ds-nfiles.ldif			\
+	ds-ipa-env.conf.template	\
 	dns.ldif			\
 	dnssec.ldif			\
 	domainlevel.ldif			\

--- a/install/share/ds-ipa-env.conf.template
+++ b/install/share/ds-ipa-env.conf.template
@@ -1,0 +1,5 @@
+# Installed and maintained by ipa update tools, please do not modify
+
+[Service]
+Environment=KRB5_KTNAME=$KRB5_KTNAME
+Environment=KRB5CCNAME=$KRB5CCNAME

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -382,6 +382,8 @@ class BasePathNamespace:
     VAR_LOG_DIRSRV_INSTANCE_TEMPLATE = "/var/log/dirsrv/slapd-%s"
     SLAPD_INSTANCE_ACCESS_LOG_TEMPLATE = "/var/log/dirsrv/slapd-%s/access"
     SLAPD_INSTANCE_ERROR_LOG_TEMPLATE = "/var/log/dirsrv/slapd-%s/errors"
+    SLAPD_INSTANCE_SYSTEMD_IPA_ENV_TEMPLATE = \
+        "/etc/systemd/system/dirsrv@%s.service.d/ipa-env.conf"
     # Legacy 389 commands
     LDIF2DB = '/usr/sbin/ldif2db'
     DB2LDIF = '/usr/sbin/db2ldif'

--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -35,6 +35,7 @@ import six
 
 from ipapython import ipautil
 from ipaplatform.paths import paths
+from ipaplatform.tasks import tasks
 
 # pylint: disable=no-name-in-module, import-error
 if six.PY3:
@@ -452,7 +453,7 @@ class SystemdService(PlatformService):
                         # Link exists and it is broken, make new one
                         os.unlink(srv_lnk)
                         os.symlink(self.lib_path, srv_lnk)
-                ipautil.run([paths.SYSTEMCTL, "--system", "daemon-reload"])
+                tasks.systemd_daemon_reload()
             except Exception:
                 pass
         else:
@@ -475,7 +476,7 @@ class SystemdService(PlatformService):
                 if os.path.isdir(srv_tgt):
                     if os.path.islink(srv_lnk):
                         os.unlink(srv_lnk)
-                ipautil.run([paths.SYSTEMCTL, "--system", "daemon-reload"])
+                tasks.systemd_daemon_reload()
             except Exception:
                 pass
         else:

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -251,5 +251,9 @@ class BaseTaskNamespace:
     def setup_httpd_logging(self):
         raise NotImplementedError()
 
+    def systemd_daemon_reload(self):
+        """Tell systemd to reload config files"""
+        raise NotImplementedError
+
 
 tasks = BaseTaskNamespace()

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -498,9 +498,11 @@ class RedHatTaskNamespace(BaseTaskNamespace):
 
         os.chmod(paths.SYSTEMD_SYSTEM_HTTPD_IPA_CONF, 0o644)
         self.restore_context(paths.SYSTEMD_SYSTEM_HTTPD_IPA_CONF)
+        self.systemd_daemon_reload()
 
-        ipautil.run([paths.SYSTEMCTL, "--system", "daemon-reload"],
-                    raiseonerr=False)
+    def systemd_daemon_reload(self):
+        """Tell systemd to reload config files"""
+        ipautil.run([paths.SYSTEMCTL, "--system", "daemon-reload"])
 
     def configure_http_gssproxy_conf(self, ipaapi_user):
         ipautil.copy_template_file(
@@ -564,8 +566,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                 )
             return
 
-        ipautil.run([paths.SYSTEMCTL, "--system", "daemon-reload"],
-                    raiseonerr=False)
+        self.systemd_daemon_reload()
 
     def set_hostname(self, hostname):
         ipautil.run([paths.BIN_HOSTNAMECTL, 'set-hostname', hostname])

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -1104,13 +1104,16 @@ def reverse_record_exists(ip_address):
     return True
 
 
-def config_replace_variables(filepath, replacevars=dict(), appendvars=dict()):
+def config_replace_variables(filepath, replacevars=dict(), appendvars=dict(),
+                             removevars=None):
     """
     Take a key=value based configuration file, and write new version
-    with certain values replaced or appended
+    with certain values replaced, appended, or removed.
 
     All (key,value) pairs from replacevars and appendvars that were not found
     in the configuration file, will be added there.
+
+    All entries in set removevars are removed.
 
     It is responsibility of a caller to ensure that replacevars and
     appendvars do not overlap.
@@ -1153,7 +1156,11 @@ $)''', re.VERBOSE)
                             elif value.find(appendvars[option]) == -1:
                                 new_line = u"%s=%s %s\n" % (option, value, appendvars[option])
                             old_values[option] = value
-                new_config.write(new_line)
+                        if removevars and option in removevars:
+                            old_values[option] = value
+                            new_line = None
+                if new_line is not None:
+                    new_config.write(new_line)
         # Now add all options from replacevars and appendvars that were not found in the file
         new_vars = replacevars.copy()
         new_vars.update(appendvars)

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -26,7 +26,6 @@ import pwd
 import os
 import time
 import tempfile
-import stat
 import fnmatch
 
 from lib389 import DirSrv
@@ -200,7 +199,6 @@ class DsInstance(service.Service):
         self.nickname = 'Server-Cert'
         self.sub_dict = None
         self.domain = domain_name
-        self.serverid = None
         self.master_fqdn = None
         self.pkcs12_info = None
         self.cacert_name = None
@@ -216,9 +214,11 @@ class DsInstance(service.Service):
         self.domainlevel = domainlevel
         if realm_name:
             self.suffix = ipautil.realm_to_suffix(self.realm)
+            self.serverid = ipaldap.realm_to_serverid(self.realm)
             self.__setup_sub_dict()
         else:
             self.suffix = DN()
+            self.serverid = None
 
     subject_base = ipautil.dn_attribute_property('_subject_base')
 
@@ -245,7 +245,8 @@ class DsInstance(service.Service):
         self.step("enabling referential integrity plugin", self.__add_referint_module)
         self.step("configuring certmap.conf", self.__certmap_conf)
         self.step("configure new location for managed entries", self.__repoint_managed_entries)
-        self.step("configure dirsrv ccache", self.configure_dirsrv_ccache)
+        self.step("configure dirsrv ccache and keytab",
+                  self.configure_systemd_ipa_env)
         self.step("enabling SASL mapping fallback",
                   self.__enable_sasl_mapping_fallback)
 
@@ -521,7 +522,6 @@ class DsInstance(service.Service):
 
     def __create_instance(self):
         self.backup_state("serverid", self.serverid)
-        self.fstore.backup_file(paths.SYSCONFIG_DIRSRV)
 
         # The new installer is api driven. We can pass it a log function
         # and it will use it. Because of this, we can pass verbose true,
@@ -756,21 +756,39 @@ class DsInstance(service.Service):
     def __repoint_managed_entries(self):
         self._ldap_mod("repoint-managed-entries.ldif", self.sub_dict)
 
-    def configure_dirsrv_ccache(self):
+    def configure_systemd_ipa_env(self):
         pent = pwd.getpwnam(platformconstants.DS_USER)
-        ccache = paths.TMP_KRB5CC % pent.pw_uid
-        filepath = paths.SYSCONFIG_DIRSRV
-        if not os.path.exists(filepath):
-            # file doesn't exist; create it with correct ownership & mode
-            open(filepath, 'a').close()
-            os.chmod(filepath,
-                stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
-            os.chown(filepath, 0, 0)
+        template = os.path.join(
+            paths.USR_SHARE_IPA_DIR, "ds-ipa-env.conf.template"
+        )
+        sub_dict = dict(
+            KRB5_KTNAME=paths.DS_KEYTAB,
+            KRB5CCNAME=paths.TMP_KRB5CC % pent.pw_uid
+        )
+        conf = ipautil.template_file(template, sub_dict)
 
-        replacevars = {'KRB5CCNAME': ccache}
-        ipautil.backup_config_and_replace_variables(
-            self.fstore, filepath, replacevars=replacevars)
-        tasks.restore_context(filepath)
+        destfile = paths.SLAPD_INSTANCE_SYSTEMD_IPA_ENV_TEMPLATE % (
+            self.serverid
+        )
+        destdir = os.path.dirname(destfile)
+
+        if not os.path.isdir(destdir):
+            # create dirsrv-$SERVERID.service.d
+            os.mkdir(destdir, 0o755)
+        with open(destfile, 'w') as f:
+            os.fchmod(f.fileno(), 0o644)
+            f.write(conf)
+        tasks.restore_context(destfile)
+
+        # remove variables from old /etc/sysconfig/dirsrv file
+        if os.path.isfile(paths.SYSCONFIG_DIRSRV):
+            self.fstore.backup_file(paths.SYSCONFIG_DIRSRV)
+            ipautil.config_replace_variables(
+                paths.SYSCONFIG_DIRSRV,
+                removevars={'KRB5_KTNAME', 'KRB5CCNAME'}
+            )
+        # reload systemd to materialize new config file
+        tasks.systemd_daemon_reload()
 
     def __managed_entries(self):
         self._ldap_mod("managed-entries.ldif", self.sub_dict)
@@ -1082,6 +1100,17 @@ class DsInstance(service.Service):
             scripts = paths.VAR_LIB_DIRSRV_INSTANCE_SCRIPTS_TEMPLATE % (
                 serverid)
             installutils.rmtree(scripts)
+
+            # remove systemd unit file
+            unitfile = paths.SLAPD_INSTANCE_SYSTEMD_IPA_ENV_TEMPLATE % (
+                serverid
+            )
+            installutils.remove_file(unitfile)
+            try:
+                os.rmdir(os.path.dirname(unitfile))
+            except OSError:
+                # not empty
+                pass
 
         # Just eat this state
         self.restore_state("user_exists")

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -375,6 +375,7 @@ class Backup(admintool.AdminTool):
         for file in (
             paths.SYSCONFIG_DIRSRV_INSTANCE % serverid,
             paths.ETC_TMPFILESD_DIRSRV % serverid,
+            paths.SLAPD_INSTANCE_SYSTEMD_IPA_ENV_TEMPLATE % serverid,
         ):
             if os.path.exists(file):
                 self.files.append(file)

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -451,7 +451,7 @@ class Restore(admintool.AdminTool):
                 oddjobd.start()
                 http.remove_httpd_ccaches()
                 # have the daemons pick up their restored configs
-                run([paths.SYSTEMCTL, "--system", "daemon-reload"])
+                tasks.systemd_daemon_reload()
         finally:
             try:
                 os.chdir(cwd)

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -386,10 +386,6 @@ class KrbInstance(service.Service):
 
         self.fstore.backup_file(paths.DS_KEYTAB)
         installutils.create_keytab(paths.DS_KEYTAB, ldap_principal)
-
-        vardict = {"KRB5_KTNAME": paths.DS_KEYTAB}
-        ipautil.config_replace_variables(paths.SYSCONFIG_DIRSRV,
-                                         replacevars=vardict)
         pent = pwd.getpwnam(constants.DS_USER)
         os.chown(paths.DS_KEYTAB, pent.pw_uid, pent.pw_gid)
 

--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -5,7 +5,9 @@ from __future__ import print_function
 
 import os
 import pprint
+import shutil
 import sys
+import tempfile
 
 import pytest
 
@@ -145,3 +147,14 @@ def pytest_runtest_setup(item):
             # pylint: disable=no-member
             if pytest.config.option.skip_ipaapi:
                 pytest.skip("Skip tests that needs an IPA API")
+
+
+@pytest.fixture
+def tempdir(request):
+    tempdir = tempfile.mkdtemp()
+
+    def fin():
+        shutil.rmtree(tempdir)
+
+    request.addfinalizer(fin)
+    return tempdir

--- a/ipatests/test_ipapython/test_directivesetter.py
+++ b/ipatests/test_ipapython/test_directivesetter.py
@@ -4,10 +4,7 @@
 from __future__ import absolute_import
 
 import os
-import shutil
 import tempfile
-
-import pytest
 
 from ipapython import directivesetter
 
@@ -20,17 +17,6 @@ WHITESPACE_CONFIG = [
     'foo 1\n',
     'foobar\t2\n',
 ]
-
-
-@pytest.fixture
-def tempdir(request):
-    tempdir = tempfile.mkdtemp()
-
-    def fin():
-        shutil.rmtree(tempdir)
-
-    request.addfinalizer(fin)
-    return tempdir
 
 
 class test_set_directive_lines:

--- a/ipatests/test_ipaserver/test_install/test_installutils.py
+++ b/ipatests/test_ipaserver/test_install/test_installutils.py
@@ -6,9 +6,7 @@ from __future__ import absolute_import
 import binascii
 import os
 import re
-import shutil
 import subprocess
-import tempfile
 import textwrap
 
 import pytest
@@ -18,17 +16,6 @@ from ipapython import ipautil
 from ipaserver.install import installutils
 from ipaserver.install import ipa_backup
 from ipaserver.install import ipa_restore
-
-
-@pytest.fixture
-def tempdir(request):
-    tempdir = tempfile.mkdtemp()
-
-    def fin():
-        shutil.rmtree(tempdir)
-
-    request.addfinalizer(fin)
-    return tempdir
 
 
 GPG_GENKEY = textwrap.dedent("""


### PR DESCRIPTION
The IPA specific env vars KRB5_KTNAME and KRB5CCNAME are now defined in a instance specific ipa-env.conf unit file.
    
Fixes: https://pagure.io/freeipa/issue/7860
