### PR TITLE
Samba 4.9 related backport to ipa-4-6

### DIFF
--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -845,8 +845,6 @@ class ADTRUSTInstance(service.Service):
                   self.__create_samba_domain_object)
         self.step("creating samba config registry", self.__write_smb_registry)
         self.step("writing samba config file", self.__write_smb_conf)
-        self.step("map BUILTIN\\Guests to nobody group",
-                  self.__map_Guests_to_nobody)
         self.step("adding cifs Kerberos principal",
                   self.request_service_keytab)
         self.step("adding cifs and host Kerberos principals to the adtrust agents group", \
@@ -858,6 +856,8 @@ class ADTRUSTInstance(service.Service):
         self.step("updating Kerberos config", self.__update_krb5_conf)
         self.step("activating CLDAP plugin", self.__add_cldap_module)
         self.step("activating sidgen task", self.__add_sidgen_task)
+        self.step("map BUILTIN\\Guests to nobody group",
+                  self.__map_Guests_to_nobody)
         self.step("configuring smbd to start on boot", self.__enable)
         self.step("adding special DNS service records", \
                   self.__add_dns_service_records)

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -123,8 +123,8 @@ def make_netbios_name(s):
 
 def map_Guests_to_nobody():
     env = {'LC_ALL': 'C'}
-    args = [paths.NET, 'groupmap', 'add', 'sid=S-1-5-32-546',
-            'unixgroup=nobody', 'type=builtin']
+    args = [paths.NET, '-s', '/dev/null', 'groupmap', 'add',
+            'sid=S-1-5-32-546', 'unixgroup=nobody', 'type=builtin']
 
     logger.debug("Map BUILTIN\\Guests to a group 'nobody'")
     ipautil.run(args, env=env, raiseonerr=False, capture_error=True)


### PR DESCRIPTION
When backporting Samba related patches for ticket https://pagure.io/freeipa/issue/7705, we missed two patches on top of those in ipa-4-6 backport.

As result, FreeIPA 4.6.5 does not work with Samba 4.9 because we aren't able to set up group mapping for BUILTIN\Guests properly.