### PR TITLE
[Backport][ipa-4-7] Verify external CA's basic constraint pathlen

### DIFF
--- a/ipatests/create_external_ca.py
+++ b/ipatests/create_external_ca.py
@@ -38,7 +38,7 @@ class ExternalCA(object):
         self.now = datetime.datetime.utcnow()
         self.delta = datetime.timedelta(days=days)
 
-    def create_ca(self, cn=ISSUER_CN):
+    def create_ca(self, cn=ISSUER_CN, path_length=None):
         """Create root CA.
 
         :returns: bytes -- Root CA in PEM format.
@@ -79,7 +79,7 @@ class ExternalCA(object):
         )
 
         builder = builder.add_extension(
-            x509.BasicConstraints(ca=True, path_length=None),
+            x509.BasicConstraints(ca=True, path_length=path_length),
             critical=True,
         )
 

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1152,7 +1152,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert
+        test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert test_integration/test_external_ca.py::TestExternalCAInvalidIntermediate
         template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1616,7 +1616,8 @@ def add_dns_zone(master, zone, skip_overlap_check=False,
         logger.debug('Zone %s already added.', zone)
 
 
-def sign_ca_and_transport(host, csr_name, root_ca_name, ipa_ca_name):
+def sign_ca_and_transport(host, csr_name, root_ca_name, ipa_ca_name,
+                          root_ca_path_length=None, ipa_ca_path_length=1):
     """
     Sign ipa csr and save signed CA together with root CA back to the host.
     Returns root CA and IPA CA paths on the host.
@@ -1629,9 +1630,9 @@ def sign_ca_and_transport(host, csr_name, root_ca_name, ipa_ca_name):
 
     external_ca = ExternalCA()
     # Create root CA
-    root_ca = external_ca.create_ca()
+    root_ca = external_ca.create_ca(path_length=root_ca_path_length)
     # Sign CSR
-    ipa_ca = external_ca.sign_csr(ipa_csr)
+    ipa_ca = external_ca.sign_csr(ipa_csr, path_length=ipa_ca_path_length)
 
     root_ca_fname = os.path.join(test_dir, root_ca_name)
     ipa_ca_fname = os.path.join(test_dir, ipa_ca_name)
@@ -1640,7 +1641,7 @@ def sign_ca_and_transport(host, csr_name, root_ca_name, ipa_ca_name):
     host.put_file_contents(root_ca_fname, root_ca)
     host.put_file_contents(ipa_ca_fname, ipa_ca)
 
-    return (root_ca_fname, ipa_ca_fname)
+    return root_ca_fname, ipa_ca_fname
 
 
 def generate_ssh_keypair():


### PR DESCRIPTION
Manual backport of PR #7877

IPA no verifies that intermediate certs of external CAs have a basic
constraint path len of at least 1 and increasing.

Fixes: https://pagure.io/freeipa/issue/7877
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Fraser Tweedale <ftweedal@redhat.com>
Reviewed-By: Alexander Bokovoy <abokovoy@redhat.com>