### PR TITLE
Remove DsInstance.request_service_keytab as it is not needed anymore

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -1352,14 +1352,6 @@ class DsInstance(service.Service):
         if self.domainlevel is not None:
             self._ldap_mod("domainlevel.ldif", self.sub_dict)
 
-    def request_service_keytab(self):
-        super(DsInstance, self).request_service_keytab()
-
-        # Configure DS to use the keytab
-        vardict = {"KRB5_KTNAME": self.keytab}
-        ipautil.config_replace_variables(paths.SYSCONFIG_DIRSRV,
-                                         replacevars=vardict)
-
 
 def write_certmap_conf(realm, ca_subject):
     """(Re)write certmap.conf with given CA subject DN."""


### PR DESCRIPTION
DsInstance.request_service_keytab() used to configure
/etc/sysconfig/dirsrv which is not needed anymore with 389-ds-base
1.4.1.2. Thus, the method became indistinguishable from the parent and
can be removed completely.