### PR TITLE
automount: rmtree temp directory

### DIFF
--- a/client/ipa-client-automount.in
+++ b/client/ipa-client-automount.in
@@ -26,6 +26,7 @@ from __future__ import print_function
 import logging
 import sys
 import os
+import shutil
 import time
 import tempfile
 import gssapi
@@ -487,8 +488,7 @@ def main():
         except errors.PublicError as e:
             sys.exit("Cannot connect to the server due to generic error: %s" % str(e))
     finally:
-        os.remove(ccache_name)
-        os.rmdir(ccache_dir)
+        shutil.rmtree(ccache_dir)
 
     if not options.unattended and not ipautil.user_input("Continue to configure the system with these values?", False):
         sys.exit("Installation aborted")


### PR DESCRIPTION
ipa-client-automount uses the host keytab to acquire a TGT. The script
sets up a temporary directory for its ccache. At the end of the script
it removes the ccache and temp directory again.

In case of a failed kinit, the ccache is not created and the removal of
the ccache causes an exception. The automount installer now uses
shutil.rmtree() to remove the temporary directory and all its content.

Fixes: https://pagure.io/freeipa/issue/7862
Signed-off-by: Christian Heimes <cheimes@redhat.com>