### PR TITLE
Skip orphan automember rule test

### DIFF
--- a/ipatests/test_xmlrpc/test_automember_plugin.py
+++ b/ipatests/test_xmlrpc/test_automember_plugin.py
@@ -831,6 +831,7 @@ class TestAutomemberFindOrphans(XMLRPC_test):
 
         hostgroup1.retrieve()
 
+    @pytest.mark.skip(reason="Fails with 389-DS 1.4.0.22, see issue 7902")
     def test_find_orphan_automember_rules(self, hostgroup1):
         """ Remove hostgroup1, find and remove obsolete automember rules. """
         # Remove hostgroup1


### PR DESCRIPTION
389-DS 1.4.0.22 was pushed to Fedora over the weekend. The new versin
breaks test_find_orphan_automember_rules. Skip the test case for now
until we have more time to investigate the issue.

Related: https://pagure.io/freeipa/issue/7902
Signed-off-by: Christian Heimes <cheimes@redhat.com>