### PR TITLE
[Backport][ipa-4-7] Skip orphan automember rule test

### DIFF
--- a/ipatests/test_xmlrpc/test_automember_plugin.py
+++ b/ipatests/test_xmlrpc/test_automember_plugin.py
@@ -831,6 +831,7 @@ class TestAutomemberFindOrphans(XMLRPC_test):
 
         hostgroup1.retrieve()
 
+    @pytest.mark.skip(reason="Fails with 389-DS 1.4.0.22, see issue 7902")
     def test_find_orphan_automember_rules(self, hostgroup1):
         """ Remove hostgroup1, find and remove obsolete automember rules. """
         # Remove hostgroup1


### PR DESCRIPTION
This PR was opened automatically because PR #3005 was pushed to master and backport to ipa-4-7 is required.