### PR TITLE
Drop upper bound on krb5 version in freeipa.spec

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -287,7 +287,7 @@ Requires: openldap-clients > 2.4.35-4
 Requires: nss >= %{nss_version}
 Requires: nss-tools >= %{nss_version}
 Requires(post): krb5-server >= %{krb5_version}
-Requires(post): krb5-server >= %{krb5_base_version}, krb5-server < %{krb5_base_version}.100
+Requires(post): krb5-server >= %{krb5_base_version}
 Requires: krb5-pkinit-openssl >= %{krb5_version}
 Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: chrony


### PR DESCRIPTION
This check is no longer needed now that krb5 exports the KDB version.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>