### PR TITLE
Gating: remove vault and kdcproxy tests

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -123,18 +123,6 @@ jobs:
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-29/test_http_kdc_proxy:
-    requires: [fedora-29/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_http_kdc_proxy.py
-        template: *ci-master-f29
-        timeout: 3600
-        topology: *master_1repl_1client
-
   fedora-29/test_forced_client_enrolment:
     requires: [fedora-29/build]
     priority: 50
@@ -193,18 +181,6 @@ jobs:
         test_suite: test_integration/test_netgroup.py
         template: *ci-master-f29
         timeout: 3600
-        topology: *master_1repl
-
-  fedora-29/test_vault:
-    requires: [fedora-29/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_vault.py
-        template: *ci-master-f29
-        timeout: 6300
         topology: *master_1repl
 
   fedora-29/test_authconfig:


### PR DESCRIPTION
Vault and KDC proxy are neither critical subsystems nor are they likely to
fail. They have been pretty stable and don't see any major development.
It's sufficient to run them in nightly tests only.

The removal speed up gating a bit. Especially vault tests are slow and
usually take more than 30 minutes to complete

Signed-off-by: Christian Heimes <cheimes@redhat.com>