### PR TITLE
[Backport][ipa-4-7] Make netifaces optional

### DIFF
--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -34,7 +34,6 @@ import socket
 import re
 import datetime
 import netaddr
-import netifaces
 import time
 import pwd
 import grp
@@ -48,6 +47,11 @@ from dns.exception import DNSException
 import six
 from six.moves import input
 from six.moves import urllib
+
+try:
+    import netifaces
+except ImportError:
+    netifaces = None
 
 from ipapython.dn import DN
 
@@ -197,6 +201,8 @@ class CheckedIPAddress(UnsafeIPAddress):
         :return: InterfaceDetails named tuple or None if no interface has
         this address
         """
+        if netifaces is None:
+            raise ImportError("netifaces")
         logger.debug("Searching for an interface of IP address: %s", self)
         if self.version == 4:
             family = netifaces.AF_INET

--- a/ipapython/setup.py
+++ b/ipapython/setup.py
@@ -43,12 +43,13 @@ if __name__ == '__main__':
             # "ipalib",  # circular dependency
             "ipaplatform",
             "netaddr",
-            "netifaces",
             "python-ldap",
             "six",
         ],
         extras_require={
             ":python_version<'3'": ["enum34"],
             "install": ["dbus-python"],  # for certmonger
+            # CheckedIPAddress.get_matching_interface
+            "netifaces": ["netifaces"],
         },
     )


### PR DESCRIPTION
Manual backport of PR #3001 

netifaces is a binary Python extension. Outside of the installer, it's
only used by CheckedIPAddress.get_matching_interface, which is only
called from installer code.

Make the import of netifaces optional to reduce the amount of
dependencies for PyPI package use case. Binary extensions are especially
annoying, because they depend on shared libraries, compiler, and header
files to be present.

Related: https://pagure.io/freeipa/issue/6468
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Oleg Kozlov <okozlov@redhat.com>