### PR TITLE
[Backport][ipa-4-7] Gating: remove vault and kdcproxy tests

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -123,18 +123,6 @@ jobs:
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-29/test_http_kdc_proxy:
-    requires: [fedora-29/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_http_kdc_proxy.py
-        template: *ci-master-f29
-        timeout: 3600
-        topology: *master_1repl_1client
-
   fedora-29/test_forced_client_enrolment:
     requires: [fedora-29/build]
     priority: 50
@@ -193,18 +181,6 @@ jobs:
         test_suite: test_integration/test_netgroup.py
         template: *ci-master-f29
         timeout: 3600
-        topology: *master_1repl
-
-  fedora-29/test_vault:
-    requires: [fedora-29/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_vault.py
-        template: *ci-master-f29
-        timeout: 6300
         topology: *master_1repl
 
   fedora-29/test_authconfig:


### PR DESCRIPTION
This PR was opened automatically because PR #3013 was pushed to master and backport to ipa-4-7 is required.