### PR TITLE
Improve error handling in DNSSEC helpers

### DIFF
--- a/daemons/dnssec/ipa-dnskeysync-replica.in
+++ b/daemons/dnssec/ipa-dnskeysync-replica.in
@@ -14,6 +14,7 @@ import os
 import sys
 
 import ipalib
+from ipalib import errors
 from ipalib.constants import SOFTHSM_DNSSEC_TOKEN_LABEL
 from ipalib.install.kinit import kinit_keytab
 from ipapython.dn import DN
@@ -162,23 +163,33 @@ except GSSError as e:
 os.environ['KRB5CCNAME'] = ccache_filename
 logger.debug('Got TGT')
 
-# LDAP initialization
-ldap = ipaldap.LDAPClient(ipalib.api.env.ldap_uri)
-logger.debug('Connecting to LDAP')
-ldap.gssapi_bind()
-logger.debug('Connected')
+keys_dn = DN(
+    ('cn', 'keys'), ('cn', 'sec'),
+    ipalib.api.env.container_dns,
+    ipalib.api.env.basedn
+)
 
+with open(paths.DNSSEC_SOFTHSM_PIN) as f:
+    localhsm = LocalHSM(
+        paths.LIBSOFTHSM2_SO,
+        SOFTHSM_DNSSEC_TOKEN_LABEL,
+        f.read()
+    )
 
-### DNSSEC master: key synchronization
-ldapkeydb = LdapKeyDB(ldap, DN(('cn', 'keys'),
-                               ('cn', 'sec'),
-                               ipalib.api.env.container_dns,
-                               ipalib.api.env.basedn))
+try:
+    # LDAP initialization
+    ldap = ipaldap.LDAPClient(ipalib.api.env.ldap_uri)
+    logger.debug('Connecting to LDAP')
+    ldap.gssapi_bind()
+    logger.debug('Connected')
 
-localhsm = LocalHSM(paths.LIBSOFTHSM2_SO, SOFTHSM_DNSSEC_TOKEN_LABEL,
-        open(paths.DNSSEC_SOFTHSM_PIN).read())
-
-ldap2replica_master_keys_sync(ldapkeydb, localhsm)
-ldap2replica_zone_keys_sync(ldapkeydb, localhsm)
-
-sys.exit(0)
+    ### DNSSEC master: key synchronization
+    ldapkeydb = LdapKeyDB(ldap, keys_dn)
+    ldap2replica_master_keys_sync(ldapkeydb, localhsm)
+    ldap2replica_zone_keys_sync(ldapkeydb, localhsm)
+except (errors.NetworkError, errors.DatabaseError) as e:
+    # SERVER_DOWN, CONNECT_ERROR
+    logger.error("LDAP server is down: %s", e)
+    sys.exit(1)
+else:
+    sys.exit(0)

--- a/daemons/dnssec/ipa-dnskeysyncd.in
+++ b/daemons/dnssec/ipa-dnskeysyncd.in
@@ -97,7 +97,7 @@ while watcher_running:
     except ldap.INVALID_CREDENTIALS as e:
         logger.exception('Login to LDAP server failed: %s', e)
         sys.exit(1)
-    except ldap.SERVER_DOWN as e:
+    except (ldap.SERVER_DOWN, ldap.CONNECT_ERROR) as e:
         logger.exception('LDAP server is down, going to retry: %s', e)
         time.sleep(5)
         continue
@@ -116,5 +116,5 @@ while watcher_running:
         while ldap_connection.syncrepl_poll(all=1, msgid=ldap_search):
             pass
     except (ldap.SERVER_DOWN, ldap.CONNECT_ERROR) as e:
-        logger.exception('syncrepl_poll: LDAP error (%s)', e)
+        logger.error('syncrepl_poll: LDAP error (%s)', e)
         sys.exit(1)


### PR DESCRIPTION
* ipa-dnskeysyncd now handles CONNECT_ERROR during bind
* ipa-dnskeysyncd no longer logs full traceback on connection error.
* ipa-dnskeysync-replica now handles SERVER_DOWN/CONNECT_ERROR
  exceptions and turns them into pretty error messages.

Fixes: https://pagure.io/freeipa/issue/7905
Signed-off-by: Christian Heimes <cheimes@redhat.com>