### PR TITLE
ipaserver/install/cainstance.py: unlink before creating new file in /tmp

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -69,6 +69,7 @@ from ipaserver.install import sysupgrade
 from ipaserver.install.dogtaginstance import DogtagInstance
 from ipaserver.plugins import ldap2
 from ipaserver.masters import ENABLED_SERVICE
+from ipaserver.install.installutils import remove_file
 
 logger = logging.getLogger(__name__)
 
@@ -514,6 +515,11 @@ class CAInstance(DogtagInstance):
                 )
 
             cafile = self.pkcs12_info[0]
+
+            # if paths.TMP_CA_P12 exists and is not owned by root,
+            # shutil.copy will fail if when fs.protected_regular=1
+            # so remove the file first
+            remove_file(paths.TMP_CA_P12)
             shutil.copy(cafile, paths.TMP_CA_P12)
             pent = pwd.getpwnam(self.service_user)
             os.chown(paths.TMP_CA_P12, pent.pw_uid, pent.pw_gid)


### PR DESCRIPTION
When fs.protected_regular=1 root cannot open temp files that
are owned by other users read-write.
So unlink temporary file before shutil.copy to it.

Fixes: https://pagure.io/freeipa/issue/7907
Signed-off-by: François Cami fcami@redhat.com