### PR TITLE
Fix wrong evaluation of attributes in check_repl_update

### DIFF
--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1070,11 +1070,23 @@ class ReplicationManager:
             inprogress = entry.single_value.get('nsds5replicaUpdateInProgress')
             status = entry.single_value.get('nsds5ReplicaLastUpdateStatus')
             try:
-                start = int(entry.single_value['nsds5ReplicaLastUpdateStart'])
+                # nsds5ReplicaLastUpdateStart is either a GMT time
+                # ending with Z or 0 (see 389-ds ticket 47836)
+                # Remove the Z and convert to int
+                start = entry.single_value['nsds5ReplicaLastUpdateStart']
+                if start.endswith('Z'):
+                    start = start[:-1]
+                start = int(start)
             except (ValueError, TypeError, KeyError):
                 start = 0
             try:
-                end = int(entry.single_value['nsds5ReplicaLastUpdateEnd'])
+                # nsds5ReplicaLastUpdateEnd is either a GMT time
+                # ending with Z or 0 (see 389-ds ticket 47836)
+                # Remove the Z and convert to int
+                end = entry.single_value['nsds5ReplicaLastUpdateEnd']
+                if end.endswith('Z'):
+                    end = end[:-1]
+                end = int(end)
             except (ValueError, TypeError, KeyError):
                 end = 0
             # incremental update is done if inprogress is false and end >= start


### PR DESCRIPTION
The method check_repl_update in ipaserver/install/replication.py badly
handles the attributes nsds5ReplicaLastUpdateStart and
nsds5ReplicaLastUpdateEnd as it expects them to contain an int.
These attributes are defined as GeneralizedTime
(OID 1.3.6.1.4.1.1466.115.121.1.24, for instance
nsds5ReplicaLastUpdateEnd='20190412122523Z') but older versions of 389-ds can
also return the value 0 for uninitialized values (see 389-ds ticket 47836).
The code must be able to handle the generalized time format or the 0 value.

The fix removes the 'Z' from the GeneralizedTime and converts to an int,
or assigns 0.

Fixes: https://pagure.io/freeipa/issue/7909