### PR TITLE
New command logger logcm as a replacement of print calls (updated)

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -9,7 +9,6 @@ Provides methods for installation, uninstallation of IPA client
 """
 
 from __future__ import (
-    print_function,
     absolute_import,
 )
 
@@ -60,6 +59,7 @@ from ipapython.ipautil import (
     run,
     user_input,
 )
+from ipapython.ipa_log_manager import CommandOutput
 from ipapython.ssh import SSHPublicKey
 from ipapython import version
 
@@ -70,6 +70,7 @@ from .ipachangeconf import IPAChangeConf
 NoneType = type(None)
 
 logger = logging.getLogger(__name__)
+logcm = CommandOutput(logger)
 
 SUCCESS = 0
 CLIENT_INSTALL_ERROR = 1
@@ -2055,9 +2056,9 @@ def install_check(options):
     global client_domain
     global cli_basedn
 
-    print("This program will set up FreeIPA client.")
-    print("Version {}".format(version.VERSION))
-    print("")
+    logcm("This program will set up FreeIPA client.")
+    logcm("Version %s", version.VERSION)
+    logcm("")
 
     cli_domain_source = 'Unknown source'
     cli_server_source = 'Unknown source'
@@ -2084,10 +2085,10 @@ def install_check(options):
         try:
             timeconf.check_timedate_services()
         except timeconf.NTPConflictingService as e:
-            print("WARNING: conflicting time&date synchronization service '{}'"
-                  " will be disabled".format(e.conflicting_service))
-            print("in favor of chronyd")
-            print("")
+            logcm("WARNING: conflicting time&date synchronization service '%s'"
+                  " will be disabled", e.conflicting_service)
+            logcm("in favor of chronyd")
+            logcm("")
         except timeconf.NTPConfigurationError:
             pass
 
@@ -2406,14 +2407,14 @@ def install_check(options):
                 is_ipaddr = False
 
         if is_ipaddr:
-            print()
+            logcm("")
             logger.warning(
                 "It seems that you are using an IP address "
                 "instead of FQDN as an argument to --server. The "
                 "installation may fail.")
             break
 
-    print()
+    logcm("")
     if not options.unattended and not user_input(
             "Continue to configure the system with these values?", False):
         raise ScriptError(rval=CLIENT_INSTALL_ERROR)
@@ -2491,7 +2492,7 @@ def sync_time(options, fstore, statestore):
                        "or pool address was provided.")
 
     if not configured:
-        print("Using default chrony configuration.")
+        logcm("Using default chrony configuration.")
 
     return timeconf.sync_chrony()
 

--- a/ipaserver/install/adtrust.py
+++ b/ipaserver/install/adtrust.py
@@ -6,7 +6,7 @@
 AD trust installer module
 """
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import
 
 import logging
 import os
@@ -21,6 +21,7 @@ from ipaplatform.paths import paths
 from ipapython.admintool import ScriptError
 from ipapython import ipaldap, ipautil
 from ipapython.dn import DN
+from ipapython.ipa_log_manager import CommandOutput
 from ipapython.install.core import group, knob
 from ipaserver.install import adtrustinstance
 from ipaserver.install import service
@@ -30,6 +31,7 @@ if six.PY3:
     unicode = str
 
 logger = logging.getLogger(__name__)
+logcm = CommandOutput(logger)
 
 netbios_name = None
 reset_netbios_name = False
@@ -45,18 +47,18 @@ def netbios_name_error(name):
 def read_netbios_name(netbios_default):
     netbios_name = ""
 
-    print("Enter the NetBIOS name for the IPA domain.")
-    print("Only up to 15 uppercase ASCII letters, digits "
+    logcm("Enter the NetBIOS name for the IPA domain.")
+    logcm("Only up to 15 uppercase ASCII letters, digits "
           "and dashes are allowed.")
-    print("Example: EXAMPLE.")
-    print("")
-    print("")
+    logcm("Example: EXAMPLE.")
+    logcm("")
+    logcm("")
     if not netbios_default:
         netbios_default = "EXAMPLE"
     while True:
         netbios_name = ipautil.user_input(
             "NetBIOS domain name", netbios_default, allow_empty=False)
-        print("")
+        logcm("")
         if adtrustinstance.check_netbios_name(netbios_name):
             break
 
@@ -108,16 +110,16 @@ def set_and_check_netbios_name(netbios_name, unattended, api):
         reset_netbios_name = False
     elif cur_netbios_name and cur_netbios_name != netbios_name:
         # change the NetBIOS name
-        print("Current NetBIOS domain name is %s, new name is %s.\n"
+        logcm("Current NetBIOS domain name is %s, new name is %s.\n"
               % (cur_netbios_name, netbios_name))
-        print("Please note that changing the NetBIOS name might "
+        logcm("Please note that changing the NetBIOS name might "
               "break existing trust relationships.")
         if unattended:
             reset_netbios_name = True
-            print("NetBIOS domain name will be changed to %s.\n"
+            logcm("NetBIOS domain name will be changed to %s.\n"
                   % netbios_name)
         else:
-            print("Say 'yes' if the NetBIOS shall be changed and "
+            logcm("Say 'yes' if the NetBIOS shall be changed and "
                   "'no' if the old one shall be kept.")
             reset_netbios_name = ipautil.user_input(
                             'Do you want to reset the NetBIOS domain name?',
@@ -134,7 +136,7 @@ def set_and_check_netbios_name(netbios_name, unattended, api):
 
         if gen_netbios_name is not None:
             # Fix existing trust configuration
-            print("Trust is configured but no NetBIOS domain name found, "
+            logcm("Trust is configured but no NetBIOS domain name found, "
                   "setting it now.")
             reset_netbios_name = True
         else:
@@ -163,16 +165,16 @@ def set_and_check_netbios_name(netbios_name, unattended, api):
 
 
 def enable_compat_tree():
-    print("Do you want to enable support for trusted domains in Schema "
+    logcm("Do you want to enable support for trusted domains in Schema "
           "Compatibility plugin?")
-    print("This will allow clients older than SSSD 1.9 and non-Linux "
+    logcm("This will allow clients older than SSSD 1.9 and non-Linux "
           "clients to work with trusted users.")
-    print("")
+    logcm("")
     enable_compat = ipautil.user_input(
         "Enable trusted domains support in slapi-nis?",
         default=False,
         allow_empty=False)
-    print("")
+    logcm("")
     return enable_compat
 
 
@@ -221,21 +223,21 @@ def retrieve_and_ask_about_sids(api, options):
 
     object_count = len(entries)
     if object_count > 0:
-        print("")
-        print("WARNING: %d existing users or groups do not have "
+        logcm("")
+        logcm("WARNING: %d existing users or groups do not have "
               "a SID identifier assigned." % len(entries))
-        print("Installer can run a task to have ipa-sidgen "
+        logcm("Installer can run a task to have ipa-sidgen "
               "Directory Server plugin generate")
-        print("the SID identifier for all these users. Please note, "
+        logcm("the SID identifier for all these users. Please note, "
               "in case of a high")
-        print("number of users and groups, the operation might "
+        logcm("number of users and groups, the operation might "
               "lead to high replication")
-        print("traffic and performance degradation. Refer to "
+        logcm("traffic and performance degradation. Refer to "
               "ipa-adtrust-install(1) man page")
-        print("for details.")
-        print("")
+        logcm("for details.")
+        logcm("")
         if options.unattended:
-            print("Unattended mode was selected, installer will "
+            logcm("Unattended mode was selected, installer will "
                   "NOT run ipa-sidgen task!")
         else:
             if ipautil.user_input(
@@ -312,20 +314,20 @@ def add_new_adtrust_agents(api, options):
     potential_agents_cns = retrieve_potential_adtrust_agents(api)
 
     if potential_agents_cns:
-        print("")
-        print("WARNING: %d IPA masters are not yet able to serve "
+        logcm("")
+        logcm("WARNING: %d IPA masters are not yet able to serve "
               "information about users from trusted forests."
               % len(potential_agents_cns))
-        print("Installer can add them to the list of IPA masters "
+        logcm("Installer can add them to the list of IPA masters "
               "allowed to access information about trusts.")
-        print("If you choose to do so, you also need to restart "
+        logcm("If you choose to do so, you also need to restart "
               "LDAP service on those masters.")
-        print("Refer to ipa-adtrust-install(1) man page for details.")
-        print("")
+        logcm("Refer to ipa-adtrust-install(1) man page for details.")
+        logcm("")
         if options.unattended:
-            print("Unattended mode was selected, installer will NOT "
+            logcm("Unattended mode was selected, installer will NOT "
                   "add other IPA masters to the list of allowed to")
-            print("access information about trusted forests!")
+            logcm("access information about trusted forests!")
             return
 
     new_agents = []
@@ -340,12 +342,12 @@ def add_new_adtrust_agents(api, options):
     if new_agents:
         add_hosts_to_adtrust_agents(api, new_agents)
 
-        print("""
+        logcm("""
 WARNING: you MUST restart (e.g. ipactl restart) the following IPA masters in
 order to activate them to serve information about users from trusted forests:
 """)
         for x in new_agents:
-            print(x)
+            logcm(x)
 
 
 def install_check(standalone, options, api):
@@ -358,7 +360,7 @@ def install_check(standalone, options, api):
     realm_not_matching_domain = (api.env.domain.upper() != api.env.realm)
 
     if realm_not_matching_domain:
-        print("WARNING: Realm name does not match the domain name.\n"
+        logcm("WARNING: Realm name does not match the domain name.\n"
               "You will not be able to establish trusts with Active "
               "Directory unless\nthe realm name of the IPA server matches its "
               "domain name.\n\n")
@@ -369,18 +371,18 @@ def install_check(standalone, options, api):
                 raise ScriptError("Aborting installation.")
 
     # Check if /etc/samba/smb.conf already exists. In case it was not generated
-    # by IPA, print a warning that we will break existing configuration.
+    # by IPA, logcm a warning that we will break existing configuration.
 
     if adtrustinstance.ipa_smb_conf_exists():
         if not options.unattended:
-            print("IPA generated smb.conf detected.")
+            logcm("IPA generated smb.conf detected.")
             if not ipautil.user_input("Overwrite smb.conf?",
                                       default=False,
                                       allow_empty=False):
                 raise ScriptError("Aborting installation.")
 
     elif os.path.exists(paths.SMB_CONF):
-        print("WARNING: The smb.conf already exists. Running "
+        logcm("WARNING: The smb.conf already exists. Running "
               "ipa-adtrust-install will break your existing samba "
               "configuration.\n\n")
         if not options.unattended:
@@ -389,7 +391,7 @@ def install_check(standalone, options, api):
                                       allow_empty=False):
                 raise ScriptError("Aborting installation.")
     elif os.path.exists(paths.SMB_CONF):
-        print("WARNING: The smb.conf already exists. Running "
+        logcm("WARNING: The smb.conf already exists. Running "
               "ipa-adtrust-install will break your existing samba "
               "configuration.\n\n")
         if not options.unattended:
@@ -410,10 +412,10 @@ def install_check(standalone, options, api):
 
 def install(standalone, options, fstore, api):
     if not options.unattended and standalone:
-        print("")
-        print("The following operations may take some minutes to complete.")
-        print("Please wait until the prompt is returned.")
-        print("")
+        logcm("")
+        logcm("The following operations may take some minutes to complete.")
+        logcm("Please wait until the prompt is returned.")
+        logcm("")
 
     smb = adtrustinstance.ADTRUSTInstance(fstore)
     smb.realm = api.env.realm

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import
 
 import logging
 import os
@@ -43,6 +43,7 @@ from ipapython.dn import DN
 from ipapython import ipaldap
 from ipapython import ipautil
 import ipapython.errors
+from ipapython.ipa_log_manager import CommandOutput
 
 import ipaclient.install.ipachangeconf
 from ipaplatform import services
@@ -54,6 +55,7 @@ if six.PY3:
     unicode = str
 
 logger = logging.getLogger(__name__)
+logcm = CommandOutput(logger)
 
 ALLOWED_NETBIOS_CHARS = string.ascii_uppercase + string.digits + '-'
 
@@ -68,8 +70,8 @@ and re-run ipa-adtrust-instal again afterwards.
 def check_inst():
     for smbfile in [paths.SMBD, paths.NET]:
         if not os.path.exists(smbfile):
-            print("%s was not found on this system" % smbfile)
-            print("Please install the 'samba' packages and " \
+            logcm("%s was not found on this system" % smbfile)
+            logcm("Please install the 'samba' packages and "
                   "start the installation again")
             return False
 
@@ -77,9 +79,9 @@ def check_inst():
     # by looking for the file /usr/share/ipa/smb.conf.empty
     if not os.path.exists(os.path.join(paths.USR_SHARE_IPA_DIR,
                                        "smb.conf.empty")):
-        print("AD Trust requires the '%s' package" %
+        logcm("AD Trust requires the '%s' package" %
               constants.IPA_ADTRUST_PACKAGE_NAME)
-        print("Please install the package and start the installation again")
+        logcm("Please install the package and start the installation again")
         return False
 
     #TODO: Add check for needed samba4 libraries

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -6,7 +6,7 @@
 CA installer module
 """
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import
 
 import enum
 import logging
@@ -24,6 +24,7 @@ from ipaserver.install import cainstance, bindinstance, dsinstance
 from ipapython import ipautil, certdb
 from ipapython import ipaldap
 from ipapython.admintool import ScriptError
+from ipapython.ipa_log_manager import CommandOutput
 from ipaplatform import services
 from ipaplatform.paths import paths
 from ipaserver.install import installutils, certs
@@ -46,6 +47,7 @@ VALID_SUBJECT_BASE_ATTRS = {
 VALID_SUBJECT_ATTRS = {'cn'} | VALID_SUBJECT_BASE_ATTRS
 
 logger = logging.getLogger(__name__)
+logcm = CommandOutput(logger)
 
 external_cert_file = None
 external_ca_file = None
@@ -103,16 +105,16 @@ def print_ca_configuration(options):
     Does not print trailing empty line.
 
     """
-    print("The CA will be configured with:")
-    print("Subject DN:   {}".format(options.ca_subject))
-    print("Subject base: {}".format(options.subject_base))
+    logcm("The CA will be configured with:")
+    logcm("Subject DN:   %s" % options.ca_subject)
+    logcm("Subject base: %s" % options.subject_base)
     if options.external_ca:
         chaining = "externally signed (two-step installation)"
     elif options.external_cert_files:
         chaining = "externally signed"
     else:
         chaining = "self-signed"
-    print("Chaining:     {}".format(chaining))
+    logcm("Chaining:     %s" % chaining)
 
 
 def uninstall_check(options):
@@ -137,7 +139,7 @@ def uninstall_check(options):
         crlgen_enabled = True
 
     if crlgen_enabled:
-        print("Deleting this server will leave your installation "
+        logcm("Deleting this server will leave your installation "
               "without a CRL generation master.")
         if (options.unattended and not options.ignore_last_of_role) or \
            not (options.unattended or ipautil.user_input(
@@ -233,7 +235,7 @@ def install_check(standalone, replica_config, options):
 
     if not options.external_cert_files:
         if not cainstance.check_ports():
-            print(
+            logcm(
                 "IPA requires ports 8080 and 8443 for PKI, but one or more "
                 "are currently in use."
             )

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -19,7 +19,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import
 
 import base64
 import binascii
@@ -57,7 +57,7 @@ from ipapython import dogtag
 from ipapython import ipautil
 from ipapython.certdb import get_ca_nickname
 from ipapython.dn import DN
-from ipapython.ipa_log_manager import standard_logging_setup
+from ipapython.ipa_log_manager import standard_logging_setup, CommandOutput
 from ipaserver.secrets.kem import IPAKEMKeys
 
 from ipaserver.install import certs
@@ -72,6 +72,7 @@ from ipaserver.masters import ENABLED_SERVICE
 from ipaserver.install.installutils import remove_file
 
 logger = logging.getLogger(__name__)
+logcm = CommandOutput(logger)
 
 
 ADMIN_GROUPS = [
@@ -596,8 +597,11 @@ class CAInstance(DogtagInstance):
             )
 
         if self.external == 1:
-            print("The next step is to get %s signed by your CA and re-run %s as:" % (self.csr_file, sys.argv[0]))
-            print("%s --external-cert-file=/path/to/signed_certificate --external-cert-file=/path/to/external_ca_certificate" % sys.argv[0])
+            logcm("The next step is to get %s signed by your CA and "
+                  "re-run %s as:" % (self.csr_file, sys.argv[0]))
+            logcm("%s --external-cert-file=/path/to/signed_certificate "
+                  "--external-cert-file=/path/to/external_ca_certificate" %
+                  sys.argv[0])
             sys.exit(0)
         else:
             shutil.move(paths.CA_BACKUP_KEYS_P12,

--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015 FreeIPa Project Contributors, see 'COPYING' for license.
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import
 
 import enum
 import logging
@@ -14,6 +14,7 @@ from ipaserver.install.service import SimpleServiceInstance
 from ipapython import ipautil
 from ipapython import ipaldap
 from ipapython.certdb import NSSDatabase
+from ipapython.ipa_log_manager import CommandOutput
 from ipaserver.install import installutils
 from ipaserver.install import ldapupdate
 from ipaserver.install import sysupgrade
@@ -25,6 +26,7 @@ import time
 import pwd
 
 logger = logging.getLogger(__name__)
+logcm = CommandOutput(logger)
 
 
 class CustodiaModes(enum.Enum):
@@ -227,10 +229,9 @@ class CustodiaInstance(SimpleServiceInstance):
                 if saved_e is None:
                     # FIXME: Change once there's better way to show this
                     # message in installer output,
-                    print(
-                        "  Waiting for keys to appear on host: {}, please "
-                        "wait until this has completed.".format(
-                            self.ldap_uri)
+                    logcm(
+                        "  Waiting for keys to appear on host: %s, please "
+                        "wait until this has completed.", self.ldap_uri
                     )
                 # log only once for the same error
                 if not isinstance(e, type(saved_e)):

--- a/ipaserver/install/dnskeysyncinstance.py
+++ b/ipaserver/install/dnskeysyncinstance.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import
 
 import logging
 import errno
@@ -21,6 +21,7 @@ from ipaserver.install import installutils
 from ipapython.dn import DN
 from ipapython import directivesetter
 from ipapython import ipautil
+from ipapython.ipa_log_manager import CommandOutput
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipalib import errors, api
@@ -28,6 +29,7 @@ from ipalib.constants import SOFTHSM_DNSSEC_TOKEN_LABEL
 from ipaserver.install.bindinstance import dns_container_exists
 
 logger = logging.getLogger(__name__)
+logcm = CommandOutput(logger)
 
 replica_keylabel_template = u"dnssec-replica:%s"
 
@@ -97,7 +99,7 @@ class DNSKeySyncInstance(service.Service):
             ldap.delete_entry(entry)
 
     def start_dnskeysyncd(self):
-        print("Restarting ipa-dnskeysyncd")
+        logcm("Restarting ipa-dnskeysyncd")
         self.__start()
 
     def create_instance(self, fqdn, realm_name):
@@ -439,7 +441,7 @@ class DNSKeySyncInstance(service.Service):
         try:
             self.restart()
         except Exception as e:
-            print("Failed to start ipa-dnskeysyncd")
+            logcm("Failed to start ipa-dnskeysyncd")
             logger.debug("Failed to start ipa-dnskeysyncd: %s", e)
 
 

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import
 
 import logging
 import shutil
@@ -41,6 +41,7 @@ from ipapython.certdb import (IPA_CA_TRUST_FLAGS,
                               TrustFlags)
 from ipapython import ipautil, ipaldap
 from ipapython import dogtag
+from ipapython.ipa_log_manager import CommandOutput
 from ipaserver.install import service
 from ipaserver.install import installutils
 from ipaserver.install import certs
@@ -58,6 +59,7 @@ from ipaplatform import services
 from ipaplatform.paths import paths
 
 logger = logging.getLogger(__name__)
+logcm = CommandOutput(logger)
 
 DS_USER = platformconstants.DS_USER
 DS_GROUP = platformconstants.DS_GROUP
@@ -1052,7 +1054,7 @@ class DsInstance(service.Service):
                 ipautil.run(args, env=env)
                 logger.debug("ldappasswd done")
             except ipautil.CalledProcessError as e:
-                print("Unable to set admin password", e)
+                logcm("Unable to set admin password %s", e)
                 logger.debug("Unable to set admin password %s", e)
 
     def uninstall(self):

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -53,6 +53,7 @@ from ipapython.certdb import EXTERNAL_CA_TRUST_FLAGS
 from ipalib.util import validate_hostname
 from ipalib import api, errors, x509
 from ipapython.dn import DN
+from ipapython.ipa_log_manager import CommandOutput
 from ipaserver.install import certs, service, sysupgrade
 from ipaplatform import services
 from ipaplatform.paths import paths
@@ -62,6 +63,7 @@ if six.PY3:
     unicode = str
 
 logger = logging.getLogger(__name__)
+logcm = CommandOutput(logger)
 
 # Used to determine install status
 IPA_MODULES = [
@@ -175,7 +177,7 @@ def verify_fqdn(host_name, no_host_dns=False, local_hostname=True):
                 e.errno, e.strerror)  # pylint: disable=no-member
 
     if no_host_dns:
-        print("Warning: skipping DNS resolution of host", host_name)
+        logcm("Warning: skipping DNS resolution of host %s", host_name)
         return
 
     try:
@@ -254,7 +256,7 @@ def record_in_hosts(ip, host_name=None, conf_file=paths.HOSTS):
                     return None
             return (hosts_ip, names)
         except IndexError:
-            print("Warning: Erroneous line '%s' in %s" % (line, conf_file))
+            logcm("Warning: Erroneous line '%s' in %s", line, conf_file)
             continue
 
     return None
@@ -278,7 +280,7 @@ def read_ip_addresses():
         try:
             ip_parsed = ipautil.CheckedIPAddress(ip)
         except Exception as e:
-            print("Error: Invalid IP Address %s: %s" % (ip, e))
+            logcm("Error: Invalid IP Address %s: %s", ip, e)
             continue
         ips.append(ip_parsed)
 
@@ -288,12 +290,12 @@ def read_ip_addresses():
 def read_dns_forwarders():
     addrs = []
     if ipautil.user_input("Do you want to configure DNS forwarders?", True):
-        print("Following DNS servers are configured in /etc/resolv.conf: %s" %
+        logcm("Following DNS servers are configured in /etc/resolv.conf: %s",
                 ", ".join(resolver.get_default_resolver().nameservers))
         if ipautil.user_input("Do you want to configure these servers as DNS "
                 "forwarders?", True):
             addrs = resolver.default_resolver.nameservers[:]
-            print("All DNS servers from /etc/resolv.conf were added. You can "
+            logcm("All DNS servers from /etc/resolv.conf were added. You can "
                   "enter additional addresses now:")
         while True:
             ip = ipautil.user_input("Enter an IP address for a DNS forwarder, "
@@ -303,15 +305,15 @@ def read_dns_forwarders():
             try:
                 ip_parsed = ipautil.CheckedIPAddress(ip, parse_netmask=False)
             except Exception as e:
-                print("Error: Invalid IP Address %s: %s" % (ip, e))
-                print("DNS forwarder %s not added." % ip)
+                logcm("Error: Invalid IP Address %s: %s", ip, e)
+                logcm("DNS forwarder %s not added.", ip)
                 continue
 
-            print("DNS forwarder %s added. You may add another." % ip)
+            logcm("DNS forwarder %s added. You may add another.", ip)
             addrs.append(str(ip_parsed))
 
     if not addrs:
-        print("No DNS forwarders configured")
+        logcm("No DNS forwarders configured")
 
     return addrs
 
@@ -360,7 +362,7 @@ def read_password(user, confirm=True, validate=True, retry=True, validator=_read
                 try:
                     validator(pwd)
                 except ValueError as e:
-                    print(str(e))
+                    logcm(str(e))
                     pwd = None
                     continue
             if not confirm:
@@ -368,15 +370,15 @@ def read_password(user, confirm=True, validate=True, retry=True, validator=_read
                 continue
             pwd_confirm = get_password("Password (confirm): ")
             if pwd != pwd_confirm:
-                print("Password mismatch!")
-                print("")
+                logcm("Password mismatch!")
+                logcm("")
                 pwd = None
             else:
                 correct = True
     except EOFError:
         return None
     finally:
-        print("")
+        logcm("")
     return pwd
 
 def update_file(filename, orig, subst):
@@ -393,7 +395,7 @@ def update_file(filename, orig, subst):
         os.chown(filename, st.st_uid, st.st_gid) # reset perms
         return 0
     else:
-        print("File %s doesn't exist." % filename)
+        logcm("File %s doesn't exist.", filename)
         return 1
 
 
@@ -544,8 +546,8 @@ def update_hosts_file(ip_addresses, host_name, fstore):
     for ip_address in ip_addresses:
         if record_in_hosts(str(ip_address)):
             continue
-        print("Adding [{address!s} {name}] to your /etc/hosts file".format(
-            address=ip_address, name=host_name))
+        logcm("Adding [%s %s] to your /etc/hosts file", ip_address,
+              host_name)
         add_record_to_hosts(str(ip_address), host_name)
 
 
@@ -759,7 +761,7 @@ def run_script(main_function, operation_name, log_file_name=None,
                 logger.debug('The %s command failed, exception: %s: %s',
                              operation_name, type(e).__name__, e)
                 if fail_message and not isinstance(e, SystemExit):
-                    print(fail_message)
+                    logcm(fail_message)
                 raise
         else:
             if return_value:

--- a/ipaserver/install/ipa_crlgen_manage.py
+++ b/ipaserver/install/ipa_crlgen_manage.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2019  FreeIPA Contributors see COPYING for license
 #
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import
 
 import os
 import logging
@@ -13,10 +13,12 @@ from ipalib import api
 from ipalib.errors import NetworkError
 from ipaplatform.paths import paths
 from ipapython.admintool import AdminTool
+from ipapython.ipa_log_manager import CommandOutput
 from ipaserver.install import cainstance
 from ipaserver.install import installutils
 
 logger = logging.getLogger(__name__)
+logcm = CommandOutput(logger)
 
 
 class CRLGenManage(AdminTool):
@@ -96,23 +98,23 @@ class CRLGenManage(AdminTool):
     def status(self, ca):
         # When the local node is not a CA, return "disabled"
         if not self.check_local_ca_instance():
-            print("CRL generation: disabled")
+            logcm("CRL generation: disabled")
             return
 
         # Local node is a CA, check its configuration
         if ca.is_crlgen_enabled():
-            print("CRL generation: enabled")
+            logcm("CRL generation: enabled")
             try:
                 crl_filename = os.path.join(paths.PKI_CA_PUBLISH_DIR,
                                             'MasterCRL.bin')
                 with open(crl_filename, 'rb') as f:
                     crl = x509.load_der_x509_crl(f.read(), default_backend())
-                    print("Last CRL update: {}".format(crl.last_update))
+                    logcm("Last CRL update: %s" % crl.last_update)
                     for ext in crl.extensions:
                         if ext.oid == x509.oid.ExtensionOID.CRL_NUMBER:
-                            print("Last CRL Number: {}".format(
-                                ext.value.crl_number))
+                            logcm("Last CRL Number: %s" %
+                                  ext.value.crl_number)
             except IOError:
                 logger.error("Unable to find last CRL")
         else:
-            print("CRL generation: disabled")
+            logcm("CRL generation: disabled")

--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -6,8 +6,7 @@
 Server installer module
 """
 
-from __future__ import print_function
-
+import logging
 import collections
 import os.path
 import random
@@ -27,6 +26,7 @@ from ipapython.dnsutil import check_zone_overlap
 from ipapython.install import typing
 from ipapython.install.core import group, knob, extend_knob
 from ipapython.install.common import step
+from ipapython.ipa_log_manager import CommandOutput
 
 from .install import validate_admin_password, validate_dm_password
 from .install import init as master_init
@@ -40,6 +40,8 @@ from .upgrade import upgrade_check, upgrade
 
 from .. import adtrust, ca, conncheck, dns, kra
 
+logger = logging.getLogger(__name__)
+logcm = CommandOutput(logger)
 
 @group
 class ServerUninstallInterface(service.ServiceInstallInterface):
@@ -522,7 +524,7 @@ class ServerMasterInstall(ServerMasterInstallInterface):
     def domain_name(self, value):
         if (self.setup_dns and
                 not self.allow_zone_overlap):
-            print("Checking DNS domain %s, please wait ..." % value)
+            logcm("Checking DNS domain %s, please wait ..." % value)
             check_zone_overlap(value, False)
 
     dm_password = extend_knob(

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import
 
 import errno
 import logging
@@ -32,6 +32,7 @@ from ipapython import ipautil, version
 from ipapython import ipaldap
 from ipapython import dnsutil, directivesetter
 from ipapython.dn import DN
+from ipapython.ipa_log_manager import CommandOutput
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipaserver import servroles
@@ -69,6 +70,7 @@ if six.PY3:
 
 
 logger = logging.getLogger(__name__)
+logcm = CommandOutput(logger)
 
 
 class KpasswdInstance(service.SimpleServiceInstance):
@@ -2199,7 +2201,7 @@ def upgrade():
         else:
             logger.info('Update complete, no data were modified')
 
-    print('Upgrading IPA services')
+    logcm('Upgrading IPA services')
     logger.info('Upgrading the configuration of the IPA services')
     with empty_ccache():
         upgrade_configuration()


### PR DESCRIPTION
New command logger logcm as a replacement of print calls

The use of print calls in the installer parts are resulting in the need to
redirect stdout using redirect_stdout in ansible-freeipa. redirect_stdout
is creating a new scope.

The CommandOutput type is a wrapper for a logger instance. It marks log
calls to be printed out on stdout using logger.INFO level. The extra
argument { "cmd_output": True } is set to make sure that a filter could
be used to filter this out for the installer log files.

Usage:

    import logging
    from ipapython.ipa_log_manager import CommandOutput

    logger = logging.getLogger(__name__)
    logcm = CommandOutput(logger)

    def install():
        logcm("Installing ...")

Design note
-----------

The command logger instance is called ``logcm``, because the name has the
same length as the ``print`` function. It may not be the prettiest name,
but it avoids code reformatting and therefore merge conflicts.

At first we considered to add a ``log_cmd`` method to all loggers.
The ``logging.setLoggerClass`` is the public function to set a new logger
class. To make it work, is has to be called before the first logger
objects is instantiated. It's not appropriate to modify the logger
early in ``ipalib``, because ``ipalib`` is also designed to get embedded
into applications. And monkey-patching the ``logging.Logger`` class is
a hack.

The log format for CommandOutput is defined in LOGGING_FORMAT_CMD_OUTPUT
and is applied with the extended Formatter class for the log level INFO
only.