### PR TITLE
Remove deprecated object logger

### DIFF
--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -46,7 +46,6 @@ from ipalib.base import ReadOnly, lock, islocked
 from ipalib.constants import DEFAULT_CONFIG
 from ipapython import ipa_log_manager, ipautil
 from ipapython.ipa_log_manager import (
-    log_mgr,
     LOGGING_FORMAT_FILE,
     LOGGING_FORMAT_STDERR)
 from ipapython.version import VERSION, API_VERSION, DEFAULT_PLUGINS
@@ -144,7 +143,6 @@ class Plugin(ReadOnly):
         self.__finalize_called = False
         self.__finalized = False
         self.__finalize_lock = threading.RLock()
-        log_mgr.get_logger(self, True)
 
     @classmethod
     def __name_getter(cls):
@@ -438,7 +436,6 @@ class API(ReadOnly):
         Initialize environment variables and logging.
         """
         self.__doing('bootstrap')
-        self.log = log_mgr.get_logger(self)
         self.env._bootstrap(**overrides)
         self.env._finalize_core(**dict(DEFAULT_CONFIG))
 

--- a/ipapython/ipa_log_manager.py
+++ b/ipapython/ipa_log_manager.py
@@ -20,11 +20,9 @@ import logging
 import os
 import re
 import time
-import warnings
-import sys
 
 # Module exports
-__all__ = ['log_mgr', 'root_logger', 'standard_logging_setup',
+__all__ = ['standard_logging_setup',
            'ISO8601_UTC_DATETIME_FMT',
            'LOGGING_FORMAT_STDERR', 'LOGGING_FORMAT_STDOUT', 'LOGGING_FORMAT_FILE']
 
@@ -53,82 +51,6 @@ LOGGING_FORMAT_STANDARD_CONSOLE = '%(name)-12s: %(levelname)-8s %(message)s'
 
 # Used by standard_logging_setup() for file message
 LOGGING_FORMAT_STANDARD_FILE = '%(asctime)s %(levelname)s %(message)s'
-
-
-class _DeprecatedLogger:
-    def __init__(self, logger, name):
-        self._logger = logger
-        self._name = name
-
-    def _warn(self):
-        warnings.warn(
-            "{} is deprecated, use a module-level logger".format(self._name),
-            DeprecationWarning)
-
-    def debug(self, *args, **kwargs):
-        self._warn()
-        self._logger.debug(*args, **kwargs)
-
-    def info(self, *args, **kwargs):
-        self._warn()
-        self._logger.info(*args, **kwargs)
-
-    def warning(self, *args, **kwargs):
-        self._warn()
-        self._logger.warning(*args, **kwargs)
-
-    def error(self, *args, **kwargs):
-        self._warn()
-        self._logger.error(*args, **kwargs)
-
-    def critical(self, *args, **kwargs):
-        self._warn()
-        self._logger.critical(*args, **kwargs)
-
-    def exception(self, *args, **kwargs):
-        self._warn()
-        self._logger.exception(*args, **kwargs)
-
-
-def get_logger(who, bind_logger_names=False):
-    if isinstance(who, str):
-        warnings.warn(
-            "{}.log_mgr.get_logger is deprecated, use "
-            "logging.getLogger".format(__name__),
-            DeprecationWarning)
-
-        logger_name = who
-    else:
-        caller_globals = sys._getframe(1).f_globals
-        logger_name = caller_globals.get('__name__', '__main__')
-        if logger_name == '__main__':
-            logger_name = caller_globals.get('__file__', logger_name)
-            logger_name = os.path.basename(logger_name)
-
-    logger = logging.getLogger(logger_name)
-
-    if not isinstance(who, str):
-        obj_name = '%s.%s' % (who.__module__, who.__class__.__name__)
-        logger = _DeprecatedLogger(logger, obj_name)
-
-    if bind_logger_names:
-        method = 'log'
-        if hasattr(who, method):
-            raise ValueError('%s is already bound to %s' % (method, repr(who)))
-        setattr(who, method, logger)
-
-        for method in ('debug',
-                       'info',
-                       'warning',
-                       'error',
-                       'exception',
-                       'critical'):
-            if hasattr(who, method):
-                raise ValueError(
-                    '%s is already bound to %s' % (method, repr(who)))
-            setattr(who, method, getattr(logger, method))
-
-    return logger
 
 
 class Filter:
@@ -195,10 +117,3 @@ def convert_log_level(value):
         except KeyError:
             raise ValueError('unknown log level (%s)' % value)
     return level
-
-
-# Single shared instance of log manager
-log_mgr = sys.modules[__name__]
-
-root_logger = _DeprecatedLogger(logging.getLogger(),
-                                '{}.log_mgr.root_logger'.format(__name__))

--- a/ipatests/test_ipalib/test_plugable.py
+++ b/ipatests/test_ipalib/test_plugable.py
@@ -77,14 +77,6 @@ class test_Plugin(ClassChecker):
         assert o.summary == u'<%s.%s>' % (another_subclass.__module__,
                                           another_subclass.__name__)
 
-        # Test that Plugin makes sure the subclass hasn't defined attributes
-        # whose names conflict with the logger methods set in Plugin.__init__():
-        class check(self.cls):
-            info = 'whatever'
-        e = raises(Exception, check, api)
-        assert str(e) == \
-            "info is already bound to ipatests.test_ipalib.test_plugable.check()"
-
     def test_finalize(self):
         """
         Test the `ipalib.plugable.Plugin.finalize` method.


### PR DESCRIPTION
The object logger methods been deprecated for about two years since release
4.6.0. The log manager used to moneky-patch additional log methods like
info(), warning(), and error() into API plugin objects. The methods have
been replaced by calls to module logger objects in 4.6.0.

Remove monkey-patch logger methods, log manager, and its root logger from
ipapython.ipa_log_manager.

Signed-off-by: Christian Heimes <cheimes@redhat.com>