### PR TITLE
Add temporary directory manager

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -157,7 +157,6 @@ class BasePathNamespace:
     SBIN_RESTORECON = "/sbin/restorecon"
     SBIN_SERVICE = "/sbin/service"
     TMP = "/tmp"
-    TMP_CA_P12 = "/tmp/ca.p12"
     TMP_KRB5CC = "/tmp/krb5cc_%d"
     USR_DIR = "/usr"
     CERTMONGER_COMMAND_TEMPLATE = "/usr/libexec/ipa/certmonger/%s"


### PR DESCRIPTION
The temporary directory manager simplifies the handling of temporary
files that are shared with other processes or kept through out the life
time of the current process. It should only be used in case
tempfile.NamedTemporaryFile is not up for the task.

The manager creates a new temporary directory for each user. The
directory and all its files are accessible by the target user and the
root group ($uid:root / 0o770 / 0o660) to avoid DAC override capability.
The temporary directory is automatically removed on process exit.

Related: https://pagure.io/freeipa/issue/7911
Signed-off-by: Christian Heimes <cheimes@redhat.com>