### PR TITLE
Add ExecStartPost hook to wait for Dogtag PKI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ install/tools/ipa-nis-manage
 install/tools/ipa-otptoken-import
 install/tools/ipa-pkinit-manage
 install/tools/ipa-pki-retrieve-key
+install/tools/ipa-pki-wait-running
 install/tools/ipa-replica-conncheck
 install/tools/ipa-replica-install
 install/tools/ipa-replica-manage

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1009,6 +1009,7 @@ fi
 %{_libexecdir}/ipa/ipa-httpd-kdcproxy
 %{_libexecdir}/ipa/ipa-httpd-pwdreader
 %{_libexecdir}/ipa/ipa-pki-retrieve-key
+%{_libexecdir}/ipa/ipa-pki-wait-running
 %{_libexecdir}/ipa/ipa-otpd
 %dir %{_libexecdir}/ipa/oddjob
 %attr(0755,root,root) %{_libexecdir}/ipa/oddjob/org.freeipa.server.conncheck

--- a/install/tools/Makefile.am
+++ b/install/tools/Makefile.am
@@ -33,6 +33,7 @@ dist_noinst_DATA =		\
 	ipa-custodia-check.in	\
 	ipa-httpd-kdcproxy.in	\
 	ipa-pki-retrieve-key.in	\
+	ipa-pki-wait-running.in	\
 	$(NULL)
 
 nodist_sbin_SCRIPTS =		\
@@ -68,6 +69,7 @@ nodist_app_SCRIPTS =		\
 	ipa-custodia-check	\
 	ipa-httpd-kdcproxy	\
 	ipa-pki-retrieve-key	\
+	ipa-pki-wait-running	\
 	$(NULL)
 
 dist_app_SCRIPTS =		\

--- a/install/tools/ipa-pki-wait-running.in
+++ b/install/tools/ipa-pki-wait-running.in
@@ -1,0 +1,131 @@
+@PYTHONSHEBANG@
+"""Wait until pki-tomcatd is up
+
+The script polls on Dogtag's HTTP port and wait until the admin interface
+reports status 'running' for the CA sub system.
+
+/etc/systemd/system/pki-tomcatd@pki-tomcat.service.d/ipa.conf
+[Service]
+ExecStartPost=/usr/libexec/ipa/ipa-pki-wait-running
+"""
+import os
+import logging
+import sys
+import time
+from xml.etree import ElementTree
+
+from ipalib import api
+from ipaplatform.paths import paths
+
+from pki.client import PKIConnection
+from pki.system import SystemStatusClient
+from requests.exceptions import ConnectionError, Timeout, RequestException
+
+logger = logging.getLogger('ipa-pki-wait-running')
+
+# check the CA subsystem. All pki-tomcatd instances in IPA have a CA
+SUBSYSTEM = 'ca'
+# time out for TCP connection attempts
+CONNECTION_TIMEOUT = 1.0
+
+EXIT_SUCCESS = 0
+EXIT_FAILURE = 1
+
+
+if hasattr(time, 'monotonic'):
+    curtime = time.monotonic
+else:
+    curtime = time.time
+
+
+def check_installed(subsystem):
+    """Check if the subsystem is configured
+    """
+    catalina_base = os.environ.get(
+        'CATALINA_BASE', '/var/lib/pki/pki-tomcat'
+    )
+    # /var/lib/pki/pki-tomcat/conf -> /etc/pki/pki-tomcat
+    cs_cfg = os.path.join(catalina_base, 'conf', subsystem, 'CS.cfg')
+    if os.path.isfile(cs_cfg):
+        logger.debug("File %s exists.", cs_cfg)
+        return True
+    else:
+        logger.info("File %s does not exist.", cs_cfg)
+        return False
+
+
+def get_conn(hostname, subsystem):
+    """Create a connection object
+    """
+    conn = PKIConnection(
+        hostname=hostname,
+        subsystem=subsystem
+    )
+    logger.info(
+        "Created connection %s://%s:%s/%s",
+        conn.protocol, conn.hostname, conn.port, conn.subsystem
+    )
+    return conn
+
+
+def get_status(conn, timeout):
+    """Get status from subsystem and return parsed (status, error)
+    """
+    client = SystemStatusClient(conn)
+    response = client.get_status(timeout=timeout)
+    root = ElementTree.fromstring(response)
+    status = root.findtext("Status")
+    error = root.findtext("Error")
+    logging.debug("Got status '%s', error '%s'", status, error)
+    return status, error
+
+
+def main():
+    if not check_installed(SUBSYSTEM):
+        logger.info(
+            "subsystem %s is not installed, exiting", SUBSYSTEM
+        )
+        sys.exit(EXIT_SUCCESS)
+
+    # bootstrap ipalib.api to parse config file
+    api.bootstrap(confdir=paths.ETC_IPA)
+    timeout = api.env.startup_timeout
+
+    conn = get_conn(api.env.host, subsystem=SUBSYSTEM)
+    end = curtime() + timeout
+    while curtime() < end:
+        try:
+            status, error = get_status(conn, CONNECTION_TIMEOUT)
+        except (ConnectionError, Timeout) as e:
+            logger.info("Connection failed: %s", e)
+        except RequestException as e:
+            logger.error("Request failed unexpectedly, %s ", e)
+        else:
+            if status == 'running':
+                logger.info("Success, subsystem %s is running!", SUBSYSTEM)
+                sys.exit(EXIT_SUCCESS)
+            elif error is not None:
+                logger.info(
+                    "Subsystem %s failed with error '%s', giving up!",
+                    SUBSYSTEM, error
+                )
+                sys.exit(EXIT_FAILURE)
+            else:
+                logger.info("Status is '%s', waiting...", status)
+
+        # wait and try again
+        time.sleep(1)
+
+    # giving up
+    logger.error(
+        "Reached end of wait timeout %s, giving up", timeout
+    )
+    sys.exit(EXIT_FAILURE)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        format='%(name)s: %(message)s',
+        level=logging.INFO
+    )
+    main()

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -145,8 +145,10 @@ DEFAULT_CONFIG = (
     ('tls_version_min', 'tls1.0'),
     ('tls_version_max', 'tls1.2'),
 
-    # Time to wait for a service to start, in seconds
-    ('startup_timeout', 300),
+    # Time to wait for a service to start, in seconds.
+    # Note that systemd has a DefaultTimeoutStartSec of 90 seconds. Higher
+    # values are not effective unless systemd is reconfigured, too.
+    ('startup_timeout', 120),
     # How long http connection should wait for reply [seconds].
     ('http_timeout', 30),
     # How long to wait for an entry to appear on a replica

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -140,6 +140,8 @@ class BasePathNamespace:
     SYSTEMD_IPA_SERVICE = "/etc/systemd/system/multi-user.target.wants/ipa.service"
     SYSTEMD_SSSD_SERVICE = "/etc/systemd/system/multi-user.target.wants/sssd.service"
     SYSTEMD_PKI_TOMCAT_SERVICE = "/etc/systemd/system/pki-tomcatd.target.wants/pki-tomcatd@pki-tomcat.service"
+    SYSTEMD_PKI_TOMCAT_IPA_CONF = \
+        "/etc/systemd/system/pki-tomcatd@pki-tomcat.service.d/ipa.conf"
     ETC_TMPFILESD_DIRSRV = "/etc/tmpfiles.d/dirsrv-%s.conf"
     DNSSEC_TRUSTED_KEY = "/etc/trusted-key.key"
     HOME_DIR = "/home"
@@ -213,6 +215,7 @@ class BasePathNamespace:
     IPA_HTTPD_KDCPROXY = "/usr/libexec/ipa/ipa-httpd-kdcproxy"
     IPA_ODS_EXPORTER = "/usr/libexec/ipa/ipa-ods-exporter"
     IPA_HTTPD_PASSWD_READER = "/usr/libexec/ipa/ipa-httpd-pwdreader"
+    IPA_PKI_WAIT_RUNNING = "/usr/libexec/ipa/ipa-pki-wait-running"
     DNSSEC_KEYFROMLABEL = "/usr/sbin/dnssec-keyfromlabel-pkcs11"
     GETSEBOOL = "/usr/sbin/getsebool"
     GROUPADD = "/usr/sbin/groupadd"

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -82,6 +82,7 @@ class DebianPathNamespace(BasePathNamespace):
     IPA_HTTPD_KDCPROXY = "/usr/lib/ipa/ipa-httpd-kdcproxy"
     IPA_ODS_EXPORTER = "/usr/lib/ipa/ipa-ods-exporter"
     IPA_HTTPD_PASSWD_READER = "/usr/lib/ipa/ipa-httpd-pwdreader"
+    IPA_PKI_WAIT_RUNNING = "/usr/lib/ipa/ipa-pki-wait-running"
     HTTPD = "/usr/sbin/apache2ctl"
     FONTS_DIR = "/usr/share/fonts/truetype"
     VAR_KERBEROS_KRB5KDC_DIR = "/var/lib/krb5kdc/"

--- a/ipaplatform/redhat/services.py
+++ b/ipaplatform/redhat/services.py
@@ -186,18 +186,6 @@ class RedHatCAService(RedHatService):
         else:
             raise RuntimeError('CA did not start in %ss' % timeout)
 
-    def start(self, instance_name="", capture_output=True, wait=True):
-        super(RedHatCAService, self).start(
-            instance_name, capture_output=capture_output, wait=wait)
-        if wait:
-            self.wait_until_running()
-
-    def restart(self, instance_name="", capture_output=True, wait=True):
-        super(RedHatCAService, self).restart(
-            instance_name, capture_output=capture_output, wait=wait)
-        if wait:
-            self.wait_until_running()
-
     def is_running(self, instance_name="", wait=True):
         if instance_name:
             return super(RedHatCAService, self).is_running(instance_name)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -399,6 +399,7 @@ class CAInstance(DogtagInstance):
                 self.step("creating installation admin user", self.setup_admin)
             self.step("configuring certificate server instance",
                       self.__spawn_instance)
+            self.step("Add ipa-pki-wait-running", self.add_ipa_wait)
             self.step("reindex attributes", self.reindex_task)
             self.step("exporting Dogtag certificate store pin",
                       self.create_certstore_passwdfile)
@@ -603,6 +604,18 @@ class CAInstance(DogtagInstance):
                         paths.CACERT_P12)
 
         logger.debug("completed creating ca instance")
+
+    def add_ipa_wait(self):
+        """Add ipa-pki-wait-running to pki-tomcatd service
+        """
+        conf = paths.SYSTEMD_PKI_TOMCAT_IPA_CONF
+        directory = os.path.dirname(conf)
+        if not os.path.isdir(directory):
+            os.mkdir(directory)
+        with open(conf, 'w') as f:
+            f.write('[Service]\n')
+            f.write('ExecStartPost={}\n'.format(paths.IPA_PKI_WAIT_RUNNING))
+        tasks.systemd_daemon_reload()
 
     def safe_backup_config(self):
         """
@@ -982,6 +995,14 @@ class CAInstance(DogtagInstance):
                 iface.remove_known_ca(path)
 
         cmonger.stop()
+
+        # remove ipa-pki-wait-running config
+        remove_file(paths.SYSTEMD_PKI_TOMCAT_IPA_CONF)
+        try:
+            os.rmdir(os.path.dirname(paths.SYSTEMD_PKI_TOMCAT_IPA_CONF))
+        except OSError:
+            pass
+        tasks.systemd_daemon_reload()
 
         # remove CRL files
         logger.debug("Remove old CRL files")

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -190,6 +190,7 @@ class Backup(admintool.AdminTool):
         paths.IPA_CUSTODIA_CONF,
         paths.GSSPROXY_CONF,
         paths.HOSTS,
+        paths.SYSTEMD_PKI_TOMCAT_IPA_CONF,
     ) + tuple(
         os.path.join(paths.IPA_NSSDB_DIR, file)
         for file in (certdb.NSS_DBM_FILES + certdb.NSS_SQL_FILES)


### PR DESCRIPTION
Dogtag PKI typically takes around 10 seconds to start and respond to
requests. Dogtag uses a simple systemd service, which means systemd is
unable to detect when Dogtag is ready. Commands like ``systemctl start``
and ``systemctl restart`` don't block and wait until the CA is up. There
have been various workarounds in Dogtag and IPA.

Systemd has an ExecStartPost hook to run programs after the main service
is started. The post hook blocks systemctl start and restart until all
post hooks report ready, too. The new ipa-pki-wait-running script polls
on port 8080 and waits until the CA subsystem returns ``running``.

The patch also changes the service timeout to 120s as documented in man default.conf(5). Even 120s won't wait 120s, because systemd uses a smaller default timeout of 90s for service startup.

Signed-off-by: Christian Heimes <cheimes@redhat.com>