### PR TITLE
[Backport][ipa-4-7] Fix unnecessary usrmerge assumptions

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -26,7 +26,7 @@ class BasePathNamespace(object):
     BASH = "/bin/bash"
     BIN_HOSTNAMECTL = "/bin/hostnamectl"
     ECHO = "/bin/echo"
-    GZIP = "/usr/bin/gzip"
+    GZIP = "/bin/gzip"
     LS = "/bin/ls"
     SH = "/bin/sh"
     SYSTEMCTL = "/bin/systemctl"
@@ -388,7 +388,7 @@ class BasePathNamespace(object):
     SLAPD_INSTANCE_SYSTEMD_IPA_ENV_TEMPLATE = \
         "/etc/systemd/system/dirsrv@%s.service.d/ipa-env.conf"
     IPA_SERVER_UPGRADE = '/usr/sbin/ipa-server-upgrade'
-    KEYCTL = '/usr/bin/keyctl'
+    KEYCTL = '/bin/keyctl'
     GETENT = '/usr/bin/getent'
     SSHD = '/usr/sbin/sshd'
     SSSCTL = '/usr/sbin/sssctl'

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -63,7 +63,6 @@ class DebianPathNamespace(BasePathNamespace):
     DNSSEC_TRUSTED_KEY = "/etc/bind/trusted-key.key"
     GSSAPI_SESSION_KEY = "/etc/apache2/ipasession.key"
     OLD_KRA_AGENT_PEM = "/etc/apache2/nssdb/kra-agent.pem"
-    KEYCTL = "/bin/keyctl"
     SBIN_SERVICE = "/usr/sbin/service"
     CERTMONGER_COMMAND_TEMPLATE = "/usr/lib/ipa/certmonger/%s"
     UPDATE_CA_TRUST = "/usr/sbin/update-ca-certificates"

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -29,7 +29,7 @@ def create_broken_resolv_conf(master):
     # Force a broken resolv.conf to simulate a bad response to
     # reverse zone lookups
     master.run_command([
-        '/usr/bin/mv',
+        '/bin/mv',
         paths.RESOLV_CONF,
         '%s.sav' % paths.RESOLV_CONF
     ])
@@ -41,7 +41,7 @@ def create_broken_resolv_conf(master):
 def restore_resolv_conf(master):
     if os.path.exists('%s.sav' % paths.RESOLV_CONF):
         master.run_command([
-            '/usr/bin/mv',
+            '/bin/mv',
             '%s.sav' % paths.RESOLV_CONF,
             paths.RESOLV_CONF
         ])

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -624,7 +624,7 @@ def update_etc_hosts(host, ip, old_hostname, new_hostname):
     :param new_hostname the new hostname to put in /etc/hosts
     '''
     # Make a backup
-    host.run_command(['/usr/bin/cp',
+    host.run_command(['/bin/cp',
                       paths.HOSTS,
                       '%s.sav' % paths.HOSTS])
     contents = host.get_file_contents(paths.HOSTS, encoding='utf-8')
@@ -644,7 +644,7 @@ def update_etc_hosts(host, ip, old_hostname, new_hostname):
 def restore_etc_hosts(host):
     '''Restores /etc/hosts.sav into /etc/hosts
     '''
-    host.run_command(['/usr/bin/mv',
+    host.run_command(['/bin/mv',
                       '%s.sav' % paths.HOSTS,
                       paths.HOSTS],
                      raiseonerr=False)

--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -156,8 +156,8 @@ class TestSudo(IntegrationTest):
 
     def test_add_sudo_commands(self):
         # Group: Readers
-        self.master.run_command(['ipa', 'sudocmd-add', '/usr/bin/cat'])
-        self.master.run_command(['ipa', 'sudocmd-add', '/usr/bin/tail'])
+        self.master.run_command(['ipa', 'sudocmd-add', '/bin/cat'])
+        self.master.run_command(['ipa', 'sudocmd-add', '/bin/tail'])
 
         # No group
         self.master.run_command(['ipa', 'sudocmd-add', '/usr/bin/yum'])
@@ -167,10 +167,10 @@ class TestSudo(IntegrationTest):
                                  '--desc', '"Applications that read"'])
 
         self.master.run_command(['ipa', 'sudocmdgroup-add-member', 'readers',
-                                 '--sudocmds', '/usr/bin/cat'])
+                                 '--sudocmds', '/bin/cat'])
 
         self.master.run_command(['ipa', 'sudocmdgroup-add-member', 'readers',
-                                 '--sudocmds', '/usr/bin/tail'])
+                                 '--sudocmds', '/bin/tail'])
 
     def test_create_allow_all_rule(self):
         # Create rule that allows everything
@@ -441,8 +441,8 @@ class TestSudo(IntegrationTest):
         result1 = self.list_sudo_commands("testuser1")
         assert "(ALL : ALL) NOPASSWD:" in result1.stdout_text
         assert "/usr/bin/yum" in result1.stdout_text
-        assert "/usr/bin/tail" in result1.stdout_text
-        assert "/usr/bin/cat" in result1.stdout_text
+        assert "/bin/tail" in result1.stdout_text
+        assert "/bin/cat" in result1.stdout_text
 
     def test_setting_category_to_all_with_valid_entries_command(self):
         result = self.reset_rule_categories(safe_delete=False)

--- a/ipatests/test_integration/test_uninstallation.py
+++ b/ipatests/test_integration/test_uninstallation.py
@@ -72,7 +72,7 @@ class TestUninstallBase(IntegrationTest):
             # uninstaller to raise an exception and return with a
             # non-zero return code.
             self.master.run_command([
-                '/usr/bin/mv',
+                '/bin/mv',
                 '%s/%s' % (paths.ETC_DIRSRV, instance_name),
                 '%s/%s.test' % (paths.ETC_DIRSRV, instance_name)
             ])
@@ -95,7 +95,7 @@ class TestUninstallBase(IntegrationTest):
             # Moving it back should allow the uninstall to finish
             # successfully.
             self.master.run_command([
-                '/usr/bin/mv',
+                '/bin/mv',
                 '%s/%s.test' % (paths.ETC_DIRSRV, instance_name),
                 '%s/%s' % (paths.ETC_DIRSRV, instance_name)
             ])

--- a/ipatests/test_ipalib/test_util.py
+++ b/ipatests/test_ipalib/test_util.py
@@ -18,12 +18,13 @@ except ImportError:
 
 @pytest.mark.parametrize('pager,expected_result', [
     # Valid values
-    ('cat', '/usr/bin/cat'),
-    ('/usr/bin/cat', '/usr/bin/cat'),
+    ('cat', '/bin/cat'),
+    ('/bin/cat', '/bin/cat'),
     # Invalid values (wrong command, package is not installed, etc)
     ('cat_', None),
     ('', None)
 ])
 def test_get_pager(pager, expected_result):
     with patch.dict(os.environ, {'PAGER': pager}):
-        assert get_pager() == expected_result
+        pager = get_pager()
+        assert(pager == expected_result or pager.endswith(expected_result))

--- a/makerpms.sh
+++ b/makerpms.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 set -o errexit
 
 pushd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
Manual backport of PR #3025 

On non-usrmerge systems (e.g., Debian), bash, mv, cp, cat, tail,
keyctl, and gzip live in /bin, not /usr/bin.

On usrmerge systems, /bin is a symlink to /usr/bin (or vice versa), so
this has no effect.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>
Reviewed-By: Alexander Bokovoy <abokovoy@redhat.com>
Reviewed-By: Christian Heimes <cheimes@redhat.com>