### PR TITLE
Pass token_name to certmonger

### DIFF
--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -427,7 +427,8 @@ def request_cert(
 
 def start_tracking(
         certpath, ca='IPA', nickname=None, pin=None, pinfile=None,
-        pre_command=None, post_command=None, profile=None, storage="NSSDB"):
+        pre_command=None, post_command=None, profile=None, storage="NSSDB",
+        token_name=None):
     """
     Tell certmonger to track the given certificate in either a file or an NSS
     database. The certificate access can be protected by a password_file.
@@ -460,6 +461,8 @@ def start_tracking(
         NSS or OpenSSL backend to track the certificate in ``certpath``
     :param profile:
         Which certificate profile should be used.
+    :param token_name:
+        Hardware token name for HSM support
     :returns: certificate tracking nickname.
     """
     if storage == 'FILE':
@@ -500,6 +503,10 @@ def start_tracking(
         params['cert-postsave-command'] = post_command
     if profile:
         params['ca-profile'] = profile
+    if token_name not in {None, "internal"}:
+        # only pass token names for external tokens (e.g. HSM)
+        params['key-token'] = token_name
+        params['cert-token'] = token_name
 
     result = cm.obj_if.add_request(params)
     try:
@@ -675,7 +682,7 @@ def modify_ca_helper(ca_name, helper):
         return old_helper
 
 
-def get_pin(token):
+def get_pin(token="internal"):
     """
     Dogtag stores its NSS pin in a file formatted as token:PIN.
 

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -98,6 +98,10 @@ class DogtagInstance(service.Service):
     tracking_reqs = None
     server_cert_name = None
 
+    # token for CA and subsystem certificates. For now, only internal token
+    # is supported.
+    token_name = "internal"
+
     ipaca_groups = DN(('ou', 'groups'), ('o', 'ipaca'))
     ipaca_people = DN(('ou', 'people'), ('o', 'ipaca'))
     groups_aci = (
@@ -204,6 +208,13 @@ class DogtagInstance(service.Service):
         """
         Enable client auth connection to the internal db.
         """
+        sub_system_nickname = "subsystemCert cert-pki-ca"
+        if self.token_name != "internal":
+            # TODO: Dogtag 10.6.9 does not like "internal" prefix.
+            sub_system_nickname = '{}:{}'.format(
+                self.token_name, sub_system_nickname
+            )
+
         with stopped_service('pki-tomcatd', 'pki-tomcat'):
             directivesetter.set_directive(
                 self.config,
@@ -212,7 +223,7 @@ class DogtagInstance(service.Service):
             directivesetter.set_directive(
                 self.config,
                 'authz.instance.DirAclAuthz.ldap.ldapauth.clientCertNickname',
-                'subsystemCert cert-pki-ca', quotes=False, separator='=')
+                sub_system_nickname, quotes=False, separator='=')
             directivesetter.set_directive(
                 self.config,
                 'authz.instance.DirAclAuthz.ldap.ldapconn.port', '636',
@@ -230,7 +241,7 @@ class DogtagInstance(service.Service):
             directivesetter.set_directive(
                 self.config,
                 'internaldb.ldapauth.clientCertNickname',
-                'subsystemCert cert-pki-ca', quotes=False, separator='=')
+                sub_system_nickname, quotes=False, separator='=')
             directivesetter.set_directive(
                 self.config,
                 'internaldb.ldapconn.port', '636', quotes=False, separator='=')
@@ -294,9 +305,9 @@ class DogtagInstance(service.Service):
                     # Give dogtag extra time to generate cert
                     timeout=CA_DBUS_TIMEOUT)
 
-    def __get_pin(self):
+    def __get_pin(self, token_name="internal"):
         try:
-            return certmonger.get_pin('internal')
+            return certmonger.get_pin(token_name)
         except IOError as e:
             logger.debug(
                 'Unable to determine PIN for the Dogtag instance: %s', e)
@@ -304,7 +315,7 @@ class DogtagInstance(service.Service):
 
     def configure_renewal(self):
         """ Configure certmonger to renew system certs """
-        pin = self.__get_pin()
+        pin = self.__get_pin(self.token_name)
 
         for nickname in self.tracking_reqs:
             try:
@@ -312,6 +323,7 @@ class DogtagInstance(service.Service):
                     certpath=self.nss_db,
                     ca='dogtag-ipa-ca-renew-agent',
                     nickname=nickname,
+                    token_name=self.token_name,
                     pin=pin,
                     pre_command='stop_pkicad',
                     post_command='renew_ca_cert "%s"' % nickname,
@@ -326,15 +338,19 @@ class DogtagInstance(service.Service):
         done by the renewal script, renew_ca_cert once all the subsystem
         certificates are renewed.
         """
-        pin = self.__get_pin()
+        # server cert is always stored in internal token
+        token_name = "internal"
+        pin = self.__get_pin(token_name)
         try:
             certmonger.start_tracking(
                 certpath=self.nss_db,
                 ca='dogtag-ipa-ca-renew-agent',
                 nickname=self.server_cert_name,
+                token_name=token_name,
                 pin=pin,
                 pre_command='stop_pkicad',
-                post_command='renew_ca_cert "%s"' % self.server_cert_name)
+                post_command='renew_ca_cert "%s"' % self.server_cert_name
+            )
         except RuntimeError as e:
             logger.error(
                 "certmonger failed to start tracking certificate: %s", e)


### PR DESCRIPTION
For HSM support, IPA has to pass the token name for CA and subsystem
certificates to certmonger. For now, only the default 'internal' token is
supported.

Related: https://pagure.io/freeipa/issue/5608
Signed-off-by: Christian Heimes <cheimes@redhat.com>