### PR TITLE
Deprecate ipa-client-install --request-cert

### DIFF
--- a/client/man/ipa-client-install.1
+++ b/client/man/ipa-client-install.1
@@ -168,6 +168,8 @@ authoritative and will be installed without checking to see if it's
 valid for the IPA domain.
 .TP
 \fB\-\-request\-cert\fR
+\fBDEPRECATED:\fR The option is deprecated and will be removed in a future release.
+
 Request certificate for the machine. The certificate will be stored in /etc/ipa/nssdb under the nickname "Local IPA host".
 
 Using this option requires that D-Bus is properly configured or not configured
@@ -269,6 +271,11 @@ Files updated, existing content is maintained:
 /etc/krb5.keytab
 .br
 /etc/sysconfig/network
+
+.SH "DEPRECATED OPTIONS"
+.TP
+\fB\-\-request\-cert\fR
+
 .SH "EXIT STATUS"
 0 if the installation was successful
 

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3691,6 +3691,7 @@ class ClientInstallInterface(hostname_.HostNameInstallInterface,
 
     request_cert = knob(
         None,
+        deprecated=True,
         description="request certificate for the machine",
     )
     request_cert = prepare_only(request_cert)
@@ -3703,7 +3704,10 @@ class ClientInstallInterface(hostname_.HostNameInstallInterface,
                 "--server cannot be used without providing --domain")
 
         if self.force_ntpd:
-            logger.warning("Option --force-ntpd has been deprecated")
+            logger.warning(
+                "Option --force-ntpd has been deprecated and will be "
+                "removed in a future release."
+            )
 
         if self.ntp_servers and self.no_ntp:
             raise RuntimeError(
@@ -3712,6 +3716,12 @@ class ClientInstallInterface(hostname_.HostNameInstallInterface,
         if self.ntp_pool and self.no_ntp:
             raise RuntimeError(
                 "--ntp-pool cannot be used together with --no-ntp")
+
+        if self.request_cert:
+            logger.warning(
+                "Option --request-cert has been deprecated and will be "
+                "removed in a future release."
+            )
 
         if self.no_nisdomain and self.nisdomain:
             raise RuntimeError(


### PR DESCRIPTION
Mark the --request-cert option for ipa-client-install as deprecated.
Users are encouraged to request a PEM certificate with certmonger
instead. The option and /etc/ipa/nssdb will be removed in a future
version.

Related: https://pagure.io/freeipa/issue/7492
Signed-off-by: Christian Heimes <cheimes@redhat.com>