### PR TITLE
Fix and extend pki config override test

### DIFF
--- a/install/share/ipaca_customize.ini
+++ b/install/share/ipaca_customize.ini
@@ -28,9 +28,10 @@ ipa_signing_algorithm=SHA256withRSA
 
 # Used for IPA CA
 # signing algorithm can be overriden on command line
-ipa_ca_signing_algorithm=%(ipa_key_algorithm)s
+ipa_ca_key_algorithm=%(ipa_key_algorithm)s
 ipa_ca_key_size=3072
 ipa_ca_key_type=%(ipa_key_type)s
+ipa_ca_signing_algorithm=%(ipa_signing_algorithm)s
 
 # HSM support
 pki_hsm_enable=False
@@ -86,7 +87,7 @@ pki_subsystem_token=%(pki_token_name)s
 pki_random_serial_numbers_enable=False
 
 ## caSigningCert cert-pki-ca
-pki_ca_signing_key_algorithm=%(ipa_ca_signing_algorithm)s
+pki_ca_signing_key_algorithm=%(ipa_ca_key_algorithm)s
 pki_ca_signing_key_size=%(ipa_ca_key_size)s
 pki_ca_signing_key_type=%(ipa_ca_key_type)s
 pki_ca_signing_signing_algorithm=%(ipa_ca_signing_algorithm)s

--- a/ipatests/test_integration/test_pki_config_override.py
+++ b/ipatests/test_integration/test_pki_config_override.py
@@ -5,6 +5,8 @@
 """
 from __future__ import absolute_import
 
+from cryptography.hazmat.primitives import hashes
+
 from ipalib.x509 import load_pem_x509_certificate
 from ipaplatform.paths import paths
 from ipatests.test_integration.base import IntegrationTest
@@ -13,7 +15,9 @@ from ipatests.pytest_ipa.integration import tasks
 
 KEY_OVERRIDE = """
 [DEFAULT]
-ipa_key_size=4096
+ipa_ca_key_size=4096
+ipa_ca_key_algorithm=SHA512withRSA
+ipa_ca_signing_algorithm=SHA512withRSA
 """
 
 
@@ -35,3 +39,4 @@ class TestPKIConfigOverride(IntegrationTest):
         )
         cert = load_pem_x509_certificate(ca_pem)
         assert cert.public_key().key_size == 4096
+        assert cert.signature_hash_algorithm.name == hashes.SHA512.name


### PR DESCRIPTION
* override ipa_ca_key_size
* test with SHA512withRSA

Related: https://pagure.io/freeipa/issue/5608
Signed-off-by: Christian Heimes <cheimes@redhat.com>