### PR TITLE
Disable global p11-kit configuration for NSS

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -366,6 +366,8 @@ class BasePathNamespace:
     AUTHCONFIG = None
     AUTHSELECT = None
     SYSCONF_NETWORK = None
+    CRYPTO_POLICY_P11_KIT_CONFIG = None
+    UPDATE_CRYPTO_POLICY = None
     # 389 DS related commands.
     DSCREATE = '/usr/sbin/dscreate'
     DSCTL = '/usr/sbin/dsctl'

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -272,5 +272,23 @@ class BaseTaskNamespace:
         if fstore is not None and fstore.has_file(paths.RESOLV_CONF):
             fstore.restore_file(paths.RESOLV_CONF)
 
+    def disable_p11_kit(self, fstore):
+        """Disable global p11-kit configuration for NSS
+
+        The p11-kit configuration injects p11-kit-proxy into all NSS
+        databases. Amongst other p11-kit loads SoftHSM2 PKCS#11 provider.
+        This interferes with 389-DS, certmonger, Dogtag and other services.
+        For example certmonger tries to open OpenDNSSEC's SoftHSM2 token,
+        although it doesn't use it at all. It also breaks Dogtag HSM support
+        testing with SoftHSM2.
+
+        IPA server does neither need nor use p11-kit.
+        """
+        raise NotImplementedError
+
+    def restore_p11_kit(self, fstore):
+        """Restore global p11-kit configuration for NSS
+        """
+        raise NotImplementedError
 
 tasks = BaseTaskNamespace()

--- a/ipaplatform/debian/tasks.py
+++ b/ipaplatform/debian/tasks.py
@@ -69,5 +69,11 @@ class DebianTaskNamespace(RedHatTaskNamespace):
         # Debian handles httpd logging differently
         pass
 
+    def disable_p11_kit(self, fstore):
+        # Debian doesn't use p11-kit
+        pass
+
+    def restore_p11_kit(self, fstore):
+        pass
 
 tasks = DebianTaskNamespace()

--- a/ipaplatform/redhat/paths.py
+++ b/ipaplatform/redhat/paths.py
@@ -39,6 +39,9 @@ class RedHatPathNamespace(BasePathNamespace):
     AUTHCONFIG = '/usr/sbin/authconfig'
     AUTHSELECT = '/usr/bin/authselect'
     SYSCONF_NETWORK = '/etc/sysconfig/network'
+    CRYPTO_POLICY_P11_KIT_CONFIG = \
+        "/etc/crypto-policies/local.d/nss-p11-kit.config"
+    UPDATE_CRYPTO_POLICY = "/usr/bin/update-crypto-policies"
 
 
 paths = RedHatPathNamespace()

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -772,6 +772,9 @@ def install(installer):
     if installer._update_hosts_file:
         update_hosts_file(ip_addresses, host_name, fstore)
 
+    if tasks.disable_p11_kit(fstore):
+        print("Disabled p11-kit-proxy")
+
     # Create a directory server instance
     if not options.external_cert_files:
         # We have to sync time before certificate handling on master.
@@ -1150,6 +1153,8 @@ def uninstall(installer):
 
     # remove upgrade state file
     sysupgrade.remove_upgrade_file()
+
+    tasks.restore_p11_kit(fstore)
 
     if fstore.has_files():
         logger.error('Some files have not been restored, see '

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1167,6 +1167,9 @@ def install(installer):
     conn = remote_api.Backend.ldap2
     ccache = os.environ['KRB5CCNAME']
 
+    if tasks.disable_p11_kit(fstore):
+        print("Disabled p11-kit-proxy")
+
     if installer._add_to_ipaservers:
         try:
             conn.connect(ccache=installer._ccache)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1822,6 +1822,9 @@ def upgrade_configuration():
     if not sysupgrade.get_upgrade_state('ntpd', 'ntpd_cleaned'):
         ntpd_cleanup(fqdn, fstore)
 
+    if tasks.disable_p11_kit(fstore):
+        print("Disabled p11-kit-proxy")
+
     check_certs()
     fix_permissions()
 


### PR DESCRIPTION
The p11-kit configuration injects p11-kit-proxy into all NSS databases.
Amongst other p11-kit loads SoftHSM2 PKCS#11 provider. This interferes
with 389-DS, certmonger, Dogtag and other services. For example certmonger
tries to open OpenDNSSEC's SoftHSM2 token, although it doesn't use it at
all. It also breaks Dogtag HSM support testing with SoftHSM2.

IPA server does neither need nor use p11-kit.

Related: https://pagure.io/freeipa/issue/7810
Signed-off-by: Christian Heimes <cheimes@redhat.com>