### PR TITLE
fix test test_integration/test_commands.py::test_ssh_key_connection

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -285,7 +285,7 @@ class TestIPACommand(IntegrationTest):
         """
         Integration test for https://pagure.io/SSSD/sssd/issue/3747
         """
-
+        tmpdir = str(tmpdir)
         test_user = 'test-ssh'
         external_master_hostname = \
             self.master.external_hostname  # pylint: disable=no-member


### PR DESCRIPTION
In testcase test_ssh_key_connection the value provided by tmpdir fixture
is used as regular string, i.e. passed as an argument to os.path.join.
tmpdir is an instance of py.path.local, and in old versions of package
python-py it does not have methods of string object,
which causes this test to fail in distributions where such version of
python-py is installed.
Fixed by explicitly changing type of tmpdir to str.