### PR TITLE
Check have packages for extra features been installed before restoring backup

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -324,6 +324,28 @@ class Restore(admintool.AdminTool):
                     not user_input("Continue to restore?", False)):
                 raise admintool.ScriptError("Aborted")
 
+        # Check have optional dependencies been installed for extra
+        # features from backup
+        if restore_type == 'FULL':
+            if 'ADTRUST' in self.backup_services:
+                if not adtrustinstance or not adtrustinstance.check_inst():
+                    raise admintool.ScriptError(
+                        "Backup includes AD trust feature, it requires '{}' "
+                        "package. Please install the package and "
+                        "run ipa-restore again.".format(
+                            constants.IPA_ADTRUST_PACKAGE_NAME
+                        )
+                    )
+            if 'DNS' in self.backup_services:
+                if not os.path.isfile(paths.IPA_DNS_INSTALL):
+                    raise admintool.ScriptError(
+                        "Backup includes Integrated DNS feature, it requires "
+                        "'{}' package. Please install the package and "
+                        "run ipa-restore again.".format(
+                            constants.IPA_DNS_PACKAGE_NAME
+                        )
+                    )
+
         pent = pwd.getpwnam(constants.DS_USER)
 
         # Temporary directory for decrypting files before restoring


### PR DESCRIPTION
Check have packages for extra features been installed before restoring backup 

`iparestore --full` should check that packages for extra features such as dns and adtrust are installed in the system before restoring a backup in case the backup includes content for these features. If the packages are not installed full backup should be refused and an error message with suggestions should be showed.

If corresponding packages for these features are not installed before the backup restoring, it may cause a situation when the packages are going to be installed after the restoring. In that case configuration files restored by `ipa-restore` will be replaced by default configuration files if the files are tracked by `rpm`. E.g. if `freeipa-server-trust-ad` is not installed before `ipa-restore --full` running, when the package will be installed it also will bring `samba` package according to the dependencies. At `samba` installation step exist correct `/etc/samba/smb.conf` is going to be replaced by the default one from the `samba` package.

Fixes: https://pagure.io/freeipa/issue/7630