### PR TITLE
Update samba configuration defaults

### DIFF
--- a/install/share/smb.conf.template
+++ b/install/share/smb.conf.template
@@ -32,3 +32,4 @@ idmap config * : backend = tdb
 idmap config * : range =  0 - 0
 idmap config $NETBIOS_NAME : backend = sss
 idmap config $NETBIOS_NAME : range = $IPA_LOCAL_RANGE
+max smbd processes = 1000

--- a/install/share/smb.conf.template
+++ b/install/share/smb.conf.template
@@ -28,3 +28,7 @@ rpc_server:netlogon = external
 rpc_server:tcpip = yes
 rpc_daemon:epmd = fork
 rpc_daemon:lsasd = fork
+idmap config * : backend = tdb
+idmap config * : range =  0 - 0
+idmap config $NETBIOS_NAME : backend = sss
+idmap config $NETBIOS_NAME : range = $IPA_LOCAL_RANGE

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -130,6 +130,15 @@ def map_Guests_to_nobody():
     logger.debug("Map BUILTIN\\Guests to a group 'nobody'")
     ipautil.run(args, env=env, raiseonerr=False, capture_error=True)
 
+
+def get_idmap_range(realm):
+    idrange = api.Command.idrange_show('{}_id_range'.format(realm))['result']
+    range_start = int(idrange['ipabaseid'][0])
+    range_size = int(idrange['ipaidrangesize'][0])
+    range_fmt = '{} - {}'.format(range_start, range_start + range_size)
+    return range_fmt
+
+
 class ADTRUSTInstance(service.Service):
 
     ATTR_SID = "ipaNTSecurityIdentifier"
@@ -838,12 +847,18 @@ class ADTRUSTInstance(service.Service):
         )
         api.Backend.ldap2.add_entry(entry)
 
+    def __retrieve_local_range(self):
+        """Retrieves local IPA ID range to make sure
+        """
+        self.sub_dict['IPA_LOCAL_RANGE'] = get_idmap_range(self.realm)
+
     def create_instance(self):
         self.step("validate server hostname",
                   self.__validate_server_hostname)
         self.step("stopping smbd", self.__stop)
         self.step("creating samba domain object", \
                   self.__create_samba_domain_object)
+        self.step("retrieve local idmap range", self.__retrieve_local_range)
         self.step("creating samba config registry", self.__write_smb_registry)
         self.step("writing samba config file", self.__write_smb_conf)
         self.step("adding cifs Kerberos principal",

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -335,6 +335,25 @@ def upgrade_adtrust_config():
     except ipautil.CalledProcessError as e:
         logger.warning("Error updating Samba registry: %s", e)
 
+    logger.info("[Update 'max smbd processes' in Samba configuration "
+                "to prevent unlimited SMBLoris attack amplification]")
+
+    args = [paths.NET, "conf", "getparm", "global", "max smbd processes"]
+
+    try:
+        ipautil.run(args)
+    except ipautil.CalledProcessError as e:
+        if e.returncode == 255:
+            # 'max smbd processes' does not exist
+            args = [paths.NET, "conf", "setparm", "global",
+                    "max smbd processes", "1000"]
+            try:
+                ipautil.run(args)
+            except ipautil.CalledProcessError as e:
+                logger.warning("Error updating Samba registry: %s", e)
+        else:
+            logger.warning("Error updating Samba registry: %s", e)
+
 
 def ca_configure_profiles_acl(ca):
     logger.info('[Authorizing RA Agent to modify profiles]')


### PR DESCRIPTION
Long overdue, we need to fix Samba configuration to follow testparm recommendations.
A second fix is to make sure smbd by default is limited in its capability to handle concurrent client requests to prevent SMBLoris attack.