### PR TITLE
chmod SYSTEMD_PKI_TOMCAT_IPA_CONF

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -613,6 +613,7 @@ class CAInstance(DogtagInstance):
         if not os.path.isdir(directory):
             os.mkdir(directory)
         with open(conf, 'w') as f:
+            os.fchmod(f.fileno(), 0o644)
             f.write('[Service]\n')
             f.write('ExecStartPost={}\n'.format(paths.IPA_PKI_WAIT_RUNNING))
         tasks.systemd_daemon_reload()


### PR DESCRIPTION
Change the permission of the new config file
/etc/systemd/system/pki-tomcatd@pki-tomcat.service.d/ipa.conf to 644.
This fixes the systemd warning

```
Configuration file /etc/systemd/system/pki-tomcatd@pki-tomcat.service.d/ipa.conf is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
```

Signed-off-by: Christian Heimes <cheimes@redhat.com>