### PR TITLE
Check for SELinux AVCs after installation

### DIFF
--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -91,16 +91,24 @@ class BaseTaskNamespace:
 
         return paths.SVC_LIST_FILE
 
-    def check_selinux_status(self):
+    def is_selinux_enabled(self):
+        """Check if SELinux is available and enabled
+
+        :return: True if SELinux is available and enabled
         """
-        Checks if SELinux is available on the platform. If it is, this task
-        also makes sure that restorecon tool is available.
+        return False
+
+    def check_selinux_status(self):
+        """Checks if SELinux is available on the platform.
+
+        If it is, this task also makes sure that restorecon tool is available.
 
         If SELinux is available, but restorcon tool is not installed, raises
         an RuntimeError, which suggest installing the package containing
         restorecon and rerunning the installation.
-        """
 
+        :return: True if SELinux is available and enabled
+        """
         raise NotImplementedError()
 
     def check_ipv6_stack_enabled(self):

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -75,22 +75,6 @@ NM_IPA_CONF = textwrap.dedent("""
 """)
 
 
-def selinux_enabled():
-    """
-    Check if SELinux is enabled.
-    """
-    if os.path.exists(paths.SELINUXENABLED):
-        try:
-            ipautil.run([paths.SELINUXENABLED])
-            return True
-        except ipautil.CalledProcessError:
-            # selinuxenabled returns 1 if not enabled
-            return False
-    else:
-        # No selinuxenabled, no SELinux
-        return False
-
-
 @total_ordering
 class IPAVersion:
     _rpmvercmp_func = None
@@ -143,7 +127,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
         ipautil.run() will do the logging.
         """
         restorecon = paths.SBIN_RESTORECON
-        if not selinux_enabled() or not os.path.exists(restorecon):
+        if not self.is_selinux_enabled() or not os.path.exists(restorecon):
             return
 
         # Force reset of context to match file_context for customizable
@@ -155,6 +139,20 @@ class RedHatTaskNamespace(BaseTaskNamespace):
         args.append(filepath)
         ipautil.run(args, raiseonerr=False)
 
+    def is_selinux_enabled(self):
+        """Check if SELinux is available and enabled
+        """
+        try:
+            ipautil.run([paths.SELINUXENABLED])
+        except ipautil.CalledProcessError:
+            # selinuxenabled returns 1 if not enabled
+            return False
+        except OSError:
+            # selinuxenabled binary not available
+            return False
+        else:
+            return True
+
     def check_selinux_status(self, restorecon=paths.RESTORECON):
         """
         We don't have a specific package requirement for policycoreutils
@@ -165,13 +163,14 @@ class RedHatTaskNamespace(BaseTaskNamespace):
         This function returns nothing but may raise a Runtime exception
         if SELinux is enabled but restorecon is not available.
         """
-        if not selinux_enabled():
-            return
+        if not self.is_selinux_enabled():
+            return False
 
         if not os.path.exists(restorecon):
             raise RuntimeError('SELinux is enabled but %s does not exist.\n'
                                'Install the policycoreutils package and start '
                                'the installation again.' % restorecon)
+        return True
 
     def check_ipv6_stack_enabled(self):
         """Checks whether IPv6 kernel module is loaded.
@@ -458,7 +457,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
 
             return args
 
-        if not selinux_enabled():
+        if not self.is_selinux_enabled():
             return False
 
         updated_vars = {}

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1433,12 +1433,13 @@ def install_ca(host, domain_level=None, first_instance=False,
     return result
 
 
-def install_dns(host, raiseonerr=True):
+def install_dns(host, raiseonerr=True, extra_args=()):
     args = [
         "ipa-dns-install",
         "--forwarder", host.config.dns_forwarder,
         "-U",
     ]
+    args.extend(extra_args)
     ret = host.run_command(args, raiseonerr=raiseonerr)
     Firewall(host).enable_service("dns")
     return ret


### PR DESCRIPTION
Look for SELinux violation after installing a master with CA, KRA, and
DNS with DNSSEC. The test does not fail yet, because there are known
SELinux violations.

Signed-off-by: Christian Heimes <cheimes@redhat.com>