### PR TITLE
ipaplatform: add more services

### DIFF
--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -50,12 +50,15 @@ logger = logging.getLogger(__name__)
 # *some* naming, set them as in Red Hat distributions. Actual implementation
 # should make them available through knownservices.<name> and take care of
 # re-mapping internally, if needed
-wellknownservices = ['certmonger', 'dirsrv', 'httpd', 'ipa', 'krb5kdc',
-                     'dbus', 'nslcd', 'nscd', 'ntpd', 'portmap',
-                     'rpcbind', 'kadmin', 'sshd', 'autofs', 'rpcgssd',
-                     'rpcidmapd', 'pki_tomcatd', 'chronyd', 'domainname',
-                     'named', 'ods_enforcerd', 'ods_signerd', 'gssproxy',
-                     'nfs-utils', 'sssd', 'NetworkManager']
+wellknownservices = [
+    'certmonger', 'dirsrv', 'httpd', 'ipa', 'krb5kdc',
+    'dbus', 'nslcd', 'nscd', 'ntpd', 'portmap',
+    'rpcbind', 'kadmin', 'sshd', 'autofs', 'rpcgssd',
+    'rpcidmapd', 'pki_tomcatd', 'chronyd', 'domainname',
+    'named', 'ods_enforcerd', 'ods_signerd', 'gssproxy',
+    'nfs-utils', 'sssd', 'NetworkManager', 'ipa-custodia',
+    'ipa-dnskeysyncd', 'ipa-otpd', 'ipa-ods-exporter'
+]
 
 # The common ports for these services. This is used to wait for the
 # service to become available.


### PR DESCRIPTION
Healthcheck needs to check more services than currently defined
in ipaplatform. Add these services.

Signed-off-by: François Cami <fcami@redhat.com>