### PR TITLE
ipa console: catch proper exception when history file can not be open

### DIFF
--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -971,7 +971,7 @@ class console(frontend.Command):
         history = os.path.join(api.env.dot_ipa, "console.history")
         try:
             readline.read_history_file(history)
-        except OSError:
+        except IOError:
             pass
 
         def save_history():
@@ -981,7 +981,7 @@ class console(frontend.Command):
             readline.set_history_length(50)
             try:
                 readline.write_history_file(history)
-            except OSError:
+            except IOError:
                 logger.exception("Unable to store history %s", history)
 
         atexit.register(save_history)


### PR DESCRIPTION
In python 2, when file can not be open, IOError is raised, but only OSEror
was catched. This caused "ipa console" command to crash when history file
did not exist.
In python3 OSError is raised in this situation, but as OSError is IOError
in python3, we can safely catch only IOError.