### PR TITLE
[Backport][ipa-4-7] chmod SYSTEMD_PKI_TOMCAT_IPA_CONF

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -717,6 +717,7 @@ class CAInstance(DogtagInstance):
         if not os.path.isdir(directory):
             os.mkdir(directory)
         with open(conf, 'w') as f:
+            os.fchmod(f.fileno(), 0o644)
             f.write('[Service]\n')
             f.write('ExecStartPost={}\n'.format(paths.IPA_PKI_WAIT_RUNNING))
         tasks.systemd_daemon_reload()


### PR DESCRIPTION
This PR was opened automatically because PR #3072 was pushed to master and backport to ipa-4-7 is required.