### PR TITLE
[Backport][ipa-4-6] ipa console: catch proper exception when history file can not be open

### DIFF
--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -969,7 +969,7 @@ class console(frontend.Command):
         history = os.path.join(api.env.dot_ipa, "console.history")
         try:
             readline.read_history_file(history)
-        except OSError:
+        except IOError:
             pass
 
         def save_history():
@@ -979,7 +979,7 @@ class console(frontend.Command):
             readline.set_history_length(50)
             try:
                 readline.write_history_file(history)
-            except OSError:
+            except IOError:
                 logger.exception("Unable to store history %s", history)
 
         atexit.register(save_history)


### PR DESCRIPTION
This PR was opened automatically because PR #3076 was pushed to ipa-4-7 and backport to ipa-4-6 is required.