### PR TITLE
 Consider configured servers as valid

### DIFF
--- a/ipaserver/servroles.py
+++ b/ipaserver/servroles.py
@@ -346,11 +346,14 @@ class ServerAttribute(LDAPBasedProperty):
     def _get_assoc_role_providers(self, api_instance):
         """get list of all servers on which the associated role is enabled
 
-        Consider a hidden server as a valid provider for a role.
+        Consider a hidden and configured server as a valid provider for a
+        role, as all services are started.
         """
         return [
-            r[u'server_server'] for r in self.associated_role.status(
-                api_instance) if r[u'status'] in {ENABLED, HIDDEN}]
+            r[u'server_server']
+            for r in self.associated_role.status(api_instance)
+            if r[u'status'] in {ENABLED, HIDDEN, CONFIGURED}
+        ]
 
     def _remove(self, api_instance, masters):
         """

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -23,6 +23,12 @@ from ipalib.constants import IPAAPI_USER
 
 from ipaplatform.paths import paths
 
+from ipapython.dn import DN
+
+from ipaserver.masters import (
+    CONFIGURED_SERVICE, ENABLED_SERVICE, HIDDEN_SERVICE
+)
+
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.create_external_ca import ExternalCA
@@ -535,3 +541,38 @@ class TestIPACommand(IntegrationTest):
         )
         assert result.returncode != 0
         assert 'HBAC rule not found' in result.stderr_text
+
+    def test_config_show_configured_services(self):
+        # https://pagure.io/freeipa/issue/7929
+        states = {CONFIGURED_SERVICE, ENABLED_SERVICE, HIDDEN_SERVICE}
+        dn = DN(
+            ('cn', 'HTTP'), ('cn', self.master.hostname), ('cn', 'masters'),
+            ('cn', 'ipa'), ('cn', 'etc'),
+            self.master.domain.basedn  # pylint: disable=no-member
+        )
+
+        conn = self.master.ldap_connect()
+        entry = conn.get_entry(dn)  # pylint: disable=no-member
+
+        # original setting and all settings without state
+        orig_cfg = list(entry['ipaConfigString'])
+        other_cfg = [item for item in orig_cfg if item not in states]
+
+        try:
+            # test with hidden
+            cfg = [HIDDEN_SERVICE]
+            cfg.extend(other_cfg)
+            entry['ipaConfigString'] = cfg
+            conn.update_entry(entry)  # pylint: disable=no-member
+            self.master.run_command(['ipa', 'config-show'])
+
+            # test with configured
+            cfg = [CONFIGURED_SERVICE]
+            cfg.extend(other_cfg)
+            entry['ipaConfigString'] = cfg
+            conn.update_entry(entry)  # pylint: disable=no-member
+            self.master.run_command(['ipa', 'config-show'])
+        finally:
+            # reset
+            entry['ipaConfigString'] = orig_cfg
+            conn.update_entry(entry)  # pylint: disable=no-member


### PR DESCRIPTION
Under some conditions, ipa config-show and several other commands were
failing with error message:

  ERROR: invalid 'PKINIT enabled server': all masters must have IPA master role enabled

Amongst others the issue can be caused by a broken installation, when
some services are left in state 'configuredServices'. The problem even
block uninstallation or removal of replicas. Now configured servers are
also consider valid providers for associated roles.

A new test verifies that config-show works with hidden and configured HTTP
service.

Remark: The original intent of the sanity check is no longer clear to me. I
think it was used to very that all services can be started by ipactl.
Since ipactl starts hidden, configured, and enabled services, the new
logic reflect the fact, too.

Fixes: https://pagure.io/freeipa/issue/7929