### PR TITLE
[Backport][ipa-4-6] Consider configured servers as valid

### DIFF
--- a/ipaserver/servroles.py
+++ b/ipaserver/servroles.py
@@ -346,11 +346,14 @@ class ServerAttribute(LDAPBasedProperty):
     def _get_assoc_role_providers(self, api_instance):
         """get list of all servers on which the associated role is enabled
 
-        Consider a hidden server as a valid provider for a role.
+        Consider a hidden and configured server as a valid provider for a
+        role, as all services are started.
         """
         return [
-            r[u'server_server'] for r in self.associated_role.status(
-                api_instance) if r[u'status'] in {ENABLED, HIDDEN}]
+            r[u'server_server']
+            for r in self.associated_role.status(api_instance)
+            if r[u'status'] in {ENABLED, HIDDEN, CONFIGURED}
+        ]
 
     def _remove(self, api_instance, masters):
         """


### PR DESCRIPTION
Manual backport of PR #3093 

Under some conditions, ipa config-show and several other commands were
failing with error message:

  ERROR: invalid 'PKINIT enabled server': all masters must have IPA master role enabled

Amongst others the issue can be caused by a broken installation, when
some services are left in state 'configuredServices'. The problem even
block uninstallation or removal of replicas. Now configured servers are
also consider valid providers for associated roles.

A new test verifies that config-show works with hidden and configured HTTP
service.

Remark: The original intent of the sanity check is no longer clear to me. I
think it was used to very that all services can be started by ipactl.
Since ipactl starts hidden, configured, and enabled services, the new
logic reflect the fact, too.

Fixes: https://pagure.io/freeipa/issue/7929
Signed-off-by: Christian Heimes <cheimes@redhat.com>