### PR TITLE
Import urllib submodules

### DIFF
--- a/ipaclient/plugins/otptoken.py
+++ b/ipaclient/plugins/otptoken.py
@@ -34,7 +34,8 @@ import qrcode
 
 import six
 from io import StringIO
-import urllib
+import urllib.parse
+import urllib.request
 
 if six.PY3:
     unicode = str


### PR DESCRIPTION
otpclient only imported the urllib parent package, not urllib.request
and urllib.parse subpackages. This may or may not work depending on the
import order of other plugins.

Signed-off-by: Christian Heimes <cheimes@redhat.com>