### PR TITLE
Correct default fontawesome path (broken by da2cf1c5)

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -249,7 +249,7 @@ class BasePathNamespace:
     USERADD = "/usr/sbin/useradd"
     FONTS_DIR = "/usr/share/fonts"
     FONTS_OPENSANS_DIR = "/usr/share/fonts/open-sans"
-    FONTS_FONTAWESOME_DIR = "/usr/share/fonts/font-awesome"
+    FONTS_FONTAWESOME_DIR = "/usr/share/fonts/fontawesome"
     USR_SHARE_IPA_DIR = "/usr/share/ipa/"
     USR_SHARE_IPA_CLIENT_DIR = "/usr/share/ipa/client"
     CA_TOPOLOGY_ULDIF = "/usr/share/ipa/ca-topology.uldif"


### PR DESCRIPTION
On Fedora/RHEL, it does not have a dash in it. The changes in
da2cf1c5 inadvertently added a dash to the path in the 'base'
paths definition (used on Fedora/RHEL), so the font wasn't found.

Signed-off-by: Adam Williamson <awilliam@redhat.com>