### PR TITLE
[Backport][ipa-4-7] Correct default fontawesome path (broken by da2cf1c5)

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -257,7 +257,7 @@ class BasePathNamespace(object):
     USERADD = "/usr/sbin/useradd"
     FONTS_DIR = "/usr/share/fonts"
     FONTS_OPENSANS_DIR = "/usr/share/fonts/open-sans"
-    FONTS_FONTAWESOME_DIR = "/usr/share/fonts/font-awesome"
+    FONTS_FONTAWESOME_DIR = "/usr/share/fonts/fontawesome"
     USR_SHARE_IPA_DIR = "/usr/share/ipa/"
     USR_SHARE_IPA_CLIENT_DIR = "/usr/share/ipa/client"
     CA_TOPOLOGY_ULDIF = "/usr/share/ipa/ca-topology.uldif"


### PR DESCRIPTION
This PR was opened automatically because PR #3104 was pushed to master and backport to ipa-4-7 is required.