### PR TITLE
Index certmap attributes

### DIFF
--- a/install/share/73certmap.ldif
+++ b/install/share/73certmap.ldif
@@ -12,3 +12,6 @@ attributeTypes: (2.16.840.1.113730.3.8.22.1.5 NAME 'ipaCertMapPriority' DESC 'Ru
 objectClasses: (2.16.840.1.113730.3.8.22.2.1 NAME 'ipaCertMapConfigObject' DESC 'IPA Certificate Mapping global config options' AUXILIARY MAY ipaCertMapPromptUsername X-ORIGIN 'IPA v4.5' )
 objectClasses: (2.16.840.1.113730.3.8.22.2.2 NAME 'ipaCertMapRule' DESC 'IPA Certificate Mapping rule' SUP top STRUCTURAL MUST cn MAY ( description $ ipaCertMapMapRule $ ipaCertMapMatchRule $ associatedDomain $ ipaCertMapPriority $ ipaEnabledFlag ) X-ORIGIN 'IPA v4.5' )
 objectClasses: (2.16.840.1.113730.3.8.22.2.3 NAME 'ipaCertMapObject' DESC 'IPA Object for Certificate Mapping' AUXILIARY MAY ipaCertMapData X-ORIGIN 'IPA v4.5' )
+# altSecurityIdentities attribute is from MS-WSPP AD schema
+# we define it here to have proper indexed searches
+attributeTypes: (1.2.840.113556.1.4.867 NAME 'altSecurityIdentities' DESC 'Alt-Security-Identities' EQUALITY caseIgnoreMatch ORDERING caseIgnoreOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'MS-WSPP')

--- a/install/share/indices.ldif
+++ b/install/share/indices.ldif
@@ -401,3 +401,19 @@ objectClass: top
 objectClass: nsIndex
 nsSystemIndex: false
 nsIndexType: eq
+
+dn: cn=ipaCertmapData,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: ipaCertmapData
+objectClass: top
+objectClass: nsIndex
+nsSystemIndex: false
+nsIndexType: eq
+
+dn: cn=altSecurityIdentities,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: altSecurityIdentities
+objectClass: top
+objectClass: nsIndex
+nsSystemIndex: false
+nsIndexType: eq

--- a/install/updates/20-aci.update
+++ b/install/updates/20-aci.update
@@ -25,6 +25,10 @@ add:aci:(targetfilter="(objectclass=domain)")(targetattr="objectclass || dc || i
 dn: $SUFFIX
 add:aci:(targetattr="parentid")(version 3.0; acl "Anonymous read access to parentID information"; allow(read, search, compare) userdn = "ldap:///anyone";)
 
+# Read access to altSecurityIdentities to allow filter optimizations in 389-ds
+dn: $SUFFIX
+add:aci:(targetattr="altSecurityIdentities")(version 3.0; acl "Authenticated read access to altSecurityIdentities information"; allow(read, search, compare) userdn = "ldap:///all";)
+
 # Read access to containers
 dn: $SUFFIX
 add:aci:(targetfilter="(&(objectclass=nsContainer)(!(objectclass=krbPwdPolicy)))")(target!="ldap:///cn=masters,cn=ipa,cn=etc,$SUFFIX")(targetattr="objectclass || cn")(version 3.0; acl "Anonymous read access to containers"; allow(read, search, compare) userdn = "ldap:///anyone";)

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -366,3 +366,17 @@ default: objectClass: top
 default: objectClass: nsIndex
 default: nsSystemIndex: false
 default: nsIndexType: eq
+
+dn: cn=ipaCertmapData,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: ipaCertmapData
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: eq
+
+dn: cn=altSecurityIdentities,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: altSecurityIdentities
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: eq

--- a/ipaserver/plugins/certmap.py
+++ b/ipaserver/plugins/certmap.py
@@ -91,6 +91,67 @@ EXAMPLES:
 register = Registry()
 
 
+def check_maprule_is_for_trusted_domain(api_inst, options, entry_attrs):
+    """
+    Check that the certmap rule references altSecurityIdentities and
+    associateddomain in options is a trusted domain.
+
+    :param api_inst: API instance
+    :param options: options passed to the command
+                    at least ipacertmapmaprule and
+                    associateddomain options are expected for the check
+
+    :raises: ValidationError if altSecurityIdentities is present in the
+             rule but no Active Directory trusted domain listed in
+             associated domains
+    """
+    is_trusted_domain_required = False
+
+    # If no explicit option passed, fallback to the content of the entry.
+    # This helps to catch cases when an associated domain value is removed
+    # while the rule requires its presence.
+    #
+    # In certmap-mod pre-callback we pass LDAPEntry instance instead of a dict
+    # LDAEntry.get() returns lists, even for single valued attrs. Using
+    # LDAPEntry.single_value would give us a single-valued result instead.
+    maprule_entry = entry_attrs
+    if not isinstance(maprule_entry, dict):
+        maprule_entry = entry_attrs.single_value
+
+    maprule = options.get('ipacertmapmaprule',
+                          maprule_entry.get('ipacertmapmaprule'))
+
+    if maprule:
+        if 'altsecurityidentities' in maprule.lower():
+            is_trusted_domain_required = True
+
+    if is_trusted_domain_required:
+        domains = options.get('associateddomain',
+                              entry_attrs.get('associateddomain'))
+        if domains:
+            trusted_domains = api_inst.Object.config.gather_trusted_domains()
+            trust_suffix_namespace = {dom_name.lower() for dom_name in
+                                      trusted_domains}
+
+            candidates = {str(dom).lower() for dom in domains}
+            invalid = candidates - trust_suffix_namespace
+
+            if invalid == candidates or len(trust_suffix_namespace) == 0:
+                raise errors.ValidationError(
+                    name=_('domain'),
+                    error=_('The domain(s) "%s" cannot be used to apply '
+                            'altSecurityIdentities check.') %
+                    ", ".join(list(invalid))
+                )
+        else:
+            raise errors.ValidationError(
+                name=_('domain'),
+                error=_('The mapping rule with altSecurityIdentities '
+                        'should be applied to a trusted Active Directory '
+                        'domain but no domain was associated with the rule.')
+            )
+
+
 def check_associateddomain_is_trusted(api_inst, options):
     """
     Check that the associateddomain in options are either IPA domain or
@@ -299,6 +360,7 @@ class certmaprule_add(LDAPCreate):
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys,
                      **options):
         check_associateddomain_is_trusted(self.api, options)
+        check_maprule_is_for_trusted_domain(self.api, options, entry_attrs)
         return dn
 
 
@@ -311,6 +373,17 @@ class certmaprule_mod(LDAPUpdate):
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys,
                      **options):
         check_associateddomain_is_trusted(self.api, options)
+        # For update of the existing certmaprule we need to retrieve
+        # content of the LDAP entry because modification may affect two cases:
+        # - altSecurityIdentities might be removed by the modification
+        # - trusted domains may be removed by the modification while they
+        #   should be in place
+        #
+        # For both these cases we need to know actual content of the entry but
+        # LDAPUpdate.execute() provides us with entry_attrs built from the
+        # options, not the original content.
+        entry = ldap.get_entry(dn)
+        check_maprule_is_for_trusted_domain(self.api, options, entry)
         return dn
 
 

--- a/ipatests/test_xmlrpc/test_certmap_plugin.py
+++ b/ipatests/test_xmlrpc/test_certmap_plugin.py
@@ -27,6 +27,17 @@ certmaprule_create_params = {
         u'ipacertmappriority': u'1',
 }
 
+certmaprule_create_trusted_params = {
+    u'cn': u'test_trusted_rule',
+    u'description': u'Certificate mapping and matching rule for test '
+                    u'purposes for trusted domain',
+    u'ipacertmapmaprule': u'altsecurityidentities=X509:<some map>',
+    u'ipacertmapmatchrule': u'arbitrary free-form matching rule defined '
+                            u'and consumed by SSSD',
+    u'associateddomain': api.env.domain,
+    u'ipacertmappriority': u'1',
+}
+
 certmaprule_update_params = {
         u'description': u'Changed description',
         u'ipacertmapmaprule': u'changed arbitrary mapping rule',
@@ -77,6 +88,12 @@ def certmap_rule(request):
 
 
 @pytest.fixture(scope='class')
+def certmap_rule_trusted_domain(request):
+    tracker = CertmapruleTracker(**certmaprule_create_trusted_params)
+    return tracker.make_fixture(request)
+
+
+@pytest.fixture(scope='class')
 def certmap_config(request):
     tracker = CertmapconfigTracker()
     return tracker.make_fixture(request)
@@ -121,6 +138,18 @@ class TestCRUD(XMLRPC_test):
     def test_delete(self, certmap_rule):
         certmap_rule.ensure_exists()
         certmap_rule.delete()
+
+    def test_failed_create(self, certmap_rule_trusted_domain):
+        certmap_rule_trusted_domain.ensure_missing()
+        try:
+            certmap_rule_trusted_domain.create([])
+        except errors.ValidationError:
+            certmap_rule_trusted_domain.exists = False
+        else:
+            certmap_rule_trusted_domain.exists = True
+            certmap_rule_trusted_domain.ensure_missing()
+            raise AssertionError("Expected validation error for "
+                                 "altSecurityIdentities used for IPA domain")
 
 
 class TestEnableDisable(XMLRPC_test):


### PR DESCRIPTION
During an investigation into filter optimisation in 389DS it was
discovered that two attributes of the certmap query are unindexed.
Due to the nature of LDAP filters, if any member of an OR query is
unindexed, the entire OR becomes unindexed.

This is then basically a full-table scan, which applies the filter test
to the contained members.

Fixes: https://pagure.io/freeipa/issue/7932
Fixes: https://pagure.io/freeipa/issue/7933
