### PR TITLE
[Backport][ipa-4-7] Remove hardcoded instances of /var/lib/ipa/backup/

### DIFF
--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -513,7 +513,7 @@ class Backup(admintool.AdminTool):
 
         logger.info("Backing up files")
         args = ['tar',
-                '--exclude=/var/lib/ipa/backup',
+                '--exclude=%s' % paths.IPA_BACKUP_DIR,
                 '--xattrs',
                 '--selinux',
                 '-cf',
@@ -538,7 +538,7 @@ class Backup(admintool.AdminTool):
 
         if missing_directories:
             args = ['tar',
-                    '--exclude=/var/lib/ipa/backup',
+                    '--exclude=%s' % paths.IPA_BACKUP_DIR,
                     '--xattrs',
                     '--selinux',
                     '--no-recursion',
@@ -616,7 +616,7 @@ class Backup(admintool.AdminTool):
         the db2bak output and an LDIF.
 
         These, along with the header, are moved into a new subdirectory
-        in /var/lib/ipa/backup.
+        in paths.IPA_BACKUP_DIR (/var/lib/ipa/backup).
         '''
 
         if data_only:


### PR DESCRIPTION
This PR was opened automatically because PR #3113 was pushed to master and backport to ipa-4-7 is required.