### PR TITLE
[Backport][ipa-4-6] Web UI tests: Get rid of *_cert_path and *_csr_path config variables

### DIFF
--- a/ipatests/test_webui/crypto_utils.py
+++ b/ipatests/test_webui/crypto_utils.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2018  FreeIPA Contributors see COPYING for license
 #
 
+from datetime import datetime, timedelta
+
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization, hashes
@@ -9,19 +11,63 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
 
-def generate_csr(hostname):
+def generate_csr(cn, is_hostname=True):
+    """
+    Generate certificate signing request
+
+    :param cn: common name (str|unicode)
+    :param is_hostname: is the common name a hostname (default: True)
+    """
     key = rsa.generate_private_key(
         public_exponent=65537,
         key_size=2048,
         backend=default_backend()
     )
-    hostname = u'{}'.format(hostname)
+    if isinstance(cn, bytes):
+        cn = cn.decode()
     csr = x509.CertificateSigningRequestBuilder()
     csr = csr.subject_name(
-        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+    )
+    if is_hostname:
+        csr = csr.add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(cn)]),
+            critical=False
+        )
+
+    csr = csr.sign(key, hashes.SHA256(), default_backend())
+    return csr.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def generate_certificate(hostname):
+    """
+    Generate self-signed certificate for some DNS name.
+    The certificate is valid for 100 days from moment of generation.
+
+    :param hostname: DNS name (str|unicode)
+    """
+    key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend()
+    )
+    if isinstance(hostname, bytes):
+        hostname = hostname.decode()
+    subject = issuer = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, hostname)]
+    )
+
+    cert = x509.CertificateBuilder()
+    cert = cert.subject_name(subject).issuer_name(issuer).public_key(
+        key.public_key()
+    ).serial_number(
+        x509.random_serial_number()
+    ).not_valid_before(
+        datetime.utcnow()
+    ).not_valid_after(
+        datetime.utcnow() + timedelta(days=100)
     ).add_extension(
         x509.SubjectAlternativeName([x509.DNSName(hostname)]),
         critical=False
-    )
-    csr = csr.sign(key, hashes.SHA256(), default_backend())
-    return csr.public_bytes(serialization.Encoding.PEM).decode()
+    ).sign(key, hashes.SHA256(), default_backend())
+    return cert.public_bytes(serialization.Encoding.PEM).decode()

--- a/ipatests/test_webui/test_host.py
+++ b/ipatests/test_webui/test_host.py
@@ -265,11 +265,11 @@ class test_host(host_tasks):
 
         # add certificate
         self.button_click('add', parents_css_sel="div[name='certificate']")
-        self.assert_dialog()
+        self.assert_dialog('cert-add-dialog')
 
         cert = generate_certificate(self.pkey)
         self.fill_textarea('new_cert', cert)
-        self.dialog_button_click('add')
+        self.dialog_button_click('ok')
 
         self.assert_visible("div.certificate-widget")
 

--- a/ipatests/test_webui/test_host.py
+++ b/ipatests/test_webui/test_host.py
@@ -24,7 +24,7 @@ Host tests
 import uuid
 from random import randint
 
-from ipatests.test_webui.crypto_utils import generate_csr
+from ipatests.test_webui.crypto_utils import generate_certificate, generate_csr
 from ipatests.test_webui.ui_driver import UI_driver
 from ipatests.test_webui.ui_driver import screenshot
 import ipatests.test_webui.data_hostgroup as hostgroup
@@ -254,15 +254,8 @@ class test_host(host_tasks):
     def test_arbitrary_certificates(self):
         """
         Test managing host arbitrary certificate.
-
-        Requires to have 'arbitrary_cert_path' configuration set.
         """
-        cert_path = self.config.get('arbitrary_cert_path')
-        if not cert_path:
-            self.skip('Arbitrary certificate file is not configured')
-
         self.init_app()
-        cert = self.load_file(cert_path)
         self.add_record(ENTITY, self.data)
 
         self.navigate_to_record(self.pkey)
@@ -273,6 +266,8 @@ class test_host(host_tasks):
         # add certificate
         self.button_click('add', parents_css_sel="div[name='certificate']")
         self.assert_dialog()
+
+        cert = generate_certificate(self.pkey)
         self.fill_textarea('new_cert', cert)
         self.dialog_button_click('add')
 

--- a/ipatests/test_webui/test_service.py
+++ b/ipatests/test_webui/test_service.py
@@ -298,9 +298,9 @@ class test_service(sevice_tasks):
 
         # add certificate
         self.button_click('add', parents_css_sel="div[name='certificate']")
-        self.assert_dialog()
+        self.assert_dialog('cert-add-dialog')
         self.fill_textarea('new_cert', cert)
-        self.dialog_button_click('add')
+        self.dialog_button_click('ok')
 
         self.assert_visible(cert_widget_sel)
 

--- a/ipatests/test_webui/test_service.py
+++ b/ipatests/test_webui/test_service.py
@@ -21,6 +21,7 @@
 Service tests
 """
 
+from ipatests.test_webui.crypto_utils import generate_certificate, generate_csr
 from ipatests.test_webui.ui_driver import UI_driver
 from ipatests.test_webui.ui_driver import screenshot
 import pytest
@@ -147,21 +148,17 @@ class test_service(sevice_tasks):
         """
         Test service certificate actions
 
-        Requires to have CA installed and 'service_csr_path' configuration
-        option set.
+        Requires to have CA installed.
         """
 
         if not self.has_ca():
             self.skip('CA is not configured')
 
-        csr_path = self.config.get('service_csr_path')
-        if not csr_path:
-            self.skip('CSR file is not configured')
-
         self.init_app()
         data = self.prep_data()
         pkey = data.get('pkey')
-        csr = self.load_file(csr_path)
+        hostname = self.config.get('ipa_server')
+        csr = generate_csr(hostname)
         cert_widget_sel = "div.certificate-widget"
 
         self.add_record(ENTITY, data)
@@ -285,17 +282,12 @@ class test_service(sevice_tasks):
     def test_arbitrary_certificates(self):
         """
         Test managing service arbitrary certificate.
-
-        Requires to have 'arbitrary_cert_path' configuration set.
         """
-        cert_path = self.config.get('arbitrary_cert_path')
-        if not cert_path:
-            self.skip('Arbitrary certificate file is not configured')
-
         self.init_app()
         data = self.prep_data()
         pkey = data.get('pkey')
-        cert = self.load_file(cert_path)
+        hostname = self.config.get('ipa_server')
+        cert = generate_certificate(hostname)
         cert_widget_sel = "div.certificate-widget"
 
         self.add_record(ENTITY, data)
@@ -626,11 +618,8 @@ class test_service(sevice_tasks):
         if not self.has_ca():
             self.skip('CA is not configured')
 
-        csr_path = self.config.get('service_csr_path')
-        if not csr_path:
-            self.skip('CSR file is not configured')
-
-        csr = self.load_file(csr_path)
+        hostname = self.config.get('ipa_server')
+        csr = generate_csr(hostname)
 
         self.init_app()
         pkey = self.get_service_pkey('cifs')

--- a/ipatests/test_webui/test_user.py
+++ b/ipatests/test_webui/test_user.py
@@ -21,6 +21,7 @@
 User tests
 """
 
+from ipatests.test_webui.crypto_utils import generate_csr
 from ipatests.test_webui.ui_driver import UI_driver
 from ipatests.test_webui.ui_driver import screenshot
 import ipatests.test_webui.data_user as user
@@ -220,26 +221,21 @@ class test_user(user_tasks):
         """
         Test user certificate actions
 
-        Requires to have CA installed and 'user_csr_path' configuration option
-        set.
+        Requires to have CA installed.
         """
 
         if not self.has_ca():
             self.skip('CA is not configured')
 
-        csr_path = self.config.get('user_csr_path')
-        if not csr_path:
-            self.skip('CSR file is not configured')
-
         self.init_app()
-        # ENHANCEMENT: generate csr dynamically
-        csr = self.load_file(csr_path)
         cert_widget_sel = "div.certificate-widget"
 
         self.add_record(user.ENTITY, user.DATA)
         self.navigate_to_record(user.PKEY)
 
         # cert request
+        csr = generate_csr(user.PKEY, False)
+
         self.action_list_action('request_cert', confirm=False)
         self.assert_dialog()
         self.fill_text("textarea[name='csr']", csr)


### PR DESCRIPTION
This is a manual backport of #2775 