### PR TITLE
Add ipa-cert-fix tool

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1066,6 +1066,7 @@ fi
 %{_mandir}/man1/ipa-winsync-migrate.1*
 %{_mandir}/man1/ipa-pkinit-manage.1*
 %{_mandir}/man1/ipa-crlgen-manage.1*
+%{_mandir}/man1/ipa-cert-fix.1*
 
 
 %files -n python3-ipaserver

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1001,6 +1001,7 @@ fi
 %{_sbindir}/ipa-winsync-migrate
 %{_sbindir}/ipa-pkinit-manage
 %{_sbindir}/ipa-crlgen-manage
+%{_sbindir}/ipa-cert-fix
 %{_libexecdir}/certmonger/dogtag-ipa-ca-renew-agent-submit
 %{_libexecdir}/certmonger/ipa-server-guard
 %{_libexecdir}/ipa/custodia/ipa-custodia-dmldap

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -85,11 +85,9 @@
 
 %endif  # Fedora
 
-# Require Dogtag PKI 10.6.8-3 (10.6.7 was never pushed to stable)
-# 10.6.7 fixes UpdateNumberRange clone installation issue
-# https://pagure.io/freeipa/issue/7654 and empty token issue
-# and https://pagure.io/dogtagpki/issue/3073
-%global pki_version 10.6.8-3
+# 10.7 includes 'pki-server cert-fix' enhancements required
+# by ipa-cert-fix: https://pagure.io/freeipa/issue/7885
+%global pki_version 10.7.0-1
 
 # https://pagure.io/certmonger/issue/90
 %global certmonger_version 0.79.7-1

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
@@ -85,20 +85,8 @@ def get_nickname():
 
     ca_subject_dn = ca.lookup_ca_subject(api, subject_base)
 
-    nickname_by_subject_dn = {
-        DN(ca_subject_dn): 'caSigningCert cert-pki-ca',
-        DN('CN=CA Audit', subject_base): 'auditSigningCert cert-pki-ca',
-        DN('CN=OCSP Subsystem', subject_base): 'ocspSigningCert cert-pki-ca',
-        DN('CN=CA Subsystem', subject_base): 'subsystemCert cert-pki-ca',
-        DN('CN=KRA Audit', subject_base): 'auditSigningCert cert-pki-kra',
-        DN('CN=KRA Transport Certificate', subject_base):
-            'transportCert cert-pki-kra',
-        DN('CN=KRA Storage Certificate', subject_base):
-            'storageCert cert-pki-kra',
-        DN('CN=IPA RA', subject_base): 'ipaCert',
-    }
-
-    return nickname_by_subject_dn.get(DN(subject))
+    return cainstance.get_ca_renewal_nickname(
+        subject_base, ca_subject_dn, DN(subject))
 
 
 def is_replicated():

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
@@ -270,23 +270,9 @@ def store_cert(**kwargs):
         return (REJECTED, "New certificate requests not supported")
     cert = x509.load_pem_x509_certificate(cert.encode('ascii'))
 
-    dn = DN(('cn', nickname), ('cn', 'ca_renewal'),
-            ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
     try:
         with ldap_connect() as conn:
-            try:
-                entry = conn.get_entry(dn, ['usercertificate'])
-                entry['usercertificate'] = [cert]
-                conn.update_entry(entry)
-            except errors.NotFound:
-                entry = conn.make_entry(
-                    dn,
-                    objectclass=['top', 'pkiuser', 'nscontainer'],
-                    cn=[nickname],
-                    usercertificate=[cert])
-                conn.add_entry(entry)
-            except errors.EmptyModlist:
-                pass
+            cainstance.update_ca_renewal_entry(conn, nickname, cert)
     except Exception as e:
         attempts += 1
         if attempts < 10:

--- a/install/tools/Makefile.am
+++ b/install/tools/Makefile.am
@@ -29,6 +29,7 @@ dist_noinst_DATA =		\
 	ipa-winsync-migrate.in	\
 	ipa-pkinit-manage.in	\
 	ipa-crlgen-manage.in	\
+	ipa-cert-fix.in		\
 	ipa-custodia.in		\
 	ipa-custodia-check.in	\
 	ipa-httpd-kdcproxy.in	\
@@ -61,6 +62,7 @@ nodist_sbin_SCRIPTS =		\
 	ipa-winsync-migrate	\
 	ipa-pkinit-manage	\
 	ipa-crlgen-manage	\
+	ipa-cert-fix		\
 	$(NULL)
 
 appdir = $(libexecdir)/ipa/

--- a/install/tools/ipa-cert-fix.in
+++ b/install/tools/ipa-cert-fix.in
@@ -1,0 +1,8 @@
+@PYTHONSHEBANG@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+from ipaserver.install.ipa_cert_fix import IPACertFix
+
+IPACertFix.run_cli()

--- a/install/tools/man/Makefile.am
+++ b/install/tools/man/Makefile.am
@@ -28,6 +28,7 @@ dist_man1_MANS = 			\
 	ipa-winsync-migrate.1		\
 	ipa-pkinit-manage.1		\
 	ipa-crlgen-manage.1		\
+	ipa-cert-fix.1			\
         $(NULL)
 
 dist_man8_MANS =			\

--- a/install/tools/man/ipa-cert-fix.1
+++ b/install/tools/man/ipa-cert-fix.1
@@ -1,0 +1,66 @@
+.\"
+.\" Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+.\"
+.TH "ipa-cert-fix" "1" "Mar 25 2019" "FreeIPA" "FreeIPA Manual Pages"
+.SH "NAME"
+ipa\-cert\-fix \- Renew expired certificates
+.SH "SYNOPSIS"
+ipa\-cert\-fix [options]
+.SH "DESCRIPTION"
+
+\fIipa-cert-fix\fR is a tool for recovery when expired certificates
+prevent the normal operation of FreeIPA.  It should ONLY be used in
+such scenarios, and backup of the system, especially certificates
+and keys, is \fBSTRONGLY RECOMMENDED\fR.
+
+Do not use this program unless expired certificates are inhibiting
+normal operation and renewal procedures.
+
+To renew the IPA CA certificate, use \fIipa-cacert-manage(1)\fR.
+
+This tool cannot renew certificates signed by external CAs.  To
+install new, externally-signed HTTP, LDAP or KDC certificates, use
+\fIipa-server-certinstall(1)\fR.
+
+\fIipa-cert-fix\fR will examine FreeIPA and Certificate System
+certificates and renew certificates that are expired, or close to
+expiry (less than two weeks).  If any "shared" certificates are
+renewed, \fIipa-cert-fix\fR will set the current server to be the CA
+renewal master, and add the new shared certificate(s) to LDAP for
+replication to other CA servers.  Shared certificates include all
+Dogtag system certificates except the HTTPS certificate, and the IPA
+RA certificate.
+
+To repair certificates across multiple CA servers, first ensure that
+LDAP replication is working across the topology.  Then run
+\fIipa-cert-fix\fR on one CA server.  Before running
+\fIipa-cert-fix\fR on another CA server, trigger Certmonger renewals
+for shared certificates via \fIgetcert-resubmit(1)\fR (on the other
+CA server).  This is to avoid unnecessary renewal of shared
+certificates.
+
+.SH "OPTIONS"
+.TP
+\fB\-\-version\fR
+Show the program's version and exit.
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Show the help for this program.
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Print debugging information.
+.TP
+\fB\-q\fR, \fB\-\-quiet\fR
+Output only errors (output from child processes may still be shown).
+.TP
+\fB\-\-log\-file\fR=\fIFILE\fR
+Log to the given file.
+.SH "EXIT STATUS"
+0 if the command was successful
+
+1 if an error occurred
+
+.SH "SEE ALSO"
+.BR ipa-cacert-manage(1)
+.BR ipa-server-certinstall(1)
+.BR getcert-resubmit(1)

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -129,6 +129,8 @@ DEFAULT_CONFIG = (
     ('container_sysaccounts', DN(('cn', 'sysaccounts'), ('cn', 'etc'))),
     ('container_certmap', DN(('cn', 'certmap'))),
     ('container_certmaprules', DN(('cn', 'certmaprules'), ('cn', 'certmap'))),
+    ('container_ca_renewal',
+        DN(('cn', 'ca_renewal'), ('cn', 'ipa'), ('cn', 'etc'))),
 
     # Ports, hosts, and URIs:
     # Following values do not have any reasonable default.

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1619,6 +1619,32 @@ def update_authority_entry(cert):
     return __update_entry_from_cert(make_filter, make_entry, cert)
 
 
+def get_ca_renewal_nickname(subject_base, ca_subject_dn, sdn):
+    """
+    Get the nickname for storage in the cn_renewal container.
+
+    :param subject_base: Certificate subject base
+    :param ca_subject_dn: IPA CA subject DN
+    :param sdn: Subject DN
+    :return: string, or None if nickname cannot be determined.
+
+    """
+    assert isinstance(sdn, DN)
+    nickname_by_subject_dn = {
+        DN(ca_subject_dn): 'caSigningCert cert-pki-ca',
+        DN('CN=CA Audit', subject_base): 'auditSigningCert cert-pki-ca',
+        DN('CN=OCSP Subsystem', subject_base): 'ocspSigningCert cert-pki-ca',
+        DN('CN=CA Subsystem', subject_base): 'subsystemCert cert-pki-ca',
+        DN('CN=KRA Audit', subject_base): 'auditSigningCert cert-pki-kra',
+        DN('CN=KRA Transport Certificate', subject_base):
+            'transportCert cert-pki-kra',
+        DN('CN=KRA Storage Certificate', subject_base):
+            'storageCert cert-pki-kra',
+        DN('CN=IPA RA', subject_base): 'ipaCert',
+    }
+    return nickname_by_subject_dn.get(sdn)
+
+
 def update_ca_renewal_entry(conn, nickname, cert):
     """
     Update the ca_renewal entry for the given nickname.

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1654,8 +1654,7 @@ def update_ca_renewal_entry(conn, nickname, cert):
     :param cert: python-cryptography X509Certificate
 
     """
-    dn = DN(('cn', nickname), ('cn', 'ca_renewal'),
-            ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+    dn = DN(('cn', nickname), api.env.container_ca_renewal, api.env.basedn)
     try:
         entry = conn.get_entry(dn, ['usercertificate'])
         entry['usercertificate'] = [cert]

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1619,6 +1619,32 @@ def update_authority_entry(cert):
     return __update_entry_from_cert(make_filter, make_entry, cert)
 
 
+def update_ca_renewal_entry(conn, nickname, cert):
+    """
+    Update the ca_renewal entry for the given nickname.
+
+    :param conn: A *connected* LDAP handle
+    :param nickname: NSSDB nickname
+    :param cert: python-cryptography X509Certificate
+
+    """
+    dn = DN(('cn', nickname), ('cn', 'ca_renewal'),
+            ('cn', 'ipa'), ('cn', 'etc'), api.env.basedn)
+    try:
+        entry = conn.get_entry(dn, ['usercertificate'])
+        entry['usercertificate'] = [cert]
+        conn.update_entry(entry)
+    except errors.NotFound:
+        entry = conn.make_entry(
+            dn,
+            objectclass=['top', 'pkiuser', 'nscontainer'],
+            cn=[nickname],
+            usercertificate=[cert])
+        conn.add_entry(entry)
+    except errors.EmptyModlist:
+        pass
+
+
 def ensure_ldap_profiles_container():
     ensure_entry(
         DN(('ou', 'certificateProfiles'), ('ou', 'ca'), ('o', 'ipaca')),

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -1,0 +1,275 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+# ipa-cert-fix performs the following steps:
+#
+# 1. Confirm running as root (AdminTool.validate_options does this)
+#
+# 2. Confirm that DS is up.
+#
+# 3. Determine which of following certs (if any) need renewing
+#     - IPA RA
+#     - Apache HTTPS
+#     - 389 LDAPS
+#     - Kerberos KDC (PKINIT)
+#
+# 4. Execute `pki-server cert-fix` with relevant options,
+#    including `--extra-cert SERIAL` for each cert from #3.
+#
+# 5. Print details of renewed certificates.
+#
+# 6. Install renewed certs from #3 in relevant places
+#
+# 7. ipactl restart
+
+from __future__ import print_function, absolute_import
+
+import datetime
+from enum import Enum
+import logging
+import shutil
+
+from ipalib import api
+from ipalib import x509
+from ipaplatform.paths import paths
+from ipapython.admintool import AdminTool
+from ipapython.certdb import NSSDatabase, EMPTY_TRUST_FLAGS
+from ipapython.dn import DN
+from ipaserver.install import ca, cainstance, dsinstance, installutils
+from ipaserver.install.installutils import is_ipa_configured
+from ipapython import ipautil
+
+msg = """
+                          WARNING
+
+ipa-cert-fix is intended for recovery when expired certificates
+prevent the normal operation of FreeIPA.  It should ONLY be used
+in such scenarios, and backup of the system, especially certificates
+and keys, is STRONGLY RECOMMENDED.
+
+"""
+
+logger = logging.getLogger(__name__)
+
+
+class IPACertType(Enum):
+    IPARA = "IPA RA"
+    HTTPS = "Apache HTTPS"
+    LDAPS = "LDAP"
+    KDC = "KDC"
+
+
+class IPACertFix(AdminTool):
+    command_name = "ipa-cert-fix"
+    usage = "%prog"
+    description = "Renew expired certificates."
+
+    def validate_options(self):
+        super(IPACertFix, self).validate_options(needs_root=True)
+
+    def run(self):
+        if not is_ipa_configured():
+            print("IPA is not configured.")
+            return 0  # not really an error
+
+        if not cainstance.is_ca_installed_locally():
+            print("CA is not installed on this server.")
+            return 0  # not really an error
+
+        try:
+            ipautil.run(['pki-server', 'cert-fix', '--help'], raiseonerr=True)
+        except ipautil.CalledProcessError:
+            print(
+                "The 'pki-server cert-fix' command is not available; "
+                "cannot proceed."
+            )
+            return 1
+
+        api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
+        api.finalize()
+        api.Backend.ldap2.connect()  # ensure DS is up
+
+        subject_base = dsinstance.DsInstance().find_subject_base()
+        if not subject_base:
+            raise RuntimeError("Cannot determine certificate subject base.")
+
+        ca_subject_dn = ca.lookup_ca_subject(api, subject_base)
+
+        now = datetime.datetime.now() + datetime.timedelta(weeks=2)
+        certs, extra_certs = expired_certs(now)
+
+        if not certs and not extra_certs:
+            print("Nothing to do.")
+            return 0
+
+        print(msg)
+
+        print_intentions(certs, extra_certs)
+
+        response = ipautil.user_input('Enter "yes" to proceed')
+        if response.lower() != 'yes':
+            print("Not proceeding.")
+            return 0
+        print("Proceeding.")
+
+        run_cert_fix(certs, extra_certs)
+
+        replicate_dogtag_certs(subject_base, ca_subject_dn, certs)
+        install_ipa_certs(subject_base, ca_subject_dn, extra_certs)
+
+        if any(x != 'sslserver' for x in certs) \
+                or any(x[0] is IPACertType.IPARA for x in extra_certs):
+            # we renewed a "shared" certificate, therefore we must
+            # become the renewal master
+            print("Becoming renewal master.")
+            cainstance.CAInstance().set_renewal_master()
+
+        ipautil.run(['ipactl', 'restart'], raiseonerr=True)
+
+        return 0
+
+
+def expired_certs(now):
+    return expired_dogtag_certs(now), expired_ipa_certs(now)
+
+
+def expired_dogtag_certs(now):
+    """
+    Determine which Dogtag certs are expired, or close to expiry.
+
+    Return a list of (cert_id, cert) pairs.
+
+    """
+    certs = []
+    db = NSSDatabase(nssdir=paths.PKI_TOMCAT_ALIAS_DIR)
+
+    for certid, nickname in [
+        ('sslserver', 'Server-Cert cert-pki-ca'),
+        ('subsystem', 'subsystemCert cert-pki-ca'),
+        ('ca_ocsp_signing', 'ocspSigningCert cert-pki-ca'),
+        ('ca_audit_signing', 'auditSigningCert cert-pki-ca'),
+        ('kra_transport', 'transportCert cert-pki-kra'),
+        ('kra_storage', 'storageCert cert-pki-kra'),
+        ('kra_audit_signing', 'auditSigningCert cert-pki-kra'),
+    ]:
+        try:
+            cert = db.get_cert(nickname)
+        except RuntimeError:
+            pass  # unfortunately certdb doesn't give us a better exception
+        else:
+            if cert.not_valid_after <= now:
+                certs.append((certid, cert))
+
+    return certs
+
+
+def expired_ipa_certs(now):
+    """
+    Determine which IPA certs are expired, or close to expiry.
+
+    Return a list of (IPACertType, cert) pairs.
+
+    """
+    certs = []
+
+    # IPA RA
+    cert = x509.load_certificate_from_file(paths.RA_AGENT_PEM)
+    if cert.not_valid_after <= now:
+        certs.append((IPACertType.IPARA, cert))
+
+    # Apache HTTPD
+    cert = x509.load_certificate_from_file(paths.HTTPD_CERT_FILE)
+    if cert.not_valid_after <= now:
+        certs.append((IPACertType.HTTPS, cert))
+
+    # LDAPS
+    ds_dbdir = dsinstance.config_dirname(
+        installutils.realm_to_serverid(api.env.realm))
+    db = NSSDatabase(nssdir=ds_dbdir)
+    cert = db.get_cert('Server-Cert')
+    if cert.not_valid_after <= now:
+        certs.append((IPACertType.LDAPS, cert))
+
+    # KDC
+    cert = x509.load_certificate_from_file(paths.KDC_CERT)
+    if cert.not_valid_after <= now:
+        certs.append((IPACertType.KDC, cert))
+
+    return certs
+
+
+def print_intentions(dogtag_certs, ipa_certs):
+    print("The following certificates will be renewed: ")
+    print()
+
+    for certid, cert in dogtag_certs:
+        print_cert_info("Dogtag", certid, cert)
+
+    for certtype, cert in ipa_certs:
+        print_cert_info("IPA", certtype.value, cert)
+
+
+def print_cert_info(context, desc, cert):
+    print("{} {} certificate:".format(context, desc))
+    print("  Subject: {}".format(DN(cert.subject)))
+    print("  Serial:  {}".format(cert.serial_number))
+    print("  Expires: {}".format(cert.not_valid_after))
+    print()
+
+
+def run_cert_fix(certs, extra_certs):
+    ldapi_path = (
+        paths.SLAPD_INSTANCE_SOCKET_TEMPLATE
+        % '-'.join(api.env.realm.split('.'))
+    )
+    cmd = [
+        'pki-server',
+        'cert-fix',
+        '--ldapi-socket', ldapi_path,
+        '--agent-uid', 'ipara',
+    ]
+    for certid, _cert in certs:
+        cmd.extend(['--cert', certid])
+    for _certtype, cert in extra_certs:
+        cmd.extend(['--extra-cert', str(cert.serial_number)])
+    ipautil.run(cmd, raiseonerr=True)
+
+
+def replicate_dogtag_certs(subject_base, ca_subject_dn, certs):
+    for certid, _oldcert in certs:
+        cert_path = "/etc/pki/pki-tomcat/certs/{}.crt".format(certid)
+        cert = x509.load_certificate_from_file(cert_path)
+        print_cert_info("Renewed Dogtag", certid, cert)
+        replicate_cert(subject_base, ca_subject_dn, cert)
+
+
+def install_ipa_certs(subject_base, ca_subject_dn, certs):
+    """Print details and install renewed IPA certificates."""
+    for certtype, oldcert in certs:
+        cert_path = "/etc/pki/pki-tomcat/certs/{}-renewed.crt" \
+            .format(oldcert.serial_number)
+        cert = x509.load_certificate_from_file(cert_path)
+        print_cert_info("Renewed IPA", certtype.value, cert)
+
+        if certtype is IPACertType.IPARA:
+            shutil.copyfile(cert_path, paths.RA_AGENT_PEM)
+            cainstance.update_people_entry(cert)
+            replicate_cert(subject_base, ca_subject_dn, cert)
+        elif certtype is IPACertType.HTTPS:
+            shutil.copyfile(cert_path, paths.HTTPD_CERT_FILE)
+        elif certtype is IPACertType.LDAPS:
+            ds_dbdir = dsinstance.config_dirname(
+                installutils.realm_to_serverid(api.env.realm))
+            db = NSSDatabase(nssdir=ds_dbdir)
+            db.delete_cert('Server-Cert')
+            db.import_pem_cert('Server-Cert', EMPTY_TRUST_FLAGS, cert_path)
+        elif certtype is IPACertType.KDC:
+            shutil.copyfile(cert_path, paths.KDC_CERT)
+
+
+def replicate_cert(subject_base, ca_subject_dn, cert):
+    nickname = cainstance.get_ca_renewal_nickname(
+        subject_base, ca_subject_dn, DN(cert.subject))
+    if nickname:
+        cainstance.update_ca_renewal_entry(api.Backend.ldap2, nickname, cert)

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -36,7 +36,8 @@ from ipaplatform.paths import paths
 from ipapython.admintool import AdminTool
 from ipapython.certdb import NSSDatabase, EMPTY_TRUST_FLAGS
 from ipapython.dn import DN
-from ipaserver.install import ca, cainstance, dsinstance, installutils
+from ipapython.ipaldap import realm_to_serverid
+from ipaserver.install import ca, cainstance, dsinstance
 from ipaserver.install.installutils import is_ipa_configured
 from ipapython import ipautil
 
@@ -194,8 +195,7 @@ def expired_ipa_certs(now):
         certs.append((IPACertType.HTTPS, cert))
 
     # LDAPS
-    ds_dbdir = dsinstance.config_dirname(
-        installutils.realm_to_serverid(api.env.realm))
+    ds_dbdir = dsinstance.config_dirname(realm_to_serverid(api.env.realm))
     db = NSSDatabase(nssdir=ds_dbdir)
     cert = db.get_cert('Server-Cert')
     if cert.not_valid_after <= now:
@@ -270,7 +270,7 @@ def install_ipa_certs(subject_base, ca_subject_dn, certs):
             shutil.copyfile(cert_path, paths.HTTPD_CERT_FILE)
         elif certtype is IPACertType.LDAPS:
             ds_dbdir = dsinstance.config_dirname(
-                installutils.realm_to_serverid(api.env.realm))
+                realm_to_serverid(api.env.realm))
             db = NSSDatabase(nssdir=ds_dbdir)
             db.delete_cert('Server-Cert')
             db.import_pem_cert('Server-Cert', EMPTY_TRUST_FLAGS, cert_path)

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -71,11 +71,11 @@ class IPACertFix(AdminTool):
     def run(self):
         if not is_ipa_configured():
             print("IPA is not configured.")
-            return 0  # not really an error
+            return 2
 
         if not cainstance.is_ca_installed_locally():
             print("CA is not installed on this server.")
-            return 0  # not really an error
+            return 1
 
         try:
             ipautil.run(['pki-server', 'cert-fix', '--help'], raiseonerr=True)

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -128,7 +128,7 @@ class IPACertFix(AdminTool):
         replicate_dogtag_certs(subject_base, ca_subject_dn, certs)
         install_ipa_certs(subject_base, ca_subject_dn, extra_certs)
 
-        if any(x != 'sslserver' for x in certs) \
+        if any(x[0] != 'sslserver' for x in certs) \
                 or any(x[0] is IPACertType.IPARA for x in extra_certs):
             # we renewed a "shared" certificate, therefore we must
             # become the renewal master

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -441,6 +441,7 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.container_automember = DN()
     api.env.container_automount = DN()
     api.env.container_ca = DN()
+    api.env.container_ca_renewal = DN()
     api.env.container_caacl = DN()
     api.env.container_certmap = DN()
     api.env.container_certmaprules = DN()


### PR DESCRIPTION
Forward-port of https://github.com/freeipa/freeipa/pull/2919 to `master`
branch.

```
da189c9cc (Fraser Tweedale, 3 days ago)
   require Dogtag 10.7.0-1

   Dogtag 10.7 includes the 'pki-server cert-fix' enhancements required by
   ipa-cert-fix.  Bump the dep min bound.

   Part of: https://pagure.io/freeipa/issue/7885

54e967095 (Fraser Tweedale, 6 weeks ago)
   ipa-cert-fix: use customary exit statuses

   It is customary to return 2 when IPA is not configured, and 1 when other
   required bits are not installed or configured.  Update ipa-cert-fix exit
   statuses accordingly.

   Part of: https://pagure.io/freeipa/issue/7885

7a836fb8c (Fraser Tweedale, 7 weeks ago)
   ipa-cert-fix: add man page

   Part of: https://pagure.io/freeipa/issue/7885

6c023f265 (Fraser Tweedale, 7 weeks ago)
   Add ipa-cert-fix tool

   The ipa-cert-fix tool wraps `pki-server cert-fix`, performing additional
   certificate requests for non-Dogtag IPA certificates and performing
   additional actions.  In particular:

   - Run cert-fix with arguments particular to the IPA deployment.

   - Update IPA RA certificate in the ipara user entry (if renewed).

   - Add shared certificates (if renewed) to the ca_renewal LDAP
    container for replication.

   - Become the CA renewal master if shared certificates were renewed.
    This ensures other CA replicas, including the previous CA renewal
    master if not the current host, pick up those new certificates
    when Certmonger attempts to renew them.

   Fixes: https://pagure.io/freeipa/issue/7885

3d1ff725e (Fraser Tweedale, 7 weeks ago)
   constants: add ca_renewal container

   Part of: https://pagure.io/freeipa/issue/7885

c956bc658 (Fraser Tweedale, 7 weeks ago)
   cainstance: add function to determine ca_renewal nickname

   The ipa-cert-fix program needs to know where to put shared certificates. 
   Extract the logic that computes the nickname from dogtag-ipa-ca-renew-agent
   to new subroutine cainstance.get_ca_renewal_nickname().

   Part of: https://pagure.io/freeipa/issue/7885

4f4c32cc6 (Fraser Tweedale, 7 weeks ago)
   Extract ca_renewal cert update subroutine

   When the CA renewal master renews certificates that are shared across CA
   replicas, it puts them in LDAP for the other CA replicas to see.  The code
   to create/update these entries lives in the dogtag-ipa-ca-renew-agent
   renewal helper, but it will be useful for the ipa-cert-fix program too. 
   Extract it to a subroutine in the cainstance module.

   Part of: https://pagure.io/freeipa/issue/7885
```