### PR TITLE
Azure pipelines setup

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -170,7 +170,7 @@ BuildRequires:  libuuid-devel
 BuildRequires:  libsss_idmap-devel
 BuildRequires:  libsss_certmap-devel
 BuildRequires:  libsss_nss_idmap-devel >= %{sssd_version}
-BuildRequires:  nodejs
+BuildRequires:  nodejs(abi) < 11
 BuildRequires:  uglify-js
 BuildRequires:  libverto-devel
 BuildRequires:  libunistring-devel

--- a/ipatests/azure/Dockerfile.build-container
+++ b/ipatests/azure/Dockerfile.build-container
@@ -1,0 +1,17 @@
+FROM fedora:30
+MAINTAINER [FreeIPA Developers freeipa-devel@lists.fedorahosted.org]
+ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
+
+ADD dist /root
+RUN echo 'deltarpm = false' >> /etc/dnf/dnf.conf \
+    && dnf update -y dnf \
+    && dnf install -y dnf-plugins-core sudo wget systemd firewalld nss-tools iptables \
+    && dnf config-manager '*modular*' --set-disabled \
+    && dnf install -y /root/rpms/*.rpm \
+    && dnf clean all && rm -rf /root/rpms /root/srpms \
+    && for i in /usr/lib/systemd/system/*-domainname.service; \
+    do sed -i 's#^ExecStart=/#ExecStart=-/#' $i ; done
+
+STOPSIGNAL RTMIN+3
+VOLUME ["/freeipa", "/run", "/tmp"]
+ENTRYPOINT [ "/usr/sbin/init" ]

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -1,0 +1,165 @@
+trigger:
+- master
+
+variables:
+  TEST_RUNNER_IMAGE: freeipa-fedora-builder:latest
+  TEST_RUNNER_CONFIG: .test_runner_azure.yaml
+  PEP8_ERROR_LOG: pycodestyle_errors.log
+  CI_RESULTS_LOG: ci_results_$(System.PullRequest.PullRequestNumber).log
+  CI_BACKLOG_SIZE: 5000
+  CI_RUNNER_LOGS_DIR: logs
+  CI_RUNNER_LOG_ARCHIVE: $(System.PullRequest.PullRequestNumber)-job-$(Build.BuildId).tar.gz
+  TRAVIS_EVENT_TYPE: $(Build.Reason)
+  TRAVIS_BRANCH: $(System.PullRequest.TargetBranch)
+  localsdir: $(Build.Repository.LocalPath)
+  builddir: /__w/1/s
+
+jobs:
+- job: Build
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  container:
+    image: registry.fedoraproject.org/f30/fedora-toolbox
+    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged
+  steps:
+    - template: templates/prepare-build.yml
+    - script: |
+        echo "Running autoconf generator"
+        ./autogen.sh
+      displayName: Configure the project
+    - script: |
+        echo "Running make target 'rpms'"
+        make V=0 rpms LOG_COMPILE='gdb -return-child-result -ex run -ex "thread apply all bt" -ex "quit" --args'
+      displayName: Build packages
+    - script: |
+        mkdir container
+        cp -pr dist container/
+        cp ipatests/azure/Dockerfile.build-container container/Dockerfile
+        cd container
+        docker build -t freeipa-fedora-builder .
+        docker save freeipa-fedora-builder | gzip > '$(builddir)/freeipa-fedora-builder-container.tar.gz'
+      displayName: Create container image for test
+    - template: templates/publish-build.yml
+
+- job: Lint
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  container:
+    image: registry.fedoraproject.org/f30/fedora-toolbox
+    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged
+  steps:
+    - template: templates/prepare-build.yml
+    - script: |
+        echo "Running autoconf generator"
+        ./autogen.sh
+      displayName: Configure the project
+    - script: |
+        echo "Running make target 'lint'"
+        make V=0 lint
+      displayName: Lint sources
+
+- job: Tox
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  container:
+    image: registry.fedoraproject.org/f30/fedora-toolbox
+    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged
+  steps:
+    - template: templates/prepare-build.yml
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.6
+        architecture: x64
+    - script: |
+        sudo dnf -y install nss-tools
+        python3 -m pip install --upgrade pip setuptools pycodestyle
+      displayName: 'Install prerequisites'
+    - script: |
+        echo "Running tox"
+        export LANG=en_US.utf8
+        export LC_CTYPE=en_US.utf8
+        locale
+        tox -e py36,pypi,pylint3
+      displayName: Tox
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: '.tox/**/junit-*.xml'
+        testRunTitle: 'Tox results'
+      condition: succeededOrFailed()
+
+- job: WebUI_Unit_Tests
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  container:
+    image: registry.fedoraproject.org/f30/fedora-toolbox
+    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged
+  steps:
+    - template: templates/prepare-build.yml
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.6
+        architecture: x64
+    - script: |
+        sudo dnf -y install npm fontconfig
+      displayName: 'Install prerequisites'
+    - script: |
+        echo "Running autoconf generator"
+        ./autogen.sh
+      displayName: Configure the project
+    - script: |
+        echo "Running WebUI unit tests"
+        cd $(builddir)/install/ui/js/libs && make
+        cd $(builddir)/install/ui && npm install
+        cd $(builddir)/install/ui && node_modules/grunt/bin/grunt --verbose test
+      displayName: WebUI Unit Tests
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: 'install/ui/_build/test-reports/TEST-*.xml'
+        testRunTitle: 'Web UI unit test results'
+      condition: succeededOrFailed()
+
+- job: Test
+  dependsOn: Build
+  condition: succeeded()
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  strategy:
+    matrix:
+        Base_tests:
+          TEST_TITLE: 'Base'
+          TASK_TO_RUN: run-tests
+          TESTS_TO_RUN: "test_cmdline
+                test_install
+                test_ipaclient
+                test_ipalib
+                test_ipaplatform
+                test_ipapython
+                test_ipaserver"
+        XMLRPC_tests:
+          TEST_TITLE: 'XMLRPC'
+          TASK_TO_RUN: run-tests
+          TESTS_TO_RUN: "test_xmlrpc/test_*.py"
+  steps:
+    - template: templates/setup-test-environment.yml
+      parameters:
+        pythonVersion: '3.6'
+        architecture: 'x64'
+        logsPath: '$(CI_RUNNER_LOGS_DIR)'
+    - script: |
+        sudo modprobe ip6_tables
+      displayName: Make sure IPv6 firewall support is allowed
+    - template: templates/run-test.yml
+      parameters:
+        containerName: 'freeipa-fedora-builder:latest'
+        logsPath: '$(CI_RUNNER_LOGS_DIR)'
+        testToRun: '$(TASK_TO_RUN)'
+        testParams: '$(TESTS_TO_RUN)'
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: 'nosetests.xml'
+        testRunTitle: 'XMLRPC test results'
+      condition: succeededOrFailed()
+    - template: templates/save-test-artifacts.yml
+      parameters:
+        logsPath: '$(CI_RUNNER_LOGS_DIR)'
+        logsArtifact: '$(TEST_TITLE)-logs-$(CI_RUNNER_LOG_ARCHIVE)'

--- a/ipatests/azure/azure-run-tests.sh
+++ b/ipatests/azure/azure-run-tests.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -ex
+server_realm=EXAMPLE.TEST
+server_domain=example.test
+server_password=Secret123
+
+# Expand list of tests into -k...  -k... -k... .. sequence
+tests_to_run=$(eval "eval echo -k{$(echo $TESTS_TO_RUN | sed -e 's/[ \t]+*/,/g')}")
+
+systemctl --now enable firewalld
+ipa-server-install -U --domain ${server_domain} --realm ${server_realm} -p ${server_password} -a ${server_password} --setup-dns --setup-kra --auto-forwarders
+sed -ri "s/mode = production/mode = development/" /etc/ipa/default.conf
+systemctl restart httpd.service
+firewall-cmd --add-service={freeipa-ldap,freeipa-ldaps,dns}
+
+
+cd /freeipa
+
+echo ${server_password} | kinit admin && ipa ping
+cp -r /etc/ipa/* ~/.ipa/
+echo ${server_password} > ~/.ipa/.dmpw
+echo 'wait_for_dns=5' >> ~/.ipa/default.conf
+ipa-test-config --help
+ipa-test-task --help
+ipa-run-tests --with-xunit -k-{test_integration,test_webui,test_ipapython/test_keyring.py,test_dns_soa} -v ${tests_to_run}
+grep -n -C5 BytesWarning /var/log/httpd/error_log
+ipa-server-install --uninstall -U
+# second uninstall to verify that --uninstall without installation works
+ipa-server-install --uninstall -U
+firewall-cmd --remove-service={freeipa-ldap,freeipa-ldaps,dns}
+
+mkdir -p /freeipa/logs
+cd /freeipa/logs
+journalctl -b --no-pager > systemd_journal.log
+tar --ignore-failed-read -cvf var_log.tar \
+    /var/log/dirsrv \
+    /var/log/httpd \
+    /var/log/ipa* \
+    /var/log/krb5kdc.log \
+    /var/log/pki \
+    systemd_journal.log
+
+ls -laZ /etc/dirsrv/slapd-*/ /etc/httpd/alias/ /etc/pki/pki-tomcat/alias/ || true
+

--- a/ipatests/azure/templates/prepare-build.yml
+++ b/ipatests/azure/templates/prepare-build.yml
@@ -1,0 +1,11 @@
+steps:
+- script: |
+    sudo rm -rf /var/cache/dnf/*
+    echo 'Disable modular repositories'
+    sudo dnf config-manager '*modular*' --set-disabled
+    sudo dnf makecache || :
+    echo "Installing base development environment"
+    sudo dnf install -y gdb make autoconf rpm-build gettext-devel automake libtool 'nodejs(abi) < 11' docker python3-paramiko || :
+    echo "Installing FreeIPA development dependencies"
+    sudo dnf builddep -y --skip-broken -D "with_wheels 1" -D "with_lint 1" --spec freeipa.spec.in --best --allowerasing --setopt=install_weak_deps=False || :
+  displayName: Prepare build environment

--- a/ipatests/azure/templates/publish-build.yml
+++ b/ipatests/azure/templates/publish-build.yml
@@ -1,0 +1,12 @@
+steps:
+- task: PublishPipelineArtifact@0
+  displayName: Publish packages
+  inputs:
+    artifactName: 'packages-$(Build.BuildId)-$(Agent.OS)-$(Agent.OSArchitecture)'
+    targetPath: $(Agent.BuildDirectory)/s/dist
+- task: PublishPipelineArtifact@0
+  displayName: Publish container image
+  inputs:
+    artifactName: 'image-$(Build.BuildId)-$(Agent.OS)-$(Agent.OSArchitecture)'
+    targetPath: $(Agent.BuildDirectory)/s/freeipa-fedora-builder-container.tar.gz
+

--- a/ipatests/azure/templates/run-test.yml
+++ b/ipatests/azure/templates/run-test.yml
@@ -1,0 +1,23 @@
+parameters:
+  imageName: 'freeipa-fedora-builder:latest'
+  containerName: 'container'
+  logsPath: 'logs'
+  testToRun: 'lint'
+  testParams: ''
+
+steps:
+- script: |
+    cnt=`docker create --hostname ipa.example.test --privileged -v $(Build.Repository.LocalPath):/freeipa -t  ${{parameters.imageName}} /usr/sbin/init`
+    echo "##vso[task.setvariable variable=containerName;isOutput=true]$cnt"
+  name: createContainer
+  displayName: Create container for running a test
+- script: |
+    docker start $(createContainer.containerName)
+    docker inspect $(createContainer.containerName)
+  displayName: Start container for running a test
+- script: |
+    docker exec --env TESTS_TO_RUN='${{parameters.testParams}}' \
+                --privileged -t \
+                $(createContainer.containerName) \
+                /bin/bash --noprofile --norc -x /freeipa/ipatests/azure/azure-${{parameters.testToRun}}.sh
+  displayName: Run test

--- a/ipatests/azure/templates/save-test-artifacts.yml
+++ b/ipatests/azure/templates/save-test-artifacts.yml
@@ -1,0 +1,11 @@
+parameters:
+  logsPath: 'logs'
+  logsArtifact: 'logs-$(Build.BuildId)-$(Agent.OS)-$(Agent.OSArchitrecture)'
+steps:
+- task: PublishPipelineArtifact@0
+  displayName: Publish logs
+  inputs:
+    artifactName: ${{parameters.logsArtifact}}
+    targetPath: ${{parameters.logsPath}}
+  condition: always()
+

--- a/ipatests/azure/templates/setup-test-environment.yml
+++ b/ipatests/azure/templates/setup-test-environment.yml
@@ -1,0 +1,35 @@
+parameters:
+  pythonVersion: '3.6'
+  architecture: 'x64'
+  pythonExec: 'python3'
+  logsPath: 'logs'
+  logsArtifact: 'logs-$(Build.BuildId)-$(Agent.OS)-$(Agent.OSArchitrecture)'
+steps:
+- script: |
+    echo '{ "ipv6": true, "fixed-cidr-v6": "2001:db8::/64" }' > docker-daemon.json
+    sudo cp docker-daemon.json /etc/docker/daemon.json
+    sudo chown root:root /etc/docker/daemon.json
+    sudo systemctl restart docker
+  displayName: Configure containerization to allow IPv6 network
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: ${{parameters.pythonVersion}}
+    architecture: ${{parameters.architecture}}
+- script: |
+    ${{parameters.pythonExec}} -m pip install --upgrade pip setuptools pycodestyle
+  displayName: 'Install prerequisites'
+- task: DownloadPipelineArtifact@0
+  displayName: Download prebuilt packages
+  inputs:
+    artifactName: 'packages-$(Build.BuildId)-$(Agent.OS)-$(Agent.OSArchitecture)'
+    targetPath: $(Agent.BuildDirectory)/s/dist
+- task: DownloadPipelineArtifact@0
+  displayName: Download pre-built container
+  inputs:
+    artifactName: 'image-$(Build.BuildId)-$(Agent.OS)-$(Agent.OSArchitecture)'
+    targetPath: $(Agent.BuildDirectory)/s
+- script: |
+    docker load --input $(Agent.BuildDirectory)/s/freeipa-fedora-builder-container.tar.gz
+    docker images
+    docker inspect freeipa-fedora-builder:latest
+  displayName: Import pre-built container to the engine


### PR DESCRIPTION
Sets up a pipeline to run FreeIPA build and tests in Azure Pipelines.
    
Azure Pipelines provides 10 parallel free runners for open source projects.
Use them to run following jobs:
    
- Build: build RPMs and Fedora 30 container with them
- Lint: run linting of the source code
- Tox: run py36,pypi,pylint tests using Tox
- Web UI unit tests: run Web UI unit tests with Grunt/QUnit/PhantomJS
- XMLRPC tests: install FreeIPA server and run XMLRPC tests against it
    
All jobs are running in Fedora 30 containers. Build, Lint, Tox, and Web UI unit tests run inside f30/fedora-toolbox container. Build job generates a container with pre-installed FreeIPA packages using official fedora:30 container. All containers are picked up from the registry.fedoraproject.org.
    
Artifacts from the build job are pushed to a pipeline storage and reused in the XMLRPC tests. They also are accessible in the 'Summary' tab to download.
    
XUnit and QUnit outputs from the tests that produce it are reported in the 'Tests' tab.
    
Logs from individual steps from each job are available for review in the 'Logs' tab. They also can be downloaded.
