### PR TITLE
Use PKCS#8 instead of traditional privkey format

### DIFF
--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -596,7 +596,7 @@ def write_pem_private_key(priv_key, filename, passwd=None):
             os.fchmod(fp.fileno(), 0o600)
             fp.write(priv_key.private_bytes(
                 Encoding.PEM,
-                PrivateFormat.TraditionalOpenSSL,
+                PrivateFormat.PKCS8,
                 encryption_algorithm=enc_alg))
     except (IOError, OSError) as e:
         raise errors.FileError(reason=str(e))

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1718,6 +1718,7 @@ def generate_ssh_keypair():
 
     pem = key.private_bytes(
         encoding=serialization.Encoding.PEM,
+        # paramiko does not support PKCS#8 format, yet.
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption()
     )


### PR DESCRIPTION
The modern PKCS#8 private key format supports better encryption standard
and is preferable over traditional, weak PKCS#1 key format.

Fixes: https://pagure.io/freeipa/issue/7943
Signed-off-by: Christian Heimes <cheimes@redhat.com>