### PR TITLE
Fix expected file permissions for ghost files

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1129,15 +1129,15 @@ fi
 %dir %{_sysconfdir}/ipa/html
 %config(noreplace) %{_sysconfdir}/ipa/html/ssbrowser.html
 %config(noreplace) %{_sysconfdir}/ipa/html/unauthorized.html
-%ghost %attr(0644,root,apache) %config(noreplace) %{_sysconfdir}/httpd/conf.d/ipa-rewrite.conf
-%ghost %attr(0644,root,apache) %config(noreplace) %{_sysconfdir}/httpd/conf.d/ipa.conf
-%ghost %attr(0644,root,apache) %config(noreplace) %{_sysconfdir}/httpd/conf.d/ipa-kdc-proxy.conf
-%ghost %attr(0644,root,apache) %config(noreplace) %{_sysconfdir}/httpd/conf.d/ipa-pki-proxy.conf
-%ghost %attr(0644,root,apache) %config(noreplace) %{_sysconfdir}/ipa/kdcproxy/ipa-kdc-proxy.conf
-%ghost %attr(0644,root,apache) %config(noreplace) %{_usr}/share/ipa/html/ca.crt
-%ghost %attr(0644,root,apache) %{_usr}/share/ipa/html/krb.con
-%ghost %attr(0644,root,apache) %{_usr}/share/ipa/html/krb5.ini
-%ghost %attr(0644,root,apache) %{_usr}/share/ipa/html/krbrealm.con
+%ghost %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/httpd/conf.d/ipa-rewrite.conf
+%ghost %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/httpd/conf.d/ipa.conf
+%ghost %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/httpd/conf.d/ipa-kdc-proxy.conf
+%ghost %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/httpd/conf.d/ipa-pki-proxy.conf
+%ghost %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/ipa/kdcproxy/ipa-kdc-proxy.conf
+%ghost %attr(0644,root,root) %config(noreplace) %{_usr}/share/ipa/html/ca.crt
+%ghost %attr(0644,root,root) %{_usr}/share/ipa/html/krb.con
+%ghost %attr(0644,root,root) %{_usr}/share/ipa/html/krb5.ini
+%ghost %attr(0644,root,root) %{_usr}/share/ipa/html/krbrealm.con
 %dir %{_usr}/share/ipa/updates/
 %{_usr}/share/ipa/updates/*
 %dir %{_localstatedir}/lib/ipa
@@ -1149,8 +1149,8 @@ fi
 %attr(755,root,root) %dir %{_localstatedir}/lib/ipa/certs
 %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/private
 %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/passwds
-%ghost %{_localstatedir}/lib/ipa/pki-ca/publish
-%ghost %{_localstatedir}/named/dyndb-ldap/ipa
+%ghost %attr(775,root,pkiuser) %{_localstatedir}/lib/ipa/pki-ca/publish
+%ghost %attr(770,named,named) %{_localstatedir}/named/dyndb-ldap/ipa
 %dir %attr(0700,root,root) %{_sysconfdir}/ipa/custodia
 %dir %{_usr}/share/ipa/schema.d
 %attr(0644,root,root) %{_usr}/share/ipa/schema.d/README
@@ -1239,19 +1239,19 @@ fi
 %doc README.md Contributors.txt
 %license COPYING
 %dir %attr(0755,root,root) %{_sysconfdir}/ipa/
-%ghost %attr(0644,root,apache) %config(noreplace) %{_sysconfdir}/ipa/default.conf
-%ghost %attr(0644,root,apache) %config(noreplace) %{_sysconfdir}/ipa/ca.crt
+%ghost %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/ipa/default.conf
+%ghost %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/ipa/ca.crt
 %dir %attr(0755,root,root) %{_sysconfdir}/ipa/nssdb
 # old dbm format
-%ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/cert8.db
-%ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/key3.db
-%ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/secmod.db
+%ghost %attr(644,root,root) %config(noreplace) %{_sysconfdir}/ipa/nssdb/cert8.db
+%ghost %attr(644,root,root) %config(noreplace) %{_sysconfdir}/ipa/nssdb/key3.db
+%ghost %attr(644,root,root) %config(noreplace) %{_sysconfdir}/ipa/nssdb/secmod.db
 # new sql format
-%ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/cert9.db
-%ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/key4.db
-%ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/pkcs11.txt
-%ghost %config(noreplace) %{_sysconfdir}/ipa/nssdb/pwdfile.txt
-%ghost %config(noreplace) %{_sysconfdir}/pki/ca-trust/source/ipa.p11-kit
+%ghost %attr(644,root,root) %config(noreplace) %{_sysconfdir}/ipa/nssdb/cert9.db
+%ghost %attr(644,root,root) %config(noreplace) %{_sysconfdir}/ipa/nssdb/key4.db
+%ghost %attr(644,root,root) %config(noreplace) %{_sysconfdir}/ipa/nssdb/pkcs11.txt
+%ghost %attr(600,root,root) %config(noreplace) %{_sysconfdir}/ipa/nssdb/pwdfile.txt
+%ghost %attr(644,root,root) %config(noreplace) %{_sysconfdir}/pki/ca-trust/source/ipa.p11-kit
 %dir %{_localstatedir}/lib/ipa-client
 %dir %{_localstatedir}/lib/ipa-client/pki
 %dir %{_localstatedir}/lib/ipa-client/sysrestore

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -278,6 +278,7 @@ class DogtagInstance(service.Service):
         template = ipautil.template_file(template_filename, sub_dict)
         with open(paths.HTTPD_IPA_PKI_PROXY_CONF, "w") as fd:
             fd.write(template)
+            os.fchmod(fd.fileno(), 0o644)
 
     def configure_certmonger_renewal(self):
         """

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -10,6 +10,7 @@ installed.
 from __future__ import absolute_import
 
 import os
+import re
 from datetime import datetime, timedelta
 import time
 
@@ -18,6 +19,7 @@ import pytest
 
 from ipalib.constants import DOMAIN_LEVEL_0
 from ipaplatform.constants import constants
+from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks as platformtasks
 from ipatests.pytest_ipa.integration.env_config import get_global_config
@@ -497,6 +499,55 @@ class TestInstallMaster(IntegrationTest):
             print('\n'.join(avcs))
             # Use expected failure until all SELinux violations are fixed
             pytest.xfail("{} AVCs found".format(len(avcs)))
+
+    def test_file_permissions(self):
+        args = [
+            "rpm", "-V",
+            "python3-ipaclient",
+            "python3-ipalib",
+            "python3-ipaserver"
+        ]
+
+        if osinfo.id == 'fedora':
+            args.extend([
+                "freeipa-client",
+                "freeipa-client-common",
+                "freeipa-common",
+                "freeipa-server",
+                "freeipa-server-common",
+                "freeipa-server-dns",
+                "freeipa-server-trust-ad"
+            ])
+        else:
+            args.extend([
+                "ipa-client",
+                "ipa-client-common",
+                "ipa-common",
+                "ipa-server",
+                "ipa-server-common",
+                "ipa-server-dns"
+            ])
+
+        result = self.master.run_command(args, raiseonerr=False)
+        if result.returncode != 0:
+            # Check the mode errors
+            mode_warnings = re.findall(
+                r"^.M.......  [cdglr ]+ (?P<filename>.*)$",
+                result.stdout_text, re.MULTILINE)
+            msg = "rpm -V found mode issues for the following files: {}"
+            assert mode_warnings == [], msg.format(mode_warnings)
+            # Check the owner errors
+            user_warnings = re.findall(
+                r"^.....U...  [cdglr ]+ (?P<filename>.*)$",
+                result.stdout_text, re.MULTILINE)
+            msg = "rpm -V found ownership issues for the following files: {}"
+            assert user_warnings == [], msg.format(user_warnings)
+            # Check the group errors
+            group_warnings = re.findall(
+                r"^......G..  [cdglr ]+ (?P<filename>.*)$",
+                result.stdout_text, re.MULTILINE)
+            msg = "rpm -V found group issues for the following files: {}"
+            assert group_warnings == [], msg.format(group_warnings)
 
 
 class TestInstallMasterKRA(IntegrationTest):


### PR DESCRIPTION
File permissions from the rpm freeipa-server-common and freeipa-client-common do not match the runtime permissions. This results in mode failures on rpm -Va.
Fix the expected file permissions on rpm spec file for
/var/lib/ipa/pki-ca/publish
/var/named/dyndb-ldap/ipa
/etc/ipa/pwdfile.txt
/etc/pki/ca-trust/source/ipa.p11-kit
(new format SQLite)
/etc/ipa/nssdb/cert9.db
/etc/ipa/nssdb/key4.db
/etc/ipa/pkcs11.txt
(old format DBM)
/etc/ipa/cert8.db
/etc/ipa/key3.db
/etc/ipa/secmod.db

Fixes: https://pagure.io/freeipa/issue/7934