### PR TITLE
Use AES-128-CBC for PKCS#12 encryption when creating files (FIPS)

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -802,6 +802,8 @@ class NSSDatabase:
                     '-out', out_file.name,
                     '-passin', 'file:' + self.pwd_file,
                     '-passout', 'file:' + out_pwdfile.name,
+                    '-certpbe', 'aes-128-cbc',
+                    '-keypbe', 'aes-128-cbc',
                 ]
                 try:
                     ipautil.run(args)


### PR DESCRIPTION
A PKCS#12 file is generated from a set of input files in various
formats. This file is then used to provide the public and private
keys and certificate chain fro importing into an NSS database.

In order to work in FIPS mode stronger encryption is required.

The default OpenSSL certificate algo is 40-bit RC2 which is not
allowed in FIPS mode. The default private key algo is 3DES.
Use AES-128 instead for both.

Fixes: https://pagure.io/freeipa/issue/7948

Signed-off-by: Rob Crittenden <rcritten@redhat.com>