### PR TITLE
Decouple integration tests from ipaserver package

### DIFF
--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -18,11 +18,7 @@ try:
     import ipaplatform  # pylint: disable=unused-import
 except ImportError:
     ipaplatform = None
-try:
-    import ipaserver
-    from ipaserver.install import installutils
-except ImportError:
-    ipaserver = None
+
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -31,10 +27,8 @@ pytest_plugins = [
     'ipatests.pytest_ipa.beakerlib',
     'ipatests.pytest_ipa.declarative',
     'ipatests.pytest_ipa.nose_compat',
+    'ipatests.pytest_ipa.integration'
 ]
-# The integration plugin is not available in client-only builds.
-if ipaserver is not None:
-    pytest_plugins.append('ipatests.pytest_ipa.integration')
 
 
 MARKERS = [
@@ -119,7 +113,7 @@ def pytest_cmdline_main(config):
 
     # XXX workaround until https://fedorahosted.org/freeipa/ticket/6408 has
     # been resolved.
-    if ipaserver is not None and installutils.is_ipa_configured():
+    if os.path.isfile(api.env.conf_default):
         api.finalize()
 
     if config.option.verbose:

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -34,7 +34,6 @@ import time
 import dns
 from ldif import LDIFWriter
 import pytest
-from SSSDConfig import SSSDConfig
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -762,6 +761,7 @@ def modify_sssd_conf(host, domain, mod_dict, provider='ipa',
     :param provider_subtype: backend subtype (e.g. id or sudo), will be added
         to the domain config if not present
     """
+    from SSSDConfig import SSSDConfig
     fd, temp_config_file = tempfile.mkstemp()
     os.close(fd)
     try:

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -70,13 +70,14 @@ if __name__ == '__main__':
             "polib",
             "pytest",
             "pytest_multihost",
+            "python-ldap",
             "six",
         ],
         extras_require={
             "integration": ["dbus-python", "pyyaml", "ipaserver"],
             "ipaserver": ["ipaserver"],
             "webui": ["selenium", "pyyaml", "ipaserver"],
-            "xmlrpc": ["ipaserver", "python-ldap"],
+            "xmlrpc": ["ipaserver"],
             ":python_version<'3'": ["mock"],
         }
     )

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -25,16 +25,17 @@ from ipaplatform.paths import paths
 
 from ipapython.dn import DN
 
-from ipaserver.masters import (
-    CONFIGURED_SERVICE, ENABLED_SERVICE, HIDDEN_SERVICE
-)
-
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.create_external_ca import ExternalCA
 from ipatests.test_ipalib.test_x509 import good_pkcs7, badcert
 
 logger = logging.getLogger(__name__)
+
+# from ipaserver.masters
+CONFIGURED_SERVICE = u'configuredService'
+ENABLED_SERVICE = u'enabledService'
+HIDDEN_SERVICE = u'hiddenService'
 
 
 class TestIPACommand(IntegrationTest):

--- a/ipatests/test_integration/test_uninstallation.py
+++ b/ipatests/test_integration/test_uninstallation.py
@@ -17,8 +17,10 @@ import os
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipaplatform.paths import paths
-from ipaserver.install import dsinstance
 from ipapython.ipaldap import realm_to_serverid
+
+# from ipaserver.install.dsinstance
+DS_INSTANCE_PREFIX = 'slapd-'
 
 
 class TestUninstallBase(IntegrationTest):
@@ -65,7 +67,7 @@ class TestUninstallBase(IntegrationTest):
         self.master.run_command(['ipactl', 'stop'])
 
         serverid = realm_to_serverid(self.master.domain.realm)
-        instance_name = ''.join([dsinstance.DS_INSTANCE_PREFIX, serverid])
+        instance_name = ''.join([DS_INSTANCE_PREFIX, serverid])
 
         try:
             # Moving the DS instance out of the way will cause the

--- a/pylintrc
+++ b/pylintrc
@@ -131,3 +131,5 @@ forbidden-imports=
     ipalib/install/:ipaserver,
     ipaplatform/:ipaclient:ipalib:ipaserver,
     ipapython/:ipaclient:ipalib:ipaserver
+    ipatests/pytest_ipa:ipaserver:ipaclient.install:ipalib.install
+    ipatests/test_integration:ipaserver


### PR DESCRIPTION
The integration test suite has weak dependencies on ipaserver. This PR replaces the few imports with copied constants and decouples integration tests from the server package.