### PR TITLE
NSSDatabase: fix get_trust_chain

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -548,7 +548,9 @@ class NSSDatabase:
         :return: List of certificate names
         """
         root_nicknames = []
-        result = self.run_certutil(["-O", "-n", nickname], capture_output=True)
+        result = self.run_certutil(
+            ["-O", "--simple-self-signed", "-n", nickname],
+            capture_output=True)
         chain = result.output.splitlines()
 
         for c in chain:


### PR DESCRIPTION
In the get_trust_chain method, use certutil -O with the option
--simple-self-signed to make sure that self-signed certs properly
get processed.
Note: this option has been introduced in nss 3.38 and our spec file
already requires nss >= 3.41.

Scenario: when IPA CA is switched from self-signed to externally-signed,
then back to self-signed, the same nickname can be used in
/etc/pki/pki-tomcat/alias for the initial cert and the renewed certs. If
the original and renewed certs are present in the NSS db, running
$ certutil -O -n <IPA CA alias>
produces a complex output like the following (this command is used to find
the trust chain):
"CN=Cert Auth,O=ExtAuth" [CN=Cert Auth,O=ExtAuth]

  "caSigningCert cert-pki-ca" [CN=Certificate Authority,O=DOMAIN.COM]

    "caSigningCert cert-pki-ca" [CN=Certificate Authority,O=DOMAIN.COM]

The renewal code is disturbed by this output.
If, on the contrary, certutil -O --simple-self-signed -n <IPA CA alias> is
used to extract the trust chain, the output is as expected for a self-signed
cert:
"caSigningCert cert-pki-ca" [CN=Certificate Authority,O=DOMAIN.COM]

As a result, the scenario self-signed > externally signed > self-signed
works.

Fixes: https://pagure.io/freeipa/issue/7926