### PR TITLE
WebUI: Add possibility to run caless UI tests separately

### DIFF
--- a/ipatests/test_webui/test_host.py
+++ b/ipatests/test_webui/test_host.py
@@ -312,6 +312,7 @@ class test_host(host_tasks):
         self.delete_record(self.pkey, self.data.get('del'))
 
     @screenshot
+    @pytest.mark.caless
     def test_ca_less(self):
         """
         Test host certificate actions in CA-less install

--- a/ipatests/test_webui/test_service.py
+++ b/ipatests/test_webui/test_service.py
@@ -343,6 +343,7 @@ class test_service(sevice_tasks):
         self.delete_record(pkey, data.get('del'))
 
     @screenshot
+    @pytest.mark.caless
     def test_ca_less(self):
         """
         Test service certificate actions in CA-less install


### PR DESCRIPTION
Add pytest mark "caless" to all related UI test suites.

Ticket: https://pagure.io/freeipa/issue/7954

Signed-off-by: Serhii Tsymbaliuk <stsymbal@redhat.com>