### PR TITLE
Getkeytab fixes

### DIFF
--- a/install/updates/60-trusts.update
+++ b/install/updates/60-trusts.update
@@ -41,6 +41,12 @@ dn: $SUFFIX
 add:aci: (targetattr = "ipaNTHash")(version 3.0; acl "Samba system principals can read and write NT passwords"; allow (read,write) groupdn="ldap:///cn=adtrust agents,cn=sysaccounts,cn=etc,$SUFFIX";)
 remove:aci: (targetattr = "ipaNTHash")(version 3.0; acl "Samba system principals can read NT passwords"; allow (read) groupdn="ldap:///cn=adtrust agents,cn=sysaccounts,cn=etc,$SUFFIX";)
 
+# For Samba as a domain member setup we need to allow synchronizing ipaNTHash value
+dn: cn=services,cn=accounts,$SUFFIX
+add:aci: (target="ldap:///krbprincipalname=cifs/($$dn),cn=services,cn=accounts,$SUFFIX")(targetattr="ipaNTHash")(version 3.0; acl "CIFS service can modify own ipaNTHash"; allow(write) userdn="ldap:///krbprincipalname=cifs/($$dn),cn=services,cn=accounts,$SUFFIX" or userattr="managedby#SELFDN";)
+add:aci: (target="ldap:///krbprincipalname=cifs/($$dn),cn=services,cn=accounts,$SUFFIX")(targattrfilters="add=objectClass:(objectClass=ipaNTUserAttrs)")(version 3.0; acl "CIFS service can add ipaNTUserAttrs to itself"; allow(write) userdn="ldap:///krbprincipalname=cifs/($$dn),cn=services,cn=accounts,$SUFFIX" or userattr="managedby#SELFDN";)
+
+
 # Add the default PAC type to configuration
 dn: cn=ipaConfig,cn=etc,$SUFFIX
 addifnew: ipaKrbAuthzData: MS-PAC

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -1151,9 +1151,9 @@ class LDAPCreate(BaseLDAPCommand, crud.Create):
         entry_attrs = ldap.make_entry(
             dn, self.args_options_2_entry(*keys, **options))
 
-        self.process_attr_options(entry_attrs, None, keys, options)
-
         entry_attrs['objectclass'] = deepcopy(self.obj.object_class)
+
+        self.process_attr_options(entry_attrs, None, keys, options)
 
         if self.obj.object_class_config:
             config = ldap.get_ipa_config()

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -301,7 +301,7 @@ class ldap2(CrudBackend, LDAPClient):
 
         attrs = self.get_effective_rights(dn, [attr])
         if 'attributelevelrights' in attrs:
-            attr_rights = attrs.get('attributelevelrights')[0].decode('UTF-8')
+            attr_rights = attrs.get('attributelevelrights')[0]
             (attr, rights) = attr_rights.split(':')
             if 'r' in rights:
                 return True

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -20,6 +20,11 @@ jobs:
         ./autogen.sh
       displayName: Configure the project
     - script: |
+        git update-ref refs/heads/$(System.PullRequest.TargetBranch) origin/$(System.PullRequest.TargetBranch)
+        make V=0 "GIT_BRANCH=$(System.PullRequest.TargetBranch)" fastlint
+      displayName: Quick code style check
+      condition: eq(variables['Build.Reason'], 'PullRequest')
+    - script: |
         echo "Running make target 'rpms'"
         make V=0 rpms LOG_COMPILE='gdb -return-child-result -ex run -ex "thread apply all bt" -ex "quit" --args'
       displayName: Build packages

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -2,15 +2,7 @@ trigger:
 - master
 
 variables:
-  TEST_RUNNER_IMAGE: freeipa-fedora-builder:latest
-  TEST_RUNNER_CONFIG: .test_runner_azure.yaml
-  PEP8_ERROR_LOG: pycodestyle_errors.log
-  CI_RESULTS_LOG: ci_results_$(System.PullRequest.PullRequestNumber).log
-  CI_BACKLOG_SIZE: 5000
   CI_RUNNER_LOGS_DIR: logs
-  CI_RUNNER_LOG_ARCHIVE: $(System.PullRequest.PullRequestNumber)-job-$(Build.BuildId).tar.gz
-  TRAVIS_EVENT_TYPE: $(Build.Reason)
-  TRAVIS_BRANCH: $(System.PullRequest.TargetBranch)
   localsdir: $(Build.Repository.LocalPath)
   builddir: /__w/1/s
 
@@ -118,49 +110,31 @@ jobs:
         testRunTitle: 'Web UI unit test results'
       condition: succeededOrFailed()
 
-- job: Test
-  dependsOn: Build
-  condition: succeeded()
-  pool:
-    vmImage: 'Ubuntu-16.04'
-  strategy:
-    matrix:
-        Base_tests:
-          TEST_TITLE: 'Base'
-          TASK_TO_RUN: run-tests
-          TESTS_TO_RUN: "test_cmdline
-                test_install
-                test_ipaclient
-                test_ipalib
-                test_ipaplatform
-                test_ipapython
-                test_ipaserver"
-        XMLRPC_tests:
-          TEST_TITLE: 'XMLRPC'
-          TASK_TO_RUN: run-tests
-          TESTS_TO_RUN: "test_xmlrpc"
+- template: templates/test-jobs.yml
+  parameters:
+    jobName: Base
+    jobTitle: Base tests
+    testsToRun:
+    - test_cmdline
+    - test_install
+    - test_ipaclient
+    - test_ipalib
+    - test_ipaplatform
+    - test_ipapython
+    testsToIgnore:
+    - test_integration
+    - test_webui
+    - test_ipapython/test_keyring.py
+    taskToRun: run-tests
 
-  steps:
-    - template: templates/setup-test-environment.yml
-      parameters:
-        pythonVersion: '3.6'
-        architecture: 'x64'
-        logsPath: '$(CI_RUNNER_LOGS_DIR)'
-    - script: |
-        sudo modprobe ip6_tables
-      displayName: Make sure IPv6 firewall support is allowed
-    - template: templates/run-test.yml
-      parameters:
-        containerName: 'freeipa-fedora-builder:latest'
-        logsPath: '$(CI_RUNNER_LOGS_DIR)'
-        testToRun: '$(TASK_TO_RUN)'
-        testParams: '$(TESTS_TO_RUN)'
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFiles: 'nosetests.xml'
-        testRunTitle: 'XMLRPC test results'
-      condition: succeededOrFailed()
-    - template: templates/save-test-artifacts.yml
-      parameters:
-        logsPath: '$(CI_RUNNER_LOGS_DIR)'
-        logsArtifact: '$(TEST_TITLE)-logs-$(CI_RUNNER_LOG_ARCHIVE)'
+- template: templates/test-jobs.yml
+  parameters:
+    jobName: XMLRPC
+    jobTitle: XMLRPC tests
+    testsToRun:
+    - test_xmlrpc
+    testsToIgnore:
+    - test_integration
+    - test_webui
+    - test_ipapython/test_keyring.py
+    taskToRun: run-tests

--- a/ipatests/azure/templates/run-test.yml
+++ b/ipatests/azure/templates/run-test.yml
@@ -2,8 +2,9 @@ parameters:
   imageName: 'freeipa-fedora-builder:latest'
   containerName: 'container'
   logsPath: 'logs'
-  testToRun: 'lint'
-  testParams: ''
+  taskToRun: 'run-tests'
+  testsToRun: ''
+  testsToIgnore: ''
 
 steps:
 - script: |
@@ -16,8 +17,10 @@ steps:
     docker inspect $(createContainer.containerName)
   displayName: Start container for running a test
 - script: |
-    docker exec --env TESTS_TO_RUN='${{parameters.testParams}}' \
+    docker exec --env TESTS_TO_RUN="${{ parameters.testsToRun }}" \
+                --env TESTS_TO_IGNORE="${{ parameters.testsToIgnore }}" \
+                --env CI_RUNNER_LOGS_DIR="${{ parameters.logsPath }}" \
                 --privileged -t \
                 $(createContainer.containerName) \
-                /bin/bash --noprofile --norc -x /freeipa/ipatests/azure/azure-${{parameters.testToRun}}.sh
+                /bin/bash --noprofile --norc -x /freeipa/ipatests/azure/azure-${{parameters.taskToRun}}.sh
   displayName: Run test

--- a/ipatests/azure/templates/save-test-artifacts.yml
+++ b/ipatests/azure/templates/save-test-artifacts.yml
@@ -1,6 +1,6 @@
 parameters:
   logsPath: 'logs'
-  logsArtifact: 'logs-$(Build.BuildId)-$(Agent.OS)-$(Agent.OSArchitrecture)'
+  logsArtifact: ''
 steps:
 - task: PublishPipelineArtifact@0
   displayName: Publish logs

--- a/ipatests/azure/templates/setup-test-environment.yml
+++ b/ipatests/azure/templates/setup-test-environment.yml
@@ -1,23 +1,11 @@
-parameters:
-  pythonVersion: '3.6'
-  architecture: 'x64'
-  pythonExec: 'python3'
-  logsPath: 'logs'
-  logsArtifact: 'logs-$(Build.BuildId)-$(Agent.OS)-$(Agent.OSArchitrecture)'
 steps:
 - script: |
     echo '{ "ipv6": true, "fixed-cidr-v6": "2001:db8::/64" }' > docker-daemon.json
     sudo cp docker-daemon.json /etc/docker/daemon.json
     sudo chown root:root /etc/docker/daemon.json
     sudo systemctl restart docker
+    sudo modprobe ip6_tables
   displayName: Configure containerization to allow IPv6 network
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: ${{parameters.pythonVersion}}
-    architecture: ${{parameters.architecture}}
-- script: |
-    ${{parameters.pythonExec}} -m pip install --upgrade pip setuptools pycodestyle
-  displayName: 'Install prerequisites'
 - task: DownloadPipelineArtifact@0
   displayName: Download prebuilt packages
   inputs:

--- a/ipatests/azure/templates/test-jobs.yml
+++ b/ipatests/azure/templates/test-jobs.yml
@@ -1,0 +1,31 @@
+parameters:
+  jobName: ''
+  jobTitle: ''
+  testsToIgnore: []
+  testsToRun: []
+  taskToRun: ''
+
+jobs:
+- job: ${{ parameters.jobName }}
+  displayName: ${{ parameters.jobTitle }}
+  dependsOn: Build
+  condition: succeeded()
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  steps:
+    - template: setup-test-environment.yml
+    - template: run-test.yml
+      parameters:
+        containerName: 'freeipa-fedora-builder:latest'
+        logsPath: $(CI_RUNNER_LOGS_DIR)
+        taskToRun: ${{ parameters.taskToRun}}
+        testsToRun: ${{ join(' ', parameters.testsToRun ) }}
+        testsToIgnore: ${{ join(' ', parameters.testsToIgnore ) }}
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: $(CI_RUNNER_LOGS_DIR)/nosetests.xml
+        testRunTitle: ${{parameters.jobTitle}} results
+      condition: succeededOrFailed()
+    - template: save-test-artifacts.yml
+      parameters:
+        logsArtifact: logs-${{parameters.jobName}}-$(Build.BuildId)-$(Agent.OS)-$(Agent.OSArchitecture)

--- a/ipatests/ipa-run-tests
+++ b/ipatests/ipa-run-tests
@@ -30,6 +30,7 @@ so any relative paths given will be based on the ipatests module's path
 import os
 import copy
 import sys
+import glob
 
 import pytest
 
@@ -59,6 +60,7 @@ class ArgsManglePlugin(object):
             # No file or directory found, run all tests
             args.append(HERE)
         else:
+            vargs = []
             for name in ns.file_or_dir:
                 idx = args.index(name)
                 # split on pytest separator
@@ -67,17 +69,48 @@ class ArgsManglePlugin(object):
                 # a file or directory relative to cwd or already absolute
                 if os.path.exists(filename):
                     continue
-                # a file or directory relative to ipatests package
-                args[idx] = sep.join((os.path.join(HERE, filename), suffix))
+                if '*' in filename:
+                    # Expand a glob, we'll flatten the list later
+                    paths = glob.glob(os.path.join(HERE, filename))
+                    vargs.append([idx, paths])
+                else:
+                    # a file or directory relative to ipatests package
+                    args[idx] = sep.join((os.path.join(HERE, filename), suffix))
+            # flatten and insert all expanded file names
+            base = 0
+            for idx, items in vargs:
+                args.pop(base + idx)
+                for item in items:
+                    args.insert(base + idx, item)
+                base += len(items)
 
         # replace ignores, e.g. "--ignore test_integration" is changed to
         # "--ignore path/to/ipatests/test_integration"
         if ns.ignore:
+            vargs = []
             for ignore in ns.ignore:
                 idx = args.index(ignore)
                 if os.path.exists(ignore):
                     continue
-                args[idx] = os.path.join(HERE, ignore)
+                if '*' in ignore:
+                    # expand a glob, we'll flatten the list later
+                    paths = glob.glob(os.path.join(HERE, ignore))
+                    vargs.append([idx, paths])
+                else:
+                    args[idx] = os.path.join(HERE, ignore)
+            # flatten and insert all expanded file names
+            base = 0
+            for idx, items in vargs:
+                # since we are expanding, remove old pair
+                # --ignore and old file name
+                args.pop(base + idx)
+                args.pop(base + idx)
+                for item in items:
+                    # careful: we need to add a pair
+                    # --ignore and new filename
+                    args.insert(base + idx, '--ignore')
+                    args.insert(base + idx, item)
+                base += len(items) * 2 - 1
 
         # rebuild early_config's known args with new args. The known args
         # are used for initial conftest.py from ipatests, which adds

--- a/ipatests/test_cmdline/test_ipagetkeytab.py
+++ b/ipatests/test_cmdline/test_ipagetkeytab.py
@@ -29,31 +29,37 @@ import tempfile
 import gssapi
 import pytest
 
-from ipalib import api
+from ipapython.ipautil import private_ccache
+from ipalib import api, errors
+from ipalib.request import context
 from ipaplatform.paths import paths
 from ipapython import ipautil, ipaldap
 from ipaserver.plugins.ldap2 import ldap2
 from ipatests.test_cmdline.cmdline import cmdline_test
 from ipatests.test_xmlrpc.tracker import host_plugin, service_plugin
+from contextlib import contextmanager
 
+
+@contextmanager
 def use_keytab(principal, keytab):
-    try:
-        tmpdir = tempfile.mkdtemp(prefix = "tmp-")
-        ccache_file = 'FILE:%s/ccache' % tmpdir
-        name = gssapi.Name(principal, gssapi.NameType.kerberos_principal)
-        store = {'ccache': ccache_file,
-                 'client_keytab': keytab}
-        os.environ['KRB5CCNAME'] = ccache_file
-        gssapi.Credentials(name=name, usage='initiate', store=store)
-        conn = ldap2(api)
-        conn.connect(autobind=ipaldap.AUTOBIND_DISABLED)
-        conn.disconnect()
-    except gssapi.exceptions.GSSError as e:
-        raise Exception('Unable to bind to LDAP. Error initializing principal %s in %s: %s' % (principal, keytab, str(e)))
-    finally:
-        os.environ.pop('KRB5CCNAME', None)
-        if tmpdir:
-            shutil.rmtree(tmpdir)
+    with private_ccache() as ccache_file:
+        try:
+            old_principal = getattr(context, 'principal', None)
+            name = gssapi.Name(principal, gssapi.NameType.kerberos_principal)
+            store = {'ccache': ccache_file,
+                     'client_keytab': keytab}
+            gssapi.Credentials(name=name, usage='initiate', store=store)
+            conn = ldap2(api)
+            conn.connect(ccache=ccache_file,
+                         autobind=ipaldap.AUTOBIND_DISABLED)
+            yield conn
+            conn.disconnect()
+        except gssapi.exceptions.GSSError as e:
+            raise Exception('Unable to bind to LDAP. Error initializing '
+                            'principal %s in %s: %s' % (principal, keytab,
+                                                        str(e)))
+        finally:
+            setattr(context, 'principal', old_principal)
 
 
 @pytest.fixture(scope='class')
@@ -98,7 +104,7 @@ class KeytabRetrievalTest(cmdline_test):
             pass
 
     def run_ipagetkeytab(self, service_principal, args=tuple(),
-                         raiseonerr=False):
+                         raiseonerr=False, stdin=None):
         new_args = [self.command,
                     "-p", service_principal,
                     "-k", self.keytabname]
@@ -110,7 +116,7 @@ class KeytabRetrievalTest(cmdline_test):
 
         return ipautil.run(
             new_args,
-            stdin=None,
+            stdin=stdin,
             raiseonerr=raiseonerr,
             capture_error=True)
 
@@ -162,7 +168,9 @@ class test_ipagetkeytab(KeytabRetrievalTest):
         """
         Try to use the service keytab.
         """
-        use_keytab(test_service.name, self.keytabname)
+        with use_keytab(test_service.name, self.keytabname) as conn:
+            assert conn.can_read(test_service.dn, 'objectclass') is True
+            assert getattr(context, 'principal') == test_service.name
 
     def test_4_disable(self, test_service):
         """
@@ -186,7 +194,9 @@ class test_ipagetkeytab(KeytabRetrievalTest):
         Try to use the disabled keytab
         """
         try:
-            use_keytab(test_service.name, self.keytabname)
+            with use_keytab(test_service.name, self.keytabname) as conn:
+                assert conn.can_read(test_service.dn, 'objectclass') is True
+                assert getattr(context, 'principal') == test_service.name
         except Exception as errmsg:
             assert('Unable to bind to LDAP. Error initializing principal' in str(errmsg))
 

--- a/ipatests/test_cmdline/test_ipagetkeytab.py
+++ b/ipatests/test_cmdline/test_ipagetkeytab.py
@@ -390,7 +390,6 @@ def test_smb_svc(request, test_host):
 
 
 @pytest.mark.tier0
-@pytest.mark.xfail(reason="freeipa ticket 7953", strict=True)
 @pytest.mark.skipif(u'ipantuserattrs' not in add_oc([], u'ipantuserattrs'),
                     reason="Must have trust support enabled for this test")
 class test_smb_service(KeytabRetrievalTest):

--- a/ipatests/test_cmdline/test_ipagetkeytab.py
+++ b/ipatests/test_cmdline/test_ipagetkeytab.py
@@ -218,6 +218,19 @@ class test_ipagetkeytab(KeytabRetrievalTest):
             os.unlink(symlink_target)
 
 
+def retrieve_dm_password():
+    dmpw_file = os.path.join(api.env.dot_ipa, '.dmpw')
+
+    if not os.path.isfile(dmpw_file):
+        raise errors.NotFound(reason='{} file required '
+                              'for this test'.format(dmpw_file))
+
+    with open(dmpw_file, 'r') as f:
+        dm_password = f.read().strip()
+
+    return dm_password
+
+
 class TestBindMethods(KeytabRetrievalTest):
     """
     Class that tests '-c'/'-H'/'-Y' flags
@@ -230,13 +243,10 @@ class TestBindMethods(KeytabRetrievalTest):
     def setup_class(cls):
         super(TestBindMethods, cls).setup_class()
 
-        dmpw_file = os.path.join(api.env.dot_ipa, '.dmpw')
-
-        if not os.path.isfile(dmpw_file):
-            pytest.skip('{} file required for this test'.format(dmpw_file))
-
-        with open(dmpw_file, 'r') as f:
-            cls.dm_password = f.read().strip()
+        try:
+            cls.dm_password = retrieve_dm_password()
+        except errors.NotFound as e:
+            pytest.skip(e.args)
 
         tempfd, temp_ca_cert = tempfile.mkstemp()
 


### PR DESCRIPTION
This is a set of initial patches needed to support a Samba server running on IPA domain member.

These patches by themselves do not enable Samba server yet. They fix assorted bugs I found when adding the support for SMB service and tests for them. Some patches were omitted due to the complexity to untangle.

Most of `test_xmlrpc` tests that rely on a comparison of the user/group results cannot tolerate running in an environment where trust to Active Directory support is enabled. Originally, I started adding fixes for these problems but it quickly escalated to several hundred failed tests. The main issue is a dictionary comparison feature that doesn't allow to specify an attribute to be optional. When trust to AD is enabled, all POSIX users and groups in IPA will get `ipaNTSecurityIdentifier` attribute and `ipantuserattrs`/`ipantgroupattrs` object class added at a creation time.

Dictionary comparison in tests will fail:
- a tracker-maintained dictionary would not have `ipantuserattrs`/`ipantgroupattrs` objectclasses
- a result returned from `user-add` / `group-add` commands might contain the objectclasses and `ipaNTSecurityIdentifier` or might not, depending on how powerful is the test machine so that `sidgen` plugin is able to add the attributes before `user-add` / `group-add` command would retrieve the entry
- if we would add `ipaNTSecurityIdentifier` into the tracker-maintained dictionary, the result comparison code will have no logic to understand that if `ipaNTSecurityIdentifier` is missing in the result, it is not a failure: `fuzzy_sid` class allows for `None` value.
- for group-finding tests, it is impossible to get just a subset of required groups. This prevents from any additional configuration on the test machines. An attempt to search by a wildcard with `ipa group-find --description="Test desc*"` fails because we escape "*" and that filter doesn't match. We need to refactor search code to allow a wildcard search to reduce the number of expected groups in such tests.

I started fixing these issues but they will evidently require a major refactoring of the test code. Meanwhile, these problems are tracked with https://pagure.io/freeipa/issue/7955

