### PR TITLE
[Backport][ipa-4-7] Respect TMPDIR, TEMP or TMP environment variables during testing

### DIFF
--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -102,7 +102,8 @@ class TempDir(object):
 
     def __get_path(self):
         assert path.abspath(self.__path) == self.__path
-        assert self.__path.startswith('/tmp/ipa.tests.')
+        assert self.__path.startswith(path.join(tempfile.gettempdir(),
+                                                'ipa.tests.'))
         assert path.isdir(self.__path) and not path.islink(self.__path)
         return self.__path
     path = property(__get_path)


### PR DESCRIPTION
This PR was opened automatically because PR #3164 was pushed to master and backport to ipa-4-7 is required.