### PR TITLE
Order of master and replica corrected in logger.info

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1226,7 +1226,7 @@ def install_topo(topo, master, replicas, clients, domain_level=None,
             logger.info('Connecting replica %s to %s', parent, child)
             connect_replica(parent, child)
         else:
-            logger.info('Installing replica %s from %s', parent, child)
+            logger.info('Installing replica %s from %s', child, parent)
             install_replica(
                 parent, child,
                 setup_ca=setup_replica_cas,


### PR DESCRIPTION
Order of master/replica was incorect which has been
corrected

Signed-off-by: Kaleemullah Siddiqui <ksiddiqu@redhat.com>