### PR TITLE
 [Backport][ipa-4-6] CA: set ipaconfigstring:compatCA in cn=DOMAIN IPA CA 

### DIFF
--- a/ipaserver/install/plugins/upload_cacrt.py
+++ b/ipaserver/install/plugins/upload_cacrt.py
@@ -92,7 +92,7 @@ class update_upload_cacrt(Updater):
                 config = entry.setdefault('ipaConfigString', [])
                 if ca_enabled:
                     config.append('ipaCa')
-                config.append('ipaCa')
+                config.append('compatCA')
 
             try:
                 ldap.add_entry(entry)


### PR DESCRIPTION
Manual backport of PR #3169 to ipa-4-6 branch.
Cherry-pick without any merge issue.