### PR TITLE
For Fedora and RHEL use system-wide crypto policy for mod_ssl

### DIFF
--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -246,6 +246,10 @@ class BaseTaskNamespace:
         """Configure WSGI for correct Python version"""
         raise NotImplementedError()
 
+    def configure_httpd_protocol(self):
+        """Configure TLS protocols in Apache"""
+        raise NotImplementedError()
+
     def is_fips_enabled(self):
         return False
 

--- a/ipaplatform/debian/tasks.py
+++ b/ipaplatform/debian/tasks.py
@@ -10,7 +10,9 @@ from __future__ import absolute_import
 
 from ipaplatform.base.tasks import BaseTaskNamespace
 from ipaplatform.redhat.tasks import RedHatTaskNamespace
+from ipaplatform.paths import paths
 
+from ipapython import directivesetter
 from ipapython import ipautil
 
 class DebianTaskNamespace(RedHatTaskNamespace):
@@ -68,6 +70,11 @@ class DebianTaskNamespace(RedHatTaskNamespace):
     def configure_httpd_wsgi_conf(self):
         # Debian doesn't require special mod_wsgi configuration
         pass
+
+    def configure_httpd_protocol(self):
+        directivesetter.set_directive(paths.HTTPD_SSL_CONF,
+                                      'SSLProtocol',
+                                      'all -SSLv3', False)
 
     def setup_httpd_logging(self):
         # Debian handles httpd logging differently

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -589,6 +589,12 @@ class RedHatTaskNamespace(BaseTaskNamespace):
 
         self.systemd_daemon_reload()
 
+    def configure_httpd_protocol(self):
+        """Drop SSLProtocol directive and let crypto policy handle it"""
+        directivesetter.set_directive(paths.HTTPD_SSL_CONF,
+                                      'SSLProtocol',
+                                      None, False)
+
     def set_hostname(self, hostname):
         ipautil.run([paths.BIN_HOSTNAMECTL, 'set-hostname', hostname])
 

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -123,7 +123,7 @@ class HTTPInstance(service.Service):
         self.step("disabling nss.conf", self.disable_nss_conf)
         self.step("configuring mod_ssl certificate paths",
                   self.configure_mod_ssl_certs)
-        self.step("setting mod_ssl protocol list to TLSv1.0 - TLSv1.2",
+        self.step("setting mod_ssl protocol list",
                   self.set_mod_ssl_protocol)
         self.step("configuring mod_ssl log directory",
                   self.set_mod_ssl_logdir)
@@ -244,9 +244,7 @@ class HTTPInstance(service.Service):
         open(paths.HTTPD_NSS_CONF, 'w').close()
 
     def set_mod_ssl_protocol(self):
-        directivesetter.set_directive(paths.HTTPD_SSL_CONF,
-                                   'SSLProtocol',
-                                   '+TLSv1 +TLSv1.1 +TLSv1.2', False)
+        tasks.configure_httpd_protocol()
 
     def set_mod_ssl_logdir(self):
         tasks.setup_httpd_logging()


### PR DESCRIPTION
Drop the SSLProtocol directive for Fedora and RHEL systems. mod_ssl
will use crypto policies for the set of protocols.

For Debian systems configure a similar set of protocols for what
was previously configured, but do it in a different way. Rather than
iterating the allowed protocols just include the ones not allowed.

Fixes: https://pagure.io/freeipa/issue/7667

Signed-off-by: Rob Crittenden <rcritten@redhat.com>