### PR TITLE
[ipa-4-6] ipa-cert-fix fixes

### DIFF
--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -128,7 +128,7 @@ class IPACertFix(AdminTool):
         replicate_dogtag_certs(subject_base, ca_subject_dn, certs)
         install_ipa_certs(subject_base, ca_subject_dn, extra_certs)
 
-        if any(x != 'sslserver' for x in certs) \
+        if any(x[0] != 'sslserver' for x in certs) \
                 or any(x[0] is IPACertType.IPARA for x in extra_certs):
             # we renewed a "shared" certificate, therefore we must
             # become the renewal master


### PR DESCRIPTION
Cherry-pick a couple of fixes from master-bound PR #3136.

```
2ff6e1ac5 (Fraser Tweedale, 67 minutes ago)
   ipa-cert-fix: fix spurious renewal master change

   We only want to become the renewal master if we actually renewed a shared
   certificate.  But there is a bug in the logic; even if the only Dogtag
   certificate to be renewed is the 'sslserver' (a non-shared certificate),
   the renewal master will be reset.  Fix the bug.

   A static type system would have excluded this bug.

   Part of: https://pagure.io/freeipa/issue/7885

ee889d2d7 (Fraser Tweedale, 2 days ago)
   ipa-cert-fix: handle 'pki-server cert-fix' failure

   When DS cert is expired, 'pki-server cert-fix' will fail at the final step
   (restart).  When this case arises, ignore the CalledProcessError and
   continue.

   We can't know for sure if the error was due to failure of final restart, or
   something going wrong earlier.  But if it was a more serious failure, the
   next step (installing the renewed IPA-specific certificates) will fail.

   Part of: https://pagure.io/freeipa/issue/7885
```