### PR TITLE
[Backport][ipa-4-7] Switch nsslapd-unhashed-pw-switch to nolog

### DIFF
--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -77,6 +77,7 @@ dist_app_DATA =				\
 	modrdn-krbprinc.ldif		\
 	entryusn.ldif			\
 	root-autobind.ldif		\
+	pw-logging-conf.ldif	\
 	sudobind.ldif			\
 	automember.ldif			\
 	replica-automember.ldif		\

--- a/install/share/pw-logging-conf.ldif
+++ b/install/share/pw-logging-conf.ldif
@@ -1,0 +1,5 @@
+dn: cn=config
+changetype: modify
+replace: nsslapd-unhashed-pw-switch
+nsslapd-unhashed-pw-switch: nolog
+

--- a/install/updates/90-post_upgrade_plugins.update
+++ b/install/updates/90-post_upgrade_plugins.update
@@ -35,3 +35,4 @@ plugin: update_passync_privilege_update
 plugin: update_dnsserver_configuration_into_ldap
 plugin: update_ldap_server_list
 plugin: update_dna_shared_config
+plugin: update_unhashed_password

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -262,6 +262,7 @@ class DsInstance(service.Service):
         self.step("adding default schema", self.__add_default_schemas)
         self.step("enabling memberof plugin", self.__add_memberof_module)
         self.step("enabling winsync plugin", self.__add_winsync_module)
+        self.step("configure password logging", self.__password_logging)
         self.step("configuring replication version plugin", self.__config_version_module)
         self.step("enabling IPA enrollment plugin", self.__add_enrollment_module)
         self.step("configuring uniqueness plugin", self.__set_unique_attrs)
@@ -741,6 +742,9 @@ class DsInstance(service.Service):
 
     def __add_winsync_module(self):
         self._ldap_mod("ipa-winsync-conf.ldif")
+
+    def __password_logging(self):
+        self._ldap_mod("pw-logging-conf.ldif")
 
     def __config_version_module(self):
         self._ldap_mod("version-conf.ldif")

--- a/ipaserver/install/plugins/update_unhashed_password.py
+++ b/ipaserver/install/plugins/update_unhashed_password.py
@@ -1,0 +1,116 @@
+# Authors:
+#   Thierry Bordaz <tbordaz@redhat.com>
+#
+# Copyright (C) 2019  Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from ipalib import Registry, errors
+from ipalib import Updater
+from ipapython.dn import DN
+
+logger = logging.getLogger(__name__)
+
+register = Registry()
+
+
+@register()
+class update_unhashed_password(Updater):
+    """
+    DS
+    """
+    def __remove_update(self, update, key, value):
+        statement = dict(action='remove', attr=key, value=value)
+        update.setdefault('updates', []).append(statement)
+
+    def __add_update(self, update, key, value):
+        statement = dict(action='add', attr=key, value=value)
+        update.setdefault('updates', []).append(statement)
+
+    def execute(self, **options):
+        logger.debug("Upgrading unhashed password configuration")
+        ldap = self.api.Backend.ldap2
+        base_config = DN(('cn', 'config'))
+        try:
+            entry = ldap.get_entry(base_config,
+                                   ['nsslapd-unhashed-pw-switch'])
+        except errors.NotFound:
+            logger.error("Unhashed password configuration not found")
+            return False, []
+
+        config_dn = entry.dn
+
+        toggle = entry.single_value.get("nsslapd-unhashed-pw-switch")
+        if toggle.lower() not in ['off', 'on', 'nolog']:
+            logger.error("Unhashed password had invalid value '%s'", toggle)
+
+        # Check if it exists winsync agreements
+        searchfilter = '(objectclass=nsDSWindowsReplicationAgreement)'
+        try:
+            winsync_agmts, _truncated = ldap.find_entries(
+                base_dn=base_config,
+                filter=searchfilter,
+                attrs_list=[]
+            )
+        except errors.NotFound:
+            logger.debug("Unhashed password this is not a winsync deployment")
+            winsync_agmts = []
+
+        update = {
+            'dn': config_dn,
+            'updates': [],
+        }
+        if len(winsync_agmts) > 0:
+            # We are running in a winsync environment
+            # Log a warning that changelog will contain sensitive data
+            try:
+                cldb_e = ldap.get_entry(
+                    DN(('cn', 'changelog5'),
+                       ('cn', 'config')),
+                    ['nsslapd-changelogdir'])
+                cldb = cldb_e.single_value.get("nsslapd-changelogdir")
+                logger.warning("This server is configured for winsync, "
+                               "the changelog files under %s "
+                               "may contain clear text passwords.\n"
+                               "Please ensure that these files can be accessed"
+                               " only by trusted accounts.\n", cldb)
+            except errors.NotFound:
+                logger.warning("This server is configured for winsync, "
+                               "the changelog files may contain "
+                               "clear text passwords.\n"
+                               "Please ensure that these files can be accessed"
+                               " only by trusted accounts.\n")
+            if toggle.lower() == 'on':
+                # The current DS configuration already logs the
+                # unhashed password
+                updates = []
+            else:
+                self.__remove_update(update, 'nsslapd-unhashed-pw-switch',
+                                     toggle)
+                self.__add_update(update, 'nsslapd-unhashed-pw-switch', 'on')
+                updates = [update]
+        else:
+            if toggle.lower() == 'nolog':
+                updates = []
+            else:
+                self.__remove_update(update, 'nsslapd-unhashed-pw-switch',
+                                     toggle)
+                self.__add_update(update, 'nsslapd-unhashed-pw-switch',
+                                  'nolog')
+                updates = [update]
+
+        return False, updates

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1192,6 +1192,46 @@ class ReplicationManager(object):
         if ret != 0:
             raise RuntimeError("Failed to start replication")
 
+    def unhashed_password_log(self, conn, value):
+        if not conn:
+            raise RuntimeError("unhashed_password_log no connection")
+
+        if not value:
+            return
+
+        # Check the validity of the value
+        if value.lower() not in ['off', 'on', 'nolog']:
+            return
+
+        # Change the value if needed
+        entry = conn.get_entry(DN(('cn', 'config')),
+                               ['nsslapd-unhashed-pw-switch'])
+        toggle = entry.single_value.get("nsslapd-unhashed-pw-switch")
+        if not toggle or not (toggle.lower() == value.lower()):
+            entry["nsslapd-unhashed-pw-switch"] = value.lower()
+            conn.update_entry(entry)
+
+        # if unhashed password are being logged, display a warning
+        if value.lower() == 'on':
+            try:
+                entry = conn.get_entry(
+                    DN(('cn', 'changelog5'),
+                       ('cn', 'config')),
+                    ['nsslapd-changelogdir'])
+                cldb = entry.single_value.get("nsslapd-changelogdir")
+                logger.warning("This configuration (\"--winsync\") may imply "
+                               "that the log file contains clear text "
+                               "passwords.\n"
+                               "Please ensure that these files can be accessed"
+                               " only by trusted accounts.\n"
+                               "Log files are under %s", cldb)
+            except errors.NotFound:
+                logger.warning("This configuration (\"--winsync\") may imply "
+                               "that the log file contains clear text "
+                               "passwords.\n"
+                               "Please ensure that these files can be accessed"
+                               " only by trusted accounts.")
+
     def setup_winsync_replication(self,
                                   ad_dc_name, ad_binddn, ad_pwd,
                                   passsync_pw, ad_subtree,
@@ -1252,6 +1292,11 @@ class ReplicationManager(object):
             self.conn.add_entry(entry)
         except Exception as e:
             logger.info("Failed to create public entry for winsync replica")
+
+        # For winsync, unhashed passwords needs to be in replication changelog
+        # Time to alarm about a security risk
+        self.unhashed_password_log(self.conn, 'on')
+
 
         #Finally start replication
         ret = self.start_replication(self.conn, ad_dc_name)


### PR DESCRIPTION
This PR was opened automatically because PR #2935 was pushed to master and backport to ipa-4-7 is required.