### PR TITLE
Require a SASL SSF of >= 56 on client side

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -314,6 +314,9 @@ TLS_VERSIONS = [
 ]
 TLS_VERSION_MINIMAL = "tls1.0"
 
+# minimum SASL secure strength factor for LDAP connections
+# 56 provides backwards compatibility with old libraries.
+LDAP_SSF_MIN_THRESHOLD = 56
 
 # Use cache path
 USER_CACHE_PATH = (

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -43,7 +43,9 @@ import six
 
 # pylint: disable=ipa-forbidden-import
 from ipalib import errors, x509, _
-from ipalib.constants import LDAP_GENERALIZED_TIME_FORMAT
+from ipalib.constants import (
+    LDAP_GENERALIZED_TIME_FORMAT, LDAP_SSF_MIN_THRESHOLD
+)
 # pylint: enable=ipa-forbidden-import
 from ipaplatform.paths import paths
 from ipapython.ipautil import format_netloc, CIDict
@@ -103,7 +105,8 @@ def realm_to_ldapi_uri(realm_name):
     return 'ldapi://' + ldapurl.ldapUrlEscape(socketname)
 
 
-def ldap_initialize(uri, cacertfile=None):
+def ldap_initialize(uri, cacertfile=None,
+                    ssf_min_threshold=LDAP_SSF_MIN_THRESHOLD):
     """Wrapper around ldap.initialize()
 
     The function undoes global and local ldap.conf settings that may cause
@@ -114,6 +117,10 @@ def ldap_initialize(uri, cacertfile=None):
       locations, also known as system-wide trust store.
     * Cert validation is enforced.
     * SSLv2 and SSLv3 are disabled.
+    * Require a minimum SASL security factor of 56. That level ensures
+      data integrity and confidentiality. Although at least AES128 is
+      enforced pretty much everywhere, 56 is required for backwards
+      compatibility with systems that announce wrong SSF.
     """
     conn = ldap.initialize(uri)
 
@@ -121,6 +128,12 @@ def ldap_initialize(uri, cacertfile=None):
     conn.set_option(ldap.OPT_X_SASL_NOCANON, ldap.OPT_ON)
 
     if not uri.startswith('ldapi://'):
+        # require a minimum SSF for TCP connections, but don't lower SSF_MIN
+        # if the current value is already larger.
+        cur_min_ssf = conn.get_option(ldap.OPT_X_SASL_SSF_MIN)
+        if cur_min_ssf < ssf_min_threshold:
+            conn.set_option(ldap.OPT_X_SASL_SSF_MIN, ssf_min_threshold)
+
         if cacertfile:
             if not os.path.isfile(cacertfile):
                 raise IOError(errno.ENOENT, cacertfile)


### PR DESCRIPTION
SSF_MINX 56 level ensures data integrity and confidentiality for SASL
GSSAPI and SASL GSS SPNEGO connections. Although at least AES128 is enforced
pretty much everywhere, 56 is required.

The origianl commit 350954589774499d99bf87cb5631c664bb0707c4 added minimum
SSF on LDAP client and LDAP server. Some LDAP consumers like realmd are
not compatible with strong SSF yet.

Related: https://pagure.io/freeipa/issue/7140
Related: https://pagure.io/freeipa/issue/4580
Signed-off-by: Christian Heimes <cheimes@redhat.com>