### PR TITLE
[Backport][ipa-4-7] NSSDatabase: fix get_trust_chain

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -543,7 +543,9 @@ class NSSDatabase(object):
         :return: List of certificate names
         """
         root_nicknames = []
-        result = self.run_certutil(["-O", "-n", nickname], capture_output=True)
+        result = self.run_certutil(
+            ["-O", "--simple-self-signed", "-n", nickname],
+            capture_output=True)
         chain = result.output.splitlines()
 
         for c in chain:


### PR DESCRIPTION
This PR was opened automatically because PR #3157 was pushed to master and backport to ipa-4-7 is required.