### PR TITLE
Make `pycodestyle` results identical

### DIFF
--- a/.travis_run_task.sh
+++ b/.travis_run_task.sh
@@ -34,7 +34,7 @@ then
     if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]
     then
         git diff origin/$TRAVIS_BRANCH -U0 | \
-            pycodestyle --ignore=W504 --diff &> $PEP8_ERROR_LOG ||:
+            pycodestyle --diff &> $PEP8_ERROR_LOG ||:
     fi
 fi
 


### PR DESCRIPTION
Currently, pycodestyle is running on:
- make fastlint:
  `$(PYTHON) -m pycodestyle --diff`

  According to docs:
  ```
  The project options are read from the [pycodestyle] section of the
  tox.ini file or the setup.cfg file located in any parent folder of the
  path(s) being processed.
  ```

  So, pycodestyle respects tox.ini:
  ```
  [pycodestyle]
  # E402 module level import not at top of file
  # W504 line break after binary operator
  ignore = E402, W504
  ```

- PR Travis `lint`:
  `pycodestyle --ignore=W504 --diff &> $PEP8_ERROR_LOG ||:`

  According to docs:
  ```
  Please note that if the option –ignore=errors is used, the
  default configuration will be overridden and ignore only the
  check(s) you skip.
  ```

  So, pycodestyle doesn't respect tox.ini.

For now, fastlint ignores E402, W504, while Travis lint ignores only W504.
This issue is exposed by Azure Pipelines, which employs fastlint.

Fixes: https://pagure.io/freeipa/issue/7962