### PR TITLE
[Backport][ipa-4-7] Make `pycodestyle` results identical

### DIFF
--- a/.travis_run_task.sh
+++ b/.travis_run_task.sh
@@ -39,7 +39,7 @@ then
     if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]
     then
         git diff origin/$TRAVIS_BRANCH -U0 | \
-            pycodestyle --ignore=W504 --diff &> $PEP8_ERROR_LOG ||:
+            pycodestyle --diff &> $PEP8_ERROR_LOG ||:
     fi
 fi
 


### PR DESCRIPTION
This PR was opened automatically because PR #3192 was pushed to master and backport to ipa-4-7 is required.