### PR TITLE
[Backport][ipa-4-7] ipa-replica-manage: remove "last init status" if it's None

### DIFF
--- a/install/tools/ipa-csreplica-manage.in
+++ b/install/tools/ipa-csreplica-manage.in
@@ -134,16 +134,18 @@ def list_replicas(realm, host, replica, dirman_passwd, verbose):
         print('%s' % entry.single_value.get('nsds5replicahost'))
 
         if verbose:
-            print("  last init status: %s" % entry.single_value.get(
-                'nsds5replicalastinitstatus'))
-            print("  last init ended: %s" % str(
-                ipautil.parse_generalized_time(
-                    entry.single_value['nsds5replicalastinitend'])))
+            initstatus = entry.single_value.get('nsds5replicalastinitstatus')
+            if initstatus is not None:
+                print("  last init status: %s" % initstatus)
+                print("  last init ended: %s" % str(
+                    ipautil.parse_generalized_time(
+                        entry.single_value['nsds5replicalastinitend'])))
             print("  last update status: %s" % entry.single_value.get(
                 'nsds5replicalastupdatestatus'))
             print("  last update ended: %s" % str(
                 ipautil.parse_generalized_time(
                     entry.single_value['nsds5replicalastupdateend'])))
+
 
 def del_link(realm, replica1, replica2, dirman_passwd, force=False):
 

--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -239,15 +239,18 @@ def list_replicas(realm, host, replica, dirman_passwd, verbose, nolookup=False):
         print('%s: %s' % (entry.single_value.get('nsds5replicahost'), ent_type))
 
         if verbose:
-            print("  last init status: %s" % entry.single_value.get(
-                'nsds5replicalastinitstatus'))
-            print("  last init ended: %s" % str(ipautil.parse_generalized_time(
-                entry.single_value['nsds5replicalastinitend'])))
+            initstatus = entry.single_value.get('nsds5replicalastinitstatus')
+            if initstatus is not None:
+                print("  last init status: %s" % initstatus)
+                print("  last init ended: %s" % str(
+                    ipautil.parse_generalized_time(
+                        entry.single_value['nsds5replicalastinitend'])))
             print("  last update status: %s" % entry.single_value.get(
                 'nsds5replicalastupdatestatus'))
             print("  last update ended: %s" % str(
                 ipautil.parse_generalized_time(
                     entry.single_value['nsds5replicalastupdateend'])))
+
 
 def del_link(realm, replica1, replica2, dirman_passwd, force=False):
     """


### PR DESCRIPTION
This PR was opened automatically because PR #2415 was pushed to master and backport to ipa-4-7 is required.