### PR TITLE
[Backport][ipa-4-6] ipa-replica-manage: remove "last init status" if it's None.

### DIFF
--- a/install/tools/ipa-csreplica-manage
+++ b/install/tools/ipa-csreplica-manage
@@ -134,16 +134,18 @@ def list_replicas(realm, host, replica, dirman_passwd, verbose):
         print('%s' % entry.single_value.get('nsds5replicahost'))
 
         if verbose:
-            print("  last init status: %s" % entry.single_value.get(
-                'nsds5replicalastinitstatus'))
-            print("  last init ended: %s" % str(
-                ipautil.parse_generalized_time(
-                    entry.single_value['nsds5replicalastinitend'])))
+            initstatus = entry.single_value.get('nsds5replicalastinitstatus')
+            if initstatus is not None:
+                print("  last init status: %s" % initstatus)
+                print("  last init ended: %s" % str(
+                    ipautil.parse_generalized_time(
+                        entry.single_value['nsds5replicalastinitend'])))
             print("  last update status: %s" % entry.single_value.get(
                 'nsds5replicalastupdatestatus'))
             print("  last update ended: %s" % str(
                 ipautil.parse_generalized_time(
                     entry.single_value['nsds5replicalastupdateend'])))
+
 
 def del_link(realm, replica1, replica2, dirman_passwd, force=False):
 

--- a/install/tools/ipa-replica-manage
+++ b/install/tools/ipa-replica-manage
@@ -239,15 +239,18 @@ def list_replicas(realm, host, replica, dirman_passwd, verbose, nolookup=False):
         print('%s: %s' % (entry.single_value.get('nsds5replicahost'), ent_type))
 
         if verbose:
-            print("  last init status: %s" % entry.single_value.get(
-                'nsds5replicalastinitstatus'))
-            print("  last init ended: %s" % str(ipautil.parse_generalized_time(
-                entry.single_value['nsds5replicalastinitend'])))
+            initstatus = entry.single_value.get('nsds5replicalastinitstatus')
+            if initstatus is not None:
+                print("  last init status: %s" % initstatus)
+                print("  last init ended: %s" % str(
+                    ipautil.parse_generalized_time(
+                        entry.single_value['nsds5replicalastinitend'])))
             print("  last update status: %s" % entry.single_value.get(
                 'nsds5replicalastupdatestatus'))
             print("  last update ended: %s" % str(
                 ipautil.parse_generalized_time(
                     entry.single_value['nsds5replicalastupdateend'])))
+
 
 def del_link(realm, replica1, replica2, dirman_passwd, force=False):
     """


### PR DESCRIPTION
This is a manual backport of PR #2415 to ipa-4-6 branch.
Manual backport was required because the scripts are named `install/tools/ipa-csreplica-manage` and `install/tools/ipa-replica-manage` in ipa-4-6 branch instead of `install/tools/ipa-csreplica-manage.in` and `install/tools/ipa-replica-manage.in` in master branch.