### PR TITLE
[ipa-4-6] Bump PR-CI template version

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -23,7 +23,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f27
           name: freeipa/ci-ipa-4-6-f27
-          version: 1.0.1
+          version: 1.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -35,7 +35,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f27
           name: freeipa/ci-ipa-4-6-f27
-          version: 1.0.1
+          version: 1.0.2
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
- Upgrade template version required by new version of PR-CI.