### PR TITLE
[master] Bump PR-CI template version

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -23,7 +23,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f29
           name: freeipa/ci-master-f29
-          version: 0.2.0
+          version: 0.2.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -35,7 +35,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f28
           name: freeipa/ci-master-f28
-          version: 0.2.0
+          version: 0.2.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -35,7 +35,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f29
           name: freeipa/ci-master-f29
-          version: 0.2.0
+          version: 0.2.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_master_pki.yaml
+++ b/ipatests/prci_definitions/nightly_master_pki.yaml
@@ -35,7 +35,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &pki-master-f29
           name: freeipa/pki-master-f29
-          version: 0.0.1
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -35,7 +35,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-frawhide
           name: freeipa/ci-master-frawhide
-          version: 0.0.4
+          version: 0.0.9
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -41,7 +41,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f29
           name: freeipa/ci-master-f29
-          version: 0.2.0
+          version: 0.2.1
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
This PR replaces https://github.com/freeipa/freeipa/pull/3210, since that is falling due to Fedora 30 issues.

These changes update the image used by PR-CI, but Fedora 29 will be used still for gating while https://github.com/freeipa/freeipa/pull/3216 is not ready. 