### PR TITLE
Stop using 389-ds legacy backup and restoration utilities

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -399,11 +399,6 @@ class BasePathNamespace:
     SLAPD_INSTANCE_ERROR_LOG_TEMPLATE = "/var/log/dirsrv/slapd-%s/errors"
     SLAPD_INSTANCE_SYSTEMD_IPA_ENV_TEMPLATE = \
         "/etc/systemd/system/dirsrv@%s.service.d/ipa-env.conf"
-    # Legacy 389 commands
-    LDIF2DB = '/usr/sbin/ldif2db'
-    DB2LDIF = '/usr/sbin/db2ldif'
-    BAK2DB = '/usr/sbin/bak2db'
-    DB2BAK = '/usr/sbin/db2bak'
     IPA_SERVER_UPGRADE = '/usr/sbin/ipa-server-upgrade'
     KEYCTL = '/bin/keyctl'
     GETENT = '/usr/bin/getent'

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -452,11 +452,12 @@ class Backup(admintool.AdminTool):
                 )
 
         else:
-            args = [paths.DB2LDIF,
-                    '-Z', instance,
-                    '-r',
-                    '-n', backend,
-                    '-a', ldiffile]
+            args = [paths.DSCTL,
+                    instance,
+                    'db2ldif',
+                    '--replication',
+                    backend,
+                    ldiffile]
             result = run(args, raiseonerr=False)
             if result.returncode != 0:
                 raise admintool.ScriptError(
@@ -519,7 +520,10 @@ class Backup(admintool.AdminTool):
                 )
 
         else:
-            args = [paths.DB2BAK, bakdir, '-Z', instance]
+            args = [paths.DSCTL,
+                    instance,
+                    'db2bak',
+                    bakdir]
             result = run(args, raiseonerr=False)
             if result.returncode != 0:
                 raise admintool.ScriptError(

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -634,10 +634,11 @@ class Restore(admintool.AdminTool):
             # Restore SELinux context of template_dir
             tasks.restore_context(template_dir)
 
-            args = [paths.LDIF2DB,
-                    '-Z', instance,
-                    '-i', ldiffile,
-                    '-n', backend]
+            args = [paths.DSCTL,
+                    instance,
+                    'ldif2db',
+                    backend,
+                    ldiffile]
             result = run(args, raiseonerr=False)
             if result.returncode != 0:
                 logger.critical("ldif2db failed: %s", result.error_log)
@@ -647,7 +648,7 @@ class Restore(admintool.AdminTool):
         '''
         Restore a BAK backup of the data and changelog in this instance.
 
-        If backend is None then all backends are restored.
+        For offline restore backend is not used. All backends are restored.
 
         If executed online create a task and wait for it to complete.
 
@@ -687,12 +688,10 @@ class Restore(admintool.AdminTool):
             logger.info("Waiting for restore to finish")
             wait_for_task(conn, dn)
         else:
-            args = [paths.BAK2DB,
-                    '-Z', instance,
+            args = [paths.DSCTL,
+                    instance,
+                    'bak2db',
                     os.path.join(self.dir, instance)]
-            if backend is not None:
-                args.append('-n')
-                args.append(backend)
             result = run(args, raiseonerr=False)
             if result.returncode != 0:
                 logger.critical("bak2db failed: %s", result.error_log)


### PR DESCRIPTION
Use dsctl instead, the modern replacement for ldif2db, db2ldif,
bak2db and db2bak.

https://pagure.io/freeipa/issue/7965

Signed-off-by: Rob Crittenden <rcritten@redhat.com>