### PR TITLE
When reading SSH pub key don't assume last character is newline

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1562,12 +1562,13 @@ def update_ssh_keys(hostname, ssh_dir, create_sshfp):
             continue
 
         for line in f:
-            line = line[:-1].lstrip()
+            line = line.strip()
             if not line or line.startswith('#'):
                 continue
             try:
                 pubkey = SSHPublicKey(line)
-            except (ValueError, UnicodeDecodeError):
+            except (ValueError, UnicodeDecodeError) as e:
+                logger.debug("Decoding line '%s' failed: %s", line, e)
                 continue
             logger.info("Adding SSH public key from %s", filename)
             pubkeys.append(pubkey)


### PR DESCRIPTION
The code was attempting to strip off any trailing newline and then
calling lstrip() on the rest.

This assumes that the key has a trailing newline. At best this
can cause the last character of the comment to be lost. If there
is no comment it will fail to load the key because it is invalid.

Patch by Félix-Antoine Fortin <felix-antoine.fortin@calculquebec.ca>

https://pagure.io/freeipa/issue/7959

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

There is a lot of very good analysis within the ticket.