### PR TITLE
Better handling for not configured when uninstalling client

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3175,9 +3175,13 @@ def uninstall_check(options):
     fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
 
     if not is_ipa_client_installed(fstore):
+        if options.on_master:
+            rval = SUCCESS
+        else:
+            rval = CLIENT_NOT_CONFIGURED
         raise ScriptError(
             "IPA client is not configured on this system.",
-            rval=CLIENT_NOT_CONFIGURED)
+            rval=rval)
 
     server_fstore = sysrestore.FileStore(paths.SYSRESTORE)
     if server_fstore.has_files() and not options.on_master:

--- a/ipaclient/install/ipa_client_install.py
+++ b/ipaclient/install/ipa_client_install.py
@@ -62,7 +62,6 @@ ClientInstall = cli.install_tool(
     verbose=True,
     console_format='%(message)s',
     uninstall_log_file_name=paths.IPACLIENT_UNINSTALL_LOG,
-    ignore_return_codes=(client.CLIENT_NOT_CONFIGURED,),
 )
 
 

--- a/ipapython/admintool.py
+++ b/ipapython/admintool.py
@@ -93,7 +93,6 @@ class AdminTool:
     log_file_name = None
     usage = None
     description = None
-    ignore_return_codes = ()
 
     _option_parsers = dict()
 
@@ -184,7 +183,7 @@ class AdminTool:
                     return_value = exception.rval  # pylint: disable=no-member
             traceback = sys.exc_info()[2]
             error_message, return_value = self.handle_error(exception)
-            if return_value and return_value not in self.ignore_return_codes:
+            if return_value:
                 self.log_failure(error_message, return_value, exception,
                     traceback)
                 return return_value

--- a/ipapython/admintool.py
+++ b/ipapython/admintool.py
@@ -279,7 +279,7 @@ class AdminTool:
         """Given an exception, return a message (or None) and process exit code
         """
         if isinstance(exception, ScriptError):
-            return exception.msg, exception.rval or 1
+            return exception.msg, exception.rval
         elif isinstance(exception, SystemExit):
             if isinstance(exception.code, int):
                 return None, exception.code
@@ -307,6 +307,11 @@ class AdminTool:
                      self.command_name, type(exception).__name__, exception)
         if error_message:
             logger.error('%s', error_message)
+        if return_value == 0:
+            # A script may raise an exception but still want quit gracefully,
+            # like the case of ipa-client-install called from
+            # ipa-server-install.
+            return
         message = "The %s command failed." % self.command_name
         if self.log_file_name and return_value != 2:
             # magic value because this is common between server and client

--- a/ipapython/install/cli.py
+++ b/ipapython/install/cli.py
@@ -58,8 +58,7 @@ def _get_usage(configurable_class):
 
 def install_tool(configurable_class, command_name, log_file_name,
                  debug_option=False, verbose=False, console_format=None,
-                 use_private_ccache=True, uninstall_log_file_name=None,
-                 ignore_return_codes=()):
+                 use_private_ccache=True, uninstall_log_file_name=None):
     """
     Some commands represent multiple related tools, e.g.
     ``ipa-server-install`` and ``ipa-server-install --uninstall`` would be
@@ -73,8 +72,6 @@ def install_tool(configurable_class, command_name, log_file_name,
     :param console_format: logging format for stderr
     :param use_private_ccache: a temporary ccache is created and used
     :param uninstall_log_file_name: if not None the log for uninstall
-    :param ignore_return_codes: tuple of error codes to not log errors
-                                for. Let the caller do it if it wants.
     """
     if uninstall_log_file_name is not None:
         uninstall_kwargs = dict(
@@ -84,7 +81,6 @@ def install_tool(configurable_class, command_name, log_file_name,
             debug_option=debug_option,
             verbose=verbose,
             console_format=console_format,
-            ignore_return_codes=ignore_return_codes,
         )
     else:
         uninstall_kwargs = None
@@ -102,14 +98,12 @@ def install_tool(configurable_class, command_name, log_file_name,
             console_format=console_format,
             uninstall_kwargs=uninstall_kwargs,
             use_private_ccache=use_private_ccache,
-            ignore_return_codes=ignore_return_codes,
         )
     )
 
 
 def uninstall_tool(configurable_class, command_name, log_file_name,
-                   debug_option=False, verbose=False, console_format=None,
-                   ignore_return_codes=()):
+                   debug_option=False, verbose=False, console_format=None):
     return type(
         'uninstall_tool({0})'.format(configurable_class.__name__),
         (UninstallTool,),
@@ -121,7 +115,6 @@ def uninstall_tool(configurable_class, command_name, log_file_name,
             debug_option=debug_option,
             verbose=verbose,
             console_format=console_format,
-            ignore_return_codes=ignore_return_codes,
         )
     )
 

--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -367,8 +367,8 @@ IPA_CLIENT_NOT_CONFIGURED = b'IPA client is not configured on this system'
     [
         # Commands delivered by the client pkg
         (['ipa'], 1, None, IPA_CLIENT_NOT_CONFIGURED),
-        (['ipa-certupdate'], 1, None, IPA_CLIENT_NOT_CONFIGURED),
-        (['ipa-client-automount'], 1, IPA_CLIENT_NOT_CONFIGURED, None),
+        (['ipa-certupdate'], 2, None, IPA_CLIENT_NOT_CONFIGURED),
+        (['ipa-client-automount'], 2, IPA_CLIENT_NOT_CONFIGURED, None),
         # Commands delivered by the server pkg
         (['ipa-adtrust-install'], 2, None, IPA_NOT_CONFIGURED),
         (['ipa-advise'], 2, None, IPA_NOT_CONFIGURED),


### PR DESCRIPTION
Second crack at this.

When uninstalling the client and it isn't configured we should return "not configured". When uninstall the client in context of the server we shouldn't error out.

So in the case of on-master raise the exception with a SUCCESS error so it doesn't cause things to blow up, and revert the previous attempt.