### PR TITLE
azure tests: make sure /etc/docker folder exists

### DIFF
--- a/ipatests/azure/templates/setup-test-environment.yml
+++ b/ipatests/azure/templates/setup-test-environment.yml
@@ -1,6 +1,7 @@
 steps:
 - script: |
     echo '{ "ipv6": true, "fixed-cidr-v6": "2001:db8::/64" }' > docker-daemon.json
+    sudo mkdir -p /etc/docker
     sudo cp docker-daemon.json /etc/docker/daemon.json
     sudo chown root:root /etc/docker/daemon.json
     sudo systemctl restart docker


### PR DESCRIPTION
Azure tests fail because we couldn't configure docker for IPv6 anymore.
This happened because we weren't able to copy our configuration file to
/etc/docker -- looks like the docker directory does not exist.