### PR TITLE
[Backport][ipa-4-7] When reading SSH pub key don't assume last character is newline

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1563,12 +1563,13 @@ def update_ssh_keys(hostname, ssh_dir, create_sshfp):
             continue
 
         for line in f:
-            line = line[:-1].lstrip()
+            line = line.strip()
             if not line or line.startswith('#'):
                 continue
             try:
                 pubkey = SSHPublicKey(line)
-            except (ValueError, UnicodeDecodeError):
+            except (ValueError, UnicodeDecodeError) as e:
+                logger.debug("Decoding line '%s' failed: %s", line, e)
                 continue
             logger.info("Adding SSH public key from %s", filename)
             pubkeys.append(pubkey)


### PR DESCRIPTION
This PR was opened automatically because PR #3228 was pushed to master and backport to ipa-4-7 is required.