### PR TITLE
ipatests: fix test_backup_and_restore.py::TestBackupAndRestore

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -27,6 +27,7 @@ import pytest
 
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
+from ipaplatform.tasks import tasks as platformtasks
 from ipapython.dn import DN
 from ipapython import ipautil
 from ipatests.test_integration.base import IntegrationTest
@@ -227,6 +228,9 @@ class TestBackupAndRestore(IntegrationTest):
             finally:
                 self.master.run_command(['userdel', 'ipatest_user1'])
 
+    @pytest.mark.skipif(
+        not platformtasks.is_selinux_enabled(),
+        reason="Test needs SELinux enabled")
     def test_full_backup_and_restore_with_selinux_booleans_off(self):
         """regression test for https://fedorahosted.org/freeipa/ticket/4157"""
         with restore_checker(self.master):


### PR DESCRIPTION
The test test_backup_and_restore.py::TestBackupAndRestore::   test_full_backup_and_restore_with_selinux_booleans_off requires SELinux to be enabled because it's using getsebool command.

Skip the test if SELinux is disabled.

Fixes: https://pagure.io/freeipa/issue/7970