### PR TITLE
[Backport][ipa-4-7] ipatests: fix test_caless.py

### DIFF
--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -61,6 +61,7 @@ def get_install_stdin(cert_passwords=()):
     ]
     lines.extend(cert_passwords)  # Enter foo.p12 unlock password
     lines += [
+        'no',   # configure chrony with NTP server or pool address?
         'yes',  # Continue with these values?
     ]
     return '\n'.join(lines + [''])


### PR DESCRIPTION
This PR is manual backport of https://github.com/freeipa/freeipa/pull/3240 please wait for CI before pushing.
In case of questions or problems contact @flo-renaud  who is author of the original PR.