### PR TITLE
ipatest : POSIX attributes, are no longer overwritten or missing.

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -29,7 +29,10 @@ topologies:
     name: master_3repl_1client
     cpu: 6
     memory: 12900
-
+  ad: &ad
+    name: ad
+    cpu: 4
+    memory: 12000
 jobs:
   fedora-29/build:
     requires: []
@@ -45,14 +48,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-29/temp_commit:
+  fedora-29/test_trust:
     requires: [fedora-29/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_trust.py
         template: *ci-master-f29
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 12000
+        topology: *ad


### PR DESCRIPTION
During SSSD lookups, SSSD incorrectly considers the attributes to be removed from the server, and removes them from the SSSD cache as well.
This test validates that POSIX attributes, such as shell or home directory, are no longer overwritten or missing.
Related Ticket : https://pagure.io/SSSD/sssd/issue/2474
