### PR TITLE
[Backport][ipa-4-7] ipatests: fix test_backup_and_restore.py::TestBackupAndRestore

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -28,6 +28,7 @@ import pytest
 
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
+from ipaplatform.tasks import tasks as platformtasks
 from ipapython.dn import DN
 from ipapython import ipautil
 from ipatests.test_integration.base import IntegrationTest
@@ -228,6 +229,9 @@ class TestBackupAndRestore(IntegrationTest):
             finally:
                 self.master.run_command(['userdel', 'ipatest_user1'])
 
+    @pytest.mark.skipif(
+        not platformtasks.is_selinux_enabled(),
+        reason="Test needs SELinux enabled")
     def test_full_backup_and_restore_with_selinux_booleans_off(self):
         """regression test for https://fedorahosted.org/freeipa/ticket/4157"""
         with restore_checker(self.master):


### PR DESCRIPTION
This PR was opened automatically because PR #3241 was pushed to master and backport to ipa-4-7 is required.