### PR TITLE
[Backport][ipa 4 6] ipatests: fix test_backup_and_restore.py::TestBackupAndRestore

### DIFF
--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -91,16 +91,24 @@ class BaseTaskNamespace(object):
 
         return paths.SVC_LIST_FILE
 
-    def check_selinux_status(self):
+    def is_selinux_enabled(self):
+        """Check if SELinux is available and enabled
+
+        :return: True if SELinux is available and enabled
         """
-        Checks if SELinux is available on the platform. If it is, this task
-        also makes sure that restorecon tool is available.
+        return False
+
+    def check_selinux_status(self):
+        """Checks if SELinux is available on the platform.
+
+        If it is, this task also makes sure that restorecon tool is available.
 
         If SELinux is available, but restorcon tool is not installed, raises
         an RuntimeError, which suggest installing the package containing
         restorecon and rerunning the installation.
-        """
 
+        :return: True if SELinux is available and enabled
+        """
         raise NotImplementedError()
 
     def check_ipv6_stack_enabled(self):

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -21,12 +21,14 @@ from __future__ import print_function, absolute_import
 
 import logging
 import os
+import pytest
 import re
 import contextlib
 from tempfile import NamedTemporaryFile
 
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
+from ipaplatform.tasks import tasks as platformtasks
 from ipapython.dn import DN
 from ipapython import ipautil
 from ipatests.test_integration.base import IntegrationTest
@@ -195,6 +197,9 @@ class TestBackupAndRestore(IntegrationTest):
             finally:
                 self.master.run_command(['userdel', 'ipatest_user1'])
 
+    @pytest.mark.skipif(
+        not platformtasks.is_selinux_enabled(),
+        reason="Test needs SELinux enabled")
     def test_full_backup_and_restore_with_selinux_booleans_off(self):
         """regression test for https://fedorahosted.org/freeipa/ticket/4157"""
         with restore_checker(self.master):


### PR DESCRIPTION
This is a manual backport of PR #3241 to ipa-4-6 and supersedes PR #3257.

Commit "Refactor tasks to include is_selinux_enabled" was also cherry-picked because the backport needs the tasks function "is_selinux_enabled".