### PR TITLE
WebUI: Fix 'user not found' traceback on user ID override details page

### DIFF
--- a/install/ui/src/freeipa/idviews.js
+++ b/install/ui/src/freeipa/idviews.js
@@ -472,6 +472,17 @@ idviews.id_override_user_details_facet = function(spec) {
         that.refresh();
     };
 
+    that.load = function(data) {
+        var is_trust_view = that.get_pkeys()[0] === idviews.DEFAULT_TRUST_VIEW;
+        var widget = that.fields.get_field('ipaanchoruuid').widget;
+
+        // Disable link for AD users
+        widget.no_check = is_trust_view;
+        widget.is_link = !is_trust_view;
+
+        that.details_facet_load(data);
+    };
+
     return that;
 };
 


### PR DESCRIPTION
Disable link to user page from user ID override in case it is in 'Default Trust View'

Ticket: https://pagure.io/freeipa/issue/7139