### PR TITLE
Wrap CustodiaClient in context manager

### DIFF
--- a/install/tools/ipa-pki-retrieve-key.in
+++ b/install/tools/ipa-pki-retrieve-key.in
@@ -2,9 +2,8 @@
 
 from __future__ import print_function
 
+import argparse
 import os
-import sys
-import traceback
 
 from ipalib import constants
 from ipalib.config import Env
@@ -16,27 +15,37 @@ def main():
     env = Env()
     env._finalize()
 
-    keyname = "ca_wrapped/" + sys.argv[1]
-    servername = sys.argv[2]
+    parser = argparse.ArgumentParser("ipa-pki-retrieve-key")
+    parser.add_argument("keyname", type=str)
+    parser.add_argument("servername", type=str)
+
+    args = parser.parse_args()
+    keyname = "ca_wrapped/{}".format(args.keyname)
 
     service = constants.PKI_GSSAPI_SERVICE_NAME
     client_keyfile = os.path.join(paths.PKI_TOMCAT, service + '.keys')
     client_keytab = os.path.join(paths.PKI_TOMCAT, service + '.keytab')
 
+    for filename in [client_keyfile, client_keytab]:
+        if not os.access(filename, os.R_OK):
+            parser.error(
+                "File '{}' missing or not readable.\n".format(filename)
+            )
+
     # pylint: disable=no-member
     client = CustodiaClient(
-        client_service='%s@%s' % (service, env.host), server=servername,
-        realm=env.realm, ldap_uri="ldaps://" + env.host,
-        keyfile=client_keyfile, keytab=client_keytab,
-        )
+        client_service="{}@{}".format(service, env.host),
+        server=args.servername,
+        realm=env.realm,
+        ldap_uri="ldaps://" + env.host,
+        keyfile=client_keyfile,
+        keytab=client_keytab,
+    )
 
     # Print the response JSON to stdout; it is already in the format
     # that Dogtag's ExternalProcessKeyRetriever expects
     print(client.fetch_key(keyname, store=False))
 
 
-try:
+if __name__ == '__main__':
     main()
-except BaseException:
-    traceback.print_exc()
-    sys.exit(1)

--- a/ipaclient/plugins/ca.py
+++ b/ipaclient/plugins/ca.py
@@ -33,13 +33,24 @@ class WithCertOutArgs(MethodOverride):
                                              error=str(e))
 
         result = super(WithCertOutArgs, self).forward(*keys, **options)
+
         if filename:
+            # if result certificate / certificate_chain not present in result,
+            # it means Dogtag did not provide it (probably due to LWCA key
+            # replication lag or failure.  The server transmits a warning
+            # message in this case, which the client automatically prints.
+            # So in this section we just ignore it and move on.
+            certs = None
             if options.get('chain', False):
-                certs = result['result']['certificate_chain']
+                if 'certificate_chain' in result['result']:
+                    certs = result['result']['certificate_chain']
             else:
-                certs = [base64.b64decode(result['result']['certificate'])]
-            certs = (x509.load_der_x509_certificate(cert) for cert in certs)
-            x509.write_certificate_list(certs, filename)
+                if 'certificate' in result['result']:
+                    certs = [base64.b64decode(result['result']['certificate'])]
+            if certs:
+                x509.write_certificate_list(
+                    (x509.load_der_x509_certificate(cert) for cert in certs),
+                    filename)
 
         return result
 

--- a/ipalib/messages.py
+++ b/ipalib/messages.py
@@ -487,6 +487,15 @@ class FailedToAddHostDNSRecords(PublicMessage):
                "%(reason)s")
 
 
+class LightweightCACertificateNotAvailable(PublicMessage):
+    """
+    **13031** Certificate is not available
+    """
+    errno = 13031
+    type = "error"
+    format = _("The certificate for %(ca)s is not available on this server.")
+
+
 def iter_messages(variables, base):
     """Return a tuple with all subclasses
     """

--- a/ipaserver/secrets/client.py
+++ b/ipaserver/secrets/client.py
@@ -1,93 +1,106 @@
 # Copyright (C) 2015  IPA Project Contributors, see COPYING for license
 
 from __future__ import print_function, absolute_import
+
+import contextlib
+import os
+import secrets
+from base64 import b64encode
+
+
 # pylint: disable=relative-import
 from custodia.message.kem import KEMClient, KEY_USAGE_SIG, KEY_USAGE_ENC
 # pylint: enable=relative-import
 from jwcrypto.common import json_decode
 from jwcrypto.jwk import JWK
+from ipalib.krb_utils import krb5_format_service_principal_name
 from ipaserver.secrets.kem import IPAKEMKeys
-from ipaserver.secrets.store import iSecStore
+from ipaserver.secrets.store import IPASecStore
 from ipaplatform.paths import paths
-from base64 import b64encode
-import ldapurl
 import gssapi
-import os
-import urllib3
 import requests
 
 
+@contextlib.contextmanager
+def ccache_env(ccache):
+    """Temporarily set KRB5CCNAME environment variable
+    """
+    orig_ccache = os.environ.get('KRB5CCNAME')
+    os.environ['KRB5CCNAME'] = ccache
+    try:
+        yield
+    finally:
+        os.environ.pop('KRB5CCNAME', None)
+        if orig_ccache is not None:
+            os.environ['KRB5CCNAME'] = orig_ccache
+
+
 class CustodiaClient:
+    def __init__(self, client_service, keyfile, keytab, server, realm,
+                 ldap_uri=None, auth_type=None):
+        if client_service.endswith(realm) or "@" not in client_service:
+            raise ValueError(
+                "Client service name must be a GSS name (service@host), "
+                "not '{}'.".format(client_service)
+            )
+        self.client_service = client_service
+        self.keytab = keytab
+        self.server = server
+        self.realm = realm
+        self.ldap_uri = ldap_uri
+        self.auth_type = auth_type
+        self.service_name = gssapi.Name(
+            'HTTP@{}'.format(server), gssapi.NameType.hostbased_service
+        )
+        self.keystore = IPASecStore()
+        # use in-process MEMORY ccache. Handler process don't need a TGT.
+        self.ccache = 'MEMORY:Custodia_{}'.format(secrets.token_hex())
+
+        with ccache_env(self.ccache):
+            # Init creds immediately to make sure they are valid.  Creds
+            # can also be re-inited by _auth_header to avoid expiry.
+            self.creds = self._init_creds()
+
+            self.ikk = IPAKEMKeys(
+                {'server_keys': keyfile, 'ldap_uri': ldap_uri}
+            )
+            self.kemcli = KEMClient(
+                self._server_keys(), self._client_keys()
+            )
 
     def _client_keys(self):
         return self.ikk.server_keys
 
-    def _server_keys(self, server, realm):
-        principal = 'host/%s@%s' % (server, realm)
+    def _server_keys(self):
+        principal = krb5_format_service_principal_name(
+            'host', self.server, self.realm
+        )
         sk = JWK(**json_decode(self.ikk.find_key(principal, KEY_USAGE_SIG)))
         ek = JWK(**json_decode(self.ikk.find_key(principal, KEY_USAGE_ENC)))
-        return (sk, ek)
+        return sk, ek
 
-    def _ldap_uri(self, realm):
-        dashrealm = '-'.join(realm.split('.'))
-        socketpath = paths.SLAPD_INSTANCE_SOCKET_TEMPLATE % (dashrealm,)
-        return 'ldapi://' + ldapurl.ldapUrlEscape(socketpath)
-
-    def _keystore(self, realm, ldap_uri, auth_type):
-        config = dict()
-        if ldap_uri is None:
-            config['ldap_uri'] = self._ldap_uri(realm)
-        else:
-            config['ldap_uri'] = ldap_uri
-        if auth_type is not None:
-            config['auth_type'] = auth_type
-
-        return iSecStore(config)
-
-    def __init__(
-            self, client_service, keyfile, keytab, server, realm,
-            ldap_uri=None, auth_type=None):
-        self.client_service = client_service
-        self.keytab = keytab
-
-        # Init creds immediately to make sure they are valid.  Creds
-        # can also be re-inited by _auth_header to avoid expiry.
-        #
-        self.creds = self.init_creds()
-
-        self.service_name = gssapi.Name('HTTP@%s' % (server,),
-                                        gssapi.NameType.hostbased_service)
-        self.server = server
-
-        self.ikk = IPAKEMKeys({'server_keys': keyfile, 'ldap_uri': ldap_uri})
-
-        self.kemcli = KEMClient(self._server_keys(server, realm),
-                                self._client_keys())
-
-        self.keystore = self._keystore(realm, ldap_uri, auth_type)
-
-        # FIXME: Remove warnings about missing subjAltName for the
-        #        requests module
-        urllib3.disable_warnings()
-
-    def init_creds(self):
-        name = gssapi.Name(self.client_service,
-                           gssapi.NameType.hostbased_service)
-        store = {'client_keytab': self.keytab,
-                 'ccache': 'MEMORY:Custodia_%s' % b64encode(
-                     os.urandom(8)).decode('ascii')}
+    def _init_creds(self):
+        name = gssapi.Name(
+            self.client_service, gssapi.NameType.hostbased_service
+        )
+        store = {
+            'client_keytab': self.keytab,
+            'ccache': self.ccache
+        }
         return gssapi.Credentials(name=name, store=store, usage='initiate')
 
     def _auth_header(self):
-        if not self.creds or self.creds.lifetime < 300:
-            self.creds = self.init_creds()
-        ctx = gssapi.SecurityContext(name=self.service_name, creds=self.creds)
+        if self.creds.lifetime < 300:
+            self.creds = self._init_creds()
+        ctx = gssapi.SecurityContext(
+            name=self.service_name,
+            creds=self.creds
+        )
         authtok = ctx.step()
         return {'Authorization': 'Negotiate %s' % b64encode(
             authtok).decode('ascii')}
 
     def fetch_key(self, keyname, store=True):
-
         # Prepare URL
         url = 'https://%s/ipa/keys/%s' % (self.server, keyname)
 
@@ -99,9 +112,11 @@ class CustodiaClient:
         headers = self._auth_header()
 
         # Perform request
-        r = requests.get(url, headers=headers,
-                         verify=paths.IPA_CA_CRT,
-                         params={'type': 'kem', 'value': request})
+        r = requests.get(
+            url, headers=headers,
+            verify=paths.IPA_CA_CRT,
+            params={'type': 'kem', 'value': request}
+        )
         r.raise_for_status()
         reply = r.json()
 


### PR DESCRIPTION
A CustodiaClient object has to the process environment a bit, e.g. set
up GSSAPI credentials. To reuse the credentials in libldap connections,
it is also necessary to set up a custom ccache store and configure
KRBCCNAME.

Credential initialization and ccache is now handled in a context
manager.