### PR TITLE
[Travis CI] Update ipa-docker-test-runner version used to test with Fedora 30

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
     - pip3 install pycodestyle
     - >
       pip3 install
-      git+https://github.com/freeipa/ipa-docker-test-runner@release-0-3-1
+      git+https://github.com/freeipa/ipa-docker-test-runner@release-0-3-2
 
 script:
     - mkdir -p $CI_RUNNER_LOGS_DIR


### PR DESCRIPTION
This change will enable Fedora 30 in Travis CI.

Containers were already updated by https://github.com/freeipa/freeipa-builder/pull/4 and https://github.com/freeipa/ipa-docker-test-runner/pull/44.

Signed-off-by: Armando Neto <abiagion@redhat.com>