### PR TITLE
[ipa-4-6] DL0 replica install: fix nsDS5ReplicaBindDN config

### DIFF
--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1775,8 +1775,13 @@ class ReplicationManager(object):
         try:
             conn.get_entry(self.repl_man_group_dn)
         except errors.NotFound:
-            self._add_replica_bind_dn(conn, my_dn)
             self._add_replication_managers(conn)
+
+        # On IPA 3.x masters (ds version < 1.3.3),
+        # add replica bind DN directly into the replica entry
+        vendor_version = get_ds_version(conn)
+        if vendor_version < (1, 3, 3):
+            self._add_replica_bind_dn(conn, my_dn)
 
         self._add_dn_to_replication_managers(conn, my_dn)
         self._add_dn_to_replication_managers(conn, remote_dn)


### PR DESCRIPTION
When setting up a 4.x replica in DL0 from a 3.x replica, the first 4.x
replica installation succeeds but if a second 4.x replica is configured,
the replication is not properly set.

This happens because the replica setup needs to add nsDS5ReplicaBindDN:
krbprincipalname=ldap/replica@DOMAIN to the entry
cn=replica,cn=...,cn=mapping tree,cn=config in order to allow replication
(on the 3.x master, the replication manager group is not supported yet).

The issue is that this attribute is added only when the entry
cn=replication managers,cn=sysaccounts,cn=etc,$BASEDN
does not exist. This condition is true for the first replica install but false
for the second replica install.

The fix consists in checking if the remote server has ds version < 1.3.0
(in this case it is a 3.x server). If it's the case, the installer
will use nsDS5ReplicaBindDN attribute with the replica krbprincipalname.
Otherwise the nsDS5ReplicaBindDN attribute will use the replication manager
group.

Fixes: https://pagure.io/freeipa/issue/7976