### PR TITLE
nfs.py: fix user creation

### DIFF
--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -117,7 +117,7 @@ class TestNFS(TestInit):
                 "ipa", "user-add",
                 "%s" % user, "--first", "%s" % user,
                 "--last", "%s" % users[user],
-                '--password'], stdin_text=temp_pass
+                '--password'], stdin_text="%s\n%s\n" % (temp_pass, temp_pass)
             )
             self.master.run_command(["kdestroy", "-A"])
             password = "Secret123"


### PR DESCRIPTION
nfs.py calls "ipa user-add" without inputting the password twice
leading to a timeout. Input password twice then.

Signed-off-by: François Cami <fcami@redhat.com>