### PR TITLE
[ipa-4-7] Update Travis config to run on Fedora 28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
 cache: pip
 env:
     global:
-        - TEST_RUNNER_IMAGE="freeipa/freeipa-test-runner:master-latest"
+        - TEST_RUNNER_IMAGE="freeipa/freeipa-test-runner:ipa-4-7_f28"
           PEP8_ERROR_LOG="pycodestyle_errors.log"
           CI_RESULTS_LOG="ci_results_${TRAVIS_BRANCH}.log"
           CI_BACKLOG_SIZE=5000


### PR DESCRIPTION
Master branch was updated to run the latest release of Fedora (30).
This makes Fedora 28 to be used to test ipa-4-7 because it has Python 2 included.

Signed-off-by: Armando Neto <abiagion@redhat.com>