### PR TITLE
Resolve tox substitutions to absolute paths

### DIFF
--- a/.tox-install.sh
+++ b/.tox-install.sh
@@ -2,8 +2,8 @@
 set -ex
 
 FLAVOR="$1"
-ENVPYTHON="$2"
-ENVSITEPACKAGESDIR="$3"
+ENVPYTHON="$(realpath "$2")"
+ENVSITEPACKAGESDIR="$(realpath "$3")"
 # 3...end are package requirements
 shift 3
 


### PR DESCRIPTION
Since tox-3.8.0 the substituted virtualenv-paths of tox
(like {envpython} or {envsitepackagesdir}) have become relative.
The documentation says nothing about this. Thus, these paths
should always be resolved as absolute.

https://github.com/tox-dev/tox/issues/1339

Fixes: https://pagure.io/freeipa/issue/7977