### PR TITLE
Exit on fail in azure multiline script

### DIFF
--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -16,19 +16,23 @@ jobs:
   steps:
     - template: templates/prepare-build.yml
     - script: |
+        set -e
         echo "Running autoconf generator"
         ./autogen.sh
       displayName: Configure the project
     - script: |
+        set -e
         git update-ref refs/heads/$(System.PullRequest.TargetBranch) origin/$(System.PullRequest.TargetBranch)
         make V=0 "GIT_BRANCH=$(System.PullRequest.TargetBranch)" fastlint
       displayName: Quick code style check
       condition: eq(variables['Build.Reason'], 'PullRequest')
     - script: |
+        set -e
         echo "Running make target 'rpms'"
         make V=0 rpms LOG_COMPILE='gdb -return-child-result -ex run -ex "thread apply all bt" -ex "quit" --args'
       displayName: Build packages
     - script: |
+        set -e
         mkdir container
         cp -pr dist container/
         cp ipatests/azure/Dockerfile.build-container container/Dockerfile
@@ -47,10 +51,12 @@ jobs:
   steps:
     - template: templates/prepare-build.yml
     - script: |
+        set -e
         echo "Running autoconf generator"
         ./autogen.sh
       displayName: Configure the project
     - script: |
+        set -e
         echo "Running make target 'lint'"
         make V=0 lint
       displayName: Lint sources
@@ -68,10 +74,12 @@ jobs:
         versionSpec: 3.6
         architecture: x64
     - script: |
+        set -e
         sudo dnf -y install nss-tools
         python3 -m pip install --upgrade pip setuptools pycodestyle
       displayName: 'Install prerequisites'
     - script: |
+        set -e
         echo "Running tox"
         export LANG=en_US.utf8
         export LC_CTYPE=en_US.utf8
@@ -97,13 +105,16 @@ jobs:
         versionSpec: 3.6
         architecture: x64
     - script: |
+        set -e
         sudo dnf -y install npm fontconfig
       displayName: 'Install prerequisites'
     - script: |
+        set -e
         echo "Running autoconf generator"
         ./autogen.sh
       displayName: Configure the project
     - script: |
+        set -e
         echo "Running WebUI unit tests"
         cd $(builddir)/install/ui/js/libs && make
         cd $(builddir)/install/ui && npm install

--- a/ipatests/azure/templates/prepare-build.yml
+++ b/ipatests/azure/templates/prepare-build.yml
@@ -1,5 +1,6 @@
 steps:
 - script: |
+    set -e
     sudo rm -rf /var/cache/dnf/*
     echo 'Disable modular repositories'
     sudo dnf config-manager '*modular*' --set-disabled

--- a/ipatests/azure/templates/run-test.yml
+++ b/ipatests/azure/templates/run-test.yml
@@ -8,15 +8,18 @@ parameters:
 
 steps:
 - script: |
+    set -e
     cnt=`docker create --hostname ipa.example.test --privileged -v $(Build.Repository.LocalPath):/freeipa -t  ${{parameters.imageName}} /usr/sbin/init`
     echo "##vso[task.setvariable variable=containerName;isOutput=true]$cnt"
   name: createContainer
   displayName: Create container for running a test
 - script: |
+    set -e
     docker start $(createContainer.containerName)
     docker inspect $(createContainer.containerName)
   displayName: Start container for running a test
 - script: |
+    set -e
     docker exec --env TESTS_TO_RUN="${{ parameters.testsToRun }}" \
                 --env TESTS_TO_IGNORE="${{ parameters.testsToIgnore }}" \
                 --env CI_RUNNER_LOGS_DIR="${{ parameters.logsPath }}" \

--- a/ipatests/azure/templates/setup-test-environment.yml
+++ b/ipatests/azure/templates/setup-test-environment.yml
@@ -1,5 +1,6 @@
 steps:
 - script: |
+    set -e
     echo '{ "ipv6": true, "fixed-cidr-v6": "2001:db8::/64" }' > docker-daemon.json
     sudo mkdir -p /etc/docker
     sudo cp docker-daemon.json /etc/docker/daemon.json
@@ -18,6 +19,7 @@ steps:
     artifactName: 'image-$(Build.BuildId)-$(Agent.OS)-$(Agent.OSArchitecture)'
     targetPath: $(Agent.BuildDirectory)/s
 - script: |
+    set -e
     docker load --input $(Agent.BuildDirectory)/s/freeipa-fedora-builder-container.tar.gz
     docker images
     docker inspect freeipa-fedora-builder:latest


### PR DESCRIPTION
By default, the `last` exit code returned from Azure script will be
checked and, if non-zero, treated as a step failure.  Luckily,
for Linux script is a shortcut for Bash. Hence errexit/e option
could be applied. But Azure pipelines doesn't set it by default:
https://github.com/microsoft/azure-pipelines-agent/issues/1803

For multiline script this is a problem unless otherwise designed.
Some of the benefits of checking the result of each subcommand:
- preventing subsequent issues (broken packages, container images, etc.)
- time saving (next steps will not run)
- good diagnostics (tells which part of the script fails)