### PR TITLE
Fix Pytest4.x warnings

### DIFF
--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 
 from ipalib import api
 from ipalib.cli import cli_plugins
+import ipatests.util
 
 try:
     import ipaplatform  # pylint: disable=unused-import
@@ -84,6 +85,11 @@ def pytest_configure(config):
     # always run doc tests
     config.option.doctestmodules = True
 
+    # apply global options
+    ipatests.util.SKIP_IPAAPI = config.option.skip_ipaapi
+    ipatests.util.IPACLIENT_UNITTESTS = config.option.ipaclient_unittests
+    ipatests.util.PRETTY_PRINT = config.option.pretty_print
+
 
 def pytest_addoption(parser):
     group = parser.getgroup("IPA integration tests")
@@ -135,11 +141,11 @@ def pytest_runtest_setup(item):
             get_marker = item.get_marker  # pylint: disable=no-member
         if get_marker('skip_ipaclient_unittest'):
             # pylint: disable=no-member
-            if pytest.config.option.ipaclient_unittests:
+            if item.config.option.ipaclient_unittests:
                 pytest.skip("Skip in ipaclient unittest mode")
         if get_marker('needs_ipaapi'):
             # pylint: disable=no-member
-            if pytest.config.option.skip_ipaapi:
+            if item.config.option.skip_ipaapi:
                 pytest.skip("Skip tests that needs an IPA API")
 
 

--- a/ipatests/test_ipaclient/test_csrgen.py
+++ b/ipatests/test_ipaclient/test_csrgen.py
@@ -259,7 +259,7 @@ class test_CSRGenerator:
 
         with pytest.raises(
                 errors.CSRTemplateError,
-                message='unrecognised attribute type: X'):
+                match=r'^unrecognised attribute type: X$'):
             csrgen_ffi.build_requestinfo(
                 config.encode('utf-8'), adaptor.get_subject_public_key_info())
 

--- a/ipatests/test_util.py
+++ b/ipatests/test_util.py
@@ -152,10 +152,10 @@ class test_Fuzzy:
         assert (None == self.klass()) is True
 
 
-def test_assert_deepequal():
+def test_assert_deepequal(pytestconfig):
     f = util.assert_deepequal
     try:  # pylint: disable=no-member
-        pretty = pytest.config.getoption("pretty_print")
+        pretty = pytestconfig.getoption("pretty_print")
     except (AttributeError, ValueError):
         pretty = False
 

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -71,12 +71,16 @@ if six.PY3:
 
 PYTEST_VERSION = tuple(int(v) for v in pytest.__version__.split('.'))
 
+# settings are configured by conftest
+IPACLIENT_UNITTESTS = None
+SKIP_IPAAPI = None
+PRETTY_PRINT = None
+
 
 def check_ipaclient_unittests(reason="Skip in ipaclient unittest mode"):
     """Call this in a package to skip the package in ipaclient-unittest mode
     """
-    config = pytest.config  # pylint: disable=no-member
-    if config.getoption('ipaclient_unittests', False):
+    if IPACLIENT_UNITTESTS:
         if PYTEST_VERSION[0] >= 3:
             # pytest 3+ does no longer allow pytest.skip() on module level
             # pylint: disable=unexpected-keyword-arg
@@ -89,8 +93,7 @@ def check_ipaclient_unittests(reason="Skip in ipaclient unittest mode"):
 def check_no_ipaapi(reason="Skip tests that needs an IPA API"):
     """Call this in a package to skip the package in no-ipaapi mode
     """
-    config = pytest.config  # pylint: disable=no-member
-    if config.getoption('skip_ipaapi', False):
+    if SKIP_IPAAPI:
         if PYTEST_VERSION[0] >= 3:
             # pylint: disable=unexpected-keyword-arg
             raise pytest.skip.Exception(reason, allow_module_level=True)
@@ -388,12 +391,7 @@ def assert_deepequal(expected, got, doc='', stack=tuple()):
     Note that lists and tuples are considered equivalent, and the order of
     their elements does not matter.
     """
-    try:
-        pretty_print = pytest.config.getoption("pretty_print")
-    except (AttributeError, ValueError):
-        pretty_print = False
-
-    if pretty_print:
+    if PRETTY_PRINT:
         expected_str = struct_to_string(expected, EXPECTED_LEN)
         got_str = struct_to_string(got, GOT_LEN)
     else:


### PR DESCRIPTION
This fixes:
- "message" parameter of pytest.raises is deprecated since Pytest4.1
https://docs.pytest.org/en/latest/deprecations.html#message-parameter-of-pytest-raises
- pytest.config global is deprecated since Pytest4.1
https://docs.pytest.org/en/latest/deprecations.html#pytest-config-global