### PR TITLE
dnsrecord-mod: allow to modify ttl without passing the record

### DIFF
--- a/ipalib/dns.py
+++ b/ipalib/dns.py
@@ -55,7 +55,7 @@ def get_extra_rrtype(name):
 
 
 def has_cli_options(cmd, options, no_option_msg, allow_empty_attrs=False):
-    sufficient = ('setattr', 'addattr', 'delattr', 'rename')
+    sufficient = ('setattr', 'addattr', 'delattr', 'rename', 'dnsttl')
     if any(k in options for k in sufficient):
         return
 

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -1948,6 +1948,34 @@ class test_dns(Declarative):
             },
         ),
 
+        dict(
+            desc='Modify ttl of record %r in zone %r' % (name1, zone1),
+            command=('dnsrecord_mod', [zone1, name1], {'dnsttl': 500}),
+            expected={
+                'value': name1_dnsname,
+                'summary': None,
+                'result': {
+                    'idnsname': [name1_dnsname],
+                    'dnsttl': ['500'],
+                    'arecord': [revname2_ip],
+                },
+            },
+        ),
+
+
+        dict(
+            desc='Delete ttl of record %r in zone %r' % (name1, zone1),
+            command=('dnsrecord_mod', [zone1, name1], {'dnsttl': None}),
+            expected={
+                'value': name1_dnsname,
+                'summary': None,
+                'result': {
+                    'idnsname': [name1_dnsname],
+                    'arecord': [revname2_ip],
+                },
+            },
+        ),
+
 
         dict(
             desc='Try to add per-zone permission for unknown zone',


### PR DESCRIPTION
### dnsrecord-mod: allow to modify ttl without passing the record
The command `ipa dnsrecord-mod <zone> <record> --ttl ` requires to provide at least one record to modify. When none is specified, it prompts by proposing each of the existing records, for instance:
```
$ ipa dnsrecord-mod ZZZZZ.org ns11 --ttl=86400
No option to modify specific record provided.
Current DNS record contents:

A record: xxx.xxx.xxx.xxx
AAAA record: xxxx:xx

Modify A record 'xxxx.xxxx.xxxx.xxxx'? Yes/No (default No):
Modify AAAA record 'xxxx:xx'? Yes/No (default No):
ipa: ERROR: No options to modify a specific record provided.
```
The admin should be able to modify the TTL value without re-entering the record information. The issue happens because of an internal check that forgot to consider 'dnsttl' as a valid standalone modification.

Fixes: https://pagure.io/freeipa/issue/7982

### XMLRPC tests: add new test for ipa dsnrecord-mod $ZONE $RECORD --ttl
    
The test suite did not have any test for modification of the TTL of an existing DNS record.
Related: https://pagure.io/freeipa/issue/7982
