### PR TITLE
[Backport][ipa-4-7] nfs.py: fix user creation

### DIFF
--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -117,7 +117,7 @@ class TestNFS(TestInit):
                 "ipa", "user-add",
                 "%s" % user, "--first", "%s" % user,
                 "--last", "%s" % users[user],
-                '--password'], stdin_text=temp_pass
+                '--password'], stdin_text="%s\n%s\n" % (temp_pass, temp_pass)
             )
             self.master.run_command(["kdestroy", "-A"])
             password = "Secret123"


### PR DESCRIPTION
This PR was opened automatically because PR #3274 was pushed to master and backport to ipa-4-7 is required.