### PR TITLE
Log the raised message when DNS check_zone_overlap fails

### DIFF
--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -327,9 +327,10 @@ def get_auto_reverse_zones(ip_addresses, allow_zone_overlap=False):
         if not allow_zone_overlap:
             try:
                 dnsutil.check_zone_overlap(default_reverse)
-            except ValueError:
+            except ValueError as e:
                 logger.info("Reverse zone %s for IP address %s already exists",
                             default_reverse, ip)
+                logger.debug('%s', e)
                 continue
         auto_zones.append((ip, default_reverse))
     return auto_zones


### PR DESCRIPTION
The check can fail for a lot of other reasons than there is
overlap so the error should be logged.

This causes confusion when --auto-reverse is requested and
some lookup fails causing the reverse to not be created.

Signed-off-by: Rob Crittenden <rcritten@redhat.com>