### PR TITLE
Replace PYTHONSHEBANG with valid shebang

### DIFF
--- a/Makefile.pythonscripts.am
+++ b/Makefile.pythonscripts.am
@@ -1,6 +1,6 @@
 # special handling of Python scripts with auto-generated shebang line
 $(PYTHON_SHEBANG):%: %.in Makefile
-	$(AM_V_GEN)sed -e 's|@PYTHONSHEBANG[@]|#!$(PYTHON) -E|g' $< > $@
+	$(AM_V_GEN)sed -e 's|^#!/usr/bin/python3.*|#!$(PYTHON) -E|g' $< > $@
 	$(AM_V_GEN)chmod +x $@
 
 .PHONY: python_scripts_sub

--- a/client/ipa-certupdate.in
+++ b/client/ipa-certupdate.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Jan Cholasta <jcholast@redhat.com>
 #
 # Copyright (C) 2014  Red Hat

--- a/client/ipa-client-automount.in
+++ b/client/ipa-client-automount.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>

--- a/client/ipa-client-install.in
+++ b/client/ipa-client-install.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Simo Sorce <ssorce@redhat.com>
 #          Karl MacMillan <kmacmillan@mentalrootkit.com>
 #

--- a/daemons/dnssec/ipa-dnskeysync-replica.in
+++ b/daemons/dnssec/ipa-dnskeysync-replica.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #

--- a/daemons/dnssec/ipa-dnskeysyncd.in
+++ b/daemons/dnssec/ipa-dnskeysyncd.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #

--- a/daemons/dnssec/ipa-ods-exporter.in
+++ b/daemons/dnssec/ipa-ods-exporter.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2014  FreeIPA Contributors see COPYING for license
 #

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Authors:
 #   Jan Cholasta <jcholast@redhat.com>

--- a/install/certmonger/ipa-server-guard.in
+++ b/install/certmonger/ipa-server-guard.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Authors:
 #   Jan Cholasta <jcholast@redhat.com>

--- a/install/custodia/ipa-custodia-dmldap.in
+++ b/install/custodia/ipa-custodia-dmldap.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2019  IPA Project Contributors, see COPYING for license
 #

--- a/install/custodia/ipa-custodia-pki-tomcat-wrapped.in
+++ b/install/custodia/ipa-custodia-pki-tomcat-wrapped.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2019  IPA Project Contributors, see COPYING for license
 #

--- a/install/custodia/ipa-custodia-pki-tomcat.in
+++ b/install/custodia/ipa-custodia-pki-tomcat.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2019  IPA Project Contributors, see COPYING for license
 #

--- a/install/custodia/ipa-custodia-ra-agent.in
+++ b/install/custodia/ipa-custodia-ra-agent.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2019  IPA Project Contributors, see COPYING for license
 #

--- a/install/oddjob/com.redhat.idm.trust-fetch-domains.in
+++ b/install/oddjob/com.redhat.idm.trust-fetch-domains.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 
 from ipaserver import dcerpc
 from ipaserver.install.installutils import is_ipa_configured, ScriptError

--- a/install/restart_scripts/renew_ca_cert.in
+++ b/install/restart_scripts/renew_ca_cert.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>

--- a/install/restart_scripts/renew_kdc_cert.in
+++ b/install/restart_scripts/renew_kdc_cert.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #

--- a/install/restart_scripts/renew_ra_cert.in
+++ b/install/restart_scripts/renew_ra_cert.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>

--- a/install/restart_scripts/renew_ra_cert_pre.in
+++ b/install/restart_scripts/renew_ra_cert_pre.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #

--- a/install/restart_scripts/restart_dirsrv.in
+++ b/install/restart_scripts/restart_dirsrv.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>

--- a/install/restart_scripts/restart_httpd.in
+++ b/install/restart_scripts/restart_httpd.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>

--- a/install/restart_scripts/stop_pkicad.in
+++ b/install/restart_scripts/stop_pkicad.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>

--- a/install/tools/ipa-adtrust-install.in
+++ b/install/tools/ipa-adtrust-install.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Authors: Sumit Bose <sbose@redhat.com>
 # Based on ipa-server-install by Karl MacMillan <kmacmillan@mentalrootkit.com>

--- a/install/tools/ipa-advise.in
+++ b/install/tools/ipa-advise.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Tomas Babej <tbabej@redhat.com>
 #
 # Copyright (C) 2013  Red Hat

--- a/install/tools/ipa-backup.in
+++ b/install/tools/ipa-backup.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Rob Crittenden <rcritten@redhat.com>
 #
 # Copyright (C) 2013  Red Hat

--- a/install/tools/ipa-ca-install.in
+++ b/install/tools/ipa-ca-install.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Rob Crittenden <rcritten@redhat.com>
 #
 # Copyright (C) 2011  Red Hat

--- a/install/tools/ipa-cacert-manage.in
+++ b/install/tools/ipa-cacert-manage.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Jan Cholasta <jcholast@redhat.com>
 #
 # Copyright (C) 2014  Red Hat

--- a/install/tools/ipa-cert-fix.in
+++ b/install/tools/ipa-cert-fix.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2019  FreeIPA Contributors see COPYING for license
 #

--- a/install/tools/ipa-compat-manage.in
+++ b/install/tools/ipa-compat-manage.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Rob Crittenden <rcritten@redhat.com>
 # Authors: Simo Sorce <ssorce@redhat.com>
 #

--- a/install/tools/ipa-crlgen-manage.in
+++ b/install/tools/ipa-crlgen-manage.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2019  FreeIPA Contributors see COPYING for license
 #

--- a/install/tools/ipa-csreplica-manage.in
+++ b/install/tools/ipa-csreplica-manage.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Rob Crittenden <rcritten@redhat.com>
 #
 # Based on ipa-replica-manage by Karl MacMillan <kmacmillan@mentalrootkit.com>

--- a/install/tools/ipa-custodia-check.in
+++ b/install/tools/ipa-custodia-check.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 """Test client for ipa-custodia
 
 The test script is expected to be executed on an IPA server with existing

--- a/install/tools/ipa-custodia.in
+++ b/install/tools/ipa-custodia.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Copyright (C) 2017  IPA Project Contributors, see COPYING for license
 from ipaserver.secrets.service import main
 

--- a/install/tools/ipa-dns-install.in
+++ b/install/tools/ipa-dns-install.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Martin Nagy <mnagy@redhat.com>
 # Based on ipa-server-install by Karl MacMillan <kmacmillan@mentalrootkit.com>
 #

--- a/install/tools/ipa-httpd-kdcproxy.in
+++ b/install/tools/ipa-httpd-kdcproxy.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors:
 #   Christian Heimes <cheimes@redhat.com>
 #

--- a/install/tools/ipa-kra-install.in
+++ b/install/tools/ipa-kra-install.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Ade Lee <alee@redhat.com>
 #
 # Copyright (C) 2014  Red Hat

--- a/install/tools/ipa-ldap-updater.in
+++ b/install/tools/ipa-ldap-updater.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Rob Crittenden <rcritten@redhat.com>
 #
 # Copyright (C) 2008  Red Hat

--- a/install/tools/ipa-managed-entries.in
+++ b/install/tools/ipa-managed-entries.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Jr Aquino <jr.aquino@citrix.com>
 #
 # Copyright (C) 2011  Red Hat

--- a/install/tools/ipa-nis-manage.in
+++ b/install/tools/ipa-nis-manage.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Rob Crittenden <rcritten@redhat.com>
 # Authors: Simo Sorce <ssorce@redhat.com>
 #

--- a/install/tools/ipa-otptoken-import.in
+++ b/install/tools/ipa-otptoken-import.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Nathaniel McCallum <npmccallum@redhat.com>
 #
 # Copyright (C) 2014  Red Hat

--- a/install/tools/ipa-pki-retrieve-key.in
+++ b/install/tools/ipa-pki-retrieve-key.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 
 from __future__ import print_function
 

--- a/install/tools/ipa-pki-wait-running.in
+++ b/install/tools/ipa-pki-wait-running.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 """Wait until pki-tomcatd is up
 
 The script polls on Dogtag's HTTP port and wait until the admin interface

--- a/install/tools/ipa-pkinit-manage.in
+++ b/install/tools/ipa-pkinit-manage.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #

--- a/install/tools/ipa-replica-conncheck.in
+++ b/install/tools/ipa-replica-conncheck.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Martin Kosek <mkosek@redhat.com>
 #
 # Copyright (C) 2011  Red Hat

--- a/install/tools/ipa-replica-install.in
+++ b/install/tools/ipa-replica-install.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Karl MacMillan <kmacmillan@mentalrootkit.com>
 #
 # Copyright (C) 2007  Red Hat

--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Karl MacMillan <kmacmillan@mentalrootkit.com>
 #
 # Copyright (C) 2007  Red Hat

--- a/install/tools/ipa-restore.in
+++ b/install/tools/ipa-restore.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Rob Crittenden <rcritten@redhat.com>
 #
 # Copyright (C) 2013  Red Hat

--- a/install/tools/ipa-server-certinstall.in
+++ b/install/tools/ipa-server-certinstall.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Jan Cholasta <jcholast@redhat.com>
 #
 # Copyright (C) 2013  Red Hat

--- a/install/tools/ipa-server-install.in
+++ b/install/tools/ipa-server-install.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Karl MacMillan <kmacmillan@mentalrootkit.com>
 #          Simo Sorce <ssorce@redhat.com>
 #          Rob Crittenden <rcritten@redhat.com>

--- a/install/tools/ipa-server-upgrade.in
+++ b/install/tools/ipa-server-upgrade.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 #
 # Copyright (C) 2015  FreeIPA Contributors see COPYING for license
 #

--- a/install/tools/ipa-winsync-migrate.in
+++ b/install/tools/ipa-winsync-migrate.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Tomas Babej <tbabej@redhat.com>
 #
 # Copyright (C) 2015  Red Hat

--- a/install/tools/ipactl.in
+++ b/install/tools/ipactl.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors: Simo Sorce <ssorce@redhat.com>
 #
 # Copyright (C) 2008-2010  Red Hat

--- a/ipa.in
+++ b/ipa.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 
 # Authors:
 #   Jason Gerard DeRose <jderose@redhat.com>

--- a/makeaci.in
+++ b/makeaci.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors:
 #   Petr Viktorin <pviktori@redhat.com>
 #   John Dennis <jdennis@redhat.com>

--- a/makeapi.in
+++ b/makeapi.in
@@ -1,4 +1,4 @@
-@PYTHONSHEBANG@
+#!/usr/bin/python3
 # Authors:
 #   Rob Crittenden <rcritten@redhat.com>
 #   John Dennis <jdennis@redhat.com>


### PR DESCRIPTION
Replace the @PYTHONSHEBANG@ substitution with a valid #!/usr/bin/python3
shebang. This turns Python .in files into valid Python files. The files
can now be checked with pylint and IDEs recognize the files as Python
files.

The shebang is still replaced with "#!$(PYTHON) -E" to support
platform-python.

Related: https://pagure.io/freeipa/issue/7984
Signed-off-by: Christian Heimes <cheimes@redhat.com>