### PR TITLE
[Backport][ipa-4-7] Log the raised message when DNS check_zone_overlap fails

### DIFF
--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -326,9 +326,10 @@ def get_auto_reverse_zones(ip_addresses, allow_zone_overlap=False):
         if not allow_zone_overlap:
             try:
                 dnsutil.check_zone_overlap(default_reverse)
-            except ValueError:
+            except ValueError as e:
                 logger.info("Reverse zone %s for IP address %s already exists",
                             default_reverse, ip)
+                logger.debug('%s', e)
                 continue
         auto_zones.append((ip, default_reverse))
     return auto_zones


### PR DESCRIPTION
This PR was opened automatically because PR #3297 was pushed to master and backport to ipa-4-7 is required.