### PR TITLE
ipatest: check if /var/log is not present in error message of ipa backup

### DIFF
--- a/ipatests/test_ipaclient/test_cli_ipa_not_configured.py
+++ b/ipatests/test_ipaclient/test_cli_ipa_not_configured.py
@@ -1,5 +1,9 @@
 import subprocess
 
+import pytest
+
+from ipapython.admintool import SERVER_NOT_CONFIGURED
+
 
 class TestIPANotConfigured:
     """
@@ -24,6 +28,7 @@ class TestIPANotConfigured:
         if unexpected_error:
             assert unexpected_error not in err
 
+    @pytest.mark.xfail(reason="Mismatch in return code, SERVER_NOT_CONFIGURED is 2, but ipa backup returns 1")
     def test_var_log_message_with_ipa_backup(self):
         """
         Test for BZ1428690: ipa-backup does not create log file at /var/log
@@ -31,4 +36,4 @@ class TestIPANotConfigured:
         As the server is not configured yet, command should fail and stderr should not
         contain link to /var/log, as no such log is created
         """
-        self.run_command("ipa backup", 1, None, "not configured on this system", "/var/log")
+        self.run_command("ipa backup", SERVER_NOT_CONFIGURED, None, "not configured on this system", "/var/log")

--- a/ipatests/test_ipaclient/test_cli_ipa_not_configured.py
+++ b/ipatests/test_ipaclient/test_cli_ipa_not_configured.py
@@ -1,0 +1,34 @@
+import subprocess
+
+
+class TestIPANotConfigured:
+    """
+    Test class for CLI commands with ipa server not configured.
+    """
+
+    @staticmethod
+    def run_command(args, return_code, expected_output, expected_error, unexpected_error=None):
+        """
+        Run command with ipa server not configured.
+        Launch the command specified in args.
+        Check that the exit code is as expected and that stdout and stderr
+        contain the expected strings.
+        """
+        p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = p.communicate()
+        assert return_code == p.returncode
+        if expected_output:
+            assert expected_output in out
+        if expected_error:
+            assert expected_error in err
+        if unexpected_error:
+            assert unexpected_error not in err
+
+    def test_var_log_message_with_ipa_backup(self):
+        """
+        Test for BZ1428690: ipa-backup does not create log file at /var/log
+        Launches ipa backup command on system with ipa server not configured.
+        As the server is not configured yet, command should fail and stderr should not
+        contain link to /var/log, as no such log is created
+        """
+        self.run_command("ipa backup", 1, None, "not configured on this system", "/var/log")

--- a/ipatests/test_webui/test_loginscreen.py
+++ b/ipatests/test_webui/test_loginscreen.py
@@ -157,7 +157,7 @@ class TestLoginScreen(UI_driver):
         new_pass_field.send_keys(new_password)
         verify_pass_field.send_keys(new_password)
         verify_pass_field.send_keys(Keys.RETURN)
-        self.wait()
+        self.wait(0.5)
         self.assert_notification(assert_text='Password change complete',
                                  link_text=link_text, link_url=link_url)
 
@@ -369,6 +369,7 @@ class TestLoginScreen(UI_driver):
         # check click on 'Cancel' button
         self.check_cancel()
         self.button_click_on_login_screen('login')
+        self.wait_for_request()
 
         # check if user is not logged
         assert not self.logged_in()


### PR DESCRIPTION
Pagure#6843 - Implemented test for ipa backup fail message mentioning log even in case
no log was created. After ipa-server package is installed, ipa backup is
executed without prior server-install. ipa backup fails and error
message should not contain mention of /var/log as no log was created.

Signed-off-by: Michal Polovka <mpolovka@redhat.com>