### PR TITLE
[Backport][ipa-4-6] adtrust upgrade: fix wrong primary principal name

### DIFF
--- a/daemons/ipa-sam/ipa_sam.c
+++ b/daemons/ipa-sam/ipa_sam.c
@@ -2011,11 +2011,13 @@ static bool handle_cross_realm_princs(struct ipasam_private *ipasam_state,
 							 pwd_outgoing, trusted_dn,
 							 KRB_PRINC_CREATE_DEFAULT);
 
-				/* Second: <OUR FLATNAME$>@<REMOTE REALM> is only used
-				 * for SSSD to be able to talk to AD DCs but it has to
-				 * have canonical name set to <OUR FLATNAME>$ because
-				 * this is the salt used by AD DCs when using this
-				 * principal, otherwise authentication will fail.
+				/* Second: krbtgt/<OUR FLATNAME>@<REMOTE REALM>
+				 * is only used for SSSD to be able to talk to
+				 * AD DCs but it has to have canonical name set
+				 * to krbtgt/<OUR FLATNAME> and alias it to
+				 * <OUR FLATNAME$> because it is the salt used
+				 * by AD DCs when using this principal,
+				 * otherwise authentication will fail.
 				 *
 				 * *disable* use of this principal on our side as it is
 				 * only used to retrieve trusted domain credentials by

--- a/doc/designs/adtrust/oneway-trust-with-shared-secret.md
+++ b/doc/designs/adtrust/oneway-trust-with-shared-secret.md
@@ -131,16 +131,18 @@ and `LOCAL-FLAT` is the NetBIOS name of the FreeIPA primary domain (e.g.
   REMOTE-FLAT$@LOCAL | Trusted domain object account for the Active Directory forest root domain
   krbtgt/REMOTE-FLAT@LOCAL | Alias to REMOTE-FLAT$ TDO
   krbtgt/LOCAL@REMOTE | Cross-realm principal representing IPA domain in Active Directory forest to allow crross-realm TGT issuance from IPA KDC side
-  LOCAL-FLAT$@REMOTE | Trusted domain object account for IPA domain in Active Directory forest
-  krbtgt/LOCAL-FLAT@REMOTE | Alias to LOCAL-FLAT$
+  krbtgt/LOCAL-FLAT@REMOTE | Trusted domain object account for IPA domain in Active Directory forest
+  LOCAL-FLAT$@REMOTE | Alias to krbtgt/LOCAL-FLAT@REMOTE
 
 For inbound trust `ipasam` module creates following principals:
   * `krbtgt/LOCAL@REMOTE`, enabled by default
-  * `LOCAL-FLAT$@REMOTE`, used by SSSD to talk to Active Directory domain
-    controllers, with canonical name set to `LOCAL-FLAT$` because Kerberos KDC
-    must use this salt when issuing tickets for this principal. The use of this
-    principal is disabled on IPA side (IPA KDC does not issue tickets in this name)
-    --- we only retrieve a keytab for the principal in SSSD.
+  * `krbtgt/LOCAL-FLAT@REMOTE`, used by SSSD to talk to Active Directory domain
+    controllers, with canonical name set to `krbtgt/LOCAL-FLAT@REMOTE` because
+    Kerberos KDC must use this salt when issuing tickets for this principal. The
+    use of this principal is disabled on IPA side (IPA KDC does not issue tickets
+    in this name) --- we only retrieve a keytab for the principal in SSSD. SSSD
+    retrieves a keytab for this principal using `LOCAL-FLAT$@REMOTE` Principal
+    name.
 
 For outbound trust `ipasam` module creates following principals:
   * `krbtgt/REMOTE@LOCAL`, enabled by default.

--- a/ipaserver/install/plugins/adtrust.py
+++ b/ipaserver/install/plugins/adtrust.py
@@ -680,12 +680,12 @@ class update_tdo_to_new_layout(Updater):
                     trust_principal, t_realm)
                 continue
 
-            # 4. Create <OUR FLATNAME$>@<REMOTE REALM>, disabled
+            # 4. Create krbtgt/<OUR FLATNAME>@<REMOTE REALM>, disabled
             nbt_principal = self.nbt_principal_template.format(
                 nbt=our_nbt_name, realm=t_realm)
             tgt_principal = self.tgt_principal_template.format(
                 remote=our_nbt_name, local=t_realm)
-            self.set_krb_principal([nbt_principal, tgt_principal],
+            self.set_krb_principal([tgt_principal, nbt_principal],
                                    passwd_incoming,
                                    t_dn,
                                    flags=self.KRB_PRINC_CREATE_DEFAULT |


### PR DESCRIPTION
This PR was opened automatically because PR #3312 was pushed to master and backport to ipa-4-6 is required.