### PR TITLE
[Backport][ipa-4-7] test_nfs.py: change pr-ci configuration to run on master_2repl_1client

### DIFF
--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -845,6 +845,18 @@ jobs:
         timeout: 3600
         topology: *ipaserver
 
+  fedora-28/nfs:
+    requires: [fedora-28/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-28/build_url}'
+        test_suite: test_integration/test_nfs.py::TestNFS
+        template: *ci-master-f28
+        timeout: 9000
+        topology: *master_2repl_1client
+
   fedora-28/automember:
     requires: [fedora-28/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1215,7 +1215,7 @@ jobs:
         test_suite: test_integration/test_nfs.py::TestNFS
         template: *ci-master-f29
         timeout: 9000
-        topology: *master_3repl_1client
+        topology: *master_2repl_1client
 
   fedora-29/automember:
     requires: [fedora-29/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -855,7 +855,7 @@ jobs:
         test_suite: test_integration/test_nfs.py::TestNFS
         template: *ci-master-frawhide
         timeout: 9000
-        topology: *master_3repl_1client
+        topology: *master_2repl_1client
 
   fedora-rawhide/automember:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
MANUAL BACKPORT

manual changes:
* suppressed any changes to ipatests/prci_definitions/nightly_f29.yaml
* added test_nfs.py::TestNFS to ipatests/prci_definitions/nightly_f28.yaml

Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Armando Neto <abiagion@redhat.com>