### PR TITLE
Makefile.am: add .in files to fastlint target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -219,8 +219,19 @@ endif
 	@echo "Fast linting with $(PYTHON) from branch '$(GIT_BRANCH)'"
 
 	@MERGEBASE=$$(git merge-base --fork-point $(GIT_BRANCH)); \
-	FILES=$$(git diff --name-only --diff-filter=d $${MERGEBASE} \
-	    | grep -E '\.py$$'); \
+	PYFILES=$$(git diff --name-only --diff-filter=d $${MERGEBASE} \
+	    | grep -E '\.py$$' ); \
+	INFILES=$$(git diff --name-only --diff-filter=d $${MERGEBASE} \
+	    | grep -E '\.in$$' \
+	    | xargs -n1 file 2>/dev/null | grep Python \
+	    | cut -d':' -f1; ); \
+	if [ -n "$${PYFILES}" ] && [ -n "$${INFILES}" ]; then \
+	    FILES="$$( printf $${PYFILES}\\n$${INFILES} )" ; \
+	elif [ -n "$${PYFILES}" ]; then \
+	    FILES="$${PYFILES}" ; \
+	else \
+	    FILES="$${INFILES}" ; \
+	fi ; \
 	if [ -n "$${FILES}" ]; then \
 	    echo -e "Fast linting files:\n$${FILES}\n"; \
 	    echo "pycodestyle"; \


### PR DESCRIPTION
Previously fastlint would only process .py files.
Detect which .in files are in fact Python files and add
them to the list of files to process during the fastlint
Makefile target.

Fixes: https://pagure.io/freeipa/issue/7984
Signed-off-by: François Cami <fcami@redhat.com>