### PR TITLE
Make dnf more robust and faster

### DIFF
--- a/ipatests/azure/templates/prepare-build.yml
+++ b/ipatests/azure/templates/prepare-build.yml
@@ -2,6 +2,13 @@ steps:
 - script: |
     set -e
     sudo rm -rf /var/cache/dnf/*
+    echo "dnf.conf: enable fastestmirror, use 8 download workers, lower timeout to fail faster, and add more retries"
+    sudo tee -a /etc/dnf/dnf.conf <<EOF > /dev/null
+    fastestmirror = True
+    max_parallel_downloads = 8
+    timeout = 8
+    retries = 20
+    EOF
     echo 'Disable modular repositories'
     sudo dnf config-manager '*modular*' --set-disabled
     sudo dnf makecache || :


### PR DESCRIPTION
Sometimes the prepare-build step of azure pipelines fails with download errors:
"configure: error: Package requirements (nspr) were not met:"
This can be due to fastestmirror not being used to check
mirror availability and sometimes speed. Combined with a
too-low default number of retries, and a high timeout this
can lead to download failures that could be avoided.
Activate fastestmirror, add more download workers, and tune
timeout/retries to make dnf more reliable.
    
Fixes: https://pagure.io/freeipa/issue/7999
Signed-off-by: François Cami <fcami@redhat.com>
