### PR TITLE
[Backport][ipa-4-6] dnsrecord-mod: allow to modify ttl without passing the record

### DIFF
--- a/ipalib/dns.py
+++ b/ipalib/dns.py
@@ -55,7 +55,7 @@ def get_extra_rrtype(name):
 
 
 def has_cli_options(cmd, options, no_option_msg, allow_empty_attrs=False):
-    sufficient = ('setattr', 'addattr', 'delattr', 'rename')
+    sufficient = ('setattr', 'addattr', 'delattr', 'rename', 'dnsttl')
     if any(k in options for k in sufficient):
         return
 

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -1952,7 +1952,7 @@ class test_dns(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [name1_dnsname],
-                    'dnsttl': ['500'],
+                    'dnsttl': [u'500'],
                     'arecord': [revname2_ip],
                 },
             },

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -1944,6 +1944,34 @@ class test_dns(Declarative):
             },
         ),
 
+        dict(
+            desc='Modify ttl of record %r in zone %r' % (name1, zone1),
+            command=('dnsrecord_mod', [zone1, name1], {'dnsttl': 500}),
+            expected={
+                'value': name1_dnsname,
+                'summary': None,
+                'result': {
+                    'idnsname': [name1_dnsname],
+                    'dnsttl': ['500'],
+                    'arecord': [revname2_ip],
+                },
+            },
+        ),
+
+
+        dict(
+            desc='Delete ttl of record %r in zone %r' % (name1, zone1),
+            command=('dnsrecord_mod', [zone1, name1], {'dnsttl': None}),
+            expected={
+                'value': name1_dnsname,
+                'summary': None,
+                'result': {
+                    'idnsname': [name1_dnsname],
+                    'arecord': [revname2_ip],
+                },
+            },
+        ),
+
 
         dict(
             desc='Try to add per-zone permission for unknown zone',


### PR DESCRIPTION
This PR was opened automatically because PR #3288 was pushed to master and backport to ipa-4-6 is required.