### PR TITLE
ipatests: filter_users should be applied correctly if SSSD starts offline

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1969,3 +1969,9 @@ def remote_ini_file(host, filename):
 def is_selinux_enabled(host):
     res = host.run_command('selinuxenabled', ok_returncode=(0, 1))
     return res.returncode == 0
+
+
+def get_logsize(host, logfile):
+    """ get current logsize"""
+    logsize = len(host.get_file_contents(logfile))
+    return logsize


### PR DESCRIPTION
Added regression tests which validates that filter_users is applied correctly
when SSSD starts in offline mode, which checks that no look up
should be in data provider.

Related Tickets:
https://pagure.io/SSSD/sssd/issue/3983
https://pagure.io/SSSD/sssd/issue/3978

Signed-off-by: Anuja More <amore@redhat.com>