### PR TITLE
[ipa-4-6] mod_nss: stop using NSSProtocols TLS 1.0 and 1.1

### DIFF
--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -46,7 +46,7 @@ from ipalib.base import check_name
 from ipalib.constants import (
     CONFIG_SECTION,
     OVERRIDE_ERROR, SET_ERROR, DEL_ERROR,
-    TLS_VERSIONS
+    TLS_VERSIONS, TLS_VERSION_DEFAULT_MIN, TLS_VERSION_DEFAULT_MAX,
 )
 from ipalib import errors
 
@@ -632,14 +632,14 @@ class Env(object):
 
         # set the best known TLS version if min/max versions are not set
         if 'tls_version_min' not in self:
-            self.tls_version_min = TLS_VERSIONS[-1]
+            self.tls_version_min = TLS_VERSION_DEFAULT_MIN
         elif self.tls_version_min not in TLS_VERSIONS:
             raise errors.EnvironmentError(
                 "Unknown TLS version '{ver}' set in tls_version_min."
                 .format(ver=self.tls_version_min))
 
         if 'tls_version_max' not in self:
-            self.tls_version_max = TLS_VERSIONS[-1]
+            self.tls_version_max = TLS_VERSION_DEFAULT_MAX
         elif self.tls_version_max not in TLS_VERSIONS:
             raise errors.EnvironmentError(
                 "Unknown TLS version '{ver}' set in tls_version_max."

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -35,6 +35,28 @@ except Exception:
     except Exception:
         FQDN = None
 
+# TLS related constants
+# * SSL2 and SSL3 are broken.
+# * TLS1.0 and TLS1.1 are no longer state of the art.
+# * TLS1.3 support is not yet stable, e.g. issues with PHA.
+# Therefore only TLS 1.2 is enabled by default.
+
+TLS_VERSIONS = [
+    "ssl2",
+    "ssl3",
+    "tls1.0",
+    "tls1.1",
+    "tls1.2",
+    "tls1.3",
+]
+TLS_VERSION_MINIMAL = "tls1.0"
+TLS_VERSION_DEFAULT_MIN = "tls1.2"
+TLS_VERSION_DEFAULT_MAX = "tls1.2"
+
+# high ciphers without RC4, MD5, TripleDES, pre-shared key
+# and secure remote password
+TLS_HIGH_CIPHERS = "HIGH:!aNULL:!eNULL:!MD5:!RC4:!3DES:!PSK:!SRP"
+
 # regular expression NameSpace member names must match:
 NAME_REGEX = r'^[a-z][_a-z0-9]*[a-z0-9]$|^[a-z]$'
 
@@ -143,8 +165,8 @@ DEFAULT_CONFIG = (
     ('rpc_protocol', 'jsonrpc'),
 
     # Define an inclusive range of SSL/TLS version support
-    ('tls_version_min', 'tls1.0'),
-    ('tls_version_max', 'tls1.2'),
+    ('tls_version_min', TLS_VERSION_DEFAULT_MIN),
+    ('tls_version_max', TLS_VERSION_DEFAULT_MAX),
 
     # Time to wait for a service to start, in seconds
     ('startup_timeout', 300),
@@ -299,19 +321,6 @@ ANON_USER = 'WELLKNOWN/ANONYMOUS'
 # IPA API Framework user
 IPAAPI_USER = 'ipaapi'
 IPAAPI_GROUP = 'ipaapi'
-
-# TLS related constants
-TLS_VERSIONS = [
-    "ssl2",
-    "ssl3",
-    "tls1.0",
-    "tls1.1",
-    "tls1.2"
-]
-TLS_VERSION_MINIMAL = "tls1.0"
-# high ciphers without RC4, MD5, TripleDES, pre-shared key
-# and secure remote password
-TLS_HIGH_CIPHERS = "HIGH:!aNULL:!eNULL:!MD5:!RC4:!3DES:!PSK:!SRP"
 
 # Use cache path
 USER_CACHE_PATH = (

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -56,7 +56,8 @@ except ImportError:
 from ipalib import errors, messages
 from ipalib.constants import (
     DOMAIN_LEVEL_0,
-    TLS_VERSIONS, TLS_VERSION_MINIMAL, TLS_HIGH_CIPHERS
+    TLS_VERSIONS, TLS_VERSION_MINIMAL, TLS_HIGH_CIPHERS,
+    TLS_VERSION_DEFAULT_MIN, TLS_VERSION_DEFAULT_MAX,
 )
 from ipalib.text import _
 from ipaplatform.paths import paths
@@ -280,8 +281,8 @@ def create_https_connection(
     cafile=None,
     client_certfile=None, client_keyfile=None,
     keyfile_passwd=None,
-    tls_version_min="tls1.1",
-    tls_version_max="tls1.2",
+    tls_version_min=TLS_VERSION_DEFAULT_MIN,
+    tls_version_max=TLS_VERSION_DEFAULT_MAX,
     **kwargs
 ):
     """
@@ -311,6 +312,7 @@ def create_https_connection(
         "tls1.0": ssl.OP_NO_TLSv1,
         "tls1.1": ssl.OP_NO_TLSv1_1,
         "tls1.2": ssl.OP_NO_TLSv1_2,
+        "tls1.3": getattr(ssl, "OP_NO_TLSv1_3", 0),
     }
     # pylint: enable=no-member
 

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -160,7 +160,7 @@ class HTTPInstance(service.Service):
         self.step("setting mod_nss port to 443", self.__set_mod_nss_port)
         self.step("setting mod_nss cipher suite",
                   self.set_mod_nss_cipher_suite)
-        self.step("setting mod_nss protocol list to TLSv1.0 - TLSv1.2",
+        self.step("setting mod_nss protocol list to TLSv1.2",
                   self.set_mod_nss_protocol)
         self.step("setting mod_nss password file", self.__set_mod_nss_passwordfile)
         self.step("enabling mod_nss renegotiate", self.enable_mod_nss_renegotiate)
@@ -274,7 +274,7 @@ class HTTPInstance(service.Service):
         return nickname
 
     def set_mod_nss_protocol(self):
-        installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSProtocol', 'TLSv1.0,TLSv1.1,TLSv1.2', False)
+        installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSProtocol', 'TLSv1.2', False)
 
     def enable_mod_nss_renegotiate(self):
         installutils.set_directive(paths.HTTPD_NSS_CONF, 'NSSRenegotiation', 'on', False)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1482,13 +1482,14 @@ def fix_trust_flags():
 def update_mod_nss_protocol(http):
     logger.info('[Updating mod_nss protocol versions]')
 
-    if sysupgrade.get_upgrade_state('nss.conf', 'protocol_updated_tls12'):
+    if sysupgrade.get_upgrade_state('nss.conf', 'protocol_remove_tls_1.0_1.1'):
         logger.info("Protocol versions already updated")
         return
 
     http.set_mod_nss_protocol()
 
-    sysupgrade.set_upgrade_state('nss.conf', 'protocol_updated_tls12', True)
+    sysupgrade.set_upgrade_state('nss.conf', 'protocol_remove_tls_1.0_1.1',
+                                 True)
 
 
 def disable_mod_nss_ocsp(http):


### PR DESCRIPTION
TLS 1.0 and 1.1 will be deprecated in march 2020, and TLS 1.2 should be used
instead.
- During installation of IPA server, the NSS module used by apache server
is configured with TLS 1.2 only.
- During upgrade, the NSS module is configured with TLS 1.2 only (other
protocols are removed).

Fixes: https://pagure.io/freeipa/issue/7995