### PR TITLE
[Backport][ipa-4-7] Use only TLS 1.2 by default

### DIFF
--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -46,7 +46,7 @@ from ipalib.base import check_name
 from ipalib.constants import (
     CONFIG_SECTION,
     OVERRIDE_ERROR, SET_ERROR, DEL_ERROR,
-    TLS_VERSIONS
+    TLS_VERSIONS, TLS_VERSION_DEFAULT_MIN, TLS_VERSION_DEFAULT_MAX,
 )
 from ipalib import errors
 
@@ -633,14 +633,14 @@ class Env(object):
 
         # set the best known TLS version if min/max versions are not set
         if 'tls_version_min' not in self:
-            self.tls_version_min = TLS_VERSIONS[-1]
+            self.tls_version_min = TLS_VERSION_DEFAULT_MIN
         elif self.tls_version_min not in TLS_VERSIONS:
             raise errors.EnvironmentError(
                 "Unknown TLS version '{ver}' set in tls_version_min."
                 .format(ver=self.tls_version_min))
 
         if 'tls_version_max' not in self:
-            self.tls_version_max = TLS_VERSIONS[-1]
+            self.tls_version_max = TLS_VERSION_DEFAULT_MAX
         elif self.tls_version_max not in TLS_VERSIONS:
             raise errors.EnvironmentError(
                 "Unknown TLS version '{ver}' set in tls_version_max."

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -35,6 +35,24 @@ except Exception:
     except Exception:
         FQDN = None
 
+# TLS related constants
+# * SSL2 and SSL3 are broken.
+# * TLS1.0 and TLS1.1 are no longer state of the art.
+# * TLS1.3 support is not yet stable, e.g. issues with PHA.
+# Therefore only TLS 1.2 is enabled by default.
+
+TLS_VERSIONS = [
+    "ssl2",
+    "ssl3",
+    "tls1.0",
+    "tls1.1",
+    "tls1.2",
+    "tls1.3",
+]
+TLS_VERSION_MINIMAL = "tls1.0"
+TLS_VERSION_DEFAULT_MIN = "tls1.2"
+TLS_VERSION_DEFAULT_MAX = "tls1.2"
+
 # regular expression NameSpace member names must match:
 NAME_REGEX = r'^[a-z][_a-z0-9]*[a-z0-9]$|^[a-z]$'
 
@@ -144,8 +162,8 @@ DEFAULT_CONFIG = (
     ('rpc_protocol', 'jsonrpc'),
 
     # Define an inclusive range of SSL/TLS version support
-    ('tls_version_min', 'tls1.0'),
-    ('tls_version_max', 'tls1.2'),
+    ('tls_version_min', TLS_VERSION_DEFAULT_MIN),
+    ('tls_version_max', TLS_VERSION_DEFAULT_MAX),
 
     # Time to wait for a service to start, in seconds.
     # Note that systemd has a DefaultTimeoutStartSec of 90 seconds. Higher
@@ -305,17 +323,6 @@ ANON_USER = 'WELLKNOWN/ANONYMOUS'
 # IPA API Framework user
 IPAAPI_USER = 'ipaapi'
 IPAAPI_GROUP = 'ipaapi'
-
-# TLS related constants
-TLS_VERSIONS = [
-    "ssl2",
-    "ssl3",
-    "tls1.0",
-    "tls1.1",
-    "tls1.2"
-]
-TLS_VERSION_MINIMAL = "tls1.0"
-
 
 # Use cache path
 USER_CACHE_PATH = (

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -56,7 +56,8 @@ except ImportError:
 from ipalib import errors, messages
 from ipalib.constants import (
     DOMAIN_LEVEL_0,
-    TLS_VERSIONS, TLS_VERSION_MINIMAL
+    TLS_VERSIONS, TLS_VERSION_MINIMAL, TLS_VERSION_DEFAULT_MIN,
+    TLS_VERSION_DEFAULT_MAX,
 )
 from ipalib.text import _
 from ipaplatform.constants import constants
@@ -314,8 +315,8 @@ def create_https_connection(
     cafile=None,
     client_certfile=None, client_keyfile=None,
     keyfile_passwd=None,
-    tls_version_min="tls1.1",
-    tls_version_max="tls1.2",
+    tls_version_min=TLS_VERSION_DEFAULT_MIN,
+    tls_version_max=TLS_VERSION_DEFAULT_MAX,
     **kwargs
 ):
     """
@@ -345,6 +346,7 @@ def create_https_connection(
         "tls1.0": ssl.OP_NO_TLSv1,
         "tls1.1": ssl.OP_NO_TLSv1_1,
         "tls1.2": ssl.OP_NO_TLSv1_2,
+        "tls1.3": getattr(ssl, "OP_NO_TLSv1_3", 0),
     }
     # pylint: enable=no-member
 

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -246,6 +246,10 @@ class BaseTaskNamespace(object):
         """Configure WSGI for correct Python version"""
         raise NotImplementedError()
 
+    def configure_httpd_protocol(self):
+        """Configure TLS protocols in Apache"""
+        raise NotImplementedError()
+
     def is_fips_enabled(self):
         return False
 

--- a/ipaplatform/debian/tasks.py
+++ b/ipaplatform/debian/tasks.py
@@ -10,7 +10,9 @@ from __future__ import absolute_import
 
 from ipaplatform.base.tasks import BaseTaskNamespace
 from ipaplatform.redhat.tasks import RedHatTaskNamespace
+from ipaplatform.paths import paths
 
+from ipapython import directivesetter
 from ipapython import ipautil
 
 class DebianTaskNamespace(RedHatTaskNamespace):
@@ -68,6 +70,11 @@ class DebianTaskNamespace(RedHatTaskNamespace):
     def configure_httpd_wsgi_conf(self):
         # Debian doesn't require special mod_wsgi configuration
         pass
+
+    def configure_httpd_protocol(self):
+        directivesetter.set_directive(paths.HTTPD_SSL_CONF,
+                                      'SSLProtocol',
+                                      'all -SSLv3', False)
 
     def setup_httpd_logging(self):
         # Debian handles httpd logging differently

--- a/ipaplatform/debian/tasks.py
+++ b/ipaplatform/debian/tasks.py
@@ -72,9 +72,10 @@ class DebianTaskNamespace(RedHatTaskNamespace):
         pass
 
     def configure_httpd_protocol(self):
+        # TLS 1.3 is not yet supported
         directivesetter.set_directive(paths.HTTPD_SSL_CONF,
                                       'SSLProtocol',
-                                      'all -SSLv3', False)
+                                      'TLSv1.2', False)
 
     def setup_httpd_logging(self):
         # Debian handles httpd logging differently

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -591,10 +591,10 @@ class RedHatTaskNamespace(BaseTaskNamespace):
         self.systemd_daemon_reload()
 
     def configure_httpd_protocol(self):
-        """Drop SSLProtocol directive and let crypto policy handle it"""
+        # TLS 1.3 is not yet supported
         directivesetter.set_directive(paths.HTTPD_SSL_CONF,
                                       'SSLProtocol',
-                                      None, False)
+                                      'TLSv1.2', False)
 
     def set_hostname(self, hostname):
         ipautil.run([paths.BIN_HOSTNAMECTL, 'set-hostname', hostname])

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -590,6 +590,12 @@ class RedHatTaskNamespace(BaseTaskNamespace):
 
         self.systemd_daemon_reload()
 
+    def configure_httpd_protocol(self):
+        """Drop SSLProtocol directive and let crypto policy handle it"""
+        directivesetter.set_directive(paths.HTTPD_SSL_CONF,
+                                      'SSLProtocol',
+                                      None, False)
+
     def set_hostname(self, hostname):
         ipautil.run([paths.BIN_HOSTNAMECTL, 'set-hostname', hostname])
 

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -123,7 +123,7 @@ class HTTPInstance(service.Service):
         self.step("disabling nss.conf", self.disable_nss_conf)
         self.step("configuring mod_ssl certificate paths",
                   self.configure_mod_ssl_certs)
-        self.step("setting mod_ssl protocol list to TLSv1.0 - TLSv1.2",
+        self.step("setting mod_ssl protocol list",
                   self.set_mod_ssl_protocol)
         self.step("configuring mod_ssl log directory",
                   self.set_mod_ssl_logdir)
@@ -244,9 +244,7 @@ class HTTPInstance(service.Service):
         open(paths.HTTPD_NSS_CONF, 'w').close()
 
     def set_mod_ssl_protocol(self):
-        directivesetter.set_directive(paths.HTTPD_SSL_CONF,
-                                   'SSLProtocol',
-                                   '+TLSv1 +TLSv1.1 +TLSv1.2', False)
+        tasks.configure_httpd_protocol()
 
     def set_mod_ssl_logdir(self):
         tasks.setup_httpd_logging()


### PR DESCRIPTION
This PR was opened automatically because PR #3350 was pushed to master and backport to ipa-4-7 is required.