### PR TITLE
ipatests: fix ipatests/test_xmlrpc/test_dns_plugin.py

### DIFF
--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -1956,7 +1956,7 @@ class test_dns(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [name1_dnsname],
-                    'dnsttl': ['500'],
+                    'dnsttl': [u'500'],
                     'arecord': [revname2_ip],
                 },
             },


### PR DESCRIPTION
The test is calling dnsrecord-mod --ttl and should expect a unicode
value in order to be python2/python3 compatible.

Related: https://pagure.io/freeipa/issue/7982