### PR TITLE
prci: bump ci-master-f30 template

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -23,7 +23,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f30
           name: freeipa/ci-master-f30
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -35,7 +35,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f30
           name: freeipa/ci-master-f30
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -41,7 +41,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f30
           name: freeipa/ci-master-f30
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
No major changes, dependencies updated.

Signed-off-by: Armando Neto <abiagion@redhat.com>

Complete `nightly_master.yaml` execution: https://github.com/freeipa-pr-ci2/freeipa/pull/29