### PR TITLE
Use system-wide crypto policy for TLS ciphers

### DIFF
--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -339,9 +339,9 @@ def create_https_connection(
         ssl.OP_SINGLE_ECDH_USE
     )
 
-    # high ciphers without RC4, MD5, TripleDES, pre-shared key and secure
-    # remote password. Uses system crypto policies on some platforms.
-    ctx.set_ciphers(constants.TLS_HIGH_CIPHERS)
+    if constants.TLS_HIGH_CIPHERS is not None:
+        # configure ciphers, uses system crypto policies on RH platforms.
+        ctx.set_ciphers(constants.TLS_HIGH_CIPHERS)
 
     # pylint: enable=no-member
     # set up the correct TLS version flags for the SSL context

--- a/ipaplatform/fedora/constants.py
+++ b/ipaplatform/fedora/constants.py
@@ -24,10 +24,6 @@ class FedoraConstantsNamespace(RedHatConstantsNamespace):
     MOD_WSGI_PYTHON2 = "modules/mod_wsgi.so"
     MOD_WSGI_PYTHON3 = "modules/mod_wsgi_python3.so"
 
-    # System-wide crypto policy, but without TripleDES, pre-shared key,
-    # secure remote password, and DSA cert authentication.
-    # see https://fedoraproject.org/wiki/Changes/CryptoPolicy
-    TLS_HIGH_CIPHERS = "PROFILE=SYSTEM:!3DES:!PSK:!SRP:!aDSS"
     if HAS_NFS_CONF:
         SECURE_NFS_VAR = None
 

--- a/ipaplatform/redhat/constants.py
+++ b/ipaplatform/redhat/constants.py
@@ -14,6 +14,10 @@ from ipaplatform.base.constants import BaseConstantsNamespace
 
 
 class RedHatConstantsNamespace(BaseConstantsNamespace):
-    pass
+    # System-wide crypto policy, but without TripleDES, pre-shared key,
+    # secure remote password, and DSA cert authentication.
+    # see https://fedoraproject.org/wiki/Changes/CryptoPolicy
+    TLS_HIGH_CIPHERS = "PROFILE=SYSTEM:!3DES:!PSK:!SRP:!aDSS"
+
 
 constants = RedHatConstantsNamespace()


### PR DESCRIPTION
IPA now uses the system-wide crypto policy for TLS ciphers on RHEL. It's
also now possible to keep the default policy by setting TLS_HIGH_CIPHERS
to None.

Fixes: https://pagure.io/freeipa/issue/7998
Signed-off-by: Christian Heimes <cheimes@redhat.com>