### PR TITLE
Use nis-domainname.service on all RH platforms

### DIFF
--- a/ipaplatform/fedora/services.py
+++ b/ipaplatform/fedora/services.py
@@ -24,20 +24,11 @@ Contains Fedora-specific service class implementations.
 
 from __future__ import absolute_import
 
-from ipaplatform.osinfo import osinfo
 from ipaplatform.redhat import services as redhat_services
 
 # Mappings from service names as FreeIPA code references to these services
 # to their actual systemd service names
 fedora_system_units = redhat_services.redhat_system_units.copy()
-
-# Fedora 28 and earlier have fedora-domainname.service. Starting from
-# Fedora 29, the service is called nis-domainname.service as defined in
-# ipaplatform.redhat.services.
-HAS_FEDORA_DOMAINNAME_SERVICE = osinfo.version_number <= (28,)
-
-if HAS_FEDORA_DOMAINNAME_SERVICE:
-    fedora_system_units['domainname'] = 'fedora-domainname.service'
 
 
 # Service classes that implement Fedora-specific behaviour
@@ -50,8 +41,6 @@ class FedoraService(redhat_services.RedHatService):
 # of specified name
 
 def fedora_service_class_factory(name, api=None):
-    if HAS_FEDORA_DOMAINNAME_SERVICE and name == 'domainname':
-        return FedoraService(name, api)
     return redhat_services.redhat_service_class_factory(name, api)
 
 

--- a/ipaplatform/rhel/services.py
+++ b/ipaplatform/rhel/services.py
@@ -28,10 +28,7 @@ from ipaplatform.redhat import services as redhat_services
 
 # Mappings from service names as FreeIPA code references to these services
 # to their actual systemd service names
-rhel_system_units = redhat_services.redhat_system_units
-
-# Service that sets domainname on RHEL is called rhel-domainname.service
-rhel_system_units['domainname'] = 'rhel-domainname.service'
+rhel_system_units = redhat_services.redhat_system_units.copy()
 
 
 # Service classes that implement RHEL-specific behaviour
@@ -44,8 +41,6 @@ class RHELService(redhat_services.RedHatService):
 # of specified name
 
 def rhel_service_class_factory(name, api=None):
-    if name == 'domainname':
-        return RHELService(name, api)
     return redhat_services.redhat_service_class_factory(name, api)
 
 


### PR DESCRIPTION
RHEL 8 and Fedora >= 29 use "nis-domainname.service" as service name for
domainname service. Remove special code in ipaplatform.rhel and for Fedora
< 28. Only Fedora 29+ is supported by IPA 4.8.

Fixes: https://pagure.io/freeipa/issue/8004
Signed-off-by: Christian Heimes <cheimes@redhat.com>