### PR TITLE
[ipa-4-6] tox: force pytest version to the 4.6.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,11 @@ commands=
     {envbindir}/ipa --help
     {envpython} -bb {envbindir}/ipa-run-tests --ipaclient-unittests
 
+[testenv:py36]
+deps=
+    pytest==4.6.4
+    {[testenv]deps}
+
 [testenv:pylint2]
 basepython=python2.7
 deps=


### PR DESCRIPTION
As of today, latest version of pytest (5.0.0), released on June 28th is freezing tox on py36 right after the test session starts.

Version 4.6.4 was released on the same date.

Signed-off-by: Armando Neto <abiagion@redhat.com>