### PR TITLE
ipatests/azure: display actual dnf repo URLs

### DIFF
--- a/ipatests/azure/templates/prepare-build.yml
+++ b/ipatests/azure/templates/prepare-build.yml
@@ -11,6 +11,10 @@ steps:
     EOF
     echo 'Disable modular repositories'
     sudo dnf config-manager '*modular*' --set-disabled
+    echo "Fedora mirror metalink content:"
+    for metalink in $(sudo dnf repolist -v |grep Repo-metalink | awk '{print $2}' ) ; do echo '###############' ; echo '####' ; echo $metalink ; echo '####' ; curl $metalink ; done
+    echo "Fastestmirror results:"
+    sudo cat /var/cache/dnf/fastestmirror.cache
     sudo dnf makecache || :
     echo "Installing base development environment"
     sudo dnf install -y gdb make autoconf rpm-build gettext-devel automake libtool 'nodejs(abi) < 11' docker python3-paramiko || :


### PR DESCRIPTION
Display which dnf repositories were available at the prepare-build step via metalink.
Also display the fastestmirror cache.
    
Signed-off-by: François Cami <fcami@redhat.com>
