### PR TITLE
[ipa-4-7] Update nodejs requirement to match master branch

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -192,7 +192,7 @@ BuildRequires:  libuuid-devel
 BuildRequires:  libsss_idmap-devel
 BuildRequires:  libsss_certmap-devel
 BuildRequires:  libsss_nss_idmap-devel >= %{sssd_version}
-BuildRequires:  nodejs
+BuildRequires:  nodejs(abi) < 11
 BuildRequires:  uglify-js
 BuildRequires:  libverto-devel
 BuildRequires:  libunistring-devel


### PR DESCRIPTION
Required to install build deps in Fedora 29 container used by Travis.

Line from `master`:
https://github.com/freeipa/freeipa/blob/4740655260caa7baee4473b0d35840a4c0da3dac/freeipa.spec.in#L171

Without that I get:
```
Error:
Problem: cannot install the best candidate for the job
- package nodejs-1:12.4.0-1.module_f29+4532+ea069662.x86_64 is excluded
(try to add '--skip-broken' to skip uninstallable packages)
```

Signed-off-by: Armando Neto <abiagion@redhat.com>