### PR TITLE
Fix `test_webui.test_selinuxusermap`

### DIFF
--- a/install/updates/50-ipaconfig.update
+++ b/install/updates/50-ipaconfig.update
@@ -1,4 +1,5 @@
 dn: cn=ipaConfig,cn=etc,$SUFFIX
+replace: ipaSELinuxUserMapOrder: guest_u:s0$$$$xguest_u:s0$$$$user_u:s0$$$$staff_u:s0-s0:c0.c1023$$$$sysadm_u:s0-s0:c0.c1023$$$$unconfined_u:s0-s0:c0.c1023::$SELINUX_USERMAP_ORDER
 replace: ipaSELinuxUserMapOrder: ipaSELinuxUserMapOrder: guest_u:s0$$xguest_u:s0$$user_u:s0$$staff_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023::guest_u:s0$$xguest_u:s0$$user_u:s0$$staff_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023
 replace: ipaSELinuxUserMapOrder: guest_u:s0$$xguest_u:s0$$user_u:s0-s0:c0.c1023$$staff_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023::guest_u:s0$$xguest_u:s0$$user_u:s0$$staff_u:s0-s0:c0.c1023$$unconfined_u:s0-s0:c0.c1023
 add:ipaSELinuxUserMapDefault: $SELINUX_USERMAP_DEFAULT

--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -62,11 +62,11 @@ class BaseConstantsNamespace:
     SELINUX_USERMAP_DEFAULT = "unconfined_u:s0-s0:c0.c1023"
     SELINUX_USERMAP_ORDER = (
         "guest_u:s0"
-        "$$xguest_u:s0"
-        "$$user_u:s0"
-        "$$staff_u:s0-s0:c0.c1023"
-        "$$sysadm_u:s0-s0:c0.c1023"
-        "$$unconfined_u:s0-s0:c0.c1023"
+        "$xguest_u:s0"
+        "$user_u:s0"
+        "$staff_u:s0-s0:c0.c1023"
+        "$sysadm_u:s0-s0:c0.c1023"
+        "$unconfined_u:s0-s0:c0.c1023"
     )
     SSSD_USER = "sssd"
     # WSGI module override, only used on Fedora

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -322,6 +322,9 @@ class LDAPUpdate:
         if not self.sub_dict.get("SELINUX_USERMAP_DEFAULT"):
             self.sub_dict["SELINUX_USERMAP_DEFAULT"] = \
                 platformconstants.SELINUX_USERMAP_DEFAULT
+        if not self.sub_dict.get("SELINUX_USERMAP_ORDER"):
+            self.sub_dict["SELINUX_USERMAP_ORDER"] = \
+                platformconstants.SELINUX_USERMAP_ORDER
         self.api = create_api(mode=None)
         self.api.bootstrap(in_server=True,
                            context='updates',

--- a/ipatests/test_integration/test_winsyncmigrate.py
+++ b/ipatests/test_integration/test_winsyncmigrate.py
@@ -59,7 +59,7 @@ class TestWinsyncMigrate(IntegrationTest):
     ipa_group = 'ipa_group'
     ad_user = 'testuser'
     default_shell = platformconstants.DEFAULT_SHELL
-    selinuxuser = platformconstants.SELINUX_USERMAP_ORDER.split("$$")[0]
+    selinuxuser = platformconstants.SELINUX_USERMAP_ORDER.split("$")[0]
     test_role = 'test_role'
     test_hbac_rule = 'test_hbac_rule'
     test_selinux_map = 'test_selinux_map'

--- a/ipatests/test_webui/data_selinuxusermap.py
+++ b/ipatests/test_webui/data_selinuxusermap.py
@@ -5,8 +5,8 @@
 from ipaplatform.constants import constants as platformconstants
 
 # for example, user_u:s0
-selinuxuser1 = platformconstants.SELINUX_USERMAP_ORDER.split("$$")[0]
-selinuxuser2 = platformconstants.SELINUX_USERMAP_ORDER.split("$$")[1]
+selinuxuser1 = platformconstants.SELINUX_USERMAP_ORDER.split("$")[0]
+selinuxuser2 = platformconstants.SELINUX_USERMAP_ORDER.split("$")[1]
 
 selinux_mcs_max = platformconstants.SELINUX_MCS_MAX
 selinux_mls_max = platformconstants.SELINUX_MLS_MAX

--- a/ipatests/test_xmlrpc/test_selinuxusermap_plugin.py
+++ b/ipatests/test_xmlrpc/test_selinuxusermap_plugin.py
@@ -32,8 +32,8 @@ from ipatests.test_xmlrpc.test_user_plugin import get_user_result
 import pytest
 
 rule1 = u'selinuxrule1'
-selinuxuser1 = platformconstants.SELINUX_USERMAP_ORDER.split("$$")[0]
-selinuxuser2 = platformconstants.SELINUX_USERMAP_ORDER.split("$$")[1]
+selinuxuser1 = platformconstants.SELINUX_USERMAP_ORDER.split("$")[0]
+selinuxuser2 = platformconstants.SELINUX_USERMAP_ORDER.split("$")[1]
 
 INVALID_MCS = "Invalid MCS value, must match {}, where max category {}".format(
     platformconstants.SELINUX_MCS_REGEX,


### PR DESCRIPTION
A previous refactoring of SELinux tests has had a wrong
assumption about the user field separator within
ipaSELinuxUserMapOrder. That was '$$', but should be just '$'.

Actually, '.ldif' and '.update' files are passed through
Python template string substitution:

> $$ is an escape; it is replaced with a single $.
> $identifier names a substitution placeholder matching
> a mapping key of "identifier"

This means that the text to be substituted on should not be escaped.
The wrong ipaSELinuxUserMapOrder previously set on a fresh install will be replaced on
upgrade.

Fixes: https://pagure.io/freeipa/issue/8005