### PR TITLE
[ipa-4-6] Update the ciphers list

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -55,7 +55,7 @@ TLS_VERSION_DEFAULT_MAX = "tls1.2"
 
 # high ciphers without RC4, MD5, TripleDES, pre-shared key
 # and secure remote password
-TLS_HIGH_CIPHERS = "HIGH:!aNULL:!eNULL:!MD5:!RC4:!3DES:!PSK:!SRP"
+TLS_HIGH_CIPHERS = "HIGH:!aNULL:!eNULL:!MD5:!RC4:!3DES:!PSK:!SRP:!kECDH:!kDH"
 
 # regular expression NameSpace member names must match:
 NAME_REGEX = r'^[a-z][_a-z0-9]*[a-z0-9]$|^[a-z]$'


### PR DESCRIPTION
The previous list of ciphers was allowing weak algorithms.
The fix removes:
- kECDH: cipher suites using fixed ECDH key agreement signed by CAs with RSA
and ECDSA keys or either respectively.
- kDH: cipher suites using DH key agreement and DH certificates signed by
CAs with RSA and DSS keys or either respectively.

Fixes: https://pagure.io/freeipa/issue/8000