### PR TITLE
Modify the way replication timeout is handled, logged

### DIFF
--- a/client/man/default.conf.5
+++ b/client/man/default.conf.5
@@ -77,6 +77,9 @@ Specifies the hostname of the dogtag CA server. The default is the hostname of t
 .B ca_port <port>
 Specifies the insecure CA end user port. The default is 8080.
 .TP
+.B certmonger_wait_timeout <seconds>
+The time to wait for a certmonger request to complete during installation. The default value is 300 seconds.
+.TP
 .B context <context>
 Specifies the context that IPA is being executed in. IPA may operate differently depending on the context. The current defined contexts are cli and server. Additionally this value is used to load /etc/ipa/\fBcontext\fR.conf to provide context\-specific configuration. For example, if you want to always perform client requests in verbose mode but do not want to have verbose enabled on the server, add the verbose option to \fI/etc/ipa/cli.conf\fR.
 .TP
@@ -97,6 +100,9 @@ Specifies whether an IPA client should attempt to fall back and try other servic
 .TP
 .B host <hostname>
 Specifies the local system hostname.
+.TP
+.B http_timeout <seconds>
+Timeout for HTTP blocking requests (e.g. connection). The default value is 30 seconds.
 .TP
 .B in_server <boolean>
 Specifies whether requests should be forwarded to an IPA server or handled locally. This is used internally by IPA in a similar way as context. The same IPA framework is used by the ipa command\-line tool and the server. This setting tells the framework whether it should execute the command as if on the server or forward it via XML\-RPC to a remote server.
@@ -159,6 +165,9 @@ Specifies the name of the CA back end to use. The current options are \fBdogtag\
 .TP
 .B realm <realm>
 Specifies the Kerberos realm.
+.TP
+.B replication_wait_timeout <seconds>
+The time to wait for a new entry to be replicated during replica installation. The default value is 300 seconds.
 .TP
 .B server <hostname>
 Specifies the IPA Server hostname.

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -173,6 +173,8 @@ DEFAULT_CONFIG = (
     ('http_timeout', 30),
     # How long to wait for an entry to appear on a replica
     ('replication_wait_timeout', 300),
+    # How long to wait for a certmonger request to finish
+    ('certmonger_wait_timeout', 300),
 
     # Web Application mount points
     ('mount_ipa', '/ipa/'),

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -874,7 +874,7 @@ class CAInstance(DogtagInstance):
                 pre_command='renew_ra_cert_pre',
                 post_command='renew_ra_cert',
                 storage="FILE",
-                resubmit_timeout=api.env.replication_wait_timeout
+                resubmit_timeout=api.env.certmonger_wait_timeout
             )
             self.__set_ra_cert_perms()
 

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -663,7 +663,7 @@ class CertDB:
     def request_service_cert(self, nickname, principal, host,
                              resubmit_timeout=None):
         if resubmit_timeout is None:
-            resubmit_timeout = api.env.replication_wait_timeout
+            resubmit_timeout = api.env.certmonger_wait_timeout
         return certmonger.request_and_wait_for_cert(
             certpath=self.secdir,
             storage='NSSDB',

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -482,7 +482,8 @@ class DogtagInstance(service.Service):
             self.master_host
         )
         logger.debug(
-            "Waiting for %s to appear on %s", self.admin_dn, master_conn
+            "Waiting %s seconds for %s to appear on %s",
+            api.env.replication_wait_timeout, self.admin_dn, master_conn
         )
         deadline = time.time() + api.env.replication_wait_timeout
         while time.time() < deadline:
@@ -498,6 +499,9 @@ class DogtagInstance(service.Service):
         else:
             logger.error(
                 "Unable to log in as %s on %s", self.admin_dn, master_conn
+            )
+            logger.info(
+                "[hint] tune with replication_wait_timeout"
             )
             raise errors.NotFound(
                 reason="{} did not replicate to {}".format(

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -872,7 +872,7 @@ class DsInstance(service.Service):
                     profile=dogtag.DEFAULT_PROFILE,
                     dns=[self.fqdn],
                     post_command=cmd,
-                    resubmit_timeout=api.env.replication_wait_timeout
+                    resubmit_timeout=api.env.certmonger_wait_timeout
                 )
             finally:
                 if prev_helper is not None:

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -385,7 +385,7 @@ class HTTPInstance(service.Service):
                     post_command='restart_httpd',
                     storage='FILE',
                     passwd_fname=key_passwd_file,
-                    resubmit_timeout=api.env.replication_wait_timeout
+                    resubmit_timeout=api.env.certmonger_wait_timeout
                 )
             finally:
                 if prev_helper is not None:

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -459,7 +459,7 @@ class KrbInstance(service.Service):
                 profile=KDC_PROFILE,
                 post_command='renew_kdc_cert',
                 perms=(0o644, 0o600),
-                resubmit_timeout=api.env.replication_wait_timeout
+                resubmit_timeout=api.env.certmonger_wait_timeout
             )
         except dbus.DBusException as e:
             # if the certificate is already tracked, ignore the error

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -186,7 +186,8 @@ def wait_for_entry(connection, dn, timeout, attr=None, attrvalue='*',
         attrlist.append(attr)
     else:
         filterstr = "(objectclass=*)"
-    log("Waiting for replication (%s) %s %s", connection, dn, filterstr)
+    log("Waiting up to %s seconds for replication (%s) %s %s",
+        connection, dn, filterstr)
     entry = []
     deadline = time.time() + timeout
     for i in itertools.count(start=1):

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -432,6 +432,7 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.ca_host = ''
     api.env.ca_install_port = None
     api.env.ca_port = 0
+    api.env.certmonger_wait_timeout = 0
     api.env.conf = ''  # object
     api.env.conf_default = ''  # object
     api.env.confdir = ''  # object


### PR DESCRIPTION
Make specific config option for certmonger timeout rather than using replication timeout.

Log the replication timeout value when waiting for an entry/attribute.

Log a hint if the dogtag admin user bind fails.

https://pagure.io/freeipa/issue/7971