### PR TITLE
[Backport][ipa-4-7] ipatests: new test for trust with partially unreachable AD topology

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1714,3 +1714,11 @@ def group_add(host, groupname, extra_args=()):
     ]
     cmd.extend(extra_args)
     return host.run_command(cmd)
+
+
+def create_temp_file(host, directory=None):
+    """Creates temproray file using mktemp."""
+    cmd = ['mktemp']
+    if directory is not None:
+        cmd += ['-p', directory]
+    return host.run_command(cmd).stdout_text


### PR DESCRIPTION
This is manual backport of #3362 

Establishing trust with partially unavailable AD hosts require usage
of --server option. The new test checks that both commands trust-add
and trust-fetch-domains properly use this option and also that
trust-add correctly passes the server value when imlicitly invoking
trust-fetch-domains.

Relates to: https://pagure.io/freeipa/issue/7895.

Reviewed-By: Tibor Dudlak <tdudlak@redhat.com>