### PR TITLE
Test: To check ipa replica-manage del <FQDN> does not fail

### DIFF
--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -411,6 +411,18 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-29/test_installation_TestInstallMasterReplica:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterReplica
+        template: *ci-master-f29
+        timeout: 10800
+        topology: *master_1repl
+
   fedora-29/test_idviews:
     requires: [fedora-29/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -423,6 +423,18 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-30/test_installation_TestInstallMasterReplica:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterReplica
+        template: *ci-master-f30
+        timeout: 10800
+        topology: *master_1repl
+
   fedora-30/test_idviews:
     requires: [fedora-30/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -411,6 +411,18 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-rawhide/test_installation_TestInstallMasterReplica:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterReplica
+        template: *ci-master-frawhide
+        timeout: 10800
+        topology: *master_1repl
+
   fedora-rawhide/test_idviews:
     requires: [fedora-rawhide/build]
     priority: 50


### PR DESCRIPTION
    Test: To check ipa replica-manage del <FQDN> does not fail
    
    Problem:
    If a replica installation fails before all the services have been enabled then
    it could leave things in a bad state.
    
    ipa-replica-manage del <replica> --cleanup --force
    invalid 'PKINIT enabled server': all masters must have IPA master role enabled
    
    Test Steps:
    1. Setup server
    2. Setup replica
    3. modify the replica entry on Master:
       dn: cn=KDC,cn=<replica hostname>,cn=masters,cn=ipa,cn=etc,dc=<test>,dc=<realm>
       changetype: modify
       delete: ipaconfigstring
       ipaconfigstring: enabledService
    
       dn: cn=KDC,cn=<replica hostname>,cn=masters,cn=ipa,cn=etc,dc=<test>,dc=<realm>
       add: ipaconfigstring
       ipaconfigstring: configuredService
    4. On master,
       run ipa-replica-manage del <replicaFQDN> --cleanup --force

    Related Ticket: https://pagure.io/freeipa/issue/7929

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>