### PR TITLE
WebUI tests: Fix timeout issues for reset password tests

### DIFF
--- a/ipatests/test_webui/test_loginscreen.py
+++ b/ipatests/test_webui/test_loginscreen.py
@@ -157,7 +157,7 @@ class TestLoginScreen(UI_driver):
         new_pass_field.send_keys(new_password)
         verify_pass_field.send_keys(new_password)
         verify_pass_field.send_keys(Keys.RETURN)
-        self.wait()
+        self.wait(0.5)
         self.assert_notification(assert_text='Password change complete',
                                  link_text=link_text, link_url=link_url)
 
@@ -369,6 +369,7 @@ class TestLoginScreen(UI_driver):
         # check click on 'Cancel' button
         self.check_cancel()
         self.button_click_on_login_screen('login')
+        self.wait_for_request()
 
         # check if user is not logged
         assert not self.logged_in()


### PR DESCRIPTION
- Increase wait timeout after password reset
- Wait for server response after login in TestLoginScreen.test_reset_password_and_login_view

Ticket: https://pagure.io/freeipa/issue/8012