### PR TITLE
Nightly test definition: add missing tests

### DIFF
--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -231,6 +231,18 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  fedora-29/test_smb:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_smb.py
+        template: *ci-master-f29
+        timeout: 4800
+        topology: *master_1repl_1client
+
   fedora-29/test_server_del:
     requires: [fedora-29/build]
     priority: 50
@@ -1240,3 +1252,15 @@ jobs:
         template: *ci-master-f29
         timeout: 3600
         topology: *ipaserver
+
+  fedora-29/test_crlgen_manage:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_crlgen_manage.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1264,3 +1264,15 @@ jobs:
         template: *ci-master-f30
         timeout: 3600
         topology: *master_1repl
+
+  fedora-30/test_crlgen_manage:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_crlgen_manage.py
+        template: *ci-master-f30
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_master_pki.yaml
+++ b/ipatests/prci_definitions/nightly_master_pki.yaml
@@ -713,3 +713,15 @@ jobs:
         template: *pki-master-f29
         timeout: 3600
         topology: *master_1repl
+
+  fedora-29/test_crlgen_manage:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_crlgen_manage.py
+        template: *pki-master-f29
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -231,6 +231,18 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  fedora-rawhide/test_smb:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_smb.py
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl_1client
+
   fedora-rawhide/test_server_del:
     requires: [fedora-rawhide/build]
     priority: 50
@@ -1249,6 +1261,18 @@ jobs:
       args:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_automember.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/test_crlgen_manage:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_crlgen_manage.py
         template: *ci-master-frawhide
         timeout: 3600
         topology: *master_1repl


### PR DESCRIPTION
The following test was missing from all nightlies:
- test_integration/test_crlgen_manage.py

The following tests were missing from nightly_f28 and nightly_f29:
- test_integration/test_nfs.py
- test_integration/test_smb.py

The following test was missing from nightly_rawhide:
- test_integration/test_smb.py