### PR TITLE
ipa-scripts: fix python3 shebang flags on scripts

### DIFF
--- a/Makefile.pythonscripts.am
+++ b/Makefile.pythonscripts.am
@@ -1,6 +1,6 @@
 # special handling of Python scripts with auto-generated shebang line
 $(PYTHON_SHEBANG):%: %.in Makefile
-	$(AM_V_GEN)sed -e 's|^#!/usr/bin/python3.*|#!$(PYTHON) -E|g' $< > $@
+	$(AM_V_GEN)sed -e 's|^#!/usr/bin/python3.*|#!$(PYTHON) -I|g' $< > $@
 	$(AM_V_GEN)chmod +x $@
 
 .PHONY: python_scripts_sub


### PR DESCRIPTION
Hi people :D, it is my first contribution to the project, it seems that ipa python scripts was using -E flag and @cheimes suggested that -I flag would be a better alternative, I saw that was part of 4.8 version milestone and make a change. Hope it everything is OK :)

All the scripts now are using this shebang:
```#!/usr/bin/python3 -I```

I am testing the scripts but until now everything is OK.

Related: https://pagure.io/freeipa/issue/7987