### PR TITLE
Remove posixAccount from service_find search filter

### DIFF
--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -889,7 +889,6 @@ class service_find(LDAPSearch):
         assert isinstance(base_dn, DN)
         # lisp style!
         custom_filter = '(&(objectclass=ipaService)' \
-                          '(!(objectClass=posixAccount))' \
                           '(!(|(krbprincipalname=kadmin/*)' \
                               '(krbprincipalname=K/M@*)' \
                               '(krbprincipalname=krbtgt/*))' \


### PR DESCRIPTION
This will allow cifs principals to be found. They were suppressed
because they include objectclass=posixAccount.

This is a bit of a historical anomaly. This was included in the
filter from the initial commit (though it was person, not
posixAccount). I believe it was a mistake from the beginning but
it wasn't noticed because it didn't cause any obvious issues.

https://pagure.io/freeipa/issue/8013