### PR TITLE
[Backport][ipa-4-8] Remove posixAccount from service_find search filter

### DIFF
--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -889,7 +889,6 @@ class service_find(LDAPSearch):
         assert isinstance(base_dn, DN)
         # lisp style!
         custom_filter = '(&(objectclass=ipaService)' \
-                          '(!(objectClass=posixAccount))' \
                           '(!(|(krbprincipalname=kadmin/*)' \
                               '(krbprincipalname=K/M@*)' \
                               '(krbprincipalname=krbtgt/*))' \


### PR DESCRIPTION
This PR was opened automatically because PR #3418 was pushed to master and backport to ipa-4-8 is required.