### PR TITLE
ipa-client-samba: remove and restore smb.conf only on first uninstall

### DIFF
--- a/ipaclient/install/ipa_client_samba.py
+++ b/ipaclient/install/ipa_client_samba.py
@@ -433,8 +433,9 @@ def uninstall(fstore, statestore, options):
     ipautil.remove_ccache(ccache_path=paths.KRB5CC_SAMBA)
 
     # Remove samba's configuration file
-    ipautil.remove_file(paths.SMB_CONF)
-    fstore.restore_file(paths.SMB_CONF)
+    if fstore.has_file(paths.SMB_CONF):
+        ipautil.remove_file(paths.SMB_CONF)
+        fstore.restore_file(paths.SMB_CONF)
 
     # Remove samba's persistent and temporary tdb files
     tdb_files = [
@@ -624,7 +625,7 @@ def run():
             api.Command.service_del(api.env.smb_princ)
         except AttributeError:
             logger.error(
-                "Chosen IPA master %s does not have support to"
+                "Chosen IPA master %s does not have support to "
                 "set up Samba domain members", server,
             )
             return 1

--- a/ipaclient/install/ipa_client_samba.py
+++ b/ipaclient/install/ipa_client_samba.py
@@ -523,11 +523,25 @@ def run():
     if options.uninstall:
         if statestore.has_state("domain_member"):
             uninstall(fstore, statestore, options)
-            print(
-                "Samba configuration is reverted. "
-                "However, Samba databases were fully cleaned and "
-                "old configuration file will not be usable anymore."
-            )
+            try:
+                keys = (
+                    "configured", "hardening", "groupmap", "tdb",
+                    "service.principal", "smb.conf"
+                )
+                for key in keys:
+                    statestore.delete_state("domain_member", key)
+            except Exception as e:
+                print(
+                    "Error: Failed to remove the domain_member statestores: "
+                    "%s" % e
+                )
+                return 1
+            else:
+                print(
+                    "Samba configuration is reverted. "
+                    "However, Samba databases were fully cleaned and "
+                    "old configuration file will not be usable anymore."
+                )
         else:
             print("Samba domain member is not configured yet")
         return 0

--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -153,3 +153,8 @@ class TestSMB(IntegrationTest):
         # test for https://pagure.io/freeipa/issue/8019
         # try another uninstall after the first one:
         smbsrv.run_command(['ipa-client-samba', '--uninstall', '-U'])
+        # test for https://pagure.io/freeipa/issue/8021
+        # try to install again:
+        smbsrv.run_command(["ipa-client-samba", "-U"])
+        # cleanup:
+        smbsrv.run_command(['ipa-client-samba', '--uninstall', '-U'])

--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -150,3 +150,6 @@ class TestSMB(IntegrationTest):
 
         smbsrv = self.replicas[0]
         smbsrv.run_command(['ipa-client-samba', '--uninstall', '-U'])
+        # test for https://pagure.io/freeipa/issue/8019
+        # try another uninstall after the first one:
+        smbsrv.run_command(['ipa-client-samba', '--uninstall', '-U'])


### PR DESCRIPTION
Fixes: https://pagure.io/freeipa/issue/8019
