### PR TITLE
[Backport][ipa-4-6] ipa-client-automount: add knob to configure NFSv4 Domain (idmapd.conf)

### DIFF
--- a/client/ipa-client-automount
+++ b/client/ipa-client-automount
@@ -353,7 +353,7 @@ def configure_nfs(fstore, statestore, options):
         changes = [conf.setOption('Domain', api.env.domain)]
     elif options.idmapdomain == 'DNS':
         # Rely on idmapd auto-detection (DNS)
-        changes = None
+        changes = [conf.rmOption('Domain')]
     else:
         # Set NFSv4 domain to what was provided
         changes = [conf.setOption('Domain', options.idmapdomain)]

--- a/client/ipa-client-automount
+++ b/client/ipa-client-automount
@@ -29,19 +29,15 @@ import os
 import time
 import tempfile
 import gssapi
-
 try:
     from xml.etree import cElementTree as etree
 except ImportError:
     from xml.etree import ElementTree as etree
-
 import SSSDConfig
 # pylint: disable=import-error
 from six.moves.urllib.parse import urlsplit
 # pylint: enable=import-error
-
 from optparse import OptionParser  # pylint: disable=deprecated-module
-
 from ipaclient.install import ipachangeconf, ipadiscovery
 from ipalib import api, errors
 from ipalib.install import sysrestore
@@ -63,19 +59,34 @@ logger = logging.getLogger(os.path.basename(__file__))
 def parse_options():
     usage = "%prog [options]\n"
     parser = OptionParser(usage=usage)
-    parser.add_option("--server", dest="server", help="FQDN of IPA server")
-    parser.add_option("--location", dest="location", help="Automount location",
-        default="default")
-    parser.add_option("-S", "--no-sssd", dest="sssd",
-                      action="store_false", default=True,
-                      help="Do not configure the client to use SSSD for automount")
-    parser.add_option("--debug", dest="debug", action="store_true",
-        default=False, help="enable debugging")
-    parser.add_option("-U", "--unattended", dest="unattended",
-        action="store_true", default=False,
-        help="unattended installation never prompts the user")
-    parser.add_option("--uninstall", dest="uninstall", action="store_true",
-        default=False, help="Unconfigure automount")
+    parser.add_option(
+        "--server", dest="server", help="FQDN of IPA server"
+    )
+    parser.add_option(
+        "--location", dest="location", default="default",
+        help="Automount location"
+    )
+    parser.add_option(
+        "-S", "--no-sssd", dest="sssd", action="store_false", default=True,
+        help="Do not configure the client to use SSSD for automount"
+    )
+    parser.add_option(
+        "--idmap-domain", dest="idmapdomain", default=None,
+        help="nfs domain for idmap.conf"
+    )
+    parser.add_option(
+        "--debug", dest="debug", action="store_true", default=False,
+        help="enable debugging"
+    )
+    parser.add_option(
+        "-U", "--unattended", dest="unattended", action="store_true",
+        default=False,
+        help="unattended installation never prompts the user"
+    )
+    parser.add_option(
+        "--uninstall", dest="uninstall", action="store_true", default=False,
+        help="Unconfigure automount"
+    )
 
     options, args = parser.parse_args()
     return options, args
@@ -316,7 +327,7 @@ def uninstall(fstore, statestore):
 
     return 0
 
-def configure_nfs(fstore, statestore):
+def configure_nfs(fstore, statestore, options):
     """
     Configure secure NFS
     """
@@ -337,16 +348,23 @@ def configure_nfs(fstore, statestore):
     conf.setOptionAssignment(" = ")
     conf.setSectionNameDelimiters(("[", "]"))
 
-    changes = [conf.setOption('Domain', api.env.domain)]
-    section_with_changes = [conf.setSection('General', changes)]
+    if options.idmapdomain is None:
+        # Set NFSv4 domain to the IPA domain
+        changes = [conf.setOption('Domain', api.env.domain)]
+    elif options.idmapdomain == 'DNS':
+        # Rely on idmapd auto-detection (DNS)
+        changes = None
+    else:
+        # Set NFSv4 domain to what was provided
+        changes = [conf.setOption('Domain', options.idmapdomain)]
 
-    # Backup the file and apply the changes
-    fstore.backup_file(paths.IDMAPD_CONF)
-    conf.changeConf(paths.IDMAPD_CONF, section_with_changes)
-
-    tasks.restore_context(paths.IDMAPD_CONF)
-
-    print("Configured %s" % paths.IDMAPD_CONF)
+    if changes is not None:
+        section_with_changes = [conf.setSection('General', changes)]
+        # Backup the file and apply the changes
+        fstore.backup_file(paths.IDMAPD_CONF)
+        conf.changeConf(paths.IDMAPD_CONF, section_with_changes)
+        tasks.restore_context(paths.IDMAPD_CONF)
+        print("Configured %s" % paths.IDMAPD_CONF)
 
     rpcidmapd = services.knownservices.rpcidmapd
     statestore.backup_state('rpcidmapd', 'enabled', rpcidmapd.is_enabled())
@@ -496,7 +514,7 @@ def main():
     try:
         if not options.sssd:
             configure_nsswitch(fstore, options)
-        configure_nfs(fstore, statestore)
+        configure_nfs(fstore, statestore, options)
         if options.sssd:
             configure_autofs_sssd(fstore, statestore, autodiscover, options)
         else:

--- a/client/man/ipa-client-automount.1
+++ b/client/man/ipa-client-automount.1
@@ -49,22 +49,25 @@ The nsswitch automount service is configured to use either sss or ldap and files
 NFSv4 is also configured. The rpc.gssd and rpc.idmapd are started on clients to support Kerberos\-secured mounts.
 .SH "OPTIONS"
 \fB\-\-server\fR=\fISERVER\fR
-Set the FQDN of the IPA server to connect to
+Set the FQDN of the IPA server to connect to.
 .TP
 \fB\-\-location\fR=\fILOCATION\fR
-Automount location
+Automount location.
 .TP
 \fB\-S\fR, \fB\-\-no\-sssd\fR
-Do not configure the client to use SSSD for automount
+Do not configure the client to use SSSD for automount.
+.TP
+\fB\-S\fR, \fB\-\-idmap\-domain\fR=\fIIDMAP_DOMAIN\fR
+NFS domain for idmapd.conf. If unset, defaults to the IPA domain. If set to DNS, let idmapd or nfsidmap determine the domain from DNS (see idmapd(8) or nfsidmap(5) for details). If set to anything else, set idmapd.conf's Domain entry to that value.
 .TP
 \fB\-d\fR, \fB\-\-debug\fR
-Print debugging information to stdout
+Print debugging information to stdout.
 .TP
 \fB\-U\fR, \fB\-\-unattended\fR
-Unattended installation. The user will not be prompted
+Unattended installation. The user will not be prompted.
 .TP
 \fB\-\-uninstall\fR
-Restore the automount configuration files
+Restore the automount configuration files.
 
 .SH "FILES"
 .TP

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -224,6 +224,8 @@ class TestNFS(TestInit):
             '-U', '--debug'
         ])
 
+        time.sleep(WAIT_AFTER_INSTALL)
+
         # systemctl non-fatal errors will show up like this:
         # stderr=Failed to restart nfs-secure.service: \
         #        Unit nfs-secure.service not found.
@@ -238,8 +240,6 @@ class TestNFS(TestInit):
         automntclt.run_command([
             "grep", "Domain = %s" % self.master.domain.name, "/etc/idmapd.conf"
         ])
-
-        time.sleep(WAIT_AFTER_INSTALL)
 
         automntclt.run_command([
             "mount", "-t", "nfs4", "-o", "sec=krb5p,vers=4.0",
@@ -264,6 +264,9 @@ class TestNFS(TestInit):
             'ipa-client-automount', '--location', 'default',
             '-U', '--debug', "--idmap-domain", "DNS"
         ])
+
+        time.sleep(WAIT_AFTER_INSTALL)
+
         # check whether idmapd.conf was setup properly:
         # grep must not find any configured Domain.
         result = automntclt.run_command(
@@ -274,6 +277,8 @@ class TestNFS(TestInit):
         automntclt.run_command([
             'ipa-client-automount', '--uninstall', '-U', '--debug'
         ])
+
+        time.sleep(WAIT_AFTER_UNINSTALL)
 
         # https://pagure.io/freeipa/issue/7918
         # test for --idmap-domain exampledomain.net
@@ -287,7 +292,12 @@ class TestNFS(TestInit):
             "grep", "Domain = %s" % nfs_domain, "/etc/idmapd.conf"
         ])
 
+        time.sleep(WAIT_AFTER_INSTALL)
+
         automntclt.run_command([
             'ipa-client-automount', '--uninstall', '-U', '--debug'
         ])
+
+        time.sleep(WAIT_AFTER_UNINSTALL)
+
         self.cleanup()


### PR DESCRIPTION
Manual backport of:
https://github.com/freeipa/freeipa/pull/3111
https://github.com/freeipa/freeipa/pull/3300

Original tickets:
https://pagure.io/freeipa/issue/7988
https://pagure.io/freeipa/issue/7918
