### PR TITLE
[Backport][ipa-4-8] Test: To check ipa replica-manage del <FQDN> does not fail

### DIFF
--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -411,6 +411,18 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-29/test_installation_TestInstallMasterReplica:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterReplica
+        template: *ci-master-f29
+        timeout: 10800
+        topology: *master_1repl
+
   fedora-29/test_idviews:
     requires: [fedora-29/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -423,6 +423,18 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-30/test_installation_TestInstallMasterReplica:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterReplica
+        template: *ci-master-f30
+        timeout: 10800
+        topology: *master_1repl
+
   fedora-30/test_idviews:
     requires: [fedora-30/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -411,6 +411,18 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-rawhide/test_installation_TestInstallMasterReplica:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterReplica
+        template: *ci-master-frawhide
+        timeout: 10800
+        topology: *master_1repl
+
   fedora-rawhide/test_idviews:
     requires: [fedora-rawhide/build]
     priority: 50


### PR DESCRIPTION
This PR was opened automatically because PR #3402 was pushed to master and backport to ipa-4-8 is required.