### PR TITLE
user-stage: transfer all attributes from preserved to stage user

### DIFF
--- a/ipatests/test_xmlrpc/test_stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/test_stageuser_plugin.py
@@ -130,6 +130,17 @@ def stageduser_notposix(request):
 
 
 @pytest.fixture(scope='class')
+def stageduser_customattr(request):
+    tracker = StageUserTracker(u'customattr', u'customattr', u'customattr',
+                               setattr=u'businesscategory=BusinessCat')
+    tracker.track_create()
+    tracker.attrs.update(
+        businesscategory=[u'BusinessCat']
+    )
+    return tracker.make_fixture(request)
+
+
+@pytest.fixture(scope='class')
 def user(request):
     tracker = UserTracker(u'auser1', u'active', u'user')
     return tracker.make_fixture(request)
@@ -572,6 +583,59 @@ class TestPreserved(XMLRPC_test):
         stageduser.check_retrieve(result)
 
         stageduser.delete()
+
+
+@pytest.mark.tier1
+class TestCustomAttr(XMLRPC_test):
+    """Test for pagure ticket 7597
+
+    When a staged user is activated, preserved and finally staged again,
+    the custom attributes are lost.
+    """
+    def test_stageduser_customattr(self, stageduser_customattr):
+        # Create a staged user with attributes not accessible
+        # through the options
+        # --setattr is needed here
+        command = stageduser_customattr.make_create_command()
+        result = command()
+        stageduser_customattr.check_create(result, [u'businesscategory'])
+
+        # Activate the staged user
+        user_customattr = UserTracker(
+            stageduser_customattr.uid, stageduser_customattr.givenname,
+            stageduser_customattr.sn)
+        user_customattr.create_from_staged(stageduser_customattr)
+        user_customattr.attrs[u'businesscategory'] = [u'BusinessCat']
+
+        command = stageduser_customattr.make_activate_command()
+        result = command()
+        user_customattr.check_activate(result)
+
+        # Check that the user contains businesscategory
+        command = user_customattr.make_retrieve_command(all=True)
+        result = command()
+        assert 'BusinessCat' in result['result'][u'businesscategory']
+
+        # delete the user with --preserve
+        command = user_customattr.make_delete_command(no_preserve=False,
+                                                      preserve=True)
+        result = command()
+        user_customattr.check_delete(result)
+
+        # Check that the preserved user contains businesscategory
+        command = user_customattr.make_retrieve_command(all=True)
+        result = command()
+        assert 'BusinessCat' in result['result'][u'businesscategory']
+
+        # Move the user from preserved to stage
+        command = user_customattr.make_stage_command()
+        result = command()
+        stageduser_customattr.check_restore_preserved(result)
+
+        # Check that the stage user contains businesscategory
+        command = stageduser_customattr.make_retrieve_command(all=True)
+        result = command()
+        assert 'BusinessCat' in result['result'][u'businesscategory']
 
 
 @pytest.mark.tier1

--- a/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
@@ -177,12 +177,13 @@ class StageUserTracker(KerberosAliasMixin, Tracker):
 
         self.exists = True
 
-    def check_create(self, result):
+    def check_create(self, result, extra_keys=()):
         """ Check 'stageuser-add' command result """
+        expected = self.filter_attrs(self.create_keys | set(extra_keys))
         assert_deepequal(dict(
             value=self.uid,
             summary=u'Added stage user "%s"' % self.uid,
-            result=self.filter_attrs(self.create_keys),
+            result=self.filter_attrs(expected),
         ), result)
 
     def check_delete(self, result):


### PR DESCRIPTION
### user-stage: transfer all attributes from preserved to stage user

The user-stage command is internally implemented as:
- user_show(all=True) in order to read the user attributes
- loop on the attributes defined as possible to add using stageuser-add and
transform them into new options for stageuser_add (for instance stageuser-add
provides the option --shell for the attribute loginshell, but there is no
option for the attribute businesscategory).
- call stageuser_add in order to create a new entry in the active users subtree
- user-del to remove the previous entry in the staged users subtree
    
The issue is in the 2nd step. Only the attributes with a stageuser-add option
are processed.
The logic of the code should be slightly modified, so that all the attributes
read in the first step are processed:
- if they correspond to an option of stageuser-add, process them like it's
currently done. For instance if the entry contains displayname, then it
should be processed as --displayName=value in the stageuser-add cmd
- if they do not correspond to an option of stageuser-add, add them with
--setattr=<attrname>=<attrvalue>

Note that some attributes may need to be filtered, for instance user-show
returns has_password or has_keytab, which do not correspond to attributes
in the LDAP entry.

Fixes: https://pagure.io/freeipa/issue/7597

### xmlrpc test: add test for preserved > stage user
    
When moving a preserved user to the stage area, check that the
custom attributes are not lost ( = the attr for which there is
no specific user_stage option).
    
Test scenario:
- add a stage user with --setattr "businesscategory=value"
- activate the user, check that businesscategory is still present
- delete (preserve) the user, check that attr is still present
- stage the user, check that attr is still present
    
Related: https://pagure.io/freeipa/issue/7597