### PR TITLE
ipapython/admintool.py: use SERVER_NOT_CONFIGURED

### DIFF
--- a/ipapython/admintool.py
+++ b/ipapython/admintool.py
@@ -317,9 +317,7 @@ class AdminTool:
             # ipa-server-install.
             return
         message = "The %s command failed." % self.command_name
-        if self.log_file_initialized and return_value != 2:
-            # magic value because this is common between server and client
-            # but imports are not straigthforward
+        if self.log_file_initialized and return_value != SERVER_NOT_CONFIGURED:
             message += " See %s for more information" % self.log_file_name
         logger.error('%s', message)
 


### PR DESCRIPTION
Commit 9182917280a5c2590fa677729db54b38a9ac4d1f introduced
SUCCESS, SERVER_INSTALL_ERROR and SERVER_NOT_CONFIGURED to
deal with cases when server is not configured.
Actually use SERVER_NOT_CONFIGURED in log_failure instead of 2.

Related-to: https://pagure.io/freeipa/issue/6843
Signed-off-by: François Cami <fcami@redhat.com>