### PR TITLE
[Backport][ipa-4-6] prci_definitions: add master_3client topology

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -3,6 +3,10 @@ topologies:
     name: build
     cpu: 2
     memory: 3800
+  master_3client: &master_3client
+    name: master_3client
+    cpu: 5
+    memory: 10150
   master_1repl: &master_1repl
     name: master_1repl
     cpu: 4


### PR DESCRIPTION
Some tests would benefit from using a multi-client topology.
As PR-CI now supports master_3client, use it.

Fixes: https://pagure.io/freeipa/issue/8026
Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Armando Neto <abiagion@redhat.com>

Manual backport of https://github.com/freeipa/freeipa/pull/3470.