### PR TITLE
[Backport][ipa-4-8] ipatests: Add tests for interactive chronyd configuration

### DIFF
--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -1190,7 +1190,7 @@ jobs:
         build_url: '{fedora-28/build_url}'
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
         template: *ci-master-f28
-        timeout: 7200
+        timeout: 10800
         topology: *master_1repl_1client
 
   fedora-28/test_pkinit_manage:

--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -1206,7 +1206,7 @@ jobs:
         build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
         template: *ci-master-f29
-        timeout: 7200
+        timeout: 10800
         topology: *master_1repl_1client
 
   fedora-29/test_pkinit_manage:

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1218,7 +1218,7 @@ jobs:
         build_url: '{fedora-30/build_url}'
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
         template: *ci-master-f30
-        timeout: 7200
+        timeout: 10800
         topology: *master_1repl_1client
 
   fedora-30/test_pkinit_manage:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1206,7 +1206,7 @@ jobs:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
         template: *ci-master-frawhide
-        timeout: 7200
+        timeout: 10800
         topology: *master_1repl_1client
 
   fedora-rawhide/test_pkinit_manage:

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -498,7 +498,7 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
     return result
 
 
-def install_client(master, client, extra_args=(), user=None,
+def install_client(master, client, extra_args=[], user=None,
                    password=None, unattended=True, stdin_text=None):
     client.collect_log(paths.IPACLIENT_INSTALL_LOG)
 
@@ -528,7 +528,9 @@ def install_client(master, client, extra_args=(), user=None,
     if unattended:
         args.append('-U')
 
-    result = client.run_command(args + list(extra_args), stdin_text=stdin_text)
+    args.extend(extra_args)
+
+    result = client.run_command(args, stdin_text=stdin_text)
 
     setup_sssd_debugging(client)
     kinit_admin(client)

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -498,8 +498,8 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
     return result
 
 
-def install_client(master, client, extra_args=(),
-                   user=None, password=None):
+def install_client(master, client, extra_args=(), user=None,
+                   password=None, unattended=True, stdin_text=None):
     client.collect_log(paths.IPACLIENT_INSTALL_LOG)
 
     apply_common_fixes(client)
@@ -516,14 +516,19 @@ def install_client(master, client, extra_args=(),
     if password is None:
         password = client.config.admin_password
 
-    result = client.run_command([
-        'ipa-client-install', '-U',
+    args = [
+        'ipa-client-install',
         '--domain', client.domain.name,
         '--realm', client.domain.realm,
         '-p', user,
         '-w', password,
-        '--server', master.hostname] + list(extra_args)
-    )
+        '--server', master.hostname
+    ]
+
+    if unattended:
+        args.append('-U')
+
+    result = client.run_command(args + list(extra_args), stdin_text=stdin_text)
 
     setup_sssd_debugging(client)
     kinit_admin(client)


### PR DESCRIPTION
This PR was opened automatically because PR #3406 was pushed to master and backport to ipa-4-8 is required.