### PR TITLE
[Backport][ipa-4-7] ipatests: Add tests for interactive chronyd configuration

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1178,7 +1178,7 @@ jobs:
         build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
         template: *ci-master-f29
-        timeout: 7200
+        timeout: 10800
         topology: *master_1repl_1client
 
   fedora-29/test_pkinit_manage:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -841,8 +841,8 @@ jobs:
       args:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
-        template: *ci-master-f29
-        timeout: 7200
+        template: *ci-master-frawhide
+        timeout: 10800
         topology: *master_1repl_1client
 
   fedora-rawhide/nfs:

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -487,7 +487,7 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
     return result
 
 
-def install_client(master, client, extra_args=(), user=None,
+def install_client(master, client, extra_args=[], user=None,
                    password=None, unattended=True, stdin_text=None):
     client.collect_log(paths.IPACLIENT_INSTALL_LOG)
 
@@ -517,7 +517,9 @@ def install_client(master, client, extra_args=(), user=None,
     if unattended:
         args.append('-U')
 
-    result = client.run_command(args + list(extra_args), stdin_text=stdin_text)
+    args.extend(extra_args)
+
+    result = client.run_command(args, stdin_text=stdin_text)
 
     setup_sssd_debugging(client)
     kinit_admin(client)

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -487,8 +487,8 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
     return result
 
 
-def install_client(master, client, extra_args=(),
-                   user=None, password=None):
+def install_client(master, client, extra_args=(), user=None,
+                   password=None, unattended=True, stdin_text=None):
     client.collect_log(paths.IPACLIENT_INSTALL_LOG)
 
     apply_common_fixes(client)
@@ -505,14 +505,19 @@ def install_client(master, client, extra_args=(),
     if password is None:
         password = client.config.admin_password
 
-    result = client.run_command([
-        'ipa-client-install', '-U',
+    args = [
+        'ipa-client-install',
         '--domain', client.domain.name,
         '--realm', client.domain.realm,
         '-p', user,
         '-w', password,
-        '--server', master.hostname] + list(extra_args)
-    )
+        '--server', master.hostname
+    ]
+
+    if unattended:
+        args.append('-U')
+
+    result = client.run_command(args + list(extra_args), stdin_text=stdin_text)
 
     setup_sssd_debugging(client)
     kinit_admin(client)

--- a/ipatests/test_integration/test_ntp_options.py
+++ b/ipatests/test_integration/test_ntp_options.py
@@ -28,6 +28,18 @@ class TestNTPoptions(IntegrationTest):
                       "no NTP server or pool address was provided."
     exp_chrony_msg = "Using default chrony configuration."
 
+    exp_exclude_msg = "Excluded by options:"
+    exp_default_msg = "Using default chrony configuration."
+
+    exp_change_msg = "Configuration of chrony was changed by installer."
+
+    exp_srv_err = "error: --ntp-server cannot be used " \
+                  "together with --no-ntp"
+    exp_pool_err = "error: --ntp-pool cannot be used " \
+                   "together with --no-ntp"
+
+    exp_prom_err = "NTP configuration cannot be updated during promotion"
+
     @classmethod
     def install(cls, mh):
         cls.client = cls.clients[0]
@@ -38,55 +50,50 @@ class TestNTPoptions(IntegrationTest):
         test to verify that ipa-server and ipa-client install uses
         default chrony configuration without any NTP options specified
         """
-        expected_msg1 = "No SRV records of NTP servers found and " \
-                        "no NTP server or pool address was provided."
-        expected_msg2 = "Using default chrony configuration."
 
         server_install = tasks.install_master(self.master, setup_dns=False)
-        assert expected_msg1 in server_install.stderr_text
-        assert expected_msg2 in server_install.stdout_text
+        assert self.exp_records_msg in server_install.stderr_text
+        assert self.exp_chrony_msg in server_install.stdout_text
 
         client_install = tasks.install_client(self.master, self.client)
 
-        assert expected_msg1 in client_install.stderr_text
-        assert expected_msg2 in client_install.stdout_text
+        assert self.exp_records_msg in client_install.stderr_text
+        assert self.exp_chrony_msg in client_install.stdout_text
 
     def test_server_client_install_no_ntp(self):
         """
         test to verify that ipa-server and ipa-client install invoked with
         option -N uses system defined NTP daemon configuration
         """
-        expected_msg1 = "Excluded by options:"
-        expected_msg2 = "Using default chrony configuration."
 
         server_install = tasks.install_master(self.master, setup_dns=False,
                                               extra_args=['-N'])
-        assert expected_msg1 in server_install.stdout_text
-        assert expected_msg2 not in server_install.stdout_text
+        assert self.exp_exclude_msg in server_install.stdout_text
+        assert self.exp_default_msg not in server_install.stdout_text
 
         client_install = tasks.install_client(self.master, self.client,
                                               extra_args=['--no-ntp'])
-        assert expected_msg2 not in client_install.stdout_text
+        assert self.exp_default_msg not in client_install.stdout_text
 
     def test_server_client_install_with_multiple_ntp_srv(self):
         """
         test to verify that ipa-server-install passes with multiple
         --ntp-server option used
         """
-        expected_msg = "Configuration of chrony was changed by installer."
+
         args = ['--ntp-server=%s' % self.ntp_server1,
                 '--ntp-server=%s' % self.ntp_server2]
 
         server_install = tasks.install_master(self.master, setup_dns=False,
                                               extra_args=args)
-        assert expected_msg in server_install.stderr_text
+        assert self.exp_change_msg in server_install.stderr_text
         cmd = self.master.run_command(['cat', paths.CHRONY_CONF])
         assert self.ntp_server1 in cmd.stdout_text
         assert self.ntp_server2 in cmd.stdout_text
 
         client_install = tasks.install_client(self.master, self.client,
                                               extra_args=args)
-        assert expected_msg in client_install.stderr_text
+        assert self.exp_change_msg in client_install.stderr_text
         cmd = self.client.run_command(['cat', paths.CHRONY_CONF])
         assert self.ntp_server1 in cmd.stdout_text
         assert self.ntp_server2 in cmd.stdout_text
@@ -96,13 +103,12 @@ class TestNTPoptions(IntegrationTest):
         test to verify that ipa-server, ipa-replica and ipa-client install
         passes with options --ntp-pool and --ntp-server together
         """
-        expected_msg = "Configuration of chrony was changed by installer."
         args = ['--ntp-pool=%s' % self.ntp_pool,
                 '--ntp-server=%s' % self.ntp_server1]
 
         server_install = tasks.install_master(self.master, setup_dns=False,
                                               extra_args=args)
-        assert expected_msg in server_install.stderr_text
+        assert self.exp_change_msg in server_install.stderr_text
         cmd = self.master.run_command(['cat', paths.CHRONY_CONF])
         assert self.ntp_pool in cmd.stdout_text
         assert self.ntp_server1 in cmd.stdout_text
@@ -110,7 +116,7 @@ class TestNTPoptions(IntegrationTest):
         replica_install = tasks.install_replica(self.master, self.replica,
                                                 extra_args=args,
                                                 promote=False)
-        assert expected_msg in replica_install.stderr_text
+        assert self.exp_change_msg in replica_install.stderr_text
 
         cmd = self.replica.run_command(['cat', paths.CHRONY_CONF])
         assert self.ntp_pool in cmd.stdout_text
@@ -118,7 +124,7 @@ class TestNTPoptions(IntegrationTest):
 
         client_install = tasks.install_client(self.master, self.client,
                                               extra_args=args)
-        assert expected_msg in client_install.stderr_text
+        assert self.exp_change_msg in client_install.stderr_text
         cmd = self.client.run_command(['cat', paths.CHRONY_CONF])
         assert self.ntp_pool in cmd.stdout_text
         assert self.ntp_server1 in cmd.stdout_text
@@ -128,12 +134,11 @@ class TestNTPoptions(IntegrationTest):
         test to verify that ipa-server, promotion of ipa-replica and
         ipa-client install passes with options --ntp-server
         """
-        expected_msg = "Configuration of chrony was changed by installer."
         args = ['--ntp-server=%s' % self.ntp_server1]
 
         server_install = tasks.install_master(self.master, setup_dns=False,
                                               extra_args=args)
-        assert expected_msg in server_install.stderr_text
+        assert self.exp_change_msg in server_install.stderr_text
         cmd = self.master.run_command(['cat', paths.CHRONY_CONF])
         assert self.ntp_server1 in cmd.stdout_text
 
@@ -141,14 +146,14 @@ class TestNTPoptions(IntegrationTest):
                                                 extra_args=args,
                                                 promote=True)
         # while promoting with tasks expected_msg will not be in output
-        assert expected_msg not in replica_install.stderr_text
+        assert self.exp_change_msg not in replica_install.stderr_text
 
         cmd = self.replica.run_command(['cat', paths.CHRONY_CONF])
         assert self.ntp_server1 in cmd.stdout_text
 
         client_install = tasks.install_client(self.master, self.client,
                                               extra_args=args)
-        assert expected_msg in client_install.stderr_text
+        assert self.exp_change_msg in client_install.stderr_text
         cmd = self.client.run_command(['cat', paths.CHRONY_CONF])
         assert self.ntp_server1 in cmd.stdout_text
 
@@ -157,36 +162,30 @@ class TestNTPoptions(IntegrationTest):
         test to verify that ipa-server and ipa-client install with
         --ntp-server and -N options would fail
         """
-        exp_str = ("error: --ntp-server cannot be used"
-                   " together with --no-ntp")
-        exp_pool_str = ("error: --ntp-pool cannot be used"
-                        " together with --no-ntp")
-
         args1 = ['ipa-server-install', '-N',
                  '--ntp-server=%s' % self.ntp_server1]
+
         server_install = self.master.run_command(args1, raiseonerr=False)
         assert server_install.returncode == 2
-        assert exp_str in server_install.stderr_text
+        assert self.exp_srv_err in server_install.stderr_text
 
         args2 = ['ipa-client-install', '--no-ntp',
                  '--ntp-server=%s' % self.ntp_server2]
         client_install = self.client.run_command(args2, raiseonerr=False)
         assert client_install.returncode == 2
-        assert exp_str in client_install.stderr_text
+        assert self.exp_srv_err in client_install.stderr_text
 
         args3 = ['ipa-client-install', '-N',
                  '--ntp-pool=%s' % self.ntp_pool]
         client_install = self.client.run_command(args3, raiseonerr=False)
         assert client_install.returncode == 2
-        assert exp_pool_str in client_install.stderr_text
+        assert self.exp_pool_err in client_install.stderr_text
 
     def test_replica_promotion_with_ntp_options(self):
         """
         test to verify that replica promotion with ntp --ntp-server,
         --ntp-pool and -N or --no-ntp option would fail
         """
-        exp_str = "NTP configuration cannot be updated during promotion"
-
         tasks.install_master(self.master, setup_dns=False)
         tasks.install_client(self.master, self.replica)
 
@@ -194,19 +193,19 @@ class TestNTPoptions(IntegrationTest):
             ['ipa-replica-install', '--no-ntp'],
             raiseonerr=False)
         assert replica_install.returncode == 1
-        assert exp_str in replica_install.stderr_text
+        assert self.exp_prom_err in replica_install.stderr_text
 
         replica_install = self.replica.run_command(
             ['ipa-replica-install', '--ntp-server=%s' % self.ntp_server1],
             raiseonerr=False)
         assert replica_install.returncode == 1
-        assert exp_str in replica_install.stderr_text
+        assert self.exp_prom_err in replica_install.stderr_text
 
         replica_install = self.replica.run_command(
             ['ipa-replica-install', '--ntp-pool=%s' % self.ntp_pool],
             raiseonerr=False)
         assert replica_install.returncode == 1
-        assert exp_str in replica_install.stderr_text
+        assert self.exp_prom_err in replica_install.stderr_text
 
     def test_replica_promotion_without_ntp(self):
         """
@@ -215,21 +214,20 @@ class TestNTPoptions(IntegrationTest):
         - ipa-replica-install without ntp option
         will be successful
         """
-        exp_str = "ipa-replica-install command was successful"
-        expected_msg = "Configuration of chrony was changed by installer."
         ntp_args = ['--ntp-pool=%s' % self.ntp_pool]
 
         server_install = tasks.install_master(self.master, setup_dns=False,
                                               extra_args=ntp_args)
-        assert expected_msg in server_install.stderr_text
+        assert self.exp_change_msg in server_install.stderr_text
 
         client_install = tasks.install_client(self.master, self.replica,
                                               extra_args=ntp_args)
-        assert expected_msg in client_install.stderr_text
+        assert self.exp_change_msg in client_install.stderr_text
 
         replica_install = tasks.install_replica(self.master, self.replica,
                                                 promote=False)
-        assert exp_str in replica_install.stderr_text
+        assert "ipa-replica-install command was successful" in \
+            replica_install.stderr_text
 
         cmd = self.replica.run_command(['cat', paths.CHRONY_CONF])
         assert self.ntp_pool in cmd.stdout_text

--- a/ipatests/test_integration/test_ntp_options.py
+++ b/ipatests/test_integration/test_ntp_options.py
@@ -22,6 +22,12 @@ class TestNTPoptions(IntegrationTest):
     ntp_server1 = "1.pool.ntp.org"
     ntp_server2 = "2.pool.ntp.org"
 
+    print_chrony_conf = ['cat', paths.CHRONY_CONF]
+
+    exp_records_msg = "No SRV records of NTP servers found and " \
+                      "no NTP server or pool address was provided."
+    exp_chrony_msg = "Using default chrony configuration."
+
     @classmethod
     def install(cls, mh):
         cls.client = cls.clients[0]
@@ -227,6 +233,157 @@ class TestNTPoptions(IntegrationTest):
 
         cmd = self.replica.run_command(['cat', paths.CHRONY_CONF])
         assert self.ntp_pool in cmd.stdout_text
+
+    def test_interactive_ntp_set_opt(self):
+        """
+        Test to verify that ipa installations with ntp options passed
+        interactively (without -U/--nattended) will be successful
+        - ipa-server-install
+        - ipa-client-install
+        Both NTP servers and pool passed interactively to options.
+        """
+        server_input = (
+            # Do you want to configure integrated DNS (BIND)? [no]:
+            "No\n"
+            # Server host name [hostname]:
+            "\n"
+            # Do you want to configure chrony with NTP server
+            #   or pool address? [no]:
+            "Yes\n"
+            # Enter NTP source server addresses separated by comma,
+            #   or press Enter to skip:
+            "{},{}\n".format(self.ntp_server2, self.ntp_server1) +
+            # Enter a NTP source pool address, or press Enter to skip:
+            "{}\n".format(self.ntp_pool) +
+            # Continue to configure the system with these values? [no]:
+            "Yes"
+        )
+
+        client_input = (
+            # Proceed with fixed values and no DNS discovery? [no]:
+            "Yes\n"
+            # Do you want to configure chrony with NTP server
+            #   or pool address? [no]:
+            "Yes\n"
+            # Enter NTP source server addresses separated by comma,
+            #   or press Enter to skip:
+            "{},{}\n".format(self.ntp_server2, self.ntp_server1) +
+            # Enter a NTP source pool address, or press Enter to skip:
+            "{}\n".format(self.ntp_pool) +
+            # Continue to configure the system with these values? [no]:
+            "Yes"
+        )
+
+        server_install = tasks.install_master(self.master,
+                                              setup_dns=False,
+                                              unattended=False,
+                                              stdin_text=server_input)
+
+        assert server_install.returncode == 0
+        assert self.ntp_pool in server_install.stdout_text
+        assert self.ntp_server1 in server_install.stdout_text
+        assert self.ntp_server2 in server_install.stdout_text
+
+        cmd = self.master.run_command(self.print_chrony_conf)
+        assert self.ntp_pool in cmd.stdout_text
+        assert self.ntp_server1 in cmd.stdout_text
+        assert self.ntp_server2 in cmd.stdout_text
+
+        client_install = tasks.install_client(self.master,
+                                              self.client,
+                                              unattended=False,
+                                              stdin_text=client_input)
+
+        assert client_install.returncode == 0
+
+        cmd = self.client.run_command(self.print_chrony_conf)
+        assert self.ntp_pool in cmd.stdout_text
+        assert self.ntp_server1 in cmd.stdout_text
+        assert self.ntp_server2 in cmd.stdout_text
+
+    def test_interactive_ntp_no_opt(self):
+        """
+        Test to verify that ipa installations without ntp options passed
+        interactively (without -U/--nattended) will be successful
+        - ipa-server-install
+        - ipa-client-install
+        Both NTP servers and pool configuration skipped interactively.
+        """
+
+        server_input = (
+            "No\n"
+            "\n"
+            "Yes\n"
+            "\n"
+            "\n"
+            "Yes"
+        )
+
+        client_input = (
+            "Yes\n"
+            "Yes\n"
+            "\n"
+            "\n"
+            "Yes"
+        )
+
+        server_install = tasks.install_master(self.master,
+                                              setup_dns=False,
+                                              unattended=False,
+                                              stdin_text=server_input)
+
+        assert server_install.returncode == 0
+        assert self.exp_records_msg in server_install.stderr_text
+        assert self.exp_chrony_msg in server_install.stdout_text
+
+        client_install = tasks.install_client(self.master,
+                                              self.client,
+                                              unattended=False,
+                                              stdin_text=client_input)
+
+        assert client_install.returncode == 0
+        assert self.exp_records_msg in client_install.stderr_text
+        assert self.exp_chrony_msg in client_install.stdout_text
+
+    def test_interactive_ntp_no_conf(self):
+        """
+        Test to verify that ipa installations without selecting
+        to configure ntp options interactively (without -U/--nattended)
+        will be successful
+        - ipa-server-install
+        - ipa-client-install
+        """
+
+        server_input = (
+            "\n" +
+            "\n"
+            "No\n"
+            "Yes"
+        )
+
+        client_input = (
+            "Yes\n"
+            "No\n"
+            "Yes"
+        )
+
+        server_install = tasks.install_master(self.master,
+                                              setup_dns=False,
+                                              unattended=False,
+                                              stdin_text=server_input)
+
+        assert server_install.returncode == 0
+        assert self.exp_records_msg in server_install.stderr_text
+        assert self.exp_chrony_msg in server_install.stdout_text
+
+        client_install = tasks.install_client(self.master,
+                                              self.client,
+                                              unattended=False,
+                                              stdin_text=client_input)
+
+        assert client_install.returncode == 0
+        assert self.exp_records_msg in client_install.stderr_text
+        assert self.exp_chrony_msg in client_install.stdout_text
 
     def teardown_method(self, method):
         """


### PR DESCRIPTION
This PR was opened manually because PR #3406 was pushed to master and backport to ipa-4-7 is required. Please review prci definitions.