### PR TITLE
Support AES wrapping in LWCA key replication

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -86,9 +86,9 @@
 # Fedora
 %endif
 
-# 10.7 includes 'pki-server cert-fix' enhancements required
-# by ipa-cert-fix: https://pagure.io/freeipa/issue/7885
-%global pki_version 10.7.0-1
+# 10.7.3 supports LWCA key replication using AES
+# https://pagure.io/freeipa/issue/8020
+%global pki_version 10.7.3-1
 
 # https://pagure.io/certmonger/issue/90
 %global certmonger_version 0.79.7-1

--- a/install/tools/ipa-pki-retrieve-key.in
+++ b/install/tools/ipa-pki-retrieve-key.in
@@ -5,6 +5,8 @@ from __future__ import print_function
 import argparse
 import os
 
+from requests import HTTPError
+
 from ipalib import constants
 from ipalib.config import Env
 from ipaplatform.paths import paths
@@ -42,9 +44,37 @@ def main():
         keytab=client_keytab,
     )
 
+    OID_AES128_CBC = "2.16.840.1.101.3.4.1.2"
+
+    try:
+        # Initially request a key wrapped using AES128-CBC.
+        # This uses the recent ability to specify additional
+        # parameters to a Custodia resource.
+        path = f'{keyname}/{OID_AES128_CBC}'  # aes128-cbc
+        resp = client.fetch_key(path, store=False)
+    except HTTPError as e:
+        if e.response.status_code == 404:
+            # The 404 indicates one of two conditions:
+            #
+            # a) The server is an older version that does not support
+            #    extra Custodia parameters.  We should retry without
+            #    specifying an algorithm.
+            #
+            # b) The key does not exist.  At this point we cannot
+            #    distinguish (a) and (b) but if we retry without
+            #    specifying an algorithm, the second attempt will
+            #    also fail with status 404.
+            #
+            # So the correct way to handle both scenarios is to
+            # retry without the algorithm parameter.
+            #
+            resp = client.fetch_key(keyname, store=False)
+        else:
+            raise  # something else went wrong; re-raise
+
     # Print the response JSON to stdout; it is already in the format
     # that Dogtag's ExternalProcessKeyRetriever expects
-    print(client.fetch_key(keyname, store=False))
+    print(resp)
 
 
 if __name__ == '__main__':

--- a/ipaserver/secrets/handlers/nsswrappedcert.py
+++ b/ipaserver/secrets/handlers/nsswrappedcert.py
@@ -26,6 +26,7 @@ def export_key(args, tmpdir):
         'ca-authority-key-export',
         '--wrap-nickname', args.wrap_nickname,
         '--target-nickname', args.nickname,
+        '--algorithm', args.algorithm,
         '-o', wrapped_key_file
     ])
 
@@ -95,6 +96,17 @@ def pki_tomcat_parser():
         help='nick name of target key',
         required=True
     )
+
+    # Caller must specify a cipher.  This gets passed on to
+    # the 'pki ca-authority-key-export' command (part of
+    # Dogtag) via its own --algorithm option.
+    parser.add_argument(
+        '--algorithm',
+        dest='algorithm',
+        help='OID of symmetric wrap algorithm',
+        required=True
+    )
+
     parser.set_defaults(
         nssdb_path=paths.PKI_TOMCAT_ALIAS_DIR,
         nssdb_pwdfile=paths.PKI_TOMCAT_ALIAS_PWDFILE_TXT,


### PR DESCRIPTION
The PR enhances the NSSWrappedCertDB custodia store to accept an optional
symmetric encryption algorithm OID to use for encrypting the key.  Also update
the ipa-pki-retrieve-key program to request AES wrapping.

For backwards compatibility when older servers request a key, default to 3DES
(which is what the older server supports).

For backwards compatibility when retrieving a key from an older server, try AES
first, and on HTTP 404 retry without the algorithm OID.

This change depends on Dogtag PR https://github.com/dogtagpki/pki/pull/232, and
new Dogtag release containing the change (so that we can bump the dep min
bound in FreeIPA).

Changes:

```
4afb3c3fa (Fraser Tweedale, 21 hours ago)
   ipa-pki-retrieve-key: request AES encryption (with fallback)

   Update the ipa-pki-retrieve-key client to issue a request that specifies
   that AES encryption should be used.  Fall back to a simple request (which
   will use default export algorithm) if the server returns 404.  The 404
   indicates that either:

     - It is an old server that does not support extra key arguments

     - It is a new server but the key does not exist, in which case the
      fallback request will also fail with 404.

   Fixes: https://pagure.io/freeipa/issue/8020

c5d150a39 (Fraser Tweedale, 8 days ago)
   NSSWrappedCertDB: accept optional symmetric algorithm

   Add support for specifying the desired symmetric encryption algorithm for
   exporting wrapped key (for LWCA key replication).  If not specified,
   defaults to DES-EDE3-CBC for backwards compatibility.

   Client-side changes will occur in a subsequent commit.

   Part of: https://pagure.io/freeipa/issue/8020

86ba401cc (Fraser Tweedale, 8 days ago)
   IPASecStore: support extra key arguments

   To support lightweight CA key replication using AES, while retaining 
   backwards compatibility with old servers, it is necessary to signal support
   for AES.  Whereas we currently request a key with the path:

     /keys/ca_wrapped/<nickname>

   and whereas paths with > 3 components are unsupported, add support for
   handlers to signal that they support extra arguments (defaulting to False),
   those arguments being conveyed as additional path components, e.g.:

     # 2.16.840.1.101.3.4.1.2 = aes128-cbc
    /keys/ca_wrapped/<nickname>/2.16.840.1.101.3.4.1.2

   This commit only adds the Custodia support for extra handler arguments. 
   Work to support LWCA key replication with AES wrapping will continue in
   subsequent commits.

   Part of: https://pagure.io/freeipa/issue/8020
```