### PR TITLE
[ipa-4-8] travis: update container used for testing ipa-4-8 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
 cache: pip
 env:
     global:
-        - TEST_RUNNER_IMAGE="freeipa/freeipa-test-runner:master-latest"
+        - TEST_RUNNER_IMAGE="freeipa/freeipa-test-runner:ipa-4-8_f30"
           PEP8_ERROR_LOG="pycodestyle_errors.log"
           CI_RESULTS_LOG="ci_results_${TRAVIS_BRANCH}.log"
           CI_BACKLOG_SIZE=5000


### PR DESCRIPTION
Based on the new Dockerfile included in https://github.com/freeipa/ipa-docker-test-runner/commit/809dde3cd5b04bf9306f3be0ef459d503288b02b

Signed-off-by: Armando Neto <abiagion@redhat.com>