### PR TITLE
[Backport][ipa-4-7] test_nfs.py: switch to tasks.config_replica_resolvconf_with_master_data()

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1219,7 +1219,7 @@ jobs:
         test_suite: test_integration/test_nfs.py::TestNFS
         template: *ci-master-f29
         timeout: 9000
-        topology: *master_2repl_1client
+        topology: *master_3client
 
   fedora-29/automember:
     requires: [fedora-29/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -859,7 +859,7 @@ jobs:
         test_suite: test_integration/test_nfs.py::TestNFS
         template: *ci-master-frawhide
         timeout: 9000
-        topology: *master_2repl_1client
+        topology: *master_3client
 
   fedora-rawhide/automember:
     requires: [fedora-rawhide/build]

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -410,13 +410,13 @@ def master_authoritative_for_client_domain(master, client):
     return result.returncode == 0
 
 
-def config_replica_resolvconf_with_master_data(master, replica):
+def config_host_resolvconf_with_master_data(master, host):
     """
-    Configure replica /etc/resolv.conf to use master as DNS server
+    Configure host /etc/resolv.conf to use master as DNS server
     """
     content = ('search {domain}\nnameserver {master_ip}'
                .format(domain=master.domain.name, master_ip=master.ip))
-    replica.put_file_contents(paths.RESOLV_CONF, content)
+    host.put_file_contents(paths.RESOLV_CONF, content)
 
 
 def install_replica(master, replica, setup_ca=True, setup_dns=False,

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -496,12 +496,12 @@ class TestBackupAndRestoreWithReplica(IntegrationTest):
         # Configure /etc/resolv.conf on each replica to use the master as DNS
         # Otherwise ipa-replica-manage re-initialize is unable to
         # resolve the master name
-        tasks.config_replica_resolvconf_with_master_data(
-            cls.master,
-            cls.replica1)
-        tasks.config_replica_resolvconf_with_master_data(
-            cls.master,
-            cls.replica2)
+        tasks.config_host_resolvconf_with_master_data(
+            cls.master, cls.replica1
+        )
+        tasks.config_host_resolvconf_with_master_data(
+            cls.master, cls.replica2
+        )
         # Configure only master and one replica.
         # Replica is configured without CA
         tasks.install_topo(

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -42,7 +42,7 @@ class TestNFS(IntegrationTest):
         clients = (cls.clients[0], cls.replicas[0], cls.replicas[1])
         for client in clients:
             tasks.backup_file(client, paths.RESOLV_CONF)
-            tasks.config_replica_resolvconf_with_master_data(
+            tasks.config_host_resolvconf_with_master_data(
                 cls.master, client
             )
             tasks.install_client(cls.master, client)

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -15,14 +15,13 @@
 
 from __future__ import absolute_import
 
-import time
+import os
 import re
+import time
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipaplatform.paths import paths
-
-import os
 
 # give some time for units to stabilize
 # otherwise we get transient errors
@@ -30,32 +29,7 @@ WAIT_AFTER_INSTALL = 5
 WAIT_AFTER_UNINSTALL = WAIT_AFTER_INSTALL
 
 
-class TestInit(IntegrationTest):
-
-    @classmethod
-    def fix_resolv_conf(cls, client, server):
-
-        contents = client.get_file_contents(paths.RESOLV_CONF,
-                                            encoding='utf-8')
-        nameserver = 'nameserver %s\n' % server.ip
-        if not contents.startswith(nameserver):
-            contents = nameserver + contents.replace(nameserver, '')
-            client.run_command([
-                '/usr/bin/cp', paths.RESOLV_CONF,
-                '%s.sav' % paths.RESOLV_CONF
-            ])
-            client.put_file_contents(paths.RESOLV_CONF, contents)
-
-    @classmethod
-    def restore_resolv_conf(cls, client):
-        client.run_command([
-            '/usr/bin/cp',
-            '%s.sav' % paths.RESOLV_CONF,
-            paths.RESOLV_CONF
-        ])
-
-
-class TestNFS(TestInit):
+class TestNFS(IntegrationTest):
 
     num_replicas = 2
     num_clients = 1
@@ -67,7 +41,10 @@ class TestNFS(TestInit):
         tasks.install_master(cls.master, setup_dns=True)
         clients = (cls.clients[0], cls.replicas[0], cls.replicas[1])
         for client in clients:
-            cls.fix_resolv_conf(client, cls.master)
+            tasks.backup_file(client, paths.RESOLV_CONF)
+            tasks.config_replica_resolvconf_with_master_data(
+                cls.master, client
+            )
             tasks.install_client(cls.master, client)
             client.run_command(["cat", "/etc/resolv.conf"])
 
@@ -89,8 +66,6 @@ class TestNFS(TestInit):
 
         nfssrv.run_command(["rm", "-rf", "/exports"])
 
-        tasks.uninstall_client(nfsclt)
-        tasks.uninstall_client(nfssrv)
         self.master.run_command([
             "ipa", "host-mod", automntclt.hostname,
             "--location", "''"
@@ -101,9 +76,9 @@ class TestNFS(TestInit):
         ])
         nfsclt.run_command(["systemctl", "restart", "nfs-utils"])
         nfssrv.run_command(["systemctl", "restart", "nfs-utils"])
+
         for client in (nfssrv, nfsclt, automntclt):
-            self.restore_resolv_conf(client)
-        tasks.uninstall_master(self.master)
+            tasks.restore_files(client)
 
     def test_prepare_users(self):
 


### PR DESCRIPTION
MANUAL BACKPORT of https://github.com/freeipa/freeipa/pull/3463