### PR TITLE
Don't return SSH keys with ipa host-find --pkey-only

### DIFF
--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -1061,7 +1061,8 @@ class host_find(LDAPSearch):
                         (filter, hosts_filter), ldap.MATCH_ALL
                     )
 
-        add_sshpubkey_to_attrs_pre(self.context, attrs_list)
+        if not options.get('pkey_only', False):
+            add_sshpubkey_to_attrs_pre(self.context, attrs_list)
 
         return (filter.replace('locality', 'l'), base_dn, scope)
 


### PR DESCRIPTION
This was introduced in 14ee02dcbd6cbb6c221ac7526e471a9fc58fcc82

https://pagure.io/freeipa/issue/8029