### PR TITLE
ipaserver/plugins/dns.py: add "Dynamic Update" and "Bind update policy" to default dnszone* output

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -2388,7 +2388,8 @@ class dnszone(DNSZoneBase):
     default_attributes = DNSZoneBase.default_attributes + [
         'idnssoamname', 'idnssoarname', 'idnssoaserial', 'idnssoarefresh',
         'idnssoaretry', 'idnssoaexpire', 'idnssoaminimum', 'idnsallowquery',
-        'idnsallowtransfer', 'idnssecinlinesigning',
+        'idnsallowtransfer', 'idnssecinlinesigning', 'idnsallowdynupdate',
+        'idnsupdatepolicy'
     ] + _record_attributes
     label = _('DNS Zones')
     label_singular = _('DNS Zone')

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -2389,7 +2389,6 @@ class dnszone(DNSZoneBase):
         'idnssoamname', 'idnssoarname', 'idnssoaserial', 'idnssoarefresh',
         'idnssoaretry', 'idnssoaexpire', 'idnssoaminimum', 'idnsallowquery',
         'idnsallowtransfer', 'idnssecinlinesigning', 'idnsallowdynupdate',
-        'idnsupdatepolicy'
     ] + _record_attributes
     label = _('DNS Zones')
     label_singular = _('DNS Zone')

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,14 +57,38 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_installation_TestInstallMasterDNS:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_installation.py::TestInstallMasterDNS
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 10800
+        topology: *master_1repl
+
+  fedora-latest/test_backup_and_restore_TestBackupAndRestoreWithDNS:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -707,8 +707,13 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowtransfer': [u'none;'],
+                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
+                                         u'grant %(realm)s krb5-self * AAAA; '
+                                         u'grant %(realm)s krb5-self * SSHFP;'
+                                         % dict(realm=api.env.realm)],
                     'idnsallowquery': [u'any;'],
+                    'idnsallowtransfer': [u'none;'],
                 },
             },
         ),
@@ -731,8 +736,13 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowtransfer': [u'none;'],
+                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
+                                         u'grant %(realm)s krb5-self * AAAA; '
+                                         u'grant %(realm)s krb5-self * SSHFP;'
+                                         % dict(realm=api.env.realm)],
                     'idnsallowquery': [u'any;'],
+                    'idnsallowtransfer': [u'none;'],
                 },
             },
         ),
@@ -899,7 +909,7 @@ class test_dns(Declarative):
                 'result': [{
                     'dn': revzone1_dn,
                     'idnsname': [revzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [u'FALSE'],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [zone1_rname_dnsname],
@@ -908,6 +918,12 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
+                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsupdatepolicy':
+                        [u'grant %(realm)s krb5-subdomain %(zone)s PTR;'
+                            % dict(
+                                realm=api.env.realm, zone=revzone1_dnsname
+                            )],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
                 },
@@ -923,6 +939,11 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
+                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
+                                         u'grant %(realm)s krb5-self * AAAA; '
+                                         u'grant %(realm)s krb5-self * SSHFP;'
+                                         % dict(realm=api.env.realm)],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
                 }],
@@ -949,6 +970,11 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
+                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
+                                         u'grant %(realm)s krb5-self * AAAA; '
+                                         u'grant %(realm)s krb5-self * SSHFP;'
+                                         % dict(realm=api.env.realm)],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
                 }],

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -708,10 +708,6 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowdynupdate': [u'FALSE'],
-                    'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
-                                         u'grant %(realm)s krb5-self * AAAA; '
-                                         u'grant %(realm)s krb5-self * SSHFP;'
-                                         % dict(realm=api.env.realm)],
                     'idnsallowquery': [u'any;'],
                     'idnsallowtransfer': [u'none;'],
                 },
@@ -737,10 +733,6 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowdynupdate': [u'FALSE'],
-                    'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
-                                         u'grant %(realm)s krb5-self * AAAA; '
-                                         u'grant %(realm)s krb5-self * SSHFP;'
-                                         % dict(realm=api.env.realm)],
                     'idnsallowquery': [u'any;'],
                     'idnsallowtransfer': [u'none;'],
                 },
@@ -919,11 +911,6 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowdynupdate': [u'FALSE'],
-                    'idnsupdatepolicy':
-                        [u'grant %(realm)s krb5-subdomain %(zone)s PTR;'
-                            % dict(
-                                realm=api.env.realm, zone=revzone1_dnsname
-                            )],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
                 },
@@ -940,10 +927,6 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowdynupdate': [u'FALSE'],
-                    'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
-                                         u'grant %(realm)s krb5-self * AAAA; '
-                                         u'grant %(realm)s krb5-self * SSHFP;'
-                                         % dict(realm=api.env.realm)],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
                 }],
@@ -971,10 +954,6 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowdynupdate': [u'FALSE'],
-                    'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
-                                         u'grant %(realm)s krb5-self * AAAA; '
-                                         u'grant %(realm)s krb5-self * SSHFP;'
-                                         % dict(realm=api.env.realm)],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
                 }],


### PR DESCRIPTION
Displaying "Dynamic Update" and "Bind update policy" by default
when 'ipa dnszone-show/find' are used would make client dns update
failures easier to diagnose, so display them.

Fixes: https://pagure.io/freeipa/issue/7938
Signed-off-by: François Cami <fcami@redhat.com>