### PR TITLE
Change RA agent certificate profile to caSubsystemCert

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -306,6 +306,9 @@ IPA_CA_RECORD = "ipa-ca"
 IPA_CA_NICKNAME = 'caSigningCert cert-pki-ca'
 RENEWAL_CA_NAME = 'dogtag-ipa-ca-renew-agent'
 RENEWAL_REUSE_CA_NAME = 'dogtag-ipa-ca-renew-agent-reuse'
+# The RA agent cert is used for client cert authentication. In the past IPA
+# used caServerCert profile, which adds clientAuth and serverAuth EKU. The
+# serverAuth EKU caused trouble with NamedConstraints, see RHBZ#1670239.
 RA_AGENT_PROFILE = 'caSubsystemCert'
 # How long dbus clients should wait for CA certificate RPCs [seconds]
 CA_DBUS_TIMEOUT = 120

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -306,7 +306,7 @@ IPA_CA_RECORD = "ipa-ca"
 IPA_CA_NICKNAME = 'caSigningCert cert-pki-ca'
 RENEWAL_CA_NAME = 'dogtag-ipa-ca-renew-agent'
 RENEWAL_REUSE_CA_NAME = 'dogtag-ipa-ca-renew-agent-reuse'
-RA_AGENT_PROFILE = 'caServerCert'
+RA_AGENT_PROFILE = 'caSubsystemCert'
 # How long dbus clients should wait for CA certificate RPCs [seconds]
 CA_DBUS_TIMEOUT = 120
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -857,7 +857,7 @@ class CAInstance(DogtagInstance):
             ipalib.constants.RENEWAL_CA_NAME, helper)
 
         try:
-            # The certificate must be requested using caServerCert profile
+            # The certificate must be requested using caSubsystemCert profile
             # because this profile does not require agent authentication
             reqId = certmonger.request_and_wait_for_cert(
                 certpath=(paths.RA_AGENT_PEM, paths.RA_AGENT_KEY),


### PR DESCRIPTION
Currently, RA agent certificate is issued using caServerCert profile.
This has unfortunate side effect of asserting id-pk-serverAuth EKU which
is not really needed for RA agent. If IPA CA certificate adds SAN DNS
constraints into issued certificates, presence of id-pk-serverAuth EKU
forces NSS (and other crypto libraries) to validate CN value with
regards to SAN DNS constraints, due to historical use of CN bearing DNS
name.

Since RA agent certificate has 'CN=IPA RA', it is guaranteed to fail
the check.

Default IPA CA configuration does *not* add SAN DNS constraints into RA
agent certificate. However, it is better to be prepared to such
behavior.

Related: https://bugzilla.redhat.com/1670239