### PR TITLE
[Backport][ipa-4-8] Fix UnboundLocalError in ipa-replica-manage on errors

### DIFF
--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -279,6 +279,7 @@ def del_link(realm, replica1, replica2, dirman_passwd, force=False):
         return False
     except Exception as e:
         print("Failed to determine agreement type for '%s': %s" % (replica2, e))
+        return False
 
     if type1 == replication.IPA_REPLICA and managed_topology:
         exit_on_managed_topology(what)


### PR DESCRIPTION
This PR was opened automatically because PR #3501 was pushed to master and backport to ipa-4-8 is required.