### PR TITLE
[Backport][ipa-4-8] Test external CA with DNS name constraints

### DIFF
--- a/ipatests/create_external_ca.py
+++ b/ipatests/create_external_ca.py
@@ -63,7 +63,7 @@ class ExternalCA:
             backend=default_backend(),
         )
 
-    def create_ca(self, cn=ISSUER_CN, path_length=None):
+    def create_ca(self, cn=ISSUER_CN, path_length=None, extensions=()):
         """Create root CA.
 
         :returns: bytes -- Root CA in PEM format.
@@ -113,6 +113,9 @@ class ExternalCA:
                  ),
             critical=False,
         )
+
+        for extension in extensions:
+            builder = builder.add_extension(extension, critical=False)
 
         cert = builder.sign(self.ca_key, hashes.SHA256(), default_backend())
 

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -70,7 +70,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
-        test_suite: test_integration/test_external_ca.py::TestExternalCA
+        test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
         template: *ci-master-f30
         timeout: 4800
         topology: *master_1repl_1client

--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -58,7 +58,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-28/build_url}'
-        test_suite: test_integration/test_external_ca.py::TestExternalCA
+        test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
         template: *ci-master-f28
         timeout: 4800
         topology: *master_1repl_1client

--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -62,7 +62,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_external_ca.py::TestExternalCA
+        test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
         template: *ci-master-f29
         timeout: 4800
         topology: *master_1repl_1client

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -62,7 +62,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
-        test_suite: test_integration/test_external_ca.py::TestExternalCA
+        test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
         template: *ci-master-f30
         timeout: 4800
         topology: *master_1repl_1client

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -62,7 +62,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-rawhide/build_url}'
-        test_suite: test_integration/test_external_ca.py::TestExternalCA
+        test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
         template: *ci-master-frawhide
         timeout: 4800
         topology: *master_1repl_1client

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1696,7 +1696,7 @@ def add_dns_zone(master, zone, skip_overlap_check=False,
 
 def sign_ca_and_transport(host, csr_name, root_ca_name, ipa_ca_name,
                           root_ca_path_length=None, ipa_ca_path_length=1,
-                          key_size=None,):
+                          key_size=None, root_ca_extensions=()):
     """
     Sign ipa csr and save signed CA together with root CA back to the host.
     Returns root CA and IPA CA paths on the host.
@@ -1709,7 +1709,10 @@ def sign_ca_and_transport(host, csr_name, root_ca_name, ipa_ca_name,
 
     external_ca = ExternalCA(key_size=key_size)
     # Create root CA
-    root_ca = external_ca.create_ca(path_length=root_ca_path_length)
+    root_ca = external_ca.create_ca(
+        path_length=root_ca_path_length,
+        extensions=root_ca_extensions,
+    )
     # Sign CSR
     ipa_ca = external_ca.sign_csr(ipa_csr, path_length=ipa_ca_path_length)
 


### PR DESCRIPTION
This PR was opened automatically because PR #3505 was pushed to master and backport to ipa-4-8 is required.