### PR TITLE
[Backport][ipa-4-7] Profile-based system cert renewal

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
@@ -205,7 +205,7 @@ def request_cert(reuse_existing, **kwargs):
             sys.argv[1:] +
             ['--submit-option', "requestor_name=IPA"])
     if os.environ.get('CERTMONGER_CA_PROFILE') == 'caCACert':
-        args += ['-N', '-O', 'bypassCAnotafter=true']
+        args += ['--force-new', '--approval-option', 'bypassCAnotafter=true']
     result = ipautil.run(args, raiseonerr=False, env=os.environ,
                          capture_output=True)
     if six.PY2:

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
@@ -203,9 +203,9 @@ def request_cert(reuse_existing, **kwargs):
              "--certfile", paths.RA_AGENT_PEM,
              "--keyfile", paths.RA_AGENT_KEY] +
             sys.argv[1:] +
-            ['--submit-option', "requestor_name=IPA"])
-    if os.environ.get('CERTMONGER_CA_PROFILE') == 'caCACert':
-        args += ['--force-new', '--approval-option', 'bypassCAnotafter=true']
+            ['--submit-option', "requestor_name=IPA"] +
+            ['--force-new', '--approval-option', 'bypassCAnotafter=true']
+    )
     result = ipautil.run(args, raiseonerr=False, env=os.environ,
                          capture_output=True)
     if six.PY2:

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -306,6 +306,7 @@ IPA_CA_RECORD = "ipa-ca"
 IPA_CA_NICKNAME = 'caSigningCert cert-pki-ca'
 RENEWAL_CA_NAME = 'dogtag-ipa-ca-renew-agent'
 RENEWAL_REUSE_CA_NAME = 'dogtag-ipa-ca-renew-agent-reuse'
+RA_AGENT_PROFILE = 'caServerCert'
 # How long dbus clients should wait for CA certificate RPCs [seconds]
 CA_DBUS_TIMEOUT = 120
 

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -427,7 +427,8 @@ def request_cert(
 
 def start_tracking(
         certpath, ca='IPA', nickname=None, pin=None, pinfile=None,
-        pre_command=None, post_command=None, profile=None, storage="NSSDB"):
+        pre_command=None, post_command=None, profile=None, storage="NSSDB",
+        token_name=None):
     """
     Tell certmonger to track the given certificate in either a file or an NSS
     database. The certificate access can be protected by a password_file.
@@ -460,6 +461,8 @@ def start_tracking(
         NSS or OpenSSL backend to track the certificate in ``certpath``
     :param profile:
         Which certificate profile should be used.
+    :param token_name:
+        Hardware token name for HSM support
     :returns: certificate tracking nickname.
     """
     if storage == 'FILE':
@@ -500,6 +503,10 @@ def start_tracking(
         params['cert-postsave-command'] = post_command
     if profile:
         params['ca-profile'] = profile
+    if token_name not in {None, "internal"}:
+        # only pass token names for external tokens (e.g. HSM)
+        params['key-token'] = token_name
+        params['cert-token'] = token_name
 
     result = cm.obj_if.add_request(params)
     try:
@@ -663,7 +670,7 @@ def modify_ca_helper(ca_name, helper):
         return old_helper
 
 
-def get_pin(token):
+def get_pin(token="internal"):
     """
     Dogtag stores its NSS pin in a file formatted as token:PIN.
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -979,7 +979,7 @@ class CAInstance(DogtagInstance):
                 principal='host/%s' % self.fqdn,
                 subject=str(DN(('CN', 'IPA RA'), self.subject_base)),
                 ca=ipalib.constants.RENEWAL_CA_NAME,
-                profile='caServerCert',
+                profile=ipalib.constants.RA_AGENT_PROFILE,
                 pre_command='renew_ra_cert_pre',
                 post_command='renew_ra_cert',
                 storage="FILE",
@@ -1106,7 +1106,7 @@ class CAInstance(DogtagInstance):
                              '/org/fedorahosted/certmonger')
         iface = dbus.Interface(obj, 'org.fedorahosted.certmonger')
         for suffix in ['', '-reuse']:
-            name = 'dogtag-ipa-ca-renew-agent' + suffix
+            name = ipalib.constants.RENEWAL_CA_NAME + suffix
             path = iface.find_ca_by_nickname(name)
             if path:
                 iface.remove_known_ca(path)
@@ -1161,7 +1161,7 @@ class CAInstance(DogtagInstance):
         try:
             certmonger.start_tracking(
                 certpath=(paths.RA_AGENT_PEM, paths.RA_AGENT_KEY),
-                ca='dogtag-ipa-ca-renew-agent',
+                ca=ipalib.constants.RENEWAL_CA_NAME,
                 profile=ipalib.constants.RA_AGENT_PROFILE,
                 pre_command='renew_ra_cert_pre',
                 post_command='renew_ra_cert',

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -298,6 +298,8 @@ class CAInstance(DogtagInstance):
        2 = have signed cert, continue installation
     """
 
+    server_cert_name = 'Server-Cert cert-pki-ca'
+
     # Mapping of nicknames for tracking requests, and the profile to
     # use for that certificate.  'configure_renewal()' reads this
     # dict.  The profile MUST be specified.
@@ -306,8 +308,12 @@ class CAInstance(DogtagInstance):
         'ocspSigningCert cert-pki-ca': 'caOCSPCert',
         'subsystemCert cert-pki-ca': 'caSubsystemCert',
         'caSigningCert cert-pki-ca': 'caCACert',
+        server_cert_name: 'caServerCert',
     }
-    server_cert_name = 'Server-Cert cert-pki-ca'
+    token_names = {
+        server_cert_name: 'internal',  # Server-Cert always on internal token
+    }
+
     # The following must be aligned with the RewriteRule defined in
     # install/share/ipa-pki-proxy.conf.template
     crl_rewrite_pattern = r"^\s*(RewriteRule\s+\^/ipa/crl/MasterCRL.bin\s.*)$"
@@ -474,7 +480,6 @@ class CAInstance(DogtagInstance):
                         "Ensuring backward compatibility",
                         self.__dogtag10_migration)
                 self.step("configure certificate renewals", self.configure_renewal)
-                self.step("configure Server-Cert certificate renewal", self.track_servercert)
                 self.step("Configure HTTP to proxy connections",
                           self.http_proxy)
                 self.step("restarting certificate server", self.restart_instance)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -298,6 +298,9 @@ class CAInstance(DogtagInstance):
        2 = have signed cert, continue installation
     """
 
+    # Mapping of nicknames for tracking requests, and the profile to
+    # use for that certificate.  'configure_renewal()' reads this
+    # dict.  The profile MUST be specified.
     tracking_reqs = {
         'auditSigningCert cert-pki-ca': 'caSignedLogCert',
         'ocspSigningCert cert-pki-ca': 'caOCSPCert',

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1162,6 +1162,7 @@ class CAInstance(DogtagInstance):
             certmonger.start_tracking(
                 certpath=(paths.RA_AGENT_PEM, paths.RA_AGENT_KEY),
                 ca='dogtag-ipa-ca-renew-agent',
+                profile=ipalib.constants.RA_AGENT_PROFILE,
                 pre_command='renew_ra_cert_pre',
                 post_command='renew_ra_cert',
                 storage='FILE')

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -298,10 +298,12 @@ class CAInstance(DogtagInstance):
        2 = have signed cert, continue installation
     """
 
-    tracking_reqs = ('auditSigningCert cert-pki-ca',
-                     'ocspSigningCert cert-pki-ca',
-                     'subsystemCert cert-pki-ca',
-                     'caSigningCert cert-pki-ca')
+    tracking_reqs = {
+        'auditSigningCert cert-pki-ca': 'caSignedLogCert',
+        'ocspSigningCert cert-pki-ca': 'caOCSPCert',
+        'subsystemCert cert-pki-ca': 'caSubsystemCert',
+        'caSigningCert cert-pki-ca': 'caCACert',
+    }
     server_cert_name = 'Server-Cert cert-pki-ca'
     # The following must be aligned with the RewriteRule defined in
     # install/share/ipa-pki-proxy.conf.template

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -377,14 +377,16 @@ class CertDB(object):
         except ipautil.CalledProcessError:
             return None
 
-    def track_server_cert(self, nickname, principal, password_file=None, command=None):
+    def track_server_cert(
+            self, nickname, principal,
+            password_file=None, command=None, profile=None):
         """
         Tell certmonger to track the given certificate nickname.
         """
         try:
             request_id = certmonger.start_tracking(
                 self.secdir, nickname=nickname, pinfile=password_file,
-                post_command=command)
+                post_command=command, profile=profile)
         except RuntimeError as e:
             logger.error("certmonger failed starting to track certificate: %s",
                          str(e))

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -91,7 +91,7 @@ class DogtagInstance(service.Service):
 
     # Mapping of nicknames for tracking requests, and the profile to
     # use for that certificate.  'configure_renewal()' reads this
-    # dict and adds the profile if configured.
+    # dict.  The profile MUST be specified.
     tracking_reqs = dict()
 
     # token for CA and subsystem certificates. For now, only internal token

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -34,7 +34,7 @@ import pki.system
 
 from ipalib import api, errors, x509
 from ipalib.install import certmonger
-from ipalib.constants import CA_DBUS_TIMEOUT
+from ipalib.constants import CA_DBUS_TIMEOUT, RENEWAL_CA_NAME
 from ipaplatform import services
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
@@ -297,7 +297,7 @@ class DogtagInstance(service.Service):
                              '/org/fedorahosted/certmonger')
         iface = dbus.Interface(obj, 'org.fedorahosted.certmonger')
         for suffix, args in [('', ''), ('-reuse', ' --reuse-existing')]:
-            name = 'dogtag-ipa-ca-renew-agent' + suffix
+            name = RENEWAL_CA_NAME + suffix
             path = iface.find_ca_by_nickname(name)
             if not path:
                 command = paths.DOGTAG_IPA_CA_RENEW_AGENT_SUBMIT + args
@@ -325,7 +325,7 @@ class DogtagInstance(service.Service):
             try:
                 certmonger.start_tracking(
                     certpath=self.nss_db,
-                    ca='dogtag-ipa-ca-renew-agent',
+                    ca=RENEWAL_CA_NAME,
                     nickname=nickname,
                     token_name=token_name,
                     pin=pin,

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -89,17 +89,21 @@ class DogtagInstance(service.Service):
     CA, KRA, and eventually TKS and TPS.
     """
 
-    # Mapping of nicknames for tracking requests, and the profile to use for
-    # that certificate.  'configure_renewal()' reads this dict and adds the
-    # profile if configured.  Certificates that use the default profile
-    # ("caServerCert", as defined by dogtag-ipa-renew-agent which is part of
-    # Certmonger) are omitted.
+    # Mapping of nicknames for tracking requests, and the profile to
+    # use for that certificate.  'configure_renewal()' reads this
+    # dict and adds the profile if configured.
     tracking_reqs = dict()
-    server_cert_name = None
 
     # token for CA and subsystem certificates. For now, only internal token
     # is supported.
     token_name = "internal"
+
+    # override token for specific nicknames
+    token_names = dict()
+
+    def get_token_name(self, nickname):
+        """Look up token name for nickname."""
+        return self.token_names.get(nickname, self.token_name)
 
     ipaca_groups = DN(('ou', 'groups'), ('o', 'ipaca'))
     ipaca_people = DN(('ou', 'people'), ('o', 'ipaca'))
@@ -314,15 +318,16 @@ class DogtagInstance(service.Service):
 
     def configure_renewal(self):
         """ Configure certmonger to renew system certs """
-        pin = self.__get_pin(self.token_name)
 
         for nickname in self.tracking_reqs:
+            token_name = self.get_token_name(nickname)
+            pin = self.__get_pin(token_name)
             try:
                 certmonger.start_tracking(
                     certpath=self.nss_db,
                     ca='dogtag-ipa-ca-renew-agent',
                     nickname=nickname,
-                    token_name=self.token_name,
+                    token_name=token_name,
                     pin=pin,
                     pre_command='stop_pkicad',
                     post_command='renew_ca_cert "%s"' % nickname,
@@ -331,29 +336,6 @@ class DogtagInstance(service.Service):
             except RuntimeError as e:
                 logger.error(
                     "certmonger failed to start tracking certificate: %s", e)
-
-    def track_servercert(self):
-        """
-        Specifically do not tell certmonger to restart the CA. This will be
-        done by the renewal script, renew_ca_cert once all the subsystem
-        certificates are renewed.
-        """
-        # server cert is always stored in internal token
-        token_name = "internal"
-        pin = self.__get_pin(token_name)
-        try:
-            certmonger.start_tracking(
-                certpath=self.nss_db,
-                ca='dogtag-ipa-ca-renew-agent',
-                nickname=self.server_cert_name,
-                token_name=token_name,
-                pin=pin,
-                pre_command='stop_pkicad',
-                post_command='renew_ca_cert "%s"' % self.server_cert_name
-            )
-        except RuntimeError as e:
-            logger.error(
-                "certmonger failed to start tracking certificate: %s", e)
 
     def stop_tracking_certificates(self, stop_certmonger=True):
         """Stop tracking our certificates. Called on uninstall.
@@ -368,11 +350,7 @@ class DogtagInstance(service.Service):
             services.knownservices.dbus.start()
         cmonger.start()
 
-        nicknames = list(self.tracking_reqs)
-        if self.server_cert_name is not None:
-            nicknames.append(self.server_cert_name)
-
-        for nickname in nicknames:
+        for nickname in self.tracking_reqs:
             try:
                 certmonger.stop_tracking(
                     self.nss_db, nickname=nickname)

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -89,7 +89,12 @@ class DogtagInstance(service.Service):
     CA, KRA, and eventually TKS and TPS.
     """
 
-    tracking_reqs = None
+    # Mapping of nicknames for tracking requests, and the profile to use for
+    # that certificate.  'configure_renewal()' reads this dict and adds the
+    # profile if configured.  Certificates that use the default profile
+    # ("caServerCert", as defined by dogtag-ipa-renew-agent which is part of
+    # Certmonger) are omitted.
+    tracking_reqs = dict()
     server_cert_name = None
 
     # token for CA and subsystem certificates. For now, only internal token
@@ -321,6 +326,7 @@ class DogtagInstance(service.Service):
                     pin=pin,
                     pre_command='stop_pkicad',
                     post_command='renew_ca_cert "%s"' % nickname,
+                    profile=self.tracking_reqs[nickname],
                 )
             except RuntimeError as e:
                 logger.error(

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -1178,9 +1178,12 @@ class DsInstance(service.Service):
         dirname = config_dirname(serverid)[:-1]
         dsdb = certs.CertDB(self.realm, nssdir=dirname)
         if dsdb.is_ipa_issued_cert(api, nickname):
-            dsdb.track_server_cert(nickname, self.principal,
-                                   dsdb.passwd_fname,
-                                   'restart_dirsrv %s' % serverid)
+            dsdb.track_server_cert(
+                nickname,
+                self.principal,
+                password_file=dsdb.passwd_fname,
+                command='restart_dirsrv %s' % serverid,
+                profile=dogtag.DEFAULT_PROFILE)
         else:
             logger.debug("Will not track DS server certificate %s as it is "
                          "not issued by IPA", nickname)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -585,11 +585,14 @@ class HTTPInstance(service.Service):
                          str(e))
 
     def start_tracking_certificates(self):
+        key_passwd_file = paths.HTTPD_PASSWD_FILE_FMT.format(host=api.env.host)
         cert = x509.load_certificate_from_file(paths.HTTPD_CERT_FILE)
         if certs.is_ipa_issued_cert(api, cert):
             request_id = certmonger.start_tracking(
                 certpath=(paths.HTTPD_CERT_FILE, paths.HTTPD_KEY_FILE),
-                post_command='restart_httpd', storage='FILE'
+                post_command='restart_httpd', storage='FILE',
+                profile=dogtag.DEFAULT_PROFILE,
+                pinfile=key_passwd_file,
             )
             subject = str(DN(cert.subject))
             certmonger.add_principal(request_id, self.principal)

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -65,6 +65,9 @@ class KRAInstance(DogtagInstance):
     be the same for both the CA and KRA.
     """
 
+    # Mapping of nicknames for tracking requests, and the profile to
+    # use for that certificate.  'configure_renewal()' reads this
+    # dict.  The profile MUST be specified.
     tracking_reqs = {
         'auditSigningCert cert-pki-kra': 'caInternalAuthAuditSigningCert',
         'transportCert cert-pki-kra': 'caInternalAuthTransportCert',

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -65,9 +65,11 @@ class KRAInstance(DogtagInstance):
     be the same for both the CA and KRA.
     """
 
-    tracking_reqs = ('auditSigningCert cert-pki-kra',
-                     'transportCert cert-pki-kra',
-                     'storageCert cert-pki-kra')
+    tracking_reqs = {
+        'auditSigningCert cert-pki-kra': 'caInternalAuthAuditSigningCert',
+        'transportCert cert-pki-kra': 'caInternalAuthTransportCert',
+        'storageCert cert-pki-kra': 'caInternalAuthDRMstorageCert',
+    }
 
     def __init__(self, realm):
         super(KRAInstance, self).__init__(

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -20,7 +20,7 @@ from contextlib import contextmanager
 from augeas import Augeas
 import dns.exception
 from ipalib import api, x509
-from ipalib.constants import RA_AGENT_PROFILE
+from ipalib.constants import RENEWAL_CA_NAME, RA_AGENT_PROFILE
 from ipalib.install import certmonger, sysrestore
 import SSSDConfig
 import ipalib.util
@@ -982,7 +982,7 @@ def certificate_renewal_update(ca, kra, ds, http):
         req = {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
             'cert-nickname': nick,
-            'ca-name': 'dogtag-ipa-ca-renew-agent',
+            'ca-name': RENEWAL_CA_NAME,
             'cert-presave-command': template % 'stop_pkicad',
             'cert-postsave-command':
                 (template % 'renew_ca_cert "{}"'.format(nick)),
@@ -994,7 +994,7 @@ def certificate_renewal_update(ca, kra, ds, http):
         {
             'cert-file': paths.RA_AGENT_PEM,
             'key-file': paths.RA_AGENT_KEY,
-            'ca-name': 'dogtag-ipa-ca-renew-agent',
+            'ca-name': RENEWAL_CA_NAME,
             'template-profile': RA_AGENT_PROFILE,
             'cert-presave-command': template % 'renew_ra_cert_pre',
             'cert-postsave-command': template % 'renew_ra_cert',
@@ -1040,7 +1040,7 @@ def certificate_renewal_update(ca, kra, ds, http):
                 {
                     'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
                     'cert-nickname': nickname,
-                    'ca-name': 'dogtag-ipa-ca-renew-agent',
+                    'ca-name': RENEWAL_CA_NAME,
                     'cert-presave-command': template % 'stop_pkicad',
                     'cert-postsave-command':
                         (template % ('renew_ca_cert "%s"' % nickname)),

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1047,14 +1047,27 @@ def certificate_renewal_update(ca, kra, ds, http):
             )
 
     # State not set, lets see if we are already configured
+    missing_or_misconfigured_requests = []
     for request in requests:
         request_id = certmonger.get_request_id(request)
         if request_id is None:
-            break
-    else:
+            missing_or_misconfigured_requests.append(request)
+
+    if len(missing_or_misconfigured_requests) == 0:
         logger.info("Certmonger certificate renewal configuration already "
                     "up-to-date")
         return False
+
+    # Print info about missing requests
+    logger.info("Missing or incorrect tracking request for certificates:")
+    for request in missing_or_misconfigured_requests:
+        cert = None
+        if 'cert-file' in request:
+            cert = request['cert-file']
+        elif 'cert-database' in request and 'cert-nickname' in request:
+            cert = '{cert-database}:{cert-nickname}'.format(**request)
+        if cert is not None:
+            logger.info("  %s", cert)
 
     # Ok, now we need to stop tracking, then we can start tracking them
     # again with new configuration:

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1010,7 +1010,7 @@ def certificate_renewal_update(ca, kra, ds, http):
         requests.append(
             {
                 'cert-file': paths.HTTPD_CERT_FILE,
-                'key-storage': paths.HTTPD_KEY_FILE,
+                'key-file': paths.HTTPD_KEY_FILE,
                 'ca-name': 'IPA',
                 'cert-postsave-command': template % 'restart_httpd',
             }

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -20,6 +20,7 @@ from contextlib import contextmanager
 from augeas import Augeas
 import dns.exception
 from ipalib import api, x509
+from ipalib.constants import RA_AGENT_PROFILE
 from ipalib.install import certmonger, sysrestore
 import SSSDConfig
 import ipalib.util
@@ -994,6 +995,7 @@ def certificate_renewal_update(ca, kra, ds, http):
             'cert-file': paths.RA_AGENT_PEM,
             'key-file': paths.RA_AGENT_KEY,
             'ca-name': 'dogtag-ipa-ca-renew-agent',
+            'template-profile': RA_AGENT_PROFILE,
             'cert-presave-command': template % 'renew_ra_cert_pre',
             'cert-postsave-command': template % 'renew_ra_cert',
         },

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -972,11 +972,7 @@ def certificate_renewal_update(ca, ds, http):
 
     requests = []
 
-    dogtag_system_nicks = (
-        list(cainstance.CAInstance.tracking_reqs) +
-        [cainstance.CAInstance.server_cert_name]
-    )
-    for nick in dogtag_system_nicks:
+    for nick in cainstance.CAInstance.tracking_reqs:
         req = {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
             'cert-nickname': nick,
@@ -1072,7 +1068,6 @@ def certificate_renewal_update(ca, ds, http):
     ca.configure_certmonger_renewal()
     ca.configure_renewal()
     ca.configure_agent_renewal()
-    ca.track_servercert()
     ca.add_lightweight_ca_tracking_requests()
     ds.start_tracking_certificates(serverid)
     http.start_tracking_certificates()

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -972,7 +972,7 @@ def certificate_renewal_update(ca, ds, http):
 
     requests = []
 
-    for nick in cainstance.CAInstance.tracking_reqs:
+    for nick, profile in cainstance.CAInstance.tracking_reqs.items():
         req = {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
             'cert-nickname': nick,
@@ -980,10 +980,8 @@ def certificate_renewal_update(ca, ds, http):
             'cert-presave-command': template % 'stop_pkicad',
             'cert-postsave-command':
                 (template % 'renew_ca_cert "{}"'.format(nick)),
+            'template-profile': profile,
         }
-        profile = cainstance.CAInstance.tracking_reqs.get(nick)
-        if profile:
-            req['template-profile'] = profile
         requests.append(req)
 
     requests.append(

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -1249,6 +1249,10 @@ class TestIPACommands(CALessBase):
         with self.host():
             self.master.run_command(['ipa', 'host-del', self.test_hostname])
 
+    def test_invoke_upgrader(self):
+        """Test that ipa-server-upgrade runs without error."""
+        self.master.run_command(['ipa-server-upgrade'], raiseonerr=True)
+
 
 class TestCertInstall(CALessBase):
     @classmethod

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -14,6 +14,13 @@ from ipatests.pytest_ipa.integration import tasks
 
 
 class TestUpgrade(IntegrationTest):
+    """
+    Test ipa-server-upgrade.
+
+    Note that ipa-server-upgrade on a CA-less installation is tested
+    in ``test_caless.TestIPACommands.test_invoke_upgrader``.
+
+    """
     @classmethod
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=False)


### PR DESCRIPTION
Manual backport of https://github.com/freeipa/freeipa/pull/3316 to ipa-4-7.  We
may need to backport this change all the way to ipa-4-6 to allow us to change
the IPA RA certificate profile on older releases.  Currently this change is on
master and ipa-4-8, so ipa-4-7 is the next step.

There were some trivial conflicts. The only substantive conflicts were in
`dogtaginstance.py`.  These were resolved by cherry-picking
8686cd3b4b69f725aee05c9cdd3034d7436055d3 ahead of the original patchset.

https://pagure.io/freeipa/issue/7991

Do not rely on CI only; I will have to test this change myself so I'll add WIP
label, and remove it when I'm satisfied.