### PR TITLE
[Backport][ipa-4-6] Don't return SSH keys with ipa host-find --pkey-only

### DIFF
--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -1050,7 +1050,8 @@ class host_find(LDAPSearch):
                         (filter, hosts_filter), ldap.MATCH_ALL
                     )
 
-        add_sshpubkey_to_attrs_pre(self.context, attrs_list)
+        if not options.get('pkey_only', False):
+            add_sshpubkey_to_attrs_pre(self.context, attrs_list)
 
         return (filter.replace('locality', 'l'), base_dn, scope)
 


### PR DESCRIPTION
This PR was opened automatically because PR #3489 was pushed to master and backport to ipa-4-6 is required.