### PR TITLE
Split TestTrust class and add it to nightly tests

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -27,6 +27,10 @@ topologies:
     name: master_3repl_1client
     cpu: 6
     memory: 12900
+  ad_master: &ad_master
+    name: ad_master
+    cpu: 4
+    memory: 12000
 
 jobs:
   fedora-30/build:
@@ -1280,3 +1284,15 @@ jobs:
         template: *ci-master-f30
         timeout: 3600
         topology: *master_1repl
+
+  fedora-30/test_trust_TestTrustWithRootDomain:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_trust.py::TestTrustWithRootDomain
+        template: *ci-master-f30
+        timeout: 12000
+        topology: *ad_master

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -33,6 +33,10 @@ topologies:
     name: master_3repl_1client
     cpu: 6
     memory: 12900
+  ad_master: &ad_master
+    name: ad_master
+    cpu: 4
+    memory: 12000
 
 jobs:
   fedora-30/build:
@@ -49,14 +53,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-30/temp_commit:
+  fedora-30/test_trust_TestTrustWithRootDomain:
     requires: [fedora-30/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-30/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_trust.py::TestTrustWithRootDomain
         template: *ci-master-f30
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 12000
+        topology: *ad_master


### PR DESCRIPTION
Move some test cases from TestTrust class to other classes, grouping them by the AD hosts they require.

Different topologies can be used to test different sets of cases.

Add test_trust.py::TestTrustWithRootDomain to nightly tests