### PR TITLE
[Backport][ipa-4-8] Restore SELinux context for p11-kit config overrides

### DIFF
--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -717,6 +717,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                 # see man(5) pkcs11.conf
                 f.write("disable-in: {}\n".format(", ".join(disabled_in)))
                 os.fchmod(f.fileno(), 0o644)
+            self.restore_context(filename)
             logger.debug("Created PKCS#11 module config '%s'.", filename)
             filenames.append(filename)
 


### PR DESCRIPTION
This PR was opened automatically because PR #3484 was pushed to master and backport to ipa-4-8 is required.