### PR TITLE
ipa-client-automount: always restore nsswitch.conf at uninstall time

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -1257,6 +1257,18 @@ jobs:
         timeout: 9000
         topology: *master_3client
 
+  fedora-29/nfs_nsswitch_restore:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_3client
+
   fedora-29/mask:
     requires: [fedora-29/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1257,6 +1257,18 @@ jobs:
         timeout: 9000
         topology: *master_3client
 
+  fedora-30/nfs_nsswitch_restore:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
+        template: *ci-master-f30
+        timeout: 3600
+        topology: *master_3client
+
   fedora-30/mask:
     requires: [fedora-30/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1269,6 +1269,18 @@ jobs:
         timeout: 9000
         topology: *master_3client
 
+  fedora-rawhide/nfs_nsswitch_restore:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
+        template: *ci-master-frawhide
+        timeout: 9000
+        topology: *master_3client
+
   fedora-rawhide/automember:
     requires: [fedora-rawhide/build]
     priority: 50

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -49,14 +49,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-30/temp_commit:
+  fedora-30/nfs_nsswitch_restore:
     requires: [fedora-30/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
         template: *ci-master-f30
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 9000
+        topology: *master_3client

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -281,6 +281,10 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
         invert_arguments_in_automount_entry=False
     ):
 
+        sha256nsswitch_cmd = ["sha256sum", "/etc/nsswitch.conf"]
+        cmd = self.clients[0].run_command(sha256nsswitch_cmd)
+        print("Original sha256 of nsswitch.conf: %s" % cmd.stdout_text)
+
         if remove_sss_from_automount_entry:
             self.clients[0].run_command([
                 "sed", "-i", "-e",
@@ -294,7 +298,6 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
                 "/etc/nsswitch.conf"
             ])
 
-        sha256nsswitch_cmd = ["sha256sum", "/etc/nsswitch.conf"]
         cmd = self.clients[0].run_command(sha256nsswitch_cmd)
         orig_sha256 = cmd.stdout_text
 
@@ -308,6 +311,10 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
             ])
         cmd = self.clients[0].run_command(grep_automount_command)
         after_ipa_client_install = cmd.stdout_text.split()
+        print(
+            "After ipa-client-install, automount database contains: %s" %
+            after_ipa_client_install
+        )
 
         if no_sssd:
             ipa_client_automount_command = [
@@ -320,6 +327,10 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
         self.clients[0].run_command(ipa_client_automount_command)
         cmd = self.clients[0].run_command(grep_automount_command)
         after_ipa_client_automount = cmd.stdout_text.split()
+        print(
+            "After ipa-client-automount, automount database contains: %s" %
+            after_ipa_client_automount
+        )
         if no_sssd:
             assert after_ipa_client_automount == ['files', 'ldap']
         else:

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -302,7 +302,7 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
         orig_sha256 = cmd.stdout_text
 
         grep_automount_command = \
-            "grep automount /etc/nsswitch.conf |cut -d: -f2"
+            "grep automount /etc/nsswitch.conf | cut -d: -f2"
 
         tasks.install_client(self.master, self.clients[0])
         if clear_automount_entry:
@@ -333,6 +333,10 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
         )
         if no_sssd:
             assert after_ipa_client_automount == ['files', 'ldap']
+        elif clear_automount_entry:
+            # empty because user forced it to be empty. We don't add
+            # sssd options.
+            assert after_ipa_client_automount == []
         else:
             assert after_ipa_client_automount == ['sss', 'files']
 

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -270,6 +270,9 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=True)
 
+    def teardown_method(self, method):
+        tasks.uninstall_client(self.clients[0])
+
     def nsswitch_backup_restore(
         self,
         no_sssd=False,


### PR DESCRIPTION
ipa-client-automount: always restore nsswitch.conf at uninstall time
    
ipa-client-automount used to only restore nsswitch.conf when sssd was not
used. However authselect's default profile is now sssd. So always
restore nsswitch.conf. This restores the behavior seen before commit:
a0e846f56c8de3b549d1d284087131da13135e34
    
Fixes: https://pagure.io/freeipa/issue/8038
