### PR TITLE
Don't move keys when key backup is disabled

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -599,8 +599,12 @@ class CAInstance(DogtagInstance):
             print("%s --external-cert-file=/path/to/signed_certificate --external-cert-file=/path/to/external_ca_certificate" % sys.argv[0])
             sys.exit(0)
         else:
-            shutil.move(paths.CA_BACKUP_KEYS_P12,
-                        paths.CACERT_P12)
+            if config.getboolean(
+                    self.subsystem, 'pki_backup_keys', fallback=True
+            ):
+                shutil.move(
+                    paths.CA_BACKUP_KEYS_P12, paths.CACERT_P12
+                )
 
         logger.debug("completed creating ca instance")
 

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -875,8 +875,7 @@ class PKIIniLoader:
         )
 
         # key backup is not compatible with HSM support
-        if (cfgtpl.has_option(section_name, 'pki_hsm_enable') and
-                cfgtpl.getboolean(section_name, 'pki_hsm_enable')):
+        if cfgtpl.getboolean(section_name, 'pki_hsm_enable', fallback=False):
             cfgtpl.set(section_name, 'pki_backup_keys', 'False')
             cfgtpl.set(section_name, 'pki_backup_password', '')
 


### PR DESCRIPTION
The CA_BACKUP_KEYS_P12 file is not enabled when pki_backup_keys is
set to False. It's the case when FreeIPA is configured with HSM support.

Related: https://pagure.io/freeipa/issue/7677
Signed-off-by: Christian Heimes <cheimes@redhat.com>