### PR TITLE
WebUI tests: Fix login screen loading issue

### DIFF
--- a/ipatests/test_webui/test_loginscreen.py
+++ b/ipatests/test_webui/test_loginscreen.py
@@ -124,6 +124,7 @@ class TestLoginScreen(UI_driver):
         WebDriverWait(self.driver, 10).until(
             lambda d: runner.files_loaded()
         )
+        self.wait()
 
     def relogin_with_new_password(self):
         """


### PR DESCRIPTION
test_webui/test_loginscreen fails because login screen is rendered with delays.
To solve the issue small pause added after login.

Ticket: https://pagure.io/freeipa/issue/8053