### PR TITLE
[Backport][ipa-4-8] Allow insecure binds for migration

### DIFF
--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -1206,12 +1206,14 @@ class LDAPClient:
         return conn
 
     def simple_bind(self, bind_dn, bind_password, server_controls=None,
-                    client_controls=None):
+                    client_controls=None, insecure_bind=False):
         """
         Perform simple bind operation.
         """
-        if self.protocol == 'ldap' and not self._start_tls and bind_password:
-            # non-empty bind must use a secure connection
+        if (self.protocol == 'ldap' and not self._start_tls and
+                bind_password and not insecure_bind):
+            # non-empty bind must use a secure connection unless
+            # insecure bind is explicitly enabled
             raise ValueError('simple_bind over insecure LDAP connection')
         with self.error_handler():
             self._flush_schema()

--- a/ipaserver/plugins/migration.py
+++ b/ipaserver/plugins/migration.py
@@ -901,20 +901,19 @@ migration process might be incomplete\n''')
             return dict(result={}, failed={}, enabled=False, compat=True)
 
         # connect to DS
-        cacert = None
         if options.get('cacertfile') is not None:
             # store CA cert into file
             tmp_ca_cert_f = write_tmp_file(options['cacertfile'])
             cacert = tmp_ca_cert_f.name
 
-            # start TLS connection
-            ds_ldap = LDAPClient(ldapuri, cacert=cacert)
+            # start TLS connection or STARTTLS
+            ds_ldap = LDAPClient(ldapuri, cacert=cacert, start_tls=True)
             ds_ldap.simple_bind(options['binddn'], bindpw)
 
             tmp_ca_cert_f.close()
         else:
-            ds_ldap = LDAPClient(ldapuri, cacert=cacert)
-            ds_ldap.simple_bind(options['binddn'], bindpw)
+            ds_ldap = LDAPClient(ldapuri)
+            ds_ldap.simple_bind(options['binddn'], bindpw, insecure_bind=True)
 
         # check whether the compat plugin is enabled
         if not options.get('compat'):


### PR DESCRIPTION
This PR was opened automatically because PR #3535 was pushed to master and backport to ipa-4-8 is required.