### PR TITLE
extdom: unify error code handling especially LDAP_NO_SUCH_OBJECT

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/back_extdom_sss_idmap.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/back_extdom_sss_idmap.c
@@ -62,10 +62,10 @@ static enum nss_status __convert_sss_nss2nss_status(int errcode) {
         return NSS_STATUS_SUCCESS;
     case ENOENT:
         return NSS_STATUS_NOTFOUND;
-    case ETIME:
-        /* fall-through */
     case ERANGE:
         return NSS_STATUS_TRYAGAIN;
+    case ETIME:
+        /* fall-through */
     case ETIMEDOUT:
         /* fall-through */
     default:

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_extop.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_extop.c
@@ -242,6 +242,8 @@ static int ipa_extdom_extop(Slapi_PBlock *pb)
     if (ret != LDAP_SUCCESS) {
         if (ret == LDAP_NO_SUCH_OBJECT) {
             rc = LDAP_NO_SUCH_OBJECT;
+        } else if (ret == LDAP_TIMELIMIT_EXCEEDED) {
+            rc = LDAP_TIMELIMIT_EXCEEDED;
         } else {
             rc = LDAP_OPERATIONS_ERROR;
             err_msg = "Failed to handle the request.\n";


### PR DESCRIPTION
A return code LDAP_NO_SUCH_OBJECT will tell SSSD on the IPA client to
remove the searched object from the cache. As a consequence
LDAP_NO_SUCH_OBJECT should only be returned if the object really does
not exists otherwise the data of existing objects might be removed form
the cache of the clients causing unexpected behaviour like
authentication errors.

Currently some code-paths use LDAP_NO_SUCH_OBJECT as default error code.
With this patch LDAP_NO_SUCH_OBJECT is only returned if the related
lookup functions return ENOENT. Timeout related error code will lead to
LDAP_TIMELIMIT_EXCEEDED and LDAP_OPERATIONS_ERROR is used as default
error code.

Related to https://pagure.io/freeipa/issue/8044