### PR TITLE
[WIP] ipa-join: allowing call with jsonrpc into freeipa API

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -86,6 +86,8 @@ ipa_join_LDADD = 		\
 	$(LDAP_LIBS)		\
 	$(SASL_LIBS)		\
 	$(XMLRPC_LIBS)		\
+	$(JSON_LIBS)		\
+	$(LIBCURL_LIBS)		\
 	$(POPT_LIBS)		\
 	$(LIBINTL_LIBS)         \
 	$(NULL)

--- a/client/ipa-client-common.h
+++ b/client/ipa-client-common.h
@@ -28,3 +28,8 @@
 #endif
 
 int init_gettext(void);
+
+struct json_results {
+        char *hostdn;
+        char *krbprinc;
+};

--- a/configure.ac
+++ b/configure.ac
@@ -179,6 +179,42 @@ if test x"$try_xmlrpc_fallback" = xtrue; then
 fi
 
 dnl ---------------------------------------------------------------------------
+dnl - Check for LIBCURL
+dnl ---------------------------------------------------------------------------
+PKG_CHECK_MODULES([LIBCURL], [libcurl], [],
+                  [try_curl_fallback=true])
+if test x"$try_curl_fallback" = xtrue; then
+    CURL_LIBS=
+    AC_CHECK_HEADER([curl/curl.h], [],
+                    [AC_MSG_ERROR([curl.h not found])])
+
+    AC_CHECK_LIB([curl], [curl_easy_perform],
+                 [CURL_LIBS="-lcurl"])
+    if test "x$CURL_LIBS" = "x" ; then
+        AC_MSG_ERROR([libcurl not found])
+    fi
+    AC_SUBST(LIBCURL_LIBS)
+fi
+
+dnl ---------------------------------------------------------------------------
+dnl - Check for JSON-C
+dnl ---------------------------------------------------------------------------
+PKG_CHECK_MODULES([JSON], [json-c], [],
+                  [try_json_fallback=true])
+if test x"$try_json_fallback" = xtrue; then
+    JSON_LIBS=
+    AC_CHECK_HEADER([json-c/json_object.h], [],
+                    [AC_MSG_ERROR([json-c/json_object.h not found])])
+
+    AC_CHECK_LIB([json-c], [json_object_get],
+                 [JSON_LIBS="-ljson-c"])
+    if test "x$JSON_LIBS" = "x" ; then
+        AC_MSG_ERROR([json-c not found])
+    fi
+    AC_SUBST(JSON_LIBS)
+fi
+
+dnl ---------------------------------------------------------------------------
 dnl - Check for libintl
 dnl ---------------------------------------------------------------------------
 SAVE_LIBS="$LIBS"


### PR DESCRIPTION
- Adding JSON-C and LibCURL library into configure.ac and Makefile.am
- Creating a API call with option '-j' or '--jsonrpc' to make host join on FreeIPA with JSONRPC and libCURL.

TODO: unenroll process with JSONRPC.

To test the call:
```
# kinit admin
# ipa-join -s server.freeipa.ipadomain -j
```

Debug:
```
# ipa-join -s server.freeipa.ipadomain -j -d
```
Results: https://pastebin.com/0h3eQXHV

Related: https://pagure.io/freeipa/issue/7966