### PR TITLE
[Backport ipa-4-7] Restore SELinux context for p11-kit config overrides

### DIFF
--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -718,6 +718,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                 # see man(5) pkcs11.conf
                 f.write("disable-in: {}\n".format(", ".join(disabled_in)))
                 os.fchmod(f.fileno(), 0o644)
+            self.restore_context(filename)
             logger.debug("Created PKCS#11 module config '%s'.", filename)
             filenames.append(filename)
 


### PR DESCRIPTION
When 74e09087 started disabling softshm2 module in p11-kit-proxy,
we missed to restore SELinux context on the configuration override
creation.

We don't need an explicit restore_context() when removing the override
because restore_file() already calls restore_context().

Related: https://pagure.io/freeipa/issue/7810
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>
Reviewed-By: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Rob Crittenden <rcritten@redhat.com>
(cherry picked from commit 8f969a5929e8a2f54fd732ea0c8d0a4931250d23)