### PR TITLE
Fix ca_initialize_hsm_state

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -480,7 +480,7 @@ def ca_initialize_hsm_state(ca):
         section_name = ca.subsystem.upper()
         config = SafeConfigParser()
         config.add_section(section_name)
-        config.set(section_name, 'pki_hsm_enable', False)
+        config.set(section_name, 'pki_hsm_enable', 'False')
         ca.set_hsm_state(config)
 
 


### PR DESCRIPTION
Fixup for commit eb2313920e20bb4a74fc0abc52c496ccf2822dab.
configparser's set() method does not convert boolean to string
automatically. Use '"false"', which is then interpreted as 'False' by
getboolean().

Related: https://pagure.io/freeipa/issue/5608
Signed-off-by: Christian Heimes <cheimes@redhat.com>