### PR TITLE
[Backport][ipa-4-8] Fix ca_initialize_hsm_state

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -480,7 +480,7 @@ def ca_initialize_hsm_state(ca):
         section_name = ca.subsystem.upper()
         config = SafeConfigParser()
         config.add_section(section_name)
-        config.set(section_name, 'pki_hsm_enable', False)
+        config.set(section_name, 'pki_hsm_enable', 'False')
         ca.set_hsm_state(config)
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #3567 was pushed to master and backport to ipa-4-8 is required.