### PR TITLE
Samba 4.10 related backports

### DIFF
--- a/daemons/ipa-sam/ipa_sam.c
+++ b/daemons/ipa-sam/ipa_sam.c
@@ -2266,7 +2266,6 @@ static bool fill_pdb_trusted_domain(TALLOC_CTX *mem_ctx,
 	if (dummy == NULL) {
 		DEBUG(9, ("Attribute %s not present.\n",
 			  LDAP_ATTRIBUTE_TRUST_SID));
-		ZERO_STRUCT(td->security_identifier);
 	} else {
 		err = sss_idmap_sid_to_smb_sid(ipasam_state->idmap_ctx,
 					       dummy, &sid);

--- a/daemons/ipa-sam/ipa_sam.c
+++ b/daemons/ipa-sam/ipa_sam.c
@@ -19,7 +19,6 @@
 #include <util/data_blob.h>
 #include <util/time.h>
 #include <util/debug.h>
-#include <util/talloc_stack.h>
 
 #ifndef _SAMBA_UTIL_H_
 bool trim_string(char *s, const char *front, const char *back);
@@ -881,8 +880,12 @@ static bool ipasam_uid_to_sid(struct pdb_methods *methods, uid_t uid,
 	struct dom_sid *user_sid = NULL;
 	int rc;
 	enum idmap_error_code err;
-	TALLOC_CTX *tmp_ctx = talloc_stackframe();
 	struct unixid id;
+
+	TALLOC_CTX *tmp_ctx = talloc_new(priv);
+	if (tmp_ctx == NULL) {
+		goto done;
+	}
 
 	/* Fast fail if we get a request for uidNumber=0 because it currently
 	 * will never exist in the directory
@@ -968,8 +971,12 @@ static bool ipasam_gid_to_sid(struct pdb_methods *methods, gid_t gid,
 	size_t c;
 	int rc;
 	enum idmap_error_code err;
-	TALLOC_CTX *tmp_ctx = talloc_stackframe();
 	struct unixid id;
+
+	TALLOC_CTX *tmp_ctx = talloc_new(priv);
+	if (tmp_ctx == NULL) {
+		goto done;
+	}
 
 	filter = talloc_asprintf(tmp_ctx,
 				 "(|(&(gidNumber=%u)"
@@ -3749,7 +3756,8 @@ static void ipasam_free_private_data(void **vp)
 		(*ipasam_state)->result = NULL;
 	}
 	if ((*ipasam_state)->domain_dn != NULL) {
-		SAFE_FREE((*ipasam_state)->domain_dn);
+		free((*ipasam_state)->domain_dn);
+		(*ipasam_state)->domain_dn = NULL;
 	}
 
 	*ipasam_state = NULL;

--- a/daemons/ipa-sam/ipa_sam.c
+++ b/daemons/ipa-sam/ipa_sam.c
@@ -104,8 +104,6 @@ enum ndr_err_code ndr_pull_trustAuthInOutBlob(struct ndr_pull *ndr, int ndr_flag
 bool sid_check_is_builtin(const struct dom_sid *sid); /* available in libpdb.so */
 /* available in libpdb.so, renamed from sid_check_is_domain() in c43505b621725c9a754f0ee98318d451b093f2ed */
 bool sid_linearize(char *outbuf, size_t len, const struct dom_sid *sid); /* available in libsmbconf.so */
-char *sid_string_talloc(TALLOC_CTX *mem_ctx, const struct dom_sid *sid); /* available in libsmbconf.so */
-char *sid_string_dbg(const struct dom_sid *sid); /* available in libsmbconf.so */
 char *escape_ldap_string(TALLOC_CTX *mem_ctx, const char *s); /* available in libsmbconf.so */
 bool secrets_store(const char *key, const void *data, size_t size); /* available in libpdb.so */
 void idmap_cache_set_sid2unixid(const struct dom_sid *sid, struct unixid *unix_id); /* available in libsmbconf.so */
@@ -259,6 +257,18 @@ static bool sid_compose(struct dom_sid *dst, const struct dom_sid *dom_sid,
 	dst->sub_auths[dst->num_auths++] = rid;
 
 	return true;
+}
+
+static char *sid_talloc_string(struct sss_idmap_ctx *ctx, void *final_ctx, const struct dom_sid *dom_sid)
+{
+	enum idmap_error_code ret;
+	char *result = NULL;
+	ret = sss_idmap_smb_sid_to_sid(ctx, discard_const(dom_sid), &result);
+	if (ret != IDMAP_SUCCESS) {
+		return NULL;
+	}
+
+	return talloc_move(final_ctx, &result);
 }
 
 static bool is_null_sid(const struct dom_sid *sid)
@@ -519,8 +529,18 @@ static bool ldapsam_extract_rid_from_entry(LDAP *ldap_struct,
 	}
 
 	if (dom_sid_compare_domain(sid, domain_sid) != 0) {
-		DEBUG(10, ("SID %s is not in expected domain %s\n",
-			   str, sid_string_dbg(domain_sid)));
+		char *debug_domain_sid = NULL;
+		err = sss_idmap_smb_sid_to_sid(idmap_ctx,
+					       discard_const(domain_sid),
+					       &debug_domain_sid);
+		if (err != IDMAP_SUCCESS) {
+			DEBUG(10, ("SID %s is not in expected domain.\n",
+				   str));
+		} else {
+			DEBUG(10, ("SID %s is not in expected domain %s\n",
+				   str, debug_domain_sid));
+			talloc_free(debug_domain_sid);
+		}
 		res = false;
 		goto done;
 	}
@@ -589,7 +609,7 @@ static NTSTATUS ldapsam_lookup_rids(struct pdb_methods *methods,
 		allsids = talloc_asprintf_append_buffer(
 			allsids, "(%s=%s)",
 			LDAP_ATTRIBUTE_SID,
-			sid_string_talloc(mem_ctx, &sid));
+			sid_talloc_string(ipasam_state->idmap_ctx, mem_ctx, &sid));
 		if (allsids == NULL) {
 			goto done;
 		}
@@ -790,7 +810,8 @@ static bool ldapsam_sid_to_id(struct pdb_methods *methods,
 	filter = talloc_asprintf(mem_ctx,
 				 "(&(%s=%s)"
 				 "(|(objectClass=%s)(objectClass=%s)))",
-				 LDAP_ATTRIBUTE_SID, sid_string_talloc(mem_ctx, sid),
+				 LDAP_ATTRIBUTE_SID,
+				 sid_talloc_string(priv->idmap_ctx, mem_ctx, sid),
 				 LDAP_OBJ_GROUPMAP, LDAP_OBJ_SAMBASAMACCOUNT);
 	if (filter == NULL) {
 		DEBUG(5, ("talloc_asprintf failed\n"));
@@ -936,7 +957,7 @@ static bool ipasam_uid_to_sid(struct pdb_methods *methods, uid_t uid,
 	err = sss_idmap_sid_to_smb_sid(priv->idmap_ctx,
 				       user_sid_string, &user_sid);
 	if (err != IDMAP_SUCCESS) {
-		DEBUG(3, ("Error calling sid_string_talloc for sid '%s'\n",
+		DEBUG(3, ("Error creating sid structure for sid '%s'\n",
 			  user_sid_string));
 		goto done;
 	}
@@ -1052,7 +1073,7 @@ found:
 	err = sss_idmap_sid_to_smb_sid(priv->idmap_ctx,
 				       group_sid_string, &group_sid);
 	if (err != IDMAP_SUCCESS) {
-		DEBUG(3, ("Error calling sid_string_talloc for sid '%s'\n",
+		DEBUG(3, ("Error creating sid structure for sid '%s'\n",
 			  group_sid_string));
 		goto done;
 	}
@@ -1595,11 +1616,11 @@ static bool ipasam_search_grouptype(struct pdb_methods *methods,
 	state->base = talloc_strdup(search, ipasam_state->base_dn);
 	state->connection = ipasam_state->ldap_state;
 	state->scope = LDAP_SCOPE_SUBTREE;
-	state->filter =	talloc_asprintf(search, "(&(objectclass=%s)"
-					"(%s=%s*))",
-					 LDAP_OBJ_GROUPMAP,
-					 LDAP_ATTRIBUTE_SID,
-					 sid_string_talloc(search, sid));
+	state->filter =	talloc_asprintf(search, "(&(objectclass=%s)(%s=%s*))",
+					LDAP_OBJ_GROUPMAP, LDAP_ATTRIBUTE_SID,
+					sid_talloc_string(
+						ipasam_state->idmap_ctx,
+						search, sid));
 	state->attrs = talloc_attrs(search, "cn", LDAP_ATTRIBUTE_SID,
 				    "displayName", "description",
 				     NULL);
@@ -2412,7 +2433,7 @@ static NTSTATUS ipasam_get_trusted_domain_by_sid(struct pdb_methods *methods,
 	char *sid_str;
 	bool ok;
 
-	sid_str = sid_string_talloc(mem_ctx, sid);
+	sid_str = sid_talloc_string(ipasam_state->idmap_ctx, mem_ctx, sid);
 	if (sid_str == NULL) {
 		return NT_STATUS_NO_MEMORY;
 	}
@@ -2593,7 +2614,8 @@ static NTSTATUS ipasam_set_trusted_domain(struct pdb_methods *methods,
 	if (!is_null_sid(&td->security_identifier)) {
 		smbldap_make_mod(priv2ld(ipasam_state), entry, &mods,
 				 LDAP_ATTRIBUTE_TRUST_SID,
-				 sid_string_talloc(tmp_ctx, &td->security_identifier));
+				 sid_talloc_string(ipasam_state->idmap_ctx,
+						   tmp_ctx, &td->security_identifier));
 	}
 
 	if (td->trust_type != 0) {

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -131,7 +131,7 @@ def map_Guests_to_nobody():
 
 
 def get_idmap_range(realm):
-    idrange = api.Command.idrange_show('{}_id_range'.format(realm))['result']
+    idrange = api.Command.idrange_show(u'{}_id_range'.format(realm))['result']
     range_start = int(idrange['ipabaseid'][0])
     range_size = int(idrange['ipaidrangesize'][0])
     range_fmt = '{} - {}'.format(range_start, range_start + range_size)


### PR DESCRIPTION
Backported patches to allow building FreeIPA 4.6 against Samba 4.10 (required for Samba rebase in enterprise distributions).

See https://bugzilla.redhat.com/show_bug.cgi?id=1744926 for the context.