### PR TITLE
ipatests: fix wrong xfail in test_domain_resolution_order

### DIFF
--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -19,7 +19,6 @@
 
 import pytest
 
-from ipaplatform.osinfo import osinfo
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration.tasks import (
     clear_sssd_cache, get_host_ip_with_hostmask, modify_sssd_conf)
@@ -715,9 +714,6 @@ class TestSudo(IntegrationTest):
                                           raiseonerr=False)
         assert result.returncode != 0
 
-    @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number < (30,),
-        reason="https://pagure.io/SSSD/sssd/issue/3957", strict=True)
     def test_domain_resolution_order(self):
         """Test sudo with runAsUser and domain resolution order.
 


### PR DESCRIPTION
The test is written for a SSSD fix delivered in 2.2.0, but has a xfail
based on fedora version < 30.
SSSD 2.2.0 was originally available only on fedora 30 but is now also
available on fedora 29, and recent runs on f29 started to succeed
(because the fix is now present) but with a strict xfail.

The fix considers the sssd version instead of the fedora version to
mark xfail.

Fixes: https://pagure.io/freeipa/issue/8052
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>