### PR TITLE
ipatests: remove xfail from test_domain_resolution_order

### DIFF
--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -19,7 +19,6 @@
 
 import pytest
 
-from ipaplatform.osinfo import osinfo
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration.tasks import (
     clear_sssd_cache, get_host_ip_with_hostmask, modify_sssd_conf)
@@ -715,9 +714,6 @@ class TestSudo(IntegrationTest):
                                           raiseonerr=False)
         assert result.returncode != 0
 
-    @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number < (30,),
-        reason="https://pagure.io/SSSD/sssd/issue/3957", strict=True)
     def test_domain_resolution_order(self):
         """Test sudo with runAsUser and domain resolution order.
 


### PR DESCRIPTION
Fedora 29 now has sssd 2.2: https://bodhi.fedoraproject.org/updates/FEDORA-2019-cf0463b5e1
Remove xfail from test_domain_resolution_order.

Link to test_sudo on Fedora 29:
http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/665191f4-c93f-11e9-b7b4-fa163ea674f4/
