### PR TITLE
[Backport][ipa-4-8] authconfig.py: restore user-nsswitch.conf at uninstall time

### DIFF
--- a/ipaplatform/redhat/authconfig.py
+++ b/ipaplatform/redhat/authconfig.py
@@ -167,6 +167,10 @@ class RedHatAuthSelect(RedHatAuthToolBase):
                 'authselect', 'features_list'
             )
             statestore.delete_state('authselect', 'mkhomedir')
+            # https://pagure.io/freeipa/issue/8054
+            if fstore.has_file(paths.NSSWITCH_CONF):
+                logger.info("Restoring user-nsswitch.conf")
+                fstore.restore_file(paths.NSSWITCH_CONF)
             # only non-empty features, https://pagure.io/freeipa/issue/7776
             if features_state is not None:
                 features = [

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 
-import pytest
 import os
 import re
 import time
@@ -324,7 +323,6 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
         cmd = self.clients[0].run_command(sha256nsswitch_cmd)
         assert cmd.stdout_text == orig_sha256
 
-    @pytest.mark.xfail(reason='freeipa ticket 8054', strict=True)
     def test_nsswitch_backup_restore_sssd(self):
         self.nsswitch_backup_restore()
 


### PR DESCRIPTION
This PR was opened automatically because PR #3593 was pushed to master and backport to ipa-4-8 is required.