### PR TITLE
Improve performance of certmonger renewal scripts

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
@@ -473,12 +473,12 @@ def main():
     else:
         kwargs['reuse_existing'] = True
 
-    api.bootstrap(in_server=True, context='renew', confdir=paths.ETC_IPA)
-    api.finalize()
-
     operation = os.environ.get('CERTMONGER_OPERATION')
     if operation not in ('SUBMIT', 'POLL'):
         return OPERATION_NOT_SUPPORTED_BY_HELPER
+
+    api.bootstrap(in_server=True, context='renew', confdir=paths.ETC_IPA)
+    api.finalize()
 
     tmpdir = tempfile.mkdtemp(prefix="tmp-")
     certs.renewal_lock.acquire()

--- a/install/certmonger/ipa-server-guard.in
+++ b/install/certmonger/ipa-server-guard.in
@@ -35,10 +35,23 @@ import six
 from ipapython import ipautil
 from ipaserver.install import certs
 
+# Return codes. Names of the constants are taken from
+# https://git.fedorahosted.org/cgit/certmonger.git/tree/src/submit-e.h
+OPERATION_NOT_SUPPORTED_BY_HELPER = 6
+
 
 def main():
     if len(sys.argv) < 2:
         raise RuntimeError("Not enough arguments")
+
+    # Avoid the lock if the operation is unsupported by ipa-submit
+    operation = os.environ.get('CERTMONGER_OPERATION')
+    if operation not in ('IDENTIFY',
+                         'FETCH-ROOTS',
+                         'GET-NEW-REQUEST-REQUIREMENTS',
+                         'SUBMIT',
+                         'POLL'):
+        return OPERATION_NOT_SUPPORTED_BY_HELPER
 
     with certs.renewal_lock:
         result = ipautil.run(sys.argv[1:], raiseonerr=False, env=os.environ)


### PR DESCRIPTION
On startup certmonger performs a number of options on the
configured CA (IPA, not to be confused with the real dogtag CA)
and the tracking requests.

For the CA checks break early for operations that are not
supported by ipa-submit. This will save both a fork and a lock
call.

For checks on existing CA subsystem certs defer some imports and
defer initializing the API until we know a supported operation
is being called (SUBMIT and POLL).

https://bugzilla.redhat.com/show_bug.cgi?id=1656519