### PR TITLE
[Backport][ipa-4-8] WebUI tests: Fix login screen loading issue

### DIFF
--- a/ipatests/test_webui/test_loginscreen.py
+++ b/ipatests/test_webui/test_loginscreen.py
@@ -124,6 +124,7 @@ class TestLoginScreen(UI_driver):
         WebDriverWait(self.driver, 10).until(
             lambda d: runner.files_loaded()
         )
+        self.wait()
 
     def relogin_with_new_password(self):
         """


### PR DESCRIPTION
This PR was opened automatically because PR #3533 was pushed to master and backport to ipa-4-8 is required.