### PR TITLE
ipatests: fix topology for TestIpaNotConfigured in PR-CI nightly definitions

### DIFF
--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -1303,4 +1303,4 @@ jobs:
         test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
         template: *ci-master-f29
         timeout: 10800
-        topology: *ipaserver
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1315,4 +1315,4 @@ jobs:
         test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
         template: *ci-master-f30
         timeout: 10800
-        topology: *ipaserver
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1315,4 +1315,4 @@ jobs:
         test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
         template: *ci-master-frawhide
         timeout: 10800
-        topology: *ipaserver
+        topology: *master_1repl


### PR DESCRIPTION
Topology for TestIpaNotConfigured is changed from ipaserver to
master_1repl in order to prevent aforementioned test suite runner from
configuring ipa-server, which is required by the test itself.

Resolves: https://pagure.io/freeipa/issue/8055
Related: https://pagure.io/freeipa/issue/6843