### PR TITLE
Replace %{_libdir} macro in BuildRequires

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -264,7 +264,7 @@ BuildRequires:  python3-yubico
 %if ! %{ONLY_CLIENT}
 BuildRequires:  libcmocka-devel
 # Required by ipa_kdb_tests
-BuildRequires:  %{_libdir}/krb5/plugins/kdb/db2.so
+BuildRequires:  krb5-server >= %{krb5_version}
 # ONLY_CLIENT
 %endif
 


### PR DESCRIPTION
The %{_libdir} macro is architecture dependend and therefore does not
correctly work across different platforms. In the past the SRPM was
created on a platform with /usr/lib64. Recent SRPMs have /usr/lib, which
breaks dnf builddep.

Depend on krb5-server directly rather than a file in krb5-server
package:

$ rpm -qf /usr/lib64/krb5/plugins/kdb/db2.so
krb5-server-1.16.1-25.fc29.x86_64

Fixes: https://pagure.io/freeipa/issue/8056
Signed-off-by: Christian Heimes <cheimes@redhat.com>