### PR TITLE
ipatests: add tests for cached_auth_timeout in sssd.conf

### DIFF
--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -31,6 +31,10 @@ topologies:
     name: ad_master_2client
     cpu: 4
     memory: 12000
+  ad_master: &ad_master
+   name: ad_master
+   cpu: 4
+   memory: 12000
 
 jobs:
   fedora-29/build:
@@ -1308,3 +1312,15 @@ jobs:
         template: *ci-master-f29
         timeout: 10800
         topology: *master_1repl
+
+  fedora-30/test_sssd:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_sssd.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *ad_master

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -31,6 +31,10 @@ topologies:
     name: ad_master_2client
     cpu: 4
     memory: 12000
+  ad_master: &ad_master
+   name: ad_master
+   cpu: 4
+   memory: 12000
 
 jobs:
   fedora-30/build:
@@ -1320,3 +1324,15 @@ jobs:
         template: *ci-master-f30
         timeout: 10800
         topology: *master_1repl
+
+  fedora-30/test_sssd:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_sssd.py
+        template: *ci-master-f30
+        timeout: 3600
+        topology: *ad_master

--- a/ipatests/prci_definitions/nightly_master_testing.yaml
+++ b/ipatests/prci_definitions/nightly_master_testing.yaml
@@ -23,6 +23,10 @@ topologies:
     name: master_3repl_1client
     cpu: 6
     memory: 12900
+  ad_master: &ad_master
+   name: ad_master
+   cpu: 4
+   memory: 12000
 
 jobs:
   fedora-30/build:
@@ -725,3 +729,15 @@ jobs:
         template: *testing-master-f30
         timeout: 3600
         topology: *master_1repl
+
+  fedora-30/test_sssd:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_sssd.py
+        template: *testing-master-f30
+        timeout: 3600
+        topology: *ad_master

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -31,6 +31,10 @@ topologies:
     name: ad_master_2client
     cpu: 4
     memory: 12000
+  ad_master: &ad_master
+   name: ad_master
+   cpu: 4
+   memory: 12000
 
 jobs:
   fedora-rawhide/build:
@@ -1320,3 +1324,15 @@ jobs:
         template: *ci-master-frawhide
         timeout: 10800
         topology: *master_1repl
+
+  fedora-30/test_sssd:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_sssd.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *ad_master

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -31,6 +31,8 @@ import itertools
 import tempfile
 import time
 from pipes import quote
+import configparser
+from contextlib import contextmanager
 
 import dns
 from ldif import LDIFWriter
@@ -1872,3 +1874,71 @@ def run_command_as_user(host, user, command, *args, **kwargs):
 
 def kinit_as_user(host, user, password):
     host.run_command(['kinit', user], stdin_text=password + '\n')
+
+
+class FileBackup:
+    """Create file backup and do restore on remote host
+
+    Examples:
+
+        config_backup = FileBackup(host, '/etc/some.conf')
+        ... modify the file and do the test ...
+        config_backup.restore()
+
+    Use as a context manager:
+
+        with FileBackup(host, '/etc/some.conf'):
+            ... modify the file and do the test ...
+
+    """
+
+    def __init__(self, host, filename):
+        """Create file backup."""
+        self._host = host
+        self._filename = filename
+        self._backup = create_temp_file(host)
+        self._cp_cmd = ['cp']
+        if is_selinux_enabled(host):
+            self._cp_cmd.append('--preserve=context')
+        host.run_command(self._cp_cmd + [filename, self._backup])
+
+    def restore(self):
+        """Restore file. Can be called multiple times."""
+        self._host.run_command(self._cp_cmd + [self._backup, self._filename])
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.restore()
+
+
+@contextmanager
+def remote_ini_file(host, filename):
+    """Context manager for editing an ini file on a remote host.
+
+    It provides RawConfigParser object which is automatically serialized and
+    uploaded to remote host upon exit from the context.
+
+    If exception is raised inside the context then the ini file is NOT updated
+    on remote host.
+
+    Example:
+
+        with remote_ini_file(master, '/etc/some.conf') as some_conf:
+            some_conf.set('main', 'timeout', 10)
+
+
+    """
+    data = host.get_file_contents(filename, encoding='utf-8')
+    ini_file = configparser.RawConfigParser()
+    ini_file.read_string(data)
+    yield ini_file
+    data = StringIO()
+    ini_file.write(data)
+    host.put_file_contents(filename, data.getvalue())
+
+
+def is_selinux_enabled(host):
+    res = host.run_command('selinuxenabled', ok_returncode=(0, 1))
+    return res.returncode == 0

--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -97,9 +97,7 @@ class TestSMB(IntegrationTest):
         smbserver.run_command(['mkdir', share_path])
         smbserver.run_command(['chmod', '777', share_path])
         # apply selinux context only if selinux is enabled
-        res = smbserver.run_command('selinuxenabled', ok_returncode=(0, 1))
-        selinux_enabled = res.returncode == 0
-        if selinux_enabled:
+        if tasks.is_selinux_enabled(smbserver):
             smbserver.run_command(['chcon', '-t', 'samba_share_t', share_path])
         smbconf_save_file = tasks.create_temp_file(smbserver)
         smbserver.run_command(['cp', paths.SMB_CONF, smbconf_save_file])

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -1,0 +1,110 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+"""This module provides tests for SSSD as used in IPA"""
+
+from __future__ import absolute_import
+
+import time
+from contextlib import contextmanager
+
+import pytest
+
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_ipa.integration import tasks
+from ipaplatform.paths import paths
+
+
+class TestSSSDAuthCache(IntegrationTest):
+    """Regression tests for cached_auth_timeout option
+
+       https://bugzilla.redhat.com/show_bug.cgi?id=1685581
+   """
+
+    topology = 'star'
+    num_ad_domains = 1
+
+    users = {
+        'ipa': {
+            'name': 'user1',
+            'password': 'SecretUser1'
+        },
+        'ad': {
+            'name_tmpl': 'testuser@{domain}',
+            'password': 'Secret123'
+        },
+    }
+    ipa_user = 'user1'
+    ipa_user_password = 'SecretUser1'
+    intermed_user = 'user2'
+    ad_user_tmpl = 'testuser@{domain}'
+    ad_user_password = 'Secret123'
+
+    @classmethod
+    def install(cls, mh):
+        super(TestSSSDAuthCache, cls).install(mh)
+
+        cls.ad = cls.ads[0]  # pylint: disable=no-member
+
+        tasks.install_adtrust(cls.master)
+        tasks.configure_dns_for_trust(cls.master, cls.ad)
+        tasks.establish_trust_with_ad(cls.master, cls.ad.domain.name)
+
+        cls.users['ad']['name'] = cls.users['ad']['name_tmpl'].format(
+            domain=cls.ad.domain.name)
+        tasks.user_add(cls.master, cls.intermed_user)
+        tasks.create_active_user(cls.master, cls.ipa_user,
+                                 cls.ipa_user_password)
+
+    @contextmanager
+    def config_sssd_cache_auth(self, cached_auth_timeout):
+        sssd_conf_backup = tasks.FileBackup(self.master, paths.SSSD_CONF)
+        with tasks.remote_ini_file(self.master, paths.SSSD_CONF) as sssd_conf:
+            domain_section = 'domain/{}'.format(self.master.domain.name)
+            if cached_auth_timeout is None:
+                sssd_conf.remove_option(domain_section, 'cached_auth_timeout')
+            else:
+                sssd_conf.set(domain_section, 'cached_auth_timeout',
+                              cached_auth_timeout)
+            sssd_conf.set('pam', 'pam_verbosity', '2')
+
+        try:
+            tasks.clear_sssd_cache(self.master)
+            yield
+        finally:
+            sssd_conf_backup.restore()
+            tasks.clear_sssd_cache(self.master)
+
+    def is_auth_cached(self, user):
+        cmd = ['su', '-l', user['name'], '-c', 'true']
+        res = tasks.run_command_as_user(self.master, self.intermed_user, cmd,
+                                        stdin_text=user['password'] + '\n')
+        return 'Authenticated with cached credentials.' in res.stdout_text
+
+    @pytest.mark.parametrize('user', ['ipa', 'ad'])
+    def test_auth_cache_disabled_by_default(self, user):
+        with self.config_sssd_cache_auth(cached_auth_timeout=None):
+            assert not self.is_auth_cached(self.users[user])
+            assert not self.is_auth_cached(self.users[user])
+
+    @pytest.mark.parametrize('user', ['ipa', 'ad'])
+    def test_auth_cache_disabled_with_value_0(self, user):
+        with self.config_sssd_cache_auth(cached_auth_timeout=0):
+            assert not self.is_auth_cached(self.users[user])
+            assert not self.is_auth_cached(self.users[user])
+
+    @pytest.mark.parametrize('user', ['ipa', 'ad'])
+    def test_auth_cache_enabled_when_configured(self, user):
+        timeout = 30
+        with self.config_sssd_cache_auth(cached_auth_timeout=timeout):
+            start = time.time()
+            # check auth is cached after first login
+            assert not self.is_auth_cached(self.users[user])
+            assert self.is_auth_cached(self.users[user])
+            # check cache expires after configured timeout
+            elapsed = time.time() - start
+            time.sleep(timeout - 5 - elapsed)
+            assert self.is_auth_cached(self.users[user])
+            time.sleep(10)
+            assert not self.is_auth_cached(self.users[user])


### PR DESCRIPTION
    The tests check that auth cache
    * is disabled by default
    * is working when enabled
    * expires after specified time
    * is inherited by trusted domain
    
    Related to: https://bugzilla.redhat.com/1685581
