### PR TITLE
[Backport] [ipa-4-7] ipatests: fix topology for TestIpaNotConfigured in PR-CI nightly definitions

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-7.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-7.yaml
@@ -1243,4 +1243,4 @@ jobs:
         test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
         template: *ci-master-f29
         timeout: 10800
-        topology: *ipaserver
+        topology: *master_1repl


### PR DESCRIPTION
This is manual backport of #3599 

Topology for TestIpaNotConfigured is changed from ipaserver to
master_1repl in order to prevent aforementioned test suite runner from
configuring ipa-server, which is required by the test itself.

Resolves: https://pagure.io/freeipa/issue/8055
Related: https://pagure.io/freeipa/issue/6843