### PR TITLE
[Backport][ipa-4-8] Replace %{_libdir} macro in BuildRequires

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -264,7 +264,7 @@ BuildRequires:  python3-yubico
 %if ! %{ONLY_CLIENT}
 BuildRequires:  libcmocka-devel
 # Required by ipa_kdb_tests
-BuildRequires:  %{_libdir}/krb5/plugins/kdb/db2.so
+BuildRequires:  krb5-server >= %{krb5_version}
 # ONLY_CLIENT
 %endif
 


### PR DESCRIPTION
This PR was opened automatically because PR #3601 was pushed to master and backport to ipa-4-8 is required.