### PR TITLE
WebUI: Fix new test initialization on "HBAC Test" page

### DIFF
--- a/install/ui/src/freeipa/facet.js
+++ b/install/ui/src/freeipa/facet.js
@@ -2510,6 +2510,7 @@ exp.table_facet = IPA.table_facet = function(spec, no_init) {
     if (!no_init) that.init_table_columns();
 
     that.table_facet_create_get_records_command = that.create_get_records_command;
+    that.table_facet_load_records = that.load_records;
 
     return that;
 };

--- a/install/ui/src/freeipa/hbactest.js
+++ b/install/ui/src/freeipa/hbactest.js
@@ -263,12 +263,28 @@ IPA.hbac.test_select_facet = function(spec) {
         that.table.multivalued = false;
 
         that.table.set_values = function(values) {
-            if (values && values.length && values[0] === '__external__') {
-                if (that.external_radio) that.external_radio.prop('checked', true);
-            } else {
-                that.table.table_set_values(values);
+            var records = that.table.records;
+            var has_values = values && values.length;
+
+            if (has_values && values[0] === '__external__') {
+                if (that.external_radio) {
+                    that.external_radio.prop('checked', true);
+                }
+                return;
             }
+
+            that.table.table_set_values(values);
         };
+    };
+
+    that.show = function() {
+        that.facet_show();
+        that._make_sure_value_selected();
+    };
+
+    that.load_records = function(records) {
+        that.table_facet_load_records(records);
+        that._make_sure_value_selected();
     };
 
     that.create_content = function(container) {
@@ -384,7 +400,8 @@ IPA.hbac.test_select_facet = function(spec) {
     };
 
     that.reset = function() {
-        delete that.selected_values;
+        that.table.set_values([]);
+
         if (that.external_radio) that.external_radio.prop('checked', false);
         if (that.external_text) that.external_text.val('');
     };
@@ -404,6 +421,15 @@ IPA.hbac.test_select_facet = function(spec) {
         if (record[that.name]) return true;
 
         return false;
+    };
+
+    that._make_sure_value_selected = function() {
+        var records = that.table.records;
+        var values = that.get_selected_values();
+
+        if (!(values && values.length) && records && records.length) {
+            that.table.set_values(records[0][that.table.name]);
+        }
     };
 
     init();
@@ -475,7 +501,8 @@ IPA.hbac.test_rules_facet = function(spec) {
     };
 
     that.reset = function() {
-        delete that.selected_values;
+        that.table.set_values([]);
+
         if (that.enabled) that.enabled.prop('checked', false);
         if (that.disabled) that.disabled.prop('checked', false);
     };

--- a/ipatests/test_webui/test_hbac.py
+++ b/ipatests/test_webui/test_hbac.py
@@ -155,10 +155,6 @@ class test_hbac(UI_driver):
             self.assert_dialog('message_dialog')
 
         __hbac_ui_click_on_run_test(self)
-        self.click_on_link('User name')
-        self.assert_facet('hbactest', 'user')
-
-        __hbac_ui_click_on_run_test(self)
         self.click_on_link('Target host')
         self.assert_facet('hbactest', 'targethost')
 


### PR DESCRIPTION
"New Test" action cleared only information about selected options but kept
radio buttons checked. It confused users and caused an error on validation step.

New behaviour is:
- tables forget all selected values after "New Test" click;
- first table record is checked initially in case the option is mandatory;
- all records is unchecked initially in case the option is not mandatory.

Ticket: https://pagure.io/freeipa/issue/8031