### PR TITLE
ipapython/ipachangeconf.py: change "is not 0" for "!= 0"

### DIFF
--- a/ipapython/ipachangeconf.py
+++ b/ipapython/ipachangeconf.py
@@ -482,7 +482,7 @@ class IPAChangeConf:
                     error=e, fname=f.name, line=line.rstrip()))
 
         # Add last section if any
-        if len(sectopts) is not 0:
+        if len(sectopts) != 0:
             opts.append({'name': section,
                          'type': 'section',
                          'value': sectopts})


### PR DESCRIPTION
Python 3.8 introduced a warning to check for usage of "is not"
when comparing literals. Any such usage will output:
SyntaxWarning: "is not" with a literal. Did you mean "!="?
See: https://bugs.python.org/issue34850

Fixes: https://pagure.io/freeipa/issue/8057
Signed-off-by: François Cami <fcami@redhat.com>