### PR TITLE
[Backport][ipa-4-8] ipapython/ipachangeconf.py: change "is not 0" for "!= 0"

### DIFF
--- a/ipapython/ipachangeconf.py
+++ b/ipapython/ipachangeconf.py
@@ -482,7 +482,7 @@ class IPAChangeConf:
                     error=e, fname=f.name, line=line.rstrip()))
 
         # Add last section if any
-        if len(sectopts) is not 0:
+        if len(sectopts) != 0:
             opts.append({'name': section,
                          'type': 'section',
                          'value': sectopts})


### PR DESCRIPTION
This PR was opened automatically because PR #3611 was pushed to master and backport to ipa-4-8 is required.