### PR TITLE
config plugin: replace 'is 0' with '== 0'

### DIFF
--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -503,12 +503,12 @@ class config_mod(LDAPUpdate):
 
         # Set ipasearchrecordslimit to -1 if 0 is used
         if 'ipasearchrecordslimit' in entry_attrs:
-            if entry_attrs['ipasearchrecordslimit'] is 0:
+            if entry_attrs['ipasearchrecordslimit'] == 0:
                  entry_attrs['ipasearchrecordslimit'] = -1
 
         # Set ipasearchtimelimit to -1 if 0 is used
         if 'ipasearchtimelimit' in entry_attrs:
-            if entry_attrs['ipasearchtimelimit'] is 0:
+            if entry_attrs['ipasearchtimelimit'] == 0:
                  entry_attrs['ipasearchtimelimit'] = -1
 
         for (attr, obj) in (('ipauserobjectclasses', 'user'),


### PR DESCRIPTION
Since python3.8, identity checks with literal produce syntax warnings.
Replace the check 'if .. is 0' with 'if .. == 0'

Related: https://pagure.io/freeipa/issue/8057
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>