### PR TITLE
Various pylint improvements

### DIFF
--- a/ipatests/test_cmdline/test_ipagetkeytab.py
+++ b/ipatests/test_cmdline/test_ipagetkeytab.py
@@ -465,4 +465,4 @@ class test_smb_service(KeytabRetrievalTest):
         entry = conn.retrieve(test_smb_svc.dn, ['ipaNTHash'])
         ipanthash = entry.single_value.get('ipanthash')
         conn.disconnect()
-        assert ipanthash is not b'MagicRegen', 'LDBM backend entry corruption'
+        assert ipanthash != b'MagicRegen', 'LDBM backend entry corruption'

--- a/ipatests/test_ipalib/test_text.py
+++ b/ipatests/test_ipalib/test_text.py
@@ -187,7 +187,7 @@ class test_Gettext:
         inst = self.klass('what up?', 'foo', 'bar')
         assert inst.domain == 'foo'
         assert inst.localedir == 'bar'
-        assert inst.msg is 'what up?'
+        assert inst.msg == 'what up?'
         assert inst.args == ('what up?', 'foo', 'bar')
 
     def test_repr(self):
@@ -349,7 +349,7 @@ class test_GettextFactory:
         inst = self.klass('foo', 'bar')
         g = inst('what up?')
         assert type(g) is text.Gettext
-        assert g.msg is 'what up?'
+        assert g.msg == 'what up?'
         assert g.domain == 'foo'
         assert g.localedir == 'bar'
 

--- a/ipatests/test_ipaserver/test_ldap.py
+++ b/ipatests/test_ipaserver/test_ldap.py
@@ -233,7 +233,7 @@ class test_LDAPEntry:
         e = self.entry
         assert e.pop('cn') == self.cn1
         assert 'cn' not in e
-        assert e.pop('cn', 'default') is 'default'
+        assert e.pop('cn', 'default') == 'default'
         with pytest.raises(KeyError):
             e.pop('cn')
 

--- a/ipatests/test_xmlrpc/test_certmap_plugin.py
+++ b/ipatests/test_xmlrpc/test_certmap_plugin.py
@@ -451,7 +451,7 @@ class TestPermission(XMLRPC_test):
         ) as ewe:
             find = certmap_rule.make_find_command()
             res = find(**{k: v for k, v in certmaprule_create_params.items()
-                          if k is not u'dn'})
+                          if k != u'dn'})
             ewe.send(res)
 
     def test_update(self, certmap_rule, certmap_user_permissions):

--- a/ipatests/test_xmlrpc/tracker/user_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/user_plugin.py
@@ -227,7 +227,7 @@ class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
         result = command()
 
         for key, value in updates.items():
-            if value is None or value is '' or value is u'':
+            if value is None or value == '':
                 del self.attrs[key]
             elif key == 'rename':
                 new_principal = u'{0}@{1}'.format(value, self.api.env.realm)
@@ -241,7 +241,7 @@ class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
                 else:
                     self.attrs[key] = [value]
         for key, value in expected_updates.items():
-            if value is None or value is '' or value is u'':
+            if value is None or value == '':
                 del self.attrs[key]
             else:
                 self.attrs[key] = value

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -499,6 +499,7 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.force_schema_check = False
     api.env.home = ''  # object
     api.env.host = ''
+    api.env.host_princ = ''
     api.env.http_timeout = 0
     api.env.in_server = False  # object
     api.env.in_tree = False  # object
@@ -524,6 +525,7 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.script = ''  # object
     api.env.site_packages = ''  # object
     api.env.skip_version_check = False
+    api.env.smb_princ = ''
     api.env.startup_timeout = 0
     api.env.startup_traceback = False
     api.env.tls_ca_cert = ''  # object

--- a/pylintrc
+++ b/pylintrc
@@ -92,7 +92,6 @@ disable=
     singleton-comparison,
     len-as-condition,  # new in pylint 1.7
     no-else-return,  # new in pylint 1.7
-    literal-comparison,  # new in pylint 1.7
     single-string-used-for-slots,  # new in pylint 1.7
     useless-super-delegation,  # new in pylint 1.7
     redefined-argument-from-local,  # new in pylint 1.7


### PR DESCRIPTION
# Enable literal-comparison linter again

The literal comparison linter checks for "value is 0" or "value is ''".
Related: https://pagure.io/freeipa/issue/8057

# Fix wrong use of identity operation

Strings should not be compared with the identity operation 'is' or 'is not'.

# Add new env vars to pylint plugin

The vars api.env.host_princ and smb_princ where introduced a while ago.
Sometimes parallel linting complain about the attributes. Add both to
the list of known members in pylint_plugins.py.
Related: https://pagure.io/freeipa/issue/3999

