### PR TITLE
WebUI: Fix changing category on HBAC/Sudo/etc Rule pages

### DIFF
--- a/install/ui/src/freeipa/association.js
+++ b/install/ui/src/freeipa/association.js
@@ -668,6 +668,7 @@ IPA.association_table_widget = function (spec) {
                 dialog.get_selected_values(),
                 function(data) {
                     that.refresh();
+                    that.facet.refresh();
                     dialog.close();
 
                     var succeeded = IPA.get_succeeded(data);
@@ -676,6 +677,7 @@ IPA.association_table_widget = function (spec) {
                 },
                 function() {
                     that.refresh();
+                    that.facet.refresh();
                     dialog.close();
                 }
             );

--- a/ipatests/test_webui/test_selinuxusermap.py
+++ b/ipatests/test_webui/test_selinuxusermap.py
@@ -53,6 +53,7 @@ INVALID_MLS = ("invalid 'selinuxuser': Invalid MLS value, must match {}, "
 HBAC_DEL_ERR = ('{} cannot be deleted because SELinux User Map {} requires '
                 'it')
 HBAC_MEMBER_ERR = 'HBAC rule and local members cannot both be set'
+BATCH_ERR = 'Some operations failed.'
 
 
 @pytest.mark.tier1
@@ -185,7 +186,7 @@ class test_selinuxusermap(UI_driver):
         self.navigate_to_record(selinuxmap.PKEY, entity=selinuxmap.ENTITY)
         self.add_table_associations('memberuser_user', ['admin'],
                                     negative=True)
-        self.assert_last_error_dialog(HBAC_MEMBER_ERR)
+        self.assert_last_error_dialog(BATCH_ERR)
         self.close_all_dialogs()
 
         # test adding HBAC rule together with user (should FAIL)


### PR DESCRIPTION
No object can be added to a rule when object category is 'all'.
So while editing rule there is needed to save actual category value before adding related objects.

Ticket: https://pagure.io/freeipa/issue/7961