### PR TITLE
[ipa-4-6 only] check for single-label domains only during server install

### DIFF
--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -406,14 +406,15 @@ def validate_dns_label(dns_label, allow_underscore=False, allow_slash=False):
 
 def validate_domain_name(
     domain_name, allow_underscore=False,
-    allow_slash=False, entity='domain'
+    allow_slash=False, entity='domain',
+    check_sld=False
 ):
     if domain_name.endswith('.'):
         domain_name = domain_name[:-1]
 
     domain_name = domain_name.split(".")
 
-    if len(domain_name) < 2:
+    if check_sld and len(domain_name) < 2:
         raise ValueError(_(
             'single label {}s are not supported'.format(entity)))
 

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -471,25 +471,25 @@ def install_check(installer):
         domain_name = read_domain_name(host_name[host_name.find(".")+1:],
                                        not installer.interactive)
         logger.debug("read domain_name: %s\n", domain_name)
-        try:
-            validate_domain_name(domain_name)
-        except ValueError as e:
-            raise ScriptError("Invalid domain name: %s" % unicode(e))
     else:
         domain_name = options.domain_name
 
     domain_name = domain_name.lower()
+    try:
+        validate_domain_name(domain_name, check_sld=True)
+    except ValueError as e:
+        raise ScriptError("Invalid domain name: %s" % unicode(e))
 
     if not options.realm_name:
         realm_name = read_realm_name(domain_name, not installer.interactive)
         logger.debug("read realm_name: %s\n", realm_name)
 
-        try:
-            validate_domain_name(realm_name, entity="realm")
-        except ValueError as e:
-            raise ScriptError("Invalid realm name: {}".format(unicode(e)))
     else:
         realm_name = options.realm_name.upper()
+    try:
+        validate_domain_name(realm_name, entity="realm", check_sld=True)
+    except ValueError as e:
+        raise ScriptError("Invalid realm name: {}".format(unicode(e)))
 
     if not options.subject_base:
         options.subject_base = installutils.default_subject_base(realm_name)

--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -400,7 +400,7 @@ class config(LDAPObject):
             )
 
         try:
-            validate_domain_name(domain)
+            validate_domain_name(domain, check_sld=True)
         except ValueError as e:
             raise errors.ValidationError(
                 name=attr_name,

--- a/ipaserver/plugins/realmdomains.py
+++ b/ipaserver/plugins/realmdomains.py
@@ -59,7 +59,7 @@ def _domain_name_normalizer(d):
 
 def _domain_name_validator(ugettext, value):
     try:
-        validate_domain_name(value, allow_slash=False)
+        validate_domain_name(value, allow_slash=False, check_sld=True)
     except ValueError as e:
         return unicode(e)
     return None


### PR DESCRIPTION
The fix for https://pagure.io/freeipa/issue/7207 and
https://pagure.io/freeipa/issue/7598 added checks against single-label
domains in client, server and replica installs. This prevents client
enrollment to existing topologies with single-label domain.

This commit removes those fixes on ipa-4-6 branch. Server installation
with single-label domain will still be refused, but client enrollment
will succeed.

Fixes: https://pagure.io/freeipa/issue/8058