### PR TITLE
[Backport][ipa-4-7] Fix two error paths around ipadb_get_global_config()

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -24,6 +24,7 @@
 #include <sys/utsname.h>
 
 #include "ipa_kdb.h"
+#include "ipa_krb5.h"
 
 #define IPADB_GLOBAL_CONFIG_CACHE_TIME 60
 
@@ -586,8 +587,9 @@ static krb5_error_code ipadb_init_module(krb5_context kcontext,
 
     ret = ipadb_get_connection(ipactx);
     if (ret != 0) {
-        /* not a fatal failure, as the LDAP server may be temporarily down */
-        /* TODO: spam syslog with this error */
+        /* Not a fatal failure, as the LDAP server may be temporarily down. */
+        krb5_klog_syslog(LOG_INFO,
+                         "Didn't connect to LDAP on startup: %d", ret);
     }
 
     kerr = krb5_db_set_context(kcontext, ipactx);

--- a/daemons/ipa-kdb/ipa_kdb_audit_as.c
+++ b/daemons/ipa-kdb/ipa_kdb_audit_as.c
@@ -20,7 +20,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <syslog.h>
 #include "ipa_kdb.h"
 #include "ipa_pwd.h"
 

--- a/daemons/ipa-kdb/ipa_kdb_certauth.c
+++ b/daemons/ipa-kdb/ipa_kdb_certauth.c
@@ -39,7 +39,6 @@
 
 #include <errno.h>
 //#include <krb5/certauth_plugin.h>
-#include <syslog.h>
 #include <sss_certmap.h>
 
 #include "ipa_krb5.h"

--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -25,7 +25,6 @@
 #include "ipa_kdb.h"
 #include "ipa_mspac.h"
 #include <talloc.h>
-#include <syslog.h>
 #include <unicase.h>
 #include "util/time.h"
 #include "gen_ndr/ndr_krb5pac.h"

--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -1057,7 +1057,7 @@ static krb5_flags maybe_require_preauth(struct ipadb_context *ipactx,
     struct ipadb_e_data *ied;
 
     config = ipadb_get_global_config(ipactx);
-    if (config->disable_preauth_for_spns) {
+    if (config && config->disable_preauth_for_spns) {
         ied = (struct ipadb_e_data *)entry->e_data;
         if (ied && ied->ipa_user != true) {
             /* not a user, assume SPN */

--- a/util/ipa_krb5.h
+++ b/util/ipa_krb5.h
@@ -4,6 +4,7 @@
 #include <lber.h>
 #include <krb5/krb5.h>
 #include <kdb.h>
+#include <syslog.h>
 
 struct krb_key_salt {
     krb5_enctype enctype;


### PR DESCRIPTION
This PR was opened automatically because PR #3622 was pushed to master and backport to ipa-4-7 is required.