### PR TITLE
prci: fix typo on nightly test definitions

### DIFF
--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -243,7 +243,7 @@ jobs:
     requires: [fedora-29/build]
     priority: 50
     job:
-      class: RunADtests
+      class: RunADTests
       args:
         build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_smb.py

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -243,7 +243,7 @@ jobs:
     requires: [fedora-rawhide/build]
     priority: 50
     job:
-      class: RunADtest
+      class: RunADTests
       args:
         build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_smb.py


### PR DESCRIPTION
PR-CI breaks if the class to execute the tests doesn't exist.

PR-CI issue: https://github.com/freeipa/freeipa-pr-ci/issues/306

Signed-off-by: Armando Neto <abiagion@redhat.com>