### PR TITLE
[Backport][ipa-4-6] Don't configure KEYRING ccache in containers

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -30,6 +30,7 @@ class BasePathNamespace(object):
     LS = "/bin/ls"
     SH = "/bin/sh"
     SYSTEMCTL = "/bin/systemctl"
+    SYSTEMD_DETECT_VIRT = "/bin/systemd-detect-virt"
     TAR = "/bin/tar"
     AUTOFS_LDAP_AUTH_CONF = "/etc/autofs_ldap_auth.conf"
     ETC_DIRSRV = "/etc/dirsrv"

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -116,6 +116,14 @@ class BaseTaskNamespace(object):
 
         raise NotImplementedError()
 
+    def detect_container(self):
+        """Check if running inside a container
+
+        :returns: container runtime or None
+        :rtype: str, None
+        """
+        raise NotImplementedError
+
     def restore_hostname(self, fstore, statestore):
         """
         Restores the original hostname as backed up in the

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -30,6 +30,7 @@ import os
 import socket
 import traceback
 import errno
+import subprocess
 import sys
 
 from ctypes.util import find_library
@@ -167,6 +168,26 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                  "interface that has ::1 address assigned. Add ::1 address "
                  "resolution to 'lo' interface. You might need to enable IPv6 "
                  "on the interface 'lo' in sysctl.conf.")
+
+    def detect_container(self):
+        """Check if running inside a container
+
+        :returns: container runtime or None
+        :rtype: str, None
+        """
+        try:
+            output = subprocess.check_output(
+                [paths.SYSTEMD_DETECT_VIRT, '--container'],
+                stderr=subprocess.STDOUT
+            )
+        except subprocess.CalledProcessError as e:
+            if e.returncode == 1:
+                # No container runtime detected
+                return None
+            else:
+                raise
+        else:
+            return output.decode('utf-8').strip()
 
     def restore_pre_ipa_client_configuration(self, fstore, statestore,
                                              was_sssd_installed,

--- a/ipapython/kernel_keyring.py
+++ b/ipapython/kernel_keyring.py
@@ -24,6 +24,7 @@ import six
 
 from ipapython.ipautil import run
 from ipaplatform.paths import paths
+from ipaplatform.tasks import tasks
 
 # NOTE: Absolute path not required for keyctl since we reset the environment
 #       in ipautil.run.
@@ -68,7 +69,14 @@ def get_persistent_key(key):
     return result.raw_output.rstrip()
 
 
-def is_persistent_keyring_supported():
+def is_persistent_keyring_supported(check_container=True):
+    """Returns True if the kernel persistent keyring is supported.
+
+    If check_container is True and a containerized environment is detected,
+    return False. There is no support for keyring namespace isolation yet.
+    """
+    if check_container and tasks.detect_container() is not None:
+        return False
     uid = os.geteuid()
     try:
         get_persistent_key(str(uid))

--- a/ipatests/test_ipaplatform/test_tasks.py
+++ b/ipatests/test_ipaplatform/test_tasks.py
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2017  FreeIPA Contributors see COPYING for license
+#
+from __future__ import absolute_import
+
+import os
+
+from ipaplatform.tasks import tasks
+
+
+def test_detect_container():
+    container = None
+    # naive detection, may fail for OpenVZ and other container runtimes
+    if os.path.isfile('/run/systemd/container'):
+        with open('/run/systemd/container') as f:
+            container = f.read().strip()
+    elif os.geteuid() == 0:
+        with open('/proc/1/environ') as f:
+            environ = f.read()
+        for item in environ.split('\x00'):
+            if not item:
+                continue
+            k, v = item.split('=', 1)
+            if k == 'container':
+                container = v
+
+    detected = tasks.detect_container()
+    if container == 'oci':
+        # systemd doesn't know about podman
+        assert detected in {'container-other', container}
+    else:
+        assert detected == container


### PR DESCRIPTION
Manual backport of PR #2677

Kernel keyrings are not namespaced yet. Keyrings can leak into other
containers. Therefore keyrings should not be used in containerized
environment.

Don't configure Kerberos to use KEYRING ccache backen when a container
environment is detected by systemd-detect-virt --container.

Fixes: https://pagure.io/freeipa/issue/7807
Signed-off-by: Christian Heimes cheimes@redhat.com