### PR TITLE
[Backport][ipa-4-8] WebUI: Make 'Unlock' option is available only on locked user page

### DIFF
--- a/ipatests/test_webui/test_user.py
+++ b/ipatests/test_webui/test_user.py
@@ -211,7 +211,8 @@ class test_user(user_tasks):
         self.reset_password_action(pwd)
         self.assert_text_field('has_password', '******')
 
-        self.action_list_action('unlock')
+        # unlock option should be disabled for new user
+        self.assert_action_list_action('unlock', enabled=False)
 
         # delete
         self.delete_action(user.ENTITY, user.PKEY, action='delete_active_user')


### PR DESCRIPTION
The implementation includes checking password policy for selected user.
'Unlock' option is available only in case user reached a limit of login failures.

Ticket: https://pagure.io/freeipa/issue/5062

This is manual backport of https://github.com/freeipa/freeipa/pull/3563