### PR TITLE
[Backport][ipa-4-6] add default access control when migrating trust objects

### DIFF
--- a/install/updates/90-post_upgrade_plugins.update
+++ b/install/updates/90-post_upgrade_plugins.update
@@ -12,6 +12,7 @@ plugin: update_default_range
 plugin: update_default_trust_view
 plugin: update_tdo_gidnumber
 plugin: update_tdo_to_new_layout
+plugin: update_tdo_default_read_keys_permissions
 plugin: update_ca_renewal_master
 plugin: update_idrange_type
 plugin: update_pacs

--- a/ipaserver/install/plugins/adtrust.py
+++ b/ipaserver/install/plugins/adtrust.py
@@ -583,6 +583,7 @@ class update_tdo_to_new_layout(Updater):
                     # Old style, no ipaAllowedToPerform;read_keys in the entry,
                     # use defaults that ipasam should have set when creating a
                     # trust
+                    # pylint: disable=deprecated-lambda
                     read_keys = list(map(
                         lambda x: x.format(basedn=self.api.env.basedn),
                         trust_read_keys_template))
@@ -770,6 +771,7 @@ class update_tdo_default_read_keys_permissions(Updater):
 
             read_keys = tdo.get('ipaAllowedToPerform;read_keys', [])
             if not read_keys:
+                # pylint: disable=deprecated-lambda
                 read_keys_values = list(map(
                     lambda x: x.format(basedn=self.api.env.basedn),
                     trust_read_keys_template))


### PR DESCRIPTION
This PR was opened automatically because PR #3643 was pushed to master and backport to ipa-4-6 is required.