### PR TITLE
[Backport][ipa-4-7] add default access control when migrating trust objects

### DIFF
--- a/install/updates/90-post_upgrade_plugins.update
+++ b/install/updates/90-post_upgrade_plugins.update
@@ -12,6 +12,7 @@ plugin: update_default_range
 plugin: update_default_trust_view
 plugin: update_tdo_gidnumber
 plugin: update_tdo_to_new_layout
+plugin: update_tdo_default_read_keys_permissions
 plugin: update_ca_renewal_master
 plugin: update_idrange_type
 plugin: update_pacs


### PR DESCRIPTION
This PR was opened automatically because PR #3643 was pushed to master and backport to ipa-4-7 is required.