### PR TITLE
[Backport][ipa-4-7] Hidden Replica: Add a test for Automatic CRL configuration

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -911,3 +911,28 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         # FIXME: restore turns hidden replica into enabled replica
         self._check_config([self.master, self.replicas[0]])
         self._check_server_role(self.replicas[0], 'enabled')
+
+    def test_hidden_replica_automatic_crl(self):
+        """Exercises if automatic CRL configuration works with
+           hidden replica.
+        """
+        # Demoting Replica to be hidden.
+        self.replicas[0].run_command([
+            'ipa', 'server-state',
+            self.replicas[0].hostname, '--state=hidden'
+        ])
+        self._check_server_role(self.replicas[0], 'hidden')
+
+        # check CRL status
+        result = self.replicas[0].run_command([
+            'ipa-crlgen-manage', 'status'])
+        assert "CRL generation: disabled" in result.stdout_text
+
+        # Enbable CRL status on hidden replica
+        self.replicas[0].run_command([
+            'ipa-crlgen-manage', 'enable'])
+
+        # check CRL status
+        result = self.replicas[0].run_command([
+            'ipa-crlgen-manage', 'status'])
+        assert "CRL generation: enabled" in result.stdout_text


### PR DESCRIPTION
This PR was opened automatically because PR #3644 was pushed to master and backport to ipa-4-7 is required.