### PR TITLE
[Backport][ipa-4-6] Add container environment check to replicainstall

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1134,7 +1134,11 @@ def promote_check(installer):
                            "certificate")
 
     installutils.verify_fqdn(config.host_name, options.no_host_dns)
-    installutils.verify_fqdn(config.master_host_name, options.no_host_dns)
+    # Inside the container environment master's IP address does not
+    # resolve to its name. See https://pagure.io/freeipa/issue/6210
+    container_environment = tasks.detect_container() is not None
+    installutils.verify_fqdn(config.master_host_name, options.no_host_dns,
+                             local_hostname=not container_environment)
 
     ccache = os.environ['KRB5CCNAME']
     kinit_keytab('host/{env.host}@{env.realm}'.format(env=api.env),


### PR DESCRIPTION
This PR was opened automatically because PR #3646 was pushed to master and backport to ipa-4-6 is required.