### PR TITLE
Make sure to have storage space for tag

### DIFF
--- a/util/ipa_krb5.c
+++ b/util/ipa_krb5.c
@@ -554,7 +554,7 @@ int ber_decode_krb5_key_data(struct berval *encoded, int *m_kvno,
         retag = ber_peek_tag(be, &setlen);
         if (retag == (LBER_CONSTRUCTED | LBER_CLASS_CONTEXT | 2)) {
             /* not supported yet, skip */
-            retag = ber_scanf(be, "t[x]}");
+            retag = ber_scanf(be, "t[x]}", &tag);
         } else {
             retag = ber_scanf(be, "}");
         }


### PR DESCRIPTION
ber_scanf expects a pointer to a ber_tag_t to return the tag pointed at
by "t", if that is not provided the pointer will be store in whatever
memory location is pointed by the stack at that time causeing a crash.

Note that this is effectively unused code because in ipa-kdb the only
party that can write a key_data structure to be stored is te kdb_driver
itself and we never encode these s2kparam data.

But we need to handle this for future proofing.

Fixes: https://pagure.io/freeipa/issue/8071