### PR TITLE
Re-order tasks.restore_pkcs11_modules() to run earlier

### DIFF
--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1145,6 +1145,7 @@ def uninstall(installer):
     custodiainstance.CustodiaInstance(realm='REALM.INVALID').uninstall()
     otpdinstance.OtpdInstance().uninstall()
     tasks.restore_hostname(fstore, sstore)
+    tasks.restore_pkcs11_modules(fstore)
     fstore.restore_all_files()
     try:
         os.remove(paths.ROOT_IPA_CACHE)
@@ -1168,8 +1169,6 @@ def uninstall(installer):
 
     # remove upgrade state file
     sysupgrade.remove_upgrade_file()
-
-    tasks.restore_pkcs11_modules(fstore)
 
     if fstore.has_files():
         logger.error('Some files have not been restored, see '


### PR DESCRIPTION
It was executed after restore_all_files() so PKCS11_MODULES was
already restored so that part was a no-op, but the redhat
restore_pkcs11_modules() also calls unlink() on each restored
file so basically the file would be restored, unlinked, then
since it was already restored, skipped.

By moving the call to restore_pkcs11_modules() earlier it can
do the expected restoration properly.

https://pagure.io/freeipa/issue/8034

Signed-off-by: Rob Crittenden <rcritten@redhat.com>