### PR TITLE
[Backport][ipa-4-7] ipatests: add tests for cached_auth_timeout in sssd.conf

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-7.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-7.yaml
@@ -27,6 +27,10 @@ topologies:
     name: master_3repl_1client
     cpu: 6
     memory: 12900
+  ad_master: &ad_master
+   name: ad_master
+   cpu: 4
+   memory: 12000
 
 jobs:
   fedora-29/build:
@@ -1244,3 +1248,15 @@ jobs:
         template: *ci-master-f29
         timeout: 10800
         topology: *master_1repl
+
+  fedora-29/test_sssd:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_sssd.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *ad_master

--- a/ipatests/pytest_ipa/integration/host.py
+++ b/ipatests/pytest_ipa/integration/host.py
@@ -63,14 +63,22 @@ class Host(pytest_multihost.host.Host):
 
     def run_command(self, argv, set_env=True, stdin_text=None,
                     log_stdout=True, raiseonerr=True,
-                    cwd=None, bg=False, encoding='utf-8'):
-        # Wrap run_command to log stderr on raiseonerr=True
+                    cwd=None, bg=False, encoding='utf-8', ok_returncode=0):
+        """Wrapper around run_command to log stderr on raiseonerr=True
+
+        :param ok_returncode: return code considered to be correct,
+                              you can pass an integer or sequence of integers
+        """
         result = super(Host, self).run_command(
             argv, set_env=set_env, stdin_text=stdin_text,
             log_stdout=log_stdout, raiseonerr=False, cwd=cwd, bg=bg,
             encoding=encoding
         )
-        if result.returncode and raiseonerr:
+        try:
+            result_ok = result.returncode in ok_returncode
+        except TypeError:
+            result_ok = result.returncode == ok_returncode
+        if not result_ok and raiseonerr:
             result.log.error('stderr: %s', result.stderr_text)
             raise subprocess.CalledProcessError(
                 result.returncode, argv,

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -30,6 +30,8 @@ import itertools
 import tempfile
 import time
 from pipes import quote
+import configparser
+from contextlib import contextmanager
 
 import dns
 from ldif import LDIFWriter
@@ -1769,3 +1771,71 @@ def run_command_as_user(host, user, command, *args, **kwargs):
 
 def kinit_as_user(host, user, password):
     host.run_command(['kinit', user], stdin_text=password + '\n')
+
+
+class FileBackup:
+    """Create file backup and do restore on remote host
+
+    Examples:
+
+        config_backup = FileBackup(host, '/etc/some.conf')
+        ... modify the file and do the test ...
+        config_backup.restore()
+
+    Use as a context manager:
+
+        with FileBackup(host, '/etc/some.conf'):
+            ... modify the file and do the test ...
+
+    """
+
+    def __init__(self, host, filename):
+        """Create file backup."""
+        self._host = host
+        self._filename = filename
+        self._backup = create_temp_file(host)
+        self._cp_cmd = ['cp']
+        if is_selinux_enabled(host):
+            self._cp_cmd.append('--preserve=context')
+        host.run_command(self._cp_cmd + [filename, self._backup])
+
+    def restore(self):
+        """Restore file. Can be called multiple times."""
+        self._host.run_command(self._cp_cmd + [self._backup, self._filename])
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.restore()
+
+
+@contextmanager
+def remote_ini_file(host, filename):
+    """Context manager for editing an ini file on a remote host.
+
+    It provides RawConfigParser object which is automatically serialized and
+    uploaded to remote host upon exit from the context.
+
+    If exception is raised inside the context then the ini file is NOT updated
+    on remote host.
+
+    Example:
+
+        with remote_ini_file(master, '/etc/some.conf') as some_conf:
+            some_conf.set('main', 'timeout', 10)
+
+
+    """
+    data = host.get_file_contents(filename, encoding='utf-8')
+    ini_file = configparser.RawConfigParser()
+    ini_file.read_string(data)
+    yield ini_file
+    data = StringIO()
+    ini_file.write(data)
+    host.put_file_contents(filename, data.getvalue())
+
+
+def is_selinux_enabled(host):
+    res = host.run_command('selinuxenabled', ok_returncode=(0, 1))
+    return res.returncode == 0

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -1,0 +1,110 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+"""This module provides tests for SSSD as used in IPA"""
+
+from __future__ import absolute_import
+
+import time
+from contextlib import contextmanager
+
+import pytest
+
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_ipa.integration import tasks
+from ipaplatform.paths import paths
+
+
+class TestSSSDAuthCache(IntegrationTest):
+    """Regression tests for cached_auth_timeout option
+
+       https://bugzilla.redhat.com/show_bug.cgi?id=1685581
+   """
+
+    topology = 'star'
+    num_ad_domains = 1
+
+    users = {
+        'ipa': {
+            'name': 'user1',
+            'password': 'SecretUser1'
+        },
+        'ad': {
+            'name_tmpl': 'testuser@{domain}',
+            'password': 'Secret123'
+        },
+    }
+    ipa_user = 'user1'
+    ipa_user_password = 'SecretUser1'
+    intermed_user = 'user2'
+    ad_user_tmpl = 'testuser@{domain}'
+    ad_user_password = 'Secret123'
+
+    @classmethod
+    def install(cls, mh):
+        super(TestSSSDAuthCache, cls).install(mh)
+
+        cls.ad = cls.ads[0]  # pylint: disable=no-member
+
+        tasks.install_adtrust(cls.master)
+        tasks.configure_dns_for_trust(cls.master, cls.ad)
+        tasks.establish_trust_with_ad(cls.master, cls.ad.domain.name)
+
+        cls.users['ad']['name'] = cls.users['ad']['name_tmpl'].format(
+            domain=cls.ad.domain.name)
+        tasks.user_add(cls.master, cls.intermed_user)
+        tasks.create_active_user(cls.master, cls.ipa_user,
+                                 cls.ipa_user_password)
+
+    @contextmanager
+    def config_sssd_cache_auth(self, cached_auth_timeout):
+        sssd_conf_backup = tasks.FileBackup(self.master, paths.SSSD_CONF)
+        with tasks.remote_ini_file(self.master, paths.SSSD_CONF) as sssd_conf:
+            domain_section = 'domain/{}'.format(self.master.domain.name)
+            if cached_auth_timeout is None:
+                sssd_conf.remove_option(domain_section, 'cached_auth_timeout')
+            else:
+                sssd_conf.set(domain_section, 'cached_auth_timeout',
+                              cached_auth_timeout)
+            sssd_conf.set('pam', 'pam_verbosity', '2')
+
+        try:
+            tasks.clear_sssd_cache(self.master)
+            yield
+        finally:
+            sssd_conf_backup.restore()
+            tasks.clear_sssd_cache(self.master)
+
+    def is_auth_cached(self, user):
+        cmd = ['su', '-l', user['name'], '-c', 'true']
+        res = tasks.run_command_as_user(self.master, self.intermed_user, cmd,
+                                        stdin_text=user['password'] + '\n')
+        return 'Authenticated with cached credentials.' in res.stdout_text
+
+    @pytest.mark.parametrize('user', ['ipa', 'ad'])
+    def test_auth_cache_disabled_by_default(self, user):
+        with self.config_sssd_cache_auth(cached_auth_timeout=None):
+            assert not self.is_auth_cached(self.users[user])
+            assert not self.is_auth_cached(self.users[user])
+
+    @pytest.mark.parametrize('user', ['ipa', 'ad'])
+    def test_auth_cache_disabled_with_value_0(self, user):
+        with self.config_sssd_cache_auth(cached_auth_timeout=0):
+            assert not self.is_auth_cached(self.users[user])
+            assert not self.is_auth_cached(self.users[user])
+
+    @pytest.mark.parametrize('user', ['ipa', 'ad'])
+    def test_auth_cache_enabled_when_configured(self, user):
+        timeout = 30
+        with self.config_sssd_cache_auth(cached_auth_timeout=timeout):
+            start = time.time()
+            # check auth is cached after first login
+            assert not self.is_auth_cached(self.users[user])
+            assert self.is_auth_cached(self.users[user])
+            # check cache expires after configured timeout
+            elapsed = time.time() - start
+            time.sleep(timeout - 5 - elapsed)
+            assert self.is_auth_cached(self.users[user])
+            time.sleep(10)
+            assert not self.is_auth_cached(self.users[user])


### PR DESCRIPTION
This is a manual backport of #3602

The tests check that auth cache
* is disabled by default
* is working when enabled
* expires after specified time
* is inherited by trusted domain

Related to: https://bugzilla.redhat.com/1685581
