### PR TITLE
ipa-backup: backup the PKCS module config files setup by IPA

### DIFF
--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -338,6 +338,11 @@ class BaseTaskNamespace:
         """
         raise NotImplementedError
 
+    def get_pkcs11_modules(self):
+        """Return the list of module config files setup by IPA.
+        """
+        return ()
+
     def configure_nsswitch_database(self, fstore, database, services,
                                     preserve=True, append=True,
                                     default_value=()):

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -744,6 +744,13 @@ class RedHatTaskNamespace(BaseTaskNamespace):
 
         return filenames
 
+    def get_pkcs11_modules(self):
+        """Return the list of module config files setup by IPA
+        """
+        return tuple(os.path.join(paths.ETC_PKCS11_MODULES_DIR,
+                                  "{}.module".format(name))
+                     for name, _module, _disabled in PKCS11_MODULES)
+
     def enable_ldap_automount(self, statestore):
         """
         Point automount to ldap in nsswitch.conf.

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -194,7 +194,7 @@ class Backup(admintool.AdminTool):
     ) + tuple(
         os.path.join(paths.IPA_NSSDB_DIR, file)
         for file in (certdb.NSS_DBM_FILES + certdb.NSS_SQL_FILES)
-    )
+    ) + tasks.get_pkcs11_modules()
 
     logs=(
       paths.VAR_LOG_PKI_DIR,

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -115,6 +115,17 @@ def check_custodia_files(host):
     return True
 
 
+def check_pkcs11_modules(host):
+    """regression test for https://pagure.io/freeipa/issue/8073"""
+    # Return a dictionary with key = filename, value = file content
+    # containing all the PKCS11 modules modified by the installer
+    result = dict()
+    for filename in platformtasks.get_pkcs11_modules():
+        assert host.transport.file_exists(filename)
+        result[filename] = host.get_file_contents(filename)
+    return result
+
+
 CHECKS = [
     (check_admin_in_ldap, assert_entries_equal),
     (check_admin_in_cli, assert_results_equal),
@@ -122,7 +133,8 @@ CHECKS = [
     (check_certs, assert_results_equal),
     (check_dns, assert_results_equal),
     (check_kinit, assert_results_equal),
-    (check_custodia_files, assert_deepequal)
+    (check_custodia_files, assert_deepequal),
+    (check_pkcs11_modules, assert_deepequal)
 ]
 
 


### PR DESCRIPTION
### ipa-backup: backup the PKCS module config files setup by IPA
    
ipa installer creates /etc/pkcs11/modules/softhsm2.module in order
to disable global p11-kit configuration for NSS.
This file was not included in the backups, and not restored.
    
The fix adds the file to the list of files to include in a backup.
    
Fixes: https://pagure.io/freeipa/issue/8073

### ipatests: ensure that backup/restore restores pkcs 11 modules config file
    
In the test_backup_and_restore, add a new test:
- before backup, save the content of /etc/pkcs11/modules/softhsm2.module
- after restore, ensure the file is present with the same content.
    
Related: https://pagure.io/freeipa/issue/8073
