### PR TITLE
[Backport][ipa-4-8] ipa-scripts: fix python3 shebang flags on scripts

### DIFF
--- a/Makefile.pythonscripts.am
+++ b/Makefile.pythonscripts.am
@@ -1,6 +1,6 @@
 # special handling of Python scripts with auto-generated shebang line
 $(PYTHON_SHEBANG):%: %.in Makefile
-	$(AM_V_GEN)sed -e 's|^#!/usr/bin/python3.*|#!$(PYTHON) -E|g' $< > $@
+	$(AM_V_GEN)sed -e 's|^#!/usr/bin/python3.*|#!$(PYTHON) -I|g' $< > $@
 	$(AM_V_GEN)chmod +x $@
 
 .PHONY: python_scripts_sub


### PR DESCRIPTION
This PR was opened automatically because PR #3416 was pushed to master and backport to ipa-4-8 is required.