### PR TITLE
Report if a certmonger CA is missing

### DIFF
--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -179,6 +179,9 @@ def _get_requests(criteria=dict()):
         for criterion in criteria:
             if criterion == 'ca-name':
                 ca_path = request.obj_if.get_ca()
+                if ca_path is None:
+                    raise RuntimeError("certmonger CA '%s' is not defined" %
+                                       criteria.get('ca-name'))
                 ca = _cm_dbus_object(cm.bus, cm, ca_path, DBUS_CM_CA_IF,
                                      DBUS_CM_IF)
                 value = ca.obj_if.get_nickname()


### PR DESCRIPTION
If a certmonger CA is not defined but is referenced within
a request (so was removed sometime after a request was
created) then anything that pulls all certmonger requests would
fail with the cryptic error:

"Failed to get request: bus, object_path and dbus_interface
must not be None."

This was often seen during upgrades.

Catch this specific condition and report a more specific error
so the user will have some bread crumb to know how to address
the issue.

https://pagure.io/freeipa/issue/7870

Signed-off-by: Rob Crittenden <rcritten@redhat.com>