### PR TITLE
[Backport][ipa-4-8] Re-add function façades removed by commit 2da9088.

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -28,6 +28,7 @@ import sys
 import tempfile
 import time
 import traceback
+import warnings
 
 from configparser import RawConfigParser
 from urllib.parse import urlparse, urlunparse
@@ -279,6 +280,36 @@ def is_ipa_client_installed(fstore, on_master=False):
     )
 
     return installed
+
+
+def configure_nsswitch_database(fstore, database, services, preserve=True,
+                                append=True, default_value=()):
+    """
+    This function was deprecated. Use ipaplatform.tasks.
+
+    Edits the specified nsswitch.conf database (e.g. passwd, group, sudoers)
+    to use the specified service(s).
+
+    Arguments:
+        fstore - FileStore to backup the nsswitch.conf
+        database - database configuration that should be ammended,
+                    e.g. 'sudoers'
+        service - list of services that should be added, e.g. ['sss']
+        preserve - if True, the already configured services will be preserved
+
+    The next arguments modify the behaviour if preserve=True:
+        append - if True, the services will be appended, if False, prepended
+        default_value - list of services that are considered as default (if
+                        the database is not mentioned in nsswitch.conf), e.g.
+                        ['files']
+    """
+    warnings.warn(
+        "Use ipaplatform.tasks.tasks.configure_nsswitch_database",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    return tasks.configure_nsswitch_database(fstore, database, services,
+                                             preserve, append, default_value)
 
 
 def configure_ipa_conf(

--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -29,6 +29,7 @@ import shutil
 import time
 import tempfile
 import gssapi
+import warnings
 
 try:
     from xml.etree import cElementTree as etree
@@ -176,6 +177,21 @@ def configure_xml(fstore):
         print("Unable to write %s: %s" % (authconf, e))
     else:
         print("Configured %s" % authconf)
+
+
+def configure_nsswitch(statestore, options):
+    """
+    This function was deprecated. Use ipaplatform.tasks.
+
+    Point automount to ldap in nsswitch.conf.
+    This function is for non-SSSD setups only.
+    """
+    warnings.warn(
+        "Use ipaplatform.tasks.tasks.enable_ldap_automount",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    return tasks.enable_ldap_automount(statestore)
 
 
 def configure_autofs_sssd(fstore, statestore, autodiscover, options):


### PR DESCRIPTION
This PR was opened automatically because PR #3679 was pushed to master and backport to ipa-4-8 is required.