### PR TITLE
ipatests: enable 389-ds audit log and collect audit file

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -399,6 +399,7 @@ class BasePathNamespace:
     VAR_LOG_DIRSRV_INSTANCE_TEMPLATE = "/var/log/dirsrv/slapd-%s"
     SLAPD_INSTANCE_ACCESS_LOG_TEMPLATE = "/var/log/dirsrv/slapd-%s/access"
     SLAPD_INSTANCE_ERROR_LOG_TEMPLATE = "/var/log/dirsrv/slapd-%s/errors"
+    SLAPD_INSTANCE_AUDIT_LOG_TEMPLATE = "/var/log/dirsrv/slapd-%s/audit"
     SLAPD_INSTANCE_SYSTEMD_IPA_ENV_TEMPLATE = \
         "/etc/systemd/system/dirsrv@%s.service.d/ipa-env.conf"
     IPA_SERVER_UPGRADE = '/usr/sbin/ipa-server-upgrade'


### PR DESCRIPTION
In test_integration, enable 389-ds audit log and auditfail log by setting
nsslapd-auditlog-logging-enabled: on
nsslapd-auditfaillog-logging-enabled: on

and collect the generated audit file. This will help troubleshoot failures
related to DS.

Fixes: https://pagure.io/freeipa/issue/8064