### PR TITLE
ipa-restore: Restore ownership and perms on 389-ds log directory

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -631,6 +631,10 @@ class Restore(admintool.AdminTool):
                 os.makedirs(template_dir)
             except OSError as e:
                 pass
+
+            os.chown(template_dir, pent.pw_uid, pent.pw_gid)
+            os.chmod(template_dir, 0o770)
+
             # Restore SELinux context of template_dir
             tasks.restore_context(template_dir)
 


### PR DESCRIPTION
Previously it would end up being owned by root:root mode 0755
instead of dirsrv:dirsrv mode 0770.

https://pagure.io/freeipa/issue/7725

Signed-off-by: Rob Crittenden <rcritten@redhat.com>