### PR TITLE
prci: update packages for pki and testing nightly runs

### DIFF
--- a/ipatests/prci_definitions/nightly_master_pki.yaml
+++ b/ipatests/prci_definitions/nightly_master_pki.yaml
@@ -46,6 +46,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_simple_replication.py
         template: *pki-master-f30
         timeout: 3600
@@ -58,6 +59,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCA
         template: *pki-master-f30
         timeout: 4800
@@ -70,6 +72,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
         template: *pki-master-f30
         timeout: 3600
@@ -82,6 +85,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
         template: *pki-master-f30
         timeout: 3600
@@ -94,6 +98,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_vault.py
         template: *pki-master-f30
         timeout: 6300
@@ -106,6 +111,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_forced_client_reenrollment.py
         template: *pki-master-f30
         timeout: 4800
@@ -118,6 +124,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
         template: *pki-master-f30
         timeout: 10800
@@ -130,6 +137,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
         template: *pki-master-f30
         timeout: 10800
@@ -142,6 +150,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
         template: *pki-master-f30
         timeout: 10800
@@ -154,6 +163,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
         template: *pki-master-f30
         timeout: 10800
@@ -166,6 +176,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
         template: *pki-master-f30
         timeout: 10800
@@ -178,6 +189,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
         template: *pki-master-f30
         timeout: 10800
@@ -190,6 +202,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
         template: *pki-master-f30
         timeout: 3600
@@ -202,6 +215,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
         template: *pki-master-f30
         timeout: 3600
@@ -214,6 +228,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
         template: *pki-master-f30
         timeout: 10800
@@ -226,6 +241,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
         template: *pki-master-f30
         timeout: 10800
@@ -238,6 +254,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMaster
         template: *pki-master-f30
         timeout: 10800
@@ -250,6 +267,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
         template: *pki-master-f30
         timeout: 10800
@@ -262,6 +280,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
         template: *pki-master-f30
         timeout: 10800
@@ -274,6 +293,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
         template: *pki-master-f30
         timeout: 10800
@@ -286,6 +306,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestServerInstall
         template: *pki-master-f30
         timeout: 12000
@@ -298,6 +319,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *pki-master-f30
         timeout: 5400
@@ -310,6 +332,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestClientInstall
         template: *pki-master-f30
         timeout: 5400
@@ -323,6 +346,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestIPACommands
         template: *pki-master-f30
         timeout: 5400
@@ -335,6 +359,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestCertInstall
         template: *pki-master-f30
         timeout: 5400
@@ -347,6 +372,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestPKINIT
         template: *pki-master-f30
         timeout: 5400
@@ -359,6 +385,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
         template: *pki-master-f30
         timeout: 5400
@@ -371,6 +398,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
         template: *pki-master-f30
         timeout: 5400
@@ -383,6 +411,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
         template: *pki-master-f30
         timeout: 5400
@@ -395,6 +424,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
         template: *pki-master-f30
         timeout: 7200
@@ -407,6 +437,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
         template: *pki-master-f30
         timeout: 7200
@@ -419,6 +450,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
         template: *pki-master-f30
         timeout: 7200
@@ -431,6 +463,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
         template: *pki-master-f30
         timeout: 7200
@@ -443,6 +476,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
         template: *pki-master-f30
         timeout: 7200
@@ -455,6 +489,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
         template: *pki-master-f30
         timeout: 7200
@@ -467,6 +502,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
         template: *pki-master-f30
         timeout: 7200
@@ -479,6 +515,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
         template: *pki-master-f30
         timeout: 7200
@@ -491,6 +528,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_upgrade.py
         template: *pki-master-f30
         timeout: 7200
@@ -503,6 +541,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
         template: *pki-master-f30
         timeout: 7200
@@ -515,6 +554,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
         template: *pki-master-f30
         timeout: 7200
@@ -527,6 +567,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
         template: *pki-master-f30
         timeout: 10800
@@ -539,6 +580,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
         template: *pki-master-f30
         timeout: 10800
@@ -551,6 +593,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
         template: *pki-master-f30
         timeout: 7200
@@ -563,6 +606,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
         template: *pki-master-f30
         timeout: 7200
@@ -575,6 +619,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
         template: *pki-master-f30
         timeout: 10800
@@ -587,6 +632,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
         template: *pki-master-f30
         timeout: 7200
@@ -599,6 +645,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
         template: *pki-master-f30
         timeout: 7200
@@ -611,6 +658,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
         template: *pki-master-f30
         timeout: 7200
@@ -623,6 +671,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_uninstallation.py
         template: *pki-master-f30
         timeout: 7200
@@ -635,6 +684,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_webui/test_cert.py
         template: *pki-master-f30
         timeout: 2400
@@ -647,6 +697,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
@@ -661,6 +712,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_dns_locations.py
         template: *pki-master-f30
         timeout: 3600
@@ -673,6 +725,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
         template: *pki-master-f30
         timeout: 3600
@@ -685,6 +738,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert
         template: *pki-master-f30
         timeout: 3600
@@ -697,6 +751,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
         template: *pki-master-f30
         timeout: 3600
@@ -709,6 +764,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_pkinit_manage.py
         template: *pki-master-f30
         timeout: 3600
@@ -721,6 +777,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_crlgen_manage.py
         template: *pki-master-f30
         timeout: 3600

--- a/ipatests/prci_definitions/nightly_master_testing.yaml
+++ b/ipatests/prci_definitions/nightly_master_testing.yaml
@@ -58,6 +58,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_simple_replication.py
         template: *testing-master-f30
         timeout: 3600
@@ -70,6 +71,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
         template: *testing-master-f30
         timeout: 4800
@@ -82,6 +84,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
         template: *testing-master-f30
         timeout: 3600
@@ -94,6 +97,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
         template: *testing-master-f30
         timeout: 3600
@@ -106,6 +110,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_topologies.py
         template: *testing-master-f30
         timeout: 3600
@@ -118,6 +123,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_sudo.py
         template: *testing-master-f30
         timeout: 4800
@@ -130,6 +136,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_commands.py
         template: *testing-master-f30
         timeout: 3600
@@ -142,6 +149,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_kerberos_flags.py
         template: *testing-master-f30
         timeout: 3600
@@ -154,6 +162,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_http_kdc_proxy.py
         template: *testing-master-f30
         timeout: 3600
@@ -166,6 +175,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_forced_client_reenrollment.py
         template: *testing-master-f30
         timeout: 4800
@@ -178,6 +188,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_advise.py
         template: *testing-master-f30
         timeout: 3600
@@ -190,6 +201,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_testconfig.py
         template: *testing-master-f30
         timeout: 3600
@@ -202,6 +214,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_service_permissions.py
         template: *testing-master-f30
         timeout: 3600
@@ -214,6 +227,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_netgroup.py
         template: *testing-master-f30
         timeout: 3600
@@ -226,6 +240,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_vault.py
         template: *testing-master-f30
         timeout: 6300
@@ -238,6 +253,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_authselect.py
         template: *testing-master-f30
         timeout: 4800
@@ -250,6 +266,7 @@ jobs:
       class: RunADTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_smb.py
         template: *testing-master-f30
         timeout: 4800
@@ -262,6 +279,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_server_del.py
         template: *testing-master-f30
         timeout: 10800
@@ -274,6 +292,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
         template: *testing-master-f30
         timeout: 10800
@@ -286,6 +305,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
         template: *testing-master-f30
         timeout: 10800
@@ -298,6 +318,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
         template: *testing-master-f30
         timeout: 10800
@@ -310,6 +331,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
         template: *testing-master-f30
         timeout: 10800
@@ -322,6 +344,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
         template: *testing-master-f30
         timeout: 10800
@@ -334,6 +357,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
         template: *testing-master-f30
         timeout: 10800
@@ -346,6 +370,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
         template: *testing-master-f30
         timeout: 3600
@@ -358,6 +383,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
         template: *testing-master-f30
         timeout: 3600
@@ -370,6 +396,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
         template: *testing-master-f30
         timeout: 10800
@@ -382,6 +409,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
         template: *testing-master-f30
         timeout: 10800
@@ -394,6 +422,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMaster
         template: *testing-master-f30
         timeout: 10800
@@ -406,6 +435,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
         template: *testing-master-f30
         timeout: 10800
@@ -418,6 +448,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
         template: *testing-master-f30
         timeout: 10800
@@ -430,6 +461,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
         template: *testing-master-f30
         timeout: 10800
@@ -442,6 +474,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterReplica
         template: *testing-master-f30
         timeout: 10800
@@ -454,6 +487,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_idviews.py::TestIDViews
         template: *testing-master-f30
         timeout: 3600
@@ -466,6 +500,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestServerInstall
         template: *testing-master-f30
         timeout: 12000
@@ -478,6 +513,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *testing-master-f30
         timeout: 5400
@@ -490,6 +526,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestClientInstall
         template: *testing-master-f30
         timeout: 5400
@@ -503,6 +540,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestIPACommands
         template: *testing-master-f30
         timeout: 5400
@@ -515,6 +553,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestCertInstall
         template: *testing-master-f30
         timeout: 5400
@@ -527,6 +566,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestPKINIT
         template: *testing-master-f30
         timeout: 5400
@@ -539,6 +579,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
         template: *testing-master-f30
         timeout: 5400
@@ -551,6 +592,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
         template: *testing-master-f30
         timeout: 5400
@@ -563,6 +605,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
         template: *testing-master-f30
         timeout: 5400
@@ -575,6 +618,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
         template: *testing-master-f30
         timeout: 7200
@@ -587,6 +631,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
         template: *testing-master-f30
         timeout: 7200
@@ -599,6 +644,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
         template: *testing-master-f30
         timeout: 7200
@@ -611,6 +657,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
         template: *testing-master-f30
         timeout: 7200
@@ -623,6 +670,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
         template: *testing-master-f30
         timeout: 7200
@@ -635,6 +683,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
         template: *testing-master-f30
         timeout: 7200
@@ -647,6 +696,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
         template: *testing-master-f30
         timeout: 7200
@@ -659,6 +709,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
         template: *testing-master-f30
         timeout: 7200
@@ -671,6 +722,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
         template: *testing-master-f30
         timeout: 7200
@@ -683,6 +735,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
         template: *testing-master-f30
         timeout: 7200
@@ -695,6 +748,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
         template: *testing-master-f30
         timeout: 7200
@@ -707,6 +761,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_dnssec.py
         template: *testing-master-f30
         timeout: 10800
@@ -719,6 +774,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
         template: *testing-master-f30
         timeout: 7200
@@ -731,6 +787,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions
         template: *testing-master-f30
         timeout: 7200
@@ -743,6 +800,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
         template: *testing-master-f30
         timeout: 7200
@@ -755,6 +813,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestWrongClientDomain
         template: *testing-master-f30
         timeout: 7200
@@ -767,6 +826,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
         template: *testing-master-f30
         timeout: 7200
@@ -779,6 +839,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallWithExistingEntry
         template: *testing-master-f30
         timeout: 7200
@@ -791,6 +852,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
         template: *testing-master-f30
         timeout: 7200
@@ -803,6 +865,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
         template: *testing-master-f30
         timeout: 7200
@@ -815,6 +878,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInForwardZone
         template: *testing-master-f30
         timeout: 7200
@@ -827,6 +891,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
         template: *testing-master-f30
         timeout: 7200
@@ -839,6 +904,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_upgrade.py
         template: *testing-master-f30
         timeout: 7200
@@ -851,6 +917,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
         template: *testing-master-f30
         timeout: 7200
@@ -863,6 +930,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_topology.py::TestTopologyOptions
         template: *testing-master-f30
         timeout: 7200
@@ -875,6 +943,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
         template: *testing-master-f30
         timeout: 7200
@@ -887,6 +956,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
         template: *testing-master-f30
         timeout: 10800
@@ -899,6 +969,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
         template: *testing-master-f30
         timeout: 10800
@@ -911,6 +982,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
         template: *testing-master-f30
         timeout: 7200
@@ -923,6 +995,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
         template: *testing-master-f30
         timeout: 7200
@@ -935,6 +1008,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
         template: *testing-master-f30
         timeout: 10800
@@ -947,6 +1021,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
         template: *testing-master-f30
         timeout: 7200
@@ -959,6 +1034,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
         template: *testing-master-f30
         timeout: 7200
@@ -971,6 +1047,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
         template: *testing-master-f30
         timeout: 7200
@@ -983,6 +1060,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_uninstallation.py
         template: *testing-master-f30
         timeout: 7200
@@ -995,6 +1073,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_user_permissions.py
         template: *testing-master-f30
         timeout: 3600
@@ -1007,6 +1086,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_webui/test_cert.py
         template: *testing-master-f30
         timeout: 2400
@@ -1019,6 +1099,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: >-
           test_webui/test_loginscreen.py
           test_webui/test_misc_cases.py
@@ -1035,6 +1116,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_webui/test_host.py
         template: *testing-master-f30
         timeout: 3600
@@ -1047,6 +1129,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: >-
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
@@ -1061,6 +1144,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
@@ -1075,6 +1159,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: >-
           test_webui/test_automount.py
           test_webui/test_dns.py
@@ -1090,6 +1175,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: >-
           test_webui/test_hbac.py
           test_webui/test_krbtpolicy.py
@@ -1107,6 +1193,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: >-
           test_webui/test_delegation.py
           test_webui/test_rbac.py
@@ -1122,6 +1209,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: >-
           test_webui/test_config.py
           test_webui/test_range.py
@@ -1138,6 +1226,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_webui/test_service.py
         template: *testing-master-f30
         timeout: 2400
@@ -1150,6 +1239,7 @@ jobs:
       class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: >-
           test_webui/test_group.py
           test_webui/test_user.py
@@ -1164,6 +1254,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_customized_ds_config_install.py
         template: *testing-master-f30
         timeout: 3600
@@ -1176,6 +1267,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_dns_locations.py
         template: *testing-master-f30
         timeout: 3600
@@ -1188,6 +1280,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
         template: *testing-master-f30
         timeout: 3600
@@ -1200,6 +1293,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert test_integration/test_external_ca.py::TestExternalCAInvalidIntermediate
         template: *testing-master-f30
         timeout: 3600
@@ -1212,6 +1306,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
         template: *testing-master-f30
         timeout: 3600
@@ -1224,6 +1319,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
         template: *testing-master-f30
         timeout: 10800
@@ -1236,6 +1332,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_pkinit_manage.py
         template: *testing-master-f30
         timeout: 3600
@@ -1248,6 +1345,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_pki_config_override.py
         template: *testing-master-f30
         timeout: 3600
@@ -1260,6 +1358,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_nfs.py::TestNFS
         template: *testing-master-f30
         timeout: 9000
@@ -1272,6 +1371,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
         template: *testing-master-f30
         timeout: 3600
@@ -1284,6 +1384,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestMaskInstall
         template: *testing-master-f30
         timeout: 3600
@@ -1296,6 +1397,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_automember.py
         template: *testing-master-f30
         timeout: 3600
@@ -1308,6 +1410,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_crlgen_manage.py
         template: *testing-master-f30
         timeout: 3600
@@ -1320,6 +1423,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
         template: *testing-master-f30
         timeout: 10800
@@ -1332,6 +1436,7 @@ jobs:
       class: RunADTests
       args:
         build_url: '{fedora-30/build_url}'
+        update_packages: True
         test_suite: test_integration/test_sssd.py
         template: *testing-master-f30
         timeout: 3600


### PR DESCRIPTION
This forces PR-CI to update the packages instead of using the versions
already included in the vagrant image.

Signed-off-by: Armando Neto <abiagion@redhat.com>