### PR TITLE
[Backport][ipa-4-7] ipa-restore: Restore ownership and perms on 389-ds log directory

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -610,6 +610,10 @@ class Restore(admintool.AdminTool):
                 os.makedirs(template_dir)
             except OSError as e:
                 pass
+
+            os.chown(template_dir, pent.pw_uid, pent.pw_gid)
+            os.chmod(template_dir, 0o770)
+
             # Restore SELinux context of template_dir
             tasks.restore_context(template_dir)
 


### PR DESCRIPTION
This PR was opened automatically because PR #3703 was pushed to master and backport to ipa-4-7 is required.