### PR TITLE
Don't create log files from help scripts

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
@@ -477,7 +477,9 @@ def main():
     if operation not in ('SUBMIT', 'POLL'):
         return OPERATION_NOT_SUPPORTED_BY_HELPER
 
-    api.bootstrap(in_server=True, context='renew', confdir=paths.ETC_IPA)
+    api.bootstrap(
+        in_server=True, context='renew', confdir=paths.ETC_IPA, log=None
+    )
     api.finalize()
 
     tmpdir = tempfile.mkdtemp(prefix="tmp-")

--- a/install/restart_scripts/renew_ca_cert.in
+++ b/install/restart_scripts/renew_ca_cert.in
@@ -43,7 +43,9 @@ from ipapython.certdb import TrustFlags
 def _main():
     nickname = sys.argv[1]
 
-    api.bootstrap(in_server=True, context='restart', confdir=paths.ETC_IPA)
+    api.bootstrap(
+        in_server=True, context='restart', confdir=paths.ETC_IPA, log=None
+    )
     api.finalize()
 
     dogtag_service = services.knownservices['pki_tomcatd']

--- a/install/restart_scripts/renew_ra_cert.in
+++ b/install/restart_scripts/renew_ra_cert.in
@@ -34,7 +34,9 @@ from ipaplatform.paths import paths
 
 
 def _main():
-    api.bootstrap(in_server=True, context='restart', confdir=paths.ETC_IPA)
+    api.bootstrap(
+        in_server=True, context='restart', confdir=paths.ETC_IPA, log=None
+    )
     api.finalize()
 
     tmpdir = tempfile.mkdtemp(prefix="tmp-")

--- a/install/restart_scripts/restart_dirsrv.in
+++ b/install/restart_scripts/restart_dirsrv.in
@@ -34,7 +34,9 @@ def _main():
     except IndexError:
         instance = ""
 
-    api.bootstrap(in_server=True, context='restart', confdir=paths.ETC_IPA)
+    api.bootstrap(
+        in_server=True, context='restart', confdir=paths.ETC_IPA, log=None
+    )
     api.finalize()
 
     syslog.syslog(syslog.LOG_NOTICE, "certmonger restarted dirsrv instance '%s'" % instance)

--- a/install/restart_scripts/stop_pkicad.in
+++ b/install/restart_scripts/stop_pkicad.in
@@ -28,7 +28,9 @@ from ipaserver.install import certs
 
 
 def main():
-    api.bootstrap(in_server=True, context='restart', confdir=paths.ETC_IPA)
+    api.bootstrap(
+        in_server=True, context='restart', confdir=paths.ETC_IPA, log=None
+    )
     api.finalize()
 
     dogtag_service = services.knownservices['pki_tomcatd']

--- a/install/tools/ipa-custodia-check.in
+++ b/install/tools/ipa-custodia-check.in
@@ -102,7 +102,7 @@ class IPACustodiaTester:
         self.args = args
         if not api.isdone('bootstrap'):
             # bootstrap to initialize api.env
-            api.bootstrap()
+            api.bootstrap(log=None)
             self.debug("IPA API bootstrapped")
         self.realm = api.env.realm
         self.host = api.env.host

--- a/install/tools/ipa-httpd-kdcproxy.in
+++ b/install/tools/ipa-httpd-kdcproxy.in
@@ -186,8 +186,10 @@ class KDCProxyConfig:
 def main(debug=DEBUG, time_limit=TIME_LIMIT):
     # initialize API without file logging
     if not api.isdone('bootstrap'):
-        api.bootstrap(context='server', confdir=paths.ETC_IPA,
-                      log=None, debug=debug)
+        api.bootstrap(
+            context='server', confdir=paths.ETC_IPA, log=None,
+            debug=debug
+        )
         standard_logging_setup(verbose=True, debug=debug)
 
     try:

--- a/install/tools/ipa-pki-wait-running.in
+++ b/install/tools/ipa-pki-wait-running.in
@@ -88,7 +88,7 @@ def main():
         sys.exit(EXIT_SUCCESS)
 
     # bootstrap ipalib.api to parse config file
-    api.bootstrap(confdir=paths.ETC_IPA)
+    api.bootstrap(confdir=paths.ETC_IPA, log=None)
     timeout = api.env.startup_timeout
 
     conn = get_conn(api.env.host, subsystem=SUBSYSTEM)

--- a/ipaserver/secrets/handlers/dmldap.py
+++ b/ipaserver/secrets/handlers/dmldap.py
@@ -8,9 +8,9 @@ import os
 
 from ipalib import api
 from ipalib import errors
+from ipaplatform.paths import paths
 from ipapython.dn import DN
-from ipapython.ipaldap import LDAPClient
-from ipaserver.install.installutils import realm_to_ldapi_uri
+from ipapython.ipaldap import LDAPClient, realm_to_ldapi_uri
 from . import common
 
 CN_CONFIG = DN(('cn', 'config'))
@@ -46,7 +46,7 @@ def main():
 
     # create LDAP connection using LDAPI and EXTERNAL bind as root
     if not api.isdone('bootstrap'):
-        api.bootstrap()
+        api.bootstrap(confdir=paths.ETC_IPA, log=None)
     realm = api.env.realm
     ldap_uri = realm_to_ldapi_uri(realm)
     conn = LDAPClient(ldap_uri=ldap_uri, no_schema=True)


### PR DESCRIPTION
Helper scripts now use api.bootstrap(log=None) to avoid the creation of
log files. Helper scripts are typically executed from daemons which
perform their own logging. The helpers still log to stderr/stdout.

This also gets rid of some SELinux AVCs when the script tries to write
to /root/.ipa/.

Fixes: https://pagure.io/freeipa/issue/8075
Signed-off-by: Christian Heimes <cheimes@redhat.com>