### PR TITLE
Fix errors newly exposed by pylint 2.4.0

### DIFF
--- a/ipaclient/discovery.py
+++ b/ipaclient/discovery.py
@@ -605,9 +605,11 @@ class IPADiscovery:
 
 
 def main():
+    # pylint: disable=import-outside-toplevel
     import argparse
     import os
     from ipapython.ipa_log_manager import standard_logging_setup
+    # pylint: enable=import-outside-toplevel
 
     parser = argparse.ArgumentParser(__name__)
 

--- a/ipalib/__init__.py
+++ b/ipalib/__init__.py
@@ -886,8 +886,10 @@ from ipapython.version import VERSION as __version__
 def _enable_warnings(error=False):
     """Enable additional warnings during development
     """
+    # pylint: disable=import-outside-toplevel
     import ctypes
     import warnings
+    # pylint: enable=import-outside-toplevel
 
     # get reference to Py_BytesWarningFlag from Python CAPI
     byteswarnings = ctypes.c_int.in_dll(  # pylint: disable=no-member
@@ -937,14 +939,23 @@ class API(plugable.API):
     def packages(self):
         if self.env.in_server:
             # pylint: disable=import-error,ipa-forbidden-import
+            # pylint: disable=import-outside-toplevel
             import ipaserver.plugins
             # pylint: enable=import-error,ipa-forbidden-import
+            # pylint: enable=import-outside-toplevel
             result = (
                 ipaserver.plugins,
             )
         else:
+            # disables immediately after an else clause
+            # do not work properly:
+            # https://github.com/PyCQA/pylint/issues/872
+            # Thus, below line was added as a workaround
+            result = None
+            # pylint: disable=import-outside-toplevel
             import ipaclient.remote_plugins
             import ipaclient.plugins
+            # pylint: enable=import-outside-toplevel
             result = (
                 ipaclient.remote_plugins.get_package(self),
                 ipaclient.plugins,
@@ -952,8 +963,10 @@ class API(plugable.API):
 
         if self.env.context in ('installer', 'updates'):
             # pylint: disable=import-error,ipa-forbidden-import
+            # pylint: disable=import-outside-toplevel
             import ipaserver.install.plugins
             # pylint: enable=import-error,ipa-forbidden-import
+            # pylint: enable=import-outside-toplevel
             result += (ipaserver.install.plugins,)
 
         return result

--- a/ipalib/frontend.py
+++ b/ipalib/frontend.py
@@ -575,7 +575,7 @@ class Command(HasParam):
             if self.params[name].attribute and name in kw:
                 value = kw[name]
                 if isinstance(value, tuple):
-                    yield (name, [v for v in value])
+                    yield (name, list(value))
                 else:
                     yield (name, kw[name])
 
@@ -1069,15 +1069,14 @@ class Command(HasParam):
 
             if o == 'value':
                 continue
-            elif o.lower() == 'count' and result == 0:
+            if o.lower() == 'count' and result == 0:
                 rv = 1
             elif o.lower() == 'failed':
                 if entry_count(result) == 0:
                     # Don't display an empty failed list
                     continue
-                else:
-                    # Return an error to the shell
-                    rv = 1
+                # Return an error to the shell
+                rv = 1
             if isinstance(outp, ListOfEntries):
                 textui.print_entries(result, order, labels, flags, print_all)
             elif isinstance(result, (tuple, list)):
@@ -1299,7 +1298,7 @@ class Object(HasParam):
         )
         if self.primary_key:
             json_dict['primary_key'] = self.primary_key.name
-        json_dict['methods'] = [m for m in self.methods]
+        json_dict['methods'] = list(self.methods)
         return json_dict
 
 

--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -557,7 +557,7 @@ class Param(ReadOnly):
         # Check that all the rules are callable
         self.class_rules = tuple(class_rules)
         self.rules = rules
-        if self.query:
+        if self.query:  # pylint: disable=using-constant-test
             # by definition a query enforces no class or parameter rules
             self.all_rules = ()
         else:
@@ -759,10 +759,10 @@ class Param(ReadOnly):
 
         :param value: A proposed value for this parameter.
         """
-        if self.multivalue:
+        if self.multivalue:  # pylint: disable=using-constant-test
             if type(value) not in (tuple, list):
                 value = (value,)
-        if self.multivalue:
+        if self.multivalue:  # pylint: disable=using-constant-test
             return tuple(
                 self._normalize_scalar(v) for v in value
             )
@@ -838,7 +838,7 @@ class Param(ReadOnly):
 
         if _is_null(value):
             return
-        if self.multivalue:
+        if self.multivalue:  # pylint: disable=using-constant-test
             if type(value) not in (tuple, list):
                 value = (value,)
             values = tuple(
@@ -870,10 +870,10 @@ class Param(ReadOnly):
             if self.required or (supplied and 'nonempty' in self.flags):
                 raise RequirementError(name=self.name)
             return
-        if self.deprecated:
+        if self.deprecated:  # pylint: disable=using-constant-test
             raise ValidationError(name=self.get_param_name(),
                                   error=_('this option is deprecated'))
-        if self.multivalue:
+        if self.multivalue:  # pylint: disable=using-constant-test
             if type(value) is not tuple:
                 raise TypeError(
                     TYPE_ERROR % ('value', tuple, value, type(value))
@@ -967,8 +967,8 @@ class Param(ReadOnly):
         for a, k, _d in self.kwargs:
             if k in (callable, DefaultFrom):
                 continue
-            elif isinstance(getattr(self, a), frozenset):
-                json_dict[a] = [k for k in getattr(self, a, [])]
+            if isinstance(getattr(self, a), frozenset):
+                json_dict[a] = list(getattr(self, a, []))
             else:
                 val = getattr(self, a, '')
                 if val is None:

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -451,7 +451,7 @@ class API(ReadOnly):
         if root_logger.handlers or self.env.validate_api:
             return
 
-        if self.env.debug:
+        if self.env.debug:  # pylint: disable=using-constant-test
             level = logging.DEBUG
         else:
             level = logging.INFO
@@ -475,7 +475,7 @@ class API(ReadOnly):
 
         # Add stderr handler:
         level = logging.INFO
-        if self.env.debug:
+        if self.env.debug:  # pylint: disable=using-constant-test
             level = logging.DEBUG
         else:
             if self.env.context == 'cli':
@@ -507,7 +507,7 @@ class API(ReadOnly):
                 return
 
         level = logging.INFO
-        if self.env.debug:
+        if self.env.debug:  # pylint: disable=using-constant-test
             level = logging.DEBUG
         try:
             handler = logging.FileHandler(self.env.log)
@@ -651,7 +651,8 @@ class API(ReadOnly):
                 logger.debug("skipping plugin module %s: %s", name, e.reason)
                 continue
             except Exception as e:
-                if self.env.startup_traceback:
+                tb = self.env.startup_traceback
+                if tb:  # pylint: disable=using-constant-test
                     logger.exception("could not load plugin module %s", name)
                 raise
 

--- a/ipapython/ipachangeconf.py
+++ b/ipapython/ipachangeconf.py
@@ -187,7 +187,7 @@ class IPAChangeConf:
                 if delim not in self.assign:
                     raise ValueError(
                         'Unknown delim "%s" must be one of "%s"' %
-                        (delim, " ".join([d for d in self.assign]))
+                        (delim, " ".join(list(self.assign)))
                     )
                 output.append(self._dump_line(self.indent[level],
                                               o['name'],

--- a/ipatests/azure/azure-run-tests.sh
+++ b/ipatests/azure/azure-run-tests.sh
@@ -1,4 +1,9 @@
 #!/bin/bash -ex
+
+# Setup DNS
+echo -e '127.0.0.1 localhost\n::1 localhost\n' > /etc/hosts
+echo 'nameserver 8.8.8.8' > /etc/resolv.conf
+
 server_realm=EXAMPLE.TEST
 server_domain=example.test
 server_password=Secret123


### PR DESCRIPTION
Newest Pylint introduced additional checks [1]:

- import-outside-toplevel [2]

> This check warns when modules are imported from places other
than a module toplevel, e.g. inside a function or a class.

- no-else-continue [3]

> These checks highlight unnecessary else and elif blocks after
break and continue statements.

- unnecessary-comprehension [4]

> This check is emitted when pylint finds list-, set- or
dict-comprehensions, that are unnecessary and can be rewritten
with the list-, set- or dict-constructors.

[1] https://github.com/PyCQA/pylint/blob/pylint-2.4.0/doc/whatsnew/2.4.rst
[2] https://github.com/PyCQA/pylint/issues/3067
[3] https://github.com/PyCQA/pylint/issues/2327
[4] https://github.com/PyCQA/pylint/issues/2905

Fixes: https://pagure.io/freeipa/issue/8077
Signed-off-by: Stanislav Levin <slev@altlinux.org>