### PR TITLE
[Backport][ipa-4-6] Wrap CustodiaClient in context manager

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -49,8 +49,8 @@
 
 %global alt_name ipa
 %if 0%{?rhel}
-# 1.15.1-7: certauth (http://krbdev.mit.edu/rt/Ticket/Display.html?id=8561)
-%global krb5_version 1.15.1-4
+# 1.15.1-36: https://bugzilla.redhat.com/show_bug.cgi?id=1755223
+%global krb5_version 1.15.1-36
 # 0.7.16: https://github.com/drkjam/netaddr/issues/71
 %global python_netaddr_version 0.7.5-8
 # Require 4.7.0 which brings Python 3 bindings

--- a/install/tools/ipa-pki-retrieve-key
+++ b/install/tools/ipa-pki-retrieve-key
@@ -2,9 +2,8 @@
 
 from __future__ import print_function
 
+import argparse
 import os
-import sys
-import traceback
 
 from ipalib import constants
 from ipalib.config import Env
@@ -16,27 +15,37 @@ def main():
     env = Env()
     env._finalize()
 
-    keyname = "ca_wrapped/" + sys.argv[1]
-    servername = sys.argv[2]
+    parser = argparse.ArgumentParser("ipa-pki-retrieve-key")
+    parser.add_argument("keyname", type=str)
+    parser.add_argument("servername", type=str)
+
+    args = parser.parse_args()
+    keyname = "ca_wrapped/{}".format(args.keyname)
 
     service = constants.PKI_GSSAPI_SERVICE_NAME
     client_keyfile = os.path.join(paths.PKI_TOMCAT, service + '.keys')
     client_keytab = os.path.join(paths.PKI_TOMCAT, service + '.keytab')
 
+    for filename in [client_keyfile, client_keytab]:
+        if not os.access(filename, os.R_OK):
+            parser.error(
+                "File '{}' missing or not readable.\n".format(filename)
+            )
+
     # pylint: disable=no-member
     client = CustodiaClient(
-        client_service='%s@%s' % (service, env.host), server=servername,
-        realm=env.realm, ldap_uri="ldaps://" + env.host,
-        keyfile=client_keyfile, keytab=client_keytab,
-        )
+        client_service="{}@{}".format(service, env.host),
+        server=args.servername,
+        realm=env.realm,
+        ldap_uri="ldaps://" + env.host,
+        keyfile=client_keyfile,
+        keytab=client_keytab,
+    )
 
     # Print the response JSON to stdout; it is already in the format
     # that Dogtag's ExternalProcessKeyRetriever expects
     print(client.fetch_key(keyname, store=False))
 
 
-try:
+if __name__ == '__main__':
     main()
-except BaseException:
-    traceback.print_exc()
-    sys.exit(1)

--- a/ipaclient/plugins/ca.py
+++ b/ipaclient/plugins/ca.py
@@ -33,13 +33,24 @@ class WithCertOutArgs(MethodOverride):
                                              error=str(e))
 
         result = super(WithCertOutArgs, self).forward(*keys, **options)
+
         if filename:
+            # if result certificate / certificate_chain not present in result,
+            # it means Dogtag did not provide it (probably due to LWCA key
+            # replication lag or failure.  The server transmits a warning
+            # message in this case, which the client automatically prints.
+            # So in this section we just ignore it and move on.
+            certs = None
             if options.get('chain', False):
-                certs = result['result']['certificate_chain']
+                if 'certificate_chain' in result['result']:
+                    certs = result['result']['certificate_chain']
             else:
-                certs = [base64.b64decode(result['result']['certificate'])]
-            certs = (x509.load_der_x509_certificate(cert) for cert in certs)
-            x509.write_certificate_list(certs, filename)
+                if 'certificate' in result['result']:
+                    certs = [base64.b64decode(result['result']['certificate'])]
+            if certs:
+                x509.write_certificate_list(
+                    (x509.load_der_x509_certificate(cert) for cert in certs),
+                    filename)
 
         return result
 

--- a/ipalib/messages.py
+++ b/ipalib/messages.py
@@ -487,6 +487,15 @@ class FailedToAddHostDNSRecords(PublicMessage):
                "%(reason)s")
 
 
+class LightweightCACertificateNotAvailable(PublicMessage):
+    """
+    **13031** Certificate is not available
+    """
+    errno = 13031
+    type = "error"
+    format = _("The certificate for %(ca)s is not available on this server.")
+
+
 def iter_messages(variables, base):
     """Return a tuple with all subclasses
     """

--- a/ipaserver/secrets/client.py
+++ b/ipaserver/secrets/client.py
@@ -13,6 +13,7 @@ from custodia.message.kem import KEMClient, KEY_USAGE_SIG, KEY_USAGE_ENC
 from jwcrypto.common import json_decode
 from jwcrypto.jwk import JWK
 from ipalib.krb_utils import krb5_format_service_principal_name
+from ipaserver.install.installutils import realm_to_ldapi_uri
 from ipaserver.secrets.kem import IPAKEMKeys
 from ipaserver.secrets.store import IPASecStore
 from ipaplatform.paths import paths
@@ -46,7 +47,7 @@ class CustodiaClient(object):
         self.keytab = keytab
         self.server = server
         self.realm = realm
-        self.ldap_uri = ldap_uri
+        self.ldap_uri = ldap_uri or realm_to_ldapi_uri(realm)
         self.auth_type = auth_type
         self.service_name = gssapi.Name(
             'HTTP@{}'.format(server), gssapi.NameType.hostbased_service

--- a/ipaserver/secrets/client.py
+++ b/ipaserver/secrets/client.py
@@ -52,7 +52,12 @@ class CustodiaClient(object):
         self.service_name = gssapi.Name(
             'HTTP@{}'.format(server), gssapi.NameType.hostbased_service
         )
-        self.keystore = IPASecStore()
+
+        config = {'ldap_uri': self.ldap_uri}
+        if auth_type is not None:
+            config['auth_type'] = auth_type
+        self.keystore = IPASecStore(config)
+
         # use in-process MEMORY ccache. Handler process don't need a TGT.
         token = b64encode(os.urandom(8)).decode('ascii')
         self.ccache = 'MEMORY:Custodia_{}'.format(token)


### PR DESCRIPTION
Backport of https://github.com/freeipa/freeipa/pull/3287.

A CustodiaClient object has to the process environment a bit, e.g. set
up GSSAPI credentials. To reuse the credentials in libldap connections,
it is also necessary to set up a custom ccache store and configure
KRBCCNAME.

Credential initialization and ccache is now handled in a context
manager.

https://pagure.io/freeipa/issue/7964
https://bugzilla.redhat.com/show_bug.cgi?id=1755223