### PR TITLE
ipatests: fix fedora29 nightly definition

### DIFF
--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -1313,13 +1313,13 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_sssd:
-    requires: [fedora-30/build]
+  fedora-29/test_sssd:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_sssd.py
         template: *ci-master-f29
         timeout: 3600


### PR DESCRIPTION
test_sssd is using a wrong dependency (fedora30 build instead
of fedora29 build). As a result, this test is not triggered
by PRCI because it's waiting forever for a dependency.
(See the status: fedora-30/test_sssd Pending — unassigned)

Fix the version in the fedora 29 nightly definition.