### PR TITLE
[Backport][ipa-4-8] Disable dogtag cert publishing

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -922,6 +922,7 @@ class CAInstance(DogtagInstance):
                 self.config, quotes=False, separator='=') as ds:
             # Enable file publishing, disable LDAP
             ds.set('ca.publish.enable', 'true')
+            ds.set('ca.publish.cert.enable', 'false')
             ds.set('ca.publish.ldappublish.enable', 'false')
 
             # Create the file publisher, der only, not b64

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -459,6 +459,28 @@ def ca_add_default_ocsp_uri(ca):
     return True  # restart needed
 
 
+def ca_disable_publish_cert(ca):
+    logger.info('[Disabling cert publishing]')
+    if not ca.is_configured():
+        logger.info('CA is not configured')
+        return False
+
+    value = directivesetter.get_directive(
+        paths.CA_CS_CFG_PATH,
+        'ca.publish.cert.enable',
+        separator='=')
+    if value:
+        return False  # already set; restart not needed
+
+    directivesetter.set_directive(
+        paths.CA_CS_CFG_PATH,
+        'ca.publish.cert.enable',
+        'false',
+        quotes=False,
+        separator='=')
+    return True  # restart needed
+
+
 def upgrade_ca_audit_cert_validity(ca):
     """
     Update the Dogtag audit signing certificate.
@@ -2072,6 +2094,7 @@ def upgrade_configuration():
         ca_configure_lightweight_ca_acls(ca),
         ca_ensure_lightweight_cas_container(ca),
         ca_add_default_ocsp_uri(ca),
+        ca_disable_publish_cert(ca),
     ])
 
     if ca_restart:


### PR DESCRIPTION
This PR was opened automatically because PR #3728 was pushed to master and backport to ipa-4-8 is required.