### PR TITLE
ipatests: fix test_replica_promotion.py::TestHiddenReplicaPromotion

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -759,13 +759,16 @@ class TestHiddenReplicaPromotion(IntegrationTest):
             query = resolve_records_from_server(
                 name_abs, rtype, self.master.ip
             )
-            txt = query.to_text()
+            if rtype == 'SRV':
+                records = [q.target.to_text() for q in query]
+            else:
+                records = [q.address for q in query]
             for host in hosts_expected:
-                value = host.hostname if rtype == 'SRV' else host.ip
-                assert value in txt
+                value = host.hostname + "." if rtype == 'SRV' else host.ip
+                assert value in records
             for host in hosts_unexpected:
-                value = host.hostname if rtype == 'SRV' else host.ip
-                assert value not in txt
+                value = host.hostname + "." if rtype == 'SRV' else host.ip
+                assert value not in records
 
     def _check_server_role(self, host, status, kra=True, dns=True):
         roles = [u'IPA master', u'CA server']


### PR DESCRIPTION
The test test_replica_promotion.py::TestHiddenReplicaPromotion randomly fails in nightly_f29.

The test is checking that a given IP address is not in the DNS records for the domain. When we are unlucky, we may come up with the following situation:
- IP address that is unexpected: 192.168.121.25
- IP address that is found for the DNS record: 192.168.121.254

As 192.168.121.25 is a substring of 192.168.121.254, the test wrongly considers that the unexpected address was found.
Extract of the log:
```
    for host in hosts_unexpected:
        value = host.hostname if rtype == 'SRV' else host.ip
>       assert value not in txt
E       AssertionError: assert '192.168.121.25' not in 'ipa-ca.ipa.test. 1 IN A 192.168.121.254'
E         '192.168.121.25' is contained here:
E           ipa-ca.ipa.test. 1 IN A 192.168.121.254
E         ?                         ++++++++++++++
```

This happens because the test is comparing the content of the output as a string. The fix is extracting the exact hostname/IP address from the record instead.

Fixes: https://pagure.io/freeipa/issue/8070