### PR TITLE
[Backport][ipa-4-8] ipa user_add: do not check group if UPG is disabled

### DIFF
--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -475,7 +475,7 @@ class user_add(baseuser_add):
         else:
             raise self.obj.handle_duplicate_entry(*keys)
 
-        if not options.get('noprivate', False):
+        if not options.get('noprivate', False) and ldap.has_upg():
             try:
                 # The Managed Entries plugin will allow a user to be created
                 # even if a group has a duplicate name. This would leave a user
@@ -609,7 +609,8 @@ class user_add(baseuser_add):
         newentry = ldap.get_entry(dn, ['*'])
 
         # delete description attribute NO_UPG_MAGIC if present
-        if options.get('noprivate', False) and 'description' in newentry and \
+        if (options.get('noprivate', False) or not ldap.has_upg()) and \
+                'description' in newentry and \
                 NO_UPG_MAGIC in newentry['description']:
             newentry['description'].remove(NO_UPG_MAGIC)
             ldap.update_entry(newentry)

--- a/ipatests/test_xmlrpc/test_user_plugin.py
+++ b/ipatests/test_xmlrpc/test_user_plugin.py
@@ -32,6 +32,7 @@ import re
 
 from ipalib import api, errors
 from ipaplatform.constants import constants as platformconstants
+from ipapython import ipautil
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.util import (
     assert_deepequal, assert_equal, assert_not_equal, raises)
@@ -784,6 +785,86 @@ class TestUserWithGroup(XMLRPC_test):
         user_npg.run_command(
             'config_mod', **{u'ipadefaultprimarygroup': u'ipausers'}
         )
+
+
+@pytest.mark.tier1
+class TestUserWithUPGDisabled(XMLRPC_test):
+    """ Tests with UPG plugin disabled """
+
+    @classmethod
+    def managed_entries_upg(cls, action='enable'):
+        """ Change the UPG plugin state """
+        assert action in ('enable', 'disable')
+        ipautil.run(['ipa-managed-entries', '-e', 'UPG Definition', action])
+
+    @classmethod
+    def setup_class(cls):
+        super(TestUserWithUPGDisabled, cls).setup_class()
+        cls.managed_entries_upg(action='disable')
+
+    @classmethod
+    def teardown_class(cls):
+        cls.managed_entries_upg(action='enable')
+        super(TestUserWithUPGDisabled, cls).teardown_class()
+
+    def test_create_without_upg(self):
+        """ Try to create user without User's Primary GID
+
+        As the UPG plugin is disabled, the user gets assigned to the Default
+        Group for new users (ipausers) which is not POSIX and the command
+        is expected to fail
+        """
+        testuser = UserTracker(
+            name=u'tuser1', givenname=u'Test', sn=u'Tuser1'
+        )
+        command = testuser.make_create_command()
+        with raises_exact(errors.NotFound(
+                reason=u'Default group for new users is not POSIX')):
+            command()
+
+    def test_create_without_upg_with_gid_set(self):
+        """ Create user without User's Primary GID with GID set
+
+        The UPG plugin is disabled, but the user is provided with a group
+        """
+        testuser = UserTracker(
+            name=u'tuser1', givenname=u'Test', sn=u'Tuser1',
+            gidnumber=1000
+        )
+        testuser.track_create()
+        del testuser.attrs['mepmanagedentry']
+        testuser.attrs.update(gidnumber=[u'1000'])
+        testuser.attrs.update(
+            description=[],
+            objectclass=add_oc(objectclasses.user_base, u'ipantuserattrs')
+        )
+        command = testuser.make_create_command()
+        result = command()
+        testuser.check_create(result, [u'description'])
+        testuser.delete()
+
+    def test_create_where_managed_group_exists(self, user, group):
+        """ Create a managed group and then try to create user
+        with the same name the group has
+
+        As the UPG plugin is disabled, there is no conflict
+        """
+        group.create()
+        testuser = UserTracker(
+            name=group.cn, givenname=u'Test', sn=u'Tuser1',
+            gidnumber=1000
+        )
+        testuser.track_create()
+        del testuser.attrs['mepmanagedentry']
+        testuser.attrs.update(gidnumber=[u'1000'])
+        testuser.attrs.update(
+            description=[],
+            objectclass=add_oc(objectclasses.user_base, u'ipantuserattrs')
+        )
+        command = testuser.make_create_command()
+        result = command()
+        testuser.check_create(result, [u'description'])
+        testuser.delete()
 
 
 @pytest.mark.tier1


### PR DESCRIPTION
This PR was opened automatically because PR #3739 was pushed to master and backport to ipa-4-8 is required.