### PR TITLE
[Backport][ipa-4-7] ipatests: fix test_replica_promotion.py::TestHiddenReplicaPromotion

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -745,13 +745,16 @@ class TestHiddenReplicaPromotion(IntegrationTest):
             query = resolve_records_from_server(
                 name_abs, rtype, self.master.ip
             )
-            txt = query.to_text()
+            if rtype == 'SRV':
+                records = [q.target.to_text() for q in query]
+            else:
+                records = [q.address for q in query]
             for host in hosts_expected:
-                value = host.hostname if rtype == 'SRV' else host.ip
-                assert value in txt
+                value = host.hostname + "." if rtype == 'SRV' else host.ip
+                assert value in records
             for host in hosts_unexpected:
-                value = host.hostname if rtype == 'SRV' else host.ip
-                assert value not in txt
+                value = host.hostname + "." if rtype == 'SRV' else host.ip
+                assert value not in records
 
     def _check_server_role(self, host, status, kra=True, dns=True):
         roles = [u'IPA master', u'CA server']


### PR DESCRIPTION
This PR was opened automatically because PR #3742 was pushed to master and backport to ipa-4-7 is required.