### PR TITLE
[Backport][ipa-4-7] ipatests: File ownership and permission for dirsrv log instance after restore

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -29,6 +29,7 @@ import pytest
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks as platformtasks
+from ipaserver.install.installutils import realm_to_serverid
 from ipapython.dn import DN
 from ipapython import ipautil
 from ipatests.test_integration.base import IntegrationTest
@@ -217,6 +218,15 @@ class TestBackupAndRestore(IntegrationTest):
             dirman_password = self.master.config.dirman_password
             self.master.run_command(['ipa-restore', backup_path],
                                     stdin_text=dirman_password + '\nyes')
+
+            # check the file permssion and ownership is set to 770 and
+            # dirsrv:dirsrv after restore on /var/log/dirsrv/slapd-<instance>
+            # related ticket : https://pagure.io/freeipa/issue/7725
+            instance = realm_to_serverid(self.master.domain.realm)
+            log_path = paths.VAR_LOG_DIRSRV_INSTANCE_TEMPLATE % instance
+            cmd = self.master.run_command(['stat', '-c',
+                                           '"%a %G:%U"', log_path])
+            assert "770 dirsrv:dirsrv" in cmd.stdout_text
 
     def test_full_backup_and_restore_with_removed_users(self):
         """regression test for https://fedorahosted.org/freeipa/ticket/3866"""


### PR DESCRIPTION
This PR was opened automatically because PR #3732 was pushed to master and backport to ipa-4-7 is required.