### PR TITLE
[ipa-4-8] prci: increase timeout for jobs that required AD

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -232,7 +232,7 @@ jobs:
         build_url: '{fedora-30/build_url}'
         test_suite: test_integration/test_smb.py
         template: *ci-master-f30
-        timeout: 4800
+        timeout: 7200
         topology: *ad_master_2client
 
   fedora-30/replica_promotion:

--- a/ipatests/prci_definitions/nightly_ipa-4-8.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8.yaml
@@ -252,7 +252,7 @@ jobs:
         build_url: '{fedora-30/build_url}'
         test_suite: test_integration/test_smb.py
         template: *ci-master-f30
-        timeout: 4800
+        timeout: 7200
         topology: *ad_master_2client
 
   fedora-30/test_server_del:


### PR DESCRIPTION
Vagrant retries to provision hosts if something happens, it was introduced
in PR-CI after https://github.com/freeipa/freeipa-pr-ci/commit/380c8b8c78a1ce277b7c1a327bda9d123c117c4d.

This takes time, some jobs are killed during test execution, so this
increases the time-out parameter from 1 hour and 20 minutes to 2 hours.

Signed-off-by: Armando Neto <abiagion@redhat.com>