### PR TITLE
[ipa-4-7] prci: increase timeout for jobs that required AD

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-7.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-7.yaml
@@ -1258,5 +1258,5 @@ jobs:
         build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_sssd.py
         template: *ci-master-f29
-        timeout: 3600
+        timeout: 7200
         topology: *ad_master


### PR DESCRIPTION
Vagrant retries to provision hosts if something happens, it was introduced
in PR-CI after https://github.com/freeipa/freeipa-pr-ci/commit/380c8b8c78a1ce277b7c1a327bda9d123c117c4d.

This takes time, some jobs are killed during test execution, so this
increases the time-out parameter from 1 hour to 2 hours.

Signed-off-by: Armando Neto <abiagion@redhat.com>