### PR TITLE
krainstance: set correct issuer DN in uid=ipakra entry

### DIFF
--- a/install/updates/90-post_upgrade_plugins.update
+++ b/install/updates/90-post_upgrade_plugins.update
@@ -23,6 +23,7 @@ plugin: update_upload_cacrt
 # update_ra_cert_store has to be executed after update_ca_renewal_master
 plugin: update_ra_cert_store
 plugin: update_mapping_Guests_to_nobody
+plugin: fix_kra_people_entry
 
 # last
 # DNS version 1

--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -16,7 +16,7 @@ from ipaplatform import services
 from ipaplatform.paths import paths
 from ipapython import ipautil
 from ipapython.install.core import group
-from ipaserver.install import cainstance
+from ipaserver.install import ca, cainstance
 from ipaserver.install import krainstance
 from ipaserver.install import dsinstance
 from ipaserver.install import service as _service
@@ -86,10 +86,13 @@ def install(api, replica_config, options, custodia):
         master_host = replica_config.kra_host_name
         promote = True
 
+    ca_subject = ca.lookup_ca_subject(api, subject_base)
+
     kra = krainstance.KRAInstance(realm_name)
     kra.configure_instance(
         realm_name, host_name, dm_password, dm_password,
         subject_base=subject_base,
+        ca_subject=ca_subject,
         pkcs12_info=pkcs12_info,
         master_host=master_host,
         promote=promote,

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -81,7 +81,7 @@ class KRAInstance(DogtagInstance):
 
     def configure_instance(self, realm_name, host_name, dm_password,
                            admin_password, pkcs12_info=None, master_host=None,
-                           subject_base=None, subject=None,
+                           subject_base=None, ca_subject=None,
                            promote=False, pki_config_override=None):
         """Create a KRA instance.
 
@@ -99,8 +99,9 @@ class KRAInstance(DogtagInstance):
 
         self.subject_base = \
             subject_base or installutils.default_subject_base(realm_name)
-        self.subject = \
-            subject or installutils.default_ca_subject_dn(self.subject_base)
+
+        # eagerly convert to DN to ensure validity
+        self.ca_subject = DN(ca_subject)
 
         self.realm = realm_name
         self.suffix = ipautil.realm_to_suffix(realm_name)
@@ -258,7 +259,7 @@ class KRAInstance(DogtagInstance):
             userCertificate=[cert],
             description=['2;%s;%s;%s' % (
                 cert.serial_number,
-                DN(self.subject),
+                self.ca_subject,
                 DN(('CN', 'IPA RA'), self.subject_base))])
         conn.add_entry(entry)
 

--- a/ipaserver/install/plugins/fix_kra_people_entry.py
+++ b/ipaserver/install/plugins/fix_kra_people_entry.py
@@ -1,0 +1,76 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+import logging
+
+from ipalib import Registry, Updater, x509
+from ipapython.dn import DN
+from ipaplatform.paths import paths
+from ipaserver.install import krainstance
+
+logger = logging.getLogger(__name__)
+
+register = Registry()
+
+
+@register()
+class fix_kra_people_entry(Updater):
+    """
+    Update the KRA uid=ipakra agent user entry.
+
+    There was a bug where this was created with an incorrect
+    'description' attribute, breaking authentication:
+    https://pagure.io/freeipa/issue/8084.
+
+    """
+    def execute(self, **options):
+        kra = krainstance.KRAInstance(self.api.env.realm)
+        if not kra.is_installed():
+            return False, []
+
+        cert = x509.load_certificate_from_file(paths.RA_AGENT_PEM)
+        entry = self.api.Backend.ldap2.get_entry(krainstance.KRA_AGENT_DN)
+
+        # check description attribute
+        description_values = entry.get('description', [])
+        if len(description_values) < 1:
+            # missing 'description' attribute is unexpected, but we can
+            # add it
+            do_fix = True
+        else:
+            # There should only be one value, so we will take the first value.
+            # But ignore the serial number when comparing, just in case.
+            description = description_values[0]
+            parts = description.split(';', 2)  # see below for syntax
+
+            if len(parts) < 3:
+                do_fix = True  # syntax error (not expected)
+            elif parts[2] != '{};{}'.format(DN(cert.issuer), DN(cert.subject)):
+                # issuer/subject does not match cert.  THIS is the condition
+                # caused by issue 8084, which we want to fix.
+                do_fix = True
+            else:
+                do_fix = False  # everything is fine
+
+        if do_fix:
+            # If other replicas have a different iteration of the IPA RA
+            # cert (e.g. renewal was triggered prematurely on some master
+            # and not on others) then authentication on those replicas will
+            # fail.  But the 'description' attribute needed fixing because
+            # the issuer value was wrong, meaning authentication was broken
+            # on ALL replicas.  So even for the corner case where different
+            # replicas have different IPA RA certs, updating the attribute
+            # will at least mean THIS replica can authenticate to the KRA.
+
+            logger.debug("Fixing KRA user entry 'description' attribute")
+            entry['description'] = [
+                '2;{};{};{}'.format(
+                    cert.serial_number,
+                    DN(cert.issuer),
+                    DN(cert.subject)
+                )
+            ]
+            self.api.Backend.ldap2.update_entry(entry)
+
+        return False, []  # don't restart DS; no LDAP updates to perform

--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -1336,3 +1336,15 @@ jobs:
         template: *ci-master-f29
         timeout: 3600
         topology: *ad_master
+
+  fedora-29/test_ca_custom_sdn:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_ca_custom_sdn.py
+        template: *ci-master-f29
+        timeout: 7200
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1348,3 +1348,15 @@ jobs:
         template: *ci-master-f30
         timeout: 3600
         topology: *ad_master
+
+  fedora-30/test_ca_custom_sdn:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_ca_custom_sdn.py
+        template: *ci-master-f30
+        timeout: 7200
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_master_pki.yaml
+++ b/ipatests/prci_definitions/nightly_master_pki.yaml
@@ -782,3 +782,16 @@ jobs:
         template: *pki-master-f30
         timeout: 3600
         topology: *master_1repl
+
+  fedora-30/test_ca_custom_sdn:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-30/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_ca_custom_sdn.py
+        template: *pki-master-f30
+        timeout: 7200
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_master_testing.yaml
+++ b/ipatests/prci_definitions/nightly_master_testing.yaml
@@ -1454,3 +1454,16 @@ jobs:
         template: *testing-master-f30
         timeout: 3600
         topology: *ad_master
+
+  fedora-30/test_ca_custom_sdn:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-30/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_ca_custom_sdn.py
+        template: *testing-master-f30
+        timeout: 7200
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1348,3 +1348,15 @@ jobs:
         template: *ci-master-frawhide
         timeout: 3600
         topology: *ad_master
+
+  fedora-rawhide/test_ca_custom_sdn:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_ca_custom_sdn.py
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_1repl

--- a/ipatests/test_integration/test_ca_custom_sdn.py
+++ b/ipatests/test_integration/test_ca_custom_sdn.py
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+import time
+
+from ipapython.dn import DN
+
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_ipa.integration import tasks
+
+
+class TestCACustomSubjectDN(IntegrationTest):
+    """
+    Test that everything works properly when IPA CA has a custom Subject DN.
+    We will also choose a custom Subject Base, that does not have anything
+    in common with the CA Subject DN.
+
+    Generating a random DN might be interest, but for now we construct one
+    that regression tests some previously encountered issues:
+
+    * Comma in RDN value: https://pagure.io/freeipa/issue/7347
+
+    * KRA authentication failed for all custom subject DNs:
+      https://pagure.io/freeipa/issue/8084
+
+    """
+
+    num_replicas = 0
+
+    @classmethod
+    def install(cls, mh):
+        """
+        Successful installation is sufficient to verify
+        https://pagure.io/freeipa/issue/7347.
+
+        """
+        tasks.install_master(
+            cls.master,
+            setup_kra=True,
+            extra_args=[
+                '--subject-base', str(create_custom_subject_base()),
+                '--ca-subject', str(create_custom_ca_subject()),
+            ],
+        )
+
+    def test_kra_authn(self):
+        """
+        vault-add is sufficient to verify
+        https://pagure.io/freeipa/issue/8084.
+
+        """
+        self.master.run_command([
+            'ipa', 'vault-add', "test1",
+            '--password', 'Secret.123', '--type', 'symmetric',
+        ])
+
+
+def create_custom_ca_subject():
+    return DN(
+        ('CN', 'IPA CA'),
+        ('O', 'Corporation {}, Inc.'.format(int(time.time()))),
+    )
+
+
+def create_custom_subject_base():
+    return DN(('O', 'Red Hat, Inc.'))


### PR DESCRIPTION
If IPA CA has custom subject DN (not "CN=Certificate
Authority,{subject_base}"), the uid=ipakra people entry gets an
incorrect 'description' attribute.  The issuer DN in the
'description' attribute is based on the aforementioned pattern,
instead of the actual IPA CA subject DN.

Update KRAInstance.configure_instance() to require the CA subject DN
argument.  Update ipaserver.install.kra.install() to pass the CA
subject DN.

Fixes: https://pagure.io/freeipa/issue/8084

**Verification steps**: https://bugzilla.redhat.com/show_bug.cgi?id=1758404#c2