### PR TITLE
[backport][ipa-4-7] Installation of replica against a specific server

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-7.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-7.yaml
@@ -407,6 +407,18 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-29/test_installation_TestInstallReplicaAgainstSpecificServer:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallReplicaAgainstSpecificServer
+        template: *ci-master-f29
+        timeout: 10800
+        topology: *master_2repl_1client
+
   fedora-29/test_idviews:
     requires: [fedora-29/build]
     priority: 50


### PR DESCRIPTION
Test to check replica install against specific server. It uses master and
replica1 without CA and having custodia service stopped. Then try to
install replica2 from replica1 and expect it to get fail as specified server
is not providing all the services.

related ticket: https://pagure.io/freeipa/issue/7566

Signed-off-by: Mohammad Rizwan Yusuf <myusuf@redhat.com>
Reviewed-By: Florence Blanc-Renaud <flo@redhat.com>
Reviewed-By: Rob Crittenden <rcritten@redhat.com>

Conflicts:
	ipatests/test_integration/test_installation.py