### PR TITLE
ipa_client_automount.py: fix typo (idmap.conf => idmapd.conf)

### DIFF
--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -87,7 +87,7 @@ def parse_options():
         "--idmap-domain",
         dest="idmapdomain",
         default=None,
-        help="nfs domain for idmap.conf",
+        help="nfs domain for idmapd.conf",
     )
     parser.add_option(
         "--debug",


### PR DESCRIPTION
660c49 introduced --idmap-domain which sets the Domain option in
idmapd.conf. However the help message for that knob mentioned
idmap.conf which is wrong. Fix that.
Reported by Marc Muehlfeld <mmuehlfe@redhat.com>.

Signed-off-by: François Cami <fcami@redhat.com>