### PR TITLE
Migrate xunit/unittest/nose tests to Pytest

### DIFF
--- a/ipalib/__init__.py
+++ b/ipalib/__init__.py
@@ -943,11 +943,6 @@ class API(plugable.API):
                 ipaserver.plugins,
             )
         else:
-            # disables immediately after an else clause
-            # do not work properly:
-            # https://github.com/PyCQA/pylint/issues/872
-            # Thus, below line was added as a workaround
-            result = None
             import ipaclient.remote_plugins
             import ipaclient.plugins
             result = (

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -172,6 +172,7 @@ class BasePathNamespace:
     FIREFOX = "/usr/bin/firefox"
     GETCERT = "/usr/bin/getcert"
     GPG2 = "/usr/bin/gpg2"
+    GPG_CONF = "/usr/bin/gpgconf"
     GPG_CONNECT_AGENT = "/usr/bin/gpg-connect-agent"
     GPG_AGENT = "/usr/bin/gpg-agent"
     IPA_GETCERT = "/usr/bin/ipa-getcert"

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -521,7 +521,7 @@ class CACertManage(admintool.AdminTool):
             for ca_nickname, _trust_flags in loaded:
                 if ca_nickname == nickname:
                     continue
-                elif ipa_ca_nickname == nickname:
+                if ipa_ca_nickname == nickname:
                     raise admintool.ScriptError(
                         "The IPA CA cannot be removed")
                 logger.debug("Verifying %s", ca_nickname)

--- a/ipatests/azure/Dockerfile.build-container
+++ b/ipatests/azure/Dockerfile.build-container
@@ -1,4 +1,4 @@
-FROM fedora:30
+FROM fedora:31
 MAINTAINER [FreeIPA Developers freeipa-devel@lists.fedorahosted.org]
 ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
   pool:
     vmImage: 'Ubuntu-16.04'
   container:
-    image: registry.fedoraproject.org/f30/fedora-toolbox
+    image: registry.fedoraproject.org/f31/fedora-toolbox
     options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged
   steps:
     - template: templates/prepare-build.yml
@@ -29,7 +29,7 @@ jobs:
     - script: |
         set -e
         echo "Running make target 'rpms'"
-        make V=0 rpms LOG_COMPILE='gdb -return-child-result -ex run -ex "thread apply all bt" -ex "quit" --args'
+        make V=0 rpms LOG_COMPILE='gdb.minimal -return-child-result -ex run -ex "thread apply all bt" -ex "quit" --args'
       displayName: Build packages
     - script: |
         set -e
@@ -46,7 +46,7 @@ jobs:
   pool:
     vmImage: 'Ubuntu-16.04'
   container:
-    image: registry.fedoraproject.org/f30/fedora-toolbox
+    image: registry.fedoraproject.org/f31/fedora-toolbox
     options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged
   steps:
     - template: templates/prepare-build.yml
@@ -65,7 +65,7 @@ jobs:
   pool:
     vmImage: 'Ubuntu-16.04'
   container:
-    image: registry.fedoraproject.org/f30/fedora-toolbox
+    image: registry.fedoraproject.org/f31/fedora-toolbox
     options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged
   steps:
     - template: templates/prepare-build.yml
@@ -96,7 +96,7 @@ jobs:
   pool:
     vmImage: 'Ubuntu-16.04'
   container:
-    image: registry.fedoraproject.org/f30/fedora-toolbox
+    image: registry.fedoraproject.org/f31/fedora-toolbox
     options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged
   steps:
     - template: templates/prepare-build.yml

--- a/ipatests/azure/templates/prepare-build.yml
+++ b/ipatests/azure/templates/prepare-build.yml
@@ -13,10 +13,20 @@ steps:
     for metalink in $(sudo dnf repolist -v |grep Repo-metalink | awk '{print $2}' ) ; do echo '###############' ; echo '####' ; echo $metalink ; echo '####' ; curl $metalink ; done
     echo "Fastestmirror results:"
     sudo cat /var/cache/dnf/fastestmirror.cache
-    sudo dnf -y module enable nodejs:12
     sudo dnf makecache || :
     echo "Installing base development environment"
-    sudo dnf install -y gdb make autoconf rpm-build gettext-devel automake libtool docker python3-paramiko python3-pyyaml
+    sudo dnf install -y \
+        gdb-minimal \
+        make \
+        autoconf \
+        rpm-build \
+        gettext-devel \
+        automake \
+        libtool \
+        docker \
+        python3-paramiko \
+        python3-pyyaml \
+
     echo "Installing FreeIPA development dependencies"
     sudo dnf builddep -y --skip-broken -D "with_wheels 1" -D "with_lint 1" --spec freeipa.spec.in --best --allowerasing --setopt=install_weak_deps=False
   displayName: Prepare build environment

--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -25,6 +25,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 
 pytest_plugins = [
     'ipatests.pytest_ipa.additional_config',
+    'ipatests.pytest_ipa.deprecated_frameworks',
     'ipatests.pytest_ipa.slicing',
     'ipatests.pytest_ipa.beakerlib',
     'ipatests.pytest_ipa.declarative',

--- a/ipatests/pytest_ipa/deprecated_frameworks.py
+++ b/ipatests/pytest_ipa/deprecated_frameworks.py
@@ -1,0 +1,66 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+"""Warns about xunit/unittest/nose tests.
+
+FreeIPA is a rather old project and hereby includes all the most
+famous in the past and present Python test idioms. Of course,
+this is difficult to play around all of them. For now, the runner
+of the IPA's test suite is Pytest.
+
+Pytest supports xunit style setups, unittest, nose tests. But this
+support is limited and may be dropped in the future releases.
+Worst of all is that the mixing of various test frameworks results
+in weird conflicts and of course, is not widely tested. In other
+words, there is a big risk. To eliminate this risk and to not pin
+Pytest to 3.x branch IPA's tests were refactored.
+
+This plugin is intended to issue warnings on collecting tests,
+which employ unittest/nose frameworks or xunit style.
+
+To treat these warnings as errors it's enough to run Pytest with:
+
+-W error:'xunit style is deprecated':pytest.PytestDeprecationWarning
+
+"""
+from unittest import TestCase
+
+import pytest
+
+forbidden_module_scopes = [
+    'setup_module',
+    'setup_function',
+    'teardown_module',
+    'teardown_function',
+]
+
+forbidden_class_scopes = [
+    'setup_class',
+    'setup_method',
+    'teardown_class',
+    'teardown_method',
+]
+
+
+def pytest_collection_finish(session):
+    for item in session.items:
+        cls = getattr(item, 'cls', None)
+        if cls is not None and issubclass(cls, TestCase):
+            item.warn(pytest.PytestDeprecationWarning(
+                "unittest is deprecated in favour of fixtures style"))
+            continue
+
+        def xunit_depr_warn(item, attr, names):
+            for n in names:
+                obj = getattr(item, attr, None)
+                method = getattr(obj, n, None)
+                fixtured = hasattr(method, '__pytest_wrapped__')
+                if method is not None and not fixtured:
+                    item.warn(
+                        pytest.PytestDeprecationWarning(
+                            "xunit style is deprecated in favour of "
+                            "fixtures style"))
+
+        xunit_depr_warn(item, 'module', forbidden_module_scopes)
+        xunit_depr_warn(item, 'cls', forbidden_class_scopes)

--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -267,8 +267,11 @@ def mh(request, class_integration_logs):
         logger.info('Preparing host %s', host.hostname)
         tasks.prepare_host(host)
 
-    setup_class(cls, mh)
-    mh._pytestmh_request.addfinalizer(lambda: teardown_class(cls))
+    add_compat_attrs(cls, mh)
+
+    def fin():
+        del_compat_attrs(cls)
+    mh._pytestmh_request.addfinalizer(fin)
 
     try:
         yield mh.install()
@@ -282,7 +285,7 @@ def mh(request, class_integration_logs):
         collect_systemd_journal(request.node, hosts, request.config)
 
 
-def setup_class(cls, mh):
+def add_compat_attrs(cls, mh):
     """Add convenience attributes to the test class
 
     This is deprecated in favor of the mh fixture.
@@ -299,7 +302,7 @@ def setup_class(cls, mh):
         cls.ad_treedomains = mh.ad_treedomains
 
 
-def teardown_class(cls):
+def del_compat_attrs(cls):
     """Remove convenience attributes from the test class
 
     This is deprecated in favor of the mh fixture.

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1873,7 +1873,7 @@ def ldapmodify_dm(host, ldif_text, **kwargs):
     args = [
         'ldapmodify',
         '-x',
-        '-D', str(host.config.dirman_dn),  # pylint: disable=no-member
+        '-D', str(host.config.dirman_dn),
         '-w', host.config.dirman_password
     ]
     return host.run_command(args, stdin_text=ldif_text, **kwargs)
@@ -1894,7 +1894,7 @@ def ldapsearch_dm(host, base, ldap_args, scope='sub', **kwargs):
         '-x', '-ZZ',
         '-h', host.hostname,
         '-p', '389',
-        '-D', str(host.config.dirman_dn),  # pylint: disable=no-member
+        '-D', str(host.config.dirman_dn),
         '-w', host.config.dirman_password,
         '-s', scope,
         '-b', base,

--- a/ipatests/pytest_ipa/nose_compat.py
+++ b/ipatests/pytest_ipa/nose_compat.py
@@ -54,23 +54,19 @@ def pytest_configure(config):
                 capture = config.pluginmanager.getplugin('capturemanager')
                 orig_stdout, orig_stderr = sys.stdout, sys.stderr
                 if capture:
-                    # pylint: disable=no-member
                     if hasattr(capture, 'suspend_global_capture'):
                         # pytest >= 3.3
                         capture.suspend_global_capture()
                     else:
                         # legacy support for pytest <= 3.2 (Fedora 27)
                         capture._capturing.suspend_capturing()
-                    # pylint: enable=no-member
                 sys.stderr.write(self.format(record))
                 sys.stderr.write('\n')
                 if capture:
-                    # pylint: disable=no-member
                     if hasattr(capture, 'resume_global_capture'):
                         capture.resume_global_capture()
                     else:
                         capture._capturing.resume_capturing()
-                    # pylint: enable=no-member
                 sys.stdout, sys.stderr = orig_stdout, orig_stderr
 
         level = convert_log_level(config.getoption('logging_level'))

--- a/ipatests/test_cmdline/cmdline.py
+++ b/ipatests/test_cmdline/cmdline.py
@@ -25,7 +25,6 @@ from __future__ import absolute_import
 
 import distutils.spawn
 import os
-import unittest
 
 import pytest
 
@@ -69,6 +68,6 @@ class cmdline_test(XMLRPC_test):
                 'Command %r not available' % original_command
             )
         if not server_available:
-            raise unittest.SkipTest(
+            pytest.skip(
                 'Server not available: %r' % api.env.xmlrpc_uri
             )

--- a/ipatests/test_cmdline/cmdline.py
+++ b/ipatests/test_cmdline/cmdline.py
@@ -27,6 +27,8 @@ import distutils.spawn
 import os
 import unittest
 
+import pytest
+
 from ipalib import api
 from ipalib import errors
 from ipaplatform.paths import paths
@@ -51,11 +53,12 @@ class cmdline_test(XMLRPC_test):
     # some reasonable default command
     command = paths.LS
 
-    @classmethod
-    def setup_class(cls):
+    @pytest.fixture(autouse=True, scope="class")
+    def cmdline_setup(self, request, xmlrpc_setup):
         # Find the executable in $PATH
         # This is neded because ipautil.run resets the PATH to
         # a system default.
+        cls = request.cls
         original_command = cls.command
         if not os.path.isabs(cls.command):
             cls.command = distutils.spawn.find_executable(cls.command)
@@ -65,7 +68,6 @@ class cmdline_test(XMLRPC_test):
             raise AssertionError(
                 'Command %r not available' % original_command
             )
-        super(cmdline_test, cls).setup_class()
         if not server_available:
             raise unittest.SkipTest(
                 'Server not available: %r' % api.env.xmlrpc_uri

--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -5,7 +5,6 @@ import shlex
 import subprocess
 import sys
 import tempfile
-import unittest
 
 import six
 
@@ -45,8 +44,8 @@ class TestCLIParsing:
         try:
             api.Command[command_name](**kw)
         except errors.NetworkError:
-            raise unittest.SkipTest('%r: Server not available: %r' %
-                                (self.__module__, api.env.xmlrpc_uri))
+            pytest.skip('%r: Server not available: %r' %
+                        (self.__module__, api.env.xmlrpc_uri))
 
     @contextlib.contextmanager
     def fake_stdin(self, string_in):
@@ -124,7 +123,7 @@ class TestCLIParsing:
         try:
             self.run_command('dnszone_add', idnsname=TEST_ZONE)
         except errors.NotFound:
-            raise unittest.SkipTest('DNS is not configured')
+            pytest.skip('DNS is not configured')
         try:
             self.run_command('dnsrecord_add',
                 dnszoneidnsname=TEST_ZONE,
@@ -152,7 +151,7 @@ class TestCLIParsing:
         try:
             self.run_command('dnszone_add', idnsname=TEST_ZONE)
         except errors.NotFound:
-            raise unittest.SkipTest('DNS is not configured')
+            pytest.skip('DNS is not configured')
         try:
             records = (u'1 1 E3B72BA346B90570EED94BE9334E34AA795CED23',
                        u'2 1 FD2693C1EFFC11A8D2BE57229212A04B45663791')
@@ -232,7 +231,7 @@ class TestCLIParsing:
             self.run_command(
                 'dnszone_add', idnsname=TEST_ZONE)
         except errors.NotFound:
-            raise unittest.SkipTest('DNS is not configured')
+            pytest.skip('DNS is not configured')
         try:
             self.run_command(
                 'dnsrecord_add',

--- a/ipatests/test_integration/base.py
+++ b/ipatests/test_integration/base.py
@@ -41,10 +41,6 @@ class IntegrationTest:
     fips_mode = None
 
     @classmethod
-    def setup_class(cls):
-        pass
-
-    @classmethod
     def host_by_role(cls, role):
         for domain in cls.get_domains():
             try:
@@ -92,10 +88,6 @@ class IntegrationTest:
             tasks.install_topo(cls.topology,
                                cls.master, cls.replicas,
                                cls.clients, domain_level)
-    @classmethod
-    def teardown_class(cls):
-        pass
-
     @classmethod
     def uninstall(cls, mh):
         for replica in cls.replicas:

--- a/ipatests/test_integration/base.py
+++ b/ipatests/test_integration/base.py
@@ -77,7 +77,7 @@ class IntegrationTest:
         else:
             domain_level = cls.master.config.domain_level
 
-        if cls.master.config.fips_mode:
+        if cls.master.config.fips_mode:  # pylint: disable=using-constant-test
             cls.fips_mode = True
         if cls.fips_mode:
             cls.enable_fips_mode()

--- a/ipatests/test_integration/test_advise.py
+++ b/ipatests/test_integration/test_advise.py
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# FIXME: Pylint errors
-# pylint: disable=no-member
-
 import re
 
 from ipalib.constants import IPAAPI_USER

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -183,7 +183,7 @@ class TestIPACommand(IntegrationTest):
             raiseonerr=False
         )
         assert result.returncode == 2
-        err = result.stderr_text.strip()  # pylint: disable=no-member
+        err = result.stderr_text.strip()
         assert err == "ipa: ERROR: loc: privilege not found"
         # add privilege
         result = self.master.run_command(
@@ -206,7 +206,7 @@ class TestIPACommand(IntegrationTest):
 
         master = self.master
 
-        base_dn = str(master.domain.basedn)  # pylint: disable=no-member
+        base_dn = str(master.domain.basedn)
         entry_ldif = textwrap.dedent("""
             dn: uid=system,cn=sysaccounts,cn=etc,{base_dn}
             changetype: add
@@ -225,7 +225,7 @@ class TestIPACommand(IntegrationTest):
                                            new_passwd, master)
 
     def get_krbinfo(self, user):
-        base_dn = str(self.master.domain.basedn)  # pylint: disable=no-member
+        base_dn = str(self.master.domain.basedn)
         result = tasks.ldapsearch_dm(
             self.master,
             'uid={user},cn=users,cn=accounts,{base_dn}'.format(
@@ -248,7 +248,7 @@ class TestIPACommand(IntegrationTest):
         new_passwd = 'userPasswd123'
         new_passwd2 = 'mynewPwd123'
         master = self.master
-        base_dn = str(master.domain.basedn)  # pylint: disable=no-member
+        base_dn = str(master.domain.basedn)
 
         # Create a user with a password
         tasks.kinit_admin(master)
@@ -293,7 +293,7 @@ class TestIPACommand(IntegrationTest):
         time.sleep(1)
         master.run_command([
             paths.LDAPPASSWD,
-            '-D', str(master.config.dirman_dn),   # pylint: disable=no-member
+            '-D', str(master.config.dirman_dn),
             '-w', master.config.dirman_password,
             '-a', new_passwd,
             '-s', new_passwd2,
@@ -376,7 +376,7 @@ class TestIPACommand(IntegrationTest):
 
         test_user = 'test-ssh'
         external_master_hostname = \
-            self.master.external_hostname  # pylint: disable=no-member
+            self.master.external_hostname
 
         pub_keys = []
 
@@ -628,7 +628,7 @@ class TestIPACommand(IntegrationTest):
         dn = DN(
             ('cn', 'HTTP'), ('cn', self.master.hostname), ('cn', 'masters'),
             ('cn', 'ipa'), ('cn', 'etc'),
-            self.master.domain.basedn  # pylint: disable=no-member
+            self.master.domain.basedn
         )
 
         conn = self.master.ldap_connect()

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -188,7 +188,7 @@ class TestInstallWithCA1(InstallTestBase1):
         https://pagure.io/freeipa/issue/7418
         """
         ldap_conf = paths.OPENLDAP_LDAP_CONF
-        base_dn = self.master.domain.basedn  # pylint: disable=no-member
+        base_dn = self.master.domain.basedn
         client = self.replicas[0]
         tasks.uninstall_master(client)
         expected_msg1 = "contains deprecated and unsupported " \

--- a/ipatests/test_integration/test_legacy_clients.py
+++ b/ipatests/test_integration/test_legacy_clients.py
@@ -24,7 +24,8 @@ from __future__ import absolute_import
 
 import os
 import re
-import unittest
+
+import pytest
 
 from ipaplatform.constants import constants as platformconstants
 from ipaplatform.paths import paths
@@ -166,8 +167,8 @@ class BaseTestLegacyClient:
 
     def test_login_ipa_user(self):
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise unittest.SkipTest('Package sshpass not available on %s'
-                                 % self.master.hostname)
+            pytest.skip('Package sshpass not available on %s'
+                        % self.master.hostname)
 
         result = self.master.run_command(
             'sshpass -p %s '
@@ -183,8 +184,8 @@ class BaseTestLegacyClient:
 
     def test_login_ad_user(self):
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise unittest.SkipTest('Package sshpass not available on %s'
-                                 % self.master.hostname)
+            pytest.skip('Package sshpass not available on %s'
+                        % self.master.hostname)
 
         testuser = 'testuser@%s' % self.ad.domain.name
         result = self.master.run_command(
@@ -200,8 +201,8 @@ class BaseTestLegacyClient:
 
     def test_login_disabled_ipa_user(self):
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise unittest.SkipTest('Package sshpass not available on %s'
-                                 % self.master.hostname)
+            pytest.skip('Package sshpass not available on %s'
+                        % self.master.hostname)
 
         self.clear_sssd_caches()
 
@@ -220,7 +221,7 @@ class BaseTestLegacyClient:
 
     def test_login_disabled_ad_user(self):
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise unittest.SkipTest('Package sshpass not available on %s'
+            pytest.skip('Package sshpass not available on %s'
                                  % self.master.hostname)
 
         testuser = 'disabledaduser@%s' % self.ad.domain.name
@@ -238,7 +239,7 @@ class BaseTestLegacyClient:
 
     def test_getent_subdomain_ad_user(self):
         if not self.ad_subdomain:
-            raise unittest.SkipTest('AD for the subdomain is not available.')
+            pytest.skip('AD for the subdomain is not available.')
 
         self.clear_sssd_caches()
         testuser = 'subdomaintestuser@%s' % self.ad_subdomain
@@ -260,7 +261,7 @@ class BaseTestLegacyClient:
 
     def test_getent_subdomain_ad_group(self):
         if not self.ad_subdomain:
-            raise unittest.SkipTest('AD for the subdomain is not available.')
+            pytest.skip('AD for the subdomain is not available.')
 
         self.clear_sssd_caches()
         testgroup = 'subdomaintestgroup@%s' % self.ad_subdomain
@@ -272,7 +273,7 @@ class BaseTestLegacyClient:
 
     def test_id_subdomain_ad_user(self):
         if not self.ad_subdomain:
-            raise unittest.SkipTest('AD for the subdomain is not available.')
+            pytest.skip('AD for the subdomain is not available.')
 
         self.clear_sssd_caches()
         testuser = 'subdomaintestuser@%s' % self.ad_subdomain
@@ -297,11 +298,11 @@ class BaseTestLegacyClient:
 
     def test_login_subdomain_ad_user(self):
         if not self.ad_subdomain:
-            raise unittest.SkipTest('AD for the subdomain is not available.')
+            pytest.skip('AD for the subdomain is not available.')
 
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise unittest.SkipTest('Package sshpass not available on %s'
-                                 % self.master.hostname)
+            pytest.skip('Package sshpass not available on %s'
+                        % self.master.hostname)
 
         testuser = 'subdomaintestuser@%s' % self.ad_subdomain
         result = self.master.run_command(
@@ -317,11 +318,11 @@ class BaseTestLegacyClient:
 
     def test_login_disabled_subdomain_ad_user(self):
         if not self.ad_subdomain:
-            raise unittest.SkipTest('AD for the subdomain is not available.')
+            pytest.skip('AD for the subdomain is not available.')
 
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise unittest.SkipTest('Package sshpass not available on %s'
-                                 % self.master.hostname)
+            pytest.skip('Package sshpass not available on %s'
+                        % self.master.hostname)
 
         testuser = 'subdomaindisabledaduser@%s' % self.ad_subdomain
         result = self.master.run_command(
@@ -338,7 +339,7 @@ class BaseTestLegacyClient:
 
     def test_getent_treedomain_ad_user(self):
         if not self.ad_treedomain:
-            raise unittest.SkipTest('AD tree root domain is not available.')
+            pytest.skip('AD tree root domain is not available.')
 
         self.clear_sssd_caches()
         testuser = 'treetestuser@{0}'.format(self.ad_treedomain)
@@ -356,7 +357,7 @@ class BaseTestLegacyClient:
 
     def test_getent_treedomain_ad_group(self):
         if not self.ad_treedomain:
-            raise unittest.SkipTest('AD tree root domain is not available')
+            pytest.skip('AD tree root domain is not available')
 
         self.clear_sssd_caches()
         testgroup = 'treetestgroup@{0}'.format(self.ad_treedomain)
@@ -369,7 +370,7 @@ class BaseTestLegacyClient:
 
     def test_id_treedomain_ad_user(self):
         if not self.ad_treedomain:
-            raise unittest.SkipTest('AD tree root domain is not available')
+            pytest.skip('AD tree root domain is not available')
 
         self.clear_sssd_caches()
 
@@ -398,10 +399,10 @@ class BaseTestLegacyClient:
 
     def test_login_treedomain_ad_user(self):
         if not self.ad_treedomain:
-            raise unittest.SkipTest('AD tree root domain is not available.')
+            pytest.skip('AD tree root domain is not available.')
 
         if not self.master.transport.file_exists('/usr/bin/sshpass'):
-            raise unittest.SkipTest(
+            pytest.skip(
                 'Package sshpass not available on {}'.format(
                     self.master.hostname)
             )

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -19,6 +19,8 @@ import os
 import re
 import time
 
+import pytest
+
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 
@@ -280,8 +282,11 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=True)
 
-    def teardown_method(self, method):
-        tasks.uninstall_client(self.clients[0])
+    @pytest.fixture(autouse=True)
+    def automountfile_restore_setup(self, request):
+        def fin():
+            tasks.uninstall_client(self.clients[0])
+        request.addfinalizer(fin)
 
     def nsswitch_backup_restore(
         self,

--- a/ipatests/test_integration/test_ordering.py
+++ b/ipatests/test_integration/test_ordering.py
@@ -25,13 +25,16 @@ in a specific order:
 - Within a class, test methods are ordered according to source line
 """
 
+import pytest
 from pytest_sourceorder import ordered
 
 
 @ordered
 class TestBase:
-    @classmethod
-    def setup_class(cls):
+    value = None
+    @pytest.fixture(autouse=True, scope="class")
+    def testbase_setup(self, request):
+        cls = request.cls
         cls.value = 'unchanged'
 
     def test_d_first(self):

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -7,6 +7,9 @@ from __future__ import absolute_import
 import time
 import re
 import textwrap
+
+import pytest
+
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.tasks import (
@@ -202,17 +205,20 @@ class TestWrongClientDomain(IntegrationTest):
     def install(cls, mh):
         tasks.install_master(cls.master, domain_level=cls.domain_level)
 
-    def teardown_method(self, method):
-        if len(config.domains) == 0:
-            # No YAML config was set
-            return
-        self.replicas[0].run_command(['ipa-client-install',
-                                     '--uninstall', '-U'],
+    @pytest.fixture(autouse=True)
+    def wrong_client_dom_setup(self, request):
+        def fin():
+            if len(config.domains) == 0:
+                # No YAML config was set
+                return
+            self.replicas[0].run_command(['ipa-client-install',
+                                         '--uninstall', '-U'],
+                                         raiseonerr=False)
+            tasks.kinit_admin(self.master)
+            self.master.run_command(['ipa', 'host-del',
+                                     self.replicas[0].hostname],
                                     raiseonerr=False)
-        tasks.kinit_admin(self.master)
-        self.master.run_command(['ipa', 'host-del',
-                                 self.replicas[0].hostname],
-                                raiseonerr=False)
+        request.addfinalizer(fin)
 
     def test_wrong_client_domain(self):
         client = self.replicas[0]

--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -54,7 +54,7 @@ class TestSMB(IntegrationTest):
                            cls.clients, domain_level,
                            clients_extra_args=('--mkhomedir',))
 
-        cls.ad = cls.ads[0]  # pylint: disable=no-member
+        cls.ad = cls.ads[0]
         cls.smbserver = cls.clients[0]
         cls.smbclient = cls.clients[1]
         cls.ad_user = '{}@{}'.format(cls.ad_user_login, cls.ad.domain.name)

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -45,7 +45,7 @@ class TestSSSDWithAdTrust(IntegrationTest):
     def install(cls, mh):
         super(TestSSSDWithAdTrust, cls).install(mh)
 
-        cls.ad = cls.ads[0]  # pylint: disable=no-member
+        cls.ad = cls.ads[0]
 
         tasks.install_adtrust(cls.master)
         tasks.configure_dns_for_trust(cls.master, cls.ad)

--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -724,7 +724,7 @@ class TestSudo(IntegrationTest):
         """
         self.master.run_command(
             ['ipa', 'config-mod', '--domain-resolution-order',
-             self.domain.name])  # pylint: disable=no-member
+             self.domain.name])
         try:
             # prepare the sudo rule: set only one user for ipasudorunas
             self.reset_rule_categories()
@@ -741,7 +741,7 @@ class TestSudo(IntegrationTest):
             # according to listing of allowed commands
             result = self.list_sudo_commands('testuser1')
             expected_rule = ('(testuser2@%s) NOPASSWD: ALL'
-                             % self.domain.name)  # pylint: disable=no-member
+                             % self.domain.name)
             assert expected_rule in result.stdout_text
 
             # check that testuser1 can actually run commands as testuser2

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -3,8 +3,9 @@
 from __future__ import absolute_import
 
 import re
-import unittest
 import textwrap
+
+import pytest
 
 from ipaplatform.constants import constants as platformconstants
 from ipaplatform.paths import paths
@@ -33,8 +34,8 @@ class BaseTestTrust(IntegrationTest):
     @classmethod
     def install(cls, mh):
         if not cls.master.transport.file_exists('/usr/bin/rpcclient'):
-            raise unittest.SkipTest("Package samba-client not available "
-                                    "on {}".format(cls.master.hostname))
+            raise pytest.skip("Package samba-client not available "
+                              "on {}".format(cls.master.hostname))
         super(BaseTestTrust, cls).install(mh)
         cls.ad = cls.ads[0]  # pylint: disable=no-member
         cls.ad_domain = cls.ad.domain.name

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -37,15 +37,15 @@ class BaseTestTrust(IntegrationTest):
             raise pytest.skip("Package samba-client not available "
                               "on {}".format(cls.master.hostname))
         super(BaseTestTrust, cls).install(mh)
-        cls.ad = cls.ads[0]  # pylint: disable=no-member
+        cls.ad = cls.ads[0]
         cls.ad_domain = cls.ad.domain.name
         tasks.install_adtrust(cls.master)
         cls.check_sid_generation()
         tasks.sync_time(cls.master, cls.ad)
 
-        cls.child_ad = cls.ad_subdomains[0]  # pylint: disable=no-member
+        cls.child_ad = cls.ad_subdomains[0]
         cls.ad_subdomain = cls.child_ad.domain.name
-        cls.tree_ad = cls.ad_treedomains[0]  # pylint: disable=no-member
+        cls.tree_ad = cls.ad_treedomains[0]
         cls.ad_treedomain = cls.tree_ad.domain.name
 
         # values used in workaround for

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -42,7 +42,7 @@ class TestUpgrade(IntegrationTest):
         """
         # Read the current entry from LDAP
         ldap = self.master.ldap_connect()
-        basedn = self.master.domain.basedn  # pylint: disable=no-member
+        basedn = self.master.domain.basedn
         dn = DN(('cn', 'CAcert'), ('cn', 'ipa'), ('cn', 'etc'), basedn)
         entry = ldap.get_entry(dn)  # pylint: disable=no-member
         # Extract the certificate as DER then double-encode

--- a/ipatests/test_integration/test_winsyncmigrate.py
+++ b/ipatests/test_integration/test_winsyncmigrate.py
@@ -74,7 +74,7 @@ class TestWinsyncMigrate(IntegrationTest):
     def install(cls, mh):
         super(TestWinsyncMigrate, cls).install(mh)
 
-        cls.ad = cls.ads[0]  # pylint: disable=no-member
+        cls.ad = cls.ads[0]
         cls.trust_test_user = '%s@%s' % (cls.ad_user, cls.ad.domain.name)
         tasks.configure_dns_for_trust(cls.master, cls.ad)
         tasks.install_adtrust(cls.master)

--- a/ipatests/test_ipalib/test_backend.py
+++ b/ipatests/test_ipalib/test_backend.py
@@ -22,10 +22,6 @@ Test the `ipalib.backend` module.
 """
 from __future__ import print_function
 
-# FIXME: Pylint errors
-# pylint: disable=no-member
-# pylint: disable=maybe-no-member
-
 import threading
 from ipatests.util import ClassChecker, raises, create_test_api
 from ipatests.data import unicode_str

--- a/ipatests/test_ipalib/test_frontend.py
+++ b/ipatests/test_ipalib/test_frontend.py
@@ -21,8 +21,6 @@
 Test the `ipalib.frontend` module.
 """
 
-# FIXME: Pylint errors
-# pylint: disable=no-member
 import pytest
 import six
 

--- a/ipatests/test_ipalib/test_rpc.py
+++ b/ipatests/test_ipalib/test_rpc.py
@@ -73,7 +73,6 @@ def test_round_trip():
     if six.PY2:
         assert_equal(dump_n_load(utf8_bytes), unicode_str)
     assert_equal(dump_n_load(unicode_str), unicode_str)
-    # "Binary" is not "str". pylint: disable=no-member
     assert_equal(dump_n_load(Binary(binary_bytes)).data, binary_bytes)
     assert isinstance(dump_n_load(Binary(binary_bytes)), Binary)
     assert type(dump_n_load(b'hello')) is output_binary_type
@@ -110,7 +109,6 @@ def test_xml_wrap():
     assert f({}, API_VERSION) == dict()
     b = f(b'hello', API_VERSION)
     assert isinstance(b, Binary)
-    # "Binary" is not "dict" or "tuple". pylint: disable=no-member
     assert b.data == b'hello'
     u = f(u'hello', API_VERSION)
     assert type(u) is unicode

--- a/ipatests/test_ipalib/test_rpc.py
+++ b/ipatests/test_ipalib/test_rpc.py
@@ -22,7 +22,6 @@ Test the `ipalib.rpc` module.
 """
 from __future__ import print_function
 
-import unittest
 from xmlrpc.client import Binary, Fault, dumps, loads
 import urllib
 
@@ -266,8 +265,8 @@ class test_xml_introspection:
         try:
             api.Backend.xmlclient.connect()
         except (errors.NetworkError, IOError):
-            raise unittest.SkipTest('%r: Server not available: %r' %
-                                (__name__, api.env.xmlrpc_uri))
+            pytest.skip('%r: Server not available: %r' %
+                        (__name__, api.env.xmlrpc_uri))
 
         def fin():
             ipa_request.destroy_context()
@@ -356,8 +355,8 @@ class test_rpcclient_context(PluginTester):
         try:
             api.Backend.rpcclient.connect(ca_certfile='foo')
         except (errors.NetworkError, IOError):
-            raise unittest.SkipTest('%r: Server not available: %r' %
-                                (__name__, api.env.xmlrpc_uri))
+            pytest.skip('%r: Server not available: %r' %
+                        (__name__, api.env.xmlrpc_uri))
 
         def fin():
             if api.Backend.rpcclient.isconnected():

--- a/ipatests/test_ipalib/test_text.py
+++ b/ipatests/test_ipalib/test_text.py
@@ -77,7 +77,8 @@ class test_TestLang:
 
         os.environ.update(self.saved_locale)
 
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def testlang_setup(self, request):
         self.tmp_dir = None
         self.setup_lang()
 
@@ -117,11 +118,12 @@ class test_TestLang:
 
         self.po_file_iterate = po_file_iterate
 
-    def teardown(self):
-        self.teardown_lang()
+        def fin():
+            self.teardown_lang()
 
-        if self.tmp_dir is not None:
-            shutil.rmtree(self.tmp_dir)
+            if self.tmp_dir is not None:
+                shutil.rmtree(self.tmp_dir)
+        request.addfinalizer(fin)
 
     def test_test_lang(self):
         print("test_test_lang")

--- a/ipatests/test_ipalib/test_text.py
+++ b/ipatests/test_ipalib/test_text.py
@@ -25,7 +25,6 @@ from __future__ import print_function
 import os
 import shutil
 import tempfile
-import unittest
 
 import six
 import pytest
@@ -103,17 +102,17 @@ class test_TestLang:
 
         result = create_po(self.pot_file, self.po_file, self.mo_file)
         if result:
-            raise unittest.SkipTest(
+            pytest.skip(
                 'Unable to create po file "%s" & mo file "%s" from pot '
                 'file "%s"' % (self.po_file, self.mo_file, self.pot_file)
             )
 
         if not os.path.isfile(self.po_file):
-            raise unittest.SkipTest(
+            pytest.skip(
                 'Test po file unavailable: {}'.format(self.po_file))
 
         if not os.path.isfile(self.mo_file):
-            raise unittest.SkipTest(
+            pytest.skip(
                 'Test mo file unavailable: {}'.format(self.mo_file))
 
         self.po_file_iterate = po_file_iterate

--- a/ipatests/test_ipapython/test_cookie.py
+++ b/ipatests/test_ipapython/test_cookie.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
 import datetime
 import email.utils
 import calendar
@@ -27,125 +26,127 @@ import pytest
 
 pytestmark = pytest.mark.tier0
 
-class TestParse(unittest.TestCase):
+
+class TestParse:
 
     def test_parse(self):
         # Empty string
         s = ''
         cookies = Cookie.parse(s)
-        self.assertEqual(len(cookies), 0)
+        assert len(cookies) == 0
 
         # Invalid single token
         s = 'color'
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             cookies = Cookie.parse(s)
 
         # Invalid single token that's keyword
         s = 'HttpOnly'
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             cookies = Cookie.parse(s)
 
         # Invalid key/value pair whose key is a keyword
         s = 'domain=example.com'
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             cookies = Cookie.parse(s)
 
         # 1 cookie with empty value
         s = 'color='
         cookies = Cookie.parse(s)
-        self.assertEqual(len(cookies), 1)
+        assert len(cookies) == 1
         cookie = cookies[0]
-        self.assertEqual(cookie.key, 'color')
-        self.assertEqual(cookie.value, '')
-        self.assertEqual(cookie.domain, None)
-        self.assertEqual(cookie.path, None)
-        self.assertEqual(cookie.max_age, None)
-        self.assertEqual(cookie.expires, None)
-        self.assertEqual(cookie.secure, None)
-        self.assertEqual(cookie.httponly, None)
-        self.assertEqual(str(cookie), "color=")
-        self.assertEqual(cookie.http_cookie(), "color=;")
+        assert cookie.key == 'color'
+        assert cookie.value == ''
+        assert cookie.domain is None
+        assert cookie.path is None
+        assert cookie.max_age is None
+        assert cookie.expires is None
+        assert cookie.secure is None
+        assert cookie.httponly is None
+        assert str(cookie) == "color="
+        assert cookie.http_cookie() == "color=;"
 
         # 1 cookie with name/value
         s = 'color=blue'
         cookies = Cookie.parse(s)
-        self.assertEqual(len(cookies), 1)
+        assert len(cookies) == 1
         cookie = cookies[0]
-        self.assertEqual(cookie.key, 'color')
-        self.assertEqual(cookie.value, 'blue')
-        self.assertEqual(cookie.domain, None)
-        self.assertEqual(cookie.path, None)
-        self.assertEqual(cookie.max_age, None)
-        self.assertEqual(cookie.expires, None)
-        self.assertEqual(cookie.secure, None)
-        self.assertEqual(cookie.httponly, None)
-        self.assertEqual(str(cookie), "color=blue")
-        self.assertEqual(cookie.http_cookie(), "color=blue;")
+        assert cookie.key == 'color'
+        assert cookie.value == 'blue'
+        assert cookie.domain is None
+        assert cookie.path is None
+        assert cookie.max_age is None
+        assert cookie.expires is None
+        assert cookie.secure is None
+        assert cookie.httponly is None
+        assert str(cookie) == "color=blue"
+        assert cookie.http_cookie() == "color=blue;"
 
         # 1 cookie with whose value is quoted
         # Use "get by name" utility to extract specific cookie
         s = 'color="blue"'
         cookie = Cookie.get_named_cookie_from_string(s, 'color')
-        self.assertIsNotNone(cookie)
-        self.assertIsNotNone(cookie, Cookie)
-        self.assertEqual(cookie.key, 'color')
-        self.assertEqual(cookie.value, 'blue')
-        self.assertEqual(cookie.domain, None)
-        self.assertEqual(cookie.path, None)
-        self.assertEqual(cookie.max_age, None)
-        self.assertEqual(cookie.expires, None)
-        self.assertEqual(cookie.secure, None)
-        self.assertEqual(cookie.httponly, None)
-        self.assertEqual(str(cookie), "color=blue")
-        self.assertEqual(cookie.http_cookie(), "color=blue;")
+        assert cookie is not None, Cookie
+        assert cookie.key == 'color'
+        assert cookie.value == 'blue'
+        assert cookie.domain is None
+        assert cookie.path is None
+        assert cookie.max_age is None
+        assert cookie.expires is None
+        assert cookie.secure is None
+        assert cookie.httponly is None
+        assert str(cookie) == "color=blue"
+        assert cookie.http_cookie() == "color=blue;"
 
         # 1 cookie with name/value and domain, path attributes.
         # Change up the whitespace a bit.
         s = 'color =blue; domain= example.com ; path = /toplevel '
         cookies = Cookie.parse(s)
-        self.assertEqual(len(cookies), 1)
+        assert len(cookies) == 1
         cookie = cookies[0]
-        self.assertEqual(cookie.key, 'color')
-        self.assertEqual(cookie.value, 'blue')
-        self.assertEqual(cookie.domain, 'example.com')
-        self.assertEqual(cookie.path, '/toplevel')
-        self.assertEqual(cookie.max_age, None)
-        self.assertEqual(cookie.expires, None)
-        self.assertEqual(cookie.secure, None)
-        self.assertEqual(cookie.httponly, None)
-        self.assertEqual(str(cookie), "color=blue; Domain=example.com; Path=/toplevel")
-        self.assertEqual(cookie.http_cookie(), "color=blue;")
+        assert cookie.key == 'color'
+        assert cookie.value == 'blue'
+        assert cookie.domain == 'example.com'
+        assert cookie.path == '/toplevel'
+        assert cookie.max_age is None
+        assert cookie.expires is None
+        assert cookie.secure is None
+        assert cookie.httponly is None
+        assert str(cookie) == "color=blue; Domain=example.com; Path=/toplevel"
+        assert cookie.http_cookie() == "color=blue;"
 
         # 2 cookies, various attributes
         s = 'color=blue; Max-Age=3600; temperature=hot; HttpOnly'
         cookies = Cookie.parse(s)
-        self.assertEqual(len(cookies), 2)
+        assert len(cookies) == 2
         cookie = cookies[0]
-        self.assertEqual(cookie.key, 'color')
-        self.assertEqual(cookie.value, 'blue')
-        self.assertEqual(cookie.domain, None)
-        self.assertEqual(cookie.path, None)
-        self.assertEqual(cookie.max_age, 3600)
-        self.assertEqual(cookie.expires, None)
-        self.assertEqual(cookie.secure, None)
-        self.assertEqual(cookie.httponly, None)
-        self.assertEqual(str(cookie), "color=blue; Max-Age=3600")
-        self.assertEqual(cookie.http_cookie(), "color=blue;")
+        assert cookie.key == 'color'
+        assert cookie.value == 'blue'
+        assert cookie.domain is None
+        assert cookie.path is None
+        assert cookie.max_age == 3600
+        assert cookie.expires is None
+        assert cookie.secure is None
+        assert cookie.httponly is None
+        assert str(cookie) == "color=blue; Max-Age=3600"
+        assert cookie.http_cookie() == "color=blue;"
         cookie = cookies[1]
-        self.assertEqual(cookie.key, 'temperature')
-        self.assertEqual(cookie.value, 'hot')
-        self.assertEqual(cookie.domain, None)
-        self.assertEqual(cookie.path, None)
-        self.assertEqual(cookie.max_age, None)
-        self.assertEqual(cookie.expires, None)
-        self.assertEqual(cookie.secure, None)
-        self.assertEqual(cookie.httponly, True)
-        self.assertEqual(str(cookie), "temperature=hot; HttpOnly")
-        self.assertEqual(cookie.http_cookie(), "temperature=hot;")
+        assert cookie.key == 'temperature'
+        assert cookie.value == 'hot'
+        assert cookie.domain is None
+        assert cookie.path is None
+        assert cookie.max_age is None
+        assert cookie.expires is None
+        assert cookie.secure is None
+        assert cookie.httponly is True
+        assert str(cookie) == "temperature=hot; HttpOnly"
+        assert cookie.http_cookie() == "temperature=hot;"
 
-class TestExpires(unittest.TestCase):
 
-    def setUp(self):
+class TestExpires:
+
+    @pytest.fixture(autouse=True)
+    def expires_setup(self):
         # Force microseconds to zero because cookie timestamps only have second resolution
         self.now = datetime.datetime.utcnow().replace(microsecond=0)
         self.now_timestamp = calendar.timegm(self.now.utctimetuple())
@@ -164,233 +165,237 @@ class TestExpires(unittest.TestCase):
         # 1 cookie with name/value and no Max-Age and no Expires
         s = 'color=blue;'
         cookies = Cookie.parse(s)
-        self.assertEqual(len(cookies), 1)
+        assert len(cookies) == 1
         cookie = cookies[0]
         # Force timestamp to known value
         cookie.timestamp = self.now
-        self.assertEqual(cookie.key, 'color')
-        self.assertEqual(cookie.value, 'blue')
-        self.assertEqual(cookie.domain, None)
-        self.assertEqual(cookie.path, None)
-        self.assertEqual(cookie.max_age, None)
-        self.assertEqual(cookie.expires, None)
-        self.assertEqual(cookie.secure, None)
-        self.assertEqual(cookie.httponly, None)
-        self.assertEqual(str(cookie), "color=blue")
-        self.assertEqual(cookie.get_expiration(), None)
+        assert cookie.key == 'color'
+        assert cookie.value == 'blue'
+        assert cookie.domain is None
+        assert cookie.path is None
+        assert cookie.max_age is None
+        assert cookie.expires is None
+        assert cookie.secure is None
+        assert cookie.httponly is None
+        assert str(cookie) == "color=blue"
+        assert cookie.get_expiration() is None
         # Normalize
-        self.assertEqual(cookie.normalize_expiration(), None)
-        self.assertEqual(cookie.max_age, None)
-        self.assertEqual(cookie.expires, None)
-        self.assertEqual(str(cookie), "color=blue")
+        assert cookie.normalize_expiration() is None
+        assert cookie.max_age is None
+        assert cookie.expires is None
+        assert str(cookie) == "color=blue"
 
         # 1 cookie with name/value and Max-Age
         s = 'color=blue; max-age=%d' % (self.max_age)
         cookies = Cookie.parse(s)
-        self.assertEqual(len(cookies), 1)
+        assert len(cookies) == 1
         cookie = cookies[0]
         # Force timestamp to known value
         cookie.timestamp = self.now
-        self.assertEqual(cookie.key, 'color')
-        self.assertEqual(cookie.value, 'blue')
-        self.assertEqual(cookie.domain, None)
-        self.assertEqual(cookie.path, None)
-        self.assertEqual(cookie.max_age, self.max_age)
-        self.assertEqual(cookie.expires, None)
-        self.assertEqual(cookie.secure, None)
-        self.assertEqual(cookie.httponly, None)
-        self.assertEqual(str(cookie), "color=blue; Max-Age=%d" % (self.max_age))
-        self.assertEqual(cookie.get_expiration(), self.age_expiration)
+        assert cookie.key == 'color'
+        assert cookie.value == 'blue'
+        assert cookie.domain is None
+        assert cookie.path is None
+        assert cookie.max_age == self.max_age
+        assert cookie.expires is None
+        assert cookie.secure is None
+        assert cookie.httponly is None
+        assert str(cookie) == "color=blue; Max-Age=%d" % (self.max_age)
+        assert cookie.get_expiration() == self.age_expiration
         # Normalize
-        self.assertEqual(cookie.normalize_expiration(), self.age_expiration)
-        self.assertEqual(cookie.max_age, None)
-        self.assertEqual(cookie.expires, self.age_expiration)
-        self.assertEqual(str(cookie), "color=blue; Expires=%s" % (self.age_string))
+        assert cookie.normalize_expiration() == self.age_expiration
+        assert cookie.max_age is None
+        assert cookie.expires == self.age_expiration
+        assert str(cookie) == "color=blue; Expires=%s" % (self.age_string)
 
 
         # 1 cookie with name/value and Expires
         s = 'color=blue; Expires=%s' % (self.expires_string)
         cookies = Cookie.parse(s)
-        self.assertEqual(len(cookies), 1)
+        assert len(cookies) == 1
         cookie = cookies[0]
         # Force timestamp to known value
         cookie.timestamp = self.now
-        self.assertEqual(cookie.key, 'color')
-        self.assertEqual(cookie.value, 'blue')
-        self.assertEqual(cookie.domain, None)
-        self.assertEqual(cookie.path, None)
-        self.assertEqual(cookie.max_age, None)
-        self.assertEqual(cookie.expires, self.expires)
-        self.assertEqual(cookie.secure, None)
-        self.assertEqual(cookie.httponly, None)
-        self.assertEqual(str(cookie), "color=blue; Expires=%s" % (self.expires_string))
-        self.assertEqual(cookie.get_expiration(), self.expires)
+        assert cookie.key == 'color'
+        assert cookie.value == 'blue'
+        assert cookie.domain is None
+        assert cookie.path is None
+        assert cookie.max_age is None
+        assert cookie.expires == self.expires
+        assert cookie.secure is None
+        assert cookie.httponly is None
+        assert str(cookie) == "color=blue; Expires=%s" % (self.expires_string)
+        assert cookie.get_expiration() == self.expires
         # Normalize
-        self.assertEqual(cookie.normalize_expiration(), self.expires)
-        self.assertEqual(cookie.max_age, None)
-        self.assertEqual(cookie.expires, self.expires)
-        self.assertEqual(str(cookie), "color=blue; Expires=%s" % (self.expires_string))
+        assert cookie.normalize_expiration() == self.expires
+        assert cookie.max_age is None
+        assert cookie.expires == self.expires
+        assert str(cookie) == "color=blue; Expires=%s" % (self.expires_string)
 
         # 1 cookie with name/value witht both Max-Age and Expires, Max-Age takes precedence
         s = 'color=blue; Expires=%s; max-age=%d' % (self.expires_string, self.max_age)
         cookies = Cookie.parse(s)
-        self.assertEqual(len(cookies), 1)
+        assert len(cookies) == 1
         cookie = cookies[0]
         # Force timestamp to known value
         cookie.timestamp = self.now
-        self.assertEqual(cookie.key, 'color')
-        self.assertEqual(cookie.value, 'blue')
-        self.assertEqual(cookie.domain, None)
-        self.assertEqual(cookie.path, None)
-        self.assertEqual(cookie.max_age, self.max_age)
-        self.assertEqual(cookie.expires, self.expires)
-        self.assertEqual(cookie.secure, None)
-        self.assertEqual(cookie.httponly, None)
-        self.assertEqual(str(cookie), "color=blue; Max-Age=%d; Expires=%s" % (self.max_age, self.expires_string))
-        self.assertEqual(cookie.get_expiration(), self.age_expiration)
+        assert cookie.key == 'color'
+        assert cookie.value == 'blue'
+        assert cookie.domain is None
+        assert cookie.path is None
+        assert cookie.max_age == self.max_age
+        assert cookie.expires == self.expires
+        assert cookie.secure is None
+        assert cookie.httponly is None
+        expected = "color=blue; Max-Age={}; Expires={}".format(
+            self.max_age, self.expires_string)
+        assert str(cookie) == expected
+        assert cookie.get_expiration() == self.age_expiration
         # Normalize
-        self.assertEqual(cookie.normalize_expiration(), self.age_expiration)
-        self.assertEqual(cookie.max_age, None)
-        self.assertEqual(cookie.expires, self.age_expiration)
-        self.assertEqual(str(cookie), "color=blue; Expires=%s" % (self.age_string))
+        assert cookie.normalize_expiration() == self.age_expiration
+        assert cookie.max_age is None
+        assert cookie.expires == self.age_expiration
+        assert str(cookie) == "color=blue; Expires=%s" % (self.age_string)
 
         # Verify different types can be assigned to the timestamp and
         # expires attribute.
 
         cookie = Cookie('color', 'blue')
         cookie.timestamp = self.now
-        self.assertEqual(cookie.timestamp, self.now)
+        assert cookie.timestamp == self.now
         cookie.timestamp = self.now_timestamp
-        self.assertEqual(cookie.timestamp, self.now)
+        assert cookie.timestamp == self.now
         cookie.timestamp = self.now_string
-        self.assertEqual(cookie.timestamp, self.now)
+        assert cookie.timestamp == self.now
 
-        self.assertEqual(cookie.expires, None)
+        assert cookie.expires is None
 
         cookie.expires = self.expires
-        self.assertEqual(cookie.expires, self.expires)
+        assert cookie.expires == self.expires
         cookie.expires = self.expires_timestamp
-        self.assertEqual(cookie.expires, self.expires)
+        assert cookie.expires == self.expires
         cookie.expires = self.expires_string
-        self.assertEqual(cookie.expires, self.expires)
+        assert cookie.expires == self.expires
 
-class TestInvalidAttributes(unittest.TestCase):
+
+class TestInvalidAttributes:
     def test_invalid(self):
         # Invalid Max-Age
         s = 'color=blue; Max-Age=over-the-hill'
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             Cookie.parse(s)
 
         cookie = Cookie('color', 'blue')
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             cookie.max_age = 'over-the-hill'
 
         # Invalid Expires
         s = 'color=blue; Expires=Sun, 06 Xxx 1994 08:49:37 GMT'
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             Cookie.parse(s)
 
         cookie = Cookie('color', 'blue')
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             cookie.expires = 'Sun, 06 Xxx 1994 08:49:37 GMT'
 
 
-class TestAttributes(unittest.TestCase):
+class TestAttributes:
     def test_attributes(self):
         cookie = Cookie('color', 'blue')
-        self.assertEqual(cookie.key, 'color')
-        self.assertEqual(cookie.value, 'blue')
-        self.assertEqual(cookie.domain, None)
-        self.assertEqual(cookie.path, None)
-        self.assertEqual(cookie.max_age, None)
-        self.assertEqual(cookie.expires, None)
-        self.assertEqual(cookie.secure, None)
-        self.assertEqual(cookie.httponly, None)
+        assert cookie.key == 'color'
+        assert cookie.value == 'blue'
+        assert cookie.domain is None
+        assert cookie.path is None
+        assert cookie.max_age is None
+        assert cookie.expires is None
+        assert cookie.secure is None
+        assert cookie.httponly is None
 
         cookie.domain = 'example.com'
-        self.assertEqual(cookie.domain, 'example.com')
+        assert cookie.domain == 'example.com'
         cookie.domain = None
-        self.assertEqual(cookie.domain, None)
+        assert cookie.domain is None
 
         cookie.path = '/toplevel'
-        self.assertEqual(cookie.path, '/toplevel')
+        assert cookie.path == '/toplevel'
         cookie.path = None
-        self.assertEqual(cookie.path, None)
+        assert cookie.path is None
 
         cookie.max_age = 400
-        self.assertEqual(cookie.max_age, 400)
+        assert cookie.max_age == 400
         cookie.max_age = None
-        self.assertEqual(cookie.max_age, None)
+        assert cookie.max_age is None
 
         cookie.expires = 'Sun, 06 Nov 1994 08:49:37 GMT'
-        self.assertEqual(cookie.expires, datetime.datetime(1994, 11, 6, 8, 49, 37))
+        assert cookie.expires == datetime.datetime(1994, 11, 6, 8, 49, 37)
         cookie.expires = None
-        self.assertEqual(cookie.expires, None)
+        assert cookie.expires is None
 
         cookie.secure = True
-        self.assertEqual(cookie.secure, True)
-        self.assertEqual(str(cookie), "color=blue; Secure")
+        assert cookie.secure is True
+        assert str(cookie) == "color=blue; Secure"
         cookie.secure = False
-        self.assertEqual(cookie.secure, False)
-        self.assertEqual(str(cookie), "color=blue")
+        assert cookie.secure is False
+        assert str(cookie) == "color=blue"
         cookie.secure = None
-        self.assertEqual(cookie.secure, None)
-        self.assertEqual(str(cookie), "color=blue")
+        assert cookie.secure is None
+        assert str(cookie) == "color=blue"
 
         cookie.httponly = True
-        self.assertEqual(cookie.httponly, True)
-        self.assertEqual(str(cookie), "color=blue; HttpOnly")
+        assert cookie.httponly is True
+        assert str(cookie) == "color=blue; HttpOnly"
         cookie.httponly = False
-        self.assertEqual(cookie.httponly, False)
-        self.assertEqual(str(cookie), "color=blue")
+        assert cookie.httponly is False
+        assert str(cookie) == "color=blue"
         cookie.httponly = None
-        self.assertEqual(cookie.httponly, None)
-        self.assertEqual(str(cookie), "color=blue")
+        assert cookie.httponly is None
+        assert str(cookie) == "color=blue"
 
 
-class TestHTTPReturn(unittest.TestCase):
-    def setUp(self):
+class TestHTTPReturn:
+    @pytest.fixture(autouse=True)
+    def http_return_setup(self):
         self.url = 'http://www.foo.bar.com/one/two'
 
     def test_no_attributes(self):
         cookie = Cookie('color', 'blue')
-        self.assertTrue(cookie.http_return_ok(self.url))
+        assert cookie.http_return_ok(self.url)
 
     def test_domain(self):
         cookie = Cookie('color', 'blue', domain='www.foo.bar.com')
-        self.assertTrue(cookie.http_return_ok(self.url))
+        assert cookie.http_return_ok(self.url)
 
         cookie = Cookie('color', 'blue', domain='.foo.bar.com')
-        self.assertTrue(cookie.http_return_ok(self.url))
+        assert cookie.http_return_ok(self.url)
 
         cookie = Cookie('color', 'blue', domain='.bar.com')
-        self.assertTrue(cookie.http_return_ok(self.url))
+        assert cookie.http_return_ok(self.url)
 
         cookie = Cookie('color', 'blue', domain='bar.com')
-        with self.assertRaises(Cookie.URLMismatch):
-            self.assertTrue(cookie.http_return_ok(self.url))
+        with pytest.raises(Cookie.URLMismatch):
+            assert cookie.http_return_ok(self.url)
 
         cookie = Cookie('color', 'blue', domain='bogus.com')
-        with self.assertRaises(Cookie.URLMismatch):
-            self.assertTrue(cookie.http_return_ok(self.url))
+        with pytest.raises(Cookie.URLMismatch):
+            assert cookie.http_return_ok(self.url)
 
         cookie = Cookie('color', 'blue', domain='www.foo.bar.com')
-        with self.assertRaises(Cookie.URLMismatch):
-            self.assertTrue(cookie.http_return_ok('http://192.168.1.1/one/two'))
+        with pytest.raises(Cookie.URLMismatch):
+            assert cookie.http_return_ok('http://192.168.1.1/one/two')
 
     def test_path(self):
         cookie = Cookie('color', 'blue')
-        self.assertTrue(cookie.http_return_ok(self.url))
+        assert cookie.http_return_ok(self.url)
 
         cookie = Cookie('color', 'blue', path='/')
-        self.assertTrue(cookie.http_return_ok(self.url))
+        assert cookie.http_return_ok(self.url)
 
         cookie = Cookie('color', 'blue', path='/one')
-        self.assertTrue(cookie.http_return_ok(self.url))
+        assert cookie.http_return_ok(self.url)
 
         cookie = Cookie('color', 'blue', path='/oneX')
-        with self.assertRaises(Cookie.URLMismatch):
-            self.assertTrue(cookie.http_return_ok(self.url))
+        with pytest.raises(Cookie.URLMismatch):
+            assert cookie.http_return_ok(self.url)
 
     def test_expires(self):
         now = datetime.datetime.utcnow().replace(microsecond=0)
@@ -399,32 +404,34 @@ class TestHTTPReturn(unittest.TestCase):
         expires = now + datetime.timedelta(days=1)
 
         cookie = Cookie('color', 'blue', expires=expires)
-        self.assertTrue(cookie.http_return_ok(self.url))
+        assert cookie.http_return_ok(self.url)
 
         # expired 1 day ago
         expires = now + datetime.timedelta(days=-1)
         cookie = Cookie('color', 'blue', expires=expires)
-        with self.assertRaises(Cookie.Expired):
-            self.assertTrue(cookie.http_return_ok(self.url))
+        with pytest.raises(Cookie.Expired):
+            assert cookie.http_return_ok(self.url)
 
 
     def test_httponly(self):
         cookie = Cookie('color', 'blue', httponly=True)
-        self.assertTrue(cookie.http_return_ok('http://example.com'))
-        self.assertTrue(cookie.http_return_ok('https://example.com'))
+        assert cookie.http_return_ok('http://example.com')
+        assert cookie.http_return_ok('https://example.com')
 
-        with self.assertRaises(Cookie.URLMismatch):
-            self.assertTrue(cookie.http_return_ok('ftp://example.com'))
+        with pytest.raises(Cookie.URLMismatch):
+            assert cookie.http_return_ok('ftp://example.com')
 
     def test_secure(self):
         cookie = Cookie('color', 'blue', secure=True)
-        self.assertTrue(cookie.http_return_ok('https://Xexample.com'))
+        assert cookie.http_return_ok('https://Xexample.com')
 
-        with self.assertRaises(Cookie.URLMismatch):
-            self.assertTrue(cookie.http_return_ok('http://Xexample.com'))
+        with pytest.raises(Cookie.URLMismatch):
+            assert cookie.http_return_ok('http://Xexample.com')
 
-class TestNormalization(unittest.TestCase):
-    def setUp(self):
+
+class TestNormalization:
+    @pytest.fixture(autouse=True)
+    def normalization_setup(self):
         # Force microseconds to zero because cookie timestamps only have second resolution
         self.now = datetime.datetime.utcnow().replace(microsecond=0)
         self.now_timestamp = calendar.timegm(self.now.utctimetuple())
@@ -440,58 +447,53 @@ class TestNormalization(unittest.TestCase):
         self.expires_string = email.utils.formatdate(self.expires_timestamp, usegmt=True)
 
     def test_path_normalization(self):
-        self.assertEqual(Cookie.normalize_url_path(''),          '/')
-        self.assertEqual(Cookie.normalize_url_path('foo'),       '/')
-        self.assertEqual(Cookie.normalize_url_path('foo/'),      '/')
-        self.assertEqual(Cookie.normalize_url_path('/foo'),      '/')
-        self.assertEqual(Cookie.normalize_url_path('/foo/'),     '/foo')
-        self.assertEqual(Cookie.normalize_url_path('/Foo/bar'),  '/foo')
-        self.assertEqual(Cookie.normalize_url_path('/foo/baR/'), '/foo/bar')
+        assert Cookie.normalize_url_path('') == '/'
+        assert Cookie.normalize_url_path('foo') == '/'
+        assert Cookie.normalize_url_path('foo/') == '/'
+        assert Cookie.normalize_url_path('/foo') == '/'
+        assert Cookie.normalize_url_path('/foo/') == '/foo'
+        assert Cookie.normalize_url_path('/Foo/bar') == '/foo'
+        assert Cookie.normalize_url_path('/foo/baR/') == '/foo/bar'
 
     def test_normalization(self):
         cookie = Cookie('color', 'blue', expires=self.expires)
         cookie.timestamp = self.now_timestamp
 
-        self.assertEqual(cookie.domain, None)
-        self.assertEqual(cookie.path, None)
+        assert cookie.domain is None
+        assert cookie.path is None
 
         url = 'http://example.COM/foo'
         cookie.normalize(url)
-        self.assertEqual(cookie.domain, 'example.com')
-        self.assertEqual(cookie.path, '/')
-        self.assertEqual(cookie.expires, self.expires)
+        assert cookie.domain == 'example.com'
+        assert cookie.path == '/'
+        assert cookie.expires == self.expires
 
         cookie = Cookie('color', 'blue', max_age=self.max_age)
         cookie.timestamp = self.now_timestamp
 
-        self.assertEqual(cookie.domain, None)
-        self.assertEqual(cookie.path, None)
+        assert cookie.domain is None
+        assert cookie.path is None
 
         url = 'http://example.com/foo/'
         cookie.normalize(url)
-        self.assertEqual(cookie.domain, 'example.com')
-        self.assertEqual(cookie.path, '/foo')
-        self.assertEqual(cookie.expires, self.age_expiration)
+        assert cookie.domain == 'example.com'
+        assert cookie.path == '/foo'
+        assert cookie.expires == self.age_expiration
 
         cookie = Cookie('color', 'blue')
         url = 'http://example.com/foo'
         cookie.normalize(url)
-        self.assertEqual(cookie.domain, 'example.com')
-        self.assertEqual(cookie.path, '/')
+        assert cookie.domain == 'example.com'
+        assert cookie.path == '/'
 
         cookie = Cookie('color', 'blue')
         url = 'http://example.com/foo/bar'
         cookie.normalize(url)
-        self.assertEqual(cookie.domain, 'example.com')
-        self.assertEqual(cookie.path, '/foo')
+        assert cookie.domain == 'example.com'
+        assert cookie.path == '/foo'
 
         cookie = Cookie('color', 'blue')
         url = 'http://example.com/foo/bar/'
         cookie.normalize(url)
-        self.assertEqual(cookie.domain, 'example.com')
-        self.assertEqual(cookie.path, '/foo/bar')
-
-
-#-------------------------------------------------------------------------------
-if __name__ == '__main__':
-    unittest.main()
+        assert cookie.domain == 'example.com'
+        assert cookie.path == '/foo/bar'

--- a/ipatests/test_ipapython/test_dn.py
+++ b/ipatests/test_ipapython/test_dn.py
@@ -1,6 +1,5 @@
 
 import contextlib
-import unittest
 import pytest
 
 from cryptography import x509
@@ -59,8 +58,9 @@ def expected_class(klass, component):
     raise ValueError("class %s with component '%s' unknown" % (klass.__name__, component))
 
 
-class TestAVA(unittest.TestCase):
-    def setUp(self):
+class TestAVA:
+    @pytest.fixture(autouse=True)
+    def ava_setup(self):
         self.attr1    = 'cn'
         self.value1   = 'Bob'
         self.str_ava1 = '%s=%s' % (self.attr1, self.value1)
@@ -77,159 +77,159 @@ class TestAVA(unittest.TestCase):
         self.ava3     = AVA(self.attr3, self.value3)
 
     def assertExpectedClass(self, klass, obj, component):
-        self.assertIs(obj.__class__, expected_class(klass, component))
+        assert obj.__class__ is expected_class(klass, component)
 
     def test_create(self):
         # Create with attr,value pair
         ava1 = AVA(self.attr1, self.value1)
         self.assertExpectedClass(AVA, ava1, 'self')
-        self.assertEqual(ava1, self.ava1)
+        assert ava1 == self.ava1
 
         # Create with "attr=value" string
         ava1 = AVA(self.str_ava1)
         self.assertExpectedClass(AVA, ava1, 'self')
-        self.assertEqual(ava1, self.ava1)
+        assert ava1 == self.ava1
 
         # Create with tuple (attr, value)
         ava1 = AVA((self.attr1, self.value1))
         self.assertExpectedClass(AVA, ava1, 'self')
-        self.assertEqual(ava1, self.ava1)
+        assert ava1 == self.ava1
 
         # Create with list [attr, value]
         ava1 = AVA([self.attr1, self.value1])
         self.assertExpectedClass(AVA, ava1, 'self')
-        self.assertEqual(ava1, self.ava1)
+        assert ava1 == self.ava1
 
         # Create with no args should fail
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             AVA()
 
         # Create with more than 3 args should fail
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             AVA(self.attr1, self.value1, self.attr1, self.attr1)
 
         # Create with 1 arg which is not string should fail
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             AVA(1)
 
         # Create with malformed AVA string should fail
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             AVA("cn")
 
         # Create with non-string parameters, should convert
         ava1 = AVA(1, self.value1)
         self.assertExpectedClass(AVA, ava1, 'self')
-        self.assertEqual(ava1.attr, u'1')
+        assert ava1.attr == u'1'
 
         ava1 = AVA((1, self.value1))
         self.assertExpectedClass(AVA, ava1, 'self')
-        self.assertEqual(ava1.attr, u'1')
+        assert ava1.attr == u'1'
 
         ava1 = AVA(self.attr1, 1)
         self.assertExpectedClass(AVA, ava1, 'self')
-        self.assertEqual(ava1.value, u'1')
+        assert ava1.value == u'1'
 
         ava1 = AVA((self.attr1, 1))
         self.assertExpectedClass(AVA, ava1, 'self')
-        self.assertEqual(ava1.value, u'1')
+        assert ava1.value == u'1'
 
     def test_indexing(self):
         ava1 = AVA(self.ava1)
 
-        self.assertEqual(ava1[self.attr1], self.value1)
+        assert ava1[self.attr1] == self.value1
 
-        self.assertEqual(ava1[0], self.attr1)
-        self.assertEqual(ava1[1], self.value1)
+        assert ava1[0] == self.attr1
+        assert ava1[1] == self.value1
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             ava1['foo']  # pylint: disable=pointless-statement
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             ava1[3]  # pylint: disable=pointless-statement
 
     def test_properties(self):
         ava1 = AVA(self.ava1)
 
-        self.assertEqual(ava1.attr, self.attr1)
-        self.assertIsInstance(ava1.attr, unicode)
+        assert ava1.attr == self.attr1
+        assert isinstance(ava1.attr, unicode)
 
-        self.assertEqual(ava1.value, self.value1)
-        self.assertIsInstance(ava1.value, unicode)
+        assert ava1.value == self.value1
+        assert isinstance(ava1.value, unicode)
 
     def test_str(self):
         ava1 = AVA(self.ava1)
 
-        self.assertEqual(str(ava1), self.str_ava1)
-        self.assertIsInstance(str(ava1), str)
+        assert str(ava1) == self.str_ava1
+        assert isinstance(str(ava1), str)
 
     def test_cmp(self):
         # Equality
         ava1 = AVA(self.attr1, self.value1)
 
-        self.assertTrue(ava1 == self.ava1)
-        self.assertFalse(ava1 != self.ava1)
+        assert ava1 == self.ava1
+        assert ava1 == self.ava1
 
-        self.assertTrue(ava1 == self.str_ava1)
-        self.assertFalse(ava1 != self.str_ava1)
+        assert ava1 == self.str_ava1
+        assert ava1 == self.str_ava1
 
         result = cmp(ava1, self.ava1)
-        self.assertEqual(result, 0)
+        assert result == 0
 
         # Upper case attr should still be equal
         ava1 = AVA(self.attr1.upper(), self.value1)
 
-        self.assertFalse(ava1.attr == self.attr1)
-        self.assertTrue(ava1.value == self.value1)
-        self.assertTrue(ava1 == self.ava1)
-        self.assertFalse(ava1 != self.ava1)
+        assert ava1.attr != self.attr1
+        assert ava1.value == self.value1
+        assert ava1 == self.ava1
+        assert ava1 == self.ava1
 
         result = cmp(ava1, self.ava1)
-        self.assertEqual(result, 0)
+        assert result == 0
 
         # Upper case value should still be equal
         ava1 = AVA(self.attr1, self.value1.upper())
 
-        self.assertTrue(ava1.attr == self.attr1)
-        self.assertFalse(ava1.value == self.value1)
-        self.assertTrue(ava1 == self.ava1)
-        self.assertFalse(ava1 != self.ava1)
+        assert ava1.attr == self.attr1
+        assert ava1.value != self.value1
+        assert ava1 == self.ava1
+        assert ava1 == self.ava1
 
         result = cmp(ava1, self.ava1)
-        self.assertEqual(result, 0)
+        assert result == 0
 
         # Make ava1's attr greater
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             ava1.attr = self.attr1 + "1"
         ava1 = AVA(self.attr1 + "1", self.value1.upper())
 
-        self.assertFalse(ava1 == self.ava1)
-        self.assertTrue(ava1 != self.ava1)
+        assert ava1 != self.ava1
+        assert ava1 != self.ava1
 
         result = cmp(ava1, self.ava1)
-        self.assertEqual(result, 1)
+        assert result == 1
 
         result = cmp(self.ava1, ava1)
-        self.assertEqual(result, -1)
+        assert result == -1
 
         # Reset ava1's attr, should be equal again
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             ava1.attr = self.attr1
         ava1 = AVA(self.attr1, self.value1.upper())
 
         result = cmp(ava1, self.ava1)
-        self.assertEqual(result, 0)
+        assert result == 0
 
         # Make ava1's value greater
         # attr will be equal, this tests secondary comparision component
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             ava1.value = self.value1 + "1"
         ava1 = AVA(self.attr1, self.value1 + "1")
 
         result = cmp(ava1, self.ava1)
-        self.assertEqual(result, 1)
+        assert result == 1
 
         result = cmp(self.ava1, ava1)
-        self.assertEqual(result, -1)
+        assert result == -1
 
     def test_hashing(self):
         # create AVA's that are equal but differ in case
@@ -237,8 +237,8 @@ class TestAVA(unittest.TestCase):
         ava2 = AVA((self.attr1.upper(), self.value1.lower()))
 
         # AVAs that are equal should hash to the same value.
-        self.assertEqual(ava1, ava2)
-        self.assertEqual(hash(ava1), hash(ava2))
+        assert ava1 == ava2
+        assert hash(ava1) == hash(ava2)
 
         # Different AVA objects with the same value should
         # map to 1 common key and 1 member in a set. The key and
@@ -253,9 +253,9 @@ class TestAVA(unittest.TestCase):
         ava3_a = AVA(self.ava3)
         ava3_b = AVA(self.ava3)
 
-        self.assertEqual(ava1_a, ava1_b)
-        self.assertEqual(ava2_a, ava2_b)
-        self.assertEqual(ava3_a, ava3_b)
+        assert ava1_a == ava1_b
+        assert ava2_a == ava2_b
+        assert ava3_a == ava3_b
 
         d = dict()
         s = set()
@@ -270,28 +270,29 @@ class TestAVA(unittest.TestCase):
         s.add(ava2_a)
         s.add(ava2_b)
 
-        self.assertEqual(len(d), 2)
-        self.assertEqual(len(s), 2)
-        self.assertEqual(sorted(d), sorted([ava1_a, ava2_a]))
-        self.assertEqual(sorted(s), sorted([ava1_a, ava2_a]))
+        assert len(d) == 2
+        assert len(s) == 2
+        assert sorted(d) == sorted([ava1_a, ava2_a])
+        assert sorted(s) == sorted([ava1_a, ava2_a])
 
-        self.assertTrue(ava1_a in d)
-        self.assertTrue(ava1_b in d)
-        self.assertTrue(ava2_a in d)
-        self.assertTrue(ava2_b in d)
-        self.assertFalse(ava3_a in d)
-        self.assertFalse(ava3_b in d)
+        assert ava1_a in d
+        assert ava1_b in d
+        assert ava2_a in d
+        assert ava2_b in d
+        assert ava3_a not in d
+        assert ava3_b not in d
 
-        self.assertTrue(ava1_a in s)
-        self.assertTrue(ava1_b in s)
-        self.assertTrue(ava2_a in s)
-        self.assertTrue(ava2_b in s)
-        self.assertFalse(ava3_a in s)
-        self.assertFalse(ava3_b in s)
+        assert ava1_a in s
+        assert ava1_b in s
+        assert ava2_a in s
+        assert ava2_b in s
+        assert ava3_a not in s
+        assert ava3_b not in s
 
 
-class TestRDN(unittest.TestCase):
-    def setUp(self):
+class TestRDN:
+    @pytest.fixture(autouse=True)
+    def rdn_setup(self):
         # ava1 must sort before ava2
         self.attr1    = 'cn'
         self.value1   = 'Bob'
@@ -315,222 +316,221 @@ class TestRDN(unittest.TestCase):
         self.rdn3 = RDN(self.ava1, self.ava2)
 
     def assertExpectedClass(self, klass, obj, component):
-        self.assertIs(obj.__class__, expected_class(klass, component))
+        assert obj.__class__ is expected_class(klass, component)
 
     def test_create(self):
         # Create with single attr,value pair
         rdn1 = RDN((self.attr1, self.value1))
 
-
-        self.assertEqual(len(rdn1), 1)
-        self.assertEqual(rdn1, self.rdn1)
+        assert len(rdn1) == 1
+        assert rdn1 == self.rdn1
         self.assertExpectedClass(RDN, rdn1, 'self')
         for i in range(0, len(rdn1)):
             self.assertExpectedClass(RDN, rdn1[i], 'AVA')
-        self.assertEqual(rdn1[0], self.ava1)
+        assert rdn1[0] == self.ava1
 
         # Create with multiple attr,value pairs
         rdn3 = RDN((self.attr1, self.value1), (self.attr2, self.value2))
-        self.assertEqual(len(rdn3), 2)
-        self.assertEqual(rdn3, self.rdn3)
+        assert len(rdn3) == 2
+        assert rdn3 == self.rdn3
         self.assertExpectedClass(RDN, rdn3, 'self')
         for i in range(0, len(rdn3)):
             self.assertExpectedClass(RDN, rdn3[i], 'AVA')
-        self.assertEqual(rdn3[0], self.ava1)
-        self.assertEqual(rdn3[1], self.ava2)
+        assert rdn3[0] == self.ava1
+        assert rdn3[1] == self.ava2
 
         # Create with multiple attr,value pairs passed as lists
         rdn3 = RDN([self.attr1, self.value1], [self.attr2, self.value2])
-        self.assertEqual(len(rdn3), 2)
-        self.assertEqual(rdn3, self.rdn3)
+        assert len(rdn3) == 2
+        assert rdn3 == self.rdn3
         self.assertExpectedClass(RDN, rdn3, 'self')
         for i in range(0, len(rdn3)):
             self.assertExpectedClass(RDN, rdn3[i], 'AVA')
-        self.assertEqual(rdn3[0], self.ava1)
-        self.assertEqual(rdn3[1], self.ava2)
+        assert rdn3[0] == self.ava1
+        assert rdn3[1] == self.ava2
 
         # Create with multiple attr,value pairs but reverse
         # constructor parameter ordering. RDN canonical ordering
         # should remain the same
         rdn3 = RDN((self.attr2, self.value2), (self.attr1, self.value1))
-        self.assertEqual(len(rdn3), 2)
-        self.assertEqual(rdn3, self.rdn3)
+        assert len(rdn3) == 2
+        assert rdn3 == self.rdn3
         self.assertExpectedClass(RDN, rdn3, 'self')
         for i in range(0, len(rdn3)):
             self.assertExpectedClass(RDN, rdn3[i], 'AVA')
-        self.assertEqual(rdn3[0], self.ava1)
-        self.assertEqual(rdn3[1], self.ava2)
+        assert rdn3[0] == self.ava1
+        assert rdn3[1] == self.ava2
 
         # Create with single AVA object
         rdn1 = RDN(self.ava1)
-        self.assertEqual(len(rdn1), 1)
-        self.assertEqual(rdn1, self.rdn1)
+        assert len(rdn1) == 1
+        assert rdn1 == self.rdn1
         self.assertExpectedClass(RDN, rdn1, 'self')
         for i in range(0, len(rdn1)):
             self.assertExpectedClass(RDN, rdn1[i], 'AVA')
-        self.assertEqual(rdn1[0], self.ava1)
+        assert rdn1[0] == self.ava1
 
         # Create with multiple AVA objects
         rdn3 = RDN(self.ava1, self.ava2)
-        self.assertEqual(len(rdn3), 2)
-        self.assertEqual(rdn3, self.rdn3)
+        assert len(rdn3) == 2
+        assert rdn3 == self.rdn3
         self.assertExpectedClass(RDN, rdn3, 'self')
         for i in range(0, len(rdn3)):
             self.assertExpectedClass(RDN, rdn3[i], 'AVA')
-        self.assertEqual(rdn3[0], self.ava1)
-        self.assertEqual(rdn3[1], self.ava2)
+        assert rdn3[0] == self.ava1
+        assert rdn3[1] == self.ava2
 
 
         # Create with multiple AVA objects but reverse constructor
         # parameter ordering.  RDN canonical ordering should remain
         # the same
         rdn3 = RDN(self.ava2, self.ava1)
-        self.assertEqual(len(rdn3), 2)
-        self.assertEqual(rdn3, self.rdn3)
+        assert len(rdn3) == 2
+        assert rdn3 == self.rdn3
         self.assertExpectedClass(RDN, rdn3, 'self')
         for i in range(0, len(rdn3)):
             self.assertExpectedClass(RDN, rdn3[i], 'AVA')
-        self.assertEqual(rdn3[0], self.ava1)
-        self.assertEqual(rdn3[1], self.ava2)
+        assert rdn3[0] == self.ava1
+        assert rdn3[1] == self.ava2
 
         # Create with single string with 1 AVA
         rdn1 = RDN(self.str_rdn1)
-        self.assertEqual(len(rdn1), 1)
-        self.assertEqual(rdn1, self.rdn1)
+        assert len(rdn1) == 1
+        assert rdn1 == self.rdn1
         self.assertExpectedClass(RDN, rdn1, 'self')
         for i in range(0, len(rdn1)):
             self.assertExpectedClass(RDN, rdn1[i], 'AVA')
-        self.assertEqual(rdn1[0], self.ava1)
+        assert rdn1[0] == self.ava1
 
         # Create with single string with 2 AVA's
         rdn3 = RDN(self.str_rdn3)
-        self.assertEqual(len(rdn3), 2)
-        self.assertEqual(rdn3, self.rdn3)
+        assert len(rdn3) == 2
+        assert rdn3 == self.rdn3
         self.assertExpectedClass(RDN, rdn3, 'self')
         for i in range(0, len(rdn3)):
             self.assertExpectedClass(RDN, rdn3[i], 'AVA')
-        self.assertEqual(rdn3[0], self.ava1)
-        self.assertEqual(rdn3[1], self.ava2)
+        assert rdn3[0] == self.ava1
+        assert rdn3[1] == self.ava2
 
     def test_properties(self):
         rdn1 = RDN(self.rdn1)
         rdn2 = RDN(self.rdn2)
         rdn3 = RDN(self.rdn3)
 
-        self.assertEqual(rdn1.attr, self.attr1)
-        self.assertIsInstance(rdn1.attr, unicode)
+        assert rdn1.attr == self.attr1
+        assert isinstance(rdn1.attr, unicode)
 
-        self.assertEqual(rdn1.value, self.value1)
-        self.assertIsInstance(rdn1.value, unicode)
+        assert rdn1.value == self.value1
+        assert isinstance(rdn1.value, unicode)
 
-        self.assertEqual(rdn2.attr, self.attr2)
-        self.assertIsInstance(rdn2.attr, unicode)
+        assert rdn2.attr == self.attr2
+        assert isinstance(rdn2.attr, unicode)
 
-        self.assertEqual(rdn2.value, self.value2)
-        self.assertIsInstance(rdn2.value, unicode)
+        assert rdn2.value == self.value2
+        assert isinstance(rdn2.value, unicode)
 
-        self.assertEqual(rdn3.attr, self.attr1)
-        self.assertIsInstance(rdn3.attr, unicode)
+        assert rdn3.attr == self.attr1
+        assert isinstance(rdn3.attr, unicode)
 
-        self.assertEqual(rdn3.value, self.value1)
-        self.assertIsInstance(rdn3.value, unicode)
+        assert rdn3.value == self.value1
+        assert isinstance(rdn3.value, unicode)
 
     def test_str(self):
         rdn1 = RDN(self.rdn1)
         rdn2 = RDN(self.rdn2)
         rdn3 = RDN(self.rdn3)
 
-        self.assertEqual(str(rdn1), self.str_rdn1)
-        self.assertIsInstance(str(rdn1), str)
+        assert str(rdn1) == self.str_rdn1
+        assert isinstance(str(rdn1), str)
 
-        self.assertEqual(str(rdn2), self.str_rdn2)
-        self.assertIsInstance(str(rdn2), str)
+        assert str(rdn2) == self.str_rdn2
+        assert isinstance(str(rdn2), str)
 
-        self.assertEqual(str(rdn3), self.str_rdn3)
-        self.assertIsInstance(str(rdn3), str)
+        assert str(rdn3) == self.str_rdn3
+        assert isinstance(str(rdn3), str)
 
     def test_cmp(self):
         # Equality
         rdn1 = RDN((self.attr1, self.value1))
 
-        self.assertTrue(rdn1 == self.rdn1)
-        self.assertFalse(rdn1 != self.rdn1)
+        assert rdn1 == self.rdn1
+        assert rdn1 == self.rdn1
 
-        self.assertTrue(rdn1 == self.str_rdn1)
-        self.assertFalse(rdn1 != self.str_rdn1)
+        assert rdn1 == self.str_rdn1
+        assert rdn1 == self.str_rdn1
 
         result = cmp(rdn1, self.rdn1)
-        self.assertEqual(result, 0)
+        assert result == 0
 
         # Make rdn1's attr greater
         rdn1 = RDN((self.attr1 + "1", self.value1))
 
-        self.assertFalse(rdn1 == self.rdn1)
-        self.assertTrue(rdn1 != self.rdn1)
+        assert rdn1 != self.rdn1
+        assert rdn1 != self.rdn1
 
         result = cmp(rdn1, self.rdn1)
-        self.assertEqual(result, 1)
+        assert result == 1
 
         result = cmp(self.rdn1, rdn1)
-        self.assertEqual(result, -1)
+        assert result == -1
 
         # Reset rdn1's attr, should be equal again
         rdn1 = RDN((self.attr1, self.value1))
 
         result = cmp(rdn1, self.rdn1)
-        self.assertEqual(result, 0)
+        assert result == 0
 
         # Make rdn1's value greater
         # attr will be equal, this tests secondary comparision component
         rdn1 = RDN((self.attr1, self.value1 + "1"))
 
         result = cmp(rdn1, self.rdn1)
-        self.assertEqual(result, 1)
+        assert result == 1
 
         result = cmp(self.rdn1, rdn1)
-        self.assertEqual(result, -1)
+        assert result == -1
 
         # Make sure rdn's with more ava's are greater
         result = cmp(self.rdn1, self.rdn3)
-        self.assertEqual(result, -1)
+        assert result == -1
         result = cmp(self.rdn3, self.rdn1)
-        self.assertEqual(result, 1)
+        assert result == 1
 
     def test_indexing(self):
         rdn1 = RDN(self.rdn1)
         rdn2 = RDN(self.rdn2)
         rdn3 = RDN(self.rdn3)
 
-        self.assertEqual(rdn1[0], self.ava1)
-        self.assertEqual(rdn1[self.ava1.attr], self.ava1.value)
-        with self.assertRaises(KeyError):
+        assert rdn1[0] == self.ava1
+        assert rdn1[self.ava1.attr] == self.ava1.value
+        with pytest.raises(KeyError):
             rdn1['foo']  # pylint: disable=pointless-statement
 
-        self.assertEqual(rdn2[0], self.ava2)
-        self.assertEqual(rdn2[self.ava2.attr], self.ava2.value)
-        with self.assertRaises(KeyError):
+        assert rdn2[0] == self.ava2
+        assert rdn2[self.ava2.attr] == self.ava2.value
+        with pytest.raises(KeyError):
             rdn2['foo']  # pylint: disable=pointless-statement
 
-        self.assertEqual(rdn3[0], self.ava1)
-        self.assertEqual(rdn3[self.ava1.attr], self.ava1.value)
-        self.assertEqual(rdn3[1], self.ava2)
-        self.assertEqual(rdn3[self.ava2.attr], self.ava2.value)
-        with self.assertRaises(KeyError):
+        assert rdn3[0] == self.ava1
+        assert rdn3[self.ava1.attr] == self.ava1.value
+        assert rdn3[1] == self.ava2
+        assert rdn3[self.ava2.attr] == self.ava2.value
+        with pytest.raises(KeyError):
             rdn3['foo']  # pylint: disable=pointless-statement
 
-        self.assertEqual(rdn1.attr, self.attr1)
-        self.assertEqual(rdn1.value, self.value1)
+        assert rdn1.attr == self.attr1
+        assert rdn1.value == self.value1
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             rdn3[1.0]  # pylint: disable=pointless-statement
 
         # Slices
-        self.assertEqual(rdn3[0:1], [self.ava1])
-        self.assertEqual(rdn3[:],   [self.ava1, self.ava2])
+        assert rdn3[0:1] == [self.ava1]
+        assert rdn3[:] == [self.ava1, self.ava2]
 
     def test_assignments(self):
         rdn = RDN((self.attr1, self.value1))
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             # pylint: disable=unsupported-assignment-operation
             rdn[0] = self.ava2
 
@@ -539,31 +539,34 @@ class TestRDN(unittest.TestCase):
         rdn2 = RDN(self.rdn2)
         rdn3 = RDN(self.rdn3)
 
-        self.assertEqual(len(rdn1), 1)
-        self.assertEqual(rdn1[:], [self.ava1])
+        assert len(rdn1) == 1
+        assert rdn1[:] == [self.ava1]
         for i, ava in enumerate(rdn1):
             if i == 0:
-                self.assertEqual(ava, self.ava1)
+                assert ava == self.ava1
             else:
-                self.fail("got iteration index %d, but len=%d" % (i, len(rdn1)))
+                pytest.fail(
+                    "got iteration index %d, but len=%d" % (i, len(rdn1)))
 
-        self.assertEqual(len(rdn2), 1)
-        self.assertEqual(rdn2[:], [self.ava2])
+        assert len(rdn2) == 1
+        assert rdn2[:] == [self.ava2]
         for i, ava in enumerate(rdn2):
             if i == 0:
-                self.assertEqual(ava, self.ava2)
+                assert ava == self.ava2
             else:
-                self.fail("got iteration index %d, but len=%d" % (i, len(rdn2)))
+                pytest.fail(
+                    "got iteration index %d, but len=%d" % (i, len(rdn2)))
 
-        self.assertEqual(len(rdn3), 2)
-        self.assertEqual(rdn3[:], [self.ava1, self.ava2])
+        assert len(rdn3) == 2
+        assert rdn3[:] == [self.ava1, self.ava2]
         for i, ava in enumerate(rdn3):
             if i == 0:
-                self.assertEqual(ava, self.ava1)
+                assert ava == self.ava1
             elif i == 1:
-                self.assertEqual(ava, self.ava2)
+                assert ava == self.ava2
             else:
-                self.fail("got iteration index %d, but len=%d" % (i, len(rdn3)))
+                pytest.fail(
+                    "got iteration index %d, but len=%d" % (i, len(rdn3)))
 
 
     def test_concat(self):
@@ -572,21 +575,21 @@ class TestRDN(unittest.TestCase):
 
         # in-place addtion
         rdn1 += rdn2
-        self.assertEqual(rdn1, self.rdn3)
+        assert rdn1 == self.rdn3
         self.assertExpectedClass(RDN, rdn1, 'self')
         for i in range(0, len(rdn1)):
             self.assertExpectedClass(RDN, rdn1[i], 'AVA')
 
         rdn1 = RDN((self.attr1, self.value1))
         rdn1 += self.ava2
-        self.assertEqual(rdn1, self.rdn3)
+        assert rdn1 == self.rdn3
         self.assertExpectedClass(RDN, rdn1, 'self')
         for i in range(0, len(rdn1)):
             self.assertExpectedClass(RDN, rdn1[i], 'AVA')
 
         rdn1 = RDN((self.attr1, self.value1))
         rdn1 += self.str_ava2
-        self.assertEqual(rdn1, self.rdn3)
+        assert rdn1 == self.rdn3
         self.assertExpectedClass(RDN, rdn1, 'self')
         for i in range(0, len(rdn1)):
             self.assertExpectedClass(RDN, rdn1[i], 'AVA')
@@ -594,19 +597,19 @@ class TestRDN(unittest.TestCase):
         # concatenation
         rdn1 = RDN((self.attr1, self.value1))
         rdn3 = rdn1 + rdn2
-        self.assertEqual(rdn3, self.rdn3)
+        assert rdn3 == self.rdn3
         self.assertExpectedClass(RDN, rdn3, 'self')
         for i in range(0, len(rdn3)):
             self.assertExpectedClass(RDN, rdn3[i], 'AVA')
 
         rdn3 = rdn1 + self.ava2
-        self.assertEqual(rdn3, self.rdn3)
+        assert rdn3 == self.rdn3
         self.assertExpectedClass(RDN, rdn3, 'self')
         for i in range(0, len(rdn3)):
             self.assertExpectedClass(RDN, rdn3[i], 'AVA')
 
         rdn3 = rdn1 + self.str_ava2
-        self.assertEqual(rdn3, self.rdn3)
+        assert rdn3 == self.rdn3
         self.assertExpectedClass(RDN, rdn3, 'self')
         for i in range(0, len(rdn3)):
             self.assertExpectedClass(RDN, rdn3[i], 'AVA')
@@ -618,12 +621,13 @@ class TestRDN(unittest.TestCase):
         rdn2 = RDN((self.attr1.upper(), self.value1.lower()))
 
         # RDNs that are equal should hash to the same value.
-        self.assertEqual(rdn1, rdn2)
-        self.assertEqual(hash(rdn1), hash(rdn2))
+        assert rdn1 == rdn2
+        assert hash(rdn1) == hash(rdn2)
 
 
-class TestDN(unittest.TestCase):
-    def setUp(self):
+class TestDN:
+    @pytest.fixture(autouse=True)
+    def dn_setup(self):
         # ava1 must sort before ava2
         self.attr1    = 'cn'
         self.value1   = u'Bob'
@@ -678,326 +682,324 @@ class TestDN(unittest.TestCase):
         ])
 
     def assertExpectedClass(self, klass, obj, component):
-        self.assertIs(obj.__class__, expected_class(klass, component))
+        assert obj.__class__ is expected_class(klass, component)
 
     def test_create(self):
         # Create with single attr,value pair
         dn1 = DN((self.attr1, self.value1))
-        self.assertEqual(len(dn1), 1)
+        assert len(dn1) == 1
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
             for j in range(0, len(dn1[i])):
                 self.assertExpectedClass(DN, dn1[i][j], 'AVA')
-        self.assertIsInstance(dn1[0].attr, unicode)
-        self.assertIsInstance(dn1[0].value, unicode)
-        self.assertEqual(dn1[0], self.rdn1)
+        assert isinstance(dn1[0].attr, unicode)
+        assert isinstance(dn1[0].value, unicode)
+        assert dn1[0] == self.rdn1
 
         # Create with single attr,value pair passed as a tuple
         dn1 = DN((self.attr1, self.value1))
-        self.assertEqual(len(dn1), 1)
+        assert len(dn1) == 1
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
             for j in range(0, len(dn1[i])):
                 self.assertExpectedClass(DN, dn1[i][j], 'AVA')
-            self.assertIsInstance(dn1[i].attr, unicode)
-            self.assertIsInstance(dn1[i].value, unicode)
-        self.assertEqual(dn1[0], self.rdn1)
+            assert isinstance(dn1[i].attr, unicode)
+            assert isinstance(dn1[i].value, unicode)
+        assert dn1[0] == self.rdn1
 
         # Creation with multiple attr,value string pairs should fail
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dn1 = DN(self.attr1, self.value1, self.attr2, self.value2)
 
         # Create with multiple attr,value pairs passed as tuples & lists
         dn1 = DN((self.attr1, self.value1), [self.attr2, self.value2])
-        self.assertEqual(len(dn1), 2)
+        assert len(dn1) == 2
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
             for j in range(0, len(dn1[i])):
                 self.assertExpectedClass(DN, dn1[i][j], 'AVA')
-            self.assertIsInstance(dn1[i].attr, unicode)
-            self.assertIsInstance(dn1[i].value, unicode)
-        self.assertEqual(dn1[0], self.rdn1)
-        self.assertEqual(dn1[1], self.rdn2)
+            assert isinstance(dn1[i].attr, unicode)
+            assert isinstance(dn1[i].value, unicode)
+        assert dn1[0] == self.rdn1
+        assert dn1[1] == self.rdn2
 
         # Create with multiple attr,value pairs passed as tuple and RDN
         dn1 = DN((self.attr1, self.value1), RDN((self.attr2, self.value2)))
-        self.assertEqual(len(dn1), 2)
+        assert len(dn1) == 2
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
             for j in range(0, len(dn1[i])):
                 self.assertExpectedClass(DN, dn1[i][j], 'AVA')
-            self.assertIsInstance(dn1[i].attr, unicode)
-            self.assertIsInstance(dn1[i].value, unicode)
-        self.assertEqual(dn1[0], self.rdn1)
-        self.assertEqual(dn1[1], self.rdn2)
+            assert isinstance(dn1[i].attr, unicode)
+            assert isinstance(dn1[i].value, unicode)
+        assert dn1[0] == self.rdn1
+        assert dn1[1] == self.rdn2
 
         # Create with multiple attr,value pairs but reverse
         # constructor parameter ordering. RDN ordering should also be
         # reversed because DN's are a ordered sequence of RDN's
         dn1 = DN((self.attr2, self.value2), (self.attr1, self.value1))
-        self.assertEqual(len(dn1), 2)
+        assert len(dn1) == 2
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
             for j in range(0, len(dn1[i])):
                 self.assertExpectedClass(DN, dn1[i][j], 'AVA')
-            self.assertIsInstance(dn1[i].attr, unicode)
-            self.assertIsInstance(dn1[i].value, unicode)
-        self.assertEqual(dn1[0], self.rdn2)
-        self.assertEqual(dn1[1], self.rdn1)
+            assert isinstance(dn1[i].attr, unicode)
+            assert isinstance(dn1[i].value, unicode)
+        assert dn1[0] == self.rdn2
+        assert dn1[1] == self.rdn1
 
         # Create with single RDN object
         dn1 = DN(self.rdn1)
-        self.assertEqual(len(dn1), 1)
+        assert len(dn1) == 1
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
             for j in range(0, len(dn1[i])):
                 self.assertExpectedClass(DN, dn1[i][j], 'AVA')
-            self.assertIsInstance(dn1[i].attr, unicode)
-            self.assertIsInstance(dn1[i].value, unicode)
-        self.assertEqual(dn1[0], self.rdn1)
+            assert isinstance(dn1[i].attr, unicode)
+            assert isinstance(dn1[i].value, unicode)
+        assert dn1[0] == self.rdn1
 
         # Create with multiple RDN objects, assure ordering is preserved.
         dn1 = DN(self.rdn1, self.rdn2)
-        self.assertEqual(len(dn1), 2)
+        assert len(dn1) == 2
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
             for j in range(0, len(dn1[i])):
                 self.assertExpectedClass(DN, dn1[i][j], 'AVA')
-            self.assertIsInstance(dn1[i].attr, unicode)
-            self.assertIsInstance(dn1[i].value, unicode)
-        self.assertEqual(dn1[0], self.rdn1)
-        self.assertEqual(dn1[1], self.rdn2)
+            assert isinstance(dn1[i].attr, unicode)
+            assert isinstance(dn1[i].value, unicode)
+        assert dn1[0] == self.rdn1
+        assert dn1[1] == self.rdn2
 
         # Create with multiple RDN objects in different order, assure
         # ordering is preserved.
         dn1 = DN(self.rdn2, self.rdn1)
-        self.assertEqual(len(dn1), 2)
+        assert len(dn1) == 2
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
             for j in range(0, len(dn1[i])):
                 self.assertExpectedClass(DN, dn1[i][j], 'AVA')
-            self.assertIsInstance(dn1[i].attr, unicode)
-            self.assertIsInstance(dn1[i].value, unicode)
-        self.assertEqual(dn1[0], self.rdn2)
-        self.assertEqual(dn1[1], self.rdn1)
+            assert isinstance(dn1[i].attr, unicode)
+            assert isinstance(dn1[i].value, unicode)
+        assert dn1[0] == self.rdn2
+        assert dn1[1] == self.rdn1
 
         # Create with single string with 1 RDN
         dn1 = DN(self.str_rdn1)
-        self.assertEqual(len(dn1), 1)
+        assert len(dn1) == 1
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
             for j in range(0, len(dn1[i])):
                 self.assertExpectedClass(DN, dn1[i][j], 'AVA')
-            self.assertIsInstance(dn1[i].attr, unicode)
-            self.assertIsInstance(dn1[i].value, unicode)
-        self.assertEqual(dn1[0], self.rdn1)
+            assert isinstance(dn1[i].attr, unicode)
+            assert isinstance(dn1[i].value, unicode)
+        assert dn1[0] == self.rdn1
 
         # Create with single string with 2 RDN's
         dn1 = DN(self.str_dn3)
-        self.assertEqual(len(dn1), 2)
+        assert len(dn1) == 2
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
             for j in range(0, len(dn1[i])):
                 self.assertExpectedClass(DN, dn1[i][j], 'AVA')
-            self.assertIsInstance(dn1[i].attr, unicode)
-            self.assertIsInstance(dn1[i].value, unicode)
-        self.assertEqual(dn1[0], self.rdn1)
-        self.assertEqual(dn1[1], self.rdn2)
+            assert isinstance(dn1[i].attr, unicode)
+            assert isinstance(dn1[i].value, unicode)
+        assert dn1[0] == self.rdn1
+        assert dn1[1] == self.rdn2
 
         # Create with a python-cryptography 'Name'
         dn1 = DN(self.x500name)
-        self.assertEqual(len(dn1), 2)
+        assert len(dn1) == 2
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
             for j in range(0, len(dn1[i])):
                 self.assertExpectedClass(DN, dn1[i][j], 'AVA')
-            self.assertIsInstance(dn1[i].attr, unicode)
-            self.assertIsInstance(dn1[i].value, unicode)
-        self.assertEqual(dn1[0], self.rdn1)
-        self.assertEqual(dn1[1], self.rdn2)
+            assert isinstance(dn1[i].attr, unicode)
+            assert isinstance(dn1[i].value, unicode)
+        assert dn1[0] == self.rdn1
+        assert dn1[1] == self.rdn2
 
         # Create from 'Name' with multi-valued RDN
         dn1 = DN(self.x500nameMultiRDN)
-        self.assertEqual(len(dn1), 2)
-        self.assertEqual(len(dn1[1]), 2)
-        self.assertIn(AVA('c', 'au'), dn1[1])
-        self.assertIn(AVA('st', 'queensland'), dn1[1])
-        self.assertEqual(len(dn1[0]), 1)
-        self.assertIn(self.ava1, dn1[0])
+        assert len(dn1) == 2
+        assert len(dn1[1]) == 2
+        assert AVA('c', 'au') in dn1[1]
+        assert AVA('st', 'queensland') in dn1[1]
+        assert len(dn1[0]) == 1
+        assert self.ava1 in dn1[0]
 
         # Create with RDN, and 2 DN's (e.g. attr + container + base)
         dn1 = DN((self.attr1, self.value1), self.container_dn, self.base_dn)
-        self.assertEqual(len(dn1), 5)
+        assert len(dn1) == 5
         dn_str = ','.join([str(self.rdn1),
                             str(self.container_rdn1), str(self.container_rdn2),
                             str(self.base_rdn1), str(self.base_rdn2)])
-        self.assertEqual(str(dn1), dn_str)
+        assert str(dn1) == dn_str
 
     def test_str(self):
         dn1 = DN(self.dn1)
         dn2 = DN(self.dn2)
         dn3 = DN(self.dn3)
 
-        self.assertEqual(str(dn1), self.str_dn1)
-        self.assertIsInstance(str(dn1), str)
+        assert str(dn1) == self.str_dn1
+        assert isinstance(str(dn1), str)
 
-        self.assertEqual(str(dn2), self.str_dn2)
-        self.assertIsInstance(str(dn2), str)
+        assert str(dn2) == self.str_dn2
+        assert isinstance(str(dn2), str)
 
-        self.assertEqual(str(dn3), self.str_dn3)
-        self.assertIsInstance(str(dn3), str)
+        assert str(dn3) == self.str_dn3
+        assert isinstance(str(dn3), str)
 
     def test_cmp(self):
         # Equality
         dn1 = DN((self.attr1, self.value1))
 
-        self.assertTrue(dn1 == self.dn1)
-        self.assertFalse(dn1 != self.dn1)
+        assert dn1 == self.dn1
+        assert dn1 == self.dn1
 
-        self.assertTrue(dn1 == self.str_dn1)
-        self.assertFalse(dn1 != self.str_dn1)
+        assert dn1 == self.str_dn1
+        assert dn1 == self.str_dn1
 
         result = cmp(dn1, self.dn1)
-        self.assertEqual(result, 0)
+        assert result == 0
 
         # Make dn1's attr greater
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             dn1[0].attr = self.attr1 + "1"
         dn1 = DN((self.attr1 + "1", self.value1))
 
-        self.assertFalse(dn1 == self.dn1)
-        self.assertTrue(dn1 != self.dn1)
+        assert dn1 != self.dn1
+        assert dn1 != self.dn1
 
         result = cmp(dn1, self.dn1)
-        self.assertEqual(result, 1)
+        assert result == 1
 
         result = cmp(self.dn1, dn1)
-        self.assertEqual(result, -1)
+        assert result == -1
 
         # Reset dn1's attr, should be equal again
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             dn1[0].attr = self.attr1
         dn1 = DN((self.attr1, self.value1))
 
         result = cmp(dn1, self.dn1)
-        self.assertEqual(result, 0)
+        assert result == 0
 
         # Make dn1's value greater
         # attr will be equal, this tests secondary comparision component
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             dn1[0].value = self.value1 + "1"
         dn1 = DN((self.attr1, self.value1 + "1"))
 
         result = cmp(dn1, self.dn1)
-        self.assertEqual(result, 1)
+        assert result == 1
 
         result = cmp(self.dn1, dn1)
-        self.assertEqual(result, -1)
+        assert result == -1
 
         # Make sure dn's with more rdn's are greater
         result = cmp(self.dn1, self.dn3)
-        self.assertEqual(result, -1)
+        assert result == -1
         result = cmp(self.dn3, self.dn1)
-        self.assertEqual(result, 1)
+        assert result == 1
 
 
         # Test startswith, endswith
         container_dn = DN(self.container_dn)
         base_container_dn = DN(self.base_container_dn)
 
-        self.assertTrue(base_container_dn.startswith(self.rdn1))
-        self.assertTrue(base_container_dn.startswith(self.dn1))
-        self.assertTrue(base_container_dn.startswith(self.dn1 + container_dn))
-        self.assertFalse(base_container_dn.startswith(self.dn2))
-        self.assertFalse(base_container_dn.startswith(self.rdn2))
-        self.assertTrue(base_container_dn.startswith((self.dn1)))
-        self.assertTrue(base_container_dn.startswith((self.rdn1)))
-        self.assertFalse(base_container_dn.startswith((self.rdn2)))
-        self.assertTrue(base_container_dn.startswith((self.rdn2, self.rdn1)))
-        self.assertTrue(base_container_dn.startswith((self.dn1, self.dn2)))
+        assert base_container_dn.startswith(self.rdn1)
+        assert base_container_dn.startswith(self.dn1)
+        assert base_container_dn.startswith(self.dn1 + container_dn)
+        assert not base_container_dn.startswith(self.dn2)
+        assert not base_container_dn.startswith(self.rdn2)
+        assert base_container_dn.startswith((self.dn1))
+        assert base_container_dn.startswith((self.rdn1))
+        assert not base_container_dn.startswith((self.rdn2))
+        assert base_container_dn.startswith((self.rdn2, self.rdn1))
+        assert base_container_dn.startswith((self.dn1, self.dn2))
 
-        self.assertTrue(base_container_dn.endswith(self.base_dn))
-        self.assertTrue(base_container_dn.endswith(container_dn + self.base_dn))
-        self.assertFalse(base_container_dn.endswith(DN(self.base_rdn1)))
-        self.assertTrue(base_container_dn.endswith(DN(self.base_rdn2)))
-        self.assertTrue(base_container_dn.endswith((DN(self.base_rdn1), DN(self.base_rdn2))))
+        assert base_container_dn.endswith(self.base_dn)
+        assert base_container_dn.endswith(container_dn + self.base_dn)
+        assert not base_container_dn.endswith(DN(self.base_rdn1))
+        assert base_container_dn.endswith(DN(self.base_rdn2))
+        assert base_container_dn.endswith(
+            (DN(self.base_rdn1), DN(self.base_rdn2)))
 
         # Test "in" membership
-        self.assertTrue(self.container_rdn1 in container_dn)
+        assert self.container_rdn1 in container_dn
         # pylint: disable=comparison-with-itself
-        self.assertTrue(container_dn in container_dn)
-        self.assertFalse(self.base_rdn1 in container_dn)
+        assert container_dn in container_dn
+        assert self.base_rdn1 not in container_dn
 
-        self.assertTrue(self.container_rdn1 in base_container_dn)
-        self.assertTrue(container_dn in base_container_dn)
-        self.assertTrue(container_dn + self.base_dn in
-                        base_container_dn)
-        self.assertTrue(self.dn1 + container_dn + self.base_dn in
-                        base_container_dn)
-        self.assertTrue(self.dn1 + container_dn + self.base_dn ==
-                        base_container_dn)
+        assert self.container_rdn1 in base_container_dn
+        assert container_dn in base_container_dn
+        assert container_dn + self.base_dn in base_container_dn
+        assert self.dn1 + container_dn + self.base_dn in base_container_dn
+        assert self.dn1 + container_dn + self.base_dn == base_container_dn
 
-        self.assertFalse(self.container_rdn1 in self.base_dn)
+        assert self.container_rdn1 not in self.base_dn
 
     def test_eq_multi_rdn(self):
         dn1 = DN(self.ava1, 'ST=Queensland+C=AU')
         dn2 = DN(self.ava1, 'C=AU+ST=Queensland')
-        self.assertEqual(dn1, dn2)
+        assert dn1 == dn2
 
         # ensure AVAs get sorted when constructing from x509.Name
         dn3 = DN(self.x500nameMultiRDN)
         dn4 = DN(self.x500nameMultiRDN2)
-        self.assertEqual(dn3, dn4)
+        assert dn3 == dn4
 
         # ensure AVAs get sorted in the same way regardless of what
         # the DN was constructed from
-        self.assertEqual(dn1, dn3)
-        self.assertEqual(dn1, dn4)
-        self.assertEqual(dn2, dn3)
-        self.assertEqual(dn2, dn4)
+        assert dn1 == dn3
+        assert dn1 == dn4
+        assert dn2 == dn3
+        assert dn2 == dn4
 
     def test_indexing(self):
         dn1 = DN(self.dn1)
         dn2 = DN(self.dn2)
         dn3 = DN(self.dn3)
 
-        self.assertEqual(dn1[0], self.rdn1)
-        self.assertEqual(dn1[self.rdn1.attr], self.rdn1.value)
-        with self.assertRaises(KeyError):
+        assert dn1[0] == self.rdn1
+        assert dn1[self.rdn1.attr] == self.rdn1.value
+        with pytest.raises(KeyError):
             dn1['foo']  # pylint: disable=pointless-statement
 
-        self.assertEqual(dn2[0], self.rdn2)
-        self.assertEqual(dn2[self.rdn2.attr], self.rdn2.value)
-        with self.assertRaises(KeyError):
+        assert dn2[0] == self.rdn2
+        assert dn2[self.rdn2.attr] == self.rdn2.value
+        with pytest.raises(KeyError):
             dn2['foo']  # pylint: disable=pointless-statement
 
-        self.assertEqual(dn3[0], self.rdn1)
-        self.assertEqual(dn3[self.rdn1.attr], self.rdn1.value)
-        self.assertEqual(dn3[1], self.rdn2)
-        self.assertEqual(dn3[self.rdn2.attr], self.rdn2.value)
-        with self.assertRaises(KeyError):
+        assert dn3[0] == self.rdn1
+        assert dn3[self.rdn1.attr] == self.rdn1.value
+        assert dn3[1] == self.rdn2
+        assert dn3[self.rdn2.attr] == self.rdn2.value
+        with pytest.raises(KeyError):
             dn3['foo']  # pylint: disable=pointless-statement
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             dn3[1.0]  # pylint: disable=pointless-statement
 
     def test_assignments(self):
         dn = DN('t=0,t=1,t=2,t=3,t=4,t=5,t=6,t=7,t=8,t=9')
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             # pylint: disable=unsupported-assignment-operation
             dn[0] = RDN('t=a')
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             # pylint: disable=unsupported-assignment-operation
             dn[0:1] = [RDN('t=a'), RDN('t=b')]
 
@@ -1006,31 +1008,34 @@ class TestDN(unittest.TestCase):
         dn2 = DN(self.dn2)
         dn3 = DN(self.dn3)
 
-        self.assertEqual(len(dn1), 1)
-        self.assertEqual(dn1[:], self.rdn1)
+        assert len(dn1) == 1
+        assert dn1[:] == self.rdn1
         for i, ava in enumerate(dn1):
             if i == 0:
-                self.assertEqual(ava, self.rdn1)
+                assert ava == self.rdn1
             else:
-                self.fail("got iteration index %d, but len=%d" % (i, len(self.rdn1)))
+                pytest.fail(
+                    "got iteration index %d, but len=%d" % (i, len(self.rdn1)))
 
-        self.assertEqual(len(dn2), 1)
-        self.assertEqual(dn2[:], self.rdn2)
+        assert len(dn2) == 1
+        assert dn2[:] == self.rdn2
         for i, ava in enumerate(dn2):
             if i == 0:
-                self.assertEqual(ava, self.rdn2)
+                assert ava == self.rdn2
             else:
-                self.fail("got iteration index %d, but len=%d" % (i, len(self.rdn2)))
+                pytest.fail(
+                    "got iteration index %d, but len=%d" % (i, len(self.rdn2)))
 
-        self.assertEqual(len(dn3), 2)
-        self.assertEqual(dn3[:], DN(self.rdn1, self.rdn2))
+        assert len(dn3) == 2
+        assert dn3[:] == DN(self.rdn1, self.rdn2)
         for i, ava in enumerate(dn3):
             if i == 0:
-                self.assertEqual(ava, self.rdn1)
+                assert ava == self.rdn1
             elif i == 1:
-                self.assertEqual(ava, self.rdn2)
+                assert ava == self.rdn2
             else:
-                self.fail("got iteration index %d, but len=%d" % (i, len(dn3)))
+                pytest.fail(
+                    "got iteration index %d, but len=%d" % (i, len(dn3)))
 
     def test_concat(self):
         dn1 = DN((self.attr1, self.value1))
@@ -1039,7 +1044,7 @@ class TestDN(unittest.TestCase):
         # in-place addtion
 
         dn1 += dn2
-        self.assertEqual(dn1, self.dn3)
+        assert dn1 == self.dn3
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
@@ -1049,7 +1054,7 @@ class TestDN(unittest.TestCase):
 
         dn1 = DN((self.attr1, self.value1))
         dn1 += self.rdn2
-        self.assertEqual(dn1, self.dn3)
+        assert dn1 == self.dn3
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
@@ -1059,7 +1064,7 @@ class TestDN(unittest.TestCase):
 
         dn1 = DN((self.attr1, self.value1))
         dn1 += self.dn2
-        self.assertEqual(dn1, self.dn3)
+        assert dn1 == self.dn3
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
@@ -1069,7 +1074,7 @@ class TestDN(unittest.TestCase):
 
         dn1 = DN((self.attr1, self.value1))
         dn1 += self.str_dn2
-        self.assertEqual(dn1, self.dn3)
+        assert dn1 == self.dn3
         self.assertExpectedClass(DN, dn1, 'self')
         for i in range(0, len(dn1)):
             self.assertExpectedClass(DN, dn1[i], 'RDN')
@@ -1080,7 +1085,7 @@ class TestDN(unittest.TestCase):
         # concatenation
         dn1 = DN((self.attr1, self.value1))
         dn3 = dn1 + dn2
-        self.assertEqual(dn3, self.dn3)
+        assert dn3 == self.dn3
         self.assertExpectedClass(DN, dn3, 'self')
         for i in range(0, len(dn3)):
             self.assertExpectedClass(DN, dn3[i], 'RDN')
@@ -1090,7 +1095,7 @@ class TestDN(unittest.TestCase):
 
         dn1 = DN((self.attr1, self.value1))
         dn3 = dn1 + self.rdn2
-        self.assertEqual(dn3, self.dn3)
+        assert dn3 == self.dn3
         self.assertExpectedClass(DN, dn3, 'self')
         for i in range(0, len(dn3)):
             self.assertExpectedClass(DN, dn3[i], 'RDN')
@@ -1098,14 +1103,14 @@ class TestDN(unittest.TestCase):
                 self.assertExpectedClass(DN, dn3[i][j], 'AVA')
 
         dn3 = dn1 + self.str_rdn2
-        self.assertEqual(dn3, self.dn3)
+        assert dn3 == self.dn3
         self.assertExpectedClass(DN, dn3, 'self')
         for i in range(0, len(dn3)):
             self.assertExpectedClass(DN, dn3[i], 'RDN')
             self.assertExpectedClass(DN, dn3[i][0], 'AVA')
 
         dn3 = dn1 + self.str_dn2
-        self.assertEqual(dn3, self.dn3)
+        assert dn3 == self.dn3
         self.assertExpectedClass(DN, dn3, 'self')
         self.assertExpectedClass(DN, dn3, 'self')
         for i in range(0, len(dn3)):
@@ -1114,7 +1119,7 @@ class TestDN(unittest.TestCase):
                 self.assertExpectedClass(DN, dn3[i][j], 'AVA')
 
         dn3 = dn1 + self.dn2
-        self.assertEqual(dn3, self.dn3)
+        assert dn3 == self.dn3
         self.assertExpectedClass(DN, dn3, 'self')
         self.assertExpectedClass(DN, dn3, 'self')
         for i in range(0, len(dn3)):
@@ -1128,42 +1133,42 @@ class TestDN(unittest.TestCase):
         pat = DN('cn=bob')
 
         # forward
-        self.assertEqual(dn.find(pat),          2)
-        self.assertEqual(dn.find(pat,  1),      2)
-        self.assertEqual(dn.find(pat,  1,  3),  2)
-        self.assertEqual(dn.find(pat,  2,  3),  2)
-        self.assertEqual(dn.find(pat,  6),      6)
+        assert dn.find(pat) == 2
+        assert dn.find(pat, 1) == 2
+        assert dn.find(pat, 1, 3) == 2
+        assert dn.find(pat, 2, 3) == 2
+        assert dn.find(pat, 6) == 6
 
-        self.assertEqual(dn.find(pat,  7),     -1)
-        self.assertEqual(dn.find(pat,  1,  2), -1)
+        assert dn.find(pat, 7) == -1
+        assert dn.find(pat, 1, 2) == -1
 
-        with self.assertRaises(ValueError):
-            self.assertEqual(dn.index(pat,  7),     -1)
-        with self.assertRaises(ValueError):
-            self.assertEqual(dn.index(pat,  1,  2), -1)
+        with pytest.raises(ValueError):
+            assert dn.index(pat, 7) == -1
+        with pytest.raises(ValueError):
+            assert dn.index(pat, 1, 2) == -1
 
         # reverse
-        self.assertEqual(dn.rfind(pat),          6)
-        self.assertEqual(dn.rfind(pat, -4),      6)
-        self.assertEqual(dn.rfind(pat,  6),      6)
-        self.assertEqual(dn.rfind(pat,  6,  8),  6)
-        self.assertEqual(dn.rfind(pat,  6,  8),  6)
-        self.assertEqual(dn.rfind(pat, -8),      6)
-        self.assertEqual(dn.rfind(pat, -8, -4),  6)
-        self.assertEqual(dn.rfind(pat, -8, -5),  2)
+        assert dn.rfind(pat) == 6
+        assert dn.rfind(pat, -4) == 6
+        assert dn.rfind(pat, 6) == 6
+        assert dn.rfind(pat, 6, 8) == 6
+        assert dn.rfind(pat, 6, 8) == 6
+        assert dn.rfind(pat, -8) == 6
+        assert dn.rfind(pat, -8, -4) == 6
+        assert dn.rfind(pat, -8, -5) == 2
 
-        self.assertEqual(dn.rfind(pat,  7),     -1)
-        self.assertEqual(dn.rfind(pat, -3),     -1)
+        assert dn.rfind(pat, 7) == -1
+        assert dn.rfind(pat, -3) == -1
 
-        with self.assertRaises(ValueError):
-            self.assertEqual(dn.rindex(pat,  7),     -1)
-        with self.assertRaises(ValueError):
-            self.assertEqual(dn.rindex(pat, -3),     -1)
+        with pytest.raises(ValueError):
+            assert dn.rindex(pat, 7) == -1
+        with pytest.raises(ValueError):
+            assert dn.rindex(pat, -3) == -1
 
     def test_replace(self):
         # pylint: disable=no-member
         dn = DN('t=0,t=1,t=2,t=3,t=4,t=5,t=6,t=7,t=8,t=9')
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             dn.replace  # pylint: disable=pointless-statement
 
     def test_hashing(self):
@@ -1172,11 +1177,11 @@ class TestDN(unittest.TestCase):
         dn2 = DN((self.attr1.upper(), self.value1.lower()))
 
         # DNs that are equal should hash to the same value.
-        self.assertEqual(dn1, dn2)
+        assert dn1 == dn2
 
         # Good, everyone's equal, now verify their hash values
 
-        self.assertEqual(hash(dn1), hash(dn2))
+        assert hash(dn1) == hash(dn2)
 
         # Different DN objects with the same value should
         # map to 1 common key and 1 member in a set. The key and
@@ -1191,9 +1196,9 @@ class TestDN(unittest.TestCase):
         dn3_a = DN(self.dn3)
         dn3_b = DN(self.dn3)
 
-        self.assertEqual(dn1_a, dn1_b)
-        self.assertEqual(dn2_a, dn2_b)
-        self.assertEqual(dn3_a, dn3_b)
+        assert dn1_a == dn1_b
+        assert dn2_a == dn2_b
+        assert dn3_a == dn3_b
 
         d = dict()
         s = set()
@@ -1208,63 +1213,66 @@ class TestDN(unittest.TestCase):
         s.add(dn2_a)
         s.add(dn2_b)
 
-        self.assertEqual(len(d), 2)
-        self.assertEqual(len(s), 2)
-        self.assertEqual(sorted(d), sorted([dn1_a, dn2_a]))
-        self.assertEqual(sorted(s), sorted([dn1_a, dn2_a]))
+        assert len(d) == 2
+        assert len(s) == 2
+        assert sorted(d) == sorted([dn1_a, dn2_a])
+        assert sorted(s) == sorted([dn1_a, dn2_a])
 
-        self.assertTrue(dn1_a in d)
-        self.assertTrue(dn1_b in d)
-        self.assertTrue(dn2_a in d)
-        self.assertTrue(dn2_b in d)
-        self.assertFalse(dn3_a in d)
-        self.assertFalse(dn3_b in d)
+        assert dn1_a in d
+        assert dn1_b in d
+        assert dn2_a in d
+        assert dn2_b in d
+        assert dn3_a not in d
+        assert dn3_b not in d
 
-        self.assertTrue(dn1_a in s)
-        self.assertTrue(dn1_b in s)
-        self.assertTrue(dn2_a in s)
-        self.assertTrue(dn2_b in s)
-        self.assertFalse(dn3_a in s)
-        self.assertFalse(dn3_b in s)
+        assert dn1_a in s
+        assert dn1_b in s
+        assert dn2_a in s
+        assert dn2_b in s
+        assert dn3_a not in s
+        assert dn3_b not in s
 
     def test_x500_text(self):
         # null DN x500 ordering and LDAP ordering are the same
         nulldn = DN()
-        self.assertEqual(nulldn.ldap_text(), nulldn.x500_text())
+        assert nulldn.ldap_text() == nulldn.x500_text()
 
         # reverse a DN with a single RDN
-        self.assertEqual(self.dn1.ldap_text(), self.dn1.x500_text())
+        assert self.dn1.ldap_text() == self.dn1.x500_text()
 
         # reverse a DN with 2 RDNs
         dn3_x500 = self.dn3.x500_text()
         dn3_rev = DN(self.rdn2, self.rdn1)
-        self.assertEqual(dn3_rev.ldap_text(), dn3_x500)
+        assert dn3_rev.ldap_text() == dn3_x500
 
         # reverse a longer DN
         longdn_x500 = self.base_container_dn.x500_text()
         longdn_rev = DN(longdn_x500)
         l = len(self.base_container_dn)
         for i in range(l):
-            self.assertEqual(longdn_rev[i], self.base_container_dn[l-1-i])
+            assert longdn_rev[i] == self.base_container_dn[l - 1 - i]
 
 
-class TestEscapes(unittest.TestCase):
-    def setUp(self):
+class TestEscapes:
+    @pytest.fixture(autouse=True)
+    def escapes_setup(self):
         self.privilege = 'R,W privilege'
         self.dn_str_hex_escape = 'cn=R\\2cW privilege,cn=privileges,cn=pbac,dc=idm,dc=lab,dc=bos,dc=redhat,dc=com'
         self.dn_str_backslash_escape = 'cn=R\\,W privilege,cn=privileges,cn=pbac,dc=idm,dc=lab,dc=bos,dc=redhat,dc=com'
 
     def test_escape(self):
         dn = DN(self.dn_str_hex_escape)
-        self.assertEqual(dn['cn'], self.privilege)
-        self.assertEqual(dn[0].value, self.privilege)
+        assert dn['cn'] == self.privilege
+        assert dn[0].value == self.privilege
 
         dn = DN(self.dn_str_backslash_escape)
-        self.assertEqual(dn['cn'], self.privilege)
-        self.assertEqual(dn[0].value, self.privilege)
+        assert dn['cn'] == self.privilege
+        assert dn[0].value == self.privilege
 
-class TestInternationalization(unittest.TestCase):
-    def setUp(self):
+
+class TestInternationalization:
+    @pytest.fixture(autouse=True)
+    def i18n_setup(self):
         # Hello in Arabic
         self.arabic_hello_utf8 = (b'\xd9\x85\xd9\x83\xd9\x8a\xd9\x84' +
                                   b'\xd8\xb9\x20\xd9\x85\xd8\xa7\xd9' +
@@ -1274,9 +1282,9 @@ class TestInternationalization(unittest.TestCase):
 
     def assert_equal_utf8(self, obj, b):
         if six.PY2:
-            self.assertEqual(str(obj), b)
+            assert str(obj) == b
         else:
-            self.assertEqual(str(obj), b.decode('utf-8'))
+            assert str(obj) == b.decode('utf-8')
 
     @contextlib.contextmanager
     def fail_py3(self, exception_type):
@@ -1287,101 +1295,102 @@ class TestInternationalization(unittest.TestCase):
                 raise
 
     def test_i18n(self):
-        self.assertEqual(self.arabic_hello_utf8,
-                         self.arabic_hello_unicode.encode('utf-8'))
+        actual = self.arabic_hello_unicode.encode('utf-8')
+        expected = self.arabic_hello_utf8
+        assert actual == expected
 
         # AVA's
         # test attr i18n
         ava1 = AVA(self.arabic_hello_unicode, 'foo')
-        self.assertIsInstance(ava1.attr,  unicode)
-        self.assertIsInstance(ava1.value, unicode)
-        self.assertEqual(ava1.attr, self.arabic_hello_unicode)
+        assert isinstance(ava1.attr, unicode)
+        assert isinstance(ava1.value, unicode)
+        assert ava1.attr == self.arabic_hello_unicode
         self.assert_equal_utf8(ava1, self.arabic_hello_utf8 + b'=foo')
 
         with self.fail_py3(TypeError):
             ava1 = AVA(self.arabic_hello_utf8, 'foo')
         if six.PY2:
-            self.assertIsInstance(ava1.attr,  unicode)
-            self.assertIsInstance(ava1.value, unicode)
-            self.assertEqual(ava1.attr, self.arabic_hello_unicode)
+            assert isinstance(ava1.attr, unicode)
+            assert isinstance(ava1.value, unicode)
+            assert ava1.attr == self.arabic_hello_unicode
             self.assert_equal_utf8(ava1, self.arabic_hello_utf8 + b'=foo')
 
         # test value i18n
         ava1 = AVA('cn', self.arabic_hello_unicode)
-        self.assertIsInstance(ava1.attr,  unicode)
-        self.assertIsInstance(ava1.value, unicode)
-        self.assertEqual(ava1.value, self.arabic_hello_unicode)
+        assert isinstance(ava1.attr, unicode)
+        assert isinstance(ava1.value, unicode)
+        assert ava1.value == self.arabic_hello_unicode
         self.assert_equal_utf8(ava1, b'cn=' + self.arabic_hello_utf8)
 
         with self.fail_py3(TypeError):
             ava1 = AVA('cn', self.arabic_hello_utf8)
         if six.PY2:
-            self.assertIsInstance(ava1.attr,  unicode)
-            self.assertIsInstance(ava1.value, unicode)
-            self.assertEqual(ava1.value, self.arabic_hello_unicode)
+            assert isinstance(ava1.attr, unicode)
+            assert isinstance(ava1.value, unicode)
+            assert ava1.value == self.arabic_hello_unicode
             self.assert_equal_utf8(ava1, b'cn=' + self.arabic_hello_utf8)
 
         # RDN's
         # test attr i18n
         rdn1 = RDN((self.arabic_hello_unicode, 'foo'))
-        self.assertIsInstance(rdn1.attr,  unicode)
-        self.assertIsInstance(rdn1.value, unicode)
-        self.assertEqual(rdn1.attr, self.arabic_hello_unicode)
+        assert isinstance(rdn1.attr, unicode)
+        assert isinstance(rdn1.value, unicode)
+        assert rdn1.attr == self.arabic_hello_unicode
         self.assert_equal_utf8(rdn1, self.arabic_hello_utf8 + b'=foo')
 
         with self.fail_py3(TypeError):
             rdn1 = RDN((self.arabic_hello_utf8, 'foo'))
         if six.PY2:
-            self.assertIsInstance(rdn1.attr,  unicode)
-            self.assertIsInstance(rdn1.value, unicode)
-            self.assertEqual(rdn1.attr, self.arabic_hello_unicode)
-            self.assertEqual(str(rdn1), self.arabic_hello_utf8 + b'=foo')
+            assert isinstance(rdn1.attr, unicode)
+            assert isinstance(rdn1.value, unicode)
+            assert rdn1.attr == self.arabic_hello_unicode
+            assert str(rdn1) == self.arabic_hello_utf8 + b'=foo'
 
         # test value i18n
         rdn1 = RDN(('cn', self.arabic_hello_unicode))
-        self.assertIsInstance(rdn1.attr,  unicode)
-        self.assertIsInstance(rdn1.value, unicode)
-        self.assertEqual(rdn1.value, self.arabic_hello_unicode)
+        assert isinstance(rdn1.attr, unicode)
+        assert isinstance(rdn1.value, unicode)
+        assert rdn1.value == self.arabic_hello_unicode
         self.assert_equal_utf8(rdn1, b'cn=' + self.arabic_hello_utf8)
 
         with self.fail_py3(TypeError):
             rdn1 = RDN(('cn', self.arabic_hello_utf8))
         if six.PY2:
-            self.assertIsInstance(rdn1.attr,  unicode)
-            self.assertIsInstance(rdn1.value, unicode)
-            self.assertEqual(rdn1.value, self.arabic_hello_unicode)
-            self.assertEqual(str(rdn1), b'cn=' + self.arabic_hello_utf8)
+            assert isinstance(rdn1.attr, unicode)
+            assert isinstance(rdn1.value, unicode)
+            assert rdn1.value == self.arabic_hello_unicode
+            assert str(rdn1) == b'cn=' + self.arabic_hello_utf8
 
         # DN's
         # test attr i18n
         dn1 = DN((self.arabic_hello_unicode, 'foo'))
-        self.assertIsInstance(dn1[0].attr,  unicode)
-        self.assertIsInstance(dn1[0].value, unicode)
-        self.assertEqual(dn1[0].attr, self.arabic_hello_unicode)
+        assert isinstance(dn1[0].attr, unicode)
+        assert isinstance(dn1[0].value, unicode)
+        assert dn1[0].attr == self.arabic_hello_unicode
         self.assert_equal_utf8(dn1, self.arabic_hello_utf8 + b'=foo')
 
         with self.fail_py3(TypeError):
             dn1 = DN((self.arabic_hello_utf8, 'foo'))
         if six.PY2:
-            self.assertIsInstance(dn1[0].attr,  unicode)
-            self.assertIsInstance(dn1[0].value, unicode)
-            self.assertEqual(dn1[0].attr, self.arabic_hello_unicode)
-            self.assertEqual(str(dn1), self.arabic_hello_utf8 + b'=foo')
+            assert isinstance(dn1[0].attr, unicode)
+            assert isinstance(dn1[0].value, unicode)
+            assert dn1[0].attr == self.arabic_hello_unicode
+            assert str(dn1) == self.arabic_hello_utf8 + b'=foo'
 
         # test value i18n
         dn1 = DN(('cn', self.arabic_hello_unicode))
-        self.assertIsInstance(dn1[0].attr,  unicode)
-        self.assertIsInstance(dn1[0].value, unicode)
-        self.assertEqual(dn1[0].value, self.arabic_hello_unicode)
+        assert isinstance(dn1[0].attr, unicode)
+        assert isinstance(dn1[0].value, unicode)
+        assert dn1[0].value == self.arabic_hello_unicode
         self.assert_equal_utf8(dn1, b'cn=' + self.arabic_hello_utf8)
 
         with self.fail_py3(TypeError):
             dn1 = DN(('cn', self.arabic_hello_utf8))
         if six.PY2:
-            self.assertIsInstance(dn1[0].attr,  unicode)
-            self.assertIsInstance(dn1[0].value, unicode)
-            self.assertEqual(dn1[0].value, self.arabic_hello_unicode)
-            self.assertEqual(str(dn1), b'cn=' + self.arabic_hello_utf8)
+            assert isinstance(dn1[0].attr, unicode)
+            assert isinstance(dn1[0].value, unicode)
+            assert dn1[0].value == self.arabic_hello_unicode
+            assert str(dn1) == b'cn=' + self.arabic_hello_utf8
 
 
 # 1: LDAP_AVA_STRING
@@ -1435,7 +1444,3 @@ def test_dn2str_special():
     assert dn2str(dn) == dnstring2
     assert dn_ctypes.str2dn(dnstring) == dn
     assert dn_ctypes.dn2str(dn) == dnstring2
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/ipatests/test_ipapython/test_ipautil.py
+++ b/ipatests/test_ipapython/test_ipautil.py
@@ -86,7 +86,8 @@ def test_ip_address(addr, words, prefixlen):
 
 
 class TestCIDict:
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def cidict_setup(self):
         self.cidict = ipautil.CIDict()
         self.cidict["Key1"] = "val1"
         self.cidict["key2"] = "val2"

--- a/ipatests/test_ipapython/test_ipautil.py
+++ b/ipatests/test_ipapython/test_ipautil.py
@@ -395,8 +395,6 @@ class TestTimeParser:
         assert_equal(800000, time.microsecond)
 
     def test_time_zones(self):
-        # pylint: disable=no-member
-
         timestr = "20051213141205Z"
 
         time = ipautil.parse_generalized_time(timestr)

--- a/ipatests/test_ipapython/test_ipavalidate.py
+++ b/ipatests/test_ipapython/test_ipavalidate.py
@@ -19,72 +19,72 @@
 import sys
 sys.path.insert(0, ".")
 
-import unittest
 import pytest
 
 from ipapython import ipavalidate
 
 pytestmark = pytest.mark.tier0
 
-class TestValidate(unittest.TestCase):
+
+class TestValidate:
     def test_validEmail(self):
-        self.assertEqual(True, ipavalidate.Email("test@freeipa.org"))
-        self.assertEqual(True, ipavalidate.Email("", notEmpty=False))
+        assert ipavalidate.Email("test@freeipa.org") is True
+        assert ipavalidate.Email("", notEmpty=False) is True
 
     def test_invalidEmail(self):
-        self.assertEqual(False, ipavalidate.Email("test"))
-        self.assertEqual(False, ipavalidate.Email("test@freeipa"))
-        self.assertEqual(False, ipavalidate.Email("test@.com"))
-        self.assertEqual(False, ipavalidate.Email(""))
-        self.assertEqual(False, ipavalidate.Email(None))
+        assert ipavalidate.Email("test") is False
+        assert ipavalidate.Email("test@freeipa") is False
+        assert ipavalidate.Email("test@.com") is False
+        assert ipavalidate.Email("") is False
+        assert ipavalidate.Email(None) is False
 
     def test_validPlain(self):
-        self.assertEqual(True, ipavalidate.Plain("Joe User"))
-        self.assertEqual(True, ipavalidate.Plain("Joe O'Malley"))
-        self.assertEqual(True, ipavalidate.Plain("", notEmpty=False))
-        self.assertEqual(True, ipavalidate.Plain(None, notEmpty=False))
-        self.assertEqual(True, ipavalidate.Plain("JoeUser", allowSpaces=False))
-        self.assertEqual(True, ipavalidate.Plain("JoeUser", allowSpaces=True))
+        assert ipavalidate.Plain("Joe User") is True
+        assert ipavalidate.Plain("Joe O'Malley") is True
+        assert ipavalidate.Plain("", notEmpty=False) is True
+        assert ipavalidate.Plain(None, notEmpty=False) is True
+        assert ipavalidate.Plain("JoeUser", allowSpaces=False) is True
+        assert ipavalidate.Plain("JoeUser", allowSpaces=True) is True
 
     def test_invalidPlain(self):
-        self.assertEqual(False, ipavalidate.Plain("Joe (User)"))
-        self.assertEqual(False, ipavalidate.Plain("Joe C. User"))
-        self.assertEqual(False, ipavalidate.Plain("", notEmpty=True))
-        self.assertEqual(False, ipavalidate.Plain(None, notEmpty=True))
-        self.assertEqual(False, ipavalidate.Plain("Joe User", allowSpaces=False))
-        self.assertEqual(False, ipavalidate.Plain("Joe C. User"))
+        assert ipavalidate.Plain("Joe (User)") is False
+        assert ipavalidate.Plain("Joe C. User") is False
+        assert ipavalidate.Plain("", notEmpty=True) is False
+        assert ipavalidate.Plain(None, notEmpty=True) is False
+        assert ipavalidate.Plain("Joe User", allowSpaces=False) is False
+        assert ipavalidate.Plain("Joe C. User") is False
 
     def test_validString(self):
-        self.assertEqual(True, ipavalidate.String("Joe User"))
-        self.assertEqual(True, ipavalidate.String("Joe O'Malley"))
-        self.assertEqual(True, ipavalidate.String("", notEmpty=False))
-        self.assertEqual(True, ipavalidate.String(None, notEmpty=False))
-        self.assertEqual(True, ipavalidate.String("Joe C. User"))
+        assert ipavalidate.String("Joe User") is True
+        assert ipavalidate.String("Joe O'Malley") is True
+        assert ipavalidate.String("", notEmpty=False) is True
+        assert ipavalidate.String(None, notEmpty=False) is True
+        assert ipavalidate.String("Joe C. User") is True
 
     def test_invalidString(self):
-        self.assertEqual(False, ipavalidate.String("", notEmpty=True))
-        self.assertEqual(False, ipavalidate.String(None, notEmpty=True))
+        assert ipavalidate.String("", notEmpty=True) is False
+        assert ipavalidate.String(None, notEmpty=True) is False
 
     def test_validPath(self):
-        self.assertEqual(True, ipavalidate.Path("/"))
-        self.assertEqual(True, ipavalidate.Path("/home/user"))
-        self.assertEqual(True, ipavalidate.Path("../home/user"))
-        self.assertEqual(True, ipavalidate.Path("", notEmpty=False))
-        self.assertEqual(True, ipavalidate.Path(None, notEmpty=False))
+        assert ipavalidate.Path("/") is True
+        assert ipavalidate.Path("/home/user") is True
+        assert ipavalidate.Path("../home/user") is True
+        assert ipavalidate.Path("", notEmpty=False) is True
+        assert ipavalidate.Path(None, notEmpty=False) is True
 
     def test_invalidPath(self):
-        self.assertEqual(False, ipavalidate.Path("(foo)"))
-        self.assertEqual(False, ipavalidate.Path("", notEmpty=True))
-        self.assertEqual(False, ipavalidate.Path(None, notEmpty=True))
+        assert ipavalidate.Path("(foo)") is False
+        assert ipavalidate.Path("", notEmpty=True) is False
+        assert ipavalidate.Path(None, notEmpty=True) is False
 
     def test_validName(self):
-        self.assertEqual(True, ipavalidate.GoodName("foo"))
-        self.assertEqual(True, ipavalidate.GoodName("1foo"))
-        self.assertEqual(True, ipavalidate.GoodName("foo.bar"))
-        self.assertEqual(True, ipavalidate.GoodName("foo.bar$"))
+        assert ipavalidate.GoodName("foo") is True
+        assert ipavalidate.GoodName("1foo") is True
+        assert ipavalidate.GoodName("foo.bar") is True
+        assert ipavalidate.GoodName("foo.bar$") is True
 
     def test_invalidName(self):
-        self.assertEqual(False, ipavalidate.GoodName("foo bar"))
-        self.assertEqual(False, ipavalidate.GoodName("foo%bar"))
-        self.assertEqual(False, ipavalidate.GoodName("*foo"))
-        self.assertEqual(False, ipavalidate.GoodName("$foo.bar$"))
+        assert ipavalidate.GoodName("foo bar") is False
+        assert ipavalidate.GoodName("foo%bar") is False
+        assert ipavalidate.GoodName("*foo") is False
+        assert ipavalidate.GoodName("$foo.bar$") is False

--- a/ipatests/test_ipapython/test_keyring.py
+++ b/ipatests/test_ipapython/test_keyring.py
@@ -41,7 +41,8 @@ class test_keyring:
     Test the kernel keyring interface
     """
 
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def keyring_setup(self):
         try:
             kernel_keyring.del_key(TEST_KEY)
         except ValueError:

--- a/ipatests/test_ipapython/test_session_storage.py
+++ b/ipatests/test_ipapython/test_session_storage.py
@@ -17,7 +17,8 @@ class test_session_storage:
     Test the session storage interface
     """
 
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def session_storage_setup(self):
         # TODO: set up test user and kinit to it
         # tmpdir = tempfile.mkdtemp(prefix = "tmp-")
         # os.environ['KRB5CCNAME'] = 'FILE:%s/ccache' % tmpdir

--- a/ipatests/test_ipaserver/test_adtrust_mockup.py
+++ b/ipatests/test_ipaserver/test_adtrust_mockup.py
@@ -4,8 +4,10 @@ from __future__ import print_function
 import ipaserver.install.adtrust as adtr
 from ipaserver.install.adtrust import set_and_check_netbios_name
 from collections import namedtuple
-from unittest import TestCase, mock
+from unittest import mock
 from io import StringIO
+
+import pytest
 
 
 class ApiMockup:
@@ -14,9 +16,12 @@ class ApiMockup:
     env = namedtuple('Environment', 'domain')
 
 
-class TestNetbiosName(TestCase):
-    @classmethod
-    def setUpClass(cls):
+class TestNetbiosName:
+    api = None
+
+    @pytest.fixture(autouse=True, scope="class")
+    def netbiosname_setup(self, request):
+        cls = request.cls
         api = ApiMockup()
         ldap2 = namedtuple('LDAP', 'isconnected')
         ldap2.isconnected = mock.MagicMock(return_value=True)
@@ -25,9 +30,9 @@ class TestNetbiosName(TestCase):
         adtr.retrieve_netbios_name = mock.MagicMock(return_value=None)
         cls.api = api
 
-    @classmethod
-    def tearDownClass(cls):
-        adtr.retrieve_netbios_name = cls.api.Calls.retrieve_netbios_name
+        def fin():
+            adtr.retrieve_netbios_name = cls.api.Calls.retrieve_netbios_name
+        request.addfinalizer(fin)
 
     def test_NetbiosName(self):
         """

--- a/ipatests/test_ipaserver/test_changepw.py
+++ b/ipatests/test_ipaserver/test_changepw.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import pytest
 
 from ipatests.test_ipaserver.httptest import Unauthorized_HTTP_test
@@ -43,7 +41,7 @@ class test_changepw(XMLRPC_test, Unauthorized_HTTP_test):
             api.Command['user_add'](uid=testuser, givenname=u'Test', sn=u'User')
             api.Command['passwd'](testuser, password=u'old_password')
         except errors.ExecutionError as e:
-            raise unittest.SkipTest(
+            pytest.skip(
                 'Cannot set up test user: %s' % e
             )
 

--- a/ipatests/test_ipaserver/test_install/test_installer.py
+++ b/ipatests/test_ipaserver/test_install/test_installer.py
@@ -9,6 +9,8 @@ from abc import ABCMeta, abstractproperty
 from collections import namedtuple
 import itertools
 
+import pytest
+
 from ipatests.util import assert_equal
 from ipaserver.install.ipa_replica_install import ReplicaInstall
 
@@ -23,16 +25,18 @@ class InstallerTestBase(six.with_metaclass(ABCMeta, object)):
     def tested_cls(self):
         return None
 
-    def setup_class(self):
+    @pytest.fixture(autouse=True, scope="class")
+    def installer_setup(self, request):
         """Initializes the tested class so that it can be used later on
         """
-        self.tested_cls.make_parser()
+        cls = request.cls
+        cls.tested_cls.make_parser()
         assert \
-            getattr(self.tested_cls, 'option_parser', False), \
+            getattr(cls.tested_cls, 'option_parser', False), \
             ("Unable to generate option parser for {}"
-             .format(self.tested_cls.__name__))
+             .format(cls.tested_cls.__name__))
 
-        self._populate_opts_dict()
+        cls._populate_opts_dict()
 
     @classmethod
     def _populate_opts_dict(cls):

--- a/ipatests/test_ipaserver/test_install/test_installutils.py
+++ b/ipatests/test_ipaserver/test_install/test_installutils.py
@@ -50,8 +50,8 @@ def gpgkey(request, tempdir):
         f.write("verbose\n")
         f.write("allow-preset-passphrase\n")
 
-    # run agent in background
-    agent = subprocess.Popen(
+    # daemonize agent (detach from the console and run in the background)
+    subprocess.Popen(
         [paths.GPG_AGENT, '--batch', '--daemon'],
         env=env, stdout=devnull, stderr=devnull
     )
@@ -61,8 +61,11 @@ def gpgkey(request, tempdir):
             os.environ['GNUPGHOME'] = orig_gnupghome
         else:
             os.environ.pop('GNUPGHOME', None)
-        agent.kill()
-        agent.wait()
+        subprocess.run(
+            [paths.GPG_CONF, '--kill', 'all'],
+            check=True,
+            env=env,
+        )
 
     request.addfinalizer(fin)
 

--- a/ipatests/test_ipaserver/test_kadmin.py
+++ b/ipatests/test_ipaserver/test_kadmin.py
@@ -72,10 +72,10 @@ def service_in_service_subtree(request):
     return princ
 
 
-@pytest.fixture(params=[service_in_kerberos_subtree,
-                        service_in_service_subtree])
+@pytest.fixture(params=["service_in_kerberos_subtree",
+                        "service_in_service_subtree"])
 def service(request):
-    return request.param(request)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.mark.skipif(

--- a/ipatests/test_ipaserver/test_ldap.py
+++ b/ipatests/test_ipaserver/test_ldap.py
@@ -29,7 +29,6 @@ from __future__ import absolute_import
 
 import os
 import sys
-import unittest
 
 import pytest
 import six
@@ -92,7 +91,7 @@ class test_ldap:
             with open(pwfile, "r") as fp:
                 dm_password = fp.read().rstrip()
         else:
-            raise unittest.SkipTest(
+            pytest.skip(
                 "No directory manager password in %s" % pwfile
             )
         self.conn = ldap2(api)
@@ -118,7 +117,7 @@ class test_ldap:
             with open(pwfile, "r") as fp:
                 dm_password = fp.read().rstrip()
         else:
-            raise unittest.SkipTest(
+            pytest.skip(
                 "No directory manager password in %s" % pwfile
             )
         myapi.Backend.ldap2.connect(bind_dn=DN(('cn', 'Directory Manager')), bind_pw=dm_password)
@@ -136,7 +135,7 @@ class test_ldap:
         try:
             self.conn.connect(autobind=True)
         except errors.ACIError:
-            raise unittest.SkipTest("Only executed as root")
+            pytest.skip("Only executed as root")
         entry_attrs = self.conn.get_entry(self.dn, ['usercertificate'])
         cert = entry_attrs.get('usercertificate')[0]
         assert cert.serial_number is not None

--- a/ipatests/test_ipaserver/test_ldap.py
+++ b/ipatests/test_ipaserver/test_ldap.py
@@ -50,15 +50,17 @@ class test_ldap:
     Test various LDAP client bind methods.
     """
 
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def ldap_setup(self, request):
         self.conn = None
         self.ldapuri = api.env.ldap_uri
         self.dn = DN(('krbprincipalname','ldap/%s@%s' % (api.env.host, api.env.realm)),
                      ('cn','services'),('cn','accounts'),api.env.basedn)
 
-    def teardown(self):
-        if self.conn and self.conn.isconnected():
-            self.conn.disconnect()
+        def fin():
+            if self.conn and self.conn.isconnected():
+                self.conn.disconnect()
+        request.addfinalizer(fin)
 
     def test_anonymous(self):
         """
@@ -151,16 +153,18 @@ class test_LDAPEntry:
     dn1 = DN(('cn', cn1[0]))
     dn2 = DN(('cn', cn2[0]))
 
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def ldapentry_setup(self, request):
         self.ldapuri = api.env.ldap_uri
         self.conn = ldap2(api)
         self.conn.connect(autobind=AUTOBIND_DISABLED)
 
         self.entry = self.conn.make_entry(self.dn1, cn=self.cn1)
 
-    def teardown(self):
-        if self.conn and self.conn.isconnected():
-            self.conn.disconnect()
+        def fin():
+            if self.conn and self.conn.isconnected():
+                self.conn.disconnect()
+        request.addfinalizer(fin)
 
     def test_entry(self):
         e = self.entry

--- a/ipatests/test_ipaserver/test_migratepw.py
+++ b/ipatests/test_ipaserver/test_migratepw.py
@@ -20,21 +20,21 @@ class test_migratepw(XMLRPC_test, Unauthorized_HTTP_test):
     """
     app_uri = '/ipa/migration/migration.py'
 
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def migratepw_setup(self, request):
         """
         Prepare for tests
         """
         api.Command['user_add'](uid=testuser, givenname=u'Test', sn=u'User')
         api.Command['passwd'](testuser, password=password)
 
-    def teardown(self):
-        """
-        Clean up
-        """
-        try:
-            api.Command['user_del']([testuser])
-        except errors.NotFound:
-            pass
+        def fin():
+            try:
+                api.Command['user_del']([testuser])
+            except errors.NotFound:
+                pass
+
+        request.addfinalizer(fin)
 
     def _migratepw(self, user, password, method='POST'):
         """

--- a/ipatests/test_ipaserver/test_secrets.py
+++ b/ipatests/test_ipaserver/test_secrets.py
@@ -6,7 +6,8 @@ import os
 import shutil
 import subprocess
 import tempfile
-import unittest
+
+import pytest
 
 
 def _test_password_callback():
@@ -15,9 +16,13 @@ def _test_password_callback():
     return password
 
 
-class TestiSecStore(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
+class TestiSecStore:
+    certdb = None
+    cert2db = None
+
+    @pytest.fixture(autouse=True, scope="class")
+    def isec_store_setup(self, request):
+        cls = request.cls
         cls.testdir = tempfile.mkdtemp(suffix='ipa-sec-store')
         pwfile = os.path.join(cls.testdir, 'pwfile')
         with open(pwfile, 'w') as f:
@@ -45,9 +50,9 @@ class TestiSecStore(unittest.TestCase):
             cwd=cls.testdir
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.testdir)
+        def fin():
+            shutil.rmtree(cls.testdir)
+        request.addfinalizer(fin)
 
     def test_iSecStore(self):
         iss = iSecStore({})

--- a/ipatests/test_ipaserver/test_topology_plugin.py
+++ b/ipatests/test_ipaserver/test_topology_plugin.py
@@ -20,15 +20,17 @@ class TestTopologyPlugin:
     """
     pwfile = os.path.join(api.env.dot_ipa, ".dmpw")
 
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def topologyplugin_setup(self, request):
         """
         setup for test
         """
         self.conn = None
 
-    def teardown(self):
-        if self.conn and self.conn.isconnected():
-            self.conn.disconnect()
+        def fin():
+            if self.conn and self.conn.isconnected():
+                self.conn.disconnect()
+        request.addfinalizer(fin)
 
     @pytest.mark.skipif(os.path.isfile(pwfile) is False,
                         reason="You did not provide a .dmpw file with the DM password")

--- a/ipatests/test_ipatests_plugins/test_depr_frameworks.py
+++ b/ipatests/test_ipatests_plugins/test_depr_frameworks.py
@@ -1,0 +1,99 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+import pytest
+
+
+@pytest.fixture
+def ipa_testdir(testdir):
+    """
+    Create conftest within testdir.
+    """
+    testdir.makeconftest(
+        """
+        pytest_plugins = ["ipatests.pytest_ipa.deprecated_frameworks"]
+        """
+    )
+    return testdir
+
+
+@pytest.fixture
+def xunit_testdir(ipa_testdir):
+    """
+    Create xnit style test module within testdir.
+    """
+    ipa_testdir.makepyfile("""
+        def setup_module():
+            pass
+        def teardown_module():
+            pass
+        def setup_function():
+            pass
+        def teardown_function():
+            pass
+
+        class TestClass:
+            @classmethod
+            def setup_class(cls):
+                pass
+            @classmethod
+            def teardown_class(cls):
+                pass
+            def setup_method(self):
+                pass
+            def teardown_method(self):
+                pass
+            def test_m(self):
+                pass
+        """)
+    return ipa_testdir
+
+
+@pytest.fixture
+def unittest_testdir(ipa_testdir):
+    """
+    Create unittest style test module within testdir.
+    """
+    ipa_testdir.makepyfile("""
+        import unittest
+        def setUpModule():
+            pass
+        def tearDownModule():
+            pass
+        class TestClass(unittest.TestCase):
+            @classmethod
+            def setUp(self):
+                pass
+            def tearDown(self):
+                pass
+            @classmethod
+            def setUpClass(cls):
+                pass
+            @classmethod
+            def tearDownClass(cls):
+                pass
+            def test_m(self):
+                pass
+        """)
+    return ipa_testdir
+
+
+def test_xunit(xunit_testdir):
+    result = xunit_testdir.runpytest()
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines([
+        "* PytestDeprecationWarning: xunit style is deprecated in favour of "
+        "fixtures style",
+        "* 8 warning*",
+    ])
+
+
+def test_unittest(unittest_testdir):
+    result = unittest_testdir.runpytest()
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines([
+        "* PytestDeprecationWarning: unittest is deprecated in favour of "
+        "fixtures style",
+        "* 1 warning*",
+    ])

--- a/ipatests/test_util.py
+++ b/ipatests/test_util.py
@@ -154,7 +154,7 @@ class test_Fuzzy:
 
 def test_assert_deepequal(pytestconfig):
     f = util.assert_deepequal
-    try:  # pylint: disable=no-member
+    try:
         pretty = pytestconfig.getoption("pretty_print")
     except (AttributeError, ValueError):
         pretty = False

--- a/ipatests/test_webui/test_automember.py
+++ b/ipatests/test_webui/test_automember.py
@@ -84,8 +84,8 @@ class TestAutomember(UI_driver):
         'Automember rule with name "{}" already exists'
     )
 
-    def setup(self):
-        super(TestAutomember, self).setup()
+    @pytest.fixture(autouse=True)
+    def automember_setup(self, ui_driver_fsetup):
         self.init_app()
 
     def add_user_group_rules(self, *pkeys, **kwargs):

--- a/ipatests/test_webui/test_automount.py
+++ b/ipatests/test_webui/test_automount.py
@@ -187,8 +187,8 @@ class Location:
 @pytest.mark.tier1
 class TestAutomount(UI_driver):
 
-    def setup(self):
-        super().setup()
+    @pytest.fixture(autouse=True)
+    def automount_setup(self, ui_driver_fsetup):
         self.init_app()
 
     def add_key(self, key, mount_info, **kwargs):

--- a/ipatests/test_webui/test_cert.py
+++ b/ipatests/test_webui/test_cert.py
@@ -83,9 +83,8 @@ def check_minimum_serial(self, serial, option):
 @pytest.mark.tier1
 class test_cert(UI_driver):
 
-    def setup(self, *args, **kwargs):
-        super(test_cert, self).setup(*args, **kwargs)
-
+    @pytest.fixture(autouse=True)
+    def cert_setup(self, ui_driver_fsetup):
         if not self.has_ca():
             self.skip('CA not configured')
 

--- a/ipatests/test_webui/test_dns.py
+++ b/ipatests/test_webui/test_dns.py
@@ -35,9 +35,8 @@ import pytest
 @pytest.mark.tier1
 class test_dns(UI_driver):
 
-    def setup(self, *args, **kwargs):
-        super(test_dns, self).setup(*args, **kwargs)
-
+    @pytest.fixture(autouse=True)
+    def dns_setup(self, ui_driver_fsetup):
         if not self.has_dns():
             self.skip('DNS not configured')
 

--- a/ipatests/test_webui/test_host.py
+++ b/ipatests/test_webui/test_host.py
@@ -48,8 +48,8 @@ ENTITY = 'host'
 @pytest.mark.tier1
 class host_tasks(UI_driver):
 
-    def setup(self, *args, **kwargs):
-        super(host_tasks, self).setup(*args, **kwargs)
+    @pytest.fixture(autouse=True)
+    def hosttasks_setup(self, ui_driver_fsetup):
         self.prep_data()
         self.prep_data2()
         self.prep_data3()

--- a/ipatests/test_webui/test_loginscreen.py
+++ b/ipatests/test_webui/test_loginscreen.py
@@ -24,22 +24,22 @@ import pytest
 @pytest.mark.tier1
 class TestLoginScreen(UI_driver):
 
-    def setup(self, *args, **kwargs):
-        super(TestLoginScreen, self).setup(*args, **kwargs)
+    @pytest.fixture(autouse=True)
+    def loginscreen_setup(self, request, ui_driver_fsetup):
         self.init_app()
         self.add_test_user()
         self.logout()
 
-    def teardown(self, *args, **kwargs):
-        # log out first
-        if (self.logged_in()):
-            self.logout()
-        else:
-            self.load_url(self.get_base_url())
-        # log in as administrator
-        self.login()
-        self.delete_test_user()
-        super(TestLoginScreen, self).teardown(*args, **kwargs)
+        def fin():
+            # log out first
+            if (self.logged_in()):
+                self.logout()
+            else:
+                self.load_url(self.get_base_url())
+            # log in as administrator
+            self.login()
+            self.delete_test_user()
+        request.addfinalizer(fin)
 
     def delete_test_user(self):
         """

--- a/ipatests/test_webui/test_range.py
+++ b/ipatests/test_webui/test_range.py
@@ -38,8 +38,8 @@ PKEY = 'itest-range'
 @pytest.mark.tier1
 class test_range(range_tasks):
 
-    def setup(self):
-        super().setup()
+    @pytest.fixture(autouse=True)
+    def range_setup(self, ui_driver_fsetup):
         self.init_app()
         self.get_shifts()
 

--- a/ipatests/test_webui/test_trust.py
+++ b/ipatests/test_webui/test_trust.py
@@ -45,6 +45,10 @@ CONFIG_DATA2 = {
 @pytest.mark.tier1
 class trust_tasks(UI_driver):
 
+    @pytest.fixture(autouse=True)
+    def trusttasks_setup(self, ui_driver_fsetup):
+        pass
+
     def get_data(self, add_data=None):
 
         domain = self.config.get('ad_domain')
@@ -100,8 +104,8 @@ class test_trust(trust_tasks):
 
     request_timeout = 120
 
-    def setup(self, *args, **kwargs):
-        super(test_trust, self).setup(*args, **kwargs)
+    @pytest.fixture(autouse=True)
+    def trust_setup(self, trusttasks_setup):
         if not self.has_trusts():
             self.skip('Trusts not configured')
 

--- a/ipatests/test_webui/test_vault.py
+++ b/ipatests/test_webui/test_vault.py
@@ -32,6 +32,10 @@ import pytest
 @pytest.mark.tier1
 class vault_tasks(UI_driver):
 
+    @pytest.fixture(autouse=True)
+    def vault_tasks_setup(self, ui_driver_fsetup):
+        pass
+
     def prep_service_data(self):
 
         host = self.config.get('ipa_server')
@@ -64,8 +68,8 @@ class vault_tasks(UI_driver):
 @pytest.mark.tier1
 class test_vault(vault_tasks):
 
-    def setup(self, *args, **kwargs):
-        super(test_vault, self).setup(*args, **kwargs)
+    @pytest.fixture(autouse=True)
+    def vault_setup(self, vault_tasks_setup):
         if not self.has_kra():
             self.skip('KRA not configured')
 

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -162,19 +162,22 @@ class UI_driver:
 
     request_timeout = 60
 
-    @classmethod
-    def setup_class(cls):
+    @pytest.fixture(autouse=True, scope="class")
+    def ui_driver_setup(self, request):
+        cls = request.cls
         if NO_SELENIUM:
             raise unittest.SkipTest('Selenium not installed')
         cls.load_config()
 
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def ui_driver_fsetup(self, request):
         self.driver = self.get_driver()
         self.driver.maximize_window()
 
-    def teardown(self):
-        self.driver.delete_all_cookies()
-        self.driver.quit()
+        def fin():
+            self.driver.delete_all_cookies()
+            self.driver.quit()
+        request.addfinalizer(fin)
 
     @classmethod
     def load_config(cls):

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -28,8 +28,8 @@ from datetime import datetime
 import time
 import re
 import os
+
 from functools import wraps
-import unittest
 from urllib.error import URLError
 
 import paramiko
@@ -102,8 +102,6 @@ def screenshot(fn):
     def screenshot_wrapper(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except unittest.SkipTest:
-            raise
         except Exception:
             self = args[0]
             name = '%s_%s_%s' % (
@@ -166,7 +164,7 @@ class UI_driver:
     def ui_driver_setup(self, request):
         cls = request.cls
         if NO_SELENIUM:
-            raise unittest.SkipTest('Selenium not installed')
+            pytest.skip('Selenium not installed')
         cls.load_config()
 
     @pytest.fixture(autouse=True)
@@ -195,9 +193,9 @@ class UI_driver:
                 with open(path, 'r') as conf:
                     cls.config = yaml.load(conf)
             except yaml.YAMLError as e:
-                raise unittest.SkipTest("Invalid Web UI config.\n%s" % e)
+                pytest.skip("Invalid Web UI config.\n%s" % e)
             except IOError as e:
-                raise unittest.SkipTest(
+                pytest.skip(
                     "Can't load Web UI test config: %s" % e
                 )
         else:
@@ -236,7 +234,7 @@ class UI_driver:
 
         if driver_type == 'remote':
             if 'host' not in cls.config:
-                raise unittest.SkipTest('Selenium server host not configured')
+                pytest.skip('Selenium server host not configured')
             host = cls.config["host"]
 
             if browser == 'chrome':
@@ -252,11 +250,11 @@ class UI_driver:
                     command_executor='http://%s:%d/wd/hub' % (host, port),
                     desired_capabilities=capabilities)
             except URLError as e:
-                raise unittest.SkipTest(
+                pytest.skip(
                     'Error connecting to selenium server: %s' % e
                 )
             except RuntimeError as e:
-                raise unittest.SkipTest(
+                pytest.skip(
                     'Error while establishing webdriver: %s' % e
                 )
         else:
@@ -272,11 +270,11 @@ class UI_driver:
                     ff_log_path = cls.config.get("geckodriver_log_path")
                     driver = webdriver.Firefox(fp, log_path=ff_log_path)
             except URLError as e:
-                raise unittest.SkipTest(
+                pytest.skip(
                     'Error connecting to selenium server: %s' % e
                 )
             except RuntimeError as e:
-                raise unittest.SkipTest(
+                pytest.skip(
                     'Error while establishing webdriver: %s' % e
                 )
 
@@ -2019,7 +2017,7 @@ class UI_driver:
         """
         Skip tests
         """
-        raise unittest.SkipTest(reason)
+        pytest.skip(reason)
 
     def assert_text(self, selector, value, parent=None):
         """

--- a/ipatests/test_xmlrpc/test_attr.py
+++ b/ipatests/test_xmlrpc/test_attr.py
@@ -29,7 +29,7 @@ import pytest
 
 
 @pytest.fixture(scope='class')
-def user(request):
+def user(request, xmlrpc_setup):
     tracker = UserTracker(name=u'user1', givenname=u'Test', sn=u'User1')
     return tracker.make_fixture(request)
 

--- a/ipatests/test_xmlrpc/test_automember_plugin.py
+++ b/ipatests/test_xmlrpc/test_automember_plugin.py
@@ -36,7 +36,6 @@ from ipaserver.plugins.automember import REBUILD_TASK_CONTAINER
 import time
 import pytest
 import re
-import unittest
 from pkg_resources import parse_version
 
 try:
@@ -263,7 +262,7 @@ def set_automember_process_modify_ops(value):
     :param value: can be either on or off
     """
     if not have_ldap2:
-        raise unittest.SkipTest('server plugin not available')
+        pytest.skip('server plugin not available')
     ldap = ldap2(api)
     ldap.connect()
     plugin_entry = ldap.get_entry(
@@ -287,7 +286,7 @@ def wait_automember_rebuild():
     If no task is found assume that the task is already finished.
     """
     if not have_ldap2:
-        raise unittest.SkipTest('server plugin not available')
+        pytest.skip('server plugin not available')
     ldap = ldap2(api)
     ldap.connect()
 
@@ -897,7 +896,7 @@ class TestAutomemberFindOrphans(XMLRPC_test):
         # rebuild fails if 389-ds is older than 1.4.0.22 where unmembering
         # feature was implemented: https://pagure.io/389-ds-base/issue/50077
         if not have_ldap2:
-            raise unittest.SkipTest('server plugin not available')
+            pytest.skip('server plugin not available')
         ldap = ldap2(api)
         ldap.connect()
         rootdse = ldap.get_entry(DN(''), ['vendorVersion'])

--- a/ipatests/test_xmlrpc/test_automember_plugin.py
+++ b/ipatests/test_xmlrpc/test_automember_plugin.py
@@ -58,7 +58,7 @@ hostgroup_exclude_regex3 = u'^webserver5'
 
 
 @pytest.fixture(scope='class')
-def manager1(request):
+def manager1(request, xmlrpc_setup):
     """ User tracker used as a manager account """
     tracker = UserTracker(name=u'mscott', sn=u'Manager1',
                           givenname=u'Automember test manager user1')
@@ -74,49 +74,49 @@ def user1(request, manager1):
 
 
 @pytest.fixture(scope='class')
-def group1(request):
+def group1(request, xmlrpc_setup):
     tracker = GroupTracker(name=u'tgroup1',
                            description=u'Automember test group1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def defaultgroup1(request):
+def defaultgroup1(request, xmlrpc_setup):
     tracker = GroupTracker(name=u'defaultgroup1',
                            description=u'Automember test defaultgroup1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def hostgroup1(request):
+def hostgroup1(request, xmlrpc_setup):
     tracker = HostGroupTracker(name=u'thostgroup1',
                                description=u'Automember test hostgroup1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def hostgroup2(request):
+def hostgroup2(request, xmlrpc_setup):
     tracker = HostGroupTracker(name=u'thostgroup2',
                                description=u'Automember test hostgroup2')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def hostgroup3(request):
+def hostgroup3(request, xmlrpc_setup):
     tracker = HostGroupTracker(name=u'thostgroup3',
                                description=u'Automember test hostgroup3')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def hostgroup4(request):
+def hostgroup4(request, xmlrpc_setup):
     tracker = HostGroupTracker(name=u'thostgroup4',
                                description=u'Automember test hostgroup4')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def defaulthostgroup1(request):
+def defaulthostgroup1(request, xmlrpc_setup):
     tracker = HostGroupTracker(name=u'defaulthostgroup1',
                                description=u'Automember test'
                                            'defaulthostgroup1')
@@ -124,31 +124,31 @@ def defaulthostgroup1(request):
 
 
 @pytest.fixture(scope='class')
-def host1(request):
+def host1(request, xmlrpc_setup):
     tracker = HostTracker(u'web1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def host2(request):
+def host2(request, xmlrpc_setup):
     tracker = HostTracker(u'dev1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def host3(request):
+def host3(request, xmlrpc_setup):
     tracker = HostTracker(u'web5')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def host4(request):
+def host4(request, xmlrpc_setup):
     tracker = HostTracker(u'www5')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def host5(request):
+def host5(request, xmlrpc_setup):
     tracker = HostTracker(u'webserver5')
     return tracker.make_fixture(request)
 

--- a/ipatests/test_xmlrpc/test_ca_plugin.py
+++ b/ipatests/test_xmlrpc/test_ca_plugin.py
@@ -45,7 +45,7 @@ def default_ca(request):
 
 
 @pytest.fixture(scope='class')
-def crud_subca(request):
+def crud_subca(request, xmlrpc_setup):
     name = u'crud-subca'
     subject = u'CN=crud subca test,O=crud testing inc'
     tracker = CATracker(name, subject)
@@ -54,7 +54,7 @@ def crud_subca(request):
 
 
 @pytest.fixture(scope='class')
-def subject_conflict_subca(request):
+def subject_conflict_subca(request, xmlrpc_setup):
     name = u'crud-subca-2'
     subject = u'CN=crud subca test,O=crud testing inc'
     tracker = CATracker(name, subject)
@@ -64,7 +64,7 @@ def subject_conflict_subca(request):
 
 
 @pytest.fixture(scope='class')
-def unrecognised_subject_dn_attrs_subca(request):
+def unrecognised_subject_dn_attrs_subca(request, xmlrpc_setup):
     name = u'crud-subca-3'
     subject = u'CN=crud subca test,DN=example.com,O=crud testing inc'
     tracker = CATracker(name, subject)

--- a/ipatests/test_xmlrpc/test_caacl_plugin.py
+++ b/ipatests/test_xmlrpc/test_caacl_plugin.py
@@ -18,7 +18,7 @@ from ipatests.test_xmlrpc.tracker.ca_plugin import CATracker
 
 
 @pytest.fixture(scope='class')
-def default_profile(request):
+def default_profile(request, xmlrpc_setup):
     name = 'caIPAserviceCert'
     desc = u'Standard profile for network services'
     tracker = CertprofileTracker(name, store=True, desc=desc)
@@ -27,7 +27,7 @@ def default_profile(request):
 
 
 @pytest.fixture(scope='class')
-def default_acl(request):
+def default_acl(request, xmlrpc_setup):
     name = u'hosts_services_caIPAserviceCert'
     tracker = CAACLTracker(name, service_category=u'all', host_category=u'all')
     tracker.track_create()
@@ -37,7 +37,7 @@ def default_acl(request):
 
 
 @pytest.fixture(scope='class')
-def crud_acl(request):
+def crud_acl(request, xmlrpc_setup):
     name = u'crud-acl'
     tracker = CAACLTracker(name)
 
@@ -45,7 +45,7 @@ def crud_acl(request):
 
 
 @pytest.fixture(scope='class')
-def category_acl(request):
+def category_acl(request, xmlrpc_setup):
     name = u'category_acl'
     tracker = CAACLTracker(name, ipacertprofile_category=u'all',
                            user_category=u'all', service_category=u'all',
@@ -55,14 +55,14 @@ def category_acl(request):
 
 
 @pytest.fixture(scope='class')
-def caacl_test_ca(request):
+def caacl_test_ca(request, xmlrpc_setup):
     name = u'caacl-test-ca'
     subject = u'CN=caacl test subca,O=test industries inc.'
     return CATracker(name, subject).make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def staged_user(request):
+def staged_user(request, xmlrpc_setup):
     name = u'st-user'
     tracker = StageUserTracker(name, u'stage', u'test')
 

--- a/ipatests/test_xmlrpc/test_caacl_profile_enforcement.py
+++ b/ipatests/test_xmlrpc/test_caacl_profile_enforcement.py
@@ -63,7 +63,7 @@ def generate_user_csr(username, domain=None):
 
 
 @pytest.fixture(scope='class')
-def smime_profile(request):
+def smime_profile(request, xmlrpc_setup):
     profile_path = prepare_config(
             SMIME_PROFILE_TEMPLATE,
             dict(ipadomain=api.env.domain, iparealm=api.env.realm))
@@ -76,7 +76,7 @@ def smime_profile(request):
 
 
 @pytest.fixture(scope='class')
-def smime_acl(request):
+def smime_acl(request, xmlrpc_setup):
     tracker = CAACLTracker(u'smime_acl')
 
     return tracker.make_fixture(request)
@@ -86,7 +86,7 @@ def smime_acl(request):
 # UserTracker has problems while setting passwords.
 # Until fixed, will use this fixture.
 @pytest.fixture(scope='class')
-def smime_user(request):
+def smime_user(request, xmlrpc_setup):
     username = u'alice'
     api.Command.user_add(uid=username, givenname=u'Alice', sn=u'SMIME',
                          userpassword=SMIME_USER_INIT_PW)
@@ -101,7 +101,7 @@ def smime_user(request):
 
 
 @pytest.fixture(scope='class')
-def smime_group(request):
+def smime_group(request, xmlrpc_setup):
     api.Command.group_add(u'smime_users')
 
     def fin():
@@ -259,7 +259,7 @@ class TestSignWithChangedProfile(XMLRPC_test):
 
 
 @pytest.fixture(scope='class')
-def smime_signing_ca(request):
+def smime_signing_ca(request, xmlrpc_setup):
     name = u'smime-signing-ca'
     subject = u'CN=SMIME CA,O=test industries Inc.'
     return CATracker(name, subject).make_fixture(request)
@@ -368,7 +368,7 @@ class TestCertSignMIMEwithSubCA(XMLRPC_test):
 
 
 @pytest.fixture(scope='class')
-def santest_subca(request):
+def santest_subca(request, xmlrpc_setup):
     name = u'default-profile-subca'
     subject = u'CN={},O=test'.format(name)
     tr = CATracker(name, subject)
@@ -376,19 +376,19 @@ def santest_subca(request):
 
 
 @pytest.fixture(scope='class')
-def santest_subca_acl(request):
+def santest_subca_acl(request, xmlrpc_setup):
     tr = CAACLTracker(u'default_profile_subca')
     return tr.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def santest_host_1(request):
+def santest_host_1(request, xmlrpc_setup):
     tr = HostTracker(u'santest-host-1')
     return tr.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def santest_host_2(request):
+def santest_host_2(request, xmlrpc_setup):
     tr = HostTracker(u'santest-host-2')
     return tr.make_fixture(request)
 

--- a/ipatests/test_xmlrpc/test_cert_plugin.py
+++ b/ipatests/test_xmlrpc/test_cert_plugin.py
@@ -23,7 +23,6 @@ from __future__ import print_function, absolute_import
 
 import base64
 import os
-import unittest
 
 import pytest
 import six
@@ -57,7 +56,7 @@ def is_db_configured():
 
     if (api.env.xmlrpc_uri == u'http://localhost:8888/ipa/xml' and
        not os.path.isfile(aliasdir)):
-        raise unittest.SkipTest('developer CA not configured in %s' % aliasdir)
+        pytest.skip('developer CA not configured in %s' % aliasdir)
 
 # Test setup
 #
@@ -86,9 +85,9 @@ class BaseCert(XMLRPC_test):
     @pytest.fixture(autouse=True, scope="class")
     def basecert_setup(self, request, xmlrpc_setup):
         if 'cert_request' not in api.Command:
-            raise unittest.SkipTest('cert_request not registered')
+            pytest.skip('cert_request not registered')
         if 'cert_show' not in api.Command:
-            raise unittest.SkipTest('cert_show not registered')
+            pytest.skip('cert_show not registered')
 
         is_db_configured()
 
@@ -275,10 +274,10 @@ class test_cert_find(XMLRPC_test):
     @pytest.fixture(autouse=True, scope="class")
     def certfind_setup(self, request, xmlrpc_setup):
         if 'cert_find' not in api.Command:
-            raise unittest.SkipTest('cert_find not registered')
+            pytest.skip('cert_find not registered')
 
         if api.env.ra_plugin != 'dogtag':
-            raise unittest.SkipTest('cert_find for dogtag CA only')
+            pytest.skip('cert_find for dogtag CA only')
 
         is_db_configured()
 

--- a/ipatests/test_xmlrpc/test_cert_request_ip_address.py
+++ b/ipatests/test_xmlrpc/test_cert_request_ip_address.py
@@ -46,7 +46,7 @@ ipv6_revrec_s = 'a.f.5.9.9.9.2.4.b.a.d.b.8.1.f.8'
 
 
 @pytest.fixture(scope='class')
-def host(request):
+def host(request, xmlrpc_setup):
     tr = HostTracker('iptest')
     return tr.make_fixture(request)
 

--- a/ipatests/test_xmlrpc/test_certmap_plugin.py
+++ b/ipatests/test_xmlrpc/test_certmap_plugin.py
@@ -82,19 +82,19 @@ def update_idfn(update):
 
 
 @pytest.fixture(scope='class')
-def certmap_rule(request):
+def certmap_rule(request, xmlrpc_setup):
     tracker = CertmapruleTracker(**certmaprule_create_params)
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def certmap_rule_trusted_domain(request):
+def certmap_rule_trusted_domain(request, xmlrpc_setup):
     tracker = CertmapruleTracker(**certmaprule_create_trusted_params)
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def certmap_config(request):
+def certmap_config(request, xmlrpc_setup):
     tracker = CertmapconfigTracker()
     return tracker.make_fixture(request)
 
@@ -344,7 +344,7 @@ def change_permissions_bindtype(perm, bindtype):
 
 
 @pytest.fixture(scope='class')
-def bindtype_permission(request):
+def bindtype_permission(request, xmlrpc_setup):
     orig_bindtype = {}
     # set bindtype to permission to actually test the permission
     for perm_name in certmaprule_permissions.values():

--- a/ipatests/test_xmlrpc/test_certprofile_plugin.py
+++ b/ipatests/test_xmlrpc/test_certprofile_plugin.py
@@ -44,7 +44,7 @@ RENAME_ERR_TEMPL = (
 
 
 @pytest.fixture(scope='class')
-def default_profile(request):
+def default_profile(request, xmlrpc_setup):
     name = 'caIPAserviceCert'
     desc = u'Standard profile for network services'
     tracker = CertprofileTracker(name, store=True, desc=desc)
@@ -53,7 +53,7 @@ def default_profile(request):
 
 
 @pytest.fixture(scope='class')
-def user_profile(request):
+def user_profile(request, xmlrpc_setup):
     name = 'caIPAserviceCert_mod'
     profile_path = prepare_config(
         CA_IPA_SERVICE_MODIFIED_TEMPLATE,
@@ -70,7 +70,7 @@ def user_profile(request):
 
 
 @pytest.fixture(scope='class')
-def malformed(request):
+def malformed(request, xmlrpc_setup):
     name = u'caIPAserviceCert_mal'
     profile_path = prepare_config(
         CA_IPA_SERVICE_MALFORMED_TEMPLATE,
@@ -86,7 +86,7 @@ def malformed(request):
 
 
 @pytest.fixture(scope='class')
-def xmlprofile(request):
+def xmlprofile(request, xmlrpc_setup):
     name = u'caIPAserviceCert_xml'
     profile_path = prepare_config(
         CA_IPA_SERVICE_XML_TEMPLATE,

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -20,8 +20,6 @@
 Test the `ipaserver/plugins/dns.py` module.
 """
 
-import unittest
-
 from ipalib import api, errors
 from ipalib.util import normalize_zone
 from ipapython.dnsutil import DNSName
@@ -432,10 +430,10 @@ class test_dns(Declarative):
             api.Backend.rpcclient.connect()
 
         if not have_ldap2:
-            raise unittest.SkipTest('server plugin not available')
+            pytest.skip('server plugin not available')
 
         if get_nameservers_error is not None:
-            raise unittest.SkipTest(
+            pytest.skip(
                 'unable to get list of nameservers (%s)' %
                 get_nameservers_error
             )
@@ -446,7 +444,7 @@ class test_dns(Declarative):
            )
            api.Command['dnszone_del'](zone1)
         except errors.NotFound:
-            raise unittest.SkipTest('DNS is not configured')
+            pytest.skip('DNS is not configured')
         except errors.DuplicateEntry:
             pass
 
@@ -3342,10 +3340,10 @@ class test_root_zone(Declarative):
             api.Backend.rpcclient.connect()
 
         if not have_ldap2:
-            raise unittest.SkipTest('server plugin not available')
+            pytest.skip('server plugin not available')
 
         if get_nameservers_error is not None:
-            raise unittest.SkipTest(
+            pytest.skip(
                 'unable to get list of nameservers (%s)' %
                 get_nameservers_error
             )
@@ -3354,7 +3352,7 @@ class test_root_zone(Declarative):
             api.Command['dnszone_add'](zone1, idnssoarname=zone1_rname,)
             api.Command['dnszone_del'](zone1)
         except errors.NotFound:
-            raise unittest.SkipTest('DNS is not configured')
+            pytest.skip('DNS is not configured')
         except errors.DuplicateEntry:
             pass
 
@@ -3426,13 +3424,13 @@ class test_forward_zones(Declarative):
             api.Backend.rpcclient.connect()
 
         if not have_ldap2:
-            raise unittest.SkipTest('server plugin not available')
+            pytest.skip('server plugin not available')
 
         try:
             api.Command['dnszone_add'](zone1, idnssoarname=zone1_rname,)
             api.Command['dnszone_del'](zone1)
         except errors.NotFound:
-            raise unittest.SkipTest('DNS is not configured')
+            pytest.skip('DNS is not configured')
         except errors.DuplicateEntry:
             pass
 
@@ -4633,13 +4631,13 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
             api.Backend.rpcclient.connect()
 
         if not have_ldap2:
-            raise unittest.SkipTest('server plugin not available')
+            pytest.skip('server plugin not available')
 
         try:
             api.Command['dnszone_add'](zone1, idnssoarname=zone1_rname,)
             api.Command['dnszone_del'](zone1)
         except errors.NotFound:
-            raise unittest.SkipTest('DNS is not configured')
+            pytest.skip('DNS is not configured')
         except errors.DuplicateEntry:
             pass
 
@@ -5011,13 +5009,13 @@ class test_forwardzone_delegation_warnings(Declarative):
             api.Backend.rpcclient.connect()
 
         if not have_ldap2:
-            raise unittest.SkipTest('server plugin not available')
+            pytest.skip('server plugin not available')
 
         try:
             api.Command['dnszone_add'](zone1, idnssoarname=zone1_rname,)
             api.Command['dnszone_del'](zone1)
         except errors.NotFound:
-            raise unittest.SkipTest('DNS is not configured')
+            pytest.skip('DNS is not configured')
         except errors.DuplicateEntry:
             pass
 
@@ -5520,17 +5518,17 @@ class test_dns_soa(Declarative):
             api.Backend.rpcclient.connect()
 
         if not have_ldap2:
-            raise unittest.SkipTest('server plugin not available')
+            pytest.skip('server plugin not available')
 
         if get_nameservers_error is not None:
-            raise unittest.SkipTest('unable to get list of nameservers (%s)' %
+            pytest.skip('unable to get list of nameservers (%s)' %
                                 get_nameservers_error)
         try:
             api.Command['dnszone_add'](zone1,
                                        idnssoarname=zone1_rname,)
             api.Command['dnszone_del'](zone1)
         except errors.NotFound:
-            raise unittest.SkipTest('DNS is not configured')
+            pytest.skip('DNS is not configured')
         except errors.DuplicateEntry:
             pass
 

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -426,10 +426,8 @@ if have_ldap2:
 @pytest.mark.tier1
 class test_dns(Declarative):
 
-    @classmethod
-    def setup_class(cls):
-        super(test_dns, cls).setup_class()
-
+    @pytest.fixture(autouse=True, scope="class")
+    def dns_setup(self, declarative_setup):
         if not api.Backend.rpcclient.isconnected():
             api.Backend.rpcclient.connect()
 
@@ -3338,10 +3336,8 @@ class test_dns(Declarative):
 @pytest.mark.tier1
 class test_root_zone(Declarative):
 
-    @classmethod
-    def setup_class(cls):
-        super(test_root_zone, cls).setup_class()
-
+    @pytest.fixture(autouse=True, scope="class")
+    def root_zone_setup(self, declarative_setup):
         if not api.Backend.rpcclient.isconnected():
             api.Backend.rpcclient.connect()
 
@@ -3424,10 +3420,8 @@ class test_root_zone(Declarative):
 class test_forward_zones(Declarative):
     # https://fedorahosted.org/freeipa/ticket/4750
 
-    @classmethod
-    def setup_class(cls):
-        super(test_forward_zones, cls).setup_class()
-
+    @pytest.fixture(autouse=True, scope="class")
+    def forward_zone_setup(self, declarative_setup):
         if not api.Backend.rpcclient.isconnected():
             api.Backend.rpcclient.connect()
 
@@ -4633,10 +4627,8 @@ class test_forward_zones(Declarative):
 class test_forward_master_zones_mutual_exlusion(Declarative):
     # https://fedorahosted.org/freeipa/ticket/4750
 
-    @classmethod
-    def setup_class(cls):
-        super(test_forward_master_zones_mutual_exlusion, cls).setup_class()
-
+    @pytest.fixture(autouse=True, scope="class")
+    def forward_master_zone_setup(self, declarative_setup):
         if not api.Backend.rpcclient.isconnected():
             api.Backend.rpcclient.connect()
 
@@ -5013,10 +5005,8 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
 @pytest.mark.tier1
 class test_forwardzone_delegation_warnings(Declarative):
 
-    @classmethod
-    def setup_class(cls):
-        super(test_forwardzone_delegation_warnings, cls).setup_class()
-
+    @pytest.fixture(autouse=True, scope="class")
+    def forw_zone_deleg_warn_setup(self, declarative_setup):
         if not api.Backend.rpcclient.isconnected():
             api.Backend.rpcclient.connect()
 
@@ -5524,10 +5514,8 @@ class test_forwardzone_delegation_warnings(Declarative):
 @pytest.mark.tier1
 class test_dns_soa(Declarative):
 
-    @classmethod
-    def setup_class(cls):
-        super(test_dns_soa, cls).setup_class()
-
+    @pytest.fixture(autouse=True, scope="class")
+    def dns_soa_setup(self, declarative_setup):
         if not api.Backend.rpcclient.isconnected():
             api.Backend.rpcclient.connect()
 
@@ -6313,9 +6301,8 @@ class test_dns_soa(Declarative):
 class test_dns_type_uri(test_dns):
     """Test behavior specific for URI RR type."""
 
-    @classmethod
-    def setup_class(cls):
-        super(test_dns_type_uri, cls).setup_class()
+    @pytest.fixture(autouse=True, scope="class")
+    def dns_type_uri_setup(self, dns_setup):
         try:
             api.Command['dnszone_add'](zone1, idnssoarname=zone1_rname)
         except errors.DuplicateEntry:

--- a/ipatests/test_xmlrpc/test_external_members.py
+++ b/ipatests/test_xmlrpc/test_external_members.py
@@ -46,9 +46,8 @@ def get_trusted_group_name():
 
 @pytest.mark.tier1
 class test_external_members(Declarative):
-    @classmethod
-    def setup_class(cls):
-        super(test_external_members, cls).setup_class()
+    @pytest.fixture(autouse=True, scope="class")
+    def ext_member_setup(self, declarative_setup):
         if not api.Backend.rpcclient.isconnected():
             api.Backend.rpcclient.connect()
 

--- a/ipatests/test_xmlrpc/test_external_members.py
+++ b/ipatests/test_xmlrpc/test_external_members.py
@@ -21,8 +21,6 @@ Test adding/removing external members (trusted domain objects) to IPA groups.
 These tests are skipped if trust is not established.
 """
 
-import unittest
-
 from ipalib import api
 from ipapython.dn import DN
 from ipatests.test_xmlrpc import objectclasses
@@ -53,7 +51,7 @@ class test_external_members(Declarative):
 
         trusts = api.Command['trust_find']()
         if trusts['count'] == 0:
-            raise unittest.SkipTest('Trust is not established')
+            pytest.skip('Trust is not established')
 
     cleanup_commands = [
         ('group_del', [group_name], {}),

--- a/ipatests/test_xmlrpc/test_group_plugin.py
+++ b/ipatests/test_xmlrpc/test_group_plugin.py
@@ -41,13 +41,13 @@ external_sid1 = u'S-1-1-123456-789-1'
 
 
 @pytest.fixture(scope='class')
-def group(request):
+def group(request, xmlrpc_setup):
     tracker = GroupTracker(name=u'testgroup1', description=u'Test desc1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def group2(request):
+def group2(request, xmlrpc_setup):
     tracker = GroupTracker(name=u'testgroup2', description=u'Test desc2')
     return tracker.make_fixture(request)
 
@@ -65,7 +65,7 @@ def managed_group(request, user):
 
 
 @pytest.fixture(scope='class')
-def user(request):
+def user(request, xmlrpc_setup):
     tracker = UserTracker(name=u'user1', givenname=u'Test', sn=u'User1')
     return tracker.make_fixture(request)
 
@@ -85,7 +85,7 @@ def user_npg2(request, group):
 
 
 @pytest.fixture(scope='class')
-def admins(request):
+def admins(request, xmlrpc_setup):
     # Track the admins group
     tracker = GroupTracker(
         name=u'admins', description=u'Account administrators group'
@@ -97,7 +97,7 @@ def admins(request):
 
 
 @pytest.fixture(scope='class')
-def trustadmins(request):
+def trustadmins(request, xmlrpc_setup):
     # Track the 'trust admins' group
     tracker = GroupTracker(
         name=u'trust admins', description=u'Trusts administrators group'

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -108,37 +108,37 @@ ipv4_in_missingrevzone_ip = u'172.16.30.22'
 
 
 @pytest.fixture(scope='class')
-def host(request):
+def host(request, xmlrpc_setup):
     tracker = HostTracker(name=u'testhost1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def host2(request):
+def host2(request, xmlrpc_setup):
     tracker = HostTracker(name=u'testhost2')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def host3(request):
+def host3(request, xmlrpc_setup):
     tracker = HostTracker(name=u'testhost3')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def host4(request):
+def host4(request, xmlrpc_setup):
     tracker = HostTracker(name=u'testhost4')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def host5(request):
+def host5(request, xmlrpc_setup):
     tracker = HostTracker(name=u'testhost5')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def lab_host(request):
+def lab_host(request, xmlrpc_setup):
     name = u'testhost1'
     tracker = HostTracker(name=name,
                           fqdn=u'%s.lab.%s' % (name, api.env.domain))
@@ -146,7 +146,7 @@ def lab_host(request):
 
 
 @pytest.fixture(scope='class')
-def this_host(request):
+def this_host(request, xmlrpc_setup):
     """Fixture for the current master"""
     tracker = HostTracker(name=api.env.host.partition('.')[0],
                           fqdn=api.env.host)
@@ -158,41 +158,41 @@ def this_host(request):
 
 
 @pytest.fixture(scope='class')
-def invalid_host(request):
+def invalid_host(request, xmlrpc_setup):
     tracker = HostTracker(name='foo_bar',)
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def ipv6only_host(request):
+def ipv6only_host(request, xmlrpc_setup):
     name = u'testipv6onlyhost'
     tracker = HostTracker(name=name, fqdn=u'%s.%s' % (name, dnszone))
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def ipv4only_host(request):
+def ipv4only_host(request, xmlrpc_setup):
     name = u'testipv4onlyhost'
     tracker = HostTracker(name=name, fqdn=u'%s.%s' % (name, dnszone))
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def ipv46both_host(request):
+def ipv46both_host(request, xmlrpc_setup):
     name = u'testipv4and6host'
     tracker = HostTracker(name=name, fqdn=u'%s.%s' % (name, dnszone))
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def ipv4_fromip_host(request):
+def ipv4_fromip_host(request, xmlrpc_setup):
     name = u'testipv4fromip'
     tracker = HostTracker(name=name, fqdn=u'%s.%s' % (name, dnszone))
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def ipv6_fromip_host(request):
+def ipv6_fromip_host(request, xmlrpc_setup):
     name = u'testipv6fromip'
     tracker = HostTracker(name=name, fqdn=u'%s.%s' % (name, dnszone))
     return tracker.make_fixture(request)

--- a/ipatests/test_xmlrpc/test_hostgroup_plugin.py
+++ b/ipatests/test_xmlrpc/test_hostgroup_plugin.py
@@ -31,25 +31,25 @@ import pytest
 
 
 @pytest.fixture(scope='class')
-def hostgroup(request):
+def hostgroup(request, xmlrpc_setup):
     tracker = HostGroupTracker(name=u'hostgroup')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def hostgroup_invalid(request):
+def hostgroup_invalid(request, xmlrpc_setup):
     tracker = HostGroupTracker(name=u'@invalid')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def hostgroup_single(request):
+def hostgroup_single(request, xmlrpc_setup):
     tracker = HostGroupTracker(name=u'a')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def host(request):
+def host(request, xmlrpc_setup):
     tracker = HostTracker(name=u'host')
     return tracker.make_fixture(request)
 

--- a/ipatests/test_xmlrpc/test_location_plugin.py
+++ b/ipatests/test_xmlrpc/test_location_plugin.py
@@ -17,25 +17,25 @@ from ipapython.dnsutil import DNSName
 
 
 @pytest.fixture(scope='class', params=[u'location1', u'sk\xfa\u0161ka.idna'])
-def location(request):
+def location(request, xmlrpc_setup):
     tracker = LocationTracker(request.param)
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def location_invalid(request):
+def location_invalid(request, xmlrpc_setup):
     tracker = LocationTracker(u'invalid..location')
     return tracker
 
 
 @pytest.fixture(scope='class')
-def location_absolute(request):
+def location_absolute(request, xmlrpc_setup):
     tracker = LocationTracker(u'invalid.absolute.')
     return tracker
 
 
 @pytest.fixture(scope='class')
-def server(request):
+def server(request, xmlrpc_setup):
     tracker = ServerTracker(api.env.host)
     return tracker.make_fixture_clean_location(request)
 

--- a/ipatests/test_xmlrpc/test_nesting.py
+++ b/ipatests/test_xmlrpc/test_nesting.py
@@ -29,67 +29,67 @@ import pytest
 
 
 @pytest.fixture(scope='class')
-def user1(request):
+def user1(request, xmlrpc_setup):
     tracker = UserTracker(name=u'tuser1', givenname=u'Test1', sn=u'User1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def user2(request):
+def user2(request, xmlrpc_setup):
     tracker = UserTracker(name=u'tuser2', givenname=u'Test2', sn=u'User2')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def user3(request):
+def user3(request, xmlrpc_setup):
     tracker = UserTracker(name=u'tuser3', givenname=u'Test3', sn=u'User3')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def user4(request):
+def user4(request, xmlrpc_setup):
     tracker = UserTracker(name=u'tuser4', givenname=u'Test4', sn=u'User4')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def group1(request):
+def group1(request, xmlrpc_setup):
     tracker = GroupTracker(name=u'testgroup1', description=u'Test desc1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def group2(request):
+def group2(request, xmlrpc_setup):
     tracker = GroupTracker(name=u'testgroup2', description=u'Test desc2')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def group3(request):
+def group3(request, xmlrpc_setup):
     tracker = GroupTracker(name=u'testgroup3', description=u'Test desc3')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def group4(request):
+def group4(request, xmlrpc_setup):
     tracker = GroupTracker(name=u'testgroup4', description=u'Test desc4')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def host1(request):
+def host1(request, xmlrpc_setup):
     tracker = HostTracker(name=u'host1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def hostgroup1(request):
+def hostgroup1(request, xmlrpc_setup):
     tracker = HostGroupTracker(name=u'hostgroup1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def hostgroup2(request):
+def hostgroup2(request, xmlrpc_setup):
     tracker = HostGroupTracker(name=u'hostgroup2')
     return tracker.make_fixture(request)
 

--- a/ipatests/test_xmlrpc/test_netgroup_plugin.py
+++ b/ipatests/test_xmlrpc/test_netgroup_plugin.py
@@ -1400,7 +1400,7 @@ class test_netgroup(Declarative):
 #            entries = conn.find_entries('cn=%s' % self.ng_cn,
 #                      base_dn='cn=ng,cn=compat,%s' % api.env.basedn)
 #        except errors.NotFound:
-#            raise unittest.SkipTest(
+#            pytest.skip(
 #                'compat and nis are not enabled, skipping test'
 #            )
 #        finally:

--- a/ipatests/test_xmlrpc/test_permission_plugin.py
+++ b/ipatests/test_xmlrpc/test_permission_plugin.py
@@ -3442,10 +3442,8 @@ class test_managed_permissions(Declarative):
         ('permission_del', [permission2], {'force': True}),
     ]
 
-    @classmethod
-    def setup_class(cls):
-        super(test_managed_permissions, cls).setup_class()
-
+    @pytest.fixture(autouse=True, scope="class")
+    def managed_perm_setup(self, declarative_setup):
         if not have_ldap2:
             raise unittest.SkipTest('server plugin not available')
 

--- a/ipatests/test_xmlrpc/test_permission_plugin.py
+++ b/ipatests/test_xmlrpc/test_permission_plugin.py
@@ -24,7 +24,6 @@ Test the `ipaserver/plugins/permission.py` module.
 from __future__ import print_function
 
 import os
-import unittest
 
 from ipalib import api, errors
 from ipatests.test_xmlrpc import objectclasses
@@ -3445,7 +3444,7 @@ class test_managed_permissions(Declarative):
     @pytest.fixture(autouse=True, scope="class")
     def managed_perm_setup(self, declarative_setup):
         if not have_ldap2:
-            raise unittest.SkipTest('server plugin not available')
+            pytest.skip('server plugin not available')
 
     def add_managed_permission(self):
         """Add a managed permission and the corresponding ACI"""

--- a/ipatests/test_xmlrpc/test_range_plugin.py
+++ b/ipatests/test_xmlrpc/test_range_plugin.py
@@ -368,10 +368,38 @@ IPA_LOCAL_RANGE_MOD_ERR = (
 
 @pytest.mark.tier1
 class test_range(Declarative):
-    @classmethod
-    def setup_class(cls):
-        super(test_range, cls).setup_class()
-        cls.teardown_class()
+    mockldap = None
+
+    @pytest.fixture(autouse=True, scope="class")
+    def range_setup(self, request, declarative_setup):
+        cls = request.cls
+
+        def fin():
+            cls.mockldap = MockLDAP()
+
+            cls.mockldap.del_entry(domain2_dn)
+            cls.mockldap.del_entry(domain3_dn)
+            cls.mockldap.del_entry(domain4_dn)
+            cls.mockldap.del_entry(domain5_dn)
+            cls.mockldap.del_entry(domain6_dn)
+            cls.mockldap.del_entry(domain7_dn)
+
+            cls.mockldap.del_entry(domain1range1_dn)
+            cls.mockldap.del_entry(domain2range1_dn)
+            cls.mockldap.del_entry(domain2range2_dn)
+            cls.mockldap.del_entry(domain3range1_dn)
+            cls.mockldap.del_entry(domain3range2_dn)
+            cls.mockldap.del_entry(domain4range1_dn)
+            cls.mockldap.del_entry(domain5range1_dn)
+            cls.mockldap.del_entry(domain5range2_dn)
+            cls.mockldap.del_entry(domain6range1_dn)
+            cls.mockldap.del_entry(domain7range1_dn)
+            cls.mockldap.del_entry(trust_container_dn)
+            cls.mockldap.del_entry(trust_local_dn)
+            cls.mockldap.del_entry(smb_cont_dn)
+            cls.mockldap.unbind()
+
+        fin()
         cls.mockldap = MockLDAP()
         cls.mockldap.add_entry(trust_container_dn, trust_container_add)
         cls.mockldap.add_entry(smb_cont_dn, smb_cont_add)
@@ -395,31 +423,7 @@ class test_range(Declarative):
         cls.mockldap.add_entry(domain6range1_dn, domain6range1_add)
         cls.mockldap.unbind()
 
-    @classmethod
-    def teardown_class(cls):
-        cls.mockldap = MockLDAP()
-
-        cls.mockldap.del_entry(domain2_dn)
-        cls.mockldap.del_entry(domain3_dn)
-        cls.mockldap.del_entry(domain4_dn)
-        cls.mockldap.del_entry(domain5_dn)
-        cls.mockldap.del_entry(domain6_dn)
-        cls.mockldap.del_entry(domain7_dn)
-
-        cls.mockldap.del_entry(domain1range1_dn)
-        cls.mockldap.del_entry(domain2range1_dn)
-        cls.mockldap.del_entry(domain2range2_dn)
-        cls.mockldap.del_entry(domain3range1_dn)
-        cls.mockldap.del_entry(domain3range2_dn)
-        cls.mockldap.del_entry(domain4range1_dn)
-        cls.mockldap.del_entry(domain5range1_dn)
-        cls.mockldap.del_entry(domain5range2_dn)
-        cls.mockldap.del_entry(domain6range1_dn)
-        cls.mockldap.del_entry(domain7range1_dn)
-        cls.mockldap.del_entry(trust_container_dn)
-        cls.mockldap.del_entry(trust_local_dn)
-        cls.mockldap.del_entry(smb_cont_dn)
-        cls.mockldap.unbind()
+        request.addfinalizer(fin)
 
     cleanup_commands = [
         ('idrange_del', [testrange1, testrange2, testrange3, testrange4,

--- a/ipatests/test_xmlrpc/test_replace.py
+++ b/ipatests/test_xmlrpc/test_replace.py
@@ -33,7 +33,7 @@ import pytest
 
 
 @pytest.fixture(scope='class')
-def user(request):
+def user(request, xmlrpc_setup):
     tracker = UserTracker(
         name=u'user1', givenname=u'Test', sn=u'User1',
         mail=[u'test1@example.com', u'test2@example.com']

--- a/ipatests/test_xmlrpc/test_stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/test_stageuser_plugin.py
@@ -9,7 +9,6 @@ Test the `ipaserver/plugins/stageuser.py` module.
 import pytest
 
 import six
-import unittest
 
 from collections import OrderedDict
 from ipalib import api, errors
@@ -327,7 +326,7 @@ class TestStagedUser(XMLRPC_test):
         # Directly create the user using ldapmod
         # without the posixaccount objectclass
         if not have_ldap2:
-            raise unittest.SkipTest('server plugin not available')
+            pytest.skip('server plugin not available')
         ldap = ldap2(api)
         ldap.connect()
         ldap.create(

--- a/ipatests/test_xmlrpc/test_stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/test_stageuser_plugin.py
@@ -89,48 +89,48 @@ options_ids = list(options_def.keys())
 
 
 @pytest.fixture(scope='class')
-def stageduser(request):
+def stageduser(request, xmlrpc_setup):
     tracker = StageUserTracker(name=u'suser1', givenname=u'staged', sn=u'user')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def stageduser_min(request):
+def stageduser_min(request, xmlrpc_setup):
     tracker = StageUserTracker(givenname=u'stagedmin', sn=u'usermin')
     return tracker.make_fixture(request)
 
 @pytest.fixture(scope='class', params=options_ok, ids=options_ids)
-def stageduser2(request):
+def stageduser2(request, xmlrpc_setup):
     tracker = StageUserTracker(u'suser2', u'staged', u'user', **request.param)
     return tracker.make_fixture_activate(request)
 
 
 @pytest.fixture(scope='class')
-def user_activated(request):
+def user_activated(request, xmlrpc_setup):
     tracker = UserTracker(u'suser2', u'staged', u'user')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def stageduser3(request):
+def stageduser3(request, xmlrpc_setup):
     tracker = StageUserTracker(name=u'suser3', givenname=u'staged', sn=u'user')
     return tracker.make_fixture_activate(request)
 
 
 @pytest.fixture(scope='class')
-def stageduser4(request):
+def stageduser4(request, xmlrpc_setup):
     tracker = StageUserTracker(u'tuser', u'test', u'user')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def stageduser_notposix(request):
+def stageduser_notposix(request, xmlrpc_setup):
     tracker = StageUserTracker(u'notposix', u'notposix', u'notposix')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def stageduser_customattr(request):
+def stageduser_customattr(request, xmlrpc_setup):
     tracker = StageUserTracker(u'customattr', u'customattr', u'customattr',
                                setattr=u'businesscategory=BusinessCat')
     tracker.track_create()
@@ -141,43 +141,43 @@ def stageduser_customattr(request):
 
 
 @pytest.fixture(scope='class')
-def user(request):
+def user(request, xmlrpc_setup):
     tracker = UserTracker(u'auser1', u'active', u'user')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def user2(request):
+def user2(request, xmlrpc_setup):
     tracker = UserTracker(u'suser3', u'staged', u'user')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def user3(request):
+def user3(request, xmlrpc_setup):
     tracker = UserTracker(u'auser2', u'active', u'user')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def user4(request):
+def user4(request, xmlrpc_setup):
     tracker = UserTracker(u'tuser', u'test', u'user')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def user5(request):
+def user5(request, xmlrpc_setup):
     tracker = UserTracker(u'tuser', u'test', u'user')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def user6(request):
+def user6(request, xmlrpc_setup):
     tracker = UserTracker(u'suser2', u'staged', u'user')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def user7(request):
+def user7(request, xmlrpc_setup):
     tracker = UserTracker(u'puser1', u'preserved', u'user')
     return tracker.make_fixture_restore(request)
 
@@ -734,7 +734,7 @@ class TestDuplicates(XMLRPC_test):
 
 
 @pytest.fixture(scope='class')
-def group(request):
+def group(request, xmlrpc_setup):
     tracker = GroupTracker(u'testgroup')
     return tracker.make_fixture(request)
 

--- a/ipatests/test_xmlrpc/test_sudocmd_plugin.py
+++ b/ipatests/test_xmlrpc/test_sudocmd_plugin.py
@@ -29,21 +29,21 @@ import pytest
 
 
 @pytest.fixture(scope='class')
-def sudocmd1(request):
+def sudocmd1(request, xmlrpc_setup):
     tracker = SudoCmdTracker(command=u'/usr/bin/sudotestcmd1',
                              description=u'Test sudo command 1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def sudocmd2(request):
+def sudocmd2(request, xmlrpc_setup):
     tracker = SudoCmdTracker(command=u'/usr/bin/sudoTestCmd1',
                              description=u'Test sudo command 2')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def sudorule1(request):
+def sudorule1(request, xmlrpc_setup):
     name = u'test_sudorule1'
 
     def fin():

--- a/ipatests/test_xmlrpc/test_sudocmdgroup_plugin.py
+++ b/ipatests/test_xmlrpc/test_sudocmdgroup_plugin.py
@@ -30,34 +30,34 @@ import pytest
 
 
 @pytest.fixture(scope='class')
-def sudocmd1(request):
+def sudocmd1(request, xmlrpc_setup):
     tracker = SudoCmdTracker(command=u'/usr/bin/sudotestcmd1',
                              description=u'Test sudo command 1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def sudocmd2(request):
+def sudocmd2(request, xmlrpc_setup):
     tracker = SudoCmdTracker(command=u'/usr/bin/sudoTestCmd1',
                              description=u'Test sudo command 2')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def sudocmd_plus(request):
+def sudocmd_plus(request, xmlrpc_setup):
     tracker = SudoCmdTracker(command=u'/bin/ls -l /lost+found/*',
                              description=u'Test sudo command 3')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def sudocmdgroup1(request):
+def sudocmdgroup1(request, xmlrpc_setup):
     tracker = SudoCmdGroupTracker(u'testsudocmdgroup1', u'Test desc1')
     return tracker.make_fixture(request)
 
 
 @pytest.fixture(scope='class')
-def sudocmdgroup2(request):
+def sudocmdgroup2(request, xmlrpc_setup):
     tracker = SudoCmdGroupTracker(u'testsudocmdgroup2', u'Test desc2')
     return tracker.make_fixture(request)
 

--- a/ipatests/test_xmlrpc/test_trust_plugin.py
+++ b/ipatests/test_xmlrpc/test_trust_plugin.py
@@ -47,10 +47,8 @@ default_group_dn = DN(('cn', default_group), api.env.container_group, api.env.ba
 
 @pytest.mark.tier1
 class test_trustconfig(Declarative):
-
-    @classmethod
-    def setup_class(cls):
-        super(test_trustconfig, cls).setup_class()
+    @pytest.fixture(autouse=True, scope="class")
+    def trustconfig_setup(self, declarative_setup):
         if not api.Backend.rpcclient.isconnected():
             api.Backend.rpcclient.connect()
         try:

--- a/ipatests/test_xmlrpc/test_trust_plugin.py
+++ b/ipatests/test_xmlrpc/test_trust_plugin.py
@@ -20,8 +20,6 @@
 Test the `ipaserver/plugins/trust.py` module.
 """
 
-import unittest
-
 import six
 
 from ipalib import api, errors
@@ -54,7 +52,7 @@ class test_trustconfig(Declarative):
         try:
            api.Command['trustconfig_show'](trust_type=u'ad')
         except errors.NotFound:
-            raise unittest.SkipTest('Trusts are not configured')
+            pytest.skip('Trusts are not configured')
 
     cleanup_commands = [
         ('group_del', [testgroup], {}),

--- a/ipatests/test_xmlrpc/test_vault_plugin.py
+++ b/ipatests/test_xmlrpc/test_vault_plugin.py
@@ -134,16 +134,13 @@ veCYju6ok4ZWnMiH8MR1jgC39RWtjJZwynCuPXUP2/vZkoVf1tCZyz7dSm8TdS/2
 
 @pytest.mark.tier1
 class test_vault_plugin(Declarative):
-
-    @classmethod
-    def setup_class(cls):
+    @pytest.fixture(autouse=True, scope="class")
+    def vault_plugin_setup(self, declarative_setup):
         if not api.Backend.rpcclient.isconnected():
             api.Backend.rpcclient.connect()
 
         if not api.Command.kra_is_enabled()['result']:
             raise unittest.SkipTest('KRA service is not enabled')
-
-        super(test_vault_plugin, cls).setup_class()
 
     cleanup_commands = [
         ('vault_del', [vault_name], {'continue': True}),

--- a/ipatests/test_xmlrpc/test_vault_plugin.py
+++ b/ipatests/test_xmlrpc/test_vault_plugin.py
@@ -21,8 +21,6 @@
 Test the `ipaserver/plugins/vault.py` module.
 """
 
-import unittest
-
 import pytest
 import six
 
@@ -140,7 +138,7 @@ class test_vault_plugin(Declarative):
             api.Backend.rpcclient.connect()
 
         if not api.Command.kra_is_enabled()['result']:
-            raise unittest.SkipTest('KRA service is not enabled')
+            pytest.skip('KRA service is not enabled')
 
     cleanup_commands = [
         ('vault_del', [vault_name], {'continue': True}),

--- a/ipatests/test_xmlrpc/xmlrpc_test.py
+++ b/ipatests/test_xmlrpc/xmlrpc_test.py
@@ -24,7 +24,6 @@ from __future__ import print_function
 
 import datetime
 import inspect
-import unittest
 
 import contextlib
 import pytest
@@ -211,9 +210,9 @@ class XMLRPC_test:
     @pytest.fixture(autouse=True, scope="class")
     def xmlrpc_setup(self, request):
         if not server_available:
-            raise unittest.SkipTest('%r: Server not available: %r' %
-                                    (request.cls.__module__,
-                                     api.env.xmlrpc_uri))
+            pytest.skip('%r: Server not available: %r' %
+                        (request.cls.__module__,
+                         api.env.xmlrpc_uri))
         if not api.Backend.rpcclient.isconnected():
             api.Backend.rpcclient.connect()
 
@@ -320,7 +319,7 @@ class Declarative(XMLRPC_test):
         (cmd, args, options) = command
         print('Cleanup:', cmd, args, options)
         if cmd not in api.Command:
-            raise unittest.SkipTest(
+            pytest.skip(
                 'cleanup command %r not in api.Command' % cmd
             )
         try:
@@ -342,7 +341,7 @@ class Declarative(XMLRPC_test):
         (cmd, args, options) = command
         options.setdefault('version', self.default_version)
         if cmd not in api.Command:
-            raise unittest.SkipTest('%r not in api.Command' % cmd)
+            pytest.skip('%r not in api.Command' % cmd)
         if isinstance(expected, errors.PublicError):
             self.check_exception(nice, cmd, args, options, expected)
         elif hasattr(expected, '__call__'):

--- a/ipatests/test_xmlrpc/xmlrpc_test.py
+++ b/ipatests/test_xmlrpc/xmlrpc_test.py
@@ -27,10 +27,11 @@ import inspect
 import unittest
 
 import contextlib
+import pytest
 import six
 
 from ipatests.util import assert_deepequal, Fuzzy
-from ipalib import api, request, errors
+from ipalib import api, request as ipa_request, errors
 from ipapython.version import API_VERSION
 
 # pylint: disable=no-name-in-module, import-error
@@ -207,18 +208,18 @@ class XMLRPC_test:
     """
     Base class for all XML-RPC plugin tests
     """
-
-    @classmethod
-    def setup_class(cls):
+    @pytest.fixture(autouse=True, scope="class")
+    def xmlrpc_setup(self, request):
         if not server_available:
             raise unittest.SkipTest('%r: Server not available: %r' %
-                                (cls.__module__, api.env.xmlrpc_uri))
+                                    (request.cls.__module__,
+                                     api.env.xmlrpc_uri))
         if not api.Backend.rpcclient.isconnected():
             api.Backend.rpcclient.connect()
 
-    @classmethod
-    def teardown_class(cls):
-        request.destroy_context()
+        def fin():
+            ipa_request.destroy_context()
+        request.addfinalizer(fin)
 
     def failsafe_add(self, obj, pk, **options):
         """
@@ -306,17 +307,13 @@ class Declarative(XMLRPC_test):
     cleanup_commands = tuple()
     tests = tuple()
 
-    @classmethod
-    def setup_class(cls):
-        super(Declarative, cls).setup_class()
-        for command in cls.cleanup_commands:
-            cls.cleanup(command)
-
-    @classmethod
-    def teardown_class(cls):
-        for command in cls.cleanup_commands:
-            cls.cleanup(command)
-        super(Declarative, cls).teardown_class()
+    @pytest.fixture(autouse=True, scope="class")
+    def declarative_setup(self, request, xmlrpc_setup):
+        def fin():
+            for command in request.cls.cleanup_commands:
+                request.cls.cleanup(command)
+        fin()
+        request.addfinalizer(fin)
 
     @classmethod
     def cleanup(cls, command):

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -550,11 +550,11 @@ class ClassChecker:
             'get_subcls()'
         )
 
-    def teardown(self):
-        """
-        nose tear-down fixture.
-        """
-        context.__dict__.clear()
+    @pytest.fixture(autouse=True)
+    def classchecker_setup(self, request):
+        def fin():
+            context.__dict__.clear()
+        request.addfinalizer(fin)
 
 
 def get_api(**kw):
@@ -622,11 +622,11 @@ class PluginTester:
         o = api[namespace][self.plugin.__name__]
         return (o, api, home)
 
-    def teardown(self):
-        """
-        nose tear-down fixture.
-        """
-        context.__dict__.clear()
+    @pytest.fixture(autouse=True)
+    def plugintester_setup(self, request):
+        def fin():
+            context.__dict__.clear()
+        request.addfinalizer(fin)
 
 
 class dummy_ugettext:

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -183,9 +183,12 @@ ipa_class_members = {
         'normalizedns',
     ],
     'ipatests.test_integration.base.IntegrationTest': [
-        'domain',
+        {'domain': [
+            {'name': dir(str)},
+        ]},
         {'master': [
             {'config': [
+                {'dirman_dn': dir(str)},
                 {'dirman_password': dir(str)},
                 {'admin_password': dir(str)},
                 {'admin_name': dir(str)},
@@ -197,15 +200,17 @@ ipa_class_members = {
                 {'fips_mode': dir(bool)},
             ]},
             {'domain': [
+                {'basedn': dir(str)},
                 {'realm': dir(str)},
                 {'name': dir(str)},
             ]},
-            'hostname',
+            {'external_hostname': dir(str)},
+            {'hostname': dir(str)},
             'ip',
             'collect_log',
             {'run_command': [
                 {'stdout_text': dir(str)},
-                'stderr_text',
+                {'stderr_text': dir(str)},
                 'returncode',
             ]},
             {'transport': ['put_file', 'file_exists']},
@@ -216,6 +221,9 @@ ipa_class_members = {
         'replicas',
         'clients',
         'ad_domains',
+        {'ads': dir(list)},
+        {'ad_subdomains': dir(list)},
+        {'ad_treedomains': dir(list)},
     ]
 }
 
@@ -227,18 +235,6 @@ def fix_ipa_classes(cls):
 
 
 MANAGER.register_transform(scoped_nodes.ClassDef, fix_ipa_classes)
-
-
-def pytest_config_transform():
-    """pylint.config attribute
-    """
-    return AstroidBuilder(MANAGER).string_build(textwrap.dedent('''
-    from _pytest.config import get_config
-    config = get_config()
-    '''))
-
-
-register_module_extender(MANAGER, 'pytest', pytest_config_transform)
 
 
 def ipaplatform_constants_transform():

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -284,6 +284,18 @@ register_module_extender(MANAGER, 'ipaplatform.tasks',
                          ipaplatform_tasks_transform)
 
 
+def ipalib_request_transform():
+    """ipalib.request.context attribute
+    """
+    return AstroidBuilder(MANAGER).string_build(textwrap.dedent('''
+    from ipalib.request import context
+    context._pylint_attr = Connection("_pylint", lambda: None)
+    '''))
+
+
+register_module_extender(MANAGER, 'ipalib.request', ipalib_request_transform)
+
+
 class IPAChecker(BaseChecker):
     __implements__ = IAstroidChecker
 


### PR DESCRIPTION
Even though Pytest supports xunit style setups, unittest and nose
tests, this support is limited and may be dropped in the future
releases. Worst of all is that the mixing of various test
frameworks results in weird conflicts and of course, is not widely
tested.

This is a part of the work to remove the mixing of test idioms in the
IPA's test suite:

- replace xunit style
- employ the fixtures' interdependencies
- replace unittest.TestCase subclasses
- replace unittest test controls (SkipTest, fail, etc.)
- replace unittest assertions

Fixes: https://pagure.io/freeipa/issue/7989