### PR TITLE
Restore running of 'test_ipaserver' tests on Azure

### DIFF
--- a/ipatests/azure/Dockerfile.build-container
+++ b/ipatests/azure/Dockerfile.build-container
@@ -7,6 +7,7 @@ RUN echo 'deltarpm = false' >> /etc/dnf/dnf.conf \
     && dnf update -y dnf \
     && dnf install -y dnf-plugins-core sudo wget systemd firewalld nss-tools iptables \
     && sed -i 's/%_install_langs \(.*\)/\0:fr/g' /etc/rpm/macros.image-language-conf \
+    && dnf install -y glibc-langpack-fr glibc-langpack-en \
     && dnf install -y /root/rpms/*.rpm \
     && dnf clean all && rm -rf /root/rpms /root/srpms \
     && for i in /usr/lib/systemd/system/*-domainname.service; \

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -137,6 +137,7 @@ jobs:
     - test_ipalib
     - test_ipaplatform
     - test_ipapython
+    - test_ipaserver
     - test_ipatests_plugins
     - test_xmlrpc
     testsToIgnore:


### PR DESCRIPTION
`test_ipaserver` was lost on refactoring in https://github.com/freeipa/freeipa/commit/c8ef093e56.
Let's run that again.