### PR TITLE
[Backport][ipa-4-8] ipa_client_automount.py: fix typo (idmap.conf => idmapd.conf)

### DIFF
--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -87,7 +87,7 @@ def parse_options():
         "--idmap-domain",
         dest="idmapdomain",
         default=None,
-        help="nfs domain for idmap.conf",
+        help="nfs domain for idmapd.conf",
     )
     parser.add_option(
         "--debug",


### PR DESCRIPTION
This PR was opened automatically because PR #3781 was pushed to master and backport to ipa-4-8 is required.