### PR TITLE
ipatests: temporarily remove test_smb from gating

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -223,18 +223,6 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_smb:
-    requires: [fedora-30/build]
-    priority: 100
-    job:
-      class: RunADTests
-      args:
-        build_url: '{fedora-30/build_url}'
-        test_suite: test_integration/test_smb.py
-        template: *ci-master-f30
-        timeout: 7200
-        topology: *ad_master_2client
-
   fedora-30/replica_promotion:
     requires: [fedora-30/build]
     priority: 100


### PR DESCRIPTION
test_smb is now failing in a repeatable way due to CI infrastructure
issues. Temporarily remove it until this is fixed.

Signed-off-by: François Cami <fcami@redhat.com>