### PR TITLE
ipa-backup: fix python2 issue with os.mkdir

### DIFF
--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -294,7 +294,7 @@ class Backup(admintool.AdminTool):
         os.chown(self.top_dir, pent.pw_uid, pent.pw_gid)
         os.chmod(self.top_dir, 0o750)
         self.dir = os.path.join(self.top_dir, "ipa")
-        os.mkdir(self.dir, mode=0o750)
+        os.mkdir(self.dir, 0o750)
         os.chown(self.dir, pent.pw_uid, pent.pw_gid)
         self.tarfile = None
 
@@ -676,7 +676,7 @@ class Backup(admintool.AdminTool):
             filename = os.path.join(backup_dir, "ipa-full.tar")
 
         try:
-            os.mkdir(backup_dir, mode=0o700)
+            os.mkdir(backup_dir, 0o700)
         except (OSError, IOError) as e:
             raise admintool.ScriptError(
                 'Could not create backup directory: %s' % e


### PR DESCRIPTION
Python2 and python3 have different interfaces for os.mkdir:
python2: os.mkdir(path[, mode])
python3: os.mkdir(path, mode=0o777, *, dir_fd=None)

ipa-backup is using the python3 format, which breaks deployments using
python2. The fix consists in using os.mkdir(path, 0o700) instead of
os.mkdir(path, mode=0o700).

Fixes: https://pagure.io/freeipa/issue/8099