### PR TITLE
ipatests: nightly_f29: disable TestIpaClientAutomountFileRestore

### DIFF
--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -1277,18 +1277,6 @@ jobs:
         timeout: 9000
         topology: *master_3client
 
-  fedora-29/nfs_nsswitch_restore:
-    requires: [fedora-29/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
-        template: *ci-master-f29
-        timeout: 3600
-        topology: *master_3client
-
   fedora-29/mask:
     requires: [fedora-29/build]
     priority: 50


### PR DESCRIPTION
The fixes for https://pagure.io/freeipa/issue/8054 and
https://pagure.io/freeipa/issue/8038 are intended for f30.
Given that the fixes will not be backported to f29, disable
that test.

Fixes: https://pagure.io/freeipa/issue/8063
Signed-off-by: François Cami <fcami@redhat.com>