### PR TITLE
[Backport][ipa-4-7] ipa-server-certinstall manpage: add missing options

### DIFF
--- a/install/tools/man/ipa-server-certinstall.1
+++ b/install/tools/man/ipa-server-certinstall.1
@@ -47,8 +47,23 @@ The password to unlock the private key
 \fB\-\-cert\-name\fR=\fINAME\fR
 Name of the certificate to install
 .TP
-\fB\-\-dirman\-password\fR=\fIDIRMAN_PASSWORD\fR
+\fB\-p\fR, \fB\-\-dirman\-password\fR=\fIDIRMAN_PASSWORD\fR
 Directory Manager password
+.TP
+\fB\-\-version\fR
+Show the program's version and exit
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Show the help for this program
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Print debugging information
+.TP
+\fB\-q\fR, \fB\-\-quiet\fR
+Output only errors
+.TP
+\fB\-\-log\-file\fR=\fIFILE\fR
+Log to the given file
 .SH "EXIT STATUS"
 0 if the installation was successful
 


### PR DESCRIPTION
This PR was opened automatically because PR #3790 was pushed to master and backport to ipa-4-7 is required.