### PR TITLE
prci: increase timeout argument for test_sssd.py

### DIFF
--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -1334,7 +1334,7 @@ jobs:
         build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_sssd.py
         template: *ci-master-f29
-        timeout: 3600
+        timeout: 4800
         topology: *ad_master
 
   fedora-29/test_ca_custom_sdn:

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1346,7 +1346,7 @@ jobs:
         build_url: '{fedora-30/build_url}'
         test_suite: test_integration/test_sssd.py
         template: *ci-master-f30
-        timeout: 3600
+        timeout: 4800
         topology: *ad_master
 
   fedora-30/test_ca_custom_sdn:

--- a/ipatests/prci_definitions/nightly_master_testing.yaml
+++ b/ipatests/prci_definitions/nightly_master_testing.yaml
@@ -1452,7 +1452,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_sssd.py
         template: *testing-master-f30
-        timeout: 3600
+        timeout: 4800
         topology: *ad_master
 
   fedora-30/test_ca_custom_sdn:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1346,7 +1346,7 @@ jobs:
         build_url: '{fedora-30/build_url}'
         test_suite: test_integration/test_sssd.py
         template: *ci-master-frawhide
-        timeout: 3600
+        timeout: 4800
         topology: *ad_master
 
   fedora-rawhide/test_ca_custom_sdn:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -37,6 +37,10 @@ topologies:
     name: ad_master_2client
     cpu: 4
     memory: 12000
+  ad_master: &ad_master
+   name: ad_master
+   cpu: 4
+   memory: 12000
 
 jobs:
   fedora-30/build:


### PR DESCRIPTION
Follow-up for commit a4ca34261a55af96e3428822f08f8b2292e6234a.

Vagrant retries to provision hosts if something happens, it was introduced
in PR-CI after freeipa/freeipa-pr-ci@380c8b8.

This takes time, some jobs are killed during test execution, so this
adds 20 minutes more to test_sssd.py test suite.

This also adds a missing but available topology to `temp_commit.yaml`.

Signed-off-by: Armando Neto <abiagion@redhat.com>