### PR TITLE
Fixes debian path for IPA_CUSTODIA_HANDLER

### DIFF
--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -109,6 +109,7 @@ class DebianPathNamespace(BasePathNamespace):
     IPA_ODS_EXPORTER_CCACHE = "/var/lib/opendnssec/tmp/ipa-ods-exporter.ccache"
     IPA_CUSTODIA_SOCKET = "/run/apache2/ipa-custodia.sock"
     IPA_CUSTODIA_AUDIT_LOG = '/var/log/ipa-custodia.audit.log'
+    IPA_CUSTODIA_HANDLER = "/usr/lib/ipa/custodia"
     WSGI_PREFIX_DIR = "/run/apache2/wsgi"
 
 paths = DebianPathNamespace()


### PR DESCRIPTION
Debian installs into a different directory for libexec files.  This patch
fixes the path to the custodia files for debian.

Signed-off-by: Spencer E. Olson <olsonse@umich.edu>