### PR TITLE
conditionally restart certmonger during ipa-client-install

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -779,7 +779,16 @@ def configure_krb5_conf(
 def configure_certmonger(
         fstore, subject_base, cli_realm, hostname, options, ca_enabled):
 
+    cmonger = services.knownservices.certmonger
     if not options.request_cert:
+        # Conditionally restart certmonger to pick up the new IPA
+        # configuration.
+        try:
+            cmonger.try_restart()
+        except Exception as e:
+            logger.error(
+                "Failed to conditionally restart the %s daemon: %s",
+                cmonger.service_name, str(e))
         return
 
     if not ca_enabled:
@@ -794,7 +803,6 @@ def configure_certmonger(
         # which principal name to use when requesting certs.
         certmonger.add_principal_to_cas(principal)
 
-    cmonger = services.knownservices.certmonger
     try:
         cmonger.enable()
         cmonger.start()

--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -173,6 +173,9 @@ class PlatformService:
     def restart(self, instance_name="", capture_output=True, wait=True):
         pass
 
+    def try_restart(self, instance_name="", capture_output=True, wait=True):
+        pass
+
     def is_running(self, instance_name="", wait=True):
         return False
 
@@ -336,6 +339,10 @@ class SystemdService(PlatformService):
 
     def restart(self, instance_name="", capture_output=True, wait=True):
         self._restart_base(instance_name, "restart",
+                           capture_output, wait)
+
+    def try_restart(self, instance_name="", capture_output=True, wait=True):
+        self._restart_base(instance_name, "try-restart",
                            capture_output, wait)
 
     def is_running(self, instance_name="", wait=True):


### PR DESCRIPTION
Conditionally restart certmonger after client installation

If certmonger is running prior to client installation then its 
IPA CA configuration will be incomplete and missing the CA chain.
    
If a certificate is subsequently requested with -F to store the 
CA chain in a file or NSS db it may not be available yet. A
conditional restart of certmonger will pick up the new IPA 
configuration and complete the IPA CA configuration in certmonger.
    
A pure restart and service activation is not done since certmonger
is not required unless --request-cert was passed ipa-client-install.
    
https://pagure.io/freeipa/issue/8105