### PR TITLE
ipatests: in DNS zone file add A record for name server

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1870,7 +1870,7 @@ def create_temp_file(host, directory=None):
     cmd = ['mktemp']
     if directory is not None:
         cmd += ['-p', directory]
-    return host.run_command(cmd).stdout_text
+    return host.run_command(cmd).stdout_text.strip()
 
 
 def create_active_user(host, login, password, first='test', last='user'):

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -632,7 +632,7 @@ class TestTrust(BaseTestTrust):
             _ldap._tcp IN SRV 0 100 389 unreachable.{ad_dom}.
             _kerberos._udp IN SRV 0 100 88 unreachable.{ad_dom}.
             _kpasswd._udp IN SRV 0 100 464 unreachable.{ad_dom}.
-            ad1 IN A {ad_ip}
+            {ad_short} IN A {ad_ip}
             unreachable IN A {unreachable}
             DomainDnsZones IN A {ad_ip}
             _ldap._tcp.Default-First-Site-Name._sites.DomainDnsZones IN SRV 0 100 389 unreachable.{ad_dom}.
@@ -642,7 +642,8 @@ class TestTrust(BaseTestTrust):
             _ldap._tcp.ForestDnsZones IN SRV 0 100 389 unreachable.{ad_dom}.
         '''.format(  # noqa: E501
             ad_ip=self.ad.ip, unreachable='192.168.254.254',
-            ad_host=self.ad.hostname, ad_dom=self.ad.domain.name))
+            ad_host=self.ad.hostname, ad_dom=self.ad.domain.name,
+            ad_short=self.ad.shortname))
         ad_zone_file = tasks.create_temp_file(self.master, directory='/etc')
         self.master.put_file_contents(ad_zone_file, ad_zone)
         self.master.run_command(


### PR DESCRIPTION
Testcase test_server_option_with_unreachable_ad creates a zone file
 for AD domain. This file had a hard-coded A record for host specified in
 NS record. Some versions of BIND consider this zone invalid and refuse
 to start with message:
 ```
 zone ad.test/IN: NS 'root-dc.ad.test' has no address records (A or AAAA)
 ```
    
 Fixed by replacing hard-coded value with short name of the AD instance.

This PR also fixed utility function create_temp_file which was returning name of created temp file with a trailing newline character added.