### PR TITLE
[Backport][ipa-4-6] ipatests: add test to check that only TLS 1.2 is enabled in Apache

### DIFF
--- a/ipatests/pytest_ipa/integration/host.py
+++ b/ipatests/pytest_ipa/integration/host.py
@@ -63,13 +63,21 @@ class Host(pytest_multihost.host.Host):
 
     def run_command(self, argv, set_env=True, stdin_text=None,
                     log_stdout=True, raiseonerr=True,
-                    cwd=None):
-        # Wrap run_command to log stderr on raiseonerr=True
+                    cwd=None, ok_returncode=0):
+        """Wrapper around run_command to log stderr on raiseonerr=True
+
+        :param ok_returncode: return code considered to be correct,
+                              you can pass an integer or sequence of integers
+        """
         result = super(Host, self).run_command(
             argv, set_env=set_env, stdin_text=stdin_text,
             log_stdout=log_stdout, raiseonerr=False, cwd=cwd
         )
-        if result.returncode and raiseonerr:
+        try:
+            result_ok = result.returncode in ok_returncode
+        except TypeError:
+            result_ok = result.returncode == ok_returncode
+        if not result_ok and raiseonerr:
             result.log.error('stderr: %s', result.stderr_text)
             raise subprocess.CalledProcessError(
                 result.returncode, argv,

--- a/ipatests/pytest_ipa/integration/host.py
+++ b/ipatests/pytest_ipa/integration/host.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Host class for integration testing"""
+import subprocess
 
 import pytest_multihost.host
 
@@ -59,6 +60,23 @@ class Host(pytest_multihost.host.Host):
     def to_env(self, **kwargs):
         from ipatests.pytest_ipa.integration.env_config import host_to_env
         return host_to_env(self, **kwargs)
+
+    def run_command(self, argv, set_env=True, stdin_text=None,
+                    log_stdout=True, raiseonerr=True,
+                    cwd=None):
+        # Wrap run_command to log stderr on raiseonerr=True
+        result = super(Host, self).run_command(
+            argv, set_env=set_env, stdin_text=stdin_text,
+            log_stdout=log_stdout, raiseonerr=False, cwd=cwd
+        )
+        if result.returncode and raiseonerr:
+            result.log.error('stderr: %s', result.stderr_text)
+            raise subprocess.CalledProcessError(
+                result.returncode, argv,
+                result.stdout_text
+            )
+        else:
+            return result
 
 
 class WinHost(pytest_multihost.host.WinHost):

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -540,3 +540,23 @@ class TestIPACommand(IntegrationTest):
             # reset
             entry['ipaConfigString'] = orig_cfg
             conn.update_entry(entry)  # pylint: disable=no-member
+
+    def test_enabled_tls_protocols(self):
+        """Check that only TLS 1.2 is enabled in Apache.
+
+        This is the regression test for issue
+        https://pagure.io/freeipa/issue/7995.
+        """
+        def is_tls_version_enabled(tls_version):
+            res = self.master.run_command(
+                ['openssl', 's_client',
+                 '-connect', '{}:443'.format(self.master.hostname),
+                 '-{}'.format(tls_version)],
+                stdin_text='\n',
+                ok_returncode=[0, 1]
+            )
+            return res.returncode == 0
+
+        assert not is_tls_version_enabled('tls1')
+        assert not is_tls_version_enabled('tls1_1')
+        assert is_tls_version_enabled('tls1_2')


### PR DESCRIPTION
This is a manual backport of #3812

Related to: https://pagure.io/freeipa/issue/7995

Reviewed-By: Rob Crittenden <rcritten@redhat.com>