### PR TITLE
[Backport][ipa-4-8] Enable AES SHA 256 and 384-bit enctypes in Kerberos

### DIFF
--- a/install/share/kerberos.ldif
+++ b/install/share/kerberos.ldif
@@ -18,6 +18,10 @@ krbSupportedEncSaltTypes: aes256-cts:normal
 krbSupportedEncSaltTypes: aes256-cts:special
 krbSupportedEncSaltTypes: aes128-cts:normal
 krbSupportedEncSaltTypes: aes128-cts:special
+krbSupportedEncSaltTypes: aes128-sha2:normal
+krbSupportedEncSaltTypes: aes128-sha2:special
+krbSupportedEncSaltTypes: aes256-sha2:normal
+krbSupportedEncSaltTypes: aes256-sha2:special
 ${FIPS}krbSupportedEncSaltTypes: camellia128-cts-cmac:normal
 ${FIPS}krbSupportedEncSaltTypes: camellia128-cts-cmac:special
 ${FIPS}krbSupportedEncSaltTypes: camellia256-cts-cmac:normal

--- a/install/updates/50-krbenctypes.update
+++ b/install/updates/50-krbenctypes.update
@@ -3,3 +3,7 @@ add: krbSupportedEncSaltTypes: camellia128-cts-cmac:normal
 add: krbSupportedEncSaltTypes: camellia128-cts-cmac:special
 add: krbSupportedEncSaltTypes: camellia256-cts-cmac:normal
 add: krbSupportedEncSaltTypes: camellia256-cts-cmac:special
+add: krbSupportedEncSaltTypes: aes128-sha2:normal
+add: krbSupportedEncSaltTypes: aes128-sha2:special
+add: krbSupportedEncSaltTypes: aes256-sha2:normal
+add: krbSupportedEncSaltTypes: aes256-sha2:special


### PR DESCRIPTION
This PR was opened automatically because PR #3841 was pushed to master and backport to ipa-4-8 is required.