### PR TITLE
[WIP] WebUI tests: Fix ElementClickInterceptedException after adding an entity

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,14 +57,26 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-30/temp_commit:
+  fedora-30/test_webui_host:
     requires: [fedora-30/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-30/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_webui/test_host.py
         template: *ci-master-f30
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *ipaserver
+
+  fedora-30/test_webui_idviews:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_webui/test_idviews.py
+        template: *ci-master-f30
+        timeout: 3600
+        topology: *ipaserver

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -733,7 +733,11 @@ class UI_driver:
         disabled = btn.get_attribute("disabled")
         assert btn.is_displayed(), 'Button is not displayed: %s' % name
         assert not disabled, 'Invalid button state: disabled. Button: %s' % name
-        btn.click()
+        try:
+            btn.click()
+        except ElementClickInterceptedException:
+            self.close_notifications()
+            btn.click()
         self.wait_for_request()
 
     def move_to_element_in_page(self, element):


### PR DESCRIPTION
When some entities are being added notification appears and intercepts buttons
on the facet.
The fix allows to click button one more time in such situation.

Ticket: https://pagure.io/freeipa/issue/8112
