### PR TITLE
Add group membership management

### DIFF
--- a/ACI.txt
+++ b/ACI.txt
@@ -99,7 +99,7 @@ aci: (targetattr = "ipaexternalmember")(targetfilter = "(objectclass=ipaexternal
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "member")(targetfilter = "(&(!(cn=admins))(objectclass=ipausergroup))")(version 3.0;acl "permission:System: Modify Group Membership";allow (write) groupdn = "ldap:///cn=System: Modify Group Membership,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "cn || description || gidnumber || ipauniqueid || mepmanagedby || objectclass")(targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Modify Groups";allow (write) groupdn = "ldap:///cn=System: Modify Groups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+aci: (targetattr = "cn || description || gidnumber || ipauniqueid || membermanager || mepmanagedby || objectclass")(targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Modify Groups";allow (write) groupdn = "ldap:///cn=System: Modify Groups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "ipaexternalmember")(targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Read External Group Membership";allow (compare,read,search) userdn = "ldap:///all";)
 dn: dc=ipa,dc=example
@@ -109,7 +109,7 @@ aci: (targetattr = "member || memberhost || memberof || memberuid || memberuser"
 dn: dc=ipa,dc=example
 aci: (targetattr = "cn || createtimestamp || entryusn || gidnumber || memberuid || modifytimestamp || objectclass")(target = "ldap:///cn=groups,cn=*,cn=views,cn=compat,dc=ipa,dc=example")(version 3.0;acl "permission:System: Read Group Views Compat Tree";allow (compare,read,search) userdn = "ldap:///anyone";)
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "businesscategory || cn || createtimestamp || description || entryusn || gidnumber || ipaexternalmember || ipantsecurityidentifier || ipauniqueid || mepmanagedby || modifytimestamp || o || objectclass || ou || owner || seealso")(targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Read Groups";allow (compare,read,search) userdn = "ldap:///anyone";)
+aci: (targetattr = "businesscategory || cn || createtimestamp || description || entryusn || gidnumber || ipaexternalmember || ipantsecurityidentifier || ipauniqueid || membermanager || mepmanagedby || modifytimestamp || o || objectclass || ou || owner || seealso")(targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Read Groups";allow (compare,read,search) userdn = "ldap:///anyone";)
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
 aci: (targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Remove Groups";allow (delete) groupdn = "ldap:///cn=System: Remove Groups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=hbac,dc=ipa,dc=example
@@ -169,11 +169,11 @@ aci: (targetfilter = "(objectclass=ipahostgroup)")(version 3.0;acl "permission:S
 dn: cn=hostgroups,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "member")(targetfilter = "(&(!(cn=ipaservers))(objectclass=ipahostgroup))")(version 3.0;acl "permission:System: Modify Hostgroup Membership";allow (write) groupdn = "ldap:///cn=System: Modify Hostgroup Membership,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=hostgroups,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "cn || description")(targetfilter = "(objectclass=ipahostgroup)")(version 3.0;acl "permission:System: Modify Hostgroups";allow (write) groupdn = "ldap:///cn=System: Modify Hostgroups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+aci: (targetattr = "cn || description || membermanager")(targetfilter = "(objectclass=ipahostgroup)")(version 3.0;acl "permission:System: Modify Hostgroups";allow (write) groupdn = "ldap:///cn=System: Modify Hostgroups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=hostgroups,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "member || memberhost || memberof || memberuser")(targetfilter = "(objectclass=ipahostgroup)")(version 3.0;acl "permission:System: Read Hostgroup Membership";allow (compare,read,search) userdn = "ldap:///all";)
 dn: cn=hostgroups,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "businesscategory || cn || createtimestamp || description || entryusn || ipauniqueid || modifytimestamp || o || objectclass || ou || owner || seealso")(targetfilter = "(objectclass=ipahostgroup)")(version 3.0;acl "permission:System: Read Hostgroups";allow (compare,read,search) userdn = "ldap:///all";)
+aci: (targetattr = "businesscategory || cn || createtimestamp || description || entryusn || ipauniqueid || membermanager || modifytimestamp || o || objectclass || ou || owner || seealso")(targetfilter = "(objectclass=ipahostgroup)")(version 3.0;acl "permission:System: Read Hostgroups";allow (compare,read,search) userdn = "ldap:///all";)
 dn: cn=hostgroups,cn=accounts,dc=ipa,dc=example
 aci: (targetfilter = "(objectclass=ipahostgroup)")(version 3.0;acl "permission:System: Remove Hostgroups";allow (delete) groupdn = "ldap:///cn=System: Remove Hostgroups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=views,cn=accounts,dc=ipa,dc=example

--- a/API.txt
+++ b/API.txt
@@ -1972,6 +1972,18 @@ option: Str('version?')
 output: Output('completed', type=[<type 'int'>])
 output: Output('failed', type=[<type 'dict'>])
 output: Entry('result')
+command: group_add_member_manager/1
+args: 1,6,3
+arg: Str('cn', cli_name='group_name')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Str('group*', alwaysask=True, cli_name='groups')
+option: Flag('no_members', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('user*', alwaysask=True, cli_name='users')
+option: Str('version?')
+output: Output('completed', type=[<type 'int'>])
+output: Output('failed', type=[<type 'dict'>])
+output: Entry('result')
 command: group_del/1
 args: 1,2,3
 arg: Str('cn+', cli_name='group_name')
@@ -1988,7 +2000,7 @@ output: Output('result', type=[<type 'bool'>])
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
 command: group_find/1
-args: 1,30,4
+args: 1,34,4
 arg: Str('criteria?')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('cn?', autofill=False, cli_name='group_name')
@@ -2001,6 +2013,8 @@ option: Str('in_hbacrule*', cli_name='in_hbacrules')
 option: Str('in_netgroup*', cli_name='in_netgroups')
 option: Str('in_role*', cli_name='in_roles')
 option: Str('in_sudorule*', cli_name='in_sudorules')
+option: Str('membermanager_group*', cli_name='membermanager_groups')
+option: Str('membermanager_user*', cli_name='membermanager_users')
 option: Str('no_group*', cli_name='no_groups')
 option: Flag('no_members', autofill=True, default=True)
 option: Principal('no_service*', cli_name='no_services')
@@ -2011,6 +2025,8 @@ option: Str('not_in_hbacrule*', cli_name='not_in_hbacrules')
 option: Str('not_in_netgroup*', cli_name='not_in_netgroups')
 option: Str('not_in_role*', cli_name='not_in_roles')
 option: Str('not_in_sudorule*', cli_name='not_in_sudorules')
+option: Str('not_membermanager_group*', cli_name='not_membermanager_groups')
+option: Str('not_membermanager_user*', cli_name='not_membermanager_users')
 option: Flag('pkey_only?', autofill=True, default=False)
 option: Flag('posix', autofill=True, cli_name='posix', default=False)
 option: Flag('private', autofill=True, cli_name='private', default=False)
@@ -2052,6 +2068,18 @@ option: Str('ipaexternalmember*', cli_name='external')
 option: Flag('no_members', autofill=True, default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Str('service*', alwaysask=True, cli_name='services')
+option: Str('user*', alwaysask=True, cli_name='users')
+option: Str('version?')
+output: Output('completed', type=[<type 'int'>])
+output: Output('failed', type=[<type 'dict'>])
+output: Entry('result')
+command: group_remove_member_manager/1
+args: 1,6,3
+arg: Str('cn', cli_name='group_name')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Str('group*', alwaysask=True, cli_name='groups')
+option: Flag('no_members', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Str('user*', alwaysask=True, cli_name='users')
 option: Str('version?')
 output: Output('completed', type=[<type 'int'>])
@@ -2708,6 +2736,18 @@ option: Str('version?')
 output: Output('completed', type=[<type 'int'>])
 output: Output('failed', type=[<type 'dict'>])
 output: Entry('result')
+command: hostgroup_add_member_manager/1
+args: 1,6,3
+arg: Str('cn', cli_name='hostgroup_name')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Str('group*', alwaysask=True, cli_name='groups')
+option: Flag('no_members', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('user*', alwaysask=True, cli_name='users')
+option: Str('version?')
+output: Output('completed', type=[<type 'int'>])
+output: Output('failed', type=[<type 'dict'>])
+output: Entry('result')
 command: hostgroup_del/1
 args: 1,2,3
 arg: Str('cn+', cli_name='hostgroup_name')
@@ -2717,7 +2757,7 @@ output: Output('result', type=[<type 'dict'>])
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: ListOfPrimaryKeys('value')
 command: hostgroup_find/1
-args: 1,21,4
+args: 1,25,4
 arg: Str('criteria?')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('cn?', autofill=False, cli_name='hostgroup_name')
@@ -2728,6 +2768,8 @@ option: Str('in_hbacrule*', cli_name='in_hbacrules')
 option: Str('in_hostgroup*', cli_name='in_hostgroups')
 option: Str('in_netgroup*', cli_name='in_netgroups')
 option: Str('in_sudorule*', cli_name='in_sudorules')
+option: Str('membermanager_group*', cli_name='membermanager_groups')
+option: Str('membermanager_user*', cli_name='membermanager_users')
 option: Str('no_host*', cli_name='no_hosts')
 option: Str('no_hostgroup*', cli_name='no_hostgroups')
 option: Flag('no_members', autofill=True, default=True)
@@ -2735,6 +2777,8 @@ option: Str('not_in_hbacrule*', cli_name='not_in_hbacrules')
 option: Str('not_in_hostgroup*', cli_name='not_in_hostgroups')
 option: Str('not_in_netgroup*', cli_name='not_in_netgroups')
 option: Str('not_in_sudorule*', cli_name='not_in_sudorules')
+option: Str('not_membermanager_group*', cli_name='not_membermanager_groups')
+option: Str('not_membermanager_user*', cli_name='not_membermanager_users')
 option: Flag('pkey_only?', autofill=True, default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Int('sizelimit?', autofill=False)
@@ -2767,6 +2811,18 @@ option: Str('host*', alwaysask=True, cli_name='hosts')
 option: Str('hostgroup*', alwaysask=True, cli_name='hostgroups')
 option: Flag('no_members', autofill=True, default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('version?')
+output: Output('completed', type=[<type 'int'>])
+output: Output('failed', type=[<type 'dict'>])
+output: Entry('result')
+command: hostgroup_remove_member_manager/1
+args: 1,6,3
+arg: Str('cn', cli_name='hostgroup_name')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Str('group*', alwaysask=True, cli_name='groups')
+option: Flag('no_members', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('user*', alwaysask=True, cli_name='users')
 option: Str('version?')
 output: Output('completed', type=[<type 'int'>])
 output: Output('failed', type=[<type 'dict'>])
@@ -6739,11 +6795,13 @@ default: env/1
 default: group/1
 default: group_add/1
 default: group_add_member/1
+default: group_add_member_manager/1
 default: group_del/1
 default: group_detach/1
 default: group_find/1
 default: group_mod/1
 default: group_remove_member/1
+default: group_remove_member_manager/1
 default: group_show/1
 default: hbacrule/1
 default: hbacrule_add/1
@@ -6796,10 +6854,12 @@ default: host_show/1
 default: hostgroup/1
 default: hostgroup_add/1
 default: hostgroup_add_member/1
+default: hostgroup_add_member_manager/1
 default: hostgroup_del/1
 default: hostgroup_find/1
 default: hostgroup_mod/1
 default: hostgroup_remove_member/1
+default: hostgroup_remove_member_manager/1
 default: hostgroup_show/1
 default: i18n_messages/1
 default: idoverridegroup/1

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -86,9 +86,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-define(IPA_API_VERSION_MINOR, 234)
-# Last change: Added new auth indicators to ipauserauthtype and krbprincipalauthind.
-#              Converted krbprincipalauthind from Str() to StrEnum()
+define(IPA_API_VERSION_MINOR, 235)
+# Last change: Add memberManager to groups.
 
 ########################################################
 # Following values are auto-generated from values above

--- a/doc/designs/membermanager.md
+++ b/doc/designs/membermanager.md
@@ -1,0 +1,130 @@
+# Member Manager for group membership
+
+## Overview
+
+A member manager is a principal that is able to manage members of a
+group. Member managers are able to add new members to a group or remove
+existing members from a group. They cannot modify additional attributes
+of a group as a part of the member manager role.
+
+Member management is implemented for *user groups* and *host groups*.
+Membership can be managed by users or user groups. Member managers are
+independent from members. A principal can be a member manager of a
+group without being a member of a group.
+
+
+## Use Cases
+
+An administrator can use member management feature to delegate some
+control over user groups and host groups to users. For example a
+project manager is now able to add new team members to a project group.
+
+A NFS admin with member management capability for a host group is able
+to indirectly influence an HBAC rules and control which hosts can
+connect to an NFS file share.
+
+## Implementation
+
+The user group commands and host group commands are extended to handle
+member managers. The plugin classes grow two additional sub commands,
+one for adding and one for removing member managers. The show command
+prints member manager users and member manager groups. The find command
+can search by member manager.
+
+Member managers are stored in a new LDAP attribute ``memberManager``
+with OID 2.16.840.1.113730.3.8.23.1. It is multi-valued and contains
+DNs of users and groups which can manage members of the group. The
+attribute can be added to entries with object class ``ipaUserGroup``
+or ``ipaHostGroup``. The attribute is indexed and its membership
+controlled by referential integrity postoperation plugin.
+New userattr ACIs grant principals with user DN or group DN in
+``memberManager`` write permission to the ``member`` attribute of the
+group.
+
+The ``memberManager`` attribute is protected by the generic read and
+modify permissions for each type of group. It is readable by everybody
+with ``System: Read Groups`` / ``System: Read Hostgroups`` permission
+and writable by everybody with ``System: Modify Groups`` /
+``System: Modify Hostgroups`` permission.
+
+
+## Examples
+
+Add example user and groups:
+
+```
+$ kinit admin
+$ ipa user-add john --first John --last Doe --random
+$ ipa user-add tom --first Tom --last Doe --random
+$ ipa group-add project
+$ ipa group-add project_admins
+```
+
+Make user and group member managers:
+
+```
+$ ipa group-add-member-manager project --users=john
+$ ipa group-add-member-manager project --groups=project_admins
+```
+
+Show group:
+
+```
+$ ipa group-show project
+  Group name: project
+  GID: 787600003
+  Membership managed by groups: project_admins
+  Membership managed by users: john
+```
+
+Find groups by member managers:
+
+```
+$ ipa group-find --membermanager-users=john
+---------------
+1 group matched
+---------------
+  Group name: project
+  GID: 787600003
+----------------------------
+Number of entries returned 1
+----------------------------
+$ ipa group-find --membermanager-groups=project_admins
+---------------
+1 group matched
+---------------
+  Group name: project
+  GID: 787600003
+----------------------------
+Number of entries returned 1
+----------------------------
+```
+
+Use member management capability:
+
+```
+$ kinit john
+$ ipa group-add-member project --users=tom
+  Group name: project
+  GID: 787600003
+  Member users: tom
+  Membership managed by groups: project_admins
+  Membership managed by users: john
+-------------------------
+Number of members added 1
+-------------------------
+```
+
+Remove member management capability:
+
+```
+$ kinit admin
+$ ipa group-remove-member-manager project --groups=project_admins
+  Group name: project
+  GID: 787600003
+  Member users: tom
+  Membership managed by users: john
+---------------------------
+Number of members removed 1
+---------------------------
+```

--- a/install/share/60basev2.ldif
+++ b/install/share/60basev2.ldif
@@ -2,6 +2,7 @@
 ##
 ## Attributes:		2.16.840.1.113730.3.8.3 - V2 base attributres
 ## ObjectClasses:	2.16.840.1.113730.3.8.4 - V2 base objectclasses
+## Attributes:		2.16.840.1.113730.3.8.23 - V4 base attributes
 ##
 dn: cn=schema
 attributeTypes: (2.16.840.1.113730.3.8.3.1 NAME 'ipaUniqueID' DESC 'Unique identifier' EQUALITY caseIgnoreMatch ORDERING caseIgnoreOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'IPA v2' )
@@ -21,8 +22,10 @@ objectClasses: (2.16.840.1.113730.3.8.4.14 NAME 'ipaEntitlement' DESC 'IPA Entit
 objectClasses: (2.16.840.1.113730.3.8.4.15 NAME 'ipaPermission' DESC 'IPA Permission objectclass' AUXILIARY MAY ( ipaPermissionType ) X-ORIGIN 'IPA v2' )
 objectClasses: (2.16.840.1.113730.3.8.4.2 NAME 'ipaService' DESC 'IPA service objectclass' AUXILIARY MAY ( memberOf $ managedBy $ ipaKrbAuthzData) X-ORIGIN 'IPA v2' )
 objectClasses: (2.16.840.1.113730.3.8.4.3 NAME 'nestedGroup' DESC 'Group that supports nesting' SUP groupOfNames STRUCTURAL MAY memberOf X-ORIGIN 'IPA v2' )
-objectClasses: (2.16.840.1.113730.3.8.4.4 NAME 'ipaUserGroup' DESC 'IPA user group object class' SUP nestedGroup STRUCTURAL X-ORIGIN 'IPA v2' )
-objectClasses: (2.16.840.1.113730.3.8.4.5 NAME 'ipaHostGroup' DESC 'IPA host group object class' SUP nestedGroup STRUCTURAL X-ORIGIN 'IPA v2' )
+# Same for memberManager except it's actually v4 attribute
+attributeTypes: (2.16.840.1.113730.3.8.23.1 NAME 'memberManager' DESC 'DNs of entries allowed to manage group membership' SUP distinguishedName EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 X-ORIGIN 'IPA v4')
+objectClasses: (2.16.840.1.113730.3.8.4.4 NAME 'ipaUserGroup' DESC 'IPA user group object class' SUP nestedGroup STRUCTURAL MAY memberManager X-ORIGIN 'IPA v2' )
+objectClasses: (2.16.840.1.113730.3.8.4.5 NAME 'ipaHostGroup' DESC 'IPA host group object class' SUP nestedGroup STRUCTURAL MAY memberManager X-ORIGIN 'IPA v2' )
 attributeTypes: (2.16.840.1.113730.3.8.3.5 NAME 'memberUser' DESC 'Reference to a principal that performs an action (usually user).' SUP distinguishedName EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 X-ORIGIN 'IPA v2' )
 attributeTypes: (2.16.840.1.113730.3.8.3.6 NAME 'userCategory' DESC 'Additional classification for users' EQUALITY caseIgnoreMatch ORDERING caseIgnoreOrderingMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'IPA v2' )
 attributeTypes: (2.16.840.1.113730.3.8.3.7 NAME 'memberHost' DESC 'Reference to a device where the operation takes place (usually host).' SUP distinguishedName EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 X-ORIGIN 'IPA v2' )

--- a/install/share/default-aci.ldif
+++ b/install/share/default-aci.ldif
@@ -70,6 +70,19 @@ changetype: modify
 add: aci
 aci: (targetattr = "krbPrincipalKey || krbLastPwdChange")(target = "ldap:///fqdn=*,cn=computers,cn=accounts,$SUFFIX")(version 3.0;acl "Admins can manage host keytab";allow (write) groupdn = "ldap:///cn=admins,cn=groups,cn=accounts,$SUFFIX";)
 
+# Allow member managers to modify members of user groups
+dn: cn=groups,cn=accounts,$SUFFIX
+changetype: modify
+add: aci
+aci: (targetattr = "member")(targetfilter = "(objectclass=ipaUserGroup)")(version 3.0; acl "Allow member managers to modify members of user groups"; allow (write) userattr = "memberManager#USERDN" or userattr = "memberManager#GROUPDN";)
+
+# Allow member managers to modify members of a host group
+dn: cn=hostgroups,cn=accounts,$SUFFIX
+changetype: modify
+add: aci
+aci: (targetattr = "member")(targetfilter = "(objectclass=ipaHostGroup)")(version 3.0; acl "Allow member managers to modify members of host groups"; allow (write) userattr = "memberManager#USERDN" or userattr = "memberManager#GROUPDN";)
+
+
 # This is used for the host/service one-time passwordn and keytab indirectors.
 # We can do a query on a DN to see if an attribute exists.
 dn: cn=accounts,$SUFFIX

--- a/install/share/indices.ldif
+++ b/install/share/indices.ldif
@@ -417,3 +417,12 @@ objectClass: top
 objectClass: nsIndex
 nsSystemIndex: false
 nsIndexType: eq
+
+dn: cn=memberManager,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+changetype: add
+cn: memberManager
+objectClass: top
+objectClass: nsIndex
+nsSystemIndex: false
+nsIndexType: eq
+nsIndexType: pres

--- a/install/ui/src/freeipa/entity.js
+++ b/install/ui/src/freeipa/entity.js
@@ -442,7 +442,8 @@ exp.entity_builder = IPA.entity_builder = function(entity) {
         'member',
         'settings',
         'memberof',
-        'managedby'
+        'managedby',
+        'membermanager'
     ];
 
     /**

--- a/install/ui/src/freeipa/group.js
+++ b/install/ui/src/freeipa/group.js
@@ -153,6 +153,20 @@ return {
         },
         {
             $type: 'association',
+            name: 'membermanager_group',
+            associator: IPA.serial_associator,
+            add_title: '@i18n:objects.group.add_membermanager_group',
+            remove_title: '@i18n:objects.group.remove_membermanager_group'
+        },
+        {
+            $type: 'association',
+            name: 'membermanager_user',
+            associator: IPA.serial_associator,
+            add_title: '@i18n:objects.group.add_membermanager_user',
+            remove_title: '@i18n:objects.group.remove_membermanager_user'
+        },
+        {
+            $type: 'association',
             name: 'memberof_group',
             associator: IPA.serial_associator,
             add_title: '@i18n:objects.group.add_into_groups',

--- a/install/ui/src/freeipa/hostgroup.js
+++ b/install/ui/src/freeipa/hostgroup.js
@@ -65,13 +65,29 @@ return {
         },
         {
             $type: 'association',
+            name: 'membermanager_group',
+            associator: IPA.serial_associator,
+            add_title: '@i18n:objects.hostgroup.add_membermanager_group',
+            remove_title: '@i18n:objects.hostgroup.remove_membermanager_group'
+        },
+        {
+            $type: 'association',
+            name: 'membermanager_user',
+            associator: IPA.serial_associator,
+            add_title: '@i18n:objects.hostgroup.add_membermanager_user',
+            remove_title: '@i18n:objects.hostgroup.remove_membermanager_user'
+        },
+        {
+            $type: 'association',
             name: 'member_host',
+            associator: IPA.serial_associator,
             add_title: '@i18n:objects.hostgroup.add_hosts',
             remove_title: '@i18n:objects.hostgroup.remove_hosts'
         },
         {
             $type: 'association',
             name: 'member_hostgroup',
+            associator: IPA.serial_associator,
             add_title: '@i18n:objects.hostgroup.add_hostgroups',
             remove_title: '@i18n:objects.hostgroup.remove_hostgroups'
         },

--- a/install/updates/20-aci.update
+++ b/install/updates/20-aci.update
@@ -132,6 +132,14 @@ add:aci: (targetfilter="(|(objectclass=ipaHost)(objectclass=ipaService))")(targe
 dn: $SUFFIX
 add:aci:(targetattr = "usercertificate")(version 3.0;acl "selfservice:Users can manage their own X.509 certificates";allow (write) userdn = "ldap:///self";)
 
+# Allow member managers to modify members of user groups
+dn: cn=groups,cn=accounts,$SUFFIX
+add:aci: (targetattr = "member")(targetfilter = "(objectclass=ipaUserGroup)")(version 3.0; acl "Allow member managers to modify members of user groups"; allow (write) userattr = "memberManager#USERDN";)
+
+# Allow member managers to modify members of host groups
+dn: cn=hostgroups,cn=accounts,$SUFFIX
+add:aci: (targetattr = "member")(targetfilter = "(objectclass=ipaHostGroup)")(version 3.0; acl "Allow member managers to modify members of host groups"; allow (write) userattr = "memberManager#USERDN";)
+
 # Hosts can add and delete their own services
 dn: cn=services,cn=accounts,$SUFFIX
 remove:aci: (target = "ldap:///krbprincipalname=*/($$dn)@$REALM,cn=services,cn=accounts,$SUFFIX")(targetfilter = "(objectClass=ipaKrbPrincipal)")(version 3.0;acl "Hosts can add own services"; allow(add) userdn="ldap:///fqdn=($$dn),cn=computers,cn=accounts,$SUFFIX";)

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -380,3 +380,11 @@ default: objectClass: top
 default: objectClass: nsIndex
 default: nsSystemIndex: false
 default: nsIndexType: eq
+
+dn: cn=memberManager,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: memberManager
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: eq
+default: nsIndexType: pres

--- a/install/updates/25-referint.update
+++ b/install/updates/25-referint.update
@@ -20,3 +20,4 @@ add: referint-membership-attr: ipaallowedtarget
 add: referint-membership-attr: ipamemberca
 add: referint-membership-attr: ipamembercertprofile
 add: referint-membership-attr: ipalocation
+add: referint-membership-attr: membermanager

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -564,6 +564,11 @@ class LDAPObject(Object):
         'memberofindirect': (
             'Indirect Member Of', None, 'not_in_indirect_'
         ),
+        'membermanager': (
+            'Group membership managed by',
+            'membermanager_',
+            'not_membermanager_'
+        ),
     }
     label = _('Entry')
     label_singular = _('Entry')

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -301,6 +301,7 @@ class i18n_messages(Command):
             "managedby": _("${primary_key} is managed by:"),
             "member": _("${primary_key} members:"),
             "memberof": _("${primary_key} is a member of:"),
+            "membermanager": _("${primary_key} member managers:"),
         },
         "facets": {
             "details": _("Settings"),
@@ -814,6 +815,22 @@ class i18n_messages(Command):
                 "add_users": _(
                     "Add users into user group '${primary_key}'"
                 ),
+                "add_membermanager_group": _(
+                    "Add groups as member managers for user group "
+                    "'${primary_key}'"
+                ),
+                "remove_membermanager_group": _(
+                    "Remove groups from member managers for user group "
+                    "'${primary_key}'"
+                ),
+                "add_membermanager_user": _(
+                    "Add users as member managers for user group "
+                    "'${primary_key}'"
+                ),
+                "remove_membermanager_user": _(
+                    "Remove users from member managers for user group "
+                    "'${primary_key}'"
+                ),
                 "details": _("Group Settings"),
                 "external": _("External"),
                 "groups": _("Groups"),
@@ -1025,6 +1042,22 @@ class i18n_messages(Command):
                 ),
                 "add_into_sudo": _(
                     "Add host group '${primary_key}' into sudo rules"
+                ),
+                "add_membermanager_group": _(
+                    "Add groups as member managers for host group "
+                    "'${primary_key}'"
+                ),
+                "remove_membermanager_group": _(
+                    "Remove groups from member managers for host group "
+                    "'${primary_key}'"
+                ),
+                "add_membermanager_user": _(
+                    "Add users as member managers for host group "
+                    "'${primary_key}'"
+                ),
+                "remove_membermanager_user": _(
+                    "Remove users from member managers for host group "
+                    "'${primary_key}'"
                 ),
                 "host_group": _("Host Groups"),
                 "identity": _("Host Group Settings"),

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -15,6 +15,10 @@ topologies:
     name: ad_master_2client
     cpu: 4
     memory: 12000
+  ipaserver: &ipaserver
+    name: ipaserver
+    cpu: 2
+    memory: 2400
 
 jobs:
   fedora-30/build:
@@ -247,3 +251,14 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-30/membermanager:
+    requires: [fedora-30/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_membermanager.py
+        template: *ci-master-f30
+        timeout: 1800
+        topology: *ipaserver

--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -1336,3 +1336,15 @@ jobs:
         template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
+
+  fedora-29/membermanager:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_membermanager.py
+        template: *ci-master-f29
+        timeout: 1800
+        topology: *ipaserver

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1360,3 +1360,15 @@ jobs:
         template: *ci-master-f30
         timeout: 7200
         topology: *master_1repl
+
+  fedora-30/membermanager:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_membermanager.py
+        template: *ci-master-f30
+        timeout: 1800
+        topology: *ipaserver

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1360,3 +1360,15 @@ jobs:
         template: *ci-master-frawhide
         timeout: 7200
         topology: *master_1repl
+
+  fedora-30/membermanager:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_membermanager.py
+        template: *ci-master-frawhide
+        timeout: 1800
+        topology: *ipaserver

--- a/ipatests/test_integration/test_membermanager.py
+++ b/ipatests/test_integration/test_membermanager.py
@@ -1,0 +1,179 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+"""Tests for member manager feature
+"""
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_ipa.integration import tasks
+
+
+PASSWORD = "DummyPassword123"
+# direct member manager
+USER_MM = "mmuser"
+# indirect member manager through group membership
+USER_INDIRECT = "indirect_mmuser"
+GROUP_INDIRECT = "group_indirect"
+
+USER1 = "testuser1"
+USER2 = "testuser2"
+GROUP1 = "testgroup1"
+GROUP2 = "testgroup2"
+HOSTGROUP1 = "testhostgroup1"
+
+
+class TestMemberManager(IntegrationTest):
+    """Tests for member manager feature for groups and hostgroups
+    """
+    @classmethod
+    def install(cls, mh):
+        super(TestMemberManager, cls).install(mh)
+        master = cls.master
+
+        tasks.create_active_user(master, USER_MM, PASSWORD)
+        tasks.create_active_user(master, USER_INDIRECT, PASSWORD)
+
+        tasks.kinit_admin(master)
+        tasks.group_add(master, GROUP_INDIRECT)
+        master.run_command([
+            'ipa', 'group-add-member', GROUP_INDIRECT, '--users', USER_INDIRECT
+        ])
+
+        tasks.user_add(master, USER1)
+        tasks.user_add(master, USER2)
+        tasks.group_add(master, GROUP1)
+        tasks.group_add(master, GROUP2)
+        master.run_command(['ipa', 'hostgroup-add', HOSTGROUP1])
+
+        # make mmuser a member manager for group and hostgroup
+        master.run_command([
+            'ipa', 'group-add-member-manager', GROUP1,
+            '--users', USER_MM
+        ])
+        master.run_command([
+            'ipa', 'hostgroup-add-member-manager', HOSTGROUP1,
+            '--users', USER_MM
+        ])
+        # make indirect group member manager for group and hostgroup
+        master.run_command([
+            'ipa', 'group-add-member-manager', GROUP1,
+            '--groups', GROUP_INDIRECT
+        ])
+        master.run_command([
+            'ipa', 'hostgroup-add-member-manager', HOSTGROUP1,
+            '--groups', GROUP_INDIRECT
+        ])
+        tasks.kdestroy_all(master)
+
+    def test_show_member_manager(self):
+        master = self.master
+        tasks.kinit_admin(master)
+
+        result = master.run_command(['ipa', 'group-show', GROUP1])
+        out = result.stdout_text
+        assert f"Membership managed by groups: {GROUP_INDIRECT}" in out
+        assert f"Membership managed by users: {USER_MM}" in out
+
+        result = master.run_command(['ipa', 'hostgroup-show', HOSTGROUP1])
+        out = result.stdout_text
+        assert f"Membership managed by groups: {GROUP_INDIRECT}" in out
+        assert f"Membership managed by users: {USER_MM}" in out
+
+        tasks.kdestroy_all(master)
+
+    def test_find_by_member_manager(self):
+        master = self.master
+        tasks.kinit_admin(master)
+
+        result = master.run_command([
+            'ipa', 'group-find', '--membermanager-users', USER_MM
+        ])
+        assert GROUP1 in result.stdout_text
+
+        result = master.run_command([
+            'ipa', 'group-find', '--membermanager-groups', GROUP_INDIRECT
+        ])
+        assert GROUP1 in result.stdout_text
+
+        result = master.run_command(
+            [
+                'ipa', 'group-find', '--membermanager-users', USER1
+            ],
+            raiseonerr=False
+        )
+        assert result.returncode == 1
+        assert "0 groups matched" in result.stdout_text
+
+        result = master.run_command([
+            'ipa', 'hostgroup-find', '--membermanager-users', USER_MM
+        ])
+        assert HOSTGROUP1 in result.stdout_text
+
+        result = master.run_command([
+            'ipa', 'hostgroup-find', '--membermanager-groups', GROUP_INDIRECT
+        ])
+        assert HOSTGROUP1 in result.stdout_text
+
+        result = master.run_command(
+            [
+                'ipa', 'hostgroup-find', '--membermanager-users', USER1
+            ],
+            raiseonerr=False
+        )
+        assert result.returncode == 1
+        assert "0 hostgroups matched" in result.stdout_text
+
+    def test_group_member_manager_user(self):
+        master = self.master
+        # mmuser: add user1 to group
+        tasks.kinit_as_user(master, USER_MM, PASSWORD)
+        master.run_command([
+            'ipa', 'group-add-member', GROUP1, '--users', USER1
+        ])
+        result = master.run_command(['ipa', 'group-show', GROUP1])
+        assert USER1 in result.stdout_text
+
+        # indirect: add user2 to group
+        tasks.kinit_as_user(master, USER_INDIRECT, PASSWORD)
+        master.run_command([
+            'ipa', 'group-add-member', GROUP1, '--users', USER2
+        ])
+        # verify
+        master.run_command(['ipa', 'group-show', GROUP1])
+        result = master.run_command(['ipa', 'group-show', GROUP1])
+        assert USER2 in result.stdout_text
+
+    def test_group_member_manager_group(self):
+        master = self.master
+        # mmuser: add group2 to group
+        tasks.kinit_as_user(master, USER_MM, PASSWORD)
+        master.run_command([
+            'ipa', 'group-add-member', GROUP1, '--groups', GROUP2
+        ])
+        result = master.run_command(['ipa', 'group-show', GROUP1])
+        assert GROUP2 in result.stdout_text
+
+    def test_hostgroup_member_manager_user(self):
+        master = self.master
+        # mmuser: add a host to host group
+        tasks.kinit_as_user(master, USER_MM, PASSWORD)
+        master.run_command([
+            'ipa', 'hostgroup-add-member', HOSTGROUP1,
+            '--hosts', master.hostname
+        ])
+        result = master.run_command(['ipa', 'hostgroup-show', HOSTGROUP1])
+        assert master.hostname in result.stdout_text
+        master.run_command([
+            'ipa', 'hostgroup-remove-member', HOSTGROUP1,
+            '--hosts', master.hostname
+        ])
+        result = master.run_command(['ipa', 'hostgroup-show', HOSTGROUP1])
+        assert master.hostname not in result.stdout_text
+
+        # indirect:
+        tasks.kinit_as_user(master, USER_INDIRECT, PASSWORD)
+        master.run_command([
+            'ipa', 'hostgroup-add-member', HOSTGROUP1,
+            '--hosts', master.hostname
+        ])
+        result = master.run_command(['ipa', 'hostgroup-show', HOSTGROUP1])
+        assert master.hostname in result.stdout_text

--- a/ipatests/test_xmlrpc/test_group_plugin.py
+++ b/ipatests/test_xmlrpc/test_group_plugin.py
@@ -757,3 +757,35 @@ class TestTrustAdminGroup(XMLRPC_test):
                           key=trustadmins.cn,
                           reason='Cannot support external non-IPA members')):
             command()
+
+
+@pytest.mark.tier1
+class TestGroupMemberManager(XMLRPC_test):
+    def test_add_member_manager_user(self, user, group):
+        user.ensure_exists()
+        group.ensure_exists()
+        group.add_member_manager({"user": user.uid})
+
+    def test_remove_member_manager_user(self, user, group):
+        user.ensure_exists()
+        group.ensure_exists()
+        group.remove_member_manager({"user": user.uid})
+
+    def test_add_member_manager_group(self, group, group2):
+        group.ensure_exists()
+        group2.ensure_exists()
+        group.add_member_manager({"group": group2.cn})
+
+    def test_remove_member_manager_group(self, group, group2):
+        group.ensure_exists()
+        group2.ensure_exists()
+        group.remove_member_manager({"group": group2.cn})
+
+    def test_member_manager_delete_user(self, user, group):
+        user.ensure_exists()
+        group.ensure_exists()
+        group.add_member_manager({"user": user.uid})
+        user.delete()
+        # deleting a user also deletes member manager reference
+        group.attrs.pop("membermanager_user")
+        group.retrieve()


### PR DESCRIPTION
A group membership manager is a user or a group that can add members to
a group or remove members from a group.

Fixes: https://pagure.io/freeipa/issue/8114
Signed-off-by: Christian Heimes <cheimes@redhat.com>