### PR TITLE
[PR-CI] Upgrade Fedora release used in gating and nightly tests

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -21,7 +21,7 @@ topologies:
     memory: 2400
 
 jobs:
-  fedora-30/build:
+  fedora-latest/build:
     requires: []
     priority: 150
     job:
@@ -29,236 +29,236 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-f30
+        template: &ci-master-latest
           name: freeipa/ci-master-f30
           version: 0.0.4
         timeout: 1800
         topology: *build
 
-  fedora-30/test_installation_TestInstallMaster:
-    requires: [fedora-30/build]
+  fedora-latest/test_installation_TestInstallMaster:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMaster
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/simple_replication:
-    requires: [fedora-30/build]
+  fedora-latest/simple_replication:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_simple_replication.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/caless:
-    requires: [fedora-30/build]
+  fedora-latest/caless:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_1:
-    requires: [fedora-30/build]
+  fedora-latest/external_ca_1:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/external_ca_2:
-    requires: [fedora-30/build]
+  fedora-latest/external_ca_2:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_templates:
-    requires: [fedora-30/build]
+  fedora-latest/external_ca_templates:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_topologies:
-    requires: [fedora-30/build]
+  fedora-latest/test_topologies:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_topologies.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_sudo:
-    requires: [fedora-30/build]
+  fedora-latest/test_sudo:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_sudo.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_commands:
-    requires: [fedora-30/build]
+  fedora-latest/test_commands:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_commands.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_kerberos_flags:
-    requires: [fedora-30/build]
+  fedora-latest/test_kerberos_flags:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_kerberos_flags.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_forced_client_enrolment:
-    requires: [fedora-30/build]
+  fedora-latest/test_forced_client_enrolment:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_advise:
-    requires: [fedora-30/build]
+  fedora-latest/test_advise:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_advise.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_testconfig:
-    requires: [fedora-30/build]
+  fedora-latest/test_testconfig:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_testconfig.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_service_permissions:
-    requires: [fedora-30/build]
+  fedora-latest/test_service_permissions:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_service_permissions.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_netgroup:
-    requires: [fedora-30/build]
+  fedora-latest/test_netgroup:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_netgroup.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_authconfig:
-    requires: [fedora-30/build]
+  fedora-latest/test_authconfig:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_authselect.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/replica_promotion:
-    requires: [fedora-30/build]
+  fedora-latest/replica_promotion:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/dnssec:
-    requires: [fedora-30/build]
+  fedora-latest/dnssec:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/membermanager:
-    requires: [fedora-30/build]
+  fedora-latest/membermanager:
+    requires: [fedora-latest/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_membermanager.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 1800
         topology: *ipaserver

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -30,8 +30,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f30
-          version: 0.0.4
+          name: freeipa/ci-master-f31
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -37,7 +37,7 @@ topologies:
    memory: 12000
 
 jobs:
-  fedora-29/build:
+  fedora-latest/build:
     requires: []
     priority: 100
     job:
@@ -45,1306 +45,1330 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-f29
-          name: freeipa/ci-master-f29
-          version: 0.2.2
+        template: &ci-master-latest
+          name: freeipa/ci-master-f30
+          version: 0.0.4
         timeout: 1800
         topology: *build
 
-  fedora-29/simple_replication:
-    requires: [fedora-29/build]
+  fedora-latest/simple_replication:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_simple_replication.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/external_ca_1:
-    requires: [fedora-29/build]
+  fedora-latest/external_ca_1:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-29/external_ca_2:
-    requires: [fedora-29/build]
+  fedora-latest/external_ca_2:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/external_ca_templates:
-    requires: [fedora-29/build]
+  fedora-latest/external_ca_templates:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_topologies:
-    requires: [fedora-29/build]
+  fedora-latest/test_topologies:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_topologies.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_sudo:
-    requires: [fedora-29/build]
+  fedora-latest/test_sudo:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_sudo.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-29/test_commands:
-    requires: [fedora-29/build]
+  fedora-latest/test_commands:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_commands.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_kerberos_flags:
-    requires: [fedora-29/build]
+  fedora-latest/test_kerberos_flags:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_kerberos_flags.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-29/test_http_kdc_proxy:
-    requires: [fedora-29/build]
+  fedora-latest/test_http_kdc_proxy:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_http_kdc_proxy.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-29/test_forced_client_enrolment:
-    requires: [fedora-29/build]
+  fedora-latest/test_forced_client_enrolment:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-29/test_advise:
-    requires: [fedora-29/build]
+  fedora-latest/test_advise:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_advise.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-29/test_testconfig:
-    requires: [fedora-29/build]
+  fedora-latest/test_testconfig:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_testconfig.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_service_permissions:
-    requires: [fedora-29/build]
+  fedora-latest/test_service_permissions:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_service_permissions.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_netgroup:
-    requires: [fedora-29/build]
+  fedora-latest/test_netgroup:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_netgroup.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_vault:
-    requires: [fedora-29/build]
+  fedora-latest/test_vault:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_vault.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 6300
         topology: *master_1repl
 
-  fedora-29/test_authconfig:
-    requires: [fedora-29/build]
+  fedora-latest/test_authconfig:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_authselect.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-29/test_smb:
-    requires: [fedora-29/build]
+  fedora-latest/test_smb:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_smb.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *ad_master_2client
 
-  fedora-29/test_server_del:
-    requires: [fedora-29/build]
+  fedora-latest/test_server_del:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_server_del.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA1:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallWithCA1:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA2:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallWithCA2:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA_KRA1:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallWithCA_KRA1:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA_KRA2:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallWithCA_KRA2:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA_DNS1:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallWithCA_DNS1:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA_DNS2:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallWithCA_DNS2:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA_DNS3:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallWithCA_DNS3:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_installation_TestInstallWithCA_DNS4:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallWithCA_DNS4:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_installation_TestInstallWithCA_KRA_DNS1:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallWithCA_KRA_DNS1:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallWithCA_KRA_DNS2:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallWithCA_KRA_DNS2:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_installation_TestInstallMaster:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallMaster:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMaster
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-29/test_installation_TestInstallMasterKRA:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallMasterKRA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-29/test_installation_TestInstallMasterDNS:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallMasterDNS:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-29/test_installation_TestInstallMasterReservedIPasForwarder:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallMasterReservedIPasForwarder:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-29/test_installation_TestInstallMasterReplica:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallMasterReplica:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterReplica
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-29/test_installation_TestInstallReplicaAgainstSpecificServer:
-    requires: [fedora-29/build]
+  fedora-latest/test_installation_TestInstallReplicaAgainstSpecificServer:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallReplicaAgainstSpecificServer
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-29/test_idviews:
-    requires: [fedora-29/build]
+  fedora-latest/test_idviews:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_idviews.py::TestIDViews
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-29/test_caless_TestServerInstall:
-    requires: [fedora-29/build]
+  fedora-latest/test_caless_TestServerInstall:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestServerInstall
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 12000
         topology: *master_1repl
 
-  fedora-29/test_caless_TestReplicaInstall:
-    requires: [fedora-29/build]
+  fedora-latest/test_caless_TestReplicaInstall:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_caless_TestClientInstall:
-    requires: [fedora-29/build]
+  fedora-latest/test_caless_TestClientInstall:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestClientInstall
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 5400
         # actually master_1client
         topology: *master_1repl_1client
 
-  fedora-29/test_caless_TestIPACommands:
-    requires: [fedora-29/build]
+  fedora-latest/test_caless_TestIPACommands:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestIPACommands
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_caless_TestCertInstall:
-    requires: [fedora-29/build]
+  fedora-latest/test_caless_TestCertInstall:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestCertInstall
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_caless_TestPKINIT:
-    requires: [fedora-29/build]
+  fedora-latest/test_caless_TestPKINIT:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestPKINIT
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_caless_TestServerReplicaCALessToCAFull:
-    requires: [fedora-29/build]
+  fedora-latest/test_caless_TestServerReplicaCALessToCAFull:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_caless_TestReplicaCALessToCAFull:
-    requires: [fedora-29/build]
+  fedora-latest/test_caless_TestReplicaCALessToCAFull:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_caless_TestServerCALessToExternalCA:
-    requires: [fedora-29/build]
+  fedora-latest/test_caless_TestServerCALessToExternalCA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
-    requires: [fedora-29/build]
+  fedora-latest/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupAndRestore:
-    requires: [fedora-29/build]
+  fedora-latest/test_backup_and_restore_TestBackupAndRestore:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
-    requires: [fedora-29/build]
+  fedora-latest/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
-    requires: [fedora-29/build]
+  fedora-latest/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithDNS:
-    requires: [fedora-29/build]
+  fedora-latest/test_backup_and_restore_TestBackupAndRestoreWithDNS:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
-    requires: [fedora-29/build]
+  fedora-latest/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithKRA:
-    requires: [fedora-29/build]
+  fedora-latest/test_backup_and_restore_TestBackupAndRestoreWithKRA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
-    requires: [fedora-29/build]
+  fedora-latest/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithReplica:
-    requires: [fedora-29/build]
+  fedora-latest/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-29/test_backup_and_restore_TestBackupAndRestoreDMPassword:
-    requires: [fedora-29/build]
+  fedora-latest/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_backup_and_restore_TestReplicaInstallAfterRestore:
-    requires: [fedora-29/build]
+  fedora-latest/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-29/test_dnssec:
-    requires: [fedora-29/build]
+  fedora-latest/test_dnssec:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_dnssec.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-29/test_replica_promotion_TestReplicaPromotionLevel1:
-    requires: [fedora-29/build]
+  fedora-latest/test_replica_promotion_TestReplicaPromotionLevel1:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestUnprivilegedUserPermissions:
-    requires: [fedora-29/build]
+  fedora-latest/test_replica_promotion_TestUnprivilegedUserPermissions:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestProhibitReplicaUninstallation:
-    requires: [fedora-29/build]
+  fedora-latest/test_replica_promotion_TestProhibitReplicaUninstallation:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-29/test_replica_promotion_TestWrongClientDomain:
-    requires: [fedora-29/build]
+  fedora-latest/test_replica_promotion_TestWrongClientDomain:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestWrongClientDomain
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestRenewalMaster:
-    requires: [fedora-29/build]
+  fedora-latest/test_replica_promotion_TestRenewalMaster:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestReplicaInstallWithExistingEntry:
-    requires: [fedora-29/build]
+  fedora-latest/test_replica_promotion_TestReplicaInstallWithExistingEntry:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallWithExistingEntry
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestSubCAkeyReplication:
-    requires: [fedora-29/build]
+  fedora-latest/test_replica_promotion_TestSubCAkeyReplication:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestReplicaInstallCustodia:
-    requires: [fedora-29/build]
+  fedora-latest/test_replica_promotion_TestReplicaInstallCustodia:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-29/test_replica_promotion_TestReplicaInForwardZone:
-    requires: [fedora-29/build]
+  fedora-latest/test_replica_promotion_TestReplicaInForwardZone:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInForwardZone
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_replica_promotion_TestHiddenReplicaPromotion:
-    requires: [fedora-29/build]
+  fedora-latest/test_replica_promotion_TestHiddenReplicaPromotion:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-29/test_upgrade:
-    requires: [fedora-29/build]
+  fedora-latest/test_upgrade:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_upgrade.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/test_topology_TestCASpecificRUVs:
-    requires: [fedora-29/build]
+  fedora-latest/test_topology_TestCASpecificRUVs:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_topology_TestTopologyOptions:
-    requires: [fedora-29/build]
+  fedora-latest/test_topology_TestTopologyOptions:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_topology.py::TestTopologyOptions
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestLineTopologyWithoutCA:
-    requires: [fedora-29/build]
+  fedora-latest/test_replication_layouts_TestLineTopologyWithoutCA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestLineTopologyWithCA:
-    requires: [fedora-29/build]
+  fedora-latest/test_replication_layouts_TestLineTopologyWithCA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestLineTopologyWithCAKRA:
-    requires: [fedora-29/build]
+  fedora-latest/test_replication_layouts_TestLineTopologyWithCAKRA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts.py_TestStarTopologyWithoutCA:
-    requires: [fedora-29/build]
+  fedora-latest/test_replication_layouts.py_TestStarTopologyWithoutCA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestStarTopologyWithCA:
-    requires: [fedora-29/build]
+  fedora-latest/test_replication_layouts_TestStarTopologyWithCA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestStarTopologyWithCAKRA:
-    requires: [fedora-29/build]
+  fedora-latest/test_replication_layouts_TestStarTopologyWithCAKRA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestCompleteTopologyWithoutCA:
-    requires: [fedora-29/build]
+  fedora-latest/test_replication_layouts_TestCompleteTopologyWithoutCA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestCompleteTopologyWithCA:
-    requires: [fedora-29/build]
+  fedora-latest/test_replication_layouts_TestCompleteTopologyWithCA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_replication_layouts_TestCompleteTopologyWithCAKRA:
-    requires: [fedora-29/build]
+  fedora-latest/test_replication_layouts_TestCompleteTopologyWithCAKRA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-29/test_client_uninstallation:
-    requires: [fedora-29/build]
+  fedora-latest/test_client_uninstallation:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_uninstallation.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
-  fedora-29/test_user_permissions:
-    requires: [fedora-29/build]
+  fedora-latest/test_user_permissions:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_user_permissions.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-29/test_webui_cert:
-    requires: [fedora-29/build]
+  fedora-latest/test_webui_cert:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_webui/test_cert.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 2400
         topology: *ipaserver
 
-  fedora-29/test_webui_general:
-    requires: [fedora-29/build]
+  fedora-latest/test_webui_general:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: >-
           test_webui/test_loginscreen.py
           test_webui/test_misc_cases.py
           test_webui/test_navigation.py
           test_webui/test_translation.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_host:
-    requires: [fedora-29/build]
+  fedora-latest/test_webui_host:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_webui/test_host.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_host_net_groups:
-    requires: [fedora-29/build]
+  fedora-latest/test_webui_host_net_groups:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: >-
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_identity:
-    requires: [fedora-29/build]
+  fedora-latest/test_webui_identity:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_network:
-    requires: [fedora-29/build]
+  fedora-latest/test_webui_network:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: >-
           test_webui/test_automount.py
           test_webui/test_dns.py
           test_webui/test_vault.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_policy:
-    requires: [fedora-29/build]
+  fedora-latest/test_webui_policy:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: >-
           test_webui/test_hbac.py
           test_webui/test_krbtpolicy.py
           test_webui/test_pwpolicy.py
           test_webui/test_selinuxusermap.py
           test_webui/test_sudo.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_rbac:
-    requires: [fedora-29/build]
+  fedora-latest/test_webui_rbac:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: >-
           test_webui/test_delegation.py
           test_webui/test_rbac.py
           test_webui/test_selfservice.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_server:
-    requires: [fedora-29/build]
+  fedora-latest/test_webui_server:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: >-
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
           test_webui/test_trust.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_webui_service:
-    requires: [fedora-29/build]
+  fedora-latest/test_webui_service:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_webui/test_service.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 2400
         topology: *ipaserver
 
-  fedora-29/test_webui_users:
-    requires: [fedora-29/build]
+  fedora-latest/test_webui_users:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: >-
           test_webui/test_group.py
           test_webui/test_user.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 4800
         topology: *ipaserver
 
-  fedora-29/customized_ds_config_install:
-    requires: [fedora-29/build]
+  fedora-latest/customized_ds_config_install:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_customized_ds_config_install.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/dns_locations:
-    requires: [fedora-29/build]
+  fedora-latest/dns_locations:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_dns_locations.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_2repl_1client
 
-  fedora-29/external_ca_TestExternalCAdirsrvStop:
-    requires: [fedora-29/build]
+  fedora-latest/external_ca_TestExternalCAdirsrvStop:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/external_ca_TestExternalCAInvalidCert:
-    requires: [fedora-29/build]
+  fedora-latest/external_ca_TestExternalCAInvalidCert:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert test_integration/test_external_ca.py::TestExternalCAInvalidIntermediate
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/external_ca_TestMultipleExternalCA:
-    requires: [fedora-29/build]
+  fedora-latest/external_ca_TestMultipleExternalCA:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_ntp_options:
-    requires: [fedora-29/build]
+  fedora-latest/test_ntp_options:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl_1client
 
-  fedora-29/test_pkinit_manage:
-    requires: [fedora-29/build]
+  fedora-latest/test_pkinit_manage:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_pkinit_manage.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_pki_config_override:
-    requires: [fedora-29/build]
+  fedora-latest/test_pki_config_override:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_pki_config_override.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/nfs:
-    requires: [fedora-29/build]
+  fedora-latest/nfs:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_nfs.py::TestNFS
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 9000
         topology: *master_3client
 
-  fedora-29/mask:
-    requires: [fedora-29/build]
+  fedora-latest/nfs_nsswitch_restore:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_3client
+
+  fedora-latest/mask:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestMaskInstall
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-29/test_crlgen_manage:
-    requires: [fedora-29/build]
+  fedora-latest/automember:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_crlgen_manage.py
-        template: *ci-master-f29
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_automember.py
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-29/test_integration_TestIPANotConfigured:
-    requires: [fedora-29/build]
+  fedora-latest/test_crlgen_manage:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_crlgen_manage.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest/test_integration_TestIPANotConfigured:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-29/test_sssd:
-    requires: [fedora-29/build]
+  fedora-latest/test_sssd:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_sssd.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 4800
         topology: *ad_master
 
-  fedora-29/test_ca_custom_sdn:
-    requires: [fedora-29/build]
+  fedora-latest/test_ca_custom_sdn:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_ca_custom_sdn.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-29/membermanager:
-    requires: [fedora-29/build]
-    priority: 50
+  fedora-latest/membermanager:
+    requires: [fedora-latest/build]
+    priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-29/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_membermanager.py
-        template: *ci-master-f29
+        template: *ci-master-latest
         timeout: 1800
         topology: *ipaserver

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -46,8 +46,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f30
-          version: 0.0.4
+          name: freeipa/ci-master-f31
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -34,7 +34,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &389ds-master-latest
-          name: freeipa/389ds-master-f30
+          name: freeipa/389ds-master-f31
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -25,7 +25,7 @@ topologies:
     memory: 12900
 
 jobs:
-  fedora-30/build:
+  389ds-fedora/build:
     requires: []
     priority: 100
     job:
@@ -33,503 +33,503 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &389ds-master-f30
+        template: &389ds-master-latest
           name: freeipa/389ds-master-f30
           version: 0.0.1
         timeout: 1800
         topology: *build
 
-  fedora-30/simple_replication:
-    requires: [fedora-30/build]
+  389ds-fedora/simple_replication:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_simple_replication.py
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_commands:
-    requires: [fedora-30/build]
+  389ds-fedora/test_commands:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_commands.py
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_server_del:
-    requires: [fedora-30/build]
+  389ds-fedora/test_server_del:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_server_del.py
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA1:
-    requires: [fedora-30/build]
+  389ds-fedora/test_installation_TestInstallWithCA1:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_caless_TestServerInstall:
-    requires: [fedora-30/build]
+  389ds-fedora/test_caless_TestServerInstall:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestServerInstall
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 12000
         topology: *master_1repl
 
-  fedora-30/test_caless_TestReplicaInstall:
-    requires: [fedora-30/build]
+  389ds-fedora/test_caless_TestReplicaInstall:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestClientInstall:
-    requires: [fedora-30/build]
+  389ds-fedora/test_caless_TestClientInstall:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestClientInstall
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 5400
         # actually master_1client
         topology: *master_1repl_1client
 
-  fedora-30/test_caless_TestCertInstall:
-    requires: [fedora-30/build]
+  389ds-fedora/test_caless_TestCertInstall:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestCertInstall
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
-    requires: [fedora-30/build]
+  389ds-fedora/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestore:
-    requires: [fedora-30/build]
+  389ds-fedora/test_backup_and_restore_TestBackupAndRestore:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
-    requires: [fedora-30/build]
+  389ds-fedora/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
-    requires: [fedora-30/build]
+  389ds-fedora/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithDNS:
-    requires: [fedora-30/build]
+  389ds-fedora/test_backup_and_restore_TestBackupAndRestoreWithDNS:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
-    requires: [fedora-30/build]
+  389ds-fedora/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithKRA:
-    requires: [fedora-30/build]
+  389ds-fedora/test_backup_and_restore_TestBackupAndRestoreWithKRA:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
-    requires: [fedora-30/build]
+  389ds-fedora/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithReplica:
-    requires: [fedora-30/build]
+  389ds-fedora/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreDMPassword:
-    requires: [fedora-30/build]
+  389ds-fedora/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestReplicaInstallAfterRestore:
-    requires: [fedora-30/build]
+  389ds-fedora/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestReplicaPromotionLevel1:
-    requires: [fedora-30/build]
+  389ds-fedora/test_replica_promotion_TestReplicaPromotionLevel1:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestProhibitReplicaUninstallation:
-    requires: [fedora-30/build]
+  389ds-fedora/test_replica_promotion_TestProhibitReplicaUninstallation:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_upgrade:
-    requires: [fedora-30/build]
+  389ds-fedora/test_upgrade:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_upgrade.py
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_topology_TestCASpecificRUVs:
-    requires: [fedora-30/build]
+  389ds-fedora/test_topology_TestCASpecificRUVs:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_topology_TestTopologyOptions:
-    requires: [fedora-30/build]
+  389ds-fedora/test_topology_TestTopologyOptions:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_topology.py::TestTopologyOptions
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithoutCA:
-    requires: [fedora-30/build]
+  389ds-fedora/test_replication_layouts_TestLineTopologyWithoutCA:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithCA:
-    requires: [fedora-30/build]
+  389ds-fedora/test_replication_layouts_TestLineTopologyWithCA:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  389ds-fedora/test_replication_layouts_TestLineTopologyWithCAKRA:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts.py_TestStarTopologyWithoutCA:
-    requires: [fedora-30/build]
+  389ds-fedora/test_replication_layouts.py_TestStarTopologyWithoutCA:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestStarTopologyWithCA:
-    requires: [fedora-30/build]
+  389ds-fedora/test_replication_layouts_TestStarTopologyWithCA:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestStarTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  389ds-fedora/test_replication_layouts_TestStarTopologyWithCAKRA:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithoutCA:
-    requires: [fedora-30/build]
+  389ds-fedora/test_replication_layouts_TestCompleteTopologyWithoutCA:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithCA:
-    requires: [fedora-30/build]
+  389ds-fedora/test_replication_layouts_TestCompleteTopologyWithCA:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  389ds-fedora/test_replication_layouts_TestCompleteTopologyWithCAKRA:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_client_uninstallation:
-    requires: [fedora-30/build]
+  389ds-fedora/test_client_uninstallation:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_uninstallation.py
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
-  fedora-30/customized_ds_config_install:
-    requires: [fedora-30/build]
+  389ds-fedora/customized_ds_config_install:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_customized_ds_config_install.py
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_TestExternalCAdirsrvStop:
-    requires: [fedora-30/build]
+  389ds-fedora/external_ca_TestExternalCAdirsrvStop:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/mask:
-    requires: [fedora-30/build]
+  389ds-fedora/mask:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestMaskInstall
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/automember:
-    requires: [fedora-30/build]
+  389ds-fedora/automember:
+    requires: [389ds-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{389ds-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_automember.py
-        template: *389ds-master-f30
+        template: *389ds-master-latest
         timeout: 3600
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -34,7 +34,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &pki-master-latest
-          name: freeipa/pki-master-f30
+          name: freeipa/pki-master-f31
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -25,7 +25,7 @@ topologies:
     memory: 12900
 
 jobs:
-  fedora-30/build:
+  pki-fedora/build:
     requires: []
     priority: 100
     job:
@@ -33,765 +33,765 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &pki-master-f30
+        template: &pki-master-latest
           name: freeipa/pki-master-f30
           version: 0.0.1
         timeout: 1800
         topology: *build
 
-  fedora-30/simple_replication:
-    requires: [fedora-30/build]
+  pki-fedora/simple_replication:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_simple_replication.py
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_1:
-    requires: [fedora-30/build]
+  pki-fedora/external_ca_1:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/external_ca_2:
-    requires: [fedora-30/build]
+  pki-fedora/external_ca_2:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_templates:
-    requires: [fedora-30/build]
+  pki-fedora/external_ca_templates:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_vault:
-    requires: [fedora-30/build]
+  pki-fedora/test_vault:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_vault.py
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 6300
         topology: *master_1repl
 
-  fedora-30/test_forced_client_enrolment:
-    requires: [fedora-30/build]
+  pki-fedora/test_forced_client_enrolment:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA1:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallWithCA1:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA2:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallWithCA2:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA1:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallWithCA_KRA1:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA2:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallWithCA_KRA2:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS1:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallWithCA_DNS1:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS2:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallWithCA_DNS2:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS3:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallWithCA_DNS3:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallWithCA_DNS4:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallWithCA_DNS4:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallWithCA_KRA_DNS1:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallWithCA_KRA_DNS1:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA_DNS2:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallWithCA_KRA_DNS2:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallMaster:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallMaster:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMaster
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterKRA:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallMasterKRA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterDNS:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallMasterDNS:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterReservedIPasForwarder:
-    requires: [fedora-30/build]
+  pki-fedora/test_installation_TestInstallMasterReservedIPasForwarder:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_caless_TestServerInstall:
-    requires: [fedora-30/build]
+  pki-fedora/test_caless_TestServerInstall:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestServerInstall
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 12000
         topology: *master_1repl
 
-  fedora-30/test_caless_TestReplicaInstall:
-    requires: [fedora-30/build]
+  pki-fedora/test_caless_TestReplicaInstall:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestClientInstall:
-    requires: [fedora-30/build]
+  pki-fedora/test_caless_TestClientInstall:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestClientInstall
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 5400
         # actually master_1client
         topology: *master_1repl_1client
 
-  fedora-30/test_caless_TestIPACommands:
-    requires: [fedora-30/build]
+  pki-fedora/test_caless_TestIPACommands:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestIPACommands
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestCertInstall:
-    requires: [fedora-30/build]
+  pki-fedora/test_caless_TestCertInstall:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestCertInstall
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestPKINIT:
-    requires: [fedora-30/build]
+  pki-fedora/test_caless_TestPKINIT:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestPKINIT
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestServerReplicaCALessToCAFull:
-    requires: [fedora-30/build]
+  pki-fedora/test_caless_TestServerReplicaCALessToCAFull:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestReplicaCALessToCAFull:
-    requires: [fedora-30/build]
+  pki-fedora/test_caless_TestReplicaCALessToCAFull:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestServerCALessToExternalCA:
-    requires: [fedora-30/build]
+  pki-fedora/test_caless_TestServerCALessToExternalCA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithKRA:
-    requires: [fedora-30/build]
+  pki-fedora/test_backup_and_restore_TestBackupAndRestoreWithKRA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
-    requires: [fedora-30/build]
+  pki-fedora/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithReplica:
-    requires: [fedora-30/build]
+  pki-fedora/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_backup_and_restore_TestReplicaInstallAfterRestore:
-    requires: [fedora-30/build]
+  pki-fedora/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestReplicaPromotionLevel1:
-    requires: [fedora-30/build]
+  pki-fedora/test_replica_promotion_TestReplicaPromotionLevel1:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestRenewalMaster:
-    requires: [fedora-30/build]
+  pki-fedora/test_replica_promotion_TestRenewalMaster:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestSubCAkeyReplication:
-    requires: [fedora-30/build]
+  pki-fedora/test_replica_promotion_TestSubCAkeyReplication:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestReplicaInstallCustodia:
-    requires: [fedora-30/build]
+  pki-fedora/test_replica_promotion_TestReplicaInstallCustodia:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_upgrade:
-    requires: [fedora-30/build]
+  pki-fedora/test_upgrade:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_upgrade.py
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_topology_TestCASpecificRUVs:
-    requires: [fedora-30/build]
+  pki-fedora/test_topology_TestCASpecificRUVs:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithoutCA:
-    requires: [fedora-30/build]
+  pki-fedora/test_replication_layouts_TestLineTopologyWithoutCA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithCA:
-    requires: [fedora-30/build]
+  pki-fedora/test_replication_layouts_TestLineTopologyWithCA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  pki-fedora/test_replication_layouts_TestLineTopologyWithCAKRA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts.py_TestStarTopologyWithoutCA:
-    requires: [fedora-30/build]
+  pki-fedora/test_replication_layouts.py_TestStarTopologyWithoutCA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestStarTopologyWithCA:
-    requires: [fedora-30/build]
+  pki-fedora/test_replication_layouts_TestStarTopologyWithCA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestStarTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  pki-fedora/test_replication_layouts_TestStarTopologyWithCAKRA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithoutCA:
-    requires: [fedora-30/build]
+  pki-fedora/test_replication_layouts_TestCompleteTopologyWithoutCA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithCA:
-    requires: [fedora-30/build]
+  pki-fedora/test_replication_layouts_TestCompleteTopologyWithCA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  pki-fedora/test_replication_layouts_TestCompleteTopologyWithCAKRA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_client_uninstallation:
-    requires: [fedora-30/build]
+  pki-fedora/test_client_uninstallation:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_uninstallation.py
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
-  fedora-30/test_webui_cert:
-    requires: [fedora-30/build]
+  pki-fedora/test_webui_cert:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_webui/test_cert.py
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 2400
         topology: *ipaserver
 
-  fedora-30/test_webui_identity:
-    requires: [fedora-30/build]
+  pki-fedora/test_webui_identity:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/dns_locations:
-    requires: [fedora-30/build]
+  pki-fedora/dns_locations:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_dns_locations.py
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 3600
         topology: *master_2repl_1client
 
-  fedora-30/external_ca_TestExternalCAdirsrvStop:
-    requires: [fedora-30/build]
+  pki-fedora/external_ca_TestExternalCAdirsrvStop:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_TestExternalCAInvalidCert:
-    requires: [fedora-30/build]
+  pki-fedora/external_ca_TestExternalCAInvalidCert:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_TestMultipleExternalCA:
-    requires: [fedora-30/build]
+  pki-fedora/external_ca_TestMultipleExternalCA:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_pkinit_manage:
-    requires: [fedora-30/build]
+  pki-fedora/test_pkinit_manage:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_pkinit_manage.py
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_crlgen_manage:
-    requires: [fedora-30/build]
+  pki-fedora/test_crlgen_manage:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_crlgen_manage.py
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_ca_custom_sdn:
-    requires: [fedora-30/build]
+  pki-fedora/test_ca_custom_sdn:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{pki-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_ca_custom_sdn.py
-        template: *pki-master-f30
+        template: *pki-master-latest
         timeout: 7200
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -37,7 +37,7 @@ topologies:
    memory: 12000
 
 jobs:
-  fedora-30/build:
+  testing-fedora/build:
     requires: []
     priority: 100
     job:
@@ -45,1149 +45,1149 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &testing-master-f30
+        template: &testing-master-latest
           name: freeipa/testing-master-f30
           version: 0.0.1
         timeout: 1800
         topology: *build
 
-  fedora-30/simple_replication:
-    requires: [fedora-30/build]
+  testing-fedora/simple_replication:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_simple_replication.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_1:
-    requires: [fedora-30/build]
+  testing-fedora/external_ca_1:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/external_ca_2:
-    requires: [fedora-30/build]
+  testing-fedora/external_ca_2:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_templates:
-    requires: [fedora-30/build]
+  testing-fedora/external_ca_templates:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_topologies:
-    requires: [fedora-30/build]
+  testing-fedora/test_topologies:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_topologies.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_sudo:
-    requires: [fedora-30/build]
+  testing-fedora/test_sudo:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_sudo.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_commands:
-    requires: [fedora-30/build]
+  testing-fedora/test_commands:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_commands.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_kerberos_flags:
-    requires: [fedora-30/build]
+  testing-fedora/test_kerberos_flags:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_kerberos_flags.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_http_kdc_proxy:
-    requires: [fedora-30/build]
+  testing-fedora/test_http_kdc_proxy:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_http_kdc_proxy.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_forced_client_enrolment:
-    requires: [fedora-30/build]
+  testing-fedora/test_forced_client_enrolment:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_advise:
-    requires: [fedora-30/build]
+  testing-fedora/test_advise:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_advise.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_testconfig:
-    requires: [fedora-30/build]
+  testing-fedora/test_testconfig:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_testconfig.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_service_permissions:
-    requires: [fedora-30/build]
+  testing-fedora/test_service_permissions:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_service_permissions.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_netgroup:
-    requires: [fedora-30/build]
+  testing-fedora/test_netgroup:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_netgroup.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_vault:
-    requires: [fedora-30/build]
+  testing-fedora/test_vault:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_vault.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 6300
         topology: *master_1repl
 
-  fedora-30/test_authconfig:
-    requires: [fedora-30/build]
+  testing-fedora/test_authconfig:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_authselect.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_smb:
-    requires: [fedora-30/build]
+  testing-fedora/test_smb:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_smb.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *ad_master_2client
 
-  fedora-30/test_server_del:
-    requires: [fedora-30/build]
+  testing-fedora/test_server_del:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_server_del.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA1:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallWithCA1:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA2:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallWithCA2:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA1:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallWithCA_KRA1:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA2:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallWithCA_KRA2:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS1:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallWithCA_DNS1:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS2:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallWithCA_DNS2:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS3:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallWithCA_DNS3:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallWithCA_DNS4:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallWithCA_DNS4:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallWithCA_KRA_DNS1:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallWithCA_KRA_DNS1:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA_DNS2:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallWithCA_KRA_DNS2:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallMaster:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallMaster:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMaster
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterKRA:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallMasterKRA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterDNS:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallMasterDNS:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterReservedIPasForwarder:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallMasterReservedIPasForwarder:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterReplica:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallMasterReplica:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMasterReplica
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallReplicaAgainstSpecificServer:
-    requires: [fedora-30/build]
+  testing-fedora/test_installation_TestInstallReplicaAgainstSpecificServer:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallReplicaAgainstSpecificServer
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_idviews:
-    requires: [fedora-30/build]
+  testing-fedora/test_idviews:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_idviews.py::TestIDViews
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_caless_TestServerInstall:
-    requires: [fedora-30/build]
+  testing-fedora/test_caless_TestServerInstall:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestServerInstall
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 12000
         topology: *master_1repl
 
-  fedora-30/test_caless_TestReplicaInstall:
-    requires: [fedora-30/build]
+  testing-fedora/test_caless_TestReplicaInstall:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestClientInstall:
-    requires: [fedora-30/build]
+  testing-fedora/test_caless_TestClientInstall:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestClientInstall
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 5400
         # actually master_1client
         topology: *master_1repl_1client
 
-  fedora-30/test_caless_TestIPACommands:
-    requires: [fedora-30/build]
+  testing-fedora/test_caless_TestIPACommands:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestIPACommands
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestCertInstall:
-    requires: [fedora-30/build]
+  testing-fedora/test_caless_TestCertInstall:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestCertInstall
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestPKINIT:
-    requires: [fedora-30/build]
+  testing-fedora/test_caless_TestPKINIT:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestPKINIT
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestServerReplicaCALessToCAFull:
-    requires: [fedora-30/build]
+  testing-fedora/test_caless_TestServerReplicaCALessToCAFull:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestReplicaCALessToCAFull:
-    requires: [fedora-30/build]
+  testing-fedora/test_caless_TestReplicaCALessToCAFull:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestServerCALessToExternalCA:
-    requires: [fedora-30/build]
+  testing-fedora/test_caless_TestServerCALessToExternalCA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
-    requires: [fedora-30/build]
+  testing-fedora/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestore:
-    requires: [fedora-30/build]
+  testing-fedora/test_backup_and_restore_TestBackupAndRestore:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
-    requires: [fedora-30/build]
+  testing-fedora/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
-    requires: [fedora-30/build]
+  testing-fedora/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithDNS:
-    requires: [fedora-30/build]
+  testing-fedora/test_backup_and_restore_TestBackupAndRestoreWithDNS:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
-    requires: [fedora-30/build]
+  testing-fedora/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithKRA:
-    requires: [fedora-30/build]
+  testing-fedora/test_backup_and_restore_TestBackupAndRestoreWithKRA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
-    requires: [fedora-30/build]
+  testing-fedora/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithReplica:
-    requires: [fedora-30/build]
+  testing-fedora/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreDMPassword:
-    requires: [fedora-30/build]
+  testing-fedora/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestReplicaInstallAfterRestore:
-    requires: [fedora-30/build]
+  testing-fedora/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_dnssec:
-    requires: [fedora-30/build]
+  testing-fedora/test_dnssec:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_dnssec.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestReplicaPromotionLevel1:
-    requires: [fedora-30/build]
+  testing-fedora/test_replica_promotion_TestReplicaPromotionLevel1:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestUnprivilegedUserPermissions:
-    requires: [fedora-30/build]
+  testing-fedora/test_replica_promotion_TestUnprivilegedUserPermissions:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestProhibitReplicaUninstallation:
-    requires: [fedora-30/build]
+  testing-fedora/test_replica_promotion_TestProhibitReplicaUninstallation:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestWrongClientDomain:
-    requires: [fedora-30/build]
+  testing-fedora/test_replica_promotion_TestWrongClientDomain:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestWrongClientDomain
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestRenewalMaster:
-    requires: [fedora-30/build]
+  testing-fedora/test_replica_promotion_TestRenewalMaster:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestReplicaInstallWithExistingEntry:
-    requires: [fedora-30/build]
+  testing-fedora/test_replica_promotion_TestReplicaInstallWithExistingEntry:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallWithExistingEntry
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestSubCAkeyReplication:
-    requires: [fedora-30/build]
+  testing-fedora/test_replica_promotion_TestSubCAkeyReplication:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestReplicaInstallCustodia:
-    requires: [fedora-30/build]
+  testing-fedora/test_replica_promotion_TestReplicaInstallCustodia:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestReplicaInForwardZone:
-    requires: [fedora-30/build]
+  testing-fedora/test_replica_promotion_TestReplicaInForwardZone:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInForwardZone
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestHiddenReplicaPromotion:
-    requires: [fedora-30/build]
+  testing-fedora/test_replica_promotion_TestHiddenReplicaPromotion:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_upgrade:
-    requires: [fedora-30/build]
+  testing-fedora/test_upgrade:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_upgrade.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_topology_TestCASpecificRUVs:
-    requires: [fedora-30/build]
+  testing-fedora/test_topology_TestCASpecificRUVs:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_topology_TestTopologyOptions:
-    requires: [fedora-30/build]
+  testing-fedora/test_topology_TestTopologyOptions:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_topology.py::TestTopologyOptions
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithoutCA:
-    requires: [fedora-30/build]
+  testing-fedora/test_replication_layouts_TestLineTopologyWithoutCA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithCA:
-    requires: [fedora-30/build]
+  testing-fedora/test_replication_layouts_TestLineTopologyWithCA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  testing-fedora/test_replication_layouts_TestLineTopologyWithCAKRA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts.py_TestStarTopologyWithoutCA:
-    requires: [fedora-30/build]
+  testing-fedora/test_replication_layouts.py_TestStarTopologyWithoutCA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestStarTopologyWithCA:
-    requires: [fedora-30/build]
+  testing-fedora/test_replication_layouts_TestStarTopologyWithCA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestStarTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  testing-fedora/test_replication_layouts_TestStarTopologyWithCAKRA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithoutCA:
-    requires: [fedora-30/build]
+  testing-fedora/test_replication_layouts_TestCompleteTopologyWithoutCA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithCA:
-    requires: [fedora-30/build]
+  testing-fedora/test_replication_layouts_TestCompleteTopologyWithCA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  testing-fedora/test_replication_layouts_TestCompleteTopologyWithCAKRA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_client_uninstallation:
-    requires: [fedora-30/build]
+  testing-fedora/test_client_uninstallation:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_uninstallation.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
-  fedora-30/test_user_permissions:
-    requires: [fedora-30/build]
+  testing-fedora/test_user_permissions:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_user_permissions.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_webui_cert:
-    requires: [fedora-30/build]
+  testing-fedora/test_webui_cert:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_webui/test_cert.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 2400
         topology: *ipaserver
 
-  fedora-30/test_webui_general:
-    requires: [fedora-30/build]
+  testing-fedora/test_webui_general:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: >-
           test_webui/test_loginscreen.py
           test_webui/test_misc_cases.py
           test_webui/test_navigation.py
           test_webui/test_translation.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_host:
-    requires: [fedora-30/build]
+  testing-fedora/test_webui_host:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_webui/test_host.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_host_net_groups:
-    requires: [fedora-30/build]
+  testing-fedora/test_webui_host_net_groups:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: >-
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_identity:
-    requires: [fedora-30/build]
+  testing-fedora/test_webui_identity:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_network:
-    requires: [fedora-30/build]
+  testing-fedora/test_webui_network:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: >-
           test_webui/test_automount.py
           test_webui/test_dns.py
           test_webui/test_vault.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_policy:
-    requires: [fedora-30/build]
+  testing-fedora/test_webui_policy:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: >-
           test_webui/test_hbac.py
@@ -1195,275 +1195,275 @@ jobs:
           test_webui/test_pwpolicy.py
           test_webui/test_selinuxusermap.py
           test_webui/test_sudo.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_rbac:
-    requires: [fedora-30/build]
+  testing-fedora/test_webui_rbac:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: >-
           test_webui/test_delegation.py
           test_webui/test_rbac.py
           test_webui/test_selfservice.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_server:
-    requires: [fedora-30/build]
+  testing-fedora/test_webui_server:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: >-
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
           test_webui/test_trust.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_service:
-    requires: [fedora-30/build]
+  testing-fedora/test_webui_service:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_webui/test_service.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 2400
         topology: *ipaserver
 
-  fedora-30/test_webui_users:
-    requires: [fedora-30/build]
+  testing-fedora/test_webui_users:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: >-
           test_webui/test_group.py
           test_webui/test_user.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 4800
         topology: *ipaserver
 
-  fedora-30/customized_ds_config_install:
-    requires: [fedora-30/build]
+  testing-fedora/customized_ds_config_install:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_customized_ds_config_install.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/dns_locations:
-    requires: [fedora-30/build]
+  testing-fedora/dns_locations:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_dns_locations.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_2repl_1client
 
-  fedora-30/external_ca_TestExternalCAdirsrvStop:
-    requires: [fedora-30/build]
+  testing-fedora/external_ca_TestExternalCAdirsrvStop:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_TestExternalCAInvalidCert:
-    requires: [fedora-30/build]
+  testing-fedora/external_ca_TestExternalCAInvalidCert:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert test_integration/test_external_ca.py::TestExternalCAInvalidIntermediate
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_TestMultipleExternalCA:
-    requires: [fedora-30/build]
+  testing-fedora/external_ca_TestMultipleExternalCA:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_ntp_options:
-    requires: [fedora-30/build]
+  testing-fedora/test_ntp_options:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_1repl_1client
 
-  fedora-30/test_pkinit_manage:
-    requires: [fedora-30/build]
+  testing-fedora/test_pkinit_manage:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_pkinit_manage.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_pki_config_override:
-    requires: [fedora-30/build]
+  testing-fedora/test_pki_config_override:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_pki_config_override.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/nfs:
-    requires: [fedora-30/build]
+  testing-fedora/nfs:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_nfs.py::TestNFS
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 9000
         topology: *master_3client
 
-  fedora-30/nfs_nsswitch_restore:
-    requires: [fedora-30/build]
+  testing-fedora/nfs_nsswitch_restore:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_3client
 
-  fedora-30/mask:
-    requires: [fedora-30/build]
+  testing-fedora/mask:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_installation.py::TestMaskInstall
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/automember:
-    requires: [fedora-30/build]
+  testing-fedora/automember:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_automember.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_crlgen_manage:
-    requires: [fedora-30/build]
+  testing-fedora/test_crlgen_manage:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_crlgen_manage.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_integration_TestIPANotConfigured:
-    requires: [fedora-30/build]
+  testing-fedora/test_integration_TestIPANotConfigured:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_sssd:
-    requires: [fedora-30/build]
+  testing-fedora/test_sssd:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_sssd.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 4800
         topology: *ad_master
 
-  fedora-30/test_ca_custom_sdn:
-    requires: [fedora-30/build]
+  testing-fedora/test_ca_custom_sdn:
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{testing-fedora/build_url}'
         update_packages: True
         test_suite: test_integration/test_ca_custom_sdn.py
-        template: *testing-master-f30
+        template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -46,7 +46,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &testing-master-latest
-          name: freeipa/testing-master-f30
+          name: freeipa/testing-master-f31
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -37,7 +37,7 @@ topologies:
    memory: 12000
 
 jobs:
-  fedora-30/build:
+  fedora-previous/build:
     requires: []
     priority: 100
     job:
@@ -45,1330 +45,1306 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-f30
-          name: freeipa/ci-master-f30
-          version: 0.0.4
+        template: &ci-master-previous
+          name: freeipa/ci-master-f29
+          version: 0.2.2
         timeout: 1800
         topology: *build
 
-  fedora-30/simple_replication:
-    requires: [fedora-30/build]
+  fedora-previous/simple_replication:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_simple_replication.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_1:
-    requires: [fedora-30/build]
+  fedora-previous/external_ca_1:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/external_ca_2:
-    requires: [fedora-30/build]
+  fedora-previous/external_ca_2:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_templates:
-    requires: [fedora-30/build]
+  fedora-previous/external_ca_templates:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_topologies:
-    requires: [fedora-30/build]
+  fedora-previous/test_topologies:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_topologies.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_sudo:
-    requires: [fedora-30/build]
+  fedora-previous/test_sudo:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_sudo.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_commands:
-    requires: [fedora-30/build]
+  fedora-previous/test_commands:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_commands.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_kerberos_flags:
-    requires: [fedora-30/build]
+  fedora-previous/test_kerberos_flags:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_kerberos_flags.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_http_kdc_proxy:
-    requires: [fedora-30/build]
+  fedora-previous/test_http_kdc_proxy:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_http_kdc_proxy.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_forced_client_enrolment:
-    requires: [fedora-30/build]
+  fedora-previous/test_forced_client_enrolment:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_advise:
-    requires: [fedora-30/build]
+  fedora-previous/test_advise:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_advise.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_testconfig:
-    requires: [fedora-30/build]
+  fedora-previous/test_testconfig:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_testconfig.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_service_permissions:
-    requires: [fedora-30/build]
+  fedora-previous/test_service_permissions:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_service_permissions.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_netgroup:
-    requires: [fedora-30/build]
+  fedora-previous/test_netgroup:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_netgroup.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_vault:
-    requires: [fedora-30/build]
+  fedora-previous/test_vault:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_vault.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 6300
         topology: *master_1repl
 
-  fedora-30/test_authconfig:
-    requires: [fedora-30/build]
+  fedora-previous/test_authconfig:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_authselect.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_smb:
-    requires: [fedora-30/build]
+  fedora-previous/test_smb:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_smb.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *ad_master_2client
 
-  fedora-30/test_server_del:
-    requires: [fedora-30/build]
+  fedora-previous/test_server_del:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_server_del.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA1:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallWithCA1:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA2:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallWithCA2:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA1:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallWithCA_KRA1:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA2:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallWithCA_KRA2:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS1:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallWithCA_DNS1:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS2:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallWithCA_DNS2:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS3:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallWithCA_DNS3:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallWithCA_DNS4:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallWithCA_DNS4:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallWithCA_KRA_DNS1:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallWithCA_KRA_DNS1:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA_DNS2:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallWithCA_KRA_DNS2:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallMaster:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallMaster:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMaster
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterKRA:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallMasterKRA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterDNS:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallMasterDNS:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterReservedIPasForwarder:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallMasterReservedIPasForwarder:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterReplica:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallMasterReplica:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterReplica
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallReplicaAgainstSpecificServer:
-    requires: [fedora-30/build]
+  fedora-previous/test_installation_TestInstallReplicaAgainstSpecificServer:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallReplicaAgainstSpecificServer
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_idviews:
-    requires: [fedora-30/build]
+  fedora-previous/test_idviews:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_idviews.py::TestIDViews
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_caless_TestServerInstall:
-    requires: [fedora-30/build]
+  fedora-previous/test_caless_TestServerInstall:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_caless.py::TestServerInstall
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 12000
         topology: *master_1repl
 
-  fedora-30/test_caless_TestReplicaInstall:
-    requires: [fedora-30/build]
+  fedora-previous/test_caless_TestReplicaInstall:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestClientInstall:
-    requires: [fedora-30/build]
+  fedora-previous/test_caless_TestClientInstall:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_caless.py::TestClientInstall
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 5400
         # actually master_1client
         topology: *master_1repl_1client
 
-  fedora-30/test_caless_TestIPACommands:
-    requires: [fedora-30/build]
+  fedora-previous/test_caless_TestIPACommands:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_caless.py::TestIPACommands
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestCertInstall:
-    requires: [fedora-30/build]
+  fedora-previous/test_caless_TestCertInstall:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_caless.py::TestCertInstall
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestPKINIT:
-    requires: [fedora-30/build]
+  fedora-previous/test_caless_TestPKINIT:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_caless.py::TestPKINIT
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestServerReplicaCALessToCAFull:
-    requires: [fedora-30/build]
+  fedora-previous/test_caless_TestServerReplicaCALessToCAFull:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestReplicaCALessToCAFull:
-    requires: [fedora-30/build]
+  fedora-previous/test_caless_TestReplicaCALessToCAFull:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestServerCALessToExternalCA:
-    requires: [fedora-30/build]
+  fedora-previous/test_caless_TestServerCALessToExternalCA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
-    requires: [fedora-30/build]
+  fedora-previous/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestore:
-    requires: [fedora-30/build]
+  fedora-previous/test_backup_and_restore_TestBackupAndRestore:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
-    requires: [fedora-30/build]
+  fedora-previous/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
-    requires: [fedora-30/build]
+  fedora-previous/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithDNS:
-    requires: [fedora-30/build]
+  fedora-previous/test_backup_and_restore_TestBackupAndRestoreWithDNS:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
-    requires: [fedora-30/build]
+  fedora-previous/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithKRA:
-    requires: [fedora-30/build]
+  fedora-previous/test_backup_and_restore_TestBackupAndRestoreWithKRA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
-    requires: [fedora-30/build]
+  fedora-previous/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithReplica:
-    requires: [fedora-30/build]
+  fedora-previous/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreDMPassword:
-    requires: [fedora-30/build]
+  fedora-previous/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestReplicaInstallAfterRestore:
-    requires: [fedora-30/build]
+  fedora-previous/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_dnssec:
-    requires: [fedora-30/build]
+  fedora-previous/test_dnssec:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_dnssec.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestReplicaPromotionLevel1:
-    requires: [fedora-30/build]
+  fedora-previous/test_replica_promotion_TestReplicaPromotionLevel1:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestUnprivilegedUserPermissions:
-    requires: [fedora-30/build]
+  fedora-previous/test_replica_promotion_TestUnprivilegedUserPermissions:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestProhibitReplicaUninstallation:
-    requires: [fedora-30/build]
+  fedora-previous/test_replica_promotion_TestProhibitReplicaUninstallation:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestWrongClientDomain:
-    requires: [fedora-30/build]
+  fedora-previous/test_replica_promotion_TestWrongClientDomain:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestWrongClientDomain
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestRenewalMaster:
-    requires: [fedora-30/build]
+  fedora-previous/test_replica_promotion_TestRenewalMaster:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestReplicaInstallWithExistingEntry:
-    requires: [fedora-30/build]
+  fedora-previous/test_replica_promotion_TestReplicaInstallWithExistingEntry:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallWithExistingEntry
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestSubCAkeyReplication:
-    requires: [fedora-30/build]
+  fedora-previous/test_replica_promotion_TestSubCAkeyReplication:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestReplicaInstallCustodia:
-    requires: [fedora-30/build]
+  fedora-previous/test_replica_promotion_TestReplicaInstallCustodia:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestReplicaInForwardZone:
-    requires: [fedora-30/build]
+  fedora-previous/test_replica_promotion_TestReplicaInForwardZone:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInForwardZone
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestHiddenReplicaPromotion:
-    requires: [fedora-30/build]
+  fedora-previous/test_replica_promotion_TestHiddenReplicaPromotion:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_upgrade:
-    requires: [fedora-30/build]
+  fedora-previous/test_upgrade:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_upgrade.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_topology_TestCASpecificRUVs:
-    requires: [fedora-30/build]
+  fedora-previous/test_topology_TestCASpecificRUVs:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_topology_TestTopologyOptions:
-    requires: [fedora-30/build]
+  fedora-previous/test_topology_TestTopologyOptions:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_topology.py::TestTopologyOptions
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithoutCA:
-    requires: [fedora-30/build]
+  fedora-previous/test_replication_layouts_TestLineTopologyWithoutCA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithCA:
-    requires: [fedora-30/build]
+  fedora-previous/test_replication_layouts_TestLineTopologyWithCA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  fedora-previous/test_replication_layouts_TestLineTopologyWithCAKRA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts.py_TestStarTopologyWithoutCA:
-    requires: [fedora-30/build]
+  fedora-previous/test_replication_layouts.py_TestStarTopologyWithoutCA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestStarTopologyWithCA:
-    requires: [fedora-30/build]
+  fedora-previous/test_replication_layouts_TestStarTopologyWithCA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestStarTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  fedora-previous/test_replication_layouts_TestStarTopologyWithCAKRA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithoutCA:
-    requires: [fedora-30/build]
+  fedora-previous/test_replication_layouts_TestCompleteTopologyWithoutCA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithCA:
-    requires: [fedora-30/build]
+  fedora-previous/test_replication_layouts_TestCompleteTopologyWithCA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  fedora-previous/test_replication_layouts_TestCompleteTopologyWithCAKRA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_client_uninstallation:
-    requires: [fedora-30/build]
+  fedora-previous/test_client_uninstallation:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_uninstallation.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl_1client
 
-  fedora-30/test_user_permissions:
-    requires: [fedora-30/build]
+  fedora-previous/test_user_permissions:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_user_permissions.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_webui_cert:
-    requires: [fedora-30/build]
+  fedora-previous/test_webui_cert:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_webui/test_cert.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 2400
         topology: *ipaserver
 
-  fedora-30/test_webui_general:
-    requires: [fedora-30/build]
+  fedora-previous/test_webui_general:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: >-
           test_webui/test_loginscreen.py
           test_webui/test_misc_cases.py
           test_webui/test_navigation.py
           test_webui/test_translation.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_host:
-    requires: [fedora-30/build]
+  fedora-previous/test_webui_host:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_webui/test_host.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_host_net_groups:
-    requires: [fedora-30/build]
+  fedora-previous/test_webui_host_net_groups:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: >-
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_identity:
-    requires: [fedora-30/build]
+  fedora-previous/test_webui_identity:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_network:
-    requires: [fedora-30/build]
+  fedora-previous/test_webui_network:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: >-
           test_webui/test_automount.py
           test_webui/test_dns.py
           test_webui/test_vault.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_policy:
-    requires: [fedora-30/build]
+  fedora-previous/test_webui_policy:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: >-
           test_webui/test_hbac.py
           test_webui/test_krbtpolicy.py
           test_webui/test_pwpolicy.py
           test_webui/test_selinuxusermap.py
           test_webui/test_sudo.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_rbac:
-    requires: [fedora-30/build]
+  fedora-previous/test_webui_rbac:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: >-
           test_webui/test_delegation.py
           test_webui/test_rbac.py
           test_webui/test_selfservice.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_server:
-    requires: [fedora-30/build]
+  fedora-previous/test_webui_server:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: >-
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
           test_webui/test_trust.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_service:
-    requires: [fedora-30/build]
+  fedora-previous/test_webui_service:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_webui/test_service.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 2400
         topology: *ipaserver
 
-  fedora-30/test_webui_users:
-    requires: [fedora-30/build]
+  fedora-previous/test_webui_users:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: >-
           test_webui/test_group.py
           test_webui/test_user.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 4800
         topology: *ipaserver
 
-  fedora-30/customized_ds_config_install:
-    requires: [fedora-30/build]
+  fedora-previous/customized_ds_config_install:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_customized_ds_config_install.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/dns_locations:
-    requires: [fedora-30/build]
+  fedora-previous/dns_locations:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_dns_locations.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_2repl_1client
 
-  fedora-30/external_ca_TestExternalCAdirsrvStop:
-    requires: [fedora-30/build]
+  fedora-previous/external_ca_TestExternalCAdirsrvStop:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_TestExternalCAInvalidCert:
-    requires: [fedora-30/build]
+  fedora-previous/external_ca_TestExternalCAInvalidCert:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert test_integration/test_external_ca.py::TestExternalCAInvalidIntermediate
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_TestMultipleExternalCA:
-    requires: [fedora-30/build]
+  fedora-previous/external_ca_TestMultipleExternalCA:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_ntp_options:
-    requires: [fedora-30/build]
+  fedora-previous/test_ntp_options:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_1repl_1client
 
-  fedora-30/test_pkinit_manage:
-    requires: [fedora-30/build]
+  fedora-previous/test_pkinit_manage:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_pkinit_manage.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_pki_config_override:
-    requires: [fedora-30/build]
+  fedora-previous/test_pki_config_override:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_pki_config_override.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/nfs:
-    requires: [fedora-30/build]
+  fedora-previous/nfs:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_nfs.py::TestNFS
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 9000
         topology: *master_3client
 
-  fedora-30/nfs_nsswitch_restore:
-    requires: [fedora-30/build]
+  fedora-previous/mask:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
-        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
-        template: *ci-master-f30
-        timeout: 3600
-        topology: *master_3client
-
-  fedora-30/mask:
-    requires: [fedora-30/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_installation.py::TestMaskInstall
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/automember:
-    requires: [fedora-30/build]
+  fedora-previous/test_crlgen_manage:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
-        test_suite: test_integration/test_automember.py
-        template: *ci-master-f30
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-30/test_crlgen_manage:
-    requires: [fedora-30/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_crlgen_manage.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_integration_TestIPANotConfigured:
-    requires: [fedora-30/build]
+  fedora-previous/test_integration_TestIPANotConfigured:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_sssd:
-    requires: [fedora-30/build]
+  fedora-previous/test_sssd:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_sssd.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 4800
         topology: *ad_master
 
-  fedora-30/test_ca_custom_sdn:
-    requires: [fedora-30/build]
+  fedora-previous/test_ca_custom_sdn:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_ca_custom_sdn.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/membermanager:
-    requires: [fedora-30/build]
+  fedora-previous/membermanager:
+    requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_membermanager.py
-        template: *ci-master-f30
+        template: *ci-master-previous
         timeout: 1800
         topology: *ipaserver

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -46,8 +46,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-previous
-          name: freeipa/ci-master-f29
-          version: 0.2.2
+          name: freeipa/ci-master-f30
+          version: 0.0.5
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1337,13 +1337,13 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_sssd:
-    requires: [fedora-30/build]
+  fedora-rawhide/test_sssd:
+    requires: [fedora-rawhide/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-rawhide/build_url}'
         test_suite: test_integration/test_sssd.py
         template: *ci-master-frawhide
         timeout: 4800
@@ -1361,7 +1361,7 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/membermanager:
+  fedora-rawhide/membermanager:
     requires: [fedora-rawhide/build]
     priority: 50
     job:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -43,7 +43,7 @@ topologies:
    memory: 12000
 
 jobs:
-  fedora-30/build:
+  fedora-latest/build:
     requires: []
     priority: 100
     job:
@@ -51,20 +51,20 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-f30
+        template: &ci-master-latest
           name: freeipa/ci-master-f30
           version: 0.0.4
         timeout: 1800
         topology: *build
 
-  fedora-30/temp_commit:
-    requires: [fedora-30/build]
+  fedora-latest/temp_commit:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_REPLACEME.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -52,8 +52,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f30
-          version: 0.0.4
+          name: freeipa/ci-master-f31
+          version: 0.0.1
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Changes:
- Rename definitions files and jobs to change how fedora releases are referenced
  - Replacing `fedora-30` with `fedora-latest` and `fedora-29` with `fedora-previous` will reduce the changes required for new releases of Fedora.
  - Future changes would only require to update the name and version of the template used.
-  Bump fedora release
   - Fedora 31 is the latest release, Fedora 30 is the previous release.
   - New template boxes were built for current tests, dependencies were updated.
   - Nightly definitions for testing `389ds` copr repo are still using Fedora 30 because packages for Fedora 31 aren't included yet.