### PR TITLE
[ipa-4-7] prci: bump template version

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -23,7 +23,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f29
           name: freeipa/ci-ipa-4-7-f29
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-7.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-7.yaml
@@ -43,7 +43,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f29
           name: freeipa/ci-ipa-4-7-f29
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -53,7 +53,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f29
           name: freeipa/ci-ipa-4-7-f29
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Template used: https://app.vagrantup.com/freeipa/boxes/ci-ipa-4-7-f29/versions/0.0.2

Installed packages updated, no other major change.

Signed-off-by: Armando Neto <abiagion@redhat.com>