### PR TITLE
[ipa-4-6] prci: bump template version

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -23,7 +23,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f27
           name: freeipa/ci-ipa-4-6-f27
-          version: 1.0.3
+          version: 1.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -39,7 +39,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f27
           name: freeipa/ci-ipa-4-6-f27
-          version: 1.0.3
+          version: 1.0.4
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Template used: https://app.vagrantup.com/freeipa/boxes/ci-ipa-4-6-f27/versions/1.0.4

Installed packages updated, no other major change.

Signed-off-by: Armando Neto <abiagion@redhat.com>