### PR TITLE
[Backport][ipa-4-8]  ipatests: replace ad hoc backup with FileBackup helper

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -262,3 +262,15 @@ jobs:
         template: *ci-master-f30
         timeout: 1800
         topology: *ipaserver
+
+  fedora-30/test_smb:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_smb.py
+        template: *ci-master-f30
+        timeout: 7200
+        topology: *ad_master_2client

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1905,14 +1905,11 @@ class FileBackup:
         self._host = host
         self._filename = filename
         self._backup = create_temp_file(host)
-        self._cp_cmd = ['cp']
-        if is_selinux_enabled(host):
-            self._cp_cmd.append('--preserve=context')
-        host.run_command(self._cp_cmd + [filename, self._backup])
+        host.run_command(['cp', '--preserve=all', filename, self._backup])
 
     def restore(self):
         """Restore file. Can be called multiple times."""
-        self._host.run_command(self._cp_cmd + [self._backup, self._filename])
+        self._host.run_command(['mv', self._backup, self._filename])
 
     def __enter__(self):
         return self


### PR DESCRIPTION
This PR was opened automatically because PR #3868 was pushed to master and backport to ipa-4-8 is required.