### PR TITLE
[Backport][ipa-4-6] Use default ssh host key algorithms

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1316,6 +1316,10 @@ if [ $1 -gt 1 ] ; then
     if [ $restore -ge 2 ]; then
         %{python} -c 'from ipaclient.install.client import update_ipa_nssdb; update_ipa_nssdb()' >/var/log/ipaupgrade.log 2>&1
     fi
+
+    if [ $restore -ge 2 ]; then
+        sed -E --in-place=.orig 's/^(HostKeyAlgorithms ssh-rsa,ssh-dss)$/# disabled by ipa-client update\n# \1/' /etc/ssh/ssh_config
+    fi
 fi
 
 

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1093,7 +1093,6 @@ def configure_ssh_config(fstore, options):
         changes['GlobalKnownHostsFile'] = paths.SSSD_PUBCONF_KNOWN_HOSTS
     if options.trust_sshfp:
         changes['VerifyHostKeyDNS'] = 'yes'
-        changes['HostKeyAlgorithms'] = 'ssh-rsa,ssh-dss'
 
     change_ssh_config(paths.SSH_CONFIG, changes, ['Host', 'Match'])
     logger.info('Configured %s', paths.SSH_CONFIG)


### PR DESCRIPTION
Manual backport of PR https://github.com/freeipa/freeipa/pull/3887

ipa-client-install no longer overrides SSH client settings for
HostKeyAlgorithms. It's no longer necessary to configure
HostKeyAlgorithms. The setting was disabling modern algorithms and
enabled a weak algorithm that is blocked in FIPS code.

The ipa-client package removes IPA's custom HostKeyAlgorithm from
/etc/ssh/ssh_config during package update. Non-IPA settings are not
touched.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1756432
Fixes: https://pagure.io/freeipa/issue/8082
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Alexander Bokovoy <abokovoy@redhat.com>