### PR TITLE
DNParam: raise Exception when multiple values provided to a 1-val param

### DIFF
--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -2015,6 +2015,10 @@ class DNParam(Param):
         if type(value) in self.allowed_types:
             return value
 
+        if type(value) in (tuple, list):
+            raise ConversionError(name=self.name,
+                                  error=ugettext(self.scalar_error))
+
         try:
             dn = DN(value)
         except Exception as e:

--- a/ipatests/test_xmlrpc/test_certmap_plugin.py
+++ b/ipatests/test_xmlrpc/test_certmap_plugin.py
@@ -7,7 +7,7 @@ import pytest
 
 from ipalib import api, errors
 from ipapython.dn import DN
-from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test
+from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test, raises_exact
 from ipatests.test_xmlrpc.tracker.certmap_plugin import (CertmapruleTracker,
                                                          CertmapconfigTracker)
 from ipatests.test_xmlrpc.tracker.user_plugin import UserTracker
@@ -229,6 +229,24 @@ class TestAddRemoveCertmap(XMLRPC_test):
         certmap_user.ensure_exists()
         certmap_user.add_certmap(ipacertmapdata=u'rawdata')
         certmap_user.remove_certmap(ipacertmapdata=u'rawdata')
+
+    def test_add_certmap_multiple_subject(self, certmap_user):
+        certmap_user.ensure_exists()
+        cmd = certmap_user.make_command('user_add_certmapdata',
+                                        certmap_user.name)
+        with raises_exact(errors.ConversionError(
+                name='subject',
+                error=u"Only one value is allowed")):
+            cmd(subject=(u'CN=subject1', u'CN=subject2'), issuer=u'CN=issuer')
+
+    def test_add_certmap_multiple_issuer(self, certmap_user):
+        certmap_user.ensure_exists()
+        cmd = certmap_user.make_command('user_add_certmapdata',
+                                        certmap_user.name)
+        with raises_exact(errors.ConversionError(
+                name='issuer',
+                error=u"Only one value is allowed")):
+            cmd(issuer=(u'CN=issuer1', u'CN=issuer2'), subject=u'CN=subject')
 
 
 class EWE:


### PR DESCRIPTION
### DNParam: raise Exception when multiple values provided to a 1-val param

When ipa user-add-certmapdata is called with multiple --subject or
multiple --issuer, the DNParam's _convert_scalar method is called with
a tuple containing all the params and should raise an exception as the
--subject and --issuer are single-value params.

The DNParam _convert_scalar method internally calls the DN init method,
and the DN init method is able to create a DN from a tuple of RDNs.
As such, it won't raise exception if a tuple/list is provided.

Check that _convert_scalar is only provided a single element.

Fixes: https://pagure.io/freeipa/issue/8097

### XMLRPCtest: add a test for add-certmapdata with multiple subject/issuer
    
ipa user-add-certmapdata defines --issuer and --subject as single valued.
Add a test checking that this is enforced.

Related: https://pagure.io/freeipa/issue/8097