### PR TITLE
Fix template for test_smb

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -263,14 +263,14 @@ jobs:
         timeout: 1800
         topology: *ipaserver
 
-  fedora-30/test_smb:
-    requires: [fedora-30/build]
+  fedora-latest/test_smb:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_smb.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 7200
         topology: *ad_master_2client


### PR DESCRIPTION
The gating.yaml file is now using ci-master-latest template
instead of ci-master-f30. Fix the template and the test name.