### PR TITLE
prci: bump template version and fix test_smb gating definition

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f31
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 
@@ -263,14 +263,14 @@ jobs:
         timeout: 1800
         topology: *ipaserver
 
-  fedora-30/test_smb:
-    requires: [fedora-30/build]
-    priority: 50
+  fedora-latest/test_smb:
+    requires: [fedora-latest/build]
+    priority: 100
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_smb.py
-        template: *ci-master-f30
+        template: *ci-master-latest
         timeout: 7200
         topology: *ad_master_2client


### PR DESCRIPTION
This commit is replacing `fedora-30` with `fedora-latest` for test_smb gating definition.