### PR TITLE
prci: bump template version for temp_commit and nightly_latest

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -47,7 +47,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f31
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -53,7 +53,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f31
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Commit cd887a48b510fe17ed181d61d4fc69eb978c771d did that for gating, this commit bumps the version for the remaining definitions.

Signed-off-by: Armando Neto <abiagion@redhat.com>