### PR TITLE
Add config that maintains existing content to ipa-client-install manpage

### DIFF
--- a/client/man/ipa-client-install.1
+++ b/client/man/ipa-client-install.1
@@ -272,6 +272,15 @@ Files updated, existing content is maintained:
 .br
 /etc/sysconfig/network
 
+.TP
+File updated, existing content is maintained if ssh is configured (default):
+
+/etc/ssh/ssh_config
+.TP
+File updated, existing content is maintained if sshd is configured (default):
+
+/etc/ssh/sshd_config
+
 .SH "DEPRECATED OPTIONS"
 .TP
 \fB\-\-request\-cert\fR


### PR DESCRIPTION
If --no-ssh and --no-sshd are not specified in ipa-client-install,
/etc/ssh/{ssh, sshd}_config is updated and existing content is maintained.