### PR TITLE
Enable TLS 1.3 support

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -379,6 +379,13 @@ Requires: python3-pki >= %{pki_version}
 Requires: python3-pyasn1 >= 0.3.2-2
 Requires: python3-sssdconfig >= %{sssd_version}
 Requires: rpm-libs
+# Indirect dependency: use newer urllib3 with TLS 1.3 PHA support
+%if 0%{?rhel}
+Requires: python3-urllib3 >= 1.24.2-3
+%else
+Requires: python3-urllib3 >= 1.25.7
+%endif
+
 
 %description -n python3-ipaserver
 IPA is an integrated solution to provide centrally managed Identity (users,

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -52,6 +52,8 @@
 # Fix for "Installation fails: Replica Busy"
 # https://pagure.io/389-ds-base/issue/49818
 %global ds_version 1.4.0.16
+# Fix for TLS 1.3 PHA, RHBZ#1775158
+%global httpd_version 2.4.37-21
 
 %else
 # Fedora
@@ -76,6 +78,13 @@
 %global ds_version 1.4.1.1
 %else
 %global ds_version 1.4.0.21
+%endif
+
+# Fix for TLS 1.3 PHA, RHBZ#1775146
+%if 0%{?fedora} >= 31
+%global httpd_version 2.4.41-9
+%else
+%global httpd_version 2.4.41-6.1
 %endif
 
 # Don't use Fedora's Python dependency generator on Fedora 30/rawhide yet.
@@ -295,15 +304,15 @@ Requires(post): krb5-server >= %{krb5_base_version}, krb5-server < %{krb5_base_v
 Requires: krb5-pkinit-openssl >= %{krb5_version}
 Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: chrony
-Requires: httpd >= 2.4.6-31
+Requires: httpd >= %{httpd_version}
 Requires(preun): python3
 Requires(postun): python3
 Requires: python3-gssapi >= 1.2.0-5
 Requires: python3-systemd
 Requires: python3-mod_wsgi
 Requires: mod_auth_gssapi >= 1.5.0
-Requires: mod_ssl
-Requires: mod_session
+Requires: mod_ssl >= %{httpd_version}
+Requires: mod_session >= %{httpd_version}
 # 0.9.9: https://github.com/adelton/mod_lookup_identity/pull/3
 Requires: mod_lookup_identity >= 0.9.9
 Requires: acl
@@ -401,7 +410,7 @@ Summary: Common files used by IPA server
 Group: System Environment/Base
 BuildArch: noarch
 Requires: %{name}-client-common = %{version}-%{release}
-Requires: httpd >= 2.4.6-31
+Requires: httpd >= %{httpd_version}
 Requires: systemd-units >= 38
 Requires: custodia >= 0.3.1
 

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -633,19 +633,29 @@ class Env:
         # set the best known TLS version if min/max versions are not set
         if 'tls_version_min' not in self:
             self.tls_version_min = TLS_VERSION_DEFAULT_MIN
-        elif self.tls_version_min not in TLS_VERSIONS:
+        if (
+                self.tls_version_min is not None and
+                self.tls_version_min not in TLS_VERSIONS
+        ):
             raise errors.EnvironmentError(
                 "Unknown TLS version '{ver}' set in tls_version_min."
                 .format(ver=self.tls_version_min))
 
         if 'tls_version_max' not in self:
             self.tls_version_max = TLS_VERSION_DEFAULT_MAX
-        elif self.tls_version_max not in TLS_VERSIONS:
+        if (
+                self.tls_version_max is not None and
+                self.tls_version_max not in TLS_VERSIONS
+        ):
             raise errors.EnvironmentError(
                 "Unknown TLS version '{ver}' set in tls_version_max."
                 .format(ver=self.tls_version_max))
 
-        if self.tls_version_max < self.tls_version_min:
+        if (
+                self.tls_version_min is not None and
+                self.tls_version_max is not None and
+                self.tls_version_max < self.tls_version_min
+        ):
             raise errors.EnvironmentError(
                 "tls_version_min is set to a higher TLS version than "
                 "tls_version_max.")

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -38,8 +38,9 @@ except Exception:
 # TLS related constants
 # * SSL2 and SSL3 are broken.
 # * TLS1.0 and TLS1.1 are no longer state of the art.
-# * TLS1.3 support is not yet stable, e.g. issues with PHA.
-# Therefore only TLS 1.2 is enabled by default.
+# * TLS1.2 and 1.3 are secure and working properly
+# * Crypto policies restrict TLS range to 1.2 and 1.3. Python 3.6 cannot
+#   override the crypto policy.
 
 TLS_VERSIONS = [
     "ssl2",
@@ -49,9 +50,10 @@ TLS_VERSIONS = [
     "tls1.2",
     "tls1.3",
 ]
-TLS_VERSION_MINIMAL = "tls1.0"
-TLS_VERSION_DEFAULT_MIN = "tls1.2"
-TLS_VERSION_DEFAULT_MAX = "tls1.3"
+TLS_VERSION_MINIMAL = "tls1.2"
+TLS_VERSION_MAXIMAL = "tls1.3"
+TLS_VERSION_DEFAULT_MIN = None
+TLS_VERSION_DEFAULT_MAX = None
 
 # regular expression NameSpace member names must match:
 NAME_REGEX = r'^[a-z][_a-z0-9]*[a-z0-9]$|^[a-z]$'

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -51,7 +51,7 @@ TLS_VERSIONS = [
 ]
 TLS_VERSION_MINIMAL = "tls1.0"
 TLS_VERSION_DEFAULT_MIN = "tls1.2"
-TLS_VERSION_DEFAULT_MAX = "tls1.2"
+TLS_VERSION_DEFAULT_MAX = "tls1.3"
 
 # regular expression NameSpace member names must match:
 NAME_REGEX = r'^[a-z][_a-z0-9]*[a-z0-9]$|^[a-z]$'

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -57,8 +57,8 @@ except ImportError:
 from ipalib import errors, messages
 from ipalib.constants import (
     DOMAIN_LEVEL_0,
-    TLS_VERSIONS, TLS_VERSION_MINIMAL, TLS_VERSION_DEFAULT_MIN,
-    TLS_VERSION_DEFAULT_MAX,
+    TLS_VERSIONS, TLS_VERSION_MINIMAL, TLS_VERSION_MAXIMAL,
+    TLS_VERSION_DEFAULT_MIN, TLS_VERSION_DEFAULT_MAX,
 )
 from ipalib.text import _
 from ipaplatform.constants import constants
@@ -248,6 +248,13 @@ def get_proper_tls_version_span(tls_version_min, tls_version_max):
         if lower than TLS_VERSION_MINIMAL
     :raises: ValueError
     """
+    if tls_version_min is None and tls_version_max is None:
+        # no defaults, use system's default TLS version range
+        return None
+    if tls_version_min is None:
+        tls_version_min = TLS_VERSION_MINIMAL
+    if tls_version_max is None:
+        tls_version_max = TLS_VERSION_MAXIMAL
     min_allowed_idx = TLS_VERSIONS.index(TLS_VERSION_MINIMAL)
 
     try:
@@ -326,9 +333,6 @@ def create_https_connection(
         raise RuntimeError("cafile \'{file}\' doesn't exist or is unreadable".
                            format(file=cafile))
 
-    # remove the slice of negating protocol options according to options
-    tls_span = get_proper_tls_version_span(tls_version_min, tls_version_max)
-
     # official Python documentation states that the best option to get
     # TLSv1 and later is to setup SSLContext with PROTOCOL_SSLv23
     # and then negate the insecure SSLv2 and SSLv3
@@ -343,16 +347,20 @@ def create_https_connection(
         # configure ciphers, uses system crypto policies on RH platforms.
         ctx.set_ciphers(constants.TLS_HIGH_CIPHERS)
 
+    # remove the slice of negating protocol options according to options
+    tls_span = get_proper_tls_version_span(tls_version_min, tls_version_max)
+
     # pylint: enable=no-member
     # set up the correct TLS version flags for the SSL context
-    for version in TLS_VERSIONS:
-        if version in tls_span:
-            # make sure the required TLS versions are available if Python
-            # decides to modify the default TLS flags
-            ctx.options &= ~tls_cutoff_map[version]
-        else:
-            # disable all TLS versions not in tls_span
-            ctx.options |= tls_cutoff_map[version]
+    if tls_span is not None:
+        for version in TLS_VERSIONS:
+            if version in tls_span:
+                # make sure the required TLS versions are available if Python
+                # decides to modify the default TLS flags
+                ctx.options &= ~tls_cutoff_map[version]
+            else:
+                # disable all TLS versions not in tls_span
+                ctx.options |= tls_cutoff_map[version]
 
     # Enable TLS 1.3 post-handshake auth
     if getattr(ctx, "post_handshake_auth", None) is not None:

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -354,6 +354,10 @@ def create_https_connection(
             # disable all TLS versions not in tls_span
             ctx.options |= tls_cutoff_map[version]
 
+    # Enable TLS 1.3 post-handshake auth
+    if getattr(ctx, "post_handshake_auth", None) is not None:
+        ctx.post_handshake_auth = True
+
     ctx.verify_mode = ssl.CERT_REQUIRED
     ctx.check_hostname = True
     ctx.load_verify_locations(cafile)

--- a/ipaplatform/fedora/tasks.py
+++ b/ipaplatform/fedora/tasks.py
@@ -25,11 +25,22 @@ This module contains default Fedora-specific implementations of system tasks.
 
 from __future__ import absolute_import
 
+from ipapython import directivesetter
 from ipaplatform.redhat.tasks import RedHatTaskNamespace
+from ipaplatform.paths import paths
 
 
 class FedoraTaskNamespace(RedHatTaskNamespace):
-    pass
+
+    def configure_httpd_protocol(self):
+        # On Fedora 31 and earlier DEFAULT crypto-policy has TLS 1.0 and 1.1
+        # enabled.
+        directivesetter.set_directive(
+            paths.HTTPD_SSL_CONF,
+            'SSLProtocol',
+            "all -SSLv3 -TLSv1 -TLSv1.1",
+            False
+        )
 
 
 tasks = FedoraTaskNamespace()

--- a/ipaplatform/redhat/constants.py
+++ b/ipaplatform/redhat/constants.py
@@ -14,10 +14,9 @@ from ipaplatform.base.constants import BaseConstantsNamespace
 
 
 class RedHatConstantsNamespace(BaseConstantsNamespace):
-    # System-wide crypto policy, but without TripleDES, pre-shared key,
-    # secure remote password, and DSA cert authentication.
+    # Use system-wide crypto policy
     # see https://fedoraproject.org/wiki/Changes/CryptoPolicy
-    TLS_HIGH_CIPHERS = "PROFILE=SYSTEM:!3DES:!PSK:!SRP:!aDSS"
+    TLS_HIGH_CIPHERS = None
 
 
 constants = RedHatConstantsNamespace()

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -590,10 +590,10 @@ class RedHatTaskNamespace(BaseTaskNamespace):
         self.systemd_daemon_reload()
 
     def configure_httpd_protocol(self):
-        # TLS 1.3 is not yet supported
-        directivesetter.set_directive(paths.HTTPD_SSL_CONF,
-                                      'SSLProtocol',
-                                      'TLSv1.2', False)
+        # use default crypto policy for SSLProtocol
+        directivesetter.set_directive(
+            paths.HTTPD_SSL_CONF, 'SSLProtocol', None, False
+        )
 
     def set_hostname(self, hostname):
         ipautil.run([paths.BIN_HOSTNAMECTL, 'set-hostname', hostname])

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -2004,6 +2004,7 @@ def upgrade_configuration():
     http.realm = api.env.realm
     http.suffix = ipautil.realm_to_suffix(api.env.realm)
     http.configure_selinux_for_httpd()
+    http.set_mod_ssl_protocol()
 
     http.configure_certmonger_renewal_guard()
 

--- a/ipatests/test_ipalib/test_util.py
+++ b/ipatests/test_ipalib/test_util.py
@@ -5,11 +5,15 @@
 """
 
 import os
+import ssl
 from unittest import mock
 
 import pytest
 
-from ipalib.util import get_pager
+from ipalib.util import (
+    get_pager, create_https_connection, get_proper_tls_version_span
+)
+from ipaplatform.constants import constants
 
 
 @pytest.mark.parametrize('pager,expected_result', [
@@ -24,3 +28,47 @@ def test_get_pager(pager, expected_result):
     with mock.patch.dict(os.environ, {'PAGER': pager}):
         pager = get_pager()
         assert(pager == expected_result or pager.endswith(expected_result))
+
+
+BASE_CTX = ssl.SSLContext(ssl.PROTOCOL_TLS)
+if constants.TLS_HIGH_CIPHERS is not None:
+    BASE_CTX.set_ciphers(constants.TLS_HIGH_CIPHERS)
+else:
+    BASE_CTX.set_ciphers("PROFILE=SYSTEM")
+
+# options: IPA still supports Python 3.6 without min/max version setters
+BASE_OPT = BASE_CTX.options
+BASE_OPT |= (
+    ssl.OP_ALL | ssl.OP_NO_COMPRESSION | ssl.OP_SINGLE_DH_USE |
+    ssl.OP_SINGLE_ECDH_USE
+)
+TLS_OPT = (
+    ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 |
+    ssl.OP_NO_TLSv1_1
+)
+OP_NO_TLSv1_3 = getattr(ssl, "OP_NO_TLSv1_3", 0)  # make pylint happy
+
+
+@pytest.mark.parametrize('minver,maxver,opt,expected', [
+    (None, None, BASE_OPT, None),
+    (None, "tls1.3", BASE_OPT | TLS_OPT, ["tls1.2", "tls1.3"]),
+    ("tls1.2", "tls1.3", BASE_OPT | TLS_OPT, ["tls1.2", "tls1.3"]),
+    ("tls1.2", None, BASE_OPT | TLS_OPT, ["tls1.2", "tls1.3"]),
+    ("tls1.2", "tls1.2", BASE_OPT | TLS_OPT | OP_NO_TLSv1_3, ["tls1.2"]),
+    (None, "tls1.2", BASE_OPT | TLS_OPT | OP_NO_TLSv1_3, ["tls1.2"]),
+    ("tls1.3", "tls1.3", BASE_OPT | TLS_OPT | ssl.OP_NO_TLSv1_2, ["tls1.3"]),
+    ("tls1.3", None, BASE_OPT | TLS_OPT | ssl.OP_NO_TLSv1_2, ["tls1.3"]),
+])
+def test_tls_version_span(minver, maxver, opt, expected):
+    assert get_proper_tls_version_span(minver, maxver) == expected
+    # file must exist and contain certs
+    cafile = ssl.get_default_verify_paths().cafile
+    conn = create_https_connection(
+        "invalid.test",
+        cafile=cafile,
+        tls_version_min=minver,
+        tls_version_max=maxver
+    )
+    ctx = getattr(conn, "_context")
+    assert ctx.options == BASE_OPT | opt
+    assert ctx.get_ciphers() == BASE_CTX.get_ciphers()


### PR DESCRIPTION
# Enable TLS 1.3 support on the server
    
urllib3 now supports post-handshake authentication with TLS 1.3. Enable TLS 1.3 support for Apache HTTPd.

The update depends on bug fixes for TLS 1.3 PHA support in urllib3 and Apache HTTPd. New builds are available in freeipa-master COPR and in F30/F31.

# Don't hard-code client's TLS versions and ciphers

Client connections no longer override TLS version range and ciphers by
default. Instead clients use the default settings from the system's
crypto policy.

Minimum configurable TLS version is now TLS 1.2. The default crypto policy
on supported systems set either TLS 1.0 or TLS 1.2 as minimum version.
Python 3.6 lacks the setters to override the system policy.

Effective minimum version depends on the system crypto policy. It's TLS 1.2
on RHEL 8 and TLS 1.0 on F31 for the DEFAULT crypto policy.

Fixes: https://pagure.io/freeipa/issue/8125
