### PR TITLE
Show group-add/remove-member-manager failures

### DIFF
--- a/ipaclient/frontend.py
+++ b/ipaclient/frontend.py
@@ -65,6 +65,11 @@ class ClientMethod(ClientCommand, Method):
             'ipamemberca',
             label=_("Failed CAs"),
         ),
+        # group, hostgroup
+        Str(
+            'membermanager',
+            label=_("Failed member manager"),
+        ),
         # host
         Str(
             'managedby',

--- a/ipaserver/plugins/group.py
+++ b/ipaserver/plugins/group.py
@@ -179,7 +179,7 @@ group_output_params = (
     ),
     Str(
         'membermanager',
-        label=_('Failed membermanager'),
+        label=_('Failed member manager'),
     ),
 )
 

--- a/ipaserver/plugins/hostgroup.py
+++ b/ipaserver/plugins/hostgroup.py
@@ -92,7 +92,7 @@ hostgroup_output_params = (
     ),
     Str(
         'membermanager',
-        label=_('Failed membermanager'),
+        label=_('Failed member manager'),
     ),
 )
 

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -251,7 +251,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest/membermanager:
+  fedora-latest/test_membermanager:
     requires: [fedora-latest/build]
     priority: 100
     job:
@@ -261,7 +261,7 @@ jobs:
         test_suite: test_integration/test_membermanager.py
         template: *ci-master-latest
         timeout: 1800
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-latest/test_smb:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1373,7 +1373,7 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
-  fedora-latest/membermanager:
+  fedora-latest/test_membermanager:
     requires: [fedora-latest/build]
     priority: 100
     job:
@@ -1383,4 +1383,4 @@ jobs:
         test_suite: test_integration/test_membermanager.py
         template: *ci-master-latest
         timeout: 1800
-        topology: *ipaserver
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1467,3 +1467,15 @@ jobs:
         template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
+
+  testing-fedora/test_membermanager:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        test_suite: test_integration/test_membermanager.py
+        template: *testing-master-latest
+        timeout: 1800
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1349,7 +1349,7 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
-  fedora-previous/membermanager:
+  fedora-previous/test_membermanager:
     requires: [fedora-previous/build]
     priority: 50
     job:
@@ -1359,4 +1359,4 @@ jobs:
         test_suite: test_integration/test_membermanager.py
         template: *ci-master-previous
         timeout: 1800
-        topology: *ipaserver
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1373,7 +1373,7 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
-  fedora-rawhide/membermanager:
+  fedora-rawhide/test_membermanager:
     requires: [fedora-rawhide/build]
     priority: 50
     job:
@@ -1383,4 +1383,4 @@ jobs:
         test_suite: test_integration/test_membermanager.py
         template: *ci-master-frawhide
         timeout: 1800
-        topology: *ipaserver
+        topology: *master_1repl


### PR DESCRIPTION
Commands like ipa group-add-member-manager now show permission
errors on failed operations.

Fixes: https://pagure.io/freeipa/issue/8122
Signed-off-by: Christian Heimes <cheimes@redhat.com>