### PR TITLE
[Backport][ipa-4-6] Do not run trust upgrade code if master lacks Samba bindings

### DIFF
--- a/ipaserver/install/plugins/adtrust.py
+++ b/ipaserver/install/plugins/adtrust.py
@@ -23,6 +23,8 @@ except ImportError:
     def ndr_unpack(x):
         raise NotImplementedError
 
+    drsblobs = None
+
 logger = logging.getLogger(__name__)
 
 register = Registry()
@@ -631,6 +633,10 @@ class update_tdo_to_new_layout(Updater):
         # First, see if trusts are enabled on the server
         if not self.api.Command.adtrust_is_enabled()['result']:
             logger.debug('AD Trusts are not enabled on this server')
+            return False, []
+
+        # If we have no Samba bindings, this master is not a trust controller
+        if drsblobs is None:
             return False, []
 
         ldap = self.api.Backend.ldap2


### PR DESCRIPTION
This PR was opened automatically because PR #3910 was pushed to master and backport to ipa-4-6 is required.