### PR TITLE
[Backport][ipa-4-8] Show group-add/remove-member-manager failures

### DIFF
--- a/ipaclient/frontend.py
+++ b/ipaclient/frontend.py
@@ -65,6 +65,11 @@ class ClientMethod(ClientCommand, Method):
             'ipamemberca',
             label=_("Failed CAs"),
         ),
+        # group, hostgroup
+        Str(
+            'membermanager',
+            label=_("Failed member manager"),
+        ),
         # host
         Str(
             'managedby',

--- a/ipaserver/plugins/group.py
+++ b/ipaserver/plugins/group.py
@@ -179,7 +179,7 @@ group_output_params = (
     ),
     Str(
         'membermanager',
-        label=_('Failed membermanager'),
+        label=_('Failed member manager'),
     ),
 )
 

--- a/ipaserver/plugins/hostgroup.py
+++ b/ipaserver/plugins/hostgroup.py
@@ -92,7 +92,7 @@ hostgroup_output_params = (
     ),
     Str(
         'membermanager',
-        label=_('Failed membermanager'),
+        label=_('Failed member manager'),
     ),
 )
 

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -251,7 +251,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/membermanager:
+  fedora-30/test_membermanager:
     requires: [fedora-30/build]
     priority: 100
     job:
@@ -261,7 +261,7 @@ jobs:
         test_suite: test_integration/test_membermanager.py
         template: *ci-master-f30
         timeout: 1800
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-30/test_smb:
     requires: [fedora-30/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-8.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8.yaml
@@ -1373,7 +1373,7 @@ jobs:
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/membermanager:
+  fedora-30/test_membermanager:
     requires: [fedora-30/build]
     priority: 50
     job:
@@ -1383,4 +1383,4 @@ jobs:
         test_suite: test_integration/test_membermanager.py
         template: *ci-master-f30
         timeout: 1800
-        topology: *ipaserver
+        topology: *master_1repl


### PR DESCRIPTION
Manual backport of PR #3912 (conflicts in PRCI yaml)

Commands like ipa group-add-member-manager now show permission
errors on failed operations.

Fixes: https://pagure.io/freeipa/issue/8122
Signed-off-by: Christian Heimes <cheimes@redhat.com>