### PR TITLE
Nightly definition: use right template for krbtpolicy

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1395,4 +1395,4 @@ jobs:
         test_suite: test_integration/test_krbtpolicy.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1491,4 +1491,4 @@ jobs:
         test_suite: test_integration/test_krbtpolicy.py
         template: *testing-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1371,4 +1371,4 @@ jobs:
         test_suite: test_integration/test_krbtpolicy.py
         template: *ci-master-previous
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1395,4 +1395,4 @@ jobs:
         test_suite: test_integration/test_krbtpolicy.py
         template: *ci-master-frawhide
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl


### PR DESCRIPTION
The ipaserver template triggers the installation of IPA server
before the tests are launched and should not be used for
test_integration tests

Switch to master_1repl template.

Related: https://pagure.io/freeipa/issue/8001