### PR TITLE
[ipa-4-6 only] ipatests: fix test_ca_custom_sdn

### DIFF
--- a/ipatests/test_integration/test_ca_custom_sdn.py
+++ b/ipatests/test_integration/test_ca_custom_sdn.py
@@ -19,8 +19,6 @@ class TestCACustomSubjectDN(IntegrationTest):
     Generating a random DN might be interest, but for now we construct one
     that regression tests some previously encountered issues:
 
-    * Comma in RDN value: https://pagure.io/freeipa/issue/7347
-
     * KRA authentication failed for all custom subject DNs:
       https://pagure.io/freeipa/issue/8084
 
@@ -30,11 +28,6 @@ class TestCACustomSubjectDN(IntegrationTest):
 
     @classmethod
     def install(cls, mh):
-        """
-        Successful installation is sufficient to verify
-        https://pagure.io/freeipa/issue/7347.
-
-        """
         tasks.install_master(
             cls.master,
             setup_kra=True,
@@ -59,9 +52,9 @@ class TestCACustomSubjectDN(IntegrationTest):
 def create_custom_ca_subject():
     return DN(
         ('CN', 'IPA CA'),
-        ('O', 'Corporation {}, Inc.'.format(int(time.time()))),
+        ('O', 'Corporation {} Inc.'.format(int(time.time()))),
     )
 
 
 def create_custom_subject_base():
-    return DN(('O', 'Red Hat, Inc.'))
+    return DN(('O', 'Red Hat Inc.'))


### PR DESCRIPTION
The test fails because it configures the server with a custom --subject-base
and --ca-subject that contains a comma. The installation failure is a known
issue 7347 that was fixed in ipa-4-7 but not in ipa-4-6 branch (the fix relies
on recent version of 389-ds-base 1.4.0.20 that is not available on fedora 27).

The fix: use a custom ca-subject and subject-base without any comma.

Fixes: https://pagure.io/freeipa/issue/8126
