### PR TITLE
[backport][ipa-4-8] Nightly definition: use right template for krbtpolicy

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8.yaml
@@ -1395,4 +1395,4 @@ jobs:
         test_suite: test_integration/test_krbtpolicy.py
         template: *ci-master-f30
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl


### PR DESCRIPTION
This is a manual backport of PR #3929 to ipa-4-8 branch.
PR was ACKed automatically because this is backport of PR #3929. Wait for CI to finish before pushing. In case of questions or problems contact @flo-renaud  who is author of the original PR.