### PR TITLE
ipatests: generic uninstall should call ipa server-del

### DIFF
--- a/ipatests/test_integration/test_crlgen_manage.py
+++ b/ipatests/test_integration/test_crlgen_manage.py
@@ -290,6 +290,10 @@ class TestCRLGenManage(IntegrationTest):
         expected_msg = "Deleting this server will leave your installation " \
                        "without a CRL generation master"
         assert expected_msg in result.stdout_text
+        tasks.run_server_del(
+            self.replicas[0], self.master.hostname, force=True,
+            ignore_topology_disconnect=True,
+            ignore_last_of_role=True)
 
     def test_uninstall_last_master_does_not_require_ignore_last_of_role(self):
         """Test uninstallation of the last master
@@ -301,4 +305,5 @@ class TestCRLGenManage(IntegrationTest):
         # Make sure CRL gen is enabled on the replica
         check_crlgen_enable(self.replicas[0])
         # call uninstall without --ignore-last-of-role, should be OK
-        self.master.run_command(['ipa-server-install', '--uninstall', '-U'])
+        self.replicas[0].run_command(
+            ['ipa-server-install', '--uninstall', '-U'])

--- a/ipatests/test_integration/test_ntp_options.py
+++ b/ipatests/test_integration/test_ntp_options.py
@@ -388,3 +388,8 @@ class TestNTPoptions(IntegrationTest):
         tasks.uninstall_client(self.client)
         tasks.uninstall_master(self.replica)
         tasks.uninstall_master(self.master)
+
+    @classmethod
+    def uninstall(cls, mh):
+        # Cleanup already done in teardown_method
+        pass


### PR DESCRIPTION
### ipatests: generic uninstall should call ipa server-del

At the end of any integration test, the method uninstall is called and
uninstalls master, replicas and clients.
Usually the master is the CA renewal master and DNSSec master, and
uninstallation may fail.
This commits modifies the uninstall method in order to:
- call 'ipa server-del replica' before running uninstall on a replica
- uninstall the replicas before uninstalling the master

Fixes: https://pagure.io/freeipa/issue/7985

### ipatests: fix teardown

The uninstall method of some tests can be skipped as the cleanup is
already done before.

### ipatests: fix test_crlgen_manage

The goal of the last test in test_crlgen_manage is to ensure that
ipa-server-install --uninstall can proceed if the server is the last one
in the topology, even if it is the CRL generation master.

The current code is wrong because it tries to uninstall the master
(which has already been uninstalled in the prev test), It should rather
uninstall replicas[0].