### PR TITLE
[Backport][ipa-4-7] ipatests: add check that ipa-adtrust-install generates sane smb.conf

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -623,3 +623,14 @@ class TestIPACommand(IntegrationTest):
         assert not is_tls_version_enabled('tls1')
         assert not is_tls_version_enabled('tls1_1')
         assert is_tls_version_enabled('tls1_2')
+
+    def test_samba_config_file(self):
+        """Check that ipa-adtrust-install generates sane smb.conf
+
+        This is regression test for issue
+        https://pagure.io/freeipa/issue/6951
+        """
+        self.master.run_command(
+            ['ipa-adtrust-install', '-a', 'Secret123', '--add-sids', '-U'])
+        res = self.master.run_command(['testparm', '-s'])
+        assert 'ERROR' not in (res.stdout_text + res.stderr_text)


### PR DESCRIPTION
This PR was opened automatically because PR #3930 was pushed to master and backport to ipa-4-7 is required.