### PR TITLE
[Backport][ipa-4-8] ipatests: generic uninstall should call ipa server-del

### DIFF
--- a/ipatests/test_integration/test_crlgen_manage.py
+++ b/ipatests/test_integration/test_crlgen_manage.py
@@ -290,6 +290,10 @@ class TestCRLGenManage(IntegrationTest):
         expected_msg = "Deleting this server will leave your installation " \
                        "without a CRL generation master"
         assert expected_msg in result.stdout_text
+        tasks.run_server_del(
+            self.replicas[0], self.master.hostname, force=True,
+            ignore_topology_disconnect=True,
+            ignore_last_of_role=True)
 
     def test_uninstall_last_master_does_not_require_ignore_last_of_role(self):
         """Test uninstallation of the last master
@@ -301,4 +305,5 @@ class TestCRLGenManage(IntegrationTest):
         # Make sure CRL gen is enabled on the replica
         check_crlgen_enable(self.replicas[0])
         # call uninstall without --ignore-last-of-role, should be OK
-        self.master.run_command(['ipa-server-install', '--uninstall', '-U'])
+        self.replicas[0].run_command(
+            ['ipa-server-install', '--uninstall', '-U'])

--- a/ipatests/test_integration/test_ntp_options.py
+++ b/ipatests/test_integration/test_ntp_options.py
@@ -388,3 +388,8 @@ class TestNTPoptions(IntegrationTest):
         tasks.uninstall_client(self.client)
         tasks.uninstall_master(self.replica)
         tasks.uninstall_master(self.master)
+
+    @classmethod
+    def uninstall(cls, mh):
+        # Cleanup already done in teardown_method
+        pass


### PR DESCRIPTION
This PR was opened automatically because PR #3943 was pushed to master and backport to ipa-4-8 is required.