### PR TITLE
[Backport][ipa-4-8] FIPS testing fixes

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -296,6 +296,8 @@ class TestIPACommand(IntegrationTest):
         """
         Integration test for https://pagure.io/SSSD/sssd/issue/3747
         """
+        if self.master.is_fips_mode:  # pylint: disable=no-member
+            pytest.skip("paramiko is not compatible with FIPS mode")
 
         test_user = 'test-ssh'
         external_master_hostname = \

--- a/ipatests/test_integration/test_user_permissions.py
+++ b/ipatests/test_integration/test_user_permissions.py
@@ -84,6 +84,9 @@ class TestUserPermissions(IntegrationTest):
 
         Related ticket https://pagure.io/SSSD/sssd/issue/3819.
         """
+        if self.master.is_fips_mode:  # pylint: disable=no-member
+            pytest.skip("paramiko is not compatible with FIPS mode")
+
         # Scenario: add an IPA user with non-default home dir, login through
         # ssh as this user and check that there is a SELinux user mapping
         # for the user with `semanage login -l`.

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -33,7 +33,7 @@ import unittest
 from urllib.error import URLError
 
 import paramiko
-
+import pytest
 
 try:
     from selenium import webdriver
@@ -59,7 +59,9 @@ try:
     NO_YAML = False
 except ImportError:
     NO_YAML = True
+
 from ipaplatform.paths import paths
+from ipaplatform.tasks import tasks
 
 ENV_MAP = {
     'MASTER': 'ipa_server',
@@ -1944,6 +1946,8 @@ class UI_driver:
 
         cmd (str): command to run
         """
+        if tasks.is_fips_enabled():
+            pytest.skip("paramiko is not compatible with FIPS mode")
 
         login = self.config.get('ipa_admin')
         hostname = self.config.get('ipa_server')


### PR DESCRIPTION
This PR was opened automatically because PR #3953 was pushed to master and backport to ipa-4-8 is required.