### PR TITLE
Don't run test_smb in gating tests

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -263,14 +263,3 @@ jobs:
         timeout: 1800
         topology: *master_1repl
 
-  fedora-latest/test_smb:
-    requires: [fedora-latest/build]
-    priority: 100
-    job:
-      class: RunADTests
-      args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_smb.py
-        template: *ci-master-latest
-        timeout: 7200
-        topology: *ad_master_2client


### PR DESCRIPTION
test_smb slows down gating and PR turnover. The test takes between 45 and
50 minutes to execute while the other gating tests finish in about or less
than half the time.

The Samba / AD integration tests are still executed in nightly tests.

Signed-off-by: Christian Heimes <cheimes@redhat.com>