### PR TITLE
locations.py: fix divide by 0

### DIFF
--- a/ipaserver/plugins/location.py
+++ b/ipaserver/plugins/location.py
@@ -225,10 +225,17 @@ class location_show(LDAPRetrieve):
                     dns_servers.append(s_name)
 
             for server in servers_additional_info.values():
-                server['service_relative_weight'] = [
-                    u'{:.1f}%'.format(
-                        int(server['ipaserviceweight'][0])*100.0/weight_sum)
-                ]
+                if weight_sum != 0:
+                    server['service_relative_weight'] = [
+                        u'{:.1f}%'.format(
+                            int(server['ipaserviceweight'][0]) * 100.0 /
+                            weight_sum
+                        )
+                    ]
+                else:
+                    server['service_relative_weight'] = [
+                        u'{:.1f}%'.format(int(100.0 / len(servers)))
+                    ]
             if servers_name:
                 result['result']['servers_server'] = servers_name
 


### PR DESCRIPTION
If all IPA servers (or the first server) of a location have
service weights == 0, the sum of the weights is zero leading
to a division by zero in relative weight calculation.
Detect the situation and set relative weight to 0 in this case.

Fixes: https://pagure.io/freeipa/issue/8135
Signed-off-by: François Cami <fcami@redhat.com>