### PR TITLE
trust upgrade: ensure that host is member of adtrust agents

### DIFF
--- a/install/updates/90-post_upgrade_plugins.update
+++ b/install/updates/90-post_upgrade_plugins.update
@@ -14,6 +14,7 @@ plugin: update_tdo_gidnumber
 plugin: update_tdo_to_new_layout
 plugin: update_host_cifs_keytabs
 plugin: update_tdo_default_read_keys_permissions
+plugin: update_adtrust_agents_members
 plugin: update_ca_renewal_master
 plugin: update_idrange_type
 plugin: update_pacs

--- a/ipaserver/install/plugins/adtrust.py
+++ b/ipaserver/install/plugins/adtrust.py
@@ -9,9 +9,11 @@ from ipalib import Updater
 from ipapython.dn import DN
 from ipapython import ipautil
 from ipaplatform.paths import paths
+from ipaserver.install import service
 from ipaserver.install import sysupgrade
 from ipaserver.install.adtrustinstance import (
     ADTRUSTInstance, map_Guests_to_nobody)
+
 from ipaserver.dcerpc_common import TRUST_BIDIRECTIONAL
 
 try:
@@ -880,5 +882,58 @@ class update_tdo_default_read_keys_permissions(Updater):
             except errors.EmptyModlist:
                 logger.debug("No update was required for TDO %s",
                              tdo.single_value.get('krbCanonicalName'))
+
+        return False, []
+
+
+@register()
+class update_adtrust_agents_members(Updater):
+    """ Ensure that each adtrust agent is a member of the adtrust agents group
+
+    cn=adtrust agents,cn=sysaccounts,cn=etc,$BASEDN must contain:
+    - member: krbprincipalname=cifs/master@realm,cn=services,cn=accounts,base
+    - member: fqdn=master,cn=computers,cn=accounts,base
+    """
+    def execute(self, **options):
+        ldap = self.api.Backend.ldap2
+
+        # First, see if trusts are enabled on the server
+        if not self.api.Command.adtrust_is_enabled()['result']:
+            logger.debug('AD Trusts are not enabled on this server')
+            return False, []
+
+        agents_dn = DN(
+            ('cn', 'adtrust agents'), ('cn', 'sysaccounts'),
+            ('cn', 'etc'), self.api.env.basedn)
+
+        try:
+            agents_entry = ldap.get_entry(agents_dn, ['member'])
+        except errors.NotFound:
+            logger.error("No adtrust agents group found")
+            return False, []
+
+        # Build a list of agents from the cifs/.. members
+        agents_list = []
+        members = agents_entry.get('member', [])
+        suffix = '@{}'.format(self.api.env.realm).lower()
+
+        for amember in members:
+            if amember[0].attr.lower() == 'krbprincipalname':
+                # Extract krbprincipalname=cifs/hostname@realm from the DN
+                value = amember[0].value
+                if (value.lower().startswith('cifs/') and
+                        value.lower().endswith(suffix)):
+                    # 5 = length of 'cifs/'
+                    hostname = value[5:-len(suffix)]
+                    agents_list.append(DN(('fqdn', hostname),
+                                       self.api.env.container_host,
+                                       self.api.env.basedn))
+
+        # Add the fqdn=hostname... to the group
+        service.add_principals_to_group(
+            ldap,
+            agents_dn,
+            "member",
+            agents_list)
 
         return False, []


### PR DESCRIPTION
After an upgrade, the group cn=adtrust agents may be missing some members.
Each ad trust controller must appear twice as member:
- krbprincipalname=cifs/hostname@realm,cn=services,cn=accounts,basedn
- fqdn=hostname,cn=computers,cn=accounts,basedn

Add an upgrade plugin that builds a list of hostnames from the cifs
principals and adds if needed fqdn=hostname...

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1778777