### PR TITLE
[Backport][ipa-4-7] trust upgrade: ensure that host is member of adtrust agents

### DIFF
--- a/install/updates/90-post_upgrade_plugins.update
+++ b/install/updates/90-post_upgrade_plugins.update
@@ -13,6 +13,7 @@ plugin: update_default_trust_view
 plugin: update_tdo_gidnumber
 plugin: update_tdo_to_new_layout
 plugin: update_tdo_default_read_keys_permissions
+plugin: update_adtrust_agents_members
 plugin: update_ca_renewal_master
 plugin: update_idrange_type
 plugin: update_pacs


### PR DESCRIPTION
Manual backport of PR #3977 to ipa-4-7 branch.

PR was ACKed automatically because this is backport of PR #3977. Wait for CI to finish before pushing. In case of questions or problems contact @flo-renaud who is author of the original PR.