### PR TITLE
ipa-cacert-manage man page: fix indentation

### DIFF
--- a/install/tools/man/ipa-cacert-manage.1
+++ b/install/tools/man/ipa-cacert-manage.1
@@ -21,9 +21,9 @@
 ipa\-cacert\-manage \- Manage CA certificates in IPA
 .SH "SYNOPSIS"
 \fBipa\-cacert\-manage\fR [\fIOPTIONS\fR...] renew
-.RE
+.br
 \fBipa\-cacert\-manage\fR [\fIOPTIONS\fR...] install \fICERTFILE\fR...
-.RE
+.br
 \fBipa\-cacert\-manage\fR [\fIOPTIONS\fR...] list
 .SH "DESCRIPTION"
 \fBipa\-cacert\-manage\fR can be used to manage CA certificates in IPA.


### PR DESCRIPTION
Fix the indentation of the SYNPOSIS section

Fixes: https://pagure.io/freeipa/issue/8138