### PR TITLE
[Backport][ipa-4-8]  ipatests:  'sss_ssh_authorizedkeys user' should return ssh key

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1843,9 +1843,11 @@ def ldapsearch_dm(host, base, ldap_args, scope='sub', **kwargs):
     return host.run_command(args, **kwargs)
 
 
-def create_temp_file(host, directory=None):
+def create_temp_file(host, directory=None, create_file=True):
     """Creates temproray file using mktemp."""
     cmd = ['mktemp']
+    if create_file is False:
+        cmd += ['--dry-run']
     if directory is not None:
         cmd += ['-p', directory]
     return host.run_command(cmd).stdout_text.strip()


### PR DESCRIPTION
This PR was opened automatically because PR #3811 was pushed to master and backport to ipa-4-8 is required.