### PR TITLE
Fix typo in idrange.py docstring

### DIFF
--- a/ipaclient/remote_plugins/2_114/idrange.py
+++ b/ipaclient/remote_plugins/2_114/idrange.py
@@ -120,7 +120,7 @@ for a different domain.
 
 (*) The RID is typically the last integer of a user or group SID which follows
 the domain SID. E.g. if the domain SID is S-1-5-21-123-456-789 and a user from
-this domain has the SID S-1-5-21-123-456-789-1010 then 1010 id the RID of the
+this domain has the SID S-1-5-21-123-456-789-1010 then 1010 is the RID of the
 user. RIDs are unique in a domain, 32bit values and are used for users and
 groups.
 

--- a/ipaclient/remote_plugins/2_156/idrange.py
+++ b/ipaclient/remote_plugins/2_156/idrange.py
@@ -120,7 +120,7 @@ for a different domain.
 
 (*) The RID is typically the last integer of a user or group SID which follows
 the domain SID. E.g. if the domain SID is S-1-5-21-123-456-789 and a user from
-this domain has the SID S-1-5-21-123-456-789-1010 then 1010 id the RID of the
+this domain has the SID S-1-5-21-123-456-789-1010 then 1010 is the RID of the
 user. RIDs are unique in a domain, 32bit values and are used for users and
 groups.
 

--- a/ipaclient/remote_plugins/2_164/idrange.py
+++ b/ipaclient/remote_plugins/2_164/idrange.py
@@ -120,7 +120,7 @@ for a different domain.
 
 (*) The RID is typically the last integer of a user or group SID which follows
 the domain SID. E.g. if the domain SID is S-1-5-21-123-456-789 and a user from
-this domain has the SID S-1-5-21-123-456-789-1010 then 1010 id the RID of the
+this domain has the SID S-1-5-21-123-456-789-1010 then 1010 is the RID of the
 user. RIDs are unique in a domain, 32bit values and are used for users and
 groups.
 

--- a/ipaclient/remote_plugins/2_49/idrange.py
+++ b/ipaclient/remote_plugins/2_49/idrange.py
@@ -120,7 +120,7 @@ for a different domain.
 
 (*) The RID is typically the last integer of a user or group SID which follows
 the domain SID. E.g. if the domain SID is S-1-5-21-123-456-789 and a user from
-this domain has the SID S-1-5-21-123-456-789-1010 then 1010 id the RID of the
+this domain has the SID S-1-5-21-123-456-789-1010 then 1010 is the RID of the
 user. RIDs are unique in a domain, 32bit values and are used for users and
 groups.
 

--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -158,7 +158,7 @@ for a different domain.
 
 (*) The RID is typically the last integer of a user or group SID which follows
 the domain SID. E.g. if the domain SID is S-1-5-21-123-456-789 and a user from
-this domain has the SID S-1-5-21-123-456-789-1010 then 1010 id the RID of the
+this domain has the SID S-1-5-21-123-456-789-1010 then 1010 is the RID of the
 user. RIDs are unique in a domain, 32bit values and are used for users and
 groups.
 


### PR DESCRIPTION
In my opinion the sentence makes more sense if one replaces this `id` with a `is`.
If this is not what was meant, then I would be pleased if the sentence could be rephrased, so that I get it right. Thank you.