### PR TITLE
Fix service ldap_disable()

### DIFF
--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -691,7 +691,7 @@ class Service:
 
         # case insensitive
         for value in entry.get('ipaConfigString', []):
-            if value.lower() == ENABLED_SERVICE:
+            if value.lower() == ENABLED_SERVICE.lower():
                 entry['ipaConfigString'].remove(value)
                 break
 


### PR DESCRIPTION
Fix comparison bug that prevents ldap_disable to actually disable a
service.

Fixes: https://pagure.io/freeipa/issue/8143
Signed-off-by: Christian Heimes <cheimes@redhat.com>