### PR TITLE
[Backport][ipa-4-8] Add config that maintains existing content to ipa-client-install manpage

### DIFF
--- a/client/man/ipa-client-install.1
+++ b/client/man/ipa-client-install.1
@@ -272,6 +272,15 @@ Files updated, existing content is maintained:
 .br
 /etc/sysconfig/network
 
+.TP
+File updated, existing content is maintained if ssh is configured (default):
+
+/etc/ssh/ssh_config
+.TP
+File updated, existing content is maintained if sshd is configured (default):
+
+/etc/ssh/sshd_config
+
 .SH "DEPRECATED OPTIONS"
 .TP
 \fB\-\-request\-cert\fR


### PR DESCRIPTION
This PR was opened automatically because PR #3907 was pushed to master and backport to ipa-4-8 is required.