### PR TITLE
[Backport][ipa-4-8] Fix service ldap_disable()

### DIFF
--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -691,7 +691,7 @@ class Service:
 
         # case insensitive
         for value in entry.get('ipaConfigString', []):
-            if value.lower() == ENABLED_SERVICE:
+            if value.lower() == ENABLED_SERVICE.lower():
                 entry['ipaConfigString'].remove(value)
                 break
 


### PR DESCRIPTION
This PR was opened automatically because PR #4005 was pushed to master and backport to ipa-4-8 is required.