### PR TITLE
ipatests/test_nfs.py: wait before umount

### DIFF
--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -39,6 +39,8 @@ class TestNFS(IntegrationTest):
         nfsclt = self.clients[1]
         automntclt = self.clients[2]
 
+        time.sleep(WAIT_AFTER_UNINSTALL)
+
         nfsclt.run_command(["umount", "-a", "-t", "nfs4"])
         nfsclt.run_command(["systemctl", "stop", "rpc-gssd"])
 
@@ -204,6 +206,8 @@ class TestNFS(IntegrationTest):
         ])
 
         # TODO leverage users
+
+        time.sleep(WAIT_AFTER_UNINSTALL)
 
         automntclt.run_command(["umount", "-a", "-t", "nfs4"])
 


### PR DESCRIPTION
umount calls including in cleanup do not wait.
The test failed once with:
"umount.nfs4: /home: device is busy"
which looks like a leftover open file descriptor.
Add wait periods before umount.
    
Fixes: https://pagure.io/freeipa/issue/8144
Signed-off-by: François Cami <fcami@redhat.com>
