### PR TITLE
ipatests: fix temp_commit.yaml indentation

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -32,9 +32,9 @@ topologies:
     cpu: 4
     memory: 12000
   ad_master: &ad_master
-   name: ad_master
-   cpu: 4
-   memory: 12000
+    name: ad_master
+    cpu: 4
+    memory: 12000
 
 jobs:
   fedora-latest/build:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -32,9 +32,9 @@ topologies:
     cpu: 4
     memory: 12000
   ad_master: &ad_master
-   name: ad_master
-   cpu: 4
-   memory: 12000
+    name: ad_master
+    cpu: 4
+    memory: 12000
 
 jobs:
   testing-fedora/build:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -32,9 +32,9 @@ topologies:
     cpu: 4
     memory: 12000
   ad_master: &ad_master
-   name: ad_master
-   cpu: 4
-   memory: 12000
+    name: ad_master
+    cpu: 4
+    memory: 12000
 
 jobs:
   fedora-previous/build:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -32,9 +32,9 @@ topologies:
     cpu: 4
     memory: 12000
   ad_master: &ad_master
-   name: ad_master
-   cpu: 4
-   memory: 12000
+    name: ad_master
+    cpu: 4
+    memory: 12000
 
 jobs:
   fedora-rawhide/build:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -38,9 +38,9 @@ topologies:
     cpu: 4
     memory: 12000
   ad_master: &ad_master
-   name: ad_master
-   cpu: 4
-   memory: 12000
+    name: ad_master
+    cpu: 4
+    memory: 12000
 
 jobs:
   fedora-latest/build:


### PR DESCRIPTION
temp_commit.yaml has wrong indentation: expected 4 but found 3
Fix indentation.

Signed-off-by: François Cami <fcami@redhat.com>