### PR TITLE
[Backport][ipa-4-8] adtrust.py: mention restarting sssd when adding trust agents

### DIFF
--- a/ipaserver/install/adtrust.py
+++ b/ipaserver/install/adtrust.py
@@ -343,8 +343,9 @@ def add_new_adtrust_agents(api, options):
         add_hosts_to_adtrust_agents(api, new_agents)
 
         print("""
-WARNING: you MUST restart (e.g. ipactl restart) the following IPA masters in
-order to activate them to serve information about users from trusted forests:
+WARNING: you MUST restart (both "ipactl restart" and "systemctl restart sssd")
+the following IPA masters in order to activate them to serve information about
+users from trusted forests:
 """)
         for x in new_agents:
             print(x)


### PR DESCRIPTION
MANUAL BACKPORT (cherry-pick)

After adding a replica to AD trust agent, the warning
message does not mention that restarting sssd is mantatory
for the trust agent to work. Fix the string.

Fixes: https://pagure.io/freeipa/issue/8148
Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Alexander Bokovoy <abokovoy@redhat.com>