### PR TITLE
[Backport][ipa-4-8] ipatests: fix pr-ci templates' indentation

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8.yaml
@@ -32,9 +32,9 @@ topologies:
     cpu: 4
     memory: 12000
   ad_master: &ad_master
-   name: ad_master
-   cpu: 4
-   memory: 12000
+    name: ad_master
+    cpu: 4
+    memory: 12000
 
 jobs:
   fedora-30/build:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -38,9 +38,9 @@ topologies:
     cpu: 4
     memory: 12000
   ad_master: &ad_master
-   name: ad_master
-   cpu: 4
-   memory: 12000
+    name: ad_master
+    cpu: 4
+    memory: 12000
 
 jobs:
   fedora-30/build:


### PR DESCRIPTION
MANUAL BACKPORT (cherry-pick)

temp_commit.yaml among others have wrong indentation:
expected 4 but found 3.
Fix indentation.

Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Armando Neto <abiagion@redhat.com>