### PR TITLE
Adding auto COPR builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,17 @@
+srpm:
+	# Setup development environment
+	echo "Installing base development environment"
+	dnf install -y dnf-plugins-core
+	echo "Installing FreeIPA development dependencies"
+	dnf builddep -y --skip-broken --spec freeipa.spec.in --best --allowerasing --setopt=install_weak_deps=False
+
+	# Run autoconf
+	autoreconf -i
+	./configure --enable-silent-rules
+
+	# Generate SRPMS
+	make srpms
+
+	if [[ "${outdir}" != "" ]]; then \
+		mv rpmbuild/SRPMS/* ${outdir}; \
+	fi


### PR DESCRIPTION
This patch adds a script which can be used to auto-build freeipa in COPR.

## Usage
Currently, PKI runs certain cert related tests from `test_xmlrpc`. It pulls `freeipa` packages from stable fedora repo. This patch can help catch bugs as quickly as possible (for every commit made to either repositories)

## Personal Demo
I setup a [personal COPR repo](https://copr.fedorainfracloud.org/coprs/dmoluguw/freeipa-master/package/freeipa/) to demonstrate that this patch works

## Next steps
Once this patch gets merged, following action items need to be performed by the admin:

1. Create a new package `freeipa` inside the [official COPR repo](https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master/packages/)
2. Setup auto build with `srpm` option
3. Setup github hook to trigger the COPR builds

Thank you, @abbra for accepting the idea.

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`