### PR TITLE
[Backport][ipa-4-8] ipatests: Improve test_commands reliability

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1853,11 +1853,13 @@ def create_temp_file(host, directory=None, create_file=True):
     return host.run_command(cmd).stdout_text.strip()
 
 
-def create_active_user(host, login, password, first='test', last='user'):
+def create_active_user(host, login, password, first='test', last='user',
+                       extra_args=()):
     """Create user and do login to set password"""
     temp_password = 'Secret456789'
     kinit_admin(host)
-    user_add(host, login, first=first, last=last, password=temp_password)
+    user_add(host, login, first=first, last=last, extra_args=extra_args,
+             password=temp_password)
     host.run_command(
         ['kinit', login],
         stdin_text='{0}\n{1}\n{1}\n'.format(temp_password, password))

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -742,7 +742,8 @@ class TestIPACommand(IntegrationTest):
         user_key = tasks.create_temp_file(self.master, create_file=False)
         pem_file = tasks.create_temp_file(self.master)
         # Create a user with a password
-        tasks.create_active_user(self.master, user, passwd)
+        tasks.create_active_user(self.master, user, passwd, extra_args=[
+            '--homedir', '/home/{}'.format(user)])
         tasks.kinit_admin(self.master)
         tasks.run_command_as_user(
             self.master, user, ['ssh-keygen', '-N', '',
@@ -773,7 +774,8 @@ class TestIPACommand(IntegrationTest):
             self.master.run_command(
                 ['ssh', '-o', 'PasswordAuthentication=no',
                  '-o', 'IdentitiesOnly=yes', '-o', 'StrictHostKeyChecking=no',
-                 '-l', user, '-i', user_key, self.master.hostname, 'true'])
+                 '-o', 'ConnectTimeout=10', '-l', user, '-i', user_key,
+                 self.master.hostname, 'true'])
         finally:
             # cleanup
             self.master.run_command(['ipa', 'user-del', user])


### PR DESCRIPTION
This PR was opened automatically because PR #4035 was pushed to master and backport to ipa-4-8 is required.