### PR TITLE
prci: bump template version for nightly_rawhide

### DIFF
--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -47,7 +47,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-frawhide
           name: freeipa/ci-master-frawhide
-          version: 0.0.9
+          version: 0.0.10
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Template used : https://app.vagrantup.com/freeipa/boxes/ci-master-frawhide/versions/0.0.10
Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>