### PR TITLE
DNS install check: Fix overlapping DNS zone from the master itself

### DIFF
--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -135,15 +135,15 @@ def install_check(standalone, api, replica, options, hostname):
                 logger.warning("%s Please make sure that the domain is "
                                "properly delegated to this IPA server.",
                                e)
-
-            hst = dnsutil.DNSName(hostname).make_absolute().to_text()
-            if hst not in e.kwargs['ns']:
-                raise ValueError(str(e))
+            else:
+                hst = dnsutil.DNSName(hostname).make_absolute().to_text()
+                if hst not in e.kwargs['ns']:
+                    raise ValueError(str(e))
 
     for reverse_zone in options.reverse_zones:
         try:
             dnsutil.check_zone_overlap(reverse_zone)
-        except ValueError as e:
+        except dnsutil.DNSZoneAlreadyExists as e:
             if options.force or options.allow_zone_overlap:
                 logger.warning('%s', str(e))
             else:


### PR DESCRIPTION
The change to allow overlapping zone to be from the master itself has
introduced two issues: The check for the master itself should only executed
if options.force and options.allow_zone_overlap are both false and the
reverse zone check later on was still handling ValueError instead of
dnsutil.DNSZoneAlreadyExists.

Both issues have been fixed and the deployment with existing name servers
is properly working again.

Fixes: https://pagure.io/freeipa/issue/8150
Signed-off-by: Thomas Woerner <twoerner@redhat.com>