### PR TITLE
Fix nightly CI regressions in CA-less tests

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1604,9 +1604,19 @@ def upload_temp_contents(host, contents, encoding='utf-8'):
     return tmpname
 
 
-def assert_error(result, stderr_text, returncode=None):
-    "Assert that `result` command failed and its stderr contains `stderr_text`"
-    assert stderr_text in result.stderr_text, result.stderr_text
+def assert_error(result, pattern, returncode=None):
+    """
+    Assert that ``result`` command failed and its stderr contains ``pattern``.
+    ``pattern`` may be a ``str`` or a ``re.Pattern`` (regular expression).
+
+    """
+    if isinstance(pattern, re.Pattern):
+        assert pattern.search(result.stderr_text), \
+            f"pattern {pattern} not found in stderr {result.stderr_text!r}"
+    else:
+        assert pattern in result.stderr_text, \
+            f"substring {pattern!r} not found in stderr {result.stderr_text!r}"
+
     if returncode is not None:
         assert result.returncode == returncode
     else:


### PR DESCRIPTION
```
118eadef6 (Fraser Tweedale, 19 minutes ago)
   Fix test regressions caused by certificate validation changes

   Some integration tests (that were enabled in nightly CI but not PR-CI) are
   failing due to changes in the error messages.  Update the error message
   assertions to get these tests going again.

   Part of: https://pagure.io/freeipa/issue/8142

2e863efb5 (Fraser Tweedale, 30 minutes ago)
   ipatests: assert_error: allow regexp match

   Enhance the assert_error subroutine to provide regular expression matching
   against the command's stderr output, in additional to substring match.

   Part of: https://pagure.io/freeipa/issue/8142
```