### PR TITLE
[Backport][ipa-4-8] ipatests: filter_users should be applied correctly if SSSD starts offline

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1951,3 +1951,9 @@ def remote_ini_file(host, filename):
 def is_selinux_enabled(host):
     res = host.run_command('selinuxenabled', ok_returncode=(0, 1))
     return res.returncode == 0
+
+
+def get_logsize(host, logfile):
+    """ get current logsize"""
+    logsize = len(host.get_file_contents(logfile))
+    return logsize


### PR DESCRIPTION
This PR was opened automatically because PR #3349 was pushed to master and backport to ipa-4-8 is required.