### PR TITLE
[Backport][ipa-4-6] ipatests: filter_users should be applied correctly if SSSD starts offline

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1821,3 +1821,9 @@ def remote_ini_file(host, filename):
 def is_selinux_enabled(host):
     res = host.run_command('selinuxenabled', ok_returncode=(0, 1))
     return res.returncode == 0
+
+
+def get_logsize(host, logfile):
+    """ get current logsize"""
+    logsize = len(host.get_file_contents(logfile))
+    return logsize

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -1,0 +1,79 @@
+#
+# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+#
+
+"""This module provides tests for SSSD as used in IPA"""
+
+from __future__ import absolute_import
+
+from contextlib import contextmanager
+
+import pytest
+
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_ipa.integration import tasks
+from ipaplatform.paths import paths
+
+
+class TestSSSDWithAdTrust(IntegrationTest):
+
+    topology = 'star'
+    num_ad_domains = 1
+
+    users = {
+        'ad': {
+            'name_tmpl': 'testuser@{domain}',
+            'password': 'Secret123'
+        },
+        'fakeuser': {
+            'name': 'some_user@some.domain'
+        },
+    }
+    ad_user_tmpl = 'testuser@{domain}'
+
+    @classmethod
+    def install(cls, mh):
+        super(TestSSSDWithAdTrust, cls).install(mh)
+
+        cls.ad = cls.ads[0]  # pylint: disable=no-member
+
+        tasks.install_adtrust(cls.master)
+        tasks.configure_dns_for_trust(cls.master, cls.ad)
+        tasks.establish_trust_with_ad(cls.master, cls.ad.domain.name)
+
+        cls.users['ad']['name'] = cls.users['ad']['name_tmpl'].format(
+            domain=cls.ad.domain.name)
+
+    @contextmanager
+    def filter_user_setup(self, user):
+        sssd_conf_backup = tasks.FileBackup(self.master, paths.SSSD_CONF)
+        filter_user = {'filter_users': self.users[user]['name']}
+        try:
+            tasks.modify_sssd_conf(self.master, self.master.domain.name,
+                                   filter_user)
+            tasks.clear_sssd_cache(self.master)
+            yield
+        finally:
+            sssd_conf_backup.restore()
+            tasks.clear_sssd_cache(self.master)
+
+    @pytest.mark.parametrize('user', ['ad', 'fakeuser'])
+    def test_is_user_filtered(self, user):
+        """No lookup in data provider from 'filter_users' config option.
+
+        Test for https://bugzilla.redhat.com/show_bug.cgi?id=1685472
+        https://bugzilla.redhat.com/show_bug.cgi?id=1724088
+
+        When there are users in filter_users in domain section then no look
+        up should be in data provider.
+        """
+        with self.filter_user_setup(user=user):
+            log_file = '{0}/sssd_nss.log'.format(paths.VAR_LOG_SSSD_DIR)
+            logsize = tasks.get_logsize(self.master, log_file)
+            self.master.run_command(
+                ['getent', 'passwd', self.users[user]['name']],
+                ok_returncode=2)
+            sssd_log = self.master.get_file_contents(log_file)[logsize:]
+            dp_req = ("Looking up [{0}] in data provider".format(
+                self.users[user]['name']))
+            assert not dp_req.encode() in sssd_log

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 from contextlib import contextmanager
 
+import ipaplatform
 import pytest
 
 from ipatests.test_integration.base import IntegrationTest
@@ -57,6 +58,9 @@ class TestSSSDWithAdTrust(IntegrationTest):
             sssd_conf_backup.restore()
             tasks.clear_sssd_cache(self.master)
 
+    @pytest.mark.xfail(
+        ipaplatform.NAME == 'fedora',
+        reason='https://pagure.io/SSSD/sssd/issue/3978', strict=True)
     @pytest.mark.parametrize('user', ['ad', 'fakeuser'])
     def test_is_user_filtered(self, user):
         """No lookup in data provider from 'filter_users' config option.


### PR DESCRIPTION
This is manual back-port of : https://github.com/freeipa/freeipa/pull/3349
