### PR TITLE
[Backport][ipa-4-8] Fix nightly CI regressions in CA-less tests

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1582,9 +1582,19 @@ def upload_temp_contents(host, contents, encoding='utf-8'):
     return tmpname
 
 
-def assert_error(result, stderr_text, returncode=None):
-    "Assert that `result` command failed and its stderr contains `stderr_text`"
-    assert stderr_text in result.stderr_text, result.stderr_text
+def assert_error(result, pattern, returncode=None):
+    """
+    Assert that ``result`` command failed and its stderr contains ``pattern``.
+    ``pattern`` may be a ``str`` or a ``re.Pattern`` (regular expression).
+
+    """
+    if isinstance(pattern, re.Pattern):
+        assert pattern.search(result.stderr_text), \
+            f"pattern {pattern} not found in stderr {result.stderr_text!r}"
+    else:
+        assert pattern in result.stderr_text, \
+            f"substring {pattern!r} not found in stderr {result.stderr_text!r}"
+
     if returncode is not None:
         assert result.returncode == returncode
     else:


### PR DESCRIPTION
This PR was opened automatically because PR #4049 was pushed to master and backport to ipa-4-8 is required.