### PR TITLE
ipatests: add test for certinstall with notBefore in the future

### DIFF
--- a/ipatests/pytest_ipa/integration/create_caless_pki.py
+++ b/ipatests/pytest_ipa/integration/create_caless_pki.py
@@ -409,6 +409,15 @@ def gen_server_certs(nick_base, hostname, org, ca=None):
              ]),
              ca, dns_name=hostname, warp=-2 * YEAR
              )
+    gen_cert(
+        profile_server, nick_base + u'-not-yet-valid',
+        x509.Name([
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, org),
+            x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, u'Future'),
+            x509.NameAttribute(NameOID.COMMON_NAME, hostname),
+        ]),
+        ca, dns_name=hostname, warp=1 * DAY,
+    )
     gen_cert(profile_server, nick_base + u'-badusage',
              x509.Name([
                 x509.NameAttribute(NameOID.ORGANIZATION_NAME, org),

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -1353,6 +1353,21 @@ class TestCertInstall(CALessBase):
     def test_expired_ds(self):
         self._test_expired_service_cert('d')
 
+    def _test_not_yet_valid_service_cert(self, w_or_d):
+        """Install new not-yet-valid HTTP/DS certificate."""
+        result = self.certinstall(w_or_d, 'ca1/server-not-yet-valid')
+        pattern = re.compile(
+            r'The server certificate in server\.p12 is not valid: '
+            '.*not valid before .* is in the future'
+        )
+        assert_error(result, pattern)
+
+    def test_not_yet_valid_http(self):
+        self._test_not_yet_valid_service_cert('w')
+
+    def test_not_yet_valid_ds(self):
+        self._test_not_yet_valid_service_cert('d')
+
     def test_http_bad_usage(self):
         "Install new HTTP certificate with invalid key usage"
 


### PR DESCRIPTION
Part of: https://pagure.io/freeipa/issue/8142