### PR TITLE
Reset per-indicator Kerberos policy

### DIFF
--- a/ipatests/test_integration/test_krbtpolicy.py
+++ b/ipatests/test_integration/test_krbtpolicy.py
@@ -112,3 +112,16 @@ class TestPWPolicy(IntegrationTest):
         assert maxlife_within_policy(result.stdout_text, 1200) is True
 
         tasks.kdestroy_all(master)
+
+    def test_krbtpolicy_reset(self):
+        """Test a hardened kerberos ticket policy reset"""
+        master = self.master
+
+        tasks.kinit_admin(master)
+        master.run_command(['ipa', 'krbtpolicy-reset', USER2])
+        master.run_command(['kinit', USER2],
+                           stdin_text=PASSWORD + '\n')
+        result = master.run_command('klist | grep krbtgt')
+        assert maxlife_within_policy(result.stdout_text, MAXLIFE) is True
+
+        tasks.kdestroy_all(master)


### PR DESCRIPTION
When 'ipa krbtpolicy-reset' is called, we need to reset all policy
settings, including per-indicator ones. Per-indicator policy uses
subtyped attributes (foo;bar), the current krbtpolicy-reset code does
not deal with those.

Add support for per-indicator policy reset. It is a bit tricky, as we
need to drop the values to defaults but avoid adding non-per-indicator
variants of the same attributes.

Add test to check that policy has been resetted by observing a new
Kerberos TGT for the user after its policy reset.

Fixes: https://pagure.io/freeipa/issue/8153
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>