### PR TITLE
[Backport][ipa-4-8] Reset per-indicator Kerberos policy

### DIFF
--- a/ipatests/test_integration/test_krbtpolicy.py
+++ b/ipatests/test_integration/test_krbtpolicy.py
@@ -112,3 +112,16 @@ class TestPWPolicy(IntegrationTest):
         assert maxlife_within_policy(result.stdout_text, 1200) is True
 
         tasks.kdestroy_all(master)
+
+    def test_krbtpolicy_reset(self):
+        """Test a hardened kerberos ticket policy reset"""
+        master = self.master
+
+        tasks.kinit_admin(master)
+        master.run_command(['ipa', 'krbtpolicy-reset', USER2])
+        master.run_command(['kinit', USER2],
+                           stdin_text=PASSWORD + '\n')
+        result = master.run_command('klist | grep krbtgt')
+        assert maxlife_within_policy(result.stdout_text, MAXLIFE) is True
+
+        tasks.kdestroy_all(master)


### PR DESCRIPTION
This PR was opened automatically because PR #4057 was pushed to master and backport to ipa-4-8 is required.