### PR TITLE
Fix fedora version for xfail.

### DIFF
--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -126,7 +126,7 @@ class TestSSSDWithAdTrust(IntegrationTest):
             tasks.clear_sssd_cache(self.master)
 
     @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number <= (28,),
+        osinfo.id == 'fedora' and osinfo.version_number <= (29,),
         reason='https://pagure.io/SSSD/sssd/issue/3978')
     @pytest.mark.parametrize('user', ['ad', 'fakeuser'])
     def test_is_user_filtered(self, user):


### PR DESCRIPTION
TestSSSDWithAdTrust::test_is_user_filtered[ad] was failing in nightly_PR for ipa-4.7
As https://pagure.io/SSSD/sssd/issue/3978 is not available on
fedora-29
Related to : https://github.com/freeipa/freeipa/pull/4069

Signed-off-by: Anuja More <amore@redhat.com>