### PR TITLE
[Backport][ipa-4-7] ipatests: Skip test_sss_ssh_authorizedkeys method

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -635,6 +635,7 @@ class TestIPACommand(IntegrationTest):
         res = self.master.run_command(['testparm', '-s'])
         assert 'ERROR' not in (res.stdout_text + res.stderr_text)
 
+    @pytest.mark.skip(reason='https://pagure.io/freeipa/issue/8151')
     def test_sss_ssh_authorizedkeys(self):
         """Login via Ssh using private-key for ipa-user should work.
 


### PR DESCRIPTION
This PR was opened automatically because PR #4046 was pushed to master and backport to ipa-4-7 is required.