### PR TITLE
[Backport][ipa-4-7] Fix fedora version for xfail.

### DIFF
--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -126,7 +126,7 @@ class TestSSSDWithAdTrust(IntegrationTest):
             tasks.clear_sssd_cache(self.master)
 
     @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number <= (28,),
+        osinfo.id == 'fedora' and osinfo.version_number <= (29,),
         reason='https://pagure.io/SSSD/sssd/issue/3978')
     @pytest.mark.parametrize('user', ['ad', 'fakeuser'])
     def test_is_user_filtered(self, user):


### PR DESCRIPTION
This PR was opened automatically because PR #4071 was pushed to master and backport to ipa-4-7 is required.