### PR TITLE
[Backport][ipa-4-7] Test for ipa-ca-install on replica

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-7.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-7.yaml
@@ -263,6 +263,18 @@ jobs:
         timeout: 10800
         topology: *master_3repl_1client
 
+  fedora-29/test_installation_TestInstallCA:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallCA
+        template: *ci-master-f29
+        timeout: 10800
+        topology: *master_2repl_1client
+
   fedora-29/test_installation_TestInstallWithCA_KRA1:
     requires: [fedora-29/build]
     priority: 50

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1429,13 +1429,18 @@ def install_kra(host, domain_level=None, first_instance=False, raiseonerr=True):
     return result
 
 
-def install_ca(host, domain_level=None, first_instance=False,
-               external_ca=False, cert_files=None, raiseonerr=True):
+def install_ca(
+        host, domain_level=None, first_instance=False, external_ca=False,
+        cert_files=None, raiseonerr=True, extra_args=()
+):
     if domain_level is None:
         domain_level = domainlevel(host)
     check_domain_level(domain_level)
     command = ["ipa-ca-install", "-U", "-p", host.config.dirman_password,
                "-P", 'admin', "-w", host.config.admin_password]
+    if not isinstance(extra_args, (tuple, list)):
+        raise TypeError("extra_args must be tuple or list")
+    command.extend(extra_args)
     # First step of ipa-ca-install --external-ca
     if external_ca:
         command.append('--external-ca')

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -221,6 +221,34 @@ class TestInstallWithCA2(InstallTestBase2):
         super(TestInstallWithCA2, self).test_replica2_ipa_kra_install()
 
 
+class TestInstallCA(IntegrationTest):
+    """
+    Tests for CA installation on a replica
+    """
+
+    num_replicas = 2
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=False)
+
+    def test_replica_ca_install_with_no_host_dns(self):
+        """
+        Test for ipa-ca-install --no-host-dns on a replica
+        """
+
+        tasks.install_replica(self.master, self.replicas[0], setup_ca=False)
+        tasks.install_ca(self.replicas[0], extra_args=["--no-host-dns"])
+
+    def test_replica_ca_install_with_skip_schema_check(self):
+        """
+        Test for ipa-ca-install --skip-schema-check on a replica
+        """
+
+        tasks.install_replica(self.master, self.replicas[1], setup_ca=False)
+        tasks.install_ca(self.replicas[1], extra_args=["--skip-schema-check"])
+
+
 class TestInstallWithCA_KRA1(InstallTestBase1):
 
     @classmethod


### PR DESCRIPTION
Test on replica for ipa-ca-install with options
--no-host-dns,--skip-schema-check,done changes in
ipatests/pytest_ipa/integration/tasks.py because
wants to pass few arguments to install_ca method

Signed-off-by: Jayesh <jgarg@redhat.com>
Reviewed-By: Florence Blanc-Renaud <flo@redhat.com>
Reviewed-By: Fraser Tweedale <ftweedal@redhat.com>