### PR TITLE
ipatests: fix compatibility with python2 (import ConfigParser)

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -30,7 +30,7 @@ import itertools
 import tempfile
 import time
 from pipes import quote
-import configparser
+from six.moves import configparser
 from contextlib import contextmanager
 
 import dns
@@ -1782,7 +1782,11 @@ def remote_ini_file(host, filename):
     """
     data = host.get_file_contents(filename, encoding='utf-8')
     ini_file = configparser.RawConfigParser()
-    ini_file.read_string(data)
+    # provide python2/3 compatibility
+    if hasattr(ini_file, 'read_string'):
+        ini_file.read_string(data)  # pylint: disable=no-member
+    else:
+        ini_file.readfp(StringIO(data))  # pylint: disable=deprecated-method
     yield ini_file
     data = StringIO()
     ini_file.write(data)


### PR DESCRIPTION
Patch ba4aaa73 backported remote_ini_file utility which requires
`configparser` module. But in python2 this module was named ConfigParser.
As we need to support both python2 and python3 in branch ipa-4-6,
I have added try-except block to allow fallback to python2 verstion import.

Related to: https://pagure.io/SSSD/sssd/issue/3937