### PR TITLE
AD user without override receive InternalServerError with API

### DIFF
--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -694,7 +694,7 @@ class KerberosWSGIExecutioner(WSGIExecutioner, KerberosSession):
             status = HTTP_STATUS_SUCCESS
             response = status.encode('utf-8')
             start_response(status, self.headers)
-            return self.marshal(None, e)
+            return [self.marshal(None, e)]
         finally:
             destroy_context()
         return response


### PR DESCRIPTION
When ipa commands are used by an Active Directory user that
does not have any idoverride-user set, they return the
following error message which can be misleading:
$ kinit aduser@ADDOMAIN.COM
$ ipa ping
ipa: ERROR: cannot connect to 'https://master.ipa.com/ipa/json': Internal Server Error

The fix properly handles ACIError exception received when
creating the context, and now the following message can be seen:

$ kinit aduser@ADDOMAIN.COM
$ ipa ping
ipa: ERROR: cannot connect to 'https://master.ipa.com/ipa/json': Unauthorized

with the following log in /var/log/httpd/error_log:
ipa: INFO: 401 Unauthorized: Insufficient access:  Invalid credentials

Fixes: https://pagure.io/freeipa/issue/8163