### PR TITLE
Add test_winsyncmigrate to nightly builds

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1432,3 +1432,15 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
+
+  fedora-latest/test_winsyncmigrate:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_winsyncmigrate.py
+        template: *ci-master-latest
+        timeout: 4800
+        topology: *ad_master

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1531,3 +1531,15 @@ jobs:
         template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
+
+  testing-fedora/test_winsyncmigrate:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{testing-fedora/build_url}'
+        test_suite: test_integration/test_winsyncmigrate.py
+        template: *testing-master-latest
+        timeout: 4800
+        topology: *ad_master

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1408,3 +1408,15 @@ jobs:
         template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
+
+  fedora-previous/test_winsyncmigrate:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_winsyncmigrate.py
+        template: *ci-master-previous
+        timeout: 4800
+        topology: *ad_master

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1545,3 +1545,15 @@ jobs:
         template: *ci-master-frawhide
         timeout: 3600
         topology: *master_1repl
+
+  fedora-rawhide/test_winsyncmigrate:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_winsyncmigrate.py
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *ad_master


### PR DESCRIPTION
The test suite test_winsyncmigrate was missing in nightly definitions
because CI was lacking configuration needed for establishing winsync
agreement: the Certificate Authority needs to be configured on
Windows AD instance. Now that PR-CI is updated to include said changes, we
can start executing this test suite. It is not reasonable to add it to
gating as this suite is time consuming just like other tests requiring
provisioning of AD instances.

PRs with changes required for executing the test suite:
https://github.com/freeipa/freeipa-pr-ci/pull/323
https://github.com/freeipa/freeipa-pr-ci/pull/335

Stability of the test suite was checked on a private prci runner: https://github.com/wladich/freeipa/pull/5