### PR TITLE
Print LDAP diagnostic messages on error

### DIFF
--- a/client/ipa-getkeytab.c
+++ b/client/ipa-getkeytab.c
@@ -177,7 +177,6 @@ static int ipa_ldap_bind(const char *ldap_uri, krb5_principal bind_princ,
                          const char *mech, const char *ca_cert_file,
                          LDAP **_ld)
 {
-    char *msg = NULL;
     struct berval bv;
     LDAP *ld;
     int ret;
@@ -205,7 +204,7 @@ static int ipa_ldap_bind(const char *ldap_uri, krb5_principal bind_princ,
         ret = ldap_sasl_bind_s(ld, bind_dn, LDAP_SASL_SIMPLE,
                                &bv, NULL, NULL, NULL);
         if (ret != LDAP_SUCCESS) {
-            fprintf(stderr, _("Simple bind failed\n"));
+            ipa_ldap_error(ld, ret, _("Simple bind failed\n"));
             goto done;
         }
     } else {
@@ -219,11 +218,7 @@ static int ipa_ldap_bind(const char *ldap_uri, krb5_principal bind_princ,
         }
 
         if (ret != LDAP_SUCCESS) {
-#ifdef LDAP_OPT_DIAGNOSTIC_MESSAGE
-            ldap_get_option(ld, LDAP_OPT_DIAGNOSTIC_MESSAGE, (void*)&msg);
-#endif
-            fprintf(stderr, "SASL Bind failed %s (%d) %s!\n",
-                            ldap_err2string(ret), ret, msg ? msg : "");
+            ipa_ldap_error(ld, ret, _("SASL Bind failed\n"));
             goto done;
         }
     }

--- a/client/ipa-join.c
+++ b/client/ipa-join.c
@@ -240,7 +240,7 @@ connect_ldap(const char *hostname, const char *binddn, const char *bindpw,
                             NULL, NULL, NULL);
 
     if (*ret != LDAP_SUCCESS) {
-        fprintf(stderr, _("Bind failed: %s\n"), ldap_err2string(*ret));
+        ipa_ldap_error(ld, *ret, _("SASL Bind failed\n"));
         goto fail;
     }
 

--- a/util/ipa_ldap.c
+++ b/util/ipa_ldap.c
@@ -24,6 +24,43 @@
 
 #include "ipa_ldap.h"
 
+
+/** Print LDAP error message to stderr
+ *
+ * The help function prints custom error message, LDAP error string,
+ * diagnostic message (if available) to stderr.
+ *
+ * @param ld      LDAP connection
+ * @param errnum  error code from LDAP operation
+ * @param msg     Additional custom error message (must include trailing
+ *                new line)
+ */
+void ipa_ldap_error(LDAP *ld, int errnum, char *msg)
+{
+    const char *errstring;
+    char *diagnostic = NULL;
+    int ret = 0;
+    int has_diagnostic = 0;
+
+    /* print custom message msg first. All msg strings have trailing newline
+     */
+    fprintf(stderr, "%s", msg);
+
+    /* Get human readable error string and diagnostic message */
+    errstring = ldap_err2string(errnum);
+    ret = ldap_get_option(ld, LDAP_OPT_DIAGNOSTIC_MESSAGE, (void*)&diagnostic);
+    has_diagnostic = ((ret == LDAP_SUCCESS) && diagnostic && *diagnostic);
+
+    if (errstring && has_diagnostic) {
+        fprintf(stderr, "    %s: %s\n", errstring, diagnostic);
+    } else if (errstring) {
+        fprintf(stderr, "    %s\n", errstring);
+    } else if (has_diagnostic) {
+        fprintf(stderr, "    %i: %s\n", errnum, diagnostic);
+    }
+    /* else no additional error message */
+}
+
 /** Initialize LDAP context
  *
  * Initializes an LDAP context for a given LDAP URI. LDAP protocol version
@@ -49,15 +86,15 @@ int ipa_ldap_init(LDAP **ld, const char *ldap_uri)
     /* StartTLS and other features need LDAP protocol version 3 */
     ret = ldap_set_option(*ld, LDAP_OPT_PROTOCOL_VERSION, &version);
     if (ret != LDAP_SUCCESS) {
-        fprintf(stderr, _("Unable to set LDAP_OPT_PROTOCOL_VERSION\n"));
-        return ret;
+        ipa_ldap_error(*ld, ret, _("Unable to set LDAP_OPT_PROTOCOL_VERSION\n")
+        );
     }
 
 #ifdef LDAP_OPT_X_SASL_NOCANON
     /* Don't do DNS canonization */
     ret = ldap_set_option(*ld, LDAP_OPT_X_SASL_NOCANON, LDAP_OPT_ON);
     if (ret != LDAP_SUCCESS) {
-        fprintf(stderr, _("Unable to set LDAP_OPT_X_SASL_NOCANON\n"));
+        ipa_ldap_error(*ld, ret, _("Unable to set LDAP_OPT_X_SASL_NOCANON\n"));
         return ret;
     }
 #endif
@@ -85,32 +122,38 @@ int ipa_tls_ssl_init(LDAP *ld, const char *ldap_uri,
 
     ret = ldap_set_option(ld, LDAP_OPT_X_TLS_CACERTFILE, ca_cert_file);
     if (ret != LDAP_OPT_SUCCESS) {
-        fprintf(stderr, _("Unable to set LDAP_OPT_X_TLS_CACERTFILE\n"));
+        ipa_ldap_error(ld, ret,
+                       _("Unable to set LDAP_OPT_X_TLS_CACERTFILE\n"));
         return ret;
     }
     /* Require a valid certificate */
     ret = ldap_set_option(ld, LDAP_OPT_X_TLS_REQUIRE_CERT, &tls_demand);
     if (ret != LDAP_OPT_SUCCESS) {
-        fprintf(stderr, _("Unable to set LDAP_OPT_X_TLS_REQUIRE_CERT\n"));
+        ipa_ldap_error(ld, ret,
+                       _("Unable to set LDAP_OPT_X_TLS_REQUIRE_CERT\n"));
         return ret;
     }
     /* Disable SSLv2 and SSLv3 */
     ret = ldap_set_option(ld, LDAP_OPT_X_TLS_PROTOCOL_MIN, &tlsv1_0);
     if (ret != LDAP_OPT_SUCCESS) {
-        fprintf(stderr, _("Unable to set LDAP_OPT_X_TLS_PROTOCOL_MIN\n"));
+        ipa_ldap_error(ld, ret,
+                       _("Unable to set LDAP_OPT_X_TLS_PROTOCOL_MIN\n"));
         return ret;
     }
     /* Apply TLS settings and create new client context */
     ret = ldap_set_option(ld, LDAP_OPT_X_TLS_NEWCTX, &newctx);
     if (ret != LDAP_OPT_SUCCESS) {
-        fprintf(stderr, _("Unable to set LDAP_OPT_X_TLS_NEWCTX\n"));
+        ipa_ldap_error(ld, ret,
+                       _("Unable to create new TLS context (OpenSSL failed "
+                         "to initialize or to load certificates)\n"));
         return ret;
     }
 
     if (strncmp(ldap_uri, SCHEMA_LDAP, sizeof(SCHEMA_LDAP) - 1) == 0) {
         ret = ldap_start_tls_s(ld, NULL, NULL);
         if (ret != LDAP_SUCCESS) {
-            fprintf(stderr, _("Unable to initialize STARTTLS session\n"));
+            ipa_ldap_error(ld, ret,
+                           _("Unable to initialize STARTTLS session\n"));
             return ret;
         }
     }

--- a/util/ipa_ldap.h
+++ b/util/ipa_ldap.h
@@ -37,3 +37,4 @@
 int ipa_ldap_init(LDAP **ld, const char *ldap_uri);
 int ipa_tls_ssl_init(LDAP *ld, const char *ldap_uri,
                      const char *ca_cert_file);
+void ipa_ldap_error(LDAP *ld, int errnum, char *msg);


### PR DESCRIPTION
ipa_ldap_init(), ipa_tls_ssl_init(), and the bind operations of ipa-join
and ipa-getkeytab now print LDAP error string and LDAP diagonstic messages
to stderr.

Signed-off-by: Christian Heimes <cheimes@redhat.com>