### PR TITLE
[Backport][ipa-4-8] AD user without override receive InternalServerError with API

### DIFF
--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -694,7 +694,7 @@ class KerberosWSGIExecutioner(WSGIExecutioner, KerberosSession):
             status = HTTP_STATUS_SUCCESS
             response = status.encode('utf-8')
             start_response(status, self.headers)
-            return self.marshal(None, e)
+            return [self.marshal(None, e)]
         finally:
             destroy_context()
         return response


### PR DESCRIPTION
This PR was opened automatically because PR #4110 was pushed to master and backport to ipa-4-8 is required.