### PR TITLE
Support KDB DAL version 8.0

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -751,8 +751,67 @@ kdb_vftabl kdb_function_table = {
 };
 #endif
 
+#if (KRB5_KDB_DAL_MAJOR_VERSION == 8)
+/* Version 8 adds several arguments here.  However, if we want to actually use
+ * them in mspac, we really ought to drop support for older DAL versions. */
+static inline krb5_error_code
+stub_sign_authdata(krb5_context context, unsigned int flags,
+                   krb5_const_principal client_princ,
+                   krb5_const_principal server_princ, krb5_db_entry *client,
+                   krb5_db_entry *server, krb5_db_entry *header_server,
+                   krb5_db_entry *local_tgt, krb5_keyblock *client_key,
+                   krb5_keyblock *server_key, krb5_keyblock *header_key,
+                   krb5_keyblock *local_tgt_key, krb5_keyblock *session_key,
+                   krb5_timestamp authtime, krb5_authdata **tgt_auth_data,
+                   void *ad_info, krb5_data ***auth_indicators,
+                   krb5_authdata ***signed_auth_data)
+{
+    krb5_db_entry *krbtgt = header_server ? header_server : server;
+    krb5_keyblock *krbtgt_key = header_key ? header_key : server_key;
+
+    return ipadb_sign_authdata(context, flags, client_princ, client, server,
+                               krbtgt, client_key, server_key, krbtgt_key,
+                               session_key, authtime, tgt_auth_data,
+                               signed_auth_data);
+}
+
+kdb_vftabl kdb_function_table = {
+    .maj_ver = KRB5_KDB_DAL_MAJOR_VERSION,
+    .min_ver = 0,
+    .init_library = ipadb_init_library,
+    .fini_library = ipadb_fini_library,
+    .init_module = ipadb_init_module,
+    .fini_module = ipadb_fini_module,
+    .create = ipadb_create,
+    .get_age = ipadb_get_age,
+    .get_principal = ipadb_get_principal,
+    .put_principal = ipadb_put_principal,
+    .delete_principal = ipadb_delete_principal,
+    .iterate = ipadb_iterate,
+    .create_policy = ipadb_create_pwd_policy,
+    .get_policy = ipadb_get_pwd_policy,
+    .put_policy = ipadb_put_pwd_policy,
+    .iter_policy = ipadb_iterate_pwd_policy,
+    .delete_policy = ipadb_delete_pwd_policy,
+    .fetch_master_key = ipadb_fetch_master_key,
+    .store_master_key_list = ipadb_store_master_key_list,
+    .change_pwd = ipadb_change_pwd,
+    .sign_authdata = stub_sign_authdata,
+    .check_transited_realms = ipadb_check_transited_realms,
+    .check_policy_as = ipadb_check_policy_as,
+    .audit_as_req = ipadb_audit_as_req,
+    .check_allowed_to_delegate = ipadb_check_allowed_to_delegate,
+    .free_principal_e_data = ipadb_free_principal_e_data,
+    .get_s4u_x509_principal = NULL,
+    .allowed_to_delegate_from = NULL,
+    .get_authdata_info = NULL,
+    .free_authdata_info = NULL,
+};
+#endif
+
 #if (KRB5_KDB_DAL_MAJOR_VERSION != 5) && \
     (KRB5_KDB_DAL_MAJOR_VERSION != 6) && \
-    (KRB5_KDB_DAL_MAJOR_VERSION != 7)
+    (KRB5_KDB_DAL_MAJOR_VERSION != 7) && \
+    (KRB5_KDB_DAL_MAJOR_VERSION != 8)
 #error unsupported DAL major version
 #endif

--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -635,56 +635,10 @@ static krb5_error_code ipadb_get_age(krb5_context kcontext,
     return 0;
 }
 
-#if KRB5_KDB_DAL_MAJOR_VERSION == 5
-static void *ipadb_alloc(krb5_context context, void *ptr, size_t size)
-{
-    return realloc(ptr, size);
-}
-
-static void ipadb_free(krb5_context context, void *ptr)
-{
-    free(ptr);
-}
-#endif
-
 /* KDB Virtual Table */
 
 /* We explicitly want to keep different ABI tables below separate. */
 /* Do not merge them together. Older ABI does not need to be updated */
-
-#if KRB5_KDB_DAL_MAJOR_VERSION == 5
-kdb_vftabl kdb_function_table = {
-    .maj_ver = KRB5_KDB_DAL_MAJOR_VERSION,
-    .min_ver = 0,
-    .init_library = ipadb_init_library,
-    .fini_library = ipadb_fini_library,
-    .init_module = ipadb_init_module,
-    .fini_module = ipadb_fini_module,
-    .create = ipadb_create,
-    .get_age = ipadb_get_age,
-    .get_principal = ipadb_get_principal,
-    .free_principal = ipadb_free_principal,
-    .put_principal = ipadb_put_principal,
-    .delete_principal = ipadb_delete_principal,
-    .iterate = ipadb_iterate,
-    .create_policy = ipadb_create_pwd_policy,
-    .get_policy = ipadb_get_pwd_policy,
-    .put_policy = ipadb_put_pwd_policy,
-    .iter_policy = ipadb_iterate_pwd_policy,
-    .delete_policy = ipadb_delete_pwd_policy,
-    .free_policy = ipadb_free_pwd_policy,
-    .alloc = ipadb_alloc,
-    .free = ipadb_free,
-    .fetch_master_key = ipadb_fetch_master_key,
-    .store_master_key_list = ipadb_store_master_key_list,
-    .change_pwd = ipadb_change_pwd,
-    .sign_authdata = ipadb_sign_authdata,
-    .check_transited_realms = ipadb_check_transited_realms,
-    .check_policy_as = ipadb_check_policy_as,
-    .audit_as_req = ipadb_audit_as_req,
-    .check_allowed_to_delegate = ipadb_check_allowed_to_delegate
-};
-#endif
 
 #if (KRB5_KDB_DAL_MAJOR_VERSION == 6) && !defined(HAVE_KDB_FREEPRINCIPAL_EDATA)
 kdb_vftabl kdb_function_table = {
@@ -809,8 +763,7 @@ kdb_vftabl kdb_function_table = {
 };
 #endif
 
-#if (KRB5_KDB_DAL_MAJOR_VERSION != 5) && \
-    (KRB5_KDB_DAL_MAJOR_VERSION != 6) && \
+#if (KRB5_KDB_DAL_MAJOR_VERSION != 6) && \
     (KRB5_KDB_DAL_MAJOR_VERSION != 7) && \
     (KRB5_KDB_DAL_MAJOR_VERSION != 8)
 #error unsupported DAL major version

--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -22,8 +22,13 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
     enum ipadb_user_auth ua;
     struct ipadb_e_data *ied;
     struct ipadb_e_pol_limits *pol_limits = NULL;
-    int valid_auth_indicators = 0;
+    int valid_auth_indicators = 0, flags = 0;
     krb5_db_entry *client_actual = NULL;
+
+#ifdef KRB5_KDB_FLAG_ALIAS_OK
+    flags = KRB5_KDB_FLAG_ALIAS_OK;
+#endif
+
 
     *status = NULL;
     *lifetime_out = 0;
@@ -33,8 +38,8 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
     if (ied == NULL || ied->magic != IPA_E_DATA_MAGIC) {
         /* e-data is not availble, getting user auth from LDAP */
         krb5_klog_syslog(LOG_INFO, "IPA kdcpolicy: client e_data not availble. Try fetching...");
-        kerr = ipadb_get_principal(context, request->client,
-                                   KRB5_KDB_FLAG_ALIAS_OK, &client_actual);
+        kerr = ipadb_get_principal(context, request->client, flags,
+                                   &client_actual);
         if (kerr != 0) {
             krb5_klog_syslog(LOG_ERR, "IPA kdcpolicy: ipadb_find_principal failed.");
             return kerr;

--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -964,8 +964,7 @@ ipadb_fetch_principals_with_extra_filter(struct ipadb_context *ipactx,
                                          LDAPMessage **result)
 {
     krb5_error_code kerr;
-    char *src_filter = NULL;
-    char *esc_original_princ = NULL;
+    char *src_filter = NULL, *esc_original_princ = NULL;
     int ret;
 
     if (!ipactx->lcontext) {
@@ -976,28 +975,33 @@ ipadb_fetch_principals_with_extra_filter(struct ipadb_context *ipactx,
         }
     }
 
-    /* escape filter but do not touch '*' as this function accepts
-     * wildcards in names */
+    /* Escape filter but do not touch '*' as this function accepts
+     * wildcards in names. */
     esc_original_princ = ipadb_filter_escape(principal, false);
     if (!esc_original_princ) {
         kerr = KRB5_KDB_INTERNAL_ERROR;
         goto done;
     }
 
-    if (filter == NULL) {
-        if (flags & KRB5_KDB_FLAG_ALIAS_OK) {
-            ret = asprintf(&src_filter, PRINC_TGS_SEARCH_FILTER,
-                           esc_original_princ, esc_original_princ);
-        } else {
-            ret = asprintf(&src_filter, PRINC_SEARCH_FILTER, esc_original_princ);
-        }
-    } else {
-        if (flags & KRB5_KDB_FLAG_ALIAS_OK) {
-            ret = asprintf(&src_filter, PRINC_TGS_SEARCH_FILTER_EXTRA,
-                           esc_original_princ, esc_original_princ, filter);
+    /* Starting in DAL 8.0, aliases are always okay. */
+#ifdef KRB5_KDB_FLAG_ALIAS_OK
+    if (!(flags & KRB5_KDB_FLAG_ALIAS_OK)) {
+        if (filter == NULL) {
+            ret = asprintf(&src_filter, PRINC_SEARCH_FILTER,
+                           esc_original_princ);
         } else {
             ret = asprintf(&src_filter, PRINC_SEARCH_FILTER_EXTRA,
                            esc_original_princ, filter);
+        }
+    } else
+#endif
+    {
+        if (filter == NULL) {
+            ret = asprintf(&src_filter, PRINC_TGS_SEARCH_FILTER,
+                           esc_original_princ, esc_original_princ);
+        } else {
+            ret = asprintf(&src_filter, PRINC_TGS_SEARCH_FILTER_EXTRA,
+                           esc_original_princ, esc_original_princ, filter);
         }
     }
 
@@ -1006,11 +1010,8 @@ ipadb_fetch_principals_with_extra_filter(struct ipadb_context *ipactx,
         goto done;
     }
 
-    kerr = ipadb_simple_search(ipactx,
-                               ipactx->base, LDAP_SCOPE_SUBTREE,
-                               src_filter, std_principal_attrs,
-                               result);
-
+    kerr = ipadb_simple_search(ipactx, ipactx->base, LDAP_SCOPE_SUBTREE,
+                               src_filter, std_principal_attrs, result);
 done:
     free(src_filter);
     free(esc_original_princ);
@@ -1054,6 +1055,7 @@ krb5_error_code ipadb_find_principal(krb5_context kcontext,
         /* We need to check for a strict match as a '*' in the name may have
          * caused the ldap server to return multiple entries. */
         for (int i = 0; vals[i]; i++) {
+#ifdef KRB5_KDB_FLAG_ALIAS_OK
             if ((flags & KRB5_KDB_FLAG_ALIAS_OK) == 0) {
                 found = strcmp(vals[i]->bv_val, *principal) == 0;
                 if (found)
@@ -1061,6 +1063,7 @@ krb5_error_code ipadb_find_principal(krb5_context kcontext,
 
                 continue;
             }
+#endif
 
             /* The KDC will accept aliases when doing TGT lookup
              * (ref_tgt_again in do_tgs_req.c), so use case-insensitive
@@ -1094,6 +1097,7 @@ krb5_error_code ipadb_find_principal(krb5_context kcontext,
         if (vals == NULL)
             break;
 
+#ifdef KRB5_KDB_FLAG_ALIAS_OK
         /* If aliases aren't accepted by the KDC, use case-sensitive
          * comparison. */
         if ((flags & KRB5_KDB_FLAG_ALIAS_OK) == 0) {
@@ -1103,6 +1107,7 @@ krb5_error_code ipadb_find_principal(krb5_context kcontext,
                 continue;
             }
         }
+#endif
 
         free(*principal);
         *principal = strdup(vals[0]->bv_val);
@@ -2601,7 +2606,9 @@ krb5_error_code ipadb_delete_principal(krb5_context kcontext,
         goto done;
     }
 
+#ifdef KRB5_KDB_FLAG_ALIAS_OK
     flags = KRB5_KDB_FLAG_ALIAS_OK;
+#endif
     kerr = ipadb_find_principal(kcontext, flags, res, &canonicalized, &lentry);
     if (kerr != 0) {
         goto done;

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -61,7 +61,6 @@
 %global alt_name ipa
 # Fix for CVE-2018-20217
 %global krb5_version 1.16.1-24
-%global krb5_kdb_version 7.0
 # 0.7.16: https://github.com/drkjam/netaddr/issues/71
 %global python_netaddr_version 0.7.16
 # Require 4.7.0 which brings Python 3 bindings
@@ -69,6 +68,13 @@
 # SELinux context for /etc/named directory, RHBZ#1759495
 %global selinux_policy_version 3.14.3-52
 %global slapi_nis_version 0.56.1
+
+# krb5 can only provide one KDB at a time
+%if 0%{?fedora} >= 32
+%global krb5_kdb_version 8.0
+%else
+%global krb5_kdb_version 7.0
+%endif
 
 # fix for segfault in python3-ldap, https://pagure.io/freeipa/issue/7324
 %global python_ldap_version 3.1.0-1


### PR DESCRIPTION
A krb5 build containing the 1.18 beta - which has this KDB version - can be found here for testing: https://koji.fedoraproject.org/koji/taskinfo?taskID=40498937

Note that samba isn't ready to go with KDB 8.0, so I don't think this can actually build.  I've reached out to @iboukris to hopefully coordinate that.

(This is based on #3842).

