### PR TITLE
ipa tests: fix backup and restore

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -165,7 +165,7 @@ def backup(host):
 
     # Test for ticket 7632: check that services are restarted
     # before the backup is compressed
-    pattern = r'.*gzip.*Starting IPA service.*'
+    pattern = r'.*{}.*Starting IPA service.*'.format(paths.GZIP)
     if (re.match(pattern, result.stderr_text, re.DOTALL)):
         raise AssertionError('IPA Services are started after compression')
 


### PR DESCRIPTION
The tests for backup_and_restore check that the ipa-backup command
compresses the tar file AFTER restarting IPA services by reading the
output and looking for a pattern with "gzip" before "Starting IPA service."

As the tar file name is randomly created, it sometimes happen that the
name contains gzip and in this case the test wrongly assumes that
the gzip cmd was called.

The fix makes a stricter comparison, looking for /bin/gzip.

Fixes: https://pagure.io/freeipa/issue/8170