### PR TITLE
[Backport][ipa-4-7] Fix occasional 'whoami.data is undefined' error in FreeIPA web UI

### DIFF
--- a/install/ui/src/freeipa/ipa.js
+++ b/install/ui/src/freeipa/ipa.js
@@ -251,7 +251,10 @@ var IPA = function () {
             on_success: function(data, text_status, xhr) {
                 that.whoami.metadata = data.result || data;
                 var wa_data = that.whoami.metadata;
-
+                // This AJAX request has no synchronization point,
+                // so we set async = false to make sure that init_metadata
+                // doesn't start before we get whoami response.
+                $.ajaxSetup({async: false});
                 rpc.command({
                     method: wa_data.details || wa_data.command,
                     args: wa_data.arguments,
@@ -275,6 +278,8 @@ var IPA = function () {
                         }
                     }
                 }).execute();
+                // Restore AJAX options
+                $.ajaxSetup(that.ajax_options);
             }
         });
     };


### PR DESCRIPTION
Manual backport of https://github.com/freeipa/freeipa/pull/3138

'Metadata' phase (Web UI initialization flow) doesn't wait "whoami" response.
It causes the error when on the next phase "whoami" data is undefined.
To avoid this "whoami" request now has flag async = false,
so init_metadata waits until it will be completed.

Ticket: https://pagure.io/freeipa/issue/7917