### PR TITLE
Make assert_error compatible with Python 3.6

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1615,7 +1615,7 @@ def assert_error(result, pattern, returncode=None):
     ``pattern`` may be a ``str`` or a ``re.Pattern`` (regular expression).
 
     """
-    if isinstance(pattern, re.Pattern):
+    if hasattr(pattern, "search"):  # re pattern
         assert pattern.search(result.stderr_text), \
             f"pattern {pattern} not found in stderr {result.stderr_text!r}"
     else:


### PR DESCRIPTION
The re.Pattern class was introduced in Python 3.7. Use duck-typing to
distinguish between str and re pattern object.

Fixes: https://pagure.io/freeipa/issue/8179
Signed-off-by: Christian Heimes <cheimes@redhat.com>