### PR TITLE
ipatests: make assert_error function compatible with python version < 3.7

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1615,7 +1615,7 @@ def assert_error(result, pattern, returncode=None):
     ``pattern`` may be a ``str`` or a ``re.Pattern`` (regular expression).
 
     """
-    if isinstance(pattern, re.Pattern):
+    if hasattr(pattern, 'search'):
         assert pattern.search(result.stderr_text), \
             f"pattern {pattern} not found in stderr {result.stderr_text!r}"
     else:


### PR DESCRIPTION
In 3d779b4 assert_error was changed to handle both strings and compiled
regexp objects in argument `pattern`. For this it used expression
`isinstance(pattern, re.Pattern)`. re.Pattern object was introduced in
python 3.7, so the tests which call this function can not be executed
with older versions of python though and for now we claim support for
python 3.6+.
Fixed by replacing the condition with duck-typing check.


Fixes: https://pagure.io/freeipa/issue/8179