### PR TITLE
ipatests: Allow zero-length arguments

### DIFF
--- a/ipatests/ipa-run-tests
+++ b/ipatests/ipa-run-tests
@@ -60,7 +60,10 @@ pyt_args = [sys.executable, "-c",
             "import sys,pytest;sys.exit(pytest.main())"] + sys.argv[1:]
 # shell is needed to perform globbing
 sh_args = ["/bin/sh", "--norc", "--noprofile", "-c", "--"]
-pyt_args_esc = ["'{}'".format(x) if " " in x else x for x in pyt_args]
+pyt_args_esc = [
+    f"'{x}'" if not x or " " in x else x
+    for x in pyt_args
+]
 args = sh_args + [" ".join(pyt_args_esc)]
 os.chdir(HERE)
 sys.stdout.flush()

--- a/ipatests/test_ipatests_plugins/test_ipa_run_tests.py
+++ b/ipatests/test_ipatests_plugins/test_ipa_run_tests.py
@@ -109,6 +109,20 @@ def test_ipa_run_tests_expression(ipatestdir, expr):
             func=FUNC_NAME.format(mod_num))])
 
 
+def test_ipa_run_tests_empty_expression(ipatestdir):
+    """
+    Run ipa-run-tests using an empty expression.
+    Expected result: all tests should pass.
+    """
+    result = ipatestdir.run_ipa_tests('-k', '')
+    assert result.ret == 0
+    result.assert_outcomes(passed=5)
+    for mod_num in range(0, MODS_NUM):
+        result.stdout.fnmatch_lines(["*{mod}.py::{func} PASSED*".format(
+            mod=MOD_NAME.format(mod_num),
+            func=FUNC_NAME.format(mod_num))])
+
+
 def test_ipa_run_tests_ignore_basic(ipatestdir):
     """
     Run ipa-run-tests ignoring one test module


### PR DESCRIPTION
Currently, such arguments are eaten by 'ipa-run-tests' script as they
are not quoted.

For example, ```running ipa-run-tests -k ''```
results in the actual invocation would be like as:
```
['/bin/sh',
 '--norc',
 '--noprofile',
 '-c',
 '--',
 "/usr/bin/python3 -c 'import sys,pytest;sys.exit(pytest.main())' -o "
 'cache_dir=/tmp/pytest-of-root/pytest-12/test_ipa_run_tests_empty_expression0/.pytest_cache '
 '--confcutdir=/usr/lib64/python3/site-packages/ipatests -k ']
```

Note: expressions or marks could be empty as a result of the building
of command line args by more high-level tools, scripts, etc.

So, a short-termed solution is the quoting of zero-length arguments.

Fixes: https://pagure.io/freeipa/issue/8173
Signed-off-by: Stanislav Levin <slev@altlinux.org>