### PR TITLE
[Backport][ipa-4-8] Make assert_error compatible with Python 3.6

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1593,7 +1593,7 @@ def assert_error(result, pattern, returncode=None):
     ``pattern`` may be a ``str`` or a ``re.Pattern`` (regular expression).
 
     """
-    if isinstance(pattern, re.Pattern):
+    if hasattr(pattern, "search"):  # re pattern
         assert pattern.search(result.stderr_text), \
             f"pattern {pattern} not found in stderr {result.stderr_text!r}"
     else:


### PR DESCRIPTION
This PR was opened automatically because PR #4144 was pushed to master and backport to ipa-4-8 is required.