### PR TITLE
[Backport][ipa-4-8] Add test_winsyncmigrate to nightly builds

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8.yaml
@@ -1432,3 +1432,15 @@ jobs:
         template: *ci-master-f30
         timeout: 3600
         topology: *master_1repl
+
+  fedora-30/test_winsyncmigrate:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_winsyncmigrate.py
+        template: *ci-master-f30
+        timeout: 4800
+        topology: *ad_master


### PR DESCRIPTION
This is a manual backport of #4113 

The test suite test_winsyncmigrate was missing in nightly definitions
because CI was lacking configuration needed for establishing winsync
agreement: the Certificate Authority needs to be configured on
Windows AD instance. Now that PR-CI is updated to include said changes, we
can start executing this test suite. It is not reasonable to add it to
gating as this suite is time consuming just like other tests requiring
provisioning of AD instances.

PRs with changes required for executing the test suite:
freeipa/freeipa-pr-ci#323
freeipa/freeipa-pr-ci#335

Stability of the test suite was checked on a private prci runner: wladich#5