### PR TITLE
[Backport][ipa-4-6] Add test_winsyncmigrate to nightly builds

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -27,6 +27,10 @@ topologies:
     name: master_3repl_1client
     cpu: 6
     memory: 12900
+  ad_master: &ad_master
+    name: ad_master
+    cpu: 4
+    memory: 12000
 
 jobs:
   fedora-27/build:
@@ -1074,3 +1078,15 @@ jobs:
         template: *ci-master-f27
         timeout: 3600
         topology: *master_1repl
+
+  fedora-27/test_winsyncmigrate:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_winsyncmigrate.py
+        template: *ci-master-f27
+        timeout: 4800
+        topology: *ad_master

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -1,0 +1,70 @@
+#
+# Template for temporary test commit
+#
+# $ ln -sf ipatests/prci_definitions/temp_commit.yaml .freeipa-pr-ci.yaml
+#
+
+topologies:
+  build: &build
+    name: build
+    cpu: 2
+    memory: 3800
+  master_3client: &master_3client
+    name: master_3client
+    cpu: 5
+    memory: 10150
+  master_1repl: &master_1repl
+    name: master_1repl
+    cpu: 4
+    memory: 6450
+  master_1repl_1client: &master_1repl_1client
+    name: master_1repl_1client
+    cpu: 4
+    memory: 7400
+  ipaserver: &ipaserver
+    name: ipaserver
+    cpu: 2
+    memory: 2400
+  master_2repl_1client: &master_2repl_1client
+    name: master_2repl_1client
+    cpu: 5
+    memory: 10150
+  master_3repl_1client: &master_3repl_1client
+    name: master_3repl_1client
+    cpu: 6
+    memory: 12900
+  ad_master_2client: &ad_master_2client
+    name: ad_master_2client
+    cpu: 4
+    memory: 12000
+  ad_master: &ad_master
+   name: ad_master
+   cpu: 4
+   memory: 12000
+
+jobs:
+  fedora-27/build:
+    requires: []
+    priority: 100
+    job:
+      class: Build
+      args:
+        git_repo: '{git_repo}'
+        git_refspec: '{git_refspec}'
+        template: &ci-master-f27
+          name: freeipa/ci-ipa-4-6-f27
+          version: 1.0.3
+        timeout: 1800
+        topology: *build
+
+  fedora-27/temp_commit:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_REPLACEME.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl_1client


### PR DESCRIPTION
This is a manual backport of #4113

The test suite test_winsyncmigrate was missing in nightly definitions
because CI was lacking configuration needed for establishing winsync
agreement: the Certificate Authority needs to be configured on
Windows AD instance. Now that PR-CI is updated to include said changes, we
can start executing this test suite. It is not reasonable to add it to
gating as this suite is time consuming just like other tests requiring
provisioning of AD instances.

PRs with changes required for executing the test suite:
freeipa/freeipa-pr-ci#323
freeipa/freeipa-pr-ci#335

Stability of the test suite was checked on a private prci runner: wladich#5