### PR TITLE
[Backport][ipa-4-6] Do not renew externally-signed CA as self-signed

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -402,7 +402,7 @@ def retrieve_cert(**kwargs):
     return result
 
 
-def renew_ca_cert(reuse_existing, **kwargs):
+def renew_ca_cert(reuse_existing, force_self_signed, **kwargs):
     """
     This is used for automatic CA certificate renewal.
     """
@@ -420,7 +420,8 @@ def renew_ca_cert(reuse_existing, **kwargs):
     if operation == 'SUBMIT':
         state = 'retrieve'
 
-        if not reuse_existing and is_renewal_master():
+        if (is_self_signed or force_self_signed) \
+                and not reuse_existing and is_renewal_master():
             state = 'request'
 
         csr_file = paths.IPA_CA_CSR
@@ -473,13 +474,22 @@ def renew_ca_cert(reuse_existing, **kwargs):
 def main():
     kwargs = {
         'reuse_existing': False,
+        'force_self_signed': False,
     }
+
     try:
         sys.argv.remove('--reuse-existing')
     except ValueError:
         pass
     else:
         kwargs['reuse_existing'] = True
+
+    try:
+        sys.argv.remove('--force-self-signed')
+    except ValueError:
+        pass
+    else:
+        kwargs['force_self_signed'] = True
 
     api.bootstrap(in_server=True, context='renew', confdir=paths.ETC_IPA)
     api.finalize()

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -307,6 +307,11 @@ IPA_CA_RECORD = "ipa-ca"
 IPA_CA_NICKNAME = 'caSigningCert cert-pki-ca'
 RENEWAL_CA_NAME = 'dogtag-ipa-ca-renew-agent'
 RENEWAL_REUSE_CA_NAME = 'dogtag-ipa-ca-renew-agent-reuse'
+RENEWAL_SELFSIGNED_CA_NAME = 'dogtag-ipa-ca-renew-agent-selfsigned'
+# The RA agent cert is used for client cert authentication. In the past IPA
+# used caServerCert profile, which adds clientAuth and serverAuth EKU. The
+# serverAuth EKU caused trouble with NamedConstraints, see RHBZ#1670239.
+RA_AGENT_PROFILE = 'caSubsystemCert'
 # How long dbus clients should wait for CA certificate RPCs [seconds]
 CA_DBUS_TIMEOUT = 120
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -433,7 +433,7 @@ class CAInstance(DogtagInstance):
         if self.external != 1:
             if not has_ra_cert:
                 self.step("configure certmonger for renewals",
-                          self.configure_certmonger_renewal)
+                          self.configure_certmonger_renewal_helpers)
                 if not self.clone:
                     self.step("requesting RA certificate from CA", self.__request_ra_certificate)
                 elif promote:
@@ -1059,8 +1059,8 @@ class CAInstance(DogtagInstance):
         obj = bus.get_object('org.fedorahosted.certmonger',
                              '/org/fedorahosted/certmonger')
         iface = dbus.Interface(obj, 'org.fedorahosted.certmonger')
-        for suffix in ['', '-reuse']:
-            name = 'dogtag-ipa-ca-renew-agent' + suffix
+        for suffix in ['', '-reuse', '-selfsigned']:
+            name = ipalib.constants.RENEWAL_CA_NAME + suffix
             path = iface.find_ca_by_nickname(name)
             if path:
                 iface.remove_known_ca(path)

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -34,7 +34,7 @@ import pki.system
 
 from ipalib import api, errors, x509
 from ipalib.install import certmonger
-from ipalib.constants import CA_DBUS_TIMEOUT
+from ipalib.constants import CA_DBUS_TIMEOUT, RENEWAL_CA_NAME
 from ipaplatform import services
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
@@ -258,7 +258,7 @@ class DogtagInstance(service.Service):
             fd.write(template)
             os.fchmod(fd.fileno(), 0o644)
 
-    def configure_certmonger_renewal(self):
+    def configure_certmonger_renewal_helpers(self):
         """
         Create a new CA type for certmonger that will retrieve updated
         certificates from the dogtag master server.
@@ -272,8 +272,12 @@ class DogtagInstance(service.Service):
         obj = bus.get_object('org.fedorahosted.certmonger',
                              '/org/fedorahosted/certmonger')
         iface = dbus.Interface(obj, 'org.fedorahosted.certmonger')
-        for suffix, args in [('', ''), ('-reuse', ' --reuse-existing')]:
-            name = 'dogtag-ipa-ca-renew-agent' + suffix
+        for suffix, args in [
+            ('', ''),
+            ('-reuse', ' --reuse-existing'),
+            ('-selfsigned', ' --force-self-signed'),
+        ]:
+            name = RENEWAL_CA_NAME + suffix
             path = iface.find_ca_by_nickname(name)
             if not path:
                 command = paths.DOGTAG_IPA_CA_RENEW_AGENT_SUBMIT + args

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -24,7 +24,9 @@ import os
 from optparse import OptionGroup  # pylint: disable=deprecated-module
 import gssapi
 
-from ipalib.constants import RENEWAL_CA_NAME, RENEWAL_REUSE_CA_NAME, IPA_CA_CN
+from ipalib.constants import (
+    RENEWAL_CA_NAME, RENEWAL_REUSE_CA_NAME, RENEWAL_SELFSIGNED_CA_NAME,
+    IPA_CA_CN)
 from ipalib.install import certmonger, certstore
 from ipapython import admintool, ipautil
 from ipapython.certdb import (EMPTY_TRUST_FLAGS,
@@ -210,7 +212,7 @@ class CACertManage(admintool.AdminTool):
         except errors.NotFound:
             raise admintool.ScriptError("CA renewal master not found")
 
-        self.resubmit_request()
+        self.resubmit_request(RENEWAL_SELFSIGNED_CA_NAME)
 
         db = certs.CertDB(api.env.realm, nssdir=paths.PKI_TOMCAT_ALIAS_DIR)
         cert = db.get_cert_from_db(self.cert_nickname)

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -129,7 +129,7 @@ class KRAInstance(DogtagInstance):
         self.step("enabling ephemeral requests", self.enable_ephemeral)
         self.step("restarting KRA", self.restart_instance)
         self.step("configure certmonger for renewals",
-                  self.configure_certmonger_renewal)
+                  self.configure_certmonger_renewal_helpers)
         self.step("configure certificate renewals", self.configure_renewal)
         self.step("configure HTTP to proxy connections",
                   self.http_proxy)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -951,6 +951,9 @@ def certificate_renewal_update(ca, ds, http):
     Update certmonger certificate renewal configuration.
     """
 
+    # First ensure the renewal helpers are defined.
+    ca.configure_certmonger_renewal_helpers()
+
     template = paths.CERTMONGER_COMMAND_TEMPLATE
     serverid = installutils.realm_to_serverid(api.env.realm)
 
@@ -1075,7 +1078,6 @@ def certificate_renewal_update(ca, ds, http):
             logger.info("Removing %s", filename)
             installutils.remove_file(filename)
 
-    ca.configure_certmonger_renewal()
     ca.configure_renewal()
     ca.configure_agent_renewal()
     ca.track_servercert()


### PR DESCRIPTION
(manual backport of https://github.com/freeipa/freeipa/pull/4148)

Commit 49cf5ec64b1b7a7437ca285430353473c215540e fixed a bug that
prevented migration from externally-signed to self-signed IPA CA.
But it introduced a subtle new issue: certmonger-initiated renewal
renews an externally-signed IPA CA as a self-signed CA.

To resolve this issue, introduce the `--force-self-signed' flag for
the dogtag-ipa-ca-renew-agent script.  Add another certmonger CA
definition that calls this script with the `--force-self-signed'
flag.  Update dogtag-ipa-ca-renew-agent to only issue a self-signed
CA certificate if the existing certificate is self-signed or if
`--force-self-signed' was given.  Update `ipa-cacert-manage renew'
to supply `--force-self-signed' when appropriate.

As a result of these changes, certmonger-initiated renewal of an
externally-signed IPA CA certificate will not issue a self-signed
certificate.

Fixes: https://pagure.io/freeipa/issue/8176
Reviewed-By: Florence Blanc-Renaud <frenaud@redhat.com>