### PR TITLE
Normalize title of test external_ca in prci-definition

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -71,7 +71,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest/external_ca_1:
+  fedora-latest/test_external_ca_TestExternalCA:
     requires: [fedora-latest/build]
     priority: 100
     job:
@@ -83,7 +83,7 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-latest/external_ca_2:
+  fedora-latest/test_external_ca_TestSelfExternalSelf:
     requires: [fedora-latest/build]
     priority: 100
     job:

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -63,7 +63,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest/external_ca_1:
+  fedora-latest/test_external_ca_TestExternalCA:
     requires: [fedora-latest/build]
     priority: 50
     job:
@@ -75,7 +75,7 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-latest/external_ca_2:
+  fedora-latest/test_external_ca_TestSelfExternalSelf:
     requires: [fedora-latest/build]
     priority: 50
     job:

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -52,7 +52,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  pki-fedora/external_ca_1:
+  pki-fedora/test_external_ca_TestExternalCA:
     requires: [pki-fedora/build]
     priority: 50
     job:
@@ -65,7 +65,7 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
-  pki-fedora/external_ca_2:
+  pki-fedora/test_external_ca_TestSelfExternalSelf:
     requires: [pki-fedora/build]
     priority: 50
     job:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -64,7 +64,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  testing-fedora/external_ca_1:
+  testing-fedora/test_external_ca_TestExternalCA:
     requires: [testing-fedora/build]
     priority: 50
     job:
@@ -77,7 +77,7 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
-  testing-fedora/external_ca_2:
+  testing-fedora/test_external_ca_TestSelfExternalSelf:
     requires: [testing-fedora/build]
     priority: 50
     job:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -63,7 +63,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-previous/external_ca_1:
+  fedora-previous/test_external_ca_TestExternalCA:
     requires: [fedora-previous/build]
     priority: 50
     job:
@@ -75,7 +75,7 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-previous/external_ca_2:
+  fedora-previous/test_external_ca_TestSelfExternalSelf:
     requires: [fedora-previous/build]
     priority: 50
     job:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -64,7 +64,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-rawhide/external_ca_1:
+  fedora-rawhide/test_external_ca_TestExternalCA:
     requires: [fedora-rawhide/build]
     priority: 50
     job:
@@ -77,7 +77,7 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-rawhide/external_ca_2:
+  fedora-rawhide/test_external_ca_TestSelfExternalSelf:
     requires: [fedora-rawhide/build]
     priority: 50
     job:


### PR DESCRIPTION
Use a consistent way to label the tests. As a result, replace external_ca_1 with test_external_ca_TestExternalCA and external_ca_2 with test_external_ca_TestSelfExternalSelf to better reflect which subtest is executed.

Issue : freeipa/freeipa-pr-ci#336

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>