### PR TITLE
[Backport][ipa-4-6] pkinit enable: use local dogtag only if host has CA

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -45,6 +45,7 @@ from ipaserver.install import replication
 from ipaserver.install import ldapupdate
 
 from ipaserver.install import certs
+from ipaserver.masters import find_providing_servers
 from ipaplatform.constants import constants
 from ipaplatform.tasks import tasks
 from ipaplatform.paths import paths
@@ -419,10 +420,13 @@ class KrbInstance(service.Service):
             prev_helper = None
             # on the first CA-ful master without '--no-pkinit', we issue the
             # certificate by contacting Dogtag directly
+            localhost_has_ca = self.fqdn in find_providing_servers(
+                'CA', conn=self.api.Backend.ldap2, api=self.api)
             use_dogtag_submit = all(
                 [self.master_fqdn is None,
                  self.pkcs12_info is None,
-                 self.config_pkinit])
+                 self.config_pkinit,
+                 localhost_has_ca])
 
             if use_dogtag_submit:
                 ca_args = [

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -420,13 +420,14 @@ class KrbInstance(service.Service):
             prev_helper = None
             # on the first CA-ful master without '--no-pkinit', we issue the
             # certificate by contacting Dogtag directly
-            localhost_has_ca = self.fqdn in find_providing_servers(
+            ca_instances = find_providing_servers(
                 'CA', conn=self.api.Backend.ldap2, api=self.api)
+
             use_dogtag_submit = all(
                 [self.master_fqdn is None,
                  self.pkcs12_info is None,
                  self.config_pkinit,
-                 localhost_has_ca])
+                 len(ca_instances) == 0])
 
             if use_dogtag_submit:
                 ca_args = [

--- a/ipatests/test_integration/test_pkinit_manage.py
+++ b/ipatests/test_integration/test_pkinit_manage.py
@@ -126,3 +126,20 @@ class TestPkinitManage(IntegrationTest):
 
         self.replicas[0].run_command(['ipa-pkinit-manage', 'enable'])
         check_pkinit(self.replicas[0], enabled=True)
+
+
+class TestPkinitInstall(IntegrationTest):
+    """Tests that ipa-server-install properly configures pkinit.
+
+    Non-regression test for issue 7795.
+    """
+    num_replicas = 0
+
+    @classmethod
+    def install(cls, mh):
+        # Install the master
+        tasks.install_master(cls.master)
+
+    def test_pkinit(self):
+        # Ensure that pkinit is properly configured
+        check_pkinit(self.master, enabled=True)


### PR DESCRIPTION
Manual backport of PR #2076 to ipa-4-6 branch.
Required because the issue https://pagure.io/freeipa/issue/7795 (ipa-pkinit-manage enable fails on replica if it doesn't host the CA) is also present on this branch.
The fix was already backported to ipa-4-7+ branches.