### PR TITLE
ipatests: update packages for rawhide and updates-testing nightlies

### DIFF
--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1514,6 +1514,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{testing-fedora/build_url}'
+        update_packages: True
         test_suite: test_integration/test_membermanager.py
         template: *testing-master-latest
         timeout: 1800
@@ -1539,6 +1540,7 @@ jobs:
       class: RunADTests
       args:
         build_url: '{testing-fedora/build_url}'
+        update_packages: True
         test_suite: test_integration/test_winsyncmigrate.py
         template: *testing-master-latest
         timeout: 4800

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1553,6 +1553,7 @@ jobs:
       class: RunADTests
       args:
         build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
         test_suite: test_integration/test_winsyncmigrate.py
         template: *ci-master-frawhide
         timeout: 4800


### PR DESCRIPTION
The nightly tests for rawhide and updates_testing are expected
to set
        update_packages: True
in all the job definitions to make sure that dnf/yum update is called
before starting the tests.

This tag was missing for some jobs, this commit fixes the issue.