### PR TITLE
Added a test to check if ipa host-find --pkey-only does not return SSH public key

### DIFF
--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -132,6 +132,12 @@ def host4(request):
 
 
 @pytest.fixture(scope='class')
+def host5(request):
+    tracker = HostTracker(name=u'testhost5')
+    return tracker.make_fixture(request)
+
+
+@pytest.fixture(scope='class')
 def lab_host(request):
     name = u'testhost1'
     tracker = HostTracker(name=name,
@@ -260,6 +266,29 @@ class TestCRUD(XMLRPC_test):
             fqdn=host.fqdn, usercertificate=host_cert)
         res = command()['result']
         assert len(res) == 1
+
+    def test_host_find_pkey_only(self, host5):
+        # test host-find with --pkey-only
+        host5.ensure_exists()
+        command = host5.make_create_command(force=True)
+        host5.update(dict(ipasshpubkey=sshpubkey),
+                     expected_updates=dict(
+                         description=['Test host <testhost5>'],
+                         fqdn=[host5.fqdn],
+                         ipasshpubkey=[sshpubkey],
+                         has_keytab=False,
+                         has_password=False,
+                         krbprincipalname=['host/%s@%s' %
+                                           (host5.fqdn, api.env.realm)],
+                         krbcanonicalname=['host/%s@%s' %
+                                           (host5.fqdn, api.env.realm)],
+                         managedby_host=[host5.fqdn],
+                         sshpubkeyfp=[sshpubkeyfp], ))
+        command = host5.make_find_command(
+            fqdn=host5.fqdn, pkey_only=True)
+        result = command()['result']
+        for item in result:
+            assert 'ipasshpubkey' not in item.keys()
 
     def test_try_rename(self, host):
         host.ensure_exists()


### PR DESCRIPTION
Added a test to check if ipa host-find --pkey-only 
does not return SSH public key

It check if 'SSH public key fingerprint' is
not present in the output of the command

Pagure Link : https://pagure.io/freeipa/issue/8029

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>