### PR TITLE
Removed hard-coded default profile subsystem class name

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -386,15 +386,34 @@ def ca_enable_ldap_profile_subsystem(ca):
     needs_update = False
     directive = None
     try:
-        for i in range(15):
+        i = 0
+        while True:
+            # find profile subsystem
+            directive = "subsystem.{}.id".format(i)
+            value = directivesetter.get_directive(
+                paths.CA_CS_CFG_PATH,
+                directive,
+                separator='=')
+            if not value:
+                logger.error('Unable to find profile subsystem in %s',
+                             paths.CA_CS_CFG_PATH)
+                return False
+            if value != 'profile':
+                i = i + 1
+                continue
+
+            # check profile subsystem class name
             directive = "subsystem.{}.class".format(i)
             value = directivesetter.get_directive(
                 paths.CA_CS_CFG_PATH,
                 directive,
                 separator='=')
-            if value == 'com.netscape.cmscore.profile.ProfileSubsystem':
+            if value != 'com.netscape.cmscore.profile.LDAPProfileSubsystem':
                 needs_update = True
-                break
+
+            # break after finding profile subsystem
+            break
+
     except OSError as e:
         logger.error('Cannot read CA configuration file "%s": %s',
                      paths.CA_CS_CFG_PATH, e)


### PR DESCRIPTION
Previously in order to enable the LDAP profile subsystem
the ca_enable_ldap_profile_subsystem() would check the
current value of the profile subsystem class parameter in
CS.cfg. If the parameter was still set to the default value
(i.e. ProfileSubsystem), the code would change it to
LDAPProfileSubsystem.

There is a effort in PKI to clean up the profile subsystem
classes which may require changing the default value for
this parameter. However, this improvement is blocked since
the ca_enable_ldap_profile_subsystem() is implicitly assuming
that the default value will always be ProfileSubsystem.

This patch updated the code such that instead of checking
for a specific value that needs to be changed, it will check
whether it has the desired value already. This mechanism
will reduce potential conflicts with future PKI improvements.