### PR TITLE
ipatests: Test for ipa-extdom-extop plugin should allow @ in group name

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1407,7 +1407,7 @@ jobs:
         test_suite: test_integration/test_sssd.py
         template: *ci-master-latest
         timeout: 4800
-        topology: *ad_master
+        topology: *ad_master_2client
 
   fedora-latest/test_ca_custom_sdn:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1504,7 +1504,7 @@ jobs:
         test_suite: test_integration/test_sssd.py
         template: *testing-master-latest
         timeout: 4800
-        topology: *ad_master
+        topology: *ad_master_2client
 
   testing-fedora/test_ca_custom_sdn:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1383,7 +1383,7 @@ jobs:
         test_suite: test_integration/test_sssd.py
         template: *ci-master-previous
         timeout: 4800
-        topology: *ad_master
+        topology: *ad_master_2client
 
   fedora-previous/test_ca_custom_sdn:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1518,7 +1518,7 @@ jobs:
         test_suite: test_integration/test_sssd.py
         template: *ci-master-frawhide
         timeout: 4800
-        topology: *ad_master
+        topology: *ad_master_2client
 
   fedora-rawhide/test_ca_custom_sdn:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
ipatests: Test for ipa-extdom-extop plugin should allow @ in group name
integration test for : https://bugzilla.redhat.com/show_bug.cgi?id=1746951
