### PR TITLE
[ACME] Add ipa-ca.$DOMAIN alias to IPA server HTTP certificates

### DIFF
--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -479,7 +479,7 @@ def request_cert(
 def start_tracking(
         certpath, ca='IPA', nickname=None, pin=None, pinfile=None,
         pre_command=None, post_command=None, profile=None, storage="NSSDB",
-        token_name=None):
+        token_name=None, dns=None):
     """
     Tell certmonger to track the given certificate in either a file or an NSS
     database. The certificate access can be protected by a password_file.
@@ -514,6 +514,8 @@ def start_tracking(
         Which certificate profile should be used.
     :param token_name:
         Hardware token name for HSM support
+    :param dns:
+        List of DNS names
     :returns: certificate tracking nickname.
     """
     if storage == 'FILE':
@@ -558,6 +560,8 @@ def start_tracking(
         # only pass token names for external tokens (e.g. HSM)
         params['key-token'] = token_name
         params['cert-token'] = token_name
+    if dns is not None and len(dns) > 0:
+        params['DNS'] = dns
 
     result = cm.obj_if.add_request(params)
     try:

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -47,6 +47,29 @@ DBUS_CM_CA_IF = 'org.fedorahosted.certmonger.ca'
 DBUS_PROPERTY_IF = 'org.freedesktop.DBus.Properties'
 
 
+"""
+Certmonger helper routines.
+
+Search criteria
+---------------
+
+Functions that look up requests take a ``dict`` of search criteria.
+In general, the key is a name of a property in the request property
+interface.  But there are some special cases with different
+behaviour:
+
+``nickname``
+  a.k.a. "request ID".  If given, only the specified request is
+  retrieved (if it exists), and it is still tested against other
+  criteria.
+
+``ca-name``
+  Test equality against the nickname of the CA (a.k.a. request
+  helper) object for the request.
+
+"""
+
+
 class _cm_dbus_object:
     """
     Auxiliary class for convenient DBus object handling.
@@ -159,6 +182,9 @@ class _certmonger(_cm_dbus_object):
 def _get_requests(criteria):
     """
     Get all requests that matches the provided criteria.
+
+    :param criteria: dict of criteria; see module doc for details
+
     """
     if not isinstance(criteria, dict):
         raise TypeError('"criteria" must be dict.')
@@ -197,11 +223,11 @@ def _get_requests(criteria):
 
 def _get_request(criteria):
     """
-    Find request that matches criteria.
-    If 'nickname' is specified other criteria are ignored because 'nickname'
-    uniquely identify single request.
-    When multiple or none request matches specified criteria RuntimeError is
-    raised.
+    Find request that matches criteria.  Return ``None`` if no match.
+    Raise ``RuntimeError`` if there is more than one matching request.
+
+    :param criteria: dict of criteria; see module doc for details
+
     """
     requests = _get_requests(criteria)
     if len(requests) == 0:
@@ -239,11 +265,11 @@ def get_request_id(criteria):
     If you don't know the certmonger request_id then try to find it by looking
     through all the requests.
 
-    criteria is a tuple of key/value to search for. The more specific
-    the better. An error is raised if multiple request_ids are returned for
-    the same criteria.
+    Return ``None`` if no match.  Raise ``RuntimeError`` if there is
+    more than one matching request.
 
-    None is returned if none of the criteria match.
+    :param criteria: dict of criteria; see module doc for details
+
     """
     try:
         request = _get_request(criteria)

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -156,7 +156,7 @@ class _certmonger(_cm_dbus_object):
                                           DBUS_CM_IF)
 
 
-def _get_requests(criteria=dict()):
+def _get_requests(criteria):
     """
     Get all requests that matches the provided criteria.
     """

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -44,7 +44,7 @@ from ipapython.dn import DN
 import ipapython.errors
 from ipaserver.install import sysupgrade
 from ipalib import api, x509
-from ipalib.constants import IPAAPI_USER, MOD_SSL_VERIFY_DEPTH
+from ipalib.constants import IPAAPI_USER, MOD_SSL_VERIFY_DEPTH, IPA_CA_RECORD
 from ipaplatform.constants import constants
 from ipaplatform.tasks import tasks
 from ipaplatform.paths import paths
@@ -593,6 +593,7 @@ class HTTPInstance(service.Service):
                 post_command='restart_httpd', storage='FILE',
                 profile=dogtag.DEFAULT_PROFILE,
                 pinfile=key_passwd_file,
+                dns=[self.fqdn, f'{IPA_CA_RECORD}.{api.env.domain}'],
             )
             subject = str(DN(cert.subject))
             certmonger.add_principal(request_id, self.principal)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -381,7 +381,7 @@ class HTTPInstance(service.Service):
                     subject=str(DN(('CN', self.fqdn), self.subject_base)),
                     ca='IPA',
                     profile=dogtag.DEFAULT_PROFILE,
-                    dns=[self.fqdn],
+                    dns=[self.fqdn, f'{IPA_CA_RECORD}.{api.env.domain}'],
                     post_command='restart_httpd',
                     storage='FILE',
                     passwd_fname=key_passwd_file,

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -13,6 +13,7 @@ import glob
 import shutil
 import pwd
 import fileinput
+import ssl
 import stat
 import sys
 import tempfile
@@ -21,7 +22,7 @@ from augeas import Augeas
 import dns.exception
 
 from ipalib import api, x509
-from ipalib.constants import RENEWAL_CA_NAME, RA_AGENT_PROFILE
+from ipalib.constants import RENEWAL_CA_NAME, RA_AGENT_PROFILE, IPA_CA_RECORD
 from ipalib.install import certmonger, sysrestore
 import SSSDConfig
 import ipalib.util
@@ -1100,6 +1101,10 @@ def certificate_renewal_update(ca, kra, ds, http):
                 'key-file': paths.HTTPD_KEY_FILE,
                 'ca-name': 'IPA',
                 'cert-postsave-command': template % 'restart_httpd',
+                'template-hostname': [
+                    http.fqdn,
+                    f'{IPA_CA_RECORD}.{ipautil.format_netloc(api.env.domain)}',
+                ],
             }
         )
 
@@ -1180,6 +1185,58 @@ def certificate_renewal_update(ca, kra, ds, http):
 
     logger.info("Certmonger certificate renewal configuration updated")
     return True
+
+
+def http_certificate_ensure_ipa_ca_dnsname(http):
+    """
+    Ensure the HTTP service certificate has the ipa-ca.$DOMAIN SAN dNSName.
+
+    This subroutine should be executed *after* ``certificate_renewal_update``,
+    which adds the name to the tracking request.  It assumes that the tracking
+    request already has the ipa-ca.$DOMAIN DNS name set, and all that is needed
+    is to resubmit the request.
+
+    If HTTP certificate is issued by a third party, print manual remediation
+    steps.
+
+    """
+    logger.info('[Adding ipa-ca alias to HTTP certificate]')
+
+    expect = f'{IPA_CA_RECORD}.{ipautil.format_netloc(api.env.domain)}'
+    cert = x509.load_certificate_from_file(paths.HTTPD_CERT_FILE)
+
+    try:
+        cert.match_hostname(expect)
+    except ssl.SSLCertVerificationError:
+        if certs.is_ipa_issued_cert(api, cert):
+            request_id = certmonger.get_request_id(
+                {'cert-file': paths.HTTPD_CERT_FILE})
+            if request_id is None:
+                # shouldn't happen
+                logger.error('Could not find HTTP cert tracking request.')
+            else:
+                logger.info('Resubmitting HTTP cert tracking request')
+                certmonger.resubmit_request(request_id)
+                # NOTE: due to https://pagure.io/certmonger/issue/143, the
+                # resubmitted request, if it does not immediately succeed
+                # (fairly likely during ipa-server-upgrade) and if the notAfter
+                # date of the current cert is still far off (also likely), then
+                # Certmonger will wait 7 days before trying again (unless
+                # restarted).  There is not much we can do about that here, in
+                # the middle of ipa-server-upgrade.
+        else:
+            logger.error('HTTP certificate is issued by third party.')
+            logger.error(
+                'Obtain a new certificate with the following DNS names, \n'
+                'and install via ipa-server-certinstall(1):\n'
+                ' - %s\n'
+                ' - %s',
+                http.fqdn,
+                expect,
+            )
+    else:
+        logger.info('Certificate is OK; nothing to do')
+
 
 def copy_crl_file(old_path, new_path=None):
     """
@@ -2209,6 +2266,10 @@ def upgrade_configuration():
     setup_spake(krb)
     setup_pkinit(krb)
     enable_server_snippet()
+
+    # Must be executed after certificate_renewal_update
+    # (see function docstring for details)
+    http_certificate_ensure_ipa_ca_dnsname(http)
 
     if not ds_running:
         ds.stop(ds.serverid)

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 
 import pytest
 from cryptography.hazmat.primitives import hashes
+from cryptography import x509 as crypto_x509
 
 from ipalib import x509
 from ipalib.constants import DOMAIN_LEVEL_0
@@ -716,6 +717,17 @@ class TestInstallMaster(IntegrationTest):
             else:
                 assert key_size == 2048
             assert cert.signature_hash_algorithm.name == hashes.SHA256.name
+
+    def test_http_cert(self):
+        """
+        Test that HTTP certificate contains ipa-ca.$DOMAIN
+        DNS name.
+
+        """
+        data = self.master.get_file_contents(paths.HTTPD_CERT_FILE)
+        cert = x509.load_pem_x509_certificate(data)
+        name = f'ipa-ca.{self.master.domain.name}'
+        assert crypto_x509.DNSName(name) in cert.san_general_names
 
     def test_p11_kit_softhsm2(self):
         # check that p11-kit-proxy does not inject SoftHSM2


### PR DESCRIPTION
First PR for the ACME effort.  This is needed so ACME clients can reach IPA
ACME service via the ``ipa-ca.$DOMAIN`` DNS name (ACME requires TLS).

This change is also reasonable, independent of the ACME effort.

https://pagure.io/freeipa/issue/8186

```
83a5a3aa6 (Fraser Tweedale, 11 hours ago)
   upgrade: add ipa-ca.$DOMAIN alias to HTTP certificate

   If the HTTP certificate does not have the ipa-ca.$DOMAIN dNSName, resubmit
   the certificate request to add the name.  This action is performed after
   the tracking request has already been updated.

   Note: due to https://pagure.io/certmonger/issue/143 the resubmitted 
   request, if it does not immediately succeed and if the notAfter date of the
   current certificate is still far off, the request could get stuck in state
   CA_UNREACHABLE until a Certmonger restart.  There is not much we can do
   about that in the middle of ipa-server-upgrade.

   Part of: https://pagure.io/freeipa/issue/8186

efe071539 (Fraser Tweedale, 12 hours ago)
   httpinstance: add ipa-ca.$DOMAIN alias in initial request

   For new server/replica installation, issue the HTTP server certificate with
   the 'ipa-ca.$DOMAIN' SAN dNSName.  This is accomplished by adding the name
   to the Certmonger tracking request.

   Part of: https://pagure.io/freeipa/issue/8186

feea49420 (Fraser Tweedale, 3 days ago)
   cert-request: allow ipa-ca.$DOMAIN dNSName for IPA servers

   ACME support requires TLS and we want ACME clients to access the service
   via the ipa-ca.$DOMAIN DNS name.  So we need to add the ipa-ca.$DOMAIN
   dNSName to IPA servers' HTTP certificates.  To facilitiate this, add a
   special case to the cert-request command processing.  The rule is:

   - if the dnsName being validated is "ipa-ca.$DOMAIN"
   - and the subject principal is an "HTTP/..." service
   - and the subject principal's hostname is an IPA server

   Then that name (i.e. "ipa-ca.$DOMAIN") is immediately allowed. Otherwise
   continue with the usual dnsName validation.

   Part of: https://pagure.io/freeipa/issue/8186

62129a44a (Fraser Tweedale, 3 days ago)
   httpinstance: add fqdn and ipa-ca alias to Certmonger request

   When (re-)tracking the HTTP certificate, explicitly add the server FQDN and
   ipa-ca.$DOMAIN DNS names to the Certmonger tracking request.

   Part of: https://pagure.io/freeipa/issue/8186

fe3489cf4 (Fraser Tweedale, 4 days ago)
   certmonger: support dnsname as request search criterion

   We need to be able to filter Certmonger tracking requests by the DNS names
   defined for the request.  The goal is to add the
   'ipa-ca.$DOMAIN' alias to the HTTP certificate tracking requests, so we
   will use that name as a search criterion.  Implement support for this.

   As a result of this commit it will be easy to add support for subset match
   of other Certmonger request list properties.  Just add the property name to
   the ARRAY_PROPERTIES list (and update the
   'criteria' description in the module docstring!)

   Part of: https://pagure.io/freeipa/issue/8186

ea6d31bdf (Fraser Tweedale, 4 days ago)
   certmonger: move 'criteria' description to module docstring

   The 'criteria' parameter is used by several subroutines in the 
   ipalib.install.certmonger module.  It has incomplete documentation spread
   across several of these subroutines.  Move the documentation to the module
   docstring and reference it where appropriate.

   Part of: https://pagure.io/freeipa/issue/8186

aa7b88ad6 (Fraser Tweedale, 4 days ago)
   certmonger: avoid mutable default argument

   certmonger._get_requests has a mutable default argument.  Although at the
   present time it is never modified, this is an antipattern to be avoided.

   Part of: https://pagure.io/freeipa/issue/8186
```