### PR TITLE
[ipa-4-8] prci: Bump template version

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f30
           name: freeipa/ci-ipa-4-8-f30
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-8.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8.yaml
@@ -47,7 +47,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f30
           name: freeipa/ci-ipa-4-8-f30
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -53,7 +53,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f30
           name: freeipa/ci-ipa-4-8-f30
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
This new image has SELinux enabled in permissive mode. After this all tests skipped because SELinux was disabled will be executed again.

Signed-off-by: Armando Neto <abiagion@redhat.com>