### PR TITLE
Adding back temp config definition removed

### DIFF
--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -56,3 +56,15 @@ jobs:
           version: 0.0.2
         timeout: 1800
         topology: *build
+
+  fedora-latest/temp_commit:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_REPLACEME.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl_1client


### PR DESCRIPTION
fedora-latest/temp_commit section was removed from
temp_commit.yaml file while working with PR4108, adding it back.