### PR TITLE
[Backport][ipa-4-7] WebUI tests: Fix broken reference to parent facet in table record check

### DIFF
--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -136,6 +136,23 @@ def dismiss_unexpected_alert(fn):
     return wrapped
 
 
+def repeat_on_stale_parent_reference(fn):
+    """
+    The decorator repeats a function once when StaleElementReferenceException
+    is caught.
+    It is not applicable if a parent reference is created outside a function.
+    """
+    @wraps(fn)
+    def wrapped(*args, **kwargs):
+        if ('parent' in kwargs) and kwargs['parent'] is None:
+            try:
+                return fn(*args, **kwargs)
+            except StaleElementReferenceException:
+                pass
+        return fn(*args, **kwargs)
+    return wrapped
+
+
 class UI_driver(object):
     """
     Base class for all UI integration tests
@@ -1183,6 +1200,7 @@ class UI_driver(object):
             val = el.text
         return val
 
+    @repeat_on_stale_parent_reference
     def has_record(self, pkey, parent=None, table_name=None):
         """
         Check if table contains specific record.


### PR DESCRIPTION
Manual backport of https://github.com/freeipa/freeipa/pull/4192

Add decorator to has_record method which repeats the check when an active facet is changed
(catch StaleElementReferenceException).

Ticket: https://pagure.io/freeipa/issue/8157