### PR TITLE
ipatests: add test_trust suite to nightly runs

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -35,6 +35,10 @@ topologies:
     name: ad_master
     cpu: 4
     memory: 12000
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14500
 
 jobs:
   fedora-latest/build:
@@ -1456,3 +1460,15 @@ jobs:
         template: *ci-master-latest
         timeout: 4800
         topology: *ad_master
+
+  fedora-latest/test_trust:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_trust.py
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -35,6 +35,10 @@ topologies:
     name: ad_master
     cpu: 4
     memory: 12000
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14500
 
 jobs:
   testing-fedora/build:
@@ -1557,3 +1561,16 @@ jobs:
         template: *testing-master-latest
         timeout: 4800
         topology: *ad_master
+
+  testing-fedora/test_trust:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_trust.py
+        template: *testing-master-latest
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -35,6 +35,10 @@ topologies:
     name: ad_master
     cpu: 4
     memory: 12000
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14500
 
 jobs:
   fedora-previous/build:
@@ -1432,3 +1436,15 @@ jobs:
         template: *ci-master-previous
         timeout: 4800
         topology: *ad_master
+
+  fedora-previous/test_trust:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_trust.py
+        template: *ci-master-previous
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -35,6 +35,10 @@ topologies:
     name: ad_master
     cpu: 4
     memory: 12000
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14500
 
 jobs:
   fedora-rawhide/build:
@@ -1571,3 +1575,16 @@ jobs:
         template: *ci-master-frawhide
         timeout: 4800
         topology: *ad_master
+
+  fedora-rawhide/test_trust:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_trust.py
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -41,6 +41,10 @@ topologies:
     name: ad_master
     cpu: 4
     memory: 12000
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14500
 
 jobs:
   fedora-latest/build:


### PR DESCRIPTION
The test suite test_trust was missing in nightly definitions
because PR-CI was not able to provision multi-AD topology.
Now that PR-CI is updated, we can start executing this test suite.
It is not reasonable to add it to gating as this suite is
time consuming like other tests requiring provisioning of AD instances.
