### PR TITLE
[Backport][ipa-4-8] ipatests: add test_trust suite to nightly runs

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8.yaml
@@ -35,6 +35,10 @@ topologies:
     name: ad_master
     cpu: 4
     memory: 12000
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14500
 
 jobs:
   fedora-30/build:
@@ -1456,3 +1460,15 @@ jobs:
         template: *ci-master-f30
         timeout: 4800
         topology: *ad_master
+
+  fedora-30/test_trust:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_trust.py
+        template: *ci-master-f30
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -41,6 +41,10 @@ topologies:
     name: ad_master
     cpu: 4
     memory: 12000
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14500
 
 jobs:
   fedora-30/build:


### PR DESCRIPTION
This is a manual backport of #4208 

The test suite test_trust was missing in nightly definitions
because PR-CI was not able to provision multi-AD topology.
Now that PR-CI is updated, we can start executing this test suite.
It is not reasonable to add it to gating as this suite is
time consuming like other tests requiring provisioning of AD instances.