### PR TITLE
[Backport][ipa-4-7] ipatests: add test_trust suite to nightly runs

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-7.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-7.yaml
@@ -31,6 +31,10 @@ topologies:
    name: ad_master
    cpu: 4
    memory: 12000
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14500
 
 jobs:
   fedora-29/build:
@@ -1308,3 +1312,15 @@ jobs:
         template: *ci-master-f29
         timeout: 4800
         topology: *ad_master
+
+  fedora-29/test_trust:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_trust.py
+        template: *ci-master-f29
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -41,6 +41,10 @@ topologies:
    name: ad_master
    cpu: 4
    memory: 12000
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14500
 
 jobs:
   fedora-29/build:


### PR DESCRIPTION
This is a manual backport of #4208

The test suite test_trust was missing in nightly definitions
because PR-CI was not able to provision multi-AD topology.
Now that PR-CI is updated, we can start executing this test suite.
It is not reasonable to add it to gating as this suite is
time consuming like other tests requiring provisioning of AD instances.