### PR TITLE
[Backport][ipa-4-6] ipatests: add test_trust suite to nightly runs

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -35,6 +35,10 @@ topologies:
     name: ad_master_2client
     cpu: 4
     memory: 12000
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14500
 
 jobs:
   fedora-27/build:
@@ -1119,3 +1123,14 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-27/test_trust:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_trust.py
+        template: *ci-master-f27
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -41,6 +41,11 @@ topologies:
    name: ad_master
    cpu: 4
    memory: 12000
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14500
+
 
 jobs:
   fedora-27/build:

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1625,7 +1625,7 @@ def ldappasswd_user_change(user, oldpw, newpw, master):
     master_ldap_uri = "ldap://{}".format(master.hostname)
 
     args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
-            '-s', newpw, '-x', '-H', master_ldap_uri]
+            '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
     master.run_command(args)
 
 

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -638,8 +638,9 @@ class TestTrust(IntegrationTest):
                  '--admin', 'Administrator', '--password'], raiseonerr=False,
                 stdin_text=self.master.config.ad_admin_password)
             assert result.returncode == 1
-            assert 'CIFS server communication error: code "3221225653", ' \
-                   'message "{Device Timeout}' in result.stderr_text
+            assert re.search(
+                'CIFS server communication error:.+message "{Device Timeout}',
+                result.stderr_text)
 
             # Check that trust is successfully established with --server option
             tasks.establish_trust_with_ad(

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -635,7 +635,8 @@ class TestTrust(IntegrationTest):
             # This checks that our setup is correct
             result = self.master.run_command(
                 ['ipa', 'trust-add', self.ad.domain.name,
-                 '--admin', 'Administrator', '--password'], raiseonerr=False)
+                 '--admin', 'Administrator', '--password'], raiseonerr=False,
+                stdin_text=self.master.config.ad_admin_password)
             assert result.returncode == 1
             assert 'CIFS server communication error: code "3221225653", ' \
                    'message "{Device Timeout}' in result.stderr_text


### PR DESCRIPTION
The test suite test_trust was missing in nightly definitions
because PR-CI was not able to provision multi-AD topology.
Now that PR-CI is updated, we can start executing this test suite.
It is not reasonable to add it to gating as this suite is
time consuming like other tests requiring provisioning of AD instances.

This PR brings backports and fixes for the test_trust suite:
* use TLS connection for LDAP
* provide AD admin password when trying to establish trust with unreachable AD DC
* adapt expected error message from `ipa trust-add` when trying to establish trust with unreachable AD DC
* Add workaround for known bug in SSSD

