### PR TITLE
ipa-client-automount: call save_domain() for each change

### DIFF
--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -355,9 +355,10 @@ def uninstall(fstore, statestore):
                         continue
                     if provider == "ipa":
                         domain.remove_option('ipa_automount_location')
+                        sssdconfig.save_domain(domain)
                         domain.remove_provider('autofs')
+                        sssdconfig.save_domain(domain)
                         break
-                sssdconfig.save_domain(domain)
                 sssdconfig.write(paths.SSSD_CONF)
                 sssd = services.service('sssd', api)
                 sssd.restart()

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -327,6 +327,20 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
             "ipa-client-automount", "--uninstall", "-U"
         ])
 
+        if not no_sssd:
+            # https://pagure.io/freeipa/issue/8190
+            # check that no ipa_automount_location is left in sssd.conf
+            # also check for autofs_provider for good measure
+            grep_automount_in_sssdconf_cmd = \
+                "egrep ipa_automount_location\\|autofs_provider " \
+                "/etc/sssd/sssd.conf"
+            cmd = self.clients[0].run_command(
+                grep_automount_in_sssdconf_cmd, raiseonerr=False
+            )
+            assert cmd.returncode == 1, \
+                "PG8190 regression found: ipa_automount_location still " \
+                "present in sssd.conf"
+
         cmd = self.clients[0].run_command(grep_automount_command)
         assert cmd.stdout_text.split() == after_ipa_client_install
 


### PR DESCRIPTION
Call sssdconfig.save_domain(domain) after each configuration
change during ipa-client-automount --uninstall.
    
Previously, sssdconfig.save_domain(domain) was called only
outside of the domain detection loop which changed the domain
configuration. This introduced issues as this method's behavior
is only consistent when configuration items are removed in a
certain order: https://pagure.io/SSSD/sssd/issue/4149
Plus, it is more correct to save the configuration from within
the loop if ever we support multiple domains.
    
Fixes: https://pagure.io/freeipa/issue/8190
Signed-off-by: François Cami <fcami@redhat.com>
