### PR TITLE
adtrust: print DNS records for external DNS case after role is enabled

### DIFF
--- a/install/tools/ipa-adtrust-install.in
+++ b/install/tools/ipa-adtrust-install.in
@@ -214,7 +214,13 @@ def main():
 
     # Enable configured services and update DNS SRV records
     service.sync_services_state(api.env.host)
-    api.Command.dns_update_system_records()
+
+    dns_help = adtrust.generate_dns_service_records_help(api)
+    if dns_help:
+        for line in dns_help:
+            service.print_msg(line, sys.stdout)
+    else:
+        api.Command.dns_update_system_records()
 
     print("""
 =============================================================================

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -984,6 +984,12 @@ def install(installer):
     service.enable_services(host_name)
     api.Command.dns_update_system_records()
 
+    if options.setup_adtrust:
+        dns_help = adtrust.generate_dns_service_records_help(api)
+        if dns_help:
+            for line in dns_help:
+                service.print_msg(line, sys.stdout)
+
     if not options.setup_dns:
         # After DNS and AD trust are configured and services are
         # enabled, create a dummy instance to dump DNS configuration.

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1351,6 +1351,12 @@ def install(installer):
     # enabled-service case, also perform update in hidden replica case.
     api.Command.dns_update_system_records()
 
+    if options.setup_adtrust:
+        dns_help = adtrust.generate_dns_service_records_help(api)
+        if dns_help:
+            for line in dns_help:
+                service.print_msg(line, sys.stdout)
+
     ca_servers = find_providing_servers('CA', api.Backend.ldap2, api=api)
     api.Backend.ldap2.disconnect()
 


### PR DESCRIPTION
We cannot gather information about required DNS records before "ADTrust
Controller" role is enabled on this server. As result, we need to call
the step to add DNS records after the role was enabled.

Fixes: https://pagure.io/freeipa/issue/8192
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>