### PR TITLE
Remove dependency on custodia package

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -418,7 +418,6 @@ BuildArch: noarch
 Requires: %{name}-client-common = %{version}-%{release}
 Requires: httpd >= %{httpd_version}
 Requires: systemd-units >= 38
-Requires: custodia >= 0.3.1
 
 Provides: %{alt_name}-server-common = %{version}
 Conflicts: %{alt_name}-server-common


### PR DESCRIPTION
ipa-server no longer use any files and features from the custodia
package. The python3-custodia package provides all Custodia features for
ipa-custodia.service.

Signed-off-by: Christian Heimes <cheimes@redhat.com>