### PR TITLE
[Backport][ipa-4-8] adtrust: print DNS records for external DNS case after role is enabled

### DIFF
--- a/install/tools/ipa-adtrust-install.in
+++ b/install/tools/ipa-adtrust-install.in
@@ -214,7 +214,13 @@ def main():
 
     # Enable configured services and update DNS SRV records
     service.sync_services_state(api.env.host)
-    api.Command.dns_update_system_records()
+
+    dns_help = adtrust.generate_dns_service_records_help(api)
+    if dns_help:
+        for line in dns_help:
+            service.print_msg(line, sys.stdout)
+    else:
+        api.Command.dns_update_system_records()
 
     print("""
 =============================================================================

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -984,6 +984,12 @@ def install(installer):
     service.enable_services(host_name)
     api.Command.dns_update_system_records()
 
+    if options.setup_adtrust:
+        dns_help = adtrust.generate_dns_service_records_help(api)
+        if dns_help:
+            for line in dns_help:
+                service.print_msg(line, sys.stdout)
+
     if not options.setup_dns:
         # After DNS and AD trust are configured and services are
         # enabled, create a dummy instance to dump DNS configuration.

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1351,6 +1351,12 @@ def install(installer):
     # enabled-service case, also perform update in hidden replica case.
     api.Command.dns_update_system_records()
 
+    if options.setup_adtrust:
+        dns_help = adtrust.generate_dns_service_records_help(api)
+        if dns_help:
+            for line in dns_help:
+                service.print_msg(line, sys.stdout)
+
     ca_servers = find_providing_servers('CA', api.Backend.ldap2, api=api)
     api.Backend.ldap2.disconnect()
 


### PR DESCRIPTION
This PR was opened automatically because PR #4221 was pushed to master and backport to ipa-4-8 is required.