### PR TITLE
[Backport][ipa-4-8] ipatests: Allow zero-length arguments

### DIFF
--- a/ipatests/ipa-run-tests
+++ b/ipatests/ipa-run-tests
@@ -60,7 +60,10 @@ pyt_args = [sys.executable, "-c",
             "import sys,pytest;sys.exit(pytest.main())"] + sys.argv[1:]
 # shell is needed to perform globbing
 sh_args = ["/bin/sh", "--norc", "--noprofile", "-c", "--"]
-pyt_args_esc = ["'{}'".format(x) if " " in x else x for x in pyt_args]
+pyt_args_esc = [
+    f"'{x}'" if not x or " " in x else x
+    for x in pyt_args
+]
 args = sh_args + [" ".join(pyt_args_esc)]
 os.chdir(HERE)
 sys.stdout.flush()

--- a/ipatests/test_ipatests_plugins/test_ipa_run_tests.py
+++ b/ipatests/test_ipatests_plugins/test_ipa_run_tests.py
@@ -109,6 +109,20 @@ def test_ipa_run_tests_expression(ipatestdir, expr):
             func=FUNC_NAME.format(mod_num))])
 
 
+def test_ipa_run_tests_empty_expression(ipatestdir):
+    """
+    Run ipa-run-tests using an empty expression.
+    Expected result: all tests should pass.
+    """
+    result = ipatestdir.run_ipa_tests('-k', '')
+    assert result.ret == 0
+    result.assert_outcomes(passed=5)
+    for mod_num in range(0, MODS_NUM):
+        result.stdout.fnmatch_lines(["*{mod}.py::{func} PASSED*".format(
+            mod=MOD_NAME.format(mod_num),
+            func=FUNC_NAME.format(mod_num))])
+
+
 def test_ipa_run_tests_ignore_basic(ipatestdir):
     """
     Run ipa-run-tests ignoring one test module


### PR DESCRIPTION
This PR was opened automatically because PR #4149 was pushed to master and backport to ipa-4-8 is required.