### PR TITLE
[Backport][ipa-4-8] ipa-client-automount: call save_domain() for each change

### DIFF
--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -355,9 +355,10 @@ def uninstall(fstore, statestore):
                         continue
                     if provider == "ipa":
                         domain.remove_option('ipa_automount_location')
+                        sssdconfig.save_domain(domain)
                         domain.remove_provider('autofs')
+                        sssdconfig.save_domain(domain)
                         break
-                sssdconfig.save_domain(domain)
                 sssdconfig.write(paths.SSSD_CONF)
                 sssd = services.service('sssd', api)
                 sssd.restart()

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -332,6 +332,20 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
             "ipa-client-automount", "--uninstall", "-U"
         ])
 
+        if not no_sssd:
+            # https://pagure.io/freeipa/issue/8190
+            # check that no ipa_automount_location is left in sssd.conf
+            # also check for autofs_provider for good measure
+            grep_automount_in_sssdconf_cmd = \
+                "egrep ipa_automount_location\\|autofs_provider " \
+                "/etc/sssd/sssd.conf"
+            cmd = self.clients[0].run_command(
+                grep_automount_in_sssdconf_cmd, raiseonerr=False
+            )
+            assert cmd.returncode == 1, \
+                "PG8190 regression found: ipa_automount_location still " \
+                "present in sssd.conf"
+
         cmd = self.clients[0].run_command(grep_automount_command)
         assert cmd.stdout_text.split() == after_ipa_client_install
 


### PR DESCRIPTION
This PR was opened automatically because PR #4212 was pushed to master and backport to ipa-4-8 is required.