### PR TITLE
[Backport][ipa-4-8] Remove dependency on custodia package

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -418,7 +418,6 @@ BuildArch: noarch
 Requires: %{name}-client-common = %{version}-%{release}
 Requires: httpd >= %{httpd_version}
 Requires: systemd-units >= 38
-Requires: custodia >= 0.3.1
 
 Provides: %{alt_name}-server-common = %{version}
 Conflicts: %{alt_name}-server-common


### PR DESCRIPTION
This PR was opened automatically because PR #4235 was pushed to master and backport to ipa-4-8 is required.