### PR TITLE
kdb: make sure audit_as_req callback signature change is preserved

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.h
+++ b/daemons/ipa-kdb/ipa_kdb.h
@@ -345,7 +345,7 @@ krb5_error_code ipadb_check_allowed_to_delegate(krb5_context kcontext,
 
 void ipadb_audit_as_req(krb5_context kcontext,
                         krb5_kdc_req *request,
-#if (KRB5_KDB_DAL_MAJOR_VERSION == 7)
+#if (KRB5_KDB_DAL_MAJOR_VERSION >= 7)
                         const krb5_address *local_addr,
                         const krb5_address *remote_addr,
 #endif

--- a/daemons/ipa-kdb/ipa_kdb_audit_as.c
+++ b/daemons/ipa-kdb/ipa_kdb_audit_as.c
@@ -25,7 +25,7 @@
 
 void ipadb_audit_as_req(krb5_context kcontext,
                         krb5_kdc_req *request,
-#if (KRB5_KDB_DAL_MAJOR_VERSION == 7)
+#if (KRB5_KDB_DAL_MAJOR_VERSION >= 7)
                         const krb5_address *local_addr,
                         const krb5_address *remote_addr,
 #endif

--- a/ipatests/azure/templates/prepare-build.yml
+++ b/ipatests/azure/templates/prepare-build.yml
@@ -13,6 +13,7 @@ steps:
     for metalink in $(sudo dnf repolist -v |grep Repo-metalink | awk '{print $2}' ) ; do echo '###############' ; echo '####' ; echo $metalink ; echo '####' ; curl $metalink ; done
     echo "Fastestmirror results:"
     sudo cat /var/cache/dnf/fastestmirror.cache
+    sudo dnf -y module enable nodejs:12
     sudo dnf makecache || :
     echo "Installing base development environment"
     sudo dnf install -y \


### PR DESCRIPTION
audit_as_req() callback has changed its signature with MIT krb5 commit
20991d55efbe1f987c1dbc1065f2d58c8f34031b in 2017, we should preserve the
change for any newer DAL versions. Otherwise audit_as_req() callback
would reference wrong data and we might crash.

Fixes: https://pagure.io/freeipa/issue/8200
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>