### PR TITLE
Don't fully quality the FQDN in ssbrowser.html for Chrome

### DIFF
--- a/install/html/ssbrowser.html
+++ b/install/html/ssbrowser.html
@@ -105,7 +105,7 @@
                 Double-click the <code>network.negotiate-auth.trusted-uris</code> entry to display the Enter string value dialog box.
             </li>
             <li>
-                Enter the name of the domain against which you want to authenticate, for example, <code class="example-domain">.example.com.</code>
+                Enter the name of the domain against which you want to authenticate, for example, <code class="example-domain">.example.com</code>.
             </li>
             <li><a href="../ui/index.html" id="return-link" class="btn btn-default">Return to Web UI</a></li>
         </ol>
@@ -147,13 +147,13 @@
             <li>
                 Create a new <code>/etc/opt/chrome/policies/managed/mydomain.json</code> file with write privileges limited to the system administrator or root, and include the following line:
                 <div><code>
-                    { "AuthServerWhitelist": "*<span class="example-domain">.example.com.</span>" }
+                    { "AuthServerWhitelist": "*<span class="example-domain">.example.com</span>" }
                 </code></div>
                 <div>
                     You can do this by running:
                 </div>
                 <div><code>
-                    [root@server]# echo '{ "AuthServerWhitelist": "*<span class="example-domain">.example.com.</span>" }' > /etc/opt/chrome/policies/managed/mydomain.json
+                    [root@server]# echo '{ "AuthServerWhitelist": "*<span class="example-domain">.example.com</span>" }' > /etc/opt/chrome/policies/managed/mydomain.json
                 </code></div>
             </li>
         </ol>


### PR DESCRIPTION
The trailing dot causes it to not function as expected, remove
it from the example.

https://pagure.io/freeipa/issue/8201