### PR TITLE
ipatests: add test for warning text displayed after AD trust agents setup

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -263,3 +263,15 @@ jobs:
         timeout: 1800
         topology: *master_1repl
 
+  fedora-latest/test_adtrust_install:
+    requires: [fedora-latest/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_adtrust_install.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1484,3 +1484,15 @@ jobs:
         template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
+
+  fedora-latest/test_adtrust_install:
+    requires: [fedora-latest/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_adtrust_install.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1587,3 +1587,16 @@ jobs:
         template: *testing-master-latest
         timeout: 7200
         topology: *master_1repl
+
+  testing-fedora/test_adtrust_install:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_adtrust_install.py
+        template: *testing-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1460,3 +1460,15 @@ jobs:
         template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl
+
+  fedora-previous/test_adtrust_install:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_adtrust_install.py
+        template: *ci-master-previous
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1601,3 +1601,16 @@ jobs:
         template: *ci-master-frawhide
         timeout: 7200
         topology: *master_1repl
+
+  fedora-rawhide/test_adtrust_install:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_adtrust_install.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+
+"""This module provides tests for ipa-adtrust-install utility"""
+
+import re
+
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestIpaAdTrustInstall(IntegrationTest):
+    topology = 'line'
+    num_replicas = 1
+
+    def test_install_ad_trust_controller(self):
+        self.master.run_command(['ipa-adtrust-install', '-U'])
+
+    def test_warnings_after_ad_trust_agents_setup(self):
+        """ Check that warning about ipa and sssd restart is displayed.
+
+        Regression test for https://bugzilla.redhat.com/1782658
+        """
+        cmd_input = (
+            # admin password:
+            self.master.config.admin_password + '\n' +
+            # WARNING: The smb.conf already exists. Running ipa-adtrust-install
+            # will break your existing samba configuration.
+            # Do you wish to continue? [no]:
+            'yes\n'
+            # Enable trusted domains support in slapi-nis? [no]:
+            '\n' +
+            # Do you want to run the ipa-sidgen task? [no]:
+            '\n'+
+            # WARNING: 1 IPA masters are not yet able to serve information
+            # about users from trusted forests.
+            # Installer can add them to the list of IPA masters allowed to
+            # access information about trusts.
+            # If you choose to do so, you also need to restart LDAP service on
+            # those masters.
+            # Refer to ipa-adtrust-install(1) man page for details.
+            # IPA master[replica1.testrelm.test]?[no]:
+            'yes\n'
+        )
+        expected_re = '"ipactl restart".+"systemctl restart sssd"'
+        res = self.master.run_command(['ipa-adtrust-install', '--add-agents'],
+                                      stdin_text=cmd_input)
+        assert re.search(expected_re, res.stdout_text, re.DOTALL)

--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -13,8 +13,16 @@ class TestIpaAdTrustInstall(IntegrationTest):
     topology = 'line'
     num_replicas = 1
 
-    def test_install_ad_trust_controller(self):
-        self.master.run_command(['ipa-adtrust-install', '-U'])
+    def test_samba_config_file(self):
+        """Check that ipa-adtrust-install generates sane smb.conf
+
+        This is regression test for issue
+        https://pagure.io/freeipa/issue/6951
+        """
+        self.master.run_command(
+            ['ipa-adtrust-install', '-a', 'Secret123', '--add-sids', '-U'])
+        res = self.master.run_command(['testparm', '-s'])
+        assert 'ERROR' not in (res.stdout_text + res.stderr_text)
 
     def test_warnings_after_ad_trust_agents_setup(self):
         """ Check that warning about ipa and sssd restart is displayed.
@@ -30,8 +38,6 @@ class TestIpaAdTrustInstall(IntegrationTest):
             'yes\n'
             # Enable trusted domains support in slapi-nis? [no]:
             '\n' +
-            # Do you want to run the ipa-sidgen task? [no]:
-            '\n'+
             # WARNING: 1 IPA masters are not yet able to serve information
             # about users from trusted forests.
             # Installer can add them to the list of IPA masters allowed to

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -792,17 +792,6 @@ class TestIPACommand(IntegrationTest):
         assert is_tls_version_enabled('tls1_2')
         assert is_tls_version_enabled('tls1_3')
 
-    def test_samba_config_file(self):
-        """Check that ipa-adtrust-install generates sane smb.conf
-
-        This is regression test for issue
-        https://pagure.io/freeipa/issue/6951
-        """
-        self.master.run_command(
-            ['ipa-adtrust-install', '-a', 'Secret123', '--add-sids', '-U'])
-        res = self.master.run_command(['testparm', '-s'])
-        assert 'ERROR' not in (res.stdout_text + res.stderr_text)
-
     @pytest.mark.skip(reason='https://pagure.io/freeipa/issue/8151')
     def test_sss_ssh_authorizedkeys(self):
         """Login via Ssh using private-key for ipa-user should work.


### PR DESCRIPTION
This PR created new suite for testing ipa-adtrust-install utility.
It adds test for proper warning text after setting up AD trust agents and moves one existing from test_commands test suite.