### PR TITLE
[Backport][ipa-4-6] ipatests: SSSD should fetch external groups without any limit.

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1827,3 +1827,21 @@ def get_logsize(host, logfile):
     """ get current logsize"""
     logsize = len(host.get_file_contents(logfile))
     return logsize
+
+
+def ldapmodify_dm(host, ldif_text, **kwargs):
+    """Run ldapmodify as Directory Manager
+
+    :param host: host object
+    :param ldif_text: ldif string
+    :param kwargs: additional keyword arguments to run_command()
+    :return: result object
+    """
+    # no hard-coded hostname, let ldapmodify pick up the host from ldap.conf.
+    args = [
+        'ldapmodify',
+        '-x',
+        '-D', str(host.config.dirman_dn),  # pylint: disable=no-member
+        '-w', host.config.dirman_password
+    ]
+    return host.run_command(args, stdin_text=ldif_text, **kwargs)

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -14,6 +14,7 @@ import textwrap
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
+from ipaplatform.tasks import tasks as platform_tasks
 from ipaplatform.paths import paths
 from ipapython.dn import DN
 
@@ -124,6 +125,12 @@ class TestSSSDWithAdTrust(IntegrationTest):
         2: Run the command id aduser@ADDOMAIN.COM
         3: sssd should retrieve all the external groups.
         """
+        cmd = self.master.run_command(['sssd', '--version'])
+        sssd_version = platform_tasks.parse_ipa_version(
+            cmd.stdout_text.strip())
+        if sssd_version <= platform_tasks.parse_ipa_version('1.16.3'):
+            pytest.xfail("Fix for https://pagure.io/SSSD/sssd/issue/4058 "
+                         "unavailable with sssd-1.16.3")
         new_limit = 50
         master = self.master
         conn = master.ldap_connect()


### PR DESCRIPTION
This is manual back-port of : #4077