### PR TITLE
prci: bump version for latest and previous templates

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f31
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f31
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-previous
           name: freeipa/ci-master-f30
-          version: 0.0.6
+          version: 0.0.7
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,7 +57,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f31
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Packages updated in the new templates.

Boxes:
* https://app.vagrantup.com/freeipa/boxes/ci-master-f31/versions/0.0.4
* https://app.vagrantup.com/freeipa/boxes/ci-master-f30/versions/0.0.7

Signed-off-by: Armando Neto <abiagion@redhat.com>

--- 
This should fix `TestInstallCA::test_certmonger_reads_token_HSM` because latest version of `certmonger` is installed.