### PR TITLE
[ipa-4-8] prci: update fedora used for testing ipa-4-8

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -21,7 +21,7 @@ topologies:
     memory: 2400
 
 jobs:
-  fedora-30/build:
+  fedora-latest-ipa-4-8/build:
     requires: []
     priority: 150
     job:
@@ -29,248 +29,248 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-f30
-          name: freeipa/ci-ipa-4-8-f30
+        template: &ci-ipa-4-8-latest
+          name: freeipa/ci-ipa-4-8-f31
           version: 0.0.3
         timeout: 1800
         topology: *build
 
-  fedora-30/test_installation_TestInstallMaster:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_installation_TestInstallMaster:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMaster
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/simple_replication:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/simple_replication:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_simple_replication.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_caless_TestServerReplicaCALessToCAFull:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_caless_TestServerReplicaCALessToCAFull:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_external_ca_TestExternalCA:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_external_ca_TestExternalCA:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_external_ca_TestSelfExternalSelf:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_external_ca_TestSelfExternalSelf:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_templates:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/external_ca_templates:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_topologies:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_topologies:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_topologies.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_sudo:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_sudo:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_sudo.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_commands:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_commands:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_commands.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_kerberos_flags:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_kerberos_flags:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_kerberos_flags.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_forced_client_enrolment:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_forced_client_enrolment:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_advise:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_advise:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_advise.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_testconfig:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_testconfig:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_testconfig.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_service_permissions:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_service_permissions:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_service_permissions.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_netgroup:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_netgroup:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_netgroup.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_authconfig:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_authconfig:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_authselect.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_replica_promotion_TestSubCAkeyReplication:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_replica_promotion_TestSubCAkeyReplication:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_dnssec_TestInstallDNSSECFirst:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_dnssec_TestInstallDNSSECFirst:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_membermanager:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_membermanager:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_membermanager.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 1800
         topology: *master_1repl
 
-  fedora-30/test_smb:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/test_smb:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_smb.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 7200
         topology: *ad_master_2client

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1,0 +1,1486 @@
+topologies:
+  build: &build
+    name: build
+    cpu: 2
+    memory: 3800
+  master_3client: &master_3client
+    name: master_3client
+    cpu: 5
+    memory: 10150
+  master_1repl: &master_1repl
+    name: master_1repl
+    cpu: 4
+    memory: 6450
+  master_1repl_1client: &master_1repl_1client
+    name: master_1repl_1client
+    cpu: 4
+    memory: 7400
+  ipaserver: &ipaserver
+    name: ipaserver
+    cpu: 2
+    memory: 2400
+  master_2repl_1client: &master_2repl_1client
+    name: master_2repl_1client
+    cpu: 5
+    memory: 10150
+  master_3repl_1client: &master_3repl_1client
+    name: master_3repl_1client
+    cpu: 6
+    memory: 12900
+  ad_master_2client: &ad_master_2client
+    name: ad_master_2client
+    cpu: 4
+    memory: 12000
+  ad_master: &ad_master
+    name: ad_master
+    cpu: 4
+    memory: 12000
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14500
+
+jobs:
+  fedora-latest-ipa-4-8/build:
+    requires: []
+    priority: 100
+    job:
+      class: Build
+      args:
+        git_repo: '{git_repo}'
+        git_refspec: '{git_refspec}'
+        template: &ci-ipa-4-8-latest
+          name: freeipa/ci-ipa-4-8-f31
+          version: 0.0.3
+        timeout: 1800
+        topology: *build
+
+  fedora-latest-ipa-4-8/simple_replication:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_simple_replication.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_external_ca_TestExternalCA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
+        template: *ci-ipa-4-8-latest
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_external_ca_TestSelfExternalSelf:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/external_ca_templates:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_topologies:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_topologies.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_sudo:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_sudo.py
+        template: *ci-ipa-4-8-latest
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_commands:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_commands.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_kerberos_flags:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_kerberos_flags.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_http_kdc_proxy:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_http_kdc_proxy.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_fips:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_fips.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_forced_client_enrolment:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_forced_client_reenrollment.py
+        template: *ci-ipa-4-8-latest
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_advise:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_advise.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_testconfig:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_testconfig.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_service_permissions:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_service_permissions.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_netgroup:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_netgroup.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_vault:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_vault.py
+        template: *ci-ipa-4-8-latest
+        timeout: 6300
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_authconfig:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_authselect.py
+        template: *ci-ipa-4-8-latest
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_smb:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_smb.py
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *ad_master_2client
+
+  fedora-latest-ipa-4-8/test_server_del:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_server_del.py
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallWithCA1:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA1
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallWithCA2:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA2
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallCA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallCA
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallWithCA_KRA1:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallWithCA_KRA2:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallWithCA_DNS1:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallWithCA_DNS2:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallWithCA_DNS3:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallWithCA_DNS4:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallWithCA_KRA_DNS1:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallWithCA_KRA_DNS2:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallMaster:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMaster
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallMasterKRA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterKRA
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallMasterDNS:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterDNS
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallMasterDNSRepeatedly:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterDNSRepeatedly
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallMasterReservedIPasForwarder:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallMasterReplica:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallMasterReplica
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_installation_TestInstallReplicaAgainstSpecificServer:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallReplicaAgainstSpecificServer
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-latest-ipa-4-8/test_idviews:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_idviews.py::TestIDViews
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_caless_TestServerInstall:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_caless.py::TestServerInstall
+        template: *ci-ipa-4-8-latest
+        timeout: 12000
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_caless_TestReplicaInstall:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_caless.py::TestReplicaInstall
+        template: *ci-ipa-4-8-latest
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_caless_TestClientInstall:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_caless.py::TestClientInstall
+        template: *ci-ipa-4-8-latest
+        timeout: 5400
+        # actually master_1client
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_caless_TestIPACommands:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_caless.py::TestIPACommands
+        template: *ci-ipa-4-8-latest
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_caless_TestCertInstall:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_caless.py::TestCertInstall
+        template: *ci-ipa-4-8-latest
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_caless_TestPKINIT:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_caless.py::TestPKINIT
+        template: *ci-ipa-4-8-latest
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_caless_TestServerReplicaCALessToCAFull:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
+        template: *ci-ipa-4-8-latest
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_caless_TestReplicaCALessToCAFull:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
+        template: *ci-ipa-4-8-latest
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_caless_TestServerCALessToExternalCA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
+        template: *ci-ipa-4-8-latest
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestBackupAndRestore:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreWithDNS:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreWithKRA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  fedora-latest-ipa-4-8/test_dnssec:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_dnssec.py
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-latest-ipa-4-8/test_replica_promotion_TestReplicaPromotionLevel1:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_replica_promotion_TestUnprivilegedUserPermissions:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_replica_promotion_TestProhibitReplicaUninstallation:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  fedora-latest-ipa-4-8/test_replica_promotion_TestWrongClientDomain:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestWrongClientDomain
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_replica_promotion_TestRenewalMaster:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_replica_promotion_TestReplicaInstallWithExistingEntry:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallWithExistingEntry
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_replica_promotion_TestSubCAkeyReplication:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_replica_promotion_TestReplicaInstallCustodia:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  fedora-latest-ipa-4-8/test_replica_promotion_TestReplicaInForwardZone:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaInForwardZone
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_replica_promotion_TestHiddenReplicaPromotion:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  fedora-latest-ipa-4-8/test_upgrade:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_upgrade.py
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_topology_TestCASpecificRUVs:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_topology_TestTopologyOptions:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_topology.py::TestTopologyOptions
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_replication_layouts_TestLineTopologyWithoutCA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_replication_layouts_TestLineTopologyWithCA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_replication_layouts_TestLineTopologyWithCAKRA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_replication_layouts.py_TestStarTopologyWithoutCA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_replication_layouts_TestStarTopologyWithCA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_replication_layouts_TestStarTopologyWithCAKRA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_replication_layouts_TestCompleteTopologyWithoutCA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_replication_layouts_TestCompleteTopologyWithCA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_replication_layouts_TestCompleteTopologyWithCAKRA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-8/test_client_uninstallation:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_uninstallation.py
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_user_permissions:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_user_permissions.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_webui_cert:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_webui/test_cert.py
+        template: *ci-ipa-4-8-latest
+        timeout: 2400
+        topology: *ipaserver
+
+  fedora-latest-ipa-4-8/test_webui_general:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: >-
+          test_webui/test_loginscreen.py
+          test_webui/test_misc_cases.py
+          test_webui/test_navigation.py
+          test_webui/test_translation.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-latest-ipa-4-8/test_webui_host:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_webui/test_host.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-latest-ipa-4-8/test_webui_host_net_groups:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: >-
+          test_webui/test_hostgroup.py
+          test_webui/test_netgroup.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-latest-ipa-4-8/test_webui_identity:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: >-
+          test_webui/test_automember.py
+          test_webui/test_idviews.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-latest-ipa-4-8/test_webui_network:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: >-
+          test_webui/test_automount.py
+          test_webui/test_dns.py
+          test_webui/test_vault.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-latest-ipa-4-8/test_webui_policy:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: >-
+          test_webui/test_hbac.py
+          test_webui/test_krbtpolicy.py
+          test_webui/test_pwpolicy.py
+          test_webui/test_selinuxusermap.py
+          test_webui/test_sudo.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-latest-ipa-4-8/test_webui_rbac:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: >-
+          test_webui/test_delegation.py
+          test_webui/test_rbac.py
+          test_webui/test_selfservice.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-latest-ipa-4-8/test_webui_server:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: >-
+          test_webui/test_config.py
+          test_webui/test_range.py
+          test_webui/test_realmdomains.py
+          test_webui/test_trust.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-latest-ipa-4-8/test_webui_service:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_webui/test_service.py
+        template: *ci-ipa-4-8-latest
+        timeout: 2400
+        topology: *ipaserver
+
+  fedora-latest-ipa-4-8/test_webui_users:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: >-
+          test_webui/test_group.py
+          test_webui/test_user.py
+        template: *ci-ipa-4-8-latest
+        timeout: 4800
+        topology: *ipaserver
+
+  fedora-latest-ipa-4-8/customized_ds_config_install:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_customized_ds_config_install.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/dns_locations:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_dns_locations.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_2repl_1client
+
+  fedora-latest-ipa-4-8/external_ca_TestExternalCAdirsrvStop:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/external_ca_TestExternalCAInvalidCert:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert test_integration/test_external_ca.py::TestExternalCAInvalidIntermediate
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/external_ca_TestMultipleExternalCA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_ipahealthcheck:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_ntp_options:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_ntp_options.py::TestNTPoptions
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-8/test_otp:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_otp.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_pkinit_manage:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_pkinit_manage.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_pki_config_override:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_pki_config_override.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/nfs:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_nfs.py::TestNFS
+        template: *ci-ipa-4-8-latest
+        timeout: 9000
+        topology: *master_3client
+
+  fedora-latest-ipa-4-8/nfs_nsswitch_restore:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_3client
+
+  fedora-latest-ipa-4-8/mask:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_installation.py::TestMaskInstall
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *ipaserver
+
+  fedora-latest-ipa-4-8/automember:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_automember.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_crlgen_manage:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_crlgen_manage.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_integration_TestIPANotConfigured:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
+        template: *ci-ipa-4-8-latest
+        timeout: 10800
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_sssd:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_sssd.py
+        template: *ci-ipa-4-8-latest
+        timeout: 4800
+        topology: *ad_master_2client
+
+  fedora-latest-ipa-4-8/test_ca_custom_sdn:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_ca_custom_sdn.py
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_membermanager:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_membermanager.py
+        template: *ci-ipa-4-8-latest
+        timeout: 1800
+        topology: *master_1repl
+
+  fedora-latest/krbtpolicy:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_krbtpolicy.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_winsyncmigrate:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_winsyncmigrate.py
+        template: *ci-ipa-4-8-latest
+        timeout: 4800
+        topology: *ad_master
+
+  fedora-latest-ipa-4-8/test_trust:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_trust.py
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client
+
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreTrust:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreTrust
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -41,7 +41,7 @@ topologies:
     memory: 14500
 
 jobs:
-  fedora-30/build:
+  fedora-previous-ipa-4-8/build:
     requires: []
     priority: 100
     job:
@@ -49,1438 +49,1438 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-f30
+        template: &ci-ipa-4-8-previous
           name: freeipa/ci-ipa-4-8-f30
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 
-  fedora-30/simple_replication:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/simple_replication:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_simple_replication.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_external_ca_TestExternalCA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_external_ca_TestExternalCA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_external_ca_TestSelfExternalSelf:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_external_ca_TestSelfExternalSelf:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_templates:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/external_ca_templates:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_topologies:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_topologies:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_topologies.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_sudo:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_sudo:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_sudo.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_commands:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_commands:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_commands.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_kerberos_flags:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_kerberos_flags:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_kerberos_flags.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_http_kdc_proxy:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_http_kdc_proxy:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_http_kdc_proxy.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_fips:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_fips:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_fips.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_forced_client_enrolment:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_forced_client_enrolment:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_advise:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_advise:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_advise.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_testconfig:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_testconfig:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_testconfig.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_service_permissions:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_service_permissions:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_service_permissions.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_netgroup:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_netgroup:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_netgroup.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_vault:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_vault:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_vault.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 6300
         topology: *master_1repl
 
-  fedora-30/test_authconfig:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_authconfig:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_authselect.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_smb:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_smb:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_smb.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *ad_master_2client
 
-  fedora-30/test_server_del:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_server_del:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_server_del.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA1:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallWithCA1:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA2:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallWithCA2:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallCA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallCA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallCA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA1:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallWithCA_KRA1:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA2:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallWithCA_KRA2:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS1:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallWithCA_DNS1:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS2:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallWithCA_DNS2:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS3:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallWithCA_DNS3:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallWithCA_DNS4:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallWithCA_DNS4:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallWithCA_KRA_DNS1:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallWithCA_KRA_DNS1:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA_DNS2:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallWithCA_KRA_DNS2:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallMaster:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallMaster:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMaster
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterKRA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallMasterKRA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterDNS:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallMasterDNS:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterDNSRepeatedly:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallMasterDNSRepeatedly:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterDNSRepeatedly
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterReservedIPasForwarder:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallMasterReservedIPasForwarder:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterReplica:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallMasterReplica:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterReplica
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallReplicaAgainstSpecificServer:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_installation_TestInstallReplicaAgainstSpecificServer:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallReplicaAgainstSpecificServer
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_idviews:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_idviews:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_idviews.py::TestIDViews
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_caless_TestServerInstall:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_caless_TestServerInstall:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_caless.py::TestServerInstall
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 12000
         topology: *master_1repl
 
-  fedora-30/test_caless_TestReplicaInstall:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_caless_TestReplicaInstall:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestClientInstall:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_caless_TestClientInstall:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_caless.py::TestClientInstall
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 5400
         # actually master_1client
         topology: *master_1repl_1client
 
-  fedora-30/test_caless_TestIPACommands:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_caless_TestIPACommands:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_caless.py::TestIPACommands
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestCertInstall:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_caless_TestCertInstall:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_caless.py::TestCertInstall
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestPKINIT:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_caless_TestPKINIT:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_caless.py::TestPKINIT
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestServerReplicaCALessToCAFull:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_caless_TestServerReplicaCALessToCAFull:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestReplicaCALessToCAFull:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_caless_TestReplicaCALessToCAFull:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestServerCALessToExternalCA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_caless_TestServerCALessToExternalCA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestore:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestBackupAndRestore:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithDNS:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreWithDNS:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithKRA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreWithKRA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithReplica:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreDMPassword:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestReplicaInstallAfterRestore:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_dnssec:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_dnssec:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_dnssec.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestReplicaPromotionLevel1:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replica_promotion_TestReplicaPromotionLevel1:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestUnprivilegedUserPermissions:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replica_promotion_TestUnprivilegedUserPermissions:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestProhibitReplicaUninstallation:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replica_promotion_TestProhibitReplicaUninstallation:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestWrongClientDomain:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replica_promotion_TestWrongClientDomain:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestWrongClientDomain
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestRenewalMaster:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replica_promotion_TestRenewalMaster:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestReplicaInstallWithExistingEntry:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replica_promotion_TestReplicaInstallWithExistingEntry:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallWithExistingEntry
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestSubCAkeyReplication:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replica_promotion_TestSubCAkeyReplication:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestReplicaInstallCustodia:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replica_promotion_TestReplicaInstallCustodia:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestReplicaInForwardZone:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replica_promotion_TestReplicaInForwardZone:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInForwardZone
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestHiddenReplicaPromotion:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replica_promotion_TestHiddenReplicaPromotion:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_upgrade:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_upgrade:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_upgrade.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_topology_TestCASpecificRUVs:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_topology_TestCASpecificRUVs:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_topology_TestTopologyOptions:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_topology_TestTopologyOptions:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_topology.py::TestTopologyOptions
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithoutCA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replication_layouts_TestLineTopologyWithoutCA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithCA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replication_layouts_TestLineTopologyWithCA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replication_layouts_TestLineTopologyWithCAKRA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts.py_TestStarTopologyWithoutCA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replication_layouts.py_TestStarTopologyWithoutCA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestStarTopologyWithCA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replication_layouts_TestStarTopologyWithCA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestStarTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replication_layouts_TestStarTopologyWithCAKRA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithoutCA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replication_layouts_TestCompleteTopologyWithoutCA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithCA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replication_layouts_TestCompleteTopologyWithCA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_replication_layouts_TestCompleteTopologyWithCAKRA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_client_uninstallation:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_client_uninstallation:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_uninstallation.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl_1client
 
-  fedora-30/test_user_permissions:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_user_permissions:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_user_permissions.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_webui_cert:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_webui_cert:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_webui/test_cert.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 2400
         topology: *ipaserver
 
-  fedora-30/test_webui_general:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_webui_general:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: >-
           test_webui/test_loginscreen.py
           test_webui/test_misc_cases.py
           test_webui/test_navigation.py
           test_webui/test_translation.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_host:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_webui_host:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_webui/test_host.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_host_net_groups:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_webui_host_net_groups:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: >-
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_identity:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_webui_identity:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_network:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_webui_network:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: >-
           test_webui/test_automount.py
           test_webui/test_dns.py
           test_webui/test_vault.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_policy:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_webui_policy:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: >-
           test_webui/test_hbac.py
           test_webui/test_krbtpolicy.py
           test_webui/test_pwpolicy.py
           test_webui/test_selinuxusermap.py
           test_webui/test_sudo.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_rbac:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_webui_rbac:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: >-
           test_webui/test_delegation.py
           test_webui/test_rbac.py
           test_webui/test_selfservice.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_server:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_webui_server:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: >-
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
           test_webui/test_trust.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_service:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_webui_service:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_webui/test_service.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 2400
         topology: *ipaserver
 
-  fedora-30/test_webui_users:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_webui_users:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: >-
           test_webui/test_group.py
           test_webui/test_user.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 4800
         topology: *ipaserver
 
-  fedora-30/customized_ds_config_install:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/customized_ds_config_install:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_customized_ds_config_install.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/dns_locations:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/dns_locations:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_dns_locations.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_2repl_1client
 
-  fedora-30/external_ca_TestExternalCAdirsrvStop:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/external_ca_TestExternalCAdirsrvStop:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_TestExternalCAInvalidCert:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/external_ca_TestExternalCAInvalidCert:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert test_integration/test_external_ca.py::TestExternalCAInvalidIntermediate
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_TestMultipleExternalCA:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/external_ca_TestMultipleExternalCA:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_ipahealthcheck:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_ipahealthcheck:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_ipahealthcheck.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_ntp_options:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_ntp_options:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_1repl_1client
 
-  fedora-30/test_otp:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_otp:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_otp.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_pkinit_manage:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_pkinit_manage:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_pkinit_manage.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_pki_config_override:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_pki_config_override:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_pki_config_override.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/nfs:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/nfs:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_nfs.py::TestNFS
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 9000
         topology: *master_3client
 
-  fedora-30/nfs_nsswitch_restore:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/nfs_nsswitch_restore:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_3client
 
-  fedora-30/mask:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/mask:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_installation.py::TestMaskInstall
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/automember:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/automember:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_automember.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_crlgen_manage:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_crlgen_manage:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_crlgen_manage.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_integration_TestIPANotConfigured:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_integration_TestIPANotConfigured:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_sssd:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_sssd:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_sssd.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 4800
         topology: *ad_master_2client
 
-  fedora-30/test_ca_custom_sdn:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_ca_custom_sdn:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_ca_custom_sdn.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_membermanager:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_membermanager:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_membermanager.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 1800
         topology: *master_1repl
 
   fedora-latest/krbtpolicy:
-    requires: [fedora-30/build]
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_krbtpolicy.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_winsyncmigrate:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_winsyncmigrate:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_winsyncmigrate.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 4800
         topology: *ad_master
 
-  fedora-30/test_trust:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_trust:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunADTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_trust.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreTrust:
-    requires: [fedora-30/build]
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreTrust:
+    requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreTrust
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -47,7 +47,7 @@ topologies:
     memory: 14500
 
 jobs:
-  fedora-30/build:
+  fedora-latest-ipa-4-8/build:
     requires: []
     priority: 100
     job:
@@ -55,20 +55,20 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-f30
-          name: freeipa/ci-ipa-4-8-f30
+        template: &ci-ipa-4-8-latest
+          name: freeipa/ci-ipa-4-8-f31
           version: 0.0.3
         timeout: 1800
         topology: *build
 
-  fedora-30/temp_commit:
-    requires: [fedora-30/build]
+  fedora-latest-ipa-4-8/temp_commit:
+    requires: [fedora-latest-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_REPLACEME.py
-        template: *ci-master-f30
+        template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl_1client


### PR DESCRIPTION
* Add nightly definitions to test with latest and previous versions of Fedora (30 and 31)
* Update gating and temp_commit to use the latest Fedora (31)
* Update templates used to include updated packages

Boxes used:
* https://app.vagrantup.com/freeipa/boxes/ci-ipa-4-8-f31/versions/0.0.3
* https://app.vagrantup.com/freeipa/boxes/ci-ipa-4-8-f30/versions/0.0.4

Signed-off-by: Armando Neto <abiagion@redhat.com>