### PR TITLE
Support opendnssec 2.1.6

### DIFF
--- a/daemons/dnssec/ipa-ods-exporter.in
+++ b/daemons/dnssec/ipa-ods-exporter.in
@@ -22,7 +22,6 @@ import os
 import socket
 import select
 import sys
-import sqlite3
 import traceback
 
 import dateutil.tz
@@ -41,6 +40,8 @@ from ipaplatform.paths import paths
 from ipaserver.dnssec.abshsm import sync_pkcs11_metadata, wrappingmech_name2id
 from ipaserver.dnssec.ldapkeydb import LdapKeyDB, str_hexlify
 from ipaserver.dnssec.localhsm import LocalHSM
+
+from ipaserver.dnssec import opendnssec
 
 logger = logging.getLogger(os.path.basename(__file__))
 
@@ -233,26 +234,19 @@ def get_ldap_keys(ldap, zone_dn):
 
 def get_ods_keys(zone_name):
     # get zone ID
-    cur = db.execute("SELECT id FROM zones WHERE LOWER(name)=LOWER(?)",
-                     (zone_name,))
-    rows = cur.fetchall()
+    rows = db.get_zone_id(zone_name)
     if len(rows) != 1:
         raise ValueError("exactly one DNS zone should exist in ODS DB")
-    zone_id = rows[0][0]
+    zone_id = rows[0]
 
     # get relevant keys for given zone ID:
     # ignore keys which were generated but not used yet
     # key state check is using constants from
     # OpenDNSSEC's enforcer/ksm/include/ksm/ksm.h
     # WARNING! OpenDNSSEC version 1 and 2 are using different constants!
-    cur = db.execute("SELECT kp.HSMkey_id, kp.generate, kp.algorithm, "
-                     "dnsk.publish, dnsk.active, dnsk.retire, dnsk.dead, "
-                     "dnsk.keytype, dnsk.state "
-                     "FROM keypairs AS kp "
-                     "JOIN dnsseckeys AS dnsk ON kp.id = dnsk.keypair_id "
-                     "WHERE dnsk.zone_id = ?", (zone_id,))
+    rows = db.get_keys_for_zone(zone_id)
     keys = {}
-    for row in cur:
+    for row in rows:
         key_data = sql2ldap_flags(row['keytype'])
         if key_data.get('idnsSecKeyZONE') != 'TRUE':
             raise ValueError("unexpected key type 0x%x" % row['keytype'])
@@ -483,11 +477,13 @@ def receive_systemd_command():
         sys.exit(1)
 
     logger.debug('accepting new connection')
-    conn, _addr = sck.accept()
+    conn_tmp, _addr = sck.accept()
+    conn = opendnssec.ODSSignerConn(conn_tmp)
     logger.debug('accepted new connection %s', repr(conn))
 
     # this implements cmdhandler_handle_cmd() logic
-    cmd = conn.recv(ODS_SE_MAXLINE).strip()
+    cmd = conn.read_cmd()
+
     # ODS uses an ASCII protocol, the rest of the code expects str
     if six.PY3:
         cmd = cmd.decode('ascii')
@@ -548,9 +544,7 @@ def send_systemd_reply(conn, reply):
         # This is necessary to let Enforcer to unlock the ODS DB.
         if six.PY3:
             reply = reply.encode('ascii')
-        conn.send(reply + b'\n')
-        conn.shutdown(socket.SHUT_RDWR)
-        conn.close()
+        conn.send_reply_and_close(reply)
 
 def cmd2ods_zone_name(cmd):
     # ODS stores zone name without trailing period
@@ -566,7 +560,11 @@ def sync_zone(ldap, dns_dn, zone_name):
     Key material has to be synchronized elsewhere.
     Keep in mind that keys could be shared among multiple zones!"""
     logger.debug('%s: synchronizing zone "%s"', zone_name, zone_name)
-    ods_keys = get_ods_keys(zone_name)
+    try:
+        ods_keys = get_ods_keys(zone_name)
+    except ValueError as e:
+        logger.error(str(e))
+        return
     ods_keys_id = set(ods_keys.keys())
 
     ldap_zone = get_ldap_zone(ldap, dns_dn, zone_name)
@@ -724,6 +722,14 @@ except KeyError as e:
     cmd = sys.argv[1]
 
 exitcode, msg, zone_name, cmd = parse_command(cmd)
+if exitcode:
+    logger.debug("parse_command returned exitcode: %d", exitcode)
+if msg:
+    logger.debug("parse_command returned msg: %s", msg)
+if zone_name:
+    logger.debug("parse_command returned zone_name: %s", zone_name)
+if cmd:
+    logger.debug("parse_command returned cmd: %s", cmd)
 
 if exitcode is not None:
     if conn:
@@ -747,9 +753,7 @@ try:
     # Beware: Reply can be sent back only after DB is unlocked and closed
     #         otherwise ods-enforcerd will fail.
 
-    db = sqlite3.connect(paths.OPENDNSSEC_KASP_DB)
-    db.row_factory = sqlite3.Row
-    db.execute('BEGIN')
+    db = opendnssec.ODSDBConnection()
 
     if zone_name is not None:
         # only one zone should be processed
@@ -759,8 +763,8 @@ try:
             cleanup_ldap_zone(ldap, dns_dn, zone_name)
     else:
         # process all zones
-        for zone_row in db.execute("SELECT name FROM zones"):
-            sync_zone(ldap, dns_dn, zone_row['name'])
+        for zone_name in db.get_zones():
+            sync_zone(ldap, dns_dn, zone_name)
 
     ### DNSSEC master: DNSSEC key material purging
     # references to old key material were removed above in sync_zone()

--- a/install/share/opendnssec_conf.template
+++ b/install/share/opendnssec_conf.template
@@ -33,7 +33,7 @@
 		</Privileges>
 
 		<Datastore><SQLite>$KASP_DB</SQLite></Datastore>
-		<Interval>PT3600S</Interval>
+		$INTERVAL
 		<!-- <ManualKeyGeneration/> -->
 		<!-- <RolloverNotification>P14D</RolloverNotification> -->
 

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -191,8 +191,8 @@ class BasePathNamespace:
     NSUPDATE = "/usr/bin/nsupdate"
     ODS_KSMUTIL = "/usr/bin/ods-ksmutil"
     ODS_SIGNER = "/usr/sbin/ods-signer"
-    ODS_ENFORCER = None
-    ODS_ENFORCER_DB_SETUP = None
+    ODS_ENFORCER = "/usr/sbin/ods-enforcer"
+    ODS_ENFORCER_DB_SETUP = "/usr/sbin/ods-enforcer-db-setup"
     OPENSSL = "/usr/bin/openssl"
     PK12UTIL = "/usr/bin/pk12util"
     SOFTHSM2_UTIL = "/usr/bin/softhsm2-util"

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -24,12 +24,10 @@ This module contains default platform-specific implementations of system tasks.
 
 from __future__ import absolute_import
 
-import os
 import logging
 
 from pkg_resources import parse_version
 
-from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipapython import ipautil
 from ipapython.ipachangeconf import IPAChangeConf
@@ -287,69 +285,6 @@ class BaseTaskNamespace:
         if fstore is not None and fstore.has_file(paths.RESOLV_CONF):
             fstore.restore_file(paths.RESOLV_CONF)
 
-    def run_ods_setup(self):
-        """Initialize a new kasp.db
-        """
-        if paths.ODS_KSMUTIL is not None and os.path.exists(paths.ODS_KSMUTIL):
-            # OpenDNSSEC 1.4
-            cmd = [paths.ODS_KSMUTIL, 'setup']
-        else:
-            # OpenDNSSEC 2.x
-            cmd = [paths.ODS_ENFORCER_DB_SETUP]
-        return ipautil.run(cmd, stdin="y", runas=constants.ODS_USER)
-
-    def run_ods_notify(self, **kwargs):
-        """Notify ods-enforcerd to reload its conf."""
-        if paths.ODS_KSMUTIL is not None and os.path.exists(paths.ODS_KSMUTIL):
-            # OpenDNSSEC 1.4
-            cmd = [paths.ODS_KSMUTIL, 'notify']
-        else:
-            # OpenDNSSEC 2.x
-            cmd = [paths.ODS_ENFORCER, 'flush']
-
-        # run commands as ODS user
-        if os.geteuid() == 0:
-            kwargs['runas'] = constants.ODS_USER
-
-        return ipautil.run(cmd, **kwargs)
-
-    def run_ods_policy_import(self, **kwargs):
-        """Run OpenDNSSEC manager command to import policy."""
-        # This step is needed with OpenDNSSEC 2.1 only
-        if paths.ODS_KSMUTIL is not None and os.path.exists(paths.ODS_KSMUTIL):
-            # OpenDNSSEC 1.4
-            return
-
-        # OpenDNSSEC 2.x
-        cmd = [paths.ODS_ENFORCER, 'policy', 'import']
-
-        # run commands as ODS user
-        if os.geteuid() == 0:
-            kwargs['runas'] = constants.ODS_USER
-        ipautil.run(cmd, **kwargs)
-
-    def run_ods_manager(self, params, **kwargs):
-        """Run OpenDNSSEC manager command (ksmutil, enforcer)
-
-        :param params: parameter for ODS command
-        :param kwargs: additional arguments for ipautil.run()
-        :return: result from ipautil.run()
-        """
-        assert params[0] != 'setup'
-
-        if paths.ODS_KSMUTIL is not None and os.path.exists(paths.ODS_KSMUTIL):
-            # OpenDNSSEC 1.4
-            cmd = [paths.ODS_KSMUTIL]
-        else:
-            # OpenDNSSEC 2.x
-            cmd = [paths.ODS_ENFORCER]
-        cmd.extend(params)
-
-        # run commands as ODS user
-        if os.geteuid() == 0:
-            kwargs['runas'] = constants.ODS_USER
-
-        return ipautil.run(cmd, **kwargs)
 
     def configure_pkcs11_modules(self, fstore):
         """Disable p11-kit modules

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -298,6 +298,36 @@ class BaseTaskNamespace:
             cmd = [paths.ODS_ENFORCER_DB_SETUP]
         return ipautil.run(cmd, stdin="y", runas=constants.ODS_USER)
 
+    def run_ods_notify(self, **kwargs):
+        """Notify ods-enforcerd to reload its conf."""
+        if paths.ODS_KSMUTIL is not None and os.path.exists(paths.ODS_KSMUTIL):
+            # OpenDNSSEC 1.4
+            cmd = [paths.ODS_KSMUTIL, 'notify']
+        else:
+            # OpenDNSSEC 2.x
+            cmd = [paths.ODS_ENFORCER, 'flush']
+
+        # run commands as ODS user
+        if os.geteuid() == 0:
+            kwargs['runas'] = constants.ODS_USER
+
+        return ipautil.run(cmd, **kwargs)
+
+    def run_ods_policy_import(self, **kwargs):
+        """Run OpenDNSSEC manager command to import policy."""
+        # This step is needed with OpenDNSSEC 2.1 only
+        if paths.ODS_KSMUTIL is not None and os.path.exists(paths.ODS_KSMUTIL):
+            # OpenDNSSEC 1.4
+            return
+
+        # OpenDNSSEC 2.x
+        cmd = [paths.ODS_ENFORCER, 'policy', 'import']
+
+        # run commands as ODS user
+        if os.geteuid() == 0:
+            kwargs['runas'] = constants.ODS_USER
+        ipautil.run(cmd, **kwargs)
+
     def run_ods_manager(self, params, **kwargs):
         """Run OpenDNSSEC manager command (ksmutil, enforcer)
 

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -290,9 +290,11 @@ class BaseTaskNamespace:
     def run_ods_setup(self):
         """Initialize a new kasp.db
         """
-        if paths.ODS_KSMUTIL is not None:
+        if paths.ODS_KSMUTIL is not None and os.path.exists(paths.ODS_KSMUTIL):
+            # OpenDNSSEC 1.4
             cmd = [paths.ODS_KSMUTIL, 'setup']
         else:
+            # OpenDNSSEC 2.x
             cmd = [paths.ODS_ENFORCER_DB_SETUP]
         return ipautil.run(cmd, stdin="y", runas=constants.ODS_USER)
 
@@ -305,7 +307,7 @@ class BaseTaskNamespace:
         """
         assert params[0] != 'setup'
 
-        if paths.ODS_KSMUTIL is not None:
+        if paths.ODS_KSMUTIL is not None and os.path.exists(paths.ODS_KSMUTIL):
             # OpenDNSSEC 1.4
             cmd = [paths.ODS_KSMUTIL]
         else:

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -68,8 +68,6 @@ class DebianPathNamespace(BasePathNamespace):
     SBIN_SERVICE = "/usr/sbin/service"
     CERTMONGER_COMMAND_TEMPLATE = "/usr/lib/ipa/certmonger/%s"
     ODS_KSMUTIL = None
-    ODS_ENFORCER = "/usr/sbin/ods-enforcer"
-    ODS_ENFORCER_DB_SETUP = "/usr/sbin/ods-enforcer-db-setup"
     UPDATE_CA_TRUST = "/usr/sbin/update-ca-certificates"
     BIND_LDAP_DNS_IPA_WORKDIR = "/var/cache/bind/dyndb-ldap/ipa/"
     BIND_LDAP_DNS_ZONE_WORKDIR = "/var/cache/bind/dyndb-ldap/ipa/master/"

--- a/ipaserver/dnssec/_ods14.py
+++ b/ipaserver/dnssec/_ods14.py
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+
+import socket
+
+from ipaserver.dnssec._odsbase import AbstractODSDBConnection
+from ipaserver.dnssec._odsbase import AbstractODSSignerConn
+from ipaserver.dnssec._odsbase import ODS_SE_MAXLINE
+
+
+class ODSDBConnection(AbstractODSDBConnection):
+    def get_zones(self):
+        cur = self._db.execute("SELECT name from zones")
+        rows = cur.fetchall()
+        return [row['name'] for row in rows]
+
+    def get_zone_id(self, zone_name):
+        cur = self._db.execute(
+            "SELECT id FROM zones WHERE LOWER(name)=LOWER(?)",
+            (zone_name,))
+        rows = cur.fetchall()
+        return [row[0] for row in rows]
+
+    def get_keys_for_zone(self, zone_id):
+        cur = self._db.execute(
+            "SELECT kp.HSMkey_id, kp.generate, kp.algorithm, "
+            "dnsk.publish, dnsk.active, dnsk.retire, dnsk.dead, "
+            "dnsk.keytype, dnsk.state "
+            "FROM keypairs AS kp "
+            "JOIN dnsseckeys AS dnsk ON kp.id = dnsk.keypair_id "
+            "WHERE dnsk.zone_id = ?", (zone_id,))
+        for row in cur:
+            yield row
+
+
+class ODSSignerConn(AbstractODSSignerConn):
+    def read_cmd(self):
+        cmd = self._conn.recv(ODS_SE_MAXLINE).strip()
+        return cmd
+
+    def send_reply_and_close(self, reply):
+        self._conn.send(reply + b'\n')
+        self._conn.shutdown(socket.SHUT_RDWR)
+        self._conn.close()

--- a/ipaserver/dnssec/_ods21.py
+++ b/ipaserver/dnssec/_ods21.py
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+
+from datetime import datetime
+
+from ipaserver.dnssec._odsbase import AbstractODSDBConnection
+from ipaserver.dnssec._odsbase import AbstractODSSignerConn
+from ipaserver.dnssec._odsbase import ODS_SE_MAXLINE
+
+CLIENT_OPC_STDOUT = 0
+CLIENT_OPC_EXIT = 4
+
+
+class ODSDBConnection(AbstractODSDBConnection):
+    def get_zones(self):
+        cur = self._db.execute("SELECT name from zone")
+        rows = cur.fetchall()
+        return [row['name'] for row in rows]
+
+    def get_zone_id(self, zone_name):
+        cur = self._db.execute(
+            "SELECT id FROM zone WHERE LOWER(name)=LOWER(?)",
+            (zone_name,))
+        rows = cur.fetchall()
+        return [row[0] for row in rows]
+
+    def get_keys_for_zone(self, zone_id):
+        cur = self._db.execute(
+            "SELECT hsmk.locator, hsmk.inception, hsmk.algorithm, "
+            "hsmk.keyType, hsmk.state "
+            "FROM hsmKey AS hsmk "
+            "JOIN keyData AS kd ON hsmk.id = kd.hsmKeyId "
+            "WHERE kd.zoneId = ?", (zone_id,))
+        for row in cur:
+            key = dict()
+            key['HSMkey_id'] = row['locator']
+            key['generate'] = str(datetime.fromtimestamp(row['inception']))
+            key['algorithm'] = row['algorithm']
+            key['publish'] = key['generate']
+            key['active'] = None
+            key['retire'] = None
+            key['dead'] = None
+            if row['keyType'] == 2:
+                key['keytype'] = 256
+            elif row['keyType'] == 1:
+                key['keytype'] = 257
+            key['state'] = row['state']
+            yield key
+
+
+class ODSSignerConn(AbstractODSSignerConn):
+    def read_cmd(self):
+        msg = self._conn.recv(ODS_SE_MAXLINE)
+        _opc = int(msg[0])
+        msglen = int(msg[1]) << 8 + int(msg[2])
+        cmd = msg[3:msglen - 1].strip()
+        return cmd
+
+    def send_reply_and_close(self, reply):
+        prefix = bytearray([CLIENT_OPC_STDOUT, len(reply) >> 8,
+                            len(reply) & 255])
+        self._conn.sendall(prefix + reply)
+        # 2nd message: CLIENT_OPC_EXIT, then len, msg len, exit code
+        prefix = bytearray([CLIENT_OPC_EXIT, 0, 1, 0])
+        self._conn.sendall(prefix)
+        self._conn.close()

--- a/ipaserver/dnssec/_odsbase.py
+++ b/ipaserver/dnssec/_odsbase.py
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+
+import six
+import abc
+import sqlite3
+from ipaplatform.paths import paths
+
+ODS_SE_MAXLINE = 1024  # from ODS common/config.h
+
+
+@six.add_metaclass(abc.ABCMeta)
+class AbstractODSDBConnection():
+    """Abstract class representing the Connection to ODS database."""
+    def __init__(self):
+        """Creates a connection to the kasp database."""
+        self._db = sqlite3.connect(paths.OPENDNSSEC_KASP_DB)
+        self._db.row_factory = sqlite3.Row
+        self._db.execute('BEGIN')
+
+    @abc.abstractmethod
+    def get_zones(self):
+        """Returns a list of zone names."""
+
+    @abc.abstractmethod
+    def get_zone_id(self, zone_name):
+        """Returns a list of zone ids for the given zone_name."""
+
+    @abc.abstractmethod
+    def get_keys_for_zone(self, zone_id):
+        """Returns a list of keys for the given zone_id."""
+
+    def close(self):
+        """Closes the connection to the kasp database."""
+        self._db.close()
+
+
+@six.add_metaclass(abc.ABCMeta)
+class AbstractODSSignerConn():
+    """Abstract class representing the Connection to ods-signer."""
+    def __init__(self, conn):
+        """Initializes the object with a socket conn."""
+        self._conn = conn
+
+    @abc.abstractmethod
+    def read_cmd(self):
+        """Reads the next command on the connection."""
+
+    @abc.abstractmethod
+    def send_reply_and_close(self, reply):
+        """Sends the reply on the connection."""

--- a/ipaserver/dnssec/odsmgr.py
+++ b/ipaserver/dnssec/odsmgr.py
@@ -12,7 +12,7 @@ except ImportError:
     from xml.etree import ElementTree as etree
 
 from ipapython import ipa_log_manager, ipautil
-from ipaplatform.tasks import tasks
+from ipaserver.dnssec.opendnssec import tasks
 
 logger = logging.getLogger(__name__)
 

--- a/ipaserver/dnssec/opendnssec.py
+++ b/ipaserver/dnssec/opendnssec.py
@@ -1,0 +1,12 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+
+import os
+from ipaplatform.paths import paths
+
+# pylint: disable=unused-import
+if paths.ODS_KSMUTIL is not None and os.path.exists(paths.ODS_KSMUTIL):
+    from ._ods14 import ODSDBConnection, ODSSignerConn
+else:
+    from ._ods21 import ODSDBConnection, ODSSignerConn

--- a/ipaserver/dnssec/opendnssec.py
+++ b/ipaserver/dnssec/opendnssec.py
@@ -7,6 +7,8 @@ from ipaplatform.paths import paths
 
 # pylint: disable=unused-import
 if paths.ODS_KSMUTIL is not None and os.path.exists(paths.ODS_KSMUTIL):
-    from ._ods14 import ODSDBConnection, ODSSignerConn
+    from ._ods14 import ODSDBConnection, ODSSignerConn, ODSTask
 else:
-    from ._ods21 import ODSDBConnection, ODSSignerConn
+    from ._ods21 import ODSDBConnection, ODSSignerConn, ODSTask
+
+tasks = ODSTask()

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -13,6 +13,7 @@ import shutil
 from subprocess import CalledProcessError
 
 from ipalib.install import sysrestore
+from ipaserver.dnssec.opendnssec import tasks
 from ipaserver.install import service
 from ipaserver.masters import ENABLED_SERVICE
 from ipapython.dn import DN
@@ -21,7 +22,6 @@ from ipapython import ipautil
 from ipaplatform import services
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
-from ipaplatform.tasks import tasks
 from ipalib import errors, api
 from ipaserver import p11helper
 from ipalib.constants import SOFTHSM_DNSSEC_TOKEN_LABEL

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -314,6 +314,7 @@ class OpenDNSSECInstance(service.Service):
 
     def __start(self):
         self.restart()  # needed to reload conf files
+        tasks.run_ods_policy_import()
 
     def uninstall(self):
         if not self.is_configured():

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -179,6 +179,12 @@ class OpenDNSSECInstance(service.Service):
         # add pin to template
         sub_conf_dict = self.conf_file_dict
         sub_conf_dict['PIN'] = pin
+        if paths.ODS_KSMUTIL is not None and os.path.exists(paths.ODS_KSMUTIL):
+            # OpenDNSSEC 1.4
+            sub_conf_dict['INTERVAL'] = '<Interval>PT3600S</Interval>'
+        else:
+            # OpenDNSSEC 2.x
+            sub_conf_dict['INTERVAL'] = '<!-- Interval not used in 2x -->'
 
         ods_conf_txt = ipautil.template_file(
             os.path.join(paths.USR_SHARE_IPA_DIR, "opendnssec_conf.template"),

--- a/ipaserver/install/opendnssecinstance.py
+++ b/ipaserver/install/opendnssecinstance.py
@@ -293,14 +293,6 @@ class OpenDNSSECInstance(service.Service):
             os.chown(paths.OPENDNSSEC_KASP_DB, self.ods_uid, self.ods_gid)
             os.chmod(paths.OPENDNSSEC_KASP_DB, 0o660)
 
-            # regenerate zonelist.xml
-            result = tasks.run_ods_manager(
-                ['zonelist', 'export'], capture_output=True
-            )
-            with open(paths.OPENDNSSEC_ZONELIST_FILE, 'w') as f:
-                f.write(result.output)
-                os.fchown(f.fileno(), self.ods_uid, self.ods_gid)
-                os.fchmod(f.fileno(), 0o660)
         else:
             # initialize new kasp.db
             tasks.run_ods_setup()
@@ -315,6 +307,15 @@ class OpenDNSSECInstance(service.Service):
     def __start(self):
         self.restart()  # needed to reload conf files
         tasks.run_ods_policy_import()
+        if self.kasp_db_file:
+            # regenerate zonelist.xml
+            result = tasks.run_ods_manager(
+                ['zonelist', 'export'], capture_output=True
+            )
+            with open(paths.OPENDNSSEC_ZONELIST_FILE, 'w') as f:
+                f.write(result.output)
+                os.fchown(f.fileno(), self.ods_uid, self.ods_gid)
+                os.fchmod(f.fileno(), 0o660)
 
     def uninstall(self):
         if not self.is_configured():


### PR DESCRIPTION
### Support opendnssec 2.1.6
The installation of IPA DNS server is using ods-ksmutil, but
openddnssec 2.1.6 does not ship any more /usr/bin/ods-ksmutil. The tool
is replaced by /usr/sbin/ods-enforcer and /usr/sbin/ods-enforcer-db-setup.
    
The master branch currently supports fedora 30+, but fedora 30 and 31 are
still shipping opendnssec 1.4 while fedora 32+ is shipping opendnssec 2.1.6.
Because of this, the code needs to check at run-time if the ods-ksmutil
command is available. If the file is missing, the code falls back to
the new ods-enforcer and ods-enforcer-db-setup commands.

This commit defines paths.ODS_ENFORCER and paths.ODS_ENFORCER_DB_SETUP
for all platforms, but the commands are used only if ods-ksmutil is not found.
    
Fixes: https://pagure.io/freeipa/issue/8214

### Remove the <Interval> from opendnssec conf
    
In opendnssec 2.1.6, the <Interval> element is not supported in the
configuration file.


Note: This PR depends on https://src.fedoraproject.org/rpms/opendnssec/pull-request/2 because currently the opendnssec package does not create the /var/opendnssec/enforcer directory.
BZ https://bugzilla.redhat.com/show_bug.cgi?id=1809492 opened to track the issue.