### PR TITLE
ipatests: fix TestSubCAkeyReplication

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -601,7 +601,8 @@ class TestSubCAkeyReplication(IntegrationTest):
         status = replica.run_command(status_cmd)
         assert 'State MONITORING, stuck: no' in status.stdout_text
 
-        ssl_cmd = ['openssl', 'x509', '-text', '-in', TEST_CRT_FILE]
+        ssl_cmd = ['openssl', 'x509', '-text', '-in', TEST_CRT_FILE,
+                   '-nameopt', 'space_eq']
         ssl = replica.run_command(ssl_cmd)
         assert 'Issuer: CN = {}'.format(self.SUBCA_MASTER) in ssl.stdout_text
 


### PR DESCRIPTION
The test is using the output of openssl to compare the SubCA issuer name
with the expected value.
Depending on the version of openssl, the issuer can be displayed
differently (with/without space around the = character). On RHEL 7.x,
there is no space by default while on Fedora the space is used.
Calling openssl with -nameopt space_eq forces a consistent output, always
adding space around =.