### PR TITLE
ipatest:Test if getcert creates cacert file with -F option

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -142,6 +142,7 @@ def check_arguments_are(slice, instanceof):
         return wrapped
     return wrapper
 
+
 def prepare_reverse_zone(host, ip):
     zone = get_reverse_zone_default(ip)
     result = host.run_command(["ipa",
@@ -150,6 +151,7 @@ def prepare_reverse_zone(host, ip):
     if result.returncode > 0:
         logger.warning("%s", result.stderr_text)
     return zone, result.returncode
+
 
 def prepare_host(host):
     if isinstance(host, Host):
@@ -240,6 +242,7 @@ def host_service_active(host, service):
 
     return res.returncode == 0
 
+
 def fix_apache_semaphores(master):
     systemd_available = master.transport.file_exists(paths.SYSTEMCTL)
 
@@ -329,6 +332,7 @@ def enable_ds_audit_log(host, enabled='on'):
         nsslapd-auditfaillog-logging-enabled: {enabled}
         """.format(enabled=enabled))
     ldapmodify_dm(host, logging_ldif)
+
 
 def set_default_ttl_for_ipa_dns_zone(host, raiseonerr=True):
     args = [
@@ -2060,3 +2064,22 @@ def uninstall_packages(host, pkgs):
     else:
         raise ValueError('install_packages: unknown platform %s' % platform)
     host.run_command(install_cmd + pkgs)
+
+
+def wait_for_request(host, request_id, timeout=120):
+    for _i in range(0, timeout, 5):
+        result = host.run_command(
+            "getcert list -i %s | grep status: | awk '{ print $2 }'" %
+            request_id
+        )
+
+        state = result.stdout_text.strip()
+        print("certmonger request is in state %r", state)
+        if state in ('CA_REJECTED', 'CA_UNREACHABLE', 'CA_UNCONFIGURED',
+                     'NEED_GUIDANCE', 'NEED_CA', 'MONITORING'):
+            break
+        time.sleep(5)
+    else:
+        raise RuntimeError("request timed out")
+
+    return state

--- a/ipatests/test_integration/test_cert.py
+++ b/ipatests/test_integration/test_cert.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Module provides tests which testing ability of various certificate
+related scenarios.
+"""
+
+from __future__ import absolute_import
+
+import re
+
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestInstallMasterClient(IntegrationTest):
+    num_clients = 1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master)
+        tasks.install_client(cls.master, cls.clients[0])
+
+    def test_cacert_file_appear_with_option_F(self):
+        """Test if getcert creates cacert file with -F option
+
+        It took longer to create the cacert file in older version.
+        restarting the certmonger service creates the file at the location
+        specified by -F option. This fix is to check that cacert file
+        creates immediately after certificate goes into MONITORING state.
+
+        related: https://pagure.io/freeipa/issue/8105
+        """
+        cmd_arg = ['ipa-getcert', 'request',
+                   '-f', '/etc/pki/tls/certs/test.pem',
+                   '-k', '/etc/pki/tls/private/test.key',
+                   '-K', 'test/%s' % self.clients[0].hostname,
+                   '-F', '/etc/pki/tls/test.CA']
+        result = self.clients[0].run_command(cmd_arg)
+        request_id = re.findall(r'\d+', result.stdout_text)
+
+        # check if certificate is in MONITORING state
+        status = tasks.wait_for_request(self.clients[0], request_id[0], 50)
+        assert status == "MONITORING"
+
+        self.clients[0].run_command(['ls', '-l', '/etc/pki/tls/test.CA'])


### PR DESCRIPTION
It took longer to create the cacert file in older version.
restarting the certmonger service creates the file at the location
specified by -F option. This fix is to check that cacert file
creates immediately after certificate goes into MONITORING state.

related: https://pagure.io/freeipa/issue/8105

Signed-off-by: Mohammad Rizwan Yusuf <myusuf@redhat.com>