### PR TITLE
ipa-backup: Make sure all roles are installed on the current master.

### DIFF
--- a/install/tools/man/ipa-backup.1
+++ b/install/tools/man/ipa-backup.1
@@ -51,6 +51,9 @@ Include the IPA service log files in the backup.
 \fB\-\-online\fR
 Perform the backup on\-line. Requires the \-\-data option.
 .TP
+\fB\-\-disable\-role\-check\fR
+Perform the backup even if this host does not have all the roles in use in the cluster. This is not recommended.
+.TP
 \fB\-\-v\fR, \fB\-\-verbose\fR
 Print debugging information
 .TP

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -752,6 +752,18 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  fedora-latest/test_backup_and_restore_TestBackupRoles:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupRoles
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
   fedora-latest/test_dnssec:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -797,6 +797,19 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  testing-fedora/test_backup_and_restore_TestBackupRoles:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupRoles
+        template: *testing-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
   testing-fedora/test_dnssec:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -752,6 +752,18 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  fedora-previous/test_backup_and_restore_TestBackupRoles:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupRoles
+        template: *ci-master-previous
+        timeout: 7200
+        topology: *master_1repl
+
   fedora-previous/test_dnssec:
     requires: [fedora-previous/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -810,6 +810,19 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  fedora-rawhide/test_backup_and_restore_TestBackupRoles:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupRoles
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_1repl
+
   fedora-rawhide/test_dnssec:
     requires: [fedora-rawhide/build]
     priority: 50

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -928,7 +928,7 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         """
         self._check_server_role(self.replicas[0], 'hidden')
         # backup
-        backup_path = backup(self.replicas[0])
+        backup_path, unused = backup(self.replicas[0])
         # uninstall
         tasks.uninstall_master(self.replicas[0])
         # restore


### PR DESCRIPTION
ipa-backup does not check whether the IPA master it is running on has
all used roles installed. This can lead into situations where backups
are done on a CAless or KRAless host when these roles are used in the
IPA cluster. These backups cannot be used to restore a complete cluster.

With this change, ipa-backup checks what roles are installed on the
current host and compares the resulting list to the list of used roles
in the cluster. A --disable-role-check knob is also provided to restore
the previous behavior.

Fixes: https://pagure.io/freeipa/issue/8217
Signed-off-by: François Cami <fcami@redhat.com>