### PR TITLE
[ipa-4-6] Travis: Enable IPv6 support for Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,10 @@ before_install:
     - ip addr show
     - ls /proc/net
     - cat /proc/net/if_inet6
+    # Enable IPv6 back in Travis CI
+    # https://github.com/travis-ci/travis-ci/issues/8891
+    - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+    - sudo service docker restart
 #    - ip addr show dev lo | grep -q inet6 || (echo "No IPv6 address found"; exit 1)
 
 install:

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -152,12 +152,6 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                 "globally, disable it on the specific interfaces in "
                 "sysctl.conf except 'lo' interface.")
 
-        # XXX This is a hack to work around an issue with Travis CI by
-        # skipping IPv6 address test. The Dec 2017 update removed ::1 from
-        # loopback, see https://github.com/travis-ci/travis-ci/issues/8891.
-        if os.environ.get('TRAVIS') == 'true':
-            return
-
         try:
             localhost6 = ipautil.CheckedIPAddress('::1', allow_loopback=True)
             if localhost6.get_matching_interface() is None:


### PR DESCRIPTION
Environment variable `TRAVIS` is not accessible inside the container anymore, passing it to the container didn't have the same effect expected by the hack this commit removes. However, enabling IPv6, as described in https://github.com/travis-ci/travis-ci/issues/8891, was effective to execute the tests.

Issue: https://pagure.io/freeipa/issue/8213

Signed-off-by: Armando Neto <abiagion@redhat.com>