### PR TITLE
[Backport][ipa-4-6] ipatests: fix TestSubCAkeyReplication

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -672,7 +672,8 @@ class TestSubCAkeyReplication(IntegrationTest):
         status = replica.run_command(status_cmd)
         assert 'State MONITORING, stuck: no' in status.stdout_text
 
-        ssl_cmd = ['openssl', 'x509', '-text', '-in', TEST_CRT_FILE]
+        ssl_cmd = ['openssl', 'x509', '-text', '-in', TEST_CRT_FILE,
+                   '-nameopt', 'space_eq']
         ssl = replica.run_command(ssl_cmd)
         assert 'Issuer: CN = {}'.format(self.SUBCA) in ssl.stdout_text
 


### PR DESCRIPTION
This PR was opened manually because PR #4301 was pushed to master and backport to ipa-4-6 is required.