### PR TITLE
[Backport][ipa-4-8] ipa-adtrust-install: run remote configuration for new agents

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -5857,6 +5857,14 @@ option: Str('version?')
 output: Output('result', type=[<type 'dict'>])
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: ListOfPrimaryKeys('value')
+command: trust_enable_agent/1
+args: 1,2,3
+arg: Str('remote_cn', cli_name='remote_name')
+option: Flag('enable_compat', autofill=True, default=False)
+option: Str('version?')
+output: Output('result', type=[<type 'bool'>])
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
 command: trust_fetch_domains/1
 args: 1,7,4
 arg: Str('cn', cli_name='realm')
@@ -7124,6 +7132,7 @@ default: topologysuffix_verify/1
 default: trust/1
 default: trust_add/1
 default: trust_del/1
+default: trust_enable_agent/1
 default: trust_fetch_domains/1
 default: trust_find/1
 default: trust_mod/1

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -86,8 +86,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-define(IPA_API_VERSION_MINOR, 235)
-# Last change: Add memberManager to groups.
+define(IPA_API_VERSION_MINOR, 236)
+# Last change: Add trust_enable_agent.
 
 ########################################################
 # Following values are auto-generated from values above

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1072,6 +1072,7 @@ fi
 %{_libexecdir}/ipa/ipa-otpd
 %dir %{_libexecdir}/ipa/oddjob
 %attr(0755,root,root) %{_libexecdir}/ipa/oddjob/org.freeipa.server.conncheck
+%attr(0755,root,root) %{_libexecdir}/ipa/oddjob/org.freeipa.server.trust-enable-agent
 %config(noreplace) %{_sysconfdir}/dbus-1/system.d/org.freeipa.server.conf
 %config(noreplace) %{_sysconfdir}/oddjobd.conf.d/ipa-server.conf
 %dir %{_libexecdir}/ipa/certmonger

--- a/install/oddjob/Makefile.am
+++ b/install/oddjob/Makefile.am
@@ -6,6 +6,7 @@ dbusconfdir = $(sysconfdir)/dbus-1/system.d
 
 dist_noinst_DATA =		\
 	com.redhat.idm.trust-fetch-domains.in	\
+	org.freeipa.server.trust-enable-agent.in	\
 	etc/oddjobd.conf.d/oddjobd-ipa-trust.conf.in	\
 	etc/oddjobd.conf.d/ipa-server.conf.in		\
 	$(NULL)
@@ -16,6 +17,7 @@ dist_oddjob_SCRIPTS =				\
 
 nodist_oddjob_SCRIPTS =				\
 	com.redhat.idm.trust-fetch-domains	\
+	org.freeipa.server.trust-enable-agent	\
 	$(NULL)
 
 

--- a/install/oddjob/etc/oddjobd.conf.d/ipa-server.conf.in
+++ b/install/oddjob/etc/oddjobd.conf.d/ipa-server.conf.in
@@ -11,6 +11,12 @@
                   prepend_user_name="no"
                   argument_passing_method="cmdline"/>
         </method>
+        <method name="trust_enable_agent">
+          <helper exec="@ODDJOBDIR@/org.freeipa.server.trust-enable-agent"
+                  arguments="1"
+                  prepend_user_name="no"
+                  argument_passing_method="cmdline"/>
+        </method>
       </interface>
       <interface name="org.freedesktop.DBus.Introspectable">
         <allow min_uid="0" max_uid="0"/>

--- a/install/oddjob/org.freeipa.server.trust-enable-agent.in
+++ b/install/oddjob/org.freeipa.server.trust-enable-agent.in
@@ -1,0 +1,8 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+
+from ipaserver.install.ipa_trust_enable_agent import IPATrustEnableAgent
+
+IPATrustEnableAgent.run_cli()

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -334,6 +334,7 @@ class BasePathNamespace:
     IPASERVER_KRA_INSTALL_LOG = "/var/log/ipaserver-kra-install.log"
     IPASERVER_UNINSTALL_LOG = "/var/log/ipaserver-uninstall.log"
     IPAUPGRADE_LOG = "/var/log/ipaupgrade.log"
+    IPATRUSTENABLEAGENT_LOG = "/var/log/ipatrust-enable-agent.log"
     KADMIND_LOG = "/var/log/kadmind.log"
     KRB5KDC_LOG = "/var/log/krb5kdc.log"
     MESSAGES = "/var/log/messages"

--- a/ipaserver/install/adtrust.py
+++ b/ipaserver/install/adtrust.py
@@ -14,6 +14,7 @@ import os
 import six
 
 from ipalib.constants import MIN_DOMAIN_LEVEL
+from ipalib import create_api, rpc
 from ipalib import errors
 from ipalib.install.service import ServiceAdminInstallInterface
 from ipalib.install.service import replica_install_only
@@ -344,13 +345,68 @@ def add_new_adtrust_agents(api, options):
     if new_agents:
         add_hosts_to_adtrust_agents(api, new_agents)
 
-        print("""
+        # The method trust_enable_agent was added on API version 2.236
+        # Specifically request this version in the remote call
+        kwargs = {u'version': u'2.236',
+                  u'enable_compat': options.enable_compat}
+        failed_agents = []
+        for agent in new_agents:
+            # Try to run the ipa-trust-enable-agent script on the agent
+            # If the agent is too old and does not support this,
+            # print a msg
+            logger.info("Execute trust_enable_agent on remote server %s",
+                        agent)
+            client = None
+            try:
+                xmlrpc_uri = 'https://{}/ipa/xml'.format(
+                    ipautil.format_netloc(agent))
+                remote_api = create_api(mode=None)
+                remote_api.bootstrap(context='installer',
+                                     confdir=paths.ETC_IPA,
+                                     xmlrpc_uri=xmlrpc_uri,
+                                     fallback=False)
+                client = rpc.jsonclient(remote_api)
+                client.finalize()
+                client.connect()
+                result = client.forward(
+                    u'trust_enable_agent',
+                    ipautil.fsdecode(agent),
+                    **kwargs)
+            except errors.CommandError as e:
+                logger.debug(
+                    "Remote server %s does not support agent enablement "
+                    "over RPC: %s", agent, e)
+                failed_agents.append(agent)
+            except (errors.PublicError, ConnectionRefusedError) as e:
+                logger.debug(
+                    "Remote call to trust_enable_agent failed on server %s: "
+                    "%s", agent, e)
+                failed_agents.append(agent)
+            else:
+                for message in result.get('messages'):
+                    logger.debug('%s', message['message'])
+                if not int(result['result']):
+                    logger.debug(
+                        "ipa-trust-enable-agent returned non-zero exit code "
+                        " on server %s", agent)
+                    failed_agents.append(agent)
+            finally:
+                if client and client.isconnected():
+                    client.disconnect()
+
+        # if enablement failed on some agents, print a WARNING:
+        if failed_agents:
+            if options.enable_compat:
+                print("""
+WARNING: you MUST manually enable the Schema compatibility Plugin and """)
+            print("""
 WARNING: you MUST restart (both "ipactl restart" and "systemctl restart sssd")
 the following IPA masters in order to activate them to serve information about
 users from trusted forests:
 """)
-        for x in new_agents:
-            print(x)
+
+            for x in failed_agents:
+                print(x)
 
 
 def install_check(standalone, options, api):

--- a/ipaserver/install/ipa_trust_enable_agent.py
+++ b/ipaserver/install/ipa_trust_enable_agent.py
@@ -1,0 +1,93 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+
+
+from __future__ import print_function, absolute_import
+
+import logging
+
+from ipalib import api
+from ipaplatform import services
+from ipaplatform.paths import paths
+from ipapython.admintool import AdminTool, ScriptError
+from ipapython.dn import DN
+from ipapython.ipautil import CalledProcessError
+from ipaserver.install import installutils
+
+logger = logging.getLogger(__name__)
+
+
+class IPATrustEnableAgent(AdminTool):
+    command_name = "ipa-trust-enable-agent"
+    log_file_name = paths.IPATRUSTENABLEAGENT_LOG
+    usage = "%prog"
+    description = "Enable this server as a trust agent"
+
+    @classmethod
+    def add_options(cls, parser):
+        super(IPATrustEnableAgent, cls).add_options(parser)
+
+        parser.add_option(
+            "--enable-compat",
+            dest="enable_compat", default=False, action="store_true",
+            help="Enable support for trusted domains for old clients")
+
+    def validate_options(self):
+        super(IPATrustEnableAgent, self).validate_options(needs_root=True)
+        installutils.check_server_configuration()
+
+    def _enable_compat_tree(self):
+        logger.info("Enabling Schema Compatibility plugin")
+        compat_plugin_dn = DN("cn=Schema Compatibility,cn=plugins,cn=config")
+        lookup_nsswitch_name = "schema-compat-lookup-nsswitch"
+        for config in (("cn=users", "user"), ("cn=groups", "group")):
+            entry_dn = DN(config[0], compat_plugin_dn)
+            current = api.Backend.ldap2.get_entry(entry_dn)
+            lookup_nsswitch = current.get(lookup_nsswitch_name, [])
+            if not(config[1] in lookup_nsswitch):
+                logger.debug("Enabling Schema Compatibility plugin "
+                             "for %s", config[0])
+                current[lookup_nsswitch_name] = [config[1]]
+                api.Backend.ldap2.update_entry(current)
+            else:
+                logger.debug("Schema Compatibility plugin already enabled "
+                             "for %s", config[0])
+
+    def run(self):
+        api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
+        api.finalize()
+
+        try:
+            api.Backend.ldap2.connect()  # ensure DS is up
+
+            # If required, enable Schema compat plugin on users/groups
+            if self.options.enable_compat:
+                try:
+                    self._enable_compat_tree()
+                except Exception as e:
+                    raise ScriptError(
+                        "Enabling Schema Compatibility plugin "
+                        "failed: {}".format(e))
+
+            # Restart 389-ds and sssd
+            logger.info("Restarting Directory Server")
+            try:
+                services.knownservices.dirsrv.restart()
+            except Exception as e:
+                raise ScriptError(
+                    "Directory Server restart was unsuccessful: {}".format(e))
+
+            logger.info("Restarting SSSD service")
+            try:
+                sssd = services.service('sssd', api)
+                sssd.restart()
+            except CalledProcessError as e:
+                raise ScriptError(
+                    "SSSD service restart was unsuccessful: {}".format(e))
+
+        finally:
+            if api.Backend.ldap2.isconnected():
+                api.Backend.ldap2.disconnect()
+
+        return 0

--- a/ipaserver/plugins/privilege.py
+++ b/ipaserver/plugins/privilege.py
@@ -83,6 +83,20 @@ def validate_permission_to_privilege(api, permission):
                     'ipapermbindruletype', 'permission')})
 
 
+def principal_has_privilege(api, principal, privilege):
+    privilege_dn = api.Object.privilege.get_dn(privilege)
+    ldap = api.Backend.ldap2
+    filter = ldap.make_filter({
+        'krbprincipalname': principal,  # pylint: disable=no-member
+        'memberof': privilege_dn},
+        rules=ldap.MATCH_ALL)
+    try:
+        ldap.find_entries(base_dn=api.env.basedn, filter=filter)
+    except errors.NotFound:
+        return False
+    return True
+
+
 @register()
 class privilege(LDAPObject):
     """

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -274,3 +274,15 @@ jobs:
         template: *ci-ipa-4-8-latest
         timeout: 7200
         topology: *ad_master_2client
+
+  fedora-latest-ipa-4-8/test_adtrust_install:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_adtrust_install.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1484,3 +1484,15 @@ jobs:
         template: *ci-ipa-4-8-latest
         timeout: 7200
         topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_adtrust_install:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_adtrust_install.py
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -1484,3 +1484,16 @@ jobs:
         template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_1repl
+
+  fedora-previous-ipa-4-8/test_adtrust_install:
+    requires: [fedora-previous-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_adtrust_install.py
+        template: *ci-ipa-4-8-previous
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -1,0 +1,201 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+
+"""This module provides tests for ipa-adtrust-install utility"""
+
+import re
+import textwrap
+
+from ipaplatform.paths import paths
+from ipapython.dn import DN
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestIpaAdTrustInstall(IntegrationTest):
+    topology = 'line'
+    num_replicas = 1
+
+    def unconfigure_replica_as_agent(self, host):
+        """ Remove a replica from the list of agents.
+
+        cn=adtrust agents,cn=sysaccounts,cn=etc,$BASEDN contains a list
+        of members representing the agents. Remove the replica principal
+        from this list.
+        This is a hack allowing to run multiple times
+        ipa-adtrust-install --add-agents
+        (otherwise if the replica is in the list of agents, it won't be seen
+        as a possible agent to be added).
+        """
+        remove_agent_ldif = textwrap.dedent("""
+             dn: cn=adtrust agents,cn=sysaccounts,cn=etc,{base_dn}
+             changetype: modify
+             delete: member
+             member: fqdn={hostname},cn=computers,cn=accounts,{base_dn}
+             """.format(base_dn=host.domain.basedn, hostname=host.hostname))
+        # ok_returncode =16 if the attribute is not present
+        tasks.ldapmodify_dm(self.master, remove_agent_ldif,
+                            ok_returncode=[0, 16])
+
+    def test_samba_config_file(self):
+        """Check that ipa-adtrust-install generates sane smb.conf
+        This is regression test for issue
+        https://pagure.io/freeipa/issue/6951
+        """
+        self.master.run_command(
+            ['ipa-adtrust-install', '-a', self.master.config.admin_password,
+             '--add-sids', '-U'])
+        res = self.master.run_command(['testparm', '-s'])
+        assert 'ERROR' not in (res.stdout_text + res.stderr_text)
+
+    def test_add_agent_not_allowed(self):
+        """Check that add-agents can be run only by Admins."""
+        user = "nonadmin"
+        passwd = "Secret123"
+        host = self.replicas[0].hostname
+        data_fmt = '{{"method":"trust_enable_agent","params":[["{}"],{{}}]}}'
+
+        try:
+            # Create a nonadmin user that will be used by curl
+            tasks.create_active_user(self.master, user, passwd,
+                                     first=user, last=user)
+            tasks.kinit_as_user(self.master, user, passwd)
+            # curl --negotiate -u : is using GSS-API i.e. nonadmin user
+            cmd_args = [
+                paths.BIN_CURL,
+                '-H', 'referer:https://{}/ipa'.format(host),
+                '-H', 'Content-Type:application/json',
+                '-H', 'Accept:applicaton/json',
+                '--negotiate', '-u', ':',
+                '--cacert', paths.IPA_CA_CRT,
+                '-d', data_fmt.format(host),
+                '-X', 'POST', 'https://{}/ipa/json'.format(host)]
+            res = self.master.run_command(cmd_args)
+            expected = 'Insufficient access: not allowed to remotely add agent'
+            assert expected in res.stdout_text
+        finally:
+            tasks.kinit_admin(self.master)
+            self.master.run_command(['ipa', 'user-del', user])
+
+    def test_add_agent_on_stopped_replica(self):
+        """ Check ipa-adtrust-install --add-agents when the replica is stopped.
+
+        Scenario: stop a replica
+        Call ipa-adtrust-install --add-agents and configure the stopped replica
+        as a new agent.
+        The tool must detect that the replica is stopped and warn that
+        a part of the configuration failed.
+
+        Test for https://pagure.io/freeipa/issue/8148
+        """
+        self.unconfigure_replica_as_agent(self.replicas[0])
+        self.replicas[0].run_command(['ipactl', 'stop'])
+
+        cmd_input = (
+            # admin password:
+            self.master.config.admin_password + '\n' +
+            # WARNING: The smb.conf already exists. Running ipa-adtrust-install
+            # will break your existing samba configuration.
+            # Do you wish to continue? [no]:
+            'yes\n'
+            # Enable trusted domains support in slapi-nis? [no]:
+            '\n' +
+            # WARNING: 1 IPA masters are not yet able to serve information
+            # about users from trusted forests.
+            # Installer can add them to the list of IPA masters allowed to
+            # access information about trusts.
+            # If you choose to do so, you also need to restart LDAP service on
+            # those masters.
+            # Refer to ipa-adtrust-install(1) man page for details.
+            # IPA master[replica1.testrelm.test]?[no]:
+            'yes\n'
+        )
+        try:
+            res = self.master.run_command(['ipa-adtrust-install',
+                                           '--add-agents'],
+                                          stdin_text=cmd_input)
+            expected_re = '"ipactl restart".+"systemctl restart sssd"'
+            assert re.search(expected_re, res.stdout_text, re.DOTALL)
+        finally:
+            self.replicas[0].run_command(['ipactl', 'start'])
+
+    def test_add_agent_on_running_replica_without_compat(self):
+        """ Check ipa-adtrust-install --add-agents when the replica is running
+
+        Scenario: replica up and running
+        Call ipa-adtrust-install --add-agents and configure the replica as
+        a new agent.
+        The Schema Compat plugin must be automatically configured on the
+        replica.
+        """
+        self.unconfigure_replica_as_agent(self.replicas[0])
+        cmd_input = (
+            # admin password:
+            self.master.config.admin_password + '\n' +
+            # WARNING: The smb.conf already exists. Running ipa-adtrust-install
+            # will break your existing samba configuration.
+            # Do you wish to continue? [no]:
+            'yes\n'
+            # Enable trusted domains support in slapi-nis? [no]:
+            '\n' +
+            # WARNING: 1 IPA masters are not yet able to serve information
+            # about users from trusted forests.
+            # Installer can add them to the list of IPA masters allowed to
+            # access information about trusts.
+            # If you choose to do so, you also need to restart LDAP service on
+            # those masters.
+            # Refer to ipa-adtrust-install(1) man page for details.
+            # IPA master[replica1.testrelm.test]?[no]:
+            'yes\n'
+        )
+        expected = '"ipactl restart"'
+        res = self.master.run_command(['ipa-adtrust-install', '--add-agents'],
+                                      stdin_text=cmd_input)
+        # The replica must have been restarted automatically, no msg required
+        assert expected not in res.stdout_text
+
+    def test_add_agent_on_running_replica_with_compat(self):
+        """ Check ipa-addtrust-install --add-agents when the replica is running
+
+        Scenario: replica up and running
+        Call ipa-adtrust-install --add-agents --enable-compat and configure
+        the replica as a new agent.
+        The Schema Compat plugin must be automatically configured on the
+        replica.
+        """
+        self.unconfigure_replica_as_agent(self.replicas[0])
+
+        cmd_input = (
+            # admin password:
+            self.master.config.admin_password + '\n' +
+            # WARNING: The smb.conf already exists. Running ipa-adtrust-install
+            # will break your existing samba configuration.
+            # Do you wish to continue? [no]:
+            'yes\n'
+            # Enable trusted domains support in slapi-nis? [no]:
+            'yes\n' +
+            # WARNING: 1 IPA masters are not yet able to serve information
+            # about users from trusted forests.
+            # Installer can add them to the list of IPA masters allowed to
+            # access information about trusts.
+            # If you choose to do so, you also need to restart LDAP service on
+            # those masters.
+            # Refer to ipa-adtrust-install(1) man page for details.
+            # IPA master[replica1.testrelm.test]?[no]:
+            'yes\n'
+        )
+        expected = '"ipactl restart"'
+        res = self.master.run_command(['ipa-adtrust-install', '--add-agents'],
+                                      stdin_text=cmd_input)
+        # The replica must have been restarted automatically, no msg required
+        assert expected not in res.stdout_text
+
+        # Ensure that the schema compat plugin is configured:
+        conn = self.replicas[0].ldap_connect()
+        entry = conn.get_entry(DN(
+            "cn=users,cn=Schema Compatibility,cn=plugins,cn=config"))
+        assert entry.single_value['schema-compat-lookup-nsswitch'] == "user"
+        entry = conn.get_entry(DN(
+            "cn=groups,cn=Schema Compatibility,cn=plugins,cn=config"))
+        assert entry.single_value['schema-compat-lookup-nsswitch'] == "group"

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -813,17 +813,6 @@ class TestIPACommand(IntegrationTest):
         assert is_tls_version_enabled('tls1_2')
         assert is_tls_version_enabled('tls1_3')
 
-    def test_samba_config_file(self):
-        """Check that ipa-adtrust-install generates sane smb.conf
-
-        This is regression test for issue
-        https://pagure.io/freeipa/issue/6951
-        """
-        self.master.run_command(
-            ['ipa-adtrust-install', '-a', 'Secret123', '--add-sids', '-U'])
-        res = self.master.run_command(['testparm', '-s'])
-        assert 'ERROR' not in (res.stdout_text + res.stderr_text)
-
     @pytest.mark.skip(reason='https://pagure.io/freeipa/issue/8151')
     def test_sss_ssh_authorizedkeys(self):
         """Login via Ssh using private-key for ipa-user should work.


### PR DESCRIPTION
This is a manual backport of PR #4277  to ipa-4-8.
The backport conflict was created by the nightly PRCI definitions.