### PR TITLE
ipatests: redesign sssd config editor

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -799,20 +799,74 @@ def setup_sssd_debugging(host):
     clear_sssd_cache(host)
 
 
-def modify_sssd_conf(host, domain, mod_dict, provider='ipa',
-                     provider_subtype=None):
-    """
-    modify options in a single domain section of host's sssd.conf
-    :param host: multihost.Host object
-    :param domain: domain section name to modify
-    :param mod_dict: dictionary of options which will be passed to
-        SSSDDomain.set_option(). To remove an option specify its value as
-        None
-    :param provider: provider backend to set. Defaults to ipa
-    :param provider_subtype: backend subtype (e.g. id or sudo), will be added
-        to the domain config if not present
-    """
+@contextmanager
+def remote_sssd_config(host):
+    """Context manager for editing sssd config file on a remote host.
+
+    It provides SimpleSSSDConfig object which is automatically serialized and
+    uploaded to remote host upon exit from the context.
+
+    If exception is raised inside the context then the ini file is NOT updated
+    on remote host.
+
+    SimpleSSSDConfig is a SSSDConfig descendant with added helper methods
+    for modifying options: edit_domain and edit_service.
+
+
+    Example:
+
+        with remote_sssd_config(master) as sssd_conf:
+            # use helper methods
+            # add/replace option
+            sssd_conf.edit_domain(master.domain, 'filter_users', 'root')
+            # add/replace provider option
+            sssd_conf.edit_domain(master.domain, 'sudo_provider', 'ipa')
+            # delete option
+            sssd_conf.edit_service('pam', 'pam_verbosity', None)
+
+            # use original methods of SSSDConfig
+            domain = sssd_conf.get_domain(master.domain.name)
+            domain.set_name('example.test')
+            self.save_domain(domain)
+        """
+
     from SSSDConfig import SSSDConfig
+
+    class SimpleSSSDConfig(SSSDConfig):
+        def edit_domain(self, domain_or_name, option, value):
+            """Add/replace/delete option in a domain section.
+
+            :param domain_or_name: Domain object or domain name
+            :param option: option name
+            :param value: value to assign to option. If None, option will be
+                deleted
+            """
+            if hasattr(domain_or_name, 'name'):
+                domain_name = domain_or_name.name
+            else:
+                domain_name = domain_or_name
+            domain = self.get_domain(domain_name)
+            if value is None:
+                domain.remove_option(option)
+            else:
+                domain.set_option(option, value)
+            self.save_domain(domain)
+
+        def edit_service(self, service_name, option, value):
+            """Add/replace/delete option in a service section.
+
+            :param service_name: a string
+            :param option: option name
+            :param value: value to assign to option. If None, option will be
+                deleted
+            """
+            service = self.get_service(service_name)
+            if value is None:
+                service.remove_option(option)
+            else:
+                service.set_option(option, value)
+            self.save_service(service)
+
     fd, temp_config_file = tempfile.mkstemp()
     os.close(fd)
     try:
@@ -842,19 +896,12 @@ def modify_sssd_conf(host, domain, mod_dict, provider='ipa',
         os.unlink(tarname)
 
         # Use the imported schema
-        sssd_config = SSSDConfig(
+        sssd_config = SimpleSSSDConfig(
             schemafile=os.path.join(tar_dir, "sssd.api.conf"),
             schemaplugindir=os.path.join(tar_dir, "sssd.api.d"))
         sssd_config.import_config(temp_config_file)
-        sssd_domain = sssd_config.get_domain(domain)
 
-        if provider_subtype is not None:
-            sssd_domain.add_provider(provider, provider_subtype)
-
-        for m in mod_dict:
-            sssd_domain.set_option(m, mod_dict[m])
-
-        sssd_config.save_domain(sssd_domain)
+        yield sssd_config
 
         new_config = sssd_config.dump(sssd_config.opts).encode('utf-8')
         host.transport.put_file_contents(paths.SSSD_CONF, new_config)

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1974,7 +1974,7 @@ class FileBackup:
         host.run_command(['cp', '--preserve=all', filename, self._backup])
 
     def restore(self):
-        """Restore file. Can be called multiple times."""
+        """Restore file. Can be called only once."""
         self._host.run_command(['mv', self._backup, self._filename])
 
     def __enter__(self):

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -698,14 +698,10 @@ class TestIPACommand(IntegrationTest):
 
         username = "testuser" + str(random.randint(200000, 9999999))
         # add ldap_deref_threshold=0 to /etc/sssd/sssd.conf
-        domain = self.master.domain
-        tasks.modify_sssd_conf(
-            self.master,
-            domain.name,
-            {
-                'ldap_deref_threshold': 0
-            },
-        )
+        sssd_conf_backup = tasks.FileBackup(self.master, paths.SSSD_CONF)
+        with tasks.remote_sssd_config(self.master) as sssd_config:
+            sssd_config.edit_domain(
+                self.master.domain, 'ldap_deref_threshold', 0)
         try:
             self.master.run_command(['systemctl', 'restart', 'sssd.service'])
 
@@ -731,15 +727,7 @@ class TestIPACommand(IntegrationTest):
                            password='Secret123')
             client.close()
         finally:
-            # revert back to original ldap config
-            # remove ldap_deref_threshold=0
-            tasks.modify_sssd_conf(
-                self.master,
-                domain.name,
-                {
-                    'ldap_deref_threshold': None
-                },
-            )
+            sssd_conf_backup.restore()
             self.master.run_command(['systemctl', 'restart', 'sssd.service'])
 
     def test_user_mod_change_capitalization_issue5879(self):

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -118,10 +118,10 @@ class TestSSSDWithAdTrust(IntegrationTest):
     @contextmanager
     def filter_user_setup(self, user):
         sssd_conf_backup = tasks.FileBackup(self.master, paths.SSSD_CONF)
-        filter_user = {'filter_users': self.users[user]['name']}
         try:
-            tasks.modify_sssd_conf(self.master, self.master.domain.name,
-                                   filter_user)
+            with tasks.remote_sssd_config(self.master) as sssd_conf:
+                sssd_conf.edit_domain(self.master.domain,
+                                      'filter_users', self.users[user]['name'])
             tasks.clear_sssd_cache(self.master)
             yield
         finally:

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -164,8 +164,6 @@ class TestSSSDWithAdTrust(IntegrationTest):
         for host in hosts:
             with tasks.remote_sssd_config(host) as sssd_conf:
                 sssd_conf.edit_service('sssd', 're_expression', expression)
-                sssd_conf.edit_service(
-                    'sssd', 'use_fully_qualified_names', True)
             tasks.clear_sssd_cache(host)
         try:
             cmd = ['getent', 'group', ad_group]

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -243,14 +243,9 @@ class TestTrust(BaseTestTrust):
 
         try:
             testuser = 'testuser@%s' % self.ad_domain
-            domain = self.master.domain
-            tasks.modify_sssd_conf(
-                self.master,
-                domain.name,
-                {
-                    'subdomain_homedir': '%o'
-                }
-            )
+            with tasks.remote_sssd_config(self.master) as sssd_conf:
+                sssd_conf.edit_domain(self.master.domain,
+                                      'subdomain_homedir', '%o')
 
             tasks.clear_sssd_cache(self.master)
             # The initgroups operation now uses the LDAP connection because
@@ -301,14 +296,9 @@ class TestTrust(BaseTestTrust):
         conn.update_entry(entry)  # pylint: disable=no-member
         self.master.run_command(['ipactl', 'restart'])
 
-        domain = self.master.domain
-        tasks.modify_sssd_conf(
-            self.master,
-            domain.name,
-            {
-                'timeout': '999999'
-            }
-        )
+        with tasks.remote_sssd_config(self.master) as sssd_conf:
+            sssd_conf.edit_domain(self.master.domain, 'timeout', '999999')
+
         remove_cache = 'sss_cache -E'
         self.master.run_command(remove_cache)
         client.run_command(remove_cache)


### PR DESCRIPTION
There are three patterns for editing sssd.conf in tests now:
1. using modify_sssd_conf() which allows to modify only domain sections
2. using remote_ini_file
3. direct file editing using `sed`

This PR introduces new utility function which combines advantages of
first two approaches:
* changes are verified against schema, so that mistakes can be spotted
  early
* has convenient interface for simple options modification,
  both in domain and service sections
* allows sophisticated modifications through SSSDConfig object

----------

ipatests: use remote_sssd_config to modify sssd.conf

Replace usage of remote_ini_file with remote_sssd_config.
The latter verifies changes against schema which helps to spot the mistakes.

----------
Fix found schema violations in test_sudo and test_sssd 
