### PR TITLE
[Backport][ipa-4-8] ipatests: redesign sssd config editor

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1952,7 +1952,7 @@ class FileBackup:
         host.run_command(['cp', '--preserve=all', filename, self._backup])
 
     def restore(self):
-        """Restore file. Can be called multiple times."""
+        """Restore file. Can be called only once."""
         self._host.run_command(['mv', self._backup, self._filename])
 
     def __enter__(self):

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -698,14 +698,10 @@ class TestIPACommand(IntegrationTest):
 
         username = "testuser" + str(random.randint(200000, 9999999))
         # add ldap_deref_threshold=0 to /etc/sssd/sssd.conf
-        domain = self.master.domain
-        tasks.modify_sssd_conf(
-            self.master,
-            domain.name,
-            {
-                'ldap_deref_threshold': 0
-            },
-        )
+        sssd_conf_backup = tasks.FileBackup(self.master, paths.SSSD_CONF)
+        with tasks.remote_sssd_config(self.master) as sssd_config:
+            sssd_config.edit_domain(
+                self.master.domain, 'ldap_deref_threshold', 0)
         try:
             self.master.run_command(['systemctl', 'restart', 'sssd.service'])
 
@@ -731,15 +727,7 @@ class TestIPACommand(IntegrationTest):
                            password='Secret123')
             client.close()
         finally:
-            # revert back to original ldap config
-            # remove ldap_deref_threshold=0
-            tasks.modify_sssd_conf(
-                self.master,
-                domain.name,
-                {
-                    'ldap_deref_threshold': None
-                },
-            )
+            sssd_conf_backup.restore()
             self.master.run_command(['systemctl', 'restart', 'sssd.service'])
 
     def test_user_mod_change_capitalization_issue5879(self):

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -118,10 +118,10 @@ class TestSSSDWithAdTrust(IntegrationTest):
     @contextmanager
     def filter_user_setup(self, user):
         sssd_conf_backup = tasks.FileBackup(self.master, paths.SSSD_CONF)
-        filter_user = {'filter_users': self.users[user]['name']}
         try:
-            tasks.modify_sssd_conf(self.master, self.master.domain.name,
-                                   filter_user)
+            with tasks.remote_sssd_config(self.master) as sssd_conf:
+                sssd_conf.edit_domain(self.master.domain,
+                                      'filter_users', self.users[user]['name'])
             tasks.clear_sssd_cache(self.master)
             yield
         finally:

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -164,8 +164,6 @@ class TestSSSDWithAdTrust(IntegrationTest):
         for host in hosts:
             with tasks.remote_sssd_config(host) as sssd_conf:
                 sssd_conf.edit_service('sssd', 're_expression', expression)
-                sssd_conf.edit_service(
-                    'sssd', 'use_fully_qualified_names', True)
             tasks.clear_sssd_cache(host)
         try:
             cmd = ['getent', 'group', ad_group]

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -243,14 +243,9 @@ class TestTrust(BaseTestTrust):
 
         try:
             testuser = 'testuser@%s' % self.ad_domain
-            domain = self.master.domain
-            tasks.modify_sssd_conf(
-                self.master,
-                domain.name,
-                {
-                    'subdomain_homedir': '%o'
-                }
-            )
+            with tasks.remote_sssd_config(self.master) as sssd_conf:
+                sssd_conf.edit_domain(self.master.domain,
+                                      'subdomain_homedir', '%o')
 
             tasks.clear_sssd_cache(self.master)
             # The initgroups operation now uses the LDAP connection because
@@ -301,14 +296,9 @@ class TestTrust(BaseTestTrust):
         conn.update_entry(entry)  # pylint: disable=no-member
         self.master.run_command(['ipactl', 'restart'])
 
-        domain = self.master.domain
-        tasks.modify_sssd_conf(
-            self.master,
-            domain.name,
-            {
-                'timeout': '999999'
-            }
-        )
+        with tasks.remote_sssd_config(self.master) as sssd_conf:
+            sssd_conf.edit_domain(self.master.domain, 'timeout', '999999')
+
         remove_cache = 'sss_cache -E'
         self.master.run_command(remove_cache)
         client.run_command(remove_cache)


### PR DESCRIPTION
This PR was opened automatically because PR #4313 was pushed to master and backport to ipa-4-8 is required.