### PR TITLE
[Backport][ipa-4-8] Fixes for ipa-adtrust-install --add-agents

### DIFF
--- a/ipaserver/plugins/trust.py
+++ b/ipaserver/plugins/trust.py
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import dbus
+import dbus.mainloop.glib
 import logging
 
 import six
@@ -74,8 +76,6 @@ except Exception as e:
 if api.env.in_server and api.env.context in ['lite', 'server']:
     try:
         import ipaserver.dcerpc
-        import dbus
-        import dbus.mainloop.glib
         _bindings_installed = True
     except ImportError:
         _bindings_installed = False

--- a/selinux/ipa.fc
+++ b/selinux/ipa.fc
@@ -18,6 +18,7 @@
 /usr/libexec/ipa/com\.redhat\.idm\.trust-fetch-domains --   gen_context(system_u:object_r:ipa_helper_exec_t,s0)
 /usr/libexec/ipa/oddjob/com\.redhat\.idm\.trust-fetch-domains  --  gen_context(system_u:object_r:ipa_helper_exec_t,s0)
 /usr/libexec/ipa/oddjob/org\.freeipa\.server\.conncheck  --  gen_context(system_u:object_r:ipa_helper_exec_t,s0)
+/usr/libexec/ipa/oddjob/org\.freeipa\.server\.trust-enable-agent  --  gen_context(system_u:object_r:ipa_helper_exec_t,s0)
 
 /var/lib/ipa(/.*)?              gen_context(system_u:object_r:ipa_var_lib_t,s0)
 
@@ -26,4 +27,3 @@
 /var/log/ipareplica-conncheck.log.*	--	gen_context(system_u:object_r:ipa_log_t,s0)
 
 /var/run/ipa(/.*)?              gen_context(system_u:object_r:ipa_var_run_t,s0)
-


### PR DESCRIPTION
This PR was opened automatically because PR #4331 was pushed to master and backport to ipa-4-8 is required.