### PR TITLE
Cleanup SELinux policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ install/custodia/ipa-custodia-dmldap
 install/custodia/ipa-custodia-pki-tomcat
 install/custodia/ipa-custodia-pki-tomcat-wrapped
 install/custodia/ipa-custodia-ra-agent
+install/oddjob/org.freeipa.server.trust-enable-agent
 install/oddjob/com.redhat.idm.trust-fetch-domains
 install/oddjob/etc/oddjobd.conf.d/ipa-server.conf
 install/oddjob/etc/oddjobd.conf.d/oddjobd-ipa-trust.conf

--- a/selinux/ipa.fc
+++ b/selinux/ipa.fc
@@ -9,16 +9,13 @@
 /usr/libexec/ipa-otpd		--	gen_context(system_u:object_r:ipa_otpd_exec_t,s0)
 /usr/libexec/ipa/ipa-otpd		--	gen_context(system_u:object_r:ipa_otpd_exec_t,s0)
 
-
 /usr/libexec/ipa/ipa-ods-exporter	--	gen_context(system_u:object_r:ipa_ods_exporter_exec_t,s0)
 
 /usr/libexec/ipa/ipa-dnskeysyncd		--	gen_context(system_u:object_r:ipa_dnskey_exec_t,s0)
 /usr/libexec/ipa/ipa-dnskeysync-replica		--	gen_context(system_u:object_r:ipa_dnskey_exec_t,s0)
 
-/usr/libexec/ipa/com\.redhat\.idm\.trust-fetch-domains --   gen_context(system_u:object_r:ipa_helper_exec_t,s0)
-/usr/libexec/ipa/oddjob/com\.redhat\.idm\.trust-fetch-domains  --  gen_context(system_u:object_r:ipa_helper_exec_t,s0)
-/usr/libexec/ipa/oddjob/org\.freeipa\.server\.conncheck  --  gen_context(system_u:object_r:ipa_helper_exec_t,s0)
-/usr/libexec/ipa/oddjob/org\.freeipa\.server\.trust-enable-agent  --  gen_context(system_u:object_r:ipa_helper_exec_t,s0)
+/usr/libexec/ipa/oddjob/com\.redhat\.idm.*  --  gen_context(system_u:object_r:ipa_helper_exec_t,s0)
+/usr/libexec/ipa/oddjob/org\.freeipa.*  --  gen_context(system_u:object_r:ipa_helper_exec_t,s0)
 
 /var/lib/ipa(/.*)?              gen_context(system_u:object_r:ipa_var_lib_t,s0)
 

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -205,7 +205,7 @@ libs_exec_ldconfig(ipa_dnskey_t)
 
 logging_send_syslog_msg(ipa_dnskey_t)
 
-miscfiles_read_certs(ipa_dnskey_t)
+miscfiles_read_generic_certs(ipa_dnskey_t)
 
 sysnet_read_config(ipa_dnskey_t)
 
@@ -262,7 +262,7 @@ libs_exec_ldconfig(ipa_ods_exporter_t)
 
 logging_send_syslog_msg(ipa_ods_exporter_t)
 
-miscfiles_read_certs(ipa_ods_exporter_t)
+miscfiles_read_generic_certs(ipa_ods_exporter_t)
 
 sysnet_read_config(ipa_ods_exporter_t)
 


### PR DESCRIPTION
* Remove FC for /usr/libexec/ipa/com.redhat.idm.trust-fetch-domains. The
  file has been moved to oddjobs/ subdirectory a long time ago.
* Simplify FC for oddjob scripts. All com.redhat.idm.* and org.freeipa.*
  scripts are labeled as ipa_helper_exec_t.
* use miscfiles_read_generic_certs() instead of deprecated
  miscfiles_read_certs() to address the warning:

```
Warning: miscfiles_read_certs() has been deprecated, please use miscfiles_read_generic_certs() instead.
```

(Also add org.freeipa.server.trust-enable-agent to .gitignore)

Related: https://pagure.io/freeipa/issue/6891
Signed-off-by: Christian Heimes <cheimes@redhat.com>