### PR TITLE
[Backport][ipa-4-7] ipatests: add test for SSSD updating expired cache items

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-29/temp_commit:
+  fedora-29/test_sssd:
     requires: [fedora-29/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_sssd.py
         template: *ci-master-f29
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 4800
+        topology: *ad_master_2client

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -57,9 +57,6 @@ class TestSSSDWithAdTrust(IntegrationTest):
 
         cls.users['ad']['name'] = cls.users['ad']['name_tmpl'].format(
             domain=cls.ad.domain.name)
-
-        # Regression tests for cached_auth_timeout option
-        # https://bugzilla.redhat.com/show_bug.cgi?id=1685581
         tasks.user_add(cls.master, cls.intermed_user)
         tasks.create_active_user(cls.master, cls.ipa_user,
                                  cls.ipa_user_password)
@@ -86,18 +83,34 @@ class TestSSSDWithAdTrust(IntegrationTest):
 
     @pytest.mark.parametrize('user', ['ipa', 'ad'])
     def test_auth_cache_disabled_by_default(self, user):
+        """Check credentials not cached with default sssd config.
+
+        Regression test for cached_auth_timeout option
+        https://bugzilla.redhat.com/show_bug.cgi?id=1685581
+        """
         with self.config_sssd_cache_auth(cached_auth_timeout=None):
             assert not self.is_auth_cached(self.users[user])
             assert not self.is_auth_cached(self.users[user])
 
     @pytest.mark.parametrize('user', ['ipa', 'ad'])
     def test_auth_cache_disabled_with_value_0(self, user):
+        """Check credentials not cached with cached_auth_timeout=0 in sssd.conf
+
+        Regression test for cached_auth_timeout option
+        https://bugzilla.redhat.com/show_bug.cgi?id=1685581
+        """
         with self.config_sssd_cache_auth(cached_auth_timeout=0):
             assert not self.is_auth_cached(self.users[user])
             assert not self.is_auth_cached(self.users[user])
 
     @pytest.mark.parametrize('user', ['ipa', 'ad'])
     def test_auth_cache_enabled_when_configured(self, user):
+        """Check credentials are cached with cached_auth_timeout=30
+
+        Regression test for cached_auth_timeout option
+        https://bugzilla.redhat.com/show_bug.cgi?id=1685581
+        """
+
         timeout = 30
         with self.config_sssd_cache_auth(cached_auth_timeout=timeout):
             start = time.time()

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 import time
 from contextlib import contextmanager
+import re
 
 import pytest
 import textwrap
@@ -29,11 +30,13 @@ class TestSSSDWithAdTrust(IntegrationTest):
     users = {
         'ipa': {
             'name': 'user1',
-            'password': 'SecretUser1'
+            'password': 'SecretUser1',
+            'group': 'user1',
         },
         'ad': {
             'name_tmpl': 'testuser@{domain}',
-            'password': 'Secret123'
+            'password': 'Secret123',
+            'group_tmpl': 'testgroup@{domain}',
         },
         'fakeuser': {
             'name': 'some_user@some.domain'
@@ -56,6 +59,8 @@ class TestSSSDWithAdTrust(IntegrationTest):
         tasks.establish_trust_with_ad(cls.master, cls.ad.domain.name)
 
         cls.users['ad']['name'] = cls.users['ad']['name_tmpl'].format(
+            domain=cls.ad.domain.name)
+        cls.users['ad']['group'] = cls.users['ad']['group_tmpl'].format(
             domain=cls.ad.domain.name)
         tasks.user_add(cls.master, cls.intermed_user)
         tasks.create_active_user(cls.master, cls.ipa_user,
@@ -247,3 +252,44 @@ class TestSSSDWithAdTrust(IntegrationTest):
             # reset to original limit
             tasks.ldapmodify_dm(master, ldap_query.format(limit=orig_limit))
             sssd_conf_backup.restore()
+
+    @pytest.mark.parametrize('user_origin', ['ipa', 'ad'])
+    def test_sssd_cache_refresh(self, user_origin):
+        """Check SSSD updates expired cache items for domain and its subdomains
+
+        Regression test for https://pagure.io/SSSD/sssd/issue/4012
+        """
+        def get_cache_update_time(obj_kind, obj_name):
+            res = self.master.run_command(
+                ['sssctl', '{}-show'.format(obj_kind), obj_name])
+            m = re.search(r'Cache entry last update time:\s+([^\n]+)',
+                          res.stdout_text)
+            update_time = m.group(1).strip()
+            assert update_time
+            return update_time
+
+        # by design, sssd does first update of expired records in 30 seconds
+        # since start
+        refresh_time = 30
+        user = self.users[user_origin]['name']
+        group = self.users[user_origin]['group']
+        sssd_conf_backup = tasks.FileBackup(self.master, paths.SSSD_CONF)
+        try:
+            with tasks.remote_sssd_config(self.master) as sssd_conf:
+                sssd_conf.edit_domain(
+                    self.master.domain, 'refresh_expired_interval', 1)
+                sssd_conf.edit_domain(
+                    self.master.domain, 'entry_cache_timeout', 1)
+            tasks.clear_sssd_cache(self.master)
+
+            start = time.time()
+            self.master.run_command(['id', user])
+            user_update_time = get_cache_update_time('user', user)
+            group_update_time = get_cache_update_time('group', group)
+            time.sleep(start + refresh_time - time.time() + 5)
+            assert get_cache_update_time('user', user) != user_update_time
+            assert (get_cache_update_time('group', group) !=
+                    group_update_time)
+        finally:
+            sssd_conf_backup.restore()
+            tasks.clear_sssd_cache(self.master)


### PR DESCRIPTION
This PR was opened automatically because PR #3955 was pushed to master and backport to ipa-4-7 is required.