### PR TITLE
[Backport][ipa-4-7] ipa-restore: restart services at the end

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -452,6 +452,14 @@ class Restore(admintool.AdminTool):
                 http.remove_httpd_ccaches()
                 # have the daemons pick up their restored configs
                 tasks.systemd_daemon_reload()
+                # Restart IPA a final time.
+                # Starting then restarting is necessary to make sure some
+                # daemons like httpd are restarted
+                # (https://pagure.io/freeipa/issue/8226).
+                logger.info('Restarting IPA services')
+                result = run([paths.IPACTL, 'restart'], raiseonerr=False)
+                if result.returncode != 0:
+                    logger.error('Restarting IPA failed: %s', result.error_log)
         finally:
             try:
                 os.chdir(cwd)


### PR DESCRIPTION
MANUAL cherry-pick of https://github.com/freeipa/freeipa/pull/4349

When IPA was not installed on the restore target host, and
when httpd was already running, "ipactl stop" does not stop
httpd. "ipactl start" at the end of the restore tool will
therefore not restart httpd either.
Calling "ipactl restart" at the end of the restore fixes the
issue, and as an added bonus, makes sure IPA can restart itself
properly.

Fixes: https://pagure.io/freeipa/issue/8226
Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Florence Blanc-Renaud <flo@redhat.com>