### PR TITLE
[Backport][ipa-4-8] ipatests: User and group with same name should not break reading AD user data.

### DIFF
--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -15,6 +15,7 @@ import textwrap
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
+from ipaplatform.tasks import tasks as platform_tasks
 from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 from ipapython.dn import DN
@@ -296,6 +297,12 @@ class TestSSSDWithAdTrust(IntegrationTest):
         in group with same name of nonprivate ipa user and possix id, then
         lookup of aduser and group should be successful when cache is empty.
         """
+        cmd = self.master.run_command(['sssd', '--version'])
+        sssd_version = platform_tasks.parse_ipa_version(
+            cmd.stdout_text.strip())
+        if sssd_version <= platform_tasks.parse_ipa_version('2.2.2'):
+            pytest.skip("Fix for https://pagure.io/SSSD/sssd/issue/4073 "
+                        "unavailable with sssd-2.2.2")
         client = self.clients[0]
         user = 'ipatest'
         userid = '100996'


### PR DESCRIPTION
This PR was opened automatically because PR #4078 was pushed to master and backport to ipa-4-8 is required.