### PR TITLE
ipatests: wait for SSSD to become online in backup/restore tests

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2130,3 +2130,27 @@ def wait_for_request(host, request_id, timeout=120):
         raise RuntimeError("request timed out")
 
     return state
+
+
+def wait_for_sssd_domain_status_online(host, timeout=120):
+    """Wait up to timeout (in seconds) for sssd domain status to become Online
+
+    The method is checking the Online Status of the domain as displayed by
+    the command sssctl domain-status <domain> -o and returns successfully
+    when the status is Online.
+    This call is useful for instance when 389-ds has been stopped and restarted
+    as SSSD may need a while before it reconnects and switches from Offline
+    mode to Online.
+    """
+    pattern = re.compile(r'Online status: (?P<state>.*)\n')
+    for _i in range(0, timeout, 5):
+        result = host.run_command(
+            [paths.SSSCTL, "domain-status", host.domain.name, "-o"]
+        )
+        match = pattern.search(result.stdout_text)
+        state = match.group('state')
+        if state == 'Online':
+            break
+        time.sleep(5)
+    else:
+        raise RuntimeError("SSSD still offline")

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -151,6 +151,8 @@ def restore_checker(host):
 
     yield
 
+    # Wait for SSSD to become online before doing any other check
+    tasks.wait_for_sssd_domain_status_online(host)
     tasks.kinit_admin(host)
 
     for (check, assert_func), expected in zip(CHECKS, results):


### PR DESCRIPTION
The backup/restore tests are calling 'id admin' after restore
to make sure that the user name can be resolved after a restore.
The test should wait for SSSD backend to become online before
doing any check, otherwise there is a risk that the call to
'id admin' fails.

Fixes: https://pagure.io/freeipa/issue/8228