### PR TITLE
pki-proxy: Don't rely on running apache until it's configured

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -363,12 +363,6 @@ class DogtagInstance(service.Service):
         with open(paths.HTTPD_IPA_PKI_PROXY_CONF, "w") as fd:
             fd.write(template)
             os.fchmod(fd.fileno(), 0o640)
-        # Restart httpd
-        http_service = services.knownservices.httpd
-        logger.debug("Restarting %s to apply AJP changes",
-                     http_service.service_name)
-        http_service.restart()
-        logger.debug("%s successfully restarted", http_service.service_name)
 
     def configure_certmonger_renewal_helpers(self):
         """


### PR DESCRIPTION
This partially restores the pre- ec73de969f state of `http_proxy`,
which fails to restart the apache service during master
installation. The failure happens because of apache is not
configured yet on 'pki-tomcatd' installation phase. The mentioned
code and proposed one relies on the installer which bootstraps the
master.

Fixes: https://pagure.io/freeipa/issue/8233