### PR TITLE
[Backport][ipa-4-7] idviews: prevent applying to a master

### DIFF
--- a/ipaserver/plugins/idviews.py
+++ b/ipaserver/plugins/idviews.py
@@ -26,6 +26,7 @@ from .baseldap import (LDAPQuery, LDAPObject, LDAPCreate,
                        LDAPAddAttributeViaOption,
                        LDAPRemoveAttributeViaOption,
                        LDAPRetrieve, global_output_params,
+                       host_is_master,
                        add_missing_object_class)
 from .hostgroup import get_complete_hostgroup_member_list
 from ipalib import (
@@ -360,6 +361,16 @@ class baseidview_apply(LDAPQuery):
 
         for host in hosts_to_apply:
             try:
+                # Check that the host is not a master
+                # IDView must not be applied to masters
+                try:
+                    host_is_master(ldap, host)
+                except errors.ValidationError:
+                    failed['host'].append(
+                        (host,
+                         unicode(_("ID View cannot be applied to IPA master")))
+                    )
+                    continue
                 host_dn = api.Object['host'].get_dn_if_exists(host)
 
                 host_entry = ldap.get_entry(host_dn,

--- a/ipatests/test_xmlrpc/test_idviews_plugin.py
+++ b/ipatests/test_xmlrpc/test_idviews_plugin.py
@@ -778,6 +778,54 @@ class test_idviews(Declarative):
         ),
 
 
+        # Test ID View applying to a master
+        # Try to apply to the localhost = master
+        dict(
+            desc=u'Apply %s to %s' % (idview1, api.env.host),
+            command=(
+                'idview_apply',
+                [idview1],
+                dict(host=api.env.host)
+            ),
+            expected=dict(
+                completed=0,
+                succeeded=dict(
+                    host=tuple(),
+                ),
+                failed=dict(
+                    memberhost=dict(
+                        host=([api.env.host,
+                               u'ID View cannot be applied to IPA master'],),
+                        hostgroup=tuple(),
+                    ),
+                ),
+                summary=u'Applied ID View "%s"' % idview1,
+            ),
+        ),
+        # Try to apply to the group ipaservers = all masters
+        dict(
+            desc=u'Apply %s to %s' % (idview1, 'ipaservers'),
+            command=(
+                'idview_apply',
+                [idview1],
+                dict(hostgroup=u'ipaservers')
+            ),
+            expected=dict(
+                completed=0,
+                succeeded=dict(
+                    host=tuple(),
+                ),
+                failed=dict(
+                    memberhost=dict(
+                        host=([api.env.host,
+                               u'ID View cannot be applied to IPA master'],),
+                        hostgroup=tuple(),
+                    ),
+                ),
+                summary=u'Applied ID View "%s"' % idview1,
+            ),
+        ),
+
         # Test ID View applying
 
         dict(


### PR DESCRIPTION
This PR was opened automatically because PR #4387 was pushed to master and backport to ipa-4-7 is required.