### PR TITLE
[Backport][ipa-4-7] Prevent adding IPA objects as external members of external groups

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -409,7 +409,12 @@ class DomainValidator(object):
         if object_name in result and \
            (pysss_nss_idmap.SID_KEY in result[object_name]):
             object_sid = result[object_name][pysss_nss_idmap.SID_KEY]
-            return object_sid
+            if self.is_trusted_sid_valid(object_sid):
+                return object_sid
+            else:
+                raise errors.ValidationError(name=_('trusted domain object'),
+                                             error=_('Object does not belong '
+                                                     'to a trusted domain'))
 
         # If fallback to AD DC LDAP is not allowed, bail out
         if not fallback_to_ldap:

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -18,6 +18,7 @@ from ipaplatform.tasks import tasks as platform_tasks
 from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 from ipapython.dn import DN
+from ipalib import errors
 
 
 class TestSSSDWithAdTrust(IntegrationTest):
@@ -276,3 +277,26 @@ class TestSSSDWithAdTrust(IntegrationTest):
         finally:
             self.master.run_command(['ipa', 'user-del', user])
             self.master.run_command(['ipa', 'group-del', user, ext_group])
+
+    @pytest.mark.parametrize('user_origin', ['ipa', 'ad'])
+    def test_external_group_member_mismatch(self, user_origin):
+        """Prevent adding IPA objects as external group external members
+
+        External groups must only allow adding non-IPA objects as external
+        members in 'ipa group-add-member foo --external bar'.
+        """
+        master = self.master
+        tasks.clear_sssd_cache(master)
+        tasks.kinit_admin(master)
+        master.run_command(['ipa', 'group-add', '--external',
+                            'ext-ipatest'])
+        try:
+            master.run_command(['ipa', 'group-add-member',
+                                'ext-ipatest',
+                                '--external',
+                                self.users[user_origin]['name']])
+        except errors.ValidationError:
+            # Only 'ipa' origin should throw a validation error
+            assert user_origin == 'ipa'
+        finally:
+            master.run_command(['ipa', 'group-del', 'ext-ipatest'])


### PR DESCRIPTION
This PR was opened automatically because PR #4374 was pushed to master and backport to ipa-4-7 is required.