### PR TITLE
Update SELinux policy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 if ENABLE_SERVER
     IPASERVER_SUBDIRS = ipaserver
-    SERVER_SUBDIRS = daemons init install selinux
+    SERVER_SUBDIRS = daemons init install
 endif
 
 if WITH_IPATESTS
@@ -26,7 +26,17 @@ PYTHON_SCRIPT_SUBDIRS = \
 AZURE_PYTHON_SCRIPT_SUBDIR = $(top_builddir)/ipatests/azure
 
 IPA_PLACEHOLDERS = freeipa ipa ipaserver ipatests
-SUBDIRS = asn1 util client contrib po pypi $(PYTHON_SUBDIRS) $(SERVER_SUBDIRS)
+SUBDIRS = \
+        asn1 \
+        util \
+        client \
+        contrib \
+        po \
+        pypi \
+        selinux \
+        $(PYTHON_SUBDIRS) \
+        $(SERVER_SUBDIRS) \
+        $(NULL)
 
 GENERATED_PYTHON_FILES = \
 	$(top_builddir)/ipaplatform/override.py \

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -363,11 +363,6 @@ Requires: oddjob
 # 0.7.0-2: https://pagure.io/gssproxy/pull-request/172
 Requires: gssproxy >= 0.7.0-2
 Requires: sssd-dbus >= %{sssd_version}
-%if 0%{?with_selinux}
-# This ensures that the *-selinux package and all it’s dependencies are not pulled
-# into containers and other systems that do not use SELinux
-Requires:       (%{name}-selinux if selinux-policy-%{selinuxtype})
-%endif
 
 Provides: %{alt_name}-server = %{version}
 Conflicts: %{alt_name}-server
@@ -714,6 +709,13 @@ Conflicts: %{alt_name}-common
 Obsoletes: %{alt_name}-common < %{version}
 
 Conflicts: %{alt_name}-python < %{version}
+
+%if 0%{?with_selinux}
+# This ensures that the *-selinux package and all it’s dependencies are not
+# pulled into containers and other systems that do not use SELinux. The
+# policy defines types and file contexts for client and server.
+Requires:       (%{name}-selinux if selinux-policy-%{selinuxtype})
+%endif
 
 %description common
 IPA is an integrated solution to provide centrally managed Identity (users,

--- a/selinux/README.md
+++ b/selinux/README.md
@@ -1,0 +1,11 @@
+# IPA SELinux policy
+
+The ``ipa`` SELinux policy is used by IPA client and server. The
+policy was forked off from [Fedora upstream policy](https://github.com/fedora-selinux/selinux-policy-contrib)
+at commit ``b1751347f4af99de8c88630e2f8d0a352d7f5937``.
+
+Some file locations are owned by other policies:
+
+* ``/var/lib/ipa/pki-ca/publish(/.*)?`` is owned by Dogtag PKI policy
+* ``/usr/lib/ipa/certmonger(/.*)?`` is owned by certmonger policy
+* ``/var/lib/ipa-client(/.*)?`` is owned by realmd policy

--- a/selinux/ipa.fc
+++ b/selinux/ipa.fc
@@ -24,3 +24,11 @@
 /var/log/ipareplica-conncheck.log.*	--	gen_context(system_u:object_r:ipa_log_t,s0)
 
 /var/run/ipa(/.*)?              gen_context(system_u:object_r:ipa_var_run_t,s0)
+
+/usr/libexec/ipa/ipa-custodia					--	gen_context(system_u:object_r:ipa_custodia_exec_t,s0)
+/usr/libexec/ipa/custodia/ipa-custodia-dmldap			--	gen_context(system_u:object_r:ipa_custodia_dmldap_exec_t,s0)
+/usr/libexec/ipa/custodia/ipa-custodia-pki-tomcat		--	gen_context(system_u:object_r:ipa_custodia_pki_tomcat_exec_t,s0)
+/usr/libexec/ipa/custodia/ipa-custodia-pki-tomcat-wrapped	--	gen_context(system_u:object_r:ipa_custodia_pki_tomcat_exec_t,s0)
+/usr/libexec/ipa/custodia/ipa-custodia-ra-agent		--	gen_context(system_u:object_r:ipa_custodia_ra_agent_exec_t,s0)
+
+/var/log/ipa-custodia.audit.log(/.*)?				--	gen_context(system_u:object_r:ipa_custodia_log_t,s0)

--- a/selinux/ipa.if
+++ b/selinux/ipa.if
@@ -308,3 +308,60 @@ interface(`ipa_read_tmp',`
 
     read_files_pattern($1, ipa_tmp_t, ipa_tmp_t)
 ')
+
+########################################
+## <summary>
+##	Execute ipa_custodia_exec_t in the ipa_custodia domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`ipa_custodia_domtrans',`
+	gen_require(`
+		type ipa_custodia_t, ipa_custodia_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, ipa_custodia_exec_t, ipa_custodia_t)
+')
+
+######################################
+## <summary>
+##	Execute ipa_custodia in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ipa_custodia_exec',`
+	gen_require(`
+		type ipa_custodia_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, ipa_custodia_exec_t)
+')
+
+#####################################
+## <summary>
+##	Connect to ipa_custodia with a unix
+##	domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ipa_custodia_stream_connect',`
+	gen_require(`
+		type ipa_custodia_t;
+	')
+
+    allow $1 ipa_custodia_t:unix_stream_socket { connectto };
+')

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -53,6 +53,25 @@ miscfiles_cert_type(ipa_cert_t)
 type ipa_tmp_t;
 files_tmp_file(ipa_tmp_t)
 
+type ipa_custodia_t;
+type ipa_custodia_exec_t;
+init_daemon_domain(ipa_custodia_t, ipa_custodia_exec_t)
+
+type ipa_custodia_dmldap_exec_t;
+init_script_file(ipa_custodia_dmldap_exec_t)
+
+type ipa_custodia_pki_tomcat_exec_t;
+init_script_file(ipa_custodia_pki_tomcat_exec_t)
+
+type ipa_custodia_ra_agent_exec_t;
+init_script_file(ipa_custodia_ra_agent_exec_t)
+
+type ipa_custodia_log_t;
+logging_log_file(ipa_custodia_log_t)
+
+type ipa_custodia_tmp_t;
+files_tmp_file(ipa_custodia_tmp_t)
+
 ########################################
 #
 # ipa_otpd local policy
@@ -285,4 +304,79 @@ optional_policy(`
 
 optional_policy(`
     ldap_stream_connect(ipa_ods_exporter_t)
+')
+
+########################################
+#
+# ipa_custodia local policy
+#
+allow ipa_custodia_t self:capability { setgid setuid };
+allow ipa_custodia_t self:fifo_file rw_fifo_file_perms;
+allow ipa_custodia_t self:netlink_route_socket { create_socket_perms nlmsg_read };
+allow ipa_custodia_t self:unix_stream_socket create_stream_socket_perms;
+allow ipa_custodia_t self:unix_dgram_socket create_socket_perms;
+allow ipa_custodia_t self:udp_socket create_socket_perms;
+
+manage_dirs_pattern(ipa_custodia_t,ipa_custodia_log_t,ipa_custodia_log_t)
+manage_files_pattern(ipa_custodia_t, ipa_custodia_log_t, ipa_custodia_log_t)
+logging_log_filetrans(ipa_custodia_t, ipa_custodia_log_t, { dir file })
+
+manage_dirs_pattern(ipa_custodia_t, ipa_custodia_tmp_t, ipa_custodia_tmp_t)
+manage_files_pattern(ipa_custodia_t, ipa_custodia_tmp_t, ipa_custodia_tmp_t)
+files_tmp_filetrans(ipa_custodia_t, ipa_custodia_tmp_t, { dir file })
+
+kernel_dgram_send(ipa_custodia_t)
+
+auth_read_passwd(ipa_custodia_t)
+
+can_exec(ipa_custodia_t, ipa_custodia_dmldap_exec_t)
+can_exec(ipa_custodia_t, ipa_custodia_pki_tomcat_exec_t)
+can_exec(ipa_custodia_t, ipa_custodia_ra_agent_exec_t)
+
+corecmd_exec_bin(ipa_custodia_t)
+corecmd_mmap_bin_files(ipa_custodia_t)
+
+domain_use_interactive_fds(ipa_custodia_t)
+
+files_mmap_usr_files(ipa_custodia_t)
+
+fs_getattr_xattr_fs(ipa_custodia_t)
+
+files_read_etc_files(ipa_custodia_t)
+
+libs_exec_ldconfig(ipa_custodia_t)
+libs_ldconfig_exec_entry_type(ipa_custodia_t)
+
+miscfiles_read_generic_certs(ipa_custodia_t)
+miscfiles_read_localization(ipa_custodia_t)
+
+sysnet_read_config(ipa_custodia_t)
+
+optional_policy(`
+	apache_search_config(ipa_custodia_t)
+	apache_systemctl(ipa_custodia_t)
+	apache_manage_pid_files(ipa_custodia_t)
+')
+
+optional_policy(`
+	dirsrv_manage_var_run(ipa_custodia_t)
+	dirsrv_stream_connect(ipa_custodia_t)
+')
+
+optional_policy(`
+	ipa_read_lib(ipa_custodia_t)
+	ipa_search_lib(ipa_custodia_t)
+')
+
+optional_policy(`
+	pki_manage_tomcat_etc_rw(ipa_custodia_t)
+	pki_read_tomcat_cert(ipa_custodia_t)
+	pki_rw_tomcat_cert(ipa_custodia_t)
+')
+
+optional_policy(`
+	sssd_read_public_files(ipa_custodia_t)
+	sssd_run_stream_connect(ipa_custodia_t)
+	sssd_search_lib(ipa_custodia_t)
+	sssd_stream_connect(ipa_custodia_t)
 ')


### PR DESCRIPTION
## Move ``ipa_custodia`` policy from upstream into IPA's policy

The SELinux policy defines file contexts that are also used by clients, e.g. /var/log/ipa/. Make freeipa-selinux a dependency of freeipa-common.

## Make freeipa-selinux a dependency of freeipa-common 

ipa-custodia is an internal service for IPA. The upstream SELinux policy has a separate module for ipa_custodia. Fold the current policy from Fedora rawhide into ipa's SELinux policy.

Related: https://pagure.io/freeipa/issue/6891