### PR TITLE
[ipa-4-6] ipatests: fix KeyError in test_sssd

### DIFF
--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 
 import ipaplatform
 import pytest
+import subprocess
 import textwrap
 
 from ipatests.test_integration.base import IntegrationTest
@@ -17,7 +18,6 @@ from ipatests.pytest_ipa.integration import tasks
 from ipaplatform.tasks import tasks as platform_tasks
 from ipaplatform.paths import paths
 from ipapython.dn import DN
-from ipalib import errors
 
 
 class TestSSSDWithAdTrust(IntegrationTest):
@@ -211,9 +211,8 @@ class TestSSSDWithAdTrust(IntegrationTest):
         self.master.run_command(
             ['ipa', 'group-add-member', '--group', ext_group, user])
         self.master.run_command([
-            'ipa', 'group-add-member', '--external',
-            self.users['ad']['name'], ext_group,
-            '--users=', '--groups='])
+            'ipa', '-n', 'group-add-member', '--external',
+            self.users['ad']['name'], ext_group])
         tasks.clear_sssd_cache(self.master)
         tasks.clear_sssd_cache(client)
         try:
@@ -237,11 +236,11 @@ class TestSSSDWithAdTrust(IntegrationTest):
         master.run_command(['ipa', 'group-add', '--external',
                             'ext-ipatest'])
         try:
-            master.run_command(['ipa', 'group-add-member',
+            master.run_command(['ipa', '-n', 'group-add-member',
                                 'ext-ipatest',
                                 '--external',
                                 self.users[user_origin]['name']])
-        except errors.ValidationError:
+        except subprocess.CalledProcessError:
             # Only 'ipa' origin should throw a validation error
             assert user_origin == 'ipa'
         finally:

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -27,6 +27,10 @@ class TestSSSDWithAdTrust(IntegrationTest):
     num_clients = 1
 
     users = {
+        'ipa': {
+            'name': 'user1',
+            'password': 'SecretUser1',
+        },
         'ad': {
             'name_tmpl': 'testuser@{domain}',
             'password': 'Secret123'
@@ -35,6 +39,8 @@ class TestSSSDWithAdTrust(IntegrationTest):
             'name': 'some_user@some.domain'
         },
     }
+    ipa_user = 'user1'
+    ipa_user_password = 'SecretUser1'
     ad_user_tmpl = 'testuser@{domain}'
 
     @classmethod
@@ -49,6 +55,8 @@ class TestSSSDWithAdTrust(IntegrationTest):
 
         cls.users['ad']['name'] = cls.users['ad']['name_tmpl'].format(
             domain=cls.ad.domain.name)
+        tasks.create_active_user(cls.master, cls.ipa_user,
+                                 cls.ipa_user_password)
 
     @contextmanager
     def filter_user_setup(self, user):


### PR DESCRIPTION
The test was missing a backport defining users['ipa'].
Fixes: https://pagure.io/freeipa/issue/8238