### PR TITLE
[Backport][ipa-4-7] ipatests: wait for SSSD to become online in backup/restore tests

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -152,6 +152,8 @@ def restore_checker(host):
 
     yield
 
+    # Wait for SSSD to become online before doing any other check
+    tasks.wait_for_sssd_domain_status_online(host)
     tasks.kinit_admin(host)
 
     for (check, assert_func), expected in zip(CHECKS, results):


### PR DESCRIPTION
Manual backport of PR #4383 to ipa-4-7 branch.
There was a conflict on ipatests/pytest_ipa/integration/tasks.py because the file contains a additional methods on the master branch, that are not needed in this PR.