### PR TITLE
ipatests: add missing tests to nightly run for ipa-4-7

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/nightly_ipa-4-7.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-7.yaml
@@ -1352,3 +1352,15 @@ jobs:
         template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
+
+  fedora-29/test_crlgen_manage:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_crlgen_manage.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-7.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-7.yaml
@@ -439,6 +439,42 @@ jobs:
         timeout: 10800
         topology: *master_2repl_1client
 
+  fedora-29/test_installation_TestADTrustInstall:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestADTrustInstall
+        template: *ci-master-f29
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-29/test_installation_TestADTrustInstallWithDNS_KRA_ADTrust:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestADTrustInstallWithDNS_KRA_ADTrust
+        template: *ci-master-f29
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-29/test_installation_TestKRAinstallAfterCertRenew:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestKRAinstallAfterCertRenew
+        template: *ci-master-f29
+        timeout: 10800
+        topology: *ipaserver
+
   fedora-29/test_idviews:
     requires: [fedora-29/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-7.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-7.yaml
@@ -446,7 +446,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_idviews.py::TestIDViews
+        test_suite: test_integration/test_idviews.py
         template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,63 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-29/temp_commit:
+  fedora-29/test_crlgen_manage:
     requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-29/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_crlgen_manage.py
+        template: *ci-master-f29
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-29/test_installation_TestADTrustInstall:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestADTrustInstall
+        template: *ci-master-f29
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-29/test_installation_TestADTrustInstallWithDNS_KRA_ADTrust:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestADTrustInstallWithDNS_KRA_ADTrust
+        template: *ci-master-f29
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-29/test_installation_TestKRAinstallAfterCertRenew:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_installation.py::TestKRAinstallAfterCertRenew
+        template: *ci-master-f29
+        timeout: 10800
+        topology: *ipaserver
+
+  fedora-29/test_idviews:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_idviews.py
         template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl_1client
+


### PR DESCRIPTION
test_integration/test_crlgen_manage was missing in nightly_ipa-4-7.yaml
for no obvious reason.
