### PR TITLE
ipatests: add missing tests to nightly run for ipa-4-6

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -824,6 +824,18 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  fedora-27/test_replica_promotion_TestReplicaPromotionLevel0:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel0
+        template: *ci-master-f27
+        timeout: 7200
+        topology: *master_1repl
+
   fedora-27/test_upgrade:
     requires: [fedora-27/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -1146,3 +1146,39 @@ jobs:
         template: *ci-master-f27
         timeout: 3600
         topology: *master_1repl_1client
+
+  fedora-27/test_crlgen_manage:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_crlgen_manage.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-27/nfs:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_nfs.py
+        template: *ci-master-f27
+        timeout: 9000
+        topology: *master_2repl_1client
+
+  fedora-27/test_otp:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_otp.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -367,6 +367,78 @@ jobs:
         timeout: 10800
         topology: *master_2repl_1client
 
+  fedora-27/test_installation_TestInstallWithCA_KRA1:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-27/test_installation_TestInstallWithCA_KRA2:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-27/test_installation_TestInstallWithCA_KRA_DNS1:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-27/test_installation_TestInstallWithCA_KRA_DNS2:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-27/test_installation_TestADTrustInstall:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestADTrustInstall
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-27/test_installation_TestADTrustInstallWithDNS_KRA_ADTrust:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestADTrustInstallWithDNS_KRA_ADTrust
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_2repl_1client
+
   fedora-27/test_idviews:
     requires: [fedora-27/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -443,13 +443,13 @@ jobs:
     requires: [fedora-27/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-27/build_url}'
-        test_suite: test_integration/test_idviews.py::TestIDViews
+        test_suite: test_integration/test_idviews.py
         template: *ci-master-f27
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *ad_master_2client
 
   fedora-27/test_caless_TestServerInstall:
     requires: [fedora-27/build]

--- a/ipatests/test_integration/base.py
+++ b/ipatests/test_integration/base.py
@@ -20,6 +20,7 @@
 """Base class for FreeIPA integration tests"""
 
 import pytest
+import subprocess
 
 from ipatests.pytest_ipa.integration import tasks
 from pytest_sourceorder import ordered
@@ -78,8 +79,16 @@ class IntegrationTest(object):
 
     @classmethod
     def uninstall(cls, mh):
-        tasks.uninstall_master(cls.master)
         for replica in cls.replicas:
+            try:
+                tasks.run_server_del(
+                    cls.master, replica.hostname, force=True,
+                    ignore_topology_disconnect=True, ignore_last_of_role=True)
+            except subprocess.CalledProcessError:
+                # If the master has already been uninstalled,
+                # this call may fail
+                pass
             tasks.uninstall_master(replica)
+        tasks.uninstall_master(cls.master)
         for client in cls.clients:
             tasks.uninstall_client(client)

--- a/ipatests/test_integration/base.py
+++ b/ipatests/test_integration/base.py
@@ -89,6 +89,10 @@ class IntegrationTest(object):
                 # this call may fail
                 pass
             tasks.uninstall_master(replica)
-        tasks.uninstall_master(cls.master)
+        if cls.domain_level is not None:
+            domain_level = cls.domain_level
+        else:
+            domain_level = cls.master.config.domain_level
+        tasks.uninstall_master(cls.master, domain_level=domain_level)
         for client in cls.clients:
             tasks.uninstall_client(client)

--- a/ipatests/test_integration/test_idviews.py
+++ b/ipatests/test_integration/test_idviews.py
@@ -84,10 +84,16 @@ class TestCertsInIDOverrides(IntegrationTest):
                            cls.reqdir, stdin=stdin_text)
 
         # Export the previously generated cert
-        tasks.run_certutil(master, ['-L', '-n', cls.adcert1, '-a', '>',
-                                    cls.adcert1_file], cls.reqdir)
-        tasks.run_certutil(master, ['-L', '-n', cls.adcert2, '-a', '>',
-                                    cls.adcert2_file], cls.reqdir)
+        res = tasks.run_certutil(master, ['-L', '-n', cls.adcert1, '-a'],
+                                 cls.reqdir)
+        master.put_file_contents(
+            os.path.join(master.config.test_dir, cls.adcert1_file),
+            res.stdout_text)
+        res = tasks.run_certutil(master, ['-L', '-n', cls.adcert2, '-a'],
+                                 cls.reqdir)
+        master.put_file_contents(
+            os.path.join(master.config.test_dir, cls.adcert2_file),
+            res.stdout_text)
         cls.cert1_base64 = cls.master.run_command(
             "openssl x509 -outform der -in %s | base64 -w 0" % cls.adcert1_file
             ).stdout_text

--- a/ipatests/test_integration/test_idviews.py
+++ b/ipatests/test_integration/test_idviews.py
@@ -53,6 +53,7 @@ class TestCertsInIDOverrides(IntegrationTest):
         # AD-related stuff
         tasks.install_adtrust(master)
         tasks.sync_time(master, cls.ad)
+        tasks.configure_dns_for_trust(master, cls.ad)
         tasks.establish_trust_with_ad(cls.master, cls.ad_domain,
                                       extra_args=['--range-type',
                                                   'ipa-ad-trust'])

--- a/ipatests/test_integration/test_idviews.py
+++ b/ipatests/test_integration/test_idviews.py
@@ -44,6 +44,7 @@ class TestCertsInIDOverrides(IntegrationTest):
         # sssd_domain.set_option knows nothing about 'services' parameter of
         # the sssd config file. Therefore I am using sed approach
         master.run_command(
+            r"grep -qP 'services\b.+\bifp\b' %s ||" % paths.SSSD_CONF +
             "sed -i '/^services/ s/$/, ifp/' %s" % paths.SSSD_CONF)
         master.run_command(
             "sed -i 's/= 7/= 0xFFF0/' %s" % paths.SSSD_CONF, raiseonerr=False)

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -170,13 +170,11 @@ class TestInstallWithCA1(InstallTestBase1):
     def test_replica1_ipa_kra_install(self):
         super(TestInstallWithCA1, self).test_replica1_ipa_kra_install()
 
-    @pytest.mark.xfail
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
     def test_replica2_with_ca_kra_install(self):
         super(TestInstallWithCA1, self).test_replica2_with_ca_kra_install()
 
-    @pytest.mark.xfail
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
     def test_replica2_ipa_dns_install(self):
@@ -228,7 +226,6 @@ class TestInstallCA(IntegrationTest):
         tasks.install_ca(self.replicas[1], extra_args=["--skip-schema-check"])
 
 
-@pytest.mark.xfail
 class TestInstallWithCA_KRA1(InstallTestBase1):
 
     @classmethod
@@ -257,13 +254,11 @@ class TestInstallWithCA_DNS1(InstallTestBase1):
     def test_replica1_ipa_kra_install(self):
         super(TestInstallWithCA_DNS1, self).test_replica1_ipa_kra_install()
 
-    @pytest.mark.xfail
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
     def test_replica2_with_ca_kra_install(self):
         super(TestInstallWithCA_DNS1, self).test_replica2_with_ca_kra_install()
 
-    @pytest.mark.xfail
     @pytest.mark.skipif(config.domain_level == DOMAIN_LEVEL_0,
                         reason='does not work on DOMAIN_LEVEL_0 by design')
     def test_replica2_ipa_dns_install(self):
@@ -345,7 +340,6 @@ class TestInstallWithCA_DNS4(CALessBase):
 
 
 @pytest.mark.cs_acceptance
-@pytest.mark.xfail
 class TestInstallWithCA_KRA_DNS1(InstallTestBase1):
 
     @classmethod

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -13,7 +13,7 @@ import os
 import re
 
 import pytest
-from ipalib.constants import DOMAIN_LEVEL_0
+from ipalib.constants import DOMAIN_LEVEL_0, DOMAIN_LEVEL_1
 import ipaplatform
 from ipapython.dn import DN
 from ipaplatform.constants import constants
@@ -23,6 +23,7 @@ from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_caless import CALessBase, ipa_certs_cleanup
 from ipaplatform import services
+
 
 config = get_global_config()
 
@@ -227,6 +228,7 @@ class TestInstallCA(IntegrationTest):
 
 
 class TestInstallWithCA_KRA1(InstallTestBase1):
+    domain_level = DOMAIN_LEVEL_1
 
     @classmethod
     def install(cls, mh):
@@ -244,6 +246,7 @@ class TestInstallWithCA_KRA2(InstallTestBase2):
 
 
 class TestInstallWithCA_DNS1(InstallTestBase1):
+    domain_level = DOMAIN_LEVEL_1
 
     @classmethod
     def install(cls, mh):


### PR DESCRIPTION
The following tests were missing in nightly_ipa-4-6.yaml:
- test_idviews (partially)
- test_replica_promotion (partially)
- test_installation (partially)
- test_crlgen_manage
- test_nfs.py
- test_otp
