### PR TITLE
selinux: disable ipa_custodia when installing custom policy

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1037,11 +1037,13 @@ fi
 %selinux_relabel_pre -s %{selinuxtype}
 
 %post selinux
+semodule -d ipa_custodia &> /dev/null || true;
 %selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.bz2
 
 %postun selinux
 if [ $1 -eq 0 ]; then
     %selinux_modules_uninstall -s %{selinuxtype} %{modulename}
+    semodule -e ipa_custodia &> /dev/null || true;
 fi
 
 %posttrans selinux


### PR DESCRIPTION
Since ipa_custodia got integrated into ipa policy package, the upstream policy
module needs to be disabled before ipa module installation (in order to be able
to make changes to the ipa_custodia policy definitions).
Upstream ipa module gets overridden automatically because of higher priority of
the custom module, but there is no mechanism to automatically disable
ipa_custodia.

Related: https://pagure.io/freeipa/issue/6891