### PR TITLE
ipatests: always skip additional input for group-add-member --external

### DIFF
--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 import re
 
 import pytest
+import subprocess
 import textwrap
 
 from ipatests.test_integration.base import IntegrationTest
@@ -19,7 +20,6 @@ from ipaplatform.tasks import tasks as platform_tasks
 from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 from ipapython.dn import DN
-from ipalib import errors
 
 
 class TestSSSDWithAdTrust(IntegrationTest):
@@ -318,9 +318,8 @@ class TestSSSDWithAdTrust(IntegrationTest):
         self.master.run_command(
             ['ipa', 'group-add-member', '--group', ext_group, user])
         self.master.run_command([
-            'ipa', 'group-add-member', '--external',
-            self.users['ad']['name'], ext_group,
-            '--users=', '--groups='])
+            'ipa', '-n', 'group-add-member', '--external',
+            self.users['ad']['name'], ext_group])
         tasks.clear_sssd_cache(self.master)
         tasks.clear_sssd_cache(client)
         try:
@@ -344,11 +343,11 @@ class TestSSSDWithAdTrust(IntegrationTest):
         master.run_command(['ipa', 'group-add', '--external',
                             'ext-ipatest'])
         try:
-            master.run_command(['ipa', 'group-add-member',
+            master.run_command(['ipa', '-n', 'group-add-member',
                                 'ext-ipatest',
                                 '--external',
                                 self.users[user_origin]['name']])
-        except errors.ValidationError:
+        except subprocess.CalledProcessError:
             # Only 'ipa' origin should throw a validation error
             assert user_origin == 'ipa'
         finally:


### PR DESCRIPTION
'ipa group-add-member groupname --external some-object' will attempt to
ask interactive questions about other optional parameters (users and
groups) if only external group member was specified. This leads to a
timeout in the tests as there is no input provided.

Do not wait for the entry that would never come by using 'ipa -n'.

Related: https://pagure.io/freeipa/issue/8236
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>