### PR TITLE
ipatests: test_replica_promotion.py: test KRA on Hidden Replica

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -884,6 +884,18 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  fedora-latest/test_replica_promotion_TestHiddenReplicaKRA:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaKRA
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
   fedora-latest/test_upgrade:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -940,6 +940,19 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  testing-fedora/test_replica_promotion_TestHiddenReplicaKRA:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaKRA
+        template: *testing-master-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
   testing-fedora/test_upgrade:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -884,6 +884,18 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  fedora-previous/test_replica_promotion_TestHiddenReplicaKRA:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaKRA
+        template: *ci-master-previous
+        timeout: 7200
+        topology: *master_2repl_1client
+
   fedora-previous/test_upgrade:
     requires: [fedora-previous/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -953,6 +953,19 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  fedora-rawhide/test_replica_promotion_TestHiddenReplicaKRA:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaKRA
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_2repl_1client
+
   fedora-rawhide/test_upgrade:
     requires: [fedora-rawhide/build]
     priority: 50


### PR DESCRIPTION
The Hidden replica tests did not test what happened when KRA was
installed on a hidden replica and then other KRAs instantiated from
this original one. Add a test scenario that covers this.
    
Related: https://pagure.io/freeipa/issue/8240
