### PR TITLE
[Backport][ipa-4-8] ipatests:Test if schema-compat-entry-attribute is set

### DIFF
--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -199,3 +199,18 @@ class TestIpaAdTrustInstall(IntegrationTest):
         entry = conn.get_entry(DN(
             "cn=groups,cn=Schema Compatibility,cn=plugins,cn=config"))
         assert entry.single_value['schema-compat-lookup-nsswitch'] == "group"
+
+    def test_schema_compat_attribute(self):
+        """Test if schema-compat-entry-attribute is set
+
+        This is to ensure if said entry is set after installation with AD.
+
+        related: https://pagure.io/freeipa/issue/8193
+        """
+        conn = self.replicas[0].ldap_connect()
+        entry = conn.get_entry(DN(
+            "cn=groups,cn=Schema Compatibility,cn=plugins,cn=config"))
+        entry_list = list(entry['schema-compat-entry-attribute'])
+        value = (r'ipaexternalmember=%deref_r('
+                 '"member","ipaexternalmember")')
+        assert value in entry_list

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -20,6 +20,7 @@ from cryptography.hazmat.primitives import hashes
 
 from ipalib import x509
 from ipalib.constants import DOMAIN_LEVEL_0
+from ipapython.dn import DN
 from ipaplatform.constants import constants
 from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
@@ -540,6 +541,24 @@ class TestInstallMaster(IntegrationTest):
 
     def test_install_master(self):
         tasks.install_master(self.master, setup_dns=False)
+
+    def test_schema_compat_attribute_and_tree_disable(self):
+        """Test if schema-compat-entry-attribute is set
+
+        This is to ensure if said entry is set after installation.
+        It also checks if compat tree is disable.
+
+        related: https://pagure.io/freeipa/issue/8193
+        """
+        conn = self.master.ldap_connect()
+        entry = conn.get_entry(DN(             # pylint: disable=no-member
+            "cn=groups,cn=Schema Compatibility,cn=plugins,cn=config"))
+
+        entry_list = list(entry['schema-compat-entry-attribute'])
+        value = (r'ipaexternalmember=%deref_r('
+                 '"member","ipaexternalmember")')
+        assert value in entry_list
+        assert 'schema-compat-lookup-nsswitch' not in entry_list
 
     def test_install_kra(self):
         tasks.install_kra(self.master, first_instance=True)


### PR DESCRIPTION
This PR was opened automatically because PR #4324 was pushed to master and backport to ipa-4-8 is required.