### PR TITLE
SELinux: apache_manage_pid_files for F30

### DIFF
--- a/selinux/ipa.if
+++ b/selinux/ipa.if
@@ -365,3 +365,30 @@ interface(`ipa_custodia_stream_connect',`
 
     allow $1 ipa_custodia_t:unix_stream_socket { connectto };
 ')
+
+########################################
+## <summary>
+##      Manage apache pid objects.
+##      The interface is defined by selinux-policy since Fedora 31 and is
+##      conditionally defined here for Fedora 30.
+##      See https://pagure.io/freeipa/issue/8241.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+
+ifndef(`apache_manage_pid_files',`
+	interface(`apache_manage_pid_files',`
+		gen_require(`
+			type httpd_var_run_t;
+		')
+
+		files_search_pids($1)
+		manage_dirs_pattern($1, httpd_var_run_t, httpd_var_run_t)
+		manage_files_pattern($1, httpd_var_run_t, httpd_var_run_t)
+		manage_sock_files_pattern($1, httpd_var_run_t, httpd_var_run_t)
+	')
+')


### PR DESCRIPTION
SELinux policy on F30 doesn't have the interface apache_manage_pid_files(). Define the interface conditionally.

Fixes: https://pagure.io/freeipa/issue/8241
Signed-off-by: Christian Heimes <cheimes@redhat.com>