### PR TITLE
[Backport][ipa-4-8] ipatests: provide AD admin password when trying to establish trust

### DIFF
--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -656,7 +656,8 @@ class TestTrust(BaseTestTrust):
             # This checks that our setup is correct
             result = self.master.run_command(
                 ['ipa', 'trust-add', self.ad.domain.name,
-                 '--admin', 'Administrator', '--password'], raiseonerr=False)
+                 '--admin', 'Administrator', '--password'], raiseonerr=False,
+                stdin_text=self.master.config.ad_admin_password)
             assert result.returncode == 1
             assert 'CIFS server communication error: code "3221225653", ' \
                    'message "{Device Timeout}' in result.stderr_text


### PR DESCRIPTION
This PR was opened automatically because PR #4399 was pushed to master and backport to ipa-4-8 is required.