### PR TITLE
[Backport][ipa-4-8] ipatests: always skip additional input for group-add-member --external

### DIFF
--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 import re
 
 import pytest
+import subprocess
 import textwrap
 
 from ipatests.test_integration.base import IntegrationTest
@@ -19,7 +20,6 @@ from ipaplatform.tasks import tasks as platform_tasks
 from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 from ipapython.dn import DN
-from ipalib import errors
 
 
 class TestSSSDWithAdTrust(IntegrationTest):
@@ -318,9 +318,8 @@ class TestSSSDWithAdTrust(IntegrationTest):
         self.master.run_command(
             ['ipa', 'group-add-member', '--group', ext_group, user])
         self.master.run_command([
-            'ipa', 'group-add-member', '--external',
-            self.users['ad']['name'], ext_group,
-            '--users=', '--groups='])
+            'ipa', '-n', 'group-add-member', '--external',
+            self.users['ad']['name'], ext_group])
         tasks.clear_sssd_cache(self.master)
         tasks.clear_sssd_cache(client)
         try:
@@ -344,11 +343,11 @@ class TestSSSDWithAdTrust(IntegrationTest):
         master.run_command(['ipa', 'group-add', '--external',
                             'ext-ipatest'])
         try:
-            master.run_command(['ipa', 'group-add-member',
+            master.run_command(['ipa', '-n', 'group-add-member',
                                 'ext-ipatest',
                                 '--external',
                                 self.users[user_origin]['name']])
-        except errors.ValidationError:
+        except subprocess.CalledProcessError:
             # Only 'ipa' origin should throw a validation error
             assert user_origin == 'ipa'
         finally:


### PR DESCRIPTION
This PR was opened automatically because PR #4420 was pushed to master and backport to ipa-4-8 is required.