### PR TITLE
ipatests: Skip test using paramiko when FIPS is enabled

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -803,6 +803,9 @@ class TestIPACommand(IntegrationTest):
         3. add an ipa user
         4. ssh from controller to master using the user created in step 3
         """
+        if self.master.is_fips_mode:  # pylint: disable=no-member
+            pytest.skip("paramiko is not compatible with FIPS mode")
+
         sssd_version = ''
         cmd_output = self.master.run_command(['sssd', '--version'])
         sssd_version = platform_tasks.\


### PR DESCRIPTION
Test used paramiko to connect to the master from controller.
Hence skip if FIPS is enabled

Signed-off-by: Mohammad Rizwan Yusuf <myusuf@redhat.com>