### PR TITLE
[backport][ipa-4-6] ipa-pwd-extop: don't check password policy for non-Kerberos account set by DM or a passsync manager

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
@@ -286,8 +286,8 @@ free_and_error:
  * slapi_pblock_destroy(pb)
  */
 static int pwd_get_values(const Slapi_Entry *ent, const char *attrname,
-			  Slapi_ValueSet** results, char** actual_type_name,
-			  int *buffer_flags)
+                          Slapi_ValueSet** results, char** actual_type_name,
+                          int *buffer_flags)
 {
     int flags=0;
     int type_name_disposition = 0;
@@ -560,7 +560,7 @@ int ipapwd_CheckPolicy(struct ipapwd_data *data)
                 LOG_TRACE("No password policy, use defaults");
             }
             break;
-	case IPA_CHANGETYPE_ADMIN:
+        case IPA_CHANGETYPE_ADMIN:
             /* The expiration date needs to be older than the current time
              * otherwise the KDC may not immediately register the password
              * as expired. The last password change needs to match the
@@ -636,7 +636,7 @@ int ipapwd_CheckPolicy(struct ipapwd_data *data)
 }
 
 /* Searches the dn in directory,
- *  If found	 : fills in slapi_entry structure and returns 0
+ *  If found     : fills in slapi_entry structure and returns 0
  *  If NOT found : returns the search result as LDAP_NO_SUCH_OBJECT
  */
 int ipapwd_getEntry(const char *dn, Slapi_Entry **e2, char **attrlist)
@@ -795,22 +795,21 @@ int ipapwd_SetPassword(struct ipapwd_krbcfg *krbcfg,
         slapi_mods_add_mod_values(smods, LDAP_MOD_REPLACE,
                                   "krbPrincipalKey", svals);
 
-		/* krbLastPwdChange is used to tell whether a host entry has a
-		 * keytab so don't set it on hosts.
-		 */
+        /* krbLastPwdChange is used to tell whether a host entry has a
+         * keytab so don't set it on hosts. */
         if (!is_host) {
-	    /* change Last Password Change field with the current date */
+            /* change Last Password Change field with the current date */
             ret = ipapwd_setdate(data->target, smods, "krbLastPwdChange",
                                  data->timeNow, false);
             if (ret != LDAP_SUCCESS)
                 goto free_and_return;
 
-	    /* set Password Expiration date */
+            /* set Password Expiration date */
             ret = ipapwd_setdate(data->target, smods, "krbPasswordExpiration",
                                  data->expireTime, (data->expireTime == 0));
             if (ret != LDAP_SUCCESS)
                 goto free_and_return;
-	}
+        }
     }
 
     if (nt && is_smb) {

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
@@ -888,8 +888,8 @@ int ipapwd_SetPassword(struct ipapwd_krbcfg *krbcfg,
     slapi_mods_add_string(smods, LDAP_MOD_REPLACE,
                           "userPassword", data->password);
 
-    /* set password history */
-    if (data->policy.history_length > 0) {
+    /* set password history if a Kerberos object */
+    if (data->policy.history_length > 0 && is_krb) {
         pwvals = ipapwd_setPasswordHistory(smods, data);
         if (pwvals) {
             slapi_mods_add_mod_values(smods, LDAP_MOD_REPLACE,

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipapwd.h
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipapwd.h
@@ -90,6 +90,7 @@ struct ipapwd_operation {
     struct ipapwd_data pwdata;
     int pwd_op;
     int is_krb;
+    int is_memberof;
     int skip_keys;
     int skip_history;
 };
@@ -113,6 +114,7 @@ struct ipapwd_krbcfg {
 
 int ipapwd_entry_checks(Slapi_PBlock *pb, struct slapi_entry *e,
                         int *is_root, int *is_krb, int *is_smb, int *is_ipant,
+			int *is_memberof,
                         char *attr, int access);
 int ipapwd_gen_checks(Slapi_PBlock *pb, char **errMesg,
                       struct ipapwd_krbcfg **config, int check_flags);

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipapwd.h
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipapwd.h
@@ -117,7 +117,7 @@ int ipapwd_entry_checks(Slapi_PBlock *pb, struct slapi_entry *e,
 int ipapwd_gen_checks(Slapi_PBlock *pb, char **errMesg,
                       struct ipapwd_krbcfg **config, int check_flags);
 int ipapwd_CheckPolicy(struct ipapwd_data *data);
-int ipapwd_getEntry(const char *dn, Slapi_Entry **e2, char **attrlist);
+int ipapwd_getEntry(Slapi_DN *sdn, Slapi_Entry **e2, char **attrlist);
 int ipapwd_get_cur_kvno(Slapi_Entry *target);
 int ipapwd_setdate(Slapi_Entry *source, Slapi_Mods *smods, const char *attr,
                    time_t date, bool remove);

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1629,15 +1629,23 @@ def ldappasswd_user_change(user, oldpw, newpw, master):
     master.run_command(args)
 
 
-def ldappasswd_sysaccount_change(user, oldpw, newpw, master):
+def ldappasswd_sysaccount_change(user, oldpw, newpw, master, use_dirman=False):
     container_sysaccounts = dict(DEFAULT_CONFIG)['container_sysaccounts']
     basedn = master.domain.basedn
 
     userdn = "uid={},{},{}".format(user, container_sysaccounts, basedn)
     master_ldap_uri = "ldap://{}".format(master.hostname)
 
-    args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
-            '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
+    if use_dirman:
+        args = [paths.LDAPPASSWD, '-D',
+                str(master.config.dirman_dn),  # pylint: disable=no-member
+                '-w', master.config.dirman_password,
+                '-a', oldpw,
+                '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri,
+                userdn]
+    else:
+        args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
+                '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
     master.run_command(args)
 
 

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1617,15 +1617,21 @@ def get_host_ip_with_hostmask(host):
         return None
 
 
-def ldappasswd_user_change(user, oldpw, newpw, master):
+def ldappasswd_user_change(user, oldpw, newpw, master, use_dirman=False):
     container_user = dict(DEFAULT_CONFIG)['container_user']
     basedn = master.domain.basedn
 
     userdn = "uid={},{},{}".format(user, container_user, basedn)
     master_ldap_uri = "ldap://{}".format(master.hostname)
 
-    args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
-            '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
+    if use_dirman:
+        args = [paths.LDAPPASSWD, '-D',
+                str(master.config.dirman_dn),  # pylint: disable=no-member
+                '-w', master.config.dirman_password,
+                '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri, userdn]
+    else:
+        args = [paths.LDAPPASSWD, '-D', userdn, '-w', oldpw, '-a', oldpw,
+                '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri]
     master.run_command(args)
 
 

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -50,6 +50,18 @@ class TestIPACommand(IntegrationTest):
     """
     topology = 'line'
 
+    @pytest.fixture
+    def pwpolicy_global(self):
+        """Fixture to change global password history policy and reset it"""
+        tasks.kinit_admin(self.master)
+        self.master.run_command(
+            ["ipa", "pwpolicy-mod", "--history=5", "--minlife=0"],
+        )
+        yield
+        self.master.run_command(
+            ["ipa", "pwpolicy-mod", "--history=0", "--minlife=1"],
+        )
+
     def get_cert_base64(self, host, path):
         """Retrieve cert and return content as single line, base64 encoded
         """
@@ -226,31 +238,16 @@ class TestIPACommand(IntegrationTest):
         assert newkrblastpwdchange != newkrblastpwdchange2
         assert newkrbexp != newkrbexp2
 
-    def test_change_sysaccount_password_issue7181(self):
+    def test_change_sysaccount_pwd_history_issue7181(self, pwpolicy_global):
         """
-        Test how a password change performed by a cn=Directory Manager
-        works against a non-Kerberos account with a policy preventing
-        re-use of previously used passwords
+        Test that a sysacount user maintains no password history
+        because they do not have a Kerberos identity.
         """
-        sysuser = 'forcedpolicy'
-        policy_group = 'forcedpolicy'
+        sysuser = 'sysuser'
         original_passwd = 'Secret123'
         new_passwd = 'userPasswd123'
 
         master = self.master
-
-        # Add a group with a custom password policy
-        tasks.kinit_admin(self.master)
-        result = master.run_command(
-            ["ipa", "group-add", policy_group]
-        )
-        assert 'Added group "{}"'.format(policy_group) in result.stdout_text
-
-        result = master.run_command(
-            ["ipa", "pwpolicy-add", policy_group,
-                "--history=5", "--priority=1"],
-        )
-        assert 'History size: 5' in result.stdout_text
 
         # Add a system account and add it to a group managed by the policy
         base_dn = str(master.domain.basedn)  # pylint: disable=no-member
@@ -259,54 +256,86 @@ class TestIPACommand(IntegrationTest):
             changetype: add
             objectclass: account
             objectclass: simplesecurityobject
-            objectclass: nsMemberOf
-            objectclass: krbPrincipalAux
             uid: {account_name}
             userPassword: {original_passwd}
             passwordExpirationTime: 20380119031407Z
             nsIdleTimeout: 0
-            memberOf: cn={group_name},cn=groups,cn=accounts,{base_dn}
         """).format(
             account_name=sysuser,
-            group_name=policy_group,
             base_dn=base_dn,
             original_passwd=original_passwd)
 
         tasks.ldapmodify_dm(master, entry_ldif)
 
-        # For an LDAP object not managed by IPA we have to use
-        # --addattr to add it as a member of a group
-        value = "member=uid={account_name},cn=sysaccounts,cn=etc,{base_dn}"
-        result = master.run_command(
-            ["ipa", "group-mod", policy_group,
-                "--addattr={value}".format(
-                    value=value.format(
-                        account_name=sysuser,
-                        base_dn=base_dn
-                    )
-                )],
-        )
-        assert 'Modified group "{}"'.format(policy_group) in result.stdout_text
-
-        # Now try to change password thrice:
-        # as a user, as a cn=Directory Manager, and as a user again
-        # If ticket 7181 is not fixed, the second change will fail
-        # Third one must fail as we are reusing the password as non-DM
+        # Now change the password. It should succeed since password
+        # policy doesn't apply to non-Kerberos users.
         tasks.ldappasswd_sysaccount_change(sysuser, original_passwd,
-                                           new_passwd, master,
-                                           use_dirman=False)
+                                           new_passwd, master)
         tasks.ldappasswd_sysaccount_change(sysuser, new_passwd,
-                                           new_passwd, master,
-                                           use_dirman=True)
+                                           original_passwd, master)
+        tasks.ldappasswd_sysaccount_change(sysuser, original_passwd,
+                                           new_passwd, master)
+
+    def test_change_user_pwd_history_issue7181(self, pwpolicy_global):
+        """
+        Test that password history for a normal IPA user is honored.
+        """
+        user = 'user1'
+        original_passwd = 'Secret123'
+        new_passwd = 'userPasswd123'
+
+        master = self.master
+
+        tasks.user_add(master, user, password=original_passwd)
+
+        tasks.ldappasswd_user_change(user, original_passwd,
+                                     new_passwd, master)
+        tasks.ldappasswd_user_change(user, new_passwd,
+                                     original_passwd, master)
         try:
-            tasks.ldappasswd_sysaccount_change(sysuser, new_passwd,
-                                               original_passwd, master,
-                                               use_dirman=False)
+            tasks.ldappasswd_user_change(user, original_passwd,
+                                         new_passwd, master)
         except CalledProcessError as e:
             if e.returncode != 1:
                 raise
         else:
             pytest.fail("Password change violating policy did not fail")
+
+    def test_dm_change_user_pwd_history_issue7181(self, pwpolicy_global):
+        """
+        Test that password policy is not applied with Directory Manager.
+
+        The minimum lifetime of the password is set to 1 hour. Confirm
+        that the user cannot re-change their password immediately but
+        the DM can.
+        """
+        user = 'user1'
+        original_passwd = 'Secret123'
+        new_passwd = 'newPasswd123'
+
+        master = self.master
+
+        # reset minimum life to 1 hour.
+        self.master.run_command(
+            ["ipa", "pwpolicy-mod", "--minlife=1"],
+        )
+
+        try:
+            tasks.ldappasswd_user_change(user, original_passwd,
+                                         new_passwd, master)
+        except CalledProcessError as e:
+            if e.returncode != 1:
+                raise
+        else:
+            pytest.fail("Password change violating policy did not fail")
+
+        # DM should be able to change any password regardless of policy
+        try:
+            tasks.ldappasswd_user_change(user, new_passwd,
+                                         original_passwd, master,
+                                         use_dirman=True)
+        except CalledProcessError:
+            pytest.fail("Password change failed when it should not")
 
     def test_change_selinuxusermaporder(self):
         """


### PR DESCRIPTION
This PR was opened manually because PR #4417 was pushed to master and backport to ipa-4-6 is required.