### PR TITLE
[Backport][ipa-4-8] ipatests: Skip test using paramiko when FIPS is enabled

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -803,6 +803,9 @@ class TestIPACommand(IntegrationTest):
         3. add an ipa user
         4. ssh from controller to master using the user created in step 3
         """
+        if self.master.is_fips_mode:  # pylint: disable=no-member
+            pytest.skip("paramiko is not compatible with FIPS mode")
+
         sssd_version = ''
         cmd_output = self.master.run_command(['sssd', '--version'])
         sssd_version = platform_tasks.\


### PR DESCRIPTION
This PR was opened automatically because PR #4442 was pushed to master and backport to ipa-4-8 is required.