### PR TITLE
Don't configure ntpd with -x

### DIFF
--- a/ipaclient/install/ntpconf.py
+++ b/ipaclient/install/ntpconf.py
@@ -80,7 +80,7 @@ keys /etc/ntp/keys
 #controlkey 8
 """
 
-ntp_sysconfig = """OPTIONS="-x -p /var/run/ntpd.pid"
+ntp_sysconfig = """OPTIONS="-p /var/run/ntpd.pid"
 
 # Set to 'yes' to sync hw clock after successful ntpdate
 SYNC_HWCLOCK=yes

--- a/ipaserver/install/ntpinstance.py
+++ b/ipaserver/install/ntpinstance.py
@@ -91,8 +91,7 @@ class NTPInstance(service.Service):
             fd.write("{}\n".format(' '.join(fudge)))
 
         #read in memory, find OPTIONS, check/change it, then overwrite file
-        needopts = [ {'val':'-x', 'need':True},
-                     {'val':'-g', 'need':True} ]
+        needopts = [ {'val':'-g', 'need':True} ]
         fd = open(paths.SYSCONFIG_NTPD, "r")
         lines = fd.readlines()
         fd.close()


### PR DESCRIPTION
slew mode (-x) may break ntpd from starting if time slew is too
great between the system and hardware clock. Slew mode is an
unstable configuration choice and has many known drawbacks.

https://pagure.io/freeipa/issue/8242

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

This applies **only** to the ipa-4-6 branch.