### PR TITLE
ipatests: Test if slew mode is not set while configuring ntpd

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_commands.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -145,6 +145,17 @@ class TestIPACommand(IntegrationTest):
         cader = ssl.PEM_cert_to_DER_cert(cacrt)
         return base64.b64encode(cader).decode('ascii')
 
+    def test_slew_mode_not_set(self):
+        """Test if slew mode is not set while configuring ntpd
+
+        This is to ensure that slew mode (-x) is not configured while
+        installing ipa-server.
+
+        related: https://pagure.io/freeipa/issue/8242
+        """
+        result = self.master.run_command(['cat', paths.SYSCONFIG_NTPD])
+        assert '-x' not in result.stdout_text
+
     def test_aes_sha_kerberos_enctypes(self):
         """Test AES SHA 256 and 384 Kerberos enctypes enabled
 


### PR DESCRIPTION
This is to ensure that slew mode (-x) is not configured while
installing ipa-server.

related: https://pagure.io/freeipa/issue/8242

Signed-off-by: Mohammad Rizwan Yusuf <myusuf@redhat.com>