### PR TITLE
[Backport][ipa-4-8] ipatests: test_replica_promotion.py: test KRA on Hidden Replica

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -884,6 +884,18 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  fedora-latest-ipa-4-8/test_replica_promotion_TestHiddenReplicaKRA:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaKRA
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
   fedora-latest-ipa-4-8/test_upgrade:
     requires: [fedora-latest-ipa-4-8/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -884,6 +884,18 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  fedora-previous-ipa-4-8/test_replica_promotion_TestHiddenReplicaKRA:
+    requires: [fedora-previous-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaKRA
+        template: *ci-ipa-4-8-previous
+        timeout: 7200
+        topology: *master_2repl_1client
+
   fedora-previous-ipa-4-8/test_upgrade:
     requires: [fedora-previous-ipa-4-8/build]
     priority: 50


### PR DESCRIPTION
MANUAL CHERRY-PICK OF https://github.com/freeipa/freeipa/pull/4428

The Hidden replica tests did not test what happened when KRA was
installed on a hidden replica and then other KRAs instantiated from
this original one. Add a test scenario that covers this.

Related: https://pagure.io/freeipa/issue/8240
Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Michal Polovka <mpolovka@redhat.com>