### PR TITLE
pr-ci templates: update test_fips timeouts

### DIFF
--- a/ipatests/azure/templates/prepare-build-fedora.yml
+++ b/ipatests/azure/templates/prepare-build-fedora.yml
@@ -2,18 +2,6 @@ steps:
 - script: |
     set -e
     sudo rm -rf /var/cache/dnf/*
-    echo "dnf.conf: enable fastestmirror, use 8 download workers, lower timeout to fail faster, and add more retries"
-    sudo tee -a /etc/dnf/dnf.conf <<EOF > /dev/null
-    fastestmirror = True
-    max_parallel_downloads = 8
-    timeout = 8
-    retries = 20
-    EOF
-    echo "Fedora mirror metalink content:"
-    for metalink in $(sudo dnf repolist -v |grep Repo-metalink | awk '{print $2}' ) ; do echo '###############' ; echo '####' ; echo $metalink ; echo '####' ; curl $metalink ; done
-    echo "Fastestmirror results:"
-    sudo cat /var/cache/dnf/fastestmirror.cache
-    sudo dnf -y module enable nodejs:12
     sudo dnf makecache || :
     echo "Installing base development environment"
     sudo dnf install -y \
@@ -29,5 +17,6 @@ steps:
         python3-pyyaml \
 
     echo "Installing FreeIPA development dependencies"
+    sudo dnf builddep -y freeipa
     sudo dnf builddep -y --skip-broken -D "with_wheels 1" -D "with_lint 1" -D "with_doc 1" --spec freeipa.spec.in --best --allowerasing --setopt=install_weak_deps=False
   displayName: Prepare build environment

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -172,7 +172,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_fips.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl_1client
 
   fedora-latest/test_forced_client_enrolment:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -172,7 +172,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_fips.py
         template: *ci-master-previous
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl_1client
 
   fedora-previous/test_forced_client_enrolment:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -182,7 +182,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_fips.py
         template: *ci-master-frawhide
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl_1client
 
   fedora-rawhide/test_forced_client_enrolment:


### PR DESCRIPTION
test_fips takes between 45 and ~80 mins to run.
The templates' timeout was 3600s which is too short for
successful execution. 7200s should do.

Fixes: https://pagure.io/freeipa/issue/8247
Signed-off-by: François Cami <fcami@redhat.com>