### PR TITLE
[Backport][ipa-4-8] pr-ci templates: update test_fips timeouts

### DIFF
--- a/ipatests/azure/templates/prepare-build-fedora.yml
+++ b/ipatests/azure/templates/prepare-build-fedora.yml
@@ -2,18 +2,6 @@ steps:
 - script: |
     set -e
     sudo rm -rf /var/cache/dnf/*
-    echo "dnf.conf: enable fastestmirror, use 8 download workers, lower timeout to fail faster, and add more retries"
-    sudo tee -a /etc/dnf/dnf.conf <<EOF > /dev/null
-    fastestmirror = True
-    max_parallel_downloads = 8
-    timeout = 8
-    retries = 20
-    EOF
-    echo "Fedora mirror metalink content:"
-    for metalink in $(sudo dnf repolist -v |grep Repo-metalink | awk '{print $2}' ) ; do echo '###############' ; echo '####' ; echo $metalink ; echo '####' ; curl $metalink ; done
-    echo "Fastestmirror results:"
-    sudo cat /var/cache/dnf/fastestmirror.cache
-    sudo dnf -y module enable nodejs:12
     sudo dnf makecache || :
     echo "Installing base development environment"
     sudo dnf install -y \
@@ -29,5 +17,6 @@ steps:
         python3-pyyaml \
 
     echo "Installing FreeIPA development dependencies"
+    sudo dnf builddep -y freeipa
     sudo dnf builddep -y --skip-broken -D "with_wheels 1" -D "with_lint 1" --spec freeipa.spec.in --best --allowerasing --setopt=install_weak_deps=False
   displayName: Prepare build environment

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -172,7 +172,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_fips.py
         template: *ci-ipa-4-8-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-8/test_forced_client_enrolment:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -172,7 +172,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_fips.py
         template: *ci-ipa-4-8-previous
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl_1client
 
   fedora-previous-ipa-4-8/test_forced_client_enrolment:


### PR DESCRIPTION
MANUAL CHERRY-PICK of:

- 7141e0702fe778f66946ae0f62eddd0ac1bd991e

    pr-ci templates: update test_fips timeouts

    test_fips takes between 45 and ~80 mins to run.
    The templates' timeout was 3600s which is too short for
    successful execution. 7200s should do.
    
    Fixes: https://pagure.io/freeipa/issue/8247
    Signed-off-by: François Cami <fcami@redhat.com>
    Reviewed-By: Armando Neto <abiagion@redhat.com>

AND

- b205bf8aca09efca90cacc28a2fcf148e90f53af

    Remove Fedora repository fastmirror selection
    
    Fast mirror selection somehow stopped working. If disabled, the
    difference is around 20 seconds for the 'Prepare build environment' step
    (2:49 versus 3:09), so while we are saving, currently it is not a lot.
    
    Also remove explicit nodejs stream choice, it seems to be not needed
    anymore (again).
    
    Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>
    Reviewed-By: Armando Neto <abiagion@redhat.com>
