### PR TITLE
[Backport][ipa-4-6] Allow rename of a host group

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -2740,7 +2740,7 @@ output: ListOfEntries('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: Output('truncated', type=[<type 'bool'>])
 command: hostgroup_mod/1
-args: 1,9,3
+args: 1,10,3
 arg: Str('cn', cli_name='hostgroup_name')
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
@@ -2748,6 +2748,7 @@ option: Str('delattr*', cli_name='delattr')
 option: Str('description?', autofill=False, cli_name='desc')
 option: Flag('no_members', autofill=True, default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('rename?', cli_name='rename')
 option: Flag('rights', autofill=True, default=False)
 option: Str('setattr*', cli_name='setattr')
 option: Str('version?')

--- a/Makefile.am
+++ b/Makefile.am
@@ -238,11 +238,23 @@ $(top_builddir)/ipapython/version.py:
 
 .PHONY: acilint
 acilint: $(GENERATED_PYTHON_FILES)
-	cd $(srcdir); $(PYTHON) ./makeaci --validate
+	cd $(srcdir); \
+	PYTHONPATH=$(abspath $(top_srcdir)) $(PYTHON) ./makeaci --validate
+
+.PHONY: aci
+aci: $(GENERATED_PYTHON_FILES)
+	cd $(srcdir); \
+	PYTHONPATH=$(abspath $(top_srcdir)) $(PYTHON) ./makeaci
 
 .PHONY: apilint
 apilint: $(GENERATED_PYTHON_FILES)
-	cd $(srcdir); $(PYTHON) ./makeapi --validate
+	cd $(srcdir); \
+	PYTHONPATH=$(abspath $(top_srcdir)) $(PYTHON) ./makeapi --validate
+
+.PHONY: api
+api: $(GENERATED_PYTHON_FILES)
+	cd $(srcdir); \
+	PYTHONPATH=$(abspath $(top_srcdir)) $(PYTHON) ./makeapi
 
 .PHONY: polint
 polint:

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -82,8 +82,9 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-define(IPA_API_VERSION_MINOR, 236)
-# Last change: Add trust_enable_agent.
+define(IPA_API_VERSION_MINOR, 237)
+# Last change: allow rename a hostgroup
+
 
 ########################################################
 # Following values are auto-generated from values above

--- a/ipaserver/plugins/hostgroup.py
+++ b/ipaserver/plugins/hostgroup.py
@@ -90,6 +90,7 @@ class hostgroup(LDAPObject):
         'memberindirect', 'memberofindirect',
     ]
     uuid_attribute = 'ipauniqueid'
+    allow_rename = True
     attribute_members = {
         'member': ['host', 'hostgroup'],
         'memberof': ['hostgroup', 'netgroup', 'hbacrule', 'sudorule'],
@@ -249,6 +250,16 @@ class hostgroup_mod(LDAPUpdate):
     __doc__ = _('Modify a hostgroup.')
 
     msg_summary = _('Modified hostgroup "%(value)s"')
+
+    def pre_callback(self, ldap, dn, entry_attrs, attrs_list,
+                     *keys, **options):
+        assert isinstance(dn, DN)
+        if keys[0] in PROTECTED_HOSTGROUPS and 'rename' in options:
+            raise errors.ProtectedEntryError(label=_(u'hostgroup'),
+                                             key=keys[0],
+                                             reason=_(u'privileged hostgroup'))
+
+        return dn
 
     def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
         assert isinstance(dn, DN)


### PR DESCRIPTION
Manual backport was created because PR#3487 was pushed to master and was marked to backport to ipa-4-6.