### PR TITLE
[Backport][ipa-4-8] ipa-backup: Make sure all roles are installed on the current master.

### DIFF
--- a/install/tools/man/ipa-backup.1
+++ b/install/tools/man/ipa-backup.1
@@ -51,6 +51,9 @@ Include the IPA service log files in the backup.
 \fB\-\-online\fR
 Perform the backup on\-line. Requires the \-\-data option.
 .TP
+\fB\-\-disable\-role\-check\fR
+Perform the backup even if this host does not have all the roles in use in the cluster. This is not recommended.
+.TP
 \fB\-\-v\fR, \fB\-\-verbose\fR
 Print debugging information
 .TP

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -788,6 +788,18 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  fedora-latest-ipa-4-8/test_backup_and_restore_TestBackupRoles:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupRoles
+        template: *ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl
+
   fedora-latest-ipa-4-8/test_dnssec:
     requires: [fedora-latest-ipa-4-8/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -788,6 +788,18 @@ jobs:
         timeout: 7200
         topology: *master_2repl_1client
 
+  fedora-previous-ipa-4-8/test_backup_and_restore_TestBackupRoles:
+    requires: [fedora-previous-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupRoles
+        template: *ci-ipa-4-8-previous
+        timeout: 7200
+        topology: *master_1repl
+
   fedora-previous-ipa-4-8/test_dnssec:
     requires: [fedora-previous-ipa-4-8/build]
     priority: 50

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -928,7 +928,7 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         """
         self._check_server_role(self.replicas[0], 'hidden')
         # backup
-        backup_path = backup(self.replicas[0])
+        backup_path, unused = backup(self.replicas[0])
         # uninstall
         tasks.uninstall_master(self.replicas[0])
         # restore


### PR DESCRIPTION
MANUAL CHERRY-PICK of https://github.com/freeipa/freeipa/pull/4304

ipa-backup does not check whether the IPA master it is running on has
all used roles installed. This can lead into situations where backups
are done on a CAless or KRAless host when these roles are used in the
IPA cluster. These backups cannot be used to restore a complete cluster.

With this change, ipa-backup checks what roles are installed on the
current host and compares the resulting list to the list of used roles
in the cluster. A --disable-role-check knob is also provided to restore
the previous behavior.

Fixes: https://pagure.io/freeipa/issue/8217
Signed-off-by: François Cami fcami@redhat.com