### PR TITLE
nightly_ipa-4-8_previous.yaml: fix typo

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -1485,7 +1485,7 @@ jobs:
         timeout: 1800
         topology: *master_1repl
 
-  fedora-latest/krbtpolicy:
+  fedora-previous-ipa-4-8/krbtpolicy:
     requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:


### PR DESCRIPTION
Fix typo in prci_definitions/nightly_ipa-4-8_previous.yaml.

Signed-off-by: François Cami <fcami@redhat.com>