### PR TITLE
pr-ci templates: update test_fips timeouts

### DIFF
--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -182,7 +182,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_fips.py
         template: *testing-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl_1client
 
   testing-fedora/test_forced_client_enrolment:


### PR DESCRIPTION
test_fips takes between 45 and ~80 mins to run.
The templates' timeout was 3600s which is too short for
successful execution. 7200s should do.

Fixes: https://pagure.io/freeipa/issue/8247