### PR TITLE
Azure: Allow distros to install Python they want

### DIFF
--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -93,7 +93,7 @@ jobs:
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.7
+        versionSpec: ${{ variables.AZURE_PYTHON_VERSION }}
         architecture: x64
     - template: templates/${{ variables.PREPARE_TOX_TEMPLATE }}
     - script: |
@@ -102,7 +102,7 @@ jobs:
         export LANG=en_US.utf8
         export LC_CTYPE=en_US.utf8
         locale
-        $(TOX_COMMAND) -e py37,pypi,pylint3
+        $(TOX_COMMAND) -e py3,pypi,pylint3
       displayName: Tox
     - task: PublishTestResults@2
       inputs:
@@ -120,7 +120,7 @@ jobs:
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.7
+        versionSpec: ${{ variables.AZURE_PYTHON_VERSION }}
         architecture: x64
     - template: templates/${{ variables.PREPARE_WEBUI_TEMPLATE }}
     - script: |

--- a/ipatests/azure/templates/variables-fedora.yml
+++ b/ipatests/azure/templates/variables-fedora.yml
@@ -15,3 +15,6 @@ variables:
   PREPARE_WEBUI_TEMPLATE: ${{ format('prepare-webui-{0}.yml', variables.IPA_PLATFORM) }}
 
   TOX_COMMAND: tox
+
+  # Python version for UsePythonVersion@0 task
+  AZURE_PYTHON_VERSION: '3.7'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion=2.3.1
-envlist=py36,py37,pylint3,pypi
+envlist=py36,py37,py38,pylint3,pypi
 skip_missing_interpreters=true
 skipsdist=true
 


### PR DESCRIPTION
The platforms may have different Pythons. But due to \[0\] the Python installed via the `UsePythonVersion@0` task should be compatible with the container's `libpythonxx.so`.

`AZURE_PYTHON_VERSION` platform variable is introduced to cover this. So, if your distro has Python3.8, set the mentioned variable to '3.8', later, this version will be installed by the `UsePythonVersion@0` Azure task for `WebUI_Unit_Tests` and `Tox`
jobs.

To allow tox to run any Python3 environment the 'py3' one is used. 'py3' is the well-known Tox's environment, which utilizes 'python3' executable.

\[0\]: https://github.com/microsoft/azure-pipelines-tasks/issues/11070

Fixes: https://pagure.io/freeipa/issue/8254