### PR TITLE
[Backport][ipa-4-8] ipatests: add test for sssd behavior with disabled trustdomains

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1458,8 +1458,8 @@ jobs:
         build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_sssd.py
         template: *ci-ipa-4-8-latest
-        timeout: 4800
-        topology: *ad_master_2client
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest-ipa-4-8/test_ca_custom_sdn:
     requires: [fedora-latest-ipa-4-8/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -1458,8 +1458,8 @@ jobs:
         build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_sssd.py
         template: *ci-ipa-4-8-previous
-        timeout: 4800
-        topology: *ad_master_2client
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client
 
   fedora-previous-ipa-4-8/test_ca_custom_sdn:
     requires: [fedora-previous-ipa-4-8/build]

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -34,6 +34,7 @@ import time
 from pipes import quote
 import configparser
 from contextlib import contextmanager
+from pkg_resources import parse_version
 
 import dns
 from ldif import LDIFWriter
@@ -2174,3 +2175,9 @@ def wait_for_sssd_domain_status_online(host, timeout=120):
         time.sleep(5)
     else:
         raise RuntimeError("SSSD still offline")
+
+
+def get_sssd_version(host):
+    """Get sssd version on remote host."""
+    version = host.run_command('sssd --version').stdout_text.strip()
+    return parse_version(version)

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -16,6 +16,7 @@ import textwrap
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
+from ipatests.util import xfail_context
 from ipaplatform.tasks import tasks as platform_tasks
 from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
@@ -395,7 +396,10 @@ class TestSSSDWithAdTrust(IntegrationTest):
         self.master.run_command(['id', user])
         with self.disabled_trustdomain():
             res = self.master.run_command(['id', user], raiseonerr=False)
-            assert res.returncode == 1
-            assert 'no such user' in res.stderr_text
+            sssd_version = tasks.get_sssd_version(self.master)
+            with xfail_context(sssd_version < tasks.parse_version('2.2.3'),
+                               'https://pagure.io/SSSD/sssd/issue/4078'):
+                assert res.returncode == 1
+                assert 'no such user' in res.stderr_text
         # verify the user can be retrieved after re-enabling trustdomain
         self.master.run_command(['id', user])

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -887,3 +887,28 @@ def get_group_dn(cn):
 
 def get_user_dn(uid):
     return DN(('uid', uid), api.env.container_user, api.env.basedn)
+
+
+@contextmanager
+def xfail_context(condition, reason):
+    """Expect a block of code to fail.
+
+    This function provides functionality similar to pytest.mark.xfail
+    but for a block of code instead of the whole test function. This has
+    two benefits:
+    1) you can mark single line as expectedly failing without suppressing
+       all other errors in the test function
+    2) you can use conditions which can not be evaluated before the test start.
+
+    The check is always done in "strict" mode, i.e. if test is expected to
+    fail but succeeds then it will be marked as failing.
+    """
+    try:
+        yield
+    except Exception:
+        if condition:
+            pytest.xfail(reason)
+        raise
+    else:
+        if condition:
+            pytest.fail('XPASS(strict) reason: {}'.format(reason), False)


### PR DESCRIPTION
This is a manual backport of #3924 