### PR TITLE
[Backport][ipa-4-6] ipatests: add test for sssd behavior with disabled trustdomains

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -1108,8 +1108,8 @@ jobs:
         build_url: '{fedora-27/build_url}'
         test_suite: test_integration/test_sssd.py
         template: *ci-master-f27
-        timeout: 4800
-        topology: *ad_master_2client
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client
 
   fedora-27/test_adtrust_install:
     requires: [fedora-27/build]

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -33,6 +33,7 @@ import time
 from pipes import quote
 from six.moves import configparser
 from contextlib import contextmanager
+from pkg_resources import parse_version
 
 import dns
 from ldif import LDIFWriter
@@ -1903,3 +1904,9 @@ def ldapmodify_dm(host, ldif_text, **kwargs):
         '-w', host.config.dirman_password
     ]
     return host.run_command(args, stdin_text=ldif_text, **kwargs)
+
+
+def get_sssd_version(host):
+    """Get sssd version on remote host."""
+    version = host.run_command('sssd --version').stdout_text.strip()
+    return parse_version(version)

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -883,3 +883,28 @@ def get_group_dn(cn):
 
 def get_user_dn(uid):
     return DN(('uid', uid), api.env.container_user, api.env.basedn)
+
+
+@contextmanager
+def xfail_context(condition, reason):
+    """Expect a block of code to fail.
+
+    This function provides functionality similar to pytest.mark.xfail
+    but for a block of code instead of the whole test function. This has
+    two benefits:
+    1) you can mark single line as expectedly failing without suppressing
+       all other errors in the test function
+    2) you can use conditions which can not be evaluated before the test start.
+
+    The check is always done in "strict" mode, i.e. if test is expected to
+    fail but succeeds then it will be marked as failing.
+    """
+    try:
+        yield
+    except Exception:
+        if condition:
+            pytest.xfail(reason)
+        raise
+    else:
+        if condition:
+            pytest.fail('XPASS(strict) reason: {}'.format(reason), False)


### PR DESCRIPTION
This is a manual backport of #3924