### PR TITLE
ipatests: move ipa_backup to tasks

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -20,7 +20,6 @@ from ipalib.constants import (
     DOMAIN_LEVEL_1, IPA_CA_NICKNAME, CA_SUFFIX_NAME)
 from ipaplatform.paths import paths
 from ipapython import certdb
-from ipatests.test_integration.test_backup_and_restore import backup
 from ipatests.test_integration.test_dns_locations import (
     resolve_records_from_server, IPA_DEFAULT_MASTER_SRV_REC
 )
@@ -928,7 +927,7 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         """
         self._check_server_role(self.replicas[0], 'hidden')
         # backup
-        backup_path, unused = backup(self.replicas[0])
+        backup_path = tasks.get_backup_dir(self.replicas[0])
         # uninstall
         tasks.uninstall_master(self.replicas[0])
         # restore


### PR DESCRIPTION
* tasks had an ipa_backup() method that was not used anywhere.
* test_backup_and_restore had a backup() method that used to return
  both the path to the backup and the whole result from run_command ;
  The path to the backup can be determined from the result.

Clean up:
* move test_backup_and_restore.backup to tasks.ipa_backup, replacing
  the unused method.
* add tasks.get_backup_dir(host) which runs ipa-backup on host and
  returns the path to the backup directory.
* adjust test_backup_and_restore and test_replica_promotion.

Related: https://pagure.io/freeipa/issue/8217
