### PR TITLE
[Backport][ipa-4-8] ipatests: move ipa_backup to tasks

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1491,11 +1491,40 @@ def resolve_record(nameserver, query, rtype="SOA", retry=True, timeout=100):
         time.sleep(1)
 
 
-def ipa_backup(master):
-    result = master.run_command(["ipa-backup"])
-    path_re = re.compile("^Backed up to (?P<backup>.*)$", re.MULTILINE)
-    matched = path_re.search(result.stdout_text + result.stderr_text)
-    return matched.group("backup")
+def ipa_backup(host, disable_role_check=False, raiseonerr=True):
+    """Run backup on host and return the run_command result.
+    """
+    cmd = ['ipa-backup', '-v']
+    if disable_role_check:
+        cmd.append('--disable-role-check')
+    result = host.run_command(cmd, raiseonerr=raiseonerr)
+
+    # Test for ticket 7632: check that services are restarted
+    # before the backup is compressed
+    pattern = r'.*{}.*Starting IPA service.*'.format(paths.GZIP)
+    if (re.match(pattern, result.stderr_text, re.DOTALL)):
+        raise AssertionError('IPA Services are started after compression')
+
+    return result
+
+
+def get_backup_dir(host, raiseonerr=True):
+    """Wrapper around ipa_backup: returns the backup directory.
+    """
+    result = ipa_backup(host, raiseonerr)
+
+    # Get the backup location from the command's output
+    for line in result.stderr_text.splitlines():
+        prefix = 'ipaserver.install.ipa_backup: INFO: Backed up to '
+        if line.startswith(prefix):
+            backup_path = line[len(prefix):].strip()
+            logger.info('Backup path for %s is %s', host.hostname, backup_path)
+            return backup_path
+    else:
+        if raiseonerr:
+            raise AssertionError('Backup directory not found in output')
+        else:
+            return None
 
 
 def ipa_restore(master, backup_path):

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -20,7 +20,6 @@ from ipalib.constants import (
     DOMAIN_LEVEL_1, IPA_CA_NICKNAME, CA_SUFFIX_NAME)
 from ipaplatform.paths import paths
 from ipapython import certdb
-from ipatests.test_integration.test_backup_and_restore import backup
 from ipatests.test_integration.test_dns_locations import (
     resolve_records_from_server, IPA_DEFAULT_MASTER_SRV_REC
 )
@@ -928,7 +927,7 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         """
         self._check_server_role(self.replicas[0], 'hidden')
         # backup
-        backup_path, unused = backup(self.replicas[0])
+        backup_path = tasks.get_backup_dir(self.replicas[0])
         # uninstall
         tasks.uninstall_master(self.replicas[0])
         # restore


### PR DESCRIPTION
MANUAL BACKPORT of https://github.com/freeipa/freeipa/pull/4489 (straight cherry-pick, no merge required)

* tasks had an ipa_backup() method that was not used anywhere.
* test_backup_and_restore had a backup() method that used to return
  both the path to the backup and the whole result from run_command ;
  The path to the backup can be determined from the result.

Clean up:
* move test_backup_and_restore.backup to tasks.ipa_backup, replacing
  the unused method.
* add tasks.get_backup_dir(host) which runs ipa-backup on host and
  returns the path to the backup directory.
* adjust test_backup_and_restore and test_replica_promotion.

Related: https://pagure.io/freeipa/issue/8217
Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Michal Polovka <mpolovka@redhat.com>
Reviewed-By: Rob Crittenden <rcritten@redhat.com>