### PR TITLE
ipatests: increase test_ipahealthcheck timeout

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1338,7 +1338,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_ipahealthcheck.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl
 
   fedora-latest/test_ntp_options:

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -793,7 +793,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_ipahealthcheck.py
         template: *pki-master-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl
 
   pki-fedora/test_pkinit_manage:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1443,7 +1443,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_ipahealthcheck.py
         template: *testing-master-latest
-        timeout: 3600
+        timeout: 4800
 
   testing-fedora/test_ntp_options:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1338,7 +1338,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_ipahealthcheck.py
         template: *ci-master-previous
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl
 
   fedora-previous/test_ntp_options:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1443,7 +1443,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_ipahealthcheck.py
         template: *ci-master-frawhide
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl
 
   fedora-rawhide/test_ntp_options:


### PR DESCRIPTION
test_ipahealthcheck tends to take more than 3600s to run.
Increate timeout to 4800s.

Fixes: https://pagure.io/freeipa/issue/8262
Signed-off-by: François Cami <fcami@redhat.com>