### PR TITLE
[Backport][ipa-4-8] ipatests: Fix healthcheck timeout ipa 4 8

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1338,7 +1338,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_ipahealthcheck.py
         template: *ci-ipa-4-8-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl
 
   fedora-latest-ipa-4-8/test_ntp_options:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -1338,7 +1338,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_ipahealthcheck.py
         template: *ci-ipa-4-8-previous
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl
 
   fedora-previous-ipa-4-8/test_ntp_options:


### PR DESCRIPTION
CHERRY-PICK OF https://github.com/freeipa/freeipa/pull/4507 with MANUAL MERGE

test_ipahealthcheck tends to take more than 3600s to run.
Increate timeout to 4800s.

Fixes: https://pagure.io/freeipa/issue/8262
Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Armando Neto <abiagion@redhat.com>