### PR TITLE
ipatests: increase test_webui_server timeout

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1240,7 +1240,7 @@ jobs:
           test_webui/test_realmdomains.py
           test_webui/test_trust.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *ipaserver
 
   fedora-latest/test_webui_service:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1337,7 +1337,7 @@ jobs:
           test_webui/test_realmdomains.py
           test_webui/test_trust.py
         template: *testing-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *ipaserver
 
   testing-fedora/test_webui_service:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1240,7 +1240,7 @@ jobs:
           test_webui/test_realmdomains.py
           test_webui/test_trust.py
         template: *ci-master-previous
-        timeout: 3600
+        timeout: 7200
         topology: *ipaserver
 
   fedora-previous/test_webui_service:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1337,7 +1337,7 @@ jobs:
           test_webui/test_realmdomains.py
           test_webui/test_trust.py
         template: *ci-master-frawhide
-        timeout: 3600
+        timeout: 7200
         topology: *ipaserver
 
   fedora-rawhide/test_webui_service:


### PR DESCRIPTION
test_webui_server tends to take more than 3600s to run.
Increase timeout to 7200s.
    
Fixes: https://pagure.io/freeipa/issue/8266
