### PR TITLE
[Backport][ipa-4-8] CVE-2020-1722: prevent use of too long passwords

### DIFF
--- a/client/ipa-getkeytab.c
+++ b/client/ipa-getkeytab.c
@@ -562,6 +562,11 @@ done:
  * set match=true to enforce that the two entered passwords match.
  *
  * To prompt for an existing password provide prompt1 and set match=false.
+ *
+ * Implementation details:
+ * krb5_prompter_posix() does not differentiate between too long entry or
+ * an entry exactly the size of a buffer. Thus, allocate a bigger buffer
+ * and do the check for a too long password afterwards.
  */
 static char *ask_password(krb5_context krbctx, char *prompt1, char *prompt2,
                           bool match)
@@ -569,8 +574,10 @@ static char *ask_password(krb5_context krbctx, char *prompt1, char *prompt2,
     krb5_prompt ap_prompts[2];
     krb5_data k5d_pw0;
     krb5_data k5d_pw1;
-    char pw0[256];
-    char pw1[256];
+#define MAX(a,b) (((a)>(b))?(a):(b))
+#define PWD_BUFFER_SIZE MAX((IPAPWD_PASSWORD_MAX_LEN + 2), 1024)
+    char pw0[PWD_BUFFER_SIZE];
+    char pw1[PWD_BUFFER_SIZE];
     char *password;
     int num_prompts = match ? 2:1;
 
@@ -593,7 +600,12 @@ static char *ask_password(krb5_context krbctx, char *prompt1, char *prompt2,
                 num_prompts, ap_prompts);
 
     if (match && (strcmp(pw0, pw1))) {
-        fprintf(stderr, _("Passwords do not match!"));
+        fprintf(stderr, _("Passwords do not match!\n"));
+        return NULL;
+    }
+
+    if (k5d_pw0.length > IPAPWD_PASSWORD_MAX_LEN) {
+        fprintf(stderr, "%s\n", ipapwd_password_max_len_errmsg);
         return NULL;
     }
 
@@ -998,6 +1010,7 @@ int main(int argc, const char *argv[])
             }
 
             fprintf(stderr, _("Failed to create key material\n"));
+            free_keys_contents(krbctx, &keys);
             exit(8);
         }
 

--- a/client/man/ipa-getkeytab.1
+++ b/client/man/ipa-getkeytab.1
@@ -93,7 +93,7 @@ AES\-256 CTS mode with 192\-bit SHA\-384 HMAC
 ArcFour with HMAC/md5
 .TP
 \fB\-P, \-\-password\fR
-Use this password for the key instead of one randomly generated.
+Use this password for the key instead of one randomly generated. The length of the password is limited by 1024 characters. Note that MIT Kerberos also limits passwords entered through kpasswd and kadmin commands to the same length.
 .TP
 \fB\-D, \-\-binddn\fR
 The LDAP DN to bind as when retrieving a keytab without Kerberos credentials. Generally used with the \fB\-w\fR or \fB\-W\fR options.

--- a/daemons/ipa-kdb/ipa_kdb_passwords.c
+++ b/daemons/ipa-kdb/ipa_kdb_passwords.c
@@ -80,6 +80,12 @@ static krb5_error_code ipadb_check_pw_policy(krb5_context context,
         return EINVAL;
     }
 
+    if (strlen(passwd) > IPAPWD_PASSWORD_MAX_LEN) {
+        krb5_set_error_message(context, E2BIG, "%s",
+                               ipapwd_password_max_len_errmsg);
+        return E2BIG;
+    }
+
     ied->passwd = strdup(passwd);
     if (!ied->passwd) {
         return ENOMEM;

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
@@ -1087,3 +1087,12 @@ void free_ipapwd_krbcfg(struct ipapwd_krbcfg **cfg)
     *cfg = NULL;
 };
 
+int ipapwd_check_max_pwd_len(size_t len, char **errMesg) {
+    if (len > IPAPWD_PASSWORD_MAX_LEN) {
+        LOG("%s\n", ipapwd_password_max_len_errmsg);
+        *errMesg = ipapwd_password_max_len_errmsg;
+        return LDAP_CONSTRAINT_VIOLATION;
+    }
+    return 0;
+}
+

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipa_pwd_extop.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipa_pwd_extop.c
@@ -334,6 +334,11 @@ parse_req_done:
 		goto free_and_return;
 	}
 
+        rc = ipapwd_check_max_pwd_len(strlen(newPasswd), &errMesg);
+        if (rc) {
+            goto free_and_return;
+        }
+
 	if (oldPasswd == NULL || *oldPasswd == '\0') {
 		/* If user is authenticated, they already gave their password during
 		the bind operation (or used sasl or client cert auth or OS creds) */
@@ -1683,6 +1688,14 @@ static int ipapwd_getkeytab(Slapi_PBlock *pb, struct ipapwd_krbcfg *krbcfg)
         }
 
     } else {
+
+        if (password != NULL) {
+            /* if password was passed-in, check its length */
+            rc = ipapwd_check_max_pwd_len(strlen(password), &err_msg);
+            if (rc) {
+                goto free_and_return;
+            }
+	}
 
         /* check if we are allowed to *write* keys */
         acl_ok = is_allowed_to_access_attr(pb, bind_dn, target_entry,

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipapwd.h
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipapwd.h
@@ -133,6 +133,7 @@ int ipapwd_set_extradata(const char *dn,
                          time_t unixtime);
 void ipapwd_free_slapi_value_array(Slapi_Value ***svals);
 void free_ipapwd_krbcfg(struct ipapwd_krbcfg **cfg);
+int ipapwd_check_max_pwd_len(size_t len, char **errMesg);
 
 /* from encoding.c */
 struct ipapwd_keyset {

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -278,6 +278,10 @@ static int ipapwd_pre_add(Slapi_PBlock *pb)
                 rc = LDAP_CONSTRAINT_VIOLATION;
                 slapi_ch_free_string(&userpw);
             } else {
+                rc = ipapwd_check_max_pwd_len(strlen(userpw_clear), &errMesg);
+                if (rc) {
+                    goto done;
+                }
                 userpw = slapi_ch_strdup(userpw_clear);
             }
 
@@ -561,6 +565,11 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
                 goto done;
             }
             bv = lmod->mod_bvalues[0];
+
+            rc = ipapwd_check_max_pwd_len(bv->bv_len, &errMesg);
+            if (rc) {
+                goto done;
+            }
             slapi_ch_free_string(&unhashedpw);
             unhashedpw = slapi_ch_malloc(bv->bv_len+1);
             if (!unhashedpw) {
@@ -783,7 +792,12 @@ static int ipapwd_pre_mod(Slapi_PBlock *pb)
     if (! unhashedpw && (gen_krb_keys || is_smb || is_ipant)) {
         if ((userpw != NULL) && ('{' == userpw[0])) {
             if (0 == strncasecmp(userpw, "{CLEAR}", strlen("{CLEAR}"))) {
-                unhashedpw = slapi_ch_strdup(&userpw[strlen("{CLEAR}")]);
+                const char *userpw_clear = &userpw[strlen("{CLEAR}")];
+                rc = ipapwd_check_max_pwd_len(strlen(userpw_clear), &errMesg);
+                if (rc) {
+                    goto done;
+                }
+                unhashedpw = slapi_ch_strdup(userpw_clear);
                 if (NULL == unhashedpw) {
                     LOG_OOM();
                     rc = LDAP_OPERATIONS_ERROR;
@@ -1419,6 +1433,8 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
     time_t expire_time;
     char *principal_expire = NULL;
     struct tm expire_tm;
+    int rc = LDAP_INVALID_CREDENTIALS;
+    char *errMesg = NULL;
 
     /* get BIND parameters */
     ret |= slapi_pblock_get(pb, SLAPI_BIND_TARGET_SDN, &target_sdn);
@@ -1480,8 +1496,14 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
         goto invalid_creds;
 
     /* Ensure that there is a password. */
-    if (credentials->bv_len == 0)
+    if (credentials->bv_len == 0) {
         goto invalid_creds;
+    } else {
+        rc = ipapwd_check_max_pwd_len(credentials->bv_len, &errMesg);
+        if (rc) {
+            goto invalid_creds;
+        }
+    }
 
     /* Authenticate the user. */
     ret = ipapwd_authenticate(dn, entry, credentials);
@@ -1505,8 +1527,7 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
 invalid_creds:
     slapi_entry_free(entry);
     slapi_sdn_free(&sdn);
-    slapi_send_ldap_result(pb, LDAP_INVALID_CREDENTIALS,
-                           NULL, NULL, 0, NULL);
+    slapi_send_ldap_result(pb, rc, NULL, errMesg, 0, NULL);
     return 1;
 }
 

--- a/util/ipa_krb5.h
+++ b/util/ipa_krb5.h
@@ -31,6 +31,9 @@ struct keys_container {
 #define KEYTAB_RET_OID "2.16.840.1.113730.3.8.10.2"
 #define KEYTAB_GET_OID "2.16.840.1.113730.3.8.10.5"
 
+#define IPAPWD_PASSWORD_MAX_LEN 1000
+extern const char *ipapwd_password_max_len_errmsg;
+
 int krb5_klog_syslog(int, const char *, ...);
 
 void


### PR DESCRIPTION
This PR was opened automatically because PR #4525 was pushed to master and backport to ipa-4-8 is required.