### PR TITLE
[Backport][ipa-4-6] CVE-2020-1722: prevent use of too long passwords

### DIFF
--- a/client/ipa-getkeytab.c
+++ b/client/ipa-getkeytab.c
@@ -626,7 +626,16 @@ done:
     return ret;
 }
 
-static char *ask_password(krb5_context krbctx)
+/* Prompt for either a password.
+ * This can be either asking for a new or existing password.
+ *
+ * To set a new password provide values for both prompt1 and prompt2 and
+ * set match=true to enforce that the two entered passwords match.
+ *
+ * To prompt for an existing password provide prompt1 and set match=false.
+ */
+static char *ask_password(krb5_context krbctx, char *prompt1, char *prompt2,
+                          bool match)
 {
     krb5_prompt ap_prompts[2];
     krb5_data k5d_pw0;
@@ -634,24 +643,27 @@ static char *ask_password(krb5_context krbctx)
     char pw0[256];
     char pw1[256];
     char *password;
+    int num_prompts = match ? 2:1;
 
     k5d_pw0.length = sizeof(pw0);
     k5d_pw0.data = pw0;
-    ap_prompts[0].prompt = _("New Principal Password");
+    ap_prompts[0].prompt = prompt1;
     ap_prompts[0].hidden = 1;
     ap_prompts[0].reply = &k5d_pw0;
 
-    k5d_pw1.length = sizeof(pw1);
-    k5d_pw1.data = pw1;
-    ap_prompts[1].prompt = _("Verify Principal Password");
-    ap_prompts[1].hidden = 1;
-    ap_prompts[1].reply = &k5d_pw1;
+    if (match) {
+        k5d_pw1.length = sizeof(pw1);
+        k5d_pw1.data = pw1;
+        ap_prompts[1].prompt = prompt2;
+        ap_prompts[1].hidden = 1;
+        ap_prompts[1].reply = &k5d_pw1;
+    }
 
     krb5_prompter_posix(krbctx, NULL,
                 NULL, NULL,
-                2, ap_prompts);
+                num_prompts, ap_prompts);
 
-    if (strcmp(pw0, pw1)) {
+    if (match && (strcmp(pw0, pw1))) {
         fprintf(stderr, _("Passwords do not match!"));
         return NULL;
     }
@@ -752,6 +764,7 @@ int main(int argc, const char *argv[])
 	static const char *ca_cert_file = NULL;
 	int quiet = 0;
 	int askpass = 0;
+	int askbindpw = 0;
 	int permitted_enctypes = 0;
 	int retrieve = 0;
         struct poptOption options[] = {
@@ -778,6 +791,8 @@ int main(int argc, const char *argv[])
               _("LDAP DN"), _("DN to bind as if not using kerberos") },
 	    { "bindpw", 'w', POPT_ARG_STRING, &bindpw, 0,
               _("LDAP password"), _("password to use if not using kerberos") },
+	    { NULL, 'W', POPT_ARG_NONE, &askbindpw, 0,
+              _("Prompt for LDAP password"), NULL },
 	    { "cacert", 0, POPT_ARG_STRING, &ca_cert_file, 0,
               _("Path to the IPA CA certificate"), _("IPA CA certificate")},
 	    { "ldapuri", 'H', POPT_ARG_STRING, &ldap_uri, 0,
@@ -849,9 +864,24 @@ int main(int argc, const char *argv[])
 		exit(2);
 	}
 
+    if (askbindpw && bindpw != NULL) {
+		fprintf(stderr, _("Bind password already provided (-w).\n"));
+		if (!quiet) {
+			poptPrintUsage(pc, stderr, 0);
+		}
+		exit(2);
+    }
+
+    if (askbindpw) {
+		bindpw = ask_password(krbctx, _("Enter LDAP password"), NULL, false);
+		if (!bindpw) {
+			exit(2);
+		}
+    }
+
 	if (NULL!=binddn && NULL==bindpw) {
 		fprintf(stderr,
-                        _("Bind password required when using a bind DN.\n"));
+                        _("Bind password required when using a bind DN (-w or -W).\n"));
 		if (!quiet)
 			poptPrintUsage(pc, stderr, 0);
 		exit(10);
@@ -915,7 +945,8 @@ int main(int argc, const char *argv[])
     }
 
         if (askpass) {
-		password = ask_password(krbctx);
+		password = ask_password(krbctx, _("New Principal Password"),
+               	                _("Verify Principal Password"), true);
 		if (!password) {
 			exit(2);
 		}

--- a/client/man/ipa-getkeytab.1
+++ b/client/man/ipa-getkeytab.1
@@ -21,7 +21,7 @@
 .SH "NAME"
 ipa\-getkeytab \- Get a keytab for a Kerberos principal
 .SH "SYNOPSIS"
-ipa\-getkeytab \fB\-p\fR \fIprincipal\-name\fR \fB\-k\fR \fIkeytab\-file\fR [ \fB\-e\fR \fIencryption\-types\fR ] [ \fB\-s\fR \fIipaserver\fR ] [ \fB\-q\fR ] [ \fB\-D\fR|\fB\-\-binddn\fR \fIBINDDN\fR ] [ \fB\-w|\-\-bindpw\fR ] [ \fB\-P\fR|\fB\-\-password\fR \fIPASSWORD\fR ] [ \fB\-\-cacert \fICACERT\fR ] [ \fB\-H|\-\-ldapuri \fIURI\fR ] [ \fB\-Y|\-\-mech \fIGSSAPI|EXTERNAL\fR ] [ \fB\-r\fR ]
+ipa\-getkeytab \fB\-p\fR \fIprincipal\-name\fR \fB\-k\fR \fIkeytab\-file\fR [ \fB\-e\fR \fIencryption\-types\fR ] [ \fB\-s\fR \fIipaserver\fR ] [ \fB\-q\fR ] [ \fB\-D\fR|\fB\-\-binddn\fR \fIBINDDN\fR ] [ \fB\-w|\-\-bindpw\fR ] [ \fB-W\fR ] [ \fB\-P\fR|\fB\-\-password\fR \fIPASSWORD\fR ] [ \fB\-\-cacert \fICACERT\fR ] [ \fB\-H|\-\-ldapuri \fIURI\fR ] [ \fB\-Y|\-\-mech \fIGSSAPI|EXTERNAL\fR ] [ \fB\-r\fR ]
 
 .SH "DESCRIPTION"
 Retrieves a Kerberos \fIkeytab\fR.
@@ -44,7 +44,7 @@ provided, so the principal name is just the service
 name and hostname (ldap/foo.example.com from the
 example above).
 
-ipa-getkeytab is used during IPA client enrollment to retrieve a host service principal and store it in /etc/krb5.keytab. It is possible to retrieve the keytab without Kerberos credentials if the host was pre\-created with a one\-time password. The keytab can be retrieved by binding as the host and authenticating with this one\-time password. The \fB\-D|\-\-binddn\fR and \fB\-w|\-\-bindpw\fR options are used for this authentication.
+ipa-getkeytab is used during IPA client enrollment to retrieve a host service principal and store it in /etc/krb5.keytab. It is possible to retrieve the keytab without Kerberos credentials if the host was pre\-created with a one\-time password. The keytab can be retrieved by binding as the host and authenticating with this one\-time password. The \fB\-D|\-\-binddn\fR \fB\-w|\-\-bindpw\fR options are used for this authentication. \fB-W\fR can be used instead of \fB\-w|\-\-bindpw\fR to interactively prompt for the bind password.
 
 \fBWARNING:\fR retrieving the keytab resets the secret for the Kerberos principal.
 This renders all other keytabs for that principal invalid.
@@ -98,10 +98,13 @@ DES cbc mode with RSA\-MD4
 Use this password for the key instead of one randomly generated.
 .TP
 \fB\-D, \-\-binddn\fR
-The LDAP DN to bind as when retrieving a keytab without Kerberos credentials. Generally used with the \fB\-w\fR option.
+The LDAP DN to bind as when retrieving a keytab without Kerberos credentials. Generally used with the \fB\-w\fR or \fB\-W\fR options.
 .TP
 \fB\-w, \-\-bindpw\fR
 The LDAP password to use when not binding with Kerberos. \fB\-D\fR and \fB\-w\fR can not be used together with \fB\-Y\fR.
+.TP
+\fB\-W\fR
+Interactive prompt for the bind password. \fB\-D\fR and \fB\-W\fR can not be used together with \fB\-Y\fR
 .TP
 \fB\-\-cacert\fR
 The path to the IPA CA certificate used to validate LDAPS/STARTTLS connections.

--- a/client/man/ipa-getkeytab.1
+++ b/client/man/ipa-getkeytab.1
@@ -95,7 +95,7 @@ DES cbc mode with RSA\-MD5
 DES cbc mode with RSA\-MD4
 .TP
 \fB\-P, \-\-password\fR
-Use this password for the key instead of one randomly generated.
+Use this password for the key instead of one randomly generated. The length of the password is limited by 1024 characters. Note that MIT Kerberos also limits passwords entered through kpasswd and kadmin commands to the same length.
 .TP
 \fB\-D, \-\-binddn\fR
 The LDAP DN to bind as when retrieving a keytab without Kerberos credentials. Generally used with the \fB\-w\fR or \fB\-W\fR options.

--- a/daemons/ipa-kdb/ipa_kdb_passwords.c
+++ b/daemons/ipa-kdb/ipa_kdb_passwords.c
@@ -80,6 +80,12 @@ static krb5_error_code ipadb_check_pw_policy(krb5_context context,
         return EINVAL;
     }
 
+    if (strlen(passwd) > IPAPWD_PASSWORD_MAX_LEN) {
+        krb5_set_error_message(context, E2BIG, "%s",
+                               ipapwd_password_max_len_errmsg);
+        return E2BIG;
+    }
+
     ied->passwd = strdup(passwd);
     if (!ied->passwd) {
         return ENOMEM;

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
@@ -1087,3 +1087,12 @@ void free_ipapwd_krbcfg(struct ipapwd_krbcfg **cfg)
     *cfg = NULL;
 };
 
+int ipapwd_check_max_pwd_len(size_t len, char **errMesg) {
+    if (len > IPAPWD_PASSWORD_MAX_LEN) {
+        LOG("%s\n", ipapwd_password_max_len_errmsg);
+        *errMesg = ipapwd_password_max_len_errmsg;
+        return LDAP_CONSTRAINT_VIOLATION;
+    }
+    return 0;
+}
+

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipa_pwd_extop.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipa_pwd_extop.c
@@ -318,6 +318,11 @@ parse_req_done:
 		goto free_and_return;
 	}
 
+        rc = ipapwd_check_max_pwd_len(strlen(newPasswd), &errMesg);
+        if (rc) {
+            goto free_and_return;
+        }
+
 	if (oldPasswd == NULL || *oldPasswd == '\0') {
 		/* If user is authenticated, they already gave their password during
 		the bind operation (or used sasl or client cert auth or OS creds) */
@@ -1660,6 +1665,14 @@ static int ipapwd_getkeytab(Slapi_PBlock *pb, struct ipapwd_krbcfg *krbcfg)
         }
 
     } else {
+
+        if (password != NULL) {
+            /* if password was passed-in, check its length */
+            rc = ipapwd_check_max_pwd_len(strlen(password), &err_msg);
+            if (rc) {
+                goto free_and_return;
+            }
+	}
 
         /* check if we are allowed to *write* keys */
         acl_ok = is_allowed_to_access_attr(pb, bind_dn, target_entry,

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipapwd.h
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/ipapwd.h
@@ -133,6 +133,7 @@ int ipapwd_set_extradata(const char *dn,
                          time_t unixtime);
 void ipapwd_free_slapi_value_array(Slapi_Value ***svals);
 void free_ipapwd_krbcfg(struct ipapwd_krbcfg **cfg);
+int ipapwd_check_max_pwd_len(size_t len, char **errMesg);
 
 /* from encoding.c */
 struct ipapwd_keyset {

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -33,6 +33,7 @@ from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipaplatform.tasks import tasks as platform_tasks
 from ipatests.pytest_ipa.integration.create_external_ca import ExternalCA
+from ipapython.ipautil import ipa_generate_password
 
 logger = logging.getLogger(__name__)
 
@@ -336,6 +337,84 @@ class TestIPACommand(IntegrationTest):
                                          use_dirman=True)
         except CalledProcessError:
             pytest.fail("Password change failed when it should not")
+
+    def test_huge_password(self):
+        user = 'toolonguser'
+        hostname = 'toolong.{}'.format(self.master.domain.name)
+        huge_password = ipa_generate_password(min_len=1536)
+        original_passwd = 'Secret123'
+        master = self.master
+        base_dn = str(master.domain.basedn)  # pylint: disable=no-member
+
+        # Create a user with a password that is too long
+        tasks.kinit_admin(master)
+        add_password_stdin_text = "{pwd}\n{pwd}".format(pwd=huge_password)
+        result = master.run_command(['ipa', 'user-add', user,
+                                     '--first', user,
+                                     '--last', user,
+                                     '--password'],
+                                    stdin_text=add_password_stdin_text,
+                                    raiseonerr=False)
+        assert result.returncode != 0
+
+        # Try again with a normal password
+        add_password_stdin_text = "{pwd}\n{pwd}".format(pwd=original_passwd)
+        master.run_command(['ipa', 'user-add', user,
+                            '--first', user,
+                            '--last', user,
+                            '--password'],
+                           stdin_text=add_password_stdin_text)
+
+        # kinit as that user in order to modify the pwd
+        user_kinit_stdin_text = "{old}\n%{new}\n%{new}\n".format(
+            old=original_passwd,
+            new=original_passwd)
+        master.run_command(['kinit', user], stdin_text=user_kinit_stdin_text)
+        # sleep 1 sec (krblastpwdchange and krbpasswordexpiration have at most
+        # a 1s precision)
+        time.sleep(1)
+        # perform ldapmodify on userpassword as dir mgr
+        entry_ldif = textwrap.dedent("""
+            dn: uid={user},cn=users,cn=accounts,{base_dn}
+            changetype: modify
+            replace: userpassword
+            userpassword: {new_passwd}
+        """).format(
+            user=user,
+            base_dn=base_dn,
+            new_passwd=huge_password)
+
+        result = tasks.ldapmodify_dm(master, entry_ldif, raiseonerr=False)
+        assert result.returncode != 0
+
+        # ask_password in ipa-getkeytab will complain about too long password
+        keytab_file = os.path.join(self.master.config.test_dir,
+                                   'user.keytab')
+        password_stdin_text = "{pwd}\n{pwd}".format(pwd=huge_password)
+        result = self.master.run_command(['ipa-getkeytab',
+                                          '-p', user,
+                                          '-P',
+                                          '-k', keytab_file,
+                                          '-s', self.master.hostname],
+                                         stdin_text=password_stdin_text,
+                                         raiseonerr=False)
+        assert result.returncode != 0
+        assert "clear-text password is too long" in result.stderr_text
+
+        # Create a host with a user-set OTP that is too long
+        tasks.kinit_admin(master)
+        result = master.run_command(['ipa', 'host-add', '--force',
+                                     hostname,
+                                     '--password', huge_password],
+                                    raiseonerr=False)
+        assert result.returncode != 0
+
+        # Try again with a valid password
+        result = master.run_command(['ipa', 'host-add', '--force',
+                                     hostname,
+                                     '--password', original_passwd],
+                                    raiseonerr=False)
+        assert result.returncode == 0
 
     def test_change_selinuxusermaporder(self):
         """

--- a/util/ipa_krb5.h
+++ b/util/ipa_krb5.h
@@ -30,6 +30,9 @@ struct keys_container {
 #define KEYTAB_RET_OID "2.16.840.1.113730.3.8.10.2"
 #define KEYTAB_GET_OID "2.16.840.1.113730.3.8.10.5"
 
+#define IPAPWD_PASSWORD_MAX_LEN 1000
+extern const char *ipapwd_password_max_len_errmsg;
+
 int krb5_klog_syslog(int, const char *, ...);
 
 void


### PR DESCRIPTION
Manual backport of https://github.com/freeipa/freeipa/pull/4525 to ipa-4-6. I had to backport the change from commit a241a81ba4 (fixed issue https://pagure.io/freeipa/issue/631) to keep `ipa-getkeytab` logic across all branches.