### PR TITLE
[Backport][ipa-4-8] ipatests: increase test_webui_server timeout

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1240,7 +1240,7 @@ jobs:
           test_webui/test_realmdomains.py
           test_webui/test_trust.py
         template: *ci-ipa-4-8-latest
-        timeout: 3600
+        timeout: 7200
         topology: *ipaserver
 
   fedora-latest-ipa-4-8/test_webui_service:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -1240,7 +1240,7 @@ jobs:
           test_webui/test_realmdomains.py
           test_webui/test_trust.py
         template: *ci-ipa-4-8-previous
-        timeout: 3600
+        timeout: 7200
         topology: *ipaserver
 
   fedora-previous-ipa-4-8/test_webui_service:


### PR DESCRIPTION
MANUAL cherry-pick of https://github.com/freeipa/freeipa/pull/4514
Self-ACKing as this is straightforward.

test_webui_server tends to take more than 3600s to run.
Increase timeout to 7200s.

Fixes: https://pagure.io/freeipa/issue/8266
Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Armando Neto <abiagion@redhat.com>