### PR TITLE
Bump required Pytest

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -744,7 +744,7 @@ Requires: ldns-utils
 Requires: python3-coverage
 Requires: python3-cryptography >= 1.6
 Requires: python3-polib
-Requires: python3-pytest >= 2.6
+Requires: python3-pytest >= 3.9.1
 Requires: python3-pytest-multihost >= 0.5
 Requires: python3-pytest-sourceorder
 Requires: python3-sssdconfig >= %{sssd_version}

--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -137,17 +137,11 @@ def pytest_cmdline_main(config):
 
 def pytest_runtest_setup(item):
     if isinstance(item, pytest.Function):
-        # pytest 3.6 has deprecated get_marker in 3.6. The method was
-        # removed in 4.x and replaced with get_closest_marker.
-        if hasattr(item, 'get_closest_marker'):
-            get_marker = item.get_closest_marker  # pylint: disable=no-member
-        else:
-            get_marker = item.get_marker  # pylint: disable=no-member
-        if get_marker('skip_ipaclient_unittest'):
+        if item.get_closest_marker('skip_ipaclient_unittest'):
             # pylint: disable=no-member
             if item.config.option.ipaclient_unittests:
                 pytest.skip("Skip in ipaclient unittest mode")
-        if get_marker('needs_ipaapi'):
+        if item.get_closest_marker('needs_ipaapi'):
             # pylint: disable=no-member
             if item.config.option.skip_ipaapi:
                 pytest.skip("Skip tests that needs an IPA API")

--- a/ipatests/ipa-run-tests
+++ b/ipatests/ipa-run-tests
@@ -63,7 +63,7 @@ if not has_option("junit_family"):
 pyt_args = [sys.executable, "-c",
             "import sys,pytest;sys.exit(pytest.main())"] + sys.argv[1:]
 # shell is needed to perform globbing
-sh_args = ["/bin/sh", "--norc", "--noprofile", "-c", "--"]
+sh_args = ["/bin/bash", "--norc", "--noprofile", "-c", "--"]
 pyt_args_esc = [
     f"'{x}'" if not x or " " in x else x
     for x in pyt_args

--- a/ipatests/ipa-run-tests
+++ b/ipatests/ipa-run-tests
@@ -55,6 +55,10 @@ if not has_option("confcutdir"):
 if not has_option("cache_dir"):
     sys.argv[1:1] = ["-o", 'cache_dir={}'.format(os.path.join(os.getcwd(),
                                                  ".pytest_cache"))]
+# Pytest 5.2 deprecation: The default value of junit_family option will change
+# to xunit2 in pytest 6.0. Current XML scheme is xunit1.
+if not has_option("junit_family"):
+    sys.argv[1:1] = ["-o", 'junit_family=xunit1']
 
 pyt_args = [sys.executable, "-c",
             "import sys,pytest;sys.exit(pytest.main())"] + sys.argv[1:]

--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -32,7 +32,6 @@ from pytest_multihost import make_multihost_fixture
 
 from ipapython import ipautil
 from ipaplatform.paths import paths
-from ipatests.test_util import yield_fixture
 from .config import Config
 from .env_config import get_global_config
 from . import tasks
@@ -187,7 +186,7 @@ def class_integration_logs():
     return {}
 
 
-@yield_fixture
+@pytest.fixture
 def integration_logs(class_integration_logs, request):
     """Provides access to test integration logs, and collects after each test
     """
@@ -197,7 +196,7 @@ def integration_logs(class_integration_logs, request):
     collect_systemd_journal(request.node, hosts, request.config)
 
 
-@yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def mh(request, class_integration_logs):
     """IPA's multihost fixture object
     """

--- a/ipatests/pytest_ipa/nose_compat.py
+++ b/ipatests/pytest_ipa/nose_compat.py
@@ -54,19 +54,11 @@ def pytest_configure(config):
                 capture = config.pluginmanager.getplugin('capturemanager')
                 orig_stdout, orig_stderr = sys.stdout, sys.stderr
                 if capture:
-                    if hasattr(capture, 'suspend_global_capture'):
-                        # pytest >= 3.3
-                        capture.suspend_global_capture()
-                    else:
-                        # legacy support for pytest <= 3.2 (Fedora 27)
-                        capture._capturing.suspend_capturing()
+                    capture.suspend_global_capture()
                 sys.stderr.write(self.format(record))
                 sys.stderr.write('\n')
                 if capture:
-                    if hasattr(capture, 'resume_global_capture'):
-                        capture.resume_global_capture()
-                    else:
-                        capture._capturing.resume_capturing()
+                    capture.resume_global_capture()
                 sys.stdout, sys.stderr = orig_stdout, orig_stderr
 
         level = convert_log_level(config.getoption('logging_level'))

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -162,7 +162,7 @@ def restore_checker(host):
         assert_func(expected, got)
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture
 def cert_sign_request(request):
     master = request.instance.master
     hosts = [master] + request.instance.replicas

--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -75,7 +75,7 @@ class TestSMB(IntegrationTest):
         for user in [cls.ipa_user1, cls.ipa_user2, cls.ad_user]:
             tasks.run_command_as_user(cls.smbserver, user, ['stat', '.'])
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def enable_smb_client_dns_lookup_kdc(self):
         smbclient = self.smbclient
         with tasks.FileBackup(smbclient, paths.KRB5_CONF):
@@ -86,7 +86,7 @@ class TestSMB(IntegrationTest):
             smbclient.put_file_contents(paths.KRB5_CONF, krb5_conf)
             yield
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def samba_share_public(self):
         """Setup share outside /home on samba server."""
         share_name = 'shared'

--- a/ipatests/test_ipaserver/test_kadmin.py
+++ b/ipatests/test_ipaserver/test_kadmin.py
@@ -13,10 +13,9 @@ import tempfile
 from ipalib import api
 
 from ipaserver.install import installutils
-from ipatests.test_util import yield_fixture
 
 
-@yield_fixture()
+@pytest.fixture
 def keytab():
     fd, keytab_path = tempfile.mkstemp(suffix='.keytab')
     os.close(fd)

--- a/ipatests/test_util.py
+++ b/ipatests/test_util.py
@@ -33,19 +33,6 @@ if six.PY3:
     unicode = str
 
 pytestmark = pytest.mark.tier0
-
-
-# pytest >= 2.10 supports yield based fixtures with pytest.fixture. In
-# pytest < 2.10 pytest.yield_fixture is required. But that function
-# also raises a deprecation warning in pytest >= 3.0.
-PYTEST_VERSION = tuple(int(p) for p in pytest.__version__.split('.'))
-
-if PYTEST_VERSION < (2, 10):
-    yield_fixture = pytest.yield_fixture
-else:
-    yield_fixture = pytest.fixture
-
-
 pattern_type = type(re.compile(""))
 
 

--- a/ipatests/test_xmlrpc/test_cert_request_ip_address.py
+++ b/ipatests/test_xmlrpc/test_cert_request_ip_address.py
@@ -24,7 +24,6 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
 from ipalib import api, errors
-from ipatests.test_util import yield_fixture
 from ipatests.test_xmlrpc.tracker.host_plugin import HostTracker
 from ipatests.test_xmlrpc.tracker.user_plugin import UserTracker
 from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test
@@ -79,41 +78,41 @@ def _record_setup(host, zone, record, **kwargs):
         host.run_command('dnsrecord_del', zone, record, **kwargs)
 
 
-@yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def ipv4_revzone(host):
     yield from _zone_setup(host, ipv4_revzone_s)
 
 
-@yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def ipv6_revzone(host):
     yield from _zone_setup(host, ipv6_revzone_s)
 
 
-@yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def ipv4_ptr(host, ipv4_revzone):
     yield from _record_setup(
         host, ipv4_revzone, ipv4_revrec_s, ptrrecord=host_ptr)
 
 
-@yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def ipv6_ptr(host, ipv6_revzone):
     yield from _record_setup(
         host, ipv6_revzone, ipv6_revrec_s, ptrrecord=host_ptr)
 
 
-@yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def ipv4_a(host):
     yield from _record_setup(
         host, api.env.domain, 'iptest', arecord=ipv4_address)
 
 
-@yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def ipv6_aaaa(host):
     yield from _record_setup(
         host, api.env.domain, 'iptest', aaaarecord=ipv6_address)
 
 
-@yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def other_forward_records(host):
     """
     Create A and AAAA records (to the "correct" IP address) for
@@ -125,19 +124,19 @@ def other_forward_records(host):
         arecord=ipv4_address, aaaarecord=ipv6_address)
 
 
-@yield_fixture(scope='function')
+@pytest.fixture(scope='function')
 def ipv4_ptr_other(host, ipv4_revzone):
     yield from _record_setup(
         host, ipv4_revzone, ipv4_revrec_s, ptrrecord=other_ptr)
 
 
-@yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def cname1(host):
     yield from _record_setup(
         host, api.env.domain, 'cname1', cnamerecord='iptest')
 
 
-@yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def cname2(host):
     yield from _record_setup(
         host, api.env.domain, 'cname2', cnamerecord='cname1')

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -36,7 +36,6 @@ from ipaplatform.paths import paths
 from ipapython import ipautil
 from ipapython.dn import DN
 from ipapython.dnsutil import DNSName
-from ipatests.test_util import yield_fixture
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.test_xmlrpc.test_user_plugin import get_group_dn
 from ipatests.test_xmlrpc.testcert import get_testcert, subject_base
@@ -643,7 +642,7 @@ class TestValidation(XMLRPC_test):
         ), result)
 
 
-@yield_fixture
+@pytest.fixture
 def keytabname(request):
     keytabfd, keytabname = tempfile.mkstemp()
     try:
@@ -727,7 +726,7 @@ class TestHostFalsePwdChange(XMLRPC_test):
             command()
 
 
-@yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def dns_setup_nonameserver(host4):
     # Make sure that the server does not handle the reverse zone used
     # for the test
@@ -819,7 +818,7 @@ class TestHostNoNameserversForRevZone(XMLRPC_test):
                 pass
 
 
-@yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def dns_setup(host):
     try:
         host.run_command('dnszone_del', dnszone, revzone, revipv6zone,

--- a/ipatests/test_xmlrpc/test_kerberos_principal_aliases.py
+++ b/ipatests/test_xmlrpc/test_kerberos_principal_aliases.py
@@ -12,7 +12,6 @@ from ipalib import errors, api
 from ipapython import ipautil
 from ipaplatform.paths import paths
 
-from ipatests.test_util import yield_fixture
 from ipatests.util import MockLDAP
 from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test
 from ipatests.test_xmlrpc.tracker.user_plugin import UserTracker
@@ -51,7 +50,7 @@ TRACKER_DATA = [
 ]
 
 
-@yield_fixture
+@pytest.fixture
 def trusted_domain():
     """Fixture providing mocked AD trust entries
 
@@ -69,7 +68,7 @@ def trusted_domain():
         ldap.del_entry(trusted_dom['dn'])
 
 
-@yield_fixture
+@pytest.fixture
 def trusted_domain_with_suffix():
     """Fixture providing mocked AD trust entries
 

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -69,8 +69,6 @@ if six.PY3:
     unicode = str
 
 
-PYTEST_VERSION = tuple(int(v) for v in pytest.__version__.split('.'))
-
 # settings are configured by conftest
 IPACLIENT_UNITTESTS = None
 SKIP_IPAAPI = None
@@ -81,25 +79,14 @@ def check_ipaclient_unittests(reason="Skip in ipaclient unittest mode"):
     """Call this in a package to skip the package in ipaclient-unittest mode
     """
     if IPACLIENT_UNITTESTS:
-        if PYTEST_VERSION[0] >= 3:
-            # pytest 3+ does no longer allow pytest.skip() on module level
-            # pylint: disable=unexpected-keyword-arg
-            raise pytest.skip.Exception(reason, allow_module_level=True)
-            # pylint: enable=unexpected-keyword-arg
-        else:
-            raise pytest.skip(reason)
+        pytest.skip(reason, allow_module_level=True)
 
 
 def check_no_ipaapi(reason="Skip tests that needs an IPA API"):
     """Call this in a package to skip the package in no-ipaapi mode
     """
     if SKIP_IPAAPI:
-        if PYTEST_VERSION[0] >= 3:
-            # pylint: disable=unexpected-keyword-arg
-            raise pytest.skip.Exception(reason, allow_module_level=True)
-            # pylint: enable=unexpected-keyword-arg
-        else:
-            raise pytest.skip(reason)
+        pytest.skip(reason, allow_module_level=True)
 
 
 class TempDir:


### PR DESCRIPTION
This bumps required Pytest to 3.9.1+ and adds cleanups:
- removed deprecated yield_fixture
- removed no longer needed 'get_marker'
- removed no longer needed 'capture' compatibility
- removed no longer needed 'skip' compatibility
- fixed PytestDeprecationWarning about 'junit_family'
- pinned the `ipa-run-tests` shell implementation to bash

Fixes: https://pagure.io/freeipa/issue/8101