### PR TITLE
Man pages: fix syntax issues

### DIFF
--- a/client/man/default.conf.5
+++ b/client/man/default.conf.5
@@ -47,14 +47,14 @@ Valid lines consist of an option name, an equals sign and a value. Spaces surrou
 
 Values should not be quoted, the quotes will not be stripped.
 
-.DS L
+.RS L
     # Wrong \- don't include quotes
     verbose = "True"
 
     # Right \- Properly formatted options
     verbose = True
     verbose=True
-.DE
+.RE
 
 Options must appear in the section named [global]. There are no other sections defined or used currently.
 

--- a/install/tools/man/ipa-cacert-manage.1
+++ b/install/tools/man/ipa-cacert-manage.1
@@ -91,7 +91,6 @@ Output only errors.
 .TP
 \fB\-\-log\-file\fR=\fIFILE\fR
 Log to the given file.
-.RE
 .SH "RENEW OPTIONS"
 .TP
 \fB\-\-self\-signed\fR
@@ -124,7 +123,6 @@ If no template is specified, the template name "SubCA" is used.
 .TP
 \fB\-\-external\-cert\-file\fR=\fIFILE\fR
 File containing the IPA CA certificate and the external CA certificate chain. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times.
-.RE
 .SH "INSTALL OPTIONS"
 .TP
 \fB\-n\fR \fINICKNAME\fR, \fB\-\-nickname\fR=\fINICKNAME\fR
@@ -146,7 +144,6 @@ p \- not trusted
 .TP
 \fB\-f\fR, \fB\-\-force\fR
 Force a CA certificate to be removed even if chain validation fails.
-.RE
 .SH "EXIT STATUS"
 0 if the command was successful
 


### PR DESCRIPTION
Fix the syntax in ipa-cacert-manage.1 and default.conf.5

Fixes: https://pagure.io/freeipa/issue/8273