### PR TITLE
[Backport][ipa-4-6] Man pages: fix syntax issues

### DIFF
--- a/client/man/default.conf.5
+++ b/client/man/default.conf.5
@@ -47,14 +47,14 @@ Valid lines consist of an option name, an equals sign and a value. Spaces surrou
 
 Values should not be quoted, the quotes will not be stripped.
 
-.DS L
+.RS L
     # Wrong \- don't include quotes
     verbose = "True"
 
     # Right \- Properly formatted options
     verbose = True
     verbose=True
-.DE
+.RE
 
 Options must appear in the section named [global]. There are no other sections defined or used currently.
 

--- a/install/tools/man/ipa-cacert-manage.1
+++ b/install/tools/man/ipa-cacert-manage.1
@@ -79,7 +79,6 @@ Output only errors.
 .TP
 \fB\-\-log\-file\fR=\fIFILE\fR
 Log to the given file.
-.RE
 .SH "RENEW OPTIONS"
 .TP
 \fB\-\-self\-signed\fR
@@ -112,7 +111,6 @@ If no template is specified, the template name "SubCA" is used.
 .TP
 \fB\-\-external\-cert\-file\fR=\fIFILE\fR
 File containing the IPA CA certificate and the external CA certificate chain. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times.
-.RE
 .SH "INSTALL OPTIONS"
 .TP
 \fB\-n\fR \fINICKNAME\fR, \fB\-\-nickname\fR=\fINICKNAME\fR


### PR DESCRIPTION
Manual backport of PR #4539 to ipa-4-6.
The file install/tools/man/ipa-cacert-manage.1 in ipa-4-6 branch does not mention the subcommand `delete`, hence the failure to do an automated backport.

PR was ACKed automatically because this is backport of PR #4539. Wait for CI to finish before pushing. In case of questions or problems contact @flo-renaud who is author of the original PR.