### PR TITLE
Define default password policy for sysaccounts

### DIFF
--- a/install/updates/20-default_password_policy.update
+++ b/install/updates/20-default_password_policy.update
@@ -1,6 +1,9 @@
-# Default password policies for hosts, services and Kerberos services
-# Setting all attributes to zero effectively disables any password policy
-# We can do this because hosts and services uses keytabs instead of passwords
+# Default password policies for hosts, services, system accounts, and
+# Kerberos services
+# Setting all attributes to zero effectively disables any password policy.
+# We can do this because hosts and services uses keytabs instead of
+# passwords. System accounts with krbPrincipalAux objectClass also use
+# keytabs.
 
 # hosts
 dn: cn=Default Host Password Policy,cn=computers,cn=accounts,$SUFFIX
@@ -55,7 +58,24 @@ default:krbPwdMaxFailure: 0
 default:krbPwdFailureCountInterval: 0
 default:krbPwdLockoutDuration: 0
 
-# default password policies for hosts, services and kerberos services
+# system accounts
+# Contrary to the other policies this policy has a minimum password length.
+dn: cn=Default System Accounts Password Policy,cn=sysaccounts,cn=etc,$SUFFIX
+default:objectClass: krbPwdPolicy
+default:objectClass: nsContainer
+default:objectClass: top
+default:cn: Default System Accounts Password Policy
+default:krbMinPwdLife: 0
+default:krbPwdMinDiffChars: 0
+default:krbPwdMinLength: 8
+default:krbPwdHistoryLength: 0
+default:krbMaxPwdLife: 0
+default:krbPwdMaxFailure: 0
+default:krbPwdFailureCountInterval: 0
+default:krbPwdLockoutDuration: 0
+
+# default password policies for hosts, services, system accounts, and
+# kerberos services
 # cosPriority is set intentionally to higher number than FreeIPA API allows
 # to set to ensure that these password policies have always lower priority
 # than any defined by user.
@@ -130,4 +150,28 @@ default:objectClass: ldapsubentry
 default:objectClass: cosSuperDefinition
 default:objectClass: cosPointerDefinition
 default:cosTemplateDn: cn=Default Password Policy,cn=cosTemplates,cn=$REALM,cn=kerberos,$SUFFIX
+default:cosAttribute: krbPwdPolicyReference default
+
+# system accounts
+dn: cn=cosTemplates,cn=sysaccounts,cn=etc,$SUFFIX
+default:objectclass: top
+default:objectclass: nsContainer
+default:cn: cosTemplates
+
+dn: cn=Default Password Policy,cn=cosTemplates,cn=sysaccounts,cn=etc,$SUFFIX
+default:objectclass: top
+default:objectclass: cosTemplate
+default:objectclass: extensibleObject
+default:objectclass: krbContainer
+default:cn: Default Password Policy
+default:cosPriority: 10000000000
+default:krbPwdPolicyReference: cn=Default System Accounts Password Policy,cn=sysaccounts,cn=etc,$SUFFIX
+
+dn: cn=Default Password Policy,cn=sysaccounts,cn=etc,$SUFFIX
+default:description: Default Password Policy for System Accounts
+default:objectClass: top
+default:objectClass: ldapsubentry
+default:objectClass: cosSuperDefinition
+default:objectClass: cosPointerDefinition
+default:cosTemplateDn: cn=Default Password Policy,cn=cosTemplates,cn=sysaccounts,cn=etc,$SUFFIX
 default:cosAttribute: krbPwdPolicyReference default

--- a/ipaserver/install/adtrust.py
+++ b/ipaserver/install/adtrust.py
@@ -297,8 +297,8 @@ def add_hosts_to_adtrust_agents(api, host_list):
     :param host_list: list of potential AD trust agent FQDNs
     """
     agents_dn = DN(
-        ('cn', 'adtrust agents'), ('cn', 'sysaccounts'),
-        ('cn', 'etc'), api.env.basedn)
+        ('cn', 'adtrust agents'), api.env.container_sysaccounts,
+        api.env.basedn)
 
     service.add_principals_to_group(
         api.Backend.ldap2,

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -192,8 +192,7 @@ class ADTRUSTInstance(service.Service):
         self.trust_dn = DN(api.env.container_trusts, self.suffix)
 
         self.smb_dn = DN(('cn', 'adtrust agents'),
-                         ('cn', 'sysaccounts'),
-                         ('cn', 'etc'),
+                         api.env.container_sysaccounts,
                          self.suffix)
 
         self.smb_dom_dn = DN(('cn', api.env.domain),

--- a/ipaserver/install/plugins/adtrust.py
+++ b/ipaserver/install/plugins/adtrust.py
@@ -903,8 +903,8 @@ class update_adtrust_agents_members(Updater):
             return False, []
 
         agents_dn = DN(
-            ('cn', 'adtrust agents'), ('cn', 'sysaccounts'),
-            ('cn', 'etc'), self.api.env.basedn)
+            ('cn', 'adtrust agents'), self.api.env.container_sysaccounts,
+            self.api.env.basedn)
 
         try:
             agents_entry = ldap.get_entry(agents_dn, ['member'])

--- a/ipaserver/install/plugins/update_passsync.py
+++ b/ipaserver/install/plugins/update_passsync.py
@@ -56,8 +56,11 @@ class update_passync_privilege_update(Updater):
 
         logger.debug("Add PassSync user as a member of PassSync privilege")
         ldap = self.api.Backend.ldap2
-        passsync_dn = DN(('uid','passsync'), ('cn', 'sysaccounts'), ('cn', 'etc'),
-            self.api.env.basedn)
+        passsync_dn = DN(
+            ('uid', 'passsync'),
+            self.api.env.container_sysaccounts,
+            self.api.env.basedn
+        )
         passsync_privilege_dn = DN(('cn','PassSync Service'),
                 self.api.env.container_privilege,
                 self.api.env.basedn)

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -720,7 +720,8 @@ class ReplicationManager:
         self.enable_chain_on_update(chainbe)
 
     def add_passsync_user(self, conn, password):
-        pass_dn = DN(('uid', 'passsync'), ('cn', 'sysaccounts'), ('cn', 'etc'), self.suffix)
+        pass_dn = DN(('uid', 'passsync'), api.env.container_sysaccounts,
+                     self.suffix)
         print("The user for the Windows PassSync service is %s" % pass_dn)
         try:
             conn.get_entry(pass_dn)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1010,8 +1010,9 @@ def promote_check(installer):
 
         # Detect if the other master can handle replication managers
         # cn=replication managers,cn=sysaccounts,cn=etc,$SUFFIX
-        dn = DN(('cn', 'replication managers'), ('cn', 'sysaccounts'),
-                ('cn', 'etc'), ipautil.realm_to_suffix(config.realm_name))
+        dn = DN(('cn', 'replication managers'),
+                api.env.container_sysaccounts,
+                ipautil.realm_to_suffix(config.realm_name))
         try:
             conn.get_entry(dn)
         except errors.NotFound:

--- a/ipaserver/servroles.py
+++ b/ipaserver/servroles.py
@@ -584,8 +584,9 @@ class ADtrustBasedRole(BaseServerRole):
 
         search_filter = ldap.make_filter_from_attr(
             "memberof",
-            DN(('cn', 'adtrust agents'), ('cn', 'sysaccounts'),
-               ('cn', 'etc'), api_instance.env.basedn)
+            DN(('cn', 'adtrust agents'),
+               api_instance.env.container_sysaccounts,
+               api_instance.env.basedn)
         )
         if server is not None:
             server_filter = ldap.make_filter_from_attr(

--- a/ipatests/test_ipaserver/test_serverroles.py
+++ b/ipatests/test_ipaserver/test_serverroles.py
@@ -55,8 +55,7 @@ def _make_master_entry(ldap_backend, dn, ca=False):
 
 _adtrust_agents = DN(
     ('cn', 'adtrust agents'),
-    ('cn', 'sysaccounts'),
-    ('cn', 'etc'),
+    api.env.container_sysaccounts,
     api.env.basedn
 )
 


### PR DESCRIPTION
cn=sysaccounts,cn=etc now has a default password policy to permit system
accounts with krbPrincipalAux object class. This allows system accounts
to have a keytab that does not expire.

Fixes: https://pagure.io/freeipa/issue/8276
Signed-off-by: Christian Heimes <cheimes@redhat.com>