### PR TITLE
Fixes to allow running the testsuite on Debian/Ubuntu

### DIFF
--- a/ipaplatform/debian/tasks.py
+++ b/ipaplatform/debian/tasks.py
@@ -206,4 +206,12 @@ Serial Number (hex): {cert.serial_number:#x}
 
         return True
 
+    # Debian doesn't use authselect, so call enable/disable_ldap_automount
+    # from BaseTaskNamespace.
+    def enable_ldap_automount(self, statestore):
+        return BaseTaskNamespace.enable_ldap_automount(self, statestore)
+
+    def disable_ldap_automount(self, statestore):
+        return BaseTaskNamespace.disable_ldap_automount(self, statestore)
+
 tasks = DebianTaskNamespace()

--- a/ipaplatform/debian/tasks.py
+++ b/ipaplatform/debian/tasks.py
@@ -72,10 +72,6 @@ class DebianTaskNamespace(RedHatTaskNamespace):
         # Debian doesn't have authselect
         return True
 
-    @staticmethod
-    def parse_ipa_version(version):
-        return BaseTaskNamespace.parse_ipa_version(version)
-
     def configure_httpd_wsgi_conf(self):
         # Debian doesn't require special mod_wsgi configuration
         pass

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -906,11 +906,10 @@ class TestIPACommand(IntegrationTest):
         if self.master.is_fips_mode:  # pylint: disable=no-member
             pytest.skip("paramiko is not compatible with FIPS mode")
 
-        sssd_version = ''
-        cmd_output = self.master.run_command(['sssd', '--version'])
-        sssd_version = platform_tasks.\
-            parse_ipa_version(cmd_output.stdout_text.strip())
-        if sssd_version.version < '2.2.0':
+        cmd = self.master.run_command(['sssd', '--version'])
+        sssd_version = platform_tasks.parse_ipa_version(
+            cmd.stdout_text.strip())
+        if sssd_version < platform_tasks.parse_ipa_version('2.2.0'):
             pytest.xfail(reason="sssd 2.2.0 unavailable in F29 nightly")
 
         username = "testuser" + str(random.randint(200000, 9999999))

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -607,24 +607,25 @@ class TestInstallMaster(IntegrationTest):
         other hand in case of restart it will change.
         """
         # listing all services
-        services = [
+        ipa_services_name = [
             "Directory", "krb5kdc", "kadmin", "named", "httpd", "ipa-custodia",
             "pki-tomcatd", "ipa-otpd", "ipa-dnskeysyncd"
         ]
 
         # checking the service status
         cmd = self.master.run_command(['ipactl', 'status'])
-        for service in services:
+        for service in ipa_services_name:
             assert f"{service} Service: RUNNING" in cmd.stdout_text
 
         # stopping few services
         service_stop = ["krb5kdc", "kadmin", "httpd"]
         for service in service_stop:
-            self.master.run_command(['systemctl', 'stop', service])
+            service_name = services.knownservices[service].systemd_name
+            self.master.run_command(['systemctl', 'stop', service_name])
 
         # checking service status
         service_start = [
-            svcs for svcs in services if svcs not in service_stop
+            svcs for svcs in ipa_services_name if svcs not in service_stop
         ]
         cmd = self.master.run_command(['ipactl', 'status'])
         for service in service_start:
@@ -637,7 +638,7 @@ class TestInstallMaster(IntegrationTest):
 
         # checking service status
         cmd = self.master.run_command(['ipactl', 'status'])
-        for service in services:
+        for service in ipa_services_name:
             assert f"{service} Service: RUNNING" in cmd.stdout_text
 
         # get process id of services
@@ -648,7 +649,7 @@ class TestInstallMaster(IntegrationTest):
 
         # checking service status
         cmd = self.master.run_command(['ipactl', 'status'])
-        for service in services:
+        for service in ipa_services_name:
             assert f"{service} Service: RUNNING" in cmd.stdout_text
 
         # check if pid for services are different
@@ -660,7 +661,7 @@ class TestInstallMaster(IntegrationTest):
 
         # checking service status
         cmd = self.master.run_command(['ipactl', 'status'])
-        for service in services:
+        for service in ipa_services_name:
             assert f"{service} Service: RUNNING" in cmd.stdout_text
 
         # check if pid for services are same


### PR DESCRIPTION
These make running the testsuite on azure easier, and while it's not fully there yet, this bunch should be safe to apply upstream.