### PR TITLE
[ipa-4-6] ipatests: fix teardown method

### DIFF
--- a/ipatests/test_integration/base.py
+++ b/ipatests/test_integration/base.py
@@ -79,6 +79,10 @@ class IntegrationTest(object):
 
     @classmethod
     def uninstall(cls, mh):
+        if cls.domain_level is not None:
+            domain_level = cls.domain_level
+        else:
+            domain_level = cls.master.config.domain_level
         for replica in cls.replicas:
             try:
                 tasks.run_server_del(
@@ -88,11 +92,7 @@ class IntegrationTest(object):
                 # If the master has already been uninstalled,
                 # this call may fail
                 pass
-            tasks.uninstall_master(replica)
-        if cls.domain_level is not None:
-            domain_level = cls.domain_level
-        else:
-            domain_level = cls.master.config.domain_level
+            tasks.uninstall_master(replica, domain_level=domain_level)
         tasks.uninstall_master(cls.master, domain_level=domain_level)
         for client in cls.clients:
             tasks.uninstall_client(client)


### PR DESCRIPTION
The teardown method of the integration tests is calling
  tasks.uninstall_master(replica)
which in turn does ipa server-del + ipa-server-install --uninstall

The uninstallation is called by default with --ignore-last-of-role
and --ignore-topology-disconnect excepted if the domain-level is 0,
in which case these options are not supported by uninstall.
    
The issue is that the call to get domain level fails because the
server has already been removed, and the code handles that failure by
assuming domain level =0, resulting in missing --ignore-last-of-role.

To workaround the issue, the call to tasks.uninstall should be done
with the actual domain level:
  tasks.uninstall_master(replica, domain_level=...)

Fixes: https://pagure.io/freeipa/issue/8280
