### PR TITLE
Fix various OpenDNSSEC 2.1 issues

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -329,12 +329,14 @@ if test "x${IPAPLATFORM}" == "xdebian"; then
     KRB5KDC_SERVICE="krb5-kdc.service"
     NAMED_GROUP="bind"
     ODS_USER="opendnssec"
+    ODS_GROUP="opendnssec"
     # see https://www.debian.org/doc/packaging-manuals/python-policy/ap-packaging_tools.html
     PYTHON_INSTALL_EXTRA_OPTIONS="--install-layout=deb"
 else
     KRB5KDC_SERVICE="krb5kdc.service"
     NAMED_GROUP="named"
     ODS_USER="ods"
+    ODS_GROUP="ods"
     PYTHON_INSTALL_EXTRA_OPTIONS=""
 fi
 
@@ -347,6 +349,10 @@ AC_MSG_RESULT([${NAMED_GROUP}])
 AC_MSG_CHECKING([ODS_USER])
 AC_SUBST([ODS_USER])
 AC_MSG_RESULT([${ODS_USER}])
+
+AC_MSG_CHECKING([ODS_GROUP])
+AC_SUBST([ODS_GROUP])
+AC_MSG_RESULT([${ODS_GROUP}])
 
 AC_MSG_CHECKING([python setup.py install extra options])
 AC_SUBST([PYTHON_INSTALL_EXTRA_OPTIONS])

--- a/daemons/dnssec/Makefile.am
+++ b/daemons/dnssec/Makefile.am
@@ -31,6 +31,7 @@ CLEANFILES = $(systemdsystemunit_DATA) $(nodist_app_SCRIPTS)
 		-e 's|@sysconfenvdir[@]|$(sysconfenvdir)|g' \
 		-e 's|@runstatedir[@]|$(runstatedir)|g' \
 		-e 's|@ODS_USER[@]|$(ODS_USER)|g' \
+		-e 's|@ODS_GROUP[@]|$(ODS_GROUP)|g' \
 		-e 's|@NAMED_GROUP[@]|$(NAMED_GROUP)|g' \
 		'$(srcdir)/$@.in' >$@
 

--- a/daemons/dnssec/ipa-ods-exporter.service.in
+++ b/daemons/dnssec/ipa-ods-exporter.service.in
@@ -7,6 +7,7 @@ After=ipa-ods-exporter.socket
 EnvironmentFile=@sysconfenvdir@/ipa-ods-exporter
 ExecStart=@libexecdir@/ipa/ipa-ods-exporter
 User=@ODS_USER@
+Group=@ODS_GROUP@
 PrivateTmp=yes
 Restart=on-failure
 RestartSec=60s

--- a/daemons/dnssec/ipa-ods-exporter.socket.in
+++ b/daemons/dnssec/ipa-ods-exporter.socket.in
@@ -1,5 +1,7 @@
 [Socket]
 ListenStream=@runstatedir@/opendnssec/engine.sock
+SocketUser=@ODS_USER@
+SocketGroup=@ODS_GROUP@
 
 [Install]
 WantedBy=sockets.target

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -462,7 +462,12 @@ Requires: bind >= 9.11.0-6.P2
 Requires: bind-utils >= 9.11.0-6.P2
 Requires: bind-pkcs11 >= 9.11.0-6.P2
 Requires: bind-pkcs11-utils >= 9.11.0-6.P2
+%if 0%{?fedora} >= 32
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1825812
+Requires: opendnssec >= 2.1.6-5
+%else
 Requires: opendnssec >= 1.4.6-4
+%endif
 %{?systemd_requires}
 
 Provides: %{alt_name}-server-dns = %{version}

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -253,6 +253,7 @@ optional_policy(`
 	opendnssec_manage_config(ipa_dnskey_t)
 	opendnssec_manage_var_files(ipa_dnskey_t)
 	opendnssec_filetrans_etc_content(ipa_dnskey_t)
+	opendnssec_stream_connect(ipa_dnskey_t)
 ')
 
 ########################################


### PR DESCRIPTION
Require OpenDNSSEC 2.1.6-5 with fix for RHBZ#1825812 (DAC override AVC)

Allow ipa-dnskeysyncd to connect to enforcer.sock (ipa_dnskey_t write
opendnssec_var_run_t and connectto opendnssec_t). The
opendnssec_stream_connect interface is available since 2016.

Change the owner of the ipa-ods-exporter socket to ODS_USER:ODS_GROUP.
The ipa-ods-exporter service already runs as ODS_USER.

Fixes: https://pagure.io/freeipa/issue/8283
Signed-off-by: Christian Heimes <cheimes@redhat.com>