### PR TITLE
Makefile.am: add doclint to fastcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -327,6 +327,16 @@ yamllint:
 	done; \
 	echo "-----------"
 
+# Build & lint documentation.
+#
+.PHONY: doclint
+doclint:
+	@echo -e "\nBuild and lint documentation";
+	@echo "-----------";
+	@$(MAKE) -C $(srcdir)/doc/ clean;
+	@$(MAKE) -C $(srcdir)/doc/ html; 
+	@echo "-----------"
+
 # Run pylint for all python files. Finds all python files/packages, skips
 # folders rpmbuild, freeipa-* and dist. Skip (match, but don't print) .*,
 # *.in, *~. Finally print all python files, including scripts that do not

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
         echo "Running make target 'lint'"
         make V=0 lint
         echo "Building documentation"
-        make -C doc/ html SPHINXOPTS="-W"
+        make -C doc/ html
       displayName: Lint sources and documentation
     - template: templates/save-test-artifacts.yml
       parameters:


### PR DESCRIPTION
Add doclint to fastcheck so that documentation syntax issues
are caught sooner (before they hit CI).

Signed-off-by: François Cami <fcami@redhat.com>