### PR TITLE
Doclint-related changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -331,10 +331,9 @@ yamllint:
 #
 .PHONY: doclint
 doclint:
-	@echo -e "\nBuild and lint documentation";
-	@echo "-----------";
-	@$(MAKE) -C $(srcdir)/doc/ clean;
-	@$(MAKE) -C $(srcdir)/doc/ html; 
+	@echo -e "\nBuild and lint documentation"
+	@echo "-----------"
+	@$(MAKE) -C $(srcdir)/doc/ html SPHINXOPTS="-E"
 	@echo "-----------"
 
 # Run pylint for all python files. Finds all python files/packages, skips

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -W
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build


### PR DESCRIPTION
- Rather than cleaning the documentation workspace, use -E to completely rebuild the environment.
- Use --keep-going with sphinx-build -W to keep going processing to the end of build even when getting warnings