### PR TITLE
ipatests: Test for ipahealthcheck ReplicationConflictCheck

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck::test_ipa_replication_conflict_check
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client


### PR DESCRIPTION
This test checks for particular objectclass (&(!(objectclass=nstombstone))(nsds5ReplConflict=*)) entry in IPA Master ldap database and when the entry is not found, it checks that ipahealthcheck tool with
ReplicationConflictCheck displays the result as SUCCESS.
