### PR TITLE
servrole: takes_params must be a tuple

### DIFF
--- a/ipaserver/plugins/serverrole.py
+++ b/ipaserver/plugins/serverrole.py
@@ -191,5 +191,5 @@ class servrole(Object):
             label=_("Role name"),
             doc=_("IPA role name"),
             flags=(u'virtual_attribute',)
-        )
+        ),
     )


### PR DESCRIPTION
The definition of servrole.takes_params was missing a comma.

Related: https://pagure.io/freeipa/issue/8290
Signed-off-by: Christian Heimes <cheimes@redhat.com>