### PR TITLE
[Backport][ipa-4-8] servrole: takes_params must be a tuple

### DIFF
--- a/ipaserver/plugins/serverrole.py
+++ b/ipaserver/plugins/serverrole.py
@@ -191,5 +191,5 @@ class servrole(Object):
             label=_("Role name"),
             doc=_("IPA role name"),
             flags=(u'virtual_attribute',)
-        )
+        ),
     )


### PR DESCRIPTION
This PR was opened automatically because PR #4592 was pushed to master and backport to ipa-4-8 is required.