### PR TITLE
Add skip_if_platform marker

### DIFF
--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -19,6 +19,9 @@ try:
     import ipaplatform  # pylint: disable=unused-import
 except ImportError:
     ipaplatform = None
+    osinfo = None
+else:
+    from ipaplatform.osinfo import osinfo
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -42,6 +45,8 @@ MARKERS = [
     'ds_acceptance: Acceptance test suite for 389 Directory Server',
     'skip_ipaclient_unittest: Skip in ipaclient unittest mode',
     'needs_ipaapi: Test needs IPA API',
+    ('skip_if_platform(platform, reason): Skip test on platform '
+     '(ID and ID_LIKE)'),
 ]
 
 
@@ -145,6 +150,14 @@ def pytest_runtest_setup(item):
             # pylint: disable=no-member
             if item.config.option.skip_ipaapi:
                 pytest.skip("Skip tests that needs an IPA API")
+    if osinfo is not None:
+        for mark in item.iter_markers(name="skip_if_platform"):
+            platform = mark.kwargs.get("platform")
+            if platform is None:
+                platform = mark.args[0]
+            reason = mark.kwargs["reason"]
+            if platform in osinfo.platform_ids:
+                pytest.skip(f"Skip test on platform {platform}: {reason}")
 
 
 @pytest.fixture

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -983,6 +983,9 @@ class TestIPACommand(IntegrationTest):
         assert 'First name: %s' % (modfirst) in cmd.stdout_text
         assert 'Last name: %s' % (modlast) in cmd.stdout_text
 
+    @pytest.mark.skip_if_platform(
+        "debian", reason="Crypto policy is not supported on Debian"
+    )
     def test_enabled_tls_protocols(self):
         """Check Apache has same TLS versions enabled as crypto policy
 

--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -152,6 +152,9 @@ class TestSudo(IntegrationTest):
             assert result1.returncode == 0 and result2.returncode == 0,\
                 'rules cleanup failed'
 
+    @pytest.mark.skip_if_platform(
+        "debian", reason="NISDOMAIN has not been set on Debian"
+    )
     def test_nisdomainname(self):
         result = self.client.run_command('nisdomainname')
         assert self.client.domain.name in result.stdout_text

--- a/ipatests/test_ipalib/test_util.py
+++ b/ipatests/test_ipalib/test_util.py
@@ -49,6 +49,9 @@ TLS_OPT = (
 OP_NO_TLSv1_3 = getattr(ssl, "OP_NO_TLSv1_3", 0)  # make pylint happy
 
 
+@pytest.mark.skip_if_platform(
+    "debian", reason="Crypto policy is not supported on Debian"
+)
 @pytest.mark.parametrize('minver,maxver,opt,expected', [
     (None, None, BASE_OPT, None),
     (None, "tls1.3", BASE_OPT | TLS_OPT, ["tls1.2", "tls1.3"]),


### PR DESCRIPTION
Make it easier to skip tests based on platform ID and platform LIKE_ID.

Skip some tests that are not working on Debian-like platforms

Signed-off-by: Christian Heimes <cheimes@redhat.com>