### PR TITLE
Fix new pylint warnings

### DIFF
--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -1170,11 +1170,11 @@ class RPCClient(Connectible):
                     try:
                         principal = getattr(context, 'principal', None)
                         delete_persistent_client_session_data(principal)
-                    except Exception as e:
+                    except Exception as e2:
                         # This shouldn't happen if we have a session
                         # but it isn't fatal.
                         logger.debug("Error trying to remove persisent "
-                                     "session data: %s", e)
+                                     "session data: %s", e2)
 
                     # Create a new serverproxy with the non-session URI
                     serverproxy = self.create_connection(

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -1567,9 +1567,9 @@ class LDAPClient:
                                 str(base_dn), scope, filter, attrs_list,
                                 serverctrls=sctrls, timeout=time_limit,
                                 sizelimit=size_limit)
-                        except ldap.LDAPError as e:
+                        except ldap.LDAPError as e2:
                             logger.warning(
-                                "Error cancelling paged search: %s", e)
+                                "Error cancelling paged search: %s", e2)
                         cookie = ''
 
                     try:

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -1580,7 +1580,7 @@ class APIVersion(tuple):
         return "<APIVersion('{}.{}')>".format(*self)
 
     def __getnewargs__(self):
-        return str(self)
+        return (str(self),)
 
     @property
     def major(self):


### PR DESCRIPTION
### Fix exception escape warning
    
``W1661(exception-escape), RPCClient.forward]
Using an exception object that was bound by an except handler)``

### Fix APIVersion.__getnewargs__

``E0312(invalid-getnewargs-returned), APIVersion.__getnewargs__]     __getnewargs__ does not return a tuple)``