### PR TITLE
Require Sphinx >2.1

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 ## m2r is not compatible with Sphinx 3.x yet
-sphinx < 3.0
+sphinx >2.1,<3.0
 
 ## convert markdown to rest
 m2r


### PR DESCRIPTION
RTD comes with Sphinx 1.8 that is missing some APIs.

Signed-off-by: Christian Heimes <cheimes@redhat.com>