### PR TITLE
ipatests: add test for kdcproxy handling reply split to several TCP packets

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -160,8 +160,8 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_http_kdc_proxy.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *ad_master_2client
 
   fedora-latest/test_fips:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -169,8 +169,8 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_http_kdc_proxy.py
         template: *testing-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *ad_master_2client
 
   testing-fedora/test_fips:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -160,8 +160,8 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_http_kdc_proxy.py
         template: *ci-master-previous
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *ad_master_2client
 
   fedora-previous/test_fips:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -169,8 +169,8 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_http_kdc_proxy.py
         template: *ci-master-frawhide
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *ad_master_2client
 
   fedora-rawhide/test_fips:
     requires: [fedora-rawhide/build]

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -47,7 +47,7 @@ topologies:
     memory: 14500
 
 jobs:
-  fedora-latest/build:
+  fedora-previous/build:
     requires: []
     priority: 100
     job:
@@ -55,20 +55,47 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-latest
-          name: freeipa/ci-master-f32
-          version: 0.0.3
+        template: &ci-master-previous
+          name: freeipa/ci-master-f31
+          version: 0.0.5
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-previous/test_http_kdc_proxy:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
-        template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_http_kdc_proxy.py
+        template: *ci-master-previous
+        timeout: 7200
+        topology: *ad_master_2client
+
+  fedora-rawhide/build:
+    requires: []
+    priority: 100
+    job:
+      class: Build
+      args:
+        git_repo: '{git_repo}'
+        git_refspec: '{git_refspec}'
+        template: &ci-master-frawhide
+          name: freeipa/ci-master-frawhide
+          version: 0.1.2
+        timeout: 1800
+        topology: *build
+
+  fedora-rawhide/test_http_kdc_proxy:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_http_kdc_proxy.py
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *ad_master_2client

--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -470,3 +470,24 @@ def del_compat_attrs(cls):
         del cls.ad_subdomains
         del cls.ad_treedomains
     del cls.ad_domains
+
+
+@pytest.fixture(scope='class')
+def ipa_ad_trust(mh):
+    ad = mh.ads[0]
+    tasks.install_adtrust(mh.master)
+    tasks.configure_dns_for_trust(mh.master, ad)
+    tasks.establish_trust_with_ad(mh.master, ad.domain.name)
+    backups = []
+    for client in mh.clients:
+        backups.append(tasks.FileBackup(client, paths.KRB5_CONF))
+        tasks.configure_ipa_client_for_ad_trust(client)
+        tasks.clear_sssd_cache(client)
+    yield
+    for backup in backups:
+        backup.restore()
+    for client in mh.clients:
+        tasks.clear_sssd_cache(client)
+    tasks.remove_trust_with_ad(mh.master, ad.domain.name)
+    tasks.unconfigure_dns_for_trust(mh.master, ad)
+    tasks.clear_sssd_cache(mh.master)

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1960,8 +1960,9 @@ def run_command_as_user(host, user, command, *args, **kwargs):
     return host.run_command(command, *args, **kwargs)
 
 
-def kinit_as_user(host, user, password):
-    host.run_command(['kinit', user], stdin_text=password + '\n')
+def kinit_as_user(host, user, password, raiseonerr=True):
+    return host.run_command(['kinit', user], stdin_text=password + '\n',
+                            raiseonerr=raiseonerr)
 
 
 KeyEntry = collections.namedtuple('KeyEntry',

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2285,3 +2285,11 @@ def configure_ipa_client_for_ad_trust(client):
         ' dns_lookup_kdc = .+', ' dns_lookup_kdc = true', krb5conf)
     assert n == 1
     client.put_file_contents(paths.KRB5_CONF, krb5conf)
+
+
+def get_python_package_version(host, package):
+    script = (
+        'import pkg_resources; '
+        'print(pkg_resources.get_distribution("{}").version)'.format(package))
+    result = host.run_command(['python3', '-c', script])
+    return parse_version(result.stdout_text.strip())

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2263,3 +2263,24 @@ def get_sssd_version(host):
     """Get sssd version on remote host."""
     version = host.run_command('sssd --version').stdout_text.strip()
     return parse_version(version)
+
+
+def configure_ipa_client_for_ad_trust(client):
+    """Configure ipa client to accept logins of Windows AD users.
+
+    This is a workaround for https://pagure.io/freeipa/issue/6523:
+    when ipa-client-install is called with --server option, dns_lookup_realm
+    and dns_lookup_kdc options in kreb5.conf are set to "false" preventing
+    libkrb5 from discovering AD realm.
+
+    This function modifies krb5.conf on client. You need to restart sssd
+    to apply the changes.
+    """
+    krb5conf = client.get_file_contents(paths.KRB5_CONF, encoding='utf-8')
+    krb5conf, n = re.subn(
+        ' dns_lookup_realm = .+', ' dns_lookup_realm = true', krb5conf)
+    assert n == 1
+    krb5conf, n = re.subn(
+        ' dns_lookup_kdc = .+', ' dns_lookup_kdc = true', krb5conf)
+    assert n == 1
+    client.put_file_contents(paths.KRB5_CONF, krb5conf)

--- a/ipatests/test_integration/test_http_kdc_proxy.py
+++ b/ipatests/test_integration/test_http_kdc_proxy.py
@@ -12,6 +12,7 @@ import pytest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.firewall import Firewall
 from ipatests.test_integration.base import IntegrationTest
+from ipatests.util import xfail_context
 from ipaplatform.paths import paths
 
 
@@ -196,4 +197,9 @@ class TestHttpKdcProxy(IntegrationTest):
         tasks.clear_sssd_cache(self.master)
         user = users['ad']
         with self.configure_kdc_proxy_for_ad_trust(use_tcp=True):
-            tasks.kinit_as_user(self.client, user['name'], user['password'])
+            kdcproxy_version = tasks.get_python_package_version(
+                self.master, 'kdcproxy')
+            with xfail_context(kdcproxy_version < tasks.parse_version('0.4.2'),
+                               'https://github.com/latchset/kdcproxy/pull/44'):
+                tasks.kinit_as_user(
+                    self.client, user['name'], user['password'])

--- a/ipatests/test_integration/test_http_kdc_proxy.py
+++ b/ipatests/test_integration/test_http_kdc_proxy.py
@@ -4,53 +4,196 @@
 
 from __future__ import absolute_import
 
-import six
+import re
+from contextlib import contextmanager
+
+import pytest
+
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.firewall import Firewall
 from ipatests.test_integration.base import IntegrationTest
 from ipaplatform.paths import paths
 
 
-if six.PY3:
-    unicode = str
-
-
+@pytest.mark.usefixtures('ipa_ad_trust')
 class TestHttpKdcProxy(IntegrationTest):
     topology = "line"
     num_clients = 1
-    # Firewall rules without --append/-A, --delete/-D, .. First entry of
-    # each rule is the chain name, the argument to add or delete the rule
-    # will be added by the used Firewall method. See firewall.py for more
-    # information.
-    fw_rules = [['OUTPUT', '-p', 'tcp', '--dport', '88', '-j', 'DROP'],
-                ['OUTPUT', '-p', 'udp', '--dport', '88', '-j', 'DROP']]
+    num_ad_domains = 1
 
     @classmethod
     def install(cls, mh):
+        cls.client = cls.clients[0]
+        cls.ad = cls.ads[0]
         super(TestHttpKdcProxy, cls).install(mh)
-        # Block access from client to master's port 88
-        Firewall(cls.clients[0]).prepend_passthrough_rules(cls.fw_rules)
-        # configure client
-        cls.clients[0].run_command(
-            r"sed -i 's/ kdc = .*$/ kdc = https:\/\/%s\/KdcProxy/' %s" % (
-                cls.master.hostname, paths.KRB5_CONF)
-            )
-        cls.clients[0].run_command(
-            r"sed -i 's/master_kdc = .*$/master_kdc"
-            r" = https:\/\/%s\/KdcProxy/' %s" % (
-                cls.master.hostname, paths.KRB5_CONF)
-            )
-        # Workaround for https://fedorahosted.org/freeipa/ticket/6443
-        cls.clients[0].run_command(['systemctl', 'restart', 'sssd.service'])
-        # End of workaround
 
-    @classmethod
-    def uninstall(cls, mh):
-        super(TestHttpKdcProxy, cls).uninstall(mh)
-        Firewall(cls.clients[0]).remove_passthrough_rules(cls.fw_rules)
+    @pytest.fixture(scope='class')
+    def users(self, mh):
+        ad = mh.ads[0]
+        users = {
+            'ipa': {
+                'name': 'ipa_test_user',
+                'password': 'SecretIpaTestUser',
+                'domain': mh.master.domain
+            },
+            'ad': {
+                'name': 'testuser@{}'.format(ad.domain.realm),
+                'password': 'Secret123',
+                'domain': ad.domain
+            }
+        }
+        tasks.kinit_admin(mh.master)
+        tasks.create_active_user(
+            mh.master, users['ipa']['name'], users['ipa']['password'])
+        yield users
+        tasks.kinit_admin(mh.master)
+        mh.master.run_command(['ipa', 'user-del', users['ipa']['name']])
 
-    def test_http_kdc_proxy_works(self):
-        result = tasks.kinit_admin(self.clients[0], raiseonerr=False)
-        assert(result.returncode == 0), (
-            "Unable to kinit using KdcProxy: %s" % result.stderr_text
-            )
+    @pytest.fixture()
+    def restrict_network_for_client(self, mh):
+        fw_rules_allow = [
+            ['OUTPUT', '-p', 'udp', '--dport', '53', '-j', 'ACCEPT'],
+            ['OUTPUT', '-p', 'tcp', '--dport', '80', '-j', 'ACCEPT'],
+            ['OUTPUT', '-p', 'tcp', '--dport', '443', '-j', 'ACCEPT'],
+            ['OUTPUT', '-p', 'tcp', '--sport', '22', '-j', 'ACCEPT']]
+        fw = Firewall(self.client)
+        fw.prepend_passthrough_rules(fw_rules_allow)
+        fw.passthrough_rule(['-P', 'OUTPUT', 'DROP'])
+        yield
+        fw.passthrough_rule(['-P', 'OUTPUT', 'ACCEPT'])
+        fw.remove_passthrough_rules(fw_rules_allow)
+
+    @pytest.fixture()
+    def client_use_kdcproxy(self, mh):
+        """Configure client for using kdcproxy for IPA and AD domains."""
+        krb5conf_backup = tasks.FileBackup(self.client, paths.KRB5_CONF)
+        krb5conf = self.client.get_file_contents(
+            paths.KRB5_CONF, encoding='utf-8')
+        kdc_url = 'https://{}/KdcProxy'.format(self.master.hostname)
+        kdc_option = 'kdc = {}'.format(kdc_url)
+
+        # configure kdc proxy for IPA realm
+        krb5conf, n = re.subn(r' kdc = .+', kdc_option, krb5conf)
+        assert n == 1
+
+        # configure kdc proxy for Windows AD realm
+        ad_realm_config = '''
+        {realm} = {{
+            {kdc}
+        }}
+        '''.format(realm=self.ad.domain.realm, kdc=kdc_option)
+        krb5conf, n = re.subn(
+            r'\[realms\]', '[realms]' + ad_realm_config, krb5conf)
+        assert n == 1
+
+        self.client.put_file_contents(paths.KRB5_CONF, krb5conf)
+        self.client.run_command(['systemctl', 'restart', 'sssd.service'])
+        yield
+        krb5conf_backup.restore()
+        self.client.run_command(['systemctl', 'restart', 'sssd.service'])
+
+    @contextmanager
+    def configure_kdc_proxy_for_ad_trust(self, use_tcp):
+        backup = tasks.FileBackup(self.master, paths.KDCPROXY_CONFIG)
+        with tasks.remote_ini_file(self.master, paths.KDCPROXY_CONFIG) as conf:
+            conf.set('global', 'use_dns', 'true')
+            conf.set('global', 'configs', 'mit')
+            if use_tcp:
+                conf.add_section(self.ad.domain.realm)
+                conf.set(self.ad.domain.realm, 'kerberos',
+                         'kerberos+tcp://{}:88'.format(self.ad.hostname))
+                conf.set(self.ad.domain.realm, 'kpasswd',
+                         'kpasswd+tcp://{}:464'.format(self.ad.hostname))
+        try:
+            self.master.run_command(['ipactl', 'restart'])
+            yield
+        finally:
+            backup.restore()
+            self.master.run_command(['ipactl', 'restart'])
+
+    @pytest.mark.parametrize('user_origin', ['ipa', 'ad'])
+    def test_user_login_on_client_without_firewall(self, users, user_origin):
+        """Basic check for test setup."""
+        tasks.clear_sssd_cache(self.master)
+        user = users[user_origin]
+        tasks.kinit_as_user(self.client, user['name'], user['password'])
+
+    @pytest.mark.usefixtures('restrict_network_for_client')
+    @pytest.mark.parametrize('user_origin', ['ipa', 'ad'])
+    def test_access_blocked_on_client_without_kdcproxy(
+            self, users, user_origin):
+        """Check for test firewall setup."""
+        tasks.clear_sssd_cache(self.master)
+        user = users[user_origin]
+        result = tasks.kinit_as_user(
+            self.client, user['name'], user['password'], raiseonerr=False)
+        expected_error = (
+            "Cannot contact any KDC for realm '{}' while getting initial "
+            "credentials".format(user['domain'].realm))
+        assert result.returncode == 1 and expected_error in result.stderr_text
+
+    @pytest.mark.usefixtures('restrict_network_for_client',
+                             'client_use_kdcproxy')
+    def test_ipa_user_login_on_client_with_kdcproxy(self, users):
+        tasks.clear_sssd_cache(self.master)
+        user = users['ipa']
+        tasks.kinit_as_user(self.client, user['name'], user['password'])
+
+    @pytest.mark.usefixtures('restrict_network_for_client',
+                             'client_use_kdcproxy')
+    @pytest.mark.parametrize('use_tcp', [True, False])
+    def test_ad_user_login_on_client_with_kdcproxy(self, users, use_tcp):
+        tasks.clear_sssd_cache(self.master)
+        user = users['ad']
+        with self.configure_kdc_proxy_for_ad_trust(use_tcp):
+            tasks.kinit_as_user(self.client, user['name'], user['password'])
+
+    @pytest.fixture()
+    def windows_small_mtu_size(self, mh):
+        new_mtu = 70
+
+        def get_iface_name():
+            result = self.ad.run_command([
+                'powershell', '-c',
+                '(Get-NetIPAddress -IPAddress {}).InterfaceAlias'.format(
+                    self.ad.ip)])
+            return result.stdout_text.strip()
+
+        def get_mtu(iface_name):
+            result = self.ad.run_command([
+                'netsh', 'interface', 'ipv4', 'show', 'subinterface',
+                iface_name])
+            mtu = result.stdout_text.strip().splitlines()[-1].split()[0]
+            return int(mtu)
+
+        def set_mtu(iface_name, mtu):
+            self.ad.run_command([
+                'netsh', 'interface', 'ipv4', 'set', 'subinterface',
+                iface_name, 'mtu={}'.format(mtu)])
+
+        iface_name = get_iface_name()
+        original_mtu = get_mtu(iface_name)
+        set_mtu(iface_name, new_mtu)
+        # `netsh` does not report failures with return code so we check
+        # it was successful by inspecting the actual value of MTU
+        assert get_mtu(iface_name) == new_mtu
+        yield
+        set_mtu(iface_name, original_mtu)
+        assert get_mtu(iface_name) == original_mtu
+
+    @pytest.mark.usefixtures('restrict_network_for_client',
+                             'client_use_kdcproxy',
+                             'windows_small_mtu_size')
+    def test_kdcproxy_handles_small_packets_from_ad(self, users):
+        """Check that kdcproxy handles AD response split to several TCP packets
+
+        This is a regression test for the bug in python-kdcproxy:
+        https://github.com/latchset/kdcproxy/pull/44
+          When the reply from AD is split into several TCP packets the kdc
+          proxy software cannot handle it and returns a false error message
+          indicating it cannot contact the KDC server.
+        """
+        tasks.clear_sssd_cache(self.master)
+        user = users['ad']
+        with self.configure_kdc_proxy_for_ad_trust(use_tcp=True):
+            tasks.kinit_as_user(self.client, user['name'], user['password'])


### PR DESCRIPTION

    This is a regression test for the bug in python-kdcproxy mentioned in
    https://github.com/latchset/kdcproxy/pull/44
      When the reply from AD is split into several TCP packets the kdc
      proxy software cannot handle it and returns a false error message
      indicating it cannot contact the KDC server.
    
    This could be observed as login failures of AD user on IPA clients
    when:
    * IPA client was configured to use kdcproxy to communicate with AD
    * kdcproxy used TCP to communicate with AD
    * response from AD to kdcproxy was split into several packets
    
    This patch also refactors and improves existing tests:
    * switch to using pytest fixtures for test setup and cleanup steps to make
      them isolated and reusable
    * simulate a much more restricted network environment: instead of blocking
      single 88 port we now block all outgoing traffic except few essential
      ports
    * add basic tests for using kdcproxy to communicate between IPA client
      and AD DC.
