### PR TITLE
tox.ini: switch from W503 to W504

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,6 @@ commands=
 
 [pycodestyle]
 # E402 module level import not at top of file
-# W504 line break after binary operator
-ignore = E402, W504
+# W503 line break before binary operator
+ignore = E402, W503
 


### PR DESCRIPTION
PEP8 recently changed from W503 to W504.
Line breaks should therefore come before operators.
See: https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator

Signed-off-by: François Cami <fcami@redhat.com>