### PR TITLE
[Backport][ipa-4-8] Address issues found by new pylint 2.5.0

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1901,9 +1901,9 @@ def get_ca_certs(fstore, options, server, basedn, realm):
             if os.path.exists(ca_file):
                 try:
                     os.unlink(ca_file)
-                except OSError as e:
+                except OSError as e2:
                     logger.error(
-                        "Failed to remove '%s': %s", ca_file, e)
+                        "Failed to remove '%s': %s", ca_file, e2)
             raise errors.FileError(
                 reason=u"cannot write certificate file '%s': %s" % (
                     ca_file, e)

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -652,21 +652,27 @@ class DsInstance(service.Service):
             # Does not apply with newer DS releases
             pass
 
-    def start(self, *args, **kwargs):
-        super(DsInstance, self).start(*args, **kwargs)
+    def start(self, instance_name="", capture_output=True, wait=True):
+        super(DsInstance, self).start(
+            instance_name, capture_output=capture_output, wait=wait
+        )
         api.Backend.ldap2.connect()
 
-    def stop(self, *args, **kwargs):
+    def stop(self, instance_name="", capture_output=True):
         if api.Backend.ldap2.isconnected():
             api.Backend.ldap2.disconnect()
 
-        super(DsInstance, self).stop(*args, **kwargs)
+        super(DsInstance, self).stop(
+            instance_name, capture_output=capture_output
+        )
 
-    def restart(self, instance=''):
+    def restart(self, instance_name="", capture_output=True, wait=True):
         api.Backend.ldap2.disconnect()
         try:
-            super(DsInstance, self).restart(instance)
-            if not is_ds_running(instance):
+            super(DsInstance, self).restart(
+                instance_name, capture_output=capture_output, wait=wait
+            )
+            if not is_ds_running(instance_name):
                 logger.critical("Failed to restart the directory server. "
                                 "See the installation log for details.")
                 raise ScriptError()

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -351,8 +351,8 @@ def upgrade_adtrust_config():
                     "max smbd processes", "1000"]
             try:
                 ipautil.run(args)
-            except ipautil.CalledProcessError as e:
-                logger.warning("Error updating Samba registry: %s", e)
+            except ipautil.CalledProcessError as e2:
+                logger.warning("Error updating Samba registry: %s", e2)
         else:
             logger.warning("Error updating Samba registry: %s", e)
 

--- a/ipaserver/plugins/migration.py
+++ b/ipaserver/plugins/migration.py
@@ -858,8 +858,8 @@ migration process might be incomplete\n''')
                         try:
                             callback(
                                 ldap, entry_attrs.dn, entry_attrs, e, options)
-                        except errors.ExecutionError as e:
-                            failed[ldap_obj_name][pkey] = unicode(e)
+                        except errors.ExecutionError as e2:
+                            failed[ldap_obj_name][pkey] = unicode(e2)
                             continue
                     else:
                         failed[ldap_obj_name][pkey] = unicode(e)

--- a/ipatests/pytest_ipa/integration/host.py
+++ b/ipatests/pytest_ipa/integration/host.py
@@ -134,7 +134,13 @@ class Host(pytest_multihost.host.Host):
         else:
             cls = Host
 
-        return cls(domain, hostname, role, ip, external_hostname)
+        return cls(
+            domain,
+            hostname,
+            role,
+            ip=ip,
+            external_hostname=external_hostname
+        )
 
     def ldap_connect(self):
         """Return an LDAPClient authenticated to this host as directory manager

--- a/pylintrc
+++ b/pylintrc
@@ -102,6 +102,7 @@ disable=
     consider-using-enumerate,  # pylint 2.1, clean up tests later
     no-else-raise, # python 2.4.0
     import-outside-toplevel, # pylint 2.4.2
+    f-string-without-interpolation,  # pylint 2.5.0, bare f-strings are ok
 
 [REPORTS]
 


### PR DESCRIPTION
Manual backport of PR #4605 (no conflicts)

* fix multiple exception-escape
* fix function signatures of DsInstance start/stop/restart
* silence f-string-without-interpolation
* fix too-many-function-args in host plugin

Fixes: https://pagure.io/freeipa/issue/8297
Signed-off-by: Christian Heimes <cheimes@redhat.com>