### PR TITLE
[Backport][ipa-4-8] WebUI tests: cover membership management with UI tests

### DIFF
--- a/ipatests/test_webui/data_user.py
+++ b/ipatests/test_webui/data_user.py
@@ -208,6 +208,19 @@ DATA_NO_LOGIN = {
     ]
 }
 
+PKEY_MEMBER_MANAGER = 'member-manager'
+PASSWD_MEMBER_MANAGER = 'Password123'
+DATA_MEMBER_MANAGER = {
+    'pkey': PKEY_MEMBER_MANAGER,
+    'add': [
+        ('textbox', 'uid', PKEY_MEMBER_MANAGER),
+        ('textbox', 'givenname', 'Name'),
+        ('textbox', 'sn', 'Surname'),
+        ('password', 'userpassword', PASSWD_MEMBER_MANAGER),
+        ('password', 'userpassword2', PASSWD_MEMBER_MANAGER),
+    ],
+}
+
 SSH_RSA = (
     'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDBVmLXpTDhrYkABOPlADFk'
     'GV8/QfgQqUQ0xn29hk18t/NTEQOW/Daq4EF84e9aTiopRXIk7jahBLzwWTZI'

--- a/ipatests/test_webui/test_group.py
+++ b/ipatests/test_webui/test_group.py
@@ -356,3 +356,63 @@ class test_group(UI_driver):
         self.delete(rbac.ROLE_ENTITY, [rbac.ROLE_DATA])
         self.delete(hbac.RULE_ENTITY, [hbac.RULE_DATA])
         self.delete(sudo.RULE_ENTITY, [sudo.RULE_DATA])
+
+    @screenshot
+    def test_member_manager_user(self):
+        """
+        Test member manager user has permissions to add and remove group
+        members
+        """
+        self.init_app()
+
+        self.add_record(user.ENTITY, [user.DATA_MEMBER_MANAGER, user.DATA])
+        self.add_record(group.ENTITY, group.DATA2)
+
+        self.navigate_to_record(group.PKEY2)
+        self.add_associations([user.PKEY_MEMBER_MANAGER],
+                              facet='membermanager_user')
+
+        # try to add user to group with member manager permissions
+        self.logout()
+        self.login(user.PKEY_MEMBER_MANAGER, user.PASSWD_MEMBER_MANAGER)
+
+        self.navigate_to_record(group.PKEY2, entity=group.ENTITY)
+        self.add_associations([user.PKEY], delete=True)
+
+        # re-login as admin and clean up data
+        self.logout()
+        self.init_app()
+
+        self.delete(user.ENTITY, [user.DATA_MEMBER_MANAGER, user.DATA])
+        self.delete(group.ENTITY, [group.DATA2])
+
+    @screenshot
+    def test_member_manager_group(self):
+        """
+        Test member managers group has permissions to add and remove group
+        members
+        """
+        self.init_app()
+
+        self.add_record(user.ENTITY, [user.DATA_MEMBER_MANAGER, user.DATA])
+        self.add_record(group.ENTITY, [group.DATA2, group.DATA3])
+
+        self.navigate_to_record(group.PKEY2)
+        self.add_associations([user.PKEY_MEMBER_MANAGER], facet='member_user')
+
+        self.navigate_to_record(group.PKEY3, entity=group.ENTITY)
+        self.add_associations([group.PKEY2], facet='membermanager_group')
+
+        # try to add host to group with member manager permissions
+        self.logout()
+        self.login(user.PKEY_MEMBER_MANAGER, user.PASSWD_MEMBER_MANAGER)
+
+        self.navigate_to_record(group.PKEY3, entity=group.ENTITY)
+        self.add_associations([user.PKEY], delete=True)
+
+        # re-login as admin and clean up data
+        self.logout()
+        self.init_app()
+
+        self.delete(user.ENTITY, [user.DATA_MEMBER_MANAGER, user.DATA])
+        self.delete(group.ENTITY, [group.DATA2, group.DATA3])


### PR DESCRIPTION
This PR was opened automatically because PR #4612 was pushed to master and backport to ipa-4-8 is required.