### PR TITLE
Fix a syntax typo

### DIFF
--- a/ipapython/cookie.py
+++ b/ipapython/cookie.py
@@ -219,7 +219,7 @@ class Cookie:
             return '/'
 
         if url_path.count('/') <= 1:
-            return'/'
+            return '/'
 
         return url_path[:url_path.rindex('/')]
 


### PR DESCRIPTION
This worked for now, but is SyntaxError in Python 3.9.0a6:

```
  File "/usr/lib/python3.9/site-packages/ipapython/cookie.py", line 222
    return'/'
         ^
SyntaxError: invalid string prefix
```

(The Python change might actually be [reverted](https://github.com/python/cpython/pull/19888) before 3.9 final, but this can be fixed anyway.)