### PR TITLE
[Backport][ipa-4-8] Fix a syntax typo

### DIFF
--- a/ipapython/cookie.py
+++ b/ipapython/cookie.py
@@ -219,7 +219,7 @@ class Cookie:
             return '/'
 
         if url_path.count('/') <= 1:
-            return'/'
+            return '/'
 
         return url_path[:url_path.rindex('/')]
 


### PR DESCRIPTION
This PR was opened automatically because PR #4636 was pushed to master and backport to ipa-4-8 is required.