### PR TITLE
Address pycodestyle violations

### DIFF
--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -1461,7 +1461,7 @@ def run(api):
         for klass in cli_plugins:
             api.add_plugin(klass)
         api.finalize()
-        if not 'config_loaded' in api.env and not 'help' in argv:
+        if 'config_loaded' not in api.env and 'help' not in argv:
             raise NotConfiguredError()
         sys.exit(api.Backend.cli.run(argv))
     except KeyboardInterrupt:

--- a/ipapython/config.py
+++ b/ipapython/config.py
@@ -131,7 +131,7 @@ class IPAOptionParser(OptionParser):
         safe_opts_dict = {}
 
         for option, value in opts.__dict__.items():
-            if all_opts_dict[option].sensitive != True:
+            if not all_opts_dict[option].sensitive:
                 safe_opts_dict[option] = value
 
         return Values(safe_opts_dict)

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -538,7 +538,7 @@ def run(args, stdin=None, raiseonerr=True, nolog=(), env=None,
         logger.debug('Process interrupted')
         p.wait()
         raise
-    except:
+    except BaseException:
         logger.debug('Process execution failed')
         raise
     finally:

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -701,7 +701,7 @@ class CIDict(dict):
     if six.PY2:
         def has_key(self, key):
             # pylint: disable=no-member
-            return super(CIDict, self).has_key(key.lower())
+            return super(CIDict, self).has_key(key.lower())  # noqa
             # pylint: enable=no-member
 
     def get(self, key, failobj=None):

--- a/ipapython/version.py.in
+++ b/ipapython/version.py.in
@@ -18,10 +18,10 @@
 #
 
 # The full version including strings
-VERSION="@VERSION@"
+VERSION = "@VERSION@"
 
 # A fuller version including the vendor tag (e.g. 3.3.3-34.fc20)
-VENDOR_VERSION="@VERSION@@VENDOR_SUFFIX@"
+VENDOR_VERSION = "@VERSION@@VENDOR_SUFFIX@"
 
 
 # Just the numeric portion of the version so one can do direct numeric
@@ -41,11 +41,11 @@ VENDOR_VERSION="@VERSION@@VENDOR_SUFFIX@"
 #   IPA 3.2.1:  NUM_VERSION=30201
 #   IPA 3.2.99: NUM_VERSION=30299 (development version)
 #   IPA 3.3.0:  NUM_VERSION=30300
-NUM_VERSION=@NUM_VERSION@
+NUM_VERSION = @NUM_VERSION@
 
 
 # The version of the API.
-API_VERSION=u'@API_VERSION@'
+API_VERSION = "@API_VERSION@"
 
 
 DEFAULT_PLUGINS = frozenset(l.strip() for l in """

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -1178,7 +1178,7 @@ class DsInstance(service.Service):
     def stop_tracking_certificates(self, serverid=None):
         if serverid is None:
             serverid = self.get_state("serverid")
-        if not serverid is None:
+        if serverid is not None:
             nickname = self.get_server_cert_nickname(serverid)
             # drop the trailing / off the config_dirname so the directory
             # will match what is in certmonger

--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -216,7 +216,7 @@ class KRAInstaller(KRAInstall):
 
         try:
             kra.install(api, config, self.options, custodia=custodia)
-        except:
+        except BaseException:
             logger.error('%s', dedent(self.FAIL_MESSAGE))
             raise
 

--- a/ipaserver/install/plugins/dns.py
+++ b/ipaserver/install/plugins/dns.py
@@ -533,7 +533,7 @@ class update_dnsserver_configuration_into_ldap(DNSUpdater):
             return False, []
 
         result = self.api.Command.server_show(self.api.env.host)['result']
-        if not 'DNS server' in result.get('enabled_role_servrole', []):
+        if 'DNS server' not in result.get('enabled_role_servrole', []):
             logger.debug('This server is not DNS server, nothing to upgrade')
             sysupgrade.set_upgrade_state('dns', 'server_config_to_ldap', True)
             return False, []

--- a/ipaserver/install/plugins/update_ldap_server_list.py
+++ b/ipaserver/install/plugins/update_ldap_server_list.py
@@ -24,7 +24,7 @@ class update_ldap_server_list(Updater):
             entry = ldap.get_entry(dn)
             srvlist = entry.single_value.get('defaultServerList', '')
             srvlist = srvlist.split()
-            if not self.api.env.host in srvlist:
+            if self.api.env.host not in srvlist:
                 srvlist.append(self.api.env.host)
                 attr = ' '.join(srvlist)
                 entry['defaultServerList'] = attr

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -742,7 +742,7 @@ def ensure_enrolled(installer):
 
 def promotion_check_ipa_domain(master_ldap_conn, basedn):
     entry = master_ldap_conn.get_entry(basedn, ['associatedDomain'])
-    if not 'associatedDomain' in entry:
+    if 'associatedDomain' not in entry:
         raise RuntimeError('IPA domain not found in LDAP.')
 
     if len(entry['associatedDomain']) > 1:

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -159,7 +159,7 @@ def set_service_entry_config(name, fqdn, config_values,
                 "service %s has already enabled config values %s", name,
                 config_values)
             return
-        except:
+        except BaseException:
             logger.debug("failed to set service %s config values", name)
             raise
 
@@ -699,7 +699,7 @@ class Service:
             api.Backend.ldap2.update_entry(entry)
         except errors.EmptyModlist:
             pass
-        except:
+        except BaseException:
             logger.debug("failed to disable service %s startup entry", name)
             raise
 

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -801,7 +801,7 @@ class SimpleServiceInstance(Service):
 
     def __enable(self):
         self.backup_state("enabled", self.is_enabled())
-        if self.gensvc_name == None:
+        if self.gensvc_name is None:
             self.enable()
         else:
             self.ldap_configure(self.gensvc_name, self.fqdn, None, self.suffix)

--- a/ipaserver/plugins/aci.py
+++ b/ipaserver/plugins/aci.py
@@ -729,7 +729,7 @@ Search for ACIs.
 
         if kw.get('attrs'):
             for a in acis:
-                if not 'targetattr' in a.target:
+                if 'targetattr' not in a.target:
                     results.remove(a)
                     continue
                 alist1 = sorted(

--- a/ipaserver/plugins/aci.py
+++ b/ipaserver/plugins/aci.py
@@ -239,7 +239,7 @@ def _make_aci(ldap, current, aciname, kw):
 
     group = 'group' in kw
     permission = 'permission' in kw
-    selfaci = 'selfaci' in kw and kw['selfaci'] == True
+    selfaci = kw.get("selfaci", False)
     if group + permission + selfaci > 1:
         raise errors.ValidationError(name='target', error=_('group, permission and self are mutually exclusive'))
     elif group + permission + selfaci == 0:
@@ -945,7 +945,7 @@ class aci_rename(crud.Update):
         # a series of keywords. Then we replace any keywords that have been
         # updated and convert that back into an ACI and write it out.
         newkw =  _aci_to_kw(ldap, aci)
-        if 'selfaci' in newkw and newkw['selfaci'] == True:
+        if newkw.get("selfaci"):
             # selfaci is set in aci_to_kw to True only if the target is self
             kw['selfaci'] = True
         if 'aciname' in newkw:

--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -94,7 +94,7 @@ def radius_dn2pk(api, entry_attrs):
         entry_attrs['ipatokenradiusconfiglink'] = [pk]
 
 def convert_nsaccountlock(entry_attrs):
-    if not 'nsaccountlock' in entry_attrs:
+    if 'nsaccountlock' not in entry_attrs:
         entry_attrs['nsaccountlock'] = False
     else:
         nsaccountlock = Bool('temp')

--- a/ipaserver/plugins/certprofile.py
+++ b/ipaserver/plugins/certprofile.py
@@ -268,7 +268,7 @@ class certprofile_import(LDAPCreate):
             with self.api.Backend.ra_certprofile as profile_api:
                 profile_api.create_profile(context.profile)
                 profile_api.enable_profile(keys[0])
-        except:
+        except BaseException:
             # something went wrong ; delete entry
             ldap.delete_entry(dn)
             raise

--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -709,7 +709,7 @@ class idrange_mod(LDAPUpdate):
                     entry_attrs['ipanttrusteddomainsid'])
 
             # Add trusted AD domain range object class, if it wasn't there
-            if not 'ipatrustedaddomainrange' in old_attrs['objectclass']:
+            if 'ipatrustedaddomainrange' not in old_attrs['objectclass']:
                 entry_attrs['objectclass'].append('ipatrustedaddomainrange')
 
         else:

--- a/ipaserver/plugins/schema.py
+++ b/ipaserver/plugins/schema.py
@@ -736,7 +736,7 @@ class output(BaseParam):
         return obj
 
     def _retrieve(self, commandfull_name, name, **kwargs):
-        if not commandfull_name in self.api.Command:
+        if commandfull_name not in self.api.Command:
             raise errors.NotFound(
                 reason=_("%(command_name)s: %(oname)s not found") % {
                     'command_name': commandfull_name, 'oname': self.name,
@@ -754,7 +754,7 @@ class output(BaseParam):
             )
 
     def _search(self, commandfull_name, **kwargs):
-        if not commandfull_name in self.api.Command:
+        if commandfull_name not in self.api.Command:
             return None
 
         cmd = self.api.Command[commandfull_name]

--- a/ipaserver/plugins/selinuxusermap.py
+++ b/ipaserver/plugins/selinuxusermap.py
@@ -335,8 +335,9 @@ class selinuxusermap_add(LDAPCreate):
         entry_attrs['ipaenabledflag'] = 'TRUE'
         validate_selinuxuser_inlist(ldap, entry_attrs['ipaselinuxuser'])
 
-        # hbacrule is not allowed when usercat or hostcat is set
-        is_to_be_set = lambda x: x in entry_attrs and entry_attrs[x] != None
+        def is_to_be_set(x):
+            """hbacrule is not allowed when usercat or hostcat is set"""
+            return x in entry_attrs and entry_attrs[x] is not None
 
         are_local_members_to_be_set = any(is_to_be_set(attr)
                                           for attr in ('usercategory',

--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -257,7 +257,7 @@ def set_certificate_attrs(entry_attrs):
 
     returns nothing
     """
-    if not 'usercertificate' in entry_attrs:
+    if 'usercertificate' not in entry_attrs:
         return
     if type(entry_attrs['usercertificate']) in (list, tuple):
         cert = entry_attrs['usercertificate'][0]

--- a/ipaserver/plugins/stageuser.py
+++ b/ipaserver/plugins/stageuser.py
@@ -575,7 +575,7 @@ class stageuser_activate(LDAPQuery):
         preserved (defined in preserved_DN_syntax_attrs)
         see http://www.freeipa.org/page/V3/User_Life-Cycle_Management#Adjustment_of_DN_syntax_attributes
         '''
-        if not attr in entry_to:
+        if attr not in entry_to:
             if isinstance(entry_from[attr], (list, tuple)):
                 # attr is multi value attribute
                 entry_to[attr] = []

--- a/ipaserver/plugins/stageuser.py
+++ b/ipaserver/plugins/stageuser.py
@@ -720,7 +720,7 @@ class stageuser_activate(LDAPQuery):
         # Now delete the Staging entry
         try:
             self._exc_wrapper(args, options, ldap.delete_entry)(staging_dn)
-        except:
+        except BaseException:
             try:
                 logger.error("Fail to delete the Staging user after "
                              "activating it %s ", staging_dn)

--- a/ipaserver/plugins/trust.py
+++ b/ipaserver/plugins/trust.py
@@ -789,7 +789,7 @@ ipa idrange-del before retrying the command with the desired range type.
         if (options.get('trust_type') == u'ad' and
                 options.get('trust_secret') is None):
 
-            if options.get('bidirectional') == True:
+            if options.get('bidirectional'):
                 # Bidirectional trust allows us to use cross-realm TGT,
                 # so we can run the call under original user's credentials
                 res = fetch_domains_from_trust(self.api, self.trustinstance,

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -341,7 +341,7 @@ class WSGIExecutioner(Executioner):
         command = None
 
         e = None
-        if not 'HTTP_REFERER' in environ:
+        if 'HTTP_REFERER' not in environ:
             return self.marshal(result, RefererError(referer='missing'), _id)
         if not environ['HTTP_REFERER'].startswith('https://%s/ipa' % self.api.env.host) and not self.env.in_tree:
             return self.marshal(result, RefererError(referer=environ['HTTP_REFERER']), _id)

--- a/ipatests/test_integration/test_vault.py
+++ b/ipatests/test_integration/test_vault.py
@@ -176,7 +176,7 @@ class TestInstallKRA(IntegrationTest):
 
         self._retrieve_secret([self.vault_name_replica_with_KRA])
 
-        ################# master #################
+        # ################ master #################
         # test master again after KRA was installed on replica
         # create vault
         self.master.run_command([
@@ -197,7 +197,7 @@ class TestInstallKRA(IntegrationTest):
 
         self._retrieve_secret([self.vault_name_master2])
 
-        ################ old vaults ###############
+        # ############### old vaults ###############
         # test if old vaults are still accessible
         self._retrieve_secret([
             self.vault_name_master,

--- a/ipatests/test_ipalib/test_parameters.py
+++ b/ipatests/test_ipalib/test_parameters.py
@@ -681,7 +681,7 @@ class test_Data(ClassChecker):
         Test the `ipalib.parameters.Data.__init__` method.
         """
         o = self.cls('my_data')
-        assert o.type is type(None)
+        assert o.type is type(None)  # noqa
         assert o.password is False
         assert o.rules == tuple()
         assert o.class_rules == tuple()
@@ -1222,7 +1222,7 @@ class test_Number(ClassChecker):
         Test the `ipalib.parameters.Number.__init__` method.
         """
         o = self.cls('my_number')
-        assert o.type is type(None)
+        assert o.type is type(None)  # noqa
         assert o.password is False
         assert o.rules == tuple()
         assert o.class_rules == tuple()

--- a/ipatests/test_ipapython/test_ipautil.py
+++ b/ipatests/test_ipapython/test_ipautil.py
@@ -164,11 +164,11 @@ class TestCIDict:
 
     @pytest.mark.skipif(not six.PY2, reason="Python 2 only")
     def test_haskey(self):
-        assert self.cidict.has_key("KEY1")
-        assert self.cidict.has_key("key2")
-        assert self.cidict.has_key("key3")
+        assert self.cidict.has_key("KEY1")  # noqa
+        assert self.cidict.has_key("key2")  # noqa
+        assert self.cidict.has_key("key3")  # noqa
 
-        assert not self.cidict.has_key("Key4")
+        assert not self.cidict.has_key("Key4")  # noqa
 
     def test_contains(self):
         assert "KEY1" in self.cidict

--- a/ipatests/test_ipapython/test_keyring.py
+++ b/ipatests/test_ipapython/test_keyring.py
@@ -119,13 +119,10 @@ class test_keyring:
         See if a key is available
         """
         kernel_keyring.add_key(TEST_KEY, TEST_VALUE)
+        assert kernel_keyring.has_key(TEST_KEY)
 
-        result = kernel_keyring.has_key(TEST_KEY)
-        assert(result == True)
         kernel_keyring.del_key(TEST_KEY)
-
-        result = kernel_keyring.has_key(TEST_KEY)
-        assert(result == False)
+        assert not kernel_keyring.has_key(TEST_KEY)
 
     def test_07(self):
         """

--- a/ipatests/test_ipapython/test_keyring.py
+++ b/ipatests/test_ipapython/test_keyring.py
@@ -119,10 +119,10 @@ class test_keyring:
         See if a key is available
         """
         kernel_keyring.add_key(TEST_KEY, TEST_VALUE)
-        assert kernel_keyring.has_key(TEST_KEY)
+        assert kernel_keyring.has_key(TEST_KEY)  # noqa
 
         kernel_keyring.del_key(TEST_KEY)
-        assert not kernel_keyring.has_key(TEST_KEY)
+        assert not kernel_keyring.has_key(TEST_KEY)  # noqa
 
     def test_07(self):
         """

--- a/ipatests/test_ipaserver/test_ldap.py
+++ b/ipatests/test_ipaserver/test_ldap.py
@@ -249,9 +249,9 @@ class test_LDAPEntry:
     @pytest.mark.skipif(sys.version_info >= (3, 0), reason="Python 2 only")
     def test_has_key(self):
         e = self.entry
-        assert not e.has_key('xyz')
-        assert e.has_key('cn')
-        assert e.has_key('COMMONNAME')
+        assert not e.has_key('xyz')  # noqa
+        assert e.has_key('cn')  # noqa
+        assert e.has_key('COMMONNAME')  # noqa
 
     def test_in(self):
         e = self.entry

--- a/ipatests/test_util.py
+++ b/ipatests/test_util.py
@@ -134,8 +134,8 @@ class test_Fuzzy:
         assert (self.klass(test=t, type=unicode) == b'foobar') is False
         assert (self.klass(test=t) == 'barfoo') is False
 
-        assert (False == self.klass()) is True
-        assert (True == self.klass()) is True
+        assert (False == self.klass()) is True  # noqa
+        assert (True == self.klass()) is True  # noqa
         assert (None == self.klass()) is True  # noqa
 
 

--- a/ipatests/test_util.py
+++ b/ipatests/test_util.py
@@ -136,7 +136,7 @@ class test_Fuzzy:
 
         assert (False == self.klass()) is True
         assert (True == self.klass()) is True
-        assert (None == self.klass()) is True
+        assert (None == self.klass()) is True  # noqa
 
 
 def test_assert_deepequal(pytestconfig):

--- a/ipatests/test_webui/test_automount.py
+++ b/ipatests/test_webui/test_automount.py
@@ -264,7 +264,7 @@ class TestAutomount(UI_driver):
         self.navigate_by_breadcrumb(LOC_PKEY)
         self.delete_record(MAP_PKEY)
 
-        ## test indirect maps
+        # test indirect maps
         direct_pkey = 'itest-direct'
         indirect_pkey = 'itest-indirect'
 

--- a/ipatests/test_webui/test_hostgroup.py
+++ b/ipatests/test_webui/test_hostgroup.py
@@ -154,8 +154,8 @@ class test_hostgroup(UI_driver):
         self.assert_indirect_record(hbac.RULE_PKEY, hostgroup.ENTITY, 'memberof_hbacrule')
         self.assert_indirect_record(sudo.RULE_PKEY, hostgroup.ENTITY, 'memberof_sudorule')
 
-        ## cleanup
-        ## -------
+        # cleanup
+        # -------
         self.delete(hostgroup.ENTITY, [hostgroup.DATA, hostgroup.DATA2,
                                        hostgroup.DATA3, hostgroup.DATA4,
                                        hostgroup.DATA5])

--- a/ipatests/test_webui/test_user.py
+++ b/ipatests/test_webui/test_user.py
@@ -184,8 +184,8 @@ class test_user(user_tasks):
         self.assert_indirect_record(hbac.RULE_PKEY, user.ENTITY, 'memberof_hbacrule')
         self.assert_indirect_record(sudo.RULE_PKEY, user.ENTITY, 'memberof_sudorule')
 
-        ## cleanup
-        ## -------
+        # cleanup
+        # -------
         self.delete(user.ENTITY, [user.DATA])
         self.delete(group.ENTITY, [group.DATA, group.DATA2])
         self.delete(netgroup.ENTITY, [netgroup.DATA])

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -2109,7 +2109,7 @@ class UI_driver:
         Assert that current facet is correct
         """
         info = self.get_facet_info()
-        if not facet is None:
+        if facet is not None:
             assert info["name"] == facet, "Invalid facet. Expected: %s, Got: %s " % (facet, info["name"])
         assert info["entity"] == entity, "Invalid entity. Expected: %s, Got: %s " % (entity, info["entity"])
 

--- a/ipatests/test_xmlrpc/test_cert_plugin.py
+++ b/ipatests/test_xmlrpc/test_cert_plugin.py
@@ -240,19 +240,19 @@ class test_cert(BaseCert):
         from ipaserver.plugins.cert import _emails_are_valid
         email_addrs = [u'any@EmAiL.CoM']
         result = _emails_are_valid(email_addrs, [u'any@email.com'])
-        assert True == result, result
+        assert result
 
         email_addrs = [u'any@EmAiL.CoM']
         result = _emails_are_valid(email_addrs, [u'any@email.com',
                                                  u'another@email.com'])
-        assert True == result, result
+        assert result
 
         result = _emails_are_valid([], [u'any@email.com'])
-        assert True == result, result
+        assert result
 
         email_addrs = [u'invalidEmailAddress']
         result = _emails_are_valid(email_addrs, [])
-        assert False == result, result
+        assert not result
 
     def test_99999_cleanup(self):
         """

--- a/ipatests/test_xmlrpc/test_hbactest_plugin.py
+++ b/ipatests/test_xmlrpc/test_hbactest_plugin.py
@@ -132,9 +132,9 @@ class test_hbactest(XMLRPC_test):
             nodetail=True
         )
         assert ret['value'] == True
-        assert ret['error'] == None
-        assert ret['matched'] == None
-        assert ret['notmatched'] == None
+        assert ret['error'] is None
+        assert ret['matched'] is None
+        assert ret['notmatched'] is None
 
     def test_c_hbactest_check_rules_enabled_detail(self):
         """
@@ -181,8 +181,8 @@ class test_hbactest(XMLRPC_test):
         )
 
         assert ret['value'] == False
-        assert ret['matched'] == None
-        assert ret['notmatched'] == None
+        assert ret['matched'] is None
+        assert ret['notmatched'] is None
         for rule in self.rule_names:
             assert u'%s_1x1' % (rule) in ret['error']
 

--- a/ipatests/test_xmlrpc/test_hbactest_plugin.py
+++ b/ipatests/test_xmlrpc/test_hbactest_plugin.py
@@ -115,7 +115,7 @@ class test_hbactest(XMLRPC_test):
             service=self.test_service,
             rules=self.rule_names
         )
-        assert ret['value'] == True
+        assert ret['value']
         assert ret['error'] is None
         for i in [0,1,2,3]:
             assert self.rule_names[i] in ret['matched']
@@ -131,7 +131,7 @@ class test_hbactest(XMLRPC_test):
             rules=self.rule_names,
             nodetail=True
         )
-        assert ret['value'] == True
+        assert ret['value']
         assert ret['error'] is None
         assert ret['matched'] is None
         assert ret['notmatched'] is None
@@ -180,7 +180,7 @@ class test_hbactest(XMLRPC_test):
             nodetail=True
         )
 
-        assert ret['value'] == False
+        assert not ret['value']
         assert ret['matched'] is None
         assert ret['notmatched'] is None
         for rule in self.rule_names:

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,12 @@ commands=
 
 [pycodestyle]
 # E402 module level import not at top of file
-# W503 line break before binary operator
-ignore = E402, W503
-
+# E203 whitespace before ':' (not PEP-8)
+# E231 missing whitespace after ',' (used by black)
+# W503 line break before binary operator (not PEP-8)
+# E731 do not assign a lambda expression
+# E741 ambiguous variable name 'l'
+ignore = E203, E402, E231, W503, E731, E741
+max-line-length = 80
+# exclude auto-generated remote plugins
+exclude=.git,.venv,build,_build,rpmbuild,2_49,2_114,2_156,2_164


### PR DESCRIPTION
* Fix E266 too many leading '#' for block comment
* Fix E711 comparison to None
* Fix E712 comparison to True / False
* Fix E713 test for membership should be 'not in'
* Fix E714 test for object identity should be 'is not'
* Fix E721 do not compare types, use 'isinstance()'
* Fix E722 do not use bare 'except'
* Silence W601 .has_key() is deprecated
* Manually reformat ipapython/version.py.in
* Reconfigure pycodestyle
  * Disable some warnings that are not PEP-8 compatible.
  * Disable warnings E731 and E741. IPA code uses ``l`` as variable names and assignment of lambda expressions a lot.
  * Ignore auto-generated remote plugins and build directories.

Related: https://pagure.io/freeipa/issue/8306