### PR TITLE
Simplify pki proxy conf

### DIFF
--- a/install/share/ipa-pki-proxy.conf.template
+++ b/install/share/ipa-pki-proxy.conf.template
@@ -1,4 +1,4 @@
-# VERSION 14 - DO NOT REMOVE THIS LINE
+# VERSION 15 - DO NOT REMOVE THIS LINE
 
 ProxyRequests Off
 
@@ -26,16 +26,8 @@ ProxyRequests Off
     ProxyPassReverse ajp://localhost:$DOGTAG_PORT
 </LocationMatch>
 
-# matches for CA REST API
-<LocationMatch "^/ca/rest/account/login|^/ca/rest/account/logout|^/ca/rest/installer/installToken|^/ca/rest/securityDomain/domainInfo|^/ca/rest/securityDomain/installToken|^/ca/rest/profiles|^/ca/rest/authorities|^/ca/rest/certrequests|^/ca/rest/admin/kraconnector/remove|^/ca/rest/certs/search">
-    SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
-    SSLVerifyClient optional
-    ProxyPassMatch ajp://localhost:$DOGTAG_PORT $DOGTAG_AJP_SECRET
-    ProxyPassReverse ajp://localhost:$DOGTAG_PORT
-</LocationMatch>
-
-# matches for KRA REST API
-<LocationMatch "^/kra/rest/config/cert/transport|^/kra/rest/account|^/kra/rest/agent/keyrequests|^/kra/rest/agent/keys">
+# matches for REST API of CA, KRA, and PKI
+<LocationMatch "^/(ca|kra|pki)/rest/">
     SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
     SSLVerifyClient optional
     ProxyPassMatch ajp://localhost:$DOGTAG_PORT $DOGTAG_AJP_SECRET


### PR DESCRIPTION
``pkispawn`` is being modified to use PKI CLI for installation.

Add ``/pki/rest`` to proxied routes and simplify location matching with
a prefix regular expression.

Signed-off-by: Christian Heimes <cheimes@redhat.com>