### PR TITLE
Make ipaplatform a regular top-level package

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1418,7 +1418,6 @@ fi
 %{python3_sitelib}/ipapython-*.egg-info
 %{python3_sitelib}/ipalib-*.egg-info
 %{python3_sitelib}/ipaplatform-*.egg-info
-%{python3_sitelib}/ipaplatform-*-nspkg.pth
 
 
 %if 0%{?with_ipatests}

--- a/ipaplatform/__init__.py
+++ b/ipaplatform/__init__.py
@@ -1,11 +1,6 @@
 #
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #
-"""ipaplatform namespace package
-
-In the presence of a namespace package, any code in this module will be
-ignore.
+"""ipaplatform package
 """
-__import__('pkg_resources').declare_namespace(__name__)
-
 NAME = None  # initialized by ipaplatform.osinfo

--- a/ipaplatform/setup.py
+++ b/ipaplatform/setup.py
@@ -31,7 +31,6 @@ if __name__ == '__main__':
         name="ipaplatform",
         doc=__doc__,
         package_dir={'ipaplatform': ''},
-        namespace_packages=['ipaplatform'],
         packages=[
             "ipaplatform",
             "ipaplatform.base",


### PR DESCRIPTION
ipaplatform was made a namespace package so that 3rd party OS
distributors can easily define their own distribution subpackage. Since
major distributions have contributed to FreeIPA project and no 3rd party
ipaplatform subpackage was uploaded to PyPI, it doesn't make much sense
to keep ipaplatform a namespace package.

The ipaplatform-*-nspkg.pth file for namespace package definition is
causing trouble with local testing on developer boxes.

Signed-off-by: Christian Heimes <cheimes@redhat.com>