### PR TITLE
[Backport][ipa-4-8] Make ipaplatform a regular top-level package

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1410,7 +1410,6 @@ fi
 %{python3_sitelib}/ipapython-*.egg-info
 %{python3_sitelib}/ipalib-*.egg-info
 %{python3_sitelib}/ipaplatform-*.egg-info
-%{python3_sitelib}/ipaplatform-*-nspkg.pth
 
 
 %if 0%{?with_ipatests}

--- a/ipaplatform/__init__.py
+++ b/ipaplatform/__init__.py
@@ -1,11 +1,6 @@
 #
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #
-"""ipaplatform namespace package
-
-In the presence of a namespace package, any code in this module will be
-ignore.
+"""ipaplatform package
 """
-__import__('pkg_resources').declare_namespace(__name__)
-
 NAME = None  # initialized by ipaplatform.osinfo

--- a/ipaplatform/setup.py
+++ b/ipaplatform/setup.py
@@ -31,7 +31,6 @@ if __name__ == '__main__':
         name="ipaplatform",
         doc=__doc__,
         package_dir={'ipaplatform': ''},
-        namespace_packages=['ipaplatform'],
         packages=[
             "ipaplatform",
             "ipaplatform.base",


### PR DESCRIPTION
This PR was opened automatically because PR #4643 was pushed to master and backport to ipa-4-8 is required.