### PR TITLE
[Backport][ipa-4-6] Make check_required_principal() case-insensitive

### DIFF
--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -282,8 +282,8 @@ def check_required_principal(ldap, principal):
     try:
         host_is_master(ldap, principal.hostname)
     except errors.ValidationError:
-        service_types = ['HTTP', 'ldap', 'DNS', 'dogtagldap']
-        if principal.service_name in service_types:
+        service_types = {'http', 'ldap', 'dns', 'dogtagldap'}
+        if principal.service_name.lower() in service_types:
             raise errors.ValidationError(name='principal', error=_('This principal is required by the IPA master'))
 
 def update_krbticketflags(ldap, entry_attrs, attrs_list, options, existing):

--- a/ipatests/test_xmlrpc/test_service_plugin.py
+++ b/ipatests/test_xmlrpc/test_service_plugin.py
@@ -791,6 +791,18 @@ class test_service(Declarative):
             expected=errors.ValidationError(name='principal', error='This principal is required by the IPA master'),
         ),
 
+        # DN is case insensitive, see https://pagure.io/freeipa/issue/8308
+        dict(
+            desc=(
+                'Delete the current host (master?) %s HTTP service, should '
+                'be caught'
+            ) % api.env.host,
+            command=('service_del', ['http/%s' % api.env.host], {}),
+            expected=errors.ValidationError(
+                name='principal',
+                error='This principal is required by the IPA master'
+            ),
+        ),
 
         dict(
             desc='Delete the current host (master?) %s ldap service, should be caught' % api.env.host,
@@ -805,6 +817,17 @@ class test_service(Declarative):
             expected=errors.ValidationError(name='principal', error='This principal is required by the IPA master'),
         ),
 
+        dict(
+            desc=(
+                'Disable the current host (master?) %s HTTP service, should '
+                'be caught'
+            ) % api.env.host,
+            command=('service_disable', ['http/%s' % api.env.host], {}),
+            expected=errors.ValidationError(
+                name='principal',
+                error='This principal is required by the IPA master'
+            ),
+        ),
 
         dict(
             desc='Disable the current host (master?) %s ldap service, should be caught' % api.env.host,


### PR DESCRIPTION
This PR was opened automatically because PR #4642 was pushed to master and backport to ipa-4-6 is required.