### PR TITLE
Switch Azure Pipelines to test Fedora 32

### DIFF
--- a/ipaplatform/osinfo.py
+++ b/ipaplatform/osinfo.py
@@ -71,7 +71,7 @@ def _parse_osrelease(filename='/etc/os-release'):
 
 
 class OSInfo(Mapping):
-    __slots__ = ('_info', '_platform')
+    __slots__ = ('_info', '_platform', '_container')
 
     bsd_family = (
         'freebsd',
@@ -95,6 +95,7 @@ class OSInfo(Mapping):
             raise ValueError("Unsupported platform: {}".format(sys.platform))
         self._info = info
         self._platform = None
+        self._container = None
 
     def _handle_linux(self):
         """Detect Linux distribution from /etc/os-release
@@ -208,6 +209,17 @@ class OSInfo(Mapping):
         raise ImportError('No ipaplatform available for "{}"'.format(
                           ', '.join(self.platform_ids)))
 
+    @property
+    def container(self):
+        if self._container is not None:
+            return self._container
+        from ipaplatform.tasks import tasks
+        try:
+            self._container = tasks.detect_container()
+        except NotImplementedError:
+            raise NotImplementedError(
+                'Platform does not support detecting containers')
+        return self._container
 
 osinfo = OSInfo()
 ipaplatform.NAME = osinfo.platform

--- a/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
+++ b/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
@@ -1,4 +1,4 @@
-FROM fedora:31
+FROM fedora:32
 MAINTAINER [FreeIPA Developers freeipa-devel@lists.fedorahosted.org]
 ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 

--- a/ipatests/azure/templates/variables-fedora.yml
+++ b/ipatests/azure/templates/variables-fedora.yml
@@ -1,7 +1,7 @@
 variables:
   IPA_PLATFORM: fedora
   # the Docker public image to build IPA packages (rpms)
-  DOCKER_BUILD_IMAGE: 'registry.fedoraproject.org/f31/fedora-toolbox'
+  DOCKER_BUILD_IMAGE: 'registry.fedoraproject.org/f32/fedora-toolbox'
 
   # the Dockerfile to build Docker image for running IPA tests
   DOCKER_DOCKERFILE: ${{ format('Dockerfile.build.{0}', variables.IPA_PLATFORM) }}
@@ -17,4 +17,4 @@ variables:
   TOX_COMMAND: tox
 
   # Python version for UsePythonVersion@0 task
-  AZURE_PYTHON_VERSION: '3.7'
+  AZURE_PYTHON_VERSION: '3.8'

--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -47,6 +47,8 @@ MARKERS = [
     'needs_ipaapi: Test needs IPA API',
     ('skip_if_platform(platform, reason): Skip test on platform '
      '(ID and ID_LIKE)'),
+    ('skip_if_container(type, reason): Skip test on container '
+     '("any" or specific type)'),
 ]
 
 
@@ -158,6 +160,15 @@ def pytest_runtest_setup(item):
             reason = mark.kwargs["reason"]
             if platform in osinfo.platform_ids:
                 pytest.skip(f"Skip test on platform {platform}: {reason}")
+        for mark in item.iter_markers(name="skip_if_container"):
+            container = mark.kwargs.get("container")
+            if container is None:
+                container = mark.args[0]
+            reason = mark.kwargs["reason"]
+            if osinfo.container is not None:
+                if container in ('any', osinfo.container):
+                    pytest.skip(
+                        f"Skip test on '{container}' container type: {reason}")
 
 
 @pytest.fixture

--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -155,6 +155,9 @@ class TestSudo(IntegrationTest):
     @pytest.mark.skip_if_platform(
         "debian", reason="NISDOMAIN has not been set on Debian"
     )
+    @pytest.mark.skip_if_container(
+        "any", reason="NISDOMAIN cannot be set in containerized environment"
+    )
     def test_nisdomainname(self):
         result = self.client.run_command('nisdomainname')
         assert self.client.domain.name in result.stdout_text


### PR DESCRIPTION
An example run can be seen here: https://dev.azure.com/freeipa/freeipa/_build/results?buildId=4128&view=results, below is an excerpt from the [build log](https://dev.azure.com/freeipa/dd9bf4ec-d636-4558-8f6e-ee17af87f33b/_apis/build/builds/4128/logs/19):

```
2020-05-03T10:30:32.1924864Z ##[section]Starting: Prepare build environment
2020-05-03T10:30:32.1931109Z ==============================================================================
2020-05-03T10:30:32.1931520Z Task         : Command line
2020-05-03T10:30:32.1931824Z Description  : Run a command line script using Bash on Linux and macOS and cmd.exe on Windows
2020-05-03T10:30:32.1932109Z Version      : 2.164.0
2020-05-03T10:30:32.1932350Z Author       : Microsoft Corporation
2020-05-03T10:30:32.1932654Z Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/command-line
2020-05-03T10:30:32.1933002Z ==============================================================================
2020-05-03T10:30:32.4805731Z Generating script.
2020-05-03T10:30:32.4836212Z ========================== Starting Command Output ===========================
2020-05-03T10:30:32.4865713Z [command]/usr/bin/bash --noprofile --norc /__w/_temp/7b74840c-b67a-4a0f-80a7-80a3a8cea8be.sh
2020-05-03T10:30:33.3615526Z Fedora Modular 32 - x86_64                      7.3 MB/s | 4.9 MB     00:00    
2020-05-03T10:30:34.9614294Z Fedora Modular 32 - x86_64 - Updates            1.3 MB/s | 1.4 MB     00:01    
2020-05-03T10:30:36.7524569Z Fedora Modular 32 - x86_64 - Test Updates       330 kB/s | 408 kB     00:01    
2020-05-03T10:30:38.5644961Z Fedora 32 - x86_64 - Test Updates                16 MB/s |  19 MB     00:01    
2020-05-03T10:30:43.8141896Z Fedora 32 - x86_64 - Updates                    8.4 MB/s | 6.7 MB     00:00    
2020-05-03T10:30:49.4475887Z Fedora 32 - x86_64                               15 MB/s |  63 MB     00:04    
2020-05-03T10:31:09.5655247Z Metadata cache created.
2020-05-03T10:31:09.5942395Z Installing base development environment
2020-05-03T10:31:10.8363019Z Last metadata expiration check: 0:00:22 ago on Sun May  3 10:30:48 2020.
2020-05-03T10:31:13.3690343Z Dependencies resolved.
2020-05-03T10:31:14.9175720Z ============================================================================================
2020-05-03T10:31:14.9177404Z  Package                      Arch    Version                         Repository        Size
2020-05-03T10:31:14.9178474Z ============================================================================================
2020-05-03T10:31:14.9179230Z Installing:
2020-05-03T10:31:14.9180942Z  autoconf                     noarch  2.69-33.fc32                    updates-testing  666 k
2020-05-03T10:31:14.9182387Z  automake                     noarch  1.16.1-14.fc32                  fedora           665 k
2020-05-03T10:31:14.9183797Z  gdb-minimal                  x86_64  9.1-3.fc32                      fedora           3.6 M
2020-05-03T10:31:14.9186096Z  gettext-devel                x86_64  0.20.2-1.fc32                   updates          194 k
2020-05-03T10:31:14.9187913Z  libtool                      x86_64  2.4.6-33.fc32                   fedora           579 k
2020-05-03T10:31:14.9189367Z  make                         x86_64  1:4.2.1-16.fc32                 fedora           494 k
2020-05-03T10:31:14.9204733Z  moby-engine                  x86_64  19.03.8-1.ce.gitafacb8b.fc32    updates-testing   51 M
2020-05-03T10:31:14.9208775Z  python3-paramiko             noarch  2.7.1-2.fc32                    fedora           287 k
2020-05-03T10:31:14.9210148Z  python3-pyyaml               x86_64  5.3.1-1.fc32                    updates-testing  202 k
2020-05-03T10:31:14.9211413Z  rpm-build                    x86_64  4.15.1-2.fc32.1                 fedora           116 k
....
```