### PR TITLE
Fix detection logic for api.env.in_tree

### DIFF
--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -457,11 +457,11 @@ class Env:
         # Merge in overrides:
         self._merge(**overrides)
 
-        # Determine if running in source tree:
+        # Determine if running in source tree. The root directory of
+        # IPA source directory contains ipasetup.py.in.
         if 'in_tree' not in self:
-            self.in_tree = (
-                self.bin == self.site_packages
-                and path.isfile(path.join(self.bin, 'setup.py'))
+            self.in_tree = os.path.isfile(
+                os.path.join(self.site_packages, "ipasetup.py.in")
             )
         if self.in_tree and 'mode' not in self:
             self.mode = 'developer'

--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -118,7 +118,7 @@ def pytest_addoption(parser):
 
 def pytest_cmdline_main(config):
     kwargs = dict(
-        context=u'cli', in_server=False, in_tree=True, fallback=False
+        context=u'cli', in_server=False, fallback=False
     )
     if not os.path.isfile(os.path.expanduser('~/.ipa/default.conf')):
         # dummy domain/host for machines without ~/.ipa/default.conf

--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -120,6 +120,8 @@ def pytest_cmdline_main(config):
     kwargs = dict(
         context=u'cli', in_server=False, fallback=False
     )
+    # FIXME: workaround for https://pagure.io/freeipa/issue/8317
+    kwargs.update(in_tree=True)
     if not os.path.isfile(os.path.expanduser('~/.ipa/default.conf')):
         # dummy domain/host for machines without ~/.ipa/default.conf
         kwargs.update(domain=u'ipa.test', server=u'master.ipa.test')


### PR DESCRIPTION
The logic to detect in-tree builds was broken and ipatests/conftest.py
had hard-coded in_tree=True.

IPA now considers an environment as in-tree when the parent directory of
the ``ipalib`` package contains ``ipasetup.py.in``. This file is only
present in source and never installed.

API bootstrap() does not use ```self.site_packages in site.getsitepackages()``
because the function call can be expensive and would require path
normalization, too.

Fixes: https://pagure.io/freeipa/issue/8312
Signed-off-by: Christian Heimes <cheimes@redhat.com>