### PR TITLE
[Backport][ipa-4-6] test_legacy_clients: fix class inheritance

### DIFF
--- a/ipatests/test_integration/test_legacy_clients.py
+++ b/ipatests/test_integration/test_legacy_clients.py
@@ -498,8 +498,8 @@ class BaseTestLegacyNssLdapRedHat(object):
 # Base classes that join legacy client specific steps with steps required
 # to setup IPA with trust (both with and without using the POSIX attributes)
 
-class BaseTestLegacyClientPosix(BaseTestLegacyClient,
-                                trust_tests.TestEnforcedPosixADTrust):
+class BaseTestLegacyClientPosix(trust_tests.BaseTestTrust,
+                                BaseTestLegacyClient):
 
     testuser_uid_regex = '10042'
     testuser_gid_regex = '10047'
@@ -513,8 +513,8 @@ class BaseTestLegacyClientPosix(BaseTestLegacyClient,
         pass
 
 
-class BaseTestLegacyClientNonPosix(BaseTestLegacyClient,
-                                   trust_tests.TestBasicADTrust):
+class BaseTestLegacyClientNonPosix(trust_tests.BaseTestTrust,
+                                   BaseTestLegacyClient):
 
     testuser_uid_regex = '(?!10042)(\d+)'
     testuser_gid_regex = '(?!10047)(\d+)'

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -13,7 +13,7 @@ from ipatests.pytest_ipa.integration import tasks
 from ipapython.dn import DN
 
 
-class TestTrust(IntegrationTest):
+class BaseTestTrust(IntegrationTest):
     num_clients = 1
     topology = 'line'
     num_ad_domains = 1
@@ -33,7 +33,7 @@ class TestTrust(IntegrationTest):
         if not cls.master.transport.file_exists('/usr/bin/rpcclient'):
             raise nose.SkipTest("Package samba-client not available "
                                 "on {}".format(cls.master.hostname))
-        super(TestTrust, cls).install(mh)
+        super(BaseTestTrust, cls).install(mh)
         cls.ad = cls.ads[0]  # pylint: disable=no-member
         cls.ad_domain = cls.ad.domain.name
         tasks.install_adtrust(cls.master)
@@ -88,8 +88,9 @@ class TestTrust(IntegrationTest):
         tasks.remove_trust_with_ad(self.master, ad.domain.name)
         tasks.clear_sssd_cache(self.master)
 
-    # Tests for non-posix AD trust
 
+# Tests for non-posix AD trust
+class TestTrust(BaseTestTrust):
     def test_establish_nonposix_trust(self):
         tasks.configure_dns_for_trust(self.master, self.ad)
         tasks.establish_trust_with_ad(


### PR DESCRIPTION
This is manual backport for 245a8bcdfe32f665a0a1902e54d49e4ba2cd4ce4

Fixes: https://pagure.io/freeipa/issue/7940
Reviewed-By: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Rob Crittenden <rcritten@redhat.com>