### PR TITLE
[Backport][ipa-4-8] Display principal name while del required principal

### DIFF
--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -289,7 +289,10 @@ def check_required_principal(ldap, principal):
     except errors.ValidationError:
         service_types = {'http', 'ldap', 'dns', 'dogtagldap'}
         if principal.service_name.lower() in service_types:
-            raise errors.ValidationError(name='principal', error=_('This principal is required by the IPA master'))
+            raise errors.ValidationError(
+                name='principal',
+                error=_('{} is required by the IPA master').format(principal)
+            )
 
 def update_krbticketflags(ldap, entry_attrs, attrs_list, options, existing):
     add = remove = 0

--- a/ipatests/test_xmlrpc/test_service_plugin.py
+++ b/ipatests/test_xmlrpc/test_service_plugin.py
@@ -811,7 +811,13 @@ class test_service(Declarative):
         dict(
             desc='Delete the current host (master?) %s HTTP service, should be caught' % api.env.host,
             command=('service_del', ['HTTP/%s' % api.env.host], {}),
-            expected=errors.ValidationError(name='principal', error='This principal is required by the IPA master'),
+            expected=errors.ValidationError(
+                name='principal',
+                error='HTTP/%s@%s is required by the IPA master' % (
+                    api.env.host,
+                    api.env.realm
+                )
+            ),
         ),
 
         # DN is case insensitive, see https://pagure.io/freeipa/issue/8308
@@ -823,21 +829,50 @@ class test_service(Declarative):
             command=('service_del', ['http/%s' % api.env.host], {}),
             expected=errors.ValidationError(
                 name='principal',
-                error='This principal is required by the IPA master'
+                error='http/%s@%s is required by the IPA master' % (
+                    api.env.host,
+                    api.env.realm
+                )
             ),
         ),
 
         dict(
             desc='Delete the current host (master?) %s ldap service, should be caught' % api.env.host,
             command=('service_del', ['ldap/%s' % api.env.host], {}),
-            expected=errors.ValidationError(name='principal', error='This principal is required by the IPA master'),
+            expected=errors.ValidationError(
+                name='principal',
+                error='ldap/%s@%s is required by the IPA master' % (
+                    api.env.host,
+                    api.env.realm
+                )
+            ),
+        ),
+
+
+        dict(
+            desc=('Delete the current host (master?) %s dns service,'
+                  ' should be caught' % api.env.host),
+            command=('service_del', ['DNS/%s' % api.env.host], {}),
+            expected=errors.ValidationError(
+                name='principal',
+                error='DNS/%s@%s is required by the IPA master' % (
+                    api.env.host,
+                    api.env.realm
+                )
+            ),
         ),
 
 
         dict(
             desc='Disable the current host (master?) %s HTTP service, should be caught' % api.env.host,
             command=('service_disable', ['HTTP/%s' % api.env.host], {}),
-            expected=errors.ValidationError(name='principal', error='This principal is required by the IPA master'),
+            expected=errors.ValidationError(
+                name='principal',
+                error='HTTP/%s@%s is required by the IPA master' % (
+                    api.env.host,
+                    api.env.realm
+                )
+            ),
         ),
 
         dict(
@@ -848,14 +883,37 @@ class test_service(Declarative):
             command=('service_disable', ['http/%s' % api.env.host], {}),
             expected=errors.ValidationError(
                 name='principal',
-                error='This principal is required by the IPA master'
+                error='http/%s@%s is required by the IPA master' % (
+                    api.env.host,
+                    api.env.realm
+                )
             ),
         ),
 
         dict(
             desc='Disable the current host (master?) %s ldap service, should be caught' % api.env.host,
             command=('service_disable', ['ldap/%s' % api.env.host], {}),
-            expected=errors.ValidationError(name='principal', error='This principal is required by the IPA master'),
+            expected=errors.ValidationError(
+                name='principal',
+                error='ldap/%s@%s is required by the IPA master' % (
+                    api.env.host,
+                    api.env.realm
+                )
+            ),
+        ),
+
+
+        dict(
+            desc=('Disable the current host (master?) %s dns service,'
+                  ' should be caught' % api.env.host),
+            command=('service_disable', ['DNS/%s' % api.env.host], {}),
+            expected=errors.ValidationError(
+                name='principal',
+                error='DNS/%s@%s is required by the IPA master' % (
+                    api.env.host,
+                    api.env.realm
+                )
+            ),
         ),
 
 


### PR DESCRIPTION
Fix is to display the proper principal in error message
while attempting to delete required principal.

related: https://pagure.io/freeipa/issue/7695

Signed-off-by: Mohammad Rizwan Yusuf <myusuf@redhat.com>
Reviewed-By: Christian Heimes <cheimes@redhat.com>
Reviewed-By: Rob Crittenden <rcritten@redhat.com>