### PR TITLE
Fix kdc memory handling

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -1039,6 +1039,7 @@ krb5_error_code ipadb_find_principal(krb5_context kcontext,
     struct berval **vals = NULL;
     int result;
     krb5_error_code ret;
+    size_t princ_len = 0;
 
     ipactx = ipadb_get_context(kcontext);
     if (!ipactx) {
@@ -1046,6 +1047,7 @@ krb5_error_code ipadb_find_principal(krb5_context kcontext,
         goto done;
     }
 
+    princ_len = strlen(*principal);
     for (le = ldap_first_entry(ipactx->lcontext, res); le != NULL;
          le = ldap_next_entry(ipactx->lcontext, le)) {
         vals = ldap_get_values_len(ipactx->lcontext, le, "krbprincipalname");
@@ -1057,7 +1059,8 @@ krb5_error_code ipadb_find_principal(krb5_context kcontext,
         for (int i = 0; vals[i]; i++) {
 #ifdef KRB5_KDB_FLAG_ALIAS_OK
             if ((flags & KRB5_KDB_FLAG_ALIAS_OK) == 0) {
-                found = strcmp(vals[i]->bv_val, *principal) == 0;
+                found = ((vals[i]->bv_len == princ_len) &&
+                         strncmp(vals[i]->bv_val, *principal, vals[i]->bv_len) == 0);
                 if (found)
                     break;
 
@@ -1069,7 +1072,7 @@ krb5_error_code ipadb_find_principal(krb5_context kcontext,
              * (ref_tgt_again in do_tgs_req.c), so use case-insensitive
              * comparison. */
             if (ulc_casecmp(vals[i]->bv_val, vals[i]->bv_len, *principal,
-                            strlen(*principal), NULL, NULL, &result) != 0) {
+                            princ_len, NULL, NULL, &result) != 0) {
                 ret = KRB5_KDB_INTERNAL_ERROR;
                 goto done;
             }
@@ -1080,19 +1083,23 @@ krb5_error_code ipadb_find_principal(krb5_context kcontext,
              * name/alias is returned even if krbCanonicalName is not
              * present. */
             free(*principal);
-            *principal = strdup(vals[i]->bv_val);
+            *principal = strndup(vals[i]->bv_val, vals[i]->bv_len);
             if (!*principal) {
                 ret = KRB5_KDB_INTERNAL_ERROR;
                 goto done;
             }
+            princ_len = strlen(*principal);
             found = true;
             break;
         }
-        if (!found)
+
+        ldap_value_free_len(vals);
+        vals = NULL;
+        if (!found) {
             continue;
+        }
 
         /* We need to check if this is the canonical name. */
-        ldap_value_free_len(vals);
         vals = ldap_get_values_len(ipactx->lcontext, le, "krbcanonicalname");
         if (vals == NULL)
             break;
@@ -1101,16 +1108,18 @@ krb5_error_code ipadb_find_principal(krb5_context kcontext,
         /* If aliases aren't accepted by the KDC, use case-sensitive
          * comparison. */
         if ((flags & KRB5_KDB_FLAG_ALIAS_OK) == 0) {
-            found = strcmp(vals[0]->bv_val, *principal) == 0;
+            found = ((vals[0]->bv_len == strlen(*principal)) &&
+                     strncmp(vals[0]->bv_val, *principal, vals[0]->bv_len) == 0);
             if (!found) {
                 ldap_value_free_len(vals);
+		vals = NULL;
                 continue;
             }
         }
 #endif
 
         free(*principal);
-        *principal = strdup(vals[0]->bv_val);
+        *principal = strndup(vals[0]->bv_val, vals[0]->bv_len);
         if (!*principal) {
             ret = KRB5_KDB_INTERNAL_ERROR;
             goto done;

--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -2579,7 +2579,7 @@ krb5_error_code ipadb_delete_principal(krb5_context kcontext,
     char *canonicalized = NULL;
     LDAPMessage *res = NULL;
     LDAPMessage *lentry;
-    unsigned int flags;
+    unsigned int flags = 0;
 
     ipactx = ipadb_get_context(kcontext);
     if (!ipactx) {

--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -224,6 +224,28 @@ class TestSMB(IntegrationTest):
         self.smbclient.run_command(['umount', mountpoint], raiseonerr=False)
         self.smbclient.run_command(['rmdir', mountpoint], raiseonerr=False)
 
+    def smb_cifs_principal_alias_check(self):
+        netbiosname = self.smbserver.hostname.split('.')[0].upper() + '$'
+        copier = tasks.KerberosKeyCopier(self.smbserver)
+
+        principal = 'cifs/{hostname}@{realm}'.format(
+            hostname=self.smbserver.hostname, realm=copier.realm)
+        alias = '{netbiosname}@{realm}'.format(
+            netbiosname=netbiosname, realm=copier.realm)
+        replacement = {principal: alias}
+
+        result = self.smbserver.run_command(['mktemp'])
+        # klist/ktutil will fail with 0-sized file
+        # so we just use the temporary file as a prefix
+        tmpname = result.stdout_text.strip() + '.keytab'
+
+        copier.copy_keys('/etc/samba/samba.keytab',
+                         tmpname, principal=principal, replacement=replacement)
+        self.smbserver.run_command(['kinit', '-kt', tmpname, netbiosname],
+                                   raiseonerr=True)
+        self.smbserver.run_command(['rm', '-f', tmpname])
+        self.smbserver.run_command(['rm', '-f', tmpname[:-7]])
+
     def test_samba_uninstallation_without_installation(self):
         res = self.smbserver.run_command(
             ['ipa-client-samba', '--uninstall', '-U'])
@@ -237,6 +259,8 @@ class TestSMB(IntegrationTest):
             result = self.smbserver.run_command(
                 ['systemctl', 'status', service], raiseonerr=False)
             assert result.returncode == 3
+        # Validate that we can authenticate with the service alias principal
+        self.smb_cifs_principal_alias_check()
         self.smbserver.run_command([
             'systemctl', 'enable', '--now', 'smb', 'winbind'
         ])


### PR DESCRIPTION
1 .kdb: fix memory handling in ipadb_find_principal
    
BER structure representing a string might not have termination '\0' character, thus we should use length-bound functions to operate on it.
    
Memory handling of LDAP values was leaving previous vals over iteration. Also, when freeing vals, we need to explicitly set it to NULL.
   
2. kdb: initialize flags in ipadb_delete_principal()

Minor fix after kdb module refactoring some time ago.

3. test_smb: test that we can auth as NetBIOS alias
    
cifs/... principal on SMB server side has NetBIOS name of the SMB server as its alias. Test that we can actually initialize credentials using this alias. We don't need to use it anywhere in Samba, just verify that alias works. This is a test for the main fix.

Fixes: https://pagure.io/freeipa/issue/8291

