### PR TITLE
Disable password schema update on LDAP bind

### DIFF
--- a/install/updates/10-config.update
+++ b/install/updates/10-config.update
@@ -66,3 +66,10 @@ only:nsslapd-allow-hashed-passwords:on
 # Decrease default value for IO blocking to prevent server unresponsiveness
 dn: cn=config
 only:nsslapd-ioblocktimeout:10000
+
+# 389-DS 1.4.1.6+ attempts to update passwords to new schema on LDAP bind.
+# IPa blocks hashed password updates and requires password changes to go
+# through proper APIs. This option disables password hashing schema updates
+# on LDAP bind, see https://pagure.io/freeipa/issue/8315
+dn: cn=config
+only: nsslapd-enable-upgrade-hash:off

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -752,6 +752,7 @@ class LDAPClient:
         'nsslapd-idlistscanlimit': True,
         'nsslapd-anonlimitsdn': True,
         'nsslapd-minssf-exclude-rootdse': True,
+        'nsslapd-enable-upgrade-hash': True,
     })
 
     time_limit = -1.0   # unlimited

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -824,6 +824,17 @@ class TestInstallMaster(IntegrationTest):
             msg = "rpm -V found group issues for the following files: {}"
             assert group_warnings == [], msg.format(group_warnings)
 
+    def test_ds_disable_upgrade_hash(self):
+        # Test case for https://pagure.io/freeipa/issue/8315
+        # Disable password schema migration on LDAP bind
+        result = tasks.ldapsearch_dm(
+            self.master,
+            "cn=config",
+            ldap_args=["nsslapd-enable-upgrade-hash"],
+            scope="base"
+        )
+        assert "nsslapd-enable-upgrade-hash: off" in result.stdout_text
+
 
 class TestInstallMasterKRA(IntegrationTest):
 


### PR DESCRIPTION
389-DS 1.4.1+ attempts to update passwords to new schema on LDAP bind. IPA
blocks hashed password updates and requires password changes to go through
proper APIs. This option disables password hashing schema updates on bind.

See: https://pagure.io/freeipa/issue/8315
See: https://bugzilla.redhat.com/show_bug.cgi?id=1833266
See: https://pagure.io/389-ds-base/issue/49421
Signed-off-by: Christian Heimes <cheimes@redhat.com>