### PR TITLE
WebUI: use python3-rjsmin to minify JavaScript files

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -39,7 +39,7 @@ extraction:
         - python3-setuptools
         - python3-wheel
         - nodejs
-        - uglifyjs
+        - python3-rjsmin
         - systemd
         - 389-ds-base-dev
         - libssl-dev
@@ -79,7 +79,7 @@ extraction:
         - python3-setuptools
         - python3-wheel
         - nodejs
-        - uglifyjs
+        - python3-rjsmin
         - systemd
         - 389-ds-base-dev
         - libssl-dev

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -192,7 +192,7 @@ BuildRequires:  libsss_idmap-devel
 BuildRequires:  libsss_certmap-devel
 BuildRequires:  libsss_nss_idmap-devel >= %{sssd_version}
 BuildRequires:  nodejs(abi)
-BuildRequires:  uglify-js
+BuildRequires:  python3-rjsmin
 BuildRequires:  libverto-devel
 BuildRequires:  libunistring-devel
 # 0.13.0: https://bugzilla.redhat.com/show_bug.cgi?id=1584773

--- a/install/ui/build/freeipa/Makefile.am
+++ b/install/ui/build/freeipa/Makefile.am
@@ -18,6 +18,6 @@ widgets := $(wildcard ../../src/freeipa/widgets/*.js)
 nav := $(wildcard ../../src/freeipa/navigation/*.js)
 
 app.js: $(core) $(base) $(widgets) $(nav)
-	$(srcdir)/../../util/make-ui.sh
+	PYTHON=$(PYTHON) $(srcdir)/../../util/make-ui.sh
 
 core.js: app.js

--- a/install/ui/src/webui.profile.js
+++ b/install/ui/src/webui.profile.js
@@ -9,7 +9,7 @@ var profile = (function(){
         releaseName: "lib",
         action: "release",
 
-        // optimization done separately by uglify.js
+        // optimization done separately by python3-rjsmin
         layerOptimize: false,
         optimize: false,
         cssOptimize: false,

--- a/install/ui/util/build/README
+++ b/install/ui/util/build/README
@@ -1,5 +1,5 @@
 build.js is builded dojo builder, with applied patches from 'patches' folder, by
-itself and compiled using uglify.js
+itself and compiled using python3-rjsmin
 
 _base/configRhino.js is unmodifed file from dojo/dojo. Required for a build to work.
 

--- a/install/ui/util/compile.sh
+++ b/install/ui/util/compile.sh
@@ -26,14 +26,14 @@ RDIR=$DIR/../release
 usage() {
 cat <<-__EOF__;
 NAME
-     compile.sh - Compiles layer file of Dojo build using uglify.js.
+     compile.sh - Compiles layer file of Dojo build using Python rjsmin.
                   Deletes all other files.
 
 SYNOPSIS
      path/to/compile.sh [--help] --release RELEASE --layer NAME/NAME
 
 DESCRIPTION
-     Compiles layer file of Dojo build output using uglify.js.
+     Compiles layer file of Dojo build output using Python rjsmin.
      Deletes all other files.
 
 OPTIONS
@@ -105,7 +105,7 @@ if [[ ! $OUTPUT_FILE ]] ; then
     OUTPUT_FILE=$RDIR/$RELEASE/$LAYER.js
 fi
 
-# compile using uglifyjs
+# compile using python rjsmin
 echo "Minimizing: $RDIR/$RELEASE/$LAYER.js"
 echo "Target file: $OUTPUT_FILE"
-uglifyjs $RDIR/$RELEASE/$LAYER.js > $OUTPUT_FILE
+${PYTHON:-python3} -m rjsmin < $RDIR/$RELEASE/$LAYER.js > $OUTPUT_FILE


### PR DESCRIPTION
Fedora 33+ deprecated uglify-js. There are other alternatives which seem
to be fine for the minify task. Use python-rjsmin instead.

Fixes: https://pagure.io/freeipa/issue/8300
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>