### PR TITLE
Make api.env.mode consistent

### DIFF
--- a/client/man/default.conf.5
+++ b/client/man/default.conf.5
@@ -152,7 +152,7 @@ will usually need to escape the dot in the logger names by
 preceding it with a backslash.
 .TP
 .B mode <mode>
-Specifies the mode the server is running in. The currently support values are \fBproduction\fR and \fBdevelopment\fR. When running in production mode some self\-tests are skipped to improve performance.
+Specifies the mode the server is running in. The currently support values are \fBproduction\fR and \fBdeveloper\fR. When running in production mode some self\-tests are skipped to improve performance.
 .TP
 .B mount_ipa <URI>
 Specifies the mount point that the development server will register. The default is /ipa/

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -561,6 +561,8 @@ class Env:
 
         # Merge in context config file and then default config file:
         mode = self.__d.get('mode')  # pylint: disable=no-member
+        # documented public modes: production, developer
+        # internal modes: dummy, unit_test
         if mode != 'dummy':
             self._merge_from_file(self.conf)
             self._merge_from_file(self.conf_default)

--- a/ipatests/azure/scripts/azure-run-base-tests.sh
+++ b/ipatests/azure/scripts/azure-run-base-tests.sh
@@ -27,7 +27,7 @@ if [ "$install_result" -eq 0 ] ; then
     echo "Installation complete. Performance of individual steps:"
     grep 'service duration:' /var/log/ipaserver-install.log | sed -e 's/DEBUG //g'
 
-    sed -ri "s/mode = production/mode = development/" /etc/ipa/default.conf
+    sed -ri "s/mode = production/mode = developer/" /etc/ipa/default.conf
     systemctl restart "$HTTPD_SYSTEMD_NAME"
     firewalld_cmd --add-service={freeipa-ldap,freeipa-ldaps,dns}
 


### PR DESCRIPTION
* use "developer" in Azure
* fix man page: "development" to "developer"
* list known modes in API bootstrap methods

Other values for mode are still supported to avoid breaking existing
installations.

Fixes: https://pagure.io/freeipa/issue/8313
Signed-off-by: Christian Heimes <cheimes@redhat.com>