### PR TITLE
WebUI: Add confirmation dialog for changing default user/host group

### DIFF
--- a/install/ui/src/freeipa/automember.js
+++ b/install/ui/src/freeipa/automember.js
@@ -601,11 +601,22 @@ IPA.automember.default_group_widget = function(spec) {
 
         if (group === that.group) return;
 
-        if (group === '') {
-            that.remove_default_group();
-        } else {
-            that.set_default_group(group);
-        }
+        var dialog = IPA.confirm_dialog({
+            title: that.get_title(),
+            message: text.get('@i18n:objects.automember.default_group_confirm'),
+            on_ok: function() {
+                if (group === '') {
+                    that.remove_default_group();
+                } else {
+                    that.set_default_group(group);
+                }
+            },
+            on_cancel: function() {
+                that.group_select.update([that.group]);
+            }
+        });
+
+        dialog.open();
     };
 
     that.load = function(data) {

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -522,6 +522,9 @@ class i18n_messages(Command):
                     "Add exclusive condition into '${primary_key}'"
                 ),
                 "attribute": _("Attribute"),
+                "default_group_confirm": _(
+                    "Are you sure you want to change default group?"
+                ),
                 "default_host_group": _("Default host group"),
                 "default_user_group": _("Default user group"),
                 "exclusive": _("Exclusive"),

--- a/ipatests/test_webui/test_automember.py
+++ b/ipatests/test_webui/test_automember.py
@@ -597,6 +597,7 @@ class TestAutomember(UI_driver):
         self.add_user_group(pkey)
         self.navigate_by_menu('identity/automember/amgroup')
         self.select_combobox('automemberdefaultgroup', pkey)
+        self.dialog_button_click('ok')
 
         self.add_user(user_pkey, 'Some', 'User')
         self.navigate_to_record(user_pkey)
@@ -606,6 +607,7 @@ class TestAutomember(UI_driver):
         # Clear default user group
         self.navigate_by_menu('identity/automember/amgroup')
         self.select_combobox('automemberdefaultgroup', '')
+        self.dialog_button_click('ok')
 
         self.delete_users(user_pkey)
         self.delete_user_groups(pkey)
@@ -623,6 +625,7 @@ class TestAutomember(UI_driver):
         self.add_host_group(pkey)
         self.navigate_by_menu('identity/automember/amhostgroup')
         self.select_combobox('automemberdefaultgroup', pkey)
+        self.dialog_button_click('ok')
 
         host_data = host_util.get_data('some-host', domain)
         self.add_record('host', host_data)
@@ -633,6 +636,7 @@ class TestAutomember(UI_driver):
         # Clear default host group
         self.navigate_by_menu('identity/automember/amhostgroup')
         self.select_combobox('automemberdefaultgroup', '')
+        self.dialog_button_click('ok')
 
         self.delete('host', [{'pkey': host_data['pkey']}])
         self.delete_host_groups(pkey)


### PR DESCRIPTION
Changing default group on automember rules page is too easy.
Add a confirmation dialog to avoid misclick in the case.

Ticket: https://pagure.io/freeipa/issue/8322