### PR TITLE
service delegation: allow to add and remove host principals

### DIFF
--- a/ipatests/test_xmlrpc/test_servicedelegation_plugin.py
+++ b/ipatests/test_xmlrpc/test_servicedelegation_plugin.py
@@ -17,6 +17,8 @@ target1 = u'test1-targets'
 target2 = u'test2-targets'
 princ1 = u'HTTP/%s@%s' % (api.env.host, api.env.realm)
 princ2 = u'ldap/%s@%s' % (api.env.host, api.env.realm)
+princ3 = u'host/%s@%s' % (api.env.host, api.env.realm)
+host3 = api.env.host
 
 
 def get_servicedelegation_dn(cn):
@@ -435,8 +437,52 @@ class test_servicedelegation(Declarative):
                     failed_memberprincipal=dict(
                         memberprincipal=[
                             [u'HTTP/notfound@%s' % api.env.realm,
-                             u'no such entry']
+                             u'no matching entry found']
                             ],
+                    ),
+                ),
+                result={
+                    'dn': get_servicedelegation_dn(rule1),
+                    'memberprincipal': (princ1,),
+                    'cn': [rule1],
+                },
+            ),
+        ),
+
+
+        dict(
+            desc='Add host as a member %r to %r' % (host3, rule1),
+            command=(
+                'servicedelegationrule_add_member', [rule1],
+                dict(principal=princ3)
+            ),
+            expected=dict(
+                completed=1,
+                failed=dict(
+                    failed_memberprincipal=dict(
+                        memberprincipal=tuple(),
+                    ),
+                ),
+                result={
+                    'dn': get_servicedelegation_dn(rule1),
+                    'memberprincipal': (princ1, princ3),
+                    'cn': [rule1],
+                },
+            ),
+        ),
+
+
+        dict(
+            desc='Remove a host member %r from %r' % (host3, rule1),
+            command=(
+                'servicedelegationrule_remove_member', [rule1],
+                dict(principal=host3)
+            ),
+            expected=dict(
+                completed=1,
+                failed=dict(
+                    failed_memberprincipal=dict(
+                        memberprincipal=tuple(),
                     ),
                 ),
                 result={
@@ -556,7 +602,7 @@ class test_servicedelegation(Declarative):
                     failed_memberprincipal=dict(
                         memberprincipal=[
                             [u'HTTP/notfound@%s' % api.env.realm,
-                             u'no such entry']
+                             u'no matching entry found']
                         ],
                     ),
                 ),


### PR DESCRIPTION
Service delegation rules and targets deal with Kerberos principals.
As FreeIPA has separate service objects for hosts and Kerberos services,
it is not possible to specify host principal in the service delegation
rule or a target because the code assumes it always operates on Kerberos
service objects.

Simplify the code to add and remove members from delegation rules and
targets. New code looks up a name of the principal in cn=accounts,$BASEDN
as a krbPrincipalName attribute of an object with krbPrincipalAux object
class. This search path is optimized already for Kerberos KDC driver.

To support host principals, the specified principal name is checked to
have only one component (a host name). Service principals have more than
one component, typically service name and a host name, separated by '/'
sign. If the principal name has only one component, the name is
prepended with 'host/' to be able to find a host principal.

The logic described above allows to capture also aliases of both
Kerberos service and host principals. Additional check was added to
allow specifying single-component aliases ending with '$' sign. These
are typically used for Active Directory-related services like databases
or file services.

RN: service delegation rules and targets now allow to specify hosts as
RN: a rule or a target's member principal.

Fixes: https://pagure.io/freeipa/issue/8289
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>