### PR TITLE
make: serialize strip-po / strip-pot

### DIFF
--- a/po/Makefile.hack.in
+++ b/po/Makefile.hack.in
@@ -9,10 +9,20 @@ MSGATTRIB = @MSGATTRIB@
 PYTHON = @PYTHON@
 GIT_BRANCH = @GIT_BRANCH@
 
-.PHONY: strip-po
-strip-po:
-	grep -v '#: ipaclient/remote_plugins/' $(DOMAIN).pot > $(DOMAIN).pot.tmp || exit 1; \
-	mv $(DOMAIN).pot.tmp $(DOMAIN).pot || exit 1; \
+# Don't use strip-po[t] as a dependency, https://pagure.io/freeipa/issue/8323
+.PHONY: strip-po strip-pot
+strip-pot: $(DOMAIN).pot
+	grep -v '#: ipaclient/remote_plugins/' $(DOMAIN).pot > $(DOMAIN).pot.tmp
+	mv $(DOMAIN).pot.tmp $(DOMAIN).pot
+	if [ "$(GIT_BRANCH)" != "" ]; then \
+		export GIT_DIFF_IPA_POT=`git diff --numstat $(DOMAIN).pot | cut -f1,2 | tr '\t' ,` || :; \
+		if [ "$$GIT_DIFF_IPA_POT" = "2,2" -o "$$GIT_DIFF_IPA_POT" = "1,1" ]; then \
+			echo "No changes in $(DOMAIN).pot, restore the original"; \
+			git checkout -q -f $(DOMAIN).pot; \
+		fi; \
+	fi
+
+strip-po: stamp-po
 	for po_file in $(POFILES); do \
 		$(MSGATTRIB) --translated --no-fuzzy --no-location -s $$po_file > $$po_file.tmp || exit 1; \
 		mv $$po_file.tmp $$po_file || exit 1; \
@@ -24,34 +34,33 @@ strip-po:
 			fi; \
 		fi; \
 	done
-	if [ "$(GIT_BRANCH)" != "" ]; then \
-		export GIT_DIFF_IPA_POT=`git diff --numstat $(DOMAIN).pot | cut -f1,2 | tr '\t' ,` || :; \
-		if [ "$$GIT_DIFF_IPA_POT" = "2,2" -o "$$GIT_DIFF_IPA_POT" = "1,1" ]; then \
-			echo "No changes in $(DOMAIN).pot, restore the original"; \
-			git checkout -q -f $(DOMAIN).pot; \
-		fi; \
-	fi
 	export FILES_TO_REMOVE=`find $(srcdir) -name '*.po' -empty` || exit 1; \
 	if [ "$$FILES_TO_REMOVE" != "" ]; then \
 		rm -v $$FILES_TO_REMOVE || exit 1; \
 		echo; echo Please remove the deleted files from LINGUAS!; echo; \
 	fi
 
-clean: strip-po mostlyclean
-	rm -f *~
+clean: mostlyclean
+	rm -rf test_locale
+	rm -f *~ *.tmp test.po
 
-all: $(DOMAIN).pot strip-po
+all: $(DOMAIN).pot
+	$(MAKE) strip-pot strip-po
 
 # linters
-test-gettext: $(DOMAIN).pot strip-po
+test-gettext: $(DOMAIN).pot
+	$(MAKE) strip-pot
 	$(PYTHON) $(IPA_TEST_I18N) --test-gettext
 
-validate-pot: $(DOMAIN).pot strip-po
-	$(PYTHON) $(IPA_TEST_I18N) --show-strings --validate-pot $(DOMAIN).pot
+validate-pot: $(DOMAIN).pot
+	$(MAKE) strip-pot
+	$(PYTHON) $(IPA_TEST_I18N) --show-strings --validate-pot $<
 
-validate-po: $(DOMAIN).pot strip-po
+validate-po: stamp-po
+	$(MAKE) strip-po
 	$(PYTHON) $(IPA_TEST_I18N) --show-strings --validate-po $(POFILES)
 
 # forcefully re-generate .pot file and test it
-validate-src-strings: $(DOMAIN).pot-update strip-po
+validate-src-strings: $(DOMAIN).pot-update
+	$(MAKE) strip-pot
 	$(MAKE) validate-pot


### PR DESCRIPTION
The strip-po target modifies files in place. This sometimes creates
conflicts with other make targets when make is run in parallel mode.

* split strip-po into strip-po and strip-pot
* move strip-po[t] from dependency to explicit, serial execution
* declare dependencies on POT/POFILES
* don't run strip on clean

Fixes: https://pagure.io/freeipa/issue/8323
Signed-off-by: Christian Heimes <cheimes@redhat.com>