### PR TITLE
Temp commit to test server_del

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -62,14 +62,122 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-27/temp_commit:
+  fedora-27/test_server_del_1:
     requires: [fedora-27/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-27/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_server_del.py
         template: *ci-master-f27
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-27/test_server_del_2:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_server_del.py
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-27/test_server_del_3:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_server_del.py
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-27/test_server_del_4:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_server_del.py
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-27/test_server_del_5:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_server_del.py
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-27/test_server_del_6:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_server_del.py
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-27/test_server_del_7:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_server_del.py
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-27/test_server_del_8:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_server_del.py
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-27/test_server_del_9:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_server_del.py
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-27/test_server_del_10:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_server_del.py
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_2repl_1client


### PR DESCRIPTION
Run 10x the times to ensure that the test is always failing at
the same location.
The assumption is that the test failure is linked to
https://pagure.io/389-ds-base/issue/49972

If that's the case I will add a xfail for fedora.