### PR TITLE
ipatests: add test_server_del to the nightly def

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -223,6 +223,18 @@ jobs:
         timeout: 6300
         topology: *master_1repl
 
+  fedora-27/test_server_del:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_server_del.py
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_2repl_1client
+
   fedora-27/test_installation_TestInstallWithCA1:
     requires: [fedora-27/build]
     priority: 50

--- a/ipatests/test_integration/test_server_del.py
+++ b/ipatests/test_integration/test_server_del.py
@@ -2,7 +2,11 @@
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
 
+from __future__ import absolute_import
+
 from itertools import permutations
+import ipaplatform
+import pytest
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
@@ -168,6 +172,9 @@ class TestServerDel(ServerDelBase):
             affected_suffixes=(CA_SUFFIX_NAME,)
         )
 
+    @pytest.mark.xfail(
+        ipaplatform.NAME == 'fedora',
+        reason='https://pagure.io/389-ds-base/issue/49972')
     def test_ignore_topology_disconnect_replica1(self):
         """
         tests that removal of replica1 with '--ignore-topology-disconnect'
@@ -199,6 +206,9 @@ class TestServerDel(ServerDelBase):
                                domain_level=self.domain_level)
         tasks.install_replica(self.master, self.replica2, setup_ca=True)
 
+    @pytest.mark.xfail(
+        ipaplatform.NAME == 'fedora',
+        reason='https://pagure.io/389-ds-base/issue/49972')
     def test_removal_of_master_disconnects_both_topologies(self):
         """
         tests that master removal will now raise errors in both suffixes.


### PR DESCRIPTION
Add the test to the nightly test suite with xfail annotation.

Because of https://pagure.io/389-ds-base/issue/49972, the test
may fail while re-installing the replica1. The issue exists only
on fedora 27 with 389-ds 1.3.9.0-1.fc27 and not in RHEL 7.x as the fix
is delivered in 389-ds 1.3.9.1.

When test_ignore_topology_disconnect_replica1 fails, the 2nd next test
test_removal_of_master_disconnects_both_topologies is also likely to fail.
Note that the failure is intermittent, hence the xfail annotation does
not use strict=True.