### PR TITLE
[Backport][ipa-4-8] Check for freeipa-server-dns package early

### DIFF
--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -111,14 +111,20 @@ def _disable_dnssec():
             conn.update_entry(entry)
 
 
+def package_check(exception):
+    if not os.path.isfile(paths.IPA_DNS_INSTALL):
+        raise exception(
+            "Integrated DNS requires '%s' package"
+            % constants.IPA_DNS_PACKAGE_NAME
+        )
+
+
 def install_check(standalone, api, replica, options, hostname):
     global ip_addresses
     global reverse_zones
     fstore = sysrestore.FileStore(paths.SYSRESTORE)
 
-    if not os.path.isfile(paths.IPA_DNS_INSTALL):
-        raise RuntimeError("Integrated DNS requires '%s' package" %
-                           constants.IPA_DNS_PACKAGE_NAME)
+    package_check(RuntimeError)
 
     # when installing first DNS instance we need to check zone overlap
     if replica or standalone:

--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -280,6 +280,11 @@ class ServerInstallInterface(ServerCertificateInstallInterface,
     )
     setup_dns = enroll_only(setup_dns)
 
+    @setup_dns.validator
+    def setup_dns(self, value):
+        if value:
+            dns.package_check(ValueError)
+
     idstart = knob(
         int, random.randint(1, 10000) * 200000,
         description="The starting value for the IDs range (default random)",

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -463,6 +463,7 @@ def install_check(installer):
     if not options.setup_dns and installer.interactive:
         if ipautil.user_input("Do you want to configure integrated DNS "
                               "(BIND)?", False):
+            dns.package_check(ScriptError)
             options.setup_dns = True
         print("")
 


### PR DESCRIPTION
This PR was opened automatically because PR #4696 was pushed to master and backport to ipa-4-8 is required.