### PR TITLE
[WIP] ipatests: Increase timeout for test_caless_TestReplicaInstall

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -568,7 +568,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   fedora-latest/test_caless_TestClientInstall:

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -114,7 +114,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *389ds-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   389ds-fedora/test_caless_TestClientInstall:

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -348,7 +348,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *pki-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   pki-fedora/test_caless_TestClientInstall:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -611,7 +611,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *testing-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   testing-fedora/test_caless_TestClientInstall:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -568,7 +568,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *ci-master-previous
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   fedora-previous/test_caless_TestClientInstall:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -611,7 +611,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *ci-master-frawhide
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   fedora-rawhide/test_caless_TestClientInstall:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,15 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_caless_TestReplicaInstall:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *master_1repl
+


### PR DESCRIPTION
The nightly test test_integration/test_caless.py::TestReplicaInstall
is often failing on timeout. Increase to 7200.
