### PR TITLE
baseldap: de-duplicate passed attributes when checking for limits

### DIFF
--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -858,7 +858,7 @@ def _check_limit_object_class(attributes, attrs, allow_only):
     # LDAP schema does not enforce any of LDAP attribute options
     # (e.g. attribute;option), thus we should avoid comparing
     # attribute names with options directly.
-    limitattrs = [x.split(';')[0] for x in attrs]
+    limitattrs = {x.split(';')[0].lower() for x in attrs}
     # Go through the MUST first
     for attr in attributes[0].values():
         if attr.names[0].lower() in limitattrs:
@@ -877,8 +877,8 @@ def _check_limit_object_class(attributes, attrs, allow_only):
             limitattrs.remove(attr.names[0].lower())
     if len(limitattrs) > 0 and allow_only:
         raise errors.ObjectclassViolation(
-            info=_('attribute "%(attribute)s" not allowed') % dict(
-                attribute=limitattrs[0]))
+            info=_('these attributes are not allowed: %(attrs)s') % dict(
+                attrs=", ".join(sorted(limitattrs))))
 
 
 class BaseLDAPCommand(Method):

--- a/ipatests/test_xmlrpc/test_krbtpolicy.py
+++ b/ipatests/test_xmlrpc/test_krbtpolicy.py
@@ -290,7 +290,8 @@ class test_krbtpolicy(Declarative):
             command=(
                 'krbtpolicy_mod', [user1], dict(setattr=u'givenname=Pete')
             ),
-            expected=errors.ObjectclassViolation(info='attribute "givenname" not allowed'),
+            expected=errors.ObjectclassViolation(
+                info='these attributes are not allowed: givenname'),
         ),
     ]
     for (value, error) in invalid_values:


### PR DESCRIPTION
LDAP attribute options aren't enforced in the schema, thus we strip them
when checking attribute conformance with the schema. This, however, can
leave us with a situation when multiple base LDAP attribute names are
present in the list of attribute names to check.

Use set of attribute names to deduplicate the list.

Fixes: https://pagure.io/freeipa/issue/8328

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>