### PR TITLE
[Backport][ipa-4-6] Test for removing a subgroup

### DIFF
--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 from contextlib import contextmanager
 import re
 import time
+import os
 
 import ipaplatform
 import pytest
@@ -17,6 +18,7 @@ import textwrap
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
+from ipatests.pytest_ipa.integration.tasks import clear_sssd_cache
 from ipatests.util import xfail_context
 from ipaplatform.tasks import tasks as platform_tasks
 from ipaplatform.paths import paths
@@ -348,3 +350,178 @@ class TestSSSDWithAdTrust(IntegrationTest):
         finally:
             sssd_conf_backup.restore()
             tasks.clear_sssd_cache(self.master)
+
+
+class TestNestedMembers(IntegrationTest):
+    num_clients = 1
+    username = "testuser001"
+    userpasswd = 'Secret123'
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master)
+        tasks.install_client(cls.master, cls.clients[0])
+
+    @pytest.fixture
+    def nested_group_setup(self, tmpdir):
+        """Setup and Clean up groups and user created"""
+        master = self.master
+        client = self.clients[0]
+
+        # add a user and set password
+        tasks.create_active_user(master, self.username, self.userpasswd)
+        tasks.kinit_admin(master)
+
+        privkey, pubkey = tasks.generate_ssh_keypair()
+        with open(os.path.join(
+                tmpdir, 'ssh_priv_key'), 'w') as fp:
+            fp.write(privkey)
+
+        master.run_command([
+            'ipa', 'user-mod', self.username, '--ssh', "{}".format(pubkey)
+        ])
+
+        master.put_file_contents('/tmp/user_ssh_priv_key', privkey)
+        master.run_command(['chmod', '600', '/tmp/user_ssh_priv_key'])
+
+        # add group groupa
+        cmd_output = master.run_command(['ipa', 'group-add', 'groupa'])
+        assert 'Added group "groupa"' in cmd_output.stdout_text
+
+        # add group groupb
+        cmd_output = master.run_command(['ipa', 'group-add', 'groupb'])
+        assert 'Added group "groupb"' in cmd_output.stdout_text
+
+        # add group groupc
+        cmd_output = master.run_command(['ipa', 'group-add', 'groupc'])
+        assert 'Added group "groupc"' in cmd_output.stdout_text
+
+        client.put_file_contents('/tmp/user_ssh_priv_key',
+                                 privkey)
+        client.run_command(['chmod', '600', '/tmp/user_ssh_priv_key'])
+        yield
+        # test cleanup
+        for group in ['groupa', 'groupb', 'groupc']:
+            self.master.run_command(['ipa', 'group-del', group, '--continue'])
+        self.master.run_command(['ipa', 'user-del', self.username,
+                                 '--no-preserve', '--continue'])
+        tasks.kdestroy_all(self.master)
+        tasks.kdestroy_all(self.clients[0])
+
+    def test_nested_group_members(self, tmpdir, nested_group_setup):
+        """Nested group memberships should be honoured
+
+        "groupc" should be a child of "groupb"
+        so that parent child relationship is as follows:
+        "groupa"->"groupb"->"groupc"
+
+        testuser001 is direct member of "groupa" and as a result
+        member of "groupb" and "groupc"".
+        Now if one adds a direct membership to "groupb"
+        nothing will change.
+
+        Now if one removes the direct membership to "groupb"
+        nothing should change, the memberships should be honored
+        Linked Issue: https://pagure.io/SSSD/sssd/issue/3636
+        """
+        master = self.master
+        client = self.clients[0]
+
+        # add group members
+        cmd_output = master.run_command(['ipa', 'group-add-member',
+                                         'groupb', '--groups', 'groupa'])
+        assert 'Group name: groupb' in cmd_output.stdout_text
+        assert 'Member groups: groupa' in cmd_output.stdout_text
+        assert 'Number of members added 1' in cmd_output.stdout_text
+
+        cmd_output = master.run_command(['ipa', 'group-add-member',
+                                         'groupc', '--groups', 'groupb'])
+        assert 'Group name: groupc' in cmd_output.stdout_text
+        assert 'Member groups: groupb' in cmd_output.stdout_text
+        assert 'Indirect Member groups: groupa' in cmd_output.stdout_text
+
+        # add user to group 'groupa'
+        cmd_output = master.run_command(['ipa', 'group-add-member',
+                                         'groupa', '--users', self.username])
+        assert 'Group name: groupa' in cmd_output.stdout_text
+        assert_str = 'Member users: {}'.format(self.username)
+        assert assert_str in cmd_output.stdout_text
+        assert 'Member of groups: groupb' in cmd_output.stdout_text
+        assert 'Indirect Member of group: groupc' in cmd_output.stdout_text
+
+        # clear sssd_cache
+        clear_sssd_cache(master)
+
+        # user lookup
+        # at this point, testuser001 has the following group memberships
+        # Member of groups: groupa, ipausers
+        # Indirect Member of group: groupb, groupc
+        cmd_output = master.run_command(['ipa', 'user-show', self.username])
+        assert 'groupa' in cmd_output.stdout_text
+        assert 'ipausers' in cmd_output.stdout_text
+        assert 'groupb' in cmd_output.stdout_text
+        assert 'groupc' in cmd_output.stdout_text
+
+        clear_sssd_cache(client)
+
+        cmd = ['ssh', '-i', '/tmp/user_ssh_priv_key',
+               '-q', '{}@{}'.format(self.username, client.hostname),
+               'groups']
+        cmd_output = master.run_command(cmd)
+        assert self.username in cmd_output.stdout_text
+        assert 'groupa' in cmd_output.stdout_text
+        assert 'groupb' in cmd_output.stdout_text
+        assert 'groupc' in cmd_output.stdout_text
+
+        # add member
+        cmd_output = master.run_command(['ipa', 'group-add-member',
+                                         'groupb', '--users', self.username])
+        assert 'Group name: groupb' in cmd_output.stdout_text
+        assert_str = 'Member users: {}'.format(self.username)
+        assert assert_str in cmd_output.stdout_text
+        assert 'Member groups: groupa' in cmd_output.stdout_text
+        assert 'Member of groups: groupc' in cmd_output.stdout_text
+        assert 'Number of members added 1' in cmd_output.stdout_text
+
+        # now check ssh on the client
+        clear_sssd_cache(client)
+
+        # after adding testuser001 to b group
+        # testuser001 will have the following memberships
+        # Member of groups: groupa, ipausers, groupb
+        # Indirect Member of group: groupc
+        cmd = ['ssh', '-i', '/tmp/user_ssh_priv_key',
+               '-q', '{}@{}'.format(self.username, client.hostname),
+               'groups']
+        cmd_output = client.run_command(cmd)
+        assert self.username in cmd_output.stdout_text
+        assert 'groupa' in cmd_output.stdout_text
+        assert 'groupb' in cmd_output.stdout_text
+        assert 'groupc' in cmd_output.stdout_text
+
+        # now back to server to remove member
+        cmd_output = master.run_command(['ipa', 'group-remove-member',
+                                         'groupb', '--users', self.username])
+        assert_str = 'Indirect Member users: {}'.format(self.username)
+        assert 'Group name: groupb' in cmd_output.stdout_text
+        assert 'Member groups: groupa' in cmd_output.stdout_text
+        assert 'Member of groups: groupc' in cmd_output.stdout_text
+        assert assert_str in cmd_output.stdout_text
+        assert 'Number of members removed 1' in cmd_output.stdout_text
+
+        clear_sssd_cache(master)
+
+        # now check ssh on the client again
+        # after removing testuser001 from b group
+        # testuser001 will have the following memberships
+        # Member of groups: groupa, ipausers
+        # Indirect Member of group: groupb, groupc
+        clear_sssd_cache(client)
+        cmd = ['ssh', '-i', '/tmp/user_ssh_priv_key',
+               '-q', '{}@{}'.format(self.username, client.hostname),
+               'groups']
+        cmd_output = client.run_command(cmd)
+        assert self.username in cmd_output.stdout_text
+        assert 'groupa' in cmd_output.stdout_text
+        assert 'groupb' in cmd_output.stdout_text
+        assert 'groupc' in cmd_output.stdout_text

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -352,6 +352,7 @@ class TestSSSDWithAdTrust(IntegrationTest):
             tasks.clear_sssd_cache(self.master)
 
 
+@pytest.mark.skip(reason="SSSD fix is not available on Fedora 27")
 class TestNestedMembers(IntegrationTest):
     num_clients = 1
     username = "testuser001"


### PR DESCRIPTION
Problem description:
Removing an IPA sub-group should NOT remove the members
from indirect parent that also belong to other subgroups

The test:
A user and three groups are created a,b,c
'c' should be a child of 'b' so that you have a->b->c

user is direct member of 'a' and as a result member of 'b'
and 'c'. Now when one adds a direct membership to 'b' nothing will
change.

If one removes the direct membership to 'b' again,
nothing should change as well

Pagure Link: https://pagure.io/SSSD/sssd/issue/3636

Manual backport of #4544

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>