### PR TITLE
Allow leading and trailing space in user passwords

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -1541,7 +1541,7 @@ class Str(Data):
 
     kwargs = Data.kwargs + (
         ('pattern', (str,), None),
-        ('noextrawhitespace', bool, True),
+        ('noextrawhitespace', bool, False),
     )
 
     type = unicode

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_commands.py::TestIPACommand::test_leading_trailing_space_user_password
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1170,3 +1170,22 @@ class TestIPACommand(IntegrationTest):
             assert msg2 not in result.stderr_text
         finally:
             bashrc_backup.restore()
+
+    def test_leading_trailing_space_user_password(self):
+        """Test to check leading and trailing spaces in password
+
+        This test is to check if leading and trailing spaces are allowed
+        in the user password.
+
+        related: https://pagure.io/freeipa/issue/7599
+        """
+        user = 'testuser'
+        leadspace_passwd = ' Secret123'
+        trailspace_passwd = 'Secret123 '
+
+        # add user with leading space in password
+        tasks.user_add(self.master, user, password=leadspace_passwd)
+
+        # modify user with password having trailing space
+        self.master.run_command(['ipa', 'user-mod', user, '--password'],
+                                stdin_text=trailspace_passwd)


### PR DESCRIPTION
IPA doesn't allow leading and trainling spaces in user passwords.
This fix allows to have it.

Fixes: https://pagure.io/freeipa/issue/7599

Signed-off-by: Mohammad Rizwan Yusuf <myusuf@redhat.com>