### PR TITLE
Azure: Make dnf repos consistent

### DIFF
--- a/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
+++ b/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
@@ -4,12 +4,23 @@ ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 
 ADD dist /root
 RUN echo 'deltarpm = false' >> /etc/dnf/dnf.conf \
+    && dnf install -y dnf-plugins-core \
+    && dnf config-manager --set-enabled updates-testing \
+    && dnf config-manager --set-enabled updates-testing-modular \
+    && dnf config-manager --set-disabled fedora-cisco-openh264 \
     && dnf update -y dnf \
-    && dnf install -y dnf-plugins-core sudo wget systemd firewalld nss-tools iptables \
     && sed -i 's/%_install_langs \(.*\)/\0:fr/g' /etc/rpm/macros.image-language-conf \
-    && dnf install -y glibc-langpack-fr glibc-langpack-en \
-    && dnf install -y /root/rpms/*.rpm \
-    && dnf install -y openssh-server \
+    && dnf install -y systemd \
+    && dnf install -y \
+        firewalld \
+        glibc-langpack-fr \
+        glibc-langpack-en \
+        iptables \
+        nss-tools \
+        openssh-server \
+        sudo \
+        wget \
+        /root/rpms/*.rpm \
     && dnf clean all && rm -rf /root/rpms /root/srpms \
     && sed -i 's/.*PermitRootLogin .*/#&/g' /etc/ssh/sshd_config \
     && echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config \


### PR DESCRIPTION
Build container(image registry.fedoraproject.org/f32/fedora-toolbox)
has two more dnf repos enabled compared to Tests container(image
fedora:32). This results in the packages built within the Build
container can have dependencies which are unresolvable(missing)
within Tests container.

This enables updates-testing and updates-testing-modular,
disables fedora-cisco-openh264 for Tests container.

Fixes: https://pagure.io/freeipa/issue/8330