### PR TITLE
Remove remains of unused config options

### DIFF
--- a/client/man/default.conf.5
+++ b/client/man/default.conf.5
@@ -68,9 +68,6 @@ Specifies the base DN to use when performing LDAP operations. The base must be i
 .B ca_agent_port <port>
 Specifies the secure CA agent port. The default is 8443.
 .TP
-.B ca_ee_port <port>
-Specifies the secure CA end user port. The default is 8443.
-.TP
 .B ca_host <hostname>
 Specifies the hostname of the dogtag CA server. The default is the hostname of the IPA server.
 .TP

--- a/install/ui/test/data/ipa_init.json
+++ b/install/ui/test/data/ipa_init.json
@@ -153,7 +153,6 @@
                "container_applications" : "cn=applications,cn=configs,cn=policies",
                "container_automember" : "cn=automember,cn=etc",
                "container_sudocmd" : "cn=sudocmds,cn=sudo",
-               "ca_ee_port" : 443,
                "ca_agent_port" : 443,
                "version" : "4.5.90.dev201706131442+gitd665224",
                "basedn" : "dc=dom,dc=example,dc=com",
@@ -180,7 +179,6 @@
                "tls_version_min" : "tls1.0",
                "config_loaded" : true,
                "logdir" : "/var/log/ipa",
-               "ca_ee_install_port" : null,
                "jsonrpc_uri" : "https://vm.example.com/ipa/json",
                "delegate" : false,
                "container_hbacservicegroup" : "cn=hbacservicegroups,cn=hbac",
@@ -199,7 +197,6 @@
                "container_configs" : "cn=configs,cn=policies",
                "conf_default" : "/etc/ipa/default.conf",
                "rpc_protocol" : "jsonrpc",
-               "ca_agent_install_port" : null,
                "home" : "/"
             },
             "total" : 115,

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -198,12 +198,9 @@ DEFAULT_CONFIG = (
     ('ca_host', FQDN),  # Set in Env._finalize_core()
     ('ca_port', 80),
     ('ca_agent_port', 443),
-    ('ca_ee_port', 443),
     # For the following ports, None means a default specific to the installed
     # Dogtag version.
     ('ca_install_port', None),
-    ('ca_agent_install_port', None),
-    ('ca_ee_install_port', None),
 
     # Topology plugin
     ('recommended_max_agmts', 4),  # Recommended maximum number of replication

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -434,10 +434,7 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
 
     api.env.api_version = ''
     api.env.bin = ''  # object
-    api.env.ca_agent_install_port = None
     api.env.ca_agent_port = 0
-    api.env.ca_ee_install_port = None
-    api.env.ca_ee_port = 0
     api.env.ca_host = ''
     api.env.ca_install_port = None
     api.env.ca_port = 0


### PR DESCRIPTION
Options removed:
 * ca_ee_port
 * ca_agent_install_port
 * ca_ee_install_port

Closes: https://pagure.io/freeipa/issue/6708