### PR TITLE
[Backport][ipa-4-8][acme] add ipa-ca.$DOMAIN alias to IPA server HTTP certificates

### DIFF
--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -479,7 +479,7 @@ def request_cert(
 def start_tracking(
         certpath, ca='IPA', nickname=None, pin=None, pinfile=None,
         pre_command=None, post_command=None, profile=None, storage="NSSDB",
-        token_name=None):
+        token_name=None, dns=None):
     """
     Tell certmonger to track the given certificate in either a file or an NSS
     database. The certificate access can be protected by a password_file.
@@ -514,6 +514,8 @@ def start_tracking(
         Which certificate profile should be used.
     :param token_name:
         Hardware token name for HSM support
+    :param dns:
+        List of DNS names
     :returns: certificate tracking nickname.
     """
     if storage == 'FILE':
@@ -558,6 +560,8 @@ def start_tracking(
         # only pass token names for external tokens (e.g. HSM)
         params['key-token'] = token_name
         params['cert-token'] = token_name
+    if dns is not None and len(dns) > 0:
+        params['DNS'] = dns
 
     result = cm.obj_if.add_request(params)
     try:

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -47,6 +47,29 @@ DBUS_CM_CA_IF = 'org.fedorahosted.certmonger.ca'
 DBUS_PROPERTY_IF = 'org.freedesktop.DBus.Properties'
 
 
+"""
+Certmonger helper routines.
+
+Search criteria
+---------------
+
+Functions that look up requests take a ``dict`` of search criteria.
+In general, the key is a name of a property in the request property
+interface.  But there are some special cases with different
+behaviour:
+
+``nickname``
+  a.k.a. "request ID".  If given, only the specified request is
+  retrieved (if it exists), and it is still tested against other
+  criteria.
+
+``ca-name``
+  Test equality against the nickname of the CA (a.k.a. request
+  helper) object for the request.
+
+"""
+
+
 class _cm_dbus_object:
     """
     Auxiliary class for convenient DBus object handling.
@@ -159,6 +182,9 @@ class _certmonger(_cm_dbus_object):
 def _get_requests(criteria):
     """
     Get all requests that matches the provided criteria.
+
+    :param criteria: dict of criteria; see module doc for details
+
     """
     if not isinstance(criteria, dict):
         raise TypeError('"criteria" must be dict.')
@@ -197,11 +223,11 @@ def _get_requests(criteria):
 
 def _get_request(criteria):
     """
-    Find request that matches criteria.
-    If 'nickname' is specified other criteria are ignored because 'nickname'
-    uniquely identify single request.
-    When multiple or none request matches specified criteria RuntimeError is
-    raised.
+    Find request that matches criteria.  Return ``None`` if no match.
+    Raise ``RuntimeError`` if there is more than one matching request.
+
+    :param criteria: dict of criteria; see module doc for details
+
     """
     requests = _get_requests(criteria)
     if len(requests) == 0:
@@ -239,11 +265,11 @@ def get_request_id(criteria):
     If you don't know the certmonger request_id then try to find it by looking
     through all the requests.
 
-    criteria is a tuple of key/value to search for. The more specific
-    the better. An error is raised if multiple request_ids are returned for
-    the same criteria.
+    Return ``None`` if no match.  Raise ``RuntimeError`` if there is
+    more than one matching request.
 
-    None is returned if none of the criteria match.
+    :param criteria: dict of criteria; see module doc for details
+
     """
     try:
         request = _get_request(criteria)

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -156,7 +156,7 @@ class _certmonger(_cm_dbus_object):
                                           DBUS_CM_IF)
 
 
-def _get_requests(criteria=dict()):
+def _get_requests(criteria):
     """
     Get all requests that matches the provided criteria.
     """

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -44,7 +44,7 @@ from ipapython.dn import DN
 import ipapython.errors
 from ipaserver.install import sysupgrade
 from ipalib import api, x509
-from ipalib.constants import IPAAPI_USER, MOD_SSL_VERIFY_DEPTH
+from ipalib.constants import IPAAPI_USER, MOD_SSL_VERIFY_DEPTH, IPA_CA_RECORD
 from ipaplatform.constants import constants
 from ipaplatform.tasks import tasks
 from ipaplatform.paths import paths
@@ -593,6 +593,7 @@ class HTTPInstance(service.Service):
                 post_command='restart_httpd', storage='FILE',
                 profile=dogtag.DEFAULT_PROFILE,
                 pinfile=key_passwd_file,
+                dns=[self.fqdn, f'{IPA_CA_RECORD}.{api.env.domain}'],
             )
             subject = str(DN(cert.subject))
             certmonger.add_principal(request_id, self.principal)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -381,7 +381,7 @@ class HTTPInstance(service.Service):
                     subject=str(DN(('CN', self.fqdn), self.subject_base)),
                     ca='IPA',
                     profile=dogtag.DEFAULT_PROFILE,
-                    dns=[self.fqdn],
+                    dns=[self.fqdn, f'{IPA_CA_RECORD}.{api.env.domain}'],
                     post_command='restart_httpd',
                     storage='FILE',
                     passwd_fname=key_passwd_file,

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 
 import pytest
 from cryptography.hazmat.primitives import hashes
+from cryptography import x509 as crypto_x509
 
 from ipalib import x509
 from ipalib.constants import DOMAIN_LEVEL_0
@@ -736,6 +737,17 @@ class TestInstallMaster(IntegrationTest):
             else:
                 assert key_size == 2048
             assert cert.signature_hash_algorithm.name == hashes.SHA256.name
+
+    def test_http_cert(self):
+        """
+        Test that HTTP certificate contains ipa-ca.$DOMAIN
+        DNS name.
+
+        """
+        data = self.master.get_file_contents(paths.HTTPD_CERT_FILE)
+        cert = x509.load_pem_x509_certificate(data)
+        name = f'ipa-ca.{self.master.domain.name}'
+        assert crypto_x509.DNSName(name) in cert.san_general_names
 
     def test_p11_kit_softhsm2(self):
         # check that p11-kit-proxy does not inject SoftHSM2


### PR DESCRIPTION
This is a backport of https://github.com/freeipa/freeipa/pull/4193 to
ipa-4-8.  There were zero conflicts.

Although we want to run through CI, we can hold off the merge until the rest of
the ACME changes are also ready (these will come in separate PR(s)).

Changes:

```
15ecff76f (Fraser Tweedale, 3 months ago)
   ipatests: check HTTP certificate contains ipa-ca.$DOMAIN dnsname

   Add integration test that confirms that on CA-ful installation, the
   (non-3rd-party) HTTP certificate bears the ipa-ca.$DOMAIN DNS name.

   For detailed discussion on the purpose of this change and the design 
   decisions made, see `git log -1 $THIS_COMMIT~4`.

   Part of: https://pagure.io/freeipa/issue/8186

   Reviewed-By: Rob Crittenden <rcritten@redhat.com>

e5fa62819 (Fraser Tweedale, 4 months ago)
   upgrade: add ipa-ca.$DOMAIN alias to HTTP certificate

   For detailed discussion on the purpose of this change and the design 
   decisions made, see `git log -1 $THIS_COMMIT~3`.

   If the HTTP certificate does not have the ipa-ca.$DOMAIN dNSName, resubmit
   the certificate request to add the name.  This action is performed after
   the tracking request has already been updated.

   Note: due to https://pagure.io/certmonger/issue/143, the resubmitted 
   request, if it does not immediately succeed (fairly likely during 
   ipa-server-upgrade) and if the notAfter date of the current cert is still
   far off (also likely), then Certmonger will wait 7 days before trying again
   (unless restarted).  There is not much we can do about that in the middle
   of ipa-server-upgrade.

   Part of: https://pagure.io/freeipa/issue/8186

   Reviewed-By: Rob Crittenden <rcritten@redhat.com>

e41d078c2 (Fraser Tweedale, 4 months ago)
   httpinstance: add ipa-ca.$DOMAIN alias in initial request

   For detailed discussion on the purpose of this change and the design 
   decisions made, see `git log -1 $THIS_COMMIT~2`.

   For new server/replica installation, issue the HTTP server certificate with
   the 'ipa-ca.$DOMAIN' SAN dNSName.  This is accomplished by adding the name
   to the Certmonger tracking request.

   Part of: https://pagure.io/freeipa/issue/8186

   Reviewed-By: Rob Crittenden <rcritten@redhat.com>

3acbfc88b (Fraser Tweedale, 4 months ago)
   cert-request: allow ipa-ca.$DOMAIN dNSName for IPA servers

   For detailed discussion on the purpose of this change and the design 
   decisions made, see `git log -1 $THIS_COMMIT~1`.

   ACME support requires TLS and we want ACME clients to access the service
   via the ipa-ca.$DOMAIN DNS name.  So we need to add the ipa-ca.$DOMAIN
   dNSName to IPA servers' HTTP certificates.  To facilitiate this, add a
   special case to the cert-request command processing.  The rule is:

   - if the dnsName being validated is "ipa-ca.$DOMAIN"
   - and the subject principal is an "HTTP/..." service
   - and the subject principal's hostname is an IPA server

   Then that name (i.e. "ipa-ca.$DOMAIN") is immediately allowed. Otherwise
   continue with the usual dnsName validation.

   Part of: https://pagure.io/freeipa/issue/8186

   Reviewed-By: Rob Crittenden <rcritten@redhat.com>

6f2adcda0 (Fraser Tweedale, 4 months ago)
   httpinstance: add fqdn and ipa-ca alias to Certmonger request

   BACKGROUND:

   We are implementing ACME support in FreeIPA (umbrella ticket: 
   https://pagure.io/freeipa/issue/4751).  ACME is defined in RFC 8555. HTTPS
   is REQUIRED (https://tools.ietf.org/html/rfc8555#section-6.1). Therefore,
   every FreeIPA server that provides the ACME service capability must be
   reachable by HTTPS.

   RFC 8555 does not say anything about which port to use for ACME. The
   default HTTPS port of 443 is implied.  Therefore, the FreeIPA ACME service
   will be reached via the Apache httpd server, which will be the TLS server
   endpoint.

   As a usability affordance for ACME clients, and as a maintainability 
   consideration i.e. to allow the topology to change without having to 
   reconfigure ACME clients, there should be a a single DNS name used to reach
   the IPA ACME service.

   The question then, is which DNS name to use.

   REQUIREMENTS:

   Each FreeIPA server that is also an ACME server must:

   1. Be reachable via a common DNS name

   2. Have an HTTP service certificate with that DNS name as a SAN
     dNSName value

   DESIGN CONSIDERATION - WHAT DNS NAME TO USE?:

   Some unrelated FreeIPA ACME design decisions provide important context for
   the DNS name decision:

   - The ACME service will be automatically and unconditionally
    deployed (but not necessarily *enabled*) on all CA servers.

   - Enabling or disabling the ACME service will have topology-wide
    effect, i.e. the ACME service is either enabled on all CA
    servers, or disabled on all CA servers.

   In a CA-ful FreeIPA deployment there is already a DNS name that resolves to
   all CA servers: ``ipa-ca.$DOMAIN``, e.g.
   ``ipa-ca.example.com``.  It is expected to point to all CA servers in the
   deployment, and *only* to CA servers.  If internal DNS is deployed, the DNS
   records for ``ipa-ca.$DOMAIN`` are created and updated automatically.  If
   internal DNS is not deployed, administrators are required to maintain these
   DNS records themselves.

   The ``ipa-ca.$DOMAIN`` alias is currently used for OCSP and CRL access. 
   TLS is not required for these applications (and it can actually be
   problematic for OCSP).  Enabling TLS for this name presents some risk of
   confusion for operators.  For example, if they see that TLS is available
   and alter the certificate profiles to include an HTTPS OCSP URL in the
   Authority Information Access (AIA) extension, OCSP-using clients may fail
   to validate such certificates.  But it is possible for administrators to
   make such a change to the profile, whether or not HTTPS is available.

   One big advantage to using the ``ipa-ca.$DOMAIN`` DNS name is that there
   are no new DNS records to manage, either in the FreeIPA implementation or
   for administrators in external DNS systems.

   The alternative approach is to define a new DNS name, e.g.
   ``ipa-acme.$DOMAIN``, that ACME clients would use.  For internal DNS, this
   means the FreeIPA implementation must manage the DNS records.  This is
   straightforward; whenever we add or remove an
   ``ipa-ca.$DOMAIN`` record, also add/remove the ``ipa-acme.$DOMAIN`` record.
    But for CA-ful deployments using external DNS, it is additional work for
   adminstrators and, unless automated, additional room for error.

   An advantage of using a different DNS name is ``ipa-ca.$DOMAIN`` can remain
   inaccessible over HTTPS.  This possibly reduces the risk of administrator
   confusion or creation of invalid AIA configuration in certificate profiles.

   Weighing up the advantages and disadvantages, I decided to use the
   ``ipa-ca.$DOMAIN`` DNS name.

   DESIGN CONSIDERATION - CA SERVERS, OR ALL SERVERS?:

   A separate decision from which name to use is whether to include it on the
   HTTP service certificate for ACME servers (i.e. CA servers) only, or on all
   IPA servers.

   Combined with the assumption that the chosen DNS name points to CA servers
   *only*, there does not seem to be any harm in adding it to the certificates
   on all IPA servers.

   The alternative is to only include the chosen DNS name on the HTTP service
   certificates of CA servers.  This approach entails some additional
   complexity:

   - If a non-CA replica gets promoted to CA replica (i.e. via
    ``ipa-ca-install``), its HTTP certificate must be re-issued with
    the relevant name.

   - ipa-server-upgrade code must consider whether the server is a CA
    replica when validating (and if necessary re-creating) Certmonger
    tracking requests

   - IPA Health Check must be made aware of this factor when checking
    certificates and Certmonger tracking requests.

   Weighing up the options, I decided to add the common DNS name to the HTTP
   service certificate on all IPA servers.  This avoids the implementation
   complexity discussed above.

   CHANGES IN THIS COMMIT

   When (re-)tracking the HTTP certificate, explicitly add the server FQDN and
   ipa-ca.$DOMAIN DNS names to the Certmonger tracking request.

   Related changes follow in subsequent commits.

   Part of: https://pagure.io/freeipa/issue/8186

   Reviewed-By: Rob Crittenden <rcritten@redhat.com>

6c8024786 (Fraser Tweedale, 4 months ago)
   certmonger: support dnsname as request search criterion

   We need to be able to filter Certmonger tracking requests by the DNS names
   defined for the request.  The goal is to add the
   'ipa-ca.$DOMAIN' alias to the HTTP certificate tracking requests, so we
   will use that name as a search criterion.  Implement support for this.

   As a result of this commit it will be easy to add support for subset match
   of other Certmonger request list properties.  Just add the property name to
   the ARRAY_PROPERTIES list (and update the
   'criteria' description in the module docstring!)

   Part of: https://pagure.io/freeipa/issue/8186

   Reviewed-By: Rob Crittenden <rcritten@redhat.com>

2fb1d70d6 (Fraser Tweedale, 4 months ago)
   certmonger: move 'criteria' description to module docstring

   The 'criteria' parameter is used by several subroutines in the 
   ipalib.install.certmonger module.  It has incomplete documentation spread
   across several of these subroutines.  Move the documentation to the module
   docstring and reference it where appropriate.

   Part of: https://pagure.io/freeipa/issue/8186

   Reviewed-By: Rob Crittenden <rcritten@redhat.com>

075102e5c (Fraser Tweedale, 4 months ago)
   certmonger: avoid mutable default argument

   certmonger._get_requests has a mutable default argument.  Although at the
   present time it is never modified, this is an antipattern to be avoided.

   In fact, we don't even need the default argument, because it is always
   called with a dict() argument.  So just remove it.

   Part of: https://pagure.io/freeipa/issue/8186

   Reviewed-By: Rob Crittenden <rcritten@redhat.com>
```