### PR TITLE
[Backport][ipa-4-8] Allow dnsrecord-add --force on clients

### DIFF
--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -3550,7 +3550,6 @@ class dnsrecord_add(LDAPCreate):
     takes_options = LDAPCreate.takes_options + (
         Flag('force',
              label=_('Force'),
-             flags=['no_option', 'no_output'],
              doc=_('force NS record creation even if its hostname is not in DNS'),
         ),
         dnsrecord.structured_flag,


### PR DESCRIPTION
This PR was opened automatically because PR #4718 was pushed to master and backport to ipa-4-8 is required.