### PR TITLE
[Backport][ipa-4-6] WebUI: Fix invalid RPC calls when link widget has no pkey passed

### DIFF
--- a/install/ui/src/freeipa/widget.js
+++ b/install/ui/src/freeipa/widget.js
@@ -5186,10 +5186,17 @@ IPA.link_widget = function(spec) {
 
         if (that.no_check) return;
 
+        var pkeys = that.other_pkeys();
+
+        if (pkeys.length === 0) {
+            that.is_link = false;
+            return;
+        }
+
         rpc.command({
             entity: that.other_entity.name,
             method: 'show',
-            args: that.other_pkeys(),
+            args: pkeys,
             options: {},
             retry: false,
             on_success: function(data) {


### PR DESCRIPTION
This PR was opened automatically because PR #4721 was pushed to master and backport to ipa-4-6 is required.