### PR TITLE
[Backport][ipa-4-8] WebUI: Use data adapter to load facet header data

### DIFF
--- a/install/ui/src/freeipa/facet.js
+++ b/install/ui/src/freeipa/facet.js
@@ -1382,6 +1382,8 @@ exp.facet_header = IPA.facet_header = function(spec) {
 
     var that = exp.simple_facet_header(spec);
 
+    that.adapter = builder.build('adapter', spec.adapter || 'adapter', { context: that });
+
     that.update_breadcrumb = function(pkey) {
 
         if (!that.breadcrumb) return;
@@ -1502,7 +1504,7 @@ exp.facet_header = IPA.facet_header = function(spec) {
      */
     that.load = function(data) {
         if (!data) return;
-        var result = data.result.result;
+        var result = that.adapter.get_record(data);
         if (!that.facet.disable_facet_tabs) {
             var pkey = that.facet.get_pkey();
 


### PR DESCRIPTION
This PR was opened automatically because PR #4722 was pushed to master and backport to ipa-4-8 is required.