### PR TITLE
Run pytest without color in Azure

### DIFF
--- a/ipatests/azure/scripts/azure-run-base-tests.sh
+++ b/ipatests/azure/scripts/azure-run-base-tests.sh
@@ -45,6 +45,7 @@ if [ "$install_result" -eq 0 ] ; then
         --logging-level=debug \
         --logfile-dir="$IPA_TESTS_LOGSDIR" \
         --verbose \
+        --color=no \
         --with-xunit \
         '-k not test_dns_soa' \
         $IPA_TESTS_TO_IGNORE \

--- a/ipatests/azure/scripts/azure-run-integration-tests.sh
+++ b/ipatests/azure/scripts/azure-run-integration-tests.sh
@@ -14,8 +14,9 @@ tests_result=1
     ipa-run-tests \
     --logging-level=debug \
     --logfile-dir="$IPA_TESTS_LOGSDIR" \
-    --with-xunit \
     --verbose \
+    --color=no \
+    --with-xunit \
     $IPA_TESTS_TO_IGNORE \
     $IPA_TESTS_TO_RUN && tests_result=0 ; } || \
     tests_result=$?


### PR DESCRIPTION
The raw log files get littered with ANSI escape sequences when pytest colors the output

Signed-off-by: Christian Heimes <cheimes@redhat.com>