### PR TITLE
ipatests: add test for overriding GID of AD domain group "domain_users"

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_sssd:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_sssd.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -428,7 +428,11 @@ class TestSSSDWithAdTrust(IntegrationTest):
             verify_user_member_of_group(self.master, user, group_name,
                                         override_id)
             tasks.clear_sssd_cache(client)
-            verify_user_member_of_group(client, user, group_name, override_id)
+            sssd_version = tasks.get_sssd_version(client)
+            with xfail_context(sssd_version < tasks.parse_version('2.3.0'),
+                               'https://pagure.io/SSSD/sssd/issue/4124'):
+                verify_user_member_of_group(client, user, group_name,
+                                            override_id)
         finally:
             self.master.run_command(['ipa', 'idoverridegroup-del',
                                      'Default Trust View', group_name])


### PR DESCRIPTION
Related to: https://pagure.io/SSSD/sssd/issue/4124
