### PR TITLE
Remove obsolete BIND named.conf options

### DIFF
--- a/install/share/bind.named.conf.template
+++ b/install/share/bind.named.conf.template
@@ -18,11 +18,8 @@ options {
 	tkey-gssapi-keytab "$NAMED_KEYTAB";
 	pid-file "$NAMED_PID";
 
-	dnssec-enable yes;
+	/* dnssec is enabled by default */
 	dnssec-validation yes;
-
-	/* Path to ISC DLV key */
-	bindkeys-file "$BINDKEYS_FILE";
 
 	managed-keys-directory "$MANAGED_KEYS_DIR";
 

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -85,7 +85,6 @@ class BasePathNamespace:
     NAMED_KEYTAB = "/etc/named.keytab"
     NAMED_RFC1912_ZONES = "/etc/named.rfc1912.zones"
     NAMED_ROOT_KEY = "/etc/named.root.key"
-    NAMED_BINDKEYS_FILE = "/etc/named.iscdlv.key"
     NAMED_MANAGED_KEYS_DIR = "/var/named/dynamic"
     NAMED_CRYPTO_POLICY_FILE = None
     NSLCD_CONF = "/etc/nslcd.conf"

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -38,7 +38,6 @@ class DebianPathNamespace(BasePathNamespace):
     NAMED_KEYTAB = "/etc/bind/named.keytab"
     NAMED_RFC1912_ZONES = "/etc/bind/named.conf.default-zones"
     NAMED_ROOT_KEY = "/etc/bind/bind.keys"
-    NAMED_BINDKEYS_FILE = "/etc/bind/bind.keys"
     NAMED_MANAGED_KEYS_DIR = "/var/cache/bind/dynamic"
     CHRONY_CONF = "/etc/chrony/chrony.conf"
     OPENLDAP_LDAP_CONF = "/etc/ldap/ldap.conf"

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -562,13 +562,12 @@ def check_forwarders(dns_forwarders):
             forwarders_dnssec_valid = False
             logger.warning("DNS server %s does not support DNSSEC: %s",
                            forwarder, e)
-            logger.warning("Please fix forwarder configuration to enable "
-                           "DNSSEC support.\n"
-                           "(For BIND 9 add directive \"dnssec-enable yes;\" "
-                           "to \"options {}\")")
+            logger.warning(
+                "Please fix forwarder configuration to enable DNSSEC "
+                "support.\n"
+            )
             print("DNS server %s: %s" % (forwarder, e))
             print("Please fix forwarder configuration to enable DNSSEC support.")
-            print("(For BIND 9 add directive \"dnssec-enable yes;\" to \"options {}\")")
         except EDNS0UnsupportedError as e:
             forwarders_dnssec_valid = False
             logger.warning("DNS server %s does not support ENDS0 "
@@ -829,7 +828,6 @@ class BindInstance(service.Service):
             FQDN=self.fqdn,
             SERVER_ID=ipaldap.realm_to_serverid(self.realm),
             SUFFIX=self.suffix,
-            BINDKEYS_FILE=paths.NAMED_BINDKEYS_FILE,
             MANAGED_KEYS_DIR=paths.NAMED_MANAGED_KEYS_DIR,
             ROOT_KEY=paths.NAMED_ROOT_KEY,
             NAMED_KEYTAB=self.keytab,

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -761,30 +761,59 @@ def named_update_pid_file():
     sysupgrade.set_upgrade_state('named.conf', 'pid-file_updated', True)
     return True
 
-def named_enable_dnssec():
-    """
-    Enable dnssec in named.conf
+
+def named_dnssec_enable():
+    """Remove obsolete dnssec-enable option from named.conf
     """
     if not bindinstance.named_conf_exists():
         # DNS service may not be configured
         logger.info('DNS is not configured')
         return False
 
-    if not sysupgrade.get_upgrade_state('named.conf', 'dnssec_enabled'):
-        logger.info('[Enabling "dnssec-enable" configuration in DNS]')
-        try:
-            bindinstance.named_conf_set_directive('dnssec-enable', 'yes',
-                                                  bindinstance.NAMED_SECTION_OPTIONS,
-                                                  str_val=False)
-        except IOError as e:
-            logger.error('Cannot update dnssec-enable configuration in %s: %s',
-                         paths.NAMED_CONF, e)
-            return False
-    else:
-        logger.debug('dnssec-enabled in %s', paths.NAMED_CONF)
+    # old upgrade state when "dnssec-enabled yes" was added
+    sysupgrade.remove_upgrade_state("named.conf", "dnssec_enabled")
 
-    sysupgrade.set_upgrade_state('named.conf', 'dnssec_enabled', True)
+    if sysupgrade.get_upgrade_state('named.conf', 'dnssec-enabled_remove'):
+        return False
+
+    # only remove when dnssec-enable is yes or not set.
+    # Official documentation says that "dnssec-enable yes;" is required and
+    # "dnssec-validation no;" should be used to disable validation.
+    # At least Bind 9.11+ has DNSSEC enabled by default.
+    enabled = bindinstance.named_conf_get_directive(
+        "dnssec-enable", bindinstance.NAMED_SECTION_OPTIONS, str_val=False
+    )
+    if enabled is not None and enabled != "yes":
+        logger.warning(
+            "[WARNING] Unable to remove obsolete 'dnssec-enable' option "
+            "from '%s' (dnssec-enabled %s;). Please remove the option "
+            "manually and set 'dnssec-validate no;' if you wish to disable "
+            "DNSSEC validation.",
+            paths.NAMED_CONF, enabled
+        )
+        return False
+
+    logger.info('[Removing obsolete "dnssec-enable" configuration]')
+    try:
+        bindinstance.named_conf_set_directive(
+            "dnssec-enable",
+            None,
+            bindinstance.NAMED_SECTION_OPTIONS,
+            str_val=False
+        )
+    except IOError as e:
+        logger.error(
+            'Cannot update dnssec-enable configuration in %s: %s',
+            paths.NAMED_CONF, e
+        )
+        return False
+    else:
+        logger.debug('Removed dnssec-enabled from %s', paths.NAMED_CONF)
+        sysupgrade.set_upgrade_state(
+            'named.conf', 'dnssec-enabled_remove', True
+        )
     return True
+
 
 def named_validate_dnssec():
     """
@@ -824,15 +853,23 @@ def named_validate_dnssec():
 
 
 def named_bindkey_file_option():
-    """
-    Add options bindkey_file to named.conf
+    """Remove options bindkey_file to named.conf
+
+    DNSSEC Lookaside Validation is deprecated and dlv.isc.org is shutting
+    down.
+
+    See: RFC 8749
+    See: https://pagure.io/freeipa/issue/8350
     """
     if not bindinstance.named_conf_exists():
         # DNS service may not be configured
         logger.info('DNS is not configured')
         return False
 
-    if sysupgrade.get_upgrade_state('named.conf', 'bindkey-file_updated'):
+    # old upgrade state for "bindkey-file"
+    sysupgrade.remove_upgrade_state("named.conf", "bindkey-file_updated")
+
+    if sysupgrade.get_upgrade_state('named.conf', 'bindkey-file_removed'):
         logger.debug('Skip bindkey-file configuration check')
         return False
 
@@ -844,24 +881,27 @@ def named_bindkey_file_option():
                      paths.NAMED_CONF, e)
         return False
     else:
-        if bindkey_file:
-            logger.debug('bindkey-file configuration already updated')
-            sysupgrade.set_upgrade_state('named.conf', 'bindkey-file_updated', True)
+        if not bindkey_file:
+            logger.debug('bindkey-file configuration already removed')
+            sysupgrade.set_upgrade_state(
+                'named.conf', 'bindkey-file_removed', True
+            )
             return False
 
-    logger.info('[Setting "bindkeys-file" option in named.conf]')
+    logger.info('[Remove "bindkeys-file" option from named.conf]')
     try:
         bindinstance.named_conf_set_directive(
-            'bindkeys-file', paths.NAMED_BINDKEYS_FILE,
+            'bindkeys-file', None,
             section=bindinstance.NAMED_SECTION_OPTIONS
         )
     except IOError as e:
         logger.error('Cannot update bindkeys-file configuration in %s: %s',
                      paths.NAMED_CONF, e)
         return False
-
-
-    sysupgrade.set_upgrade_state('named.conf', 'bindkey-file_updated', True)
+    else:
+        sysupgrade.set_upgrade_state(
+            'named.conf', 'bindkey-file_removed', True
+        )
     return True
 
 def named_managed_keys_dir_option():
@@ -2173,7 +2213,7 @@ def upgrade_configuration():
                           named_set_minimum_connections(),
                           named_update_gssapi_configuration(),
                           named_update_pid_file(),
-                          named_enable_dnssec(),
+                          named_dnssec_enable(),
                           named_validate_dnssec(),
                           named_bindkey_file_option(),
                           named_managed_keys_dir_option(),


### PR DESCRIPTION
``dnssec-enable`` is obsolete in 9.16 and raises a warning. The option
defaults to ``yes`` in all supported versions of bind.

DNSSEC lookaside validation has been deprecated by RFC 8749 and the
feature removed from Bind 9.16. The only available lookaside provider
dlv.isc.org no longer provides DLV information since 2017.

Fixes: https://pagure.io/freeipa/issue/8349
Fixes: https://pagure.io/freeipa/issue/8350
Signed-off-by: Christian Heimes <cheimes@redhat.com>