### PR TITLE
[Backport][ipa-4-8] Remove obsolete BIND named.conf options

### DIFF
--- a/install/share/bind.named.conf.template
+++ b/install/share/bind.named.conf.template
@@ -18,11 +18,8 @@ options {
 	tkey-gssapi-keytab "$NAMED_KEYTAB";
 	pid-file "$NAMED_PID";
 
-	dnssec-enable yes;
+	/* dnssec is enabled by default */
 	dnssec-validation yes;
-
-	/* Path to ISC DLV key */
-	bindkeys-file "$BINDKEYS_FILE";
 
 	managed-keys-directory "$MANAGED_KEYS_DIR";
 

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -85,7 +85,6 @@ class BasePathNamespace:
     NAMED_KEYTAB = "/etc/named.keytab"
     NAMED_RFC1912_ZONES = "/etc/named.rfc1912.zones"
     NAMED_ROOT_KEY = "/etc/named.root.key"
-    NAMED_BINDKEYS_FILE = "/etc/named.iscdlv.key"
     NAMED_MANAGED_KEYS_DIR = "/var/named/dynamic"
     NAMED_CRYPTO_POLICY_FILE = None
     NSLCD_CONF = "/etc/nslcd.conf"

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -38,7 +38,6 @@ class DebianPathNamespace(BasePathNamespace):
     NAMED_KEYTAB = "/etc/bind/named.keytab"
     NAMED_RFC1912_ZONES = "/etc/bind/named.conf.default-zones"
     NAMED_ROOT_KEY = "/etc/bind/bind.keys"
-    NAMED_BINDKEYS_FILE = "/etc/bind/bind.keys"
     NAMED_MANAGED_KEYS_DIR = "/var/cache/bind/dynamic"
     CHRONY_CONF = "/etc/chrony/chrony.conf"
     OPENLDAP_LDAP_CONF = "/etc/ldap/ldap.conf"

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -562,13 +562,12 @@ def check_forwarders(dns_forwarders):
             forwarders_dnssec_valid = False
             logger.warning("DNS server %s does not support DNSSEC: %s",
                            forwarder, e)
-            logger.warning("Please fix forwarder configuration to enable "
-                           "DNSSEC support.\n"
-                           "(For BIND 9 add directive \"dnssec-enable yes;\" "
-                           "to \"options {}\")")
+            logger.warning(
+                "Please fix forwarder configuration to enable DNSSEC "
+                "support.\n"
+            )
             print("DNS server %s: %s" % (forwarder, e))
             print("Please fix forwarder configuration to enable DNSSEC support.")
-            print("(For BIND 9 add directive \"dnssec-enable yes;\" to \"options {}\")")
         except EDNS0UnsupportedError as e:
             forwarders_dnssec_valid = False
             logger.warning("DNS server %s does not support ENDS0 "
@@ -829,7 +828,6 @@ class BindInstance(service.Service):
             FQDN=self.fqdn,
             SERVER_ID=ipaldap.realm_to_serverid(self.realm),
             SUFFIX=self.suffix,
-            BINDKEYS_FILE=paths.NAMED_BINDKEYS_FILE,
             MANAGED_KEYS_DIR=paths.NAMED_MANAGED_KEYS_DIR,
             ROOT_KEY=paths.NAMED_ROOT_KEY,
             NAMED_KEYTAB=self.keytab,


### PR DESCRIPTION
This PR was opened automatically because PR #4745 was pushed to master and backport to ipa-4-8 is required.