### PR TITLE
Remove unused support for dm_password arg from ldapupdate.connect

### DIFF
--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -54,7 +54,7 @@ UPDATES_DIR=paths.UPDATES_DIR
 UPDATE_SEARCH_TIME_LIMIT = 30  # seconds
 
 
-def connect(ldapi=False, realm=None, fqdn=None, dm_password=None):
+def connect(ldapi=False, realm=None, fqdn=None):
     """Create a connection for updates"""
     if ldapi:
         conn = ipaldap.LDAPClient.from_realm(realm, decode_attrs=False)
@@ -63,10 +63,7 @@ def connect(ldapi=False, realm=None, fqdn=None, dm_password=None):
             fqdn, decode_attrs=False
         )
     try:
-        if dm_password:
-            conn.simple_bind(bind_dn=ipaldap.DIRMAN_DN,
-                             bind_password=dm_password)
-        elif os.getegid() == 0:
+        if os.getegid() == 0:
             try:
                 # autobind
                 conn.external_bind()

--- a/ipaserver/install/schemaupdate.py
+++ b/ipaserver/install/schemaupdate.py
@@ -83,7 +83,7 @@ def _get_oid_dependency_order(schema, cls):
     return ordered_oid_groups
 
 
-def update_schema(schema_files, ldapi=False, dm_password=None,):
+def update_schema(schema_files, ldapi=False):
     """Update schema to match the given ldif files
 
     Schema elements present in the LDIF files but missing from the DS schema
@@ -105,7 +105,7 @@ def update_schema(schema_files, ldapi=False, dm_password=None,):
     """
     SCHEMA_ELEMENT_CLASSES_KEYS = [x[0] for x in SCHEMA_ELEMENT_CLASSES]
 
-    conn = connect(ldapi=ldapi, dm_password=dm_password,
+    conn = connect(ldapi=ldapi,
                    realm=api.env.realm,
                    fqdn=installutils.get_fqdn())
 

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -265,8 +265,7 @@ class IPAUpgrade(service.Service):
 
     def __update_schema(self):
         self.modified = schemaupdate.update_schema(
-            self.schema_files,
-            dm_password='', ldapi=True) or self.modified
+            self.schema_files, ldapi=True) or self.modified
 
     def __upgrade(self):
         try:


### PR DESCRIPTION
**`ipa-next` only**

Related: https://pagure.io/freeipa/issue/7610