### PR TITLE
Specify min and max values for TTL of a DNS record

### DIFF
--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -3021,6 +3021,8 @@ class dnsrecord(LDAPObject):
             cli_name='ttl',
             label=_('Time to live'),
             doc=_('Time to live'),
+            minvalue=0,
+            maxvalue=2147483647,  # see RFC 2181,
         ),
         StrEnum('dnsclass?',
             # Deprecated


### PR DESCRIPTION
Fixes: https://pagure.io/freeipa/issue/8358