### PR TITLE
[Backport][ipa-4-6] WebUI: Refresh DNS record data correctly after mod operation

### DIFF
--- a/install/ui/src/freeipa/dns.js
+++ b/install/ui/src/freeipa/dns.js
@@ -1418,6 +1418,12 @@ IPA.dns.record_details_facet = function(spec) {
         return command;
     };
 
+    that.create_update_command = function () {
+        var command = that.details_facet_create_update_command();
+        command.set_option('structured', true);
+        return command;
+    };
+
     return that;
 };
 


### PR DESCRIPTION
This PR was opened automatically because PR #4755 was pushed to master and backport to ipa-4-6 is required.