### PR TITLE
[Backport][ipa-4-6] WebUI: Expose TTL of DNS records

### DIFF
--- a/install/ui/src/freeipa/dns.js
+++ b/install/ui/src/freeipa/dns.js
@@ -1323,6 +1323,12 @@ return {
                     name: 'idnsname',
                     other_entity: 'host',
                     widget: 'identity.idnsname'
+                },
+                {
+                    $type: 'text',
+                    name: 'dnsttl',
+                    measurement_unit: 'seconds',
+                    widget: 'record_settings.dnsttl'
                 }
             ],
             widgets:[
@@ -1338,6 +1344,18 @@ return {
                             label: '@mo-param:dnsrecord:idnsname:label'
                         }
                    ]
+                },
+                {
+                    name: 'record_settings',
+                    label: '@i18n:details.record',
+                    $type: 'details_section',
+                    widgets: [
+                        {
+                            $type: 'text',
+                            name: 'dnsttl',
+                            label: '@mo-param:dnsrecord:dnsttl:label'
+                        }
+                    ]
                 }
             ]
         }

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -263,6 +263,7 @@ class i18n_messages(Command):
             "expand_all": _("Expand All"),
             "general": _("General"),
             "identity": _("Identity Settings"),
+            "record": _("Record Settings"),
             "settings": _("${entity} ${primary_key} Settings"),
             "to_top": _("Back to Top"),
             "updated": _("${entity} ${primary_key} updated"),


### PR DESCRIPTION
This PR was opened automatically because PR #4756 was pushed to master and backport to ipa-4-6 is required.