### PR TITLE
[Backport][ipa-4-6] WebUI: Add units to some DNS zone and IPA config fields

### DIFF
--- a/install/ui/src/freeipa/dns.js
+++ b/install/ui/src/freeipa/dns.js
@@ -159,12 +159,30 @@ return {
                     },
                     'idnssoarname',
                     'idnssoaserial',
-                    'idnssoarefresh',
-                    'idnssoaretry',
-                    'idnssoaexpire',
-                    'idnssoaminimum',
-                    'dnsdefaultttl',
-                    'dnsttl',
+                    {
+                        name: 'idnssoarefresh',
+                        measurement_unit: 'seconds'
+                    },
+                    {
+                        name: 'idnssoaretry',
+                        measurement_unit: 'seconds'
+                    },
+                    {
+                        name: 'idnssoaexpire',
+                        measurement_unit: 'seconds'
+                    },
+                    {
+                        name: 'idnssoaminimum',
+                        measurement_unit: 'seconds'
+                    },
+                    {
+                        name: 'dnsdefaultttl',
+                        measurement_unit: 'seconds'
+                    },
+                    {
+                        name: 'dnsttl',
+                        measurement_unit: 'seconds'
+                    },
                     {
                         $type: 'radio',
                         name: 'idnsallowdynupdate',

--- a/install/ui/src/freeipa/serverconfig.js
+++ b/install/ui/src/freeipa/serverconfig.js
@@ -45,8 +45,15 @@ return {
                     name: 'search',
                     label: '@i18n:objects.config.search',
                     fields: [
-                        'ipasearchrecordslimit',
-                        'ipasearchtimelimit'
+                        {
+                            name: 'ipasearchrecordslimit',
+                            tooltip: '@mc-opt:config_mod:ipasearchtimelimit:doc'
+                        },
+                        {
+                            name: 'ipasearchtimelimit',
+                            measurement_unit: 'seconds',
+                            tooltip: '@mc-opt:config_mod:ipasearchtimelimit:doc'
+                        }
                     ]
                 },
                 {


### PR DESCRIPTION
This PR was opened automatically because PR #4757 was pushed to master and backport to ipa-4-6 is required.