### PR TITLE
[Backport][ipa-4-6] Specify min and max values for TTL of a DNS record

### DIFF
--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -3020,6 +3020,8 @@ class dnsrecord(LDAPObject):
             cli_name='ttl',
             label=_('Time to live'),
             doc=_('Time to live'),
+            minvalue=0,
+            maxvalue=2147483647,  # see RFC 2181,
         ),
         StrEnum('dnsclass?',
             # Deprecated


### PR DESCRIPTION
This PR was opened automatically because PR #4754 was pushed to master and backport to ipa-4-6 is required.