### PR TITLE
ipatests: Test for ipa-nis-manage CLI tool

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,7 +69,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-27/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_adtrust_install.py::TestIpaNisManage
         template: *ci-master-f27
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl


### PR DESCRIPTION
The testcases check the various options of ipa-nis-manage CLI tool as below

1. ipa-nis-mange enable
2. ipa-nis-manage disable
3. Enabling NIS plugin with invalid admin password