### PR TITLE
ipatests: add KRB5_TRACE to kinit in test_adtrust_install.py

### DIFF
--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -58,10 +58,14 @@ class TestIpaAdTrustInstall(IntegrationTest):
         data_fmt = '{{"method":"trust_enable_agent","params":[["{}"],{{}}]}}'
 
         try:
-            # Create a nonadmin user that will be used by curl
-            tasks.create_active_user(self.master, user, passwd,
-                                     first=user, last=user)
-            tasks.kinit_as_user(self.master, user, passwd)
+            # Create a nonadmin user that will be used by curl.
+            # krb5_trace set to True: https://pagure.io/freeipa/issue/8353
+            tasks.create_active_user(
+                self.master, user, passwd, first=user, last=user,
+                krb5_trace=True
+            )
+            tasks.kinit_as_user(self.master, user, passwd, krb5_trace=True)
+
             # curl --negotiate -u : is using GSS-API i.e. nonadmin user
             cmd_args = [
                 paths.BIN_CURL,


### PR DESCRIPTION
The test test_adtrust_install.py::TestIpaAdTrustInstall::test_add_agent_not_allowed
sometimes fails at the kinit stage:
kinit: Password has expired while getting initial credentials
The only way to debug this further is to add debug information to the
client.

Related-to: https://pagure.io/freeipa/issue/8353
Related-to: https://pagure.io/freeipa/issue/8271
Signed-off-by: François Cami <fcami@redhat.com>