### PR TITLE
[Backport][ipa-4-8] ipa-pwd-extop: use timegm() instead of mktime() to preserve timezone …

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -1365,7 +1365,7 @@ static void ipapwd_write_krb_keys(Slapi_PBlock *pb, char *dn,
     if (expire) {
         memset(&expire_tm, 0, sizeof (expire_tm));
         if (strptime(expire, "%Y%m%d%H%M%SZ", &expire_tm))
-            pwdata.expireTime = mktime(&expire_tm);
+            pwdata.expireTime = timegm(&expire_tm);
     }
 
     /* check password policy */
@@ -1467,10 +1467,10 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
         memset(&expire_tm, 0, sizeof (expire_tm));
 
         if (strptime(principal_expire, "%Y%m%d%H%M%SZ", &expire_tm)) {
-            expire_time = mktime(&expire_tm);
+            expire_time = timegm(&expire_tm);
             current_time = time(NULL);
 
-            /* mktime returns -1 if the tm struct cannot be represented as
+            /* timegm returns -1 if the tm struct cannot be represented as
              * as calendar time (seconds since the Epoch). This might
              * happen with tm structs that are ill-formated or on 32-bit
              * platforms with dates that would cause overflow

--- a/server.m4
+++ b/server.m4
@@ -21,6 +21,8 @@ if test "x$ac_cv_header_dirsrv_slapi_plugin_h" = "xno" ; then
     AC_MSG_ERROR([Required DS slapi plugin header not available (fedora-ds-base-devel)])
 fi
 
+AC_CHECK_FUNC(timegm, [], [AC_MSG_ERROR([timegm not found])])
+
 dnl -- dirsrv is needed for the extdom unit tests --
 PKG_CHECK_MODULES([DIRSRV], [dirsrv  >= 1.3.0])
 # slapi-plugin.h includes nspr.h


### PR DESCRIPTION
This PR was opened automatically because PR #4775 was pushed to master and backport to ipa-4-8 is required.