### PR TITLE
webui: hide user attributes for SMB services section if empty

### DIFF
--- a/install/ui/src/freeipa/user.js
+++ b/install/ui/src/freeipa/user.js
@@ -367,36 +367,39 @@ return {
                 {
                     name: 'smb_attributes',
                     label: '@i18n:objects.smb_attributes.title',
-                    show_cond: ['oc_ipantuserattrs'],
                     fields: [{
                             name: 'ipantlogonscript',
                             tooltip: {
                                 title: '@i18n:objects.smb_attributes.ipantlogonscript_tooltip'
-                            }
+                            },
+                            hidden_if_empty: true
                         },
                         {
                             name: 'ipantprofilepath',
                             tooltip: {
                                 title: '@i18n:objects.smb_attributes.ipantprofilepath_tooltip'
-                            }
+                            },
+                            hidden_if_empty: true
                         },
                         {
                             name: 'ipanthomedirectory',
                             tooltip: {
                                 title: '@i18n:objects.smb_attributes.ipanthomedirectory_tooltip'
-                            }
+                            },
+                            hidden_if_empty: true
                         },
                         {
                             name: 'ipanthomedirectorydrive',
                             $type: 'select',
                             options: IPA.create_options([
-                                'A:', 'B:', 'C:', 'D:', 'E:', 'F:', 'G:', 'H:', 'I:',
-                                'J:', 'K:', 'L:', 'M:', 'N:', 'O:', 'P:', 'Q:', 'R:',
-                                'S:', 'T:', 'U:', 'V:', 'W:', 'X:', 'Y:', 'Z:'
+                                '', 'A:', 'B:', 'C:', 'D:', 'E:', 'F:', 'G:', 'H:',
+                                'I:', 'J:', 'K:', 'L:', 'M:', 'N:', 'O:', 'P:', 'Q:',
+                                'R:', 'S:', 'T:', 'U:', 'V:', 'W:', 'X:', 'Y:', 'Z:'
                             ]),
                             tooltip: {
                                 title: '@i18n:objects.smb_attributes.ipanthomedirectorydrive_tooltip'
-                            }
+                            },
+                            hidden_if_empty: true
                         }
                     ]
                 }
@@ -482,7 +485,6 @@ return {
                     IPA.user.self_service_other_user_evaluator,
                     IPA.user.preserved_user_evaluator,
                     IPA.user.is_locked_evaluator,
-                    IPA.object_class_evaluator,
                     IPA.cert.certificate_evaluator
                 ],
                 summary_conditions: [


### PR DESCRIPTION
This section should be hidded if user object hasn't ipantuserattrs
object class. I.e. when trusts are not enabled.

Web UI framework already supports hidding of sections if the
section contains no visible field. So to achieve it we simply needs
to hide the fields. Given that attributelevelrights
contains rights only for attributes of current object classes, all
of these are regarded as not writable.

We can leverage feature of input_widget that it gets hidden
when the attribute is not writable and has no value and widget's
"hidden_if_empty" is set to true. Thus doing it here.

For this to work, it is also required to fix an issue with
"ipanthomedirectorydrive" which is optional (in API) but Web UI
doesn't offer "empty" ("") value. Adding it here.

fixes: https://pagure.io/freeipa/issue/8336

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>