### PR TITLE
httpinstance: retry request without ipa-ca.$DOMAIN dnsName on failure

### DIFF
--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -350,7 +350,7 @@ def request_and_wait_for_cert(
         certpath, subject, principal, nickname=None, passwd_fname=None,
         dns=None, ca='IPA', profile=None,
         pre_command=None, post_command=None, storage='NSSDB', perms=None,
-        resubmit_timeout=0):
+        resubmit_timeout=0, stop_tracking_on_error=False):
     """Request certificate, wait and possibly resubmit failing requests
 
     Submit a cert request to certmonger and wait until the request has
@@ -402,6 +402,9 @@ def request_and_wait_for_cert(
             logger.debug("Sleep and resubmit cert request %s", req_id)
             time.sleep(10)
             resubmit_request(req_id)
+
+    if stop_tracking_on_error:
+        stop_tracking(request_id=req_id)
 
     raise RuntimeError(
         "Certificate issuance failed ({}: {})".format(state, ca_error)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1065,8 +1065,11 @@ class CAInstance(DogtagInstance):
             logger.error(
                 "certmonger failed to start tracking certificate: %s", e)
 
-    def stop_tracking_certificates(self):
-        """Stop tracking our certificates. Called on uninstall.
+    def stop_tracking_certificates(self, stop_certmonger=True):
+        """
+        Stop tracking our certificates. Called on uninstall.  Also called
+        during upgrade to fix discrepancies.
+
         """
         super(CAInstance, self).stop_tracking_certificates(False)
 
@@ -1082,7 +1085,8 @@ class CAInstance(DogtagInstance):
             logger.error(
                 "certmonger failed to stop tracking certificate: %s", e)
 
-        services.knownservices.certmonger.stop()
+        if stop_certmonger:
+            services.knownservices.certmonger.stop()
 
 
     def set_audit_renewal(self):

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -426,7 +426,10 @@ class DogtagInstance(service.Service):
                     "certmonger failed to start tracking certificate: %s", e)
 
     def stop_tracking_certificates(self, stop_certmonger=True):
-        """Stop tracking our certificates. Called on uninstall.
+        """
+        Stop tracking our certificates. Called on uninstall.  Also called
+        during upgrade to fix discrepancies.
+
         """
         logger.debug(
             "Configuring certmonger to stop tracking system certificates "

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -375,7 +375,11 @@ class HTTPInstance(service.Service):
             else:
                 prev_helper = None
             try:
-                certmonger.request_and_wait_for_cert(
+                # In migration case, if CA server is older version it may not
+                # have codepaths to support the ipa-ca.$DOMAIN dnsName in HTTP
+                # cert.  Therefore if request fails, try again without the
+                # ipa-ca.$DOMAIN dnsName.
+                args = dict(
                     certpath=(paths.HTTPD_CERT_FILE, paths.HTTPD_KEY_FILE),
                     principal=self.principal,
                     subject=str(DN(('CN', self.fqdn), self.subject_base)),
@@ -385,8 +389,15 @@ class HTTPInstance(service.Service):
                     post_command='restart_httpd',
                     storage='FILE',
                     passwd_fname=key_passwd_file,
-                    resubmit_timeout=api.env.certmonger_wait_timeout
+                    resubmit_timeout=api.env.certmonger_wait_timeout,
+                    stop_tracking_on_error=True,
                 )
+                try:
+                    certmonger.request_and_wait_for_cert(**args)
+                except Exception as e:
+                    args['dns'] = [self.fqdn]  # remove ipa-ca.$DOMAIN
+                    args['stop_tracking_on_error'] = False
+                    certmonger.request_and_wait_for_cert(**args)
             finally:
                 if prev_helper is not None:
                     certmonger.modify_ca_helper('IPA', prev_helper)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1212,9 +1212,9 @@ def certificate_renewal_update(ca, kra, ds, http):
 
     # Ok, now we need to stop tracking, then we can start tracking them
     # again with new configuration:
-    ca.stop_tracking_certificates()
+    ca.stop_tracking_certificates(stop_certmonger=False)
     if kra.is_installed():
-        kra.stop_tracking_certificates()
+        kra.stop_tracking_certificates(stop_certmonger=False)
     ds.stop_tracking_certificates(serverid)
     http.stop_tracking_certificates()
 


### PR DESCRIPTION
In the migration case of replica installation, if the CA server is an older
version it may not support the ipa-ca.$DOMAIN dnsName in the HTTP cert (it
is a special case in the cert_request command). Therefore if the request
fails, try it again without the ipa-ca.$DOMAIN dnsName.

Part of: https://pagure.io/freeipa/issue/8186