### PR TITLE
Use DogTag's two step installation for CA only

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/nightly_latest.yaml

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -435,6 +435,7 @@ class BasePathNamespace:
     LIBARCH = "64"
     TDBTOOL = '/usr/bin/tdbtool'
     SECRETS_TDB = '/var/lib/samba/private/secrets.tdb'
+    DOGTAG_CACACERT_CFG = "/var/lib/pki/pki-tomcat/ca/profiles/ca/caCACert.cfg"
 
     def check_paths(self):
         """Check paths for missing files

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -606,7 +606,13 @@ class CAInstance(DogtagInstance):
 
             DogtagInstance.spawn_instance(
                 self, f.name,
-                nolog_list=nolog_list
+                nolog_list=nolog_list,
+                skip_configuration=True
+            )
+            DogtagInstance.spawn_instance(
+                self, f.name,
+                nolog_list=nolog_list,
+                skip_installation=True
             )
 
         if self.external == 1:

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -36,7 +36,9 @@ import sys
 import syslog
 import time
 import tempfile
+
 from configparser import RawConfigParser
+from datetime import date
 
 from ipalib import api
 from ipalib import x509
@@ -609,6 +611,23 @@ class CAInstance(DogtagInstance):
                 nolog_list=nolog_list,
                 skip_configuration=True
             )
+
+            # Y2K38: 19 January 2038, 03:14:07 UTC
+            delta_t = date(2038, 1, 14) - date.today()
+            ca_validity_range_in_days = str(delta_t.days)
+            directives = [
+                "policyset.caCertSet.2.constraint.params.range",
+                "policyset.caCertSet.2.default.params.range"
+            ]
+            for directive in directives:
+                directivesetter.set_directive(
+                    paths.DOGTAG_CACACERT_CFG,
+                    directive,
+                    ca_validity_range_in_days,
+                    quotes=False,
+                    separator='='
+                )
+
             DogtagInstance.spawn_instance(
                 self, f.name,
                 nolog_list=nolog_list,


### PR DESCRIPTION
Some configuration items of Dogtag are only available using a 2-step
installation method described at:
https://www.dogtagpki.org/wiki/Two-Step_Installation

dogtaginstance.py: enable two-step Dogtag instance installation


cainstance.py: use Dogtag's two-step installation method
    
Use Dogtag's two-step installation method for CAs to be
able to customize some parameters like CA lifetime.
    
    
Related: https://pagure.io/freeipa/issue/7827
Fixes: https://pagure.io/freeipa/issue/8438