### PR TITLE
ipatests: fix the disable_dnssec_validation method

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -531,11 +531,14 @@ def install_adtrust(host):
 
 
 def disable_dnssec_validation(host):
-    backup_file(host, paths.NAMED_CONF)
-    named_conf = host.get_file_contents(paths.NAMED_CONF)
+    """
+    Edits ipa-options-ext.conf snippet in order to disable dnssec validation
+    """
+    backup_file(host, paths.NAMED_CUSTOM_OPTIONS_CONF)
+    named_conf = host.get_file_contents(paths.NAMED_CUSTOM_OPTIONS_CONF)
     named_conf = re.sub(br'dnssec-validation\s*yes;', b'dnssec-validation no;',
                         named_conf)
-    host.put_file_contents(paths.NAMED_CONF, named_conf)
+    host.put_file_contents(paths.NAMED_CUSTOM_OPTIONS_CONF, named_conf)
     restart_named(host)
 
 


### PR DESCRIPTION
Bind configuration now includes 2 snippet config files, in
/etc/named/ipa-ext.conf and /etc/named/ipa-options-ext.conf
    
When a test needs to disable dnssec-validation, it needs to edit
the snippet ipa-options-ext.conf instead of /etc/named.conf.
    
This commit fixes the method tasks.disable_dnssec_validation so that it
correctly updates the snippet.
    
Fixes: https://pagure.io/freeipa/issue/8364
