### PR TITLE
ipatests: Update the pki-master-f32 image version

### DIFF
--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -35,7 +35,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &pki-master-latest
           name: freeipa/pki-master-f32
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
There is a new Vagrant image for pki-master-f32, that contains
jss 4.7.0-0 instead of jss 4.7.0-1.
This change is required because the copr repo @pki/master initially
provided 4.7.0-1 but went backwards in the version number, and
critical fixes are available in 4.7.0-0.
    
Without this change, the vagrant image is using 4.7.0-1 and tries to
update (not downgrade), hence does not install the most recent version
with the fixes.
