### PR TITLE
ipa-replica-install: --setup-ca and *-cert-file are mutually exclusive

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -776,6 +776,12 @@ def promote_check(installer):
     # check selinux status, http and DS ports, NTP conflicting services
     common_check(options.no_ntp)
 
+    if options.setup_ca and any([options.dirsrv_cert_files,
+                                 options.http_cert_files,
+                                 options.pkinit_cert_files]):
+        raise ScriptError("--setup-ca and --*-cert-file options are "
+                          "mutually exclusive")
+
     client_fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
     if not client_fstore.has_files():
         # One-step replica installation


### PR DESCRIPTION
### ipa-replica-install: --setup-ca and *-cert-file are mutually exclusive

ipa-replica-install currently accepts both --setup-ca and *-cert-file
even though the options should be mutually exclusive (either install
CA-less with *-cert-file options or with a CA).

Add a check enforcing the options are mutually exclusive.

Fixes: https://pagure.io/freeipa/issue/8366

### ipatests: add a test for ipa-replica-install --setup-ca --http-cert-file

The options *-cert-file are used for a CA-less replica installation and
are mutually exclusive with --setup-ca.
Add a test for this use case.

Related: https://pagure.io/freeipa/issue/8366