### PR TITLE
[Backport][ipa-4-8] gitignore client/ipa-epn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,8 @@ freeipa2-dev-doc
 /init/ipa_memcached
 /init/systemd/ipa-custodia.service
 /init/systemd/ipa.service
-/init/systemd/ipa_memcached.service
+/init/systemd/ipa-epn.service
+/init/systemd/ipa-epn.timer
 /init/tmpfilesd/ipa.conf
 
 !/install/ui/doc/Makefile.in
@@ -130,6 +131,7 @@ client/ipa-certupdate
 client/ipa-client-automount
 client/ipa-client-install
 client/ipa-client-samba
+client/ipa-epn
 daemons/dnssec/ipa-dnskeysyncd
 daemons/dnssec/ipa-dnskeysync-replica
 daemons/dnssec/ipa-ods-exporter


### PR DESCRIPTION
This PR was opened automatically because PR #4798 was pushed to master and backport to ipa-4-8 is required.