### PR TITLE
[Backport][ipa-4-8] ipatests: fix the disable_dnssec_validation method

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -531,11 +531,14 @@ def install_adtrust(host):
 
 
 def disable_dnssec_validation(host):
-    backup_file(host, paths.NAMED_CONF)
-    named_conf = host.get_file_contents(paths.NAMED_CONF)
+    """
+    Edits ipa-options-ext.conf snippet in order to disable dnssec validation
+    """
+    backup_file(host, paths.NAMED_CUSTOM_OPTIONS_CONF)
+    named_conf = host.get_file_contents(paths.NAMED_CUSTOM_OPTIONS_CONF)
     named_conf = re.sub(br'dnssec-validation\s*yes;', b'dnssec-validation no;',
                         named_conf)
-    host.put_file_contents(paths.NAMED_CONF, named_conf)
+    host.put_file_contents(paths.NAMED_CUSTOM_OPTIONS_CONF, named_conf)
     restart_named(host)
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #4800 was pushed to master and backport to ipa-4-8 is required.