### PR TITLE
[ipa-4-8] CVE-2020-10747: Prevent local account takeover

### DIFF
--- a/ACI.txt
+++ b/ACI.txt
@@ -99,7 +99,7 @@ aci: (targetattr = "ipaexternalmember")(targetfilter = "(objectclass=ipaexternal
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "member")(targetfilter = "(&(!(cn=admins))(objectclass=ipausergroup))")(version 3.0;acl "permission:System: Modify Group Membership";allow (write) groupdn = "ldap:///cn=System: Modify Group Membership,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "cn || description || gidnumber || ipauniqueid || membermanager || mepmanagedby || objectclass")(targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Modify Groups";allow (write) groupdn = "ldap:///cn=System: Modify Groups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+aci: (targetattr = "cn || description || gidnumber || ipauniqueid || membermanager || mepmanagedby || objectclass")(targetfilter = "(&(!(cn=admins))(|(objectclass=ipausergroup)(objectclass=posixgroup)))")(version 3.0;acl "permission:System: Modify Groups";allow (write) groupdn = "ldap:///cn=System: Modify Groups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "ipaexternalmember")(targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Read External Group Membership";allow (compare,read,search) userdn = "ldap:///all";)
 dn: dc=ipa,dc=example
@@ -111,7 +111,7 @@ aci: (targetattr = "cn || createtimestamp || entryusn || gidnumber || memberuid 
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "businesscategory || cn || createtimestamp || description || entryusn || gidnumber || ipaexternalmember || ipantsecurityidentifier || ipauniqueid || membermanager || mepmanagedby || modifytimestamp || o || objectclass || ou || owner || seealso")(targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Read Groups";allow (compare,read,search) userdn = "ldap:///anyone";)
 dn: cn=groups,cn=accounts,dc=ipa,dc=example
-aci: (targetfilter = "(|(objectclass=ipausergroup)(objectclass=posixgroup))")(version 3.0;acl "permission:System: Remove Groups";allow (delete) groupdn = "ldap:///cn=System: Remove Groups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+aci: (targetfilter = "(&(!(|(cn=admins)(cn=trust admins)(cn=default smb group)))(|(objectclass=ipausergroup)(objectclass=posixgroup)))")(version 3.0;acl "permission:System: Remove Groups";allow (delete) groupdn = "ldap:///cn=System: Remove Groups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=hbac,dc=ipa,dc=example
 aci: (targetfilter = "(objectclass=ipahbacrule)")(version 3.0;acl "permission:System: Add HBAC Rule";allow (add) groupdn = "ldap:///cn=System: Add HBAC Rule,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=hbac,dc=ipa,dc=example
@@ -355,17 +355,19 @@ aci: (targetattr = "member")(target = "ldap:///cn=ipausers,cn=groups,cn=accounts
 dn: cn=users,cn=accounts,dc=ipa,dc=example
 aci: (targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Add Users";allow (add) groupdn = "ldap:///cn=System: Add Users,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
+aci: (targetattr = "krbpasswordexpiration || krbprincipalkey || passwordhistory || sambalmpassword || sambantpassword || userpassword")(targetfilter = "(memberOf=cn=admins,cn=groups,cn=accounts,dc=ipa,dc=example)")(version 3.0;acl "permission:System: Change Admin User password";allow (write) groupdn = "ldap:///cn=System: Change Admin User password,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+dn: cn=users,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "krbpasswordexpiration || krbprincipalkey || passwordhistory || sambalmpassword || sambantpassword || userpassword")(targetfilter = "(&(!(memberOf=cn=admins,cn=groups,cn=accounts,dc=ipa,dc=example))(objectclass=posixaccount))")(version 3.0;acl "permission:System: Change User password";allow (write) groupdn = "ldap:///cn=System: Change User password,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "ipacertmapdata || objectclass")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Manage User Certificate Mappings";allow (write) groupdn = "ldap:///cn=System: Manage User Certificate Mappings,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "usercertificate")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Manage User Certificates";allow (write) groupdn = "ldap:///cn=System: Manage User Certificates,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+aci: (targetattr = "usercertificate")(targetfilter = "(&(!(memberOf=cn=admins,cn=groups,cn=accounts,dc=ipa,dc=example))(objectclass=posixaccount))")(version 3.0;acl "permission:System: Manage User Certificates";allow (write) groupdn = "ldap:///cn=System: Manage User Certificates,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "krbcanonicalname || krbprincipalname")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Manage User Principals";allow (write) groupdn = "ldap:///cn=System: Manage User Principals,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+aci: (targetattr = "krbcanonicalname || krbprincipalname")(targetfilter = "(&(!(memberOf=cn=admins,cn=groups,cn=accounts,dc=ipa,dc=example))(objectclass=posixaccount))")(version 3.0;acl "permission:System: Manage User Principals";allow (write) groupdn = "ldap:///cn=System: Manage User Principals,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "ipasshpubkey")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Manage User SSH Public Keys";allow (write) groupdn = "ldap:///cn=System: Manage User SSH Public Keys,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+aci: (targetattr = "ipasshpubkey")(targetfilter = "(&(!(memberOf=cn=admins,cn=groups,cn=accounts,dc=ipa,dc=example))(objectclass=posixaccount))")(version 3.0;acl "permission:System: Manage User SSH Public Keys";allow (write) groupdn = "ldap:///cn=System: Manage User SSH Public Keys,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "businesscategory || carlicense || cn || departmentnumber || description || displayname || employeenumber || employeetype || facsimiletelephonenumber || gecos || givenname || homedirectory || homephone || inetuserhttpurl || initials || l || labeleduri || loginshell || mail || manager || mepmanagedentry || mobile || objectclass || ou || pager || postalcode || preferredlanguage || roomnumber || secretary || seealso || sn || st || street || telephonenumber || title || userclass")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Modify Users";allow (write) groupdn = "ldap:///cn=System: Modify Users,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+aci: (targetattr = "businesscategory || carlicense || cn || departmentnumber || description || displayname || employeenumber || employeetype || facsimiletelephonenumber || gecos || givenname || homedirectory || homephone || inetuserhttpurl || initials || l || labeleduri || loginshell || mail || manager || mepmanagedentry || mobile || objectclass || ou || pager || postalcode || preferredlanguage || roomnumber || secretary || seealso || sn || st || street || telephonenumber || title || userclass")(targetfilter = "(&(!(memberOf=cn=admins,cn=groups,cn=accounts,dc=ipa,dc=example))(objectclass=posixaccount))")(version 3.0;acl "permission:System: Modify Users";allow (write) groupdn = "ldap:///cn=System: Modify Users,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=UPG Definition,cn=Definitions,cn=Managed Entries,cn=etc,dc=ipa,dc=example
 aci: (targetattr = "*")(target = "ldap:///cn=UPG Definition,cn=Definitions,cn=Managed Entries,cn=etc,dc=ipa,dc=example")(version 3.0;acl "permission:System: Read UPG Definition";allow (compare,read,search) groupdn = "ldap:///cn=System: Read UPG Definition,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
@@ -387,9 +389,9 @@ aci: (targetattr = "cn || createtimestamp || description || displayname || entry
 dn: dc=ipa,dc=example
 aci: (targetattr = "cn || createtimestamp || entryusn || gecos || gidnumber || homedirectory || loginshell || modifytimestamp || objectclass || uid || uidnumber")(target = "ldap:///cn=users,cn=*,cn=views,cn=compat,dc=ipa,dc=example")(version 3.0;acl "permission:System: Read User Views Compat Tree";allow (compare,read,search) userdn = "ldap:///anyone";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
-aci: (targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Remove Users";allow (delete) groupdn = "ldap:///cn=System: Remove Users,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+aci: (targetfilter = "(&(!(memberOf=cn=admins,cn=groups,cn=accounts,dc=ipa,dc=example))(objectclass=posixaccount))")(version 3.0;acl "permission:System: Remove Users";allow (delete) groupdn = "ldap:///cn=System: Remove Users,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "krblastadminunlock || krbloginfailedcount || nsaccountlock")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Unlock User";allow (write) groupdn = "ldap:///cn=System: Unlock User,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+aci: (targetattr = "krblastadminunlock || krbloginfailedcount || nsaccountlock")(targetfilter = "(&(!(memberOf=cn=admins,cn=groups,cn=accounts,dc=ipa,dc=example))(objectclass=posixaccount))")(version 3.0;acl "permission:System: Unlock User";allow (write) groupdn = "ldap:///cn=System: Unlock User,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: dc=ipa,dc=example
 aci: (target = "ldap:///cn=vaults,cn=kra,dc=ipa,dc=example")(targetfilter = "(objectclass=ipaVault)")(version 3.0;acl "permission:System: Add Vaults";allow (add) groupdn = "ldap:///cn=System: Add Vaults,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: dc=ipa,dc=example

--- a/install/share/bootstrap-template.ldif
+++ b/install/share/bootstrap-template.ldif
@@ -232,6 +232,7 @@ objectClass: ipaobject
 objectClass: ipasshuser
 uid: admin
 krbPrincipalName: admin@$REALM
+krbPrincipalName: root@$REALM
 cn: Administrator
 sn: Administrator
 uidNumber: $IDSTART

--- a/ipalib/errors.py
+++ b/ipalib/errors.py
@@ -1462,6 +1462,15 @@ class CSRTemplateError(ExecutionError):
     format = _('%(reason)s')
 
 
+class AlreadyContainsValueError(ExecutionError):
+    """
+    **4038** Raised when BaseLDAPAddAttribute operation fails because one
+    or more new values are already present.
+    """
+    errno = 4038
+    format = _("'%(attr)s' already contains one or more values")
+
+
 class BuiltinError(ExecutionError):
     """
     **4100** Base class for builtin execution errors (*4100 - 4199*).

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -2443,9 +2443,7 @@ class BaseLDAPAddAttribute(BaseLDAPModAttribute):
             value_to_add = set(value)
 
             if not old_value.isdisjoint(value_to_add):
-                raise errors.ExecutionError(
-                    message=_('\'%(attr)s\' already contains one or more '
-                              'values') % dict(attr=name))
+                raise errors.AlreadyContainsValueError(attr=name)
 
             update[name] = list(old_value | value_to_add)
 

--- a/ipaserver/plugins/group.py
+++ b/ipaserver/plugins/group.py
@@ -157,6 +157,7 @@ Example:
 
 register = Registry()
 
+# also see "System: Remove Groups"
 PROTECTED_GROUPS = (u'admins', u'trust admins', u'default smb group')
 
 
@@ -196,6 +197,9 @@ class group(LDAPObject):
     object_class_config = 'ipagroupobjectclasses'
     possible_objectclasses = ['posixGroup', 'mepManagedEntry', 'ipaExternalGroup']
     permission_filter_objectclasses = ['posixgroup', 'ipausergroup']
+    permission_filter_objectclasses_string = (
+        '(|(objectclass=ipausergroup)(objectclass=posixgroup))'
+    )
     search_attributes_config = 'ipagroupsearchfields'
     default_attributes = [
         'cn', 'description', 'gidnumber', 'member', 'memberof',
@@ -249,7 +253,7 @@ class group(LDAPObject):
         'System: Modify Group Membership': {
             'ipapermright': {'write'},
             'ipapermtargetfilter': [
-                '(objectclass=ipausergroup)',
+                '(objectclass=ipausergroup)',  # only ipausergroups
                 '(!(cn=admins))',
             ],
             'ipapermdefaultattr': {'member'},
@@ -273,6 +277,10 @@ class group(LDAPObject):
         },
         'System: Modify Groups': {
             'ipapermright': {'write'},
+            'ipapermtargetfilter': [
+                permission_filter_objectclasses_string,
+                '(!(cn=admins))',
+            ],
             'ipapermdefaultattr': {
                 'cn', 'description', 'gidnumber', 'ipauniqueid',
                 'mepmanagedby', 'objectclass', 'membermanager',
@@ -284,6 +292,11 @@ class group(LDAPObject):
         },
         'System: Remove Groups': {
             'ipapermright': {'delete'},
+            'ipapermtargetfilter': [
+                permission_filter_objectclasses_string,
+                # prevent removal of PROTECTED_GROUPS
+                '(!(|(cn=admins)(cn=trust admins)(cn=default smb group)))',
+            ],
             'replaces': [
                 '(target = "ldap:///cn=*,cn=groups,cn=accounts,$SUFFIX")(version 3.0;acl "permission:Remove Groups";allow (delete) groupdn = "ldap:///cn=Remove Groups,cn=permissions,cn=pbac,$SUFFIX";)',
             ],

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -125,6 +125,12 @@ register = Registry()
 
 user_output_params = baseuser_output_params
 
+MEMBEROF_ADMINS = "(memberOf={})".format(
+    DN('cn=admins', api.env.container_group, api.env.basedn)
+)
+
+NOT_MEMBEROF_ADMINS = '(!{})'.format(MEMBEROF_ADMINS)
+
 
 def check_protected_member(user, protected_group_name=u'admins'):
     '''
@@ -155,6 +161,7 @@ class user(baseuser):
     label_singular            = _('User')
     object_name               = _('user')
     object_name_plural        = _('users')
+    permission_filter_objectclasses_string = '(objectclass=posixaccount)'
     managed_permissions = {
         'System: Read User Standard Attributes': {
             'replaces_global_anonymous_aci': True,
@@ -259,10 +266,8 @@ class user(baseuser):
         'System: Change User password': {
             'ipapermright': {'write'},
             'ipapermtargetfilter': [
-                '(objectclass=posixaccount)',
-                '(!(memberOf=%s))' % DN('cn=admins',
-                                        api.env.container_group,
-                                        api.env.basedn),
+                permission_filter_objectclasses_string,
+                NOT_MEMBEROF_ADMINS,
             ],
             'ipapermdefaultattr': {
                 'krbprincipalkey', 'passwordhistory', 'sambalmpassword',
@@ -279,8 +284,25 @@ class user(baseuser):
                 'PassSync Service',
             },
         },
+        'System: Change Admin User password': {
+            'ipapermright': {'write'},
+            'ipapermtargetfilter': [
+                MEMBEROF_ADMINS,
+            ],
+            'ipapermdefaultattr': {
+                'krbprincipalkey', 'passwordhistory', 'sambalmpassword',
+                'sambantpassword', 'userpassword', 'krbpasswordexpiration'
+            },
+            'default_privileges': {
+                'PassSync Service',
+            },
+        },
         'System: Manage User SSH Public Keys': {
             'ipapermright': {'write'},
+            'ipapermtargetfilter': [
+                permission_filter_objectclasses_string,
+                NOT_MEMBEROF_ADMINS,
+            ],
             'ipapermdefaultattr': {'ipasshpubkey'},
             'replaces': [
                 '(targetattr = "ipasshpubkey")(target = "ldap:///uid=*,cn=users,cn=accounts,$SUFFIX")(version 3.0;acl "permission:Manage User SSH Public Keys";allow (write) groupdn = "ldap:///cn=Manage User SSH Public Keys,cn=permissions,cn=pbac,$SUFFIX";)',
@@ -289,6 +311,10 @@ class user(baseuser):
         },
         'System: Manage User Certificates': {
             'ipapermright': {'write'},
+            'ipapermtargetfilter': [
+                permission_filter_objectclasses_string,
+                NOT_MEMBEROF_ADMINS,
+            ],
             'ipapermdefaultattr': {'usercertificate'},
             'default_privileges': {
                 'User Administrators',
@@ -297,6 +323,10 @@ class user(baseuser):
         },
         'System: Manage User Principals': {
             'ipapermright': {'write'},
+            'ipapermtargetfilter': [
+                permission_filter_objectclasses_string,
+                NOT_MEMBEROF_ADMINS,
+            ],
             'ipapermdefaultattr': {'krbprincipalname', 'krbcanonicalname'},
             'default_privileges': {
                 'User Administrators',
@@ -305,6 +335,10 @@ class user(baseuser):
         },
         'System: Modify Users': {
             'ipapermright': {'write'},
+            'ipapermtargetfilter': [
+                permission_filter_objectclasses_string,
+                NOT_MEMBEROF_ADMINS,
+            ],
             'ipapermdefaultattr': {
                 'businesscategory', 'carlicense', 'cn', 'departmentnumber',
                 'description', 'displayname', 'employeetype',
@@ -326,6 +360,10 @@ class user(baseuser):
         },
         'System: Remove Users': {
             'ipapermright': {'delete'},
+            'ipapermtargetfilter': [
+                permission_filter_objectclasses_string,
+                NOT_MEMBEROF_ADMINS,
+            ],
             'replaces': [
                 '(target = "ldap:///uid=*,cn=users,cn=accounts,$SUFFIX")(version 3.0;acl "permission:Remove Users";allow (delete) groupdn = "ldap:///cn=Remove Users,cn=permissions,cn=pbac,$SUFFIX";)',
             ],
@@ -333,6 +371,10 @@ class user(baseuser):
         },
         'System: Unlock User': {
             'ipapermright': {'write'},
+            'ipapermtargetfilter': [
+                permission_filter_objectclasses_string,
+                NOT_MEMBEROF_ADMINS,
+            ],
             'ipapermdefaultattr': {
                 'krblastadminunlock', 'krbloginfailedcount', 'nsaccountlock',
             },

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -835,6 +835,20 @@ class TestInstallMaster(IntegrationTest):
         )
         assert "nsslapd-enable-upgrade-hash: off" in result.stdout_text
 
+    def test_admin_root_alias_CVE_2020_10747(self):
+        # Test for CVE-2020-10747 fix
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1810160
+        rootprinc = "root@{}".format(self.master.domain.realm)
+        result = self.master.run_command(["ipa", "user-show", "admin"])
+        assert rootprinc in result.stdout_text
+
+        result = self.master.run_command(
+            ["ipa", "user-add", "root", "--first", "root", "--last", "root"],
+            raiseonerr=False
+        )
+        assert result.returncode != 0
+        assert 'user with name "root" already exists' in result.stderr_text
+
 
 class TestInstallMasterKRA(IntegrationTest):
 

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -245,3 +245,17 @@ class TestUpgrade(IntegrationTest):
         assert named_conf.count(inc_opt_conf) == 1
         inc_custom_conf = f'include "{paths.NAMED_CUSTOM_CONF}";'
         assert named_conf.count(inc_custom_conf) == 1
+
+    def test_admin_root_alias_upgrade_CVE_2020_10747(self):
+        # Test upgrade for CVE-2020-10747 fix
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1810160
+        rootprinc = "root@{}".format(self.master.domain.realm)
+        self.master.run_command(
+            ["ipa", "user-remove-principal", "admin", rootprinc]
+        )
+        result = self.master.run_command(["ipa", "user-show", "admin"])
+        assert rootprinc not in result.stdout_text
+
+        self.master.run_command(['ipa-server-upgrade'])
+        result = self.master.run_command(["ipa", "user-show", "admin"])
+        assert rootprinc in result.stdout_text


### PR DESCRIPTION
It was found that if an account was created with a name corresponding to
an account local to a system, such as 'root', was created via IPA, such
account could access any enrolled machine with that account, and the local
system privileges. This also bypass the absence of explicit HBAC rules.

root principal alias
-------------------

The principal "root@REALM" is now a Kerberos principal alias for
"admin". This prevent user with "User Administrator" role or
"System: Add User" privilege to create an account with "root" principal
name.

Modified user permissions
-------------------------

Several user permissions no longer apply to admin users and filter on
posixaccount object class. This prevents user managers from modifying admin
acounts.

- System: Manage User Certificates
- System: Manage User Principals
- System: Manage User SSH Public Keys
- System: Modify Users
- System: Remove Users
- System: Unlock user

``System: Unlock User`` is restricted because the permission also allow a
user manager to lock an admin account. ``System: Modify Users`` is restricted
to prevent user managers from changing login shell or notification channels
(mail, mobile) of admin accounts.

New user permission
-------------------

- System: Change Admin User password

The new permission allows manipulation of admin user password fields. By
default only the ``PassSync Service`` privilege is allowed to modify
admin user password fields.

Modified group permissions
--------------------------

Group permissions are now restricted as well. Group admins can no longer
modify the admins group and are limited to groups with object class
``ipausergroup``.

- System: Modify Groups
- System: Remove Groups

The permission ``System: Modify Group Membership`` was already limited.

Notes
-----

Admin users are mostly unaffected by the new restrictions, except for
the fact that admins can no longer change krbPrincipalAlias of another
admin or manipulate password fields directly. Commands like ``ipa passwd
otheradmin`` still work, though. The ACI ``Admin can manage any entry``
allows admins to modify other entries and most attributes.

Managed permissions don't install ``obj.permission_filter_objectclasses``
when ``ipapermtargetfilter`` is set. Group and user objects now have a
``permission_filter_objectclasses_string`` attribute that is used
by new target filters.

Misc changes
------------

Also add new exception AlreadyContainsValueError. BaseLDAPAddAttribute
was raising a generic base class for LDAP execution errors.

Fixes: https://pagure.io/freeipa/issue/8326
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1810160
Signed-off-by: Christian Heimes <cheimes@redhat.com>