### PR TITLE
Specify cert_paths when calling PKIConnection

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -112,9 +112,9 @@
 # Fedora
 %endif
 
-# 10.7.3 supports LWCA key replication using AES
-# https://pagure.io/freeipa/issue/8020
-%global pki_version 10.7.3-1
+# PKIConnection has been modified to always validate certs.
+# https://pagure.io/freeipa/issue/8379
+%global pki_version 10.9.0-0.4
 
 # https://pagure.io/certmonger/issue/90
 %global certmonger_version 0.79.7-1

--- a/install/tools/ipa-pki-wait-running.in
+++ b/install/tools/ipa-pki-wait-running.in
@@ -59,7 +59,8 @@ def get_conn(hostname, subsystem):
     """
     conn = PKIConnection(
         hostname=hostname,
-        subsystem=subsystem
+        subsystem=subsystem,
+        cert_paths=paths.IPA_CA_CRT
     )
     logger.info(
         "Created connection %s://%s:%s/%s",

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -509,6 +509,13 @@ class CAInstance(DogtagInstance):
         else:
             pki_pin = None
 
+        # When spawning a CA instance, always point to IPA_CA_CRT if it
+        # exists. Later, when we're performing step 2 of an external CA
+        # installation, we'll overwrite this key to point to the real
+        # external CA.
+        if os.path.exists(paths.IPA_CA_CRT):
+            cfg['pki_cert_chain_path'] = paths.IPA_CA_CRT
+
         if self.clone:
             if self.no_db_setup:
                 cfg.update(

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -70,7 +70,8 @@ def get_security_domain():
     connection = PKIConnection(
         protocol='https',
         hostname=api.env.ca_host,
-        port='8443'
+        port='8443',
+        cert_paths=paths.IPA_CA_CRT
     )
     domain_client = pki.system.SecurityDomainClient(connection)
     info = domain_client.get_security_domain_info()

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1969,13 +1969,12 @@ class kra(Backend):
             'https',
             self.kra_host,
             str(self.kra_port),
-            'kra')
+            'kra',
+            cert_paths=paths.IPA_CA_CRT
+        )
 
-        connection.session.cert = (paths.RA_AGENT_PEM, paths.RA_AGENT_KEY)
-        # uncomment the following when this commit makes it to release
-        # https://git.fedorahosted.org/cgit/pki.git/commit/?id=71ae20c
-        # connection.set_authentication_cert(paths.RA_AGENT_PEM,
-        #                                    paths.RA_AGENT_KEY)
+        connection.set_authentication_cert(paths.RA_AGENT_PEM,
+                                           paths.RA_AGENT_KEY)
 
         try:
             yield KRAClient(connection, crypto)


### PR DESCRIPTION
`PKIConnection` now defaults to specifying `verify=True`. We've introduced
a new parameter, `cert_paths`, to specify additional paths (directories or
files) to load as certificates. Specify the IPA CA certificate file so
we can guarantee connections succeed.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---

This is blocked on dogtagpki/pki#443. Once that is merged, this can be updated and merged. What's this project's preference on requiring attributes from a new Dogtag API?