### PR TITLE
fix cert-find errors in CA-less deployment

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1839,9 +1839,14 @@ class cert_find(Search, CertMethod):
         truncated = False
         complete = False
 
-        for sub_search in (self._cert_search,
-                           self._ca_search,
-                           self._ldap_search):
+        # Do not execute the CA sub-search in CA-less deployment.
+        # See https://pagure.io/freeipa/issue/8369.
+        if ca_enabled:
+            searches = [self._cert_search, self._ca_search, self._ldap_search]
+        else:
+            searches = [self._cert_search, self._ldap_search]
+
+        for sub_search in searches:
             sub_result, sub_truncated, sub_complete = sub_search(
                 all=all,
                 raw=raw,


### PR DESCRIPTION
Under some search conditions (in particular, when user is
specified), the CA sub-search of cert-find command throws an error
on CA-less deployments.  Do not execute the CA sub-search on CA-less
deployments.

Fixes: https://pagure.io/freeipa/issue/8369