### PR TITLE
[Backport][ipa-4-8] webui: hide user attributes for SMB services section if empty

### DIFF
--- a/install/ui/src/freeipa/user.js
+++ b/install/ui/src/freeipa/user.js
@@ -367,36 +367,39 @@ return {
                 {
                     name: 'smb_attributes',
                     label: '@i18n:objects.smb_attributes.title',
-                    show_cond: ['oc_ipantuserattrs'],
                     fields: [{
                             name: 'ipantlogonscript',
                             tooltip: {
                                 title: '@i18n:objects.smb_attributes.ipantlogonscript_tooltip'
-                            }
+                            },
+                            hidden_if_empty: true
                         },
                         {
                             name: 'ipantprofilepath',
                             tooltip: {
                                 title: '@i18n:objects.smb_attributes.ipantprofilepath_tooltip'
-                            }
+                            },
+                            hidden_if_empty: true
                         },
                         {
                             name: 'ipanthomedirectory',
                             tooltip: {
                                 title: '@i18n:objects.smb_attributes.ipanthomedirectory_tooltip'
-                            }
+                            },
+                            hidden_if_empty: true
                         },
                         {
                             name: 'ipanthomedirectorydrive',
                             $type: 'select',
                             options: IPA.create_options([
-                                'A:', 'B:', 'C:', 'D:', 'E:', 'F:', 'G:', 'H:', 'I:',
-                                'J:', 'K:', 'L:', 'M:', 'N:', 'O:', 'P:', 'Q:', 'R:',
-                                'S:', 'T:', 'U:', 'V:', 'W:', 'X:', 'Y:', 'Z:'
+                                '', 'A:', 'B:', 'C:', 'D:', 'E:', 'F:', 'G:', 'H:',
+                                'I:', 'J:', 'K:', 'L:', 'M:', 'N:', 'O:', 'P:', 'Q:',
+                                'R:', 'S:', 'T:', 'U:', 'V:', 'W:', 'X:', 'Y:', 'Z:'
                             ]),
                             tooltip: {
                                 title: '@i18n:objects.smb_attributes.ipanthomedirectorydrive_tooltip'
-                            }
+                            },
+                            hidden_if_empty: true
                         }
                     ]
                 }
@@ -482,7 +485,6 @@ return {
                     IPA.user.self_service_other_user_evaluator,
                     IPA.user.preserved_user_evaluator,
                     IPA.user.is_locked_evaluator,
-                    IPA.object_class_evaluator,
                     IPA.cert.certificate_evaluator
                 ],
                 summary_conditions: [


### PR DESCRIPTION
This PR was opened automatically because PR #4787 was pushed to master and backport to ipa-4-8 is required.