### PR TITLE
ipatests: Tests to check ipahealthcheck tool with IPA-AD trust scenario

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1336,10 +1336,22 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_ipahealthcheck.py
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS
         template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl
+
+  fedora-latest/test_ipahealthcheck_adtrust:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithADtrust
+        template: *ci-master-latest
+        timeout: 4800
+        topology: *ad_master
 
   fedora-latest/test_ntp_options:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -23,6 +23,10 @@ topologies:
     name: master_3repl_1client
     cpu: 6
     memory: 12900
+  ad_master: &ad_master
+    name: ad_master
+    cpu: 4
+    memory: 12000
 
 jobs:
   pki-fedora/build:
@@ -791,7 +795,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        test_suite: test_integration/test_ipahealthcheck.py
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS
         template: *pki-master-latest
         timeout: 4800
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1441,9 +1441,23 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
-        test_suite: test_integration/test_ipahealthcheck.py
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS
+        template: *testing-master-latest
+        topology: *master_1repl
+        timeout: 4800
+
+  testing-fedora/test_ipahealthcheck_adtrust:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithADtrust
         template: *testing-master-latest
         timeout: 4800
+        topology: *ad_master
 
   testing-fedora/test_ntp_options:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1336,10 +1336,22 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-previous/build_url}'
-        test_suite: test_integration/test_ipahealthcheck.py
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS
         template: *ci-master-previous
         timeout: 4800
         topology: *master_1repl
+
+  fedora-previous/test_ipahealthcheck_adtrust:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithADtrust
+        template: *ci-master-previous
+        timeout: 4800
+        topology: *ad_master
 
   fedora-previous/test_ntp_options:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1441,10 +1441,23 @@ jobs:
       args:
         build_url: '{fedora-rawhide/build_url}'
         update_packages: True
-        test_suite: test_integration/test_ipahealthcheck.py
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS
         template: *ci-master-frawhide
         timeout: 4800
         topology: *master_1repl
+
+  fedora-rawhide/test_ipahealthcheck_adtrust:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithADtrust
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *ad_master
 
   fedora-rawhide/test_ntp_options:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
Tests to check ipahealthcheck tool with IPA-AD trust scenario for the below checks.
    IPATrustDomainsCheck
    IPATrustControllerConfCheck
    IPAsidgenpluginCheck
    IPATrustControllerServiceCheck