### PR TITLE
WebUI: Disable certificate loading for CA-less installation

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/install/ui/src/freeipa/field.js
+++ b/install/ui/src/freeipa/field.js
@@ -1392,6 +1392,8 @@ field.certs_field = IPA.certs_field = function(spec) {
     that.acl_result_index = spec.acl_result_index;
 
     that.load = function(data) {
+        if (!IPA.cert.is_enabled()) return;
+
         var value = that.adapter.load(data);
         var parsed = util.parse(that.data_parser, value, "Parse error:"+that.name);
         value = parsed.value;

--- a/install/ui/src/freeipa/host.js
+++ b/install/ui/src/freeipa/host.js
@@ -520,18 +520,20 @@ IPA.host.details_facet = function(spec, no_init) {
         var host_command = that.details_facet_create_refresh_command();
         batch.add_command(host_command);
 
-        var certificates = rpc.command({
-            entity: 'cert',
-            method: 'find',
-            retry: false,
-            options: {
-                host: [ pkey ],
-                sizelimit: 0,
-                all: true
-            }
-        });
+        if (IPA.cert.is_enabled()) {
+            var certificates = rpc.command({
+                entity: 'cert',
+                method: 'find',
+                retry: false,
+                options: {
+                    host: [ pkey ],
+                    sizelimit: 0,
+                    all: true
+                }
+            });
 
-        batch.add_command(certificates);
+            batch.add_command(certificates);
+        }
 
         return batch;
 

--- a/install/ui/src/freeipa/service.js
+++ b/install/ui/src/freeipa/service.js
@@ -511,18 +511,20 @@ IPA.service.details_facet = function(spec, no_init) {
         var service_command = that.details_facet_create_refresh_command();
         batch.add_command(service_command);
 
-        var certificates = rpc.command({
-            entity: 'cert',
-            method: 'find',
-            retry: false,
-            options: {
-                service: [ pkey ],
-                sizelimit: 0,
-                all: true
-            }
-        });
+        if (IPA.cert.is_enabled()) {
+            var certificates = rpc.command({
+                entity: 'cert',
+                method: 'find',
+                retry: false,
+                options: {
+                    service: [ pkey ],
+                    sizelimit: 0,
+                    all: true
+                }
+            });
 
-        batch.add_command(certificates);
+            batch.add_command(certificates);
+        }
 
         return batch;
     };

--- a/install/ui/src/freeipa/user.js
+++ b/install/ui/src/freeipa/user.js
@@ -662,18 +662,20 @@ IPA.user.details_facet = function(spec, no_init) {
 
         batch.add_command(krbtpolicy_command);
 
-        var certificates = rpc.command({
-            entity: 'cert',
-            method: 'find',
-            retry: false,
-            options: {
-                user: [ pkey ],
-                sizelimit: 0,
-                all: true
-            }
-        });
+        if (IPA.cert.is_enabled()) {
+            var certificates = rpc.command({
+                entity: 'cert',
+                method: 'find',
+                retry: false,
+                options: {
+                    user: [ pkey ],
+                    sizelimit: 0,
+                    all: true
+                }
+            });
 
-        batch.add_command(certificates);
+            batch.add_command(certificates);
+        }
 
         return batch;
     };

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,38 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_webui_host:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_webui/test_host.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *ipaserver
+
+  fedora-latest/test_webui_service:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_webui/test_service.py
+        template: *ci-master-latest
+        timeout: 2400
+        topology: *ipaserver
+
+  fedora-latest/test_webui_user:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_webui/test_user.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *ipaserver


### PR DESCRIPTION
- prevent parsing data in certs_field if certificates are disabled
- fix the corresponding issue on user, host and service details pages

Ticket: https://pagure.io/freeipa/issue/8203