### PR TITLE
[Backport][ipa-4-8] Build ipa-selinux package on RHEL 8

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -37,7 +37,7 @@
 %endif
 
 # Include SELinux subpackage
-%if 0%{?fedora} >= 30 || 0%{?rhel} > 8
+%if 0%{?fedora} >= 30 || 0%{?rhel}
     %global with_selinux 1
     %global selinuxtype targeted
     %global modulename ipa


### PR DESCRIPTION
This PR was opened automatically because PR #4830 was pushed to master and backport to ipa-4-8 is required.