### PR TITLE
[Backport][ipa-4-8] Use old uglifyjs on RHEL 8

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -191,7 +191,12 @@ BuildRequires:  libsss_idmap-devel
 BuildRequires:  libsss_certmap-devel
 BuildRequires:  libsss_nss_idmap-devel >= %{sssd_version}
 BuildRequires:  nodejs(abi)
+# use old dependency on RHEL 8 for now
+%if 0%{?rhel}
+BuildRequires:  uglify-js
+%else
 BuildRequires:  python3-rjsmin
+%endif
 BuildRequires:  libverto-devel
 BuildRequires:  libunistring-devel
 # 0.13.0: https://bugzilla.redhat.com/show_bug.cgi?id=1584773

--- a/install/ui/util/compile.sh
+++ b/install/ui/util/compile.sh
@@ -23,6 +23,9 @@ set -o errexit
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 RDIR=$DIR/../release
 
+# for platform ID
+. /etc/os-release
+
 usage() {
 cat <<-__EOF__;
 NAME
@@ -105,7 +108,13 @@ if [[ ! $OUTPUT_FILE ]] ; then
     OUTPUT_FILE=$RDIR/$RELEASE/$LAYER.js
 fi
 
-# compile using python rjsmin
+# compile using python rjsmin on most platforms and uglify-js on RHEL 8
 echo "Minimizing: $RDIR/$RELEASE/$LAYER.js"
 echo "Target file: $OUTPUT_FILE"
-${PYTHON:-python3} -m rjsmin < $RDIR/$RELEASE/$LAYER.js > $OUTPUT_FILE
+if [ $ID = "rhel" ]; then
+    echo "Minifier: uglifyjs"
+    uglifyjs < $RDIR/$RELEASE/$LAYER.js > $OUTPUT_FILE
+else
+    echo "Minifier: rjsmin"
+    ${PYTHON:-python3} -m rjsmin < $RDIR/$RELEASE/$LAYER.js > $OUTPUT_FILE
+fi


### PR DESCRIPTION
This PR was opened automatically because PR #4834 was pushed to master and backport to ipa-4-8 is required.