### PR TITLE
Test that override_gid is working for subdomain

### DIFF
--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -471,15 +471,19 @@ class TestSSSDWithAdTrust(IntegrationTest):
             "--matchrule='<ISSUER>{}'".format(cert_subject),
             "--domain={}".format(self.master.domain.name)
         ])
-        tasks.clear_sssd_cache(self.master)
-
-        # verify the user can be retrieved after the certmaprule is added
-        second_res = self.master.run_command(['id', self.users['ad']['name']])
-
-        assert first_res.stdout_text == second_res.stdout_text
-        verify_in_stdout = ['gid', 'uid', 'groups', self.users['ad']['name']]
-        for text in verify_in_stdout:
-            assert text in second_res.stdout_text
+        try:
+            tasks.clear_sssd_cache(self.master)
+            # verify the user can be retrieved after the certmaprule is added
+            second_res = self.master.run_command(
+                ['id', self.users['ad']['name']])
+            assert first_res.stdout_text == second_res.stdout_text
+            verify_in_stdout = ['gid', 'uid', 'groups',
+                                self.users['ad']['name']]
+            for text in verify_in_stdout:
+                assert text in second_res.stdout_text
+        finally:
+            self.master.run_command(
+                ['ipa', 'certmaprule-del', "'{}'".format(cert_subject)])
 
     @contextmanager
     def override_gid_setup(self, gid):

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -507,7 +507,10 @@ class TestSSSDWithAdTrust(IntegrationTest):
         self.master.run_command(['id', user])
         with self.override_gid_setup(gid):
             test_gid = self.master.run_command(['id', user])
-            assert 'gid={id}'.format(id=gid) in test_gid.stdout_text
+            sssd_version = tasks.get_sssd_version(self.master)
+            with xfail_context(sssd_version < tasks.parse_version('2.3.0'),
+                               'https://pagure.io/SSSD/sssd/issue/4061'):
+                assert 'gid={id}'.format(id=gid) in test_gid.stdout_text
 
 
 class TestNestedMembers(IntegrationTest):


### PR DESCRIPTION
When override_gid is set in sssd.conf in IPA domain section
Then it should also work for subdomain.  
Related: https://pagure.io/SSSD/sssd/issue/4061
