### PR TITLE
ipatests: increase test_caless_TestReplicaInstall timeout

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -568,7 +568,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   fedora-latest/test_caless_TestClientInstall:

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -114,7 +114,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *389ds-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   389ds-fedora/test_caless_TestClientInstall:

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -348,7 +348,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *pki-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   pki-fedora/test_caless_TestClientInstall:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -611,7 +611,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *testing-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   testing-fedora/test_caless_TestClientInstall:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -568,7 +568,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *ci-master-previous
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   fedora-previous/test_caless_TestClientInstall:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -611,7 +611,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *ci-master-frawhide
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   fedora-rawhide/test_caless_TestClientInstall:


### PR DESCRIPTION
test_caless_TestReplicaInstall timeout seems too short.
Extend it.

Fixes: https://pagure.io/freeipa/issue/8377
Signed-off-by: François Cami <fcami@redhat.com>