### PR TITLE
[Backport][ipa-4-8] Use 256 bit AJP secret 

### DIFF
--- a/install/share/ipaca_customize.ini
+++ b/install/share/ipaca_customize.ini
@@ -12,6 +12,7 @@
 #
 # Predefined variables
 #  - ipa_ca_subject
+#  - ipa_ajp_secret
 #  - ipa_fqdn
 #  - ipa_subject_base
 #  - pki_admin_password

--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -12,6 +12,7 @@ ipa_ca_pem_file=/etc/ipa/ca.crt
 
 ## dynamic values
 # ipa_ca_subject=
+# ipa_ajp_secret=
 # ipa_subject_base=
 # ipa_fqdn=
 # ipa_ocsp_uri=
@@ -66,6 +67,7 @@ pki_issuing_ca=%(pki_issuing_ca_uri)s
 pki_replication_password=
 
 pki_enable_proxy=True
+pki_ajp_secret=%(ipa_ajp_secret)s
 pki_restart_configured_instance=False
 pki_security_domain_hostname=%(ipa_fqdn)s
 pki_security_domain_https_port=443

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -840,7 +840,9 @@ class PKIIniLoader:
             pki_subsystem_type=subsystem.lower(),
             home_dir=os.path.expanduser("~"),
             # for softhsm2 testing
-            softhsm2_so=paths.LIBSOFTHSM2_SO
+            softhsm2_so=paths.LIBSOFTHSM2_SO,
+            # Configure a more secure AJP password by default
+            ipa_ajp_secret=ipautil.ipa_generate_password(special=None)
         )
 
     @classmethod


### PR DESCRIPTION
This PR was opened automatically because PR #4819 was pushed to master and backport to ipa-4-8 is required.