### PR TITLE
[Backport][ipa-4-8] ipa-client-install: use sshd drop-in configuration

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1081,7 +1081,7 @@ fi
 %endif
 
 
-%triggerin client -- openssh-server
+%triggerin client -- openssh-server < 8.2
 # Has the client been configured?
 restore=0
 test -f '/var/lib/ipa-client/sysrestore/sysrestore.index' && restore=$(wc -l '/var/lib/ipa-client/sysrestore/sysrestore.index' | awk '{print $1}')
@@ -1111,6 +1111,26 @@ if [ -f '/etc/ssh/sshd_config' -a $restore -ge 2 ]; then
 
         mv -Z /etc/ssh/sshd_config.ipanew /etc/ssh/sshd_config
         chmod 600 /etc/ssh/sshd_config
+
+        /bin/systemctl condrestart sshd.service 2>&1 || :
+    fi
+fi
+
+
+%triggerin client -- openssh-server >= 8.2
+# Has the client been configured?
+restore=0
+test -f '/var/lib/ipa-client/sysrestore/sysrestore.index' && restore=$(wc -l '/var/lib/ipa-client/sysrestore/sysrestore.index' | awk '{print $1}')
+
+if [ -f '/etc/ssh/sshd_config' -a $restore -ge 2 ]; then
+    # If the snippet already exists, skip
+    if [ ! -f '/etc/ssh/sshd_config.d/04-ipa.conf' ]; then
+        # Take the values from /etc/ssh/sshd_config and put them in 04-ipa.conf
+        grep -E '^(PubkeyAuthentication|KerberosAuthentication|GSSAPIAuthentication|UsePAM|ChallengeResponseAuthentication|AuthorizedKeysCommand|AuthorizedKeysCommandUser)' /etc/ssh/sshd_config 2>/dev/null > /etc/ssh/sshd_config.d/04-ipa.conf
+        # Remove the values from sshd_conf
+        sed -ri '
+            /^(PubkeyAuthentication|KerberosAuthentication|GSSAPIAuthentication|UsePAM|ChallengeResponseAuthentication|AuthorizedKeysCommand|AuthorizedKeysCommandUser)[ \t]/ d
+        ' /etc/ssh/sshd_config
 
         /bin/systemctl condrestart sshd.service 2>&1 || :
     fi

--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -101,6 +101,7 @@ dist_app_DATA =				\
 	ipaca_default.ini		\
 	ipaca_customize.ini		\
 	ipaca_softhsm2.ini		\
+	sshd_ipa.conf.template	\
 	$(NULL)
 
 kdcproxyconfdir = $(IPA_SYSCONF_DIR)/kdcproxy

--- a/install/share/sshd_ipa.conf.template
+++ b/install/share/sshd_ipa.conf.template
@@ -1,0 +1,8 @@
+# IPA-related configuration changes to sshd_config
+
+PubkeyAuthentication yes
+KerberosAuthentication no
+GSSAPIAuthentication yes
+UsePAM yes
+ChallengeResponseAuthentication yes
+$SSSD_SSHD_OPTIONS

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -126,6 +126,8 @@ class BasePathNamespace:
     SSH_CONFIG_DIR = "/etc/ssh"
     SSH_CONFIG = "/etc/ssh/ssh_config"
     SSHD_CONFIG = "/etc/ssh/sshd_config"
+    SSHD_IPA_CONFIG = "/etc/ssh/sshd_config.d/04-ipa.conf"
+    SSHD_IPA_CONFIG_TEMPLATE = "/usr/share/ipa/sshd_ipa.conf.template"
     SSSD_CONF = "/etc/sssd/sssd.conf"
     SSSD_CONF_BKP = "/etc/sssd/sssd.conf.bkp"
     SSSD_CONF_DELETED = "/etc/sssd/sssd.conf.deleted"

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -155,6 +155,7 @@ class Backup(admintool.AdminTool):
         paths.HTTPD_KEY_FILE,
         paths.HTTPD_IPA_CONF,
         paths.SSHD_CONFIG,
+        paths.SSHD_IPA_CONFIG,
         paths.SSH_CONFIG,
         paths.KRB5_CONF,
         paths.KDC_CA_BUNDLE_PEM,


### PR DESCRIPTION
This PR was opened automatically because PR #4839 was pushed to master and backport to ipa-4-8 is required.