### PR TITLE
Ship EPN's configuration file.

### DIFF
--- a/client/man/epn.conf.5
+++ b/client/man/epn.conf.5
@@ -16,7 +16,7 @@
 .\"
 .\" Author: Rob Crittenden <rcritten@@redhat.com>
 .\"
-.TH "epn.conf" "5" "Apr 28 2020" "FreeIPA" "FreeIPA Manual Pages"
+.TH "EPN.CONF" "5" "April 28, 2020" "FreeIPA" "FreeIPA Manual Pages"
 .SH "NAME"
 epn.conf \- Expiring Password Notification configuration file
 .SH "SYNOPSIS"

--- a/client/man/epn.conf.5
+++ b/client/man/epn.conf.5
@@ -71,11 +71,10 @@ Specifies the From e-mail address value in the e-mails sent. The default is
 root@localhost. Bounces will be sent here.
 .TP
 .B smtp_delay <milliseconds>
-Time to wait, in milliseconds, between each e-mail sent to try to avoid overloading the mail queue.
+Time to wait, in milliseconds, between each e-mail sent to try to avoid overloading the mail queue. The default is 0.
 .TP
 .B mail_from <address>
-Specifies the From: e-mal address value in the e-mails sent. The default is
-noreply@ipadefaultemaildomain. This value can be found by running
+Specifies the From: e-mail address value in the e-mails sent. The default is noreply@ipadefaultemaildomain. This value can be found by running
 .I ipa config-show
 .TP
 .B notify_ttls <list of days>

--- a/client/man/ipa-epn.1
+++ b/client/man/ipa-epn.1
@@ -15,14 +15,14 @@
 .\" along with this program.  If not, see <http://www.gnu.org/licenses/>.
 .\"
 .\"
-.TH "ipa-epn" "1" "Apr 24 2020" "FreeIPA" "FreeIPA Manual Pages"
+.TH "IPA-EPN" "1" "April 24, 2020" "FreeIPA" "FreeIPA Manual Pages"
 .SH "NAME"
 ipa\-epn \- Send expiring password nofications
 .SH "SYNOPSIS"
-ipa\-epn \[options\]
+ipa\-epn \fR[options\fR]
 
 .SH "DESCRIPTION"
-ipa\-epn provides a method to warn users via email that their IPA account password is about to expire. 
+ipa\-epn provides a method to warn users via email that their IPA account password is about to expire.
 
 It can be used in dry\-run mode which is recommmended during setup. The output is always JSON in this case.
 
@@ -38,7 +38,7 @@ The \-\-to\-nbdays CLI option can be used to determine the number of notificatio
 
 If \fB\-\-from\-nbdays\fR is not specified, ipa\-epn will look within a 24\-hour long time range in <number of days> days.
 
-if \fB\-\-from\-nbdays\fR is specified, the date range starts at \fB\-\-from\-nbdays\fR days in the future and ends at \fB\-\-to\-nbdays\fR in the future. 
+if \fB\-\-from\-nbdays\fR is specified, the date range starts at \fB\-\-from\-nbdays\fR days in the future and ends at \fB\-\-to\-nbdays\fR in the future.
 
 Together, these two CLI options can be used to determine how many emails would be sent in a specific time in the future.
 

--- a/client/share/Makefile.am
+++ b/client/share/Makefile.am
@@ -5,7 +5,12 @@ dist_app_DATA =				\
 	freeipa.template		\
 	$(NULL)
 
-epnconfdir = $(IPA_SYSCONF_DIR)/epn
+epnconfdir = $(IPA_SYSCONF_DIR)
 dist_epnconf_DATA =			\
+	epn.conf			\
+	$(NULL)
+
+epntemplatedir = $(IPA_SYSCONF_DIR)/epn
+dist_epntemplate_DATA =			\
 	expire_msg.template	\
 	$(NULL)

--- a/client/share/epn.conf
+++ b/client/share/epn.conf
@@ -1,0 +1,54 @@
+# Global IPA-EPN [0] configuration file.
+# For a complete explanation of each parameter, see the epn.conf(5)
+# manual page.
+# For best results, change no more than a single parameter at a time,
+# and test if ipa-epn(1) still works as intended, using --dry-run when
+# it makes sense.
+#
+# [0] https://github.com/freeipa/freeipa/blob/master/doc/designs/expiring-password-notification.md
+
+[global]
+
+# Specifies the SMTP server to use. 
+smtp_server = localhost
+
+# Specifies the SMTP port.
+smtp_port = 25
+
+# Specifies the id of the user to authenticate with the SMTP server.
+# Default None (empty value).
+# smtp_user =
+
+# Specifies the password for the authorized user.
+# Default None (empty value).
+# smtp_password =
+
+# pecifies the number of seconds to wait for SMTP to respond.
+smtp_timeout = 60
+
+# Specifies the type of secure connection to make. Options are: none,
+# starttls and ssl.
+smtp_security = none
+
+# Specifies the From e-mail address value in the e-mails sent. Bounces will
+# be sent here.
+smtp_admin = root@localhost
+
+# Time to wait, in milliseconds, between each e-mail sent to try to avoid
+# overloading the mail queue.
+smtp_delay = 0
+
+# Specifies the From: e-mail address value in the e-mails sent.
+# The default when unset is noreply@ipadefaultemaildomain.
+# This value can be found by running ipa config-show.
+# mail_from =
+
+# The list of days before a password expiration when ipa-epn should notify
+# a user that their password will soon require a reset.
+notify_ttls = 28, 14, 7, 3, 1
+
+# Set the character set of the message.
+msg_charset = utf8
+
+# Set the message's MIME sub-content type.
+msg_subtype = plain

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1375,13 +1375,15 @@ fi
 
 %files client-epn
 %doc README.md Contributors.txt
+%dir %{_sysconfdir}/ipa/epn
 %license COPYING
 %{_sbindir}/ipa-epn
 %{_mandir}/man1/ipa-epn.1*
 %{_mandir}/man5/epn.conf.5*
 %attr(644,root,root) %{_unitdir}/ipa-epn.service
 %attr(644,root,root) %{_unitdir}/ipa-epn.timer
-%attr(644,root,root) %{_sysconfdir}/ipa/epn/expire_msg.template
+%attr(600,root,root) %config(noreplace) %{_sysconfdir}/ipa/epn.conf
+%attr(644,root,root) %config(noreplace) %{_sysconfdir}/ipa/epn/expire_msg.template
 
 %files -n python3-ipaclient
 %doc README.md Contributors.txt

--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -209,6 +209,20 @@ class TestEPN(IntegrationTest):
         cls.master.run_command(r'rm -f /etc/pki/tls/private/postfix.key')
         cls.master.run_command(r'rm -f /etc/pki/tls/certs/postfix.pem')
 
+    @pytest.mark.xfail(reason='pr-ci issue 378', strict=True)
+    def test_EPN_config_file(self):
+        """Check that the EPN configuration file is installed.
+           https://pagure.io/freeipa/issue/8374
+        """
+        epn_conf = "/etc/ipa/epn.conf"
+        epn_template = "/etc/ipa/epn/expire_msg.template"
+        cmd1 = self.master.run_command(["rpm", "-qc", "freeipa-client-epn"])
+        assert epn_conf in cmd1.stdout_text
+        assert epn_template in cmd1.stdout_text
+        cmd2 = self.master.run_command(["sha256sum", epn_conf])
+        ck = "4c207b5c9c760c36db0d3b2b93da50ea49edcc4002d6d1e7383601f0ec30b957"
+        assert cmd2.stdout_text.find(ck) == 0
+
     def test_EPN_smoketest_1(self):
         """No users except admin. Check --dry-run output.
            With the default configuration, the result should be an empty list.


### PR DESCRIPTION
ipatests: check that EPN's configuration file is installed.
Fixes: https://pagure.io/freeipa/issue/8374

man pages: fix epn.conf.5 and ipa-epn.1 formatting
Fix formatting issues found with mandoc.

EPN: ship the configuration file.
Ship and install /etc/ipa/epn.conf.
Minor fixes to the associated man page.
Fixes: https://pagure.io/freeipa/issue/8374
