### PR TITLE
Unify spelling of "One-Time Password" (take 2)

### DIFF
--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -406,7 +406,7 @@ class i18n_messages(Command):
             "logout": _("Log out"),
             "logout_error": _("Log out error"),
             "password": _("Password"),
-            "password_and_otp": _("Password or Password+One Time-Password"),
+            "password_and_otp": _("Password or Password+One-Time Password"),
             "redirect_msg": _("You will be redirected in ${count}s"),
             "sync_otp_token": _("Sync OTP Token"),
             "synchronizing": _("Synchronizing"),
@@ -1692,7 +1692,7 @@ class i18n_messages(Command):
             "otp_sync_invalid": _("The username, password or token codes are not correct"),
             "otp_sync_success":_("Token was synchronized"),
             "password": _("Password"),
-            "password_and_otp": _("Password or Password+One Time-Password"),
+            "password_and_otp": _("Password or Password+One-Time Password"),
             "password_change_complete": _("Password change complete"),
             "password_expired": _(
                 "Your password has expired. Please enter a new password."),

--- a/ipatests/test_webui/data_loginscreen.py
+++ b/ipatests/test_webui/data_loginscreen.py
@@ -31,7 +31,7 @@ FILLED_LOGIN_FORM = {
         ('username', 'Username', True, True, 'text', 'username',
          PKEY, 'Username'),
         ('password', 'Password', True, True, 'password', 'password',
-         PASSWD_ITEST_USER, 'Password or Password+One Time-Password'),
+         PASSWD_ITEST_USER, 'Password or Password+One-Time Password'),
     ],
     # structure of buttons
     # button_name, button_title


### PR DESCRIPTION
The previous fix for the spelling of "One-Time Password"
missed a few lines.

Fixes: https://pagure.io/freeipa/issue/8381
Related: https://pagure.io/freeipa/issue/5628
