### PR TITLE
[Backport][ipa-4-8] RHEL 8.3 has KRB5 1.18 with KDB 8.0

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -46,8 +46,8 @@
 %if 0%{?rhel}
 %global package_name ipa
 %global alt_name freeipa
-%global krb5_version 1.16.1
-%global krb5_kdb_version 7.0
+%global krb5_version 1.18
+%global krb5_kdb_version 8.0
 # 0.7.16: https://github.com/drkjam/netaddr/issues/71
 %global python_netaddr_version 0.7.16
 # Require 4.7.0 which brings Python 3 bindings


### PR DESCRIPTION
This PR was opened automatically because PR #4829 was pushed to master and backport to ipa-4-8 is required.