### PR TITLE
ipatests: Tests for ipahealthcheck tool with IPA external CA step1 installation only.

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_ipahealtcheck.py::TestIpaHealthCheckWithExternalCAStep1
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl


### PR DESCRIPTION
This testsuite checks whether the healthcheck tool reports correct status in a scenario where only Step1 installation
is performed for an IPA Server with external CA option. Below are some of the checks which report the status accordingly.

DogtagCertsConnectivityCheck, 
IPADomainCheck
IPACRLManagerCheck
IPAFileCheck
IPADNARangeCheck
IPACAChainExpirationCheck
IPACertRevocation
IPARAAgent
IPACertTracking
IPACertNSSTrust
IPANSSChainValidation
IPAOpenSSLChainValidation
IPACertmongerCA
IPAOpenSSLChainValidation