### PR TITLE
ipatests: Creating tmp files for systemd on behalf of certmonger

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_commands.py::TestIPACommand::test_systemd_tmpfile_create_error_on_console
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1216,3 +1216,23 @@ class TestIPACommand(IntegrationTest):
                                           '-u', 'sshd',
                                           '--since={}'.format(since)])
         assert exp_msg in result.stdout_text
+
+    def test_systemd_tmpfile_create_error_on_console(self):
+        """
+        This testcase checks that error message related to certonger
+        is not displayed when systemd-tmpfiles --create command is
+        run on IPA server
+        """
+        certmonger_tmp_conf = "/usr/lib/tmpfiles.d/certmonger.conf"
+        error_msg = (
+            "[/usr/lib/tmpfiles.d/certmonger.conf:3] Line references path "
+            "below legacy directory /var/run/, "
+            "updating /var/run/certmonger → /run/certmonger; "
+            "please update the tmpfiles.d/ drop-in file accordingly."
+        )
+        with open(certmonger_tmp_conf) as fp:
+            file_contents = fp.readlines()
+        assert "d /run/certmonger 0755 root root\n" in file_contents
+        result = self.master.run_command(["systemd-tmpfiles", "--create"])
+        assert result.returncode == 0
+        assert error_msg not in result.stdout_text


### PR DESCRIPTION
This testcase checks that error related to certmonger is not displayed on the console when the command 'systemd-tmpfiles --create' is run.