### PR TITLE
certupdate: update config when deployment becomes CA-ful

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -2205,17 +2205,20 @@ def add_lightweight_ca_tracking_requests(lwcas):
                 'already tracking certificate "%s"', nickname)
 
 
-def update_ipa_conf():
+def update_ipa_conf(ca_host=None):
     """
     Update IPA configuration file to ensure that RA plugins are enabled and
-    that CA host points to localhost
+    that CA host points to specified server (or localhost if ca_host=None).
     """
     parser = RawConfigParser()
     parser.read(paths.IPA_DEFAULT_CONF)
     parser.set('global', 'enable_ra', 'True')
     parser.set('global', 'ra_plugin', 'dogtag')
     parser.set('global', 'dogtag_version', '10')
-    parser.remove_option('global', 'ca_host')
+    if ca_host is None:
+        parser.remove_option('global', 'ca_host')
+    else:
+        parser.set('global', 'ca_host', ca_host)
     with open(paths.IPA_DEFAULT_CONF, 'w') as f:
         parser.write(f)
 

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -386,7 +386,8 @@ class DogtagInstance(service.Service):
             fd.write(template)
             os.fchmod(fd.fileno(), 0o640)
 
-    def configure_certmonger_renewal_helpers(self):
+    @staticmethod
+    def configure_certmonger_renewal_helpers():
         """
         Create a new CA type for certmonger that will retrieve updated
         certificates from the dogtag master server.


### PR DESCRIPTION
*Another aged-in-oak branch I've had sitting around for years.*

When a deployment gets promoted from CA-less to CA-ful other
replicas still have enable_ra=False in default.conf, and do not have
the ra-agent key and certificate.  Enhance ipa-certupdate to detect
when the deployment has become CA-ful; retrieve the ra-agent
credential and update default.conf.

The rationale for adding this behaviour to ipa-certupdate is that it
is already necessary to use this command to update local trust
stores with the new CA certificate(s).  So by using ipa-certupdate
we avoid introducing additional steps for administrators.

It is necessary to choose a CA master to use as the ca_host.  We use
the first server returned by LDAP.  A better heuristic might be to
choose a master in the same location but this is just left as a
comment unless or until the need is proven.

This change also addresses the case of a CA server being removed
from the topology, i.e. ipa-certupdate detects when non-CA replicas
are pointing at the removed server, and chooses a new ca_host.

HOW TO TEST:

1. Install a CA-less server (first server).

2. Install a CA-less replica.

3. Run 'ipa-ca-install' on first server, promoting deployment from
   CA-less to CA-ful.

4. Run 'ipa-certupdate' on second server.

5. Exceute 'ipa cert-show 5' on second server.  Should succeed,
   because ra-agent credential was retrieve and default.conf
   updated at step #4.

Fixes: https://pagure.io/freeipa/issue/7188
