### PR TITLE
[Backport][ipa-4-8] ipatests: increase test_caless_TestReplicaInstall timeout

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -568,7 +568,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *ci-ipa-4-8-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   fedora-latest-ipa-4-8/test_caless_TestClientInstall:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -568,7 +568,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *ci-ipa-4-8-previous
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   fedora-previous-ipa-4-8/test_caless_TestClientInstall:


### PR DESCRIPTION
MANUAL CHERRY PICK of https://github.com/freeipa/freeipa/pull/4841

test_caless_TestReplicaInstall timeout seems too short.
Extend it.

Fixes: https://pagure.io/freeipa/issue/8377
Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Florence Blanc-Renaud <flo@redhat.com>
Reviewed-By: Armando Neto <abiagion@redhat.com>