### PR TITLE
[Backport][ipa-4-8] Define errors_by_code in ipalib.errors

### DIFF
--- a/ipalib/errors.py
+++ b/ipalib/errors.py
@@ -2016,5 +2016,7 @@ class GenericError(PublicError):
 public_errors = tuple(sorted(
     messages.iter_messages(globals(), PublicError), key=lambda E: E.errno))
 
+errors_by_code = dict((e.errno, e) for e in public_errors)
+
 if __name__ == '__main__':
     messages.print_report('public errors', public_errors)

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -52,7 +52,7 @@ import six
 
 from ipalib.backend import Connectible
 from ipalib.constants import LDAP_GENERALIZED_TIME_FORMAT
-from ipalib.errors import (public_errors, UnknownError, NetworkError,
+from ipalib.errors import (errors_by_code, UnknownError, NetworkError,
                            XMLRPCMarshallError, JSONError)
 from ipalib import errors, capabilities
 from ipalib.request import context, Connection
@@ -96,8 +96,6 @@ logger = logging.getLogger(__name__)
 
 COOKIE_NAME = 'ipa_session'
 CCACHE_COOKIE_KEY = 'X-IPA-Session-Cookie'
-
-errors_by_code = dict((e.errno, e) for e in public_errors)
 
 
 def update_persistent_client_session_data(principal, data):


### PR DESCRIPTION
This PR was opened automatically because PR #4860 was pushed to master and backport to ipa-4-8 is required.