### PR TITLE
[Backport][ipa-4-8] WebUI: Fix "IPA Error 3007: RequirmentError" while adding idoverrideu…

### DIFF
--- a/install/ui/src/freeipa/association.js
+++ b/install/ui/src/freeipa/association.js
@@ -25,6 +25,7 @@
 define([
     'dojo/_base/lang',
     'dojo/Deferred',
+    './builder',
     './metadata',
     './ipa',
     './jquery',
@@ -38,7 +39,7 @@ define([
     './facet',
     './search',
     './dialog'],
-        function(lang, Deferred, metadata_provider, IPA, $, metadata,
+        function(lang, Deferred, builder, metadata_provider, IPA, $, metadata,
                  navigation, phases, reg, rpc, su, text) {
 
 /**
@@ -1209,7 +1210,8 @@ exp.association_facet = IPA.association_facet = function (spec, no_init) {
 
         var pkeys = that.data.result.result[that.get_attribute_name()];
 
-        var dialog = IPA.association_adder_dialog({
+        var dialog = builder.build('association_adder_dialog', {
+            $type: that.other_entity.name,
             title: title,
             entity: that.entity,
             pkey: pkey,
@@ -1674,6 +1676,13 @@ IPA.attr_read_only_evaluator = function(spec) {
 
     return that;
 };
+
+// Create a registry for adder dialogs where key is name of 'other entity'.
+// It allows to override dialogs for some specific cases of association
+// creation.
+var dialog_builder = builder.get('association_adder_dialog');
+dialog_builder.factory = IPA.association_adder_dialog;
+reg.set('association_adder_dialog', dialog_builder.registry);
 
 phases.on('registration', function() {
     var w = reg.widget;

--- a/install/ui/src/freeipa/dialog.js
+++ b/install/ui/src/freeipa/dialog.js
@@ -919,35 +919,7 @@ IPA.adder_dialog = function(spec) {
             'class': 'input-group col-md-12 adder-dialog-top'
         }).appendTo(container);
 
-        var filter_placeholder = text.get('@i18n:association.filter_placeholder');
-        filter_placeholder = filter_placeholder.replace('${other_entity}',
-            that.other_entity.metadata.label);
-
-        that.filter_field = $('<input/>', {
-            type: 'text',
-            name: 'filter',
-            'class': 'form-control',
-            'placeholder': filter_placeholder,
-            keyup: function(event) {
-                if (event.keyCode === keys.ENTER) {
-                    that.search();
-                    return false;
-                }
-            }
-        }).appendTo(input_group);
-
-        var input_group_btn = $('<div/>', {
-            'class': 'input-group-btn'
-        }).appendTo(input_group);
-
-        that.find_button = IPA.button({
-            name: 'find',
-            label: '@i18n:buttons.filter',
-            click: function() {
-                that.search();
-                return false;
-            }
-        }).appendTo(input_group_btn);
+        that.filter_field = that.get_filter_field(input_group);
 
         var row = $('<div/>', { 'class': 'row adder-dialog-main'}).appendTo(container);
         //
@@ -1130,6 +1102,49 @@ IPA.adder_dialog = function(spec) {
      */
     that.get_filter = function() {
         return that.filter_field.val();
+    };
+
+    /**
+     * Return field for filtering available items
+     *
+     * Default implementation returns text input + "Filter" button.
+     * It can be overridden.
+     *
+     * @param {HTMLElement} input_group - container for a filter field
+     * @return {HTMLElement}
+     */
+    that.get_filter_field = function(input_group) {
+        var filter_placeholder = text.get(
+            '@i18n:association.filter_placeholder'
+        ).replace('${other_entity}', that.other_entity.metadata.label);
+
+        var filter_field = $('<input/>', {
+            type: 'text',
+            name: 'filter',
+            'class': 'form-control',
+            'placeholder': filter_placeholder,
+            keyup: function(event) {
+                if (event.keyCode === keys.ENTER) {
+                    that.search();
+                    return false;
+                }
+            }
+        }).appendTo(input_group);
+
+        var input_group_btn = $('<div/>', {
+            'class': 'input-group-btn'
+        }).appendTo(input_group);
+
+        that.find_button = IPA.button({
+            name: 'find',
+            label: '@i18n:buttons.filter',
+            click: function() {
+                that.search();
+                return false;
+            }
+        }).appendTo(input_group_btn);
+
+        return filter_field;
     };
 
     /**

--- a/install/ui/src/freeipa/group.js
+++ b/install/ui/src/freeipa/group.js
@@ -205,6 +205,20 @@ return {
             add_title: '@i18n:objects.group.add_into_sudo',
             remove_method: 'remove_user',
             remove_title: '@i18n:objects.group.remove_from_sudo'
+        },
+        {
+            $type: 'association',
+            name: 'member_idoverrideuser',
+            associator: IPA.serial_associator,
+            add_title: '@i18n:objects.group.add_idoverride_user',
+            remove_title: '@i18n:objects.group.remove_idoverride_users',
+            columns: [
+                {
+                    name: 'ipaanchoruuid',
+                    label: '@i18n:objects.idoverrideuser.anchor_label',
+                    link: false
+                }
+            ]
         }
     ],
     standard_association_facets: true,

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -835,6 +835,9 @@ class i18n_messages(Command):
                     "Remove users from member managers for user group "
                     "'${primary_key}'"
                 ),
+                "add_idoverride_user": _(
+                    "Add user ID override into user group '${primary_key}'"
+                ),
                 "details": _("Group Settings"),
                 "external": _("External"),
                 "groups": _("Groups"),
@@ -867,6 +870,9 @@ class i18n_messages(Command):
                 ),
                 "remove_users": _(
                     "Remove users from user group '${primary_key}'"
+                ),
+                "remove_idoverride_users": _(
+                    "Remove user ID overrides from user group '${primary_key}'"
                 ),
                 "type": _("Group Type"),
                 "user_groups": _("User Groups"),


### PR DESCRIPTION
…ser association

Add builder for association adder dialog which allows to override behavior of the component.
Replace default implementation with a custom one for idoverrideuser.
Replace text filter with 'ID view' select box in the idoverrideuser dialog.

Ticket: https://pagure.io/freeipa/issue/8335

Signed-off-by: Serhii Tsymbaliuk <stsymbal@redhat.com>
Reviewed-By: Alexander Bokovoy <abokovoy@redhat.com>