### PR TITLE
ca-del: require CA to already be disabled

### DIFF
--- a/ipaserver/plugins/ca.py
+++ b/ipaserver/plugins/ca.py
@@ -342,7 +342,12 @@ class ca_del(LDAPDelete):
 
         ca_id = self.api.Command.ca_show(keys[0])['result']['ipacaid'][0]
         with self.api.Backend.ra_lightweight_ca as ca_api:
-            ca_api.disable_ca(ca_id)
+            data = ca_api.read_ca(ca_id)
+            if data['enabled']:
+                raise errors.ProtectedEntryError(
+                    label=_("CA"),
+                    key=keys[0],
+                    reason=_("Must be disabled first"))
             ca_api.delete_ca(ca_id)
 
         return dn

--- a/ipaserver/plugins/ca.py
+++ b/ipaserver/plugins/ca.py
@@ -35,20 +35,22 @@ certificate to be revoked and its private key deleted.
 """) + _("""
 EXAMPLES:
 """) + _("""
-  Create new CA, subordinate to the IPA CA.
+  Create new CA, subordinate to the IPA CA (requires permission
+  "System: Add CA"):
 
     ipa ca-add puppet --desc "Puppet" \\
         --subject "CN=Puppet CA,O=EXAMPLE.COM"
 """) + _("""
-  Disable a CA.
+  Disable a CA (requires permission "System: Modify CA"):
 
     ipa ca-disable puppet
 """) + _("""
-  Re-enable a CA.
+  Re-enable a CA (requires permission "System: Modify CA"):
 
     ipa ca-enable puppet
 """) + _("""
-  Delete a CA.
+  Delete a CA (requires permission "System: Delete CA"; also requires
+  CA to be disabled first):
 
     ipa ca-del puppet
 """)
@@ -321,7 +323,7 @@ class ca_add(LDAPCreate):
 
 @register()
 class ca_del(LDAPDelete):
-    __doc__ = _('Delete a CA.')
+    __doc__ = _('Delete a CA (must be disabled first).')
 
     msg_summary = _('Deleted CA "%(value)s"')
 

--- a/ipatests/test_xmlrpc/test_ca_plugin.py
+++ b/ipatests/test_xmlrpc/test_ca_plugin.py
@@ -78,7 +78,13 @@ class TestDefaultCA(XMLRPC_test):
     def test_default_ca_present(self, default_ca):
         default_ca.retrieve()
 
+    def test_default_ca_disable(self, default_ca):
+        """IPA CA cannot be disabled."""
+        with pytest.raises(errors.ProtectedEntryError):
+            default_ca.disable()
+
     def test_default_ca_delete(self, default_ca):
+        """IPA CA cannot be deleted."""
         with pytest.raises(errors.ProtectedEntryError):
             default_ca.delete()
 
@@ -104,7 +110,14 @@ class TestCAbasicCRUD(XMLRPC_test):
         )
         command()
 
-    def test_delete(self, crud_subca):
+    def test_delete_while_enabled_fails(self, crud_subca):
+        with pytest.raises(errors.ProtectedEntryError):
+            crud_subca.delete()
+
+    def test_disable(self, crud_subca):
+        crud_subca.disable()
+
+    def test_delete_after_disable_succeeds(self, crud_subca):
         crud_subca.delete()
 
     def test_find(self, crud_subca):

--- a/ipatests/test_xmlrpc/test_ca_plugin.py
+++ b/ipatests/test_xmlrpc/test_ca_plugin.py
@@ -48,7 +48,7 @@ def default_ca(request):
 def crud_subca(request, xmlrpc_setup):
     name = u'crud-subca'
     subject = u'CN=crud subca test,O=crud testing inc'
-    tracker = CATracker(name, subject)
+    tracker = CATracker(name, subject, auto_disable_for_delete=False)
 
     return tracker.make_fixture(request)
 
@@ -208,3 +208,11 @@ class TestCAbasicCRUD(XMLRPC_test):
             self, unrecognised_subject_dn_attrs_subca):
         with pytest.raises(errors.ValidationError):
             unrecognised_subject_dn_attrs_subca.create()
+
+    def test_pre_cleanup_disable(self, crud_subca):
+        # crud_subca was initialised with auto_disable_for_delete=False.  But
+        # we already tested disablement and deletion.  Then we recreated it for
+        # subsequent tests.  Now we have finished the tests; crud_subca is
+        # about to be deleted.  But we have to explicitly disable it first,
+        # otherwise deletion will will and raise a test teardown failure.
+        crud_subca.disable()

--- a/ipatests/test_xmlrpc/tracker/base.py
+++ b/ipatests/test_xmlrpc/tracker/base.py
@@ -302,6 +302,11 @@ class EnableTracker(BaseTracker):
         (enabled/disabled) after the test as it was before it.
         """
         def cleanup():
+            if isinstance(self, CreationTracker):
+                # special case: if it already got deleted there is
+                # nothing to enable or disable
+                return
+
             if self.original_enabled != self.enabled:
                 if self.original_enabled:
                     command = self.make_enable_command()

--- a/ipatests/test_xmlrpc/tracker/ca_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/ca_plugin.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 import six
 
 from ipapython.dn import DN
-from ipatests.test_xmlrpc.tracker.base import Tracker
+from ipatests.test_xmlrpc.tracker.base import Tracker, EnableTracker
 from ipatests.util import assert_deepequal
 from ipatests.test_xmlrpc.xmlrpc_test import (
     fuzzy_issuer,
@@ -22,7 +22,7 @@ if six.PY3:
     unicode = str
 
 
-class CATracker(Tracker):
+class CATracker(Tracker, EnableTracker):
     """Implementation of a Tracker class for CA plugin."""
 
     ldap_keys = {
@@ -79,6 +79,16 @@ class CATracker(Tracker):
             objectclass=objectclasses.ca
         )
         self.exists = True
+
+    def make_disable_command(self):
+        return self.make_command('ca_disable', self.name)
+
+    def check_disable(self, result):
+        assert_deepequal(dict(
+            result=True,
+            value=self.name,
+            summary=f'Disabled CA "{self.name}"',
+        ), result)
 
     def make_delete_command(self):
         """Make function that deletes the plugin entry object."""


### PR DESCRIPTION
*Another aged-in-oak commit from the IPA->Dogtag GSS-API effort.
This one should be ipa-next and have a release note attached.*

Currently ca-del disables the target CA before deleting it.
Conceptually, this involves two separate permissions: modify and
delete.  A user with delete permission does not necessarily have
modify permission.

As we head toward enforcing IPA permissions in Dogtag, it is
necessary to decouple disablement from deletion, otherwise the
disable operation shall fail if the user does not have modify
permission.  Although it introduces an additional step for
administrators, the process is consistent, required permissions map
1:1 to the operations, and the error messages make it clear what
needs to happen (i.e. disable first).

Part of: https://fedorahosted.org/freeipa/ticket/5011