### PR TITLE
ra.get_certificate: use REST API

### DIFF
--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -63,9 +63,13 @@ if six.PY3:
 PEM = 0
 DER = 1
 
+# The first group is the whole PEM datum and the second group is
+# the base64 content (with newlines).  For findall() the result is
+# a list of 2-tuples of the PEM and base64 data.
 PEM_CERT_REGEX = re.compile(
-    b'-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----',
+    b'(-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----)',
     re.DOTALL)
+
 PEM_PRIV_REGEX = re.compile(
     b'-----BEGIN(?: ENCRYPTED)?(?: (?:RSA|DSA|DH|EC))? PRIVATE KEY-----.*?'
     b'-----END(?: ENCRYPTED)?(?: (?:RSA|DSA|DH|EC))? PRIVATE KEY-----',
@@ -447,7 +451,7 @@ def load_certificate_list(data):
     Return a list of python-cryptography ``Certificate`` objects.
     """
     certs = PEM_CERT_REGEX.findall(data)
-    return [load_pem_x509_certificate(cert) for cert in certs]
+    return [load_pem_x509_certificate(cert[0]) for cert in certs]
 
 
 def load_certificate_list_from_file(filename):


### PR DESCRIPTION
*Another patch dragged kicking and screaming into the new decade.*

Update ra.get_certificate to use the Dogtag REST API.  This change
is being done as part of the Dogtag GSS-API authentication effort
because the servlet-based method expects an internal Dogtag user.
It is less intrusive to just change FreeIPA to call the REST API
instead (which is also part of an existing ticket).

Depends on https://pagure.io/dogtagpki/issue/2601 (which was merged
and released long ago).

Part of: https://pagure.io/freeipa/issue/3473
Part of: https://pagure.io/freeipa/issue/5011