### PR TITLE
cainstance.is_crlgen_enabled: handle missing ipa-pki-proxy.conf

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1402,7 +1402,7 @@ class CAInstance(DogtagInstance):
                         rewriteRuleDisabled = False
                         break
         except IOError:
-            raise RuntimeError(
+            raise InconsistentCRLGenConfigException(
                 "Unable to read {}".format(paths.HTTPD_IPA_PKI_PROXY_CONF))
 
         # if enableCRLUpdates and rewriteRuleDisabled are different, the config


### PR DESCRIPTION
A failed ipa-ca-install left my installation in an inconsistent
state.  Then, 'ipa-server-install --uninstall' also failed when
is_crlgen_enabled() tried to read ipa-pki-proxy.conf, which was
missing.

Update is_crlgen_enabled() to handle missing ipa-pki-proxy.conf so
that uninstallation works.