### PR TITLE
[Backport][ipa-4-8] Allow ipa-adtrust-install restart sssd and dirsrv services

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -72,8 +72,12 @@
 %global python_netaddr_version 0.7.16
 # Require 4.7.0 which brings Python 3 bindings
 %global samba_version 2:4.7.0
-# SELinux context for /etc/named directory, RHBZ#1759495
-%global selinux_policy_version 3.14.3-52
+# SELinux context for dirsrv unit file, BZ 1820298
+%if 0%{?fedora} >= 32
+%global selinux_policy_version 3.14.5-39
+%else
+%global selinux_policy_version 3.14.4-52
+%endif
 %global slapi_nis_version 0.56.1
 
 # krb5 can only provide one KDB at a time

--- a/selinux/ipa.if
+++ b/selinux/ipa.if
@@ -392,3 +392,30 @@ ifndef(`apache_manage_pid_files',`
 		manage_sock_files_pattern($1, httpd_var_run_t, httpd_var_run_t)
 	')
 ')
+
+########################################
+## <summary>
+##	Execute dirsrv server in the dirsrv domain.
+##  Backport from https://github.com/fedora-selinux/selinux-policy-contrib/pull/241
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+ifndef(`dirsrv_systemctl',`
+    interface(`dirsrv_systemctl',`
+        gen_require(`
+            type dirsrv_unit_file_t;
+            type dirsrv_t;
+        ')
+
+        systemd_exec_systemctl($1)
+        init_reload_services($1)
+        allow $1 dirsrv_unit_file_t:file read_file_perms;
+        allow $1 dirsrv_unit_file_t:service manage_service_perms;
+
+        ps_process_pattern($1, dirsrv_t)
+    ')
+')

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -147,6 +147,9 @@ auth_use_nsswitch(ipa_helper_t)
 
 files_list_tmp(ipa_helper_t)
 
+init_read_state(ipa_helper_t)
+init_stream_connect(ipa_helper_t)
+
 ipa_manage_pid_files(ipa_helper_t)
 ipa_read_lib(ipa_helper_t)
 
@@ -154,6 +157,10 @@ logging_send_syslog_msg(ipa_helper_t)
 
 optional_policy(`
     dirsrv_stream_connect(ipa_helper_t)
+')
+
+optional_policy(`
+    dirsrv_systemctl(ipa_helper_t)
 ')
 
 optional_policy(`
@@ -182,6 +189,7 @@ optional_policy(`
 
 optional_policy(`
     sssd_manage_lib_files(ipa_helper_t)
+    sssd_systemctl(ipa_helper_t)
 ')
 
 ########################################


### PR DESCRIPTION
This PR was opened automatically because PR #4671 was pushed to master and backport to ipa-4-8 is required.