### PR TITLE
[Backport][ipa-4-8] ipatests: display SSSD kdcinfo in test_adtrust_install.py

### DIFF
--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -59,7 +59,13 @@ class TestIpaAdTrustInstall(IntegrationTest):
 
         try:
             # Create a nonadmin user that will be used by curl.
-            # krb5_trace set to True: https://pagure.io/freeipa/issue/8353
+            # First, display SSSD kdcinfo:
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1850445#c1
+            self.master.run_command([
+                "cat",
+                "/var/lib/sss/pubconf/kdcinfo.%s" % self.master.domain.realm
+            ], raiseonerr=False)
+            # Set krb5_trace to True: https://pagure.io/freeipa/issue/8353
             tasks.create_active_user(
                 self.master, user, passwd, first=user, last=user,
                 krb5_trace=True


### PR DESCRIPTION
MANUAL, CLEAN CHERRY PICK of #4853

The test test_adtrust_install.py::TestIpaAdTrustInstall::test_add_agent_not_allowed
sometimes fails at kinit in create_active_user:
```
kinit: Password has expired while getting initial credentials
```
krb5_strace shows that this happens when kinit changes servers
between password change and TGT requests.
Display SSSD's kdcinfo to see if kinit should be pinned to one
server.

Related-to: https://pagure.io/freeipa/issue/8353
Related-to: https://pagure.io/freeipa/issue/8271
Signed-off-by: François Cami <fcami@redhat.com>
Reviewed-By: Michal Polovka <mpolovka@redhat.com>
Reviewed-By: Sumit Bose <sbose@redhat.com>
Reviewed-By: Robbie Harwood <rharwood@redhat.com>