### PR TITLE
ipatests: remove dnf workaround from test_epn.py

### DIFF
--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -216,22 +216,6 @@ class TestEPN(IntegrationTest):
         """Check that the EPN configuration file is installed.
            https://pagure.io/freeipa/issue/8374
         """
-        # workaround for https://github.com/freeipa/freeipa-pr-ci/issues/378
-        rpm_q_cmds = [
-            ["rpm", "-qi", "freeipa-client"],
-            ["rpm", "-qi", "freeipa-client-epn"],
-            ["rpm", "-qc", "freeipa-client-epn"],
-            ["rpm", "-V", "freeipa-client-epn"],
-            ["rpm", "-qvc", "freeipa-client-epn"],
-            ["ls", "-l", "/etc/ipa", "/etc/ipa/epn"],
-        ]
-        for cmd in rpm_q_cmds:
-            self.master.run_command(cmd, raiseonerr=False)
-        tasks.uninstall_packages(self.master, ["*ipa-client-epn"])
-        tasks.install_packages(self.master, ["*ipa-client-epn"])
-        for cmd in rpm_q_cmds:
-            self.master.run_command(cmd, raiseonerr=False)
-        # end workaround
         epn_conf = "/etc/ipa/epn.conf"
         epn_template = "/etc/ipa/epn/expire_msg.template"
         cmd1 = self.master.run_command(["rpm", "-qc", "freeipa-client-epn"])


### PR DESCRIPTION
73c02f635 introduced a workaround to make sure the latest version
of (free)ipa-client-epn was installed.
Since cc624fb17 this should not be needed anymore.

Fixes: https://pagure.io/freeipa/issue/8391
Signed-off-by: François Cami <fcami@redhat.com>