### PR TITLE
ipatests: Add test_fips to pki nightly tests

### DIFF
--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -838,3 +838,16 @@ jobs:
         template: *pki-master-latest
         timeout: 7200
         topology: *master_1repl
+
+  pki-fedora/test_fips:
+    requires: [pki-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{pki-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_fips.py
+        template: *pki-master-latest
+        timeout: 7200
+        topology: *master_1repl_1client


### PR DESCRIPTION
Bugs in Dogtag can block replica installation in FIPS mode.

Successful run output: http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/497134e2-bb3b-11ea-8501-fa163e37ad70/