### PR TITLE
WebUI: Fix rendering of boolean_status_formatter

### DIFF
--- a/install/ui/src/freeipa/widget.js
+++ b/install/ui/src/freeipa/widget.js
@@ -3109,7 +3109,7 @@ IPA.boolean_status_formatter = function(spec) {
     that.format = function(value) {
         var icon_cls = value ? that.enabled_icon : that.disabled_icon;
         var formatted_value = that.boolean_formatter_format(value);
-        formatted_value = '<i class=\"'+icon_cls+'\"/> '+formatted_value;
+        formatted_value = '<i class=\"'+icon_cls+'\"></i> '+formatted_value;
         return formatted_value;
     };
 


### PR DESCRIPTION
With commit "WebUI: Apply jQuery patch to fix htmlPrefilter issue" (bc9f3e0557)
jQuery's handling of self-closing elements.

DOM before the above mentioned commit:
  `<div name="nsaccountlock"><i class="fa fa-check"></i> Enabled</div>`
and after:
  `<div name="nsaccountlock"><i class="fa fa-check"> Enabled</i></div>`

Explicitly closing the `<i>` element fixes the issue:
  `<div name="nsaccountlock"><i class="fa fa-check"></i> Enabled</div>`

Fixes: https://pagure.io/freeipa/issue/8396