### PR TITLE
[Backport][ipa-4-8] selinux: allow oddjobd to set up ipa_helper_t context for execution

### DIFF
--- a/selinux/ipa.if
+++ b/selinux/ipa.if
@@ -419,3 +419,21 @@ ifndef(`dirsrv_systemctl',`
         ps_process_pattern($1, dirsrv_t)
     ')
 ')
+
+
+########################################
+## <summary>
+##	Allow ipa_helper noatsecure
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ipa_helper_noatsecure',`
+    gen_require(`
+	type ipa_helper_t;
+    ')
+    allow $1 ipa_helper_t:process { noatsecure };
+')

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -390,3 +390,7 @@ optional_policy(`
 	sssd_search_lib(ipa_custodia_t)
 	sssd_stream_connect(ipa_custodia_t)
 ')
+
+optional_policy(`
+       systemd_private_tmp(ipa_custodia_tmp_t)
+')

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -115,6 +115,7 @@ optional_policy(`
 
 
 allow ipa_helper_t self:capability { net_admin dac_read_search dac_override chown };
+seutil_read_config(ipa_helper_t);
 
 #kernel bug
 dontaudit ipa_helper_t self:capability2  block_suspend;


### PR DESCRIPTION
This PR was opened automatically because PR #4882 was pushed to master and backport to ipa-4-8 is required.