### PR TITLE
[Backport][ipa-4-8] cainstance.is_crlgen_enabled: handle missing ipa-pki-proxy.conf

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1402,7 +1402,7 @@ class CAInstance(DogtagInstance):
                         rewriteRuleDisabled = False
                         break
         except IOError:
-            raise RuntimeError(
+            raise InconsistentCRLGenConfigException(
                 "Unable to read {}".format(paths.HTTPD_IPA_PKI_PROXY_CONF))
 
         # if enableCRLUpdates and rewriteRuleDisabled are different, the config


### PR DESCRIPTION
This PR was opened automatically because PR #4873 was pushed to master and backport to ipa-4-8 is required.