### PR TITLE
certupdate: only add LWCA tracking requests on CA servers

### DIFF
--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -107,14 +107,19 @@ def run_with_args(api):
     server_fstore = sysrestore.FileStore(paths.SYSRESTORE)
     if server_fstore.has_files():
         update_server(certs)
-        try:
-            # pylint: disable=import-error,ipa-forbidden-import
-            from ipaserver.install import cainstance
-            # pylint: enable=import-error,ipa-forbidden-import
-            cainstance.add_lightweight_ca_tracking_requests(lwcas)
-        except Exception:
-            logger.exception(
-                "Failed to add lightweight CA tracking requests")
+
+        # pylint: disable=import-error,ipa-forbidden-import
+        from ipaserver.install import cainstance
+        # pylint: enable=import-error,ipa-forbidden-import
+
+        # Add LWCA tracking requests.  Only execute if *this server*
+        # has CA installed (ca_enabled indicates CA-ful topology).
+        if cainstance.CAInstance().is_configured():
+            try:
+                cainstance.add_lightweight_ca_tracking_requests(lwcas)
+            except Exception:
+                logger.exception(
+                    "Failed to add lightweight CA tracking requests")
 
     update_client(certs)
 


### PR DESCRIPTION
ipa-certupdate throws an exception when executed on a non-CA server
in a CA-ful deployment with lightweight sub-CAs (LWCAs).  Check that
we are on a CA server before attempting to create Certmonger
tracking requests for LWCAs.

HOW TO TEST

1. Install first server (with CA)
2. Install replica without CA
3. Create sub-CA (`ipa ca-add`)
4. Run `ipa-certupdate` on replica.  Observe that no stack trace is
   produced.

Fixes: https://pagure.io/freeipa/issue/8399