### PR TITLE
[ipa-4-8] ipatests: bump pr-ci templates

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-latest
           name: freeipa/ci-ipa-4-8-f32
-          version: 0.0.4
+          version: 0.0.5
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-latest
           name: freeipa/ci-ipa-4-8-f32
-          version: 0.0.4
+          version: 0.0.5
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-previous
           name: freeipa/ci-ipa-4-8-f31
-          version: 0.0.6
+          version: 0.0.7
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,7 +57,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-latest
           name: freeipa/ci-ipa-4-8-f32
-          version: 0.0.4
+          version: 0.0.5
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
New template images for ci-ipa-4-8-f32 and ci-ipa-4-8-f31 with updated packages.

Signed-off-by: Armando Neto <abiagion@redhat.com>