### PR TITLE
[Backport][ipa-4-8] Populate nshardwareplatform and nsosversion during join operation

### DIFF
--- a/ACI.txt
+++ b/ACI.txt
@@ -141,7 +141,7 @@ aci: (targetfilter = "(objectclass=ipahost)")(version 3.0;acl "permission:System
 dn: cn=computers,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "krbprincipalname")(targetfilter = "(&(!(krbprincipalname=*))(objectclass=ipahost))")(version 3.0;acl "permission:System: Add krbPrincipalName to a Host";allow (write) groupdn = "ldap:///cn=System: Add krbPrincipalName to a Host,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=computers,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "enrolledby || objectclass")(targetfilter = "(objectclass=ipahost)")(version 3.0;acl "permission:System: Enroll a Host";allow (write) groupdn = "ldap:///cn=System: Enroll a Host,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+aci: (targetattr = "enrolledby || nshardwareplatform || nsosversion || objectclass")(targetfilter = "(objectclass=ipahost)")(version 3.0;acl "permission:System: Enroll a Host";allow (write) groupdn = "ldap:///cn=System: Enroll a Host,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=computers,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "usercertificate")(targetfilter = "(objectclass=ipahost)")(version 3.0;acl "permission:System: Manage Host Certificates";allow (write) groupdn = "ldap:///cn=System: Manage Host Certificates,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=computers,cn=accounts,dc=ipa,dc=example

--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -361,7 +361,9 @@ class host(LDAPObject):
         },
         'System: Enroll a Host': {
             'ipapermright': {'write'},
-            'ipapermdefaultattr': {'objectclass', 'enrolledby'},
+            'ipapermdefaultattr': {
+                'objectclass', 'enrolledby', 'nshardwareplatform', 'nsosversion'
+            },
             'replaces': [
                 '(targetattr = "objectclass")(target = "ldap:///fqdn=*,cn=computers,cn=accounts,$SUFFIX")(version 3.0;acl "permission:Enroll a host";allow (write) groupdn = "ldap:///cn=Enroll a host,cn=permissions,cn=pbac,$SUFFIX";)',
                 '(targetattr = "enrolledby || objectclass")(target = "ldap:///fqdn=*,cn=computers,cn=accounts,$SUFFIX")(version 3.0;acl "permission:Enroll a host";allow (write) groupdn = "ldap:///cn=Enroll a host,cn=permissions,cn=pbac,$SUFFIX";)',


### PR DESCRIPTION
This PR was opened automatically because PR #4818 was pushed to master and backport to ipa-4-8 is required.