### PR TITLE
Don't delegate the TGT in ipa-join

### DIFF
--- a/client/ipa-join.c
+++ b/client/ipa-join.c
@@ -187,13 +187,11 @@ callRPC(char * user_agent,
     curlXportParmsP->no_ssl_verifyhost = 0;
     curlXportParmsP->cainfo = DEFAULT_CA_CERT_FILE;
     curlXportParmsP->user_agent = user_agent;
-    /* Enable GSSAPI credentials delegation */
-    curlXportParmsP->gssapi_delegation = 1;
 
     clientparms.transport = "curl";
     clientparms.transportparmsP = (struct xmlrpc_xportparms *)
             curlXportParmsP;
-    clientparms.transportparm_size = XMLRPC_CXPSIZE(gssapi_delegation);
+    clientparms.transportparm_size = XMLRPC_CXPSIZE(cainfo);
     xmlrpc_client_create(envP, XMLRPC_CLIENT_NO_FLAGS, NAME, VERSION,
                          &clientparms, sizeof(clientparms),
                          &clientP);
@@ -740,8 +738,6 @@ jsonrpc_request(const char *ipaserver, const json_t *json, curl_buffer *response
     CURL_SETOPT(curl, CURLOPT_WRITEFUNCTION, &jsonrpc_handle_response);
     CURL_SETOPT(curl, CURLOPT_WRITEDATA, response);
 
-    /* delegate authentication to GSSAPI */
-    CURL_SETOPT(curl, CURLOPT_GSSAPI_DELEGATION, CURLGSSAPI_DELEGATION_FLAG);
     CURL_SETOPT(curl, CURLOPT_HTTPAUTH, CURLAUTH_NEGOTIATE);
     CURL_SETOPT(curl, CURLOPT_USERPWD, ":");
 


### PR DESCRIPTION
Pre 3.0.0 IPA delegated the TGT to enforce access control in
389-ds. At the point that S4U2Proxy support was added there
were still IPA 2.0.x servers in use so this delegation was
left in place in ipa-join so that enrollment would work.

Those days are long gone, remove that support in the XML and
JSON RPC requests.

https://pagure.io/freeipa/issue/8405

Signed-off-by: Rob Crittenden <rcritten@redhat.com>