### PR TITLE
Support changelog integrated into main database

### DIFF
--- a/install/updates/20-replication.update
+++ b/install/updates/20-replication.update
@@ -64,5 +64,8 @@ default: nsslapd-pluginVendor: none
 default: nsslapd-pluginDescription: none
 
 # Set replication changelog limit (#5086)
-dn: cn=changelog5,cn=config
+dn: cn=changelog,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+addifnew: nsslapd-changelogmaxage: 7d
+
+dn: cn=changelog,cn=ipaca,cn=ldbm database,cn=plugins,cn=config
 addifnew: nsslapd-changelogmaxage: 7d

--- a/ipaserver/install/plugins/update_unhashed_password.py
+++ b/ipaserver/install/plugins/update_unhashed_password.py
@@ -79,7 +79,10 @@ class update_unhashed_password(Updater):
             # Log a warning that changelog will contain sensitive data
             try:
                 cldb_e = ldap.get_entry(
-                    DN(('cn', 'changelog5'),
+                    DN(('cn', 'changelog'),
+                       ('cn', 'userRoot'),
+                       ('cn', 'ldbm database'),
+                       ('cn', 'plugins'),
                        ('cn', 'config')),
                     ['nsslapd-changelogdir'])
                 cldb = cldb_e.single_value.get("nsslapd-changelogdir")

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -584,7 +584,7 @@ class ReplicationManager:
         )
         try:
             conn.add_entry(entry)
-        except errors.DuplicateEntry:
+        except (errors.DuplicateEntry, errors.DatabaseError):
             return
 
     def _finalize_replica_settings(self, conn):


### PR DESCRIPTION
389-ds will integrate changelog into main database:
https://pagure.io/389-ds-base/issue/49562
http://www.port389.org/docs/389ds/design/integrate-changelog-database-and-backend-database.html

It also changes the location of the configuration from a single entry
`cn=changelog5,cn=config` to an entry for each backend in
`cn=changelog,<backend>,cn=ldbm database,cn=plugins,cn=config`

This breaks IPA in a few places, in particular:

* `setup_changelog()`
Here the expected failure is err=68, it would be trivial to add err=53.
A better way would be to reuse lib389 for setting up changelog,
not sure how much refactoring that would involve.

* `update_unhashed_password()`
Since the entry no longer exists, log message would be affected.

* `update scripts`
nsslapd-changelogmaxage now needs to be set for each backend.

This fix updates the locations of a new changelog. 

Related: https://pagure.io/freeipa/issue/8407
Signed-off-by: Viktor Ashirov <vashirov@redhat.com>