### PR TITLE
Add unauthenticated nsupdate

### DIFF
--- a/client/man/ipa-client-install.1
+++ b/client/man/ipa-client-install.1
@@ -205,7 +205,11 @@ Create DNS A/AAAA record for each IP address on this host.
 Configure SSSD to permit all access. Otherwise the machine will be controlled by the Host\-based Access Controls (HBAC) on the IPA server.
 .TP
 \fB\-\-enable\-dns\-updates\fR
-This option tells SSSD to automatically update DNS with the IP address of this client.
+This option tells SSSD to automatically update DNS with the IP address of this
+client.
+The default is to use GSS-TSIG. However, if using GSS-TSIG fails for any reason
+at install time, \fBipa\-client\-install\fR will configure SSSD to use
+unauthenticated nsupdates instead.
 .TP
 \fB\-\-no\-krb5\-offline\-passwords\fR
 Configure SSSD not to store user password when the server is offline.

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1370,6 +1370,11 @@ def do_nsupdate(update_txt):
         result = True
     except CalledProcessError as e:
         logger.debug('nsupdate failed: %s', str(e))
+        try:
+            ipautil.run([paths.NSUPDATE, UPDATE_FILE])
+            result = True
+        except CalledProcessError as e:
+            logger.debug('Unauthenticated nsupdate failed: %s', str(e))
 
     try:
         os.remove(UPDATE_FILE)

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1363,7 +1363,6 @@ def do_nsupdate(update_txt):
 
     with open(UPDATE_FILE, "w") as f:
         f.write(update_txt)
-        ipautil.flush_sync(f)
 
     result = False
     try:


### PR DESCRIPTION
    ipa-client-install: update sssd.conf if nsupdate requires -g
    
    If dynamic DNS updates are selected, sssd will use GSS-TSIG
    by default for nsupdate.
    When ipa-client-install notices that plain nsupdate is required,
    switch sssd to use no authentication for dynamic updates too.
    
    Fixes: https://pagure.io/freeipa/issue/8402

+

    ipa-client-install: invoke nsupdate twice (GSS-TSIG, plain)
    
    ipa-client-install invokes nsupdate with GSS-TSIG at client
    enrollment time. If that fails, no retry is done.
    Change that behavior to try again without GSS-TSIG.
    
    Fixes: https://pagure.io/freeipa/issue/8402


####
This is purely WIP as it needs a proper test, however in my manual testing it behaves like it should (sssd configuration included).