### PR TITLE
vault.py: flush the certificate after renaming

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -591,9 +591,8 @@ class _TransportCertCache:
                                              mode='wb') as f:
                 try:
                     f.write(pem)
-                    ipautil.flush_sync(f)
-                    f.close()
                     os.rename(f.name, filename)
+                    ipautil.flush_sync(f)
                 except Exception:
                     os.unlink(f.name)
                     raise

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_vault:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_vault.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 6300
+        topology: *master_1repl


### PR DESCRIPTION
store_cert() does f.write, flush_sync, f.close, os.rename(f.name)
in that order. The directory is not flushed.
* get rid of f.close as this is taken care of by the nested block
* rename the file first then use flush_sync(f)

Signed-off-by: François Cami <fcami@redhat.com>