### PR TITLE
replica: Ensure that ipaapi user is allowed to access ifp

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -22,7 +22,7 @@ import traceback
 from pkg_resources import parse_version
 import six
 
-from ipaclient.install.client import check_ldap_conf
+from ipaclient.install.client import check_ldap_conf, sssd_enable_ifp
 import ipaclient.install.timeconf
 from ipalib.install import certstore, sysrestore
 from ipalib.install.kinit import kinit_keytab
@@ -462,6 +462,9 @@ def promote_sssd(host_name):
     domain.set_option('ipa_server', host_name)
     domain.set_option('ipa_server_mode', True)
     sssdconfig.save_domain(domain)
+
+    sssd_enable_ifp(sssdconfig)
+
     sssdconfig.write()
 
     sssd = services.service('sssd', api)


### PR DESCRIPTION
`ipa-server-install` executes `ipa-client-install` with the `--on-master` flag set, which causes the `ipaclient.install.client.sssd_enable_ifp()` function to be called.  This function configures `sssd` so that the `ipaapi` user is allowed to access `ifp`.  Any FreeIPA replica should also have `sssd` configured like this, but in that case we cannot simply pass the `--on-master` flag to `ipa-client-install` because it has other side effects.  The solution is to call the `ipaclient.install.client.sssd_enable_ifp()` function from inside the `ipaserver.install.server.replicainstall.promote_sssd()` function.

https://pagure.io/freeipa/issue/8403