### PR TITLE
[Backport][ipa-4-8] replica: Ensure that ipaapi user is allowed to access ifp

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -22,7 +22,7 @@ import traceback
 from pkg_resources import parse_version
 import six
 
-from ipaclient.install.client import check_ldap_conf
+from ipaclient.install.client import check_ldap_conf, sssd_enable_ifp
 import ipaclient.install.timeconf
 from ipalib.install import certstore, sysrestore
 from ipalib.install.kinit import kinit_keytab
@@ -462,6 +462,9 @@ def promote_sssd(host_name):
     domain.set_option('ipa_server', host_name)
     domain.set_option('ipa_server_mode', True)
     sssdconfig.save_domain(domain)
+
+    sssd_enable_ifp(sssdconfig)
+
     sssdconfig.write()
 
     sssd = services.service('sssd', api)


### PR DESCRIPTION
This PR was opened automatically because PR #4914 was pushed to master and backport to ipa-4-8 is required.