### PR TITLE
Add missing SELinux rule for ipa-custodia.sock

### DIFF
--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -379,6 +379,13 @@ optional_policy(`
 ')
 
 optional_policy(`
+    gen_require(`
+        type httpd_t;
+    ')
+    ipa_custodia_stream_connect(httpd_t)
+')
+
+optional_policy(`
 	pki_manage_tomcat_etc_rw(ipa_custodia_t)
 	pki_read_tomcat_cert(ipa_custodia_t)
 	pki_rw_tomcat_cert(ipa_custodia_t)


### PR DESCRIPTION
A SELinux rule for ipa_custodia_stream_connect(httpd_t) was not copied
from upstream rules. It breaks installations on systems that don't have
ipa_custodia_stream_connect in SELinux domain for apache, e.g. RHEL 8.3.

Fixes: https://pagure.io/freeipa/issue/8412
Signed-off-by: Christian Heimes <cheimes@redhat.com>