### PR TITLE
[Backport][ipa-4-8] Add missing SELinux rule for ipa-custodia.sock

### DIFF
--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -379,6 +379,13 @@ optional_policy(`
 ')
 
 optional_policy(`
+    gen_require(`
+        type httpd_t;
+    ')
+    ipa_custodia_stream_connect(httpd_t)
+')
+
+optional_policy(`
 	pki_manage_tomcat_etc_rw(ipa_custodia_t)
 	pki_read_tomcat_cert(ipa_custodia_t)
 	pki_rw_tomcat_cert(ipa_custodia_t)


### PR DESCRIPTION
This PR was opened automatically because PR #4920 was pushed to master and backport to ipa-4-8 is required.