### PR TITLE
[Backport][ipa-4-8] ipatests: test_epn: test_EPN_config_file: Package name fix

### DIFF
--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -218,7 +218,10 @@ class TestEPN(IntegrationTest):
         """
         epn_conf = "/etc/ipa/epn.conf"
         epn_template = "/etc/ipa/epn/expire_msg.template"
-        cmd1 = self.master.run_command(["rpm", "-qc", "freeipa-client-epn"])
+        if tasks.get_platform(self.master) != "fedora":
+            cmd1 = self.master.run_command(["rpm", "-qc", "ipa-client-epn"])
+        else:
+            cmd1 = self.master.run_command(["rpm", "-qc", "freeipa-client-epn"])
         assert epn_conf in cmd1.stdout_text
         assert epn_template in cmd1.stdout_text
         cmd2 = self.master.run_command(["sha256sum", epn_conf])


### PR DESCRIPTION
This PR was opened automatically because PR #4918 was pushed to master and backport to ipa-4-8 is required.