### PR TITLE
WebUI: Fix error "unknown command 'idoverrideuser_add_member'"

### DIFF
--- a/install/ui/src/freeipa/group.js
+++ b/install/ui/src/freeipa/group.js
@@ -209,7 +209,6 @@ return {
         {
             $type: 'association',
             name: 'member_idoverrideuser',
-            associator: IPA.serial_associator,
             add_title: '@i18n:objects.group.add_idoverride_user',
             remove_title: '@i18n:objects.group.remove_idoverride_users',
             columns: [


### PR DESCRIPTION
There was wrong IPA.associator class used for 'Groups' -> 'User ID overrides' association,
as a result a wrong command was sent to the server.

Ticket: https://pagure.io/freeipa/issue/8416