### PR TITLE
[Backport][ipa-4-8] ipatests: Increase timeout value in test_getcert_list_profile_using_subca

### DIFF
--- a/ipatests/test_integration/test_cert.py
+++ b/ipatests/test_integration/test_cert.py
@@ -206,7 +206,7 @@ class TestInstallMasterClient(IntegrationTest):
         assert (
             'New signing request "test-request" added.\n' in result.stdout_text
         )
-        status = tasks.wait_for_request(self.master, "test-request", 50)
+        status = tasks.wait_for_request(self.master, "test-request", 300)
         if status == "MONITORING":
             result = self.master.run_command(
                 ["getcert", "list", "-i", "test-request"]


### PR DESCRIPTION
This PR was opened automatically because PR #4924 was pushed to master and backport to ipa-4-8 is required.