### PR TITLE
Teach pylint how dnspython 2.x works

### DIFF
--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -545,3 +545,26 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.webui_prod = True
     """
 ))
+
+# dnspython 2.x introduces enums and creates module level globals from them
+# pylint does not understand the trick
+AstroidBuilder(MANAGER).string_build(textwrap.dedent(
+    """
+    import dns.flags
+    import dns.rdataclass
+    import dns.rdatatype
+
+    dns.flags.CD = 0
+    dns.flags.DO = 0
+    dns.flags.RD = 0
+
+    dns.rdataclass.IN = 0
+
+    dns.rdatatype.NS = 0
+    dns.rdatatype.MX = 0
+    dns.rdatatype.RRSIG = 0
+    dns.rdatatype.SOA = 0
+    dns.rdatatype.SRV = 0
+    dns.rdatatype.TXT = 0
+    """
+))


### PR DESCRIPTION
pylint does not understand pylint's
globals().update(RdataType.__members__) trick.

Fixes: https://pagure.io/freeipa/issue/8419
Signed-off-by: Christian Heimes <cheimes@redhat.com>