### PR TITLE
Add fips-mode-setup to ipaplatform.paths to determine FIPS status

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -27,6 +27,7 @@ import os
 class BasePathNamespace:
     BIN_HOSTNAMECTL = "/bin/hostnamectl"
     ECHO = "/bin/echo"
+    FIPS_MODE_SETUP = "/usr/bin/fips-mode-setup"
     GZIP = "/bin/gzip"
     LS = "/bin/ls"
     SYSTEMCTL = "/bin/systemctl"


### PR DESCRIPTION
This will be used by freeipa-healthcheck to report FIPS config
status. It is added here to avoid duplicating platform independence
in a sister project.

https://pagure.io/freeipa/issue/8429

Signed-off-by: Rob Crittenden <rcritten@redhat.com>