### PR TITLE
[Backport][ipa-4-8] Add fips-mode-setup to ipaplatform.paths to determine FIPS status

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -27,6 +27,7 @@ import os
 class BasePathNamespace:
     BIN_HOSTNAMECTL = "/bin/hostnamectl"
     ECHO = "/bin/echo"
+    FIPS_MODE_SETUP = "/usr/bin/fips-mode-setup"
     GZIP = "/bin/gzip"
     LS = "/bin/ls"
     SYSTEMCTL = "/bin/systemctl"


### PR DESCRIPTION
This PR was opened automatically because PR #4942 was pushed to master and backport to ipa-4-8 is required.