### PR TITLE
[Backport][ipa-4-8] ipatests: fix test_replica_promotion.py

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -115,15 +115,9 @@ class TestReplicaPromotionLevel1(ReplicaPromotionBase):
         result = self.replicas[0].run_command(['ipa-pkinit-manage', 'status'])
         assert "PKINIT is enabled" in result.stdout_text
 
-    @replicas_cleanup
-    def test_sssd_config_allows_ipaapi_access_to_ifp(self):
-        """Verify that the sssd configuration allows the ipaapi user to
-        access ifp
-
-        Test for ticket 8403.
-        """
-        for replica in self.replicas:
-            sssd_config_allows_ipaapi_access_to_ifp(replica)
+        # Verify that the sssd configuration allows the ipaapi user to
+        # access ifp
+        sssd_config_allows_ipaapi_access_to_ifp(self.replicas[0])
 
 
 class TestUnprivilegedUserPermissions(IntegrationTest):

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -197,19 +197,6 @@ class TestUnprivilegedUserPermissions(IntegrationTest):
                                       '-U'])
 
     def test_sssd_config_allows_ipaapi_access_to_ifp(self):
-        self.master.run_command(['ipa', 'group-add-member', 'admins',
-                                 '--users=%s' % self.username])
-
-        # Configure firewall first
-        Firewall(self.replicas[0]).enable_services(["freeipa-ldap",
-                                                    "freeipa-ldaps"])
-        self.replicas[0].run_command(['ipa-replica-install',
-                                      '-P', self.username,
-                                      '-p', self.new_password,
-                                      '-n', self.master.domain.name,
-                                      '-r', self.master.domain.realm,
-                                      '-U'])
-
         sssd_config_allows_ipaapi_access_to_ifp(self.replicas[0])
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #4926 was pushed to master and backport to ipa-4-8 is required.