### PR TITLE
[Backport][ipa-4-8] re-enable test_sss_ssh_authorizedkeys

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1067,7 +1067,7 @@ class TestIPACommand(IntegrationTest):
             assert ssh_pub_key in result.stdout_text
             # login to the system
             self.master.run_command(
-                ['ssh', '-o', 'PasswordAuthentication=no',
+                ['ssh', '-v', '-o', 'PasswordAuthentication=no',
                  '-o', 'IdentitiesOnly=yes', '-o', 'StrictHostKeyChecking=no',
                  '-o', 'ConnectTimeout=10', '-l', user, '-i', user_key,
                  self.master.hostname, 'true'])

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1023,7 +1023,6 @@ class TestIPACommand(IntegrationTest):
         assert is_tls_version_enabled('tls1_2')
         assert is_tls_version_enabled('tls1_3')
 
-    @pytest.mark.skip(reason='https://pagure.io/freeipa/issue/8151')
     def test_sss_ssh_authorizedkeys(self):
         """Login via Ssh using private-key for ipa-user should work.
 


### PR DESCRIPTION
test_sss_ssh_authorizedkeys was disabled but recent test runs show it might be working properly.
Run in multiple times to see if it works.

Note two commits: I'd rather keep the -v even if we end up disabling the test again, so these commits should not be squashed.