### PR TITLE
ipatests: Don't turn Pytest IPA deprecation warnings into errors

### DIFF
--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -26,6 +26,10 @@ else:
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
+
+class PytestIPADeprecationWarning(pytest.PytestWarning, DeprecationWarning):
+    """Warning class for features that will be removed in a future version."""
+
 pytest_plugins = [
     'ipatests.pytest_ipa.additional_config',
     'ipatests.pytest_ipa.deprecated_frameworks',

--- a/ipatests/pytest_ipa/deprecated_frameworks.py
+++ b/ipatests/pytest_ipa/deprecated_frameworks.py
@@ -21,12 +21,12 @@ which employ unittest/nose frameworks or xunit style.
 
 To treat these warnings as errors it's enough to run Pytest with:
 
--W error:'xunit style is deprecated':pytest.PytestDeprecationWarning
+-W error:'xunit style is deprecated':pytest.PytestIPADeprecationWarning
 
 """
 from unittest import TestCase
 
-import pytest
+from ipatests.conftest import PytestIPADeprecationWarning
 
 forbidden_module_scopes = [
     'setup_module',
@@ -47,7 +47,7 @@ def pytest_collection_finish(session):
     for item in session.items:
         cls = getattr(item, 'cls', None)
         if cls is not None and issubclass(cls, TestCase):
-            item.warn(pytest.PytestDeprecationWarning(
+            item.warn(PytestIPADeprecationWarning(
                 "unittest is deprecated in favour of fixtures style"))
             continue
 
@@ -57,10 +57,9 @@ def pytest_collection_finish(session):
                 method = getattr(obj, n, None)
                 fixtured = hasattr(method, '__pytest_wrapped__')
                 if method is not None and not fixtured:
-                    item.warn(
-                        pytest.PytestDeprecationWarning(
-                            "xunit style is deprecated in favour of "
-                            "fixtures style"))
+                    item.warn(PytestIPADeprecationWarning(
+                        "xunit style is deprecated in favour of "
+                        "fixtures style"))
 
         xunit_depr_warn(item, 'module', forbidden_module_scopes)
         xunit_depr_warn(item, 'cls', forbidden_class_scopes)

--- a/ipatests/test_ipatests_plugins/test_depr_frameworks.py
+++ b/ipatests/test_ipatests_plugins/test_depr_frameworks.py
@@ -83,7 +83,7 @@ def test_xunit(xunit_testdir):
     result = xunit_testdir.runpytest()
     result.assert_outcomes(passed=1)
     result.stdout.fnmatch_lines([
-        "* PytestDeprecationWarning: xunit style is deprecated in favour of "
+        "* PytestIPADeprecationWarning: xunit style is deprecated in favour of "
         "fixtures style",
         "* 8 warning*",
     ])
@@ -93,7 +93,7 @@ def test_unittest(unittest_testdir):
     result = unittest_testdir.runpytest()
     result.assert_outcomes(passed=1)
     result.stdout.fnmatch_lines([
-        "* PytestDeprecationWarning: unittest is deprecated in favour of "
+        "* PytestIPADeprecationWarning: unittest is deprecated in favour of "
         "fixtures style",
         "* 1 warning*",
     ])


### PR DESCRIPTION
With new Pytest 6.0 \[0\]:

> PytestDeprecationWarning are now errors by default.
Following our plan to remove deprecated features with as little disruption as
possible, all warnings of type PytestDeprecationWarning now generate errors
instead of warning messages.

PytestWarnings are no longer marked as the part of public API, but as
internal warnings. It's unsafe to use bare PytestDeprecationWarning,
which is turned into the error on major releases.

\[0\]: https://github.com/pytest-dev/pytest/releases/tag/6.0.0

Fixes: https://pagure.io/freeipa/issue/8435

Added:
Note: this fixes only `pypi` task. The whole IPA test framework should be run against the new Pytest 6.0.