### PR TITLE
ipa-client-install: use the authselect backup during uninstall

### DIFF
--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -363,10 +363,6 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
         cmd = self.clients[0].run_command(sha256nsswitch_cmd)
         assert cmd.stdout_text == orig_sha256
 
-    @pytest.mark.xfail(
-        reason="https://pagure.io/freeipa/issue/8189",
-        strict=True
-    )
     def test_nsswitch_backup_restore_sssd(self):
         self.nsswitch_backup_restore()
 


### PR DESCRIPTION
### ipa-client-install: use the authselect backup during uninstall

When ipa-client-install is run on a system with no existing
authselect configuration (for instance a fedora 31 new install),
uninstallation is picking sssd profile but this may lead to
a configuration with differences compared to the pre-ipa-client
state.

Now that authselect provides an option to backup the existing
configuration prior to setting a profile, the client install
can save the backup name and uninstall is able to apply the
backup in order to go back to the pre-ipa-client state.

Fixes: https://pagure.io/freeipa/issue/8189

### ipatests: remove the xfail for test_nfs.py

Related: https://pagure.io/freeipa/issue/8189

