### PR TITLE
Replace SSLCertVerificationError with SSLCertificateError for py36

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -686,7 +686,7 @@ def http_certificate_ensure_ipa_ca_dnsname(http):
 
     try:
         cert.match_hostname(expect)
-    except ssl.SSLCertVerificationError:
+    except ssl.CertificateError:
         if certs.is_ipa_issued_cert(api, cert):
             request_id = certmonger.get_request_id(
                 {'cert-file': paths.HTTPD_CERT_FILE})


### PR DESCRIPTION
This exception was added in python 3.7. Use SSLCertificateError
instead which is an alias and will work with older python releases.

https://bugzilla.redhat.com/show_bug.cgi?id=1858318