### PR TITLE
[Backport][ipa-4-8] Replace SSLCertVerificationError with SSLCertificateError for py36

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -667,7 +667,7 @@ def http_certificate_ensure_ipa_ca_dnsname(http):
 
     try:
         cert.match_hostname(expect)
-    except ssl.SSLCertVerificationError:
+    except ssl.CertificateError:
         if certs.is_ipa_issued_cert(api, cert):
             request_id = certmonger.get_request_id(
                 {'cert-file': paths.HTTPD_CERT_FILE})


### PR DESCRIPTION
This PR was opened automatically because PR #4956 was pushed to master and backport to ipa-4-8 is required.