### PR TITLE
[Backport][ipa-4-8] ipa-client-install: use the authselect backup during uninstall

### DIFF
--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -363,10 +363,6 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
         cmd = self.clients[0].run_command(sha256nsswitch_cmd)
         assert cmd.stdout_text == orig_sha256
 
-    @pytest.mark.xfail(
-        reason="https://pagure.io/freeipa/issue/8189",
-        strict=True
-    )
     def test_nsswitch_backup_restore_sssd(self):
         self.nsswitch_backup_restore()
 


### PR DESCRIPTION
This PR was opened automatically because PR #4954 was pushed to master and backport to ipa-4-8 is required.