### PR TITLE
[ipa-4-6] ipatests: fix test_sssd.py::TestNestedMembers

### DIFF
--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -485,7 +485,7 @@ class TestNestedMembers(IntegrationTest):
 
         privkey, pubkey = tasks.generate_ssh_keypair()
         with open(os.path.join(
-                tmpdir, 'ssh_priv_key'), 'w') as fp:
+                str(tmpdir), 'ssh_priv_key'), 'w') as fp:
             fp.write(privkey)
 
         master.run_command([


### PR DESCRIPTION
On RHEL 7.9, python2 is still used and pytest fails in this line:
        with open(os.path.join(
>               tmpdir, 'ssh_priv_key'), 'w') as fp:

because tmpdir is a LocalPath object (built as a pytest fixture) and
os.path.join() supports Path-like objects since python 3.6 only (see
https://docs.python.org/3.7/library/os.path.html#os.path.join for
more info).

The issue doesn't happen upstream because python3 is used.
The fix is very simple and consists in using str(tmpdir).
