### PR TITLE
Issue 8407 - Support changelog integration into main database

### DIFF
--- a/install/updates/05-pre_upgrade_plugins.update
+++ b/install/updates/05-pre_upgrade_plugins.update
@@ -1,5 +1,6 @@
 # first
 plugin: update_managed_post_first
+plugin: update_changelog_maxage
 
 # middle
 plugin: update_replica_attribute_lists

--- a/install/updates/20-replication.update
+++ b/install/updates/20-replication.update
@@ -62,7 +62,3 @@ default: nsslapd-plugin-depends-on-named: Multimaster Replication Plugin
 default: nsslapd-pluginVersion: 1.0
 default: nsslapd-pluginVendor: none
 default: nsslapd-pluginDescription: none
-
-# Set replication changelog limit (#5086)
-dn: cn=changelog5,cn=config
-addifnew: nsslapd-changelogmaxage: 7d

--- a/ipaserver/install/plugins/update_changelog_maxage.py
+++ b/ipaserver/install/plugins/update_changelog_maxage.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+import logging
+from ipalib import Registry, errors
+from ipalib import Updater
+from ipapython.dn import DN
+
+logger = logging.getLogger(__name__)
+
+register = Registry()
+
+
+@register()
+class update_changelog_maxage(Updater):
+    """
+    Update the changelog maxage if it is not set
+    """
+
+    def update_entry(self, cl_entry, conn):
+        maxage = cl_entry.single_value.get('nsslapd-changelogmaxage')
+        if maxage is None:
+            cl_entry['nsslapd-changelogmaxage'] = '7d'
+            conn.update_entry(cl_entry)
+
+    def execute(self, **options):
+        ldap = self.api.Backend.ldap2
+
+        for backend in ('userroot', 'ipaca'):
+            dn = DN(
+                ('cn', 'changelog'),
+                ('cn', backend),
+                ('cn', 'ldbm database'),
+                ('cn', 'plugins'),
+                ('cn', 'config'))
+            try:
+                cl_entry = ldap.get_entry(dn, ['nsslapd-changelogmaxage'])
+                self.update_entry(cl_entry, ldap)
+            except errors.NotFound:
+                # Try the old global changelog, and return
+                dn = DN(
+                    ('cn', 'changelog5'),
+                    ('cn', 'config'))
+                try:
+                    cl_entry = ldap.get_entry(dn, ['nsslapd-changelogmaxage'])
+                    self.update_entry(cl_entry, ldap)
+                except errors.NotFound:
+                    logger.warning('Error retrieving: %s', str(dn))
+                return False, []
+
+        return False, []


### PR DESCRIPTION
Description: Add support for both the old and new replication changelogs.
             First try to get and update the new entry, if it's not found
             then we know we need to update the old global changelog entry.

https://pagure.io/freeipa/issue/8407

Reviewed by: ?