### PR TITLE
    ipatests: test_epn: enhance CLI testing

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1470,9 +1470,9 @@ def ipa_epn(
         cmd.append("--dry-run")
     if mailtest:
         cmd.append("--mail-test")
-    if from_nbdays:
+    if from_nbdays is not None:
         cmd.extend(("--from-nbdays", str(from_nbdays)))
-    if to_nbdays:
+    if to_nbdays is not None:
         cmd.extend(("--to-nbdays", str(to_nbdays)))
     return host.run_command(cmd, raiseonerr=raiseonerr)
 


### PR DESCRIPTION
Enhance test_EPN_nbdays so that it checks:
* that no emails get sent when using --dry-run
* that --from-nbdays implies --dry-run
* that --to-nbdays requires --from-nbdays
    
Signed-off-by: François Cami <fcami@redhat.com>
