### PR TITLE
ipatests: increase test_trust timeout

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1542,7 +1542,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_trust.py
         template: *ci-master-latest
-        timeout: 7200
+        timeout: 9000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1664,7 +1664,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_trust.py
         template: *testing-master-latest
-        timeout: 7200
+        timeout: 9000
         topology: *adroot_adchild_adtree_master_1client
 
   testing-fedora/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1542,7 +1542,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_trust.py
         template: *ci-master-previous
-        timeout: 7200
+        timeout: 9000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-previous/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1664,7 +1664,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_trust.py
         template: *ci-master-frawhide
-        timeout: 7200
+        timeout: 9000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-rawhide/test_backup_and_restore_TestBackupAndRestoreTrust:


### PR DESCRIPTION
The integration test test_trust is often failing on timeout.
Add 30 minutes to increase the chances of completion.

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>