### PR TITLE
CAless installation: set the perms on KDC cert file

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -536,6 +536,8 @@ class KrbInstance(service.Service):
         certs.install_pem_from_p12(self.pkcs12_info[0],
                                    self.pkcs12_info[1],
                                    paths.KDC_CERT)
+        # The KDC cert needs to be readable by everyone
+        os.chmod(paths.KDC_CERT, 0o644)
         certs.install_key_from_p12(self.pkcs12_info[0],
                                    self.pkcs12_info[1],
                                    paths.KDC_KEY)

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -1527,6 +1527,13 @@ class TestCertInstall(CALessBase):
         assert result.returncode == 0
 
 
+def verify_kdc_cert_perms(host):
+    """Verify that the KDC cert pem file has 0644 perms"""
+    cmd = host.run_command(['stat', '-c',
+                           '"%a %G:%U"', paths.KDC_CERT])
+    assert "644 root:root" in cmd.stdout_text
+
+
 class TestPKINIT(CALessBase):
     """Install master and replica with PKINIT"""
     num_replicas = 1
@@ -1540,6 +1547,7 @@ class TestPKINIT(CALessBase):
         result = cls.install_server(pkinit_pkcs12_exists=True,
                                     pkinit_pin=_DEFAULT)
         assert result.returncode == 0
+        verify_kdc_cert_perms(cls.master)
 
     @replica_install_teardown
     def test_server_replica_install_pkinit(self):
@@ -1549,6 +1557,7 @@ class TestPKINIT(CALessBase):
                                       pkinit_pin=_DEFAULT)
         assert result.returncode == 0
         self.verify_installation()
+        verify_kdc_cert_perms(self.replicas[0])
 
 
 class TestServerReplicaCALessToCAFull(CALessBase):


### PR DESCRIPTION
###  CAless installation: set the perms on KDC cert file

In CA less installation, the KDC certificate file does not have
the expected 644 permissions. As a consequence, WebUI login
fails.

The fix makes sure that the KDC cert file is saved with 644 perms.

Fixes: https://pagure.io/freeipa/issue/8440

###  ipatests: check KDC cert permissions in CA less install

The KDC certificate file must be stored with 644 permissions.
Add a test checking the file permissions on server + replica.

Related: https://pagure.io/freeipa/issue/8440