### PR TITLE
[Backport][ipa-4-8] ipatests: increase test_trust timeout

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1542,7 +1542,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_trust.py
         template: *ci-ipa-4-8-latest
-        timeout: 7200
+        timeout: 9000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -1542,7 +1542,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_trust.py
         template: *ci-ipa-4-8-previous
-        timeout: 7200
+        timeout: 9000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-previous-ipa-4-8/test_backup_and_restore_TestBackupAndRestoreTrust:


### PR DESCRIPTION
This is a manual backport of PR #4973 to ipa-4-8.