### PR TITLE
[Backport][ipa-4-6] ipatests: increase test_trust timeout

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -1228,7 +1228,7 @@ jobs:
         build_url: '{fedora-27/build_url}'
         test_suite: test_integration/test_trust.py
         template: *ci-master-f27
-        timeout: 7200
+        timeout: 9000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-27/test_cert:


### PR DESCRIPTION
This is a manual backport of PR #4973 to ipa-4-6.