### PR TITLE
[Backport][ipa-4-6] CAless installation: set the perms on KDC cert file

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -527,6 +527,8 @@ class KrbInstance(service.Service):
         certs.install_pem_from_p12(self.pkcs12_info[0],
                                    self.pkcs12_info[1],
                                    paths.KDC_CERT)
+        # The KDC cert needs to be readable by everyone
+        os.chmod(paths.KDC_CERT, 0o644)
         certs.install_key_from_p12(self.pkcs12_info[0],
                                    self.pkcs12_info[1],
                                    paths.KDC_KEY)

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -1564,6 +1564,13 @@ class TestCertInstall(CALessBase):
         assert result.returncode == 0
 
 
+def verify_kdc_cert_perms(host):
+    """Verify that the KDC cert pem file has 0644 perms"""
+    cmd = host.run_command(['stat', '-c',
+                           '"%a %G:%U"', paths.KDC_CERT])
+    assert "644 root:root" in cmd.stdout_text
+
+
 class TestPKINIT(CALessBase):
     """Install master and replica with PKINIT"""
     num_replicas = 1
@@ -1577,6 +1584,7 @@ class TestPKINIT(CALessBase):
         result = cls.install_server(pkinit_pkcs12_exists=True,
                                     pkinit_pin=_DEFAULT)
         assert result.returncode == 0
+        verify_kdc_cert_perms(cls.master)
 
     @replica_install_teardown
     def test_server_replica_install_pkinit(self):
@@ -1586,6 +1594,7 @@ class TestPKINIT(CALessBase):
                                       pkinit_pin=_DEFAULT)
         assert result.returncode == 0
         self.verify_installation()
+        verify_kdc_cert_perms(self.replicas[0])
 
 
 class TestServerReplicaCALessToCAFull(CALessBase):


### PR DESCRIPTION
This PR was opened automatically because PR #4974 was pushed to master and backport to ipa-4-6 is required.