### PR TITLE
Tests for fake_mname parameter setup

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1604,3 +1604,15 @@ jobs:
          template: *ci-master-latest
          timeout: 7200
          topology: *master_1repl_1client
+
+  fedora-latest/test_dns:
+     requires: [fedora-latest/build]
+     priority: 50
+     job:
+       class: RunPytest
+       args:
+         build_url: '{fedora-latest/build_url}'
+         test_suite: test_integration/test_dns.py
+         template: *ci-master-latest
+         timeout: 3600
+         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1731,3 +1731,16 @@ jobs:
          template: *testing-master-latest
          timeout: 7200
          topology: *master_1repl_1client
+
+  testing-fedora/test_dns:
+     requires: [testing-fedora/build]
+     priority: 50
+     job:
+       class: RunPytest
+       args:
+         build_url: '{testing-fedora/build_url}'
+         update_packages: True
+         test_suite: test_integration/test_dns.py
+         template: *testing-master-latest
+         timeout: 3600
+         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1592,3 +1592,15 @@ jobs:
          template: *ci-master-previous
          timeout: 7200
          topology: *master_3client
+
+  fedora-previous/test_dns:
+     requires: [fedora-previous/build]
+     priority: 50
+     job:
+       class: RunPytest
+       args:
+         build_url: '{fedora-previous/build_url}'
+         test_suite: test_integration/test_dns.py
+         template: *ci-master-previous
+         timeout: 3600
+         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1731,3 +1731,16 @@ jobs:
          template: *ci-master-frawhide
          timeout: 7200
          topology: *master_1repl_1client
+
+  fedora-rawhide/test_dns:
+     requires: [fedora-rawhide/build]
+     priority: 50
+     job:
+       class: RunPytest
+       args:
+         build_url: '{fedora-rawhide/build_url}'
+         update_packages: True
+         test_suite: test_integration/test_dns.py
+         template: *ci-master-frawhide
+         timeout: 3600
+         topology: *master_1repl

--- a/ipatests/test_integration/test_dns.py
+++ b/ipatests/test_integration/test_dns.py
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+"""This covers tests for dns related feature"""
+
+from __future__ import absolute_import
+
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestDNS(IntegrationTest):
+    """Tests for DNS feature.
+
+    This test class covers the tests for DNS feature.
+    """
+    topology = 'line'
+    num_replicas = 0
+
+    def test_fake_mname_param(self):
+        """Test that fake_mname param is set using dnsserver-mod option.
+
+        Test for BZ 1488732 which checks that  --soa-mname-override option
+        from dnsserver-mod sets the fake_mname.
+        """
+        tasks.kinit_admin(self.master)
+        self.master.run_command(['ipa', 'dnsserver-mod', self.master.hostname,
+                                 '--soa-mname-override', 'fake'])
+        tasks.restart_named(self.master)
+        cmd = self.master.run_command(['dig', '+short', '-t', 'SOA',
+                                       self.master.domain.name])
+        assert 'fake' in cmd.stdout_text
+
+        # reverting the fake_mname change to check it is reverted correctly
+        self.master.run_command(['ipa', 'dnsserver-mod', self.master.hostname,
+                                 '--soa-mname-override', ''])
+        tasks.restart_named(self.master)
+        cmd = self.master.run_command(['dig', '+short', '-t', 'SOA',
+                                       self.master.domain.name])
+        assert 'fake' not in cmd.stdout_text


### PR DESCRIPTION
fake_mname can be set through dnsserver-mod's --soa-mname-override
option which was not doable through same parameter setup in
/etc/named.conf

https://bugzilla.redhat.com/show_bug.cgi?id=1488732

Signed-off-by: Kaleemullah Siddiqui <ksiddiqu@redhat.com>