### PR TITLE
ipatests: fix test_ipahealthcheck.py::TestIpaHealthCheck

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -799,7 +799,7 @@ class TestIpaHealthCheck(IntegrationTest):
             )
 
             assert returncode == 1
-            assert len(data) == 9  # non-KRA is 9 tracked certs
+            assert len(data) == 12  # KRA is 12 tracked certs
 
             for check in data:
                 if check["result"] == "SUCCESS":


### PR DESCRIPTION
test_ipa_healthcheck_expiring is assuming that it's executed
on a KRA-less installation, but the test is executed after
test_ipa_healthcheck_no_errors that configures the KRA.

With a KRA install, 12 certs are monitored instead of 9.

Fixes: https://pagure.io/freeipa/issue/8439