### PR TITLE
ipatests: collect IPA_RENEWAL_LOCK file

### DIFF
--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -76,6 +76,8 @@ CLASS_LOGFILES = [
     # system
     paths.RESOLV_CONF,
     paths.HOSTS,
+    # IPA renewal lock
+    paths.IPA_RENEWAL_LOCK,
 ]
 
 


### PR DESCRIPTION
In order to troubleshoot certmonger timeouts, collect the
file /run/ipa/renewal.lock that is used as cross-process lock
by ipa-server-guard.