### PR TITLE
[Backport][ipa-4-8] ipatests: fix test_ipahealthcheck.py::TestIpaHealthCheck

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -799,7 +799,7 @@ class TestIpaHealthCheck(IntegrationTest):
             )
 
             assert returncode == 1
-            assert len(data) == 9  # non-KRA is 9 tracked certs
+            assert len(data) == 12  # KRA is 12 tracked certs
 
             for check in data:
                 if check["result"] == "SUCCESS":


### PR DESCRIPTION
This PR was opened automatically because PR #4984 was pushed to master and backport to ipa-4-8 is required.