### PR TITLE
[Backport][ipa-4-8] pylint: Fix warning and error

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -285,6 +285,7 @@ BuildRequires:  python3-sss
 BuildRequires:  python3-sss-murmur
 BuildRequires:  python3-sssdconfig >= %{sssd_version}
 BuildRequires:  python3-systemd
+BuildRequires:  python3-yaml
 BuildRequires:  python3-yubico
 # with_lint
 %endif

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -394,7 +394,7 @@ class HTTPInstance(service.Service):
                 )
                 try:
                     certmonger.request_and_wait_for_cert(**args)
-                except Exception as e:
+                except Exception:
                     args['dns'] = [self.fqdn]  # remove ipa-ca.$DOMAIN
                     args['stop_tracking_on_error'] = False
                     certmonger.request_and_wait_for_cert(**args)


### PR DESCRIPTION
This PR was opened automatically because PR #4982 was pushed to master and backport to ipa-4-8 is required.