### PR TITLE
IPA-EPN: enhance input validation

### DIFF
--- a/ipaclient/install/ipa_epn.py
+++ b/ipaclient/install/ipa_epn.py
@@ -246,9 +246,33 @@ class EPN(admintool.AdminTool):
 
     def validate_options(self):
         super(EPN, self).validate_options(needs_root=True)
-        if self.options.to_nbdays:
+        if self.options.to_nbdays is not None:
+            try:
+                if int(self.options.to_nbdays) < 0:
+                    raise RuntimeError('Input is negative.')
+            except Exception as e:
+                self.option_parser.error(
+                    "--to-nbdays must be a positive integer. "
+                    "{error}".format(error=e)
+                )
             self.options.dry_run = True
-        if self.options.from_nbdays and not self.options.to_nbdays:
+        if self.options.from_nbdays is not None:
+            try:
+                if int(self.options.from_nbdays) < 0:
+                    raise RuntimeError('Input is negative.')
+            except Exception as e:
+                self.option_parser.error(
+                    "--from-nbdays must be a positive integer. "
+                    "{error}".format(error=e)
+                )
+        if self.options.from_nbdays is not None and \
+                self.options.to_nbdays is not None:
+            if int(self.options.from_nbdays) >= int(self.options.to_nbdays):
+                self.option_parser.error(
+                    "--from-nbdays must be smaller than --to-nbdays."
+                )
+        if self.options.from_nbdays is not None and \
+                self.options.to_nbdays is None:
             self.option_parser.error(
                 "You cannot specify --from-nbdays without --to-nbdays"
             )

--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -450,7 +450,6 @@ class TestEPN(IntegrationTest):
             in stderr_text_client
         assert rc > 0
 
-    @pytest.mark.xfail(reason='freeipa ticket 8444', strict=True)
     def test_EPN_nbdays_input_2(self):
         """alpha input"""
 
@@ -461,7 +460,6 @@ class TestEPN(IntegrationTest):
         assert "error: --to-nbdays must be an integer." in stderr
         assert rc > 0
 
-    @pytest.mark.xfail(reason='freeipa ticket 8444', strict=True)
     def test_EPN_nbdays_input_3(self):
         """from_nbdays > to_nbdays"""
 
@@ -473,7 +471,6 @@ class TestEPN(IntegrationTest):
             stderr
         assert rc > 0
 
-    @pytest.mark.xfail(reason='freeipa ticket 8444', strict=True)
     def test_EPN_nbdays_input_4(self):
         """decimal input"""
 

--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -457,7 +457,7 @@ class TestEPN(IntegrationTest):
             self.clients[0], to_nbdays="abc",
             raiseonerr=False, validatejson=False
         )
-        assert "error: --to-nbdays must be an integer." in stderr
+        assert "error: --to-nbdays must be a positive integer." in stderr
         assert rc > 0
 
     def test_EPN_nbdays_input_3(self):
@@ -480,7 +480,7 @@ class TestEPN(IntegrationTest):
         )
         logger.info(stderr)
         assert rc > 0
-        assert "error: --to-nbdays must be an integer." in stderr
+        assert "error: --to-nbdays must be a positive integer." in stderr
 
     # From here the tests build on one another:
     #  1) add auth


### PR DESCRIPTION
Enhance input validation:
* make sure --from-nbdays and --to-nbdays are integer
* make sure --from-nbdays < --to-nbdays

Fixes: https://pagure.io/freeipa/issue/8444
Signed-off-by: François Cami <fcami@redhat.com>