### PR TITLE
Treat container subplatforms like main platform

### DIFF
--- a/ipapython/admintool.py
+++ b/ipapython/admintool.py
@@ -28,6 +28,7 @@ import os
 import traceback
 from optparse import OptionGroup  # pylint: disable=deprecated-module
 
+from ipaplatform.osinfo import osinfo
 from ipapython import version
 from ipapython import config
 from ipapython.ipa_log_manager import standard_logging_setup
@@ -304,6 +305,8 @@ class AdminTool:
         logger.debug('%s was invoked with arguments %s and options: %s',
                      self.command_name, self.args, self.safe_options)
         logger.debug('IPA version %s', version.VENDOR_VERSION)
+        logger.debug('IPA platform %s', osinfo.platform)
+        logger.debug('IPA os-release %s %s', osinfo.name, osinfo.version)
 
     def log_failure(self, error_message, return_value, exception, backtrace):
         logger.debug('%s', ''.join(traceback.format_tb(backtrace)))

--- a/ipatests/test_ipaserver/test_install/test_installutils.py
+++ b/ipatests/test_ipaserver/test_install/test_installutils.py
@@ -140,3 +140,19 @@ def test_gpg_asymmetric(tempdir, gpgkey):
     assert os.path.isfile(src)
     with open(src) as f:
         assert f.read() == payload
+
+
+@pytest.mark.parametrize(
+    "platform, expected",
+    [
+        ("fedora", "fedora"),
+        ("fedora_container", "fedora"),
+        ("fedora_containers", "fedora_containers"),
+        ("fedoracontainer", "fedoracontainer"),
+        ("rhel", "rhel"),
+        ("rhel_container", "rhel"),
+    ]
+)
+def test_get_current_platform(monkeypatch, platform, expected):
+    monkeypatch.setattr(installutils.ipaplatform, "NAME", platform)
+    assert installutils.get_current_platform() == expected


### PR DESCRIPTION
ipa-server-upgrade does not like platform mismatches. Upgrade from an
old container to recent container fails with error message:

```
  IPA server upgrade failed: Inspect /var/log/ipaupgrade.log and run command ipa-server-upgrade manually.
  ("Unable to execute IPA upgrade: platform mismatch (expected 'fedora', current 'fedora_container')", 1)
```

Upgrade state now treats a container subplatform like its main platform.
``fedora_container`` is really a ``fedora`` platform with some paths
redirected to ``/data`` partition.

The patch also enhances debug logging for installer and upgrader.

Related: https://pagure.io/freeipa/issue/8401
Signed-off-by: Christian Heimes <cheimes@redhat.com>