### PR TITLE
ipatests: refactor new tests in test_smb

### DIFF
--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -14,7 +14,6 @@ import re
 import os
 
 import pytest
-from contextlib import contextmanager
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
@@ -78,18 +77,22 @@ class TestSMB(IntegrationTest):
         for user in [cls.ipa_user1, cls.ipa_user2, cls.ad_user]:
             tasks.run_command_as_user(cls.smbserver, user, ['stat', '.'])
 
+    def enable_dns_lookup_kdc(self, host):
+        with tasks.FileBackup(host, paths.KRB5_CONF):
+            krb5_conf = host.get_file_contents(
+                paths.KRB5_CONF, encoding='utf-8')
+            krb5_conf = krb5_conf.replace(
+                'dns_lookup_kdc = false', 'dns_lookup_kdc = true')
+            host.put_file_contents(paths.KRB5_CONF, krb5_conf)
+            yield
+
     @pytest.fixture
     def enable_smb_client_dns_lookup_kdc(self):
-        @contextmanager
-        def _enable_for(smbclient):
-            with tasks.FileBackup(smbclient, paths.KRB5_CONF):
-                krb5_conf = smbclient.get_file_contents(
-                    paths.KRB5_CONF, encoding='utf-8')
-                krb5_conf = krb5_conf.replace(
-                    'dns_lookup_kdc = false', 'dns_lookup_kdc = true')
-                smbclient.put_file_contents(paths.KRB5_CONF, krb5_conf)
-                yield
-        return _enable_for
+        yield from self.enable_dns_lookup_kdc(self.smbclient)
+
+    @pytest.fixture
+    def enable_smb_server_dns_lookup_kdc(self):
+        yield from self.enable_dns_lookup_kdc(self.smbserver)
 
     @pytest.fixture
     def samba_share_public(self):
@@ -318,15 +321,14 @@ class TestSMB(IntegrationTest):
 
     def test_smb_access_for_ad_user_at_ipa_client(
             self, enable_smb_client_dns_lookup_kdc):
-        with enable_smb_client_dns_lookup_kdc(self.smbclient):
-            samba_share = {
-                'name': 'homes',
-                'server_path': '/home/{}/{}'.format(self.ad.domain.name,
-                                                    self.ad_user_login),
-                'unc': '//{}/homes'.format(self.smbserver.hostname)
-            }
-            self.check_smb_access_at_ipa_client(
-                self.ad_user, self.ad_user_password, samba_share)
+        samba_share = {
+            'name': 'homes',
+            'server_path': '/home/{}/{}'.format(self.ad.domain.name,
+                                                self.ad_user_login),
+            'unc': '//{}/homes'.format(self.smbserver.hostname)
+        }
+        self.check_smb_access_at_ipa_client(
+            self.ad_user, self.ad_user_password, samba_share)
 
     def test_smb_mount_and_access_by_different_users(self, samba_share_public):
         user1 = self.ipa_user1
@@ -346,8 +348,7 @@ class TestSMB(IntegrationTest):
         finally:
             self.cleanup_mount(mount_point)
 
-    def test_smb_service_s4u2self(
-            self, enable_smb_client_dns_lookup_kdc):
+    def test_smb_service_s4u2self(self, enable_smb_server_dns_lookup_kdc):
         """Test S4U2Self operation by IPA service
            against both AD and IPA users
         """
@@ -358,25 +359,24 @@ class TestSMB(IntegrationTest):
         {print_pac} -k /etc/samba/samba.keytab -E impersonate {user_princ}
         klist -f
         """)
-        with enable_smb_client_dns_lookup_kdc(self.smbserver):
-            principal = 'cifs/{hostname}'.format(
-                hostname=self.smbserver.hostname)
-            # Copy ipa-print-pac to SMB server
-            # We can do so because Samba and GSSAPI libraries
-            # are present there
-            print_pac = self.master.get_file_contents(
-                os.path.join(paths.LIBEXEC_IPA_DIR, "ipa-print-pac"))
-            result = self.smbserver.run_command(['mktemp'])
-            tmpname = result.stdout_text.strip()
-            self.smbserver.put_file_contents(tmpname, print_pac)
-            self.smbserver.run_command(['chmod', 'a+x', tmpname])
-            for user in (self.ad_user, self.ipa_user1,):
-                shell_script = script.format(principal=principal,
-                                             user_princ=user,
-                                             print_pac=tmpname)
-                self.smbserver.run_command(['/bin/bash', '-s', '-e'],
-                                           stdin_text=shell_script)
-            self.smbserver.run_command(['rm', '-f', tmpname])
+        principal = 'cifs/{hostname}'.format(
+            hostname=self.smbserver.hostname)
+        # Copy ipa-print-pac to SMB server
+        # We can do so because Samba and GSSAPI libraries
+        # are present there
+        print_pac = self.master.get_file_contents(
+            os.path.join(paths.LIBEXEC_IPA_DIR, "ipa-print-pac"))
+        result = self.smbserver.run_command(['mktemp'])
+        tmpname = result.stdout_text.strip()
+        self.smbserver.put_file_contents(tmpname, print_pac)
+        self.smbserver.run_command(['chmod', 'a+x', tmpname])
+        for user in (self.ad_user, self.ipa_user1,):
+            shell_script = script.format(principal=principal,
+                                         user_princ=user,
+                                         print_pac=tmpname)
+            self.smbserver.run_command(['/bin/bash', '-s', '-e'],
+                                       stdin_text=shell_script)
+        self.smbserver.run_command(['rm', '-f', tmpname])
         tasks.kdestroy_all(self.smbserver)
 
     def test_smb_mount_fails_without_kerberos_ticket(self, samba_share_public):


### PR DESCRIPTION
ipatests: refactor test for login using cifs alias principal
The test had two problems:
* if it was failing,  samba services were not started and all other
tests also failed
* Utility for copying keys obscured fatal problems i.e. if file does not
exist or can not be parsed.

Fixed by moving the check to separate test and raising exceptions in
KerberosKeyCopier on any unexpected problem.

----

ipatests: simplify fixture
Fixture enable_smb_client_dns_lookup_kdc had an unobvious structure
"contextmanage inside pytest fixture". Replaced with simple pytest
fixture.