### PR TITLE
ipatests: Test certmonger rekey command works fine

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_cert.py::TestInstallMasterClient::test_certmonger_rekey_option
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client


### PR DESCRIPTION
Certmonger's rekey command was throwing an error as
unrecognized command. Test is to check if it is working fine.

related: https://bugzilla.redhat.com/show_bug.cgi?id=1249165

Signed-off-by: Mohammad Rizwan <myusuf@redhat.com>