### PR TITLE
Don't configure authselect in containers

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2160,6 +2160,14 @@ def install_check(options):
             "authentication resources",
             rval=CLIENT_INSTALL_ERROR)
 
+    # --mkhomedir is not supported by fedora_container and rhel_container
+    if not tasks.is_mkhomedir_supported() and options.mkhomedir:
+        raise ScriptError(
+            "Option '--mkhomedir' is incompatible with the 'authselect' tool "
+            "provided by this distribution for configuring system "
+            "authentication resources",
+            rval=CLIENT_INSTALL_ERROR)
+
     # when installing with '--no-sssd' option, check whether nss-ldap is
     # installed
     if not options.sssd:

--- a/ipaplatform/README.md
+++ b/ipaplatform/README.md
@@ -1,0 +1,50 @@
+# IPA platform abstraction
+
+The ``ipaplatform`` package provides an abstraction layer for
+supported Linux distributions and flavors. The package contains
+constants, paths to commands and config files, services, and tasks.
+
+* **base** abstract base platform
+* **debian** Debian- and Ubuntu-like
+* **redhat** abstract base for Red Hat platforms
+* **fedora** Fedora
+* **fedora_container** freeipa-container on Fedora
+* **rhel** RHEL and CentOS
+* **rhel_container** freeipa-container on RHEL and CentOS
+* **suse** OpenSUSE and SLES
+
+```
+[base]
+  ├─ debian
+  ├─[redhat]
+  │   ├─ fedora
+  │   │   └─ fedora_container
+  │   └─ rhel
+  │       └─ rhel_container
+  └─ suse
+```
+(Note: Debian and SUSE use some definitions from Red Hat namespace.)
+
+
+## freeipa-container platform
+
+The **fedora_container** and **rhel_container** platforms are flavors
+of the **fedora** and **rhel** platforms. These platform definitions
+are specifically designed for
+[freeipa-container](https://github.com/freeipa/freeipa-container).
+The FreeIPA server container implements a read-only container. Paths
+like ``/etc``, ``/usr``, and ``/var`` are mounted read-only and cannot
+be modified. The image uses symlinks to store all variable data like
+config files and LDAP database in ``/data``.
+
+* Some commands don't write through dangling symlinks. The IPA
+  platforms for containers prefix some paths with ``/data``.
+* ``ipa-server-upgrade`` verifies that the platform does not change
+  between versions. To allow upgrades of old containers, sysupgrade
+  maps ``$distro_container`` to ``$distro`` platform.
+* The container images come with authselect pre-configured with
+  ``sssd with-sudo`` option. The tasks ``modify_nsswitch_pam_stack``
+  and ``migrate_auth_configuration`` are no-ops. ``ipa-restore``
+  does not restore authselect settings. ``ipa-backup`` still stores
+  authselect settings in backup data.
+* The ``--mkhomedir`` option is not supported.

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -208,7 +208,12 @@ class BaseTaskNamespace:
         """
         Check if the flag --no-sssd is supported for client install.
         """
+        return True
 
+    def is_mkhomedir_supported(self):
+        """
+        Check if the flag --mkhomedir is supported for client install.
+        """
         return True
 
     def backup_auth_configuration(self, path):

--- a/ipaplatform/fedora_container/__init__.py
+++ b/ipaplatform/fedora_container/__init__.py
@@ -4,4 +4,4 @@
 """
 This module contains Fedora Container specific platform files.
 """
-NAME = 'fedora_container'
+NAME = "fedora_container"

--- a/ipaplatform/fedora_container/tasks.py
+++ b/ipaplatform/fedora_container/tasks.py
@@ -3,11 +3,32 @@
 #
 """Fedora container tasks
 """
+import logging
+
 from ipaplatform.fedora.tasks import FedoraTaskNamespace
 
 
+logger = logging.getLogger(__name__)
+
+
 class FedoraContainerTaskNamespace(FedoraTaskNamespace):
-    pass
+    def modify_nsswitch_pam_stack(
+        self, sssd, mkhomedir, statestore, sudo=True
+    ):
+        # freeipa-container images are preconfigured
+        # authselect select sssd with-sudo --force
+        logger.debug("Authselect is pre-configured in container images.")
+
+    def is_mkhomedir_supported(self):
+        # authselect is not pre-configured with mkhomedir
+        return False
+
+    def restore_auth_configuration(self, path):
+        # backup is supported but restore is a no-op
+        logger.debug("Authselect is pre-configured in container images.")
+
+    def migrate_auth_configuration(self, statestore):
+        logger.debug("Authselect is pre-configured in container images.")
 
 
 tasks = FedoraContainerTaskNamespace()

--- a/ipaplatform/rhel_container/__init__.py
+++ b/ipaplatform/rhel_container/__init__.py
@@ -4,4 +4,4 @@
 """
 This module contains RHEL Container specific platform files.
 """
-NAME = 'rhel_container'
+NAME = "rhel_container"

--- a/ipaplatform/rhel_container/tasks.py
+++ b/ipaplatform/rhel_container/tasks.py
@@ -3,11 +3,32 @@
 #
 """RHEL container tasks
 """
+import logging
+
 from ipaplatform.rhel.tasks import RHELTaskNamespace
 
 
+logger = logging.getLogger(__name__)
+
+
 class RHELContainerTaskNamespace(RHELTaskNamespace):
-    pass
+    def modify_nsswitch_pam_stack(
+        self, sssd, mkhomedir, statestore, sudo=True
+    ):
+        # freeipa-container images are preconfigured
+        # authselect select sssd with-sudo --force
+        logger.debug("Authselect is pre-configured in container images.")
+
+    def is_mkhomedir_supported(self):
+        # authselect is not pre-configured with mkhomedir
+        return False
+
+    def restore_auth_configuration(self, path):
+        # backup is supported but restore is a no-op
+        logger.debug("Authselect is pre-configured in container images.")
+
+    def migrate_auth_configuration(self, statestore):
+        logger.debug("Authselect is pre-configured in container images.")
 
 
 tasks = RHELContainerTaskNamespace()


### PR DESCRIPTION
freeipa-container images come with authselect pre-configured. There is
no need to configure, migrate, or restore authselect. The --mkhomedir
option is not supported, too.

Related: https://pagure.io/freeipa/issue/8401
Signed-off-by: Christian Heimes <cheimes@redhat.com>