### PR TITLE
[Backport][ipa-4-8] Set permissions of /etc/ipa/ca.crt to 0644 in CA-less installs

### DIFF
--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -329,7 +329,7 @@ class CertDB:
         ipautil.backup_file(cacert_fname)
         root_nicknames = self.find_root_cert(nickname)[:-1]
         with open(cacert_fname, "w") as f:
-            os.fchmod(f.fileno(), stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+            os.fchmod(f.fileno(), 0o644)
             for root in root_nicknames:
                 result = self.run_certutil(["-L", "-n", root, "-a"],
                                            capture_output=True)

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -891,9 +891,8 @@ def install(installer):
 
         ca.install_step_0(False, None, options, custodia=custodia)
     else:
-        # Put the CA cert where other instances expect it
-        x509.write_certificate(http_ca_cert, paths.IPA_CA_CRT)
-        os.chmod(paths.IPA_CA_CRT, 0o444)
+        # /etc/ipa/ca.crt is created as a side-effect of
+        # dsinstance::enable_ssl() via export_ca_cert()
 
         if not options.no_pkinit:
             x509.write_certificate(http_ca_cert, paths.KDC_CA_BUNDLE_PEM)

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -394,6 +394,14 @@ class CALessBase(IntegrationTest):
                          host, cert_from_ldap.public_bytes(x509.Encoding.PEM))
             assert cert_from_ldap == expected_cacrt
 
+            result = host.run_command(
+                ["/usr/bin/stat", "-c", "%U:%G:%a", paths.IPA_CA_CRT]
+            )
+            (owner, group, mode) = result.stdout_text.strip().split(':')
+            assert owner == "root"
+            assert group == "root"
+            assert mode == "644"
+
             # Verify certmonger was not started
             result = host.run_command(['getcert', 'list'], raiseonerr=False)
             assert result.returncode == 0

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -346,6 +346,16 @@ class TestInstallCA(IntegrationTest):
         status = tasks.wait_for_request(self.master, request_id[0], 300)
         assert status == "MONITORING"
 
+    def test_ipa_ca_crt_permissions(self):
+        """Verify that /etc/ipa/ca.cert is mode 0644 root:root"""
+        result = self.master.run_command(
+            ["/usr/bin/stat", "-c", "%U:%G:%a", paths.IPA_CA_CRT]
+        )
+        out = str(result.stdout_text.strip())
+        (owner, group, mode) = out.split(':')
+        assert mode == "644"
+        assert owner == "root"
+        assert group == "root"
 
 class TestInstallWithCA_KRA1(InstallTestBase1):
 


### PR DESCRIPTION
This PR was opened automatically because PR #4989 was pushed to master and backport to ipa-4-8 is required.