### PR TITLE
ipatests: Test certmonger rekey command works fine

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_cert.py::TestInstallMasterClient::test_certmonger_rekey_option
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_cert.py
+++ b/ipatests/test_integration/test_cert.py
@@ -9,7 +9,6 @@ related scenarios.
 import ipaddress
 import pytest
 import re
-import time
 
 from ipaplatform.paths import paths
 from cryptography import x509
@@ -231,6 +230,10 @@ class TestInstallMasterClient(IntegrationTest):
             '-k', '/etc/pki/tls/private/test.key',
             '-K', 'test/{}'.format(self.master.hostname)])
         request_id = re.findall(r'\d+', result.stdout_text)
+
+        status = tasks.wait_for_request(self.master, request_id[0], 50)
+        assert status == "MONITORING"
+
         certdata = self.master.get_file_contents(
             '/etc/pki/tls/certs/test_rekey.pem'
         )
@@ -243,7 +246,10 @@ class TestInstallMasterClient(IntegrationTest):
         self.master.run_command(['getcert', 'rekey',
                                  '-i', request_id[0],
                                  '-g', '3072'])
-        time.sleep(60)
+
+        status = tasks.wait_for_request(self.master, request_id[0], 50)
+        assert status == "MONITORING"
+
         certdata = self.master.get_file_contents(
             '/etc/pki/tls/certs/test_rekey.pem'
         )


### PR DESCRIPTION
Certmonger's rekey command was throwing an error as
unrecognized command. Test is to check if it is working fine.
    
related: https://bugzilla.redhat.com/show_bug.cgi?id=1249165
    
Signed-off-by: Mohammad Rizwan <myusuf@redhat.com>
