### PR TITLE
IPA-EPN: use entry.get() to retrieve attributes

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/client/share/epn.conf
+++ b/client/share/epn.conf
@@ -23,7 +23,7 @@ smtp_port = 25
 # Default None (empty value).
 # smtp_password =
 
-# pecifies the number of seconds to wait for SMTP to respond.
+# Specifies the number of seconds to wait for SMTP to respond.
 smtp_timeout = 60
 
 # Specifies the type of secure connection to make. Options are: none,

--- a/ipaclient/install/ipa_epn.py
+++ b/ipaclient/install/ipa_epn.py
@@ -131,14 +131,14 @@ class EPNUserList:
             self._sorted = False
             self._expiring_password_user_dq.append(
                 dict(
-                    uid=str(entry["uid"].pop(0)),
-                    cn=str(entry["cn"].pop(0)),
-                    givenname=str(entry["givenname"].pop(0)),
-                    sn=str(entry["sn"].pop(0)),
+                    uid=str(entry.get("uid")),
+                    cn=str(entry.get("cn")),
+                    givenname=str(entry.get("givenname")),
+                    sn=str(entry.get("sn")),
                     krbpasswordexpiration=str(
-                        entry["krbpasswordexpiration"].pop(0)
+                        entry.get("krbpasswordexpiration")
                     ),
-                    mail=str(entry["mail"]),
+                    mail=str(entry.get("mail")),
                 )
             )
         except IndexError as e:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_epn:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_epn.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *master_3client


### PR DESCRIPTION
Use entry.get() to retrieve attributes to avoid tripping on missing attrs.

Fixes: TBD
Signed-off-by: François Cami <fcami@redhat.com>