### PR TITLE
EPN: handle empty attributes

### DIFF
--- a/client/share/epn.conf
+++ b/client/share/epn.conf
@@ -23,7 +23,7 @@ smtp_port = 25
 # Default None (empty value).
 # smtp_password =
 
-# pecifies the number of seconds to wait for SMTP to respond.
+# Specifies the number of seconds to wait for SMTP to respond.
 smtp_timeout = 60
 
 # Specifies the type of secure connection to make. Options are: none,


### PR DESCRIPTION
The admin user doesn't have a givenname and mail is empty by default. Handle those in a general way.

Add test for this case.

Based on https://github.com/freeipa/freeipa/pull/5006/