### PR TITLE
[Backport][ipa-4-8] Tests for fake_mname parameter setup

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1592,3 +1592,15 @@ jobs:
          template: *ci-ipa-4-8-latest
          timeout: 7200
          topology: *master_3client
+
+  fedora-latest-ipa-4-8/test_dns:
+     requires: [fedora-latest-ipa-4-8/build]
+     priority: 50
+     job:
+       class: RunPytest
+       args:
+         build_url: '{fedora-latest-ipa-4-8/build_url}'
+         test_suite: test_integration/test_dns.py
+         template: *ci-ipa-4-8-latest
+         timeout: 3600
+         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -1593,3 +1593,15 @@ jobs:
         template: *ci-ipa-4-8-previous
         timeout: 7200
         topology: *master_3client
+
+  fedora-previous-ipa-4-8/test_dns:
+     requires: [fedora-previous-ipa-4-8/build]
+     priority: 50
+     job:
+       class: RunPytest
+       args:
+         build_url: '{fedora-previous-ipa-4-8/build_url}'
+         test_suite: test_integration/test_dns.py
+         template: *ci-ipa-4-8-previous
+         timeout: 3600
+         topology: *master_1repl

--- a/ipatests/test_integration/test_dns.py
+++ b/ipatests/test_integration/test_dns.py
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+"""This covers tests for dns related feature"""
+
+from __future__ import absolute_import
+
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestDNS(IntegrationTest):
+    """Tests for DNS feature.
+
+    This test class covers the tests for DNS feature.
+    """
+    topology = 'line'
+    num_replicas = 0
+
+    def test_fake_mname_param(self):
+        """Test that fake_mname param is set using dnsserver-mod option.
+
+        Test for BZ 1488732 which checks that  --soa-mname-override option
+        from dnsserver-mod sets the fake_mname.
+        """
+        tasks.kinit_admin(self.master)
+        self.master.run_command(['ipa', 'dnsserver-mod', self.master.hostname,
+                                 '--soa-mname-override', 'fake'])
+        tasks.restart_named(self.master)
+        cmd = self.master.run_command(['dig', '+short', '-t', 'SOA',
+                                       self.master.domain.name])
+        assert 'fake' in cmd.stdout_text
+
+        # reverting the fake_mname change to check it is reverted correctly
+        self.master.run_command(['ipa', 'dnsserver-mod', self.master.hostname,
+                                 '--soa-mname-override', ''])
+        tasks.restart_named(self.master)
+        cmd = self.master.run_command(['dig', '+short', '-t', 'SOA',
+                                       self.master.domain.name])
+        assert 'fake' not in cmd.stdout_text


### PR DESCRIPTION
This PR was opened manually because PR #4983 was pushed to master and backport to ipa-4-8 is required.
