### PR TITLE
CLI Validation of ipa-healtcheck tool for list-sources option

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCLI
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client


### PR DESCRIPTION
Test ensure that error message is displayed on the console when arguments are specified to --list-sources option
to ipa-healthcheck command.