### PR TITLE
[Azure] Switch to dockerhub

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -262,6 +262,7 @@ BuildRequires: python3-m2r
 BuildRequires:  jsl
 BuildRequires:  rpmlint
 BuildRequires:  softhsm
+BuildRequires:  keyutils
 BuildRequires:  python3-augeas
 BuildRequires:  python3-cffi
 BuildRequires:  python3-cryptography >= 1.6

--- a/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
+++ b/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
@@ -4,10 +4,6 @@ ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 
 ADD dist /root
 RUN echo 'deltarpm = false' >> /etc/dnf/dnf.conf \
-    && dnf install -y dnf-plugins-core \
-    && dnf config-manager --set-enabled updates-testing \
-    && dnf config-manager --set-enabled updates-testing-modular \
-    && dnf config-manager --set-disabled fedora-cisco-openh264 \
     && dnf update -y dnf \
     && sed -i 's/%_install_langs \(.*\)/\0:fr/g' /etc/rpm/macros.image-language-conf \
     && dnf install -y systemd \

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
     vmImage: $(VM_IMAGE)
   container:
     image: $(DOCKER_BUILD_IMAGE)
-    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged
+    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
   steps:
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - script: |
@@ -63,7 +63,7 @@ jobs:
     vmImage: $(VM_IMAGE)
   container:
     image: $(DOCKER_BUILD_IMAGE)
-    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged
+    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
   steps:
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - script: |
@@ -88,7 +88,7 @@ jobs:
     vmImage: $(VM_IMAGE)
   container:
     image: $(DOCKER_BUILD_IMAGE)
-    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged
+    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
   steps:
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - task: UsePythonVersion@0
@@ -115,7 +115,7 @@ jobs:
     vmImage: $(VM_IMAGE)
   container:
     image: $(DOCKER_BUILD_IMAGE)
-    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged
+    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
   steps:
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - task: UsePythonVersion@0

--- a/ipatests/azure/azure_definitions/base-fedora.yml
+++ b/ipatests/azure/azure_definitions/base-fedora.yml
@@ -11,8 +11,6 @@ vms:
     - test_ipaserver
     - test_ipatests_plugins
     - test_xmlrpc/test_dns_plugin.py
-    ignore:
-    - test_ipapython/test_keyring.py
     type: base
 
   - container_job: xmlrpc

--- a/ipatests/azure/templates/prepare-build-fedora.yml
+++ b/ipatests/azure/templates/prepare-build-fedora.yml
@@ -5,6 +5,7 @@ steps:
     sudo dnf makecache || :
     echo "Installing base development environment"
     sudo dnf install -y \
+        'dnf-command(builddep)' \
         gdb-minimal \
         make \
         autoconf \

--- a/ipatests/azure/templates/variables-fedora.yml
+++ b/ipatests/azure/templates/variables-fedora.yml
@@ -1,7 +1,7 @@
 variables:
   IPA_PLATFORM: fedora
   # the Docker public image to build IPA packages (rpms)
-  DOCKER_BUILD_IMAGE: 'registry.fedoraproject.org/f32/fedora-toolbox'
+  DOCKER_BUILD_IMAGE: 'fedora:32'
 
   # the Dockerfile to build Docker image for running IPA tests
   DOCKER_DOCKERFILE: ${{ format('Dockerfile.build.{0}', variables.IPA_PLATFORM) }}

--- a/ipatests/test_ipapython/test_keyring.py
+++ b/ipatests/test_ipapython/test_keyring.py
@@ -36,6 +36,9 @@ SIZE_512 = 'abcdefgh' * 64
 SIZE_1024 = 'abcdefgh' * 128
 
 
+@pytest.mark.skip_if_container(
+    "any", reason="kernel keyrings are not namespaced yet"
+)
 class test_keyring:
     """
     Test the kernel keyring interface


### PR DESCRIPTION
`registry.fedoraproject.org/f32/fedora-toolbox` image is used to build packages on Azure Pipelines.
registry.fedoraproject.org experiences an availability problem and makes unstable FreeIPA CI.

Fedora also distributes its official images on https://hub.docker.com/_/fedora.
`fedora:32` is already used by FreeIPA CI to build the image for tests.