### PR TITLE
[Backport][ipa-4-8]     ipatests: test_epn: enhance CLI testing

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1470,9 +1470,9 @@ def ipa_epn(
         cmd.append("--dry-run")
     if mailtest:
         cmd.append("--mail-test")
-    if from_nbdays:
+    if from_nbdays is not None:
         cmd.extend(("--from-nbdays", str(from_nbdays)))
-    if to_nbdays:
+    if to_nbdays is not None:
         cmd.extend(("--to-nbdays", str(to_nbdays)))
     return host.run_command(cmd, raiseonerr=raiseonerr)
 


### PR DESCRIPTION
This PR was opened automatically because PR #4970 was pushed to master and backport to ipa-4-8 is required.