### PR TITLE
Address legacy pylint issues in sysrestore.py

### DIFF
--- a/ipalib/install/sysrestore.py
+++ b/ipalib/install/sysrestore.py
@@ -8,10 +8,12 @@ Facade for ipalib.sysrestore for backwards compatibility
 
 from ipalib import sysrestore as real_sysrestore
 
+
 class FileStore(real_sysrestore.FileStore):
     def __init__(self, path=real_sysrestore.SYSRESTORE_PATH,
                  index_file=real_sysrestore.SYSRESTORE_INDEXFILE):
         super(FileStore, self).__init__(path, index_file)
+
 
 class StateFile(real_sysrestore.StateFile):
     def __init__(self, path=real_sysrestore.SYSRESTORE_PATH,

--- a/ipalib/sysrestore.py
+++ b/ipalib/sysrestore.py
@@ -58,7 +58,7 @@ SYSRESTORE_STATEFILE = "sysrestore.state"
 class FileStore:
     """Class for handling backup and restore of files"""
 
-    def __init__(self, path = SYSRESTORE_PATH, index_file = SYSRESTORE_INDEXFILE):
+    def __init__(self, path=SYSRESTORE_PATH, index_file=SYSRESTORE_INDEXFILE):
         """Create a _StoreFiles object, that uses @path as the
         base directory.
 
@@ -90,7 +90,6 @@ class FileStore:
             if section == "files":
                 for (key, value) in p.items(section):
                     self.files[key] = value
-
 
     def save(self):
         """Save the file list to @_index. If @files is an empty
@@ -133,8 +132,8 @@ class FileStore:
         with open(path, 'rb') as f:
             cont_hash = sha256(f.read()).hexdigest()
 
-        filename = "{hexhash}-{bcppath}".format(
-                hexhash=cont_hash, bcppath=backupfile)
+        filename = "{hexhash}-{bcppath}".format(hexhash=cont_hash,
+                                                bcppath=backupfile)
 
         backup_path = os.path.join(self._path, filename)
         if os.path.exists(backup_path):
@@ -163,7 +162,7 @@ class FileStore:
                 break
         return result
 
-    def restore_file(self, path, new_path = None):
+    def restore_file(self, path, new_path=None):
         """Restore the copy of a file at @path to its original
         location and delete the copy.
 
@@ -320,7 +319,7 @@ class StateFile:
     enabled=False
     """
 
-    def __init__(self, path = SYSRESTORE_PATH, state_file = SYSRESTORE_STATEFILE):
+    def __init__(self, path=SYSRESTORE_PATH, state_file=SYSRESTORE_STATEFILE):
         """Create a StateFile object, loading from @path.
 
         The dictionary @modules, a member of the returned object,
@@ -391,7 +390,8 @@ class StateFile:
         a string or boolean.
         """
         if not isinstance(value, (str, bool, unicode)):
-            raise ValueError("Only strings, booleans or unicode strings are supported")
+            raise ValueError("Only strings, booleans or unicode strings "
+                             "are supported")
 
         self._load()
 


### PR DESCRIPTION
These were triggered because of the movement of sysrestore.py in
the tree

https://pagure.io/freeipa/issue/8384

This is a forward port from ipa-4-8 from PR 5004

I don't know why pylint didn't trigger on this file when the original patch merged but these changes are pretty minor and will make any future backports easier.