### PR TITLE
[Backport][ipa-4-8] EPN: handle empty attributes

### DIFF
--- a/client/share/epn.conf
+++ b/client/share/epn.conf
@@ -23,7 +23,7 @@ smtp_port = 25
 # Default None (empty value).
 # smtp_password =
 
-# pecifies the number of seconds to wait for SMTP to respond.
+# Specifies the number of seconds to wait for SMTP to respond.
 smtp_timeout = 60
 
 # Specifies the type of secure connection to make. Options are: none,


### PR DESCRIPTION
This PR was opened automatically because PR #5008 was pushed to master and backport to ipa-4-8 is required.