### PR TITLE
[Backport][ipa-4-8] ipatests: test_epn: add test_EPN_connection_refused

### DIFF
--- a/ipaclient/install/ipa_epn.py
+++ b/ipaclient/install/ipa_epn.py
@@ -38,6 +38,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.header import Header
 from email.utils import make_msgid
+from socket import error as socketerror
 
 from ipaplatform.paths import paths
 from ipalib import api, errors
@@ -640,13 +641,15 @@ class MTAClient:
                     port=self._smtp_port,
                     timeout=self._smtp_timeout,
                 )
-        except smtplib.SMTPException as e:
-            logger.error(
-                "IPA-EPN: Unable to connect to %s:%s: %s",
-                self._smtp_hostname,
-                self._smtp_port,
-                e,
-            )
+        except (socketerror, smtplib.SMTPException) as e:
+            msg = \
+                "IPA-EPN: Could not connect to the configured SMTP server: " \
+                "{host}:{port}: {error}".format(
+                    host=self._smtp_hostname,
+                    port=self._smtp_port,
+                    error=e
+                )
+            raise admintool.ScriptError(msg)
 
         try:
             self._conn.ehlo()

--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -249,7 +249,6 @@ class TestEPN(IntegrationTest):
         ck = "192481b52fb591112afd7b55b12a44c6618fdbc7e05a3b1866fd67ec579c51df"
         assert cmd2.stdout_text.find(ck) == 0
 
-    @pytest.mark.xfail(reason='freeipa ticket 8445', strict=True)
     def test_EPN_connection_refused(self):
         """Test EPN behavior when the configured SMTP is down
         """


### PR DESCRIPTION
This PR was opened automatically because PR #5010 was pushed to master and backport to ipa-4-8 is required.