### PR TITLE
rpm-spec: Don't fail on missing /etc/ssh/ssh_config

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1078,14 +1078,11 @@ if [ $1 -gt 1 ] ; then
         fi
 
         %{__python3} -c 'from ipaclient.install.client import configure_krb5_snippet; configure_krb5_snippet()' >>/var/log/ipaupgrade.log 2>&1
-    fi
-
-    if [ $restore -ge 2 ]; then
         %{__python3} -c 'from ipaclient.install.client import update_ipa_nssdb; update_ipa_nssdb()' >>/var/log/ipaupgrade.log 2>&1
-    fi
-
-    if [ $restore -ge 2 ]; then
-        sed -E --in-place=.orig 's/^(HostKeyAlgorithms ssh-rsa,ssh-dss)$/# disabled by ipa-client update\n# \1/' /etc/ssh/ssh_config
+        SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config"
+        if [ -f "$SSH_CLIENT_SYSTEM_CONF" ]; then
+            sed -E --in-place=.orig 's/^(HostKeyAlgorithms ssh-rsa,ssh-dss)$/# disabled by ipa-client update\n# \1/' "$SSH_CLIENT_SYSTEM_CONF"
+        fi
     fi
 fi
 


### PR DESCRIPTION
`openssh-clients` is not a strict requirement of `freeipa-client`
package and if it's missing then this case should be handled in
post scriptlet of `freeipa-client` package. Otherwise, the remaining
part of that scriptlet will not be run at all.

Fixes: https://pagure.io/freeipa/issue/8459