### PR TITLE
Support older servers in is_ipa_configured() call

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -63,10 +63,6 @@ if six.PY3:
 
 logger = logging.getLogger(__name__)
 
-# Used to determine install status
-IPA_MODULES = [
-    'httpd', 'kadmin', 'dirsrv', 'pki-tomcatd', 'install', 'krb5kdc', 'named']
-
 
 class BadHostError(Exception):
     pass

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -665,7 +665,7 @@ def check_server_configuration():
     Most convenient use case for the function is in install tools that require
     configured IPA for its function.
     """
-    if not is_ipa_configured():
+    if not facts.is_ipa_configured():
         raise ScriptError("IPA is not configured on this system.",
                           rval=SERVER_NOT_CONFIGURED)
 

--- a/ipaserver/install/ipa_acme_manage.py
+++ b/ipaserver/install/ipa_acme_manage.py
@@ -9,7 +9,7 @@ from ipaplatform.paths import paths
 from ipapython.admintool import AdminTool
 from ipapython.directivesetter import DirectiveSetter
 from ipaserver.install import cainstance
-from ipaserver.install.installutils import is_ipa_configured
+from ipalib.facts import is_ipa_configured
 
 # Manages the FreeIPA ACME service on a per-server basis.
 #

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -37,13 +37,14 @@ from ipalib.util import (
     validate_domain_name,
     no_matching_interface_for_ip_address_warning,
 )
+from ipalib.facts import IPA_MODULES
 from ipaserver.install import (
     adtrust, adtrustinstance, bindinstance, ca, dns, dsinstance,
     httpinstance, installutils, kra, krbinstance,
     otpdinstance, custodiainstance, replication, service,
     sysupgrade, cainstance)
 from ipaserver.install.installutils import (
-    IPA_MODULES, BadHostError, get_fqdn, get_server_ip_address,
+    BadHostError, get_fqdn, get_server_ip_address,
     load_pkcs12, read_password, verify_fqdn, update_hosts_file,
     validate_mask)
 

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1486,8 +1486,11 @@ def upgrade_configuration():
     fstore = sysrestore.FileStore(paths.SYSRESTORE)
     sstore = sysrestore.StateFile(paths.SYSRESTORE)
 
-    if is_ipa_configured() is None:
-        sstore.backup_state('installation', 'complete', True)
+    if not sstore.has_state('installation'):
+        if is_ipa_configured():
+            sstore.backup_state('installation', 'complete', True)
+        else:
+            sstore.backup_state('installation', 'complete', False)
 
     fqdn = api.env.host
 


### PR DESCRIPTION
is_ipa_configured() incorrectly returned False if the installation section didn't exist. Fall back to the original detection method if the section doesn't exist.

Add a test for this case.