### PR TITLE
ipatests: remove xfail from test_dnssec

### DIFF
--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -13,8 +13,6 @@ import dns.dnssec
 import dns.resolver
 import dns.name
 
-import pytest
-
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.firewall import Firewall
@@ -320,7 +318,6 @@ class TestInstallDNSSECFirst(IntegrationTest):
             self.replicas[0].ip, root_zone, timeout=300
         ), "Zone %s is not signed (replica)" % root_zone
 
-    @pytest.mark.xfail(reason='dnspython issue 343', strict=False)
     def test_chain_of_trust(self):
         """
         Validate signed DNS records, using our own signed root zone


### PR DESCRIPTION
The nightly test test_dnssec.py::TestInstallDNSSECFirst::test_chain_of_trust
used to fail because of https://github.com/rthalley/dnspython/issues/343,
but the issue has been fixed upstream and does not happen any more since
PRCI is using python3-dns-1.16.0-7.

Remove the xfail.