### PR TITLE
[Backport][ipa-4-8] Issue 8456 - Add new aci's for the new replication changelog entries

### DIFF
--- a/install/updates/40-delegation.update
+++ b/install/updates/40-delegation.update
@@ -212,6 +212,28 @@ default:ipapermissiontype: SYSTEM
 dn: cn=config
 add:aci: (targetattr = "cn || createtimestamp || entryusn || modifytimestamp || objectclass || passsyncmanagersdns*")(target = "ldap:///cn=ipa_pwd_extop,cn=plugins,cn=config")(version 3.0;acl "permission:Read PassSync Managers Configuration";allow (compare,read,search) groupdn = "ldap:///cn=Read PassSync Managers Configuration,cn=permissions,cn=pbac,$SUFFIX";)
 
+dn: cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,$SUFFIX
+default:objectClass: groupofnames
+default:objectClass: ipapermission
+default:objectClass: top
+default:cn: Read Replication Changelog Configuration
+default:member: cn=Replication Administrators,cn=privileges,cn=pbac,$SUFFIX
+default:ipapermissiontype: SYSTEM
+
+dn: cn=config
+add:aci: (targetattr = "cn || objectclass || nsslapd-changelogmaxentries || nsslapd-changelogmaxage || nsslapd-changelogtrim-interval || nsslapd-encryptionalgorithm || nsSymmetricKey")(targetfilter = "cn=changelog")(target = "ldap:///cn=ldbm database,cn=plugins,cn=config")(version 3.0; acl "permission:Read Replication Changelog Configuration"; allow (read,search) groupdn = "ldap:///cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,$SUFFIX";)
+
+dn: cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,$SUFFIX
+default:objectClass: groupofnames
+default:objectClass: ipapermission
+default:objectClass: top
+default:cn: Write Replication Changelog Configuration
+default:member: cn=Replication Administrators,cn=privileges,cn=pbac,$SUFFIX
+default:ipapermissiontype: SYSTEM
+
+dn: cn=config
+add:aci: (targetattr = "nsslapd-changelogmaxentries || nsslapd-changelogmaxage || nsslapd-changelogtrim-interval || nsslapd-encryptionalgorithm || nsSymmetricKey")(targetfilter = "cn=changelog")(target = "ldap:///cn=ldbm database,cn=plugins,cn=config")(version 3.0; acl "permission:Write Replication Changelog Configuration"; allow (write) groupdn = "ldap:///cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,$SUFFIX";)
+
 dn: cn=Modify PassSync Managers Configuration,cn=permissions,cn=pbac,$SUFFIX
 default:objectClass: groupofnames
 default:objectClass: ipapermission

--- a/ipaserver/install/plugins/update_changelog_maxage.py
+++ b/ipaserver/install/plugins/update_changelog_maxage.py
@@ -45,7 +45,7 @@ class update_changelog_maxage(Updater):
                     cl_entry = ldap.get_entry(dn, ['nsslapd-changelogmaxage'])
                     self.update_entry(cl_entry, ldap)
                 except errors.NotFound:
-                    logger.warning('Error retrieving: %s', str(dn))
+                    logger.debug('Error retrieving: %s', str(dn))
                 return False, []
 
         return False, []

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -619,7 +619,11 @@ class ReplicationManager:
         else:
             # Set the changelog trimming
             cl_entry['nsslapd-changelogmaxage'] = '7d'
-            conn.update_entry(cl_entry)
+            try:
+                conn.update_entry(cl_entry)
+            except errors.EmptyModlist:
+                # not a problem since the trimming is already set
+                pass
 
     def _finalize_replica_settings(self, conn):
         """Change replica settings to final values


### PR DESCRIPTION
This PR was opened automatically because PR #5023 was pushed to master and backport to ipa-4-8 is required.