### PR TITLE
[Backport][ipa-4-6] rpm-spec: Don't fail on missing /etc/ssh/ssh_config

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1316,10 +1316,10 @@ if [ $1 -gt 1 ] ; then
 
     if [ $restore -ge 2 ]; then
         %{python} -c 'from ipaclient.install.client import update_ipa_nssdb; update_ipa_nssdb()' >/var/log/ipaupgrade.log 2>&1
-    fi
-
-    if [ $restore -ge 2 ]; then
-        sed -E --in-place=.orig 's/^(HostKeyAlgorithms ssh-rsa,ssh-dss)$/# disabled by ipa-client update\n# \1/' /etc/ssh/ssh_config
+        SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config"
+        if [ -f "$SSH_CLIENT_SYSTEM_CONF" ]; then
+            sed -E --in-place=.orig 's/^(HostKeyAlgorithms ssh-rsa,ssh-dss)$/# disabled by ipa-client update\n# \1/' "$SSH_CLIENT_SYSTEM_CONF"
+        fi
     fi
 fi
 


### PR DESCRIPTION
This PR was opened manually because PR #5026 was pushed to master and backport to ipa-4-6 is required.