### PR TITLE
Increase replication changelog trimming to 30 days

### DIFF
--- a/ipaserver/install/plugins/update_changelog_maxage.py
+++ b/ipaserver/install/plugins/update_changelog_maxage.py
@@ -20,7 +20,7 @@ class update_changelog_maxage(Updater):
     def update_entry(self, cl_entry, conn):
         maxage = cl_entry.single_value.get('nsslapd-changelogmaxage')
         if maxage is None:
-            cl_entry['nsslapd-changelogmaxage'] = '7d'
+            cl_entry['nsslapd-changelogmaxage'] = '30d'
             conn.update_entry(cl_entry)
 
     def execute(self, **options):

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -609,7 +609,7 @@ class ReplicationManager:
                     'objectclass': ["top", "extensibleobject"],
                     'cn': ["changelog5"],
                     'nsslapd-changelogdir': [os.path.join(dbdir, "cldb")],
-                    'nsslapd-changelogmaxage': ['7d'],
+                    'nsslapd-changelogmaxage': ['30d'],
                 }
             )
             try:
@@ -618,7 +618,7 @@ class ReplicationManager:
                 return
         else:
             # Set the changelog trimming
-            cl_entry['nsslapd-changelogmaxage'] = '7d'
+            cl_entry['nsslapd-changelogmaxage'] = '30d'
             try:
                 conn.update_entry(cl_entry)
             except errors.EmptyModlist:


### PR DESCRIPTION
A long time ago the DS team recommended that the changelog trimming interval be set to 7 days.  However, more recently we tend to see more time skews on certain platforms, and issues where it appears changes were trimmed too early (which can break replication).

It would be better to set the trimming interval to 30 days.  This still prevents the changelog from getting too large, and it should help with some of the other issues we are now seeing.

Fixes: https://pagure.io/freeipa/issue/8464

Signed-off-by: Mark Reynolds <mreynolds@redhat.com>