### PR TITLE
Add dependency on pki-acme

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -370,6 +370,7 @@ Requires(post): systemd-units
 Requires: selinux-policy >= %{selinux_policy_version}
 Requires(post): selinux-policy-base >= %{selinux_policy_version}
 Requires: slapi-nis >= %{slapi_nis_version}
+Requires: pki-acme >= %{pki_version}
 Requires: pki-ca >= %{pki_version}
 Requires: pki-kra >= %{pki_version}
 Requires(preun): systemd-units


### PR DESCRIPTION
With the merging of #4723, pki-acme should be added as a dependency of
IPA. Note that this is only necessary on PKI >= 10.10 and shouldn't be
backported to RHEL 8.3 as the subpackage doesn't exist there.

Related: https://github.com/dogtagpki/pki/pull/513

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`