### PR TITLE
[Backport][ipa-4-8] uninstall: Don't fail on missing /var/lib/samba

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1203,7 +1203,6 @@ fi
 %attr(755,root,root) %{plugin_dir}/libipa_uuid.so
 %attr(755,root,root) %{plugin_dir}/libipa_modrdn.so
 %attr(755,root,root) %{plugin_dir}/libipa_lockout.so
-%attr(755,root,root) %{plugin_dir}/libipa_cldap.so
 %attr(755,root,root) %{plugin_dir}/libipa_dns.so
 %attr(755,root,root) %{plugin_dir}/libipa_range_check.so
 %attr(755,root,root) %{plugin_dir}/libipa_otp_counter.so
@@ -1260,6 +1259,7 @@ fi
 %{_usr}/share/ipa/kdcproxy.wsgi
 %{_usr}/share/ipa/ipaca*.ini
 %{_usr}/share/ipa/*.ldif
+%exclude %{_datadir}/ipa/ipa-cldap-conf.ldif
 %{_usr}/share/ipa/*.uldif
 %{_usr}/share/ipa/*.template
 %dir %{_usr}/share/ipa/advise
@@ -1351,6 +1351,8 @@ fi
 %{_sbindir}/ipa-adtrust-install
 %{_usr}/share/ipa/smb.conf.empty
 %attr(755,root,root) %{_libdir}/samba/pdb/ipasam.so
+%attr(755,root,root) %{plugin_dir}/libipa_cldap.so
+%{_datadir}/ipa/ipa-cldap-conf.ldif
 %{_mandir}/man1/ipa-adtrust-install.1*
 %ghost %{_libdir}/krb5/plugins/libkrb5/winbind_krb5_locator.so
 %{_sysconfdir}/dbus-1/system.d/oddjob-ipa-trust.conf

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -899,10 +899,11 @@ class ADTRUSTInstance(service.Service):
         ipautil.remove_file(self.smb_conf)
 
         # Remove samba's persistent and temporary tdb files
-        tdb_files = [tdb_file for tdb_file in os.listdir(paths.SAMBA_DIR)
-                                           if tdb_file.endswith(".tdb")]
-        for tdb_file in tdb_files:
-            ipautil.remove_file(tdb_file)
+        if os.path.isdir(paths.SAMBA_DIR):
+            tdb_files = [tdb_file for tdb_file in os.listdir(paths.SAMBA_DIR)
+                         if tdb_file.endswith(".tdb")]
+            for tdb_file in tdb_files:
+                ipautil.remove_file(tdb_file)
 
         # Remove our keys from samba's keytab
         self.clean_samba_keytab()

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -38,7 +38,7 @@ from ipalib.util import (
     no_matching_interface_for_ip_address_warning,
 )
 from ipaserver.install import (
-    adtrust, bindinstance, ca, dns, dsinstance,
+    adtrust, adtrustinstance, bindinstance, ca, dns, dsinstance,
     httpinstance, installutils, kra, krbinstance,
     otpdinstance, custodiainstance, replication, service,
     sysupgrade)
@@ -49,12 +49,6 @@ from ipaserver.install.installutils import (
 
 if six.PY3:
     unicode = str
-
-try:
-    from ipaserver.install import adtrustinstance
-    _server_trust_ad_installed = True
-except ImportError:
-    _server_trust_ad_installed = False
 
 NoneType = type(None)
 
@@ -1170,8 +1164,7 @@ def uninstall(installer):
     httpinstance.HTTPInstance(fstore).uninstall()
     krbinstance.KrbInstance(fstore).uninstall()
     dsinstance.DsInstance(fstore=fstore).uninstall()
-    if _server_trust_ad_installed:
-        adtrustinstance.ADTRUSTInstance(fstore).uninstall()
+    adtrustinstance.ADTRUSTInstance(fstore).uninstall()
     # realm isn't used, but IPAKEMKeys parses /etc/ipa/default.conf
     # otherwise, see https://pagure.io/freeipa/issue/7474 .
     custodiainstance.CustodiaInstance(realm='REALM.INVALID').uninstall()


### PR DESCRIPTION
This PR was opened manually because PR #5032 was pushed to master and backport to ipa-4-8 is required.