### PR TITLE
[Azure] Add rawhide definitions

### DIFF
--- a/.tox-install.sh
+++ b/.tox-install.sh
@@ -2,8 +2,8 @@
 set -ex
 
 FLAVOR="$1"
-ENVPYTHON="$(realpath "$2")"
-ENVSITEPACKAGESDIR="$(realpath "$3")"
+ENVPYTHON="$(realpath -s "$2")"
+ENVSITEPACKAGESDIR="$(realpath -s "$3")"
 ENVDIR="$4"
 # 4...end are package requirements
 shift 4

--- a/client/certbot-dns-ipa.in
+++ b/client/certbot-dns-ipa.in
@@ -20,7 +20,6 @@ dnsrecord_del commands.
 import os
 import sys
 
-from dns import resolver
 from ipalib import api, errors
 from ipapython import dnsutil
 
@@ -37,7 +36,7 @@ else:
 
 validation_domain = f'_acme-challenge.{certbot_domain}'
 fqdn = dnsutil.DNSName(validation_domain).make_absolute()
-zone = dnsutil.DNSName(resolver.zone_for_name(fqdn))
+zone = dnsutil.DNSName(dnsutil.zone_for_name(fqdn))
 name = fqdn.relativize(zone)
 
 try:

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -260,6 +260,7 @@ BuildRequires: python3-m2r
 #
 %if 0%{?with_lint}
 BuildRequires:  jsl
+BuildRequires:  nss-tools
 BuildRequires:  rpmlint
 BuildRequires:  softhsm
 BuildRequires:  keyutils

--- a/ipaclient/discovery.py
+++ b/ipaclient/discovery.py
@@ -24,11 +24,11 @@ import socket
 
 import six
 
-from dns import resolver, rdatatype
+from dns import rdatatype
 from dns.exception import DNSException
 from ipalib import errors
 from ipalib.util import validate_domain_name
-from ipapython.dnsutil import query_srv
+from ipapython.dnsutil import query_srv, resolve
 
 from ipaplatform.paths import paths
 from ipapython.ipautil import valid_ip, realm_to_suffix
@@ -562,7 +562,7 @@ class IPADiscovery:
         logger.debug("Search DNS for TXT record of %s", qname)
 
         try:
-            answers = resolver.query(qname, rdatatype.TXT)
+            answers = resolve(qname, rdatatype.TXT)
         except DNSException as e:
             logger.debug("DNS record not found: %s", e.__class__.__name__)
             answers = []

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -53,7 +53,7 @@ from ipaplatform import services
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks
-from ipapython import certdb, kernel_keyring, ipaldap, ipautil
+from ipapython import certdb, kernel_keyring, ipaldap, ipautil, dnsutil
 from ipapython.admintool import ScriptError
 from ipapython.dn import DN
 from ipapython.install import typing
@@ -1440,7 +1440,7 @@ def verify_dns_update(fqdn, ips):
         logger.debug('DNS resolver: Query: %s IN %s',
                      fqdn, dns.rdatatype.to_text(record_type))
         try:
-            answers = dns.resolver.query(fqdn, record_type)
+            answers = dnsutil.resolve(fqdn, record_type)
         except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
             logger.debug('DNS resolver: No record.')
         except dns.resolver.NoNameservers:
@@ -1460,10 +1460,9 @@ def verify_dns_update(fqdn, ips):
     missing_reverse = [str(ip) for ip in ips]
     for ip in ips:
         ip_str = str(ip)
-        addr = dns.reversename.from_address(ip_str)
-        logger.debug('DNS resolver: Query: %s IN PTR', addr)
+        logger.debug('DNS resolver: Query: %s IN PTR', ip_str)
         try:
-            answers = dns.resolver.query(addr, dns.rdatatype.PTR)
+            answers = dnsutil.resolve_address(ip_str)
         except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
             logger.debug('DNS resolver: No record.')
         except dns.resolver.NoNameservers:

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -43,9 +43,6 @@ import locale
 import collections
 import urllib
 
-from dns import resolver, reversename
-from dns.exception import DNSException
-
 import six
 from six.moves import input
 
@@ -1110,22 +1107,6 @@ def check_port_bindable(port, socket_type=socket.SOCK_STREAM):
         return True
     finally:
         s.close()
-
-
-def reverse_record_exists(ip_address):
-    """
-    Checks if IP address have some reverse record somewhere.
-    Does not care where it points.
-
-    Returns True/False
-    """
-    reverse = reversename.from_address(str(ip_address))
-    try:
-        resolver.query(reverse, "PTR")
-    except DNSException:
-        # really don't care what exception, PTR is simply unresolvable
-        return False
-    return True
 
 
 def config_replace_variables(filepath, replacevars=dict(), appendvars=dict(),

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -30,9 +30,9 @@ import shutil
 import sys
 import time
 
-import dns.resolver
 import ldap
 import six
+from dns.exception import DNSException
 
 from ipaserver.dns_data_management import (
     IPASystemRecords,
@@ -320,10 +320,15 @@ def read_reverse_zone(default, ip_address, allow_zone_overlap=False):
 def get_auto_reverse_zones(ip_addresses, allow_zone_overlap=False):
     auto_zones = []
     for ip in ip_addresses:
-        if ipautil.reverse_record_exists(ip):
+        try:
+            dnsutil.resolve_address(str(ip))
+        except DNSException:
+            pass
+        else:
             # PTR exist there is no reason to create reverse zone
             logger.info("Reverse record for IP address %s already exists", ip)
             continue
+
         default_reverse = get_reverse_zone_default(ip)
         if not allow_zone_overlap:
             try:
@@ -1135,7 +1140,7 @@ class BindInstance(service.Service):
         else:
             # python DNS might have global resolver cached in this variable
             # we have to re-initialize it because resolv.conf has changed
-            dns.resolver.reset_default_resolver()
+            dnsutil.reset_default_resolver()
 
     def __generate_rndc_key(self):
         installutils.check_entropy()

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -12,13 +12,9 @@ from __future__ import print_function
 import enum
 import logging
 import os
-
-# absolute import is necessary because IPA module dns clashes with python-dns
-from dns import resolver
-import six
-
 import sys
 
+import six
 from subprocess import CalledProcessError
 
 from ipalib import api
@@ -294,7 +290,7 @@ def install_check(standalone, api, replica, options, hostname):
         if not options.forwarders:
             options.forwarders = []
         if options.auto_forwarders:
-            options.forwarders += resolver.get_default_resolver().nameservers
+            options.forwarders += dnsutil.get_ipa_resolver().nameservers
     elif standalone or not replica:
         options.forwarders = read_dns_forwarders()
 

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1193,7 +1193,7 @@ def _san_ip_update_reachable(reachable, dnsname, cname_depth):
     """
     fqdn = dnsutil.DNSName(dnsname).make_absolute()
     try:
-        zone = dnsutil.DNSName(resolver.zone_for_name(fqdn))
+        zone = dnsutil.DNSName(dnsutil.zone_for_name(fqdn))
     except resolver.NoNameservers:
         return  # if there's no zone, there are no records
     name = fqdn.relativize(zone)
@@ -1227,7 +1227,7 @@ def _ip_ptr_records(ip):
     """
     rname = dnsutil.DNSName(reversename.from_address(ip))
     try:
-        zone = dnsutil.DNSName(resolver.zone_for_name(rname))
+        zone = dnsutil.DNSName(dnsutil.zone_for_name(rname))
         name = rname.relativize(zone)
         result = api.Command['dnsrecord_show'](zone, name)['result']
     except resolver.NoNameservers:

--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -22,8 +22,6 @@ from __future__ import absolute_import
 
 import logging
 
-import dns.resolver
-
 import six
 
 from ipalib import api, errors, util
@@ -64,7 +62,7 @@ from ipapython.ipautil import (
     CheckedIPAddress,
     TMP_PWD_ENTROPY_BITS
 )
-from ipapython.dnsutil import DNSName
+from ipapython.dnsutil import DNSName, zone_for_name
 from ipapython.ssh import SSHPublicKey
 from ipapython.dn import DN
 from ipapython import kerberos
@@ -826,7 +824,7 @@ class host_del(LDAPDelete):
         if updatedns:
             # Remove A, AAAA, SSHFP and PTR records of the host
             fqdn_dnsname = DNSName(fqdn).make_absolute()
-            zone = DNSName(dns.resolver.zone_for_name(fqdn_dnsname))
+            zone = DNSName(zone_for_name(fqdn_dnsname))
             relative_hostname = fqdn_dnsname.relativize(zone)
 
             # Get all resources for this host

--- a/ipatests/azure/Dockerfiles/Dockerfile.build.rawhide
+++ b/ipatests/azure/Dockerfiles/Dockerfile.build.rawhide
@@ -1,0 +1,31 @@
+# replace with 'fedora:rawhide' on fix:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1869612
+FROM registry.fedoraproject.org/fedora:rawhide
+MAINTAINER [FreeIPA Developers freeipa-devel@lists.fedorahosted.org]
+ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
+
+ADD dist /root
+RUN echo 'deltarpm = false' >> /etc/dnf/dnf.conf \
+    && dnf update -y dnf \
+    && sed -i 's/%_install_langs \(.*\)/\0:fr/g' /etc/rpm/macros.image-language-conf \
+    && dnf install -y systemd \
+    && dnf install -y \
+        firewalld \
+        glibc-langpack-fr \
+        glibc-langpack-en \
+        iptables \
+        nss-tools \
+        openssh-server \
+        sudo \
+        wget \
+        /root/rpms/*.rpm \
+    && dnf clean all && rm -rf /root/rpms /root/srpms \
+    && sed -i 's/.*PermitRootLogin .*/#&/g' /etc/ssh/sshd_config \
+    && echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config \
+    && systemctl enable sshd \
+    && for i in /usr/lib/systemd/system/*-domainname.service; \
+    do sed -i 's#^ExecStart=/#ExecStart=-/#' $i ; done
+
+STOPSIGNAL RTMIN+3
+VOLUME ["/freeipa", "/run", "/tmp"]
+ENTRYPOINT [ "/usr/sbin/init" ]

--- a/ipatests/azure/azure-pipelines-rawhide.yml
+++ b/ipatests/azure/azure-pipelines-rawhide.yml
@@ -1,0 +1,4 @@
+extends:
+  template: azure-pipelines.yml
+  parameters:
+    VARIABLES_FILE: 'templates/variables-rawhide.yml'

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -102,7 +102,7 @@ jobs:
         export LANG=en_US.utf8
         export LC_CTYPE=en_US.utf8
         locale
-        $(TOX_COMMAND) -e py3,pypi,pylint3
+        $(TOX_COMMAND) -e py3,pypi,pylint3 -vv
       displayName: Tox
     - task: PublishTestResults@2
       inputs:

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -95,10 +95,6 @@ jobs:
     options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
   steps:
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: ${{ variables.AZURE_PYTHON_VERSION }}
-        architecture: x64
     - template: templates/${{ variables.PREPARE_TOX_TEMPLATE }}
     - script: |
         set -e
@@ -122,10 +118,6 @@ jobs:
     options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
   steps:
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: ${{ variables.AZURE_PYTHON_VERSION }}
-        architecture: x64
     - template: templates/${{ variables.PREPARE_WEBUI_TEMPLATE }}
     - script: |
         set -e

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -1,10 +1,14 @@
+parameters:
+- name: VARIABLES_FILE
+  default: 'templates/variables.yml'
+
 trigger:
 - master
 
 variables:
 - template: templates/variables-common.yml
 # platform specific variables, links to
-- template: templates/variables.yml
+- template: ${{ parameters.VARIABLES_FILE }}
 
 jobs:
 - job: Build

--- a/ipatests/azure/templates/prepare-tox-fedora.yml
+++ b/ipatests/azure/templates/prepare-tox-fedora.yml
@@ -1,6 +1,6 @@
 steps:
 - script: |
     set -e
-    sudo dnf -y install nss-tools
+    sudo dnf -y install nss-tools python3-pip
     python3 -m pip install --user --upgrade pip setuptools pycodestyle
   displayName: Install Tox prerequisites

--- a/ipatests/azure/templates/variables-fedora.yml
+++ b/ipatests/azure/templates/variables-fedora.yml
@@ -15,6 +15,3 @@ variables:
   PREPARE_WEBUI_TEMPLATE: ${{ format('prepare-webui-{0}.yml', variables.IPA_PLATFORM) }}
 
   TOX_COMMAND: tox
-
-  # Python version for UsePythonVersion@0 task
-  AZURE_PYTHON_VERSION: '3.8'

--- a/ipatests/azure/templates/variables-rawhide.yml
+++ b/ipatests/azure/templates/variables-rawhide.yml
@@ -1,0 +1,23 @@
+variables:
+  IPA_PLATFORM: fedora
+  # the Docker public image to build IPA packages (rpms)
+  #
+  # replace with 'fedora:rawhide' on fix:
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1869612
+  DOCKER_BUILD_IMAGE: 'registry.fedoraproject.org/fedora:rawhide'
+
+  # the Dockerfile to build Docker image for running IPA tests
+  DOCKER_DOCKERFILE: 'Dockerfile.build.rawhide'
+
+  # the template to install IPA's buildtime dependencies
+  PREPARE_BUILD_TEMPLATE: ${{ format('prepare-build-{0}.yml', variables.IPA_PLATFORM) }}
+
+  # the template to build IPA packages (rpms)
+  BUILD_TEMPLATE: ${{ format('build-{0}.yml', variables.IPA_PLATFORM) }}
+  PREPARE_TOX_TEMPLATE: ${{ format('prepare-tox-{0}.yml', variables.IPA_PLATFORM) }}
+  PREPARE_WEBUI_TEMPLATE: ${{ format('prepare-webui-{0}.yml', variables.IPA_PLATFORM) }}
+
+  TOX_COMMAND: tox
+
+  # Python version for UsePythonVersion@0 task
+  AZURE_PYTHON_VERSION: '3.9'

--- a/ipatests/azure/templates/variables-rawhide.yml
+++ b/ipatests/azure/templates/variables-rawhide.yml
@@ -18,6 +18,3 @@ variables:
   PREPARE_WEBUI_TEMPLATE: ${{ format('prepare-webui-{0}.yml', variables.IPA_PLATFORM) }}
 
   TOX_COMMAND: tox
-
-  # Python version for UsePythonVersion@0 task
-  AZURE_PYTHON_VERSION: '3.9'

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -49,6 +49,7 @@ from cryptography.hazmat.backends import default_backend
 
 from ipapython import certdb
 from ipapython import ipautil
+from ipapython.dnsutil import DNSResolver
 from ipaplatform.paths import paths
 from ipaplatform.services import knownservices
 from ipapython.dn import DN
@@ -1436,7 +1437,7 @@ def resolve_record(nameserver, query, rtype="SOA", retry=True, timeout=100):
     :timeout: max period of time while method will try to resolve query
      (requires retry=True)
     """
-    res = dns.resolver.Resolver()
+    res = DNSResolver()
     res.nameservers = [nameserver]
     res.lifetime = 10  # wait max 10 seconds for reply
 
@@ -1444,7 +1445,7 @@ def resolve_record(nameserver, query, rtype="SOA", retry=True, timeout=100):
 
     while time.time() < wait_until:
         try:
-            ans = res.query(query, rtype)
+            ans = res.resolve(query, rtype)
             return ans
         except dns.exception.DNSException:
             if not retry:

--- a/ipatests/test_integration/test_dns_locations.py
+++ b/ipatests/test_integration/test_dns_locations.py
@@ -12,7 +12,7 @@ import dns.rdataclass
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
-from ipapython.dnsutil import DNSName
+from ipapython.dnsutil import DNSName, DNSResolver
 from ipalib.constants import IPA_CA_RECORD
 
 logger = logging.getLogger(__name__)
@@ -45,14 +45,14 @@ IPA_CA_A_REC = (
 
 def resolve_records_from_server(rname, rtype, nameserver):
     error = None
-    res = dns.resolver.Resolver()
+    res = DNSResolver()
     res.nameservers = [nameserver]
     res.lifetime = 30
     logger.info("Query: %s %s, nameserver %s", rname, rtype, nameserver)
     # lets try to query 3x
     for _i in range(3):
         try:
-            ans = res.query(rname, rtype)
+            ans = res.resolve(rname, rtype)
             logger.info("Answer: %s", ans.rrset)
             return ans.rrset
         except (dns.resolver.NXDOMAIN, dns.resolver.Timeout) as e:

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -10,13 +10,13 @@ import subprocess
 import time
 
 import dns.dnssec
-import dns.resolver
 import dns.name
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.firewall import Firewall
 from ipaplatform.paths import paths
+from ipapython.dnsutil import DNSResolver
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ example3_test_zone = "example3.test."
 
 
 def resolve_with_dnssec(nameserver, query, rtype="SOA"):
-    res = dns.resolver.Resolver()
+    res = DNSResolver()
     res.nameservers = [nameserver]
     res.lifetime = 10  # wait max 10 seconds for reply
     # enable Authenticated Data + Checking Disabled flags
@@ -42,7 +42,7 @@ def resolve_with_dnssec(nameserver, query, rtype="SOA"):
     # enable EDNS v0 + enable DNSSEC-Ok flag
     res.use_edns(0, dns.flags.DO, 0)
 
-    ans = res.query(query, rtype)
+    ans = res.resolve(query, rtype)
     return ans
 
 


### PR DESCRIPTION
- allow override variables template file with an externally provided one. This allows adding new Azure Pipeline which will point to a custom platform definition. Note: Azure's WebUI variables are runtime variables and not available at parsing time, that's why it's impossible to override template from WebUI in this case.

- add Rawhide templates

- add Dockerfile for build Docker image for tests phase
Note: 'fedora:rawhide' is too old, use for now 'registry.fedoraproject.org/fedora:rawhide'. See, https://bugzilla.redhat.com/show_bug.cgi?id=1869612

Use case:
- make it possible to trigger several CIs with different definitions on a push to a branch.
The Pipeline configuration file and tests definitions should be in a target branch.