### PR TITLE
Fix resolv conf on smbserver test

### DIFF
--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -61,8 +61,9 @@ class TestSMB(IntegrationTest):
         cls.smbclient = cls.clients[1]
         cls.ad_user = '{}@{}'.format(cls.ad_user_login, cls.ad.domain.name)
 
-        tasks.config_host_resolvconf_with_master_data(cls.master,
-                                                      cls.smbclient)
+        for h in [cls.smbserver, cls.smbclient]:
+            tasks.config_host_resolvconf_with_master_data(cls.master, h)
+
         tasks.install_adtrust(cls.master)
         tasks.configure_dns_for_trust(cls.master, cls.ad)
         tasks.configure_windows_dns_for_trust(cls.ad, cls.master)


### PR DESCRIPTION
test_smb test suite sets up IPA master, AD forest, and two clients. The clients are used as an SMB server and an SMB client and they need to resolve and authenticate AD users with Kerberos.

Previously, the test only configured SMB client to use IPA master as its DNS server. SMB server wasn't using IPA master and thus any attempt to resolve SRV records from AD DNS zone was failing.

Make sure that both SMB client's and SMB server's DNS resolution is set up in the same way.

Fixes: https://pagure.io/freeipa/issue/8344
