### PR TITLE
Increase timeout for test_cert.py 

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -284,7 +284,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_cert.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest/test_upgrade:

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1578,7 +1578,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_cert.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest/test_epn:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1703,7 +1703,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_cert.py
         template: *testing-master-latest
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl_1client
 
   testing-fedora/test_epn:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1578,7 +1578,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_cert.py
         template: *ci-master-previous
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-previous/test_epn:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1703,7 +1703,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_cert.py
         template: *ci-master-frawhide
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-rawhide/test_epn:


### PR DESCRIPTION
test_cert.py is timing out due to newly added test

test_cert.py::TestCertmongerRekey which needs more time to execute.
Adding additional 30 mins to the timeout in order to complete the test run

Failing test run:
http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/249e30e4-e349-11ea-ac03-fa163e1ffcbd

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>