### PR TITLE
Update pylintrc to ignore aggressive errors from pylint 2.6.0

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -103,6 +103,8 @@ disable=
     no-else-raise, # python 2.4.0
     import-outside-toplevel, # pylint 2.4.2
     f-string-without-interpolation,  # pylint 2.5.0, bare f-strings are ok
+    raise-missing-from, # pylint 2.6.0
+    super-with-arguments, # pylint 2.6.0
 
 [REPORTS]
 


### PR DESCRIPTION
pylint 2.6.0 forces aggressive switch to Python 3 constructs that would make
FreeIPA 4.8+ incompatible with most of FreeIPA 4.6 code base.

Disable 'raise-missing-from' and 'super-with-arguments' right now.

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>