### PR TITLE
ipatests: Bump PR-CI templates

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f32
-          version: 0.0.7
+          version: 0.0.8
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f32
-          version: 0.0.7
+          version: 0.0.8
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,7 +57,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f32
-          version: 0.0.7
+          version: 0.0.8
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
New template images for ci-master-f32 to include latest packages.

Mainly reason was `samba-4.12.6-0.fc32`.

Signed-off-by: Armando Neto <abiagion@redhat.com>

--- 

`ipa-4-8` backport: https://github.com/freeipa/freeipa/pull/5058