### PR TITLE
[Backport][ipa-4-8] Increase timeout for test_cert

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -284,7 +284,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_cert.py
         template: *ci-ipa-4-8-latest
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-8/test_upgrade:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1578,7 +1578,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-8/build_url}'
         test_suite: test_integration/test_cert.py
         template: *ci-ipa-4-8-latest
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-8/test_epn:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -1579,7 +1579,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-8/build_url}'
         test_suite: test_integration/test_cert.py
         template: *ci-ipa-4-8-previous
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-previous-ipa-4-8/test_epn:


### PR DESCRIPTION
This is a manual back port for https://github.com/freeipa/freeipa/pull/5053/

Increase test_cert.py timeout from 3600 to 5400
to accomodate newly added tests that need more time
to execute

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>