### PR TITLE
[Backport][ipa-4-8] Fix resolv conf on smbserver test

### DIFF
--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -61,8 +61,9 @@ class TestSMB(IntegrationTest):
         cls.smbclient = cls.clients[1]
         cls.ad_user = '{}@{}'.format(cls.ad_user_login, cls.ad.domain.name)
 
-        tasks.config_host_resolvconf_with_master_data(cls.master,
-                                                      cls.smbclient)
+        for h in [cls.smbserver, cls.smbclient]:
+            tasks.config_host_resolvconf_with_master_data(cls.master, h)
+
         tasks.install_adtrust(cls.master)
         tasks.configure_dns_for_trust(cls.master, cls.ad)
         tasks.configure_windows_dns_for_trust(cls.ad, cls.master)


### PR DESCRIPTION
This PR was opened automatically because PR #5052 was pushed to master and backport to ipa-4-8 is required.