### PR TITLE
When parsing options require name/value pairs

### DIFF
--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -600,13 +600,18 @@ class API(ReadOnly):
             assert type(options.env) is list
             for item in options.env:
                 try:
-                    (key, value) = item.split('=', 1)
+                    values = item.split('=', 1)
                 except ValueError:
                     # FIXME: this should raise an IPA exception with an
                     # error code.
                     # --Jason, 2008-10-31
                     pass
-                overrides[str(key.strip())] = value.strip()
+                if len(values) == 2:
+                    (key, value) = values
+                    overrides[str(key.strip())] = value.strip()
+                else:
+                    raise errors.OptionError(_('Unable to parse option {item}'
+                                               .format(item=item)))
         for key in ('conf', 'debug', 'verbose', 'prompt_all', 'interactive',
             'fallback', 'delegate'):
             value = getattr(options, key, None)


### PR DESCRIPTION
If single-option values are combined together with invalid options
an exception would be raised.
    
For example -verbose was treated as -v -e rbose. Since rbose isn't
a name/value pair things would blow up. This is now caught and
a somewhat more reable error returned. The -v and -e are consumed,
not much we can do about that, but at least a more usable error is
returned.
    
https://pagure.io/freeipa/issue/6115