### PR TITLE
[Backport][ipa-4-8] When parsing options require name/value pairs

### DIFF
--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -597,13 +597,18 @@ class API(ReadOnly):
             assert type(options.env) is list
             for item in options.env:
                 try:
-                    (key, value) = item.split('=', 1)
+                    values = item.split('=', 1)
                 except ValueError:
                     # FIXME: this should raise an IPA exception with an
                     # error code.
                     # --Jason, 2008-10-31
                     pass
-                overrides[str(key.strip())] = value.strip()
+                if len(values) == 2:
+                    (key, value) = values
+                    overrides[str(key.strip())] = value.strip()
+                else:
+                    raise errors.OptionError(_('Unable to parse option {item}'
+                                               .format(item=item)))
         for key in ('conf', 'debug', 'verbose', 'prompt_all', 'interactive',
             'fallback', 'delegate'):
             value = getattr(options, key, None)


### PR DESCRIPTION
This PR was opened automatically because PR #5063 was pushed to master and backport to ipa-4-8 is required.