### PR TITLE
ipatests: run test_ipahealthcheck.py::TestIpaHealthCheck separately

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1336,9 +1336,21 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
-        timeout: 7200
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest/test_ipahealthcheck_nodns_extca:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        template: *ci-master-latest
+        timeout: 3600
         topology: *master_1repl
 
   fedora-latest/test_ipahealthcheck_adtrust:

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1341,14 +1341,26 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest/test_ipahealthcheck_nodns_extca:
+  fedora-latest/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFileCheck
+        template: *ci-master-latest
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-latest/test_ipahealthcheck_cli_fsspace:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCLI test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFilesystemSpace
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -800,7 +800,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  pki-fedora/test_ipahealthcheck_nodns_extca:
+  pki-fedora/test_ipahealthcheck_nodns_extca_file:
     requires: [pki-fedora/build]
     priority: 50
     job:
@@ -808,9 +808,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFileCheck
         template: *pki-master-latest
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl
 
   pki-fedora/test_pkinit_manage:

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -795,9 +795,22 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *pki-master-latest
-        timeout: 7200
+        timeout: 3600
+        topology: *master_1repl
+
+  pki-fedora/test_ipahealthcheck_nodns_extca:
+    requires: [pki-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{pki-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        template: *pki-master-latest
+        timeout: 3600
         topology: *master_1repl
 
   pki-fedora/test_pkinit_manage:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1446,7 +1446,7 @@ jobs:
         topology: *master_1repl
         timeout: 3600
 
-  testing-fedora/test_ipahealthcheck_nodns_extca:
+  testing-fedora/test_ipahealthcheck_nodns_extca_file:
     requires: [testing-fedora/build]
     priority: 50
     job:
@@ -1454,10 +1454,23 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFileCheck
         template: *testing-master-latest
         topology: *master_1repl
+        timeout: 5400
+
+  testing-fedora/test_ipahealthcheck_cli_fsspace:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCLI test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFilesystemSpace
+        template: *testing-master-latest
         timeout: 3600
+        topology: *master_1repl
 
   testing-fedora/test_ipahealthcheck_adtrust:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1441,10 +1441,23 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *testing-master-latest
         topology: *master_1repl
-        timeout: 7200
+        timeout: 3600
+
+  testing-fedora/test_ipahealthcheck_nodns_extca:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        template: *testing-master-latest
+        topology: *master_1repl
+        timeout: 3600
 
   testing-fedora/test_ipahealthcheck_adtrust:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1336,9 +1336,21 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-previous/build_url}'
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-previous
-        timeout: 7200
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-previous/test_ipahealthcheck_nodns_extca:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        template: *ci-master-previous
+        timeout: 3600
         topology: *master_1repl
 
   fedora-previous/test_ipahealthcheck_adtrust:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1341,17 +1341,29 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-previous/test_ipahealthcheck_nodns_extca:
+  fedora-previous/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-previous/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-previous/build_url}'
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFileCheck
         template: *ci-master-previous
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl
+
+  fedora-previous/test_ipahealthcheck_cli_fsspace:
+   requires: [fedora-previous/build]
+   priority: 50
+   job:
+     class: RunPytest
+     args:
+       build_url: '{fedora-previous/build_url}'
+       test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCLI test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFilesystemSpace
+       template: *ci-master-previous
+       timeout: 3600
+       topology: *master_1repl
 
   fedora-previous/test_ipahealthcheck_adtrust:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1446,7 +1446,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-rawhide/test_ipahealthcheck_nodns_extca:
+  fedora-rawhide/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-rawhide/build]
     priority: 50
     job:
@@ -1454,10 +1454,23 @@ jobs:
       args:
         build_url: '{fedora-rawhide/build_url}'
         update_packages: True
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFileCheck
         template: *ci-master-frawhide
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl
+
+  fedora-rawhide/test_ipahealthcheck_cli_fsspace:
+   requires: [fedora-rawhide/build]
+   priority: 50
+   job:
+     class: RunPytest
+     args:
+       build_url: '{fedora-rawhide/build_url}'
+       update_packages: True
+       test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCLI test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFilesystemSpace
+       template: *ci-master-frawhide
+       timeout: 3600
+       topology: *master_1repl
 
   fedora-rawhide/test_ipahealthcheck_adtrust:
     requires: [fedora-rawhide/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1441,9 +1441,22 @@ jobs:
       args:
         build_url: '{fedora-rawhide/build_url}'
         update_packages: True
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-frawhide
-        timeout: 7200
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-rawhide/test_ipahealthcheck_nodns_extca:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        template: *ci-master-frawhide
+        timeout: 3600
         topology: *master_1repl
 
   fedora-rawhide/test_ipahealthcheck_adtrust:


### PR DESCRIPTION
The test is changing the date back and forth. Due to PRCI
infra issue, chronyd is not able to connect to the default
NTP servers from the fedora pool, and the date is not
synchronized any more after this test.

To avoid polluting other tests, run this one separately.

Fixes: https://pagure.io/freeipa/issue/8472