### PR TITLE
    Require at least 2Gb of available RAM to install the server

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -242,6 +242,7 @@ BuildRequires:  python3-netaddr >= %{python_netaddr_version}
 BuildRequires:  python3-pyasn1
 BuildRequires:  python3-pyasn1-modules
 BuildRequires:  python3-six
+BuildRequires:  python3-psutil
 
 #
 # Build dependencies for wheel packaging and PyPI upload
@@ -444,6 +445,7 @@ Requires: python3-lxml
 Requires: python3-pki >= %{pki_version}
 Requires: python3-pyasn1 >= 0.3.2-2
 Requires: python3-sssdconfig >= %{sssd_version}
+Requires: python3-psutil
 Requires: rpm-libs
 # Indirect dependency: use newer urllib3 with TLS 1.3 PHA support
 %if 0%{?rhel}

--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -330,6 +330,12 @@ class ServerInstallInterface(ServerCertificateInstallInterface,
     )
     dirsrv_config_file = enroll_only(dirsrv_config_file)
 
+    skip_mem_check = knob(
+        None,
+        description="Skip checking for minimum required memory",
+    )
+    skip_mem_check = enroll_only(skip_mem_check)
+
     @dirsrv_config_file.validator
     def dirsrv_config_file(self, value):
         if not os.path.exists(value):

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -346,6 +346,8 @@ def install_check(installer):
     dirsrv_ca_cert = None
     pkinit_ca_cert = None
 
+    if not options.skip_mem_check:
+        installutils.check_available_memory(ca=options.setup_ca)
     tasks.check_ipv6_stack_enabled()
     tasks.check_selinux_status()
     check_ldap_conf()

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -569,7 +569,9 @@ def check_remote_version(client, local_version):
             "the local version ({})".format(remote_version, local_version))
 
 
-def common_check(no_ntp):
+def common_check(no_ntp, skip_mem_check, setup_ca):
+    if not skip_mem_check:
+        installutils.check_available_memory(ca=setup_ca)
     tasks.check_ipv6_stack_enabled()
     tasks.check_selinux_status()
     check_ldap_conf()
@@ -776,7 +778,7 @@ def promote_check(installer):
     installer._top_dir = tempfile.mkdtemp("ipa")
 
     # check selinux status, http and DS ports, NTP conflicting services
-    common_check(options.no_ntp)
+    common_check(options.no_ntp, options.skip_mem_check, options.setup_ca)
 
     if options.setup_ca and any([options.dirsrv_cert_files,
                                  options.http_cert_files,


### PR DESCRIPTION
Require at least 2Gb of available RAM to install the server
    
Verify that there is at least 2Gb of usable RAM on the system. Swap
is not considered. While swap would allow a user to minimally install
IPA it would not be a great experience.

Using any proc-based method to check for available RAM does not
work in containers unless /proc is re-mounted so use cgroups
instead. This also handles the case if the container has memory
constraints on it (-m).
    
Add a switch to skip this memory test if the user is sure they
know what they are doing.
    
https://pagure.io/freeipa/issue/8404

NOTE: I'm not aware of a pythonic "is this in a contaner" so I rolled my own.

IPA is actually installable, with a CA in < 2GB of RAM but things are very tight
and the end result isn't all that useful. 2GB should be considered the absolute
minimum. This is not including swap.
