### PR TITLE
[Backport][ipa-4-8] ipatests: run test_ipahealthcheck.py::TestIpaHealthCheck separately

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1341,14 +1341,26 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest-ipa-4-8/test_ipahealthcheck_nodns_extca:
+  fedora-latest-ipa-4-8/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-latest-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest-ipa-4-8/build_url}'
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFileCheck
+        template: *ci-ipa-4-8-latest
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_ipahealthcheck_cli_fsspace:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCLI test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFilesystemSpace
         template: *ci-ipa-4-8-latest
         timeout: 3600
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1336,9 +1336,21 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest-ipa-4-8/build_url}'
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-ipa-4-8-latest
-        timeout: 7200
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-8/test_ipahealthcheck_nodns_extca:
+    requires: [fedora-latest-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-8/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        template: *ci-ipa-4-8-latest
+        timeout: 3600
         topology: *master_1repl
 
   fedora-latest-ipa-4-8/test_ipahealthcheck_trust:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -1336,9 +1336,21 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-previous-ipa-4-8/build_url}'
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-ipa-4-8-previous
-        timeout: 7200
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-previous-ipa-4-8/test_ipahealthcheck_nodns_extca:
+    requires: [fedora-previous-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        template: *ci-ipa-4-8-previous
+        timeout: 3600
         topology: *master_1repl
 
   fedora-previous-ipa-4-8/test_ipahealthcheck_trust:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -1341,14 +1341,26 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-previous-ipa-4-8/test_ipahealthcheck_nodns_extca:
+  fedora-previous-ipa-4-8/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-previous-ipa-4-8/build_url}'
-        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFileCheck
+        template: *ci-ipa-4-8-previous
+        timeout: 5400
+        topology: *master_1repl
+
+  fedora-previous-ipa-4-8/test_ipahealthcheck_cli_fsspace:
+    requires: [fedora-previous-ipa-4-8/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-8/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCLI test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFilesystemSpace
         template: *ci-ipa-4-8-previous
         timeout: 3600
         topology: *master_1repl


### PR DESCRIPTION
This is a manual backport of PR #5066 to ipa-4-8 branch.