### PR TITLE
DNSResolver: Make use of `resolve_address` of a current resolver instead of the global one

### DIFF
--- a/ipapython/dnsutil.py
+++ b/ipapython/dnsutil.py
@@ -111,7 +111,7 @@ class DNSResolver(dns.resolver.Resolver):
         :param ip_address: IPv4 or IPv6 address
         :type ip_address: str
         """
-        return resolve(
+        return self.resolve(
             dns.reversename.from_address(ip_address),
             rdtype=dns.rdatatype.PTR,
             *args,


### PR DESCRIPTION
For now, `resolve_address` for `dnspython` < 2.0.0 is actually the instance method of the global DNSResolver object and is not the instance method of the corresponding object from which it was called. This can result in unexpected behavior.

Signed-off-by: Stanislav Levin <slev@altlinux.org>