### PR TITLE
389-DS BDB: switch deadlock behavior to DB_LOCK_MINWRITE

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -104,6 +104,12 @@
 %global ds_version 1.4.0.21
 %endif
 
+# Configuring nsslapd-db-deadlock-policy to DB_LOCK_MINWRITE
+# requires 389-DS 1.4.2.3 and higher.
+%if 0%{?fedora} >= 31
+%global ds_version 1.4.2.3
+%endif
+
 # Fix for TLS 1.3 PHA, RHBZ#1775146
 %if 0%{?fedora} >= 31
 %global httpd_version 2.4.41-9

--- a/install/updates/10-nsslapd-db-deadlock-policy.update
+++ b/install/updates/10-nsslapd-db-deadlock-policy.update
@@ -1,0 +1,22 @@
+# Configure 389-DS BDB backend to use DB_LOCK_MINWRITE.
+# 
+# Some IPA updates are expensive in term of processing and #page hit.
+# The likelihood to generate a DS Berkeley DB database deadlock can be high
+# for some common operations.
+#
+# When a deadlock is detected one deadlocking thread needs to be
+# rejected to let the other(s) complete.
+# DB_LOCK_YOUNGEST (9) is the DS default: it  means the most recent operation
+# fails in favor to the oldest one.
+# DB_LOCK_MINWRITE (6) means the reader(s) are rejected in favor
+# of the writers even if the reader(s) are older.
+# 
+# Switch the default for FreeIPA to DB_LOCK_MINWRITE.
+# This depends on the backend redesign (https://pagure.io/389-ds-base/issue/49476)
+# and therefore is valid on 389-DS 1.4.2.3 and higher.
+# 
+# BDB header:
+# https://github.com/berkeleydb/libdb/blob/5b7b02ae052442626af54c176335b67ecc613a30/src/dbinc/db.in#L287
+# 
+dn: cn=bdb,cn=config,cn=ldbm database,cn=plugins,cn=config
+replace: nsslapd-db-deadlock-policy:9::6

--- a/install/updates/Makefile.am
+++ b/install/updates/Makefile.am
@@ -6,6 +6,7 @@ app_DATA =				\
 	10-config.update		\
 	10-enable-betxn.update		\
 	10-ipapwd.update		\
+	10-nsslapd-db-deadlock-policy.update \
 	10-selinuxusermap.update	\
 	10-rootdse.update		\
 	10-uniqueness.update		\

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1640,3 +1640,15 @@ jobs:
          template: *ci-master-latest
          timeout: 3600
          topology: *master_1repl
+
+  fedora-latest/test_settings:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_settings.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1770,3 +1770,16 @@ jobs:
          template: *testing-master-latest
          timeout: 3600
          topology: *master_1repl
+
+  testing-fedora/test_settings:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_settings.py
+        template: *testing-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1628,3 +1628,15 @@ jobs:
          template: *ci-master-previous
          timeout: 3600
          topology: *master_1repl
+
+  fedora-previous/test_settings:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_settings.py
+        template: *ci-master-previous
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1770,3 +1770,16 @@ jobs:
          template: *ci-master-frawhide
          timeout: 3600
          topology: *master_1repl
+
+  fedora-rawhide/test_settings:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_settings.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/test_integration/test_settings.py
+++ b/ipatests/test_integration/test_settings.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestSettings(IntegrationTest):
+    """
+    Test installation settings
+    """
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master)
+        tasks.install_replica(cls.master, cls.replicas[0], setup_ca=False)
+
+    def test_nsslapd_db_deadlock_policy(self):
+        """
+        Check that nsslapd-db-deadlock-policy was set to DB_LOCK_MINWRITE (6)
+        rather than DB_LOCK_YOUNGEST (9).
+        """
+        config_dn = 'cn=bdb,cn=config,cn=ldbm database,cn=plugins,cn=config'
+        config_attr = 'nsslapd-db-deadlock-policy'
+        expected_txt = 'nsslapd-db-deadlock-policy: 6'
+        for host in (self.master, self.replicas[0]):
+            result = tasks.ldapsearch_dm(
+                host,
+                config_dn,
+                [config_attr],
+            )
+            text = result.stdout_text.lower()
+            assert expected_txt in text


### PR DESCRIPTION
Some IPA updates are expensive in term of processing and #page hit.
The likelihood to generate a DS Berkeley DB database deadlock can be high
for some common operations.

When a deadlock is detected one deadlocking thread needs to be
rejected to let the other(s) complete.
DB_LOCK_YOUNGEST (9) is the DS default: it  means the most recent operation
fails in favor to the oldest one.
DB_LOCK_MINWRITE (6) means the reader(s) are rejected in favor
of the writers even if the reader(s) are older.

Switch the default for FreeIPA to DB_LOCK_MINWRITE for new installs and
also existing installs at update time.
This depends on the backend redesign (https://pagure.io/389-ds-base/issue/49476)
and therefore is valid on 389-DS 1.4.2.3 and higher.

Explanation provided by Thierry Bordaz.

Fixes: https://pagure.io/freeipa/issue/8479
Signed-off-by: François Cami <fcami@redhat.com>