### PR TITLE
[Backport][ipa-4-8] DNSResolver: Make use of `resolve_address` of a current resolver instead of the global one

### DIFF
--- a/ipapython/dnsutil.py
+++ b/ipapython/dnsutil.py
@@ -111,7 +111,7 @@ class DNSResolver(dns.resolver.Resolver):
         :param ip_address: IPv4 or IPv6 address
         :type ip_address: str
         """
-        return resolve(
+        return self.resolve(
             dns.reversename.from_address(ip_address),
             rdtype=dns.rdatatype.PTR,
             *args,


### PR DESCRIPTION
This PR was opened manually because PR #5070 was pushed to master and backport to `ipa-4-8` is required.