### PR TITLE
delete unused subroutine get_host_name()

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -457,18 +457,6 @@ def resolve_ip_addresses_nss(fqdn):
     logger.debug('Name %s resolved to %s', fqdn, ip_addresses)
     return ip_addresses
 
-def get_host_name(no_host_dns):
-    """
-    Get the current FQDN from the socket and verify that it is valid.
-
-    no_host_dns is a boolean that determines whether we enforce that the
-    hostname is resolvable.
-
-    Will raise a RuntimeError on error, returns hostname on success
-    """
-    hostname = get_fqdn()
-    verify_fqdn(hostname, no_host_dns)
-    return hostname
 
 def get_server_ip_address(host_name, unattended, setup_dns, ip_addresses):
     hostaddr = resolve_ip_addresses_nss(host_name)


### PR DESCRIPTION
Commit a42a711394178a459bde006e6b49ed799a7cce1a, from September
2018, removed the only call site of installutils.get_host_name().
Delete the definition.