### PR TITLE
ipatests: fix bind service name

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -184,7 +184,11 @@ def restart_service():
             serverid = (realm_to_serverid(host.domain.realm)).upper()
             service_name = 'dirsrv@%s.service' % serverid
         elif service_name == 'named':
-            service_name = 'named-pkcs11'
+            # The service name may differ depending on the host OS
+            script = ("from ipaplatform.services import knownservices; "
+                      "print(knownservices.named.systemd_name)")
+            result = host.run_command(['python3', '-c', script])
+            service_name = result.stdout_text.strip()
         if 'host' not in service:
             service['host'] = host
             service['name'] = [service_name]


### PR DESCRIPTION
With the commit 721435c
the service name for bind is now 'named' instead of
'named-pkcs11' on fedora. The ipa-healthcheck test was hardcoding
the service name but it should instead use the name stored in
knownservices.named.systemd_name as it varies depending on
the OS.

Fixes: https://pagure.io/freeipa/issue/8482