### PR TITLE
dnsforwardzone-add: support dnspython 2.0 

### DIFF
--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -4313,7 +4313,7 @@ class dnsforwardzone(DNSZoneBase):
             except dns.exception.DNSException:
                 continue
             else:
-                ipa_dns_ip = str(ans.rrset.items[0])
+                ipa_dns_ip = str(next(iter(ans.rrset.items)))
                 break
 
         if not ipa_dns_ip:


### PR DESCRIPTION
The command dnsforwardzone-add is assuming that the dns.rrset.RRset
type stores "items" as a list. With dnspython 2.0 this is not true
as a dict is used instead.

As a consequence, in order to get the first record, it is not possible
to use items[0]. As dict and list are both iterables, next(iter(items))
can be used in order to be compatible with dnspython 1.16 and 2.0.

Fixes: https://pagure.io/freeipa/issue/8481