### PR TITLE
ipa-kdb: support getprincs request in kadmin.local

### DIFF
--- a/ipatests/test_ipaserver/test_kadmin.py
+++ b/ipatests/test_ipaserver/test_kadmin.py
@@ -123,3 +123,9 @@ class TestKadmin:
             installutils.create_keytab,
             keytab,
             service)
+
+    def test_getprincs(self):
+        """
+        tests that kadmin.local getprincs command returns a list of principals
+        """
+        self.assert_success(installutils.kadmin, 'getprincs')


### PR DESCRIPTION
kadmin.local getprincs command results in passing '*' as a principal to KDB driver function that looks up the principals.
    
The whole filter looks like this
```    
     (&(|
        (objectclass=krbprincipalaux)
        (objectclass=krbprincipal)
        (objectclass=ipakrbprincipal))
       (|(ipakrbprincipalalias=*)
         (krbprincipalname:caseIgnoreIA5Match:=*)))
```
    
There are two parts of the LDAP filter we use to look up principals, the part with 'krbprincipalname' uses extensible filter syntax of RFC 4515 section 3:
```    
          extensible     = ( attr [dnattrs]
                               [matchingrule] COLON EQUALS assertionvalue )
                           / ( [dnattrs]
                                matchingrule COLON EQUALS assertionvalue )
```    
In case we've got a principal name as '*' we have to follow RFC 4515 section 3 and reencode it using <valueencoding> rule from RFC 4511 section 4.1.6 but only to the part of the filter that does use assertion value.
    
Fixes: https://pagure.io/freeipa/issue/8490
