### PR TITLE
[Backport][ipa-4-8] dnsforwardzone-add: support dnspython 2.0 

### DIFF
--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -4313,7 +4313,7 @@ class dnsforwardzone(DNSZoneBase):
             except dns.exception.DNSException:
                 continue
             else:
-                ipa_dns_ip = str(ans.rrset.items[0])
+                ipa_dns_ip = str(next(iter(ans.rrset.items)))
                 break
 
         if not ipa_dns_ip:


### PR DESCRIPTION
This PR was opened automatically because PR #5085 was pushed to master and backport to ipa-4-8 is required.