### PR TITLE
[Backport][ipa-4-8] ipa-kdb: support getprincs request in kadmin.local

### DIFF
--- a/ipatests/test_ipaserver/test_kadmin.py
+++ b/ipatests/test_ipaserver/test_kadmin.py
@@ -123,3 +123,9 @@ class TestKadmin:
             installutils.create_keytab,
             keytab,
             service)
+
+    def test_getprincs(self):
+        """
+        tests that kadmin.local getprincs command returns a list of principals
+        """
+        self.assert_success(installutils.kadmin, 'getprincs')


### PR DESCRIPTION
This PR was opened automatically because PR #5086 was pushed to master and backport to ipa-4-8 is required.