### PR TITLE
Add index for more trust-related attributes

### DIFF
--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -395,3 +395,24 @@ default: objectClass: top
 default: objectClass: nsIndex
 default: nsSystemIndex: false
 default: nsIndexType: eq
+
+dn: cn=ipaNTTrustPartner,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: ipaNTTrustPartner
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: pres
+
+dn: cn=ipaNTSecurityIdentifier,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: ipaNTSecurityIdentifier
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: pres
+
+dn: cn=krbprincipalname,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: krbprincipalname
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: pres


### PR DESCRIPTION
Add index for ipaNTTrustPartner, ipaNTSecurityIdentifier and
krbprincipalname

https://pagure.io/freeipa/issue/8491

Signed-off-by: Rob Crittenden <rcritten@redhat.com>