### PR TITLE
[Backport][ipa-4-8] Don't allow both a zone name and --name-from-ip to be provided

### DIFF
--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -2142,6 +2142,14 @@ class DNSZoneBase_add(LDAPCreate):
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys, **options):
         assert isinstance(dn, DN)
 
+        if options.get('name_from_ip'):
+            zone = _reverse_zone_name(options.get('name_from_ip'))
+            if keys[-1] != DNSName(zone):
+                raise errors.ValidationError(
+                    name='name-from-ip',
+                    error=_("cannot be used when a zone is specified")
+                )
+
         try:
             entry = ldap.get_entry(dn)
         except errors.NotFound:

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -686,6 +686,20 @@ class test_dns(Declarative):
 
 
         dict(
+            desc='Try to create a zone w/ a name and name-from-ipa %r' % zone1,
+            command=(
+                'dnszone_add', [zone1], {
+                    'idnssoarname': zone1_rname,
+                    'name_from_ip': revzone1_ip,
+                }
+            ),
+            expected=errors.ValidationError(
+                message=u'invalid \'name-from-ip\': cannot be used when a '
+                        'zone is specified'),
+        ),
+
+
+        dict(
             desc='Retrieve zone %r' % zone1,
             command=('dnszone_show', [zone1], {}),
             expected={


### PR DESCRIPTION
This PR was opened automatically because PR #5091 was pushed to master and backport to ipa-4-8 is required.