### PR TITLE
[Backport][ipa-4-8] De-duplicate ACI attributes and permissions

### DIFF
--- a/ipaserver/plugins/aci.py
+++ b/ipaserver/plugins/aci.py
@@ -271,7 +271,7 @@ def _make_aci(ldap, current, aciname, kw):
     try:
         a = ACI(current)
         a.name = _make_aci_name(kw['aciprefix'], aciname)
-        a.permissions = kw['permissions']
+        a.set_permissions(kw['permissions'])
         if 'selfaci' in kw and kw['selfaci']:
             a.set_bindrule('userdn = "ldap:///self"')
         else:

--- a/ipatests/test_xmlrpc/test_delegation_plugin.py
+++ b/ipatests/test_xmlrpc/test_delegation_plugin.py
@@ -299,4 +299,38 @@ class test_delegation(Declarative):
             )
         ),
 
+
+        dict(
+            desc='Create %r with duplicate attrs & perms' % delegation1,
+            command=(
+                'delegation_add', [delegation1], dict(
+                    attrs=[u'street', u'street'],
+                    permissions=[u'write', u'write'],
+                    group=u'editors',
+                    memberof=u'admins',
+                )
+            ),
+            expected=dict(
+                value=delegation1,
+                summary=u'Added delegation "%s"' % delegation1,
+                result=dict(
+                    attrs=[u'street'],
+                    permissions=[u'write'],
+                    aciname=delegation1,
+                    group=u'editors',
+                    memberof=member1,
+                ),
+            ),
+        ),
+
+
+        dict(
+            desc='Delete %r' % delegation1,
+            command=('delegation_del', [delegation1], {}),
+            expected=dict(
+                result=True,
+                value=delegation1,
+                summary=u'Deleted delegation "%s"' % delegation1,
+            )
+        ),
     ]


### PR DESCRIPTION
This PR was opened automatically because PR #5094 was pushed to master and backport to ipa-4-8 is required.