### PR TITLE
[Backport][ipa-4-8] Add index for more trust-related attributes

### DIFF
--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -395,3 +395,24 @@ default: objectClass: top
 default: objectClass: nsIndex
 default: nsSystemIndex: false
 default: nsIndexType: eq
+
+dn: cn=ipaNTTrustPartner,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: ipaNTTrustPartner
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: pres
+
+dn: cn=ipaNTSecurityIdentifier,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: ipaNTSecurityIdentifier
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: pres
+
+dn: cn=krbprincipalname,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default: cn: krbprincipalname
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+default: nsIndexType: pres


### PR DESCRIPTION
This PR was opened automatically because PR #5096 was pushed to master and backport to ipa-4-8 is required.