### PR TITLE
Add ldap_update() helper to service class

### DIFF
--- a/install/tools/ipa-compat-manage.in
+++ b/install/tools/ipa-compat-manage.in
@@ -132,7 +132,7 @@ def main():
                 print("Enabling plugin")
 
                 if entry is None:
-                    ld = LDAPUpdate(dm_password=dirman_password, sub_dict={})
+                    ld = LDAPUpdate()
                     if not ld.update(files):
                         print("Updating Directory Server failed.")
                         retval = 1

--- a/install/tools/ipa-nis-manage.in
+++ b/install/tools/ipa-nis-manage.in
@@ -149,7 +149,7 @@ def main():
         # could be turned off, handle both cases.
         if entry is None:
             print("Enabling plugin")
-            ld = LDAPUpdate(dm_password=dirman_password, sub_dict={}, ldapi=True)
+            ld = LDAPUpdate()
             if ld.update(files) != True:
                 retval = 1
         elif entry.get('nsslapd-pluginenabled', [''])[0].lower() == 'off':

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -59,7 +59,6 @@ from ipaserver.secrets.kem import IPAKEMKeys
 from ipaserver.install import certs
 from ipaserver.install import dsinstance
 from ipaserver.install import installutils
-from ipaserver.install import ldapupdate
 from ipaserver.install import replication
 from ipaserver.install import sysupgrade
 from ipaserver.install.dogtaginstance import DogtagInstance, INTERNAL_TOKEN
@@ -671,11 +670,14 @@ class CAInstance(DogtagInstance):
         db.create_passwd_file(passwd)
 
     def __update_topology(self):
-        ld = ldapupdate.LDAPUpdate(ldapi=True, sub_dict={
-            'SUFFIX': api.env.basedn,
-            'FQDN': self.fqdn,
-        })
-        ld.update([paths.CA_TOPOLOGY_ULDIF])
+        self._ldap_update(
+            [paths.CA_TOPOLOGY_ULDIF],
+            basedir=None,
+            sub_dict={
+                'SUFFIX': api.env.basedn,
+                'FQDN': self.fqdn,
+            }
+        )
 
     def __disable_nonce(self):
         # Turn off Nonces
@@ -1359,13 +1361,13 @@ class CAInstance(DogtagInstance):
                 "Did not find any lightweight CAs; nothing to track")
 
     def __dogtag10_migration(self):
-        ld = ldapupdate.LDAPUpdate(ldapi=True, sub_dict={
-            'SUFFIX': api.env.basedn,
-            'FQDN': self.fqdn,
-        })
-        ld.update([os.path.join(paths.UPDATES_DIR,
-                                '50-dogtag10-migration.update')]
-                  )
+        self._ldap_update(
+            ['50-dogtag10-migration.update'],
+            sub_dict={
+                'SUFFIX': api.env.basedn,
+                'FQDN': self.fqdn,
+            }
+        )
 
     def is_crlgen_enabled(self):
         """Check if the local CA instance is generating CRL

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -673,10 +673,6 @@ class CAInstance(DogtagInstance):
         self._ldap_update(
             [paths.CA_TOPOLOGY_ULDIF],
             basedir=None,
-            sub_dict={
-                'SUFFIX': api.env.basedn,
-                'FQDN': self.fqdn,
-            }
         )
 
     def __disable_nonce(self):
@@ -1361,13 +1357,7 @@ class CAInstance(DogtagInstance):
                 "Did not find any lightweight CAs; nothing to track")
 
     def __dogtag10_migration(self):
-        self._ldap_update(
-            ['50-dogtag10-migration.update'],
-            sub_dict={
-                'SUFFIX': api.env.basedn,
-                'FQDN': self.fqdn,
-            }
-        )
+        self._ldap_update(['50-dogtag10-migration.update'])
 
     def is_crlgen_enabled(self):
         """Check if the local CA instance is generating CRL

--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -14,7 +14,6 @@ from ipaserver.install.service import SimpleServiceInstance
 from ipapython import ipautil
 from ipapython import ipaldap
 from ipapython.certdb import NSSDatabase
-from ipaserver.install import ldapupdate
 from ipaserver.install import sysupgrade
 from base64 import b64decode
 from jwcrypto.common import json_decode
@@ -190,13 +189,7 @@ class CustodiaInstance(SimpleServiceInstance):
         """
         Runs the custodia update file to ensure custodia container is present.
         """
-
-        sub_dict = {
-            'SUFFIX': self.suffix,
-        }
-
-        updater = ldapupdate.LDAPUpdate(sub_dict=sub_dict)
-        updater.update([os.path.join(paths.UPDATES_DIR, '73-custodia.update')])
+        self._ldap_update(['73-custodia.update'])
 
     def import_ra_key(self):
         cli = self._get_custodia_client()

--- a/ipaserver/install/ipa_ldap_updater.py
+++ b/ipaserver/install/ipa_ldap_updater.py
@@ -142,10 +142,7 @@ class LDAPUpdater_NonUpgrade(LDAPUpdater):
                 options.schema_files,
                 ldapi=True) or modified
 
-        ld = LDAPUpdate(
-            sub_dict={},
-            ldapi=True)
-
+        ld = LDAPUpdate()
         if not self.files:
             self.files = ld.get_all_files(UPDATES_DIR)
 

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -34,7 +34,6 @@ from ipapython import ipautil
 from ipapython.dn import DN
 from ipaserver.install import cainstance
 from ipaserver.install import installutils
-from ipaserver.install import ldapupdate
 from ipaserver.install.dogtaginstance import DogtagInstance
 from ipaserver.plugins import ldap2
 
@@ -274,13 +273,7 @@ class KRAInstance(DogtagInstance):
             'vault.ldif', {'SUFFIX': self.suffix}, raise_on_err=True)
 
     def __apply_updates(self):
-        sub_dict = {
-            'SUFFIX': self.suffix,
-        }
-
-        ld = ldapupdate.LDAPUpdate(dm_password=self.dm_password,
-                                   sub_dict=sub_dict)
-        ld.update([os.path.join(paths.UPDATES_DIR, '40-vault.update')])
+        self._ldap_update(['40-vault.update'])
 
     def enable_ephemeral(self):
         """

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -42,8 +42,6 @@ from ipapython.dn import DN
 from ipapython.dogtag import KDC_PROFILE
 
 from ipaserver.install import replication
-from ipaserver.install import ldapupdate
-
 from ipaserver.install import certs
 from ipaserver.masters import find_providing_servers
 from ipaplatform.constants import constants
@@ -162,9 +160,7 @@ class KrbInstance(service.Service):
         api.Backend.ldap2.add_entry(host_entry)
 
         # Add the host to the ipaserver host group
-        ld = ldapupdate.LDAPUpdate(ldapi=True)
-        ld.update([os.path.join(paths.UPDATES_DIR,
-                                '20-ipaservers_hostgroup.update')])
+        self._ldap_update(['20-ipaservers_hostgroup.update'])
 
     def __common_setup(self, realm_name, host_name, domain_name, admin_password):
         self.fqdn = host_name

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -144,7 +144,7 @@ class LDAPUpdate:
         ('cn', 'plugins'), ('cn', 'config')
     )
 
-    def __init__(self, dm_password=None, sub_dict={},
+    def __init__(self, dm_password=None, sub_dict=None,
                  online=True, ldapi=False):
         '''
         :parameters:
@@ -260,7 +260,7 @@ class LDAPUpdate:
         update format.
 
         '''
-        self.sub_dict = sub_dict
+        self.sub_dict = sub_dict if sub_dict is not None else {}
         self.dm_password = dm_password
         self.conn = None
         self.modified = False
@@ -274,8 +274,8 @@ class LDAPUpdate:
         )
         suffix = None
 
-        if sub_dict.get("REALM"):
-            self.realm = sub_dict["REALM"]
+        if self.sub_dict.get("REALM"):
+            self.realm = self.sub_dict["REALM"]
         else:
             self.realm = api.env.realm
             suffix = ipautil.realm_to_suffix(self.realm) if self.realm else None

--- a/ipaserver/install/plugins/update_ca_topology.py
+++ b/ipaserver/install/plugins/update_ca_topology.py
@@ -32,10 +32,7 @@ class update_ca_topology(Updater):
             logger.debug("CA is not configured on this host")
             return False, []
 
-        ld = ldapupdate.LDAPUpdate(ldapi=True, sub_dict={
-            'SUFFIX': self.api.env.basedn,
-            'FQDN': self.api.env.host,
-        })
+        ld = ldapupdate.LDAPUpdate(api=self.api)
 
         ld.update([paths.CA_TOPOLOGY_ULDIF])
 

--- a/ipaserver/install/plugins/update_nis.py
+++ b/ipaserver/install/plugins/update_nis.py
@@ -67,7 +67,7 @@ class update_nis_configuration(Updater):
                                      True)
 
         # bug is effective run update to recreate missing maps
-        ld = LDAPUpdate(sub_dict={}, ldapi=True)
+        ld = LDAPUpdate(api=self.api)
         ld.update([paths.NIS_ULDIF])
 
     def execute(self, **options):
@@ -86,7 +86,7 @@ class update_nis_configuration(Updater):
             self.__recover_from_missing_maps(ldap)
 
             logger.debug("Executing NIS Server update")
-            ld = LDAPUpdate(sub_dict={}, ldapi=True)
+            ld = LDAPUpdate(api=self.api)
             ld.update([paths.NIS_UPDATE_ULDIF])
 
         return False, ()

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -313,7 +313,6 @@ class Service:
         self.keytab_user = service_user
         self.dm_password = None  # silence pylint
         self.promote = False
-        self.sub_dict = None
 
     @property
     def principal(self):
@@ -325,22 +324,20 @@ class Service:
             kerberos.Principal(
                 (self.service_prefix, self.fqdn), realm=self.realm))
 
-    def _ldap_update(
-            self, filenames, *, basedir=paths.UPDATES_DIR, sub_dict=None
-    ):
+    def _ldap_update(self, filenames, *, basedir=paths.UPDATES_DIR):
         """Apply update ldif files
+
+        Note: Additional substitution must be added to LDAPUpdate() to ensure
+        that ipa-ldap-updater is able to handle all update files as well.
 
         :param filenames: list of file names
         :param basedir: base directory for files (default: UPDATES_DIR)
-        :param sub_dict: substitution dict (defaults to self.sub_dict)
         :return: modified state
         """
         assert isinstance(filenames, (list, tuple))
-        if sub_dict is None:
-            sub_dict = self.sub_dict
         if basedir is not None:
             filenames = [os.path.join(basedir, fname) for fname in filenames]
-        ld = LDAPUpdate(sub_dict=sub_dict)
+        ld = LDAPUpdate(api=self.api)
         # assume that caller supplies files in correct order
         return ld.update(filenames, ordered=False)
 

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -269,7 +269,7 @@ class IPAUpgrade(service.Service):
 
     def __upgrade(self):
         try:
-            ld = ldapupdate.LDAPUpdate(dm_password='', ldapi=True)
+            ld = ldapupdate.LDAPUpdate(api=self.api)
             if len(self.files) == 0:
                 self.files = ld.get_all_files(ldapupdate.UPDATES_DIR)
             self.modified = (ld.update(self.files) or self.modified)

--- a/ipatests/test_install/test_updates.py
+++ b/ipatests/test_install/test_updates.py
@@ -63,7 +63,7 @@ class TestUpdate:
                 self.dm_password = fp.read().rstrip()
         else:
             pytest.skip("No directory manager password")
-        self.updater = LDAPUpdate(dm_password=self.dm_password, sub_dict={})
+        self.updater = LDAPUpdate()
         self.ld = ipaldap.LDAPClient.from_hostname_secure(fqdn)
         self.ld.simple_bind(bind_dn=ipaldap.DIRMAN_DN,
                             bind_password=self.dm_password)


### PR DESCRIPTION
The new _ldap_update() helper methods makes it easier to apply LDAP
update files from a service instance.

Signed-off-by: Christian Heimes <cheimes@redhat.com>