### PR TITLE
Specify memory limits as strings for docker compose

### DIFF
--- a/ipatests/azure/Dockerfiles/docker-compose.yml
+++ b/ipatests/azure/Dockerfiles/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     security_opt:
     - apparmor:unconfined
     - seccomp:./seccomp.json
-    mem_limit: 1900m
+    mem_limit: "1900m"
     volumes:
     - /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd
     - ./ipa-test-config.yaml:/root/.ipa/ipa-test-config.yaml:ro
@@ -25,7 +25,7 @@ services:
     security_opt:
     - apparmor:unconfined
     - seccomp:./seccomp.json
-    mem_limit: 1900m
+    mem_limit: "1900m"
     volumes:
     - /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd
     networks:
@@ -39,7 +39,7 @@ services:
     security_opt:
     - apparmor:unconfined
     - seccomp:./seccomp.json
-    mem_limit: 536870912
+    mem_limit: "536870912"
     volumes:
     - /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd
     # nfs server


### PR DESCRIPTION
Fixes the following error in Azure Pipelines CI after upgrade of Docker
setup:

[2020-09-14 06:50:07] The Compose file './docker-compose.yml' is invalid because:
[2020-09-14 06:50:07] services.client.mem_limit contains an invalid type, it should be a string

Fixes: https://pagure.io/freeipa/issue/8494
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>