### PR TITLE
[Backport][ipa-4-8] Specify memory limits as strings for docker compose

### DIFF
--- a/ipatests/azure/Dockerfiles/docker-compose.yml
+++ b/ipatests/azure/Dockerfiles/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     security_opt:
     - apparmor:unconfined
     - seccomp:./seccomp.json
-    mem_limit: 1900m
+    mem_limit: "1900m"
     volumes:
     - /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd
     - ./ipa-test-config.yaml:/root/.ipa/ipa-test-config.yaml:ro
@@ -25,7 +25,7 @@ services:
     security_opt:
     - apparmor:unconfined
     - seccomp:./seccomp.json
-    mem_limit: 1900m
+    mem_limit: "1900m"
     volumes:
     - /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd
     networks:
@@ -39,7 +39,7 @@ services:
     security_opt:
     - apparmor:unconfined
     - seccomp:./seccomp.json
-    mem_limit: 536870912
+    mem_limit: "536870912"
     volumes:
     - /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd
     # nfs server


### PR DESCRIPTION
This PR was opened automatically because PR #5103 was pushed to master and backport to ipa-4-8 is required.