### PR TITLE
[Backport][ipa-4-8] Add krbPrincipalName pres index correctly

### DIFF
--- a/install/share/indices.ldif
+++ b/install/share/indices.ldif
@@ -6,6 +6,7 @@ cn:krbPrincipalName
 nsSystemIndex:false
 nsIndexType:eq
 nsIndexType:sub
+nsIndexType:pres
 nsMatchingRule:caseIgnoreIA5Match
 nsMatchingRule:caseExactIA5Match
 

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -282,6 +282,7 @@ only: nsMatchingRule: caseIgnoreIA5Match
 only: nsMatchingRule: caseExactIA5Match
 only:nsIndexType: eq
 only:nsIndexType: sub
+only:nsIndexType: pres
 
 dn: cn=krbCanonicalName,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 default: cn: krbCanonicalName
@@ -405,13 +406,6 @@ default: nsIndexType: pres
 
 dn: cn=ipaNTSecurityIdentifier,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 default: cn: ipaNTSecurityIdentifier
-default: objectClass: top
-default: objectClass: nsIndex
-default: nsSystemIndex: false
-default: nsIndexType: pres
-
-dn: cn=krbprincipalname,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
-default: cn: krbprincipalname
 default: objectClass: top
 default: objectClass: nsIndex
 default: nsSystemIndex: false


### PR DESCRIPTION
This PR was opened automatically because PR #5101 was pushed to master and backport to ipa-4-8 is required.