### PR TITLE
ipatests: webui: test_host.py Fix expected item visibility

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -65,10 +65,10 @@ jobs:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_webui/test_host.py
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_webui/test_host.py
+++ b/ipatests/test_webui/test_host.py
@@ -324,7 +324,8 @@ class test_host(host_tasks):
         self.add_record(ENTITY, self.data)
         self.navigate_to_record(self.pkey)
 
-        self.assert_action_list_action('request_cert', visible=False)
+        self.assert_action_list_action('request_cert', visible=True,
+                                       enabled=False)
 
         self.navigate_by_breadcrumb('Hosts')
         self.delete_record(self.pkey, self.data.get('del'))

--- a/ipatests/test_webui/test_service.py
+++ b/ipatests/test_webui/test_service.py
@@ -359,7 +359,8 @@ class test_service(sevice_tasks):
         self.add_record(ENTITY, data)
         self.navigate_to_record(pkey)
 
-        self.assert_action_list_action('request_cert', visible=False)
+        self.assert_action_list_action('request_cert', visible=True,
+                                       enabled=False)
 
         self.navigate_by_breadcrumb('Services')
         self.delete_record(pkey, data.get('del'))


### PR DESCRIPTION
Fix test to expect `request_cert` to be visible in host drop-down menu.

Resolves: https://pagure.io/freeipa/issue/8504

Signed-off-by: Michal Polovka <mpolovka@redhat.com>
