### PR TITLE
Don't create DS SSCA and self-signed cert

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -544,6 +544,7 @@ class DsInstance(service.Service):
         slapd_options = Slapd2Base(logger)
         slapd_options.set('instance_name', self.serverid)
         slapd_options.set('root_password', self.dm_password)
+        slapd_options.set('self_sign_cert', False)
         slapd_options.verify()
         slapd = slapd_options.collect()
 

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -971,6 +971,14 @@ class TestInstallMaster(IntegrationTest):
         assert result.returncode != 0
         assert 'user with name "root" already exists' in result.stderr_text
 
+    def test_dirsrv_no_ssca(self):
+        # verify that lib389 installer no longer creates self-signed CA
+        result = self.master.run_command(
+            ["stat", "/etc/dirsrv/ssca"],
+            raiseonerr=False
+        )
+        assert result.returncode != 0
+
 
 class TestInstallMasterKRA(IntegrationTest):
 


### PR DESCRIPTION
Instruct lib389 to not create its self-signed CA and temporary
self-signed certificate. FreeIPA uses local connections and Unix socket
for bootstrapping.

Fixes: https://pagure.io/freeipa/issue/8502
Signed-off-by: Christian Heimes <cheimes@redhat.com>