### PR TITLE
Check ca_wrapped in ipa-custodia-check

### DIFF
--- a/install/tools/ipa-custodia-check.in
+++ b/install/tools/ipa-custodia-check.in
@@ -49,6 +49,8 @@ KEYS = [
     'dm/DMHash',
     'ra/ipaCert',
     'ca/auditSigningCert cert-pki-ca',
+    'ca_wrapped/auditSigningCert cert-pki-ca',
+    'ca_wrapped/auditSigningCert cert-pki-ca/1.2.840.113549.3.7',
     'ca/caSigningCert cert-pki-ca',
     'ca/ocspSigningCert cert-pki-ca',
     'ca/subsystemCert cert-pki-ca',

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -267,6 +267,7 @@ class BasePathNamespace:
     RESTORECON = "/usr/sbin/restorecon"
     SELINUXENABLED = "/usr/sbin/selinuxenabled"
     SETSEBOOL = "/usr/sbin/setsebool"
+    SEMODULE = "/usr/sbin/semodule"
     SMBD = "/usr/sbin/smbd"
     USERADD = "/usr/sbin/useradd"
     FONTS_DIR = "/usr/share/fonts"

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -395,6 +395,7 @@ class BasePathNamespace:
     IPA_CUSTODIA_SOCKET = '/run/httpd/ipa-custodia.sock'
     IPA_CUSTODIA_AUDIT_LOG = '/var/log/ipa-custodia.audit.log'
     IPA_CUSTODIA_HANDLER = "/usr/libexec/ipa/custodia"
+    IPA_CUSTODIA_CHECK = "/usr/libexec/ipa/ipa-custodia-check"
     IPA_GETKEYTAB = '/usr/sbin/ipa-getkeytab'
     EXTERNAL_SCHEMA_DIR = '/usr/share/ipa/schema.d'
     GSSPROXY_CONF = '/etc/gssproxy/10-ipa.conf'

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -117,6 +117,7 @@ class DebianPathNamespace(BasePathNamespace):
     IPA_CUSTODIA_SOCKET = "/run/apache2/ipa-custodia.sock"
     IPA_CUSTODIA_AUDIT_LOG = '/var/log/ipa-custodia.audit.log'
     IPA_CUSTODIA_HANDLER = "/usr/lib/ipa/custodia"
+    IPA_CUSTODIA_CHECK = "/usr/lib/ipa/ipa-custodia-check"
     WSGI_PREFIX_DIR = "/run/apache2/wsgi"
 
 paths = DebianPathNamespace()

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1013,6 +1013,12 @@ class TestInstallMaster(IntegrationTest):
         )
         assert result.returncode != 0
 
+    def test_ipa_custodia_check(self):
+        # check local key retrieval
+        self.master.run_command(
+            [paths.IPA_CUSTODIA_CHECK, self.master.hostname]
+        )
+
 
 class TestInstallMasterKRA(IntegrationTest):
 

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1019,6 +1019,25 @@ class TestInstallMaster(IntegrationTest):
             [paths.IPA_CUSTODIA_CHECK, self.master.hostname]
         )
 
+    @pytest.mark.skipif(
+        paths.SEMODULE is None, reason="test requires semodule command"
+    )
+    def test_ipa_selinux_policy(self):
+        # check that freeipa-selinux's policy module is loaded and
+        # not disabled
+        result = self.master.run_command(
+            [paths.SEMODULE, "-lfull"]
+        )
+        # prio module pp [disabled]
+        # 100: default priority
+        # 200: decentralized SELinux policy priority
+        entries = {
+            tuple(line.split())
+            for line in result.stdout_text.split('\n')
+            if line.strip()
+        }
+        assert ('200', 'ipa', 'pp') in entries
+
 
 class TestInstallMasterKRA(IntegrationTest):
 

--- a/ipatests/test_integration/test_simple_replication.py
+++ b/ipatests/test_integration/test_simple_replication.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 
 import pytest
 
+from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.base import IntegrationTest
@@ -93,6 +94,15 @@ class TestSimpleReplication(IntegrationTest):
             stdin_text=self.master.config.dirman_password)
         assert msg1 not in result.stdout_text
         assert msg2 not in result.stdout_text
+
+    def test_ipa_custodia_check(self):
+        replica = self.replicas[0]
+        self.master.run_command(
+            [paths.IPA_CUSTODIA_CHECK, replica.hostname]
+        )
+        replica.run_command(
+            [paths.IPA_CUSTODIA_CHECK, self.master.hostname]
+        )
 
     def test_replica_removal(self):
         """Test replica removal"""


### PR DESCRIPTION
ca_wrapped uses Dogtag's pki tool (written in Java) to wrap key
material. Add checks to custodia to verify that key wrapping works.

Signed-off-by: Christian Heimes <cheimes@redhat.com>