### PR TITLE
[Backport][ipa-4-8] dogtaginstance.py: add --debug to pkispawn

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -183,7 +183,8 @@ class DogtagInstance(service.Service):
         subsystem = self.subsystem
         args = [paths.PKISPAWN,
                 "-s", subsystem,
-                "-f", cfg_file]
+                "-f", cfg_file,
+                "--debug"]
 
         with open(cfg_file) as f:
             logger.debug(

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1295,3 +1295,26 @@ class TestIPACommand(IntegrationTest):
         )
         assert result.returncode == 1
         assert msg in result.stderr_text
+
+    def test_pkispawn_log_is_present(self):
+        """
+        This testcase checks if pkispawn logged properly.
+        It is a candidate from being moved out of test_commands.
+        """
+        result = self.master.run_command(
+            ["ls", "/var/log/pki/"]
+        )
+        pkispawnlogfile = None
+        for file in result.stdout_text.splitlines():
+            if file.startswith("pki-ca-spawn"):
+                pkispawnlogfile = file
+                break
+        assert pkispawnlogfile is not None
+        pkispawnlogfile = os.path.sep.join(("/var/log/pki", pkispawnlogfile))
+        pkispawnlog = self.master.get_file_contents(
+            pkispawnlogfile, encoding='utf-8'
+        )
+        # Totally arbitrary. pkispawn debug logs tend to be > 10KiB.
+        assert len(pkispawnlog) > 1024
+        assert "DEBUG" in pkispawnlog
+        assert "INFO" in pkispawnlog


### PR DESCRIPTION
MANUAL cherry-pick of https://github.com/freeipa/freeipa/pull/5113

Since commits:
dogtagpki/pki@0102d83
dogtagpki/pki@de21755
pkispawn will not honor the pki_log_level configuration item.
All 10.9 Dogtag versions have these commits.
This affects FreeIPA in that it makes debugging Dogtag installation issues next
to impossible.
Adding --debug to the pkispawn CLI is required to revert to the previous
behavior.

Fixes: https://pagure.io/freeipa/issue/8503