### PR TITLE
spec: require pki-acme if pki-ca >= 10.10

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -383,6 +383,8 @@ Requires(post): selinux-policy-base >= %{selinux_policy_version}
 Requires: slapi-nis >= %{slapi_nis_version}
 Requires: pki-ca >= %{pki_version}
 Requires: pki-kra >= %{pki_version}
+# pki-acme package was split out in pki-10.10.0
+Requires: (pki-acme >= %{pki_version} if pki-ca >= 10.10.0)
 Requires(preun): systemd-units
 Requires(postun): systemd-units
 Requires: policycoreutils >= 2.1.12-5


### PR DESCRIPTION
We can use conditional dependencies (described at [1]) to require
the pki-acme package if pki-ca >= 10.10.0 (the version at which the
ACME service was separated to a subpackage).

[1] https://rpm.org/user_doc/boolean_dependencies.html

I have tested this with repos having only pki-10.9.x (and therefore
no pki-acme package), and dnf is happy.  I have also testing package
installation with pki-10.10 packages installed, but /without/
pki-acme installed. pki-acme was seen as a missing dependency and
installed alongside the freeipa packages.  This change seems to
satisfy all the scenarios.

Related: https://github.com/dogtagpki/pki/pull/513