### PR TITLE
Require an ipa-ca SAN on 3rd party certs if ACME is enabled

### DIFF
--- a/install/tools/man/ipa-acme-manage.1
+++ b/install/tools/man/ipa-acme-manage.1
@@ -31,6 +31,8 @@ Display the status of the ACME service.
 .SH "EXIT STATUS"
 0 if the command was successful
 
-1 if the host is not a CA server
+1 if an error occurred
 
 2 if the host is not a FreeIPA server
+
+3 if the host is not a CA server

--- a/install/tools/man/ipa-server-certinstall.1
+++ b/install/tools/man/ipa-server-certinstall.1
@@ -30,6 +30,8 @@ They may be generated and managed using the NSS pk12util command or the OpenSSL 
 
 The service(s) are not automatically restarted. In order to use the newly installed certificate(s) you will need to manually restart the Directory, Apache and/or Krb5kdc servers.
 
+If the ACME service is enabled then the web certificate must have a Subject Alternative Name (SAN) for ipa-ca.$DOMAIN.
+
 .SH "OPTIONS"
 .TP 
 \fB\-d\fR, \fB\-\-dirsrv\fR

--- a/ipaserver/install/ipa_acme_manage.py
+++ b/ipaserver/install/ipa_acme_manage.py
@@ -104,7 +104,7 @@ class IPAACMEManage(AdminTool):
 
         if not cainstance.is_ca_installed_locally():
             print("CA is not installed on this server.")
-            return 1
+            return 3
 
         api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
         api.finalize()

--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -327,7 +327,7 @@ class TestACMECALess(IntegrationTest):
         # check status of acme on replica, result: CA is not installed
         result = self.replicas[0].run_command(['ipa-acme-manage', 'status'],
                                               raiseonerr=False)
-        assert result.returncode == 1
+        assert result.returncode == 3
 
         # Install CA on replica
         tasks.install_ca(self.replicas[0])


### PR DESCRIPTION
Require an ipa-ca SAN on 3rd party certs if ACME is enabled

ACME requires an ipa-ca SAN to have a fixed URL to connect to.
If the Apache certificate is replaced by a 3rd party cert then
it must provide this SAN otherwise it will break ACME.

Add a status option to ipa-acme-manage.

https://pagure.io/freeipa/issue/8498

Marking as ipa-next since I'm sure yet if ACME is going to be backported to ipa-4-8.