### PR TITLE
[Test PR] ipatests: enhance TestSubCAkeyReplication

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,28 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_replica_promotion_TestSubCAkeyReplication:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_replica_promotion_TestSubCAkeyReplication_2:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
+        selinux_enforcing: True
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+


### PR DESCRIPTION
    enhance the test suite so that it covers:
    - deleting subCAs (disabling them first)
    - checking what happens when creating a dozen+ subCAs at a time
    - adding a subCA that already exists and expect failure
    
    Related: https://pagure.io/freeipa/issue/8488
    Signed-off-by: François Cami <fcami@redhat.com>
