### PR TITLE
[Backport][ipa-4-8] test_smb: mark test_smb_service_s4u2self as xfail for fed31 

### DIFF
--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -17,6 +17,7 @@ import pytest
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
+from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 
 
@@ -348,6 +349,9 @@ class TestSMB(IntegrationTest):
         finally:
             self.cleanup_mount(mount_point)
 
+    @pytest.mark.skipif(
+        osinfo.id == 'fedora' and osinfo.version_number <= (31,),
+        reason='Test requires krb 1.18')
     def test_smb_service_s4u2self(self, enable_smb_server_dns_lookup_kdc):
         """Test S4U2Self operation by IPA service
            against both AD and IPA users


### PR DESCRIPTION
This PR was opened automatically because PR #5118 was pushed to master and backport to ipa-4-8 is required.