### PR TITLE
Clean up entire /run/ipa/ccaches directory not just files

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -33,6 +33,7 @@ class BasePathNamespace:
     LS = "/bin/ls"
     SYSTEMCTL = "/bin/systemctl"
     SYSTEMD_DETECT_VIRT = "/usr/bin/systemd-detect-virt"
+    SYSTEMD_TMPFILES = "/usr/bin/systemd-tmpfiles"
     TAR = "/bin/tar"
     AUTOFS_LDAP_AUTH_CONF = "/etc/autofs_ldap_auth.conf"
     ETC_FEDORA_RELEASE = "/etc/fedora-release"

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -26,6 +26,7 @@ import glob
 import errno
 import shlex
 import pipes
+import shutil
 import tempfile
 
 from augeas import Augeas
@@ -172,8 +173,10 @@ class HTTPInstance(service.Service):
         # Make sure that empty env is passed to avoid passing KRB5CCNAME from
         # current env
         ipautil.remove_file(paths.HTTP_CCACHE)
-        for f in os.listdir(paths.IPA_CCACHES):
-            os.remove(os.path.join(paths.IPA_CCACHES, f))
+        shutil.rmtree(paths.IPA_CCACHES)
+        ipautil.run(
+            [paths.SYSTEMD_TMPFILES, '--create', '--prefix', paths.IPA_CCACHES]
+        )
 
     def __configure_http(self):
         self.update_httpd_service_ipa_conf()

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -239,7 +239,22 @@ class TestInstallCA(IntegrationTest):
 
     @classmethod
     def install(cls, mh):
+        cls.master.put_file_contents(
+            os.path.join(paths.IPA_CCACHES, 'foo'),
+            'somerandomstring'
+        )
+        cls.master.run_command(
+            ['mkdir', os.path.join(paths.IPA_CCACHES, 'bar')]
+        )
         tasks.install_master(cls.master, setup_dns=False)
+
+    def test_ccaches_cleanup(self):
+        """
+        The IPA ccaches directory is cleaned up on install. Verify
+        that the file we created is now gone.
+        """
+        assert os.path.exists(os.path.join(paths.IPA_CCACHES, 'foo')) is False
+        assert os.path.exists(os.path.join(paths.IPA_CCACHES, 'bar')) is False
 
     def test_replica_ca_install_with_no_host_dns(self):
         """


### PR DESCRIPTION
Remove entire /run/ipa/ccaches directory not just files

If there are any sub-directories in the ccaches directory
then cleaning it up will fail.

Instead remove the whole directory and allow systemd-tmpfiles
to re-create it.

https://pagure.io/freeipa/issue/8248

This seems rather strange, deleting the whole thing then re-creating it, but walking the directory deleting discrete files and directories just seems slower and is quite a bit more code.