### PR TITLE
Make git a build requirement

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -269,6 +269,7 @@ BuildRequires: python3-m2r
 # Build dependencies for lint and fastcheck
 #
 %if 0%{?with_lint}
+BuildRequires:  git
 BuildRequires:  jsl
 BuildRequires:  nss-tools
 BuildRequires:  rpmlint

--- a/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
+++ b/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
@@ -9,6 +9,7 @@ RUN echo 'deltarpm = false' >> /etc/dnf/dnf.conf \
     && dnf install -y systemd \
     && dnf install -y \
         firewalld \
+        git \
         glibc-langpack-fr \
         glibc-langpack-en \
         iptables \

--- a/ipatests/azure/Dockerfiles/Dockerfile.build.rawhide
+++ b/ipatests/azure/Dockerfiles/Dockerfile.build.rawhide
@@ -11,6 +11,7 @@ RUN echo 'deltarpm = false' >> /etc/dnf/dnf.conf \
     && dnf install -y systemd \
     && dnf install -y \
         firewalld \
+        git \
         glibc-langpack-fr \
         glibc-langpack-en \
         iptables \

--- a/ipatests/azure/templates/prepare-build-fedora.yml
+++ b/ipatests/azure/templates/prepare-build-fedora.yml
@@ -11,6 +11,7 @@ steps:
         autoconf \
         rpm-build \
         gettext-devel \
+        git \
         automake \
         libtool \
         docker \

--- a/ipatests/azure/templates/prepare-tox-fedora.yml
+++ b/ipatests/azure/templates/prepare-tox-fedora.yml
@@ -1,6 +1,6 @@
 steps:
 - script: |
     set -e
-    sudo dnf -y install nss-tools python3-pip
+    sudo dnf -y install nss-tools python3-pip git
     python3 -m pip install --user --upgrade pip setuptools pycodestyle
   displayName: Install Tox prerequisites


### PR DESCRIPTION
FreeIPA uses git in its build process. In the past git was automatically
pulled in. On Fedora 33 builds are failing because git is missing.

Signed-off-by: Christian Heimes <cheimes@redhat.com>