### PR TITLE
[Backport][ipa-4-8] SELinux: add dedicated policy for ipa-pki-retrieve-key + ipatests: enhance TestSubCAkeyReplication for better coverage

### DIFF
--- a/selinux/ipa.fc
+++ b/selinux/ipa.fc
@@ -30,5 +30,6 @@
 /usr/libexec/ipa/custodia/ipa-custodia-pki-tomcat		--	gen_context(system_u:object_r:ipa_custodia_pki_tomcat_exec_t,s0)
 /usr/libexec/ipa/custodia/ipa-custodia-pki-tomcat-wrapped	--	gen_context(system_u:object_r:ipa_custodia_pki_tomcat_exec_t,s0)
 /usr/libexec/ipa/custodia/ipa-custodia-ra-agent		--	gen_context(system_u:object_r:ipa_custodia_ra_agent_exec_t,s0)
+/usr/libexec/ipa/ipa-pki-retrieve-key				--	gen_context(system_u:object_r:ipa_pki_retrieve_key_exec_t,s0)
 
 /var/log/ipa-custodia.audit.log(/.*)?				--	gen_context(system_u:object_r:ipa_custodia_log_t,s0)

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -78,6 +78,8 @@ type node_t;
 type ipa_pki_retrieve_key_exec_t;
 init_script_file(ipa_pki_retrieve_key_exec_t)
 
+type ipa_pki_retrieve_key_t;
+
 ########################################
 #
 # ipa_otpd local policy
@@ -422,7 +424,7 @@ optional_policy(`
         type tomcat_t;
     ')
     can_exec(tomcat_t, ipa_pki_retrieve_key_exec_t)
-    pki_manage_tomcat_etc_rw(ipa_pki_retrieve_key_exec_t)
+    pki_manage_tomcat_etc_rw(ipa_pki_retrieve_key_t)
 ')
 
 optional_policy(`

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -448,3 +448,11 @@ optional_policy(`
     java_exec(ipa_custodia_pki_tomcat_t)
     # allow Java to read system status and RNG
 ')
+
+optional_policy(`
+    gen_require(`
+        type tomcat_t;
+    ')
+    kerberos_read_config(tomcat_t)
+    kerberos_read_keytab(tomcat_t)
+')

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -63,6 +63,8 @@ init_script_file(ipa_custodia_dmldap_exec_t)
 type ipa_custodia_pki_tomcat_exec_t;
 init_script_file(ipa_custodia_pki_tomcat_exec_t)
 
+type ipa_custodia_pki_tomcat_t;
+
 type ipa_custodia_ra_agent_exec_t;
 init_script_file(ipa_custodia_ra_agent_exec_t)
 
@@ -436,7 +438,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-    java_exec(ipa_custodia_pki_tomcat_exec_t)
+    java_exec(ipa_custodia_pki_tomcat_t)
     # allow Java to read system status and RNG
     dev_read_urand(ipa_custodia_t)
     dev_read_rand(ipa_custodia_t)

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -347,6 +347,7 @@ logging_log_filetrans(ipa_custodia_t, ipa_custodia_log_t, { dir file })
 
 manage_dirs_pattern(ipa_custodia_t, ipa_custodia_tmp_t, ipa_custodia_tmp_t)
 manage_files_pattern(ipa_custodia_t, ipa_custodia_tmp_t, ipa_custodia_tmp_t)
+mmap_exec_files_pattern(ipa_custodia_t, ipa_custodia_tmp_t, ipa_custodia_tmp_t)
 files_tmp_filetrans(ipa_custodia_t, ipa_custodia_tmp_t, { dir file })
 
 kernel_dgram_send(ipa_custodia_t)

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -78,6 +78,7 @@ type pki_tomcat_cert_t;
 type node_t;
 
 type ipa_pki_retrieve_key_exec_t;
+domain_type(ipa_pki_retrieve_key_exec_t)
 init_script_file(ipa_pki_retrieve_key_exec_t)
 
 type ipa_pki_retrieve_key_t;

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -75,6 +75,9 @@ files_tmp_file(ipa_custodia_tmp_t)
 type pki_tomcat_cert_t;
 type node_t;
 
+type ipa_pki_retrieve_key_exec_t;
+init_script_file(ipa_pki_retrieve_key_exec_t)
+
 ########################################
 #
 # ipa_otpd local policy
@@ -411,4 +414,29 @@ optional_policy(`
 
 optional_policy(`
        systemd_private_tmp(ipa_custodia_tmp_t)
+')
+
+optional_policy(`
+    gen_require(`
+        type tomcat_t;
+    ')
+    can_exec(tomcat_t, ipa_pki_retrieve_key_exec_t)
+    pki_manage_tomcat_etc_rw(ipa_pki_retrieve_key_exec_t)
+')
+
+optional_policy(`
+    gen_require(`
+        type devlog_t;
+    ')
+
+    dontaudit ipa_custodia_t devlog_t:lnk_file read_lnk_file_perms;
+')
+
+optional_policy(`
+    java_exec(ipa_custodia_pki_tomcat_exec_t)
+    # allow Java to read system status and RNG
+    dev_read_urand(ipa_custodia_t)
+    dev_read_rand(ipa_custodia_t)
+    kernel_read_network_state(ipa_custodia_t)
+    dev_read_sysfs(ipa_custodia_t)
 ')

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -78,10 +78,9 @@ type pki_tomcat_cert_t;
 type node_t;
 
 type ipa_pki_retrieve_key_exec_t;
-domain_type(ipa_pki_retrieve_key_exec_t)
-init_script_file(ipa_pki_retrieve_key_exec_t)
-
 type ipa_pki_retrieve_key_t;
+domain_type(ipa_pki_retrieve_key_t)
+init_script_file(ipa_pki_retrieve_key_exec_t)
 
 ########################################
 #
@@ -356,6 +355,7 @@ mmap_exec_files_pattern(ipa_custodia_t, ipa_custodia_tmp_t, ipa_custodia_tmp_t)
 files_tmp_filetrans(ipa_custodia_t, ipa_custodia_tmp_t, { dir file })
 
 kernel_dgram_send(ipa_custodia_t)
+kernel_read_network_state(ipa_custodia_t)
 
 auth_read_passwd(ipa_custodia_t)
 
@@ -365,6 +365,10 @@ can_exec(ipa_custodia_t, ipa_custodia_ra_agent_exec_t)
 
 corecmd_exec_bin(ipa_custodia_t)
 corecmd_mmap_bin_files(ipa_custodia_t)
+
+dev_read_urand(ipa_custodia_t)
+dev_read_rand(ipa_custodia_t)
+dev_read_sysfs(ipa_custodia_t)
 
 domain_use_interactive_fds(ipa_custodia_t)
 
@@ -376,6 +380,8 @@ files_read_etc_files(ipa_custodia_t)
 
 libs_exec_ldconfig(ipa_custodia_t)
 libs_ldconfig_exec_entry_type(ipa_custodia_t)
+
+logging_send_syslog_msg(ipa_custodia_t)
 
 miscfiles_read_generic_certs(ipa_custodia_t)
 miscfiles_read_localization(ipa_custodia_t)
@@ -441,8 +447,4 @@ optional_policy(`
 optional_policy(`
     java_exec(ipa_custodia_pki_tomcat_t)
     # allow Java to read system status and RNG
-    dev_read_urand(ipa_custodia_t)
-    dev_read_rand(ipa_custodia_t)
-    kernel_read_network_state(ipa_custodia_t)
-    dev_read_sysfs(ipa_custodia_t)
 ')


### PR DESCRIPTION
MANUAL CHERRY PICK of commits in https://github.com/freeipa/freeipa/pull/5109
This PR was opened because PR https://github.com/freeipa/freeipa/pull/5109 was pushed to master and backport to ipa-4-8 is required.