### PR TITLE
Require a matching server package for the selinux subpackage

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -832,6 +832,7 @@ This package contains tests that verify IPA functionality under Python 3.
 %package selinux
 Summary:             FreeIPA SELinux policy
 BuildArch:           noarch
+Requires:            %{name}-server = %{version}-%{release}
 Requires:            selinux-policy-%{selinuxtype}
 Requires(post):      selinux-policy-%{selinuxtype}
 %{?selinux_requires}


### PR DESCRIPTION
Ensure that the selinux subpackage is upgraded along with the
rest of IPA if it is built.

https://pagure.io/freeipa/issue/8511

Signed-off-by: Rob Crittenden <rcritten@redhat.com>