### PR TITLE
[Backport][ipa-4-8] Require a matching server package for the selinux subpackage

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -794,6 +794,7 @@ This package contains tests that verify IPA functionality under Python 3.
 %package selinux
 Summary:             FreeIPA SELinux policy
 BuildArch:           noarch
+Requires:            %{name}-server = %{version}-%{release}
 Requires:            selinux-policy-%{selinuxtype}
 Requires(post):      selinux-policy-%{selinuxtype}
 %{?selinux_requires}


### PR DESCRIPTION
This PR was opened automatically because PR #5129 was pushed to master and backport to ipa-4-8 is required.