### PR TITLE
Add ipa_pki_retrieve_key_exec() interface

### DIFF
--- a/selinux/ipa.if
+++ b/selinux/ipa.if
@@ -330,6 +330,25 @@ interface(`ipa_custodia_domtrans',`
 
 ######################################
 ## <summary>
+##	Execute ipa-pki-retrieve-key in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ipa_pki_retrieve_key_exec',`
+	gen_require(`
+		type ipa_pki_retrieve_key_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, ipa_pki_retrieve_key_exec_t)
+')
+
+######################################
+## <summary>
 ##	Execute ipa_custodia in the caller domain.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The ipa_pki_retrieve_key_exec() interface is needed to allow other
domains execute ipa-pki-retrieve-key.

Related: https://github.com/freeipa/freeipa/pull/5109
Signed-off-by: Zdenek Pytela <zpytela@redhat.com>