### PR TITLE
Delay import of psutil to avoid AVC

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -29,7 +29,6 @@ import ldif
 import os
 import re
 import fileinput
-import psutil
 import sys
 import tempfile
 import shutil
@@ -1035,6 +1034,9 @@ def check_available_memory(ca=False):
                 "Unable to determine the amount of available RAM"
             )
     else:
+        # delay import of psutil. On import it opens files in /proc and
+        # can trigger a SELinux violation.
+        import psutil
         available = psutil.virtual_memory().available
     logger.debug("Available memory is %sB", available)
     if available < minimum_suggested:

--- a/ipaserver/plugins/join.py
+++ b/ipaserver/plugins/join.py
@@ -25,7 +25,7 @@ from ipalib import Registry, api
 from ipalib import Command, Str
 from ipalib import errors
 from ipalib import _
-from ipaserver.install import installutils
+from ipalib.constants import FQDN
 
 __doc__ = _("""
 Joining an IPA domain
@@ -60,7 +60,7 @@ class join(Command):
             validate_host,
             cli_name='hostname',
             doc=_("The hostname to register as"),
-            default_from=lambda: unicode(installutils.get_fqdn()),
+            default_from=lambda: FQDN,
             autofill=True,
             #normalizer=lamda value: value.lower(),
         ),

--- a/ipaserver/setup.py
+++ b/ipaserver/setup.py
@@ -59,6 +59,7 @@ if __name__ == '__main__':
             "jwcrypto",
             "lxml",
             "netaddr",
+            "psutil",
             "pyasn1",
             "requests",
             "six",


### PR DESCRIPTION
Commit cfad7af35dd5a2cdd4081d1e9ac7c245f47f1dce added a check to ensure a
system has sufficient amount of memory. The feature uses psutil to get
available memory. On import psutil opens files in /proc which can result in
an SELinux violations and Python exception.

     PermissionError: [Errno 13] Permission denied: '/proc/stat'

Fixes: https://pagure.io/freeipa/issue/8512
Signed-off-by: Christian Heimes <cheimes@redhat.com>