### PR TITLE
Fix various C compiler warnings

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -1005,7 +1005,7 @@ ipadb_fetch_principals_with_extra_filter(struct ipadb_context *ipactx,
          * only to the part of the filter that does use assertion
          * value. */
         const char *asterisk = "%x2A";
-        char *assertion_value = esc_original_princ;
+        const char *assertion_value = esc_original_princ;
 
         if ((len == 1) && (esc_original_princ[0] == '*')) {
             assertion_value = asterisk;

--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
@@ -1090,7 +1090,7 @@ void free_ipapwd_krbcfg(struct ipapwd_krbcfg **cfg)
 int ipapwd_check_max_pwd_len(size_t len, char **errMesg) {
     if (len > IPAPWD_PASSWORD_MAX_LEN) {
         LOG("%s\n", ipapwd_password_max_len_errmsg);
-        *errMesg = ipapwd_password_max_len_errmsg;
+        *errMesg = (char *)ipapwd_password_max_len_errmsg;
         return LDAP_CONSTRAINT_VIOLATION;
     }
     return 0;

--- a/daemons/ipa-slapi-plugins/libotp/hotp.c
+++ b/daemons/ipa-slapi-plugins/libotp/hotp.c
@@ -70,7 +70,6 @@ static bool hmac(const struct hotp_token_key *key, const char *sn_mech,
 {
     unsigned char in[sizeof(uint64_t)];
     const EVP_MD *evp;
-    unsigned char *result;
 
     memcpy(in, &counter, sizeof(uint64_t));
 
@@ -95,7 +94,6 @@ bool hotp(const struct hotp_token *token, uint64_t counter, uint32_t *out)
     const char *mech = SN_sha1;
     struct digest_buffer digest;
     unsigned char counter_buf[sizeof(uint64_t)];
-    const EVP_MD *evp;
     int digits = token->digits;
     int i;
     uint64_t div, offset, binary;


### PR DESCRIPTION
- remove unused variables in hotp.c
- fix const of assertion_value
- cast const error message to non-const char*

I tried to make errMesg a const char* but it gets passed down to
slapi_send_ldap_result() which accepts a char*.

Signed-off-by: Christian Heimes <cheimes@redhat.com>