### PR TITLE
ipatests: ipa-healthcheck test fixes running on RHEL

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -47,7 +47,7 @@ topologies:
     memory: 14500
 
 jobs:
-  fedora-latest-ipa-4-8/build:
+  fedora-latest/build:
     requires: []
     priority: 100
     job:
@@ -61,14 +61,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest-ipa-4-8/temp_commit:
-    requires: [fedora-latest-ipa-4-8/build]
+  fedora-latest/temp_commit:
+    requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-latest-ipa-4-8/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
-        template: *ci-ipa-4-8-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
+        template: &ci-ipa-4-8-latest
+        timeout: 7200
+        topology: *master_1repl

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2345,6 +2345,28 @@ def get_sssd_version(host):
     return parse_version(version)
 
 
+def get_healthcheck_version(host):
+    """
+    Function to get healthcheck version on fedora and rhel
+    """
+    platform = get_platform(host)
+    if platform in ("rhel", "fedora"):
+        cmd = host.run_command(
+            ["rpm", "-qa", "--qf", "%{VERSION}", "*ipa-healthcheck"]
+        )
+        healthcheck_version = cmd.stdout_text
+        if not healthcheck_version:
+            raise ValueError(
+                "get_healthcheck_version: "
+                "ipa-healthcheck package is not installed"
+            )
+    else:
+        raise ValueError(
+            "get_healthcheck_version: unknown platform %s" % platform
+        )
+    return healthcheck_version
+
+
 def run_ssh_cmd(
     from_host=None, to_host=None, username=None, cmd=None,
     auth_method=None, password=None, private_key_path=None,


### PR DESCRIPTION
ipatests: ipa-healthcheck test fixes running on RHEL
    
1. Added function in tasks.py to get healthcheck version.
2. Added if else condition to certain tests to check healthcheck version and then assert the expected test output
