### PR TITLE
[Backport][ipa-4-8] Add ipa_pki_retrieve_key_exec() interface

### DIFF
--- a/selinux/ipa.if
+++ b/selinux/ipa.if
@@ -330,6 +330,25 @@ interface(`ipa_custodia_domtrans',`
 
 ######################################
 ## <summary>
+##	Execute ipa-pki-retrieve-key in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ipa_pki_retrieve_key_exec',`
+	gen_require(`
+		type ipa_pki_retrieve_key_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, ipa_pki_retrieve_key_exec_t)
+')
+
+######################################
+## <summary>
 ##	Execute ipa_custodia in the caller domain.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
This PR was opened automatically because PR #5131 was pushed to master and backport to ipa-4-8 is required.