### PR TITLE
Reduce runtime of server installer by about 90 seconds or more

### DIFF
--- a/install/tools/ipa-ca-install.in
+++ b/install/tools/ipa-ca-install.in
@@ -316,8 +316,9 @@ def main():
     api.Backend.ldap2.disconnect()
 
     # execute ipactl to refresh services status
+    logger.info("Starting IPA services")
     ipautil.run([paths.IPACTL, 'start', '--ignore-service-failures'],
-                raiseonerr=False)
+                raiseonerr=False, redirect_output=True)
 
 
 fail_message = '''

--- a/install/tools/ipa-dns-install.in
+++ b/install/tools/ipa-dns-install.in
@@ -143,11 +143,12 @@ def main():
     dns_installer.install(True, False, options)
     # Services are enabled in dns_installer.install()
 
-    # execute ipactl to refresh services status
-    ipautil.run([paths.IPACTL, 'start', '--ignore-service-failures'],
-                raiseonerr=False)
-
     api.Backend.ldap2.disconnect()
+
+    # execute ipactl to refresh services status
+    logger.info("Starting IPA services")
+    ipautil.run([paths.IPACTL, 'start', '--ignore-service-failures'],
+                raiseonerr=False, redirect_output=True)
 
     return 0
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -462,8 +462,6 @@ class CAInstance(DogtagInstance):
                         self.step("exposing CA instance on LDAP",
                                   self.__expose_ca_in_ldap)
 
-                    self.step("migrating certificate profiles to LDAP",
-                              migrate_profiles_to_ldap)
                     self.step("importing IPA certificate profiles",
                               import_included_profiles)
                     self.step("adding default CA ACL", ensure_default_caacl)

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -329,7 +329,7 @@ class DsInstance(service.Service):
                       self.__import_ca_certs)
         self.step("restarting directory server", self.__restart_instance)
 
-        self.start_creation()
+        self.start_creation(timing_name="dirsrv_tls")
 
     def create_replica(self, realm_name, master_fqdn, fqdn,
                        domain_name, dm_password,

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -538,6 +538,7 @@ class LDAPUpdate:
     def monitor_index_task(self, dn):
         """Give a task DN monitor it and wait until it has completed (or failed)
         """
+        start = time.time()
 
         assert isinstance(dn, DN)
 
@@ -569,6 +570,12 @@ class LDAPUpdate:
 
             logger.debug("Indexing in progress")
             time.sleep(1)
+
+        dur = time.time() - start
+        logger.debug(
+            "LDAP index task: %s %.03f sec", dn, dur,
+            extra={'timing': ('ldapupdate', "indextask", None, dur)}
+        )
 
         return
 
@@ -869,6 +876,7 @@ class LDAPUpdate:
         return f
 
     def _run_update_plugin(self, plugin_name):
+        start = time.time()
         logger.debug("Executing upgrade plugin: %s", plugin_name)
         restart_ds, updates = self.api.Updater[plugin_name]()
         if updates:
@@ -879,6 +887,11 @@ class LDAPUpdate:
             self.close_connection()
             self.restart_ds()
             self.create_connection()
+        dur = time.time() - start
+        logger.debug(
+            "Upgrade plugin duration: %s %.03f sec", plugin_name, dur,
+            extra={'timing': ('ldapupdate', 'plugin', plugin_name, dur)}
+        )
 
     def create_connection(self):
         if self.conn is None:

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -563,7 +563,8 @@ class Service:
         self.steps.append((message, method, run_after_failure))
 
     def start_creation(self, start_message=None, end_message=None,
-                       show_service_name=True, runtime=None):
+                       show_service_name=True, runtime=None,
+                       timing_name=None):
         """
         Starts creation of the service.
 
@@ -600,6 +601,9 @@ class Service:
                 else:
                     end_message = "Done configuring %s." % self.service_desc
 
+        if timing_name is None:
+            timing_name = self.service_name
+
         if runtime is not None and runtime > 0:
             self.print_msg('%s. Estimated time: %s' % (start_message,
                                                       format_seconds(runtime)))
@@ -615,7 +619,7 @@ class Service:
             logger.debug(
                 "step duration: %s %s %.02f sec",
                 self.service_name, name, dur,
-                extra={'timing': ('step', self.service_name, name, dur)},
+                extra={'timing': ('step', timing_name, name, dur)},
             )
 
         step = 0

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -130,7 +130,8 @@ class IPAUpgrade(service.Service):
             self.step("starting directory server", self.__start)
         self.start_creation(start_message="Upgrading IPA:",
                             show_service_name=False,
-                            runtime=90)
+                            runtime=90,
+                            timing_name="upgrade")
 
     def __save_config(self):
         shutil.copy2(self.filename, self.savefilename)

--- a/ipatests/azure/scripts/azure-run-base-tests.sh
+++ b/ipatests/azure/scripts/azure-run-base-tests.sh
@@ -44,7 +44,8 @@ tests_result=1
 if [ "$install_result" -eq 0 ] ; then
     echo "Run IPA tests"
     echo "Installation complete. Performance of individual steps:"
-    grep 'service duration:' /var/log/ipaserver-install.log | sed -e 's/DEBUG //g'
+    grep -Po 'TIMING: \K.*' /var/log/ipaserver-install.log
+    grep -Po 'TIMING: \K.*' /var/log/ipaclient-install.log
 
     sed -ri "s/mode = production/mode = developer/" /etc/ipa/default.conf
     systemctl restart "$HTTPD_SYSTEMD_NAME"


### PR DESCRIPTION
This experimental patch speeds up installer by tightening poll/sleep loops, reducing timeouts for DNS and NTP to a sensible value, avoiding duplicate work.

## Reduce CA record DNS timeout to 10s

30 seconds is still a lot of time for a DNS query. Clients typically
do not wait that long. OpenSSH uses 10 seconds for reverse DNS lookup.
That's considered a long timeout already. It's unlikely that a DNS query
is going to succeed after 10 seconds of failed lookups.

At this point during the installer IPA's BIND DNS instance has been
running long enough to be fully available, too.

The changeset reduces installation time by 40 seconds when ipa-ca DNS
has not been created yet.

See: https://pagure.io/freeipa/issue/6176

## Skip duplicate import of cert profiles
    
All supported Dogtag versions import the cert profiles during pkispawn
when using the LDAP profile backend.

This reduces the installation time by 9 to 14 seconds

## Add timings to install logs
    
The logging manager now adds timings for installation steps to the
installer logs. The information can be extracted and dumped to a CSV
file with a simple grep command:

    grep -a -Po 'TIMING: \K.*' /var/log/ipaserver-install.log > ipaserver.csv
