### PR TITLE
Fix nsslapd-db-lock tuning of BDB backend

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -62,10 +62,9 @@
 %global selinux_policy_version 3.14.3-21
 %global slapi_nis_version 0.56.1-4
 %global python_ldap_version 3.1.0-1
-# python3-lib389
-# Fix for "Installation fails: Replica Busy"
-# https://pagure.io/389-ds-base/issue/49818
-%global ds_version 1.4.0.16
+# 1.4.3 moved nsslapd-db-locks to cn=bdb sub-entry
+# https://pagure.io/freeipa/issue/8515
+%global ds_version 1.4.3
 # Fix for TLS 1.3 PHA, RHBZ#1775158
 %global httpd_version 2.4.37-21
 
@@ -96,13 +95,9 @@
 
 # fix for segfault in python3-ldap, https://pagure.io/freeipa/issue/7324
 %global python_ldap_version 3.1.0-1
-# Fix for create suffix
-# https://pagure.io/389-ds-base/issue/49984
-%if 0%{?fedora} >= 30
-%global ds_version 1.4.1.1
-%else
-%global ds_version 1.4.0.21
-%endif
+# 1.4.3 moved nsslapd-db-locks to cn=bdb sub-entry
+# https://pagure.io/freeipa/issue/8515
+%global ds_version 1.4.3
 
 # Fix for TLS 1.3 PHA, RHBZ#1775146
 %if 0%{?fedora} >= 31

--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -108,6 +108,7 @@ dist_app_DATA =				\
 	pki-acme-database.conf.template	\
 	pki-acme-engine.conf.template	\
 	pki-acme-issuer.conf.template	\
+	ldbm-tuning.ldif		\
 	$(NULL)
 
 kdcproxyconfdir = $(IPA_SYSCONF_DIR)/kdcproxy

--- a/install/share/ldbm-tuning.ldif
+++ b/install/share/ldbm-tuning.ldif
@@ -1,0 +1,4 @@
+dn: cn=bdb,cn=config,cn=ldbm database,cn=plugins,cn=config
+changetype: modify
+replace: nsslapd-db-locks
+nsslapd-db-locks: 50000

--- a/install/updates/10-db-locks.update
+++ b/install/updates/10-db-locks.update
@@ -1,0 +1,10 @@
+# Fix nsslapd-db-locks move
+# https://pagure.io/freeipa/issue/8515
+
+# replace 389-DS default with 50000 locks
+dn: cn=bdb,cn=config,cn=ldbm database,cn=plugins,cn=config
+replace: nsslapd-db-locks:10000::50000
+
+# remove setting from old location
+dn: cn=config,cn=ldbm database,cn=plugins,cn=config
+remove: nsslapd-db-locks: 50000

--- a/install/updates/Makefile.am
+++ b/install/updates/Makefile.am
@@ -4,6 +4,7 @@ appdir = $(IPA_DATA_DIR)/updates
 app_DATA =				\
 	05-pre_upgrade_plugins.update	\
 	10-config.update		\
+	10-db-locks.update		\
 	10-enable-betxn.update		\
 	10-ipapwd.update		\
 	10-selinuxusermap.update	\

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -759,6 +759,7 @@ class LDAPClient:
         'nsslapd-anonlimitsdn': True,
         'nsslapd-minssf-exclude-rootdse': True,
         'nsslapd-enable-upgrade-hash': True,
+        'nsslapd-db-locks': True,
     })
 
     time_limit = -1.0   # unlimited

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -225,6 +225,7 @@ class DsInstance(service.Service):
 
         self.step("creating directory server instance", self.__create_instance)
         self.step("configure autobind for root", self.__root_autobind)
+        self.step("tune ldbm plugin", self.__tune_ldbm)
         self.step("stopping directory server", self.__stop_instance)
         self.step("updating configuration in dse.ldif", self.__update_dse_ldif)
         self.step("starting directory server", self.__start_instance)
@@ -592,6 +593,9 @@ class DsInstance(service.Service):
         # Done!
         logger.debug("completed creating DS instance")
 
+    def __tune_ldbm(self):
+        self._ldap_mod("ldbm-tuning.ldif")
+
     def __update_dse_ldif(self):
         """
         This method updates dse.ldif right after instance creation. This is
@@ -610,11 +614,6 @@ class DsInstance(service.Service):
             temp_filename = new_dse_ldif.name
             with open(dse_filename, "r") as input_file:
                 parser = installutils.ModifyLDIF(input_file, new_dse_ldif)
-                parser.replace_value(
-                        'cn=config,cn=ldbm database,cn=plugins,cn=config',
-                        'nsslapd-db-locks',
-                        [b'50000']
-                        )
                 if self.config_ldif:
                     # parse modifications from ldif file supplied by the admin
                     with open(self.config_ldif, "r") as config_ldif:

--- a/ipatests/test_integration/test_customized_ds_config_install.py
+++ b/ipatests/test_integration/test_customized_ds_config_install.py
@@ -4,7 +4,8 @@ from ipatests.pytest_ipa.integration import tasks
 
 DIRSRV_CONFIG_MODS = """
 # https://fedorahosted.org/freeipa/ticket/4949
-dn: cn=config,cn=ldbm database,cn=plugins,cn=config
+# https://pagure.io/freeipa/issue/8515
+dn: cn=bdb,cn=config,cn=ldbm database,cn=plugins,cn=config
 changetype: modify
 replace: nsslapd-db-locks
 nsslapd-db-locks: 100000

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -972,6 +972,25 @@ class TestInstallMaster(IntegrationTest):
         )
         assert "nsslapd-enable-upgrade-hash: off" in result.stdout_text
 
+    def test_ldbm_tuning(self):
+        # check db-locks in new cn=bdb subentry (1.4.3+)
+        result = tasks.ldapsearch_dm(
+            self.master,
+            "cn=bdb,cn=config,cn=ldbm database,cn=plugins,cn=config",
+            ["nsslapd-db-locks"],
+            scope="base"
+        )
+        assert "nsslapd-db-locks: 50000" in result.stdout_text
+
+        # no db-locks configuration in old global entry
+        result = tasks.ldapsearch_dm(
+            self.master,
+            "cn=config,cn=ldbm database,cn=plugins,cn=config",
+            ["nsslapd-db-locks"],
+            scope="base"
+        )
+        assert "nsslapd-db-locks" not in result.stdout_text
+
     def test_admin_root_alias_CVE_2020_10747(self):
         # Test for CVE-2020-10747 fix
         # https://bugzilla.redhat.com/show_bug.cgi?id=1810160


### PR DESCRIPTION
nsslapd-db-lock was moved from cn=config,cn=ldbm database,cn=plugins,cn=config
entry to cn=bdb subentry. Manual patching of dse.ldif was no longer
working. Installations with 389-DS 1.4.3 and newer are affected.

Low lock count can affect performance during high load, e.g. mass-import
of users or lots of concurrent connections.

Bump minimal DS version to 1.4.3. Fedora 32 and RHEL 8.3 have 1.4.3.

Fixes: https://pagure.io/freeipa/issue/8515
See: https://pagure.io/freeipa/issue/5914
Signed-off-by: Christian Heimes <cheimes@redhat.com>
