### PR TITLE
External-CA scenarios for ACME service

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -27,11 +27,11 @@ ROOT_CA = "root_ca.crt"
 # RHEL does not have certbot.  EPEL's version is broken with
 # python-cryptography-2.3; likewise recent PyPI releases.
 # So for now, on RHEL we suppress tests that use certbot.
-skip_certbot_tests = osinfo.id not in ['fedora',]
+skip_certbot_tests = osinfo.id not in ['fedora', ]
 
 # Fedora mod_md package needs some patches before it will work.
 # RHEL version has the patches.
-skip_mod_md_tests = osinfo.id not in ['rhel','fedora',]
+skip_mod_md_tests = osinfo.id not in ['rhel', 'fedora', ]
 
 CERTBOT_DNS_IPA_SCRIPT = '/usr/libexec/ipa/acme/certbot-dns-ipa'
 

--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -91,18 +91,22 @@ class TestACME(CALessBase):
     num_clients = 1
 
     @classmethod
-    def install(cls, mh):
-        super(TestACME, cls).install(mh)
-
+    def prepare_acme_client(cls):
         # cache the acme service uri
         acme_host = f'{IPA_CA_RECORD}.{cls.master.domain.name}'
         cls.acme_server = f'https://{acme_host}/acme/directory'
 
-        # install packages before client install in case of IPA DNS problems
+        # install acme client packages
         if not skip_certbot_tests:
             tasks.install_packages(cls.clients[0], ['certbot'])
         if not skip_mod_md_tests:
             tasks.install_packages(cls.clients[0], ['mod_md'])
+
+    @classmethod
+    def install(cls, mh):
+
+        # install packages before client install in case of IPA DNS problems
+        cls.prepare_acme_client()
 
         tasks.install_master(cls.master, setup_dns=True)
 
@@ -486,15 +490,8 @@ class TestACMEwithExternalCA(TestACME):
 
     @classmethod
     def install(cls, mh):
-        # cache the acme service uri
-        acme_host = f'{IPA_CA_RECORD}.{cls.master.domain.name}'
-        cls.acme_server = f'https://{acme_host}/acme/directory'
 
-        # install packages before client install in case of IPA DNS problems
-        if not skip_certbot_tests:
-            tasks.install_packages(cls.clients[0], ["certbot"])
-        if not skip_mod_md_tests:
-            tasks.install_packages(cls.clients[0], ["mod_md"])
+        cls.prepare_acme_client()
 
         # install master with external-ca
         result = install_server_external_ca_step1(cls.master)


### PR DESCRIPTION
Inherited the TestACME class by overriding install()
to install the ipa master with external CA. It will
setup the External-CA and will call all the test
method from TestACME class.

related: https://pagure.io/freeipa/issue/4751

Signed-off-by: Mohammad Rizwan <myusuf@redhat.com>