### PR TITLE
trust-add: Catch correct exception when chown SSSD

### DIFF
--- a/install/oddjob/com.redhat.idm.trust-fetch-domains.in
+++ b/install/oddjob/com.redhat.idm.trust-fetch-domains.in
@@ -97,7 +97,7 @@ def retrieve_keytab(api, ccache_name, oneway_keytab_name, oneway_principal):
     # Make sure SSSD is able to read the keytab
     try:
         constants.SSSD_USER.chown(oneway_keytab_name)
-    except KeyError:
+    except ValueError:
         # If user 'sssd' does not exist, we don't need to chown from root to sssd
         # because it means SSSD does not run as sssd user
         pass


### PR DESCRIPTION
Commit 72fb4e6 introduced a regression. SSSD_USER.chown() raises
ValueError instead of KeyError when SSSD user does not exist.

Fixes: https://pagure.io/freeipa/issue/8516
Signed-off-by: Christian Heimes <cheimes@redhat.com>