### PR TITLE
IPA-EPN: Make ipa-epn.timer a configuration file

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1446,7 +1446,7 @@ fi
 %{_mandir}/man1/ipa-epn.1*
 %{_mandir}/man5/epn.conf.5*
 %attr(644,root,root) %{_unitdir}/ipa-epn.service
-%attr(644,root,root) %{_unitdir}/ipa-epn.timer
+%attr(644,root,root) %config(noreplace) %{_unitdir}/ipa-epn.timer
 %attr(600,root,root) %config(noreplace) %{_sysconfdir}/ipa/epn.conf
 %attr(644,root,root) %config(noreplace) %{_sysconfdir}/ipa/epn/expire_msg.template
 


### PR DESCRIPTION
The time at which ipa-epn runs using the timer should be configurable.
Currently, ipa-epn.timer is not marked as a config file, resulting in
overwriting the file at each update.
Add %config(noreplace) so that customisation can persist.

Fixes: https://pagure.io/freeipa/issue/8517
Signed-off-by: François Cami <fcami@redhat.com>