### PR TITLE
Pre-populate IP addresses for the name server upgrades

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1451,6 +1451,9 @@ def upgrade_bind(fstore):
     # resolve1's stub resolver config file.
     has_resolved_ipa_conf = os.path.isfile(paths.SYSTEMD_RESOLVED_IPA_CONF)
     if not has_resolved_ipa_conf and detect_resolve1_resolv_conf():
+        ip_addresses = installutils.get_server_ip_address(
+            api.env.host, True, False, [])
+        bind.ip_addresses = ip_addresses
         bind.setup_resolv_conf()
         logger.info("Updated systemd-resolved configuration")
 


### PR DESCRIPTION
Setting up resolv.conf in BIND instance expects IP addresses of the
server to be provided. This is done wiht BindInstance.setup() method
call. However, when reusing resolver setup during upgrade BIND instance
has no IP addresses configured and fails with an assert in
tasks.configure_dns_resolver().

Pass through the server's IP addresses during upgrade.

Fixes: https://pagure.io/freeipa/issue/8518

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>