### PR TITLE
[Backport][ipa-4-8] Pre-populate IP addresses for the name server upgrades

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1402,6 +1402,9 @@ def upgrade_bind(fstore):
     # resolve1's stub resolver config file.
     has_resolved_ipa_conf = os.path.isfile(paths.SYSTEMD_RESOLVED_IPA_CONF)
     if not has_resolved_ipa_conf and detect_resolve1_resolv_conf():
+        ip_addresses = installutils.get_server_ip_address(
+            api.env.host, True, False, [])
+        bind.ip_addresses = ip_addresses
         bind.setup_resolv_conf()
         logger.info("Updated systemd-resolved configuration")
 


### PR DESCRIPTION
This PR was opened automatically because PR #5153 was pushed to master and backport to ipa-4-8 is required.