### PR TITLE
Ensure that resolved.conf.d is accessible

### DIFF
--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -194,6 +194,8 @@ class Backup(admintool.AdminTool):
         paths.GSSPROXY_CONF,
         paths.HOSTS,
         paths.SYSTEMD_PKI_TOMCAT_IPA_CONF,
+        paths.NETWORK_MANAGER_IPA_CONF,
+        paths.SYSTEMD_RESOLVED_IPA_CONF,
     ) + tuple(
         os.path.join(paths.IPA_NSSDB_DIR, file)
         for file in (certdb.NSS_DBM_FILES + certdb.NSS_SQL_FILES)


### PR DESCRIPTION
systemd-resolved runs as user systemd-resolve. Ensure that
resolved.conf.d drop-in directory is accessible when installer runs with
restricted umask. Also ensure the file and directory has correct SELinux
context.

The parent directory /etc/systemd exists on all platforms.

Also backup DNS config drop-ins

Fixes: https://pagure.io/freeipa/issue/8275
Signed-off-by: Christian Heimes <cheimes@redhat.com>