### PR TITLE
[Backport][ipa-4-8] Ensure that resolved.conf.d is accessible

### DIFF
--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -194,6 +194,8 @@ class Backup(admintool.AdminTool):
         paths.GSSPROXY_CONF,
         paths.HOSTS,
         paths.SYSTEMD_PKI_TOMCAT_IPA_CONF,
+        paths.NETWORK_MANAGER_IPA_CONF,
+        paths.SYSTEMD_RESOLVED_IPA_CONF,
     ) + tuple(
         os.path.join(paths.IPA_NSSDB_DIR, file)
         for file in (certdb.NSS_DBM_FILES + certdb.NSS_SQL_FILES)


### PR DESCRIPTION
This PR was opened automatically because PR #5156 was pushed to master and backport to ipa-4-8 is required.