### PR TITLE
configure_dns_resolver: call self.restore_context

### DIFF
--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -340,7 +340,7 @@ class BaseTaskNamespace:
                 os.mkdir(confd)
                 # owned by root, readable by systemd-resolve user
                 os.chmod(confd, 0o755)
-                tasks.restore_context(confd, force=True)
+                self.restore_context(confd, force=True)
 
             cfg = RESOLVE1_IPA_CONF.format(
                 searchdomains=" ".join(searchdomains)
@@ -349,7 +349,7 @@ class BaseTaskNamespace:
                 os.fchmod(f.fileno(), 0o644)
                 f.write(cfg)
 
-            tasks.restore_context(
+            self.restore_context(
                 paths.SYSTEMD_RESOLVED_IPA_CONF, force=True
             )
 


### PR DESCRIPTION
Use the platform implementation of restore_context() instead of the base
implementation.

Fixes: https://pagure.io/freeipa/issue/8518
Signed-off-by: Christian Heimes <cheimes@redhat.com>