### PR TITLE
[Backport][ipa-4-8] Add missing fedora_container platform members

### DIFF
--- a/ipaplatform/fedora_container/constants.py
+++ b/ipaplatform/fedora_container/constants.py
@@ -3,7 +3,10 @@
 #
 """Fedora container constants
 """
-from ipaplatform.fedora.constants import FedoraConstantsNamespace
+from ipaplatform.fedora.constants import FedoraConstantsNamespace, User, Group
+
+
+__all__ = ("constants", "User", "Group")
 
 
 class FedoraContainerConstantsNamespace(FedoraConstantsNamespace):

--- a/ipatests/test_ipaplatform/test_platforms.py
+++ b/ipatests/test_ipaplatform/test_platforms.py
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+"""Test import and basic properties of platforms
+"""
+from importlib import import_module
+
+import pytest
+
+from ipaplatform.base.constants import BaseConstantsNamespace, User, Group
+from ipaplatform.base.paths import BasePathNamespace
+from ipaplatform.base.services import KnownServices
+from ipaplatform.base.tasks import BaseTaskNamespace
+
+PLATFORMS = [
+    "debian",
+    "fedora",
+    "fedora_container",
+    "rhel",
+    "rhel_container",
+    "suse",
+]
+
+
+@pytest.mark.parametrize("name", PLATFORMS)
+def test_import_platform(name):
+    constants = import_module(f"ipaplatform.{name}.constants")
+    assert isinstance(constants.constants, BaseConstantsNamespace)
+    assert issubclass(constants.User, User)
+    assert issubclass(constants.Group, Group)
+
+    paths = import_module(f"ipaplatform.{name}.paths")
+    assert isinstance(paths.paths, BasePathNamespace)
+
+    services = import_module(f"ipaplatform.{name}.services")
+    assert isinstance(services.knownservices, KnownServices)
+    assert isinstance(services.timedate_services, list)
+    assert callable(services.service)
+
+    tasks = import_module(f"ipaplatform.{name}.tasks")
+    assert isinstance(tasks.tasks, BaseTaskNamespace)


### PR DESCRIPTION
This PR was opened automatically because PR #5161 was pushed to master and backport to ipa-4-8 is required.