### PR TITLE
Speed up PKI installer steps

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -435,8 +435,6 @@ class CAInstance(DogtagInstance):
                               self.__import_ra_cert)
 
             if not ra_only:
-                self.step("setting audit signing renewal to 2 years", self.set_audit_renewal)
-                self.step("restarting certificate server", self.restart_instance)
                 if not self.clone:
                     self.step("publishing the CA certificate",
                               self.__export_ca_chain)
@@ -1088,41 +1086,6 @@ class CAInstance(DogtagInstance):
 
         if stop_certmonger:
             services.knownservices.certmonger.stop()
-
-
-    def set_audit_renewal(self):
-        """
-        The default renewal time for the audit signing certificate is
-        six months rather than two years. Fix it. This is BZ 843979.
-        """
-        # Check the default validity period of the audit signing cert
-        # and set it to 2 years if it is 6 months.
-        cert_range = directivesetter.get_directive(
-            paths.CASIGNEDLOGCERT_CFG,
-            'policyset.caLogSigningSet.2.default.params.range',
-            separator='='
-        )
-        logger.debug(
-            'caSignedLogCert.cfg profile validity range is %s', cert_range)
-        if cert_range == "180":
-            directivesetter.set_directive(
-                paths.CASIGNEDLOGCERT_CFG,
-                'policyset.caLogSigningSet.2.default.params.range',
-                '720',
-                quotes=False,
-                separator='='
-            )
-            directivesetter.set_directive(
-                paths.CASIGNEDLOGCERT_CFG,
-                'policyset.caLogSigningSet.2.constraint.params.range',
-                '720',
-                quotes=False,
-                separator='='
-            )
-            logger.debug(
-                'updated caSignedLogCert.cfg profile validity range to 720')
-            return True
-        return False
 
     def is_renewal_master(self, fqdn=None):
         if fqdn is None:

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -502,20 +502,6 @@ def ca_disable_publish_cert(ca):
     return True  # restart needed
 
 
-def upgrade_ca_audit_cert_validity(ca):
-    """
-    Update the Dogtag audit signing certificate.
-
-    Returns True if restart is needed, False otherwise.
-    """
-    logger.info('[Verifying that CA audit signing cert has 2 year validity]')
-    if ca.is_configured():
-        return ca.set_audit_renewal()
-    else:
-        logger.info('CA is not configured')
-        return False
-
-
 def ca_initialize_hsm_state(ca):
     """Initializse HSM state as False / internal token
     """
@@ -1774,7 +1760,6 @@ def upgrade_configuration():
     ca_restart = any([
         ca_restart,
         ca_upgrade_schema(ca),
-        upgrade_ca_audit_cert_validity(ca),
         certificate_renewal_update(ca, kra, ds, http),
         ca_enable_pkix(ca),
         ca_configure_profiles_acl(ca),


### PR DESCRIPTION
## Dogtag: Remove set_audit_renewal step

The step set_audit_renewal modifies Dogtag's caSignedLogCert.cfg to bump
renewal to 2 years. The problem was fixed in Dogtag upstream in 2012 before
Dogtag 10.0 came out, see https://github.com/dogtagpki/pki/commit/f5b8ea5b087f642a0208c228dce6f700cd7d91c1

The update step would also no longer work. Profiles have been migrated
to LDAP several FreeIPA releases ago. pkispawn populates LDAP with all
of Dogtag's default profiles. FreeIPA does not overwrite any existing
profiles.

Win: 11 to 50 seconds

## Spawn PKI: Execute more steps early

Move several steps to an earlier phase of CA spawn. RA and ACME agent
ACLs are now configured while the server is down. This avoids yet
another restart and saves between 11 and 50 seconds per installation.

Total: ~20s to ~75s 
Related: https://pagure.io/freeipa/issue/8521
