### PR TITLE
ipatests: test_adtrust_install: Adtrust agents are recreated after upgrade

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_adtrust_install:
     requires: [fedora-latest/build]
-    priority: 50
+    priority: 100
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_adtrust_install.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 4800
+        topology: *master_1repl


### PR DESCRIPTION
Test for adtrust agents being recreated after ipa-upgrade. If adtrust
agents are manually removed before an upgrade, they should be automatically
recreated after.

Related: https://pagure.io/freeipa/issue/8543

Signed-off-by: Michal Polovka <mpolovka@redhat.com>