### PR TITLE
Lookup ipa-ca record with NSS

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -39,7 +39,7 @@ from contextlib import contextmanager
 from configparser import ConfigParser as SafeConfigParser
 from configparser import NoOptionError
 
-from dns import rdatatype
+from dns import rrset, rdatatype, rdataclass
 from dns.exception import DNSException
 import ldap
 import six
@@ -55,7 +55,7 @@ from ipalib.util import validate_hostname
 from ipalib import api, errors, x509
 from ipalib.install import dnsforwarders
 from ipapython.dn import DN
-from ipapython.dnsutil import resolve
+from ipapython.dnsutil import DNSName, resolve
 from ipaserver.install import certs, service, sysupgrade
 from ipaplatform import services
 from ipaplatform.paths import paths
@@ -478,6 +478,40 @@ def resolve_ip_addresses_nss(fqdn):
             ip_addresses.add(ip)
     logger.debug('Name %s resolved to %s', fqdn, ip_addresses)
     return ip_addresses
+
+
+def resolve_rrsets_nss(fqdn):
+    """Get list of dnspython RRsets from NSS"""
+    if not isinstance(fqdn, DNSName):
+        fqdn = DNSName.from_text(fqdn)
+
+    ip_addresses = resolve_ip_addresses_nss(fqdn.to_text())
+
+    # split IP addresses into IPv4 and IPv6
+    ipv4 = []
+    ipv6 = []
+    for ip_address in ip_addresses:
+        if ip_address.version == 4:
+            ipv4.append(str(ip_address))
+        elif ip_address.version == 6:
+            ipv6.append(str(ip_address))
+
+    # construct an RRset for each address type. TTL is irrelevant
+    ttl = 3600
+    rrs = []
+    if ipv4:
+        rrs.append(
+            rrset.from_text_list(
+                fqdn, ttl, rdataclass.IN, rdatatype.A, ipv4
+            )
+        )
+    if ipv6:
+        rrs.append(
+            rrset.from_text_list(
+                fqdn, ttl, rdataclass.IN, rdatatype.AAAA, ipv6
+            )
+        )
+    return rrs
 
 
 def get_server_ip_address(host_name, unattended, setup_dns, ip_addresses):


### PR DESCRIPTION
DNS data management now uses NSS's getaddrinfo() instead of direct DNS
queries to resolve the ipa-ca record. This fixes missing ipa-ca records
when the current hostname is not resolvable in DNS but has correct
records in /etc/hosts.

Reduce timeout to 15 seconds and tighten timeout loop.

The changeset can speed up installation by almost 60 seconds.
ipa-server-install without built-in DNS calls into DNS data management
twice with a timeout of 30 seconds for each call.

Fixes: https://pagure.io/freeipa/issue/8529
Related: https://pagure.io/freeipa/issue/8521
Related: https://pagure.io/freeipa/issue/8501
Signed-off-by: Christian Heimes <cheimes@redhat.com>