### PR TITLE
Require(post) systemd with resolved enabled on F33

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -67,6 +67,7 @@
 %global ds_version 1.4.3
 # Fix for TLS 1.3 PHA, RHBZ#1775158
 %global httpd_version 2.4.37-21
+%global systemd_version 239
 
 %else
 # Fedora
@@ -144,6 +145,14 @@
 
 %define krb5_base_version %(LC_ALL=C rpm -q --qf '%%{VERSION}' krb5-devel | grep -Eo '^[^.]+\.[^.]+')
 
+%if 0%{?fedora} >= 33
+# systemd with resolved enabled
+# see https://pagure.io/freeipa/issue/8275
+%global systemd_version 246.6-3
+%else
+%global systemd_version 245
+%endif
+
 %global plugin_dir %{_libdir}/dirsrv/plugins
 %global etc_systemd_dir %{_sysconfdir}/systemd/system
 %global gettext_domain ipa
@@ -194,7 +203,7 @@ BuildRequires:  gettext
 BuildRequires:  gettext-devel
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
-BuildRequires:  systemd
+BuildRequires:  systemd >= %{systemd_version}
 # systemd-tmpfiles which is executed from make install requires apache user
 BuildRequires:  httpd
 BuildRequires:  nspr-devel
@@ -370,10 +379,12 @@ Requires: mod_session >= %{httpd_version}
 # 0.9.9: https://github.com/adelton/mod_lookup_identity/pull/3
 Requires: mod_lookup_identity >= 0.9.9
 Requires: acl
-Requires: systemd-units >= 38
+Requires: systemd-units >= %{systemd_version}
+Requires(pre): systemd-units >= %{systemd_version}
+Requires(post): systemd-units >= %{systemd_version}
+Requires(preun): systemd-units >= %{systemd_version}
+Requires(postun): systemd-units >= %{systemd_version}
 Requires(pre): shadow-utils
-Requires(pre): systemd-units
-Requires(post): systemd-units
 Requires: selinux-policy >= %{selinux_policy_version}
 Requires(post): selinux-policy-base >= %{selinux_policy_version}
 Requires: slapi-nis >= %{slapi_nis_version}
@@ -381,8 +392,6 @@ Requires: pki-ca >= %{pki_version}
 Requires: pki-kra >= %{pki_version}
 # pki-acme package was split out in pki-10.10.0
 Requires: (pki-acme >= %{pki_version} if pki-ca >= 10.10.0)
-Requires(preun): systemd-units
-Requires(postun): systemd-units
 Requires: policycoreutils >= 2.1.12-5
 Requires: tar
 Requires(pre): certmonger >= %{certmonger_version}
@@ -468,7 +477,7 @@ Group: System Environment/Base
 BuildArch: noarch
 Requires: %{name}-client-common = %{version}-%{release}
 Requires: httpd >= %{httpd_version}
-Requires: systemd-units >= 38
+Requires: systemd-units >= %{systemd_version}
 
 Provides: %{alt_name}-server-common = %{version}
 Conflicts: %{alt_name}-server-common
@@ -633,10 +642,10 @@ on the machine enrolled into a FreeIPA environment
 %package client-epn
 Summary: Tools to configure Expiring Password Notification in IPA
 Group: System Environment/Base
-Requires: systemd-units
-Requires(post): systemd-units
-Requires(preun): systemd-units
-Requires(postun): systemd-units
+Requires: systemd-units >= %{systemd_version}
+Requires(post): systemd-units >= %{systemd_version}
+Requires(preun): systemd-units >= %{systemd_version}
+Requires(postun): systemd-units >= %{systemd_version}
 Requires: %{name}-client = %{version}-%{release}
 
 %description client-epn

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -1121,18 +1121,18 @@ class BindInstance(service.Service):
 
     def setup_resolv_conf(self):
         searchdomains = [self.domain]
-        nameservers = []
+        nameservers = set()
         resolve1_enabled = dnsforwarders.detect_resolve1_resolv_conf()
 
         for ip_address in self.ip_addresses:
             if ip_address.version == 4:
-                nameservers.append("127.0.0.1")
+                nameservers.add("127.0.0.1")
             elif ip_address.version == 6:
-                nameservers.append("::1")
+                nameservers.add("::1")
 
         try:
             tasks.configure_dns_resolver(
-                nameservers, searchdomains,
+                sorted(nameservers), searchdomains,
                 resolve1_enabled=resolve1_enabled, fstore=self.fstore
             )
         except IOError as e:

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1437,8 +1437,9 @@ def upgrade_bind(fstore):
     # resolve1's stub resolver config file.
     has_resolved_ipa_conf = os.path.isfile(paths.SYSTEMD_RESOLVED_IPA_CONF)
     if not has_resolved_ipa_conf and detect_resolve1_resolv_conf():
-        ip_addresses = installutils.get_server_ip_address(
-            api.env.host, True, False, [])
+        ip_addresses = installutils.resolve_ip_addresses_nss(
+            api.env.host
+        )
         bind.ip_addresses = ip_addresses
         bind.setup_resolv_conf()
         logger.info("Updated systemd-resolved configuration")


### PR DESCRIPTION
FreeIPA's systemd-resolved integration for Fedora 33 depends on a
working and fully configured systemd-resolved service. Ensure that
systemd's post installation RPM hook runs before FreeIPA's post hook.

Note: Other systemd version numbers are current versions on Fedora 32 and
RHEL 8.2.0.

Also make sure that 127.0.0.1 is only added once to resolv.conf and simplify
a related function call.

Related: https://pagure.io/freeipa/issue/8275
Signed-off-by: Christian Heimes <cheimes@redhat.com>