### PR TITLE
freeipa.spec.in: client: depend on libsss_sudo

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -634,6 +634,11 @@ Requires: nfs-utils
 Requires: sssd-tools >= %{sssd_version}
 Requires(post): policycoreutils
 
+# https://pagure.io/freeipa/issue/8530
+Recommends: libsss_sudo
+Recommends: sudo
+Requires: (libsss_sudo if sudo)
+
 Provides: %{alt_name}-client = %{version}
 Conflicts: %{alt_name}-client
 Obsoletes: %{alt_name}-client < %{version}

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -24,6 +24,7 @@ import re
 import SSSDConfig
 import shutil
 import socket
+import subprocess
 import sys
 import tempfile
 import textwrap
@@ -2198,7 +2199,18 @@ def install_check(options):
             "authentication resources",
             rval=CLIENT_INSTALL_ERROR)
 
-    # when installing with '--no-sssd' option, check whether nss-ldap is
+    # When installing without the "--no-sudo" option, check whether sudo is
+    # available.
+    if options.conf_sudo:
+        try:
+            subprocess.Popen(['sudo -V'])
+        except FileNotFoundError:
+            logger.info(
+                "The sudo binary does not seem to be present on this "
+                "system. Please consider installing sudo if required."
+            )
+
+    # when installing with the '--no-sssd' option, check whether nss-ldap is
     # installed
     if not options.sssd:
         if not os.path.exists(paths.PAM_KRB5_SO):

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -535,6 +535,18 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-latest/test_installation_TestInstallWithoutSudo:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithoutSudo
+        template: *ci-master-latest
+        timeout: 4800
+        topology: *master_1repl_1client
+
   fedora-latest/test_idviews:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -575,6 +575,19 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-latest/test_installation_TestInstallWithoutSudo:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestInstallWithoutSudo
+        template: *ci-master-latest
+        timeout: 4800
+        topology: *master_1repl_1client
+
   fedora-latest/test_idviews:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -575,6 +575,19 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  testing-fedora/test_installation_TestInstallWithoutSudo:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallWithoutSudo
+        template: *testing-master-latest
+        timeout: 4800
+        topology: *master_1repl_1client
+
   testing-fedora/test_idviews:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -615,6 +615,20 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  testing-fedora/test_installation_TestInstallWithoutSudo:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestInstallWithoutSudo
+        template: *testing-master-latest
+        timeout: 4800
+        topology: *master_1repl_1client
+
   testing-fedora/test_idviews:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -535,6 +535,18 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-previous/test_installation_TestInstallWithoutSudo:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithoutSudo
+        template: *ci-master-previous
+        timeout: 4800
+        topology: *master_1repl_1client
+
   fedora-previous/test_idviews:
     requires: [fedora-previous/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -575,6 +575,19 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-rawhide/test_installation_TestInstallWithoutSudo:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallWithoutSudo
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl_1client
+
   fedora-rawhide/test_idviews:
     requires: [fedora-rawhide/build]
     priority: 50

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -29,6 +29,7 @@ import re
 import collections
 import itertools
 import shutil
+import shlex
 import copy
 import subprocess
 import tempfile
@@ -2371,20 +2372,33 @@ def download_packages(host, pkgs):
     return tmpdir
 
 
-def uninstall_packages(host, pkgs):
+def uninstall_packages(host, pkgs, nodeps=False):
     """Uninstall packages on a remote host.
-    :param host: the host where the uninstallation takes place
-    :param pkgs: packages to uninstall, provided as a list of strings
+    :param host: the host where the uninstallation takes place.
+    :param pkgs: packages to uninstall, provided as a list of strings.
+    :param nodeps: ignore dependencies (dangerous!).
     """
     platform = get_platform(host)
-    # Only supports RHEL 8+ and Fedora for now
-    if platform in ('rhel', 'fedora'):
-        install_cmd = ['/usr/bin/dnf', 'remove', '-y']
-    elif platform in ('ubuntu'):
-        install_cmd = ['apt-get', 'remove', '-y']
+    if platform not in ('rhel', 'fedora', 'ubuntu'):
+        raise ValueError('uninstall_packages: unknown platform %s' % platform)
+    if nodeps:
+        if platform in ('rhel', 'fedora'):
+            cmd = "rpm -e --nodeps"
+        elif platform in ('ubuntu'):
+            cmd = "dpkg -P --force-depends"
+        for package in pkgs:
+            uninstall_cmd = shlex.split(cmd)
+            uninstall_cmd.append(package)
+            # keep raiseonerr=True here. --fcami
+            host.run_command(uninstall_cmd)
     else:
-        raise ValueError('install_packages: unknown platform %s' % platform)
-    host.run_command(install_cmd + pkgs, raiseonerr=False)
+        if platform in ('rhel', 'fedora'):
+            cmd = "/usr/bin/dnf remove -y"
+        elif platform in ('ubuntu'):
+            cmd = "apt-get remove -y"
+        uninstall_cmd = shlex.split(cmd)
+        uninstall_cmd.extend(pkgs)
+        host.run_command(uninstall_cmd, raiseonerr=False)
 
 
 def wait_for_request(host, request_id, timeout=120):
@@ -2639,3 +2653,20 @@ def run_ssh_cmd(
             assert "Authentication succeeded" not in stderr
             assert "No more authentication methods to try." in stderr
     return (return_code, stdout, stderr)
+
+
+def is_package_installed(host, pkg):
+    platform = get_platform(host)
+    if platform in ('rhel', 'fedora'):
+        result = host.run_command(
+            ['rpm', '-q', pkg], raiseonerr=False
+        )
+    elif platform in ['ubuntu']:
+        result = host.run_command(
+            ['dpkg', '-s', pkg], raiseonerr=False
+        )
+    else:
+        raise ValueError(
+            'is_package_installed: unknown platform %s' % platform
+        )
+    return result.returncode == 0


### PR DESCRIPTION
On 10.10+ releases of Dogtag, the PKI installer will not depend on sudo anymore. This opens the possibility of creating IPA servers without a properly configured sudo.
In fact, even IPA clients should have sudo and libsss_sudo installed in most cases, so: add a weak dependency on libsss_sudo to freeipa-client.

Fixes: https://pagure.io/freeipa/issue/8530
