### PR TITLE
Replace sudo with runuser

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -743,7 +743,7 @@ class TestIPACommand(IntegrationTest):
 
         # test IFP as ipaapi
         result = self.master.run_command(
-            ['sudo', '-u', IPAAPI_USER, '--'] + cmd
+            ['runuser', '-u', IPAAPI_USER, '--'] + cmd
         )
         assert uid in result.stdout_text
 


### PR DESCRIPTION
runuser is in util-linux and does not require sudo package.

Related: https://pagure.io/freeipa/issue/8530
Signed-off-by: Christian Heimes <cheimes@redhat.com>