### PR TITLE
[Backport][ipa-4-8] Replace sudo with runuser

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -743,7 +743,7 @@ class TestIPACommand(IntegrationTest):
 
         # test IFP as ipaapi
         result = self.master.run_command(
-            ['sudo', '-u', IPAAPI_USER, '--'] + cmd
+            ['runuser', '-u', IPAAPI_USER, '--'] + cmd
         )
         assert uid in result.stdout_text
 


### PR DESCRIPTION
This PR was opened automatically because PR #5177 was pushed to master and backport to ipa-4-8 is required.