### PR TITLE
Speed up cainstance.migrate_profiles_to_ldap

### DIFF
--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -34,7 +34,7 @@ from ipapython.dn import DN
 from ipaserver.install import cainstance
 from ipaserver.install import installutils
 from ipaserver.install.dogtaginstance import DogtagInstance
-from ipaserver.plugins import ldap2
+
 
 logger = logging.getLogger(__name__)
 
@@ -233,13 +233,10 @@ class KRAInstance(DogtagInstance):
         Create KRA agent, assign a certificate, and add the user to
         the appropriate groups for accessing KRA services.
         """
+        conn = api.Backend.ldap2
 
         # get RA agent certificate
         cert = x509.load_certificate_from_file(paths.RA_AGENT_PEM)
-
-        # connect to KRA database
-        conn = ldap2.ldap2(api)
-        conn.connect(autobind=True)
 
         # create ipakra user with RA agent certificate
         entry = conn.make_entry(
@@ -262,8 +259,6 @@ class KRAInstance(DogtagInstance):
             ('cn', 'Data Recovery Manager Agents'), ('ou', 'groups'),
             KRA_BASEDN)
         conn.add_entry_to_group(KRA_AGENT_DN, group_dn, 'uniqueMember')
-
-        conn.disconnect()
 
     def __add_vault_container(self):
         self._ldap_mod(


### PR DESCRIPTION
The ra_certprofile API is slow. It takes ~200ms to migrate and enable a
profile even when the profile already available. The migration step
slows down the installer and upgrader by about 12 to 15 seconds.

Skip all profiles that have been imported by Dogtag already.

Related: https://pagure.io/freeipa/issue/8522
Related: https://pagure.io/freeipa/issue/8521
Signed-off-by: Christian Heimes <cheimes@redhat.com>