### PR TITLE
ipatests: various enhancement to hidden replica tests

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,15 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_replica_promotion_TestHiddenReplicaPromotion:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *master_2repl_1client
+

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2477,6 +2477,16 @@ def wait_for_ipa_to_start(host, timeout=60):
             break
 
 
+def dns_update_system_records(host):
+    """Runs "ipa dns-update-system-records" on "host".
+    """
+    kinit_admin(host)
+    result = host.run_command(
+        ["ipa", "dns-update-system-records"]
+    )
+    return result
+
+
 def run_ssh_cmd(
     from_host=None, to_host=None, username=None, cmd=None,
     auth_method=None, password=None, private_key_path=None,

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -916,7 +916,7 @@ class TestHiddenReplicaPromotion(IntegrationTest):
             )
             assert returncode == 0
 
-    def test_hide_master_fails(self):
+    def test_hide_last_visible_server_fails(self):
         # verify state
         self._check_config([self.master], [self.replicas[0]])
         # nothing to do
@@ -953,6 +953,7 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         self._check_config([self.master, self.replicas[0]])
         self._check_dnsrecords([self.master, self.replicas[0]])
 
+    def test_promote_twice_fails(self):
         result = self.replicas[0].run_command([
             'ipa', 'server-state',
             self.replicas[0].hostname, '--state=enabled'

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -1024,6 +1024,9 @@ class TestHiddenReplicaPromotion(IntegrationTest):
             stdin_text=dirman_password + '\nyes'
         )
 
+        # wait for the replica to be available
+        tasks.wait_for_ipa_to_start(self.replicas[0])
+
         # give replication some time
         time.sleep(5)
         tasks.kinit_admin(self.replicas[0])

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -948,6 +948,8 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         tasks.wait_for_replication(
             self.replicas[0].ldap_connect()
         )
+        for srv in (self.master, self.replicas[0]):
+            tasks.dns_update_system_records(srv)
         self._check_config([self.master, self.replicas[0]])
         self._check_dnsrecords([self.master, self.replicas[0]])
 
@@ -967,6 +969,8 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         tasks.wait_for_replication(
             self.replicas[0].ldap_connect()
         )
+        for srv in (self.master, self.replicas[0]):
+            tasks.dns_update_system_records(srv)
         self._check_config([self.master], [self.replicas[0]])
         self._check_dnsrecords([self.master], [self.replicas[0]])
 


### PR DESCRIPTION
+
    ipatests: add wait_for_ipa_to_start
    
    wait_for_ipa_to_start(host) waits for ipactl to return RUNNING for all
    IPA services on the specified host.

    Related: https://pagure.io/freeipa/issue/8534
+
    ipatests: hiddenreplica:  use wait_for_ipa_to_start after restore
    
    Use wait_for_ipa_to_start to wait until the restored replica is online.

    Related: https://pagure.io/freeipa/issue/8534
+
    ipatests: use wait_for_replication for hidden replica checks
    
    Previously, hidden replica checks were run without waiting for replication
    to complete, potentially leading to unstable behavior.
    Use wait_for_replication.

    Fixes: https://pagure.io/freeipa/issue/8534
+
    ipatests: hidden replica: misc fixes
    
    Split a test in two and add additional fixes.
    
    Related: https://pagure.io/freeipa/issue/8534
