### PR TITLE
[Backport][ipa-4-8] ipatests: run freeipa-healthcheck on hidden replica

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1901,6 +1901,11 @@ def user_add(host, login, first='test', last='user', extra_args=(),
     return host.run_command(cmd, stdin_text=stdin_text)
 
 
+def user_del(host, login):
+    cmd = ["ipa", "user-del", login]
+    return host.run_command(cmd)
+
+
 def group_add(host, groupname, extra_args=()):
     cmd = [
         "ipa", "group-add", groupname,


### PR DESCRIPTION
This PR was opened automatically because PR #5184 was pushed to master and backport to ipa-4-8 is required.