### PR TITLE
ipatests: properly handle journalctl return code 

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -902,7 +902,7 @@ class TestInstallMaster(IntegrationTest):
         # installed by default and journalctl gives us all AVCs.
         result = self.master.run_command([
             "journalctl", "--full", "--grep=AVC", "--since=yesterday"
-        ])
+        ], raiseonerr=False)
         avcs = list(
             line.strip() for line in result.stdout_text.split('\n')
             if "AVC avc:" in line


### PR DESCRIPTION
The test test_installation.py::TestInstallMaster::test_selinux_avcs
is failing when no AVCs are detected because it is calling
journalctl --full --grep=AVC--since=yesterday
and the command exits with return code 1.

Call the command with raiseonerr=False to support this case.

Fixes: https://pagure.io/freeipa/issue/8541