### PR TITLE
[Backport][ipa-4-8] ipatests: properly handle journalctl return code 

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -902,7 +902,7 @@ class TestInstallMaster(IntegrationTest):
         # installed by default and journalctl gives us all AVCs.
         result = self.master.run_command([
             "journalctl", "--full", "--grep=AVC", "--since=yesterday"
-        ])
+        ], raiseonerr=False)
         avcs = list(
             line.strip() for line in result.stdout_text.split('\n')
             if "AVC avc:" in line


### PR DESCRIPTION
This PR was opened automatically because PR #5194 was pushed to master and backport to ipa-4-8 is required.