### PR TITLE
ipatests: invoke JRE with -Djava.security.debug=access:failure

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,374 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_01:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_02:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_03:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_04:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_05:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_06:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_07:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_08:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_09:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_10:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_11:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_12:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_13:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_14:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_15:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_16:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_17:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_18:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_19:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_20:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_21:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_22:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_23:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_24:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_25:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_26:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_27:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_28:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_29:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_30:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_installation_TestInstallWithCA_KRA1_31:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -79,6 +79,21 @@ class InstallTestBase1(IntegrationTest):
 
     @classmethod
     def install(cls, mh):
+        pki_tomcat_conf_path = "/usr/share/pki/server/conf/tomcat.conf"
+        for srv in [cls.master].extend(cls.replicas):
+            tomcat_conf = srv.get_file_contents(
+                pki_tomcat_conf_path
+            )
+            new_tomcat_conf = []
+            for line in tomcat_conf:
+                if line.startswith("JAVA_OPTS="):
+                    new_tomcat_conf.append(
+                        'JAVA_OPTS="-Dcom.redhat.fips=false '
+                        '-Djava.security.debug=access:failure"'
+                    )
+                else:
+                    new_tomcat_conf.append(line)
+            srv.put_file_contents(pki_tomcat_conf_path, new_tomcat_conf)
         tasks.install_master(cls.master, setup_dns=False)
 
     def test_replica0_ca_less_install(self):


### PR DESCRIPTION
ipatests: invoke JRE with -Djava.security.debug=access:failure
    
DO NOT MERGE.
https://github.com/dogtagpki/pki/issues/3299
    
