### PR TITLE
tox.ini: Extend max-line-length from 80 to 88+

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,6 @@ commands=
 # E731 do not assign a lambda expression
 # E741 ambiguous variable name 'l'
 ignore = E203, E402, E231, W503, E731, E741
-max-line-length = 80
+max-line-length = 88
 # exclude auto-generated remote plugins
 exclude=.git,.venv,build,_build,rpmbuild,2_49,2_114,2_156,2_164


### PR DESCRIPTION
Change tox.ini's 80c character limit to 88.
- 88 is the limit for a font size of 14 on a FHD (1920x1200) screen
  with two editors side-by-side.
- A too-high number can become an issue for potential contributors
  with eyesight problems. So we want to avoid that.

Fixes: https://pagure.io/freeipa/issue/8546
Signed-off-by: François Cami <fcami@redhat.com>