### PR TITLE
Change KRA profiles in certmonger tracking so they can renew

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -124,9 +124,9 @@
 # Fedora
 %endif
 
-# PKIConnection has been modified to always validate certs.
-# https://pagure.io/freeipa/issue/8379
-%global pki_version 10.9.0-0.4
+# New KRA profile, ACME support
+# https://pagure.io/freeipa/issue/8545
+%global pki_version 10.10.0-2
 
 # https://pagure.io/certmonger/issue/90
 %global certmonger_version 0.79.7-1

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -65,9 +65,9 @@ class KRAInstance(DogtagInstance):
     # use for that certificate.  'configure_renewal()' reads this
     # dict.  The profile MUST be specified.
     tracking_reqs = {
-        'auditSigningCert cert-pki-kra': 'caInternalAuthAuditSigningCert',
-        'transportCert cert-pki-kra': 'caInternalAuthTransportCert',
-        'storageCert cert-pki-kra': 'caInternalAuthDRMstorageCert',
+        'auditSigningCert cert-pki-kra': 'caAuditSigningCert',
+        'transportCert cert-pki-kra': 'caTransportCert',
+        'storageCert cert-pki-kra': 'caStorageCert',
     }
 
     def __init__(self, realm):

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -33,6 +33,7 @@ from ipatests.pytest_ipa.integration.env_config import get_global_config
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.test_integration.test_caless import CALessBase, ipa_certs_cleanup
 from ipaplatform import services
+from ipaserver.install import krainstance
 
 config = get_global_config()
 
@@ -1052,6 +1053,38 @@ class TestInstallMasterKRA(IntegrationTest):
 
     def test_install_dns(self):
         tasks.install_dns(self.master)
+
+    def test_kra_certs_renewal(self):
+        """
+        Test that the KRA subsystem certificates renew properly
+        """
+        kra = krainstance.KRAInstance(self.master.domain.realm)
+        for nickname in kra.tracking_reqs:
+            cert = tasks.certutil_fetch_cert(
+                self.master,
+                paths.PKI_TOMCAT_ALIAS_DIR,
+                paths.PKI_TOMCAT_ALIAS_PWDFILE_TXT,
+                nickname
+            )
+            starting_serial = int(cert.serial_number)
+            cmd_arg = [
+                'ipa-getcert', 'resubmit', '-v', '-w',
+                '-d', paths.PKI_TOMCAT_ALIAS_DIR,
+                '-n', nickname,
+            ]
+            result = self.master.run_command(cmd_arg)
+            request_id = re.findall(r'\d+', result.stdout_text)
+
+            status = tasks.wait_for_request(self.master, request_id[0], 120)
+            assert status == "MONITORING"
+
+            cert = tasks.certutil_fetch_cert(
+                self.master,
+                paths.PKI_TOMCAT_ALIAS_DIR,
+                paths.PKI_TOMCAT_ALIAS_PWDFILE_TXT,
+                nickname
+            )
+            assert starting_serial != int(cert.serial_number)
 
 
 class TestInstallMasterDNS(IntegrationTest):


### PR DESCRIPTION
Change KRA profiles in certmonger tracking so they can renew

Internal profiles were assigned which prevented rewewals.

dogtag is providing a new profile for the audit signing cert,
caAuditSigningCert.

There are existing profiles for the transport (caTransportCert)
and storage (caStorageCert) certificates.

https://pagure.io/freeipa/issue/8545

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

**NOTE**: This is WIP because the necessary profile is only in the pki nightly repo. We want this backported to other supported IPA branches but they may be delayed depending on when pki builds are available.
