### PR TITLE
[Backport][ipa-4-8] Don't restart certmonger after stopping tracking in uninstall

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -425,7 +425,7 @@ def install_step_1(standalone, replica_config, options, custodia):
 
 def uninstall():
     ca_instance = cainstance.CAInstance(api.env.realm)
-    ca_instance.stop_tracking_certificates()
+    ca_instance.stop_tracking_certificates(stop_certmonger=False)
     ipautil.remove_file(paths.RA_AGENT_PEM)
     ipautil.remove_file(paths.RA_AGENT_KEY)
     if ca_instance.is_configured():


### PR DESCRIPTION
This PR was opened automatically because PR #5197 was pushed to master and backport to ipa-4-8 is required.