### PR TITLE
On password reset also set krbLastAdminUnlock to unlock account

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/common.c
@@ -855,6 +855,20 @@ int ipapwd_SetPassword(struct ipapwd_krbcfg *krbcfg,
                                  data->expireTime, (data->expireTime == 0));
             if (ret != LDAP_SUCCESS)
                 goto free_and_return;
+
+            switch(data->changetype) {
+                case IPA_CHANGETYPE_DSMGR:
+                case IPA_CHANGETYPE_ADMIN:
+                    /* Mark as administratively reset which will unlock acct */
+                    ret = ipapwd_setdate(data->target, smods, 
+                                         "krbLastAdminUnlock",
+                                         data->timeNow, false);
+                    if (ret != LDAP_SUCCESS)
+                        goto free_and_return;
+                    break;
+                default:
+                    break;
+            }
         }
     }
 

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -935,9 +935,14 @@ def disconnect_replica(master, replica, domain_level=None,
                             ])
 
 
+def kinit_user(host, user, password, raiseonerr=True):
+    return host.run_command(['kinit', user], raiseonerr=raiseonerr,
+                            stdin_text=password)
+
+
 def kinit_admin(host, raiseonerr=True):
-    return host.run_command(['kinit', 'admin'], raiseonerr=raiseonerr,
-                            stdin_text=host.config.admin_password)
+    return kinit_user(host, 'admin', host.config.admin_password,
+                      raiseonerr=raiseonerr)
 
 
 def uninstall_master(host, ignore_topology_disconnect=True,


### PR DESCRIPTION
On password reset also set krbLastAdminUnlock to unlock account

This fixes the case where an account is locked on one or more servers
and the password is reset by an administrator. The account would
remain locked on those servers for the duration of the lockout.

This is done by setting krbLastAdminUnlock to the current date and
time. The lockout plugin will see this and unlock the account. Since
the value should be replicated along with the password any server
that has the new password will also be unlocked.

This does incur an additional attribute that must be replicated,
whether it is needed or not, but since lockout is computed
per-server this is the only guaranteed way to be sure that the
account will be unlocked everywhere.

https://pagure.io/freeipa/issue/8551

Signed-off-by: Rob Crittenden <rcritten@redhat.com>