### PR TITLE
Add ipwpwdpolicy objectclass to all policies on upgrade

### DIFF
--- a/install/updates/90-post_upgrade_plugins.update
+++ b/install/updates/90-post_upgrade_plugins.update
@@ -25,6 +25,7 @@ plugin: update_upload_cacrt
 plugin: update_ra_cert_store
 plugin: update_mapping_Guests_to_nobody
 plugin: fix_kra_people_entry
+plugin: update_pwpolicy
 
 # last
 # DNS version 1

--- a/ipaserver/install/plugins/update_idranges.py
+++ b/ipaserver/install/plugins/update_idranges.py
@@ -51,7 +51,7 @@ class update_idrange_type(Updater):
                 (entries, truncated) = ldap.find_entries(search_filter,
                     ['objectclass'], base_dn, time_limit=0, size_limit=0)
 
-            except errors.NotFound:
+            except errors.EmptyResult:
                 logger.debug("update_idrange_type: no ID range without "
                              "type set found")
                 return False, []
@@ -59,11 +59,6 @@ class update_idrange_type(Updater):
             except errors.ExecutionError as e:
                 logger.error("update_idrange_type: cannot retrieve list "
                              "of ranges with no type set: %s", e)
-                return False, []
-
-            if not entries:
-                # No entry was returned, rather break than continue cycling
-                logger.debug("update_idrange_type: no ID range was returned")
                 return False, []
 
             logger.debug("update_idrange_type: found %d "

--- a/ipaserver/install/plugins/update_pwpolicy.py
+++ b/ipaserver/install/plugins/update_pwpolicy.py
@@ -1,0 +1,80 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+
+import logging
+
+from ipalib import Registry, errors
+from ipalib import Updater
+from ipapython.dn import DN
+
+logger = logging.getLogger(__name__)
+
+register = Registry()
+
+
+@register()
+class update_pwpolicy(Updater):
+    """
+    Add new ipapwdpolicy objectclass to all password policies
+
+    Otherwise pwpolicy-find will not find them.
+    """
+
+    def execute(self, **options):
+        ldap = self.api.Backend.ldap2
+
+        base_dn = DN(('cn', self.api.env.realm), ('cn', 'kerberos'),
+                     self.api.env.basedn)
+        search_filter = (
+            "(&(objectClass=krbpwdpolicy)(!(objectclass=ipapwdpolicy)))"
+        )
+
+        while True:
+            # Run the search in loop to avoid issues when LDAP limits are hit
+            # during update
+
+            try:
+                (entries, truncated) = ldap.find_entries(
+                    search_filter, ['objectclass'], base_dn, time_limit=0,
+                    size_limit=0)
+
+            except errors.EmptyResult:
+                logger.debug("update_pwpolicy: no policies without "
+                             "objectclass set")
+                return False, []
+
+            except errors.ExecutionError as e:
+                logger.error("update_pwpolicy: cannot retrieve list "
+                             "of policies missing an objectclass: %s", e)
+                return False, []
+
+            logger.debug("update_pwpolicy: found %d "
+                         "policies to update, truncated: %s",
+                         len(entries), truncated)
+
+            error = False
+
+            for entry in entries:
+                entry['objectclass'].append('ipapwdpolicy')
+                try:
+                    ldap.update_entry(entry)
+                except (errors.EmptyModlist, errors.NotFound):
+                    pass
+                except errors.ExecutionError as e:
+                    logger.debug("update_pwpolicy: cannot "
+                                 "update policy: %s", e)
+                    error = True
+
+            if error:
+                # Exit loop to avoid infinite cycles
+                logger.error("update_pwpolicy: error(s) "
+                             "detected during pwpolicy update")
+                return False, []
+
+            elif not truncated:
+                # All affected entries updated, exit the loop
+                logger.debug("update_pwpolicy: all policies updated")
+                return False, []
+
+        return False, []


### PR DESCRIPTION
Add ipwpwdpolicy objectclass to all policies on upgrade

ipapwdpolicy is the objectclass which defines the libpwquality
attributes. For older sytems it isn't strictly necessary (or
visible) but not having it included will result in policies
not being visible with pwpolicy-find.

https://pagure.io/freeipa/issue/8555
