### PR TITLE
New validation efforts in 389-ds-base require that the backend entry for

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1162,17 +1162,6 @@ class CAInstance(DogtagInstance):
         backend = 'ipaca'
         suffix = DN(('o', 'ipaca'))
 
-        # replication
-        dn = DN(('cn', str(suffix)), ('cn', 'mapping tree'), ('cn', 'config'))
-        entry = api.Backend.ldap2.make_entry(
-            dn,
-            objectclass=["top", "extensibleObject", "nsMappingTree"],
-            cn=[suffix],
-        )
-        entry['nsslapd-state'] = ['Backend']
-        entry['nsslapd-backend'] = [backend]
-        api.Backend.ldap2.add_entry(entry)
-
         # database
         dn = DN(('cn', 'ipaca'), ('cn', 'ldbm database'), ('cn', 'plugins'),
                 ('cn', 'config'))
@@ -1182,6 +1171,17 @@ class CAInstance(DogtagInstance):
             cn=[backend],
         )
         entry['nsslapd-suffix'] = [suffix]
+        api.Backend.ldap2.add_entry(entry)
+
+        # replication
+        dn = DN(('cn', str(suffix)), ('cn', 'mapping tree'), ('cn', 'config'))
+        entry = api.Backend.ldap2.make_entry(
+            dn,
+            objectclass=["top", "extensibleObject", "nsMappingTree"],
+            cn=[suffix],
+        )
+        entry['nsslapd-state'] = ['Backend']
+        entry['nsslapd-backend'] = [backend]
         api.Backend.ldap2.add_entry(entry)
 
     def __setup_replication(self):


### PR DESCRIPTION
a database be created before the mapping tree entry. This enforces that
the mapping tree entry (the suffix) actually belongs to an existing backend.

For IPA we simply need to reverse the order of the backend vs mapping tree
creation in cainstance.py -> __create_ds_db()

Fixes: https://pagure.io/freeipa/issue/8558