### PR TITLE
[Backport][ipa-4-8] rpcserver: fallback to non-armored kinit in case of trusted domains

### DIFF
--- a/ipalib/errors.py
+++ b/ipalib/errors.py
@@ -245,6 +245,12 @@ class PluginModuleError(PrivateError):
     format = '%(name)s is not a valid plugin module'
 
 
+class KrbPrincipalWrongFAST(PrivateError):
+    """
+    Raised when it is not possible to use our FAST armor for kinit
+    """
+    format = '%(principal)s cannot use Anonymous PKINIT as a FAST armor'
+
 ##############################################################################
 # Public errors:
 

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -972,7 +972,7 @@ class login_password(Backend, KerberosSession):
 
         try:
             query_dict = parse_qs(query_string)
-        except Exception as e:
+        except Exception:
             return self.bad_request(environ, start_response, "cannot parse query data")
 
         user = query_dict.get('user', None)


### PR DESCRIPTION
This PR was opened automatically because PR #5213 was pushed to master and backport to ipa-4-8 is required.