### PR TITLE
ipatests: Fix for test_ipahealthcheck_ds_encryption

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1006,9 +1006,10 @@ class TestIpaHealthCheck(IntegrationTest):
             assert check["result"] == "CRITICAL"
             assert exception_msg in check["kw"]["exception"]
 
+    @pytest.fixture
     def modify_tls(self, restart_service):
         """
-        Modify DS tls version to TLS1.0 using dsconf tool and
+        Fixture to modify DS tls version to TLS1.0 using dsconf tool and
         revert back to the default TLS1.2
         """
         instance = realm_to_serverid(self.master.domain.realm)


### PR DESCRIPTION
Nightly test failure was seen for test_ipahealthcheck_ds_encryption ,the test was failing since @pytest.fixture was not specified before the function modify_tls
   
Ref: https://pagure.io/freeipa/issue/8560
