### PR TITLE
[Backport][ipa-4-8] ipatests: curl outputs the cookie in stderr and not in sdtout

### DIFF
--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -193,7 +193,7 @@ class TestTrust(BaseTestTrust):
             '--data', user_and_password,
             'https://{}/ipa/session/login_password'.format(host)]
         result = self.master.run_command(cmd_args)
-        assert "Set-Cookie: ipa_session=MagBearerToken" in result.stdout_text
+        assert "Set-Cookie: ipa_session=MagBearerToken" in result.stderr_text
         tasks.kinit_admin(self.master)
 
     def test_ipauser_authentication_with_nonposix_trust(self):


### PR DESCRIPTION
This PR was opened automatically because PR #5223 was pushed to master and backport to ipa-4-8 is required.