### PR TITLE
ipatests: Fix for test_ipahealthcheck_ds_riplugincheck

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1059,6 +1059,7 @@ class TestIpaHealthCheck(IntegrationTest):
             assert "cn=encryption,cn=config" in check["kw"]["items"]
             assert check["kw"]["msg"] == enc_msg
 
+    @pytest.fixture
     def update_riplugin(self):
         """
         Fixture modifies the value of update delay for RI plugin to -1


### PR DESCRIPTION
Fix for Nightly test failure in test_ipahealthcheck.py::TestIpaHealthCheck::test_ipahealthcheck_ds_riplugincheck
