### PR TITLE
wgi/plugins.py: ignore empty plugin directories

### DIFF
--- a/install/wsgi/plugins.py
+++ b/install/wsgi/plugins.py
@@ -36,7 +36,10 @@ def get_plugin_index():
 
     dirs = os.listdir(paths.IPA_JS_PLUGINS_DIR)
     index = 'define([],function(){return['
-    index += ','.join("'"+x+"'" for x in dirs)
+    for x in dirs:
+        p = os.path.join(paths.IPA_JS_PLUGINS_DIR, x, x + '.js')
+        if os.path.exists(p):
+            index += "'" + x + "',"
     index += '];});'
     return index.encode('utf-8')
 

--- a/ipatests/test_ipaserver/test_jsplugins.py
+++ b/ipatests/test_ipaserver/test_jsplugins.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+
+import os
+import pytest
+
+from ipatests.test_ipaserver.httptest import Unauthorized_HTTP_test
+from ipatests.util import assert_equal, assert_not_equal
+from ipaplatform.paths import paths
+
+
+@pytest.mark.tier1
+class test_jsplugins(Unauthorized_HTTP_test):
+    app_uri = '/ipa/ui/js/freeipa/plugins.js'
+    jsplugins = (('foo', 'foo.js'), ('bar', ''))
+    content_type = 'application/javascript'
+
+    def test_jsplugins(self):
+        empty_response = "define([],function(){return[];});"
+
+        # Step 1: make sure default response has no additional plugins
+        response = self.send_request(method='GET')
+        assert_equal(response.status, 200)
+        response_data = response.read().decode(encoding='utf-8')
+        assert_equal(response_data, empty_response)
+
+        # Step 2: add fake plugins
+        try:
+            for (d, f) in self.jsplugins:
+                dir = os.path.join(paths.IPA_JS_PLUGINS_DIR, d)
+                if not os.path.exists(dir):
+                    os.mkdir(dir, 0o755)
+                if f:
+                    with open(os.path.join(dir, f), 'w') as js:
+                        js.write("/* test js plugin */")
+
+        except OSError as e:
+            pytest.skip(
+                'Cannot set up test JS plugin: %s' % e
+            )
+
+        # Step 3: query plugins to see if our plugins exist
+        response = self.send_request(method='GET')
+        assert_equal(response.status, 200)
+        response_data = response.read().decode(encoding='utf-8')
+        assert_not_equal(response_data, empty_response)
+        for (d, f) in self.jsplugins:
+            if f:
+                assert "'" + d + "'" in response_data
+            else:
+                assert "'" + d + "'" not in response_data
+
+        # Step 4: remove fake plugins
+        try:
+            for (d, f) in self.jsplugins:
+                dir = os.path.join(paths.IPA_JS_PLUGINS_DIR, d)
+                file = os.path.join(dir, f)
+                if f and os.path.exists(file):
+                    os.unlink(file)
+                if os.path.exists(dir):
+                    os.rmdir(dir)
+        except OSError:
+            pass
+
+        # Step 5: make sure default response has no additional plugins
+        response = self.send_request(method='GET')
+        assert_equal(response.status, 200)
+        response_data = response.read().decode(encoding='utf-8')
+        assert_equal(response_data, empty_response)


### PR DESCRIPTION
Dynamic plugin registry returns as a plugin any folder within the
plugins directory. Web UI then attempts to load for each plugin 'foo' a
JavaScript file named 'foo/foo.js'. The problem is that if 'foo/foo.js'
does not exist, Web UI breaks and it is impossible to recover until the
empty folder is removed or 'foo/foo.js' (even empty) is created at the
server side.

Check that 'foo/foo.js' actual exists when including a plugin into the
registry.

Test the registry generator by creating fake plugins and removing them
during the test.

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>