### PR TITLE
ipatests: Test certmonger IPA responder switched to JSONRPC

### DIFF
--- a/ipatests/test_integration/test_cert.py
+++ b/ipatests/test_integration/test_cert.py
@@ -68,6 +68,10 @@ class TestInstallMasterClient(IntegrationTest):
         )
         tasks.install_client(cls.master, cls.clients[0])
 
+        # time to look into journal logs in
+        # test_certmonger_ipa_responder_jsonrpc
+        cls.since = time.strftime('%H:%M:%S')
+
     def test_cacert_file_appear_with_option_F(self):
         """Test if getcert creates cacert file with -F option
 
@@ -91,6 +95,27 @@ class TestInstallMasterClient(IntegrationTest):
         assert status == "MONITORING"
 
         self.clients[0].run_command(['ls', '-l', '/etc/pki/tls/test.CA'])
+
+    def test_certmonger_ipa_responder_jsonrpc(self):
+        """Test certmonger IPA responder switched to JSONRPC
+
+        This is to test if certmonger IPA responder swithed to JSONRPC
+        from XMLRPC
+
+        This test utilizes the cert request made in previous test.
+        (test_cacert_file_appear_with_option_F)
+
+        related: https://pagure.io/freeipa/issue/3299
+        """
+        # check that request is made against /ipa/json so that
+        # IPA enforce json data type
+        exp_str = 'Submitting request to "https://{}/ipa/json"'.format(
+            self.master.hostname
+        )
+        result = self.clients[0].run_command([
+            'journalctl', '-u', 'certmonger', '--since={}'.format(self.since)
+        ])
+        assert exp_str in result.stdout_text
 
     def test_ipa_getcert_san_aci(self):
         """Test for DNS and IP SAN extensions + ACIs


### PR DESCRIPTION
This is to test if certmonger IPA responder swithed to JSONRPC
from XMLRPC

related: https://pagure.io/freeipa/issue/3299

Signed-off-by: Mohammad Rizwan <myusuf@redhat.com>