### PR TITLE
Wrap libpwquality PKG_CHECK_MODULES in ENABLE_SERVER test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,7 +116,9 @@ PKG_CHECK_MODULES([CRYPTO], [libcrypto])
 dnl ---------------------------------------------------------------------------
 dnl - Check for pwquality library
 dnl ---------------------------------------------------------------------------
-PKG_CHECK_MODULES([PWQUALITY], [pwquality])
+AM_COND_IF([ENABLE_SERVER], [
+	PKG_CHECK_MODULES([PWQUALITY], [pwquality])
+])
 
 dnl ---------------------------------------------------------------------------
 dnl - Check for Python 3
@@ -670,12 +672,12 @@ echo "
         jslint:                   ${JSLINT}
         LDAP libs:                ${LDAP_LIBS}
         OpenSSL crypto libs:      ${CRYPTO_LIBS}
-        pwquality libs:           ${PWQUALITY_LIBS}
         KRB5 libs:                ${KRB5_LIBS}
         systemdsystemunitdir:     ${systemdsystemunitdir}"
 
 AM_COND_IF([ENABLE_SERVER], [
     echo "\
+        pwquality libs:           ${PWQUALITY_LIBS}
         KRAD libs:                ${KRAD_LIBS}
         krb5rundir:               ${krb5rundir}
         systemdtmpfilesdir:       ${systemdtmpfilesdir}


### PR DESCRIPTION
libpwquality is only needed when building a server. Don't test
for it in a client build.

https://pagure.io/freeipa/issue/6964
https://pagure.io/freeipa/issue/5948
https://pagure.io/freeipa/issue/2445
https://pagure.io/freeipa/issue/298

Signed-off-by: Rob Crittenden <rcritten@redhat.com>