### PR TITLE
[Backport][ipa-4-8] ipatests: Fix for test_ipahealthcheck_ds_encryption

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1043,9 +1043,10 @@ class TestIpaHealthCheck(IntegrationTest):
             assert check["result"] == "WARNING"
             assert warn_msg in check["kw"]["msg"]
 
+    @pytest.fixture
     def modify_tls(self, restart_service):
         """
-        Modify DS tls version to TLS1.0 using dsconf tool and
+        Fixture to modify DS tls version to TLS1.0 using dsconf tool and
         revert back to the default TLS1.2
         """
         instance = realm_to_serverid(self.master.domain.realm)


### PR DESCRIPTION
This is a manual backport of PR #5221 to ipa-4-8 branch.

Auto-ACKed as this is a trivial backport