### PR TITLE
ipatests: ipa-acme-manage status returns 3 on a CA-less server

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -443,7 +443,7 @@ class TestACMECALess(IntegrationTest):
         # check status of acme on replica, result: CA is not installed
         result = self.replicas[0].run_command(['ipa-acme-manage', 'status'],
                                               raiseonerr=False)
-        assert result.returncode == 1
+        assert result.returncode == 3
 
         # Install CA on replica
         tasks.install_ca(self.replicas[0])


### PR DESCRIPTION
test_acme.py::TestACMECALess::test_enable_caless_to_cafull_replica is
running ipa-acme-manage status on a CA-less server and wrongly
expects retcode =1. According to the man page, the command returns 3
when executed on a server where the CA is not installed.

Fixes: https://pagure.io/freeipa/issue/8572