### PR TITLE
[Backport][ipa-4-8] Wrap libpwquality PKG_CHECK_MODULES in ENABLE_SERVER test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,7 +108,9 @@ PKG_CHECK_MODULES([CRYPTO], [libcrypto])
 dnl ---------------------------------------------------------------------------
 dnl - Check for pwquality library
 dnl ---------------------------------------------------------------------------
-PKG_CHECK_MODULES([PWQUALITY], [pwquality])
+AM_COND_IF([ENABLE_SERVER], [
+	PKG_CHECK_MODULES([PWQUALITY], [pwquality])
+])
 
 dnl ---------------------------------------------------------------------------
 dnl - Check for Python 3
@@ -664,12 +666,12 @@ echo "
         jslint:                   ${JSLINT}
         LDAP libs:                ${LDAP_LIBS}
         OpenSSL crypto libs:      ${CRYPTO_LIBS}
-        pwquality libs:           ${PWQUALITY_LIBS}
         KRB5 libs:                ${KRB5_LIBS}
         systemdsystemunitdir:     ${systemdsystemunitdir}"
 
 AM_COND_IF([ENABLE_SERVER], [
     echo "\
+        pwquality libs:           ${PWQUALITY_LIBS}
         KRAD libs:                ${KRAD_LIBS}
         krb5rundir:               ${krb5rundir}
         systemdtmpfilesdir:       ${systemdtmpfilesdir}


### PR DESCRIPTION
This PR was opened automatically because PR #5233 was pushed to master and backport to ipa-4-8 is required.