### PR TITLE
[Backport][ipa-4-8] ipatests: IPADNSSystemRecordsCheck also checks for AAAA records 

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1125,6 +1125,7 @@ class TestIpaHealthCheckWithoutDNS(IntegrationTest):
         """
         msg1 = "Expected SRV record missing"
         msg2 = "Got {count} ipa-ca A records, expected {expected}"
+        msg3 = "Got {count} ipa-ca AAAA records, expected {expected}"
         tasks.install_packages(self.master, HEALTHCHECK_PKG)
         returncode, data = run_healthcheck(
             self.master,
@@ -1134,7 +1135,11 @@ class TestIpaHealthCheckWithoutDNS(IntegrationTest):
         assert returncode == 1
         for check in data:
             assert check["result"] == "WARNING"
-            assert check["kw"]["msg"] == msg1 or check["kw"]["msg"] == msg2
+            assert (
+                check["kw"]["msg"] == msg1
+                or check["kw"]["msg"] == msg2
+                or check["kw"]["msg"] == msg3
+            )
 
     def test_ipa_certs_check_ipacertnsstrust(self):
         """


### PR DESCRIPTION
This PR was opened automatically because PR #5241 was pushed to master and backport to ipa-4-8 is required.