### PR TITLE
ipa-kdb: implement AS-REQ lifetime jitter

### DIFF
--- a/doc/designs/krb-ticket-policy.md
+++ b/doc/designs/krb-ticket-policy.md
@@ -91,8 +91,10 @@ where administrators can specify max renew and life for each supported auth indi
 
 ### Ticket lifetime jitter
 
-Ticket lifetimes can be jittered so that renewals / re-issues do not overwhelm the KDC at a certain moment.
-The feature is enabled automatically so that we can avoid triggering an LDAP query on every `AS_REQ` and `TGS_REQ`.
+All TGT lifetimes are varied slightly to avoid overwhelming the KDC with
+simultaneous renewal requests.  Jitter will reduce lifetimes by up to one hour
+from the configured maximum lifetime (per policy).  Significantly shorter
+requested lifetimes will be unaffected.
 
 ## Implementation
 

--- a/ipatests/test_integration/test_krbtpolicy.py
+++ b/ipatests/test_integration/test_krbtpolicy.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+# Copyright (C) 2019,2020  FreeIPA Contributors see COPYING for license
 #
 
 """
@@ -8,6 +8,7 @@ Module provides tests for Kerberos ticket policy options
 
 from __future__ import absolute_import
 
+import pytest
 import time
 from datetime import datetime
 
@@ -44,8 +45,15 @@ def reset_to_default_policy(host, user):
     """Reset default user authentication and user authentication type"""
     tasks.kinit_admin(host)
     host.run_command(['ipa', 'user-mod', user, '--user-auth-type='])
-    host.run_command(['ipa', 'krbtpolicy-reset'])
     host.run_command(['ipa', 'krbtpolicy-reset', user])
+
+
+def kinit_check_life(master, user):
+    """Acquire a TGT and check if it's within the lifetime window"""
+    master.run_command(["kinit", user], stdin_text=f"{PASSWORD}\n")
+    result = master.run_command("klist | grep krbtgt")
+    assert maxlife_within_policy(result.stdout_text, MAXLIFE,
+                                 slush=60) is True
 
 
 class TestPWPolicy(IntegrationTest):
@@ -59,11 +67,15 @@ class TestPWPolicy(IntegrationTest):
         tasks.create_active_user(cls.master, USER1, PASSWORD)
         tasks.create_active_user(cls.master, USER2, PASSWORD)
 
+    @pytest.fixture(autouse=True, scope="class")
+    def with_admin(self):
+        tasks.kinit_admin(self.master)
+        yield
+        tasks.kdestroy_all(self.master)
+
     def test_krbtpolicy_default(self):
         """Test the default kerberos ticket policy 24-hr tickets"""
         master = self.master
-
-        tasks.kinit_admin(master)
         master.run_command(['ipa', 'krbtpolicy-mod', USER1,
                             '--maxlife', str(MAXLIFE)])
         tasks.kdestroy_all(master)
@@ -73,13 +85,9 @@ class TestPWPolicy(IntegrationTest):
         result = master.run_command('klist | grep krbtgt')
         assert maxlife_within_policy(result.stdout_text, MAXLIFE) is True
 
-        tasks.kdestroy_all(master)
-
     def test_krbtpolicy_hardended(self):
         """Test a hardened kerberos ticket policy with 10 min tickets"""
         master = self.master
-
-        tasks.kinit_admin(master)
         master.run_command(['ipa', 'user-mod', USER1,
                             '--user-auth-type', 'password',
                             '--user-auth-type', 'hardened'])
@@ -104,13 +112,9 @@ class TestPWPolicy(IntegrationTest):
         result = master.run_command('klist | grep krbtgt')
         assert maxlife_within_policy(result.stdout_text, MAXLIFE) is True
 
-        tasks.kdestroy_all(master)
-
     def test_krbtpolicy_password(self):
         """Test the kerberos ticket policy which issues 20 min tickets"""
         master = self.master
-
-        tasks.kinit_admin(master)
         master.run_command(['ipa', 'krbtpolicy-mod', USER2,
                             '--maxlife', '1200'])
 
@@ -121,25 +125,18 @@ class TestPWPolicy(IntegrationTest):
         result = master.run_command('klist | grep krbtgt')
         assert maxlife_within_policy(result.stdout_text, 1200) is True
 
-        tasks.kdestroy_all(master)
-
     def test_krbtpolicy_reset(self):
         """Test a hardened kerberos ticket policy reset"""
         master = self.master
-
-        tasks.kinit_admin(master)
         master.run_command(['ipa', 'krbtpolicy-reset', USER2])
         master.run_command(['kinit', USER2],
                            stdin_text=PASSWORD + '\n')
         result = master.run_command('klist | grep krbtgt')
         assert maxlife_within_policy(result.stdout_text, MAXLIFE) is True
 
-        tasks.kdestroy_all(master)
-
     def test_krbtpolicy_otp(self):
         """Test otp ticket policy"""
         master = self.master
-        tasks.kinit_admin(self.master)
         master.run_command(['ipa', 'user-mod', USER1,
                             '--user-auth-type', 'otp'])
         master.run_command(['ipa', 'config-mod',
@@ -177,3 +174,21 @@ class TestPWPolicy(IntegrationTest):
             reset_to_default_policy(master, USER1)
             self.master.run_command(['rm', '-f', armor])
             master.run_command(['ipa', 'config-mod', '--user-auth-type='])
+
+    def test_krbtpolicy_jitter(self):
+        """Test jitter lifetime with no auth indicators"""
+        kinit_check_life(self.master, USER1)
+
+    def test_krbtpolicy_jitter_otp(self):
+        """Test jitter lifetime with OTP"""
+        self.master.run_command(["ipa", "user-mod", USER1,
+                                 "--user-auth-type", "otp"])
+        kinit_check_life(self.master, USER1)
+        reset_to_default_policy(self.master, USER1)
+
+    def test_krbtpolicy_jitter_pkinit(self):
+        """Test jitter lifetime with PKINIT"""
+        self.master.run_command(["ipa", "user-mod", USER2,
+                                 "--user-auth-type", "pkinit"])
+        kinit_check_life(self.master, USER2)
+        reset_to_default_policy(self.master, USER2)


### PR DESCRIPTION
Jitter is always enabled, so there is no additional configuration.
Update design docs to fix rationale and include information about
current behavior.

An earlier version of this patch was authored by Becky Shanley.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>

[Supersedes #5055]