### PR TITLE
[Backport][ipa-4-8] dns: allow PTR records in arbitrary zones

### DIFF
--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -3111,10 +3111,11 @@ class dnsrecord(LDAPObject):
                 zone_len = REVERSE_DNS_ZONES[valid_zone]
 
         if not zone_len:
-            allowed_zones = ', '.join([unicode(revzone) for revzone in
-                                       REVERSE_DNS_ZONES])
-            raise errors.ValidationError(name='ptrrecord',
-                    error=unicode(_('Reverse zone for PTR record should be a sub-zone of one the following fully qualified domains: %s') % allowed_zones))
+            # PTR records in zones other than in-addr.arpa and ip6.arpa are
+            # legal, e.g. DNS-SD [RFC6763] uses such records.  If we have
+            # such a record there's nothing more to do.  Otherwise continue
+            # with the ip4/ip6 reverse zone checks below.
+            return
 
         addr_len = len(addr.labels)
 

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -3331,6 +3331,24 @@ class test_dns(Declarative):
             },
         ),
 
+        dict(
+            desc='Add PTR record in a non-.arpa zone [DNS-SD]',
+            command=(
+                'dnsrecord_add',
+                [zone1, '_http._tcp'],
+                {'ptrrecord': 'home._http._tcp'},
+            ),
+            expected={
+                'value': DNSName('_http._tcp'),
+                'summary': None,
+                'result': {
+                    'dn': DN(('idnsname', '_http._tcp'), zone1_dn),
+                    'idnsname': [DNSName('_http._tcp')],
+                    'ptrrecord': ['home._http._tcp'],
+                    'objectclass': objectclasses.dnsrecord,
+                },
+            },
+        ),
 
         dict(
             desc='Delete zone %r' % zone1,


### PR DESCRIPTION
This PR was opened automatically because PR #5239 was pushed to master and backport to ipa-4-8 is required.