### PR TITLE
mailmap: add ftweedal

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -10,6 +10,7 @@ Felipe Volpone <felipevolpone@gmail.com> Felipe Volpone <fbarreto@redhat.com>
 Felipe Volpone <fbarreto@redhat.com>
 François Cami <fcami@redhat.com>
 François Cami <fcami@redhat.com> <fcami@fedoraproject.org>
+Fraser Tweedale <ftweedal@redhat.com> <frase@frase.id.au>
 Gabe Alford     <redhatrises@gmail.com>
 Ganna Kaihorodova <gkaihoro@redhat.com> <gkaihoro@example.com>
 Jan Zelený      <jzeleny@redhat.com>


### PR DESCRIPTION
I noticed from draft release notes that some commits with a
different email address slipped in.  Add myself to mailmap so that I
do not have doppelganger.