### PR TITLE
WebUI: Fix topology graph navigation crash

### DIFF
--- a/install/ui/src/freeipa/facet.js
+++ b/install/ui/src/freeipa/facet.js
@@ -1088,6 +1088,15 @@ exp.facet = IPA.facet = function(spec, no_init) {
     };
 
     /**
+     * Form navigation options
+     *
+     * The options allow to build a link to the given facet.
+     */
+    that.get_navigation_options = function() {
+        return {pkeys: that.get_pkeys()};
+    };
+
+    /**
      * Initialize facet
      * @protected
      */
@@ -1639,9 +1648,9 @@ exp.FacetGroupsWidget = declare([], {
         $('<a/>', {
             text: tab.tab_label,
             'class': 'tab-link',
-            href: "#" + navigation.create_hash(tab, {
-                pkeys: self.facet.get_pkeys()
-            }),
+            href: "#" + navigation.create_hash(
+                tab, self.facet.get_navigation_options()
+            ),
             name: tab.name
         }).appendTo(el);
 

--- a/install/ui/src/freeipa/facets/Facet.js
+++ b/install/ui/src/freeipa/facets/Facet.js
@@ -333,6 +333,15 @@ define(['dojo/_base/declare',
             window.console.warning('Unimplemented');
         },
 
+        /**
+         * Form navigation options
+         *
+         * The method is needed to keep compatibility with IPA.facet class.
+         */
+        get_navigation_options: function() {
+            return {};
+        },
+
         /** Constructor */
         constructor: function(spec) {
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1238,6 +1238,7 @@ jobs:
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
+          test_webui/test_topology.py
           test_webui/test_trust.py
         template: *ci-master-latest
         timeout: 7200

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1335,6 +1335,7 @@ jobs:
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
+          test_webui/test_topology.py
           test_webui/test_trust.py
         template: *ci-master-latest
         timeout: 7200

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1335,6 +1335,7 @@ jobs:
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
+          test_webui/test_topology.py
           test_webui/test_trust.py
         template: *testing-master-latest
         timeout: 7200

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1432,6 +1432,7 @@ jobs:
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
+          test_webui/test_topology.py
           test_webui/test_trust.py
         template: *testing-master-latest
         timeout: 7200

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1238,6 +1238,7 @@ jobs:
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
+          test_webui/test_topology.py
           test_webui/test_trust.py
         template: *ci-master-previous
         timeout: 7200

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1335,6 +1335,7 @@ jobs:
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
+          test_webui/test_topology.py
           test_webui/test_trust.py
         template: *ci-master-frawhide
         timeout: 7200

--- a/ipatests/test_webui/test_topology.py
+++ b/ipatests/test_webui/test_topology.py
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+
+from ipatests.test_webui.ui_driver import screenshot, UI_driver
+
+
+class TestTopology(UI_driver):
+
+    @screenshot
+    def test_topology_graph(self):
+        self.init_app()
+        self.navigate_to_page('topology-graph')
+        self.assert_visible('.topology-view')

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -505,6 +505,10 @@ class UI_driver:
         self.driver.get(self.get_url(entity, facet))
         self.wait_for_request(n=3, d=0.4)
 
+    def navigate_to_page(self, page):
+        self.driver.get('/'.join([self.get_base_url(), '#', 'p', page]))
+        self.wait_for_request(n=3, d=0.4)
+
     def navigate_by_menu(self, item, complete=True):
         """
         Navigate by using menu


### PR DESCRIPTION
Add get_navigation_options method to all facet variations to unify forming facet links.

Ticket: https://pagure.io/freeipa/issue/8523