### PR TITLE
Create IPA ssh client configuration and move ProxyCommand

### DIFF
--- a/client/share/Makefile.am
+++ b/client/share/Makefile.am
@@ -4,6 +4,7 @@ appdir = $(IPA_DATA_DIR)/client
 dist_app_DATA =				\
 	freeipa.template		\
 	sshd_ipa.conf.template	\
+	ssh_ipa.conf.template	\
 	$(NULL)
 
 epnconfdir = $(IPA_SYSCONF_DIR)

--- a/client/share/ssh_ipa.conf.template
+++ b/client/share/ssh_ipa.conf.template
@@ -1,0 +1,10 @@
+# IPA-related configuration changes to ssh_config
+#
+PubkeyAuthentication yes
+${ENABLEPROXY}GlobalKnownHostsFile $KNOWNHOSTS
+${VERIFYHOSTKEYDNS}VerifyHostKeyDNS yes
+
+# assumes that if a user does not have shell (/sbin/nologin),
+# this will return nonzero exit code and proxy command will be ignored
+${ENABLEPROXY}Match exec true   
+${ENABLEPROXY}	ProxyCommand $KNOWNHOSTSPROXY -p %p %h

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -135,6 +135,8 @@ class BasePathNamespace:
     LIMITS_CONF = "/etc/security/limits.conf"
     SSH_CONFIG_DIR = "/etc/ssh"
     SSH_CONFIG = "/etc/ssh/ssh_config"
+    SSH_IPA_CONFIG_TEMPLATE = "/usr/share/ipa/client/ssh_ipa.conf.template"
+    SSH_IPA_CONFIG = "/etc/ssh/ssh_config.d/04-ipa.conf"
     SSHD_CONFIG = "/etc/ssh/sshd_config"
     SSHD_IPA_CONFIG = "/etc/ssh/sshd_config.d/04-ipa.conf"
     SSHD_IPA_CONFIG_TEMPLATE = "/usr/share/ipa/client/sshd_ipa.conf.template"

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -141,7 +141,7 @@ jobs:
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-latest/test_kerberos_flags:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -137,7 +137,7 @@ jobs:
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-latest/test_kerberos_flags:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -63,7 +63,7 @@ jobs:
         test_suite: test_integration/test_commands.py
         template: *389ds-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   389ds-fedora/test_server_del:
     requires: [389ds-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -144,7 +144,7 @@ jobs:
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-latest/test_kerberos_flags:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -144,7 +144,7 @@ jobs:
         test_suite: test_integration/test_commands.py
         template: *testing-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   testing-fedora/test_kerberos_flags:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -151,7 +151,7 @@ jobs:
         test_suite: test_integration/test_commands.py
         template: *testing-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   testing-fedora/test_kerberos_flags:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -137,7 +137,7 @@ jobs:
         test_suite: test_integration/test_commands.py
         template: *ci-master-previous
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-previous/test_kerberos_flags:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -144,7 +144,7 @@ jobs:
         test_suite: test_integration/test_commands.py
         template: *ci-master-frawhide
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-rawhide/test_kerberos_flags:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
Create IPA ssh client configuration and move ProxyCommand

The ProxyCommand is non-executable if the user does not have
a valid shell (like /sbin/nologin) so skip it in that case.

https://pagure.io/freeipa/issue/7676

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
