### PR TITLE
[ipa-4-8] ipatests: Update PRCI Fedora 32 templates

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-latest
           name: freeipa/ci-ipa-4-8-f32
-          version: 0.0.9
+          version: 0.0.11
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-latest
           name: freeipa/ci-ipa-4-8-f32
-          version: 0.0.9
+          version: 0.0.11
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest_selinux.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-latest
           name: freeipa/ci-ipa-4-8-f32
-          version: 0.0.9
+          version: 0.0.11
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,7 +57,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-latest
           name: freeipa/ci-ipa-4-8-f32
-          version: 0.0.9
+          version: 0.0.11
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Updating templates with upgraded packages installed.

This is required by https://github.com/freeipa/freeipa/pull/5231

Signed-off-by: Armando Neto <abiagion@redhat.com>