### PR TITLE
ipatests: temporarily remove test_dnssec.py::TestInstallDNSSECFirst f…

### DIFF
--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -26,11 +26,12 @@ vms:
     - test_integration/test_membermanager.py
 
 - vm_jobs:
-  - container_job: InstallDNSSECFirst
-    containers:
-      replicas: 1
-    tests:
-    - test_integration/test_dnssec.py::TestInstallDNSSECFirst
+  # Temporarily disabled because of https://pagure.io/freeipa/issue/8496
+  # - container_job: InstallDNSSECFirst
+  #     containers:
+  #       replicas: 1
+  #     tests:
+  #     - test_integration/test_dnssec.py::TestInstallDNSSECFirst
 
   - container_job: simple_replication
     containers:

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -239,17 +239,17 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest/test_dnssec_TestInstallDNSSECFirst:
-    requires: [fedora-latest/build]
-    priority: 100
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
-        template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl
+#  fedora-latest/test_dnssec_TestInstallDNSSECFirst:
+#    requires: [fedora-latest/build]
+#    priority: 100
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-latest/build_url}'
+#        test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
+#        template: *ci-master-latest
+#        timeout: 3600
+#        topology: *master_1repl
 
   fedora-latest/test_membermanager:
     requires: [fedora-latest/build]


### PR DESCRIPTION
…rom gating

The test test_dnssec.py::TestInstallDNSSECFirst is failing due to known
issue https://pagure.io/freeipa/issue/8496
currently under investigation by 389ds team.

In the meantime, remove the test from gating to avoid blocking the PRs.

Related: https://pagure.io/freeipa/issue/8496