### PR TITLE
WebUI: Test if links are opened in new tab correctly

### DIFF
--- a/ipatests/test_webui/test_navigation.py
+++ b/ipatests/test_webui/test_navigation.py
@@ -171,6 +171,36 @@ class test_navigation(UI_driver):
             self.assert_menu_item('ipaserver/trusts', False)
         self.navigate_by_menu('ipaserver/config', False)
 
+    def test_new_tab_navigation(self):
+        """
+        Test for PF#7137: [RFE]: Able to browse different links
+        from IPA web gui in new tabs
+
+        Test verifies whether opening target link in new tab
+        navigates to target (desired behaviour) compared to creation of copy of
+        current state of page on new tab (old behaviour).
+
+        Related: https://pagure.io/freeipa/issue/7137
+        """
+        self.init_app()
+        crubs = {
+            'identity/host': 'host',
+            'identity/user_search': 'user',
+            'identity/group_search': 'group',
+            'policy': 'hbacrule',
+            'policy/pwpolicy': 'pwpolicy',
+            'authentication': 'cert',
+            'network_services': 'automountlocation',
+            'ipaserver': 'role'
+        }
+        for crub, active_facet in crubs.items():
+            self.navigate_by_menu(crub, False)
+            initial_url = self.driver.current_url
+            rows = self.get_rows()
+            if len(rows) > 0:
+                self.navigate_to_row_record_in_new_tab(rows[-1])
+                assert self.driver.current_url != initial_url
+                assert self.get_facet_info()['entity'] == active_facet
 
     def assert_e_url(self, url, e):
         """

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -24,11 +24,10 @@ Contains browser driver and common tasks.
 """
 from __future__ import print_function, absolute_import
 
-from datetime import datetime
-import time
-import re
 import os
-
+import re
+import time
+from datetime import datetime
 from functools import wraps
 from urllib.error import URLError
 
@@ -1161,6 +1160,26 @@ class UI_driver:
         link = self.find(s, By.CSS_SELECTOR, row, strict=True)
         link.click()
         self.wait_for_request(0.4)
+        self.wait_for_request()
+
+    def navigate_to_row_record_in_new_tab(self, row, pkey_column=None):
+        """
+        Navigate to record in a new tab by CTRL + SHIFT clicking on the link
+        which brings target focused in a new tab.
+        """
+        selector = 'a'
+        if pkey_column:
+            selector = "div[name='%s'] a" % pkey_column
+        link = self.find(selector, By.CSS_SELECTOR, row, strict=True)
+        action_driver = ActionChains(self.driver)
+        action_driver\
+            .key_down(Keys.CONTROL)\
+            .key_down(Keys.SHIFT)\
+            .click(link)\
+            .key_up(Keys.CONTROL)\
+            .key_up(Keys.SHIFT)\
+            .perform()
+
         self.wait_for_request()
 
     def get_table_selector(self, name=None):


### PR DESCRIPTION
    WebUI: Test if links are opened in new tab correctly
    
    Test for PF#7137: [RFE]: Able to browse different links
    from IPA web gui in new tabs
    
    Test verifies whether opening target link in new tab
    navigates to target (desired behaviour) compared to creation of copy of
    current state of page on new tab (old behaviour).
    
    WebUI: Add method for opening link in a new tab
    
    Add `navigate_to_row_record_in_new_tab`  method.
    `navigate_to_row_record_in_new_tab` works as
    `navigate_to_row_record` but opens link in new tab instead and focuses
    on it.
    
    Related: https://pagure.io/freeipa/issue/7137
    Signed-off-by: Michal Polovka <mpolovka@redhat.com>
