### PR TITLE
ipatests: call the CALess install method to generate the CA

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -308,5 +308,5 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_acme.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl_1client

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f32
-          version: 0.0.13
+          version: 0.0.16
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f32
-          version: 0.0.13
+          version: 0.0.16
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f32
-          version: 0.0.13
+          version: 0.0.16
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,7 +57,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f32
-          version: 0.0.13
+          version: 0.0.16
         timeout: 1800
         topology: *build
 

--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -197,6 +197,19 @@ class TestACME(CALessBase):
 
     @pytest.mark.skipif(skip_certbot_tests, reason='certbot not available')
     def test_certbot_register(self):
+        # clean up any existing registration and certificates
+        self.clients[0].run_command(
+            [
+                'rm', '-rf',
+                '/etc/letsencrypt/accounts',
+                '/etc/letsencrypt/archive',
+                '/etc/letsencrypt/csr',
+                '/etc/letsencrypt/keys',
+                '/etc/letsencrypt/live',
+                '/etc/letsencrypt/renewal',
+                '/etc/letsencrypt/renewal-hooks'
+            ]
+        )
         # service is enabled; registration should succeed
         self.clients[0].run_command(
             [

--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -109,6 +109,10 @@ class TestACME(CALessBase):
         # install packages before client install in case of IPA DNS problems
         cls.prepare_acme_client()
 
+        # Each subclass handles its own server installation procedure
+        if cls.__name__ != 'TestACME':
+            return
+
         tasks.install_master(cls.master, setup_dns=True)
 
         tasks.install_client(cls.master, cls.clients[0])
@@ -510,8 +514,7 @@ class TestACMEwithExternalCA(TestACME):
 
     @classmethod
     def install(cls, mh):
-
-        cls.prepare_acme_client()
+        super(TestACMEwithExternalCA, cls).install(mh)
 
         # install master with external-ca
         result = install_server_external_ca_step1(cls.master)

--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -291,11 +291,13 @@ class TestACME(CALessBase):
     def test_mod_md(self):
         # write config
         self.clients[0].run_command(['mkdir', '-p', '/etc/httpd/conf.d'])
+        self.clients[0].run_command(['mkdir', '-p', '/etc/httpd/md'])
         self.clients[0].put_file_contents(
             '/etc/httpd/conf.d/md.conf',
             '\n'.join([
                 f'MDCertificateAuthority {self.acme_server}',
                 'MDCertificateAgreement accepted',
+                'MDStoreDir  /etc/httpd/md',
                 f'MDomain {self.clients[0].hostname}',
                 '<VirtualHost *:443>',
                 f'    ServerName {self.clients[0].hostname}',
@@ -324,6 +326,10 @@ class TestACME(CALessBase):
         # HTTPS request from server to client (should succeed)
         self.master.run_command(
             ['curl', f'https://{self.clients[0].hostname}'])
+
+        # clean-up
+        self.clients[0].run_command(['rm', '-rf', '/etc/httpd/md'])
+        self.clients[0].run_command(['rm', '-f', '/etc/httpd/conf.d/md.conf'])
 
     ######################
     # Disable ACME service

--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -104,6 +104,7 @@ class TestACME(CALessBase):
 
     @classmethod
     def install(cls, mh):
+        super(TestACME, cls).install(mh)
 
         # install packages before client install in case of IPA DNS problems
         cls.prepare_acme_client()

--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -486,7 +486,7 @@ class TestACMECALess(IntegrationTest):
 class TestACMEwithExternalCA(TestACME):
     """Test the FreeIPA ACME service with external CA"""
 
-    num_replicas = 0
+    num_replicas = 1
     num_clients = 1
 
     @classmethod
@@ -509,4 +509,8 @@ class TestACMEwithExternalCA(TestACME):
         tasks.install_client(cls.master, cls.clients[0])
         tasks.config_host_resolvconf_with_master_data(
             cls.master, cls.clients[0]
+        )
+        tasks.install_replica(cls.master, cls.replicas[0])
+        tasks.config_host_resolvconf_with_master_data(
+            cls.master, cls.replicas[0]
         )


### PR DESCRIPTION
ipatests: call the CALess install method to generate the CA

https://pagure.io/freeipa/issue/8581

Signed-off-by: Rob Crittenden <rcritten@redhat.com>