### PR TITLE
[Backport][ipa-4-8] ipatests: temporarily remove test_dnssec.py::TestInstallDNSSECFirst from gating

### DIFF
--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -26,11 +26,12 @@ vms:
     - test_integration/test_membermanager.py
 
 - vm_jobs:
-  - container_job: InstallDNSSECFirst
-    containers:
-      replicas: 1
-    tests:
-    - test_integration/test_dnssec.py::TestInstallDNSSECFirst
+  # Temporarily disabled because of https://pagure.io/freeipa/issue/8496
+  # - container_job: InstallDNSSECFirst
+  #     containers:
+  #       replicas: 1
+  #     tests:
+  #     - test_integration/test_dnssec.py::TestInstallDNSSECFirst
 
   - container_job: simple_replication
     containers:

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -239,17 +239,17 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest-ipa-4-8/test_dnssec_TestInstallDNSSECFirst:
-    requires: [fedora-latest-ipa-4-8/build]
-    priority: 100
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-latest-ipa-4-8/build_url}'
-        test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
-        template: *ci-ipa-4-8-latest
-        timeout: 3600
-        topology: *master_1repl
+#  fedora-latest-ipa-4-8/test_dnssec_TestInstallDNSSECFirst:
+#    requires: [fedora-latest-ipa-4-8/build]
+#    priority: 100
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-latest-ipa-4-8/build_url}'
+#        test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
+#        template: *ci-ipa-4-8-latest
+#        timeout: 3600
+#        topology: *master_1repl
 
   fedora-latest-ipa-4-8/test_membermanager:
     requires: [fedora-latest-ipa-4-8/build]


### PR DESCRIPTION
This is a manual backport of PR #5263 to ipa-4-8 branch.