### PR TITLE
Merge fixes from rawhide experiments

### DIFF
--- a/daemons/ipa-kdb/Makefile.am
+++ b/daemons/ipa-kdb/Makefile.am
@@ -92,6 +92,7 @@ ipa_kdb_tests_SOURCES += ipa_kdb_kdcpolicy.c
 endif
 
 ipa_kdb_tests_CFLAGS = $(CMOCKA_CFLAGS)
+ipa_kdb_tests_LDFLAGS = -L$(libdir)/samba -Wl,-rpath=$(libdir)/samba
 ipa_kdb_tests_LDADD =          \
        $(CMOCKA_LIBS)          \
        $(KRB5_LIBS)            \
@@ -102,6 +103,7 @@ ipa_kdb_tests_LDADD =          \
        $(top_builddir)/util/libutil.la	\
        -lkdb5                  \
        -lsss_idmap             \
+       -lsamba-security-samba4 \
        $(NULL)
 
 appdir = $(libexecdir)/ipa

--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -2352,7 +2352,7 @@ done:
 
 static char *get_server_netbios_name(struct ipadb_context *ipactx)
 {
-    char hostname[IPA_HOST_FQDN_LEN]; /* NOTE: long enough for DNS name */
+    char hostname[IPA_HOST_FQDN_LEN + 1]; /* NOTE: long enough for DNS name */
     char *p;
 
     strncpy(hostname, ipactx->kdc_hostname, IPA_HOST_FQDN_LEN);

--- a/daemons/ipa-kdb/tests/ipa_kdb_tests.c
+++ b/daemons/ipa-kdb/tests/ipa_kdb_tests.c
@@ -72,7 +72,7 @@ struct test_ctx {
 #define DOM_SID_TRUST "S-1-5-21-4-5-6"
 #define BLOCKLIST_SID "S-1-5-1"
 #define NUM_SUFFIXES 10
-#define SUFFIX_TEMPLATE "d%0d" DOMAIN_NAME
+#define SUFFIX_TEMPLATE "d%zu" DOMAIN_NAME
 #define TEST_REALM_TEMPLATE "some." SUFFIX_TEMPLATE
 #define EXTERNAL_REALM "WRONG.DOMAIN"
 
@@ -136,7 +136,8 @@ static int setup(void **state)
     ipa_ctx->mspac->trusts[0].upn_suffixes = calloc(NUM_SUFFIXES + 1, sizeof(char *));
     ipa_ctx->mspac->trusts[0].upn_suffixes_len = calloc(NUM_SUFFIXES, sizeof(size_t));
     for (size_t i = 0; i < NUM_SUFFIXES; i++) {
-	asprintf(&(ipa_ctx->mspac->trusts[0].upn_suffixes[i]), SUFFIX_TEMPLATE, i);
+	assert_int_not_equal(asprintf(&(ipa_ctx->mspac->trusts[0].upn_suffixes[i]),
+                                      SUFFIX_TEMPLATE, i), -1);
         ipa_ctx->mspac->trusts[0].upn_suffixes_len[i] =
             strlen(ipa_ctx->mspac->trusts[0].upn_suffixes[i]);
 
@@ -504,7 +505,7 @@ void test_check_trusted_realms(void **state)
 
     for(size_t i = 0; i < NUM_SUFFIXES; i++) {
         char *test_realm = NULL;
-        asprintf(&test_realm, TEST_REALM_TEMPLATE, i);
+        assert_int_not_equal(asprintf(&test_realm, TEST_REALM_TEMPLATE, i), -1);
 
         if (test_realm) {
             kerr = ipadb_is_princ_from_trusted_realm(

--- a/daemons/ipa-otpd/main.c
+++ b/daemons/ipa-otpd/main.c
@@ -214,7 +214,7 @@ static krb5_error_code setup_ldap(const char *uri, krb5_boolean bind,
 int main(int argc, char **argv)
 {
     const char *hostname;
-    char fqdn[IPA_HOST_FQDN_LEN];
+    char fqdn[IPA_HOST_FQDN_LEN + 1];
     krb5_error_code retval;
     krb5_data hndata;
     verto_ev *sig;

--- a/daemons/ipa-sam/ipa_sam.c
+++ b/daemons/ipa-sam/ipa_sam.c
@@ -4441,7 +4441,7 @@ static char *sec_key(TALLOC_CTX *mem_ctx, const char *d)
 
 static NTSTATUS save_sid_to_secret(struct ipasam_private *ipasam_state)
 {
-	char hostname[IPA_HOST_FQDN_LEN];
+	char hostname[IPA_HOST_FQDN_LEN + 1];
 	const char *fqdn;
 	char *p;
 	TALLOC_CTX *tmp_ctx;
@@ -4475,7 +4475,7 @@ static NTSTATUS save_sid_to_secret(struct ipasam_private *ipasam_state)
 	}
 	/* Copy is necessary, otherwise we this will corrupt the static
 	 * buffer returned by ipa_gethostfqdn(). */
-	strncpy(hostname, fqdn, sizeof(hostname));
+	strncpy(hostname, fqdn, IPA_HOST_FQDN_LEN);
 	p = strchr(hostname, '.');
 	if (p != NULL) {
 		*p = '\0';

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -143,7 +143,7 @@
 # https://bugzilla.redhat.com/show_bug.cgi?id=1345975#c20
 %global sssd_version 1.16.3-2
 
-%define krb5_base_version %(LC_ALL=C rpm -q --qf '%%{VERSION}' krb5-devel | grep -Eo '^[^.]+\.[^.]+')
+%define krb5_base_version %(LC_ALL=C pkgconf --modversion krb5 | grep -Eo '^[^.]+\.[^.]+' || echo %krb5_version)
 
 %if 0%{?fedora} >= 33
 # systemd with resolved enabled
@@ -185,6 +185,7 @@ BuildRequires:  openldap-devel
 # DAL version change may cause code crash or memory leaks, it is better to fail early.
 BuildRequires:  krb5-kdb-version = %{krb5_kdb_version}
 BuildRequires:  krb5-devel >= %{krb5_version}
+BuildRequires:  pkgconfig(krb5)
 %if 0%{?with_ipa_join_xml}
 # 1.27.4: xmlrpc_curl_xportparms.gssapi_delegation
 BuildRequires:  xmlrpc-c-devel >= 1.27.4
@@ -195,7 +196,7 @@ BuildRequires:  jansson-devel
 BuildRequires:  popt-devel
 BuildRequires:  gcc
 BuildRequires:  make
-BuildRequires:  pkgconfig
+BuildRequires:  pkgconf
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -365,7 +365,7 @@ Requires: 389-ds-base >= %{ds_version}
 Requires: openldap-clients > 2.4.35-4
 Requires: nss-tools >= %{nss_version}
 Requires(post): krb5-server >= %{krb5_version}
-Requires(post): krb5-server >= %{krb5_base_version}, krb5-server < %{krb5_base_version}.100
+Requires(post): krb5-server >= %{krb5_base_version}
 Requires: krb5-pkinit-openssl >= %{krb5_version}
 Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: chrony

--- a/ipaserver/install/ipa_acme_manage.py
+++ b/ipaserver/install/ipa_acme_manage.py
@@ -25,13 +25,15 @@ from ipaserver.plugins.dogtag import RestClient
 
 class acme_state(RestClient):
 
-    def _request(self, url):
+    def _request(self, url, headers=None):
+        headers = headers or {}
         return dogtag.https_request(
             self.ca_host, 8443,
             url=url,
             cafile=self.ca_cert,
             client_certfile=paths.RA_AGENT_PEM,
             client_keyfile=paths.RA_AGENT_KEY,
+            headers=headers,
             method='POST'
         )
 
@@ -48,20 +50,21 @@ class acme_state(RestClient):
     def __exit__(self, exc_type, exc_value, traceback):
         """Log out of the REST API"""
         headers = dict(Cookie=self.cookie)
-        status, unused, _unused = self._request('/acme/logout')
+        status, unused, _unused = self._request('/acme/logout', headers=headers)
         object.__setattr__(self, 'cookie', None)
         if status != 204:
             raise RuntimeError('Failed to logout')
 
     def enable(self):
         headers = dict(Cookie=self.cookie)
-        status, unused, _unused = self._request('/acme/enable')
+        status, unused, _unused = self._request('/acme/enable', headers=headers)
         if status != 200:
             raise RuntimeError('Failed to enable ACME')
 
     def disable(self):
         headers = dict(Cookie=self.cookie)
-        status, unused, _unused = self._request('/acme/disable')
+        status, unused, _unused = self._request('/acme/disable',
+                                                headers=headers)
         if status != 200:
             raise RuntimeError('Failed to disble ACME')
 

--- a/ipatests/azure/Dockerfiles/seccomp.json
+++ b/ipatests/azure/Dockerfiles/seccomp.json
@@ -90,6 +90,7 @@
 				"exit",
 				"exit_group",
 				"faccessat",
+				"faccessat2",
 				"fadvise64",
 				"fadvise64_64",
 				"fallocate",

--- a/ipatests/azure/scripts/setup_containers.py
+++ b/ipatests/azure/scripts/setup_containers.py
@@ -195,7 +195,7 @@ class Container:
         """
         Set services known to not work in containers to be ignored
         """
-        for service in ['nis-domainname',]:
+        for service in ['nis-domainname', 'chronyd']:
             self.ignore_service_in_container(service)
 
         self.execute_all(args=["systemctl", "daemon-reload"])

--- a/ipatests/azure/templates/test-jobs.yml
+++ b/ipatests/azure/templates/test-jobs.yml
@@ -12,7 +12,11 @@ steps:
         moreutils \
         rng-tools \
         systemd-coredump \
-        python3-docker
+        python3-docker \
+        software-properties-common
+    sudo add-apt-repository -y ppa:abbra/freeipa-libseccomp
+    sudo apt-get update
+    sudo apt-get install -y libseccomp2
     # ubuntu's one is too old: different API
     python3 -m pip install docker --user
   displayName: Install Host's tests requirements

--- a/ipatests/azure/templates/variables-common.yml
+++ b/ipatests/azure/templates/variables-common.yml
@@ -6,7 +6,7 @@ variables:
   # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1604-REA    DME.md
   # Ubuntu-18.04 - 3.6.9
   # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-REA    DME.md
-  VM_IMAGE: 'Ubuntu-18.04'
+  VM_IMAGE: 'ubuntu-20.04'
   MAX_CONTAINER_ENVS: 5
   IPA_TESTS_ENV_WORKING_DIR: $(Build.Repository.LocalPath)/ipa_envs
   IPA_TESTS_SCRIPTS: 'ipatests/azure/scripts'


### PR DESCRIPTION
- 11f8ec48c spec: use pkgconf to find out krb5 version
- eecf4dbb3 Drop upper bound on krb5 version in freeipa.spec
- aaf0232f0 Azure CI: use PPA to provide newer libseccomp version
- dde3528ee Azure CI: use Ubuntu-20.04 image by default
- 70175f61b ipa-acme-manage: user a cookie created for the communication with dogtag REST endpoints
- ed3258563 ipa-otpd: fix gcc complaints in Rawhide
- 95bd6402e ipa-sam: fix gcc complaints on Rawhide
- 300961a13 ipa-kdb: fix gcc complaints in kdb tests
- bb2369329 ipa-kdb: fix gcc complaints
