### PR TITLE
[ipa-4-8] ipatests: Fix the test name for krbtpolicy

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1534,7 +1534,7 @@ jobs:
         timeout: 1800
         topology: *master_1repl
 
-  fedora-latest/krbtpolicy:
+  fedora-latest-ipa-4-8/krbtpolicy:
     requires: [fedora-latest-ipa-4-8/build]
     priority: 50
     job:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest_selinux.yaml
@@ -1655,7 +1655,7 @@ jobs:
         timeout: 1800
         topology: *master_1repl
 
-  fedora-latest/krbtpolicy:
+  fedora-latest-ipa-4-8/krbtpolicy:
     requires: [fedora-latest-ipa-4-8/build]
     priority: 50
     job:


### PR DESCRIPTION
To have consistent naming, rename
fedora-latest/krbtpolicy
into
fedora-latest-ipa-4-8/krbtpolicy