### PR TITLE
ipa-kdb: handle dates up to 2106-02-07 06:28:16

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_audit_as.c
+++ b/daemons/ipa-kdb/ipa_kdb_audit_as.c
@@ -103,13 +103,15 @@ void ipadb_audit_as_req(krb5_context kcontext,
         }
         if (ied->pol->lockout_duration != 0 &&
             ied->pol->failcnt_interval != 0 &&
-            client->last_failed + ied->pol->failcnt_interval < authtime) {
+            !krb5_ts_after(krb5_ts_incr(client->last_failed,
+                    ied->pol->failcnt_interval), authtime)) {
             /* Reset fail_auth_count, the interval's expired already */
             client->fail_auth_count = 0;
             client->mask |= KMASK_FAIL_AUTH_COUNT;
         }
 
-        if (client->last_failed + ied->pol->lockout_duration > authtime &&
+        if (krb5_ts_after(krb5_ts_incr(client->last_failed,
+                        ied->pol->lockout_duration), authtime) &&
             (client->fail_auth_count >= ied->pol->max_fail && 
              ied->pol->max_fail != 0)) {
             /* client already locked, nothing more to do */

--- a/daemons/ipa-kdb/ipa_kdb_common.c
+++ b/daemons/ipa-kdb/ipa_kdb_common.c
@@ -524,25 +524,11 @@ int ipadb_ldap_attr_to_krb5_timestamp(LDAP *lcontext, LDAPMessage *le,
                                       char *attrname, krb5_timestamp *result)
 {
     time_t res_time;
-    long long res_long;
 
     int ret = ipadb_ldap_attr_to_time_t(lcontext, le,
                                         attrname, &res_time);
     if (ret) return ret;
-
-    /* this will cast correctly maintaing sign to a 64bit variable */
-    res_long = res_time;
-
-    /* For dates beyond IPAPWD_END_OF_TIME, rest_time might oveflow
-     * on 32-bit platforms. This does not apply for 64-bit platforms.
-     * However, since krb5 uses 32-bit time representation, we need
-     * to limit the result.*/
-
-    if (res_long < 0 || res_long > IPAPWD_END_OF_TIME)  {
-        *result = IPAPWD_END_OF_TIME; // 1 Jan 2038, 00:00 GMT
-    } else {
-        *result = (krb5_timestamp)res_long;
-    }
+    *result = (krb5_timestamp)res_time;
 
     return 0;
 }

--- a/daemons/ipa-kdb/ipa_kdb_passwords.c
+++ b/daemons/ipa-kdb/ipa_kdb_passwords.c
@@ -279,21 +279,18 @@ krb5_error_code ipadb_get_pwd_expiration(krb5_context context,
     if (truexp) {
         if (ied->pol) {
             if (ied->pol->max_pwd_life) {
-                *expire_time = mod_time + ied->pol->max_pwd_life;
+                *expire_time = krb5_ts2tt(krb5_ts_incr(
+                            mod_time, ied->pol->max_pwd_life));
             } else {
                 *expire_time = 0;
             }
         } else {
-            *expire_time = mod_time + IPAPWD_DEFAULT_PWDLIFE;
+            *expire_time = krb5_ts2tt(krb5_ts_incr(
+                        mod_time, IPAPWD_DEFAULT_PWDLIFE));
         }
     } else {
         /* not 'self', so reset */
-        *expire_time = mod_time;
-    }
-
-    /* in the case of integer owerflow, set expiration to IPAPWD_END_OF_TIME */
-    if ((*expire_time) < 0 || (*expire_time) > IPAPWD_END_OF_TIME) {
-        *expire_time = IPAPWD_END_OF_TIME; // 1 Jan 2038, 00:00 GMT
+        *expire_time = krb5_ts2tt(mod_time);
     }
 
     kerr = 0;

--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -906,7 +906,7 @@ static krb5_error_code ipadb_parse_ldap_entry(krb5_context kcontext,
             goto done;
         }
 
-        ied->last_pwd_change = restime;
+        ied->last_pwd_change = krb5_ts2tt(restime);
     }
 
     ret = ipadb_ldap_attr_to_krb5_timestamp(lcontext, lentry,
@@ -922,7 +922,7 @@ static krb5_error_code ipadb_parse_ldap_entry(krb5_context kcontext,
             goto done;
         }
 
-        ied->last_admin_unlock = restime;
+        ied->last_admin_unlock = krb5_ts2tt(restime);
     }
 
     ret = ipadb_ldap_attr_to_strlist(lcontext, lentry,
@@ -1790,7 +1790,7 @@ static krb5_error_code ipadb_get_ldap_mod_time(struct ipadb_mods *imods,
     time_t timeval;
     char v[20];
 
-    timeval = (time_t)value;
+    timeval = krb5_ts2tt(value);
     t = gmtime_r(&timeval, &date);
     if (t == NULL) {
         return EINVAL;

--- a/daemons/ipa-kdb/ipa_kdb_pwdpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_pwdpolicy.c
@@ -367,7 +367,8 @@ krb5_error_code ipadb_check_policy_as(krb5_context kcontext,
     }
 
     if (ied->pol->lockout_duration == 0 ||
-        client->last_failed + ied->pol->lockout_duration > kdc_time) {
+        krb5_ts_after(krb5_ts_incr(
+                client->last_failed, ied->pol->lockout_duration), kdc_time)) {
         /* ok client permanently locked, or within lockout period */
         *status = "LOCKED_OUT";
         return KRB5KDC_ERR_CLIENT_REVOKED;

--- a/util/ipa_pwd.h
+++ b/util/ipa_pwd.h
@@ -30,9 +30,6 @@
 #define IPAPWD_DEFAULT_PWDLIFE (90 * 24 *3600)
 #define IPAPWD_DEFAULT_MINLEN 0
 
-/* 1 Jan 2038, 00:00 GMT */
-#define IPAPWD_END_OF_TIME 2145916800
-
 /*
  * IMPORTANT: please update error string table in ipa_pwd.c if you change this
  * error code table.


### PR DESCRIPTION
krb5 uses the negative part of `krb5_timestamp` to store time values after 2038
https://k5wiki.kerberos.org/wiki/Projects/Timestamps_after_2038
In other words, krb5 uses `krb5_timestamp` (signed int) with unsigned arithmetic for expanding the timestamp's upper bound.

This commit:
- adds some helper functions for working with `krb5_timestamp` as unsigned (actually copied from the link above)
- replaces operations with `krb5_timestamp`'s by these new functions
- sets `IPAPWD_END_OF_TIME` to `4291747200L` (1 Jan 2106, 00:00 GMT)