### PR TITLE
Improve PKI subsystem detection

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -177,8 +177,14 @@ class DogtagInstance(service.Service):
 
         Returns True/False
         """
-        return os.path.exists(os.path.join(
-            paths.VAR_LIB_PKI_TOMCAT_DIR, self.subsystem.lower()))
+        try:
+            result = ipautil.run(
+                ['pki-server', 'subsystem-show', self.subsystem.lower()],
+                capture_output=True)
+            # parse the command output
+            return 'Enabled: True' in result.output
+        except ipautil.CalledProcessError:
+            return False
 
     def spawn_instance(self, cfg_file, nolog_list=()):
         """

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2439,6 +2439,18 @@ def get_sssd_version(host):
     return parse_version(version)
 
 
+def get_pki_version(host):
+    """Get pki version on remote host."""
+    data = host.get_file_contents("/usr/share/pki/VERSION", encoding="utf-8")
+
+    groups = re.match(r'.*\nSpecification-Version: ([\d+\.]*)\n.*', data)
+    if groups:
+        version_string = groups.groups(0)[0]
+        return parse_version(version_string)
+    else:
+        raise ValueError("get_pki_version: pki is not installed")
+
+
 def get_healthcheck_version(host):
     """
     Function to get healthcheck version on fedora and rhel


### PR DESCRIPTION
### Improve PKI subsystem detection

The dogtaginstance.is_installed() method currently relies on
the presence of the directory /var/lib/pki/pki-tomcat/{ca|kra},
even if it is empty.
An unwanted consequence is ipa-server-upgrade wrongly assuming the KRA
is installed and crashing when trying to upgrade a not-installed
component.

The fix relies on the command "pki-server subsystem-show {ca|kra}" to
detect if a subsystem is installed. The command does not require PKI
to be running (hence can be called anytime) and is delivered by
the pki-server package which is already required by ipa server pkg.

Fixes: https://pagure.io/freeipa/issue/8596

### ipatests: add test for PKI subsystem detection

Add a new upgrade test. Scenario:
- create an empty /var/lib/pki/pki-tomcat/kra directory
- call ipa-server-upgrade

With issue 8596, the upgrade fails because it assumes KRA is
installed. With the fix, ipa-server-upgrade completes successfully.

Related: https://pagure.io/freeipa/issue/8596