### PR TITLE
ipa-client-install manpage: add ipa.p11-kit to list of files created

### DIFF
--- a/client/man/ipa-client-install.1
+++ b/client/man/ipa-client-install.1
@@ -263,6 +263,8 @@ Files always created (replacing existing content):
 /etc/ipa/nssdb
 .br
 /etc/openldap/ldap.conf
+.br
+/etc/pki/ca-trust/source/ipa.p11-kit
 .TP
 Files updated, existing content is maintained:
 


### PR DESCRIPTION
Add missing ipa.p11-kit file to list of files created in ipa-client-install manpage.

https://pagure.io/freeipa/issue/8424

Signed-off-by: Antonio Torres Moríñigo <atorresm@protonmail.com>