### PR TITLE
[Backport][ipa-4-8] ipa-client-install manpage: add ipa.p11-kit to list of files created

### DIFF
--- a/client/man/ipa-client-install.1
+++ b/client/man/ipa-client-install.1
@@ -263,6 +263,8 @@ Files always created (replacing existing content):
 /etc/ipa/nssdb
 .br
 /etc/openldap/ldap.conf
+.br
+/etc/pki/ca-trust/source/ipa.p11-kit
 .TP
 Files updated, existing content is maintained:
 


### PR DESCRIPTION
This PR was opened automatically because PR #5297 was pushed to master and backport to ipa-4-8 is required.