### PR TITLE
Allow leading/trailing whitespaces in passwords

### DIFF
--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -1646,6 +1646,11 @@ class Password(Str):
     A parameter for passwords (stored in the ``unicode`` type).
     """
 
+    kwargs = Data.kwargs + (
+        ('pattern', (str,), None),
+        ('noextrawhitespace', bool, False),
+    )
+
     password = True
 
     def _convert_scalar(self, value, index=None):

--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -27,7 +27,7 @@ import six
 from ipalib import api, errors, util
 from ipalib import messages
 from ipalib import Str, StrEnum, Flag
-from ipalib.parameters import Principal, Certificate
+from ipalib.parameters import Data, Principal, Certificate
 from ipalib.plugable import Registry
 from .baseldap import (LDAPQuery, LDAPObject, LDAPCreate,
                                      LDAPDelete, LDAPUpdate, LDAPSearch,
@@ -260,6 +260,12 @@ class HostPassword(Str):
     setting a password on the command-line which would break
     backwards compatibility.
     """
+
+    kwargs = Data.kwargs + (
+        ('pattern', (str,), None),
+        ('noextrawhitespace', bool, False),
+    )
+
     def safe_value(self, value):
         return u'********'
 

--- a/ipatests/test_ipalib/test_parameters.py
+++ b/ipatests/test_ipalib/test_parameters.py
@@ -346,6 +346,12 @@ class test_Param(ClassChecker):
             assert_equal(p.safe_value(value), u'********')
         assert p.safe_value(None) is None
 
+    def test_password_whitespaces(self):
+        values = ('Secret123', ' Secret123', 'Secret123 ', ' Secret123 ',)
+        p = parameters.Password('my_passwd')
+        for value in values:
+            assert(p.validate(value)) is None
+
     def test_clone(self):
         """
         Test the `ipalib.parameters.Param.clone` method.


### PR DESCRIPTION
Since PR #4709 was stale and closed, this PR fixes the issue taking into account comments from that PR.

kwargs is redefined to Data.kwargs, which doesn't contain the restriction of no leading/trailing whitespaces from the Str class.

Fixes: https://pagure.io/freeipa/issue/7599

Signed-off-by: Antonio Torres Moríñigo <atorresm@protonmail.com>