### PR TITLE
[Backport][ipa-4-9] Always define the path DNSSEC_OPENSSL_CONF

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -70,7 +70,7 @@ class BasePathNamespace:
     IPA_DEFAULT_CONF = "/etc/ipa/default.conf"
     IPA_DNSKEYSYNCD_KEYTAB = "/etc/ipa/dnssec/ipa-dnskeysyncd.keytab"
     IPA_ODS_EXPORTER_KEYTAB = "/etc/ipa/dnssec/ipa-ods-exporter.keytab"
-    DNSSEC_OPENSSL_CONF = None
+    DNSSEC_OPENSSL_CONF = "/etc/ipa/dnssec/openssl.cnf"
     DNSSEC_SOFTHSM2_CONF = "/etc/ipa/dnssec/softhsm2.conf"
     DNSSEC_SOFTHSM_PIN_SO = "/etc/ipa/dnssec/softhsm_pin_so"
     IPA_NSSDB_DIR = "/etc/ipa/nssdb"

--- a/ipaplatform/fedora/paths.py
+++ b/ipaplatform/fedora/paths.py
@@ -36,7 +36,6 @@ class FedoraPathNamespace(RedHatPathNamespace):
     NAMED_CRYPTO_POLICY_FILE = "/etc/crypto-policies/back-ends/bind.config"
     if HAS_NFS_CONF:
         SYSCONFIG_NFS = '/etc/nfs.conf'
-    DNSSEC_OPENSSL_CONF = "/etc/ipa/dnssec/openssl.cnf"
     DNSSEC_KEYFROMLABEL = "/usr/sbin/dnssec-keyfromlabel"
 
 

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -626,7 +626,7 @@ class Backup(admintool.AdminTool):
     def file_backup(self, options):
 
         def verify_directories(dirs):
-            return [s for s in dirs if os.path.exists(s)]
+            return [s for s in dirs if s and os.path.exists(s)]
 
         self.tarfile = os.path.join(self.dir, 'files.tar')
 


### PR DESCRIPTION
This PR was opened automatically because PR #5292 was pushed to master and backport to ipa-4-9 is required.