### PR TITLE
Add IPA RA Agent to ACME group on the CA

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -14,7 +14,6 @@ from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_caless import CALessBase, ipa_certs_cleanup
 from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
-from ipaserver.install import cainstance
 from ipatests.test_integration.test_external_ca import (
     install_server_external_ca_step1,
     install_server_external_ca_step2,
@@ -61,8 +60,6 @@ def server_install_teardown(func):
     return wrapped
 
 
-@pytest.mark.skipif(not cainstance.minimum_acme_support(),
-                    reason="does not provide ACME")
 class TestACME(CALessBase):
     """
     Test the FreeIPA ACME service by using ACME clients on a FreeIPA client.
@@ -402,8 +399,6 @@ class TestACME(CALessBase):
         assert "invalid 'certificate'" in result.stderr_text
 
 
-@pytest.mark.skipif(not cainstance.minimum_acme_support(),
-                    reason="does not provide ACME")
 class TestACMECALess(IntegrationTest):
     """Test to check the CA less replica setup"""
     num_replicas = 1


### PR DESCRIPTION
Add IPA RA Agent to ACME group on the CA

Move the addition of the RA agent to the ACME Enterprise Users
group into setup_acme() so it is also added on upgrades.

This allows ipa-acme-manage to authenticate to the CA REST
API using the RA Agent credentials.

https://pagure.io/freeipa/issue/8603

Signed-off-by: Rob Crittenden <rcritten@redhat.com>