### PR TITLE
ipatests: Enable httpd_can_network_connect for mod_md test

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -50,6 +50,23 @@ def check_acme_status(host, exp_status, timeout=60):
     return status
 
 
+def get_selinux_status(host):
+    """
+    Return the SELinux enforcing status.
+
+    Return True if enabled and enforcing, otherwise False
+    """
+    result = host.run_command(['/usr/sbin/selinuxenabled'], raiseonerr=False)
+    if result.returncode != 0:
+        return False
+
+    result = host.run_command(['/usr/sbin/getenforce'], raiseonerr=False)
+    if 'Enforcing' in result.stdout_text:
+        return True
+
+    return False
+
+
 def server_install_teardown(func):
     def wrapped(*args):
         master = args[0].master
@@ -290,6 +307,10 @@ class TestACME(CALessBase):
 
     @pytest.mark.skipif(skip_mod_md_tests, reason='mod_md not available')
     def test_mod_md(self):
+        if get_selinux_status(self.clients[0]):
+            # mod_md requires its own SELinux policy to grant perms to
+            # maintaining ACME registration and cert state.
+            raise pytest.skip("SELinux is enabled, this will fail")
         # write config
         self.clients[0].run_command(['mkdir', '-p', '/etc/httpd/conf.d'])
         self.clients[0].run_command(['mkdir', '-p', '/etc/httpd/md'])


### PR DESCRIPTION
This is required because the test runs a local Apache instance.

https://pagure.io/freeipa/issue/8514

Signed-off-by: Rob Crittenden <rcritten@redhat.com>