### PR TITLE
Generate a unique cache for each connection

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1314,6 +1314,7 @@ fi
 %{_libexecdir}/certmonger/dogtag-ipa-ca-renew-agent-submit
 %{_libexecdir}/certmonger/ipa-server-guard
 %dir %{_libexecdir}/ipa
+%{_libexecdir}/ipa/ipa-ccache-sweeper
 %{_libexecdir}/ipa/ipa-custodia
 %{_libexecdir}/ipa/ipa-custodia-check
 %{_libexecdir}/ipa/ipa-httpd-kdcproxy
@@ -1338,6 +1339,8 @@ fi
 %attr(644,root,root) %{_unitdir}/ipa.service
 %attr(644,root,root) %{_unitdir}/ipa-otpd.socket
 %attr(644,root,root) %{_unitdir}/ipa-otpd@.service
+%attr(644,root,root) %{_unitdir}/ipa-ccache-sweep.service
+%attr(644,root,root) %{_unitdir}/ipa-ccache-sweep.timer
 # END
 %attr(755,root,root) %{plugin_dir}/libipa_pwd_extop.so
 %attr(755,root,root) %{plugin_dir}/libipa_enrollment_extop.so

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1067,6 +1067,11 @@ if [  $? -eq 0 ]; then
     if [  $? -eq 0 ]; then
         /bin/systemctl restart ipa.service >/dev/null
     fi
+
+    /bin/systemctl is-enabled ipa-ccache-sweep.timer >/dev/null 2>&1
+    if [  $? -eq 1 ]; then
+        /bin/systemctl enable ipa-ccache-sweep.timer>/dev/null
+    fi
 fi
 # END
 

--- a/init/systemd/Makefile.am
+++ b/init/systemd/Makefile.am
@@ -7,11 +7,15 @@ NULL =
 dist_noinst_DATA = 			\
 	ipa-custodia.service.in		\
 	ipa.service.in			\
+	ipa-ccache-sweep.service.in	\
+	ipa-ccache-sweep.timer.in	\
 	$(NULL)
 
 systemdsystemunit_DATA = 	\
 	ipa-custodia.service	\
 	ipa.service				\
+	ipa-ccache-sweep.service	\
+	ipa-ccache-sweep.timer	\
 	$(NULL)
 
 CLEANFILES = $(systemdsystemunit_DATA)

--- a/init/systemd/ipa-ccache-sweep.service.in
+++ b/init/systemd/ipa-ccache-sweep.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=IPA Kerberos Ccache Sweeper Service
+Wants=gssproxy.service
+
+[Service]
+Type=simple
+ExecStart=@libexecdir@/ipa/ipa-ccache-sweeper
+PrivateTmp=yes
+User=ipaapi
+
+[Install]
+WantedBy=multi-user.target

--- a/init/systemd/ipa-ccache-sweep.timer.in
+++ b/init/systemd/ipa-ccache-sweep.timer.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Remove Expired Kerberos Credential Caches
+
+[Timer]
+OnUnitActiveSec=12h
+
+[Install]
+WantedBy=timers.target

--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 31 - DO NOT REMOVE THIS LINE
+# VERSION 32 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -76,6 +76,7 @@ WSGIScriptReloading Off
   GssapiImpersonate On
   GssapiDelegCcacheDir $IPA_CCACHES
   GssapiDelegCcachePerms mode:0660 gid:ipaapi
+  GssapiDelegCcacheUnique On
   GssapiUseS4U2Proxy on
   GssapiAllowedMech krb5
   Require valid-user
@@ -117,6 +118,7 @@ Alias /ipa/session/cookie "/usr/share/ipa/gssapi.login"
   AuthType none
   GssapiDelegCcacheDir $IPA_CCACHES
   GssapiDelegCcachePerms mode:0660 gid:ipaapi
+  GssapiDelegCcacheUnique On
   SSLVerifyClient require
   SSLUserName SSL_CLIENT_CERT
   LookupUserByCertificate On

--- a/install/tools/Makefile.am
+++ b/install/tools/Makefile.am
@@ -6,6 +6,7 @@ SUBDIRS = 			\
 
 dist_noinst_DATA =		\
 	ipa-ca-install.in		\
+	ipa-ccache-sweeper.in	\
 	ipa-dns-install.in		\
 	ipa-kra-install.in		\
 	ipa-server-install.in	\
@@ -70,6 +71,7 @@ nodist_sbin_SCRIPTS =		\
 
 appdir = $(libexecdir)/ipa/
 nodist_app_SCRIPTS =		\
+	ipa-ccache-sweeper	\
 	ipa-custodia		\
 	ipa-custodia-check	\
 	ipa-httpd-kdcproxy	\

--- a/install/tools/ipa-ccache-sweeper.in
+++ b/install/tools/ipa-ccache-sweeper.in
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+# Based heavily on
+# https://github.com/gssapi/mod_auth_gssapi/blob/master/contrib/sweeper.py
+
+# Copyright (C) 2016 mod_auth_gssapi contributors - See COPYING for (C) terms
+
+# If one uses both sessions and unique ccache names, then the filesystem will
+# become littered with ccache files unless the accessed application cleans
+# them up itself.  This script will minimize ccache file proliferation by
+# removing any ccaches that have expired from the filesystem, and serves as an
+# example of how this cleaning can be performed.
+
+import argparse
+import os
+import stat
+import sys
+import time
+
+from gssapi.raw import acquire_cred_from
+from ipaplatform.paths import paths
+
+
+# process file as a ccache and indicate whether it is expired
+def should_delete(fname, t, minlife):
+    try:
+        # skip directories and other non-files
+        st = os.stat(fname)
+        if not stat.S_ISREG(st.st_mode):
+            return False
+
+        # ignore files that are newer than minlife minutes
+        if t - st.st_mtime < minlife * 60:
+            return False
+
+        creds = acquire_cred_from({b"ccache": fname.encode("UTF-8")})
+    except FileNotFoundError:
+        # someone else did the work for us
+        return False
+    except Exception as e:
+        print("Not deleting %s due to error %s" % (fname, e))
+        return False
+
+    return creds.lifetime == 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Sweep expired ccaches")
+    parser.add_argument("-m", dest="minlife", type=int,
+                        help="ignore newer files than this (default: 30)",
+                        default=30)
+    args = parser.parse_args()
+
+    os.environ["GSS_USE_PROXY"] = "yes"
+    os.environ["GSSPROXY_BEHAVIOR"] = "REMOTE_FIRST"
+
+    print("Running sweeper...")
+
+    t = time.time()
+
+    os.chdir(paths.IPA_CCACHES)
+    for fname in os.listdir(paths.IPA_CCACHES):
+        if should_delete(fname, t, args.minlife):
+            os.unlink(fname)
+
+    print("Sweeper finished successfully!")
+    sys.exit(0)

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1543,7 +1543,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_krbtpolicy.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl
 
   fedora-latest/test_winsyncmigrate:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1665,7 +1665,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_krbtpolicy.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl
 
   fedora-latest/test_winsyncmigrate:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1665,7 +1665,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_krbtpolicy.py
         template: *testing-master-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl
 
   testing-fedora/test_winsyncmigrate:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1787,7 +1787,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_krbtpolicy.py
         template: *testing-master-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl
 
   testing-fedora/test_winsyncmigrate:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1543,7 +1543,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_krbtpolicy.py
         template: *ci-master-previous
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl
 
   fedora-previous/test_winsyncmigrate:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1665,7 +1665,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_krbtpolicy.py
         template: *ci-master-frawhide
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl
 
   fedora-rawhide/test_winsyncmigrate:


### PR DESCRIPTION
Generate a unique cache for each connection

Rather than having a shared ccache per user, configure
mod_auth_gssapi to create a unique one. This requires cleanup
to remove expired caches. A new script is added,
ipa-ccache-sweeper to do this. It will be invoked by a
new service, ipa-ccache-sweep, which will be executed every
12 hours by an equally-named timer.

https://pagure.io/freeipa/issue/8589