### PR TITLE
[Backport][ipa-4-8] Change KRA profiles in certmonger tracking so they can renew

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -108,9 +108,9 @@
 # Fedora
 %endif
 
-# PKIConnection has been modified to always validate certs.
-# https://pagure.io/freeipa/issue/8379
-%global pki_version 10.9.0-0.4
+# New KRA profile, ACME support
+# https://pagure.io/freeipa/issue/8545
+%global pki_version 10.10.0-2
 
 # https://pagure.io/certmonger/issue/90
 %global certmonger_version 0.79.7-1

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -66,9 +66,9 @@ class KRAInstance(DogtagInstance):
     # use for that certificate.  'configure_renewal()' reads this
     # dict.  The profile MUST be specified.
     tracking_reqs = {
-        'auditSigningCert cert-pki-kra': 'caInternalAuthAuditSigningCert',
-        'transportCert cert-pki-kra': 'caInternalAuthTransportCert',
-        'storageCert cert-pki-kra': 'caInternalAuthDRMstorageCert',
+        'auditSigningCert cert-pki-kra': 'caAuditSigningCert',
+        'transportCert cert-pki-kra': 'caTransportCert',
+        'storageCert cert-pki-kra': 'caStorageCert',
     }
 
     def __init__(self, realm):


### PR DESCRIPTION
This PR was opened automatically because PR #5199 was pushed to master and backport to ipa-4-8 is required.