### PR TITLE
[Backport][ipa-4-6] Change KRA profiles in certmonger tracking so they can renew

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -211,9 +211,9 @@ def request_cert(reuse_existing, **kwargs):
              "--certfile", paths.RA_AGENT_PEM,
              "--keyfile", paths.RA_AGENT_KEY] +
             sys.argv[1:] +
-            ['--submit-option', "requestor_name=IPA"])
-    if os.environ.get('CERTMONGER_CA_PROFILE') == 'caCACert':
-        args += ['--force-new', '--approval-option', 'bypassCAnotafter=true']
+            ['--submit-option', "requestor_name=IPA"] +
+            ['--force-new', '--approval-option', 'bypassCAnotafter=true']
+    )
     result = ipautil.run(args, raiseonerr=False, env=os.environ,
                          capture_output=True)
     if six.PY2:

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -213,7 +213,7 @@ def request_cert(reuse_existing, **kwargs):
             sys.argv[1:] +
             ['--submit-option', "requestor_name=IPA"])
     if os.environ.get('CERTMONGER_CA_PROFILE') == 'caCACert':
-        args += ['-N', '-O', 'bypassCAnotafter=true']
+        args += ['--force-new', '--approval-option', 'bypassCAnotafter=true']
     result = ipautil.run(args, raiseonerr=False, env=os.environ,
                          capture_output=True)
     if six.PY2:

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -99,6 +99,7 @@ class BasePathNamespace(object):
     PKI_TOMCAT = "/etc/pki/pki-tomcat"
     PKI_TOMCAT_ALIAS_DIR = "/etc/pki/pki-tomcat/alias"
     PKI_TOMCAT_PASSWORD_CONF = "/etc/pki/pki-tomcat/password.conf"
+    PKI_TOMCAT_ALIAS_PWDFILE_TXT = "/etc/pki/pki-tomcat/alias/pwdfile.txt"
     PKI_TOMCAT_SERVER_XML = "/etc/pki/pki-tomcat/server.xml"
     ETC_REDHAT_RELEASE = "/etc/redhat-release"
     RESOLV_CONF = "/etc/resolv.conf"

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -296,10 +296,12 @@ class CAInstance(DogtagInstance):
        2 = have signed cert, continue installation
     """
 
-    tracking_reqs = ('auditSigningCert cert-pki-ca',
-                     'ocspSigningCert cert-pki-ca',
-                     'subsystemCert cert-pki-ca',
-                     'caSigningCert cert-pki-ca')
+    tracking_reqs = {
+        'auditSigningCert cert-pki-ca': 'caSignedLogCert',
+        'ocspSigningCert cert-pki-ca': 'caOCSPCert',
+        'subsystemCert cert-pki-ca': 'caSubsystemCert',
+        'caSigningCert cert-pki-ca': 'caCACert',
+    }
     server_cert_name = 'Server-Cert cert-pki-ca'
     # The following must be aligned with the RewriteRule defined in
     # install/share/ipa-pki-proxy.conf.template

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -296,6 +296,9 @@ class CAInstance(DogtagInstance):
        2 = have signed cert, continue installation
     """
 
+    # Mapping of nicknames for tracking requests, and the profile to
+    # use for that certificate.  'configure_renewal()' reads this
+    # dict.  The profile MUST be specified.
     tracking_reqs = {
         'auditSigningCert cert-pki-ca': 'caSignedLogCert',
         'ocspSigningCert cert-pki-ca': 'caOCSPCert',

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -946,7 +946,7 @@ class CAInstance(DogtagInstance):
                 principal='host/%s' % self.fqdn,
                 subject=str(DN(('CN', 'IPA RA'), self.subject_base)),
                 ca=ipalib.constants.RENEWAL_CA_NAME,
-                profile='caServerCert',
+                profile=ipalib.constants.RA_AGENT_PROFILE,
                 pre_command='renew_ra_cert_pre',
                 post_command='renew_ra_cert',
                 storage="FILE",
@@ -1119,7 +1119,7 @@ class CAInstance(DogtagInstance):
         try:
             certmonger.start_tracking(
                 certpath=(paths.RA_AGENT_PEM, paths.RA_AGENT_KEY),
-                ca='dogtag-ipa-ca-renew-agent',
+                ca=ipalib.constants.RENEWAL_CA_NAME,
                 profile=ipalib.constants.RA_AGENT_PROFILE,
                 pre_command='renew_ra_cert_pre',
                 post_command='renew_ra_cert',

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1120,6 +1120,7 @@ class CAInstance(DogtagInstance):
             certmonger.start_tracking(
                 certpath=(paths.RA_AGENT_PEM, paths.RA_AGENT_KEY),
                 ca='dogtag-ipa-ca-renew-agent',
+                profile=ipalib.constants.RA_AGENT_PROFILE,
                 pre_command='renew_ra_cert_pre',
                 post_command='renew_ra_cert',
                 storage='FILE')

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -296,6 +296,8 @@ class CAInstance(DogtagInstance):
        2 = have signed cert, continue installation
     """
 
+    server_cert_name = 'Server-Cert cert-pki-ca'
+
     # Mapping of nicknames for tracking requests, and the profile to
     # use for that certificate.  'configure_renewal()' reads this
     # dict.  The profile MUST be specified.
@@ -304,8 +306,12 @@ class CAInstance(DogtagInstance):
         'ocspSigningCert cert-pki-ca': 'caOCSPCert',
         'subsystemCert cert-pki-ca': 'caSubsystemCert',
         'caSigningCert cert-pki-ca': 'caCACert',
+        server_cert_name: 'caServerCert',
     }
-    server_cert_name = 'Server-Cert cert-pki-ca'
+    token_names = {
+        server_cert_name: 'internal',  # Server-Cert always on internal token
+    }
+
     # The following must be aligned with the RewriteRule defined in
     # install/share/ipa-pki-proxy.conf.template
     crl_rewrite_pattern = r"^\s*(RewriteRule\s+\^/ipa/crl/MasterCRL.bin\s.*)$"
@@ -465,7 +471,6 @@ class CAInstance(DogtagInstance):
                         "Ensuring backward compatibility",
                         self.__dogtag10_migration)
                 self.step("configure certificate renewals", self.configure_renewal)
-                self.step("configure Server-Cert certificate renewal", self.track_servercert)
                 self.step("Configure HTTP to proxy connections",
                           self.http_proxy)
                 # This restart is needed for ACL reload in CA, do not remove it

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -327,14 +327,16 @@ class CertDB(object):
         except ipautil.CalledProcessError:
             return None
 
-    def track_server_cert(self, nickname, principal, password_file=None, command=None):
+    def track_server_cert(
+            self, nickname, principal,
+            password_file=None, command=None, profile=None):
         """
         Tell certmonger to track the given certificate nickname.
         """
         try:
             request_id = certmonger.start_tracking(
                 self.secdir, nickname=nickname, pinfile=password_file,
-                post_command=command)
+                post_command=command, profile=profile)
         except RuntimeError as e:
             logger.error("certmonger failed starting to track certificate: %s",
                          str(e))

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -396,7 +396,7 @@ class DogtagInstance(service.Service):
             try:
                 certmonger.start_tracking(
                     certpath=self.nss_db,
-                    ca='dogtag-ipa-ca-renew-agent',
+                    ca=RENEWAL_CA_NAME,
                     nickname=nickname,
                     pin=pin,
                     pre_command='stop_pkicad',

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -93,7 +93,12 @@ class DogtagInstance(service.Service):
     CA, KRA, and eventually TKS and TPS.
     """
 
-    tracking_reqs = None
+    # Mapping of nicknames for tracking requests, and the profile to use for
+    # that certificate.  'configure_renewal()' reads this dict and adds the
+    # profile if configured.  Certificates that use the default profile
+    # ("caServerCert", as defined by dogtag-ipa-renew-agent which is part of
+    # Certmonger) are omitted.
+    tracking_reqs = dict()
     server_cert_name = None
 
     ipaca_groups = DN(('ou', 'groups'), ('o', 'ipaca'))
@@ -384,6 +389,7 @@ class DogtagInstance(service.Service):
                     pin=pin,
                     pre_command='stop_pkicad',
                     post_command='renew_ca_cert "%s"' % nickname,
+                    profile=self.tracking_reqs[nickname],
                 )
             except RuntimeError as e:
                 logger.error(

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -98,7 +98,7 @@ class DogtagInstance(service.Service):
 
     # Mapping of nicknames for tracking requests, and the profile to
     # use for that certificate.  'configure_renewal()' reads this
-    # dict and adds the profile if configured.
+    # dict.  The profile MUST be specified.
     tracking_reqs = dict()
 
     # token for CA and subsystem certificates. For now, only internal token

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -1148,9 +1148,12 @@ class DsInstance(service.Service):
         dirname = config_dirname(serverid)[:-1]
         dsdb = certs.CertDB(self.realm, nssdir=dirname)
         if dsdb.is_ipa_issued_cert(api, nickname):
-            dsdb.track_server_cert(nickname, self.principal,
-                                   dsdb.passwd_fname,
-                                   'restart_dirsrv %s' % serverid)
+            dsdb.track_server_cert(
+                nickname,
+                self.principal,
+                password_file=dsdb.passwd_fname,
+                command='restart_dirsrv %s' % serverid,
+                profile=dogtag.DEFAULT_PROFILE)
         else:
             logger.debug("Will not track DS server certificate %s as it is "
                          "not issued by IPA", nickname)

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -628,7 +628,8 @@ class HTTPInstance(service.Service):
         nickname = self.get_mod_nss_nickname()
         if db.is_ipa_issued_cert(api, nickname):
             db.track_server_cert(nickname, self.principal,
-                                 db.passwd_fname, 'restart_httpd')
+                                 db.passwd_fname, 'restart_httpd',
+                                 profile=dogtag.DEFAULT_PROFILE)
         else:
             logger.debug("Will not track HTTP server cert %s as it is not "
                          "issued by IPA", nickname)

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -71,9 +71,9 @@ class KRAInstance(DogtagInstance):
     # use for that certificate.  'configure_renewal()' reads this
     # dict.  The profile MUST be specified.
     tracking_reqs = {
-        'auditSigningCert cert-pki-kra': 'caInternalAuthAuditSigningCert',
-        'transportCert cert-pki-kra': 'caInternalAuthTransportCert',
-        'storageCert cert-pki-kra': 'caInternalAuthDRMstorageCert',
+        'auditSigningCert cert-pki-kra': 'caAuditSigningCert',
+        'transportCert cert-pki-kra': 'caTransportCert',
+        'storageCert cert-pki-kra': 'caStorageCert',
     }
 
     def __init__(self, realm):

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -67,9 +67,11 @@ class KRAInstance(DogtagInstance):
     be the same for both the CA and KRA.
     """
 
-    tracking_reqs = ('auditSigningCert cert-pki-kra',
-                     'transportCert cert-pki-kra',
-                     'storageCert cert-pki-kra')
+    tracking_reqs = {
+        'auditSigningCert cert-pki-kra': 'caInternalAuthAuditSigningCert',
+        'transportCert cert-pki-kra': 'caInternalAuthTransportCert',
+        'storageCert cert-pki-kra': 'caInternalAuthDRMstorageCert',
+    }
 
     def __init__(self, realm):
         super(KRAInstance, self).__init__(

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -67,6 +67,9 @@ class KRAInstance(DogtagInstance):
     be the same for both the CA and KRA.
     """
 
+    # Mapping of nicknames for tracking requests, and the profile to
+    # use for that certificate.  'configure_renewal()' reads this
+    # dict.  The profile MUST be specified.
     tracking_reqs = {
         'auditSigningCert cert-pki-kra': 'caInternalAuthAuditSigningCert',
         'transportCert cert-pki-kra': 'caInternalAuthTransportCert',

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -959,11 +959,7 @@ def certificate_renewal_update(ca, ds, http):
 
     requests = []
 
-    dogtag_system_nicks = (
-        list(cainstance.CAInstance.tracking_reqs) +
-        [cainstance.CAInstance.server_cert_name]
-    )
-    for nick in dogtag_system_nicks:
+    for nick in cainstance.CAInstance.tracking_reqs:
         req = {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
             'cert-nickname': nick,
@@ -1059,7 +1055,6 @@ def certificate_renewal_update(ca, ds, http):
 
     ca.configure_renewal()
     ca.configure_agent_renewal()
-    ca.track_servercert()
     ca.add_lightweight_ca_tracking_requests()
     ds.start_tracking_certificates(serverid)
     http.start_tracking_certificates()

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -5,6 +5,7 @@
 from __future__ import print_function, absolute_import
 
 import errno
+import itertools
 import logging
 import re
 import os
@@ -946,7 +947,34 @@ def named_add_server_id():
     return True
 
 
-def certificate_renewal_update(ca, ds, http):
+def named_add_crypto_policy():
+    """Add crypto policy include
+    """
+    if not bindinstance.named_conf_exists():
+        logger.info('DNS is not configured')
+        return False
+
+    if sysupgrade.get_upgrade_state('named.conf', 'add_crypto_policy'):
+        # upgrade was done already
+        return False
+    policy_file = paths.NAMED_CRYPTO_POLICY_FILE
+    if policy_file is None:
+        # no crypto policy
+        return False
+
+    if bindinstance.named_conf_include_exists(policy_file):
+        sysupgrade.set_upgrade_state('named.conf', 'add_crypto_policy', True)
+        return False
+
+    logger.info('[Adding crypto policy include to named.conf]')
+    bindinstance.named_conf_set_directive(
+        'include', policy_file, section=bindinstance.NAMED_SECTION_OPTIONS
+    )
+    sysupgrade.set_upgrade_state('named.conf', 'add_crypto_policy', True)
+    return True
+
+
+def certificate_renewal_update(ca, kra, ds, http):
     """
     Update certmonger certificate renewal configuration.
     """
@@ -959,7 +987,11 @@ def certificate_renewal_update(ca, ds, http):
 
     requests = []
 
-    for nick, profile in cainstance.CAInstance.tracking_reqs.items():
+    dogtag_reqs = ca.tracking_reqs.items()
+    if kra.is_installed():
+        dogtag_reqs = itertools.chain(dogtag_reqs, kra.tracking_reqs.items())
+
+    for nick, profile in dogtag_reqs:
         req = {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
             'cert-nickname': nick,
@@ -1042,6 +1074,8 @@ def certificate_renewal_update(ca, ds, http):
     # Ok, now we need to stop tracking, then we can start tracking them
     # again with new configuration:
     ca.stop_tracking_certificates()
+    if kra.is_installed():
+        kra.stop_tracking_certificates()
     ds.stop_tracking_certificates(serverid)
     http.stop_tracking_certificates()
 
@@ -1054,6 +1088,8 @@ def certificate_renewal_update(ca, ds, http):
     ca.configure_renewal()
     ca.configure_agent_renewal()
     ca.add_lightweight_ca_tracking_requests()
+    if kra.is_installed():
+        kra.configure_renewal()
     ds.start_tracking_certificates(serverid)
     http.start_tracking_certificates()
 
@@ -2022,7 +2058,7 @@ def upgrade_configuration():
         ca_restart,
         ca_upgrade_schema(ca),
         upgrade_ca_audit_cert_validity(ca),
-        certificate_renewal_update(ca, ds, http),
+        certificate_renewal_update(ca, kra, ds, http),
         ca_enable_pkix(ca),
         ca_configure_profiles_acl(ca),
         ca_configure_lightweight_ca_acls(ca),

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -957,48 +957,27 @@ def certificate_renewal_update(ca, ds, http):
     template = paths.CERTMONGER_COMMAND_TEMPLATE
     serverid = installutils.realm_to_serverid(api.env.realm)
 
-    requests = [
-        {
+    requests = []
+
+    dogtag_system_nicks = (
+        list(cainstance.CAInstance.tracking_reqs) +
+        [cainstance.CAInstance.server_cert_name]
+    )
+    for nick in dogtag_system_nicks:
+        req = {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
-            'cert-nickname': 'auditSigningCert cert-pki-ca',
+            'cert-nickname': nick,
             'ca-name': 'dogtag-ipa-ca-renew-agent',
             'cert-presave-command': template % 'stop_pkicad',
             'cert-postsave-command':
-                (template % 'renew_ca_cert "auditSigningCert cert-pki-ca"'),
-        },
-        {
-            'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
-            'cert-nickname': 'ocspSigningCert cert-pki-ca',
-            'ca-name': 'dogtag-ipa-ca-renew-agent',
-            'cert-presave-command': template % 'stop_pkicad',
-            'cert-postsave-command':
-                (template % 'renew_ca_cert "ocspSigningCert cert-pki-ca"'),
-        },
-        {
-            'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
-            'cert-nickname': 'subsystemCert cert-pki-ca',
-            'ca-name': 'dogtag-ipa-ca-renew-agent',
-            'cert-presave-command': template % 'stop_pkicad',
-            'cert-postsave-command':
-                (template % 'renew_ca_cert "subsystemCert cert-pki-ca"'),
-        },
-        {
-            'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
-            'cert-nickname': 'caSigningCert cert-pki-ca',
-            'ca-name': 'dogtag-ipa-ca-renew-agent',
-            'cert-presave-command': template % 'stop_pkicad',
-            'cert-postsave-command':
-                (template % 'renew_ca_cert "caSigningCert cert-pki-ca"'),
-            'template-profile': None,
-        },
-        {
-            'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
-            'cert-nickname': 'Server-Cert cert-pki-ca',
-            'ca-name': 'dogtag-ipa-ca-renew-agent',
-            'cert-presave-command': template % 'stop_pkicad',
-            'cert-postsave-command':
-                (template % 'renew_ca_cert "Server-Cert cert-pki-ca"'),
-        },
+                (template % 'renew_ca_cert "{}"'.format(nick)),
+        }
+        profile = cainstance.CAInstance.tracking_reqs.get(nick)
+        if profile:
+            req['template-profile'] = profile
+        requests.append(req)
+
+    requests.append(
         {
             'cert-file': paths.RA_AGENT_PEM,
             'key-file': paths.RA_AGENT_KEY,
@@ -1006,7 +985,7 @@ def certificate_renewal_update(ca, ds, http):
             'cert-presave-command': template % 'renew_ra_cert_pre',
             'cert-postsave-command': template % 'renew_ra_cert',
         },
-    ]
+    )
 
     logger.info("[Update certmonger certificate renewal configuration]")
     if not ca.is_configured():

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -20,7 +20,7 @@ from contextlib import contextmanager
 from augeas import Augeas
 import dns.exception
 
-from ipalib import api, x509
+from ipalib import api
 from ipalib.constants import RENEWAL_CA_NAME, RA_AGENT_PROFILE
 from ipalib.install import certmonger, sysrestore
 import SSSDConfig
@@ -946,33 +946,6 @@ def named_add_server_id():
     logger.info('[Adding server_id to named.conf]')
     bindinstance.named_conf_set_directive('server_id', api.env.host)
     sysupgrade.set_upgrade_state('named.conf', 'add_server_id', True)
-    return True
-
-
-def named_add_crypto_policy():
-    """Add crypto policy include
-    """
-    if not bindinstance.named_conf_exists():
-        logger.info('DNS is not configured')
-        return False
-
-    if sysupgrade.get_upgrade_state('named.conf', 'add_crypto_policy'):
-        # upgrade was done already
-        return False
-    policy_file = paths.NAMED_CRYPTO_POLICY_FILE
-    if policy_file is None:
-        # no crypto policy
-        return False
-
-    if bindinstance.named_conf_include_exists(policy_file):
-        sysupgrade.set_upgrade_state('named.conf', 'add_crypto_policy', True)
-        return False
-
-    logger.info('[Adding crypto policy include to named.conf]')
-    bindinstance.named_conf_set_directive(
-        'include', policy_file, section=bindinstance.NAMED_SECTION_OPTIONS
-    )
-    sysupgrade.set_upgrade_state('named.conf', 'add_crypto_policy', True)
     return True
 
 

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -959,7 +959,7 @@ def certificate_renewal_update(ca, ds, http):
 
     requests = []
 
-    for nick in cainstance.CAInstance.tracking_reqs:
+    for nick, profile in cainstance.CAInstance.tracking_reqs.items():
         req = {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
             'cert-nickname': nick,
@@ -967,10 +967,8 @@ def certificate_renewal_update(ca, ds, http):
             'cert-presave-command': template % 'stop_pkicad',
             'cert-postsave-command':
                 (template % 'renew_ca_cert "{}"'.format(nick)),
+            'template-profile': profile,
         }
-        profile = cainstance.CAInstance.tracking_reqs.get(nick)
-        if profile:
-            req['template-profile'] = profile
         requests.append(req)
 
     requests.append(

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -19,7 +19,9 @@ import tempfile
 from contextlib import contextmanager
 from augeas import Augeas
 import dns.exception
-from ipalib import api
+
+from ipalib import api, x509
+from ipalib.constants import RA_AGENT_PROFILE
 from ipalib.install import certmonger, sysrestore
 import SSSDConfig
 import ipalib.util
@@ -1008,6 +1010,7 @@ def certificate_renewal_update(ca, kra, ds, http):
             'cert-file': paths.RA_AGENT_PEM,
             'key-file': paths.RA_AGENT_KEY,
             'ca-name': 'dogtag-ipa-ca-renew-agent',
+            'template-profile': RA_AGENT_PROFILE,
             'cert-presave-command': template % 'renew_ra_cert_pre',
             'cert-postsave-command': template % 'renew_ra_cert',
         },

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -21,7 +21,7 @@ from augeas import Augeas
 import dns.exception
 
 from ipalib import api, x509
-from ipalib.constants import RA_AGENT_PROFILE
+from ipalib.constants import RENEWAL_CA_NAME, RA_AGENT_PROFILE
 from ipalib.install import certmonger, sysrestore
 import SSSDConfig
 import ipalib.util
@@ -997,7 +997,7 @@ def certificate_renewal_update(ca, kra, ds, http):
         req = {
             'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
             'cert-nickname': nick,
-            'ca-name': 'dogtag-ipa-ca-renew-agent',
+            'ca-name': RENEWAL_CA_NAME,
             'cert-presave-command': template % 'stop_pkicad',
             'cert-postsave-command':
                 (template % 'renew_ca_cert "{}"'.format(nick)),
@@ -1009,7 +1009,7 @@ def certificate_renewal_update(ca, kra, ds, http):
         {
             'cert-file': paths.RA_AGENT_PEM,
             'key-file': paths.RA_AGENT_KEY,
-            'ca-name': 'dogtag-ipa-ca-renew-agent',
+            'ca-name': RENEWAL_CA_NAME,
             'template-profile': RA_AGENT_PROFILE,
             'cert-presave-command': template % 'renew_ra_cert_pre',
             'cert-postsave-command': template % 'renew_ra_cert',
@@ -1056,7 +1056,7 @@ def certificate_renewal_update(ca, kra, ds, http):
                 {
                     'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
                     'cert-nickname': nickname,
-                    'ca-name': 'dogtag-ipa-ca-renew-agent',
+                    'ca-name': RENEWAL_CA_NAME,
                     'cert-presave-command': template % 'stop_pkicad',
                     'cert-postsave-command':
                         (template % ('renew_ca_cert "%s"' % nickname)),

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1062,14 +1062,27 @@ def certificate_renewal_update(ca, kra, ds, http):
             )
 
     # State not set, lets see if we are already configured
+    missing_or_misconfigured_requests = []
     for request in requests:
         request_id = certmonger.get_request_id(request)
         if request_id is None:
-            break
-    else:
+            missing_or_misconfigured_requests.append(request)
+
+    if len(missing_or_misconfigured_requests) == 0:
         logger.info("Certmonger certificate renewal configuration already "
                     "up-to-date")
         return False
+
+    # Print info about missing requests
+    logger.info("Missing or incorrect tracking request for certificates:")
+    for request in missing_or_misconfigured_requests:
+        cert = None
+        if 'cert-file' in request:
+            cert = request['cert-file']
+        elif 'cert-database' in request and 'cert-nickname' in request:
+            cert = '{cert-database}:{cert-nickname}'.format(**request)
+        if cert is not None:
+            logger.info("  %s", cert)
 
     # Ok, now we need to stop tracking, then we can start tracking them
     # again with new configuration:

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -1299,6 +1299,10 @@ class TestIPACommands(CALessBase):
         with self.host():
             self.master.run_command(['ipa', 'host-del', self.test_hostname])
 
+    def test_invoke_upgrader(self):
+        """Test that ipa-server-upgrade runs without error."""
+        self.master.run_command(['ipa-server-upgrade'], raiseonerr=True)
+
 
 class TestCertInstall(CALessBase):
     @classmethod

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -23,6 +23,7 @@ from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_caless import CALessBase, ipa_certs_cleanup
 from ipaplatform import services
+from ipaserver.install import krainstance
 
 
 config = get_global_config()
@@ -681,6 +682,38 @@ class TestInstallMasterKRA(IntegrationTest):
 
     def test_install_dns(self):
         tasks.install_dns(self.master)
+
+    def test_kra_certs_renewal(self):
+        """
+        Test that the KRA subsystem certificates renew properly
+        """
+        kra = krainstance.KRAInstance(self.master.domain.realm)
+        for nickname in kra.tracking_reqs:
+            cert = tasks.certutil_fetch_cert(
+                self.master,
+                paths.PKI_TOMCAT_ALIAS_DIR,
+                paths.PKI_TOMCAT_ALIAS_PWDFILE_TXT,
+                nickname
+            )
+            starting_serial = int(cert.serial_number)
+            cmd_arg = [
+                'ipa-getcert', 'resubmit', '-v', '-w',
+                '-d', paths.PKI_TOMCAT_ALIAS_DIR,
+                '-n', nickname,
+            ]
+            result = self.master.run_command(cmd_arg)
+            request_id = re.findall(r'\d+', result.stdout_text)
+
+            status = tasks.wait_for_request(self.master, request_id[0], 120)
+            assert status == "MONITORING"
+
+            cert = tasks.certutil_fetch_cert(
+                self.master,
+                paths.PKI_TOMCAT_ALIAS_DIR,
+                paths.PKI_TOMCAT_ALIAS_PWDFILE_TXT,
+                nickname
+            )
+            assert starting_serial != int(cert.serial_number)
 
 
 class TestInstallMasterDNS(IntegrationTest):

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -14,6 +14,13 @@ from ipatests.pytest_ipa.integration import tasks
 
 
 class TestUpgrade(IntegrationTest):
+    """
+    Test ipa-server-upgrade.
+
+    Note that ipa-server-upgrade on a CA-less installation is tested
+    in ``test_caless.TestIPACommands.test_invoke_upgrader``.
+
+    """
     @classmethod
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=False)


### PR DESCRIPTION
This PR was opened manually because PR #5199 was pushed to master and backport to ipa-4-6 is required.

This also required backporting fixes from ticket https://pagure.io/freeipa/issue/7991

I'm not sure this is going to pass as I don't believe the required profile is available in downstream and a backport seems unlikely given the Fedora release is EOL.