### PR TITLE
Move where the restore state is marked during IPA server upgrade

### DIFF
--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -199,11 +199,11 @@ class IPAUpgrade(service.Service):
         shutil.copy2(ldif_outfile, self.filename)
 
     def __restore_config(self):
-        port = self.restore_state('nsslapd-port')
-        security = self.restore_state('nsslapd-security')
-        global_lock = self.restore_state('nsslapd-global-backend-lock')
-        schema_compat_enabled = self.restore_state('schema_compat_enabled')
-        self.restore_state('upgrade-in-progress')
+        # peek the values during the restoration
+        port = self.get_state('nsslapd-port')
+        security = self.get_state('nsslapd-security')
+        global_lock = self.get_state('nsslapd-global-backend-lock')
+        schema_compat_enabled = self.get_state('schema_compat_enabled')
 
         ldif_outfile = "%s.modified.out" % self.filename
         with open(ldif_outfile, "w") as out_file:
@@ -230,6 +230,15 @@ class IPAUpgrade(service.Service):
                 parser.parse()
 
         shutil.copy2(ldif_outfile, self.filename)
+
+        # Now the restore is really done, remove upgrade-in-progress
+        self.restore_state('upgrade-in-progress')
+
+        # the values are restored, remove from the state file
+        self.restore_state('nsslapd-port')
+        self.restore_state('nsslapd-security')
+        self.restore_state('nsslapd-global-backend-lock')
+        self.restore_state('schema_compat_enabled')
 
     def __disable_listeners(self):
         ldif_outfile = "%s.modified.out" % self.filename


### PR DESCRIPTION
There is still some exposure to killing in a bad place. This was
reproduced by killing the process in the parser.parse() call within
__restore_config (line 230) so the values were restored from the
backup but the new dse.ldif never written or copied. But the values
had already been restored from the state file.

I'm not sure this can ever be 100% bullet-proof since it can be
externally killed but if rather than calling restore_state() on the
values in __restore_config we use get_state() which will peek at the
values in the state file without removing them. Then the last step
is to pop upgrade-in-progress and then the rest.

If the values have been restored and the new ldif written and copied
then it's only upgrade-in-progress that really matters. The rest will
be overwritten.

https://pagure.io/freeipa/issue/7534

Signed-off-by: Rob Crittenden <rcritten@redhat.com>