### PR TITLE
Gracefully handle Nsds5replicalastupdateend's absence

### DIFF
--- a/install/tools/ipa-csreplica-manage.in
+++ b/install/tools/ipa-csreplica-manage.in
@@ -31,7 +31,7 @@ from ipaserver.install import (replication, installutils, bindinstance,
     cainstance)
 from ipalib import api, errors
 from ipalib.constants import FQDN
-from ipalib.util import has_managed_topology
+from ipalib.util import has_managed_topology, print_replication_status
 from ipapython import ipautil, ipaldap, version
 from ipapython.admintool import ScriptError
 from ipapython.dn import DN
@@ -133,19 +133,7 @@ def list_replicas(realm, host, replica, dirman_passwd, verbose):
 
     for entry in entries:
         print('%s' % entry.single_value.get('nsds5replicahost'))
-
-        if verbose:
-            initstatus = entry.single_value.get('nsds5replicalastinitstatus')
-            if initstatus is not None:
-                print("  last init status: %s" % initstatus)
-                print("  last init ended: %s" % str(
-                    ipautil.parse_generalized_time(
-                        entry.single_value['nsds5replicalastinitend'])))
-            print("  last update status: %s" % entry.single_value.get(
-                'nsds5replicalastupdatestatus'))
-            print("  last update ended: %s" % str(
-                ipautil.parse_generalized_time(
-                    entry.single_value['nsds5replicalastupdateend'])))
+        print_replication_status(entry, verbose)
 
 
 def del_link(realm, replica1, replica2, dirman_passwd, force=False):

--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -39,7 +39,11 @@ from ipaserver.install import opendnssecinstance, dnskeysyncinstance
 from ipapython import version, ipaldap
 from ipalib import api, errors
 from ipalib.constants import FQDN
-from ipalib.util import has_managed_topology, verify_host_resolvable
+from ipalib.util import (
+    has_managed_topology,
+    print_replication_status,
+    verify_host_resolvable,
+)
 from ipapython.ipa_log_manager import standard_logging_setup
 from ipapython.dn import DN
 from ipapython.config import IPAOptionParser
@@ -235,25 +239,7 @@ def list_replicas(realm, host, replica, dirman_passwd, verbose, nolookup=False):
 
     for entry in entries:
         print('%s: %s' % (entry.single_value.get('nsds5replicahost'), ent_type))
-
-        if verbose:
-            initstatus = entry.single_value.get('nsds5replicalastinitstatus')
-            print("  last init status: %s" % initstatus)
-            if initstatus is not None:
-                print("  last init ended: %s" % str(
-                    ipautil.parse_generalized_time(
-                        entry.single_value['nsds5replicalastinitend']))
-                    )
-            updatestatus = entry.single_value.get(
-                    'nsds5replicalastupdatestatus'
-            )
-            print("  last update status: %s" % updatestatus)
-            if updatestatus is not None:
-                print("  last update ended: %s" % str(
-                    ipautil.parse_generalized_time(
-                        entry.single_value['nsds5replicalastupdateend']
-                    ))
-                )
+        print_replication_status(entry, verbose)
 
 
 def del_link(realm, replica1, replica2, dirman_passwd, force=False):

--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -238,8 +238,8 @@ def list_replicas(realm, host, replica, dirman_passwd, verbose, nolookup=False):
 
         if verbose:
             initstatus = entry.single_value.get('nsds5replicalastinitstatus')
+            print("  last init status: %s" % initstatus)
             if initstatus is not None:
-                print("  last init status: %s" % initstatus)
                 print("  last init ended: %s" % str(
                     ipautil.parse_generalized_time(
                         entry.single_value['nsds5replicalastinitend'])))

--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -242,12 +242,18 @@ def list_replicas(realm, host, replica, dirman_passwd, verbose, nolookup=False):
             if initstatus is not None:
                 print("  last init ended: %s" % str(
                     ipautil.parse_generalized_time(
-                        entry.single_value['nsds5replicalastinitend'])))
-            print("  last update status: %s" % entry.single_value.get(
-                'nsds5replicalastupdatestatus'))
-            print("  last update ended: %s" % str(
-                ipautil.parse_generalized_time(
-                    entry.single_value['nsds5replicalastupdateend'])))
+                        entry.single_value['nsds5replicalastinitend']))
+                    )
+            updatestatus = entry.single_value.get(
+                    'nsds5replicalastupdatestatus'
+            )
+            print("  last update status: %s" % updatestatus)
+            if updatestatus is not None:
+                print("  last update ended: %s" % str(
+                    ipautil.parse_generalized_time(
+                        entry.single_value['nsds5replicalastupdateend']
+                    ))
+                )
 
 
 def del_link(realm, replica1, replica2, dirman_passwd, force=False):

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -65,6 +65,7 @@ from ipalib.facts import is_ipa_client_configured
 from ipalib.text import _
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
+from ipapython import ipautil
 from ipapython.ssh import SSHPublicKey
 from ipapython.dn import DN, RDN
 from ipapython.dnsutil import (
@@ -1027,6 +1028,31 @@ def detect_dns_zone_realm_type(api, domain):
 def has_managed_topology(api):
     domainlevel = api.Command['domainlevel_get']().get('result', DOMAIN_LEVEL_0)
     return domainlevel > DOMAIN_LEVEL_0
+
+
+def print_replication_status(entry, verbose):
+    """Pretty print nsds5replicalastinitstatus, nsds5replicalastinitend,
+    nsds5replicalastupdatestatus, nsds5replicalastupdateend for a
+    replication agreement.
+    """
+
+    if verbose:
+        initstatus = entry.single_value.get('nsds5replicalastinitstatus')
+        if initstatus is not None:
+            print("  last init status: %s" % initstatus)
+            print("  last init ended: %s" % str(
+                ipautil.parse_generalized_time(
+                    entry.single_value['nsds5replicalastinitend'])))
+        updatestatus = entry.single_value.get(
+            'nsds5replicalastupdatestatus'
+        )
+        if updatestatus is not None:
+            print("  last update status: %s" % updatestatus)
+            print("  last update ended: %s" % str(
+                ipautil.parse_generalized_time(
+                    entry.single_value['nsds5replicalastupdateend']
+                ))
+            )
 
 
 class classproperty:


### PR DESCRIPTION
https://pagure.io/freeipa/issue/8605

    ipa-replica-manage: handle missing attributes
    If nsds5replicalastupdateend is not yet present,
    ipa-replica-manage will backtrace as it tries to retrieve that
    attribute unconditionally.
    Gracefully handle that situation.

    ipalib/util.py: add print_replication_status

    ipa-csreplica-manage, ipa-replica-manage: refactor
