### PR TITLE
ipatests: Update Rawhide template for PR-CI

### DIFF
--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-frawhide
           name: freeipa/ci-master-frawhide
-          version: 0.1.4
+          version: 0.2.1
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
New Rawhide aiming Fedora 34.

Template based on `Fedora-Cloud-Base-Vagrant-Rawhide-20201116.n.0.x86_64.vagrant-libvirt.box`.

This was part of https://github.com/freeipa/freeipa/pull/5187 but moved to an independent PR to unblock nightly runs.