### PR TITLE
[Backport][ipa-4-8] ipatests: fix TestTrust::test_subordinate_suffix

### DIFF
--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -245,6 +245,11 @@ class TestTrust(BaseTestTrust):
         self.master.run_command(['kinit', '-C', '-E', self.upn_principal],
                                 stdin_text=self.upn_password)
 
+    def test_remove_nonposix_trust(self):
+        self.remove_trust(self.ad)
+        tasks.unconfigure_dns_for_trust(self.master, self.ad)
+
+    # Test with AD trust defining subordinate suffixes
     def test_subordinate_suffix(self):
         """Test subordinate UPN Suffixes"""
         tasks.configure_dns_for_trust(self.master, self.ad)
@@ -290,7 +295,7 @@ class TestTrust(BaseTestTrust):
         )
         tasks.kdestroy_all(self.master)
 
-    def test_remove_nonposix_trust(self):
+    def test_remove_subordinate_suffixes_trust(self):
         self.remove_trust(self.ad)
         tasks.unconfigure_dns_for_trust(self.master, self.ad)
 


### PR DESCRIPTION
This PR was opened automatically because PR #5303 was pushed to master and backport to ipa-4-8 is required.