### PR TITLE
Allow mod_auth_gssapi to create and access ccaches in /run/ipa/ccaches

### DIFF
--- a/init/tmpfilesd/ipa.conf.in
+++ b/init/tmpfilesd/ipa.conf.in
@@ -1,2 +1,3 @@
 d /run/ipa 0711 root root
-d /run/ipa/ccaches 0770 ipaapi ipaapi
+d /run/ipa/ccaches 6770 ipaapi ipaapi
+a+ /run/ipa/ccaches - - - - g:apache:rwx

--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -75,7 +75,7 @@ WSGIScriptReloading Off
 
   GssapiImpersonate On
   GssapiDelegCcacheDir $IPA_CCACHES
-  GssapiDelegCcachePerms mode:0660 gid:ipaapi
+  GssapiDelegCcachePerms mode:0660
   GssapiDelegCcacheUnique On
   GssapiUseS4U2Proxy on
   GssapiAllowedMech krb5
@@ -117,7 +117,7 @@ Alias /ipa/session/cookie "/usr/share/ipa/gssapi.login"
 <Location "/ipa/session/login_x509">
   AuthType none
   GssapiDelegCcacheDir $IPA_CCACHES
-  GssapiDelegCcachePerms mode:0660 gid:ipaapi
+  GssapiDelegCcachePerms mode:0660
   GssapiDelegCcacheUnique On
   SSLVerifyClient require
   SSLUserName SSL_CLIENT_CERT

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1578,6 +1578,7 @@ def upgrade_configuration():
         IPA_CCACHES=paths.IPA_CCACHES,
         IPA_CUSTODIA_SOCKET=paths.IPA_CUSTODIA_SOCKET,
         KDCPROXY_CONFIG=paths.KDCPROXY_CONFIG,
+        DOMAIN=api.env.domain,
     )
 
     subject_base = find_subject_base()


### PR DESCRIPTION
With commit c6644b8566f747fa80e2c1925b79bad9f8c92bd7 we default to
create unique credential caches in /run/ipa/ccaches for every client
that connects to IPA with a new session. On F34, mod_auth_gssapi process
running as 'apache' cannot create the ccache in /run/ipa/ccaches because
it has no access rights.

The core of the problem is that we have two different paths to obtaining
a ccache: one where 'apache' running httpd process creates it directly
and one where an internal redirect from 'ipaapi' running httpd process
is happening.

Since /run/ipa/ccaches is a temporary directory created in /run which is
mounted as tmpfs, POSIX ACLs can be used to add 'apache' group
permission to create the ccaches.

When '/run/ipa/ccaches' has SGID bit, created files inside it would
automatically get 'ipaapi' group assigned. So all we need is to mark the
directory as 02770 (SGID bit).

Fixes: https://pagure.io/freeipa/issue/8613

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>