### PR TITLE
[Backport][ipa-4-6] Improve PKI subsystem detection 

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -148,8 +148,14 @@ class DogtagInstance(service.Service):
 
         Returns True/False
         """
-        return os.path.exists(os.path.join(
-            paths.VAR_LIB_PKI_TOMCAT_DIR, self.subsystem.lower()))
+        try:
+            result = ipautil.run(
+                ['pki-server', 'subsystem-show', self.subsystem.lower()],
+                capture_output=True)
+            # parse the command output
+            return 'Enabled: True' in result.output
+        except ipautil.CalledProcessError:
+            return False
 
     def spawn_instance(self, cfg_file, nolog_list=()):
         """

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1938,3 +1938,15 @@ def get_sssd_version(host):
     """Get sssd version on remote host."""
     version = host.run_command('sssd --version').stdout_text.strip()
     return parse_version(version)
+
+
+def get_pki_version(host):
+    """Get pki version on remote host."""
+    data = host.get_file_contents("/usr/share/pki/VERSION", encoding="utf-8")
+
+    groups = re.match(r'.*\nSpecification-Version: ([\d+\.]*)\n.*', data)
+    if groups:
+        version_string = groups.groups(0)[0]
+        return parse_version(version_string)
+    else:
+        raise ValueError("get_pki_version: pki is not installed")

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -5,9 +5,14 @@
 """
 Module provides tests to verify that the upgrade script works.
 """
+from __future__ import absolute_import
 
 import base64
+import os
 from cryptography.hazmat.primitives import serialization
+import pytest
+
+from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
@@ -72,3 +77,29 @@ class TestUpgrade(IntegrationTest):
         self.master.run_command(['ipa-server-upgrade'])
         result = self.master.run_command(["ipa", "user-show", "admin"])
         assert rootprinc in result.stdout_text
+
+    def test_kra_detection(self):
+        """Test that ipa-server-upgrade correctly detects KRA presence
+
+        Test for https://pagure.io/freeipa/issue/8596
+        When the directory /var/lib/pki/pki-tomcat/kra/ exists, the upgrade
+        wrongly assumes that KRA component is installed and crashes.
+        The test creates an empty dir and calls ipa-server-upgrade
+        to make sure that KRA detection is not based on the directory
+        presence.
+        """
+        # Skip test if pki 10.10.0 is installed
+        # because of https://github.com/dogtagpki/pki/issues/3397
+        # pki fails to start if empty dir /var/lib/pki/pki-tomcat/kra exists
+        if tasks.get_pki_version(self.master) \
+           == tasks.parse_version('10.10.0'):
+            pytest.skip("Skip test with pki 10.10.0")
+
+        kra_path = os.path.join(paths.VAR_LIB_PKI_TOMCAT_DIR, "kra")
+        try:
+            self.master.run_command(["mkdir", "-p", kra_path])
+            result = self.master.run_command(['ipa-server-upgrade'])
+            err_msg = 'Upgrade failed with no such entry'
+            assert err_msg not in result.stderr_text
+        finally:
+            self.master.run_command(["rmdir", kra_path])


### PR DESCRIPTION
This is a manual backport of PR #5290 to ipa-4-6 branch.
Cherry-pick had issues with the tests commit (missing imports, line length).