### PR TITLE
xmlrpctests: remove harcoded expiration date from test_user_plugin

### DIFF
--- a/ipatests/test_xmlrpc/test_user_plugin.py
+++ b/ipatests/test_xmlrpc/test_user_plugin.py
@@ -72,8 +72,10 @@ invalidlanguages = {
     u'en-us;q=0.1234', u'en-us;q=1.1', u'en-us;q=1.0000'
     }
 
-principal_expiration_string = "2020-12-07T19:54:13Z"
-principal_expiration_date = datetime.datetime(2020, 12, 7, 19, 54, 13)
+now = datetime.datetime.now().replace(microsecond=0)
+principal_expiration_date = now + datetime.timedelta(days=365)
+principal_expiration_string = principal_expiration_date.strftime(
+    "%Y-%m-%dT%H:%M:%SZ")
 
 invalid_expiration_string = "2020-12-07 19:54:13"
 expired_expiration_string = "1991-12-07T19:54:13Z"


### PR DESCRIPTION
The test test_user_plugin is using a hardcoded date for
password expiration and started failed since we passed this date.
Replace the hardcoded date with now + 1 year.

Fixes: https://pagure.io/freeipa/issue/8616
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>