### PR TITLE
systemd: enforce en_US.UTF-8 locale in systemd units

### DIFF
--- a/client/systemd/ipa-epn.service.in
+++ b/client/systemd/ipa-epn.service.in
@@ -3,6 +3,7 @@ Description=Execute IPA Expiring Password Notification (EPN)
 
 [Service]
 Type=simple
+Environment=LC_ALL=C.UTF-8
 ExecStart=@sbindir@/ipa-epn
 
 [Install]

--- a/daemons/dnssec/ipa-dnskeysyncd.service.in
+++ b/daemons/dnssec/ipa-dnskeysyncd.service.in
@@ -2,6 +2,7 @@
 Description=IPA key daemon
 
 [Service]
+Environment=LC_ALL=C.UTF-8
 EnvironmentFile=@sysconfenvdir@/ipa-dnskeysyncd
 ExecStart=@libexecdir@/ipa/ipa-dnskeysyncd
 User=@ODS_USER@

--- a/daemons/dnssec/ipa-ods-exporter.service.in
+++ b/daemons/dnssec/ipa-ods-exporter.service.in
@@ -4,6 +4,7 @@ Wants=ipa-ods-exporter.socket
 After=ipa-ods-exporter.socket
 
 [Service]
+Environment=LC_ALL=C.UTF-8
 EnvironmentFile=@sysconfenvdir@/ipa-ods-exporter
 ExecStart=@libexecdir@/ipa/ipa-ods-exporter
 User=@ODS_USER@

--- a/daemons/ipa-otpd/ipa-otpd@.service.in
+++ b/daemons/ipa-otpd/ipa-otpd@.service.in
@@ -2,6 +2,7 @@
 Description=ipa-otpd service
 
 [Service]
+Environment=LC_ALL=C.UTF-8
 EnvironmentFile=@sysconfdir@/ipa/default.conf
 ExecStart=@libexecdir@/ipa/ipa-otpd $ldap_uri
 StandardInput=socket

--- a/init/systemd/ipa-ccache-sweep.service.in
+++ b/init/systemd/ipa-ccache-sweep.service.in
@@ -4,6 +4,7 @@ Wants=gssproxy.service
 
 [Service]
 Type=simple
+Environment=LC_ALL=C.UTF-8
 ExecStart=@libexecdir@/ipa/ipa-ccache-sweeper
 PrivateTmp=yes
 User=ipaapi

--- a/init/systemd/ipa-custodia.service.in
+++ b/init/systemd/ipa-custodia.service.in
@@ -3,6 +3,7 @@ Description=IPA Custodia Service
 
 [Service]
 Type=notify
+Environment=LC_ALL=C.UTF-8
 ExecStart=@libexecdir@/ipa/ipa-custodia @IPA_SYSCONF_DIR@/custodia/custodia.conf
 PrivateTmp=yes
 Restart=on-failure

--- a/init/systemd/ipa.service.in
+++ b/init/systemd/ipa.service.in
@@ -6,6 +6,7 @@ After=network.target
 
 [Service]
 Type=oneshot
+Environment=LC_ALL=C.UTF-8
 ExecStart=@sbindir@/ipactl start
 ExecStop=@sbindir@/ipactl stop
 RemainAfterExit=yes

--- a/install/share/ds-ipa-env.conf.template
+++ b/install/share/ds-ipa-env.conf.template
@@ -1,5 +1,6 @@
 # Installed and maintained by ipa update tools, please do not modify
 
 [Service]
+Environment=LC_ALL=C.UTF-8
 Environment=KRB5_KTNAME=$KRB5_KTNAME
 Environment=KRB5CCNAME=$KRB5CCNAME

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -629,6 +629,7 @@ class CAInstance(DogtagInstance):
         with open(conf, 'w') as f:
             os.fchmod(f.fileno(), 0o644)
             f.write('[Service]\n')
+            f.write('Environment=LC_ALL=C.UTF-8\n')
             f.write('ExecStartPost={}\n'.format(paths.IPA_PKI_WAIT_RUNNING))
         tasks.systemd_daemon_reload()
 


### PR DESCRIPTION
Python code does detection of the system encoding based on the locale
settings. On RHEL 8.4 development images we somehow get LANG=en_US which
defaults to iso8859-1 _inside_ the systemd-started service, even though
the whole environment defaults to LANG=en_US.UTF-8.

When instrumented with ExecStartPre=/usr/bin/locale, the following
output can be seen:
```
locale[45481]: LANG=en_US
locale[45481]: LC_CTYPE="en_US"
locale[45481]: LC_NUMERIC="en_US"
locale[45481]: LC_TIME="en_US"
locale[45481]: LC_COLLATE="en_US"
locale[45481]: LC_MONETARY="en_US"
locale[45481]: LC_MESSAGES="en_US"
locale[45481]: LC_PAPER="en_US"
locale[45481]: LC_NAME="en_US"
locale[45481]: LC_ADDRESS="en_US"
locale[45481]: LC_TELEPHONE="en_US"
locale[45481]: LC_MEASUREMENT="en_US"
locale[45481]: LC_IDENTIFICATION="en_US"
locale[45481]: LC_ALL=
ipactl[45483]: Unexpected error
ipactl[45483]: SystemEncodingError: System encoding must be UTF-8, 'iso8859-1' is not supported. Set LC_ALL="C.UTF-8", or LC_ALL="" and LC_CTYPE="C.UTF-8".
systemd[1]: ipa.service: Main process exited, code=exited, status=1/FAILURE
```
Set the environment to explicit LANG=en_US.UTF-8 to please the Python
code. FreeIPA server side only cares about actual encoding, not the
language itself.

Fixes: https://pagure.io/freeipa/issue/8617
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>