### PR TITLE
[Backport][ipa-4-9] Allow mod_auth_gssapi to create and access ccaches in /run/ipa/ccaches

### DIFF
--- a/init/tmpfilesd/ipa.conf.in
+++ b/init/tmpfilesd/ipa.conf.in
@@ -1,2 +1,3 @@
 d /run/ipa 0711 root root
-d /run/ipa/ccaches 0770 ipaapi ipaapi
+d /run/ipa/ccaches 6770 ipaapi ipaapi
+a+ /run/ipa/ccaches - - - - g:apache:rwx

--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -75,7 +75,7 @@ WSGIScriptReloading Off
 
   GssapiImpersonate On
   GssapiDelegCcacheDir $IPA_CCACHES
-  GssapiDelegCcachePerms mode:0660 gid:ipaapi
+  GssapiDelegCcachePerms mode:0660
   GssapiDelegCcacheUnique On
   GssapiUseS4U2Proxy on
   GssapiAllowedMech krb5
@@ -117,7 +117,7 @@ Alias /ipa/session/cookie "/usr/share/ipa/gssapi.login"
 <Location "/ipa/session/login_x509">
   AuthType none
   GssapiDelegCcacheDir $IPA_CCACHES
-  GssapiDelegCcachePerms mode:0660 gid:ipaapi
+  GssapiDelegCcachePerms mode:0660
   GssapiDelegCcacheUnique On
   SSLVerifyClient require
   SSLUserName SSL_CLIENT_CERT

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1578,6 +1578,7 @@ def upgrade_configuration():
         IPA_CCACHES=paths.IPA_CCACHES,
         IPA_CUSTODIA_SOCKET=paths.IPA_CUSTODIA_SOCKET,
         KDCPROXY_CONFIG=paths.KDCPROXY_CONFIG,
+        DOMAIN=api.env.domain,
     )
 
     subject_base = find_subject_base()


### PR DESCRIPTION
This PR was opened automatically because PR #5328 was pushed to master and backport to ipa-4-9 is required.