### PR TITLE
Change mkdir logic in DNSSEC

### DIFF
--- a/ipaserver/dnssec/bindmgr.py
+++ b/ipaserver/dnssec/bindmgr.py
@@ -182,10 +182,9 @@ class BINDMgr:
         zone_path = os.path.join(paths.BIND_LDAP_DNS_ZONE_WORKDIR,
                 self.get_zone_dir_name(zone))
         try:
-            os.makedirs(zone_path)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise e
+            os.mkdir(zone_path, 0o770)
+        except FileExistsError:
+            pass
 
         # fix HSM permissions
         # TODO: move out

--- a/ipaserver/install/dnskeysyncinstance.py
+++ b/ipaserver/install/dnskeysyncinstance.py
@@ -66,12 +66,19 @@ class DNSKeySyncInstance(service.Service):
         """
         Setting up correct permissions to allow write/read access for daemons
         """
-        if not os.path.exists(paths.BIND_LDAP_DNS_IPA_WORKDIR):
-            os.mkdir(paths.BIND_LDAP_DNS_IPA_WORKDIR, 0o770)
-        # dnssec daemons require to have access into the directory
-        os.chmod(paths.BIND_LDAP_DNS_IPA_WORKDIR, 0o770)
-        os.chown(paths.BIND_LDAP_DNS_IPA_WORKDIR, self.named_uid,
-                 self.named_gid)
+        directories = [
+            paths.BIND_LDAP_DNS_IPA_WORKDIR,
+            paths.BIND_LDAP_DNS_ZONE_WORKDIR,
+        ]
+        for directory in directories:
+            try:
+                os.mkdir(directory, 0o770)
+            except FileExistsError:
+                pass
+            else:
+                os.chmod(directory, 0o770)
+            # dnssec daemons require to have access into the directory
+            os.chown(directory, self.named_uid, self.named_gid)
 
     def remove_replica_public_keys(self, replica_fqdn):
         ldap = api.Backend.ldap2

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1749,6 +1749,7 @@ def upgrade_configuration():
             else:
                 if dnssec_set_openssl_engine(dnskeysyncd):
                     dnskeysyncd.start_dnskeysyncd()
+            dnskeysyncd.set_dyndb_ldap_workdir_permissions()
 
     cleanup_kdc(fstore)
     cleanup_adtrust(fstore)


### PR DESCRIPTION
- Create /var/named/dyndb-ldap/ipa/master/ early
- Assume that /var/named/dyndb-ldap/ipa/master/ exists in BINDMgr.sync()

Signed-off-by: Christian Heimes <cheimes@redhat.com>