### PR TITLE
selinux: Fix/waive issues reported by SELint

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -41,6 +41,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMaster
         template: *ci-master-latest
@@ -53,6 +54,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_simple_replication.py
         template: *ci-master-latest
@@ -65,6 +67,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
         template: *ci-master-latest
@@ -77,6 +80,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
         template: *ci-master-latest
@@ -89,6 +93,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
         template: *ci-master-latest
@@ -101,6 +106,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
         template: *ci-master-latest
@@ -113,6 +119,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_topologies.py
         template: *ci-master-latest
@@ -125,6 +132,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_sudo.py
         template: *ci-master-latest
@@ -137,6 +145,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
@@ -149,6 +158,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_kerberos_flags.py
         template: *ci-master-latest
@@ -161,6 +171,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_forced_client_reenrollment.py
         template: *ci-master-latest
@@ -173,6 +184,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_advise.py
         template: *ci-master-latest
@@ -185,6 +197,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_testconfig.py
         template: *ci-master-latest
@@ -197,6 +210,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_service_permissions.py
         template: *ci-master-latest
@@ -209,6 +223,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_netgroup.py
         template: *ci-master-latest
@@ -221,6 +236,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_authselect.py
         template: *ci-master-latest
@@ -233,6 +249,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
         template: *ci-master-latest
@@ -245,6 +262,7 @@ jobs:
 #    job:
 #      class: RunPytest
 #      args:
+        selinux_enforcing: True
 #        build_url: '{fedora-latest/build_url}'
 #        test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
 #        template: *ci-master-latest
@@ -257,6 +275,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_membermanager.py
         template: *ci-master-latest
@@ -269,6 +288,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_adtrust_install.py
         template: *ci-master-latest
@@ -281,6 +301,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_cert.py
         template: *ci-master-latest
@@ -293,6 +314,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_upgrade.py
         template: *ci-master-latest
@@ -305,6 +327,7 @@ jobs:
     job:
       class: RunPytest
       args:
+        selinux_enforcing: True
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_acme.py
         template: *ci-master-latest

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -138,9 +138,8 @@ optional_policy(`
 # ipa-helper local policy
 #
 
-
-allow ipa_helper_t self:capability { net_admin dac_read_search dac_override chown };
-seutil_read_config(ipa_helper_t);
+allow ipa_helper_t self:capability { chown dac_override dac_read_search net_admin };
+seutil_read_config(ipa_helper_t)
 
 #kernel bug
 dontaudit ipa_helper_t self:capability2  block_suspend;
@@ -414,7 +413,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-    gen_require(`
+    gen_require(` #selint-disable:S-001
         type httpd_t;
     ')
     ipa_custodia_stream_connect(httpd_t)
@@ -438,7 +437,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-    gen_require(`
+    gen_require(` #selint-disable:S-001
         type tomcat_t;
     ')
     can_exec(tomcat_t, ipa_pki_retrieve_key_exec_t)
@@ -446,7 +445,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-    gen_require(`
+    gen_require(` #selint-disable:S-001
         type devlog_t;
     ')
 
@@ -459,7 +458,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-    gen_require(`
+    gen_require(` #selint-disable:S-001
         type tomcat_t;
     ')
     kerberos_read_config(tomcat_t)
@@ -467,14 +466,14 @@ optional_policy(`
 ')
 
 optional_policy(`
-    gen_require(`
+    gen_require(` #selint-disable:S-001
         type node_t;
     ')
     allow ipa_custodia_t node_t:tcp_socket node_bind;
 ')
 
 optional_policy(`
-    gen_require(`
+    gen_require(` #selint-disable:S-001
         type pki_tomcat_cert_t;
     ')
     allow ipa_custodia_t pki_tomcat_cert_t:dir remove_name;


### PR DESCRIPTION
- order permissions alphabeticaly
- do not use semicollon after interfaces
- gen_require should only be used in interfaces
-- to resolve this issue, corresponding changes have to be made in
distribution policy instead of ipa module - disabling check for now