### PR TITLE
Fix spelling mistake: filen ame -> filename

### DIFF
--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -56,7 +56,7 @@ logger = logging.getLogger(__name__)
 
 
 # /etc/pkcs11/modules override
-# base filen ame, module, list of disabled-in
+# base filename, module, list of disabled-in
 # 'p11-kit-proxy' disables proxying of module, see man(5) pkcs11.conf
 PKCS11_MODULES = [
     ('softhsm2', paths.LIBSOFTHSM2_SO, ['p11-kit-proxy']),


### PR DESCRIPTION
I was trying to figure out why softhsm wasn't getting added to the NSS DB (and why p11-kit-proxy wasn't being removed) and I stumbled upon https://pagure.io/dogtagpki/issue/3091 and https://github.com/freeipa/freeipa/pull/3063. While it was in my mind, figured I'd fix this obvious typo. Thanks @tiran :)