### PR TITLE
Fix configured service

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1832,6 +1832,13 @@ def upgrade_configuration():
     # (see function docstring for details)
     http_certificate_ensure_ipa_ca_dnsname(http)
 
+    # Convert configuredService to either enabledService or hiddenService
+    # depending on the state of the server role.  This is to fix situations
+    # when deployment has happened before introduction of hidden replicas
+    # as those services will stay as configuredService and will not get
+    # started after upgrade, rendering the system non-functioning
+    service.sync_services_state(fqdn)
+
     if not ds_running:
         ds.stop(ds.serverid)
 

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1732,12 +1732,12 @@ def upgrade_configuration():
         (otpdinstance.OtpdInstance(), 'OTPD'),
     )
 
-    for service, ldap_name in simple_service_list:
+    for svc, ldap_name in simple_service_list:
         try:
-            if not service.is_configured():
-                service.create_instance(ldap_name, fqdn,
-                                        ipautil.realm_to_suffix(api.env.realm),
-                                        realm=api.env.realm)
+            if not svc.is_configured():
+                svc.create_instance(ldap_name, fqdn,
+                                    ipautil.realm_to_suffix(api.env.realm),
+                                    realm=api.env.realm)
         except ipalib.errors.DuplicateEntry:
             pass
 

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -252,12 +252,18 @@ def _set_services_state(fqdn, dest_state):
         rules=ldap2.MATCH_ALL
     )
 
-    entries = ldap2.get_entries(
-        search_base,
-        filter=search_filter,
-        scope=api.Backend.ldap2.SCOPE_ONELEVEL,
-        attrs_list=['cn', 'ipaConfigString']
-    )
+    try:
+        entries = ldap2.get_entries(
+            search_base,
+            filter=search_filter,
+            scope=api.Backend.ldap2.SCOPE_ONELEVEL,
+            attrs_list=['cn', 'ipaConfigString']
+        )
+    except errors.EmptyResult:
+        logger.debug("No services with a state from %s, ignoring",
+                     list(source_states))
+        return
+
     for entry in entries:
         name = entry['cn']
         cfgstrings = entry.setdefault('ipaConfigString', [])


### PR DESCRIPTION
Convert configuredService to either enabledService or hiddenService
depending on the state of the server role.  This is to fix situations
when deployment has happened before introduction of hidden replicas
as those services will stay as configuredService and will not get
started after upgrade, rendering the system non-functioning.

Fixes: https://pagure.io/freeipa/issue/8623