### PR TITLE
[Backport][ipa-4-8] ipa-client-install: unilaterally set dns_lookup_kdc to True

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -693,16 +693,15 @@ def configure_krb5_conf(
     if not dnsok or not cli_kdc or force:
         libopts.extend([
             krbconf.setOption('dns_lookup_realm', 'false'),
-            krbconf.setOption('dns_lookup_kdc', 'false')
         ])
     else:
         libopts.extend([
             krbconf.setOption('dns_lookup_realm', 'true'),
-            krbconf.setOption('dns_lookup_kdc', 'true')
         ])
     libopts.extend([
         krbconf.setOption('rdns', 'false'),
         krbconf.setOption('dns_canonicalize_hostname', 'false'),
+        krbconf.setOption('dns_lookup_kdc', 'true'),
         krbconf.setOption('ticket_lifetime', '24h'),
         krbconf.setOption('forwardable', 'true'),
         krbconf.setOption('udp_preference_limit', '0')

--- a/ipatests/test_integration/test_installation_client.py
+++ b/ipatests/test_integration/test_installation_client.py
@@ -8,6 +8,8 @@ Module provides tests for various options of ipa-client-install.
 
 from __future__ import absolute_import
 
+import shlex
+
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 
@@ -18,6 +20,40 @@ class TestInstallClient(IntegrationTest):
     @classmethod
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=True)
+        tasks.install_client(cls.master, cls.clients[0])
+
+    def check_dns_lookup_kdc(self, client):
+        """Check that dns_lookup_kdc is never set to false.
+
+        https://pagure.io/freeipa/issue/6523
+
+        Setting dns_lookup_kdc to False would result in a hardcoded
+        configuration which is less reliable in the long run.
+        For instance, adding a trust to an Active Directory forest
+        after clients are enrolled would result in clients not being
+        able to authenticate AD users. Recycling FreeIPA servers
+        could prove problematic if the original hostnames are not
+        reused too.
+        """
+
+        result = client.run_command(
+            shlex.split("grep dns_lookup_kdc /etc/krb5.conf")
+        )
+        assert 'false' not in result.stdout_text.lower()
+        assert 'true' in result.stdout_text.lower()
+
+    def test_dns_lookup_kdc_is_true_with_default_enrollment_options(self):
+        self.check_dns_lookup_kdc(self.clients[0])
+        tasks.uninstall_client(self.clients[0])
+
+    def test_dns_lookup_kdc_is_true_with_ipa_server_on_cli(self):
+        tasks.install_client(
+            self.master,
+            self.clients[0],
+            extra_args=["--server", self.master.hostname]
+        )
+        self.check_dns_lookup_kdc(self.clients[0])
+        tasks.uninstall_client(self.clients[0])
 
     def test_client_install_with_ssh_trust_dns(self):
         """no host key verification if ssh-trust-dns option is used


### PR DESCRIPTION
This PR was opened automatically because PR #5341 was pushed to master and backport to ipa-4-8 is required.