### PR TITLE
Use uglifyjs on CentOS too

### DIFF
--- a/install/ui/util/compile.sh
+++ b/install/ui/util/compile.sh
@@ -111,7 +111,7 @@ fi
 # compile using python rjsmin on most platforms and uglify-js on RHEL 8
 echo "Minimizing: $RDIR/$RELEASE/$LAYER.js"
 echo "Target file: $OUTPUT_FILE"
-if [ $ID = "rhel" ]; then
+if [[ "$ID" == "rhel" ]] || [[ "$ID_LIKE" =~ "rhel" ]]; then
     echo "Minifier: uglifyjs"
     uglifyjs < $RDIR/$RELEASE/$LAYER.js > $OUTPUT_FILE
 else


### PR DESCRIPTION
Only checking for ID to equal "rhel" causes build failures on CentOS Stream.  Instead check both ID and ID_LIKE.  This should also work later on when rebuilds like CentOS Linux get this update.