### PR TITLE
ipatests: fix race condition in finalizer of encrypted backup test

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -32,6 +32,7 @@ class BasePathNamespace:
     GZIP = "/bin/gzip"
     LS = "/bin/ls"
     SYSTEMCTL = "/bin/systemctl"
+    SYSTEMD_RUN = "/bin/systemd-run"
     SYSTEMD_DETECT_VIRT = "/usr/bin/systemd-detect-virt"
     SYSTEMD_TMPFILES = "/usr/bin/systemd-tmpfiles"
     TAR = "/bin/tar"


### PR DESCRIPTION
When using a fixture, we get a temporary directory created and then
removed by pytest. Pytest uses `shutil.rmtree` call which collects all
files in the directory being removed and then removes them one by one.
At the point of removal of our GNUPGHOME directory, gpg daemon is being
shut down and there might still be an agent UNIX domain socket. The
removal actually overlaps in time with shut down of the gpg daemon, thus
causing `shutil.rmtree()` to fail when an agent UNIX domain socket is
removed by the daemon.

Wait in the finalizer method until the UNIX domain socket of gpg agent
does disappear.

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>