### PR TITLE
Fix uninstall without dns

### DIFF
--- a/ipaserver/install/odsexporterinstance.py
+++ b/ipaserver/install/odsexporterinstance.py
@@ -31,8 +31,6 @@ class ODSExporterInstance(service.Service):
             keytab=paths.IPA_ODS_EXPORTER_KEYTAB,
             service_prefix=u'ipa-ods-exporter'
         )
-        self.ods_uid = constants.ODS_USER.uid
-        self.ods_gid = constants.ODS_GROUP.gid
         self.enable_if_exists = False
 
     suffix = ipautil.dn_attribute_property('_suffix')
@@ -71,7 +69,7 @@ class ODSExporterInstance(service.Service):
                                    quotes=False, separator='=')
 
     def __setup_principal(self):
-        assert self.ods_uid is not None
+        assert constants.ODS_GROUP.gid is not None
 
         for f in [paths.IPA_ODS_EXPORTER_CCACHE, self.keytab]:
             try:
@@ -95,7 +93,7 @@ class ODSExporterInstance(service.Service):
 
         # Make sure access is strictly reserved to the ods user
         os.chmod(self.keytab, 0o440)
-        os.chown(self.keytab, 0, self.ods_gid)
+        os.chown(self.keytab, 0, constants.ODS_GROUP.gid)
 
         dns_group = DN(('cn', 'DNS Servers'), ('cn', 'privileges'),
                        ('cn', 'pbac'), self.suffix)


### PR DESCRIPTION
Service constructors are called even when the service itself is not configured. A common pattern in FreeIPA code is to instantiate a service and check whether it is configured, then perform uninstall of the service configuration. This fails if the service constructor does depend on the artifacts only present if other (relevant to the service) packages were installed.

A common pattern is:
```
  svc = SVCClass(..)
  if svc.is_configured(): 
      svc.uninstall()
```

Most of DNS-related service classes do resolution of UID/GIDs for ODS and NAMED in their constructors which breaks uninstallation of a DNS-less FreeIPA deployment because neither 'bind' nor 'opendnssec' packages are not installed and user and group they provide are not available in the system.

Fixes: https://pagure.io/freeipa/issue/8630