### PR TITLE
[Backport][ipa-4-9] ipatests: fix race condition in finalizer of encrypted backup test

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -32,6 +32,7 @@ class BasePathNamespace:
     GZIP = "/bin/gzip"
     LS = "/bin/ls"
     SYSTEMCTL = "/bin/systemctl"
+    SYSTEMD_RUN = "/bin/systemd-run"
     SYSTEMD_DETECT_VIRT = "/usr/bin/systemd-detect-virt"
     SYSTEMD_TMPFILES = "/usr/bin/systemd-tmpfiles"
     TAR = "/bin/tar"


### PR DESCRIPTION
This PR was opened automatically because PR #5373 was pushed to master and backport to ipa-4-9 is required.