### PR TITLE
selinux: modify policy to allow one-way trust

### DIFF
--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -480,3 +480,10 @@ optional_policy(`
     allow ipa_custodia_t pki_tomcat_cert_t:file create;
     allow ipa_custodia_t pki_tomcat_cert_t:file unlink;
 ')
+
+optional_policy(`
+    gen_require(` #selint-disable:S-001
+        type oddjob_t;
+    ')
+	ipa_helper_noatsecure(oddjob_t)
+')


### PR DESCRIPTION
In selinux enforcing mode, the command ipa trust-add fails
to establish a one-way trust, during the step fetching the remote
domains.

This step calls a script over DBus and oddjob, that is executed
with oddjob_t context. The policy must allow noatsecure.

Currently the optional_policy is defined in selinux-policy
repo but is ineffective as ipa_helper_noatsecure is not defined
in this repo. When the optional_policy is defined in our own
module, it is taken into account and ipa trust-add succeeds.

Fixes: https://pagure.io/freeipa/issue/8508