### PR TITLE
Fix ACME installation with pki-core 10.9

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1481,7 +1481,11 @@ class CAInstance(DogtagInstance):
             logger.debug('ACME service is already deployed')
             return False
 
-        self._ldap_mod('/usr/share/pki/acme/database/ds/schema.ldif')
+        for path in ('/usr/share/pki/acme/database/ds/schema.ldif',
+                     '/usr/share/pki/acme/database/ldap/schema.ldif'):
+            if os.path.exists(path):
+                self._ldap_mod(path)
+                break
 
         configure_acme_acls()
 


### PR DESCRIPTION
pki-core 10.9 uses different location for ACME LDAP content sources.
As a result, provisioning CA fails on CentOS 8 Stream.

Use any of the known locations for ACME LDAP schema, the correct
location will be fixed up in the ipa-server-upgrade run afterwards.

Fixes: https://pagure.io/freeipa/issue/8634
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>