### PR TITLE
Revert "Remove test for minimum ACME support and rely on package deps"

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -14,6 +14,7 @@ from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_caless import CALessBase, ipa_certs_cleanup
 from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
+from ipaserver.install import cainstance
 from ipatests.test_integration.test_external_ca import (
     install_server_external_ca_step1,
     install_server_external_ca_step2,
@@ -77,6 +78,8 @@ def server_install_teardown(func):
     return wrapped
 
 
+@pytest.mark.skipif(not cainstance.minimum_acme_support(),
+                    reason="does not provide ACME")
 class TestACME(CALessBase):
     """
     Test the FreeIPA ACME service by using ACME clients on a FreeIPA client.
@@ -420,6 +423,8 @@ class TestACME(CALessBase):
         assert "invalid 'certificate'" in result.stderr_text
 
 
+@pytest.mark.skipif(not cainstance.minimum_acme_support(),
+                    reason="does not provide ACME")
 class TestACMECALess(IntegrationTest):
     """Test to check the CA less replica setup"""
     num_replicas = 1


### PR DESCRIPTION
This reverts commit 81c97bb9928a88a595b3afe6fa70fcfb267b1440.

This is to make IPA installable again with older versions of dogtag
so it will install on CentOS 8 Stream.

ACME will not be deployed but on upgrade, if pki 10.10.x is available
then it will be.

https://pagure.io/freeipa/issue/8634

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

Alternative PR to #5386