### PR TITLE
Re-enable ACME gate testing, limit to single server

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -298,3 +298,15 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
+
+  fedora-latest/test_acme:
+    requires: [fedora-latest/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_acme.py
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl_1client

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,62 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/temp_commit_1:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_acme.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 7200
+        topology: *master_1repl_1client
+
+  fedora-latest/temp_commit_2:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_acme.py
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl_1client
+
+  fedora-latest/temp_commit_3:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_acme.py
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl_1client
+
+  fedora-latest/temp_commit_4:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_acme.py
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl_1client
+
+  fedora-latest/temp_commit_5:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_acme.py
+        template: *ci-master-latest
+        timeout: 7200
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -9,7 +9,6 @@ from cryptography import x509
 import pytest
 
 from ipalib.constants import IPA_CA_RECORD
-from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_caless import CALessBase, ipa_certs_cleanup
 from ipaplatform.osinfo import osinfo
@@ -101,7 +100,7 @@ class TestACME(CALessBase):
         * Other clients or service scenarios
 
     """
-    num_replicas = 1
+    num_replicas = 0
     num_clients = 1
 
     @classmethod
@@ -132,10 +131,6 @@ class TestACME(CALessBase):
         tasks.install_client(cls.master, cls.clients[0])
         tasks.config_host_resolvconf_with_master_data(
             cls.master, cls.clients[0]
-        )
-        tasks.install_replica(cls.master, cls.replicas[0])
-        tasks.config_host_resolvconf_with_master_data(
-            cls.master, cls.replicas[0]
         )
 
     def certinstall(self, certfile=None, keyfile=None,
@@ -203,11 +198,6 @@ class TestACME(CALessBase):
                 exc = e
         else:
             raise exc
-
-    def test_centralize_acme_enable(self):
-        """Test if ACME enable on replica if enabled on master"""
-        status = check_acme_status(self.replicas[0], 'enabled')
-        assert status == 'enabled'
 
     ###############
     # Certbot tests
@@ -375,11 +365,6 @@ class TestACME(CALessBase):
             ok_returncode=22,
         )
 
-    def test_centralize_acme_disable(self):
-        """Test if ACME disable on replica if disabled on master"""
-        status = check_acme_status(self.replicas[0], 'disabled')
-        assert status == 'disabled'
-
     @server_install_teardown
     def test_third_party_certs(self):
         """Require ipa-ca SAN on replacement web certificates"""
@@ -420,112 +405,10 @@ class TestACME(CALessBase):
         assert "invalid 'certificate'" in result.stderr_text
 
 
-class TestACMECALess(IntegrationTest):
-    """Test to check the CA less replica setup"""
-    num_replicas = 1
-    num_clients = 0
-
-    @pytest.fixture
-    def test_setup_teardown(self):
-        tasks.install_master(self.master, setup_dns=True)
-
-        tasks.install_replica(self.master, self.replicas[0], setup_ca=False)
-        tasks.config_host_resolvconf_with_master_data(
-            self.master, self.replicas[0]
-        )
-
-        yield
-
-        tasks.uninstall_replica(self.master, self.replicas[0])
-        tasks.uninstall_master(self.master)
-
-    def test_caless_to_cafull_replica(self, test_setup_teardown):
-        """Test ACME is enabled on CA-less replica when converted to CA-full
-
-        Deployment where one server is deployed as CA-less, when converted
-        to CA full, should have ACME enabled by default.
-
-        related: https://pagure.io/freeipa/issue/8524
-        """
-        tasks.kinit_admin(self.master)
-        # enable acme on master
-        self.master.run_command(['ipa-acme-manage', 'enable'])
-
-        # check status of acme server on master
-        status = check_acme_status(self.master, 'enabled')
-        assert status == 'enabled'
-
-        tasks.kinit_admin(self.replicas[0])
-        # check status of acme on replica, result: CA is not installed
-        result = self.replicas[0].run_command(['ipa-acme-manage', 'status'],
-                                              raiseonerr=False)
-        assert result.returncode == 3
-
-        # Install CA on replica
-        tasks.install_ca(self.replicas[0])
-
-        # check acme status, should be enabled now
-        status = check_acme_status(self.replicas[0], 'enabled')
-        assert status == 'enabled'
-
-        # disable acme on replica
-        self.replicas[0].run_command(['ipa-acme-manage', 'disable'])
-
-        # check acme status on master, should be disabled
-        status = check_acme_status(self.master, 'disabled')
-        assert status == 'disabled'
-
-    def test_enable_caless_to_cafull_replica(self, test_setup_teardown):
-        """Test ACME with CA-less replica when converted to CA-full
-
-        Deployment have one ca-less replica and ACME is not enabled.
-        After converting ca-less replica to ca-full, ACME can be
-        enabled or disabled.
-
-        related: https://pagure.io/freeipa/issue/8524
-        """
-        tasks.kinit_admin(self.master)
-
-        # check status of acme server on master
-        status = check_acme_status(self.master, 'disabled')
-        assert status == 'disabled'
-
-        tasks.kinit_admin(self.replicas[0])
-        # check status of acme on replica, result: CA is not installed
-        result = self.replicas[0].run_command(['ipa-acme-manage', 'status'],
-                                              raiseonerr=False)
-        assert result.returncode == 3
-
-        # Install CA on replica
-        tasks.install_ca(self.replicas[0])
-
-        # check acme status on replica, should not throw error
-        status = check_acme_status(self.replicas[0], 'disabled')
-        assert status == 'disabled'
-
-        # enable acme on replica
-        self.replicas[0].run_command(['ipa-acme-manage', 'enable'])
-
-        # check acme status on master
-        status = check_acme_status(self.master, 'enabled')
-        assert status == 'enabled'
-
-        # check acme status on replica
-        status = check_acme_status(self.replicas[0], 'enabled')
-        assert status == 'enabled'
-
-        # disable acme on master
-        self.master.run_command(['ipa-acme-manage', 'disable'])
-
-        # check acme status on replica, should be disabled
-        status = check_acme_status(self.replicas[0], 'disabled')
-        assert status == 'disabled'
-
-
 class TestACMEwithExternalCA(TestACME):
     """Test the FreeIPA ACME service with external CA"""
 
-    num_replicas = 1
+    num_replicas = 0
     num_clients = 1
 
     @classmethod
@@ -547,8 +430,4 @@ class TestACMEwithExternalCA(TestACME):
         tasks.install_client(cls.master, cls.clients[0])
         tasks.config_host_resolvconf_with_master_data(
             cls.master, cls.clients[0]
-        )
-        tasks.install_replica(cls.master, cls.replicas[0])
-        tasks.config_host_resolvconf_with_master_data(
-            cls.master, cls.replicas[0]
         )


### PR DESCRIPTION
The ACME tests exposed an issue in the pki ACME implementation where auth nonces would sometimes not replicate fast enough which resulting in failures.

The whole suite was disabled.

Re-enable the suite but only set up a single ACME server. Better limited than no testing.