### PR TITLE
Include the CA profile when modifying request in ipa_certupdate

### DIFF
--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -188,7 +188,7 @@ def update_server(certs):
         #
         logger.debug("resubmitting certmonger request '%s'", request_id)
         certmonger.resubmit_request(
-            request_id, ca='dogtag-ipa-ca-renew-agent-reuse', profile='')
+            request_id, ca='dogtag-ipa-ca-renew-agent-reuse')
         try:
             state = certmonger.wait_for_request(request_id, timeout)
         except RuntimeError:

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -284,6 +284,20 @@ class TestIpaHealthCheck(IntegrationTest):
         assert output == \
             "ERROR: ipahealthcheck.meta.services.sssd: sssd: not running"
 
+    def test_ipa_healthcheck_after_certupdate(self):
+        """
+        Verify that ipa-certupdate hasn't messed up tracking
+
+        ipa-certupdate was dropping the profile value from the CA
+        signing cert tracking. ipa-healthcheck discovered this.
+
+        Run ipa-healthcheck after ipa-certupdate to ensure that
+        no problems are discovered.
+        """
+        self.master.run_command([paths.IPA_CERTUPDATE])
+        returncode, _data = run_healthcheck(self.master)
+        assert returncode == 0
+
     def test_dogtag_ca_check_exists(self):
         """
         Testcase to verify checks available in


### PR DESCRIPTION
The CA tracking request is modified (it calls renew but it doesn't
actually do a renewal) as part of ipa-certupdate and it dropped
the profile. ipa-healthcheck discovered this condition.

https://pagure.io/freeipa/issue/8644

Signed-off-by: Rob Crittenden <rcritten@redhat.com>