### PR TITLE
[Backport][ipa-4-9] ipatests: clear initgroups cache in clear_sssd_cache

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -342,6 +342,7 @@ class BasePathNamespace:
     SSSD_DB = "/var/lib/sss/db"
     SSSD_MC_GROUP = "/var/lib/sss/mc/group"
     SSSD_MC_PASSWD = "/var/lib/sss/mc/passwd"
+    SSSD_MC_INITGROUPS = "/var/lib/sss/mc/initgroups"
     SSSD_PUBCONF_DIR = "/var/lib/sss/pubconf"
     SSSD_PUBCONF_KNOWN_HOSTS = "/var/lib/sss/pubconf/known_hosts"
     SSSD_PUBCONF_KRB5_INCLUDE_D_DIR = "/var/lib/sss/pubconf/krb5.include.d/"

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -872,6 +872,7 @@ def clear_sssd_cache(host):
                      "xargs rm -fv")
     host.run_command(['rm', '-fv', paths.SSSD_MC_GROUP])
     host.run_command(['rm', '-fv', paths.SSSD_MC_PASSWD])
+    host.run_command(['rm', '-fv', paths.SSSD_MC_INITGROUPS])
 
     if systemd_available:
         host.run_command(['systemctl', 'start', 'sssd'])


### PR DESCRIPTION
This PR was opened automatically because PR #5350 was pushed to master and backport to ipa-4-9 is required.