### PR TITLE
[Backport][ipa-4-8] Include the CA profile when modifying request in ipa_certupdate

### DIFF
--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -171,7 +171,7 @@ def update_server(certs):
         #
         logger.debug("resubmitting certmonger request '%s'", request_id)
         certmonger.resubmit_request(
-            request_id, ca='dogtag-ipa-ca-renew-agent-reuse', profile='')
+            request_id, ca='dogtag-ipa-ca-renew-agent-reuse')
         try:
             state = certmonger.wait_for_request(request_id, timeout)
         except RuntimeError:

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -280,6 +280,20 @@ class TestIpaHealthCheck(IntegrationTest):
         assert output == \
             "ERROR: ipahealthcheck.meta.services.sssd: sssd: not running"
 
+    def test_ipa_healthcheck_after_certupdate(self):
+        """
+        Verify that ipa-certupdate hasn't messed up tracking
+
+        ipa-certupdate was dropping the profile value from the CA
+        signing cert tracking. ipa-healthcheck discovered this.
+
+        Run ipa-healthcheck after ipa-certupdate to ensure that
+        no problems are discovered.
+        """
+        self.master.run_command([paths.IPA_CERTUPDATE])
+        returncode, _data = run_healthcheck(self.master)
+        assert returncode == 0
+
     def test_dogtag_ca_check_exists(self):
         """
         Testcase to verify checks available in


### PR DESCRIPTION
This PR was opened automatically because PR #5393 was pushed to master and backport to ipa-4-8 is required.