### PR TITLE
Set client keytab location for 389ds

### DIFF
--- a/install/share/ds-ipa-env.conf.template
+++ b/install/share/ds-ipa-env.conf.template
@@ -3,4 +3,5 @@
 [Service]
 Environment=LC_ALL=C.UTF-8
 Environment=KRB5_KTNAME=$KRB5_KTNAME
+Environment=KRB5_CLIENT_KTNAME=$KRB5_KTNAME
 Environment=KRB5CCNAME=$KRB5CCNAME


### PR DESCRIPTION
Handles behavior change in
https://github.com/389ds/389-ds-base/pull/4523

Fixes: https://pagure.io/freeipa/issue/8656

(It may be preferable to wait until the 389ds PR is closed, but I wanted to show the change needed for that.)