### PR TITLE
Remove virtual attributes before rolling back a permission

### DIFF
--- a/ipaserver/plugins/permission.py
+++ b/ipaserver/plugins/permission.py
@@ -1236,8 +1236,15 @@ class permission_mod(baseldap.LDAPUpdate):
             else:
                 self.obj.update_aci(entry, old_entry.single_value['cn'])
         except Exception:
-            # Don't revert attribute which doesn't exist in LDAP
+            # Don't revert attributes which don't exist in LDAP
             entry.pop('attributelevelrights', None)
+            for attr in list(
+                filter(
+                    lambda x: x not in ["member", "memberof"],
+                    [*self.obj.relationships],
+                )
+            ):
+                entry.pop(attr, None)
 
             logger.error('Error updating ACI: %s', traceback.format_exc())
             logger.warning('Reverting entry')

--- a/ipatests/test_xmlrpc/test_permission_plugin.py
+++ b/ipatests/test_xmlrpc/test_permission_plugin.py
@@ -3850,6 +3850,31 @@ class test_managed_permissions(Declarative):
         ),
 
         dict(
+            desc='Try to add invalid attribute to %r' % permission1,
+            command=('permission_mod', [permission1],
+                     {'attrs': [u'calicense',]}),
+            expected=errors.InvalidSyntax(
+                attr=r'targetattr "calicense" does not exist in schema. '
+                     r'Please add attributeTypes "calicense" to '
+                     r'schema if necessary. '
+                     r'ACL Syntax Error(-5):'
+                     r'(targetattr = \22calicense\22)'
+                     r'(targetfilter = \22(objectclass=posixaccount)\22)'
+                     r'(version 3.0;acl \22permission:%(name)s\22;'
+                     r'allow (write) userdn = \22ldap:///all\22;)' %
+                     dict(name=permission1),
+            ),
+        ),
+
+        verify_permission_aci(
+            permission1, users_dn,
+            '(targetattr = "l || o || sn")' \
+            '(targetfilter = "(objectclass=posixaccount)")' \
+            '(version 3.0;acl "permission:%s";' \
+            'allow (write) userdn = "ldap:///all";)' % permission1,
+        ),
+
+        dict(
             desc='Search for %r using all its --attrs' % permission1,
             command=('permission_find', [permission1],
                      {'cn': permission1, 'attrs': [u'l', u'o', u'sn']}),


### PR DESCRIPTION
On a failed permission update if the generated ACI is
invalid then the updated permission is rolled back.

Add the virtual relationship attributes to list of attributes
to be ignored when rolling back the entry.

This relies on the current order in the LDAPObject
relationships field where member and memberof are the first
two values.

https://pagure.io/freeipa/issue/8646

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
