### PR TITLE
[Backport][ipa-4-9] selinux: modify policy to allow one-way trust

### DIFF
--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -480,3 +480,10 @@ optional_policy(`
     allow ipa_custodia_t pki_tomcat_cert_t:file create;
     allow ipa_custodia_t pki_tomcat_cert_t:file unlink;
 ')
+
+optional_policy(`
+    gen_require(` #selint-disable:S-001
+        type oddjob_t;
+    ')
+	ipa_helper_noatsecure(oddjob_t)
+')


### PR DESCRIPTION
This PR was opened automatically because PR #5385 was pushed to master and backport to ipa-4-9 is required.