### PR TITLE
[master] ipatests: update PR-CI templates to Fedora 33

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f32
-          version: 0.0.16
+          name: freeipa/ci-master-f33
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -34,7 +34,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &389ds-master-latest
-          name: freeipa/389ds-master-f32
+          name: freeipa/389ds-master-f33
           version: 0.0.2
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -38,8 +38,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &pki-master-latest
-          name: freeipa/pki-master-f32
-          version: 0.0.3
+          name: freeipa/pki-master-f33
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f32
-          version: 0.0.16
+          name: freeipa/ci-master-f33
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &testing-master-latest
-          name: freeipa/testing-master-f32
+          name: freeipa/testing-master-f33
           version: 0.0.2
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &testing-master-latest
-          name: freeipa/testing-master-f32
+          name: freeipa/testing-master-f33
           version: 0.0.2
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-previous
-          name: freeipa/ci-master-f31
-          version: 0.0.9
+          name: freeipa/ci-master-f32
+          version: 0.0.16
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Gating tests are still on Fedora 32 because some tests are failing. (https://pagure.io/freeipa/issue/8611)

Rest is being updated to unblock nightly runs:
- "previous" updated to Fedora 32
- "latest" updated to Fedora 33
- 389ds, testing and pki definitions updated to Fedora 33

Signed-off-by: Armando Neto <abiagion@redhat.com>