### PR TITLE
[ipa-4-8] ipatests: update PR-CI templates to Fedora 33

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-latest
           name: freeipa/ci-ipa-4-8-f32
-          version: 0.0.11
+          version: 0.0.12
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-latest
-          name: freeipa/ci-ipa-4-8-f32
-          version: 0.0.11
+          name: freeipa/ci-ipa-4-8-f33
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest_selinux.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-latest
-          name: freeipa/ci-ipa-4-8-f32
-          version: 0.0.11
+          name: freeipa/ci-ipa-4-8-f33
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-previous
-          name: freeipa/ci-ipa-4-8-f31
-          version: 0.0.8
+          name: freeipa/ci-ipa-4-8-f32
+          version: 0.0.12
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,7 +57,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-8-latest
           name: freeipa/ci-ipa-4-8-f32
-          version: 0.0.11
+          version: 0.0.12
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Gating tests are still on Fedora 32 because some tests are failing. (https://pagure.io/freeipa/issue/8611)

Rest is being updated to unblock nightly runs:
- "previous" updated to Fedora 32
- "latest" updated to Fedora 33

Signed-off-by: Armando Neto <abiagion@redhat.com>