### PR TITLE
Support trust in FIPS mode

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -1595,6 +1595,13 @@ def fetch_domains(api, mydomain, trustdomain, creds=None, server=None):
     return result
 
 
+def enforce_smb_encryption(creds):
+    try:
+        creds.set_smb_encryption(credentials.SMB_ENCRYPTION_REQUIRED)
+    except AttributeError:
+        pass
+
+
 def retrieve_remote_domain(hostname, local_flatname,
                            realm, realm_server=None,
                            realm_admin=None, realm_passwd=None):
@@ -1639,6 +1646,7 @@ def retrieve_remote_domain(hostname, local_flatname,
                           % (realm_admin, realm_passwd)
             td = get_instance(local_flatname)
             td.creds.set_kerberos_state(credentials.MUST_USE_KERBEROS)
+            enforce_smb_encryption(td.creds)
             td.creds.parse_string(auth_string)
             td.creds.set_workstation(hostname)
             if realm_server is None:
@@ -1678,6 +1686,7 @@ class TrustDomainJoins:
         ld = TrustDomainInstance(self.local_flatname)
         ld.creds = credentials.Credentials()
         ld.creds.set_kerberos_state(credentials.MUST_USE_KERBEROS)
+        enforce_smb_encryption(ld.creds)
         ld.creds.guess(ld.parm)
         ld.creds.set_workstation(ld.hostname)
         ld.retrieve(FQDN)


### PR DESCRIPTION
## ipaserver/dcerpc.py: enforce SMB encryption on LSA pipe if available
    
We want to always use SMB encryption if it is possible on LSA pipe as we are going to pass what accounts to a plain-text content within CreateTrustedDomainEx2 call.
    
The catch is that older Samba version might not have a way to enforce this and we need fall back to work with existing connection then.
    
## ipaserver/dcerpc.py: use Kerberos authentication for discovery
    
In FIPS mode we cannot rely on NTLMSSP at all, so we have ensure Kerberos is used by Samba Python libraries. This is achieved by requiring credentials objects to always use Kerberos authentication.
    
Additionally, we have to normalize the principal used to authenticate. In case it was passed without realm, add forest root domain as a realm. In case it was passed with NetBIOS domain name, remove it and replace with a realm. Since we only know about the forest root domain as a realm, require that for other domains' users a real Kerberos principal is specified.

## ipaserver/dcerpc: use Samba-provided trust helper to establish trust
    
When establishing trust to Active Directory forest, RC4 is used to encrypt trusted domain object credentials as an application-specific material in a secure channel based on AES session key.
    
In FIPS mode it is not possible to use RC4 directly.
    
Samba 4.14 and backports to 4.13 in Fedora 33+ and RHEL 8.4+ now provide a helper that wraps LSA RPC call CreateTrustedDomainEx2.  This helper ensures that in FIPS mode we first check that LSA session key is AES before allowing RC4 use internally in Samba bindings. Thus, it becomes possible to establish trust to Active Directory forest in
FIPS mode.
    
Adopt FreeIPA code to use the helper provided by Samba when it is available. If neither the helper nor unprotected arcfour_encrypt utility is available from Samba bindings, fail import of the ipaserver.dcerpc module.
    
Fixes: https://pagure.io/freeipa/issue/8655
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>

