### PR TITLE
Test that IPA certs are removed on server uninstall 

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -963,6 +963,15 @@ def uninstall_master(host, ignore_topology_disconnect=True,
 
     result = host.run_command(uninstall_cmd)
     assert "Traceback" not in result.stdout_text
+
+    # Check that IPA certs have been deleted after uninstall
+    # Related: https://pagure.io/freeipa/issue/8614
+    assert host.run_command(['test', '-f', paths.IPA_CA_CRT],
+                            raiseonerr=False).returncode == 1
+    assert host.run_command(['test', '-f', paths.IPA_P11_KIT],
+                            raiseonerr=False).returncode == 1
+    assert "IPA CA" not in host.run_command(['trust', 'list']).stdout_text
+
     if clean:
         Firewall(host).disable_services(["freeipa-ldap", "freeipa-ldaps",
                                          "freeipa-trust", "dns"])

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -888,6 +888,15 @@ class TestInstallMaster(IntegrationTest):
         name = f'ipa-ca.{self.master.domain.name}'
         assert crypto_x509.DNSName(name) in cert.san_general_names
 
+    def test_ipa_cert_in_store(self):
+        """
+        Test that IPA cert has been added to trust store.
+        """
+
+        assert "IPA CA" in self.master.run_command(
+            ['trust', 'list'],
+            raiseonerr=False).stdout_text
+
     def test_p11_kit_softhsm2(self):
         # check that p11-kit-proxy does not inject SoftHSM2
         result = self.master.run_command([


### PR DESCRIPTION
Test that IPA certs are removed after the server uninstall
process.

Related: https://pagure.io/freeipa/issue/8614
Signed-off-by: Antonio Torres <antorres@redhat.com>