### PR TITLE
[Backport][ipa-4-9] Set client keytab location for 389ds

### DIFF
--- a/install/share/ds-ipa-env.conf.template
+++ b/install/share/ds-ipa-env.conf.template
@@ -3,4 +3,5 @@
 [Service]
 Environment=LC_ALL=C.UTF-8
 Environment=KRB5_KTNAME=$KRB5_KTNAME
+Environment=KRB5_CLIENT_KTNAME=$KRB5_KTNAME
 Environment=KRB5CCNAME=$KRB5CCNAME


### PR DESCRIPTION
This PR was opened automatically because PR #5409 was pushed to master and backport to ipa-4-9 is required.