### PR TITLE
ipatests: use fully qualified name for AD admin when establishing trust

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_trust:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_trust.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 9000
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -53,6 +53,8 @@ class BaseTestTrust(IntegrationTest):
         cls.srv_gc_record_name = \
             '_ldap._tcp.Default-First-Site-Name._sites.gc._msdcs'
         cls.srv_gc_record_value = '0 100 389 {}.'.format(cls.master.hostname)
+        cls.master.put_file_contents('/usr/share/ipa/smb.conf.empty',
+                                     '[global]\n  log level = 10\n')
 
     @classmethod
     def check_sid_generation(cls):

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -461,7 +461,7 @@ class TestTrust(BaseTestTrust):
 
                 result = self.master.run_command(
                     ['ipa', 'trust-add', '--type', 'ad', self.ad_domain,
-                     '--admin', 'Administrator',
+                     '--admin', 'Administrator@' + self.ad_domain,
                      '--range-type', range_type, '--password'],
                     raiseonerr=False,
                     stdin_text=self.master.config.ad_admin_password)
@@ -512,8 +512,8 @@ class TestTrust(BaseTestTrust):
 
             result = self.master.run_command([
                 'ipa', 'trust-add', '--type', 'ad', self.ad_subdomain,
-                '--admin',
-                'Administrator', '--password', '--range-type', 'ipa-ad-trust'
+                '--admin', 'Administrator@' + self.ad_subdomain,
+                '--password', '--range-type', 'ipa-ad-trust'
             ], stdin_text=self.master.config.ad_admin_password,
                 raiseonerr=False)
 
@@ -564,8 +564,8 @@ class TestTrust(BaseTestTrust):
 
             result = self.master.run_command([
                 'ipa', 'trust-add', '--type', 'ad', self.ad_treedomain,
-                '--admin',
-                'Administrator', '--password', '--range-type', 'ipa-ad-trust'
+                '--admin', 'Administrator@' + self.ad_treedomain,
+                '--password', '--range-type', 'ipa-ad-trust'
             ], stdin_text=self.master.config.ad_admin_password,
                 raiseonerr=False)
 
@@ -774,8 +774,9 @@ class TestTrust(BaseTestTrust):
             # Check that trust can not be established without --server option
             # This checks that our setup is correct
             result = self.master.run_command(
-                ['ipa', 'trust-add', self.ad.domain.name,
-                 '--admin', 'Administrator', '--password'], raiseonerr=False,
+                ['ipa', 'trust-add', self.ad_domain,
+                 '--admin', 'Administrator@' + self.ad_domain, '--password'],
+                raiseonerr=False,
                 stdin_text=self.master.config.ad_admin_password)
             assert result.returncode == 1
             assert 'CIFS server communication error: code "3221225653", ' \


### PR DESCRIPTION
Changes in https://pagure.io/freeipa/issue/8655 made it impossible
to use AD admin name without domain part in "ipa trust-add" command to
establish external trust with an AD tree domain.
Also use fully qualified admin name by default in all trust related tests
to reduce abiguity

UPDATE: related to https://pagure.io/freeipa/issue/8664