### PR TITLE
ipatests: check error message less strictly

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_trust:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_trust.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 9000
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -141,10 +141,9 @@ class TestTrust(BaseTestTrust):
         ad_admin = 'Administrator@%s' % self.ad_domain
         tasks.kinit_as_user(self.master, ad_admin,
                             self.master.config.ad_admin_password)
-        err_string = ('ipa: ERROR: Insufficient access: SASL(-14):'
-                      ' authorization failure: Invalid credentials')
-        result = self.master.run_command(['ipa', 'ping'], raiseonerr=False)
-        assert err_string in result.stderr_text
+        result = self.master.run_command(['ipa', 'ping'], ok_returncode=1)
+        assert 'ipa: ERROR: Insufficient access:' in result.stderr_text
+        assert 'Invalid credentials' in result.stderr_text
 
         tasks.kdestroy_all(self.master)
         tasks.kinit_admin(self.master)


### PR DESCRIPTION
Error reporting of 389ds was changed in
389ds/389-ds-base#4480 to return no
additional information about a failing bind (to avoid leaking information).

As a consequence, when an unauthorized user tries to perform
administrative task on IPA server the error message contains less info.

The assertion was changed to accept old and new variants of error message.