### PR TITLE
ipatests: fix healthcheck test for ipahealthcheck.ds.encryption 

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1026,6 +1026,10 @@ class TestIpaHealthCheck(IntegrationTest):
         """
         instance = realm_to_serverid(self.master.domain.realm)
         cmd = ["systemctl", "restart", "dirsrv@{}".format(instance)]
+        # The crypto policy must be set to LEGACY otherwise 389ds
+        # combines crypto policy amd minSSLVersion and removes
+        # TLS1.0 on fedora>=33 as the DEFAULT policy forbids TLS1.0
+        self.master.run_command(['update-crypto-policies', '--set', 'LEGACY'])
         self.master.run_command(
             [
                 "dsconf",
@@ -1037,6 +1041,7 @@ class TestIpaHealthCheck(IntegrationTest):
         )
         self.master.run_command(cmd)
         yield
+        self.master.run_command(['update-crypto-policies', '--set', 'DEFAULT'])
         self.master.run_command(
             [
                 "dsconf",


### PR DESCRIPTION
389ds is combining the value set in dse.ldif and the current crypto
policy to evaluate the min TLS version that it will be using.
The test needs to change the crypto policy to LEGACY in order to allow
TLS 1.0, because the DEFAULT policy prevents TLS 1.0 on fc33+.

Fixes: https://pagure.io/freeipa/issue/8670

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>