### PR TITLE
ipatests: Test if server setup without dns uninstall properly

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1677,3 +1677,15 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
+
+  fedora-latest/test_uninstall:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_uninstall.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1810,3 +1810,16 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
+
+  fedora-latest/test_uninstall:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_uninstall.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1810,3 +1810,16 @@ jobs:
         template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
+
+  testing-fedora/test_uninstall:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_uninstall.py
+        template: *testing-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1943,3 +1943,17 @@ jobs:
         template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
+
+  testing-fedora/test_uninstall:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        test_suite: test_integration/test_uninstall.py
+        template: *testing-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1665,3 +1665,15 @@ jobs:
         template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
+
+  fedora-previous/test_uninstall:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_uninstall.py
+        template: *ci-master-previous
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1809,3 +1809,16 @@ jobs:
         template: *ci-master-frawhide
         timeout: 3600
         topology: *master_1repl
+
+  fedora-rawhide/test_uninstall:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_uninstall.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/test_integration/test_uninstall.py
+++ b/ipatests/test_integration/test_uninstall.py
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Module for ipa uninstall related scenarios.
+"""
+
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestUninstallWithoutDNS(IntegrationTest):
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=False)
+
+    def test_uninstall_server_without_dns(self):
+        """Test if server setup without dns uninstall properly
+
+        IPA server uninstall was failing if dns was not setup.
+        This test check if it uninstalls propelry.
+
+        related: https://pagure.io/freeipa/issue/8630
+        """
+        tasks.uninstall_master(self.master)


### PR DESCRIPTION
IPA server uninstall was failing if dns was not setup.
This test check if it uninstalls propelry.

related: https://pagure.io/freeipa/issue/8630
Signed-off-by: Mohammad Rizwan <myusuf@redhat.com>