### PR TITLE
Various dnssec fixes

### DIFF
--- a/ipaserver/dnssec/_ods21.py
+++ b/ipaserver/dnssec/_ods21.py
@@ -3,6 +3,7 @@
 #
 
 import os
+import dateutil.tz
 
 from ipaserver.dnssec._odsbase import AbstractODSDBConnection
 from ipaserver.dnssec._odsbase import AbstractODSSignerConn
@@ -38,9 +39,12 @@ class ODSDBConnection(AbstractODSDBConnection):
         for row in cur:
             key = dict()
             key['HSMkey_id'] = row['locator']
+            # The date is stored in UTC format but OpenDNSSEC 1.4 was
+            # returning a local tz format
+            tz = dateutil.tz.tzlocal()
             key['generate'] = ipautil.datetime_from_utctimestamp(
                 row['inception'],
-                units=1).replace(tzinfo=None).isoformat(
+                units=1).astimezone(tz).replace(tzinfo=None).isoformat(
                     sep=' ', timespec='seconds')
             key['algorithm'] = row['algorithm']
             key['publish'] = key['generate']

--- a/ipaserver/dnssec/_ods21.py
+++ b/ipaserver/dnssec/_ods21.py
@@ -31,7 +31,7 @@ class ODSDBConnection(AbstractODSDBConnection):
     def get_keys_for_zone(self, zone_id):
         cur = self._db.execute(
             "SELECT hsmk.locator, hsmk.inception, hsmk.algorithm, "
-            "hsmk.keyType, hsmk.state "
+            "hsmk.role, hsmk.state "
             "FROM hsmKey AS hsmk "
             "JOIN keyData AS kd ON hsmk.id = kd.hsmKeyId "
             "WHERE kd.zoneId = ?", (zone_id,))
@@ -47,9 +47,9 @@ class ODSDBConnection(AbstractODSDBConnection):
             key['active'] = None
             key['retire'] = None
             key['dead'] = None
-            if row['keyType'] == 2:
+            if row['role'] == 2:
                 key['keytype'] = 256
-            elif row['keyType'] == 1:
+            elif row['role'] == 1:
                 key['keytype'] = 257
             key['state'] = row['state']
             yield key


### PR DESCRIPTION
- dnssec: fix the key type with OpenDNSSEC 2.1
- ipatests: add a test for ZSK/KSK keytype in DNSKEY record 
- OpenDNSSEC: fix timezone in key creation date

- Run a temp commit using @tbordaz's fix for 389ds sync_repl issue

Note: the patch does not handle the upgrade yet (when ZSK was created as a KSK, then upgrade should fix the LDAP entry and make sure that dns re-loads the record).