### PR TITLE
[Backport][ipa-4-9] ipatests: fix healthcheck test for ipahealthcheck.ds.encryption 

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1026,6 +1026,10 @@ class TestIpaHealthCheck(IntegrationTest):
         """
         instance = realm_to_serverid(self.master.domain.realm)
         cmd = ["systemctl", "restart", "dirsrv@{}".format(instance)]
+        # The crypto policy must be set to LEGACY otherwise 389ds
+        # combines crypto policy amd minSSLVersion and removes
+        # TLS1.0 on fedora>=33 as the DEFAULT policy forbids TLS1.0
+        self.master.run_command(['update-crypto-policies', '--set', 'LEGACY'])
         self.master.run_command(
             [
                 "dsconf",
@@ -1037,6 +1041,7 @@ class TestIpaHealthCheck(IntegrationTest):
         )
         self.master.run_command(cmd)
         yield
+        self.master.run_command(['update-crypto-policies', '--set', 'DEFAULT'])
         self.master.run_command(
             [
                 "dsconf",


### PR DESCRIPTION
This PR was opened automatically because PR #5442 was pushed to master and backport to ipa-4-9 is required.