### PR TITLE
ipatests: fix discrepancies in nightly defs

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1536,7 +1536,7 @@ jobs:
 
   fedora-latest/test_membermanager:
     requires: [fedora-latest/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:
@@ -1596,7 +1596,7 @@ jobs:
 
   fedora-latest/test_adtrust_install:
     requires: [fedora-latest/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1657,7 +1657,7 @@ jobs:
 
   fedora-latest/test_membermanager:
     requires: [fedora-latest/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:
@@ -1722,7 +1722,7 @@ jobs:
 
   fedora-latest/test_adtrust_install:
     requires: [fedora-latest/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1188,7 +1188,7 @@ jobs:
         topology: *master_1repl_1client
 
   testing-fedora/test_installation_client:
-    requires: [fedora-latest/build]
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1275,7 +1275,7 @@ jobs:
         topology: *master_1repl_1client
 
   testing-fedora/test_installation_client:
-    requires: [fedora-latest/build]
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest


### PR DESCRIPTION
- Build is using a prio of 100 while tests use 50, use consistent
values
- fix the requires for test_installation_client