### PR TITLE
[Backport][ipa-4-8] ipatests: test_ipahealthcheck: fix units

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1953,8 +1953,10 @@ class TestIpaHealthCheckFilesystemSpace(IntegrationTest):
 
         path = os.path.join('/tmp', str(uuid.uuid4()))
         # CI has a single big disk so we may end up allocating most of it.
-        result = self.master.run_command(['df', '--output=avail', '/tmp'])
-        free = (int(result.stdout_text.split('\n')[1]) // 1000) - 50
+        result = self.master.run_command(
+            ['df', '--block-size=1024', '--output=avail', '/tmp']
+        )
+        free = (int(result.stdout_text.split('\n')[1]) // 1024) - 50
         self.master.run_command(['fallocate', '-l', '%dMiB' % free, path])
 
         yield


### PR DESCRIPTION
This PR was opened automatically because PR #5451 was pushed to master and backport to ipa-4-8 is required.