### PR TITLE
[Backport][ipa-4-9] ipatests: Test if server setup without dns uninstall properly

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1677,3 +1677,15 @@ jobs:
         template: *ci-ipa-4-9-latest
         timeout: 3600
         topology: *master_1repl
+
+  fedora-latest-ipa-4-9/test_uninstall:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        test_suite: test_integration/test_uninstall.py
+        template: *ci-ipa-4-9-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1810,3 +1810,16 @@ jobs:
         template: *ci-ipa-4-9-latest
         timeout: 3600
         topology: *master_1repl
+
+  fedora-latest-ipa-4-9/test_uninstall:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_uninstall.py
+        template: *ci-ipa-4-9-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1677,3 +1677,16 @@ jobs:
         template: *ci-ipa-4-9-previous
         timeout: 3600
         topology: *master_1repl
+
+  fedora-previous-ipa-4-9/test_uninstall:
+    requires: [fedora-previous-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-9/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_uninstall.py
+        template: *ci-ipa-4-9-previous
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/test_integration/test_uninstall.py
+++ b/ipatests/test_integration/test_uninstall.py
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2021  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Module for ipa uninstall related scenarios.
+"""
+
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestUninstallWithoutDNS(IntegrationTest):
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=False)
+
+    def test_uninstall_server_without_dns(self):
+        """Test if server setup without dns uninstall properly
+
+        IPA server uninstall was failing if dns was not setup.
+        This test check if it uninstalls propelry.
+
+        related: https://pagure.io/freeipa/issue/8630
+        """
+        tasks.uninstall_master(self.master)


### PR DESCRIPTION
IPA server uninstall was failing if dns was not setup.
This test check if it uninstalls propelry.

related: https://pagure.io/freeipa/issue/8630
Signed-off-by: Mohammad Rizwan <myusuf@redhat.com>
Reviewed-By: Kaleemullah Siddiqui <ksiddiqu@redhat.com>
Reviewed-By: Florence Blanc-Renaud <flo@redhat.com>