### PR TITLE
[Backport][ipa-4-9] ipatests: fix discrepancies in nightly defs

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1536,7 +1536,7 @@ jobs:
 
   fedora-latest-ipa-4-9/test_membermanager:
     requires: [fedora-latest-ipa-4-9/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:
@@ -1596,7 +1596,7 @@ jobs:
 
   fedora-latest-ipa-4-9/test_adtrust_install:
     requires: [fedora-latest-ipa-4-9/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1657,7 +1657,7 @@ jobs:
 
   fedora-latest-ipa-4-9/test_membermanager:
     requires: [fedora-latest-ipa-4-9/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:
@@ -1722,7 +1722,7 @@ jobs:
 
   fedora-latest-ipa-4-9/test_adtrust_install:
     requires: [fedora-latest-ipa-4-9/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1536,7 +1536,7 @@ jobs:
 
   fedora-previous-ipa-4-9/test_membermanager:
     requires: [fedora-previous-ipa-4-9/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:
@@ -1596,7 +1596,7 @@ jobs:
 
   fedora-previous-ipa-4-9/test_adtrust_install:
     requires: [fedora-previous-ipa-4-9/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:


### PR DESCRIPTION
- Build is using a prio of 100 while tests use 50, use consistent
values
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>