### PR TITLE
[Backport][ipa-4-8] ipatests: fix discrepancies in nightly defs

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1642,7 +1642,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest/test_cert_fix:
+  fedora-latest-ipa-4-8/test_cert_fix:
     requires: [fedora-latest-ipa-4-8/build]
     priority: 50
     job:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest.yaml
@@ -1584,7 +1584,7 @@ jobs:
 
   fedora-latest-ipa-4-8/test_adtrust_install:
     requires: [fedora-latest-ipa-4-8/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest_selinux.yaml
@@ -1709,7 +1709,7 @@ jobs:
 
   fedora-latest-ipa-4-8/test_adtrust_install:
     requires: [fedora-latest-ipa-4-8/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_latest_selinux.yaml
@@ -1772,7 +1772,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest/test_cert_fix:
+  fedora-latest-ipa-4-8/test_cert_fix:
     requires: [fedora-latest-ipa-4-8/build]
     priority: 50
     job:

--- a/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-8_previous.yaml
@@ -1644,7 +1644,7 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-previous/test_cert_fix:
+  fedora-previous-ipa-4-8/test_cert_fix:
     requires: [fedora-previous-ipa-4-8/build]
     priority: 50
     job:


### PR DESCRIPTION
- Build is using a prio of 100 while tests use 50, use consistent
values

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>