### PR TITLE
[Backport][ipa-4-6] ipatests: fix discrepancies in nightly defs

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -15,7 +15,7 @@ topologies:
 jobs:
   fedora-27/build:
     requires: []
-    priority: 100
+    priority: 150
     job:
       class: Build
       args:
@@ -29,7 +29,7 @@ jobs:
 
   fedora-27/simple_replication:
     requires: [fedora-27/build]
-    priority: 50
+    priority: 100
     job:
       class: RunPytest
       args:
@@ -41,7 +41,7 @@ jobs:
 
   fedora-27/test_caless_TestServerReplicaCALessToCAFull:
     requires: [fedora-27/build]
-    priority: 50
+    priority: 100
     job:
       class: RunPytest
       args:
@@ -53,7 +53,7 @@ jobs:
 
   fedora-27/test_external_ca_TestExternalCA:
     requires: [fedora-27/build]
-    priority: 50
+    priority: 100
     job:
       class: RunPytest
       args:
@@ -65,7 +65,7 @@ jobs:
 
   fedora-27/test_commands:
     requires: [fedora-27/build]
-    priority: 50
+    priority: 100
     job:
       class: RunPytest
       args:
@@ -77,7 +77,7 @@ jobs:
 
   fedora-27/test_dnssec_TestInstallDNSSECFirst:
     requires: [fedora-27/build]
-    priority: 50
+    priority: 100
     job:
       class: RunPytest
       args:

--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -1209,7 +1209,7 @@ jobs:
 
   fedora-27/test_adtrust_install:
     requires: [fedora-27/build]
-    priority: 100
+    priority: 50
     job:
       class: RunPytest
       args:


### PR DESCRIPTION
- Build is using a prio of 100 while tests use 50, use consistent
values

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>