### PR TITLE
Manual backport of 9f0ec27e9f13ed40b8e58162d99bf9b0e8b4afd5.

### DIFF
--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -380,3 +380,32 @@ default: objectClass: top
 default: objectClass: nsIndex
 default: nsSystemIndex: false
 default: nsIndexType: eq
+
+dn: cn=ipaCASubjectDN,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+only:cn: ipaCASubjectDN
+default:objectClass: nsIndex
+default:objectClass: top
+default:nsSystemIndex: false
+add:nsIndexType: eq
+
+dn: cn=ipaExternalMember,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+only:cn: ipaExternalMember
+default:objectClass: nsIndex
+default:objectClass: top
+default:nsSystemIndex: false
+add:nsIndexType: eq
+
+dn: cn=memberPrincipal,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+only:cn: memberPrincipal
+default:objectClass: nsIndex
+default:objectClass: top
+default:nsSystemIndex: false
+add:nsIndexType: eq
+
+dn: cn=ipaNTSecurityIdentifier,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+only: cn: ipaNTSecurityIdentifier
+default: objectClass: top
+default: objectClass: nsIndex
+default: nsSystemIndex: false
+add: nsIndexType: eq
+add: nsIndexType: pres


### PR DESCRIPTION
Manual backport of 9f0ec27e9f13ed40b8e58162d99bf9b0e8b4afd5.
Original commit message:
****************************************************
ipaCASubjectDN is used by lightweight sub CA feature.

ipaExternalMember is used by KRB driver to assemble MS-PAC records.

ipaNTSecurityIdentifier was only index for "pres" and was missing an
index on "eq". Samba and ipasam perform queries with SID string.

memberPrincipal is used by S4U2Proxy constrained delegation and by
ipa-custodia.

Also note that dnaHostname, ipServiceProtocol, ipaCertSubject, and
ipaKeyUsage are currently not index because an index would rarely used
or have a poor selectivity.

Signed-off-by: Christian Heimes <cheimes@redhat.com>
****************************************************

The ipaNTSecurityIdentifier entry was missing in ipa-4-6 and is
added by this commit.

Fixes: https://pagure.io/freeipa/issue/8677
Signed-off-by: François Cami <fcami@redhat.com>