### PR TITLE
ipatests: when talking to AD DCs, use FQDN credentials

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -722,8 +722,8 @@ def remove_trust_with_ad(master, ad_domain):
 def remove_trust_info_from_ad(master, ad_domain):
     # Remove record about trust from AD
     master.run_command(['rpcclient', ad_domain,
-                        '-U\\Administrator%{}'.format(
-                            master.config.ad_admin_password),
+                        '-UAdministrator@{}%{}'.format(
+                            ad_domain, master.config.ad_admin_password),
                         '-c', 'deletetrustdom {}'.format(master.domain.name)],
                        raiseonerr=False)
 


### PR DESCRIPTION
Samba 4.13+ in Fedora 33+ and RHEL 8.4+ defaults to Kerberos
authentication. This means user name used for authentication must be
mapped to a target realm.

Fixes: https://pagure.io/freeipa/issue/8678
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>