### PR TITLE
Use Fedora 33 for temp commit

### DIFF
--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -56,8 +56,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f32
-          version: 0.0.16
+          name: freeipa/ci-master-f33
+          version: 0.0.4
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
This is to keep temp commit template in line with "nightly_latest.yaml"