### PR TITLE
ipatests: fix incomplete nightly def in nightly_previous

### DIFF
--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1107,7 +1107,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-previous/build_url}'
-        test_suite: test_integration/test_installation_client
+        test_suite: test_integration/test_installation_client.py
         template: *ci-master-previous
         timeout: 7200
         topology: *master_1repl_1client


### PR DESCRIPTION
The job definition for fedora-previous/test_installation_client
is missing the .py in the test file:
        test_suite: test_integration/test_installation_client
should be instead:
        test_suite: test_integration/test_installation_client.py