### PR TITLE
fix collecting log files which are symlinks

### DIFF
--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -202,7 +202,8 @@ def collect_logs(name, logs_dict, logfile_dir=None, beakerlib_plugin=None):
             tmpname = cmd.stdout_text.strip()
             # Tar up the logs on the remote server
             cmd = host.run_command(
-                ['tar', 'cJvf', tmpname, '--ignore-failed-read'] + logs,
+                ['tar', 'cJvf', tmpname, '--ignore-failed-read',
+                 '--dereference'] + logs,
                 log_stdout=False, raiseonerr=False)
             if cmd.returncode:
                 logger.warning('Could not collect all requested logs')


### PR DESCRIPTION
One of the files that are collected after each test is /etc/resolv.conf.
In Fedora 33 this file is actually a symlink. `tar` does not follow
symlinks by default which results in either a broken link in test
artifacts or a symlink pointing to local file on the tests controller
machine.
Fixed by instructing `tar` to resolve the symlinks, so that actual file
pointed by symlink is stored in test artifacts.