### PR TITLE
Webui test hostgroup

### DIFF
--- a/ipatests/test_webui/test_hostgroup.py
+++ b/ipatests/test_webui/test_hostgroup.py
@@ -278,6 +278,7 @@ class test_hostgroup(UI_driver):
         assert hostgroup.DESCRIPTION_ERROR_DIALOG in \
             self.get_last_error_dialog().text
         self.dialog_button_click('cancel')
+        self.wait(0.6)  # wait for modal dialog to appear
         self.dialog_button_click('cancel')
 
         # duplicate


### PR DESCRIPTION
test_webui: test_hostgroup: Wait for modal dialog to appear
    
Modal dialog transition is currently set to 300ms, we have to wait
for it to appear in order to interact with it. Double that time is a
safe value.
    
Resolves: https://pagure.io/freeipa/issue/8684
    
Signed-off-by: Michal Polovka <mpolovka@redhat.com>
