### PR TITLE
Ensure IPA is running (ideally) before uninstalling the KRA

### DIFF
--- a/install/tools/man/ipactl.8
+++ b/install/tools/man/ipactl.8
@@ -52,3 +52,30 @@ If any service start fails, do not rollback the services, continue with the oper
 .TP
 \fB\-f\fR, \fB\-\-force\fR
 Force IPA to start. Combine options --skip-version-check and --ignore-service-failures
+.SH "EXIT STATUS"
+
+All actions except status:
+
+0 success
+
+1 a generic error occurred
+
+2 unknown or invalid argument(s)
+
+4 user has insufficient privilege
+
+6 IPA server is not configured
+
+For the status action:
+
+0 service is running
+
+3 service is not running
+
+4 service status is unknown (or unconfigured)
+
+If not executed as root then the status action will return 4 for
+insufficient privileges.
+
+Some services are socket activated and may show as STOPPED by the status
+action. These services include ipa-ods-exporter and ipa-otpd.

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1959,7 +1959,7 @@ def import_included_profiles():
             _create_dogtag_profile(profile_id, profile_data, overwrite=True)
             logger.debug("Imported profile '%s'", profile_id)
         else:
-            logger.info(
+            logger.debug(
                 "Profile '%s' is already in LDAP; skipping", profile_id
             )
 
@@ -2034,7 +2034,7 @@ def migrate_profiles_to_ldap():
         state = profile_states.get(profile_id.lower(), ProfileState.MISSING)
         if state != ProfileState.MISSING:
             # We don't reconsile enabled/disabled state.
-            logger.info(
+            logger.debug(
                 "Profile '%s' is already in LDAP and %s; skipping",
                 profile_id, state.value
             )

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -84,7 +84,7 @@ def get_security_domain():
         cert_paths=paths.IPA_CA_CRT
     )
     domain_client = pki.system.SecurityDomainClient(connection)
-    info = domain_client.get_security_domain_info()
+    info = domain_client.get_domain_info()
     return info
 
 
@@ -97,7 +97,7 @@ def is_installing_replica(sys_type):
     """
     info = get_security_domain()
     try:
-        sys_list = info.systems[sys_type]
+        sys_list = info.subsystems[sys_type]
         return len(sys_list.hosts) > 0
     except KeyError:
         return False

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1098,6 +1098,8 @@ def uninstall_check(installer):
                           "uninstall procedure?", False):
             raise ScriptError("Aborting uninstall operation.")
 
+    kra.uninstall_check(options)
+
     try:
         api.Backend.ldap2.connect(autobind=True)
 
@@ -1165,6 +1167,10 @@ def uninstall(installer):
 
     rv = 0
 
+    # Uninstall the KRA prior to shutting the services down so it
+    # can un-register with the CA.
+    kra.uninstall()
+
     print("Shutting down all IPA services")
     try:
         services.knownservices.ipa.stop()
@@ -1176,8 +1182,6 @@ def uninstall(installer):
             pass
 
     restore_time_sync(sstore, fstore)
-
-    kra.uninstall()
 
     ca.uninstall()
 

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -766,7 +766,8 @@ class TestInstallMaster(IntegrationTest):
         service_start = [
             svcs for svcs in ipa_services_name if svcs not in service_stop
         ]
-        cmd = self.master.run_command(['ipactl', 'status'])
+        cmd = self.master.run_command(['ipactl', 'status'], raiseonerr=False)
+        assert cmd.returncode == 3
         for service in service_start:
             assert f"{service} Service: RUNNING" in cmd.stdout_text
         for service in service_stop:


### PR DESCRIPTION
Ensure IPA is running (ideally) before uninstalling the KRA

The KRA attempts to unregister itself from the security domain
which requires that IPA be running for this to succeed.

1. Move the KRA uninstall call prior to stopping all IPA
   services
2. Try to start IPA if it isn't running and a KRA is configured

It isn't mandatory that IPA be running for the KRA uninstall to
succeed but it will suppress a pretty scary backtrace and error
message.

https://pagure.io/freeipa/issue/8550

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

This also removes two deprecated API warnings from dogtag and changes a log level from info to debug to suppress unnecessary output.