### PR TITLE
[ipatests][Azure Pipelines] Populate containers with self-AAAA records

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -861,6 +861,8 @@ Requires: python3-pexpect
 # These packages do not exist on RHEL and for ipatests use
 # they are installed on the controller through other means
 Requires: ldns-utils
+# update-crypto-policies
+Requires: crypto-policies-scripts
 Requires: python3-polib
 Requires: python3-pytest >= 3.9.1
 Requires: python3-pytest-multihost >= 0.5

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -22,6 +22,7 @@ from ipapython.certdb import NSS_SQL_FILES
 from ipatests.pytest_ipa.integration import tasks
 from ipaplatform.paths import paths
 from ipaplatform.osinfo import osinfo
+from ipaserver.install.installutils import resolve_ip_addresses_nss
 from ipatests.test_integration.base import IntegrationTest
 from pkg_resources import parse_version
 from ipatests.test_integration.test_cert import get_certmonger_fs_id
@@ -659,9 +660,16 @@ class TestIpaHealthCheck(IntegrationTest):
             "_kpasswd._udp." + self.master.domain.name + ".:" +
             self.master.hostname + ".",
             "\"" + self.master.domain.realm.upper() + "\"",
-            self.master.ip,
-            self.replicas[0].ip
         ]
+
+        for hostname in [
+                self.master.external_hostname,
+                self.replicas[0].external_hostname,
+        ]:
+            # resolve hostname on controller
+            ips = resolve_ip_addresses_nss(hostname)
+            SRV_RECORDS.extend([str(ip) for ip in ips])
+
         returncode, data = run_healthcheck(
             self.master,
             "ipahealthcheck.ipa.idns",


### PR DESCRIPTION
- IPA server's AAAA records at embedded DNS mode depend on result of `get_server_ip_address` function(`ipaserver.install.installutils`), which in turn, relies on NSS. In case of Azure Pipelines, there are neither IPv6 records in '/etc/hosts' nor external DNS, which may provide such. This leads to the missing AAAA records for master and missing AAAA records for `ipa-ca` pointing to master in embedded DNS. In particular, tests `test_ipa_healthcheck_no_errors`, `test_ipa_dns_systemrecords_check` fail with:
```
    [
      {
        "source": "ipahealthcheck.ipa.idns",
        "check": "IPADNSSystemRecordsCheck",
        "result": "WARNING",
        "uuid": "b979a88a-6373-4990-bc83-ce724e9730b4",
        "when": "20210120055054Z",
        "duration": "0.032740",
        "kw": {
          "msg": "Got {count} ipa-ca AAAA records, expected {expected}",
          "count": 1,
          "expected": 2
        }
      }
    ]
```
where `ipa-ca` record exists only for replica.
    
Note: since the most of the code in setup_containers was touched it has been reformatted.


- Handle AAAA records in test_ipa_dns_systemrecords_check


Fixes: https://pagure.io/freeipa/issue/8683