### PR TITLE
[Backport][ipa-4-8] fix collecting log files which are symlinks

### DIFF
--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -197,7 +197,8 @@ def collect_logs(name, logs_dict, logfile_dir=None, beakerlib_plugin=None):
             tmpname = cmd.stdout_text.strip()
             # Tar up the logs on the remote server
             cmd = host.run_command(
-                ['tar', 'cJvf', tmpname, '--ignore-failed-read'] + logs,
+                ['tar', 'cJvf', tmpname, '--ignore-failed-read',
+                 '--dereference'] + logs,
                 log_stdout=False, raiseonerr=False)
             if cmd.returncode:
                 logger.warning('Could not collect all requested logs')


### PR DESCRIPTION
This PR was opened automatically because PR #5478 was pushed to master and backport to ipa-4-8 is required.