### PR TITLE
Better support for unreadable NSS database

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -265,7 +265,8 @@ class NSSDatabase:
 
         if dbtype == "dbm" and not nss_supports_dbm():
             raise ValueError(
-                "NSS is built without support of the legacy database(DBM)"
+                f"NSS is built without support of the legacy database(DBM) "
+                f"directory '{nssdir}'",
             )
 
         if nssdir is None:

--- a/ipaserver/install/plugins/update_ra_cert_store.py
+++ b/ipaserver/install/plugins/update_ra_cert_store.py
@@ -33,7 +33,14 @@ class update_ra_cert_store(Updater):
         if not ca_enabled:
             return False, []
 
-        certdb = NSSDatabase(nssdir=paths.HTTPD_ALIAS_DIR)
+        try:
+            certdb = NSSDatabase(nssdir=paths.HTTPD_ALIAS_DIR)
+        except ValueError as e:
+            logger.warning("Problem opening NSS database in "
+                           "%s. Skipping check for existing RA "
+                           "agent certificate: %s", paths.HTTPD_ALIAS_DIR, e)
+            return False, []
+
         if not certdb.has_nickname(ra_nick):
             # Nothign to do
             return False, []


### PR DESCRIPTION
Ignore database errors when trying to extract ipaCert on upgrade

If NSSDatabase() throws a ValueError it means we can't open it
to look for an existing ipaCert to migrate. Chances are there is
no certificate to migrate at this point in Fedora so don't let
it blow up the entire installation/upgrade. Warn the user and let
them figure it out.

We have no real path forward on this and by proceeding it could
lead to more errors (like no RA) but it is extremely unlikely and
would require a user to upgrade from very old Fedora to very
new Fedora in one step.

https://pagure.io/freeipa/issue/8675

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

I added no specific test for this because it a corner case. This code is just to mitigate the problem and make it more understandable.