### PR TITLE
[Backport][ipa-4-9] Better support for unreadable NSS database

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -265,7 +265,8 @@ class NSSDatabase:
 
         if dbtype == "dbm" and not nss_supports_dbm():
             raise ValueError(
-                "NSS is built without support of the legacy database(DBM)"
+                f"NSS is built without support of the legacy database(DBM) "
+                f"directory '{nssdir}'",
             )
 
         if nssdir is None:

--- a/ipaserver/install/plugins/update_ra_cert_store.py
+++ b/ipaserver/install/plugins/update_ra_cert_store.py
@@ -33,7 +33,14 @@ class update_ra_cert_store(Updater):
         if not ca_enabled:
             return False, []
 
-        certdb = NSSDatabase(nssdir=paths.HTTPD_ALIAS_DIR)
+        try:
+            certdb = NSSDatabase(nssdir=paths.HTTPD_ALIAS_DIR)
+        except ValueError as e:
+            logger.warning("Problem opening NSS database in "
+                           "%s. Skipping check for existing RA "
+                           "agent certificate: %s", paths.HTTPD_ALIAS_DIR, e)
+            return False, []
+
         if not certdb.has_nickname(ra_nick):
             # Nothign to do
             return False, []

--- a/ipatests/test_ipapython/test_certdb.py
+++ b/ipatests/test_ipapython/test_certdb.py
@@ -76,8 +76,8 @@ def test_dbm_raise():
     with pytest.raises(ValueError) as e:
         NSSDatabase(dbtype="dbm")
     assert (
-        str(e.value) == "NSS is built without support of the legacy "
-        "database(DBM)"
+        "NSS is built without support of the legacy database(DBM)"
+        in str(e.value)
     )
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #5489 was pushed to master and backport to ipa-4-9 is required.