### PR TITLE
ipatests: Update NSSDatabase DBM test on non-DBM-capable installs

### DIFF
--- a/ipatests/test_ipapython/test_certdb.py
+++ b/ipatests/test_ipapython/test_certdb.py
@@ -76,8 +76,8 @@ def test_dbm_raise():
     with pytest.raises(ValueError) as e:
         NSSDatabase(dbtype="dbm")
     assert (
-        str(e.value) == "NSS is built without support of the legacy "
-        "database(DBM)"
+        "NSS is built without support of the legacy database(DBM)"
+        in str(e.value)
     )
 
 


### PR DESCRIPTION
The string was updated to include the directory the for the database
but this was not reflected in the test and not picked up because
the tests were executed on Fedora 32 which supports dbm so the
test wasn't executed.

https://pagure.io/freeipa/issue/8675

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
