### PR TITLE
Ensure that KDC cert has SAN DNS entry

### DIFF
--- a/install/share/profiles/KDCs_PKINIT_Certs.cfg
+++ b/install/share/profiles/KDCs_PKINIT_Certs.cfg
@@ -12,7 +12,7 @@ input.i2.class_id=submitterInfoInputImpl
 output.list=o1
 output.o1.class_id=certOutputImpl
 policyset.list=serverCertSet
-policyset.serverCertSet.list=1,2,3,4,5,6,7,8,9,10,11
+policyset.serverCertSet.list=1,2,3,4,5,6,7,8,9,10,11,12
 policyset.serverCertSet.1.constraint.class_id=subjectNameConstraintImpl
 policyset.serverCertSet.1.constraint.name=Subject Name Constraint
 policyset.serverCertSet.1.constraint.params.pattern=CN=[^,]+,.+
@@ -107,3 +107,7 @@ policyset.serverCertSet.11.constraint.name=No Constraint
 policyset.serverCertSet.11.default.class_id=userExtensionDefaultImpl
 policyset.serverCertSet.11.default.name=User Supplied Extension Default
 policyset.serverCertSet.11.default.params.userExtOID=2.5.29.17
+policyset.serverCertSet.12.constraint.class_id=noConstraintImpl
+policyset.serverCertSet.12.constraint.name=No Constraint
+policyset.serverCertSet.12.default.class_id=commonNameToSANDefaultImpl
+policyset.serverCertSet.12.default.name=Copy Common Name to Subject Alternative Name

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -450,7 +450,9 @@ def request_cert(
         request_parameters["KEY_NICKNAME"] = nickname
     if principal:
         request_parameters['PRINCIPAL'] = [principal]
-    if dns is not None and len(dns) > 0:
+    if dns:
+        if not isinstance(dns, (list, tuple)):
+            raise TypeError(dns)
         request_parameters['DNS'] = dns
     if passwd_fname:
         request_parameters['KEY_PIN_FILE'] = passwd_fname

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -663,6 +663,7 @@ class CertDB:
             nickname=nickname,
             principal=principal,
             subject=host,
+            dns=[host],
             passwd_fname=self.passwd_fname,
             resubmit_timeout=resubmit_timeout
         )

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -449,7 +449,7 @@ class KrbInstance(service.Service):
                 subject=subject,
                 principal=krbtgt,
                 ca=certmonger_ca,
-                dns=self.fqdn,
+                dns=[self.fqdn],
                 storage='FILE',
                 profile=KDC_PROFILE,
                 post_command='renew_kdc_cert',

--- a/ipatests/test_integration/test_pkinit_manage.py
+++ b/ipatests/test_integration/test_pkinit_manage.py
@@ -46,6 +46,10 @@ def check_pkinit_cert_issuer(host, issuer):
     pkinit_cert = x509.load_pem_x509_certificate(data)
     # Make sure that the issuer is the expected one
     assert DN(pkinit_cert.issuer) == DN(issuer)
+    # KDC cert must have SAN for KDC hostname
+    assert host.hostname in pkinit_cert.san_a_label_dns_names
+    # at least three SANs, profile adds UPN and KRB principal name
+    assert len(pkinit_cert.san_general_names) >= 3
 
 
 def check_pkinit(host, enabled=True):


### PR DESCRIPTION
The dns parameter of request_and_wait_for_cert() must be a string of
hostnames.

* Enforce list/tuple type so that API misuse no longer passes silently.
* Add commonNameToSANDefaultImpl to KDCs_PKINIT_Certs profile
* Explicitly pass hostname for service certs

Fixes: https://pagure.io/freeipa/issue/8685
Signed-off-by: Christian Heimes <cheimes@redhat.com>