### PR TITLE
Fix cert_request for KDC cert

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -875,7 +875,7 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
                             "with subject alt name '%s'.") % name)
                 if not bypass_caacl:
                     if principal_type == KRBTGT:
-                        ca_kdc_check(ldap, alt_principal.hostname)
+                        ca_kdc_check(self.api, alt_principal.hostname)
                     else:
                         caacl_check(alt_principal, ca, profile_id)
 


### PR DESCRIPTION
ca_kdc_check() expects an API object, not an LDAP connection. Issue was
introduced in commit 8f4abf7bc1607fc44f528b8a443b69cb82269e69.

See: https://pagure.io/freeipa/issue/6739
Fixes: https://pagure.io/freeipa/issue/8686
Signed-off-by: Christian Heimes <cheimes@redhat.com>