### PR TITLE
[Backport][ipa-4-8] Fix cert_request for KDC cert

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -873,7 +873,7 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
                             "with subject alt name '%s'.") % name)
                 if not bypass_caacl:
                     if principal_type == KRBTGT:
-                        ca_kdc_check(ldap, alt_principal.hostname)
+                        ca_kdc_check(self.api, alt_principal.hostname)
                     else:
                         caacl_check(alt_principal, ca, profile_id)
 


### PR DESCRIPTION
This PR was opened automatically because PR #5496 was pushed to master and backport to ipa-4-8 is required.