### PR TITLE
Don't stop certmonger during IPA uninstallation

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -425,7 +425,7 @@ def install_step_1(standalone, replica_config, options, custodia):
 
 def uninstall():
     ca_instance = cainstance.CAInstance(api.env.realm)
-    ca_instance.stop_tracking_certificates(stop_certmonger=False)
+    ca_instance.stop_tracking_certificates()
     ipautil.remove_file(paths.RA_AGENT_PEM)
     ipautil.remove_file(paths.RA_AGENT_KEY)
     if ca_instance.is_configured():

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1075,13 +1075,13 @@ class CAInstance(DogtagInstance):
             logger.error(
                 "certmonger failed to start tracking certificate: %s", e)
 
-    def stop_tracking_certificates(self, stop_certmonger=True):
+    def stop_tracking_certificates(self):
         """
         Stop tracking our certificates. Called on uninstall.  Also called
         during upgrade to fix discrepancies.
 
         """
-        super(CAInstance, self).stop_tracking_certificates(False)
+        super(CAInstance, self).stop_tracking_certificates()
 
         # stop tracking lightweight CA signing certs
         for request_id in certmonger.get_requests_for_dir(self.nss_db):
@@ -1094,9 +1094,6 @@ class CAInstance(DogtagInstance):
         except RuntimeError as e:
             logger.error(
                 "certmonger failed to stop tracking certificate: %s", e)
-
-        if stop_certmonger:
-            services.knownservices.certmonger.stop()
 
     def is_renewal_master(self, fqdn=None):
         if fqdn is None:

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -453,7 +453,7 @@ class DogtagInstance(service.Service):
                 logger.error(
                     "certmonger failed to start tracking certificate: %s", e)
 
-    def stop_tracking_certificates(self, stop_certmonger=True):
+    def stop_tracking_certificates(self):
         """
         Stop tracking our certificates. Called on uninstall.  Also called
         during upgrade to fix discrepancies.
@@ -476,9 +476,6 @@ class DogtagInstance(service.Service):
             except RuntimeError as e:
                 logger.error(
                     "certmonger failed to stop tracking certificate: %s", e)
-
-        if stop_certmonger:
-            cmonger.stop()
 
     def update_cert_cs_cfg(self, directive, cert):
         """

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -648,9 +648,9 @@ def certificate_renewal_update(ca, kra, ds, http):
 
     # Ok, now we need to stop tracking, then we can start tracking them
     # again with new configuration:
-    ca.stop_tracking_certificates(stop_certmonger=False)
+    ca.stop_tracking_certificates()
     if kra.is_installed():
-        kra.stop_tracking_certificates(stop_certmonger=False)
+        kra.stop_tracking_certificates()
     ds.stop_tracking_certificates(serverid)
     http.stop_tracking_certificates()
 
@@ -920,7 +920,7 @@ def uninstall_dogtag_9(ds, http):
     ca = dogtaginstance.DogtagInstance(
         api.env.realm, "CA", "certificate server",
         nss_db=paths.VAR_LIB_PKI_CA_ALIAS_DIR)
-    ca.stop_tracking_certificates(False)
+    ca.stop_tracking_certificates()
 
     if serverid is not None:
         # drop the trailing / off the config_dirname so the directory


### PR DESCRIPTION
An effort prevent CI failures.

https://pagure.io/freeipa/issue/8533

Signed-off-by: Rob Crittenden <rcritten@redhat.com>