### PR TITLE
ipa-sam: return NetBIOS domain name instead of DNS one

### DIFF
--- a/daemons/ipa-sam/ipa_sam.c
+++ b/daemons/ipa-sam/ipa_sam.c
@@ -3649,7 +3649,7 @@ static bool init_sam_from_ldap(struct ipasam_private *ipasam_state,
 		goto fn_exit;
 	}
 
-	domain = talloc_strdup(tmp_ctx, ipasam_state->domain_name);
+	domain = talloc_strdup(tmp_ctx, ipasam_state->flat_name);
 	if (!domain) {
 		goto fn_exit;
 	}


### PR DESCRIPTION
[MS-NRPC] section 2.2.1.4.11 requires that the structure
NETLOGON_VALIDATION_SAM_INFO has the same values as defined in the
KERB_VALIDATION_INFO structure from [MS-PAC] section 2.5.

Samba's netr_SamBaseInfo.domain_name corresponds to
KERB_VALIDATION_INFO.LogonDomainName and must be a NetBIOS name of the
domain, not a DNS one.

Failure to provide NetBIOS name here actually breaks
netr_LogonSamLogonEx call issued by IPA-enrolled Samba domain member
which is confused by the returned value:

[2021/01/30 16:36:36.636010,  0, pid=1633, effective(0, 0), real(0, 0), class=winbind]
  ../../source3/winbindd/winbindd_util.c: 175(add_trusted_domain)
  add_trusted_domain: SID [S-1-5-21-3342930694-1632731913-1318603033]
  already used by domain [INTERNAL], expected [internal.example.test]
[2021/01/30 16:36:36.636050, 10, pid=1633, effective(0, 0), real(0, 0), class=winbind]
  ../../source3/winbindd/winbindd_util.c:362(add_trusted_domain_from_auth)
  add_trusted_domain_from_auth: Adding domain [internal.example.test]
  with sid [S-1-5-21-3342930694-1632731913-1318603033] failed
[2021/01/30 16:36:36.636060,  0, pid=1633, effective(0, 0), real(0, 0), class=winbind]
  ../../source3/winbindd/winbindd_pam_auth_crap.c:169(winbindd_pam_auth_crap_done)
  winbindd_pam_auth_crap_done: add_trusted_domain_from_auth failed
[2021/01/30 16:36:36.636079, 10, pid=1633, effective(0, 0), real(0, 0), class=winbind]
  ../../source3/winbindd/winbindd.c:814(process_request_done)
  process_request_done: [smbd(1650):PAM_AUTH_CRAP]: NT_STATUS_LOGON_FAILURE

Fixes: https://pagure.io/freeipa/issue/8636
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>