### PR TITLE
[Backport][ipa-4-9] ipa-sam: return NetBIOS domain name instead of DNS one

### DIFF
--- a/daemons/ipa-sam/ipa_sam.c
+++ b/daemons/ipa-sam/ipa_sam.c
@@ -3649,7 +3649,7 @@ static bool init_sam_from_ldap(struct ipasam_private *ipasam_state,
 		goto fn_exit;
 	}
 
-	domain = talloc_strdup(tmp_ctx, ipasam_state->domain_name);
+	domain = talloc_strdup(tmp_ctx, ipasam_state->flat_name);
 	if (!domain) {
 		goto fn_exit;
 	}


### PR DESCRIPTION
This PR was opened automatically because PR #5508 was pushed to master and backport to ipa-4-9 is required.