### PR TITLE
ipatests: Test if ipa-cert-fix renews expired certs

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1687,5 +1687,5 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_ipa_cert_fix.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -888,5 +888,5 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_ipa_cert_fix.py
         template: *pki-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1821,5 +1821,5 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_ipa_cert_fix.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1821,5 +1821,5 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_ipa_cert_fix.py
         template: *testing-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1955,5 +1955,5 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_ipa_cert_fix.py
         template: *testing-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1675,5 +1675,5 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_ipa_cert_fix.py
         template: *ci-master-previous
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1820,5 +1820,5 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_ipa_cert_fix.py
         template: *ci-master-frawhide
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl

--- a/ipatests/test_integration/test_ipa_cert_fix.py
+++ b/ipatests/test_integration/test_ipa_cert_fix.py
@@ -225,3 +225,28 @@ class TestIpaCertFixThirdParty(CALessBase):
         # the DS nickname is used and not a hardcoded value.
         result = self.master.run_command(['ipa-cert-fix', '-v'],)
         assert self.nickname in result.stderr_text
+
+
+class TestCertFixKRA(IntegrationTest):
+    @classmethod
+    def uninstall(cls, mh):
+        # Uninstall method is empty as the uninstallation is done in
+        # the fixture
+        pass
+
+    def test_renew_expired_cert_with_kra(self, expire_cert_critical):
+        """Test if ipa-cert-fix renews expired certs with kra installed
+
+        This test check if ipa-cert-fix renews certs with kra
+        certificate installed.
+
+        related: https://pagure.io/freeipa/issue/7885
+        """
+        expire_cert_critical(self.master, setup_kra=True)
+
+        # check if all subsystem cert expired
+        check_status(self.master, 11, "CA_UNREACHABLE")
+
+        self.master.run_command(['ipa-cert-fix', '-v'], stdin_text='yes\n')
+
+        check_status(self.master, 12, "MONITORING")


### PR DESCRIPTION
Test moves system date to expire certs. Then calls ipa-cert-fix
to renew them. This certs include subsystem, audit-signing,
OCSP signing, Dogtag HTTPS, IPA RA agent, LDAP and KDC certs.

related: https://pagure.io/freeipa/issue/7885

Signed-off-by: Mohammad Rizwan <myusuf@redhat.com>