### PR TITLE
client: synchronize ignored return codes with ipa-rmkeytab

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2077,9 +2077,11 @@ def purge_host_keytab(realm):
             '-k', paths.KRB5_KEYTAB, '-r', realm
         ])
     except CalledProcessError as e:
-        if e.returncode not in (3, 5):
+        if e.returncode not in (3, 5, 7):
             # 3 - Unable to open keytab
             # 5 - Principal name or realm not found in keytab
+            # 7 - Failed to set cursor, typically when errcode
+            #     would be issued in past
             logger.error(
                 "Error trying to clean keytab: "
                 "/usr/sbin/ipa-rmkeytab returned %s", e.returncode)


### PR DESCRIPTION
Refactoring ipa-rmkeytab with commit
f3f9672d527008dc741ac90aa465bac842eea08d led to new error code 7 when
MIT Kerberos fails to iterate through the keys. It appears now in places
where in past error code 3 was returned.

Related: https://pagure.io/freeipa/issue/8658
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>