### PR TITLE
Update samba configuration on IPA master to explicitly use 'server role' setting

### DIFF
--- a/install/share/smb.conf.registry.template
+++ b/install/share/smb.conf.registry.template
@@ -5,6 +5,7 @@ realm = $REALM
 kerberos method = dedicated keytab
 dedicated keytab file = /etc/samba/samba.keytab
 create krb5 conf = no
+server role = CLASSIC PRIMARY DOMAIN CONTROLLER
 security = user
 domain master = yes
 domain logons = yes


### PR DESCRIPTION
The default for this setting is 'auto', which may affect
IPA Samba configuration on future Samba versions. By explicitly
setting this parameter in the template, future manual
intervention is prevented.

Fixes: https://pagure.io/freeipa/issue/8452
Signed-off-by: Antonio Torres <antorres@redhat.com>