### PR TITLE
Fix pylint issues with pexpect wrapper

### DIFF
--- a/ipatests/pytest_ipa/integration/expect.py
+++ b/ipatests/pytest_ipa/integration/expect.py
@@ -107,18 +107,44 @@ class IpaTestExpect(pexpect.spawn):
         logger.debug('Sending %r', s)
         return super().send(s)
 
-    def expect_list(self, pattern_list, *args, **kwargs):
+    def expect_list(
+        self,
+        pattern_list,
+        timeout=-1,
+        searchwindowsize=-1,
+        async_=False,
+        **kw
+    ):
         """Wrapper to provide logging output string and expected patterns"""
         try:
-            result = super().expect_list(pattern_list, *args, **kwargs)
+            result = super().expect_list(
+                pattern_list,
+                timeout=timeout,
+                searchwindowsize=searchwindowsize,
+                async_=async_,
+                **kw
+            )
         finally:
             self._log_output(pattern_list)
         return result
 
-    def expect_exact(self, pattern_list, *args, **kwargs):
+    def expect_exact(
+        self,
+        pattern_list,
+        timeout=-1,
+        searchwindowsize=-1,
+        async_=False,
+        **kw
+    ):
         """Wrapper to provide logging output string and expected patterns"""
         try:
-            result = super().expect_exact(pattern_list, *args, **kwargs)
+            result = super().expect_exact(
+                pattern_list,
+                timeout=timeout,
+                searchwindowsize=searchwindowsize,
+                async_=async_,
+                **kw
+            )
         finally:
             self._log_output(pattern_list)
         return result

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -73,10 +73,14 @@ if __name__ == '__main__':
             "pytest_multihost",
             "python-ldap",
             "six",
-            "pexpect",
         ],
         extras_require={
-            "integration": ["dbus-python", "pyyaml", "ipaserver"],
+            "integration": [
+                "dbus-python",
+                "pexpect",
+                "pyyaml",
+                "ipaserver",
+            ],
             "ipaserver": ["ipaserver"],
             "webui": ["selenium", "pyyaml", "ipaserver"],
             "xmlrpc": ["ipaserver"],


### PR DESCRIPTION
Also move dependencies to extras_require.

See: https://pagure.io/freeipa/issue/8690
See: https://github.com/freeipa/freeipa/pull/5460
Signed-off-by: Christian Heimes <cheimes@redhat.com>