### PR TITLE
[Backport][ipa-4-9] Update samba configuration on IPA master to explicitly use 'server role' setting

### DIFF
--- a/install/share/smb.conf.registry.template
+++ b/install/share/smb.conf.registry.template
@@ -5,6 +5,7 @@ realm = $REALM
 kerberos method = dedicated keytab
 dedicated keytab file = /etc/samba/samba.keytab
 create krb5 conf = no
+server role = CLASSIC PRIMARY DOMAIN CONTROLLER
 security = user
 domain master = yes
 domain logons = yes


### PR DESCRIPTION
This PR was opened automatically because PR #5519 was pushed to master and backport to ipa-4-9 is required.