### PR TITLE
ipa-cert-fix: Don't hardcode the NSS certificate nickname

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -128,11 +128,11 @@
 %if 0%{?rhel} == 8
 # PKIConnection has been modified to always validate certs.
 # https://pagure.io/freeipa/issue/8379
-%global pki_version 10.9.0-0.4
+%global pki_version 10.10.4-1
 %else
 # New KRA profile, ACME support
 # https://pagure.io/freeipa/issue/8545
-%global pki_version 10.10.0-2
+%global pki_version 10.10.3-1
 %endif
 
 # RHEL 8.3+, F32+ has 0.79.13


### PR DESCRIPTION
ipa-cert-fix: Don't hardcode the NSS certificate nickname

The nickname of the 389-ds certificate was hardcoded as
Server-Cert which failed if the user had installed a
third-party certificate using ipa-server-certinstall.

Instead pull the nickname from the DS configuration and
retrieve it based on that.

https://pagure.io/freeipa/issue/8600

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

**NOTE**: I'm not sure that the test is completely worth it as this is a bit of an edge case. It is not a fast test at all.