### PR TITLE
ipatests: fix ipahealthcheck fixture _modify_permission

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1583,7 +1583,7 @@ def modify_permissions():
         if 'host' not in state:
             state['host'] = host
         if path not in state:
-            cmd = ["/usr/bin/stat", "-c", "%U:%G:%a", path]
+            cmd = ["/usr/bin/stat", "-L", "-c", "%U:%G:%a", path]
             result = host.run_command(cmd)
             state[path] = result.stdout_text.strip()
         if owner is not None:


### PR DESCRIPTION
The test is storing the initial file permissions obtained with 'stat',
then modifies them, calls ipa-healthcheck and reverts the permissions
to the original value.

When the file is a symlink, stat returns the permission of the link,
not of the pointed-to file. But chmod modifies the permissions of the
pointed-to file, not of the link.
As a consequence, the fixture does not properly restore the original
file permissions.

The fix consists in calling 'stat -L' because the command follows
links.

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>