### PR TITLE
ipatests: ipactl status now exits with 3 when a service is stopped

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1481,7 +1481,7 @@ class TestInstallReplicaAgainstSpecificServer(IntegrationTest):
         self.replicas[0].run_command('systemctl stop ipa-custodia.service')
 
         # check if custodia service is stopped
-        cmd = self.replicas[0].run_command('ipactl status')
+        cmd = self.replicas[0].run_command('ipactl status', raiseonerr=False)
         assert 'ipa-custodia Service: STOPPED' in cmd.stdout_text
 
         try:

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -486,7 +486,8 @@ class TestIpaHealthCheck(IntegrationTest):
         restart_service(self.master, "dirsrv")
         dirsrv_ipactl_status = 'Directory Service: STOPPED'
         result = self.master.run_command(
-            ["ipactl", "status"])
+            ["ipactl", "status"],
+            raiseonerr=False)
         returncode, data = run_healthcheck(
             self.master,
             "ipahealthcheck.ipa.host",

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -702,7 +702,7 @@ class TestReplicaInstallCustodia(IntegrationTest):
         tasks.install_replica(master, replica1, setup_ca=False)
         replica1.run_command(['ipactl', 'status'])
         replica1.run_command(['systemctl', 'stop', 'ipa-custodia'])
-        replica1.run_command(['ipactl', 'status'])
+        replica1.run_command(['ipactl', 'status'], raiseonerr=False)
 
         # Install Replica2 with CA with source as Replica1.
         tasks.install_replica(replica1, replica2, setup_ca=True)


### PR DESCRIPTION
ipatests: ipactl status now exits with 3 when a service is stopped
    
Some tests are individually stopping a service and call
ipactl status to ensure it is stopped. They need to use
run_command with raiseonerr=False as ipactl status now
exits with 3 when one of the IPA services is down
(since commit 928ab51).
    
Related: https://pagure.io/freeipa/issue/8588
