### PR TITLE
[Backport][ipa-4-9] ipatests: fix ipahealthcheck fixture _modify_permission

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1583,7 +1583,7 @@ def modify_permissions():
         if 'host' not in state:
             state['host'] = host
         if path not in state:
-            cmd = ["/usr/bin/stat", "-c", "%U:%G:%a", path]
+            cmd = ["/usr/bin/stat", "-L", "-c", "%U:%G:%a", path]
             result = host.run_command(cmd)
             state[path] = result.stdout_text.strip()
         if owner is not None:


### PR DESCRIPTION
This PR was opened automatically because PR #5526 was pushed to master and backport to ipa-4-9 is required.