### PR TITLE
[Backport][ipa-4-9] ipatests: ipactl status now exits with 3 when a service is stopped

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1481,7 +1481,7 @@ class TestInstallReplicaAgainstSpecificServer(IntegrationTest):
         self.replicas[0].run_command('systemctl stop ipa-custodia.service')
 
         # check if custodia service is stopped
-        cmd = self.replicas[0].run_command('ipactl status')
+        cmd = self.replicas[0].run_command('ipactl status', raiseonerr=False)
         assert 'ipa-custodia Service: STOPPED' in cmd.stdout_text
 
         try:

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -486,7 +486,8 @@ class TestIpaHealthCheck(IntegrationTest):
         restart_service(self.master, "dirsrv")
         dirsrv_ipactl_status = 'Directory Service: STOPPED'
         result = self.master.run_command(
-            ["ipactl", "status"])
+            ["ipactl", "status"],
+            raiseonerr=False)
         returncode, data = run_healthcheck(
             self.master,
             "ipahealthcheck.ipa.host",

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1583,7 +1583,7 @@ def modify_permissions():
         if 'host' not in state:
             state['host'] = host
         if path not in state:
-            cmd = ["/usr/bin/stat", "-c", "%U:%G:%a", path]
+            cmd = ["/usr/bin/stat", "-L", "-c", "%U:%G:%a", path]
             result = host.run_command(cmd)
             state[path] = result.stdout_text.strip()
         if owner is not None:

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -702,7 +702,7 @@ class TestReplicaInstallCustodia(IntegrationTest):
         tasks.install_replica(master, replica1, setup_ca=False)
         replica1.run_command(['ipactl', 'status'])
         replica1.run_command(['systemctl', 'stop', 'ipa-custodia'])
-        replica1.run_command(['ipactl', 'status'])
+        replica1.run_command(['ipactl', 'status'], raiseonerr=False)
 
         # Install Replica2 with CA with source as Replica1.
         tasks.install_replica(replica1, replica2, setup_ca=True)


### PR DESCRIPTION
This PR was opened automatically because PR #5528 was pushed to master and backport to ipa-4-9 is required.