### PR TITLE
Set the ACME baseURL in order to pin a client to a single IPA server

### DIFF
--- a/install/share/pki-acme-configsources.conf.template
+++ b/install/share/pki-acme-configsources.conf.template
@@ -1,2 +1,3 @@
+# VERSION 2 - DO NOT REMOVE THIS LINE
 engine.class=org.dogtagpki.acme.server.ACMEEngineConfigFileSource
 engine.filename=/etc/pki/pki-tomcat/acme/engine.conf

--- a/install/share/pki-acme-database.conf.template
+++ b/install/share/pki-acme-database.conf.template
@@ -1,3 +1,4 @@
+# VERSION 2 - DO NOT REMOVE THIS LINE
 class=org.dogtagpki.acme.database.LDAPDatabase
 basedn=ou=acme,o=ipaca
 configFile=/etc/pki/pki-tomcat/ca/CS.cfg

--- a/install/share/pki-acme-engine.conf.template
+++ b/install/share/pki-acme-engine.conf.template
@@ -9,3 +9,5 @@ enabled=false
 
 # Whether to accept wildcard DNS identifiers:
 policy.wildcard=false
+
+baseURL=https://$FQDN/acme

--- a/install/share/pki-acme-engine.conf.template
+++ b/install/share/pki-acme-engine.conf.template
@@ -1,3 +1,4 @@
+# VERSION 2 - DO NOT REMOVE THIS LINE
 # Parameters read by ACMEEngineConfigFileSource, i.e. these are
 # expected to be in the file pointed to by the 'filename' directive
 # above.

--- a/install/share/pki-acme-issuer.conf.template
+++ b/install/share/pki-acme-issuer.conf.template
@@ -1,3 +1,4 @@
+# VERSION 2 - DO NOT REMOVE THIS LINE
 class=org.dogtagpki.acme.issuer.PKIIssuer
 url=https://$FQDN:8443
 profile=acmeIPAServerCert

--- a/install/share/pki-acme-realm.conf.template
+++ b/install/share/pki-acme-realm.conf.template
@@ -1,3 +1,4 @@
+# VERSION 2 - DO NOT REMOVE THIS LINE
 authType=BasicAuth
 class=org.dogtagpki.acme.realm.DSRealm
 groupsDN=ou=groups,o=ipaca

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -77,6 +77,15 @@ ACME_AGENT_GROUP = 'Enterprise ACME Administrators'
 
 PROFILES_DN = DN(('ou', 'certificateProfiles'), ('ou', 'ca'), ('o', 'ipaca'))
 
+ACME_CONFIG_FILES = (
+    ('pki-acme-configsources.conf.template',
+        paths.PKI_ACME_CONFIGSOURCES_CONF),
+    ('pki-acme-database.conf.template', paths.PKI_ACME_DATABASE_CONF),
+    ('pki-acme-engine.conf.template', paths.PKI_ACME_ENGINE_CONF),
+    ('pki-acme-issuer.conf.template', paths.PKI_ACME_ISSUER_CONF),
+    ('pki-acme-realm.conf.template', paths.PKI_ACME_REALM_CONF),
+)
+
 
 def check_ports():
     """Check that dogtag ports (8080, 8443) are available.
@@ -1524,20 +1533,12 @@ class CAInstance(DogtagInstance):
         ipautil.run(['pki-server', 'acme-create'])
 
         # write configuration files
-        files = [
-            ('pki-acme-configsources.conf.template',
-                paths.PKI_ACME_CONFIGSOURCES_CONF),
-            ('pki-acme-database.conf.template', paths.PKI_ACME_DATABASE_CONF),
-            ('pki-acme-engine.conf.template', paths.PKI_ACME_ENGINE_CONF),
-            ('pki-acme-issuer.conf.template', paths.PKI_ACME_ISSUER_CONF),
-            ('pki-acme-realm.conf.template', paths.PKI_ACME_REALM_CONF),
-        ]
         sub_dict = dict(
             FQDN=self.fqdn,
             USER=acme_user,
             PASSWORD=password,
         )
-        for template_name, target in files:
+        for template_name, target in ACME_CONFIG_FILES:
             template_filename = \
                 os.path.join(paths.USR_SHARE_IPA_DIR, template_name)
             filled = ipautil.template_file(template_filename, sub_dict)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1493,8 +1493,10 @@ class CAInstance(DogtagInstance):
             return False
 
         if not minimum_acme_support():
+            logger.debug('Minimum ACME support not available')
             return False
 
+        logger.debug('Deploying ACME')
         self._ldap_mod('/usr/share/pki/acme/database/ds/schema.ldif')
 
         configure_acme_acls()


### PR DESCRIPTION
ACME uses nonce values to prevent replay attacks. Since the
ipa-ca name can go to any of the IPA servers in order to verify the
nonce the servers need to know the value that was set which
relies on replication. Sometimes the client is faster than
replication so a request can fail.

This change returns the baseURL to the client as the name of the
ACME server during discovery which should pin all requests to this
one IPA server and alleviate the replication issue.

Signed-off-by: Rob Crittenden <rcritten@redhat.com>