### PR TITLE
[Backport][ipa-4-9] freeipa.spec.in: client: depend on libsss_sudo

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -640,6 +640,11 @@ Requires: nfs-utils
 Requires: sssd-tools >= %{sssd_version}
 Requires(post): policycoreutils
 
+# https://pagure.io/freeipa/issue/8530
+Recommends: libsss_sudo
+Recommends: sudo
+Requires: (libsss_sudo if sudo)
+
 Provides: %{alt_name}-client = %{version}
 Conflicts: %{alt_name}-client
 Obsoletes: %{alt_name}-client < %{version}

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -24,6 +24,7 @@ import re
 import SSSDConfig
 import shutil
 import socket
+import subprocess
 import sys
 import tempfile
 import textwrap
@@ -2200,7 +2201,18 @@ def install_check(options):
             "authentication resources",
             rval=CLIENT_INSTALL_ERROR)
 
-    # when installing with '--no-sssd' option, check whether nss-ldap is
+    # When installing without the "--no-sudo" option, check whether sudo is
+    # available.
+    if options.conf_sudo:
+        try:
+            subprocess.Popen(['sudo -V'])
+        except FileNotFoundError:
+            logger.info(
+                "The sudo binary does not seem to be present on this "
+                "system. Please consider installing sudo if required."
+            )
+
+    # when installing with the '--no-sssd' option, check whether nss-ldap is
     # installed
     if not options.sssd:
         if not os.path.exists(paths.PAM_KRB5_SO):

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -535,6 +535,18 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-latest-ipa-4-9/test_installation_TestInstallWithoutSudo:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithoutSudo
+        template: *ci-ipa-4-9-latest
+        timeout: 4800
+        topology: *master_1repl_1client
+
   fedora-latest-ipa-4-9/test_idviews:
     requires: [fedora-latest-ipa-4-9/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -575,6 +575,19 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-latest-ipa-4-9/test_installation_TestInstallWithoutSudo:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestInstallWithoutSudo
+        template: *ci-ipa-4-9-latest
+        timeout: 4800
+        topology: *master_1repl_1client
+
   fedora-latest-ipa-4-9/test_idviews:
     requires: [fedora-latest-ipa-4-9/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -535,6 +535,18 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  fedora-previous-ipa-4-9/test_installation_TestInstallWithoutSudo:
+    requires: [fedora-previous-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-9/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithoutSudo
+        template: *ci-ipa-4-9-previous
+        timeout: 4800
+        topology: *master_1repl_1client
+
   fedora-previous-ipa-4-9/test_idviews:
     requires: [fedora-previous-ipa-4-9/build]
     priority: 50

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1537,3 +1537,69 @@ class TestInstallReplicaAgainstSpecificServer(IntegrationTest):
                                             self.replicas[0].hostname],
                                            stdin_text=dirman_password)
         assert self.replicas[0].hostname not in cmd.stdout_text
+
+
+class TestInstallWithoutSudo(IntegrationTest):
+
+    num_clients = 1
+    num_replicas = 1
+    no_sudo_str = "The sudo binary does not seem to be present on this"
+
+    @classmethod
+    def install(cls, mh):
+        pass
+
+    def test_sudo_removal(self):
+        # ipa-client makes sudo depend on libsss_sudo.
+
+        # --nodeps is mandatory because dogtag uses sudo at install
+        # time until commit 49585867207922479644a03078c29548de02cd03
+        # which is scheduled to land in 10.10.
+
+        # This also means sudo+libsss_sudo cannot be uninstalled on
+        # IPA servers with a CA.
+        assert tasks.is_package_installed(self.clients[0], 'sudo')
+        assert tasks.is_package_installed(self.clients[0], 'libsss_sudo')
+        tasks.uninstall_packages(
+            self.clients[0], ['sudo', 'libsss_sudo'], nodeps=True
+        )
+
+    def test_ipa_installation_without_sudo(self):
+        # FixMe: When Dogtag 10.10 is out, test installation without sudo
+        tasks.install_master(self.master, setup_dns=True)
+
+    def test_replica_installation_without_sudo(self):
+        # FixMe: When Dogtag 10.10 is out, test replica installation
+        # without sudo and with CA
+        tasks.uninstall_packages(
+            self.replicas[0], ['sudo', 'libsss_sudo'], nodeps=True
+        )
+        # One-step install is needed.
+        # With promote=True, two-step install is done and that only captures
+        # the ipa-replica-install stdout/stderr, not ipa-client-install's.
+        result = tasks.install_replica(
+            self.master, self.replicas[0], promote=False,
+            setup_dns=True, setup_ca=False
+        )
+        assert self.no_sudo_str in result.stderr_text
+
+    def test_client_installation_without_sudo(self):
+        result = tasks.install_client(self.master, self.clients[0])
+        assert self.no_sudo_str in result.stderr_text
+
+    def test_remove_sudo_on_ipa(self):
+        tasks.uninstall_packages(
+            self.master, ['sudo', 'libsss_sudo'], nodeps=True
+        )
+        self.master.run_command(
+            ['ipactl', 'restart']
+        )
+
+    def test_install_sudo_on_client(self):
+        """ Check that installing sudo pulls libsss_sudo in"""
+        for pkg in ('sudo', 'libsss_sudo'):
+            assert tasks.is_package_installed(self.clients[0], pkg) is False
+        tasks.uninstall_client(self.clients[0])
+        tasks.install_packages(self.clients[0], ['sudo'])
+        for pkg in ('sudo', 'libsss_sudo'):
+            assert tasks.is_package_installed(self.clients[0], pkg)


### PR DESCRIPTION
MANUAL BACKPORT of https://github.com/freeipa/freeipa/pull/5176

On 10.10+ releases of Dogtag, the PKI installer will not depend on sudo anymore. This opens the possibility of creating IPA servers without a properly configured sudo.
In fact, even IPA clients should have sudo and libsss_sudo installed in most cases, so: add a weak dependency on libsss_sudo to freeipa-client.

Fixes: https://pagure.io/freeipa/issue/8530
