### PR TITLE
test_installutils: run gpg-agent under a specific SELinux context

### DIFF
--- a/ipatests/test_ipaserver/test_install/test_installutils.py
+++ b/ipatests/test_ipaserver/test_install/test_installutils.py
@@ -57,10 +57,12 @@ def gpgkey(request, tempdir):
     # daemonize agent (detach from the console and run in the background)
     subprocess.run(
         [paths.SYSTEMD_RUN, '--service-type=forking',
+         '--property', 'SELinuxContext=system_u:system_r:initrc_t:s0',
          '--setenv=GNUPGHOME={}'.format(gnupghome),
          '--setenv=LC_ALL=C.UTF-8',
          '--setenv=LANGUAGE=C',
-         '--unit=gpg-agent', paths.GPG_AGENT, '--daemon', '--batch'],
+         '--unit=gpg-agent', '/bin/bash',
+         '-c', ' '.join([paths.GPG_AGENT, '--daemon', '--batch'])],
         check=True,
         env=env,
     )


### PR DESCRIPTION
system_u:system_r:init_t:s0 cannot execute gpg=agent when SELinux is in
enforcing mode. Use SELinux context that allows this execution:
system_u:system_r:initrc_t:s0

Fixes: https://pagure.io/freeipa/issue/8699
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>