### PR TITLE
WebUI: change FreeIPA naming to IPA in About dialog

### DIFF
--- a/install/ui/src/freeipa/dialog.js
+++ b/install/ui/src/freeipa/dialog.js
@@ -1325,7 +1325,7 @@ IPA.about_dialog = function(spec) {
     spec = spec || {};
 
     spec.name = spec.name || 'version_dialog';
-    var product = 'FreeIPA';
+    var product = 'IPA';
     var version = 'Unknown';
     var msg = text.get('@i18n:dialogs.about_message', '${product}, version: ${version}');
     if (IPA.env) {


### PR DESCRIPTION
As part of the effort for reducing differences between
upstream and dowmstream releases, product naming in WebUI
About dialog is changed from FreeIPA to IPA.

Related: https://pagure.io/freeipa/issue/8669
Signed-off-by: Antonio Torres <antorres@redhat.com>