### PR TITLE
 ipa cert-remove-hold <invalid_cert_id> returns an incorrect error message

### DIFF
--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1471,6 +1471,7 @@ class ra(rabase.rabase, RestClient):
         except errors.HTTPRequestError as e:
             self.raise_certificate_operation_error(
                 'get_certificate',
+                err_msg=e.msg,
                 detail=e.status  # pylint: disable=no-member
             )
 


### PR DESCRIPTION
### cert plugin: propagate the error for non-existent cert

ipa cert-show, ipa cert-revoke and ipa cert-remove-hold do not
print meaningful info when called on a non-existent cert id:
Certificate operation cannot be completed: Unable to communicate
with CMS

Propagate the reason from the HTTP message in order to print
'Certificate ID 0x.. not found'

Fixes: https://pagure.io/freeipa/issue/8704

### xmlrpc tests: add a test for cert-remove-hold
Add tests for the ipa cert-remove-hold command.
Scenario 1:
add host entry, request cert, revoke cert with "hold" reason, remove hold

Scenario 2:
call ipa cert-move-hold with a non-existent cert ID and ensure that
the exception mentions 'Certificate ID .. not found'

Related: https://pagure.io/freeipa/issue/8704