### PR TITLE
Reduce confusing output when CA fails to deploy

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -222,6 +222,9 @@ def get_crl_files(path=None):
     if path is None:
         path = paths.PKI_CA_PUBLISH_DIR
 
+    if not os.path.exists(path):
+        return
+
     files = os.listdir(path)
     for f in files:
         if f == "MasterCRL.bin":

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -523,13 +523,15 @@ class DogtagInstance(service.Service):
         return admin_cert
 
     def handle_setup_error(self, e):
-        logger.critical("Failed to configure %s instance: %s",
-                        self.subsystem, e)
+        logger.critical("Failed to configure %s instance",
+                        self.subsystem)
         logger.critical("See the installation logs and the following "
                         "files/directories for more information:")
         logger.critical("  %s", paths.TOMCAT_TOPLEVEL_DIR)
 
-        raise RuntimeError("%s configuration failed." % self.subsystem)
+        raise RuntimeError(
+            "%s configuration failed." % self.subsystem
+        ) from None
 
     def add_ipaca_aci(self):
         """Add ACI to allow ipaca users to read their own group information


### PR DESCRIPTION
Don't double-report any errors from pki-spawn failures

The output from pki-spawn is already displayed to the user
as well as a short traceback so re-displaying the CalledProcess
error provides no value and only provokes confusion,
particularly because it is condensed and includes embedded
newlines.

Re-raise the exception from None so that the traceback is
removed and while there is still an immense traceback from
the admintool class it is significantly shorter than before
and removes:

"During handling of the above exception, another exception occurred"

The handling is in fact expected.

This changes the user-facing installer output from:

  [1/28]: configuring certificate server instance
Failed to configure CA instance: CalledProcessError(Command ['/usr/sbin/pkispawn', '-s', 'CA', '-f', '/tmp/tmpr5x2l0gm', '--debug'] returned non-zero exit status 1: 'INFO: Connecting to LDAP server at ldap://ipa.example.test:389\nINFO: Connecting to LDAP server at ldap://ipa.example.test:389\nDEBUG: Installing Maven dependencies: False\nERROR: KeyError: \'CA\'\n  File "/usr/lib/python3.9/site-packages/pki/server/pkispawn.py", line 575, in main\n    raise KeyError(\'CA\')\n\n')
See the installation logs and the following files/directories for more information:
  /var/log/pki/pki-tomcat
  [error] RuntimeError: CA configuration failed.
CA configuration failed.
The ipa-server-install command failed. See /var/log/ipaserver-install.log for more information

to

  [1/28]: configuring certificate server instance
Failed to configure CA instance
See the installation logs and the following files/directories for more information:
  /var/log/pki/pki-tomcat
  [error] RuntimeError: CA configuration failed.
CA configuration failed.
The ipa-server-install command failed. See /var/log/ipaserver-install.log for more information

The output is similarly reduced in the installer log. There is no
reason to acknowledge that a CalledProcessError was raised since
the output is already available and it's just an intermediary.

Hopefully this will encourage users to focus on the logs rather than
the malformed traceback.

https://pagure.io/freeipa/issue/8565

I noticed that while uninstalling I got an error about a missing CRL directory because it hadn't been created yet so don't try removing things that don't exist.

Others may have more creative ways to reproduce this but I hacked on  /usr/lib/python3.X/site-packages/pki/server/pkispawn.py

And added a raise KeyError('CA') before the spawn ala:

            scriptlet.instance = instance
            raise KeyError('CA')
            scriptlet.spawn(deployer)
