### PR TITLE
[Backport][ipa-4-9]  ipa cert-remove-hold <invalid_cert_id> returns an incorrect error message

### DIFF
--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1471,6 +1471,7 @@ class ra(rabase.rabase, RestClient):
         except errors.HTTPRequestError as e:
             self.raise_certificate_operation_error(
                 'get_certificate',
+                err_msg=e.msg,
                 detail=e.status  # pylint: disable=no-member
             )
 


### PR DESCRIPTION
This PR was opened automatically because PR #5541 was pushed to master and backport to ipa-4-9 is required.