### PR TITLE
[Backport][ipa-4-9] WebUI: change FreeIPA naming to IPA in About dialog

### DIFF
--- a/install/ui/src/freeipa/dialog.js
+++ b/install/ui/src/freeipa/dialog.js
@@ -1325,7 +1325,7 @@ IPA.about_dialog = function(spec) {
     spec = spec || {};
 
     spec.name = spec.name || 'version_dialog';
-    var product = 'FreeIPA';
+    var product = 'IPA';
     var version = 'Unknown';
     var msg = text.get('@i18n:dialogs.about_message', '${product}, version: ${version}');
     if (IPA.env) {


### PR DESCRIPTION
This PR was opened automatically because PR #5540 was pushed to master and backport to ipa-4-9 is required.