### PR TITLE
[Backport][ipa-4-9] [ipatests][Azure Pipelines] Populate containers with self-AAAA records

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -856,6 +856,8 @@ Requires: python3-pexpect
 # These packages do not exist on RHEL and for ipatests use
 # they are installed on the controller through other means
 Requires: ldns-utils
+# update-crypto-policies
+Requires: crypto-policies-scripts
 Requires: python3-polib
 Requires: python3-pytest >= 3.9.1
 Requires: python3-pytest-multihost >= 0.5

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -22,6 +22,7 @@ from ipapython.certdb import NSS_SQL_FILES
 from ipatests.pytest_ipa.integration import tasks
 from ipaplatform.paths import paths
 from ipaplatform.osinfo import osinfo
+from ipaserver.install.installutils import resolve_ip_addresses_nss
 from ipatests.test_integration.base import IntegrationTest
 from pkg_resources import parse_version
 from ipatests.test_integration.test_cert import get_certmonger_fs_id
@@ -659,9 +660,16 @@ class TestIpaHealthCheck(IntegrationTest):
             "_kpasswd._udp." + self.master.domain.name + ".:" +
             self.master.hostname + ".",
             "\"" + self.master.domain.realm.upper() + "\"",
-            self.master.ip,
-            self.replicas[0].ip
         ]
+
+        for hostname in [
+                self.master.external_hostname,
+                self.replicas[0].external_hostname,
+        ]:
+            # resolve hostname on controller
+            ips = resolve_ip_addresses_nss(hostname)
+            SRV_RECORDS.extend([str(ip) for ip in ips])
+
         returncode, data = run_healthcheck(
             self.master,
             "ipahealthcheck.ipa.idns",


### PR DESCRIPTION
This PR was opened automatically because PR #5486 was pushed to master and backport to ipa-4-9 is required.