### PR TITLE
[Backport][ipa-4-9]  sudocmd: ensure command doesn't contain trailing dot before adding it

### DIFF
--- a/ipaserver/plugins/sudocmd.py
+++ b/ipaserver/plugins/sudocmd.py
@@ -49,6 +49,12 @@ register = Registry()
 
 topic = 'sudo'
 
+
+def command_validator(ugettext, value):
+    if value.endswith('.'):
+        return _('must not contain trailing dot: %s') % value
+    return None
+
 @register()
 class sudocmd(LDAPObject):
     """
@@ -112,7 +118,7 @@ class sudocmd(LDAPObject):
     label_singular = _('Sudo Command')
 
     takes_params = (
-        Str('sudocmd',
+        Str('sudocmd', command_validator,
             cli_name='command',
             label=_('Sudo Command'),
             primary_key=True,
@@ -146,7 +152,6 @@ class sudocmd_add(LDAPCreate):
     __doc__ = _('Create new Sudo Command.')
 
     msg_summary = _('Added Sudo Command "%(value)s"')
-
 
 @register()
 class sudocmd_del(LDAPDelete):

--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -170,6 +170,11 @@ class TestSudo(IntegrationTest):
         # No group
         self.master.run_command(['ipa', 'sudocmd-add', '/usr/bin/yum'])
 
+        # Invalid command
+        result = self.master.run_command(
+            ['ipa', 'sudocmd-add', '/bin/cat.'], raiseonerr=False)
+        assert result.returncode == 1
+
     def test_add_sudo_command_groups(self):
         self.master.run_command(['ipa', 'sudocmdgroup-add', 'readers',
                                  '--desc', '"Applications that read"'])


### PR DESCRIPTION
This PR was opened automatically because PR #5538 was pushed to master and backport to ipa-4-9 is required.