### PR TITLE
ipatests: various enhancement to hidden replica tests

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -47,6 +47,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
+from datetime import datetime, timedelta
 
 from ipapython import certdb
 from ipapython import ipautil
@@ -2584,6 +2585,26 @@ def get_healthcheck_version(host):
             "get_healthcheck_version: unknown platform %s" % platform
         )
     return healthcheck_version
+
+
+def wait_for_ipa_to_start(host, timeout=60):
+    """Wait up to timeout seconds for ipa to start on a given host.
+
+    If DS is restarted, and SSSD must be online, please consider using
+    wait_for_sssd_domain_status_online(host) in the test after calling
+    this method.
+    """
+    interval = 1
+    end_time = datetime.now() + timedelta(seconds=timeout)
+    for _i in range(0, timeout, interval):
+        if datetime.now() > end_time:
+            raise RuntimeError("Request timed out")
+        time.sleep(interval)
+        result = host.run_command(
+            [paths.IPACTL, "status"], raiseonerr=False
+        )
+        if result.returncode == 0:
+            break
 
 
 def run_ssh_cmd(

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2607,6 +2607,15 @@ def wait_for_ipa_to_start(host, timeout=60):
             break
 
 
+def dns_update_system_records(host):
+    """Runs "ipa dns-update-system-records" on "host".
+    """
+    kinit_admin(host)
+    host.run_command(
+        ["ipa", "dns-update-system-records"]
+    )
+
+
 def run_ssh_cmd(
     from_host=None, to_host=None, username=None, cmd=None,
     auth_method=None, password=None, private_key_path=None,

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -922,7 +922,7 @@ class TestHiddenReplicaPromotion(IntegrationTest):
             )
             assert returncode == 0
 
-    def test_hide_master_fails(self):
+    def test_hide_last_visible_server_fails(self):
         # verify state
         self._check_config([self.master], [self.replicas[0]])
         # nothing to do
@@ -961,6 +961,7 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         self._check_config([self.master, self.replicas[0]])
         self._check_dnsrecords([self.master, self.replicas[0]])
 
+    def test_promote_twice_fails(self):
         result = self.replicas[0].run_command([
             'ipa', 'server-state',
             self.replicas[0].hostname, '--state=enabled'

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -951,8 +951,11 @@ class TestHiddenReplicaPromotion(IntegrationTest):
             self.replicas[0].hostname, '--state=enabled'
         ])
         self._check_server_role(self.replicas[0], 'enabled')
-        self._check_dnsrecords([self.master, self.replicas[0]])
+        tasks.wait_for_replication(
+            self.replicas[0].ldap_connect()
+        )
         self._check_config([self.master, self.replicas[0]])
+        self._check_dnsrecords([self.master, self.replicas[0]])
 
         result = self.replicas[0].run_command([
             'ipa', 'server-state',
@@ -967,6 +970,10 @@ class TestHiddenReplicaPromotion(IntegrationTest):
             self.replicas[0].hostname, '--state=hidden'
         ])
         self._check_server_role(self.replicas[0], 'hidden')
+        tasks.wait_for_replication(
+            self.replicas[0].ldap_connect()
+        )
+        self._check_config([self.master], [self.replicas[0]])
         self._check_dnsrecords([self.master], [self.replicas[0]])
 
     def test_replica_from_hidden(self):
@@ -1030,14 +1037,11 @@ class TestHiddenReplicaPromotion(IntegrationTest):
             stdin_text=dirman_password + '\nyes'
         )
 
-        # wait for the replica to be available
-        tasks.wait_for_ipa_to_start(self.replicas[0])
-
-        # give replication some time
-        time.sleep(5)
+        tasks.kinit_admin(self.master)
         tasks.kinit_admin(self.replicas[0])
 
-        # FIXME: restore turns hidden replica into enabled replica
+        # restore turns a hidden replica into an enabled replica
+        # https://pagure.io/freeipa/issue/7894
         self._check_config([self.master, self.replicas[0]])
         self._check_server_role(self.replicas[0], 'enabled')
 

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -954,6 +954,10 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         tasks.wait_for_replication(
             self.replicas[0].ldap_connect()
         )
+        tasks.dns_update_system_records(self.master)
+        tasks.wait_for_replication(
+            self.master.ldap_connect()
+        )
         self._check_config([self.master, self.replicas[0]])
         self._check_dnsrecords([self.master, self.replicas[0]])
 
@@ -972,6 +976,10 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         self._check_server_role(self.replicas[0], 'hidden')
         tasks.wait_for_replication(
             self.replicas[0].ldap_connect()
+        )
+        tasks.dns_update_system_records(self.master)
+        tasks.wait_for_replication(
+            self.master.ldap_connect()
         )
         self._check_config([self.master], [self.replicas[0]])
         self._check_dnsrecords([self.master], [self.replicas[0]])

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -1030,6 +1030,9 @@ class TestHiddenReplicaPromotion(IntegrationTest):
             stdin_text=dirman_password + '\nyes'
         )
 
+        # wait for the replica to be available
+        tasks.wait_for_ipa_to_start(self.replicas[0])
+
         # give replication some time
         time.sleep(5)
         tasks.kinit_admin(self.replicas[0])

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -905,6 +905,9 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         self._check_dnsrecords([self.master], [self.replicas[0]])
         self._check_config([self.master], [self.replicas[0]])
 
+    @pytest.mark.xfail(
+        reason='https://pagure.io/freeipa/issue/8582', strict=True
+    )
     def test_ipahealthcheck_hidden_replica(self):
         """Ensure that ipa-healthcheck runs successfully on all members
         of an IPA cluster that includes a hidden replica.


### PR DESCRIPTION
https://github.com/freeipa/freeipa/pull/5183 redux. I cannot reopen the original PR because the branch was force-pushed.

+
    ipatests: add wait_for_ipa_to_start
    
    wait_for_ipa_to_start(host) waits for ipactl to return RUNNING for all
    IPA services on the specified host.

    Related: https://pagure.io/freeipa/issue/8534
+
    ipatests: hiddenreplica:  use wait_for_ipa_to_start after restore
    
    Use wait_for_ipa_to_start to wait until the restored replica is online.

    Related: https://pagure.io/freeipa/issue/8534
+
    ipatests: use wait_for_replication for hidden replica checks
    
    Previously, hidden replica checks were run without waiting for replication
    to complete, potentially leading to unstable behavior.
    Use wait_for_replication.

    Fixes: https://pagure.io/freeipa/issue/8534
+
    ipatests: hidden replica: misc fixes
    
    Split a test in two and add additional fixes.
    
    Related: https://pagure.io/freeipa/issue/8534