### PR TITLE
[Backport][ipa-4-9] ipatests: update expected error message 

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -436,7 +436,8 @@ class TestIpaHealthCheck(IntegrationTest):
         error_msg = (
             "Request for certificate failed, "
             "Certificate operation cannot be completed: "
-            "Unable to communicate with CMS (503)"
+            "Request failed with status 503: "
+            "Non-2xx response from CA REST API: 503.  (503)"
         )
         returncode, data = run_healthcheck(
             self.master, "ipahealthcheck.dogtag.ca",


### PR DESCRIPTION
This PR was opened automatically because PR #5547 was pushed to master and backport to ipa-4-9 is required.