### PR TITLE
ipatests: check localhost is actually used for domain name resolution

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,40 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/temp_dns:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_dns.py
         template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-latest-f33/build:
+    requires: []
+    priority: 100
+    job:
+      class: Build
+      args:
+        git_repo: '{git_repo}'
+        git_refspec: '{git_refspec}'
+        template: &ci-master-latest-f33
+          name: freeipa/ci-master-f33
+          version: 0.0.6
+        timeout: 1800
+        topology: *build
+
+  fedora-latest-f33/temp_dns:
+    requires: [fedora-latest-f33/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-f33/build_url}'
+        test_suite: test_integration/test_dns.py
+        template: *ci-master-latest-f33
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -461,12 +461,6 @@ class TestInstallDNSSECFirst(IntegrationTest):
         self.master.run_command(args)
         self.replicas[0].run_command(args)
 
-    def test_resolvconf(self):
-        # check that resolv.conf contains IP address for localhost
-        for host in [self.master, self.replicas[0]]:
-            resolvconf = host.get_file_contents(paths.RESOLV_CONF, 'utf-8')
-            assert any(ip in resolvconf for ip in ('127.0.0.1', '::1'))
-
 
 class TestMigrateDNSSECMaster(IntegrationTest):
     """test DNSSEC master migration


### PR DESCRIPTION
The original test "test_resolvconf" only checked that ip address of
 localhost is present in /etc/resolv.conf. This does not guarantee that
 it is actually used for name resolution as there can be other nameservers
 before the line.
 Another issue is this test is not applicable to systems where name
 resolution is managed by systemd-resolved.
    
 The test is modified to check that 127.0.0.1 is actually used in DNS query
 chain.
    
 Also test is moved to test_dns suite as it is not directly related to
 dnssec.
    
 Related to https://pagure.io/freeipa/issue/7900
 Fixes https://pagure.io/freeipa/issue/8695
