### PR TITLE
azure: Pin Pylint

### DIFF
--- a/.wheelconstraints.in
+++ b/.wheelconstraints.in
@@ -10,4 +10,5 @@ ipaserver == @VERSION@
 ipatests == @VERSION@
 
 # upstream pylint 1.7.5 fixed bad python3 import of stat module
-pylint >= 1.7.5
+pylint == 2.6.0
+astroid < 2.5


### PR DESCRIPTION
Temporarily pin Pylint to 2.6.0, since 2.6.2 has the crash regression.

Related: https://pagure.io/freeipa/issue/8716
