### PR TITLE
WebUI: test_user: test if user is enabled by default

### DIFF
--- a/ipatests/test_webui/test_user.py
+++ b/ipatests/test_webui/test_user.py
@@ -87,6 +87,30 @@ class user_tasks(UI_driver):
 
         return data
 
+    def assert_user_auth_type(self, auth_type, enabled=True):
+        """
+        Check if provided auth type is enabled or disabled for the user
+        :param auth_type: one of password, radius, otp, pkinit or hardened
+        :param enabled: check if enabled if True, check for disabled if False
+        """
+        s_checkbox = 'div[name="ipauserauthtype"] input[value="{}"]'.format(
+            auth_type)
+        checkbox = self.find(s_checkbox, By.CSS_SELECTOR, strict=True)
+        assert checkbox.is_selected() == enabled
+
+    def add_user_auth_type(self, auth_type, save=False):
+        """
+        Select user auth type
+        :param auth_type: one of password, radius, otp, pkinit or hardened
+        """
+        s_checkbox = 'div[name="ipauserauthtype"] input[value="{}"]'.format(
+            auth_type)
+        checkbox = self.find(s_checkbox, By.CSS_SELECTOR, strict=True)
+        if not checkbox.is_selected():
+            checkbox.click()
+        if save:
+            self.facet_button_click('save')
+
 
 @pytest.mark.tier1
 class test_user(user_tasks):
@@ -676,6 +700,31 @@ class test_user(user_tasks):
 
         # cleanup
         self.delete(user.ENTITY, [user.DATA2])
+
+    @screenshot
+    def test_enabled_by_default(self):
+        """
+        Test if valid user created in both ca and
+        caless env is enabled by default.
+
+        https://pagure.io/freeipa/issue/8203
+        """
+        self.init_app()
+
+        # check if the user is enabled
+        self.add_record(user.ENTITY, user.DATA, navigate=False)
+        self.assert_record_value(expected="Enabled",
+                                 pkeys=user.PKEY,
+                                 column="nsaccountlock")
+
+        self.navigate_to_record(user.PKEY)
+        self.assert_action_list_action("disable", visible=True, enabled=True)
+        self.assert_action_list_action("reset_password",
+                                       visible=True, enabled=True)
+
+        # add OTP authentication type and verify the change is persistent
+        self.add_user_auth_type("otp", save=True)
+        self.assert_user_auth_type("otp", enabled=True)
 
 
 @pytest.mark.tier1


### PR DESCRIPTION
Test checks if the user is enabled, able to reset their password and
authentication types in CA-less environment.
    
Related: https://pagure.io/freeipa/issue/8203
    
Signed-off-by: Michal Polovka <mpolovka@redhat.com>
