### PR TITLE
freeipa.spec: bump the required version of 389ds 

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -74,9 +74,9 @@
 %global slapi_nis_version 0.56.4
 %global python_ldap_version 3.1.0-1
 # python3-lib389
-# Fix for "Installation fails: Replica Busy"
-# https://pagure.io/389-ds-base/issue/49818
-%global ds_version 1.4.2.4-6
+# Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1912822
+# sync_repl issue
+%global ds_version 1.4.3.16-11
 # Fix for TLS 1.3 PHA, RHBZ#1775158
 %global httpd_version 2.4.37-21
 %global bind_version 9.11.20-6
@@ -101,9 +101,14 @@
 
 # fix for segfault in python3-ldap, https://pagure.io/freeipa/issue/7324
 %global python_ldap_version 3.1.0-1
-# 1.4.3 moved nsslapd-db-locks to cn=bdb sub-entry
-# https://pagure.io/freeipa/issue/8515
+# https://github.com/389ds/389-ds-base/issues/4526
+# sync_repl issue
+%if 0%{?fedora} >= 33
+%global ds_version 1.4.4.12-1
+%else
+# TBD: update the version when fedora32 ships the fix
 %global ds_version 1.4.3
+%endif
 
 # Fix for TLS 1.3 PHA, RHBZ#1775146
 %global httpd_version 2.4.41-9


### PR DESCRIPTION
In order to get the fix for sync_repl, the following versions
are required:
on fedora32: 1.4.3.18-1
on fedora33 and above: 1.4.4.12-1
on rhel 8.4: 1.4.3.16-11

Fixes: https://pagure.io/freeipa/issue/8496