### PR TITLE
[Backport][ipa-4-9] ipa-cert-fix: Don't hardcode the NSS certificate nickname

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -128,11 +128,11 @@
 %if 0%{?rhel} == 8
 # PKIConnection has been modified to always validate certs.
 # https://pagure.io/freeipa/issue/8379
-%global pki_version 10.9.0-0.4
+%global pki_version 10.10.4-1
 %else
 # New KRA profile, ACME support
 # https://pagure.io/freeipa/issue/8545
-%global pki_version 10.10.0-2
+%global pki_version 10.10.3-1
 %endif
 
 # RHEL 8.3+, F32+ has 0.79.13


### PR DESCRIPTION
This PR was opened automatically because PR #5525 was pushed to master and backport to ipa-4-9 is required.