### PR TITLE
[Backport][ipa-4-9] Reduce confusing output when CA fails to deploy

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -231,6 +231,9 @@ def get_crl_files(path=None):
     if path is None:
         path = paths.PKI_CA_PUBLISH_DIR
 
+    if not os.path.exists(path):
+        return
+
     files = os.listdir(path)
     for f in files:
         if f == "MasterCRL.bin":

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -520,13 +520,15 @@ class DogtagInstance(service.Service):
         return admin_cert
 
     def handle_setup_error(self, e):
-        logger.critical("Failed to configure %s instance: %s",
-                        self.subsystem, e)
+        logger.critical("Failed to configure %s instance",
+                        self.subsystem)
         logger.critical("See the installation logs and the following "
                         "files/directories for more information:")
         logger.critical("  %s", paths.TOMCAT_TOPLEVEL_DIR)
 
-        raise RuntimeError("%s configuration failed." % self.subsystem)
+        raise RuntimeError(
+            "%s configuration failed." % self.subsystem
+        ) from None
 
     def add_ipaca_aci(self):
         """Add ACI to allow ipaca users to read their own group information


### PR DESCRIPTION
This PR was opened automatically because PR #5542 was pushed to master and backport to ipa-4-9 is required.