### PR TITLE
[ipa-4-9] ipatests: Update PRCI templates for ipa-4-9

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f32
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.1
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.1
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-previous
           name: freeipa/ci-ipa-4-9-f32
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,7 +57,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f32
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
The new templates include updated versions of pki and 389ds.
- pki 10.10.3-3
- 389-ds 1.4.3.18-1 on fc32 and 1.4.4.12-1 on fc33

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>