### PR TITLE
ipa-kdb: do not use OpenLDAP functions with NULL LDAP context

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -57,6 +57,7 @@ static void ipadb_context_free(krb5_context kcontext,
         /* ldap free lcontext */
         if ((*ctx)->lcontext) {
             ldap_unbind_ext_s((*ctx)->lcontext, NULL, NULL);
+            (*ctx)->lcontext = NULL;
         }
         free((*ctx)->supp_encs);
         free((*ctx)->def_encs);

--- a/daemons/ipa-kdb/ipa_kdb_audit_as.c
+++ b/daemons/ipa-kdb/ipa_kdb_audit_as.c
@@ -112,13 +112,13 @@ void ipadb_audit_as_req(krb5_context kcontext,
 
         if (krb5_ts_after(krb5_ts_incr(client->last_failed,
                         ied->pol->lockout_duration), authtime) &&
-            (client->fail_auth_count >= ied->pol->max_fail && 
+            (client->fail_auth_count >= (krb5_kvno) ied->pol->max_fail &&
              ied->pol->max_fail != 0)) {
             /* client already locked, nothing more to do */
             break;
         }
         if (ied->pol->max_fail == 0 ||
-            client->fail_auth_count < ied->pol->max_fail) {
+            client->fail_auth_count < (krb5_kvno) ied->pol->max_fail) {
             /* let's increase the fail counter */
             client->fail_auth_count++;
             client->mask |= KMASK_FAIL_AUTH_COUNT;

--- a/daemons/ipa-kdb/ipa_kdb_certauth.c
+++ b/daemons/ipa-kdb/ipa_kdb_certauth.c
@@ -71,10 +71,13 @@ struct krb5_certauth_moddata_st {
     time_t valid_until;
 };
 
-void ipa_certmap_debug(void *private,
-                       const char *file, long line,
-                       const char *function,
-                       const char *format, ...)
+krb5_error_code certauth_ipakdb_initvt(krb5_context context,
+                                       int maj_ver, int min_ver,
+                                       krb5_plugin_vtable vtable);
+
+static void ipa_certmap_debug(void *private, const char *file, long line,
+                              const char *function,
+                              const char *format, ...)
 {
     va_list ap;
     char str[255] = { 0 };
@@ -354,12 +357,12 @@ static krb5_error_code ipa_certauth_authorize(krb5_context context,
      * so there is nothing more to add here. */
     auth_inds = calloc(2, sizeof(char *));
     if (auth_inds != NULL) {
-	ret = asprintf(&auth_inds[0], "pkinit");
-	if (ret != -1) {
+        ret = asprintf(&auth_inds[0], "pkinit");
+        if (ret != -1) {
             auth_inds[1] = NULL;
             *authinds_out = auth_inds;
-	} else {
-	    free(auth_inds);
+        } else {
+            free(auth_inds);
         }
     }
 
@@ -404,12 +407,12 @@ static void ipa_certauth_free_indicator(krb5_context context,
     size_t i = 0;
 
     if ((authinds == NULL) || (moddata == NULL)) {
-	return;
+        return;
     }
 
     for(i=0; authinds[i]; i++) {
-	free(authinds[i]);
-	authinds[i] = NULL;
+        free(authinds[i]);
+        authinds[i] = NULL;
     }
 
     free(authinds);

--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -14,6 +14,10 @@
 #define ONE_DAY_SECONDS (24 * 60 * 60)
 #define JITTER_WINDOW_SECONDS (1 * 60 * 60)
 
+krb5_error_code kdcpolicy_ipakdb_initvt(krb5_context context,
+                                        int maj_ver, int min_ver,
+                                        krb5_plugin_vtable vtable);
+
 static void
 jitter(krb5_deltat baseline, krb5_deltat *lifetime_out)
 {

--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -2408,9 +2408,10 @@ void ipadb_mspac_struct_free(struct ipadb_mspac **mspac)
     *mspac = NULL;
 }
 
-krb5_error_code ipadb_adtrusts_fill_sid_blacklist(char **source_sid_blacklist,
-                                                  struct dom_sid **result_sids,
-                                                  int *result_length)
+static krb5_error_code
+ipadb_adtrusts_fill_sid_blacklist(char **source_sid_blacklist,
+                                  struct dom_sid **result_sids,
+                                  int *result_length)
 {
     int len, i;
     char **source;
@@ -2441,9 +2442,10 @@ krb5_error_code ipadb_adtrusts_fill_sid_blacklist(char **source_sid_blacklist,
     return 0;
 }
 
-krb5_error_code ipadb_adtrusts_fill_sid_blacklists(struct ipadb_adtrusts *adtrust,
-                                                   char **sid_blocklist_incoming,
-                                                   char **sid_blocklist_outgoing)
+static krb5_error_code
+ipadb_adtrusts_fill_sid_blacklists(struct ipadb_adtrusts *adtrust,
+                                   char **sid_blocklist_incoming,
+                                   char **sid_blocklist_outgoing)
 {
     krb5_error_code kerr;
 
@@ -2464,7 +2466,8 @@ krb5_error_code ipadb_adtrusts_fill_sid_blacklists(struct ipadb_adtrusts *adtrus
     return 0;
 }
 
-krb5_error_code ipadb_mspac_check_trusted_domains(struct ipadb_context *ipactx)
+static krb5_error_code
+ipadb_mspac_check_trusted_domains(struct ipadb_context *ipactx)
 {
     char *attrs[] = { NULL };
     char *filter = "(objectclass=ipaNTTrustedDomain)";
@@ -2509,7 +2512,8 @@ static void ipadb_free_sid_blacklists(char ***sid_blocklist_incoming, char ***si
     }
 }
 
-krb5_error_code ipadb_mspac_get_trusted_domains(struct ipadb_context *ipactx)
+static krb5_error_code
+ipadb_mspac_get_trusted_domains(struct ipadb_context *ipactx)
 {
     struct ipadb_adtrusts *t;
     LDAP *lc = NULL;

--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -148,9 +148,9 @@ int string_to_sid(const char *str, struct dom_sid *sid)
 
 char *dom_sid_string(TALLOC_CTX *memctx, const struct dom_sid *dom_sid)
 {
-    size_t c;
+    int8_t c;
     size_t len;
-    int ofs;
+    size_t ofs;
     uint32_t ia;
     char *buf;
 
@@ -2612,7 +2612,7 @@ krb5_error_code ipadb_mspac_get_trusted_domains(struct ipadb_context *ipactx)
 
         t[n].upn_suffixes_len = NULL;
         if (t[n].upn_suffixes != NULL) {
-            size_t len = 0;
+            int len = 0;
 
             for (; t[n].upn_suffixes[len] != NULL; len++);
 

--- a/daemons/ipa-kdb/ipa_kdb_mspac_private.h
+++ b/daemons/ipa-kdb/ipa_kdb_mspac_private.h
@@ -53,3 +53,7 @@ struct ipadb_adtrusts {
 
 int string_to_sid(const char *str, struct dom_sid *sid);
 char *dom_sid_string(TALLOC_CTX *memctx, const struct dom_sid *dom_sid);
+krb5_error_code filter_logon_info(krb5_context context, TALLOC_CTX *memctx,
+                                  krb5_data realm, struct PAC_LOGON_INFO_CTR *info);
+void get_authz_data_types(krb5_context context, krb5_db_entry *entry,
+                          bool *_with_pac, bool *_with_pad);

--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -333,6 +333,11 @@ static enum ipadb_user_auth ipadb_get_user_auth(struct ipadb_context *ipactx,
     if (gcfg != NULL)
         gua = gcfg->user_auth;
 
+    /* lcontext == NULL means ipadb_get_global_config() failed to load
+     * global config and cleared the ipactx */
+    if (ipactx->lcontext == NULL)
+        return IPADB_USER_AUTH_NONE;
+
     /* Get the user's user_auth settings if not disabled. */
     if ((gua & IPADB_USER_AUTH_DISABLED) == 0)
         ipadb_parse_user_auth(ipactx->lcontext, lentry, &ua);
@@ -607,8 +612,16 @@ static krb5_error_code ipadb_parse_ldap_entry(krb5_context kcontext,
         free(entry);
         return KRB5_KDB_DBNOTINITED;
     }
-    lcontext = ipactx->lcontext;
-    if (!lcontext) {
+
+    entry->magic = KRB5_KDB_MAGIC_NUMBER;
+    entry->len = KRB5_KDB_V1_BASE_LENGTH;
+
+    /* Get User Auth configuration. */
+    ua = ipadb_get_user_auth(ipactx, lentry);
+
+    /* ipadb_get_user_auth() calls into ipadb_get_global_config()
+     * and that might fail, causing lcontext to become NULL */
+    if (!ipactx->lcontext) {
         krb5_klog_syslog(LOG_INFO,
                          "No LDAP connection in ipadb_parse_ldap_entry(); retrying...\n");
         ret = ipadb_get_connection(ipactx);
@@ -620,11 +633,10 @@ static krb5_error_code ipadb_parse_ldap_entry(krb5_context kcontext,
         }
     }
 
-    entry->magic = KRB5_KDB_MAGIC_NUMBER;
-    entry->len = KRB5_KDB_V1_BASE_LENGTH;
-
-    /* Get User Auth configuration. */
-    ua = ipadb_get_user_auth(ipactx, lentry);
+    /* If any code below would result in invalidating ipactx->lcontext,
+     * lcontext must be updated with the new ipactx->lcontext value.
+     * We rely on the fact that none of LDAP-parsing helpers does it. */
+    lcontext = ipactx->lcontext;
 
     /* ignore mask for now */
 

--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -494,7 +494,7 @@ static krb5_error_code ipadb_get_ldap_auth_ind(krb5_context kcontext,
     l = len;
     for (i = 0; i < count; i++) {
         ret = snprintf(ap, l, "%s ", authinds[i]);
-        if (ret <= 0 || ret > l) {
+        if (ret <= 0 || ret > (int) l) {
             ret = ENOMEM;
             goto cleanup;
         }
@@ -2086,7 +2086,7 @@ static krb5_error_code ipadb_get_ldap_mod_auth_ind(krb5_context kcontext,
     char *s = NULL;
     size_t ai_size = 0;
     int cnt = 0;
-    int i = 0;
+    size_t i = 0;
 
     ret = krb5_dbe_get_string(kcontext, entry, "require_auth", &ais);
     if (ret) {
@@ -2467,7 +2467,7 @@ static krb5_error_code ipadb_entry_default_attrs(struct ipadb_mods *imods)
 {
     krb5_error_code kerr;
     LDAPMod *m = NULL;
-    int i;
+    size_t i;
 
     kerr = ipadb_mods_new(imods, &m);
     if (kerr) {

--- a/daemons/ipa-kdb/ipa_kdb_pwdpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_pwdpolicy.c
@@ -361,7 +361,7 @@ krb5_error_code ipadb_check_policy_as(krb5_context kcontext,
     }
 
     if (ied->pol->max_fail == 0 ||
-        client->fail_auth_count < ied->pol->max_fail) {
+        client->fail_auth_count < (krb5_kvno) ied->pol->max_fail) {
         /* still within allowed failures range */
         return 0;
     }

--- a/daemons/ipa-kdb/tests/ipa_kdb_tests.c
+++ b/daemons/ipa-kdb/tests/ipa_kdb_tests.c
@@ -181,7 +181,7 @@ extern krb5_error_code filter_logon_info(krb5_context context,
                                   krb5_data realm,
                                   struct PAC_LOGON_INFO_CTR *info);
 
-void test_filter_logon_info(void **state)
+static void test_filter_logon_info(void **state)
 {
     krb5_error_code kerr;
     krb5_data realm = {KV5M_DATA, REALM_LEN, REALM};
@@ -316,10 +316,7 @@ void test_filter_logon_info(void **state)
 
 }
 
-extern void get_authz_data_types(krb5_context context, krb5_db_entry *entry,
-                                 bool *with_pac, bool *with_pad);
-
-void test_get_authz_data_types(void **state)
+static void test_get_authz_data_types(void **state)
 {
     bool with_pac;
     bool with_pad;
@@ -437,7 +434,7 @@ void test_get_authz_data_types(void **state)
     krb5_free_principal(test_ctx->krb5_ctx, non_nfs_princ);
 }
 
-void test_string_to_sid(void **state)
+static void test_string_to_sid(void **state)
 {
     int ret;
     struct dom_sid sid;
@@ -469,7 +466,7 @@ void test_string_to_sid(void **state)
     assert_memory_equal(&exp_sid, &sid, sizeof(struct dom_sid));
 }
 
-void test_dom_sid_string(void **state)
+static void test_dom_sid_string(void **state)
 {
     struct test_ctx *test_ctx;
     char *str_sid;
@@ -495,7 +492,7 @@ void test_dom_sid_string(void **state)
 }
 
 
-void test_check_trusted_realms(void **state)
+static void test_check_trusted_realms(void **state)
 {
     struct test_ctx *test_ctx;
     krb5_error_code kerr = 0;


### PR DESCRIPTION
Calling to ipadb_get_connection() will remove LDAP context if any error
happens. This means upper layers must always verify that LDAP context
exists after such calls.

ipadb_get_user_auth() may re-read global configuration and that may fail
and cause IPA context to have NULL LDAP context.

Fixes: https://pagure.io/freeipa/issue/8681

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>