### PR TITLE
pylint: fix inconsistent-return-statements

### DIFF
--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -571,6 +571,7 @@ class _TransportCertCache:
                     raise
         except Exception:
             logger.warning("Failed to load %s", filename, exc_info=True)
+        return None
 
     def store_cert(self, domain, transport_cert):
         """Store a new cert or override existing cert
@@ -677,6 +678,7 @@ class ModVaultData(Local):
             _transport_cert_cache.remove_cert(self.api.env.domain)
             if raise_unexpected:
                 raise
+        return None
 
     def internal(self, algo, *args, **options):
         """

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -684,6 +684,9 @@ class KerbTransport(SSLTransport):
             return False
         return True
 
+    # pylint: disable=inconsistent-return-statements
+    # pylint does not properly manage the _handle_exception call
+    # that is always raising an exception
     def single_request(self, host, handler, request_body, verbose=0):
         # Based on Python 2.7's xmllib.Transport.single_request
         try:
@@ -745,6 +748,7 @@ class KerbTransport(SSLTransport):
             logger.debug("HTTP connection destroyed (%s)",
                          host, exc_info=True)
             raise
+    # pylint: enable=inconsistent-return-statements
 
     if six.PY3:
         def __send_request(self, connection, host, handler, request_body, debug):


### PR DESCRIPTION
pylint 2.7.0 now emits inconsistent-return-statements if one of
try/except statement is not returning explicitly while the other do.

Fixes: https://pagure.io/freeipa/issue/8720
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>