### PR TITLE
[Backport][ipa-4-9] ipaserver: don't ignore zonemgr option on install

### DIFF
--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -355,7 +355,7 @@ def add_zone(name, zonemgr=None, dns_backup=None, ns_hostname=None,
         else:
             update_policy = get_dns_forward_zone_update_policy(api.env.realm)
 
-    if zonemgr is None:
+    if not zonemgr:
         zonemgr = 'hostmaster.%s' % name
 
     if ns_hostname:
@@ -682,7 +682,7 @@ class BindInstance(service.Service):
         self.forward_policy = forward_policy
         self.reverse_zones = reverse_zones
 
-        if zonemgr is not None:
+        if not zonemgr:
             self.zonemgr = 'hostmaster.%s' % normalize_zone(self.domain)
         else:
             self.zonemgr = normalize_zonemgr(zonemgr)

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1171,6 +1171,13 @@ class TestInstallMasterDNS(IntegrationTest):
             extra_args=['--zonemgr', 'me@example.org'],
         )
 
+        tasks.kinit_admin(self.master)
+        result = self.master.run_command(
+            ['ipa', 'dnszone-show', self.master.domain.name]
+        ).stdout_text
+
+        assert "Administrator e-mail address: me.example.org" in result
+
     def test_server_install_lock_bind_recursion(self):
         """Test if server installer lock Bind9 recursion
 


### PR DESCRIPTION
This PR was opened automatically because PR #5567 was pushed to master and backport to ipa-4-9 is required.