### PR TITLE
freeipa.spec: synchronize with Fedora for 389-ds and PKI versions

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -73,10 +73,13 @@
 %global selinux_policy_version 3.14.3-52
 %global slapi_nis_version 0.56.4
 %global python_ldap_version 3.1.0-1
-# python3-lib389
-# Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1912822
-# sync_repl issue
-%global ds_version 1.4.3.16-11
+%if 0%{?rhel} < 9
+# Bug 1929067 - PKI instance creation failed with new 389-ds-base build
+%global ds_version 1.4.3.16-12
+%else
+%global ds_version 2.0.3-3
+%endif
+
 # Fix for TLS 1.3 PHA, RHBZ#1775158
 %global httpd_version 2.4.37-21
 %global bind_version 9.11.20-6
@@ -101,13 +104,12 @@
 
 # fix for segfault in python3-ldap, https://pagure.io/freeipa/issue/7324
 %global python_ldap_version 3.1.0-1
-# https://github.com/389ds/389-ds-base/issues/4526
-# sync_repl issue
-%if 0%{?fedora} >= 33
-%global ds_version 1.4.4.12-1
+
+# Make sure to use 389-ds-base versions that fix https://github.com/389ds/389-ds-base/issues/4609
+%if 0%{?fedora} < 34
+%global ds_version %{lua: local v={}; v['32']='1.4.3.20-2'; v['33']='1.4.4.13-2'; print(v[rpm.expand('%{fedora}')])}
 %else
-# TBD: update the version when fedora32 ships the fix
-%global ds_version 1.4.3
+%global ds_version 2.0.3-3
 %endif
 
 # Fix for TLS 1.3 PHA, RHBZ#1775146
@@ -131,13 +133,11 @@
 %endif
 
 %if 0%{?rhel} == 8
-# PKIConnection has been modified to always validate certs.
-# https://pagure.io/freeipa/issue/8379
-%global pki_version 10.10.4-1
+# Make sure to use PKI versions that work with 389-ds fix for https://github.com/389ds/389-ds-base/issues/4609
+%global pki_version 10.10.5
 %else
-# New KRA profile, ACME support
-# https://pagure.io/freeipa/issue/8545
-%global pki_version 10.10.3-1
+# Make sure to use PKI versions that work with 389-ds fix for https://github.com/389ds/389-ds-base/issues/4609
+%global pki_version 10.10.5
 %endif
 
 # RHEL 8.3+, F32+ has 0.79.13


### PR DESCRIPTION
- 389-ds fixes an information disclosure during unsuccessful LDAP BIND
  operation, CVE-2020-35518, https://github.com/389ds/389-ds-base/issues/4609

- Dogtag PKI adopted to work with 389-ds with the fix,
  https://github.com/dogtagpki/pki/issues/3458

FreeIPA needs to require new Dogtag and 389-ds versions on all Fedora
and RHEL versions.

I am leaving RHEL 8 version intact yet for 389-ds because it wasn't
updated yet but Dogtag PKI version was already built.

In order to avoid excessive %if/%endif conditionals in the spec file, I
have added a short Lua table with 389-ds versions for F32-33. F34 and
Rawhide will fallback to the same newer 389-ds 2.0.3 version. We do not
support building on F31 or older Fedora anymore as they are EOLed
already.

Fixes: https://pagure.io/freeipa/issue/8705

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>