### PR TITLE
ipatests: use whole date when calling journalctl --since

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -642,7 +642,8 @@ class TestIPACommand(IntegrationTest):
         # start to look at logs a bit before "now"
         # https://pagure.io/freeipa/issue/8432
         since = time.strftime(
-            '%H:%M:%S', (datetime.now() - timedelta(seconds=10)).timetuple()
+            '%Y-%m-%d %H:%M:%S',
+            (datetime.now() - timedelta(seconds=10)).timetuple()
         )
 
         tasks.run_ssh_cmd(


### PR DESCRIPTION
The test test_commands.py::TestIPACommand::test_ssh_key_connection
is checking the content of the journal using journalctl --since ...
but provides only the time, not the whole date with year-month-day.
As a consequence, if the test is executed around midnight it may
find nothing in the journal because it's looking for logs after 11:50PM,
which is a date in the future.

The fix provides a complete date with year-month-day hours:min:sec.

Fixes: https://pagure.io/freeipa/issue/8728