### PR TITLE
[Backport][ipa-4-9] ipatests: use whole date when calling journalctl --since

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -642,7 +642,8 @@ class TestIPACommand(IntegrationTest):
         # start to look at logs a bit before "now"
         # https://pagure.io/freeipa/issue/8432
         since = time.strftime(
-            '%H:%M:%S', (datetime.now() - timedelta(seconds=10)).timetuple()
+            '%Y-%m-%d %H:%M:%S',
+            (datetime.now() - timedelta(seconds=10)).timetuple()
         )
 
         tasks.run_ssh_cmd(


### PR DESCRIPTION
This PR was opened automatically because PR #5596 was pushed to master and backport to ipa-4-9 is required.