### PR TITLE
Enhance error message when adding non-posix group with a GID

### DIFF
--- a/ipaserver/plugins/group.py
+++ b/ipaserver/plugins/group.py
@@ -387,6 +387,15 @@ class group_add(LDAPCreate):
                 entry_attrs['gidnumber'] = baseldap.DNA_MAGIC
         return dn
 
+    def exc_callback(self, keys, options, exc, call_func,
+                     *call_args, **call_kwargs):
+        if isinstance(exc, errors.ObjectclassViolation):
+            if options['nonposix'] and 'gidnumber' in options:
+                raise errors.ObjectclassViolation(
+                    info=_('attribute "gidNumber" not allowed with --nonposix')
+                )
+        raise exc
+
 
 @register()
 class group_del(LDAPDelete):

--- a/ipatests/test_xmlrpc/test_group_plugin.py
+++ b/ipatests/test_xmlrpc/test_group_plugin.py
@@ -388,6 +388,15 @@ class TestNonexistentGroup(XMLRPC_test):
 
 @pytest.mark.tier1
 class TestNonposixGroup(XMLRPC_test):
+    def test_create_nonposix_with_gid(self, group):
+        """ Try to create non-posix group with GID """
+        command = group.make_create_command(**dict(nonposix=True,
+                                                   gidnumber=10011))
+
+        with raises_exact(errors.ObjectclassViolation(
+                info=u'attribute "gidNumber" not allowed with --nonposix')):
+            command()
+
     def test_create_nonposix(self, group):
         """ Create a non-posix group """
         group.track_create()


### PR DESCRIPTION
Enhance error message when adding non-posix group
with a GID so the user knows that a GID should not
be passed when adding a group with the --nonposix option.

Fixes: https://pagure.io/freeipa/issue/8155
Signed-off-by: Antonio Torres <antorres@redhat.com>