### PR TITLE
ipatests: fix nightly_latest_testing_selinux template

### DIFF
--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -616,7 +616,7 @@ jobs:
         topology: *master_1repl
 
   testing-fedora/test_installation_TestInstallWithoutSudo:
-    requires: [fedora-latest/build]
+    requires: [testing-fedora/build]
     priority: 50
     job:
       class: RunPytest


### PR DESCRIPTION
The TestInstallWithoutSudo entry referenced fedora-latest instead
of testing-fedora for its build dependency. Fix it.

Fixes: https://pagure.io/freeipa/issue/8530
Signed-off-by: François Cami <fcami@redhat.com>