### PR TITLE
[Backport][ipa-4-8] ipatests: Fix expectation about GSS error in test for healthcheck

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -473,11 +473,19 @@ class TestIpaHealthCheck(IntegrationTest):
         ipahealthcheck.ipa.host when dirsrv service is stopped and
         running on IPA master
         """
-        msg = (
-            "Failed to obtain host TGT: Major (851968): "
-            "Unspecified GSS failure.  "
-            "Minor code may provide more information, "
-            "Minor (2529638972): Generic error (see e-text)"
+        msgs = (
+            (
+                "Failed to obtain host TGT: Major (851968): "
+                "Unspecified GSS failure.  "
+                "Minor code may provide more information, "
+                "Minor (2529638972): Generic error (see e-text)"
+            ),
+            (
+                "Failed to obtain host TGT: Major (458752): "
+                "No credentials were supplied, or the credentials "
+                "were unavailable or inaccessible, "
+                "Minor (2529638972): Generic error (see e-text)"
+            ),
         )
         restart_service(self.master, "dirsrv")
         dirsrv_ipactl_status = 'Directory Service: STOPPED'
@@ -491,7 +499,7 @@ class TestIpaHealthCheck(IntegrationTest):
         assert returncode == 1
         if dirsrv_ipactl_status in result.stdout_text:
             assert data[0]["result"] == "ERROR"
-            assert data[0]["kw"]["msg"] == msg
+            assert data[0]["kw"]["msg"] in msgs
         else:
             assert data[0]["result"] == "SUCCESS"
 


### PR DESCRIPTION
This PR was opened automatically because PR #5601 was pushed to master and backport to ipa-4-8 is required.