### PR TITLE
DNSSEC key synchronization issues

### DIFF
--- a/daemons/dnssec/ipa-ods-exporter.in
+++ b/daemons/dnssec/ipa-ods-exporter.in
@@ -375,7 +375,18 @@ def master2ldap_master_keys_sync(ldapkeydb, localhsm):
                      str_hexlify(mkey_id), hex_set(new_replica_keys))
 
         # wrap master key with new replica keys
-        mkey_local = localhsm.find_keys(id=mkey_id).popitem()[1]
+        try:
+            mkey_local = localhsm.find_keys(id=mkey_id).popitem()[1]
+        except KeyError:
+            # The master key is present in LDAP but could not be found
+            # in the local HSM. Let's hope it's not the active key,
+            # log an error and process the next master key
+            logger.error("master key 0x%s missing in local HSM, "
+                "will not be able to add master key wrapped with "
+                "replica keys",
+                str_hexlify(mkey_id))
+            continue
+
         for replica_key_id in new_replica_keys:
             logger.info('adding master key 0x%s wrapped with replica key 0x%s',
                         str_hexlify(mkey_id), str_hexlify(replica_key_id))

--- a/daemons/dnssec/ipa-ods-exporter.in
+++ b/daemons/dnssec/ipa-ods-exporter.in
@@ -37,6 +37,7 @@ from ipapython.dn import DN
 from ipapython.ipa_log_manager import standard_logging_setup
 from ipapython import ipaldap
 from ipaplatform.paths import paths
+from ipaserver import p11helper
 from ipaserver.dnssec.abshsm import sync_pkcs11_metadata, wrappingmech_name2id
 from ipaserver.dnssec.ldapkeydb import LdapKeyDB, str_hexlify
 from ipaserver.dnssec.localhsm import LocalHSM
@@ -301,7 +302,19 @@ def ldap2master_replica_keys_sync(ldapkeydb, localhsm):
                      new_key_ldap['ipk11label'],
                      str_hexlify(new_key_ldap['ipk11id']),
                      str_hexlify(new_key_ldap['ipapublickey']))
-        localhsm.import_public_key(new_key_ldap, new_key_ldap['ipapublickey'])
+        try:
+            localhsm.import_public_key(
+                new_key_ldap, new_key_ldap['ipapublickey'])
+        except p11helper.DuplicationError:
+            # we may have been called in the middle of operations
+            # disabling dnssec on the current node, while the
+            # replica key has already been disabled in localhsm but
+            # not yet in LDAP.
+            # Ignore the import error (key is already in localhsm but disabled)
+            # and log a warning
+            logger.warning("import of replica key to localhsm %s failed, "
+                           "key already present but disabled",
+                           str_hexlify(new_key_ldap['ipk11id']))
 
     # set CKA_WRAP = FALSE for all replica keys removed from LDAP
     removed_replica_keys = set(localhsm.replica_pubkeys_wrap.keys()) \


### PR DESCRIPTION
### dnssec: fix ipa-ods-exporter crash when master key missing

When a master key is missing from the local HSM, ipa-ods-exporter crashes.
This can happen when the DNSSEC master role is moved from one node to
another with the following scenario:
- install server1 with dns + dnssec
- install server2 without dns
- disable dnssec from server1
- install dns + dnssec on server2

With the above scenario, server2 never had the opportunity to get
the master key (this happens only when the replica is already
configured as DNS server and has put its public replica key in LDAP +
the current DNSSEC master wraps its master key with the replica key).

ipa-ods-exporter can only log an error instead of crashing.

Related: https://pagure.io/freeipa/issue/8654


### dnssec: concurrency issue when disabling old replica key

When dnssec role is removed from the local node, the uninstaller
creates a new replica key and marks the older replica keys as disabled
(both in the local HSM and in LDAP).
If ipa-ods-exporter runs in the middle of this operation, the old replica
key may be disabled in the local HSM but not yet in LDAP and
ipa-ods-exporter believes that it is a new replica key that needs to be
imported from LDAP to local hsm. The op fails as there is already the key
in the local HSM.

The error can be ignored, ipa-ods-exporter simply needs to log a warning.

Fixes: https://pagure.io/freeipa/issue/8654