### PR TITLE
ipa-kra-install: exit if ca_host is overriden

### DIFF
--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -53,6 +53,11 @@ def install_check(api, replica_config, options):
                 "KRA is not installed on the master system. Please use "
                 "'ipa-kra-install' command to install the first instance.")
 
+    if api.env.ca_host is not None and api.env.ca_host != api.env.host:
+        raise RuntimeError(
+            "KRA can not be installed when 'ca_host' is overriden in "
+            "IPA configuration file.")
+
 
 def install(api, replica_config, options, custodia):
     if replica_config is None:


### PR DESCRIPTION
`ipa-kra-install` should exit if `ca_host` line is present in `/etc/ipa/default.conf`, 
as it may lead to a misconfigured setup.

Fixes: https://pagure.io/freeipa/issue/8245
Signed-off-by: Antonio Torres <antorres@redhat.com>