### PR TITLE
[Backport][ipa-4-9] Fix lgtm file classification

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -7,7 +7,7 @@ path_classifiers:
     - "asn1/asn1c/.*"
   ipaclient:
     - client
-    - ipalcient
+    - ipaclient
     - util
   ipalib:
     - ipalib


### PR DESCRIPTION
This PR was opened automatically because PR #5614 was pushed to master and backport to ipa-4-9 is required.