### PR TITLE
ipatests: use proper template for TestMaskInstall

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1484,7 +1484,7 @@ jobs:
         test_suite: test_integration/test_installation.py::TestMaskInstall
         template: *ci-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-latest/automember:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -558,7 +558,7 @@ jobs:
         test_suite: test_integration/test_installation.py::TestMaskInstall
         template: *389ds-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   389ds-fedora/automember:
     requires: [389ds-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1601,7 +1601,7 @@ jobs:
         test_suite: test_integration/test_installation.py::TestMaskInstall
         template: *ci-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-latest/automember:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1601,7 +1601,7 @@ jobs:
         test_suite: test_integration/test_installation.py::TestMaskInstall
         template: *testing-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   testing-fedora/automember:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1718,7 +1718,7 @@ jobs:
         test_suite: test_integration/test_installation.py::TestMaskInstall
         template: *testing-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   testing-fedora/automember:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1484,7 +1484,7 @@ jobs:
         test_suite: test_integration/test_installation.py::TestMaskInstall
         template: *ci-master-previous
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-previous/automember:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1574,7 +1574,7 @@ jobs:
         test_suite: test_integration/test_installation.py::TestMaskInstall
         template: *ci-master-frawhide
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-rawhide/nfs:
     requires: [fedora-rawhide/build]

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1354,8 +1354,7 @@ class TestMaskInstall(IntegrationTest):
 
     related ticket: https://pagure.io/freeipa/issue/7193
     """
-
-    num_replicas = 0
+    topology = 'star'
 
     @classmethod
     def install(cls, mh):


### PR DESCRIPTION
    TestMaskInstall is a usual integration tests and should
    install freeipa server during test run.
    "ipaserver" template provides pre-install freeipa server and
    is intended for use with webui and xmlrpc tests.
