### PR TITLE
[Backport][ipa-4-9] ipatests: use proper template for TestMaskInstall

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1484,7 +1484,7 @@ jobs:
         test_suite: test_integration/test_installation.py::TestMaskInstall
         template: *ci-ipa-4-9-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-latest-ipa-4-9/automember:
     requires: [fedora-latest-ipa-4-9/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1601,7 +1601,7 @@ jobs:
         test_suite: test_integration/test_installation.py::TestMaskInstall
         template: *ci-ipa-4-9-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-latest-ipa-4-9/automember:
     requires: [fedora-latest-ipa-4-9/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1484,7 +1484,7 @@ jobs:
         test_suite: test_integration/test_installation.py::TestMaskInstall
         template: *ci-ipa-4-9-previous
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-previous-ipa-4-9/automember:
     requires: [fedora-previous-ipa-4-9/build]

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1354,8 +1354,7 @@ class TestMaskInstall(IntegrationTest):
 
     related ticket: https://pagure.io/freeipa/issue/7193
     """
-
-    num_replicas = 0
+    topology = 'star'
 
     @classmethod
     def install(cls, mh):


### PR DESCRIPTION
TestMaskInstall is a usual integration tests and should
install freeipa server during test run.
"ipaserver" template provides pre-install freeipa server and
is intended for use with webui and xmlrpc tests.