### PR TITLE
[Backport][ipa-4-6] ipatests: use proper template for TestMaskInstall

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -1157,7 +1157,7 @@ jobs:
         test_suite: test_integration/test_installation.py::TestMaskInstall
         template: *ci-master-f27
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-27/test_ca_custom_sdn:
     requires: [fedora-27/build]

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -752,8 +752,7 @@ class TestMaskInstall(IntegrationTest):
 
     related ticket: https://pagure.io/freeipa/issue/7193
     """
-
-    num_replicas = 0
+    topology = 'star'
 
     @classmethod
     def install(cls, mh):


### PR DESCRIPTION
This is a manual backport of #5620