### PR TITLE
Return nsaccountlock in user-add as boolean

### DIFF
--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -545,6 +545,8 @@ class baseuser_add(LDAPCreate):
         self.obj.convert_usercertificate_post(entry_attrs, **options)
         self.obj.get_password_attributes(ldap, dn, entry_attrs)
         convert_sshpubkey_post(entry_attrs)
+        if 'nsaccountlock' in entry_attrs:
+            convert_nsaccountlock(entry_attrs)
         radius_dn2pk(self.api, entry_attrs)
 
 

--- a/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
@@ -147,7 +147,7 @@ class StageUserTracker(KerberosAliasMixin, Tracker):
             loginshell=[platformconstants.DEFAULT_SHELL],
             has_keytab=False,
             has_password=False,
-            nsaccountlock=[u'true'],
+            nsaccountlock=True,
             )
 
         for key in self.kwargs:
@@ -201,14 +201,6 @@ class StageUserTracker(KerberosAliasMixin, Tracker):
         else:
             expected = self.filter_attrs(self.retrieve_keys)
 
-        # small override because stageuser-find returns different
-        # type of nsaccountlock value than DS, but overall the value
-        # fits expected result
-        if expected[u'nsaccountlock'] == [u'true']:
-            expected[u'nsaccountlock'] = True
-        elif expected[u'nsaccountlock'] == [u'false']:
-            expected[u'nsaccountlock'] = False
-
         assert_deepequal(dict(
             value=self.uid,
             summary=None,
@@ -221,14 +213,6 @@ class StageUserTracker(KerberosAliasMixin, Tracker):
             expected = self.filter_attrs(self.find_all_keys)
         else:
             expected = self.filter_attrs(self.find_keys)
-
-        # small override because stageuser-find returns different
-        # type of nsaccountlock value than DS, but overall the value
-        # fits expected result
-        if expected[u'nsaccountlock'] == [u'true']:
-            expected[u'nsaccountlock'] = True
-        elif expected[u'nsaccountlock'] == [u'false']:
-            expected[u'nsaccountlock'] = False
 
         assert_deepequal(dict(
             count=1,


### PR DESCRIPTION
The `nsaccountlock` attribute was being returned as a
list of string ("TRUE"/"FALSE") instead of a boolean.
Use the convert function used in `user-find` and `user-mod`
for consistency, since these commands return the parameter as a boolean.

Fixes: https://pagure.io/freeipa/issue/8743
Signed-off-by: Antonio Torres <antorres@redhat.com>