### PR TITLE
[Backport][ipa-4-9] ipa-client-install: output a warning if sudo is not present

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2205,7 +2205,7 @@ def install_check(options):
     # available.
     if options.conf_sudo:
         try:
-            subprocess.Popen(['sudo -V'])
+            subprocess.Popen(['sudo', '-V'])
         except FileNotFoundError:
             logger.info(
                 "The sudo binary does not seem to be present on this "

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1620,3 +1620,5 @@ class TestInstallWithoutSudo(IntegrationTest):
         tasks.install_packages(self.clients[0], ['sudo'])
         for pkg in ('sudo', 'libsss_sudo'):
             assert tasks.is_package_installed(self.clients[0], pkg)
+        result = tasks.install_client(self.master, self.clients[0])
+        assert self.no_sudo_str not in result.stderr_text


### PR DESCRIPTION
This PR was opened automatically because PR #5636 was pushed to master and backport to ipa-4-9 is required.