### PR TITLE
ipatests: filter_users belongs to nss section

### DIFF
--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -147,7 +147,7 @@ class TestSSSDWithAdTrust(IntegrationTest):
         sssd_conf_backup = tasks.FileBackup(self.master, paths.SSSD_CONF)
         try:
             with tasks.remote_sssd_config(self.master) as sssd_conf:
-                sssd_conf.edit_domain(self.master.domain,
+                sssd_conf.edit_service("nss",
                                       'filter_users', self.users[user]['name'])
             tasks.clear_sssd_cache(self.master)
             yield


### PR DESCRIPTION
In the test test_sssd.py::TestSSSDWithAdTrust::test_is_user_filtered
the config file sssd.conf is modified with a parameter
filter_users written in the [domain/..] section but
the parameter should appear in [nss] section instead.

Fixes: https://pagure.io/freeipa/issue/8747