### PR TITLE
ipatests: add test_acme.py in nightly previous

### DIFF
--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1642,6 +1642,18 @@ jobs:
         timeout: 7200
         topology: *master_3client
 
+  fedora-previous/test_acme:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_acme.py
+        template: *ci-master-previous
+        timeout: 7200
+        topology: *master_1repl_1client
+
   fedora-previous/test_dns:
     requires: [fedora-previous/build]
     priority: 50


### PR DESCRIPTION
The nightly_latest.yaml file is missing the test test_acme.py
Add the job definition.