### PR TITLE
[Backport][ipa-4-9] ipatests: re-add test_dnssec.py::TestInstallDNSSECFirst in gating

### DIFF
--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -26,12 +26,11 @@ vms:
     - test_integration/test_membermanager.py
 
 - vm_jobs:
-  # Temporarily disabled because of https://pagure.io/freeipa/issue/8496
-  # - container_job: InstallDNSSECFirst
-  #     containers:
-  #       replicas: 1
-  #     tests:
-  #     - test_integration/test_dnssec.py::TestInstallDNSSECFirst
+  - container_job: InstallDNSSECFirst
+    containers:
+      replicas: 1
+    tests:
+    - test_integration/test_dnssec.py::TestInstallDNSSECFirst
 
   - container_job: simple_replication
     containers:

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -239,17 +239,17 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-#  fedora-latest-ipa-4-9/test_dnssec_TestInstallDNSSECFirst:
-#    requires: [fedora-latest-ipa-4-9/build]
-#    priority: 100
-#    job:
-#      class: RunPytest
-#      args:
-#        build_url: '{fedora-latest-ipa-4-9/build_url}'
-#        test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
-#        template: *ci-ipa-4-9-latest
-#        timeout: 3600
-#        topology: *master_1repl
+  fedora-latest-ipa-4-9/test_dnssec_TestInstallDNSSECFirst:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
+        template: *ci-ipa-4-9-latest
+        timeout: 3600
+        topology: *master_1repl
 
   fedora-latest-ipa-4-9/test_membermanager:
     requires: [fedora-latest-ipa-4-9/build]

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -462,11 +462,10 @@ class TestInstallDNSSECFirst(IntegrationTest):
         self.master.run_command(args)
         self.replicas[0].run_command(args)
 
-    def test_resolvconf(self):
-        # check that resolv.conf contains IP address for localhost
+    def test_servers_use_localhost_as_dns(self):
+        # check that localhost is set as DNS server
         for host in [self.master, self.replicas[0]]:
-            resolvconf = host.get_file_contents(paths.RESOLV_CONF, 'utf-8')
-            assert any(ip in resolvconf for ip in ('127.0.0.1', '::1'))
+            assert host.resolver.uses_localhost_as_dns()
 
 
 class TestMigrateDNSSECMaster(IntegrationTest):


### PR DESCRIPTION
This is a manual backport of PR #5632 into ipa-4-9 branch.