### PR TITLE
ipatests: Bump PR-CI Rawhide template

### DIFF
--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-frawhide
-          name: freeipa/ci-master-f34
-          version: 0.0.2
+          name: freeipa/ci-master-frawhide
+          version: 0.4.0
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Template based on future Fedora 35.

Build job is working: https://github.com/freeipa-pr-ci2/freeipa/pull/794