### PR TITLE
[Backport][ipa-4-9] Avoid comparing 'max' with 'max\n'.

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1098,7 +1098,7 @@ def check_available_memory(ca=False):
             )
 
         with open(limit_file) as fd:
-            limit = fd.readline()
+            limit = fd.readline().rstrip()
         with open(usage_file) as fd:
             used = int(fd.readline())
 


### PR DESCRIPTION
This PR was opened automatically because PR #5651 was pushed to master and backport to ipa-4-9 is required.