### PR TITLE
configure: Make rpmlint optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -194,7 +194,10 @@ endif WITH_PYLINT
 if WITH_JSLINT
 JSLINT_TARGET = jslint
 endif WITH_JSLINT
-lint: acilint apilint $(POLINT_TARGET) $(PYLINT_TARGET) $(JSLINT_TARGET) rpmlint yamllint
+if WITH_RPMLINT
+RPMLINT_TARGET = rpmlint
+endif  # WITH_RPMLINT
+lint: acilint apilint $(POLINT_TARGET) $(PYLINT_TARGET) $(JSLINT_TARGET) $(RPMLINT_TARGET) yamllint
 
 .PHONY: devcheck
 devcheck: all
@@ -210,12 +213,12 @@ endif
 	@ # just tests, aci, api and pylint on Python 3
 	PATH=$(abspath ipatests):$$PATH PYTHONPATH=$(abspath $(top_srcdir)) \
 	    $(PYTHON) ipatests/ipa-run-tests --ipaclient-unittests
-	$(MAKE) $(AM_MAKEFLAGS) acilint apilint polint pylint jslint rpmlint yamllint check
+	$(MAKE) $(AM_MAKEFLAGS) acilint apilint polint pylint jslint $(RPMLINT_TARGET) yamllint check
 	@echo "All tests passed."
 
 .PHONY: fastcheck fasttest fastlint
 fastcheck:
-	@$(MAKE) -j1 $(AM_MAKEFLAGS) fastlint rpmlint yamllint fasttest apilint acilint
+	@$(MAKE) -j1 $(AM_MAKEFLAGS) fastlint $(RPMLINT_TARGET) yamllint fasttest apilint acilint
 
 fasttest: $(GENERATED_PYTHON_FILES) ipasetup.py
 	@ # --ignore doubles speed of total test run compared to pytest.skip()
@@ -297,8 +300,10 @@ polint:
 	    validate-src-strings validate-po test-gettext
 
 .PHONY: rpmlint
+if WITH_RPMLINT
 rpmlint: freeipa.spec
-	rpmlint ./$<
+	@RPMLINT@ ./$<
+endif  # WITH_RPMLINT
 
 # Try to load yml/yaml files via safe_load, which recognizes only standard
 # YAML tags and cannot construct an arbitrary Python object.

--- a/configure.ac
+++ b/configure.ac
@@ -559,6 +559,23 @@ AS_CASE([$JSLINT],
 AC_SUBST([JSLINT])
 AM_CONDITIONAL([WITH_JSLINT], [test "x${JSLINT}" != "xno"])
 
+
+AC_ARG_ENABLE(
+    [rpmlint],
+    [AC_HELP_STRING([--enable-rpmlint], [Enable rpmlint for the rpm spec])],
+    [case "${enableval}" in
+         yes) ENABLE_RPMLINT=yes ;;
+          no) ENABLE_RPMLINT=no ;;
+           *) AC_MSG_ERROR([bad value ${enableval} for --enable-rpmlint]) ;;
+     esac],
+    [ENABLE_RPMLINT=no])
+AS_IF([test "x$ENABLE_RPMLINT" = "xyes"],
+      [AC_PATH_PROG([RPMLINT], [rpmlint])
+       AS_IF([test "x$RPMLINT" = "x"],
+             [AC_MSG_ERROR([Could not find rpmlint])])],
+)
+AM_CONDITIONAL([WITH_RPMLINT], [test "x$ENABLE_RPMLINT" = "xyes"])
+
 AM_CONDITIONAL([HAVE_UNSHARE],
     [test "x${ac_cv_func_unshare}" = "xyes" -a "x${ac_cv_func_chroot}" = "xyes"])
 
@@ -672,6 +689,7 @@ echo "
         Python:                   ${PYTHON} (${PYTHON_VERSION})
         pylint:                   ${PYLINT}
         jslint:                   ${JSLINT}
+        rpmlint:                  ${ENABLE_RPMLINT}
         LDAP libs:                ${LDAP_LIBS}
         OpenSSL crypto libs:      ${CRYPTO_LIBS}
         KRB5 libs:                ${KRB5_LIBS}

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -49,9 +49,9 @@
 # lint is not executed during rpmbuild
 # %%global with_lint 1
 %if %{with lint}
-    %global linter_options --enable-pylint --with-jslint
+    %global linter_options --enable-pylint --with-jslint --enable-rpmlint
 %else
-    %global linter_options --disable-pylint --without-jslint
+    %global linter_options --disable-pylint --without-jslint --disable-rpmlint
 %endif
 
 # Include SELinux subpackage

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -19,11 +19,7 @@ jobs:
     options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
   steps:
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
-    - script: |
-        set -e
-        echo "Running autoconf generator"
-        ./autogen.sh
-      displayName: Configure the project
+    - template: templates/${{ variables.AUTOCONF_TEMPLATE }}
     - script: |
         set -e
         git update-ref refs/heads/$(System.PullRequest.TargetBranch) origin/$(System.PullRequest.TargetBranch)
@@ -70,11 +66,7 @@ jobs:
     options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
   steps:
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
-    - script: |
-        set -e
-        echo "Running autoconf generator"
-        ./autogen.sh
-      displayName: Configure the project
+    - template: templates/${{ variables.AUTOCONF_TEMPLATE }}
     - script: |
         set -e
         echo "Running make target 'lint'"
@@ -119,11 +111,7 @@ jobs:
   steps:
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - template: templates/${{ variables.PREPARE_WEBUI_TEMPLATE }}
-    - script: |
-        set -e
-        echo "Running autoconf generator"
-        ./autogen.sh
-      displayName: Configure the project
+    - template: templates/${{ variables.AUTOCONF_TEMPLATE }}
     - script: |
         set -e
         echo "Running WebUI unit tests"

--- a/ipatests/azure/templates/autoconf-fedora.yml
+++ b/ipatests/azure/templates/autoconf-fedora.yml
@@ -1,0 +1,12 @@
+parameters:
+    options: ''
+
+steps:
+- script: |
+    set -e
+    echo "Running autoconf generator"
+    ./autogen.sh \
+        ${{ parameters.options }} \
+        --enable-rpmlint \
+
+  displayName: Configure the project

--- a/ipatests/azure/templates/variables-fedora.yml
+++ b/ipatests/azure/templates/variables-fedora.yml
@@ -6,6 +6,9 @@ variables:
   # the Dockerfile to build Docker image for running IPA tests
   DOCKER_DOCKERFILE: ${{ format('Dockerfile.build.{0}', variables.IPA_PLATFORM) }}
 
+  # the template to autoconf the project
+  AUTOCONF_TEMPLATE: ${{ format('autoconf-{0}.yml', variables.IPA_PLATFORM) }}
+
   # the template to install IPA's buildtime dependencies
   PREPARE_BUILD_TEMPLATE: ${{ format('prepare-build-{0}.yml', variables.IPA_PLATFORM) }}
 

--- a/ipatests/azure/templates/variables-rawhide.yml
+++ b/ipatests/azure/templates/variables-rawhide.yml
@@ -9,6 +9,9 @@ variables:
   # the Dockerfile to build Docker image for running IPA tests
   DOCKER_DOCKERFILE: 'Dockerfile.build.rawhide'
 
+  # the template to autoconf the project
+  AUTOCONF_TEMPLATE: ${{ format('autoconf-{0}.yml', variables.IPA_PLATFORM) }}
+
   # the template to install IPA's buildtime dependencies
   PREPARE_BUILD_TEMPLATE: ${{ format('prepare-build-{0}.yml', variables.IPA_PLATFORM) }}
 


### PR DESCRIPTION
Distributions may want to run comprehensive fastcheck or lint tasks, but rpmlint tool is mandatory for these targets while some platforms don't have it at all.

With this change the rpmlint becomes optional for fastcheck, devcheck and lint make targets.

Note: rpmlint option is `disabled` by default.
To enable: `./configure --enable-rpmlint`
To explicitly disable: `./configure --disable-rpmlint`

Fixes: https://pagure.io/freeipa/issue/8768
