### PR TITLE
[Backport][ipa-4-9] ipatests: Enable certbot test on rhel

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -27,7 +27,7 @@ ROOT_CA = "root_ca.crt"
 # RHEL does not have certbot.  EPEL's version is broken with
 # python-cryptography-2.3; likewise recent PyPI releases.
 # So for now, on RHEL we suppress tests that use certbot.
-skip_certbot_tests = osinfo.id not in ['fedora', ]
+skip_certbot_tests = osinfo.id not in ['fedora', 'rhel']
 
 # Fedora mod_md package needs some patches before it will work.
 # RHEL version has the patches.


### PR DESCRIPTION
This PR was opened automatically because PR #5562 was pushed to master and backport to ipa-4-9 is required.