### PR TITLE
[ipa-4-8] ipatests: remove test cases for unsupported NTLM authentication scenarios

### DIFF
--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -419,28 +419,6 @@ class TestSMB(IntegrationTest):
 
         self.check_repeated_smb_mount(mount_options)
 
-    @skip_if_fips()
-    def test_ntlm_authentication_with_upn_with_lowercase_domain(self):
-        tasks.kdestroy_all(self.smbclient)
-
-        mount_options = 'user={user}@{domain},pass={password}'.format(
-            user=self.ipa_user1,
-            password=self.ipa_user1_password,
-            domain=self.master.domain.name.lower()
-        )
-        self.check_repeated_smb_mount(mount_options)
-
-    @skip_if_fips()
-    def test_ntlm_authentication_with_upn_with_uppercase_domain(self):
-        tasks.kdestroy_all(self.smbclient)
-
-        mount_options = 'user={user}@{domain},pass={password}'.format(
-            user=self.ipa_user1,
-            password=self.ipa_user1_password,
-            domain=self.master.domain.name.upper()
-        )
-        self.check_repeated_smb_mount(mount_options)
-
     def test_uninstall_samba(self):
         self.smbserver.run_command(['ipa-client-samba', '--uninstall', '-U'])
         res = self.smbserver.run_command(


### PR DESCRIPTION
The test cases were added as part of testing
https://pagure.io/freeipa/issue/8636 - authentication at samba file server
with login and password.
Original issue only required authentication to be working with
auto-detected domain but scenarios with manually specified domain proved
to be working as well. Unfortunately the latter is not true for ipa-4-8
branch. As this branch is reaching end of life it is not reasonable to
commit to investigation why it is not working, so removing test cases
for those additional scenarios.