### PR TITLE
[Backport][ipa-4-9] Don't start the CA during healthcheck grace period check so uninstall succeeds

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1363,7 +1363,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl
 
   fedora-latest-ipa-4-9/test_ipahealthcheck_nodns_extca_file:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1470,7 +1470,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl
 
   fedora-latest-ipa-4-9/test_ipahealthcheck_nodns_extca_file:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1363,7 +1363,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-9/build_url}'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-ipa-4-9-previous
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl
 
   fedora-previous-ipa-4-9/test_ipahealthcheck_nodns_extca_file:


### PR DESCRIPTION
This PR was opened manually because PR #5573 was pushed to master and backport to ipa-4-9 is required.

A manual backport was needed because there was a merge conflict in updating the test_integration/test_ipahealthcheck.py::TestIpaHealthCheck timeouts

Adding needs_review to double-check I did the merge correctly.