### PR TITLE
Adapt redhat ipaplatform to RHEL9/ELN

### DIFF
--- a/ipaplatform/rhel/constants.py
+++ b/ipaplatform/rhel/constants.py
@@ -17,6 +17,8 @@ from ipaplatform.osinfo import osinfo
 # RHEL 7 and earlier use /etc/sysconfig/nfs
 # RHEL 8 uses /etc/nfs.conf
 HAS_NFS_CONF = osinfo.version_number >= (8,)
+# RHEL 9 uses pkcs11 as openssl engine
+HAS_PKCS11_OPENSSL_ENGINE = osinfo.version_number >= (9,)
 
 
 __all__ = ("constants", "User", "Group")
@@ -27,5 +29,7 @@ class RHELConstantsNamespace(RedHatConstantsNamespace):
     IPA_DNS_PACKAGE_NAME = "ipa-server-dns"
     if HAS_NFS_CONF:
         SECURE_NFS_VAR = None
+    if HAS_PKCS11_OPENSSL_ENGINE:
+        NAMED_OPENSSL_ENGINE = "pkcs11"
 
 constants = RHELConstantsNamespace()

--- a/ipaplatform/rhel/services.py
+++ b/ipaplatform/rhel/services.py
@@ -24,11 +24,15 @@ Contains RHEL-specific service class implementations.
 
 from __future__ import absolute_import
 
+from ipaplatform.osinfo import osinfo
 from ipaplatform.redhat import services as redhat_services
 
 # Mappings from service names as FreeIPA code references to these services
 # to their actual systemd service names
 rhel_system_units = redhat_services.redhat_system_units.copy()
+if osinfo.version_number >= (9,):
+    rhel_system_units['named'] = rhel_system_units['named-regular']
+    rhel_system_units['named-conflict'] = rhel_system_units['named-pkcs11']
 
 
 # Service classes that implement RHEL-specific behaviour
@@ -41,6 +45,8 @@ class RHELService(redhat_services.RedHatService):
 # of specified name
 
 def rhel_service_class_factory(name, api=None):
+    if name in ['named', 'named-conflict']:
+        return RHELService(name, api)
     return redhat_services.redhat_service_class_factory(name, api)
 
 


### PR DESCRIPTION
On RHEL8, ipa is using named-pkcs11.service but RHEL9 is based on
fedora34 and uses named.service instead. There is already some support
for this distinction in ipaplatform, and the patch relies on the
specific settings that can be configured in ipaplatform/xx/services.py
and ipaplatform/xx/constants.py

On RHEL9 ipa also needs to define NAMED_OPENSSL_ENGINE for named
to use openssl's okcs11 engine.

Fixes: https://pagure.io/freeipa/issue/8753