### PR TITLE
ipatests: update expected message

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1127,7 +1127,6 @@ class TestIpaHealthCheck(IntegrationTest):
         """
         warn_msg = (
             "We advise that you set this value to 0, and enable referint "
-            "on all masters as it provides a more predictable behaviour.\n"
         )
         returncode, data = run_healthcheck(
             self.master,


### PR DESCRIPTION
The test TestIpaHealthCheck::test_ipahealthcheck_ds_riplugincheck
is expecting a specific message for the RIPluginCheck
but the message has been updated to fix
4656 - Remove problematic language from UI/CLI/lib389
("enable referint on all suppliers" instead of
"enable referint on all masters").

Shorten the expected msg so that it fits both situations.

Fixes: https://pagure.io/freeipa/issue/8779