### PR TITLE
[Backport][ipa-4-8] ipatests: allocate pseudo-terminal only for specific command

### DIFF
--- a/ipatests/pytest_ipa/integration/expect.py
+++ b/ipatests/pytest_ipa/integration/expect.py
@@ -68,6 +68,8 @@ class IpaTestExpect(pexpect.spawn):
         else:
             command = argv[0]
             args = argv[1:]
+        logger.debug('Expect will spawn command "%s" with args %s',
+                     command, args)
         super().__init__(
             command, args, timeout=default_timeout, encoding=encoding,
             echo=False

--- a/ipatests/pytest_ipa/integration/host.py
+++ b/ipatests/pytest_ipa/integration/host.py
@@ -204,9 +204,11 @@ class Host(pytest_multihost.host.Host):
         else:
             return result
 
-    def spawn_expect(self, argv, default_timeout=10, encoding='utf-8'):
-        """Run command on host using IpaTestExpect"""
-        return self.transport.spawn_expect(argv, default_timeout, encoding)
+    def spawn_expect(self, argv, default_timeout=10, encoding='utf-8',
+                     extra_ssh_options=None):
+        """Run command on remote host using IpaTestExpect"""
+        return self.transport.spawn_expect(argv, default_timeout, encoding,
+                                           extra_ssh_options)
 
 class WinHost(pytest_multihost.host.WinHost):
     """

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2166,7 +2166,8 @@ class KerberosKeyCopier:
 
         mtime_before = get_keytab_mtime()
 
-        with self.host.spawn_expect(paths.KTUTIL, default_timeout=5) as e:
+        with self.host.spawn_expect(paths.KTUTIL, default_timeout=5,
+                                    extra_ssh_options=['-t']) as e:
             e.expect_exact('ktutil:')
             e.sendline('rkt {}'.format(keytab))
             e.expect_exact('ktutil:')

--- a/ipatests/pytest_ipa/integration/transport.py
+++ b/ipatests/pytest_ipa/integration/transport.py
@@ -49,9 +49,11 @@ class IPAOpenSSHTransport(OpenSSHTransport):
 
         return argv
 
-    def spawn_expect(self, argv, default_timeout, encoding):
+    def spawn_expect(self, argv, default_timeout, encoding, extra_ssh_options):
         self.log.debug('Starting pexpect ssh session')
         if isinstance(argv, str):
             argv = [argv]
-        argv = self._get_ssh_argv() + ['-t', '-q'] + argv
+        if extra_ssh_options is None:
+            extra_ssh_options = []
+        argv = self._get_ssh_argv() + ['-q'] + extra_ssh_options + argv
         return IpaTestExpect(argv, default_timeout, encoding)


### PR DESCRIPTION
This PR was opened automatically because PR #5650 was pushed to master and backport to ipa-4-8 is required.