### PR TITLE
ipatests: Skip test_jsplugins in server-less environments

### DIFF
--- a/ipatests/test_ipaserver/test_jsplugins.py
+++ b/ipatests/test_ipaserver/test_jsplugins.py
@@ -3,12 +3,17 @@
 import os
 import pytest
 
+from ipalib import facts
 from ipatests.test_ipaserver.httptest import Unauthorized_HTTP_test
 from ipatests.util import assert_equal, assert_not_equal
 from ipaplatform.paths import paths
 
 
 @pytest.mark.tier1
+@pytest.mark.skipif(
+    not facts.is_ipa_configured(),
+    reason="Requires configured IPA server",
+)
 class test_jsplugins(Unauthorized_HTTP_test):
     app_uri = '/ipa/ui/js/freeipa/plugins.js'
     jsplugins = (('foo', 'foo.js'), ('bar', ''))


### PR DESCRIPTION
This test assumes that IPA server is installed and configured.
But test_jsplugins is the subtask of fasttest which is designed
(unittest) to be run in server-less environment.

Note: `needs_ipaapi` is not completely suitable because there is
no direct IPA API usage. `xmlrpc_setup` fixture is also not
suitable because it assumes XMLRPC.

Fixes: https://pagure.io/freeipa/issue/8781