### PR TITLE
 Implement simple LDAP cache layer

### DIFF
--- a/client/man/default.conf.5
+++ b/client/man/default.conf.5
@@ -113,6 +113,12 @@ Specifies whether values should be prompted for or not. The default is True.
 .B kinit_lifetime <time duration spec>
 Controls the lifetime of ticket obtained by users authenticating to the WebGUI using login/password. The expected format is a time duration string. Examples are "2 hours", "1h:30m", "10 minutes", "5min, 30sec". When the parameter is not set in default.conf, the ticket will have a duration inherited from the default value for kerberos clients, that can be set as ticket_lifetime in krb5.conf. When the ticket lifetime has expired, the ticket is not valid anymore and the GUI will prompt to re-login with a message "Your session has expired. Please re-login."
 .TP
+.B ldap_cache <boolean>
+Enable a per-request LDAP cache. The default is True.
+.TP
+.B ldap_cache_size <integer>
+The maximum number of entries cached if ldap_cache is True. Since this cache is per-request it is not expected to be very large. The default is 100. Setting the value < 1 effectively disables the cache regardless of the ldap_cache setting
+.TP
 .B ldap_uri <URI>
 Specifies the URI of the IPA LDAP server to connect to. The URI scheme may be one of \fBldap\fR or \fBldapi\fR. The default is to use ldapi, e.g. ldapi://%2fvar%2frun%2fslapd\-EXAMPLE\-COM.socket
 .TP

--- a/contrib/cachelog
+++ b/contrib/cachelog
@@ -1,0 +1,118 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2021  FreeIPA Contributors see COPYING for license
+#
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import division
+
+from datetime import datetime
+import logging
+import re
+
+from ipapython import admintool
+from ipalib.facts import is_ipa_configured
+
+
+# r'(?P<command>\S+)/1\(.*\): (?P<result>\S+) etime=(?P<etime>\d+)'
+TIME_RE = re.compile(
+    r'\[(?P<date>.*)\] \[.*\].* \[pid \d+:tid \d+\] \[remote .*\] '
+    r'ipa: DEBUG: FINAL: Hits (?P<hits>\d+) Misses (?P<misses>\d+) '
+    r'Size (?P<size>\d+)'
+)
+
+DATE_FORMAT = '%a %b %d %H:%M:%S.%f %Y'
+
+logger = logging.getLogger(__name__)
+
+
+class cachelog(admintool.AdminTool):
+    command_name = "cachelog"
+
+    usage = "%prog [options]"
+    description = "Parse the Apache error log for cache performance data. " \
+                  "Enable debugging by creating /etc/ipa/server.conf with " \
+                  "the contents: [global]\\ndebug = True"
+
+    def __init__(self, options, args):
+        super(cachelog, self).__init__(options, args)
+        self.since = None
+
+    @classmethod
+    def add_options(cls, parser):
+        super(cachelog, cls).add_options(parser, debug_option=True)
+        parser.add_option(
+            "--command",
+            dest="command",
+            action="store",
+            default=None,
+            help="Command to analyze",
+        )
+        parser.add_option(
+            "--start-time",
+            dest="start_time",
+            action="store",
+            default=None,
+            help="time to begin analyzing logfile from, e.g. "
+                 "Fri May 7 16:33:08.0 2021",
+        )
+        parser.add_option(
+            "--file",
+            dest="file",
+            action="store",
+            default="/var/log/httpd/error_log",
+            help="Log file to parse",
+        )
+
+    def validate_options(self):
+        super(cachelog, self).validate_options(needs_root=True)
+
+        if self.options.start_time:
+            self.since = datetime.strptime(
+                self.options.start_time,
+                DATE_FORMAT
+            )
+
+    def run(self):
+        super(cachelog, self).run()
+
+        if not is_ipa_configured():
+            logger.error("IPA server is not configured on this system.")
+            raise admintool.ScriptError()
+
+        with open(self.options.file, 'r') as f:
+            data = f.read()
+
+        matches = list(re.finditer(TIME_RE, data))
+
+        hits = 0
+        misses = 0
+        count = 0
+
+        for match in matches:
+            if self.since:
+                logtime = datetime.strptime(match.group('date'), DATE_FORMAT)
+                if logtime < self.since:
+                    continue
+            hits += int(match.group('hits'))
+            misses += int(match.group('misses'))
+            count += 1
+
+        print('Total reads %d, hits %d, misses %d, avg %1.4f' %
+              (hits + misses, hits, misses, hits / (hits + misses)))
+
+
+if __name__ == '__main__':
+    cachelog.run_cli()

--- a/install/tools/ipa-adtrust-install.in
+++ b/install/tools/ipa-adtrust-install.in
@@ -161,7 +161,7 @@ def main():
     api.bootstrap(
         in_server=True,
         debug=options.debug,
-        context='install',
+        context='installer',
         confdir=paths.ETC_IPA
     )
     api.finalize()

--- a/install/tools/ipa-ca-install.in
+++ b/install/tools/ipa-ca-install.in
@@ -294,7 +294,7 @@ def main():
     # override ra_plugin setting read from default.conf so that we have
     # functional dogtag backend plugins during CA install
     api.bootstrap(
-        context='install', confdir=paths.ETC_IPA,
+        context='installer', confdir=paths.ETC_IPA,
         in_server=True, ra_plugin='dogtag'
     )
     api.finalize()

--- a/install/tools/ipa-dns-install.in
+++ b/install/tools/ipa-dns-install.in
@@ -131,7 +131,7 @@ def main():
 
     # Initialize the ipalib api
     api.bootstrap(
-        context='install', confdir=paths.ETC_IPA,
+        context='installer', confdir=paths.ETC_IPA,
         in_server=True, debug=options.debug,
     )
     api.finalize()

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -160,6 +160,9 @@ DEFAULT_CONFIG = (
 
     ('rpc_protocol', 'jsonrpc'),
 
+    ('ldap_cache', True),
+    ('ldap_cache_size', 100),
+
     # Define an inclusive range of SSL/TLS version support
     ('tls_version_min', TLS_VERSION_DEFAULT_MIN),
     ('tls_version_max', TLS_VERSION_DEFAULT_MAX),

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -425,7 +425,7 @@ class ldap2(CrudBackend, LDAPClient):
             with self.error_handler():
                 modlist = [(a, b, self.encode(c))
                            for a, b, c in modlist]
-                self.conn.modify_s(str(group_dn), modlist)
+                self.modify_s(str(group_dn), modlist)
         except errors.DuplicateEntry:
             # TYPE_OR_VALUE_EXISTS
             raise errors.AlreadyGroupMember()
@@ -448,7 +448,7 @@ class ldap2(CrudBackend, LDAPClient):
             with self.error_handler():
                 modlist = [(a, b, self.encode(c))
                            for a, b, c in modlist]
-                self.conn.modify_s(str(group_dn), modlist)
+                self.modify_s(str(group_dn), modlist)
         except errors.MidairCollision:
             raise errors.NotGroupMember()
 
@@ -502,7 +502,7 @@ class ldap2(CrudBackend, LDAPClient):
                (_ldap.MOD_REPLACE, 'krblastpwdchange', None)]
 
         with self.error_handler():
-            self.conn.modify_s(str(dn), mod)
+            self.modify_s(str(dn), mod)
 
     # CrudBackend methods
 

--- a/ipatests/test_ipapython/test_ldap_cache.py
+++ b/ipatests/test_ipapython/test_ldap_cache.py
@@ -1,0 +1,137 @@
+#
+# Copyright (C) 2021  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Test the LDAPCache class.
+"""
+# pylint: disable=no-member
+
+from ipalib import api, errors
+from ipapython import ipaldap
+from ipapython.dn import DN
+
+import pytest
+
+
+def hits_and_misses(cache, hits, misses):
+    assert cache._cache_hits == hits
+    assert cache._cache_misses == misses
+
+
+@pytest.fixture(scope='class')
+@pytest.mark.tier1
+@pytest.mark.needs_ipaapi
+def class_cache(request):
+    cache = ipaldap.LDAPCache(api.env.ldap_uri)
+    hits_and_misses(cache, 0, 0)
+
+    request.cls.cache = cache
+    request.cls.userdn = DN(
+        'uid=testuser', api.env.container_user, api.env.basedn
+    )
+
+    rpcclient = api.Backend.rpcclient
+    was_connected = rpcclient.isconnected()
+
+    if not was_connected:
+        rpcclient.connect()
+
+    api.Command.user_add('testuser', givenname=u'Test', sn=u'User')
+
+    yield
+
+    try:
+        api.Command.user_del('testuser')
+    except Exception:
+        pass
+
+    try:
+        if not was_connected:
+            rpcclient.disconnect()
+    except Exception:
+        pass
+
+
+@pytest.mark.usefixtures('class_cache')
+@pytest.mark.skip_ipaclient_unittest
+@pytest.mark.needs_ipaapi
+class TestLDAPCache:
+
+    def test_one(self):
+        dn = DN('uid=notfound', api.env.container_user, api.env.basedn)
+        try:
+            self.cache.get_entry(dn)
+        except errors.EmptyResult:
+            pass
+
+        assert dn in self.cache.cache
+        exc = self.cache.cache[dn].exception
+        assert isinstance(exc, errors.EmptyResult)
+
+        hits_and_misses(self.cache, 0, 1)
+
+    def test_retrieve_exception(self):
+        dn = DN('uid=notfound', api.env.container_user, api.env.basedn)
+        try:
+            self.cache.get_entry(dn)
+        except errors.EmptyResult:
+            pass
+        assert dn in self.cache.cache
+        exc = self.cache.cache[dn].exception
+        assert isinstance(exc, errors.EmptyResult)
+        hits_and_misses(self.cache, 1, 1)
+
+    def test_get_testuser(self):
+        assert self.userdn not in self.cache.cache
+        self.cache.get_entry(self.userdn)
+        assert self.userdn in self.cache.cache
+        hits_and_misses(self.cache, 1, 2)
+
+    def test_get_testuser_again(self):
+        assert self.userdn in self.cache.cache
+        self.cache.get_entry(self.userdn)
+        hits_and_misses(self.cache, 2, 2)
+
+    def test_update_testuser(self):
+        entry = self.cache.cache[self.userdn].entry
+        try:
+            self.cache.update_entry(entry)
+        except errors.EmptyModlist:
+            pass
+        assert self.userdn not in self.cache.cache
+        hits_and_misses(self.cache, 2, 2)
+
+    def test_modify_testuser(self):
+        self.cache.get_entry(self.userdn)
+        entry = self.cache.cache[self.userdn].entry
+        try:
+            self.cache.modify_s(entry.dn, [])
+        except errors.EmptyModlist:
+            pass
+        assert self.userdn not in self.cache.cache
+        hits_and_misses(self.cache, 2, 3)
+
+    def test_delete_entry(self):
+        # We don't care if this is successful or not, just that the
+        # cache doesn't retain the deleted entry
+        try:
+            self.cache.delete_entry(self.userdn)
+        except Exception:
+            pass
+        assert self.userdn not in self.cache.cache
+        hits_and_misses(self.cache, 2, 3)
+
+    def test_add_entry(self):
+        # We don't care if this is successful or not, just that the
+        # cache doesn't get the added entry
+        try:
+            self.cache.add_entry(self.userdn)
+        except Exception:
+            pass
+        assert self.userdn not in self.cache.cache
+        hits_and_misses(self.cache, 2, 3)
+
+    def test_clear_cache(self):
+        self.cache.clear_cache()
+        hits_and_misses(self.cache, 0, 0)


### PR DESCRIPTION
Pretty straightforward caching except for the attribute
handling. We probably won't want to cache the entire entry
since that could be expensive (userCertificate, ssh keys, etc)
but not storing it could lead to multiple requests for the
same thing. Also, requesting * vs a set of attributes may not
return all a plugin needs, as it will skip operational attributes.
    
Still, this saves 20-50% of queries in my limited testing.

Mar 29: initial implementation works about 80% of the time. 
I guarantee the xmlrpc tests will fail. We'll see about the integration tests.
There are still corner cases to find and the member modlist stuff
is a mess.

Apr 7: ready for review