### PR TITLE
[Backport][ipa-4-9] ipatests: update expected message

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1127,7 +1127,6 @@ class TestIpaHealthCheck(IntegrationTest):
         """
         warn_msg = (
             "We advise that you set this value to 0, and enable referint "
-            "on all masters as it provides a more predictable behaviour.\n"
         )
         returncode, data = run_healthcheck(
             self.master,


### PR DESCRIPTION
This PR was opened automatically because PR #5670 was pushed to master and backport to ipa-4-9 is required.