### PR TITLE
ipatests: collect PKI config files and NSSDB

### DIFF
--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -75,6 +75,12 @@ CLASS_LOGFILES = [
     paths.VAR_LOG_HTTPD_DIR,
     # dogtag logs
     paths.VAR_LOG_PKI_DIR,
+    # dogtag conf
+    paths.PKI_TOMCAT_SERVER_XML,
+    paths.PKI_TOMCAT + "/ca/CS.cfg",
+    paths.PKI_TOMCAT + "/kra/CS.cfg",
+    paths.PKI_TOMCAT_ALIAS_DIR,
+    paths.PKI_TOMCAT_ALIAS_PWDFILE_TXT,
     # selinux logs
     paths.VAR_LOG_AUDIT,
     # sssd


### PR DESCRIPTION
To ease debugging, also collect:
- /etc/pki/pki-tomcat/server.xml
- /etc/pki/pki-tomcat/ca/CS.cfg
- /etc/pki/pki-tomcat/kra/CS.cfg
- /etc/pki/pki-tomcat/alias
- /etc/pki/pki-tomcat/alias/pwdfile.txt