### PR TITLE
hbacrule: reduce number of LDAP searches during deletion

### DIFF
--- a/ipaserver/plugins/hbacrule.py
+++ b/ipaserver/plugins/hbacrule.py
@@ -317,7 +317,7 @@ class hbacrule_del(LDAPDelete):
 
     def pre_callback(self, ldap, dn, *keys, **options):
         assert isinstance(dn, DN)
-        kw = dict(seealso=keys[0])
+        kw = dict(seealso=str(dn), pkey_only=True)
         _entries = api.Command.selinuxusermap_find(None, **kw)
         if _entries['count']:
             raise errors.DependentEntry(key=keys[0], label=self.api.Object['selinuxusermap'].label_singular, dependent=_entries['result'][0]['cn'][0])


### PR DESCRIPTION
The `hbacrule` module performs a call to `selinuxusermap-find`
during entry deletion. This can be optimized by passing pkey_only=True
to the search, skipping the post-callback function. Passing the full
DN of the hbacrule and detecting it in the selinuxusermap find
also saves one call to hbacrule-show, further reducing the searches.

Related: https://pagure.io/freeipa/issue/8784
Signed-off-by: Antonio Torres <antorres@redhat.com>