### PR TITLE
Add pkey_only to the service_find calls in the host plugin

### DIFF
--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -808,7 +808,7 @@ class host_del(LDAPDelete):
         truncated = True
         while truncated:
             try:
-                ret = api.Command['service_find'](fqdn)
+                ret = api.Command['service_find'](fqdn, pkey_only=True)
                 truncated = ret['truncated']
                 services = ret['result']
             except errors.NotFound:
@@ -1205,7 +1205,7 @@ class host_disable(LDAPQuery):
         truncated = True
         while truncated:
             try:
-                ret = api.Command['service_find'](fqdn)
+                ret = api.Command['service_find'](fqdn, pkey_only=True)
                 truncated = ret['truncated']
                 services = ret['result']
             except errors.NotFound:


### PR DESCRIPTION
This limits the amount of data and post-processing done
in when host_del and host_disable call service_find.
This also saves a presence query for host_keytab.

https://pagure.io/freeipa/issue/8787

Signed-off-by: Rob Crittenden <rcritten@redhat.com>