### PR TITLE
Also use uglifyjs on CentOS Stream 8

### DIFF
--- a/install/ui/util/compile.sh
+++ b/install/ui/util/compile.sh
@@ -112,7 +112,7 @@ fi
 echo "Minimizing: $RDIR/$RELEASE/$LAYER.js"
 echo "Target file: $OUTPUT_FILE"
 if [[ ("$ID" == "rhel" || "$ID_LIKE" =~ "rhel")
-      && "$VERSION_ID" =~ "8." ]];
+      && ("$VERSION_ID" =~ "8." || "$VERSION_ID" == "8") ]];
 then
     echo "Minifier: uglifyjs"
     uglifyjs < $RDIR/$RELEASE/$LAYER.js > $OUTPUT_FILE


### PR DESCRIPTION
This conditional was recently changed to match VERSION_ID "8." to only apply to RHEL 8 releases, but it should also match CentOS Stream 8 which has VERSION_ID "8".

https://pagure.io/freeipa/c/43f344b931db3f72f50e1620443be9f21623e29a

Please also cherry-pick this to the ipa-4-9 branch to be included in future RHEL 8 releases.