### PR TITLE
[Backport][ipa-4-9] ipatests: collect PKI config files and NSSDB

### DIFF
--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -75,6 +75,12 @@ CLASS_LOGFILES = [
     paths.VAR_LOG_HTTPD_DIR,
     # dogtag logs
     paths.VAR_LOG_PKI_DIR,
+    # dogtag conf
+    paths.PKI_TOMCAT_SERVER_XML,
+    paths.PKI_TOMCAT + "/ca/CS.cfg",
+    paths.PKI_TOMCAT + "/kra/CS.cfg",
+    paths.PKI_TOMCAT_ALIAS_DIR,
+    paths.PKI_TOMCAT_ALIAS_PWDFILE_TXT,
     # selinux logs
     paths.VAR_LOG_AUDIT,
     # sssd


### PR DESCRIPTION
This PR was opened automatically because PR #5688 was pushed to master and backport to ipa-4-9 is required.