### PR TITLE
[Backport][ipa-4-9] Also use uglifyjs on CentOS Stream 8

### DIFF
--- a/install/ui/util/compile.sh
+++ b/install/ui/util/compile.sh
@@ -112,7 +112,7 @@ fi
 echo "Minimizing: $RDIR/$RELEASE/$LAYER.js"
 echo "Target file: $OUTPUT_FILE"
 if [[ ("$ID" == "rhel" || "$ID_LIKE" =~ "rhel")
-      && "$VERSION_ID" =~ "8." ]];
+      && ("$VERSION_ID" =~ "8." || "$VERSION_ID" == "8") ]];
 then
     echo "Minifier: uglifyjs"
     uglifyjs < $RDIR/$RELEASE/$LAYER.js > $OUTPUT_FILE


### PR DESCRIPTION
This PR was opened automatically because PR #5691 was pushed to master and backport to ipa-4-9 is required.