### PR TITLE
ipatests: TestIpaHealthCheck now needs 1 client

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1364,7 +1364,7 @@ jobs:
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
         timeout: 5400
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-latest/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -798,7 +798,7 @@ jobs:
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *pki-master-latest
         timeout: 5400
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   pki-fedora/test_ipahealthcheck_nodns_extca_file:
     requires: [pki-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1471,7 +1471,7 @@ jobs:
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
         timeout: 5400
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-latest/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1470,7 +1470,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *testing-master-latest
-        topology: *master_1repl
+        topology: *master_1repl_1client
         timeout: 5400
 
   testing-fedora/test_ipahealthcheck_nodns_extca_file:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1577,7 +1577,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *testing-master-latest
-        topology: *master_1repl
+        topology: *master_1repl_1client
         timeout: 5400
 
   testing-fedora/test_ipahealthcheck_nodns_extca_file:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1364,7 +1364,7 @@ jobs:
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-previous
         timeout: 5400
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-previous/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1470,7 +1470,7 @@ jobs:
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-frawhide
         timeout: 5400
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-rawhide/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
The test TestIpaHealthCheck has been updated with commit
e86ff48 and now needs 1 master, 1 replica and 1 client
in order to execute.
Update the nightly definitions accordingly.