### PR TITLE
Bumps openssl requires

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -439,7 +439,12 @@ Requires(pre): certmonger >= %{certmonger_version}
 Requires(pre): 389-ds-base >= %{ds_version}
 Requires: fontawesome-fonts
 Requires: open-sans-fonts
+%if 0%{?fedora} >= 32 || 0%{?rhel} >= 9
+# https://pagure.io/freeipa/issue/8632
+Requires: openssl > 1.1.1i
+%else
 Requires: openssl
+%endif
 Requires: softhsm >= 2.0.0rc1-1
 Requires: p11-kit
 Requires: %{etc_systemd_dir}


### PR DESCRIPTION
openssl-1.1.1i introduced a regression preventing WebUI
login when the server is installed with --no-pkinit option.

On fedora 32/33/34/rawhide openssl-1.1.1k-1 is now available.
On RHEL8, openssl-1.1.1g is still shipped and doesn't have the
issue.

Fixes: https://pagure.io/freeipa/issue/8632