### PR TITLE
[Backport][ipa-4-9] Bumps openssl requires

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -439,7 +439,12 @@ Requires(pre): certmonger >= %{certmonger_version}
 Requires(pre): 389-ds-base >= %{ds_version}
 Requires: fontawesome-fonts
 Requires: open-sans-fonts
+%if 0%{?fedora} >= 32 || 0%{?rhel} >= 9
+# https://pagure.io/freeipa/issue/8632
+Requires: openssl > 1.1.1i
+%else
 Requires: openssl
+%endif
 Requires: softhsm >= 2.0.0rc1-1
 Requires: p11-kit
 Requires: %{etc_systemd_dir}


### PR DESCRIPTION
This PR was opened automatically because PR #5697 was pushed to master and backport to ipa-4-9 is required.