### PR TITLE
[Backport][ipa-4-9] ipatests: TestIpaHealthCheck now needs 1 client

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1364,7 +1364,7 @@ jobs:
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-ipa-4-9-latest
         timeout: 5400
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-latest-ipa-4-9/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1471,7 +1471,7 @@ jobs:
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-ipa-4-9-latest
         timeout: 5400
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-latest-ipa-4-9/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1364,7 +1364,7 @@ jobs:
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-ipa-4-9-previous
         timeout: 5400
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-previous-ipa-4-9/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-previous-ipa-4-9/build]


### PR DESCRIPTION
This is a manual backport of PR #5696 to ipa-4-9 branch.