### PR TITLE
[Backport][ipa-4-9] ipatests: call server-del before replica uninstall

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -402,7 +402,7 @@ class TestRenewalMaster(IntegrationTest):
     def test_automatic_renewal_master_transfer_ondelete(self):
         # Test that after replica uninstallation, master overtakes the cert
         # renewal master role from replica (which was previously set there)
-        tasks.uninstall_master(self.replicas[0])
+        tasks.uninstall_replica(self.master, self.replicas[0])
         result = self.master.run_command(['ipa', 'config-show']).stdout_text
         assert("IPA CA renewal master: %s" % self.master.hostname in result), (
             "Master hostname not found among CA renewal masters"


### PR DESCRIPTION
This PR was opened automatically because PR #5698 was pushed to master and backport to ipa-4-9 is required.