### PR TITLE
Do not change hostname if it is not neccessary

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -213,12 +213,14 @@ def backup_file(host, filename):
 
 
 def fix_hostname(host):
-    backup_file(host, paths.ETC_HOSTNAME)
-    host.put_file_contents(paths.ETC_HOSTNAME, host.hostname + '\n')
-    host.run_command(['hostname', host.hostname])
+    res = host.run_command(["hostname"])
+    if res.stdout_text.strip() != host.hostname:
+        backup_file(host, paths.ETC_HOSTNAME)
+        host.put_file_contents(paths.ETC_HOSTNAME, host.hostname + '\n')
+        host.run_command(['hostname', host.hostname])
 
-    backupname = os.path.join(host.config.test_dir, 'backup_hostname')
-    host.run_command('hostname > %s' % ipautil.shell_quote(backupname))
+        backupname = os.path.join(host.config.test_dir, 'backup_hostname')
+        host.run_command('hostname > %s' % ipautil.shell_quote(backupname))
 
 
 def host_service_active(host, service):


### PR DESCRIPTION
TLDR:
While testing using containers hostname can not be changed/set up on runtime only when creating container.

Setting hostname in container is not possible using podman:
```
[root@perun ltevenv]# podman exec -ti master sh -c "hostnamectl set-hostname master.tesrelm.test"
Could not set property: Access denied
[root@perun ltevenv]# podman exec -ti master sh -c "hostname master.tesrelm.test"
hostname: you must be root to change the host name
[root@perun ltevenv]# podman exec -ti master sh -c "hostname"
master.testrelm.test
[root@perun ltevenv]# podman exec -ti master sh -c "echo $USER"
root
[root@perun ltevenv]# 
```
while running tests:
```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ipatests.pytest_ipa.integration.host.Host master.testrelm.test (master)>
argv = ['hostname', 'master.testrelm.test'], set_env = True, stdin_text = None
log_stdout = True, raiseonerr = True, cwd = None, bg = False, encoding = 'utf-8'
ok_returncode = 0

    def run_command(self, argv, set_env=True, stdin_text=None,
                    log_stdout=True, raiseonerr=True,
                    cwd=None, bg=False, encoding='utf-8', ok_returncode=0):
        """Wrapper around run_command to log stderr on raiseonerr=True
    
        :param ok_returncode: return code considered to be correct,
                              you can pass an integer or sequence of integers
        """
        result = super().run_command(
            argv, set_env=set_env, stdin_text=stdin_text,
            log_stdout=log_stdout, raiseonerr=False, cwd=cwd, bg=bg,
            encoding=encoding
        )
        # in FIPS mode SSH may print noise to stderr, remove the string
        # "FIPS mode initialized" + optional newline.
        result.stderr_bytes = FIPS_NOISE_RE.sub(b'', result.stderr_bytes)
        try:
            result_ok = result.returncode in ok_returncode
        except TypeError:
            result_ok = result.returncode == ok_returncode
        if not result_ok and raiseonerr:
            result.log.error('stderr: %s', result.stderr_text)
>           raise subprocess.CalledProcessError(
                result.returncode, argv,
                result.stdout_text, result.stderr_text
            )
E           subprocess.CalledProcessError: Command '['hostname', 'master.testrelm.test']' returned non-zero exit status 1.
```
Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>