### PR TITLE
ipaserver/install/dns: handle SERVFAIL when checking reverse zone

### DIFF
--- a/ipapython/dnsutil.py
+++ b/ipapython/dnsutil.py
@@ -447,7 +447,13 @@ def check_zone_overlap(zone, raise_on_error=True):
     except dns.exception.DNSException as e:
         msg = ("DNS check for domain %s failed: %s." % (zone, e))
         if raise_on_error:
-            raise ValueError(msg)
+            if isinstance(e, dns.resolver.NoNameservers):
+                # Show warning and continue in case we've got SERVFAIL
+                # because we are supposedly going to create this reverse zone
+                logger.warning('%s', msg)
+                return
+            else:
+                raise ValueError(msg)
         else:
             logger.warning('%s', msg)
             return


### PR DESCRIPTION
systemd-resolved in Fedora 34+ returns SERVFAIL for reverse zone that
does not yet exist when we attempt to look it up before installation.
Assume that this is OK -- we are going to create the zone ourselves
during installation.

Fixes: https://pagure.io/freeipa/issue/8794

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>