### PR TITLE
client install: do not capture sudo -V stdout

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -24,7 +24,6 @@ import re
 import SSSDConfig
 import shutil
 import socket
-import subprocess
 import sys
 import tempfile
 import textwrap
@@ -2205,7 +2204,7 @@ def install_check(options):
     # available.
     if options.conf_sudo:
         try:
-            subprocess.Popen(['sudo', '-V'])
+            ipautil.run(['sudo', '-V'])
         except FileNotFoundError:
             logger.info(
                 "The sudo binary does not seem to be present on this "

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1561,6 +1561,7 @@ class TestInstallWithoutSudo(IntegrationTest):
     num_clients = 1
     num_replicas = 1
     no_sudo_str = "The sudo binary does not seem to be present on this"
+    sudo_version_str = "Sudo version"
 
     @classmethod
     def install(cls, mh):
@@ -1622,3 +1623,4 @@ class TestInstallWithoutSudo(IntegrationTest):
             assert tasks.is_package_installed(self.clients[0], pkg)
         result = tasks.install_client(self.master, self.clients[0])
         assert self.no_sudo_str not in result.stderr_text
+        assert self.sudo_version_str not in result.stdout_text


### PR DESCRIPTION
### client install: do not capture sudo -V stdout

ipa-client-install is checking if the sudo command is available
by calling 'sudo -V'. The call is currently using subprocess.popen
which redirects the output to the default stdout.
Use ipautil.run instead of subprocess.popen as this does not
capture stdout (the command output is just logged in the debug file).

Fixes: https://pagure.io/freeipa/issue/8767

### ipatests: check that the output of sudo -V is not displayed

During client installation, the installer calls sudo -V
to check if sudo command is installed. The output must not
be displayed in stdout.

Related: https://pagure.io/freeipa/issue/8767