### PR TITLE
Add support subordinate user/group ids as separate entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,7 @@ install/tools/ipa-restore
 install/tools/ipa-server-certinstall
 install/tools/ipa-server-install
 install/tools/ipa-server-upgrade
+install/tools/ipa-subids
 install/tools/ipa-winsync-migrate
 ipatests/i18n.py
 ipatests/ipa-run-tests

--- a/ACI.txt
+++ b/ACI.txt
@@ -375,7 +375,7 @@ aci: (targetattr = "audio || businesscategory || carlicense || departmentnumber 
 dn: dc=ipa,dc=example
 aci: (targetattr = "cn || createtimestamp || entryusn || gecos || gidnumber || homedirectory || loginshell || modifytimestamp || objectclass || uid || uidnumber")(target = "ldap:///cn=users,cn=compat,dc=ipa,dc=example")(version 3.0;acl "permission:System: Read User Compat Tree";allow (compare,read,search) userdn = "ldap:///anyone";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "ipasshpubkey || ipauniqueid || ipauserauthtype || userclass")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Read User IPA Attributes";allow (compare,read,search) userdn = "ldap:///all";)
+aci: (targetattr = "ipasshpubkey || ipasubgidcount || ipasubgidnumber || ipasubuidcount || ipasubuidnumber || ipauniqueid || ipauserauthtype || userclass")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Read User IPA Attributes";allow (compare,read,search) userdn = "ldap:///all";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "krbcanonicalname || krblastpwdchange || krbpasswordexpiration || krbprincipalaliases || krbprincipalexpiration || krbprincipalname || krbprincipaltype || nsaccountlock")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Read User Kerberos Attributes";allow (compare,read,search) userdn = "ldap:///all";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example

--- a/ACI.txt
+++ b/ACI.txt
@@ -61,7 +61,7 @@ aci: (targetattr = "cn || description || ipacertprofilestoreissued")(targetfilte
 dn: cn=certprofiles,cn=ca,dc=ipa,dc=example
 aci: (targetattr = "cn || createtimestamp || description || entryusn || ipacertprofilestoreissued || modifytimestamp || objectclass")(targetfilter = "(objectclass=ipacertprofile)")(version 3.0;acl "permission:System: Read Certificate Profiles";allow (compare,read,search) userdn = "ldap:///all";)
 dn: cn=ipaconfig,cn=etc,dc=ipa,dc=example
-aci: (targetattr = "cn || createtimestamp || entryusn || ipacertificatesubjectbase || ipaconfigstring || ipacustomfields || ipadefaultemaildomain || ipadefaultloginshell || ipadefaultprimarygroup || ipadomainresolutionorder || ipagroupobjectclasses || ipagroupsearchfields || ipahomesrootdir || ipakrbauthzdata || ipamaxhostnamelength || ipamaxusernamelength || ipamigrationenabled || ipapwdexpadvnotify || ipasearchrecordslimit || ipasearchtimelimit || ipaselinuxusermapdefault || ipaselinuxusermaporder || ipauserauthtype || ipauserobjectclasses || ipausersearchfields || modifytimestamp || objectclass")(targetfilter = "(objectclass=ipaguiconfig)")(version 3.0;acl "permission:System: Read Global Configuration";allow (compare,read,search) userdn = "ldap:///all";)
+aci: (targetattr = "cn || createtimestamp || entryusn || ipacertificatesubjectbase || ipaconfigstring || ipacustomfields || ipadefaultemaildomain || ipadefaultloginshell || ipadefaultprimarygroup || ipadomainresolutionorder || ipagroupobjectclasses || ipagroupsearchfields || ipahomesrootdir || ipakrbauthzdata || ipamaxhostnamelength || ipamaxusernamelength || ipamigrationenabled || ipapwdexpadvnotify || ipasearchrecordslimit || ipasearchtimelimit || ipaselinuxusermapdefault || ipaselinuxusermaporder || ipauserauthtype || ipauserdefaultsubordinateid || ipauserobjectclasses || ipausersearchfields || modifytimestamp || objectclass")(targetfilter = "(objectclass=ipaguiconfig)")(version 3.0;acl "permission:System: Read Global Configuration";allow (compare,read,search) userdn = "ldap:///all";)
 dn: cn=costemplates,cn=accounts,dc=ipa,dc=example
 aci: (targetfilter = "(objectclass=costemplate)")(version 3.0;acl "permission:System: Add Group Password Policy costemplate";allow (add) groupdn = "ldap:///cn=System: Add Group Password Policy costemplate,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=costemplates,cn=accounts,dc=ipa,dc=example
@@ -318,6 +318,14 @@ dn: cn=deleted users,cn=accounts,cn=provisioning,dc=ipa,dc=example
 aci: (targetattr = "krblastpwdchange || krbpasswordexpiration || krbprincipalkey || userpassword")(target = "ldap:///uid=*,cn=deleted users,cn=accounts,cn=provisioning,dc=ipa,dc=example")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Reset Preserved User password";allow (read,search,write) groupdn = "ldap:///cn=System: Reset Preserved User password,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: dc=ipa,dc=example
 aci: (target_to = "ldap:///cn=users,cn=accounts,dc=ipa,dc=example")(target_from = "ldap:///cn=deleted users,cn=accounts,cn=provisioning,dc=ipa,dc=example")(targetfilter = "(objectclass=nsContainer)")(version 3.0;acl "permission:System: Undelete User";allow (moddn) groupdn = "ldap:///cn=System: Undelete User,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+dn: cn=subids,cn=accounts,dc=ipa,dc=example
+aci: (targetattr = "description || ipaowner")(targetfilter = "(objectclass=ipasubordinateidentry)")(version 3.0;acl "permission:System: Manage Subordinate Ids";allow (write) groupdn = "ldap:///cn=System: Manage Subordinate Ids,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+dn: cn=subids,cn=accounts,dc=ipa,dc=example
+aci: (targetattr = "createtimestamp || description || entryusn || ipaowner || ipasubgidcount || ipasubgidnumber || ipasubuidcount || ipasubuidnumber || ipauniqueid || modifytimestamp || objectclass")(targetfilter = "(objectclass=ipasubordinateidentry)")(version 3.0;acl "permission:System: Read Subordinate Id Attributes";allow (compare,read,search) userdn = "ldap:///all";)
+dn: cn=subids,cn=accounts,dc=ipa,dc=example
+aci: (targetattr = "numsubordinates")(target = "ldap:///cn=subids,cn=accounts,dc=ipa,dc=example")(version 3.0;acl "permission:System: Read Subordinate Id Count";allow (compare,read,search) userdn = "ldap:///all";)
+dn: cn=subids,cn=accounts,dc=ipa,dc=example
+aci: (targetfilter = "(objectclass=ipasubordinateidentry)")(version 3.0;acl "permission:System: Remove Subordinate Ids";allow (delete) groupdn = "ldap:///cn=System: Remove Subordinate Ids,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=sudocmds,cn=sudo,dc=ipa,dc=example
 aci: (targetfilter = "(objectclass=ipasudocmd)")(version 3.0;acl "permission:System: Add Sudo Command";allow (add) groupdn = "ldap:///cn=System: Add Sudo Command,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=sudocmds,cn=sudo,dc=ipa,dc=example
@@ -375,7 +383,7 @@ aci: (targetattr = "audio || businesscategory || carlicense || departmentnumber 
 dn: dc=ipa,dc=example
 aci: (targetattr = "cn || createtimestamp || entryusn || gecos || gidnumber || homedirectory || loginshell || modifytimestamp || objectclass || uid || uidnumber")(target = "ldap:///cn=users,cn=compat,dc=ipa,dc=example")(version 3.0;acl "permission:System: Read User Compat Tree";allow (compare,read,search) userdn = "ldap:///anyone";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "ipasshpubkey || ipasubgidcount || ipasubgidnumber || ipasubuidcount || ipasubuidnumber || ipauniqueid || ipauserauthtype || userclass")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Read User IPA Attributes";allow (compare,read,search) userdn = "ldap:///all";)
+aci: (targetattr = "ipasshpubkey || ipauniqueid || ipauserauthtype || userclass")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Read User IPA Attributes";allow (compare,read,search) userdn = "ldap:///all";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "krbcanonicalname || krblastpwdchange || krbpasswordexpiration || krbprincipalaliases || krbprincipalexpiration || krbprincipalname || krbprincipaltype || nsaccountlock")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Read User Kerberos Attributes";allow (compare,read,search) userdn = "ldap:///all";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example

--- a/API.txt
+++ b/API.txt
@@ -4974,7 +4974,7 @@ output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
 command: stageuser_add/1
-args: 1,45,3
+args: 1,46,3
 arg: Str('uid', cli_name='login')
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
@@ -4992,6 +4992,7 @@ option: Str('givenname', cli_name='first')
 option: Str('homedirectory?', cli_name='homedir')
 option: Str('initials?', autofill=True)
 option: Str('ipasshpubkey*', cli_name='sshpubkey')
+option: Int('ipasubuidnumber?', cli_name='subuid')
 option: Str('ipatokenradiusconfiglink?', cli_name='radius')
 option: Str('ipatokenradiususername?', cli_name='radius_username')
 option: StrEnum('ipauserauthtype*', cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened'])
@@ -5080,7 +5081,7 @@ output: Output('result', type=[<type 'dict'>])
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: ListOfPrimaryKeys('value')
 command: stageuser_find/1
-args: 1,58,4
+args: 1,60,4
 arg: Str('criteria?')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('carlicense*', autofill=False)
@@ -5104,6 +5105,8 @@ option: Str('ipanthomedirectory?', autofill=False, cli_name='smb_home_dir')
 option: StrEnum('ipanthomedirectorydrive?', autofill=False, cli_name='smb_home_drive', values=[u'A:', u'B:', u'C:', u'D:', u'E:', u'F:', u'G:', u'H:', u'I:', u'J:', u'K:', u'L:', u'M:', u'N:', u'O:', u'P:', u'Q:', u'R:', u'S:', u'T:', u'U:', u'V:', u'W:', u'X:', u'Y:', u'Z:'])
 option: Str('ipantlogonscript?', autofill=False, cli_name='smb_logon_script')
 option: Str('ipantprofilepath?', autofill=False, cli_name='smb_profile_path')
+option: Int('ipasubgidnumber?', autofill=False, cli_name='subgid')
+option: Int('ipasubuidnumber?', autofill=False, cli_name='subuid')
 option: Str('ipatokenradiusconfiglink?', autofill=False, cli_name='radius')
 option: Str('ipatokenradiususername?', autofill=False, cli_name='radius_username')
 option: StrEnum('ipauserauthtype*', autofill=False, cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened'])
@@ -5145,7 +5148,7 @@ output: ListOfEntries('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: Output('truncated', type=[<type 'bool'>])
 command: stageuser_mod/1
-args: 1,51,3
+args: 1,52,3
 arg: Str('uid', cli_name='login')
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
@@ -5167,6 +5170,7 @@ option: StrEnum('ipanthomedirectorydrive?', autofill=False, cli_name='smb_home_d
 option: Str('ipantlogonscript?', autofill=False, cli_name='smb_logon_script')
 option: Str('ipantprofilepath?', autofill=False, cli_name='smb_profile_path')
 option: Str('ipasshpubkey*', autofill=False, cli_name='sshpubkey')
+option: Int('ipasubuidnumber?', autofill=False, cli_name='subuid')
 option: Str('ipatokenradiusconfiglink?', autofill=False, cli_name='radius')
 option: Str('ipatokenradiususername?', autofill=False, cli_name='radius_username')
 option: StrEnum('ipauserauthtype*', autofill=False, cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened'])
@@ -6058,7 +6062,7 @@ output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
 command: user_add/1
-args: 1,46,3
+args: 1,47,3
 arg: Str('uid', cli_name='login')
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
@@ -6075,6 +6079,7 @@ option: Str('givenname', cli_name='first')
 option: Str('homedirectory?', cli_name='homedir')
 option: Str('initials?', autofill=True)
 option: Str('ipasshpubkey*', cli_name='sshpubkey')
+option: Int('ipasubuidnumber?', cli_name='subuid')
 option: Str('ipatokenradiusconfiglink?', cli_name='radius')
 option: Str('ipatokenradiususername?', cli_name='radius_username')
 option: StrEnum('ipauserauthtype*', cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened'])
@@ -6156,6 +6161,16 @@ option: Str('version?')
 output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
+command: user_auto_subid/1
+args: 1,4,3
+arg: Str('uid', cli_name='login')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('no_members', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
 command: user_del/1
 args: 1,3,3
 arg: Str('uid+', cli_name='login')
@@ -6180,7 +6195,7 @@ output: Output('result', type=[<type 'bool'>])
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
 command: user_find/1
-args: 1,61,4
+args: 1,63,4
 arg: Str('criteria?')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('carlicense*', autofill=False)
@@ -6204,6 +6219,8 @@ option: Str('ipanthomedirectory?', autofill=False, cli_name='smb_home_dir')
 option: StrEnum('ipanthomedirectorydrive?', autofill=False, cli_name='smb_home_drive', values=[u'A:', u'B:', u'C:', u'D:', u'E:', u'F:', u'G:', u'H:', u'I:', u'J:', u'K:', u'L:', u'M:', u'N:', u'O:', u'P:', u'Q:', u'R:', u'S:', u'T:', u'U:', u'V:', u'W:', u'X:', u'Y:', u'Z:'])
 option: Str('ipantlogonscript?', autofill=False, cli_name='smb_logon_script')
 option: Str('ipantprofilepath?', autofill=False, cli_name='smb_profile_path')
+option: Int('ipasubgidnumber?', autofill=False, cli_name='subgid')
+option: Int('ipasubuidnumber?', autofill=False, cli_name='subuid')
 option: Str('ipatokenradiusconfiglink?', autofill=False, cli_name='radius')
 option: Str('ipatokenradiususername?', autofill=False, cli_name='radius_username')
 option: StrEnum('ipauserauthtype*', autofill=False, cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened'])
@@ -6247,8 +6264,23 @@ output: Output('count', type=[<type 'int'>])
 output: ListOfEntries('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: Output('truncated', type=[<type 'bool'>])
+command: user_match_subid/1
+args: 1,8,4
+arg: Str('criteria?')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Int('ipasubuidnumber', autofill=False, cli_name='subuid')
+option: Flag('no_members', autofill=True, default=True)
+option: Flag('pkey_only?', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Int('sizelimit?', autofill=False)
+option: Int('timelimit?', autofill=False)
+option: Str('version?')
+output: Output('count', type=[<type 'int'>])
+output: ListOfEntries('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: Output('truncated', type=[<type 'bool'>])
 command: user_mod/1
-args: 1,52,3
+args: 1,53,3
 arg: Str('uid', cli_name='login')
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
@@ -6270,6 +6302,7 @@ option: StrEnum('ipanthomedirectorydrive?', autofill=False, cli_name='smb_home_d
 option: Str('ipantlogonscript?', autofill=False, cli_name='smb_logon_script')
 option: Str('ipantprofilepath?', autofill=False, cli_name='smb_profile_path')
 option: Str('ipasshpubkey*', autofill=False, cli_name='sshpubkey')
+option: Int('ipasubuidnumber?', autofill=False, cli_name='subuid')
 option: Str('ipatokenradiusconfiglink?', autofill=False, cli_name='radius')
 option: Str('ipatokenradiususername?', autofill=False, cli_name='radius_username')
 option: StrEnum('ipauserauthtype*', autofill=False, cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened'])
@@ -7183,10 +7216,12 @@ default: user_add_cert/1
 default: user_add_certmapdata/1
 default: user_add_manager/1
 default: user_add_principal/1
+default: user_auto_subid/1
 default: user_del/1
 default: user_disable/1
 default: user_enable/1
 default: user_find/1
+default: user_match_subid/1
 default: user_mod/1
 default: user_remove_cert/1
 default: user_remove_certmapdata/1

--- a/API.txt
+++ b/API.txt
@@ -1076,7 +1076,7 @@ args: 0,1,1
 option: Str('version?')
 output: Output('result')
 command: config_mod/1
-args: 0,28,3
+args: 0,29,3
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('ca_renewal_master_server?', autofill=False)
@@ -1099,6 +1099,7 @@ option: Int('ipasearchtimelimit?', autofill=False, cli_name='searchtimelimit')
 option: Str('ipaselinuxusermapdefault?', autofill=False)
 option: Str('ipaselinuxusermaporder?', autofill=False)
 option: StrEnum('ipauserauthtype*', autofill=False, cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened', u'disabled'])
+option: Bool('ipauserdefaultsubordinateid?', autofill=False, cli_name='user_default_subid')
 option: Str('ipauserobjectclasses*', autofill=False, cli_name='userobjectclasses')
 option: IA5Str('ipausersearchfields?', autofill=False, cli_name='usersearch')
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
@@ -4974,7 +4975,7 @@ output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
 command: stageuser_add/1
-args: 1,46,3
+args: 1,45,3
 arg: Str('uid', cli_name='login')
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
@@ -4992,7 +4993,6 @@ option: Str('givenname', cli_name='first')
 option: Str('homedirectory?', cli_name='homedir')
 option: Str('initials?', autofill=True)
 option: Str('ipasshpubkey*', cli_name='sshpubkey')
-option: Int('ipasubuidnumber?', cli_name='subuid')
 option: Str('ipatokenradiusconfiglink?', cli_name='radius')
 option: Str('ipatokenradiususername?', cli_name='radius_username')
 option: StrEnum('ipauserauthtype*', cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened'])
@@ -5099,14 +5099,13 @@ option: Str('in_group*', cli_name='in_groups')
 option: Str('in_hbacrule*', cli_name='in_hbacrules')
 option: Str('in_netgroup*', cli_name='in_netgroups')
 option: Str('in_role*', cli_name='in_roles')
+option: Str('in_subid*', cli_name='in_subids')
 option: Str('in_sudorule*', cli_name='in_sudorules')
 option: Str('initials?', autofill=False)
 option: Str('ipanthomedirectory?', autofill=False, cli_name='smb_home_dir')
 option: StrEnum('ipanthomedirectorydrive?', autofill=False, cli_name='smb_home_drive', values=[u'A:', u'B:', u'C:', u'D:', u'E:', u'F:', u'G:', u'H:', u'I:', u'J:', u'K:', u'L:', u'M:', u'N:', u'O:', u'P:', u'Q:', u'R:', u'S:', u'T:', u'U:', u'V:', u'W:', u'X:', u'Y:', u'Z:'])
 option: Str('ipantlogonscript?', autofill=False, cli_name='smb_logon_script')
 option: Str('ipantprofilepath?', autofill=False, cli_name='smb_profile_path')
-option: Int('ipasubgidnumber?', autofill=False, cli_name='subgid')
-option: Int('ipasubuidnumber?', autofill=False, cli_name='subuid')
 option: Str('ipatokenradiusconfiglink?', autofill=False, cli_name='radius')
 option: Str('ipatokenradiususername?', autofill=False, cli_name='radius_username')
 option: StrEnum('ipauserauthtype*', autofill=False, cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened'])
@@ -5123,6 +5122,7 @@ option: Str('not_in_group*', cli_name='not_in_groups')
 option: Str('not_in_hbacrule*', cli_name='not_in_hbacrules')
 option: Str('not_in_netgroup*', cli_name='not_in_netgroups')
 option: Str('not_in_role*', cli_name='not_in_roles')
+option: Str('not_in_subid*', cli_name='not_in_subids')
 option: Str('not_in_sudorule*', cli_name='not_in_sudorules')
 option: Str('ou?', autofill=False, cli_name='orgunit')
 option: Str('pager*', autofill=False)
@@ -5148,7 +5148,7 @@ output: ListOfEntries('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: Output('truncated', type=[<type 'bool'>])
 command: stageuser_mod/1
-args: 1,52,3
+args: 1,51,3
 arg: Str('uid', cli_name='login')
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
@@ -5170,7 +5170,6 @@ option: StrEnum('ipanthomedirectorydrive?', autofill=False, cli_name='smb_home_d
 option: Str('ipantlogonscript?', autofill=False, cli_name='smb_logon_script')
 option: Str('ipantprofilepath?', autofill=False, cli_name='smb_profile_path')
 option: Str('ipasshpubkey*', autofill=False, cli_name='sshpubkey')
-option: Int('ipasubuidnumber?', autofill=False, cli_name='subuid')
 option: Str('ipatokenradiusconfiglink?', autofill=False, cli_name='radius')
 option: Str('ipatokenradiususername?', autofill=False, cli_name='radius_username')
 option: StrEnum('ipauserauthtype*', autofill=False, cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened'])
@@ -5263,6 +5262,100 @@ option: Str('version?')
 output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
+command: subid_add/1
+args: 1,8,3
+arg: Str('ipauniqueid?', cli_name='id')
+option: Str('addattr*', cli_name='addattr')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Str('description?', cli_name='desc')
+option: Str('ipaowner', cli_name='owner')
+option: Int('ipasubuidnumber?', cli_name='subuid')
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('setattr*', cli_name='setattr')
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
+command: subid_del/1
+args: 1,2,3
+arg: Str('ipauniqueid+', cli_name='id')
+option: Flag('continue', autofill=True, cli_name='continue', default=False)
+option: Str('version?')
+output: Output('result', type=[<type 'dict'>])
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: ListOfPrimaryKeys('value')
+command: subid_find/1
+args: 1,11,4
+arg: Str('criteria?')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Str('description?', autofill=False, cli_name='desc')
+option: Str('ipaowner?', autofill=False, cli_name='owner')
+option: Int('ipasubgidnumber?', autofill=False, cli_name='subgid')
+option: Int('ipasubuidnumber?', autofill=False, cli_name='subuid')
+option: Str('ipauniqueid?', autofill=False, cli_name='id')
+option: Flag('pkey_only?', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Int('sizelimit?', autofill=False)
+option: Int('timelimit?', autofill=False)
+option: Str('version?')
+output: Output('count', type=[<type 'int'>])
+output: ListOfEntries('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: Output('truncated', type=[<type 'bool'>])
+command: subid_generate/1
+args: 0,4,3
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Str('ipaowner?', cli_name='owner')
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
+command: subid_match/1
+args: 1,7,4
+arg: Str('criteria?')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Int('ipasubuidnumber', autofill=False, cli_name='subuid')
+option: Flag('pkey_only?', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Int('sizelimit?', autofill=False)
+option: Int('timelimit?', autofill=False)
+option: Str('version?')
+output: Output('count', type=[<type 'int'>])
+output: ListOfEntries('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: Output('truncated', type=[<type 'bool'>])
+command: subid_mod/1
+args: 1,8,3
+arg: Str('ipauniqueid', cli_name='id')
+option: Str('addattr*', cli_name='addattr')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Str('delattr*', cli_name='delattr')
+option: Str('description?', autofill=False, cli_name='desc')
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Flag('rights', autofill=True, default=False)
+option: Str('setattr*', cli_name='setattr')
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
+command: subid_show/1
+args: 1,4,3
+arg: Str('ipauniqueid', cli_name='id')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Flag('rights', autofill=True, default=False)
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
+command: subid_stats/1
+args: 0,3,2
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 command: sudocmd_add/1
 args: 1,7,3
 arg: Str('sudocmd', cli_name='command')
@@ -6062,7 +6155,7 @@ output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
 command: user_add/1
-args: 1,47,3
+args: 1,46,3
 arg: Str('uid', cli_name='login')
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
@@ -6079,7 +6172,6 @@ option: Str('givenname', cli_name='first')
 option: Str('homedirectory?', cli_name='homedir')
 option: Str('initials?', autofill=True)
 option: Str('ipasshpubkey*', cli_name='sshpubkey')
-option: Int('ipasubuidnumber?', cli_name='subuid')
 option: Str('ipatokenradiusconfiglink?', cli_name='radius')
 option: Str('ipatokenradiususername?', cli_name='radius_username')
 option: StrEnum('ipauserauthtype*', cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened'])
@@ -6161,16 +6253,6 @@ option: Str('version?')
 output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
-command: user_auto_subid/1
-args: 1,4,3
-arg: Str('uid', cli_name='login')
-option: Flag('all', autofill=True, cli_name='all', default=False)
-option: Flag('no_members', autofill=True, default=False)
-option: Flag('raw', autofill=True, cli_name='raw', default=False)
-option: Str('version?')
-output: Entry('result')
-output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
-output: PrimaryKey('value')
 command: user_del/1
 args: 1,3,3
 arg: Str('uid+', cli_name='login')
@@ -6213,14 +6295,13 @@ option: Str('in_group*', cli_name='in_groups')
 option: Str('in_hbacrule*', cli_name='in_hbacrules')
 option: Str('in_netgroup*', cli_name='in_netgroups')
 option: Str('in_role*', cli_name='in_roles')
+option: Str('in_subid*', cli_name='in_subids')
 option: Str('in_sudorule*', cli_name='in_sudorules')
 option: Str('initials?', autofill=False)
 option: Str('ipanthomedirectory?', autofill=False, cli_name='smb_home_dir')
 option: StrEnum('ipanthomedirectorydrive?', autofill=False, cli_name='smb_home_drive', values=[u'A:', u'B:', u'C:', u'D:', u'E:', u'F:', u'G:', u'H:', u'I:', u'J:', u'K:', u'L:', u'M:', u'N:', u'O:', u'P:', u'Q:', u'R:', u'S:', u'T:', u'U:', u'V:', u'W:', u'X:', u'Y:', u'Z:'])
 option: Str('ipantlogonscript?', autofill=False, cli_name='smb_logon_script')
 option: Str('ipantprofilepath?', autofill=False, cli_name='smb_profile_path')
-option: Int('ipasubgidnumber?', autofill=False, cli_name='subgid')
-option: Int('ipasubuidnumber?', autofill=False, cli_name='subuid')
 option: Str('ipatokenradiusconfiglink?', autofill=False, cli_name='radius')
 option: Str('ipatokenradiususername?', autofill=False, cli_name='radius_username')
 option: StrEnum('ipauserauthtype*', autofill=False, cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened'])
@@ -6237,6 +6318,7 @@ option: Str('not_in_group*', cli_name='not_in_groups')
 option: Str('not_in_hbacrule*', cli_name='not_in_hbacrules')
 option: Str('not_in_netgroup*', cli_name='not_in_netgroups')
 option: Str('not_in_role*', cli_name='not_in_roles')
+option: Str('not_in_subid*', cli_name='not_in_subids')
 option: Str('not_in_sudorule*', cli_name='not_in_sudorules')
 option: Bool('nsaccountlock?', autofill=False, cli_name='disabled', default=False)
 option: Str('ou?', autofill=False, cli_name='orgunit')
@@ -6264,23 +6346,8 @@ output: Output('count', type=[<type 'int'>])
 output: ListOfEntries('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: Output('truncated', type=[<type 'bool'>])
-command: user_match_subid/1
-args: 1,8,4
-arg: Str('criteria?')
-option: Flag('all', autofill=True, cli_name='all', default=False)
-option: Int('ipasubuidnumber', autofill=False, cli_name='subuid')
-option: Flag('no_members', autofill=True, default=True)
-option: Flag('pkey_only?', autofill=True, default=False)
-option: Flag('raw', autofill=True, cli_name='raw', default=False)
-option: Int('sizelimit?', autofill=False)
-option: Int('timelimit?', autofill=False)
-option: Str('version?')
-output: Output('count', type=[<type 'int'>])
-output: ListOfEntries('result')
-output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
-output: Output('truncated', type=[<type 'bool'>])
 command: user_mod/1
-args: 1,53,3
+args: 1,52,3
 arg: Str('uid', cli_name='login')
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
@@ -6302,7 +6369,6 @@ option: StrEnum('ipanthomedirectorydrive?', autofill=False, cli_name='smb_home_d
 option: Str('ipantlogonscript?', autofill=False, cli_name='smb_logon_script')
 option: Str('ipantprofilepath?', autofill=False, cli_name='smb_profile_path')
 option: Str('ipasshpubkey*', autofill=False, cli_name='sshpubkey')
-option: Int('ipasubuidnumber?', autofill=False, cli_name='subuid')
 option: Str('ipatokenradiusconfiglink?', autofill=False, cli_name='radius')
 option: Str('ipatokenradiususername?', autofill=False, cli_name='radius_username')
 option: StrEnum('ipauserauthtype*', autofill=False, cli_name='user_auth_type', values=[u'password', u'radius', u'otp', u'pkinit', u'hardened'])
@@ -7138,6 +7204,15 @@ default: stageuser_remove_certmapdata/1
 default: stageuser_remove_manager/1
 default: stageuser_remove_principal/1
 default: stageuser_show/1
+default: subid/1
+default: subid_add/1
+default: subid_del/1
+default: subid_find/1
+default: subid_generate/1
+default: subid_match/1
+default: subid_mod/1
+default: subid_show/1
+default: subid_stats/1
 default: sudocmd/1
 default: sudocmd_add/1
 default: sudocmd_del/1
@@ -7216,12 +7291,10 @@ default: user_add_cert/1
 default: user_add_certmapdata/1
 default: user_add_manager/1
 default: user_add_principal/1
-default: user_auto_subid/1
 default: user_del/1
 default: user_disable/1
 default: user_enable/1
 default: user_find/1
-default: user_match_subid/1
 default: user_mod/1
 default: user_remove_cert/1
 default: user_remove_certmapdata/1

--- a/Makefile.am
+++ b/Makefile.am
@@ -229,7 +229,7 @@ fasttest: $(GENERATED_PYTHON_FILES) ipasetup.py
 	    --ignore $(abspath $(top_srcdir))/ipatests/test_integration \
 	    --ignore $(abspath $(top_srcdir))/ipatests/test_xmlrpc
 
-fastlint: $(GENERATED_PYTHON_FILES) ipasetup.py
+fastlint: $(GENERATED_PYTHON_FILES) ipasetup.py acilint apilint
 if ! WITH_PYLINT
 	@echo "ERROR: pylint not available"; exit 1
 endif

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -86,8 +86,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-define(IPA_API_VERSION_MINOR, 242)
-# Last change: add status options for cert-find
+# Last change: add subordinate id feature
+define(IPA_API_VERSION_MINOR, 243)
 
 
 ########################################################

--- a/doc/designs/index.rst
+++ b/doc/designs/index.rst
@@ -19,3 +19,4 @@ FreeIPA design documentation
    hidden-replicas.md
    disable-stale-users.md
    ldapi-autobind-services.md
+   subordinate-ids.md

--- a/doc/designs/subordinate-ids.md
+++ b/doc/designs/subordinate-ids.md
@@ -1,0 +1,468 @@
+# Central management of subordinate user and group ids
+
+Subordinate ids are a Linux Kernel feature to grant a user additional
+user and group id ranges. Amongst others the feature can be used
+by container runtime engies to implement rootless containers.
+Traditionally subordinate id ranges are configured in ``/etc/subuid``
+and ``/etc/subgid``.
+
+To make rootless containers in a large environment as easy as pie, IPA
+gains the ability to centrally manage and assign subordinate id ranges.
+SSSD and shadow-util are extended to read subordinate ids from IPA and
+provide them to userspace tools.
+
+## Overview
+
+Feature requests
+
+* [FreeIPA feature request #8361](https://pagure.io/freeipa/issue/8361)
+* [SSSD feature request #5197](https://github.com/SSSD/sssd/issues/5197)
+* [shadow-util feature request #154](https://github.com/shadow-maint/shadow/issues/154)
+* [389-DS RFE for DNA plugin rhbz#1938239](https://bugzilla.redhat.com/show_bug.cgi?id=1938239)
+
+Man pages
+
+* [man subuid(5)](https://man7.org/linux/man-pages/man5/subuid.5.html)
+* [man subgid(5)](https://man7.org/linux/man-pages/man5/subgid.5.html)
+* [man user_namespaces(7)](https://man7.org/linux/man-pages/man7/user_namespaces.7.html)
+* [man newuidmap(1)](https://man7.org/linux/man-pages/man1/newuidmap.1.html)
+
+Articles / blog posts
+* [Basic Setup and Use of Podman in a Rootless environment](https://github.com/containers/podman/blob/master/docs/tutorials/rootless_tutorial.md)
+* [How does rootless Podman work](https://opensource.com/article/19/2/how-does-rootless-podman-work)
+
+## Design choices
+
+Some design choices are owed to the circumstance that uids and gids
+are limited datatypes. The Linux Kernel and userland defines
+``uid_t`` and ``gid_t`` as unsigned 32bit integers (``uint32_t``), which
+limits possible values for numeric user and group ids to
+``0 .. 2^32-2``. ``(uid_t)-1`` is reserved for error reporting. On the
+other hand the user ``nobody`` typically has uid 65534 / gid 65534. This
+means we need to assign 65,536 subordinate ids to every user. The
+theoretical maximum amount of subordinate ranges is less than 65,536
+(``65536 * 65536 == 2^32``). [``logins.def``](https://man7.org/linux/man-pages/man5/login.defs.5.html)
+also uses 65536 as default setting for ``SUB_UID_COUNT``.
+
+The practical limit is far smaller. Subordinate ids should not overlap
+with system accounts, local user accounts, IPA user accounts, and
+mapped accounts from Active Directory. Therefore IPA uses the upper
+half of the uid_t range (>= 2^31 == 2,147,483,648) for subordinate ids.
+The high bit is rarely used. IPA limits general numeric ids
+(``uidNumber``, ``gidNumber``, ID ranges) to maximum values of signed
+32bit integer (2^31-1) for backwards compatibility with XML-RPC.
+``logins.def`` defaults to ``SUB_UID_MAX`` 600,100,000.
+
+A default subordinate id count of 65,536 and a total range of approx.
+2.1 billion limits IPA to slightly more than 32,000 possible ranges. It
+may sound like a lot of users, but there are much bigger installations
+of IPA. For comparison Fedora Accounts has over 120,000 users stored in
+IPA.
+
+For that reason we treat subordinate id space as premium real estate
+and don't auto-map or auto-assign subordinate ids by default. Instead
+we give the admin several options to assign them manually, semi-manual,
+or automatically.
+
+### Revision 1 limitation
+
+The first revision of the feature is deliberately limited and
+restricted. We are aiming for a simple implementation that covers
+basic use cases. Some restrictions may be lifted in the future.
+
+* subuid and subgids cannot be set independently. They are always set
+  to the same value.
+* counts are hard-coded to value 65536
+* once assigned subids cannot be removed
+* IPA does not support multiple subordinate id ranges. Contrary to
+  ``/etc/subuid``, users are limited to one set of subordinate ids.
+* subids are auto-assigned. Auto-assignment is currently emulated
+  until 389-DS has been extended to support DNA with step interval.
+* subids are allocated from hard-coded range
+  ``[2147483648..4294901767]`` (``2^31`` to ``2^32-1-65536``), which
+  is the upper 2.1 billion uids of ``uid_t`` (``uint32_t``). The range
+  can hold little 32,767 subordinate id ranges.
+* Active Directory support is out of scope and may be provided in the
+  future.
+
+### Subid assignment example
+
+```
+>>> import itertools
+>>> def subids():
+...     for n in itertools.count(start=0):
+...         start = SUBID_RANGE_START + (n * SUBID_COUNT)
+...         last = start + SUBID_COUNT - 1
+...         yield (start, last)
+...
+>>> gen = subids()
+>>> next(gen)
+(2147483648, 2147549183)
+>>> next(gen)
+(2147549184, 2147614719)
+>>> next(gen)
+(2147614720, 2147680255)
+```
+
+The first user has 65565 subordinate ids from uid/gid ``2147483648``
+to ``2147549183``, the next user has ``2147549184`` to ``2147614719``,
+and so on. The range count includes the start value.
+
+An installation with multiple servers, 389-DS'
+[DNA](https://directory.fedoraproject.org/docs/389ds/design/dna-plugin.html)
+plug-in takes care of delegating and assigning chunks of subid ranges
+to servers. The DNA plug-in guarantees uniqueness across servers.
+
+## LDAP
+
+### LDAP schema extension
+
+The subordinate id feature introduces a new auxiliar object class
+``ipaSubordinateId`` with four required attributes ``ipaSubUidNumber``,
+``ipaSubUidCount``, ``ipaSubGidNumber``, and ``ipaSubGidCount``. The
+attributes with ``number`` suffix store the start value of the interval.
+The ``count`` attributes contain the size of the interval including the
+start value. The maximum subid is
+``ipaSubUidNumber + ipaSubUidCount - 1``.
+
+All four attributes are single-value ``INTEGER`` type with standard
+integer matching rules. OIDs ``2.16.840.1.113730.3.8.23.8`` and
+``2.16.840.1.113730.3.8.23.11`` are reserved for future use.
+
+```raw
+attributeTypes: (
+  2.16.840.1.113730.3.8.23.6
+  NAME 'ipaSubUidNumber'
+  DESC 'Numerical subordinate user ID (range start value)'
+  EQUALITY integerMatch ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'IPA v4.9'
+)
+attributeTypes: (
+  2.16.840.1.113730.3.8.23.7
+  NAME 'ipaSubUidCount'
+  DESC 'Subordinate user ID count (range size)'
+  EQUALITY integerMatch ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'IPA v4.9'
+)
+attributeTypes: (
+  2.16.840.1.113730.3.8.23.9
+  NAME 'ipaSubGidNumber'
+  DESC 'Numerical subordinate group ID (range start value)'
+  EQUALITY integerMatch ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'IPA v4.9'
+)
+attributeTypes: (
+  2.16.840.1.113730.3.8.23.10
+  NAME 'ipaSubGidCount'
+  DESC 'Subordinate group ID count (range size)'
+  EQUALITY integerMatch ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'IPA v4.9'
+)
+```
+
+The ``ipaSubordinateId`` object class is an auxiliar subclass of
+``top`` and requires all four subordinate id attributes as well as
+``uidNumber``. It does not subclass ``posixAccount`` to make
+the class reusable in idview overrides later.
+
+```raw
+objectClasses: (
+  2.16.840.1.113730.3.8.24.4
+  NAME 'ipaSubordinateId'
+  DESC 'Subordinate uid and gid for users'
+  SUP top AUXILIARY
+  MUST ( uidNumber $ ipaSubUidNumber $ ipaSubUidCount $ ipaSubGidNumber $ ipaSubGidCount )
+  X-ORIGIN 'IPA v4.9'
+)
+```
+
+The ``ipaSubordinateGid`` and ``ipaSubordinateUid`` are defined for
+future use. IPA always assumes the presence of ``ipaSubordinateId`` and
+does not use these object classes.
+
+```raw
+objectClasses: (
+  2.16.840.1.113730.3.8.24.2
+  NAME 'ipaSubordinateUid'
+  DESC 'Subordinate uids for users, see subuid(5)'
+  SUP top AUXILIARY
+  MUST ( uidNumber $ ipaSubUidNumber $ ipaSubUidCount )
+  X-ORIGIN 'IPA v4.9'
+ )
+objectClasses: (
+  2.16.840.1.113730.3.8.24.3
+  NAME 'ipaSubordinateGid'
+  DESC 'Subordinate gids for users, see subgid(5)'
+  SUP top AUXILIARY
+  MUST ( uidNumber $ ipaSubGidNumber $ ipaSubGidCount )
+  X-ORIGIN 'IPA v4.9'
+)
+```
+
+### Index
+
+The attributes ``ipaSubUidNumber`` and ``ipaSubGidNumber`` are index
+for ``pres`` and ``eq`` with ``nsMatchingRule: integerOrderingMatch``
+to enable efficient ``=``, ``>=``, and ``<=`` searches.
+
+### Distributed numeric assignment (DNA) plug-in extension
+
+Subordinate id auto-assignment requires an extension of 389-DS'
+[DNA](https://directory.fedoraproject.org/docs/389ds/design/dna-plugin.html)
+plug-in. The DNA plug-in is responsible for safely assigning unique
+numeric ids across all replicas.
+
+Currently the DNA plug-in only supports a step size of ``1``. A new
+option ``dnaStepAttr`` (name is tentative) will tell the DNA plug-in
+to use the value of entry attributes as step size.
+
+
+## Permissions, Privileges, Roles
+
+### Self-servive RBAC
+
+The self-service permission enables users to request auto-assignment
+of subordinate uid and gid ranges for themselves. Subordinate ids cannot
+be modified or deleted.
+
+* ACI: *selfservice: Add subordinate id*
+* Permission: *Self-service subordinate ID*
+* Privilege: *Subordinate ID Selfservice User*
+* Role: *Subordinate ID Selfservice Users*
+* role default member: n/a
+
+### Administrator RBAC
+
+The administrator permission allows privileged users to auto-assign
+subordinate ids to users. Once assigned subordinate ids cannot
+be modified or deleted.
+
+* ACI: *Add subordinate ids to any user*
+* Permission: *Manage subordinate ID*
+* Privilege: *Subordinate ID Administrators*
+* default privilege role: *User Administrator*
+
+
+## Workflows
+
+In the default configuration of IPA, neither existing users nor new
+users will have subordinate ids assigned. There are a couple of ways
+to assign subordinate ids to users.
+
+### User administrator
+
+Users with *User Administrator* role and members of the *admins* group
+have permission to auto-assign new subordinate ids to any user. Auto
+assignment can be performed with new ``user-auto-subid`` command on the
+command line or with the *Auto assign subordinate ids* action in the
+*Actions* drop-down menu in the web UI.
+
+```shell
+$ ipa user-auto-subid someusername
+```
+
+### Self-service for group members
+
+Ordinary users cannot self-service subordinate ids by default. Admins
+can assign the new *Subordinate ID Selfservice User* to users group to
+enable self-service for members of the group.
+
+For example to enable self-service for all members of the default user
+group ``ipausers``, do:
+
+```shell
+$ ipa role-add-member "Subordinate ID Selfservice User" --groups=ipausers
+```
+
+This allows members of ``ipausers`` to request subordinate ids with
+the ``user-auto-subid`` command or the *Auto assign subordinate ids*
+action in the web UI.
+
+```shell
+$ ipa user-auto-subid myusername
+```
+
+### Auto assignment with user default object class
+
+Admins can also enable auto-assignment of subordinate ids for all new
+users by adding ``ipasubordinateid`` as a default user objectclass.
+This can be accomplished in the web UI under "IPA Server" /
+"Configuration" / "Default user objectclasses" or on the command line
+with:
+
+```shell
+$ ipa config-mod --addattr="ipaUserObjectClasses=ipasubordinateid"
+```
+
+**NOTE:** The objectclass must be written all lower case.
+
+### ipa-subid tool
+
+Finally IPA includes a new tool for mass-assignment of subordinate ids.
+The command uses automatic LDAPI EXTERNAL bind when it's executed as
+root user. Other it requires valid Kerberos TGT of an admin or user
+administrator.
+
+```raw
+
+# /usr/libexec/ipa/ipa-subids --help
+Usage: ipa-subids
+
+Mass-assign subordinate ids
+
+Options:
+  --version             show program's version number and exit
+  -h, --help            show this help message and exit
+  --group=GROUP         Filter by group membership
+  --filter=USER_FILTER  Raw LDAP filter
+  --dry-run             Dry run mode.
+  --all-users           All users
+
+  Logging and output options:
+    -v, --verbose       print debugging information
+    -d, --debug         alias for --verbose (deprecated)
+    -q, --quiet         output only errors
+    --log-file=FILE     log to the given file
+
+# # /usr/libexec/ipa/ipa-subids --group ipausers
+Processing user 'testsubordinated1' (1/15)
+Processing user 'testsubordinated2' (2/15)
+Processing user 'testsubordinated3' (3/15)
+Processing user 'testsubordinated4' (4/15)
+Processing user 'testsubordinated5' (5/15)
+Processing user 'testsubordinated6' (6/15)
+Processing user 'testsubordinated7' (7/15)
+Processing user 'testsubordinated8' (8/15)
+Processing user 'testsubordinated9' (9/15)
+Processing user 'testsubordinated10' (10/15)
+Processing user 'testsubordinated11' (11/15)
+Processing user 'testsubordinated12' (12/15)
+Processing user 'testsubordinated13' (13/15)
+Processing user 'testsubordinated14' (14/15)
+Processing user 'testsubordinated15' (15/15)
+Processed 15 user(s)
+The ipa-subids command was successful
+```
+
+### Find and match users by any subordinate id
+
+The ``user-find`` command search by start value of subordinate uid and
+gid range. The new command ``user-match-subid`` can be used to find a
+user by any subordinate id in their range.
+
+```raw
+$ ipa user-match-subid --subuid=2153185287
+  User login: asmith
+  First name: Alice
+  Last name: Smith
+  ...
+  SubUID range start: 2153185280
+  SubUID range size: 65536
+  SubGID range start: 2153185280
+  SubGID range size: 65536
+----------------------------
+Number of entries returned 1
+----------------------------
+$ ipa user-match-subid --subuid=2153185279
+  User login: bjones
+  First name: Bob
+  Last name: Jones
+  ...
+  SubUID range start: 2153119744
+  SubUID range size: 65536
+  SubGID range start: 2153119744
+  SubGID range size: 65536
+----------------------------
+Number of entries returned 1
+----------------------------
+```
+
+## SSSD integration
+
+* base: ``cn=accounts,$SUFFIX`` / ``cn=users,cn=accounts,$SUFFIX``
+* scope: ``SCOPE_SUBTREE`` (2) / ``SCOPE_ONELEVEL`` (1)
+* user filter: should include ``(objectClass=posixAccount)``
+* attributes: ``uidNumber ipaSubUidNumber ipaSubUidCount ipaSubGidNumber ipaSubGidCount``
+
+SSSD can safely assume that only *user accounts* of type ``posixAccount``
+have subordinate ids. In the first revision there are no other entries
+with subordinate ids. The ``posixAccount`` object class has ``uid``
+(user login name) and ``uidNumber`` (numeric user id) as mandatory
+attributes. The ``uid`` attribute is guaranteed to be unique across
+all user accounts in an IPA domain.
+
+The ``uidNumber`` attribute is commonly unique, too. However it's
+technically possible that an administrator has assigned the same
+numeric user id to multiple users. Automatically assigned uid numbers
+don't conflict. SSSD should treat multiple users with same numeric
+user id as an error.
+
+The attribute ``ipaSubUidNumber`` is always accompanied by
+``ipaSubUidCount`` and ``ipaSubGidNumber`` is always accompanied
+by ``ipaSubGidCount``. In revision 1 the presence of
+``ipaSubUidNumber`` implies presence of the other three attributes.
+All four subordinate id attributes and ``uidNumber`` are single-value
+``INTEGER`` types. Any value outside of range of ``uint32_t`` must
+treated as invalid. SSSD will never see the DNA magic value ``-1``
+in ``cn=accounts,$SUFFIX`` subtree.
+
+IPA recommends that SSSD simply extends its existing query for user
+accounts and requests the four subordinate attributes additionally to
+RFC 2307 attributes ``rfc2307_user_map``. SSSD can directly take the
+values and return them without further processing, e.g.
+``uidNumber:ipaSubUidNumber:ipaSubUidCount`` for ``/etc/subuid``.
+
+Filters for additional cases:
+
+* subuid filter (find user with subuid by numeric uid):
+  ``&((objectClass=posixAccount)(ipaSubUidNumber=*)(uidNumber=$UID))``,
+  ``(&(objectClass=ipaSubordinateId)(uidNumber=$UID))``, or similar
+* subuid enumeration filter:
+  ``&((objectClass=posixAccount)(ipaSubUidNumber=*)(uidNumber=*))``,
+  ``(objectClass=ipaSubordinateId)``, or similar
+* subgid filter (find user with subgid by numeric uid):
+  ``&((objectClass=posixAccount)(ipaSubGidNumber=*)(uidNumber=$UID))``,
+  ``(&(objectClass=ipaSubordinateId)(uidNumber=$UID))``, or similar
+* subgid enumeration filter:
+  ``&((objectClass=posixAccount)(ipaSubGidNumber=*)(uidNumber=*))``,
+  ``(objectClass=ipaSubordinateId)``, or similar
+
+## Implementation details
+
+* The four subid attributes are not included in
+  ``baseuser.default_attributes`` on purpose. The ``config-mod``
+  command does not permit removal of a user default objectclasses
+  when the class is the last provider of an attribute in
+  ``default_attributes``.
+* ``ipaSubordinateId`` object class does not subclass the other two
+  object classes. LDAP supports
+  ``SUP ( ipaSubordinateGid $ ipaSubordinateUid )`` but 389-DS only
+  auto-inherits from first object class.
+* The idrange entry ``$REALM_subid_range`` has preconfigured base RIDs
+  and SID so idrange plug-in and sidgen task ignore the entry. It's the
+  simplest approach to ensure backwards compatibility with older IPA
+  server versions that don't know how to handle the new range.
+  The SID is ``S-1-5-21-738065-838566-$DOMAIN_HASH``. ``S-1-5-21``
+  is the well-known SID prefix for domain SIDs.  ``738065-838566`` is
+  the decimal representation of the string ``IPA-SUB``. ``DOMAIN_HASH``
+  is the MURMUR-3 hash of the domain name for key ``0xdeadbeef``. SSSD
+  rejects SIDs unless they are prefixed with ``S-1-5-21`` (see
+  ``sss_idmap.c:is_domain_sid()``).
+* The new ``$REALM_subid_range`` entry uses range type ``ipa-ad-trust``
+  instead of range type ``ipa-local-subid`` for backwards compatibility
+  with older SSSD clients, see
+  [SSSD #5571](https://github.com/SSSD/sssd/issues/5571).
+* Shared DNA configuration entries in ``cn=dna,cn=ipa,cn=etc,$SUFFIX``
+  are automatically removed by existing code. Server and replication
+  plug-ins search and delete entries by ``dnaHostname`` attribute.
+
+### TODO
+
+* enable configuration for ``dnaStepAttr``
+* remove ``fake_dna_plugin`` hack from ``baseuser`` plug-in.
+* add custom range type for idranges and teach AD trust, sidgen, and
+  range overlap check code to deal with new range type.

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -106,8 +106,9 @@
 %global python_ldap_version 3.1.0-1
 
 # Make sure to use 389-ds-base versions that fix https://github.com/389ds/389-ds-base/issues/4700
+# and has DNA interval enabled
 %if 0%{?fedora} < 34
-%global ds_version %{lua: local v={}; v['32']='1.4.3.20-2'; v['33']='1.4.4.16-1'; print(v[rpm.expand('%{fedora}')])}
+%global ds_version 1.4.4.16-1
 %else
 %global ds_version 2.0.5-1
 %endif

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1361,6 +1361,7 @@ fi
 %{_libexecdir}/ipa/ipa-pki-wait-running
 %{_libexecdir}/ipa/ipa-otpd
 %{_libexecdir}/ipa/ipa-print-pac
+%{_libexecdir}/ipa/ipa-subids
 %dir %{_libexecdir}/ipa/custodia
 %attr(755,root,root) %{_libexecdir}/ipa/custodia/ipa-custodia-dmldap
 %attr(755,root,root) %{_libexecdir}/ipa/custodia/ipa-custodia-pki-tomcat

--- a/install/share/60basev2.ldif
+++ b/install/share/60basev2.ldif
@@ -3,6 +3,7 @@
 ## Attributes:		2.16.840.1.113730.3.8.3 - V2 base attributres
 ## ObjectClasses:	2.16.840.1.113730.3.8.4 - V2 base objectclasses
 ## Attributes:		2.16.840.1.113730.3.8.23 - V4 base attributes
+## ObjectClasses:	2.16.840.1.113730.3.8.24 - V4 base objectclasses
 ##
 dn: cn=schema
 attributeTypes: (2.16.840.1.113730.3.8.3.1 NAME 'ipaUniqueID' DESC 'Unique identifier' EQUALITY caseIgnoreMatch ORDERING caseIgnoreOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'IPA v2' )

--- a/install/share/60basev4.ldif
+++ b/install/share/60basev4.ldif
@@ -5,15 +5,16 @@
 ##
 dn: cn=schema
 # subordinate ids
-# range ceiling OIDs are reserved for future use (operational attribute?)
-# object class requires uidNumber but does not subclass posixAccount so we
-# can re-use the object class in idview overrides later.
-attributeTypes: ( 2.16.840.1.113730.3.8.23.6 NAME 'ipaSubUidNumber' DESC 'Numerical subordinate user ID (range start value)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE  X-ORIGIN 'IPA v4.9')
-attributeTypes: ( 2.16.840.1.113730.3.8.23.7 NAME 'ipaSubUidCount' DESC 'Subordinate user ID count (range size)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE  X-ORIGIN 'IPA v4.9')
-# attributeTypes: ( 2.16.840.1.113730.3.8.23.8 NAME 'ipaSubUidCeiling' DESC 'Numerical subordinate user ID ceiling (largest value in range)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE  X-ORIGIN 'IPA v4.9')
-attributeTypes: ( 2.16.840.1.113730.3.8.23.9 NAME 'ipaSubGidNumber' DESC 'Numerical subordinate group ID (range start value)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE  X-ORIGIN 'IPA v4.9')
-attributeTypes: ( 2.16.840.1.113730.3.8.23.10 NAME 'ipaSubGidCount' DESC 'Subordinate group ID count (range size)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE  X-ORIGIN 'IPA v4.9')
-# attributeTypes: ( 2.16.840.1.113730.3.8.23.11 NAME 'ipaSubGidCeiling' DESC 'Numerical subordinate user ID ceiling (largest value in range)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE  X-ORIGIN 'IPA v4.9')
-objectClasses: (2.16.840.1.113730.3.8.24.2 NAME 'ipaSubordinateUid' DESC 'Subordinate uids for users, see subuid(5)' SUP top AUXILIARY MUST ( uidNumber $ ipaSubUidNumber $ ipaSubUidCount ) X-ORIGIN 'IPA v4.9')
-objectClasses: (2.16.840.1.113730.3.8.24.3 NAME 'ipaSubordinateGid' DESC 'Subordinate gids for users, see subgid(5)' SUP top AUXILIARY MUST ( uidNumber $ ipaSubGidNumber $ ipaSubGidCount ) X-ORIGIN 'IPA v4.9')
-objectClasses: (2.16.840.1.113730.3.8.24.4 NAME 'ipaSubordinateId' DESC 'Subordinate uid and gid for users' SUP top AUXILIARY MUST ( uidNumber $ ipaSubUidNumber $ ipaSubUidCount $ ipaSubGidNumber $ ipaSubGidCount ) X-ORIGIN 'IPA v4.9')
+# range ceiling OIDs are reserved for future use
+attributeTypes: ( 2.16.840.1.113730.3.8.23.7 NAME 'ipaSubUidNumber' DESC 'Numerical subordinate user ID (range start value)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'IPA v4.9')
+attributeTypes: ( 2.16.840.1.113730.3.8.23.8 NAME 'ipaSubUidCount' DESC 'Subordinate user ID count (range size)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'IPA v4.9')
+# attributeTypes: ( 2.16.840.1.113730.3.8.23.9 NAME 'ipaSubUidCeiling' DESC 'Numerical subordinate user ID ceiling (largest value in range)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'IPA v4.9')
+attributeTypes: ( 2.16.840.1.113730.3.8.23.10 NAME 'ipaSubGidNumber' DESC 'Numerical subordinate group ID (range start value)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'IPA v4.9')
+attributeTypes: ( 2.16.840.1.113730.3.8.23.11 NAME 'ipaSubGidCount' DESC 'Subordinate group ID count (range size)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'IPA v4.9')
+# attributeTypes: ( 2.16.840.1.113730.3.8.23.12 NAME 'ipaSubGidCeiling' DESC 'Numerical subordinate user ID ceiling (largest value in range)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'IPA v4.9')
+attributeTypes: ( 2.16.840.1.113730.3.8.23.13 NAME 'ipaOwner' DESC 'Owner of an entry' SUP distinguishedName EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE X-ORIGIN 'IPA v4.9')
+# attribute 2.16.840.1.113730.3.8.23.14 'ipaUserDefaultSubordinateId' is defined in 60ipaconfig.ldif
+objectClasses: (2.16.840.1.113730.3.8.24.2 NAME 'ipaSubordinateUid' DESC 'Subordinate uids for users, see subuid(5)' SUP top AUXILIARY MUST ( ipaOwner $ ipaSubUidNumber $ ipaSubUidCount ) X-ORIGIN 'IPA v4.9')
+objectClasses: (2.16.840.1.113730.3.8.24.3 NAME 'ipaSubordinateGid' DESC 'Subordinate gids for users, see subgid(5)' SUP top AUXILIARY MUST ( ipaOwner $ ipaSubGidNumber $ ipaSubGidCount ) X-ORIGIN 'IPA v4.9')
+objectClasses: (2.16.840.1.113730.3.8.24.4 NAME 'ipaSubordinateId' DESC 'Subordinate uid and gid for users' SUP top AUXILIARY MUST ( ipaOwner $ ipaSubUidNumber $ ipaSubUidCount $ ipaSubGidNumber $ ipaSubGidCount ) X-ORIGIN 'IPA v4.9')
+objectClasses: (2.16.840.1.113730.3.8.24.5 NAME 'ipaSubordinateIdEntry' DESC 'Subordinate uid and gid entry' SUP top STRUCTURAL MUST ( ipaUniqueId ) MAY ( description ) X-ORIGIN 'IPA v4.9')

--- a/install/share/60basev4.ldif
+++ b/install/share/60basev4.ldif
@@ -1,0 +1,19 @@
+## IPA Base OID:	2.16.840.1.113730.3.8
+##
+## Attributes:		2.16.840.1.113730.3.8.23 - V4 base attributes
+## ObjectClasses:	2.16.840.1.113730.3.8.24 - V4 base objectclasses
+##
+dn: cn=schema
+# subordinate ids
+# range ceiling OIDs are reserved for future use (operational attribute?)
+# object class requires uidNumber but does not subclass posixAccount so we
+# can re-use the object class in idview overrides later.
+attributeTypes: ( 2.16.840.1.113730.3.8.23.6 NAME 'ipaSubUidNumber' DESC 'Numerical subordinate user ID (range start value)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE  X-ORIGIN 'IPA v4.9')
+attributeTypes: ( 2.16.840.1.113730.3.8.23.7 NAME 'ipaSubUidCount' DESC 'Subordinate user ID count (range size)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE  X-ORIGIN 'IPA v4.9')
+# attributeTypes: ( 2.16.840.1.113730.3.8.23.8 NAME 'ipaSubUidCeiling' DESC 'Numerical subordinate user ID ceiling (largest value in range)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE  X-ORIGIN 'IPA v4.9')
+attributeTypes: ( 2.16.840.1.113730.3.8.23.9 NAME 'ipaSubGidNumber' DESC 'Numerical subordinate group ID (range start value)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE  X-ORIGIN 'IPA v4.9')
+attributeTypes: ( 2.16.840.1.113730.3.8.23.10 NAME 'ipaSubGidCount' DESC 'Subordinate group ID count (range size)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE  X-ORIGIN 'IPA v4.9')
+# attributeTypes: ( 2.16.840.1.113730.3.8.23.11 NAME 'ipaSubGidCeiling' DESC 'Numerical subordinate user ID ceiling (largest value in range)' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE  X-ORIGIN 'IPA v4.9')
+objectClasses: (2.16.840.1.113730.3.8.24.2 NAME 'ipaSubordinateUid' DESC 'Subordinate uids for users, see subuid(5)' SUP top AUXILIARY MUST ( uidNumber $ ipaSubUidNumber $ ipaSubUidCount ) X-ORIGIN 'IPA v4.9')
+objectClasses: (2.16.840.1.113730.3.8.24.3 NAME 'ipaSubordinateGid' DESC 'Subordinate gids for users, see subgid(5)' SUP top AUXILIARY MUST ( uidNumber $ ipaSubGidNumber $ ipaSubGidCount ) X-ORIGIN 'IPA v4.9')
+objectClasses: (2.16.840.1.113730.3.8.24.4 NAME 'ipaSubordinateId' DESC 'Subordinate uid and gid for users' SUP top AUXILIARY MUST ( uidNumber $ ipaSubUidNumber $ ipaSubUidCount $ ipaSubGidNumber $ ipaSubGidCount ) X-ORIGIN 'IPA v4.9')

--- a/install/share/60ipaconfig.ldif
+++ b/install/share/60ipaconfig.ldif
@@ -6,6 +6,7 @@
 ## ObjectClasses:	2.16.840.1.113730.3.8.2 - V1
 ## Attributes:		2.16.840.1.113730.3.8.3 - V2
 ## ObjectClasses:	2.16.840.1.113730.3.8.4 - V2
+## Attributes:		2.16.840.1.113730.3.8.23 - V4 base attributes
 dn: cn=schema
 ###############################################
 ##
@@ -45,11 +46,13 @@ attributeTypes: ( 2.16.840.1.113730.3.8.3.26 NAME 'ipaSELinuxUserMapDefault' DES
 attributeTypes: ( 2.16.840.1.113730.3.8.3.27 NAME 'ipaSELinuxUserMapOrder' DESC 'Available SELinux user context ordering' EQUALITY caseIgnoreMatch ORDERING caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'IPA v3')
 ## ipaMaxHostnameLength - maximum hostname length to allow
 attributeTypes: ( 2.16.840.1.113730.3.8.1.28 NAME 'ipaMaxHostnameLength' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE)
+# ipaUserDefaultSubordinateId - if TRUE new user entries gain subordinate id by default
+attributeTypes: ( 2.16.840.1.113730.3.8.3.23.14 NAME 'ipaUserDefaultSubordinateId' DESC 'Enable adding user entries with subordinate id' SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE X-ORIGIN 'IPA v4.9')
 ###############################################
 ##
 ## ObjectClasses
 ##
 ## ipaGuiConfig - GUI config parameters objectclass
-objectClasses: ( 2.16.840.1.113730.3.8.2.1 NAME 'ipaGuiConfig' AUXILIARY MAY ( ipaUserSearchFields $ ipaGroupSearchFields $ ipaSearchTimeLimit $ ipaSearchRecordsLimit $ ipaCustomFields $ ipaHomesRootDir $ ipaDefaultLoginShell $ ipaDefaultPrimaryGroup $ ipaMaxUsernameLength $ ipaPwdExpAdvNotify $ ipaUserObjectClasses $ ipaGroupObjectClasses $ ipaDefaultEmailDomain $ ipaMigrationEnabled $ ipaCertificateSubjectBase $ ipaSELinuxUserMapDefault $ ipaSELinuxUserMapOrder $ ipaKrbAuthzData $ ipaMaxHostnameLength) )
+objectClasses: ( 2.16.840.1.113730.3.8.2.1 NAME 'ipaGuiConfig' AUXILIARY MAY ( ipaUserSearchFields $ ipaGroupSearchFields $ ipaSearchTimeLimit $ ipaSearchRecordsLimit $ ipaCustomFields $ ipaHomesRootDir $ ipaDefaultLoginShell $ ipaDefaultPrimaryGroup $ ipaMaxUsernameLength $ ipaPwdExpAdvNotify $ ipaUserObjectClasses $ ipaGroupObjectClasses $ ipaDefaultEmailDomain $ ipaMigrationEnabled $ ipaCertificateSubjectBase $ ipaSELinuxUserMapDefault $ ipaSELinuxUserMapOrder $ ipaKrbAuthzData $ ipaMaxHostnameLength $ ipaUserDefaultSubordinateId) )
 ## ipaConfigObject - Generic config strings object holder
 objectClasses: (2.16.840.1.113730.3.8.4.13 NAME 'ipaConfigObject' DESC 'generic config object for IPA' AUXILIARY MAY ( ipaConfigString ) X-ORIGIN 'IPA v2' )

--- a/install/share/60ipaconfig.ldif
+++ b/install/share/60ipaconfig.ldif
@@ -47,7 +47,7 @@ attributeTypes: ( 2.16.840.1.113730.3.8.3.27 NAME 'ipaSELinuxUserMapOrder' DESC 
 ## ipaMaxHostnameLength - maximum hostname length to allow
 attributeTypes: ( 2.16.840.1.113730.3.8.1.28 NAME 'ipaMaxHostnameLength' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE)
 # ipaUserDefaultSubordinateId - if TRUE new user entries gain subordinate id by default
-attributeTypes: ( 2.16.840.1.113730.3.8.3.23.14 NAME 'ipaUserDefaultSubordinateId' DESC 'Enable adding user entries with subordinate id' SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE X-ORIGIN 'IPA v4.9')
+attributeTypes: ( 2.16.840.1.113730.3.8.23.14 NAME 'ipaUserDefaultSubordinateId' DESC 'Enable adding user entries with subordinate id' SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE X-ORIGIN 'IPA v4.9')
 ###############################################
 ##
 ## ObjectClasses

--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -16,6 +16,7 @@ dist_app_DATA =				\
 	60ipaconfig.ldif		\
 	60basev2.ldif			\
 	60basev3.ldif			\
+	60basev4.ldif			\
 	60ipadns.ldif			\
 	60ipapk11.ldif			\
 	60certificate-profiles.ldif	\

--- a/install/share/bootstrap-template.ldif
+++ b/install/share/bootstrap-template.ldif
@@ -491,7 +491,7 @@ cn: ${REALM}_subid_range
 ipaBaseID: eval($SUBID_RANGE_START)
 ipaIDRangeSize: eval($SUBID_RANGE_SIZE)
 # HACK: RIDs to work around adtrust sidgen issue
-ipaBaseRID: eval($SUBID_RANGE_START - $IDRANGE_SIZE)
+ipaBaseRID: eval($SUBID_BASE_RID)
 # 738065-838566 = IPA-SUB
 ipaNTTrustedDomainSID: S-1-5-21-738065-838566-$DOMAIN_HASH
 # HACK: "ipa-local-subid" range type causes issues with older SSSD clients

--- a/install/share/bootstrap-template.ldif
+++ b/install/share/bootstrap-template.ldif
@@ -167,6 +167,12 @@ objectClass: nsContainer
 objectClass: top
 cn: posix-ids
 
+dn: cn=subordinate-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
+changetype: add
+objectClass: nsContainer
+objectClass: top
+cn: subordinate-ids
+
 dn: cn=ca_renewal,cn=ipa,cn=etc,$SUFFIX
 changetype: add
 objectClass: nsContainer
@@ -475,6 +481,22 @@ cn: ${REALM}_id_range
 ipaBaseID: $IDSTART
 ipaIDRangeSize: $IDRANGE_SIZE
 ipaRangeType: ipa-local
+
+dn: cn=${REALM}_subid_range,cn=ranges,cn=etc,$SUFFIX
+changetype: add
+objectClass: top
+objectClass: ipaIDrange
+objectClass: ipaTrustedADDomainRange
+cn: ${REALM}_subid_range
+ipaBaseID: eval($SUBID_RANGE_START)
+ipaIDRangeSize: eval($SUBID_RANGE_SIZE)
+# HACK: RIDs to work around adtrust sidgen issue
+ipaBaseRID: eval($SUBID_RANGE_START - $IDRANGE_SIZE)
+# 738065-838566 = IPA-SUB
+ipaNTTrustedDomainSID: S-1-5-21-738065-838566-$DOMAIN_HASH
+# HACK: "ipa-local-subid" range type causes issues with older SSSD clients
+# see https://github.com/SSSD/sssd/issues/5571
+ipaRangeType: ipa-ad-trust
 
 dn: cn=ca,$SUFFIX
 changetype: add

--- a/install/share/dna.ldif
+++ b/install/share/dna.ldif
@@ -29,12 +29,12 @@ dnaMagicRegen: -1
 dnaFilter: (objectClass=ipaSubordinateId)
 dnaScope: $SUFFIX
 dnaThreshold: eval($SUBID_DNA_THRESHOLD)
-# TODO: enable when 389-DS' DNA plugin supports dnaStepAttr
-# dnaStepAttr: ipaSubUidCount
-# dnaStepAttr: ipaSubGidCount
-# dnaStepAllowedValues: eval($SUBID_COUNT)
 dnaSharedCfgDN: cn=subordinate-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
 dnaExcludeScope: cn=provisioning,$SUFFIX
+# TODO: enable when 389-DS' DNA plugin supports dnaStepAttr
+# dnaIntervalAttr: ipasubuidcount
+# dnaIntervalAttr: ipasubgidcount
+# dnaMaxInterval: eval($SUBID_COUNT)
 
 # Enable the DNA plugin
 dn: cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config

--- a/install/share/dna.ldif
+++ b/install/share/dna.ldif
@@ -16,6 +16,26 @@ dnaThreshold: 500
 dnaSharedCfgDN: cn=posix-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
 dnaExcludeScope: cn=provisioning,$SUFFIX
 
+dn: cn=Subordinate IDs,cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config
+changetype: add
+objectclass: top
+objectclass: extensibleObject
+cn: Subordinate IDs
+dnaType: ipasubuidnumber
+dnaType: ipasubgidnumber
+dnaNextValue: eval($SUBID_RANGE_START)
+dnaMaxValue: eval($SUBID_RANGE_MAX)
+dnaMagicRegen: -1
+dnaFilter: (objectClass=ipaSubordinateId)
+dnaScope: $SUFFIX
+dnaThreshold: eval($SUBID_DNA_THRESHOLD)
+# TODO: enable when 389-DS' DNA plugin supports dnaStepAttr
+# dnaStepAttr: ipaSubUidCount
+# dnaStepAttr: ipaSubGidCount
+# dnaStepAllowedValues: eval($SUBID_COUNT)
+dnaSharedCfgDN: cn=subordinate-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
+dnaExcludeScope: cn=provisioning,$SUFFIX
+
 # Enable the DNA plugin
 dn: cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config
 changetype: modify

--- a/install/share/dna.ldif
+++ b/install/share/dna.ldif
@@ -31,6 +31,7 @@ dnaScope: $SUFFIX
 dnaThreshold: eval($SUBID_DNA_THRESHOLD)
 dnaSharedCfgDN: cn=subordinate-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
 dnaExcludeScope: cn=provisioning,$SUFFIX
+dnaInterval: eval($SUBID_COUNT)
 # TODO: enable when 389-DS' DNA plugin supports dnaStepAttr
 # dnaIntervalAttr: ipasubuidcount
 # dnaIntervalAttr: ipasubgidcount

--- a/install/share/memberof-conf.ldif
+++ b/install/share/memberof-conf.ldif
@@ -8,4 +8,6 @@ memberofgroupattr: memberUser
 -
 add: memberofgroupattr
 memberofgroupattr: memberHost
-
+-
+add: memberofgroupattr
+memberofgroupattr: ipaOwner

--- a/install/tools/Makefile.am
+++ b/install/tools/Makefile.am
@@ -38,6 +38,7 @@ dist_noinst_DATA =		\
 	ipa-pki-retrieve-key.in	\
 	ipa-pki-wait-running.in	\
 	ipa-acme-manage.in	\
+	ipa-subids.in	\
 	$(NULL)
 
 nodist_sbin_SCRIPTS =		\
@@ -78,6 +79,7 @@ nodist_app_SCRIPTS =		\
 	ipa-httpd-pwdreader	\
 	ipa-pki-retrieve-key	\
 	ipa-pki-wait-running	\
+	ipa-subids	\
 	$(NULL)
 
 PYTHON_SHEBANG = 					\

--- a/install/tools/ipa-subids.in
+++ b/install/tools/ipa-subids.in
@@ -1,0 +1,8 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2021  FreeIPA Contributors see COPYING for license
+#
+
+from ipaserver.install.ipa_subids import IPASubids
+
+IPASubids.run_cli()

--- a/install/ui/src/freeipa/app.js
+++ b/install/ui/src/freeipa/app.js
@@ -52,6 +52,7 @@ define([
     './serverconfig',
     './service',
     './stageuser',
+    './subid',
     './sudo',
     './trust',
     './topology',

--- a/install/ui/src/freeipa/details.js
+++ b/install/ui/src/freeipa/details.js
@@ -603,6 +603,12 @@ exp.details_facet = IPA.details_facet = function(spec, no_init) {
     that.facet_group = spec.facet_group || 'settings';
 
     /**
+     * Indicates if the details facet depends on pkey
+     * @property {boolean}
+     */
+    that.require_pkey = spec.require_pkey !== undefined ? spec.require_pkey : true;
+
+    /**
      * Widgets
      * @property {IPA.widget_container}
      */
@@ -1105,7 +1111,7 @@ exp.details_facet = IPA.details_facet = function(spec, no_init) {
      */
     that.refresh = function(on_success, on_error) {
 
-        if (!that.get_pkey() && that.entity.redirect_facet) {
+        if (that.require_pkey && !that.get_pkey() && that.entity.redirect_facet) {
             that.redirect();
             return;
         }

--- a/install/ui/src/freeipa/navigation/menu_spec.js
+++ b/install/ui/src/freeipa/navigation/menu_spec.js
@@ -104,7 +104,24 @@ var nav = {};
                         }
                     ]
                 },
-                { entity: 'subid' }
+                {
+                    name: 'subid',
+                    label: '@i18n:tabs.subid',
+                    children: [
+                        {
+                            name: 'subid',
+                            entity: 'subid',
+                            facet: 'search',
+                            label: '@i18n:tabs.subid'
+                        },
+                        {
+                            name: 'subid-stats',
+                            entity: 'subid',
+                            facet: 'stats',
+                            label: '@i18n:objects.subid.stats'
+                        }
+                    ]
+                }
             ]
         },
         {

--- a/install/ui/src/freeipa/navigation/menu_spec.js
+++ b/install/ui/src/freeipa/navigation/menu_spec.js
@@ -103,7 +103,8 @@ var nav = {};
                             ]
                         }
                     ]
-                }
+                },
+                { entity: 'subid' }
             ]
         },
         {

--- a/install/ui/src/freeipa/serverconfig.js
+++ b/install/ui/src/freeipa/serverconfig.js
@@ -124,6 +124,10 @@ return {
                             name: 'ipamigrationenabled'
                         },
                         {
+                            $type: 'checkbox',
+                            name: 'ipauserdefaultsubordinateid'
+                        },
+                        {
                             $type: 'multivalued',
                             name: 'ipauserobjectclasses'
                         }

--- a/install/ui/src/freeipa/subid.js
+++ b/install/ui/src/freeipa/subid.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2021  FreeIPA Contributors see COPYING for license
+ */
+
+define([
+        'dojo/on',
+        './ipa',
+        './jquery',
+        './phases',
+        './reg',
+        './details',
+        './search',
+        './association',
+        './entity'],
+            function(on, IPA, $, phases, reg) {
+
+var exp = IPA.subid = {};
+
+var make_spec = function() {
+return {
+    name: 'subid',
+    facets: [
+        {
+            $type: 'search',
+            columns: [
+                'ipauniqueid',
+                'ipaowner',
+                'ipasubgidnumber',
+                'ipasubuidnumber'
+            ]
+        },
+        {
+            $type: 'details',
+            sections: [
+                {
+                    name: 'details',
+                    fields: [
+                        'ipauniqueid',
+                        'description',
+                        {
+                            name: 'ipaowner',
+                            label: '@i18n:objects.subid.ipaowner',
+                            title: '@mo-param:subid:ipaowner:label'
+                        },
+                        {
+                            name: 'ipasubgidnumber',
+                            label: '@i18n:objects.subid.ipasubgidnumber',
+                            title: '@mo-param:subid:ipasubgidnumber:label'
+                        },
+                        {
+                            name: 'ipasubgidcount',
+                            label: '@i18n:objects.subid.ipasubgidcount',
+                            title: '@mo-param:subid:ipasubgidcount:label'
+                        },
+                        {
+                            name: 'ipasubuidnumber',
+                            label: '@i18n:objects.subid.ipasubuidnumber',
+                            title: '@mo-param:subid:ipasubuidnumber:label'
+                        },
+                        {
+                            name: 'ipasubuidcount',
+                            label: '@i18n:objects.subid.ipasubuidcount',
+                            title: '@mo-param:subid:ipasubuidcount:label'
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    adder_dialog: {
+        title: '@i18n:objects.subid.add',
+        method: 'generate',
+        fields: [
+            {
+                $type: 'entity_select',
+                name: 'ipaowner',
+                other_entity: 'user',
+                other_field: 'uid'
+            }
+        ]
+    }
+};};
+
+exp.entity_spec = make_spec();
+exp.register = function() {
+    var e = reg.entity;
+    e.register({type: 'subid', spec: exp.entity_spec});
+};
+phases.on('registration', exp.register);
+
+return {};
+});

--- a/install/ui/src/freeipa/subid.js
+++ b/install/ui/src/freeipa/subid.js
@@ -31,6 +31,7 @@ return {
         },
         {
             $type: 'details',
+            disable_facet_tabs: true,
             sections: [
                 {
                     name: 'details',
@@ -38,9 +39,11 @@ return {
                         'ipauniqueid',
                         'description',
                         {
+                            $type: 'link',
                             name: 'ipaowner',
                             label: '@i18n:objects.subid.ipaowner',
-                            title: '@mo-param:subid:ipaowner:label'
+                            title: '@mo-param:subid:ipaowner:label',
+                            other_entity: 'user'
                         },
                         {
                             name: 'ipasubgidnumber',
@@ -63,6 +66,44 @@ return {
                             title: '@mo-param:subid:ipasubuidcount:label'
                         }
                     ]
+                }
+            ]
+        },
+        {
+            $type: 'details',
+            name: 'stats',
+            label: '@i18n:objects.subid.stats',
+            refresh_command_name: 'stats',
+            check_rights: false,
+            no_update: true,
+            disable_facet_tabs: true,
+            disable_breadcrumb: true,
+            require_pkey: false,
+            fields: [
+                {
+                    name: 'assigned_subids',
+                    label: '@i18n:objects.subid.assigned_subids',
+                    read_only: true
+                },
+                {
+                    name: 'baseid',
+                    label: '@i18n:objects.subid.baseid',
+                    read_only: true
+                },
+                {
+                    name: 'dna_remaining',
+                    label: '@i18n:objects.subid.dna_remaining',
+                    read_only: true
+                },
+                {
+                    name: 'rangesize',
+                    label: '@i18n:objects.subid.rangesize',
+                    read_only: true
+                },
+                {
+                    name: 'remaining_subids',
+                    label: '@i18n:objects.subid.remaining_subids',
+                    read_only: true
                 }
             ]
         }

--- a/install/ui/src/freeipa/user.js
+++ b/install/ui/src/freeipa/user.js
@@ -260,6 +260,33 @@ return {
                     ]
                 },
                 {
+                    name: 'subordinate',
+                    label: '@i18n:objects.subordinate.identity',
+                    fields: [
+                        {
+                            name: 'ipasubuidnumber',
+                            label: '@i18n:objects.subordinate.subuidnumber',
+                            read_only: true
+                        },
+                        {
+                            name: 'ipasubuidcount',
+                            label: '@i18n:objects.subordinate.subuidcount',
+                            read_only: true
+
+                        },
+                        {
+                            name: 'ipasubgidnumber',
+                            label: '@i18n:objects.subordinate.subgidnumber',
+                            read_only: true
+                        },
+                        {
+                            name: 'ipasubgidcount',
+                            label: '@i18n:objects.subordinate.subgidcount',
+                            read_only: true
+                        }
+                    ]
+                },
+                {
                     name: 'pwpolicy',
                     label: '@i18n:objects.pwpolicy.identity',
                     field_adapter: { result_index: 1 },
@@ -452,6 +479,16 @@ return {
                     confirm_msg: '@i18n:objects.user.unlock_confirm'
                 },
                 {
+                    $factory: IPA.object_action,
+                    name: 'auto_subid',
+                    method: 'auto_subid',
+                    label: '@i18n:objects.user.auto_subid',
+                    needs_confirm: true,
+                    hide_cond: ['preserved-user'],
+                    enable_cond: ['no-subid'],
+                    confirm_msg: '@i18n:objects.user.auto_subid_confirm'
+                },
+                {
                     $type: 'automember_rebuild',
                     name: 'automember_rebuild',
                     hide_cond: ['preserved-user'],
@@ -461,12 +498,22 @@ return {
                     $type: 'cert_request',
                     hide_cond: ['preserved-user'],
                     title: '@i18n:objects.cert.issue_for_user'
+                },
+                {
+                    $factory: IPA.object_action,
+                    name: 'auto_subid',
+                    method: 'auto_subid',
+                    label: '@i18n:objects.user.auto_subid',
+                    needs_confirm: true,
+                    hide_cond: ['preserved-user'],
+                    enable_cond: ['no-subid'],
+                    confirm_msg: '@i18n:objects.user.auto_subid_confirm'
                 }
             ],
             header_actions: [
                 'reset_password', 'enable', 'disable', 'stage', 'undel',
                 'delete_active_user', 'delete', 'unlock', 'add_otptoken',
-                'automember_rebuild', 'request_cert'
+                'automember_rebuild', 'request_cert', 'auto_subid'
             ],
             state: {
                 evaluators: [
@@ -1157,6 +1204,10 @@ IPA.user.is_locked_evaluator = function(spec) {
             if (user.krbloginfailedcount[0] >= max_failure) {
                 that.state.push('is-locked');
             }
+        }
+
+        if (!user.ipasubuidnumber) {
+            that.state.push('no-subid');
         }
 
         that.notify_on_change(old_state);

--- a/install/updates/10-uniqueness.update
+++ b/install/updates/10-uniqueness.update
@@ -109,3 +109,22 @@ default:nsslapd-plugin-depends-on-type: database
 default:nsslapd-pluginId: NSUniqueAttr
 default:nsslapd-pluginVersion: 1.1.0
 default:nsslapd-pluginVendor: Fedora Project
+
+dn: cn=ipaSubordinateIdEntry ipaOwner uniqueness,cn=plugins,cn=config
+default:objectClass: top
+default:objectClass: nsSlapdPlugin
+default:objectClass: extensibleObject
+default:cn: ipaSubordinateIdEntry ipaOwner uniqueness
+default:nsslapd-pluginDescription: Enforce unique attribute values of ipaOwner
+default:nsslapd-pluginPath: libattr-unique-plugin
+default:nsslapd-pluginInitfunc: NSUniqueAttr_Init
+default:nsslapd-pluginType: preoperation
+default:nsslapd-pluginEnabled: on
+default:uniqueness-attribute-name: ipaOwner
+default:uniqueness-subtrees: cn=subids,cn=accounts,$SUFFIX
+default:uniqueness-across-all-subtrees: on
+default:uniqueness-subtree-entries-oc: ipaSubordinateIdEntry
+default:nsslapd-plugin-depends-on-type: database
+default:nsslapd-pluginId: NSUniqueAttr
+default:nsslapd-pluginVersion: 1.1.0
+default:nsslapd-pluginVendor: Fedora Project

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -272,6 +272,24 @@ add:nsIndexType: eq
 add:nsIndexType: pres
 add:nsIndexType: sub
 
+dn: cn=ipaSubGidNumber,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+only:cn: ipaSubGidNumber
+default:objectClass: nsIndex
+default:objectClass: top
+default:nsSystemIndex: false
+add:nsIndexType: eq
+add:nsIndexType: pres
+add:nsMatchingRule: integerOrderingMatch
+
+dn: cn=ipaSubUidNumber,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+only:cn: ipaSubUidNumber
+default:objectClass: nsIndex
+default:objectClass: top
+default:nsSystemIndex: false
+add:nsIndexType: eq
+add:nsIndexType: pres
+add:nsMatchingRule: integerOrderingMatch
+
 dn: cn=ipasudorunasgroup,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 only:cn: ipasudorunasgroup
 default:objectClass: nsIndex

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -263,6 +263,14 @@ default:nsSystemIndex: false
 add:nsIndexType: eq
 add:nsIndexType: pres
 
+dn: cn=ipaOwner,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+only:cn: ipaOwner
+default:objectClass: nsIndex
+default:objectClass: top
+default:nsSystemIndex: false
+add:nsIndexType: eq
+add:nsIndexType: pres
+
 dn: cn=ipasudorunas,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 only:cn: ipasudorunas
 default:objectClass: nsIndex
@@ -424,6 +432,10 @@ default:objectClass: top
 default:nsSystemIndex: false
 add:nsIndexType: eq
 add:nsIndexType: pres
+
+dn: cn=memberOf,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+only:cn: member
+add:nsIndexType: sub
 
 dn: cn=memberPrincipal,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 only:cn: memberPrincipal

--- a/install/updates/25-referint.update
+++ b/install/updates/25-referint.update
@@ -21,3 +21,4 @@ add: referint-membership-attr: ipamemberca
 add: referint-membership-attr: ipamembercertprofile
 add: referint-membership-attr: ipalocation
 add: referint-membership-attr: membermanager
+add: referint-membership-attr: ipaowner

--- a/install/updates/73-subid.update
+++ b/install/updates/73-subid.update
@@ -1,5 +1,15 @@
 # subordinate ids
 
+# create memberOf attributes for ipaOwner
+dn: cn=MemberOf Plugin,cn=plugins,cn=config
+add: memberofgroupattr: ipaOwner
+
+# container
+dn: cn=subids,cn=accounts,$SUFFIX
+default: objectClass: top
+default: objectClass: nsContainer
+default: cn: subids
+
 # self-service RBAC
 dn: cn=Subordinate ID Selfservice User,cn=roles,cn=accounts,$SUFFIX
 default:objectClass: groupofnames
@@ -56,9 +66,9 @@ default:member: cn=Subordinate ID Administrators,cn=privileges,cn=pbac,$SUFFIX
 # self-service permission when 389-DS' DNA plugin supports dnaStepAttr and
 # fake_dna_plugin hack has been removed.
 #
-dn: $SUFFIX
-add: aci: (targetfilter = "(objectclass=posixaccount)")(targattrfilters = "add=objectClass:(|(objectClass=ipasubordinateid)(objectClass=ipasubordinategid)(objectClass=ipasubordinateuid)) && ipasubuidnumber:(|(ipasubuidnumber>=eval($SUBID_RANGE_START))(ipasubuidnumber=-1)) && ipasubuidcount:(ipasubuidcount=eval($SUBID_COUNT)) && ipasubgidnumber:(|(ipasubgidnumber>=eval($SUBID_RANGE_START))(ipasubgidnumber=-1)) && ipasubgidcount:(ipasubgidcount=eval($SUBID_COUNT)), del=ipasubuidnumber:(!(ipasubuidnumber=*)) && ipasubuidcount:(!(ipasubuidcount=*)) && ipasubgidnumber:(!(ipasubgidnumber=*)) && ipasubgidcount:(!(ipasubgidcount=*))")(version 3.0;acl "selfservice: Add subordinate id";allow (write) userdn = "ldap:///self" and groupdn="ldap:///cn=Self-service subordinate ID,cn=permissions,cn=pbac,$SUFFIX";)
-add: aci: (targetfilter = "(objectclass=posixaccount)")(targattrfilters = "add=objectClass:(|(objectClass=ipasubordinateid)(objectClass=ipasubordinategid)(objectClass=ipasubordinateuid)) && ipasubuidnumber:(|(ipasubuidnumber>=1)(ipasubuidnumber=-1)) && ipasubuidcount:(ipasubuidcount=eval($SUBID_COUNT)) && ipasubgidnumber:(|(ipasubgidnumber>=1)(ipasubgidnumber=-1)) && ipasubgidcount:(ipasubgidcount=eval($SUBID_COUNT)), del=ipasubuidnumber:(!(ipasubuidnumber=*)) && ipasubuidcount:(!(ipasubuidcount=*)) && ipasubgidnumber:(!(ipasubgidnumber=*)) && ipasubgidcount:(!(ipasubgidcount=*))")(version 3.0;acl "Add subordinate ids to any user";allow (write) groupdn="ldap:///cn=Subordinate ID Administrators,cn=privileges,cn=pbac,$SUFFIX";)
+dn: cn=subids,cn=accounts,$SUFFIX
+add: aci: (targetfilter = "(objectclass=ipasubordinateidentry)")(targetattr="description || ipaowner || ipauniqueid")(targattrfilters = "add=objectClass:(|(objectClass=top)(objectClass=ipasubordinateid)(objectClass=ipasubordinateidentry)(objectClass=ipasubordinategid)(objectClass=ipasubordinateuid)) && ipasubuidnumber:(|(ipasubuidnumber>=eval($SUBID_RANGE_START))(ipasubuidnumber=-1)) && ipasubuidcount:(ipasubuidcount=eval($SUBID_COUNT)) && ipasubgidnumber:(|(ipasubgidnumber>=eval($SUBID_RANGE_START))(ipasubgidnumber=-1)) && ipasubgidcount:(ipasubgidcount=eval($SUBID_COUNT)), del=ipasubuidnumber:(!(ipasubuidnumber=*)) && ipasubuidcount:(!(ipasubuidcount=*)) && ipasubgidnumber:(!(ipasubgidnumber=*)) && ipasubgidcount:(!(ipasubgidcount=*))")(version 3.0;acl "selfservice: Add subordinate id";allow (add, write) userattr = "ipaowner#SELFDN" and groupdn="ldap:///cn=Self-service subordinate ID,cn=permissions,cn=pbac,$SUFFIX";)
+add: aci: (targetfilter = "(objectclass=ipasubordinateidentry)")(targetattr="description || ipaowner || ipauniqueid")(targattrfilters = "add=objectClass:(|(objectClass=top)(objectClass=ipasubordinateid)(objectClass=ipasubordinateidentry)(objectClass=ipasubordinategid)(objectClass=ipasubordinateuid)) && ipasubuidnumber:(|(ipasubuidnumber>=1)(ipasubuidnumber=-1)) && ipasubuidcount:(ipasubuidcount=eval($SUBID_COUNT)) && ipasubgidnumber:(|(ipasubgidnumber>=1)(ipasubgidnumber=-1)) && ipasubgidcount:(ipasubgidcount=eval($SUBID_COUNT)), del=ipasubuidnumber:(!(ipasubuidnumber=*)) && ipasubuidcount:(!(ipasubuidcount=*)) && ipasubgidnumber:(!(ipasubgidnumber=*)) && ipasubgidcount:(!(ipasubgidcount=*))")(version 3.0;acl "Add subordinate ids to any user";allow (add, write) groupdn="ldap:///cn=Subordinate ID Administrators,cn=privileges,cn=pbac,$SUFFIX";)
 
 # DNA plugin and idrange configuration
 dn: cn=subordinate-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
@@ -78,14 +88,14 @@ default: dnaMagicRegen: -1
 default: dnaFilter: (objectClass=ipaSubordinateId)
 default: dnaScope: $SUFFIX
 default: dnaThreshold: eval($SUBID_DNA_THRESHOLD)
-# TODO: enable when 389-DS' DNA plugin supports dnaStepAttr
-# default: dnaStepAttr: ipaSubUidCount
-# default: dnaStepAttr: ipaSubGidCount
-# default: dnaStepAllowedValues: eval($SUBID_COUNT)
 default: dnaSharedCfgDN: cn=subordinate-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
 default: dnaExcludeScope: cn=provisioning,$SUFFIX
-default: aci: (targetattr = "dnaNextRange || dnaNextValue || dnaMaxValue")(version 3.0;acl "permission:Modify DNA Range";allow (write) groupdn = "ldap:///cn=Modify DNA Range,cn=permissions,cn=pbac,$SUFFIX";)
-default: aci: (targetattr = "cn || dnaMaxValue || dnaNextRange || dnaNextValue  || dnaThreshold || dnaType || objectclass")(version 3.0;acl "permission:Read DNA Range";allow (read, search, compare) groupdn = "ldap:///cn=Read DNA Range,cn=permissions,cn=pbac,$SUFFIX";)
+# TODO: enable when 389-DS' DNA plugin supports dnaStepAttr
+# add: dnaIntervalAttr: ipasubuidcount
+# add: dnaIntervalAttr: ipasubgidcount
+# addifnew: dnaMaxInterval: eval($SUBID_COUNT)
+add: aci: (targetattr = "dnaNextRange || dnaNextValue || dnaMaxValue")(version 3.0;acl "permission:Modify DNA Range";allow (write) groupdn = "ldap:///cn=Modify DNA Range,cn=permissions,cn=pbac,$SUFFIX";)
+add: aci: (targetattr = "cn || dnaMaxValue || dnaNextRange || dnaNextValue  || dnaThreshold || dnaType || objectclass")(version 3.0;acl "permission:Read DNA Range";allow (read, search, compare) groupdn = "ldap:///cn=Read DNA Range,cn=permissions,cn=pbac,$SUFFIX";)
 
 dn: cn=${REALM}_subid_range,cn=ranges,cn=etc,$SUFFIX
 default: objectClass: top

--- a/install/updates/73-subid.update
+++ b/install/updates/73-subid.update
@@ -1,0 +1,102 @@
+# subordinate ids
+
+# self-service RBAC
+dn: cn=Subordinate ID Selfservice User,cn=roles,cn=accounts,$SUFFIX
+default:objectClass: groupofnames
+default:objectClass: nestedgroup
+default:objectClass: top
+default:cn: Subordinate ID Selfservice User
+default:description: User that can self-request subordiante ids
+# default: member: cn=ipausers,cn=groups,cn=accounts,$SUFFIX
+
+dn: cn=Subordinate ID Selfservice Users,cn=privileges,cn=pbac,$SUFFIX
+default:objectClass: top
+default:objectClass: groupofnames
+default:objectClass: nestedgroup
+default:cn: Subordinate ID Selfservice Users
+default:description: Subordinate ID Selfservice User
+default:member: cn=Subordinate ID Selfservice User,cn=roles,cn=accounts,$SUFFIX
+
+dn: cn=Self-service subordinate ID,cn=permissions,cn=pbac,$SUFFIX
+default:objectClass: top
+default:objectClass: groupofnames
+default:objectClass: ipapermission
+default:cn: Self-service subordinate ID
+default:ipapermissiontype: SYSTEM
+default:member: cn=Subordinate ID Selfservice Users,cn=privileges,cn=pbac,$SUFFIX
+
+# Administrator RBAC
+dn: cn=Subordinate ID Administrators,cn=privileges,cn=pbac,$SUFFIX
+default:objectClass: top
+default:objectClass: groupofnames
+default:objectClass: nestedgroup
+default:cn: Subordinate ID Administrators
+default:description: Subordinate ID Administrators
+default:member: cn=User Administrator,cn=roles,cn=accounts,$SUFFIX
+
+dn: cn=Manage subordinate ID,cn=permissions,cn=pbac,$SUFFIX
+default:objectClass: top
+default:objectClass: groupofnames
+default:objectClass: ipapermission
+default:cn: Manage subordinate ID
+default:ipapermissiontype: SYSTEM
+default:member: cn=Subordinate ID Administrators,cn=privileges,cn=pbac,$SUFFIX
+
+# ACIs (in domain database root so they also apply to staging area)
+#
+# - allow users to request new subid with DNA_MAGIC value, subid count=65536,
+#   and subgid == subuid.
+# - allow user admins to set subids. count=65536 and subgid == subuid
+#   properties are enforced as wel.
+#
+# The delete-when-empty check is required because IPA uses MOD_REPLACE to
+# set attributes, see https://github.com/389ds/389-ds-base/issues/4597.
+#
+# TODO: remove (ipasubuidnumber>=eval($SUBID_RANGE_START) from
+# self-service permission when 389-DS' DNA plugin supports dnaStepAttr and
+# fake_dna_plugin hack has been removed.
+#
+dn: $SUFFIX
+add: aci: (targetfilter = "(objectclass=posixaccount)")(targattrfilters = "add=objectClass:(|(objectClass=ipasubordinateid)(objectClass=ipasubordinategid)(objectClass=ipasubordinateuid)) && ipasubuidnumber:(|(ipasubuidnumber>=eval($SUBID_RANGE_START))(ipasubuidnumber=-1)) && ipasubuidcount:(ipasubuidcount=eval($SUBID_COUNT)) && ipasubgidnumber:(|(ipasubgidnumber>=eval($SUBID_RANGE_START))(ipasubgidnumber=-1)) && ipasubgidcount:(ipasubgidcount=eval($SUBID_COUNT)), del=ipasubuidnumber:(!(ipasubuidnumber=*)) && ipasubuidcount:(!(ipasubuidcount=*)) && ipasubgidnumber:(!(ipasubgidnumber=*)) && ipasubgidcount:(!(ipasubgidcount=*))")(version 3.0;acl "selfservice: Add subordinate id";allow (write) userdn = "ldap:///self" and groupdn="ldap:///cn=Self-service subordinate ID,cn=permissions,cn=pbac,$SUFFIX";)
+add: aci: (targetfilter = "(objectclass=posixaccount)")(targattrfilters = "add=objectClass:(|(objectClass=ipasubordinateid)(objectClass=ipasubordinategid)(objectClass=ipasubordinateuid)) && ipasubuidnumber:(|(ipasubuidnumber>=1)(ipasubuidnumber=-1)) && ipasubuidcount:(ipasubuidcount=eval($SUBID_COUNT)) && ipasubgidnumber:(|(ipasubgidnumber>=1)(ipasubgidnumber=-1)) && ipasubgidcount:(ipasubgidcount=eval($SUBID_COUNT)), del=ipasubuidnumber:(!(ipasubuidnumber=*)) && ipasubuidcount:(!(ipasubuidcount=*)) && ipasubgidnumber:(!(ipasubgidnumber=*)) && ipasubgidcount:(!(ipasubgidcount=*))")(version 3.0;acl "Add subordinate ids to any user";allow (write) groupdn="ldap:///cn=Subordinate ID Administrators,cn=privileges,cn=pbac,$SUFFIX";)
+
+# DNA plugin and idrange configuration
+dn: cn=subordinate-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
+default: objectClass: nsContainer
+default: objectClass: top
+default: cn: subordinate-ids
+
+dn: cn=Subordinate IDs,cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config
+default: objectclass: top
+default: objectclass: extensibleObject
+default: cn: Subordinate IDs
+default: dnaType: ipasubuidnumber
+default: dnaType: ipasubgidnumber
+default: dnaNextValue: eval($SUBID_RANGE_START)
+default: dnaMaxValue: eval($SUBID_RANGE_MAX)
+default: dnaMagicRegen: -1
+default: dnaFilter: (objectClass=ipaSubordinateId)
+default: dnaScope: $SUFFIX
+default: dnaThreshold: eval($SUBID_DNA_THRESHOLD)
+# TODO: enable when 389-DS' DNA plugin supports dnaStepAttr
+# default: dnaStepAttr: ipaSubUidCount
+# default: dnaStepAttr: ipaSubGidCount
+# default: dnaStepAllowedValues: eval($SUBID_COUNT)
+default: dnaSharedCfgDN: cn=subordinate-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
+default: dnaExcludeScope: cn=provisioning,$SUFFIX
+default: aci: (targetattr = "dnaNextRange || dnaNextValue || dnaMaxValue")(version 3.0;acl "permission:Modify DNA Range";allow (write) groupdn = "ldap:///cn=Modify DNA Range,cn=permissions,cn=pbac,$SUFFIX";)
+default: aci: (targetattr = "cn || dnaMaxValue || dnaNextRange || dnaNextValue  || dnaThreshold || dnaType || objectclass")(version 3.0;acl "permission:Read DNA Range";allow (read, search, compare) groupdn = "ldap:///cn=Read DNA Range,cn=permissions,cn=pbac,$SUFFIX";)
+
+dn: cn=${REALM}_subid_range,cn=ranges,cn=etc,$SUFFIX
+default: objectClass: top
+default: objectClass: ipaIDrange
+default: objectClass: ipaTrustedADDomainRange
+default: cn: ${REALM}_subid_range
+default: ipaBaseID: $SUBID_RANGE_START
+default: ipaIDRangeSize: $SUBID_RANGE_SIZE
+# HACK: RIDs to work around adtrust sidgen issue
+default: ipaBaseRID: eval($SUBID_RANGE_START - $IDRANGE_SIZE)
+default: ipaNTTrustedDomainSID: S-1-5-21-738065-838566-$DOMAIN_HASH
+# HACK: "ipa-local-subid" range type causes issues with older SSSD clients
+# see https://github.com/SSSD/sssd/issues/5571
+default: ipaRangeType: ipa-ad-trust

--- a/install/updates/73-subid.update
+++ b/install/updates/73-subid.update
@@ -102,7 +102,7 @@ default: cn: ${REALM}_subid_range
 default: ipaBaseID: $SUBID_RANGE_START
 default: ipaIDRangeSize: $SUBID_RANGE_SIZE
 # HACK: RIDs to work around adtrust sidgen issue
-default: ipaBaseRID: eval($SUBID_RANGE_START - $IDRANGE_SIZE)
+default: ipaBaseRID: eval($SUBID_BASE_RID)
 default: ipaNTTrustedDomainSID: S-1-5-21-738065-838566-$DOMAIN_HASH
 # HACK: "ipa-local-subid" range type causes issues with older SSSD clients
 # see https://github.com/SSSD/sssd/issues/5571

--- a/install/updates/73-subid.update
+++ b/install/updates/73-subid.update
@@ -62,12 +62,8 @@ default:member: cn=Subordinate ID Administrators,cn=privileges,cn=pbac,$SUFFIX
 # The delete-when-empty check is required because IPA uses MOD_REPLACE to
 # set attributes, see https://github.com/389ds/389-ds-base/issues/4597.
 #
-# TODO: remove (ipasubuidnumber>=eval($SUBID_RANGE_START) from
-# self-service permission when 389-DS' DNA plugin supports dnaStepAttr and
-# fake_dna_plugin hack has been removed.
-#
 dn: cn=subids,cn=accounts,$SUFFIX
-add: aci: (targetfilter = "(objectclass=ipasubordinateidentry)")(targetattr="description || ipaowner || ipauniqueid")(targattrfilters = "add=objectClass:(|(objectClass=top)(objectClass=ipasubordinateid)(objectClass=ipasubordinateidentry)(objectClass=ipasubordinategid)(objectClass=ipasubordinateuid)) && ipasubuidnumber:(|(ipasubuidnumber>=eval($SUBID_RANGE_START))(ipasubuidnumber=-1)) && ipasubuidcount:(ipasubuidcount=eval($SUBID_COUNT)) && ipasubgidnumber:(|(ipasubgidnumber>=eval($SUBID_RANGE_START))(ipasubgidnumber=-1)) && ipasubgidcount:(ipasubgidcount=eval($SUBID_COUNT)), del=ipasubuidnumber:(!(ipasubuidnumber=*)) && ipasubuidcount:(!(ipasubuidcount=*)) && ipasubgidnumber:(!(ipasubgidnumber=*)) && ipasubgidcount:(!(ipasubgidcount=*))")(version 3.0;acl "selfservice: Add subordinate id";allow (add, write) userattr = "ipaowner#SELFDN" and groupdn="ldap:///cn=Self-service subordinate ID,cn=permissions,cn=pbac,$SUFFIX";)
+add: aci: (targetfilter = "(objectclass=ipasubordinateidentry)")(targetattr="description || ipaowner || ipauniqueid")(targattrfilters = "add=objectClass:(|(objectClass=top)(objectClass=ipasubordinateid)(objectClass=ipasubordinateidentry)(objectClass=ipasubordinategid)(objectClass=ipasubordinateuid)) && ipasubuidnumber:(ipasubuidnumber=-1) && ipasubuidcount:(ipasubuidcount=eval($SUBID_COUNT)) && ipasubgidnumber:(ipasubgidnumber=-1) && ipasubgidcount:(ipasubgidcount=eval($SUBID_COUNT)), del=ipasubuidnumber:(!(ipasubuidnumber=*)) && ipasubuidcount:(!(ipasubuidcount=*)) && ipasubgidnumber:(!(ipasubgidnumber=*)) && ipasubgidcount:(!(ipasubgidcount=*))")(version 3.0;acl "selfservice: Add subordinate id";allow (add, write) userattr = "ipaowner#SELFDN" and groupdn="ldap:///cn=Self-service subordinate ID,cn=permissions,cn=pbac,$SUFFIX";)
 add: aci: (targetfilter = "(objectclass=ipasubordinateidentry)")(targetattr="description || ipaowner || ipauniqueid")(targattrfilters = "add=objectClass:(|(objectClass=top)(objectClass=ipasubordinateid)(objectClass=ipasubordinateidentry)(objectClass=ipasubordinategid)(objectClass=ipasubordinateuid)) && ipasubuidnumber:(|(ipasubuidnumber>=1)(ipasubuidnumber=-1)) && ipasubuidcount:(ipasubuidcount=eval($SUBID_COUNT)) && ipasubgidnumber:(|(ipasubgidnumber>=1)(ipasubgidnumber=-1)) && ipasubgidcount:(ipasubgidcount=eval($SUBID_COUNT)), del=ipasubuidnumber:(!(ipasubuidnumber=*)) && ipasubuidcount:(!(ipasubuidcount=*)) && ipasubgidnumber:(!(ipasubgidnumber=*)) && ipasubgidcount:(!(ipasubgidcount=*))")(version 3.0;acl "Add subordinate ids to any user";allow (add, write) groupdn="ldap:///cn=Subordinate ID Administrators,cn=privileges,cn=pbac,$SUFFIX";)
 
 # DNA plugin and idrange configuration
@@ -90,6 +86,7 @@ default: dnaScope: $SUFFIX
 default: dnaThreshold: eval($SUBID_DNA_THRESHOLD)
 default: dnaSharedCfgDN: cn=subordinate-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
 default: dnaExcludeScope: cn=provisioning,$SUFFIX
+default: dnaInterval: eval($SUBID_COUNT)
 # TODO: enable when 389-DS' DNA plugin supports dnaStepAttr
 # add: dnaIntervalAttr: ipasubuidcount
 # add: dnaIntervalAttr: ipasubgidcount

--- a/install/updates/Makefile.am
+++ b/install/updates/Makefile.am
@@ -62,6 +62,7 @@ app_DATA =				\
 	71-idviews-sasl-mapping.update  \
 	72-domainlevels.update		\
 	73-custodia.update		\
+	73-subid.update		\
 	73-winsync.update		\
 	73-certmap.update		\
 	75-user-trust-attributes.update	\

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -343,3 +343,16 @@ SOFTHSM_DNSSEC_TOKEN_LABEL = u'ipaDNSSEC'
 # Apache's mod_ssl SSLVerifyDepth value (Maximum depth of CA
 # Certificates in Client Certificate verification)
 MOD_SSL_VERIFY_DEPTH = '5'
+
+# subuid / subgid counts are hard-coded
+# An interval of 65536 uids/gids is required to map nobody (65534).
+SUBID_COUNT = 65536
+
+# upper half of uid_t (uint32_t)
+SUBID_RANGE_START = 2 ** 31
+# theoretical max limit is UINT32_MAX-1 ((2 ** 32) - 2)
+# We use a smaller value to keep the topmost subid interval unused.
+SUBID_RANGE_MAX = (2 ** 32) - (2 * SUBID_COUNT)
+SUBID_RANGE_SIZE = SUBID_RANGE_MAX - SUBID_RANGE_START
+# threshold before DNA plugin requests a new range
+SUBID_DNA_THRESHOLD = 500 * SUBID_COUNT

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -131,6 +131,9 @@ DEFAULT_CONFIG = (
     ('container_ranges', DN(('cn', 'ranges'), ('cn', 'etc'))),
     ('container_dna', DN(('cn', 'dna'), ('cn', 'ipa'), ('cn', 'etc'))),
     ('container_dna_posix_ids', DN(('cn', 'posix-ids'), ('cn', 'dna'), ('cn', 'ipa'), ('cn', 'etc'))),
+    ('container_dna_subordinate_ids', DN(
+        ('cn', 'subordinate-ids'), ('cn', 'dna'), ('cn', 'ipa'), ('cn', 'etc')
+    )),
     ('container_realm_domains', DN(('cn', 'Realm Domains'), ('cn', 'ipa'), ('cn', 'etc'))),
     ('container_otp', DN(('cn', 'otp'))),
     ('container_radiusproxy', DN(('cn', 'radiusproxy'))),
@@ -148,6 +151,7 @@ DEFAULT_CONFIG = (
     ('container_certmaprules', DN(('cn', 'certmaprules'), ('cn', 'certmap'))),
     ('container_ca_renewal',
         DN(('cn', 'ca_renewal'), ('cn', 'ipa'), ('cn', 'etc'))),
+    ('container_subids', DN(('cn', 'subids'), ('cn', 'accounts'))),
 
     # Ports, hosts, and URIs:
     # Following values do not have any reasonable default.
@@ -355,4 +359,4 @@ SUBID_RANGE_START = 2 ** 31
 SUBID_RANGE_MAX = (2 ** 32) - (2 * SUBID_COUNT)
 SUBID_RANGE_SIZE = SUBID_RANGE_MAX - SUBID_RANGE_START
 # threshold before DNA plugin requests a new range
-SUBID_DNA_THRESHOLD = 500 * SUBID_COUNT
+SUBID_DNA_THRESHOLD = 500

--- a/ipaserver/install/ipa_subids.py
+++ b/ipaserver/install/ipa_subids.py
@@ -1,0 +1,154 @@
+#
+# Copyright (C) 2021  FreeIPA Contributors see COPYING for license
+#
+
+import logging
+
+from ipalib import api
+from ipalib import errors
+from ipalib.facts import is_ipa_configured
+from ipaplatform.paths import paths
+from ipapython.admintool import AdminTool, ScriptError
+from ipapython.dn import DN
+from ipaserver.plugins.baseldap import DNA_MAGIC
+
+logger = logging.getLogger(__name__)
+
+
+class IPASubids(AdminTool):
+    command_name = "ipa-subids"
+    usage = "%prog [--group GROUP|--all-users]"
+    description = "Mass-assign subordinate ids to users"
+
+    @classmethod
+    def add_options(cls, parser):
+        super(IPASubids, cls).add_options(parser, debug_option=True)
+        parser.add_option(
+            "--group",
+            dest="group",
+            action="store",
+            default=None,
+            help="Updates members of a user group.",
+        )
+        parser.add_option(
+            "--all-users",
+            dest="all_users",
+            action="store_true",
+            default=False,
+            help="Update all users.",
+        )
+        parser.add_option(
+            "--filter",
+            dest="user_filter",
+            action="store",
+            default="(!(nsaccountlock=TRUE))",
+            help="Additional raw LDAP filter (default: active users).",
+        )
+        parser.add_option(
+            "--dry-run",
+            dest="dry_run",
+            action="store_true",
+            default=False,
+            help="Dry run mode.",
+        )
+
+    def validate_options(self, neends_root=False):
+        super().validate_options(needs_root=True)
+        opt = self.safe_options
+
+        if opt.all_users and opt.group:
+            raise ScriptError("--group and --all-users are mutually exclusive")
+        if not opt.all_users and not opt.group:
+            raise ScriptError("Either --group or --all-users required")
+
+    def get_group_info(self):
+        assert api.isdone("finalize")
+        group = self.safe_options.group
+        if group is None:
+            return None
+        try:
+            result = api.Command.group_show(group, no_members=True)
+            return result["result"]
+        except errors.NotFound:
+            raise ScriptError(f"Unknown users group '{group}'.")
+
+    def make_filter(self, groupinfo, user_filter):
+        filters = [
+            # only users with posixAccount
+            "(objectClass=posixAccount)",
+            # without subordinate ids
+            "(!(objectClass=ipaSubordinateId))",
+        ]
+        if groupinfo is not None:
+            filters.append(
+                self.ldap2.make_filter({"memberof": groupinfo["dn"]})
+            )
+        if user_filter:
+            filters.append(user_filter)
+        return self.ldap2.combine_filters(filters, self.ldap2.MATCH_ALL)
+
+    def search_users(self, filters):
+        users_dn = DN(api.env.container_user, api.env.basedn)
+        attrs = ["objectclass", "uid", "uidnumber"]
+
+        logger.debug("basedn: %s", users_dn)
+        logger.debug("attrs: %s", attrs)
+        logger.debug("filter: %s", filters)
+
+        try:
+            entries = self.ldap2.get_entries(
+                base_dn=users_dn,
+                filter=filters,
+                attrs_list=attrs,
+            )
+        except errors.NotFound:
+            logger.debug("No entries found")
+            return []
+        else:
+            return entries
+
+    def run(self):
+        if not is_ipa_configured():
+            print("IPA is not configured.")
+            return 2
+
+        api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
+        api.finalize()
+        api.Backend.ldap2.connect()
+        self.ldap2 = api.Backend.ldap2
+        user_obj = api.Object["user"]
+
+        dry_run = self.safe_options.dry_run
+        group_info = self.get_group_info()
+        filters = self.make_filter(
+            group_info, self.safe_options.user_filter
+        )
+
+        entries = self.search_users(filters)
+        total = len(entries)
+        logger.info("Found %i user(s) without subordinate ids", total)
+
+        total = len(entries)
+        for i, entry in enumerate(entries, start=1):
+            logger.info(
+                "  Processing user '%s' (%i/%i)",
+                entry.single_value["uid"],
+                i,
+                total
+            )
+            user_obj.set_subordinate_ids(
+                self.ldap2, entry.dn, entry, DNA_MAGIC
+            )
+            if not dry_run:
+                self.ldap2.update_entry(entry)
+
+        if dry_run:
+            logger.info("Dry run mode, no user was modified")
+        else:
+            logger.info("Updated %s user(s)", total)
+
+        return 0
+
+
+if __name__ == "__main__":
+    IPASubids.run_cli()

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -59,8 +59,10 @@ def get_sub_dict(realm, domain, suffix, fqdn, idstart=None, idmax=None):
     """
     if idstart is None:
         idrange_size = None
+        subid_base_rid = None
     else:
         idrange_size = idmax - idstart + 1
+        subid_base_rid = constants.SUBID_RANGE_START - idrange_size
 
     return dict(
         REALM=realm,
@@ -81,6 +83,7 @@ def get_sub_dict(realm, domain, suffix, fqdn, idstart=None, idmax=None):
         SUBID_RANGE_SIZE=constants.SUBID_RANGE_SIZE,
         SUBID_RANGE_MAX=constants.SUBID_RANGE_MAX,
         SUBID_DNA_THRESHOLD=constants.SUBID_DNA_THRESHOLD,
+        SUBID_BASE_RID=subid_base_rid,
         DOMAIN_HASH=murmurhash3(domain, len(domain), 0xdeadbeef),
         MAX_DOMAIN_LEVEL=constants.MAX_DOMAIN_LEVEL,
         MIN_DOMAIN_LEVEL=constants.MIN_DOMAIN_LEVEL,

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -32,6 +32,7 @@ import os
 import fnmatch
 import warnings
 
+from pysss_murmur import murmurhash3  # pylint: disable=no-name-in-module
 import six
 
 from ipapython import ipautil, ipaldap
@@ -51,6 +52,54 @@ logger = logging.getLogger(__name__)
 
 UPDATES_DIR=paths.UPDATES_DIR
 UPDATE_SEARCH_TIME_LIMIT = 30  # seconds
+
+
+def get_sub_dict(realm, domain, suffix, fqdn, idstart=None, idmax=None):
+    """LDAP template substitution dict for installer and updater
+    """
+    if idstart is None:
+        idrange_size = None
+    else:
+        idrange_size = idmax - idstart + 1
+
+    return dict(
+        REALM=realm,
+        DOMAIN=domain,
+        SUFFIX=suffix,
+        ESCAPED_SUFFIX=str(suffix),
+        FQDN=fqdn,
+        HOST=fqdn,
+        LIBARCH=paths.LIBARCH,
+        TIME=int(time.time()),
+        FIPS="#" if tasks.is_fips_enabled() else "",
+        # idstart, idmax, and idrange_size may be None
+        IDSTART=idstart,
+        IDMAX=idmax,
+        IDRANGE_SIZE=idrange_size,
+        SUBID_COUNT=constants.SUBID_COUNT,
+        SUBID_RANGE_START=constants.SUBID_RANGE_START,
+        SUBID_RANGE_SIZE=constants.SUBID_RANGE_SIZE,
+        SUBID_RANGE_MAX=constants.SUBID_RANGE_MAX,
+        SUBID_DNA_THRESHOLD=constants.SUBID_DNA_THRESHOLD,
+        DOMAIN_HASH=murmurhash3(domain, len(domain), 0xdeadbeef),
+        MAX_DOMAIN_LEVEL=constants.MAX_DOMAIN_LEVEL,
+        MIN_DOMAIN_LEVEL=constants.MIN_DOMAIN_LEVEL,
+        STRIP_ATTRS=" ".join(replication.STRIP_ATTRS),
+        EXCLUDES=(
+            '(objectclass=*) $ EXCLUDE ' + ' '.join(replication.EXCLUDES)
+        ),
+        TOTAL_EXCLUDES=(
+            '(objectclass=*) $ EXCLUDE '
+            + ' '.join(replication.TOTAL_EXCLUDES)
+        ),
+        DEFAULT_SHELL=platformconstants.DEFAULT_SHELL,
+        DEFAULT_ADMIN_SHELL=platformconstants.DEFAULT_ADMIN_SHELL,
+        SELINUX_USERMAP_DEFAULT=platformconstants.SELINUX_USERMAP_DEFAULT,
+        SELINUX_USERMAP_ORDER=platformconstants.SELINUX_USERMAP_ORDER,
+        # uid / gid for autobind
+        NAMED_UID=platformconstants.NAMED_USER.uid,
+        NAMED_GID=platformconstants.NAMED_GROUP.gid,
+    )
 
 
 def connect(ldapi=False, realm=None, fqdn=None):
@@ -314,38 +363,33 @@ class LDAPUpdate:
             ldap_uri=self.ldapuri
         )
         self.api.finalize()
-
         self.create_connection()
 
+        # get ipa-local domain idrange settings
+        domain_range = f"{self.api.env.realm}_id_range"
+        try:
+            result = self.api.Command.idrange_show(domain_range)["result"]
+        except errors.NotFound:
+            idstart = None
+            idmax = None
+        else:
+            idstart = int(result['ipabaseid'][0])
+            idrange_size = int(result['ipaidrangesize'][0])
+            idmax = idstart + idrange_size - 1
+
+        default_sub = get_sub_dict(
+            realm=api.env.realm,
+            domain=api.env.domain,
+            suffix=api.env.basedn,
+            fqdn=api.env.host,
+            idstart=idstart,
+            idmax=idmax,
+        )
         replication_plugin = (
             installutils.get_replication_plugin_name(self.conn.get_entry)
         )
+        default_sub["REPLICATION_PLUGIN"] = replication_plugin
 
-        default_sub = dict(
-            REALM=api.env.realm,
-            DOMAIN=api.env.domain,
-            SUFFIX=api.env.basedn,
-            ESCAPED_SUFFIX=str(api.env.basedn),
-            FQDN=api.env.host,
-            LIBARCH=paths.LIBARCH,
-            TIME=int(time.time()),
-            MIN_DOMAIN_LEVEL=str(constants.MIN_DOMAIN_LEVEL),
-            MAX_DOMAIN_LEVEL=str(constants.MAX_DOMAIN_LEVEL),
-            STRIP_ATTRS=" ".join(constants.REPL_AGMT_STRIP_ATTRS),
-            EXCLUDES="(objectclass=*) $ EXCLUDE %s" % (
-                " ".join(constants.REPL_AGMT_EXCLUDES)
-            ),
-            TOTAL_EXCLUDES="(objectclass=*) $ EXCLUDE %s" % (
-                " ".join(constants.REPL_AGMT_TOTAL_EXCLUDES)
-            ),
-            SELINUX_USERMAP_DEFAULT=platformconstants.SELINUX_USERMAP_DEFAULT,
-            SELINUX_USERMAP_ORDER=platformconstants.SELINUX_USERMAP_ORDER,
-            FIPS="#" if tasks.is_fips_enabled() else "",
-            # uid / gid for autobind
-            NAMED_UID=platformconstants.NAMED_USER.uid,
-            NAMED_GID=platformconstants.NAMED_GROUP.gid,
-            REPLICATION_PLUGIN=replication_plugin,
-        )
         for k, v in default_sub.items():
             self.sub_dict.setdefault(k, v)
 

--- a/ipaserver/install/plugins/update_dna_shared_config.py
+++ b/ipaserver/install/plugins/update_dna_shared_config.py
@@ -17,7 +17,7 @@ register = Registry()
 
 @register()
 class update_dna_shared_config(Updater):
-    dna_plugin_names = ('posix IDs',)
+    dna_plugin_names = ('posix IDs', 'Subordinate IDs')
 
     dna_plugin_dn = DN(
         ('cn', 'Distributed Numeric Assignment Plugin'),

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -121,6 +121,8 @@ global_output_params = (
     Str('memberof_hbacrule?',
         label='Member of HBAC rule',
     ),
+    Str('memberof_subid?',
+        label='Subordinate ids',),
     Str('member_idoverrideuser?',
         label=_('Member ID user overrides'),),
     Str('memberindirect_idoverrideuser?',
@@ -795,7 +797,13 @@ class LDAPObject(Object):
 
         dn = entry.dn
         filter = self.backend.make_filter(
-            {'member': dn, 'memberuser': dn, 'memberhost': dn})
+            {
+                'member': dn,
+                'memberuser': dn,
+                'memberhost': dn,
+                'ipaowner': dn
+            }
+        )
         try:
             result = self.backend.get_entries(
                 self.api.env.basedn,

--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -17,10 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import random
 import six
 
-from ipalib import api, errors, output, constants
+from ipalib import api, errors, constants
 from ipalib import (
     Flag, Int, Password, Str, Bool, StrEnum, DateTime, DNParam)
 from ipalib.parameters import Principal, Certificate
@@ -28,9 +27,9 @@ from ipalib.plugable import Registry
 from .baseldap import (
     DN, LDAPObject, LDAPCreate, LDAPUpdate, LDAPSearch, LDAPDelete,
     LDAPRetrieve, LDAPAddAttribute, LDAPModAttribute, LDAPRemoveAttribute,
-    LDAPQuery, LDAPAddMember, LDAPRemoveMember,
+    LDAPAddMember, LDAPRemoveMember,
     LDAPAddAttributeViaOption, LDAPRemoveAttributeViaOption,
-    add_missing_object_class, DNA_MAGIC, pkey_to_value, entry_to_dict
+    add_missing_object_class
 )
 from ipaserver.plugins.service import (validate_realm, normalize_principal)
 from ipalib.request import context
@@ -162,7 +161,7 @@ class baseuser(LDAPObject):
     possible_objectclasses = [
         'meporiginentry', 'ipauserauthtypeclass', 'ipauser',
         'ipatokenradiusproxyuser', 'ipacertmapobject',
-        'ipantuserattrs', 'ipasubordinateid',
+        'ipantuserattrs',
     ]
     disallow_object_classes = ['krbticketpolicyaux']
     permission_filter_objectclasses = ['posixaccount']
@@ -183,13 +182,13 @@ class baseuser(LDAPObject):
         'krbprincipalname', 'loginshell',
         'mail', 'telephonenumber', 'title', 'nsaccountlock',
         'uidnumber', 'gidnumber', 'sshpubkeyfp',
-        'ipasubuidnumber', 'ipasubuidcount', 'ipasubgidnumber',
-        'ipasubgidcount',
     ]
     uuid_attribute = 'ipauniqueid'
     attribute_members = {
         'manager': ['user'],
-        'memberof': ['group', 'netgroup', 'role', 'hbacrule', 'sudorule'],
+        'memberof': [
+            'group', 'netgroup', 'role', 'hbacrule', 'sudorule', 'subid'
+        ],
         'memberofindirect': ['group', 'netgroup', 'role', 'hbacrule', 'sudorule'],
     }
     allow_rename = True
@@ -432,41 +431,6 @@ class baseuser(LDAPObject):
                     'J:', 'K:', 'L:', 'M:', 'N:', 'O:', 'P:', 'Q:', 'R:',
                     'S:', 'T:', 'U:', 'V:', 'W:', 'X:', 'Y:', 'Z:'),
                 ),
-        Int(
-            'ipasubuidnumber?',
-            label=_('SubUID range start'),
-            cli_name='subuid',
-            doc=_('Start value for subordinate user ID (subuid) range'),
-            minvalue=constants.SUBID_RANGE_START,
-            maxvalue=constants.SUBID_RANGE_MAX,
-        ),
-        Int(
-            'ipasubuidcount?',
-            label=_('SubUID range size'),
-            cli_name='subuidcount',
-            doc=_('Subordinate user ID count'),
-            flags={'no_create', 'no_update', 'no_search'},
-            minvalue=constants.SUBID_COUNT,
-            maxvalue=constants.SUBID_COUNT,
-        ),
-        Int(
-            'ipasubgidnumber?',
-            label=_('SubGID range start'),
-            cli_name='subgid',
-            doc=_('Start value for subordinate group ID (subgid) range'),
-            flags={'no_create', 'no_update'},
-            minvalue=constants.SUBID_RANGE_START,
-            maxvalue=constants.SUBID_RANGE_MAX,
-        ),
-        Int(
-            'ipasubgidcount?',
-            label=_('SubGID range size'),
-            cli_name='subgidcount',
-            doc=_('Subordinate group ID count'),
-            flags={'no_create', 'no_update', 'no_search'},
-            minvalue=constants.SUBID_COUNT,
-            maxvalue=constants.SUBID_COUNT,
-        ),
     )
 
     def normalize_and_validate_email(self, email, config=None):
@@ -564,131 +528,6 @@ class baseuser(LDAPObject):
         except KeyError:
             pass
 
-    def handle_subordinate_ids(self, ldap, dn, entry_attrs):
-        """Handle ipaSubordinateId object class
-        """
-        obj_classes = entry_attrs.get("objectclass")
-        new_subuid = entry_attrs.single_value.get("ipasubuidnumber")
-        new_subgid = entry_attrs.single_value.get("ipasubgidnumber")
-
-        # entry has object class ipaSubordinateId
-        # default to auto-assigment of subuids
-        if (
-            new_subuid is None
-            and obj_classes is not None
-            and self.has_objectclass(obj_classes, "ipasubordinateid")
-        ):
-            new_subuid = DNA_MAGIC
-
-        # neither auto-assignment nor explicit assignment
-        if new_subuid is None:
-            # nothing to do
-            return False
-
-        # enforce subuid == subgid
-        if new_subgid is not None and new_subgid != new_subuid:
-            raise errors.ValidationError(
-                name="ipasubgidnumber",
-                error=_("subgidnumber must be equal to subuidnumber")
-            )
-
-        self.set_subordinate_ids(ldap, dn, entry_attrs, new_subuid)
-        return True
-
-    def set_subordinate_ids(self, ldap, dn, entry_attrs, subuid):
-        """Set subuid value of an entry
-
-        Takes care of objectclass and sibbling attributes
-        """
-        if "objectclass" in entry_attrs:
-            obj_classes = entry_attrs["objectclass"]
-        else:
-            _entry_attrs = ldap.get_entry(dn, ["objectclass"])
-            entry_attrs["objectclass"] = _entry_attrs["objectclass"]
-            obj_classes = entry_attrs["objectclass"]
-
-        if not self.has_objectclass(obj_classes, "ipasubordinateid"):
-            # could append ipasubordinategid and ipasubordinateuid, too
-            obj_classes.append("ipasubordinateid")
-
-        # XXX HACK, remove later
-        if subuid == DNA_MAGIC:
-            subuid = self._fake_dna_plugin(ldap, dn, entry_attrs)
-
-        entry_attrs["ipasubuidnumber"] = subuid
-        # enforice subuid == subgid for now
-        entry_attrs["ipasubgidnumber"] = subuid
-        # hard-coded constants
-        entry_attrs["ipasubuidcount"] = constants.SUBID_COUNT
-        entry_attrs["ipasubgidcount"] = constants.SUBID_COUNT
-
-    def get_subid_match_candidate_filter(
-        self, ldap, *, subuid, subgid, extra_filters=(), offset=None,
-    ):
-        """Create LDAP filter to locate matching/overlapping subids
-        """
-        if subuid is None and subgid is None:
-            raise ValueError("subuid and subgid are both None")
-        if offset is None:
-            # assumes that no subordinate count is larger than SUBID_COUNT
-            offset = constants.SUBID_COUNT - 1
-
-        class_filters = "(objectclass=ipasubordinateid)"
-        subid_filters = []
-        if subuid is not None:
-            subid_filters.append(
-                ldap.combine_filters(
-                    [
-                        f"(ipasubuidnumber>={subuid - offset})",
-                        f"(ipasubuidnumber<={subuid + offset})",
-                    ],
-                    rules=ldap.MATCH_ALL
-                )
-            )
-        if subgid is not None:
-            subid_filters.append(
-                ldap.combine_filters(
-                    [
-                        f"(ipasubgidnumber>={subgid - offset})",
-                        f"(ipasubgidnumber<={subgid + offset})",
-                    ],
-                    rules=ldap.MATCH_ALL
-                )
-            )
-
-        subid_filters = ldap.combine_filters(
-            subid_filters, rules=ldap.MATCH_ANY
-        )
-        filters = [class_filters, subid_filters]
-        filters.extend(extra_filters)
-        return ldap.combine_filters(filters, rules=ldap.MATCH_ALL)
-
-    def _fake_dna_plugin(self, ldap, dn, entry_attrs):
-        """XXX HACK, remove when 389-DS DNA plugin supports steps"""
-        uidnumber = entry_attrs.single_value.get("uidnumber")
-        if uidnumber is None:
-            entry = ldap.get_entry(dn, ["uidnumber"])
-            uidnumber = entry.single_value["uidnumber"]
-        uidnumber = int(uidnumber)
-
-        if uidnumber == DNA_MAGIC:
-            return (
-                3221225472
-                + random.randint(1, 16382) * constants.SUBID_COUNT
-            )
-
-        if not hasattr(context, "idrange_ipabaseid"):
-            range_name = f"{self.api.env.realm}_id_range"
-            range = self.api.Command.idrange_show(range_name)["result"]
-            context.idrange_ipabaseid = int(range["ipabaseid"][0])
-
-        range_start = context.idrange_ipabaseid
-
-        assert uidnumber >= range_start
-        assert uidnumber < range_start + 2**14
-
-        return (uidnumber - range_start) * constants.SUBID_COUNT + 2**31
-
 
 class baseuser_add(LDAPCreate):
     """
@@ -699,7 +538,6 @@ class baseuser_add(LDAPCreate):
         assert isinstance(dn, DN)
         set_krbcanonicalname(entry_attrs)
         self.obj.convert_usercertificate_pre(entry_attrs)
-        self.obj.handle_subordinate_ids(ldap, dn, entry_attrs)
         if entry_attrs.get('ipatokenradiususername', None):
             add_missing_object_class(ldap, u'ipatokenradiusproxyuser', dn,
                                      entry_attrs, update=False)
@@ -852,7 +690,6 @@ class baseuser_mod(LDAPUpdate):
 
         self.check_objectclass(ldap, dn, entry_attrs)
         self.obj.convert_usercertificate_pre(entry_attrs)
-        self.obj.handle_subordinate_ids(ldap, dn, entry_attrs)
         self.preserve_krbprincipalname_pre(ldap, entry_attrs, *keys, **options)
         update_samba_attrs(ldap, dn, entry_attrs, **options)
 
@@ -1133,98 +970,3 @@ class baseuser_remove_certmapdata(ModCertMapData,
                                   LDAPRemoveAttribute):
     __doc__ = _("Remove one or more certificate mappings from the user entry.")
     msg_summary = _('Removed certificate mappings from user "%(value)s"')
-
-
-class baseuser_auto_subid(LDAPQuery):
-    __doc__ = _("Auto-assign subuid and subgid range to user entry")
-
-    has_output = output.standard_entry
-
-    def execute(self, cn, **options):
-        ldap = self.obj.backend
-        dn = self.obj.get_dn(cn)
-
-        try:
-            entry_attrs = ldap.get_entry(
-                dn, ["objectclass", "ipasubuidnumber"]
-            )
-        except errors.NotFound:
-            raise self.obj.handle_not_found(cn)
-
-        if "ipasubuidnumber" in entry_attrs:
-            raise errors.AlreadyContainsValueError(attr="ipasubuidnumber")
-
-        self.obj.set_subordinate_ids(ldap, dn, entry_attrs, subuid=DNA_MAGIC)
-        ldap.update_entry(entry_attrs)
-
-        # fetch updated entry (use search display attribute to show subids)
-        if options.get('all', False):
-            attrs_list = ['*'] + self.obj.search_display_attributes
-        else:
-            attrs_list = set(self.obj.search_display_attributes)
-            attrs_list.update(entry_attrs.keys())
-            if options.get('no_members', False):
-                attrs_list.difference_update(self.obj.attribute_members)
-            attrs_list = list(attrs_list)
-
-        entry = self._exc_wrapper((cn,), options, ldap.get_entry)(
-            dn, attrs_list
-        )
-        entry_attrs = entry_to_dict(entry, **options)
-        entry_attrs['dn'] = dn
-
-        return dict(result=entry_attrs, value=pkey_to_value(cn, options))
-
-
-class baseuser_match_subid(baseuser_find):
-    __doc__ = _("Match users by any subordinate uid in their range")
-
-    _subid_attrs = {
-        "ipasubuidnumber",
-        "ipasubuidcount",
-        "ipasubgidnumber",
-        "ipasubgidcount"
-    }
-
-    def get_options(self):
-        base_options = {p.name for p in self.obj.takes_params}
-        for option in super().get_options():
-            if option.name == "ipasubuidnumber":
-                yield option.clone(
-                    label=_('SubUID match'),
-                    doc=_('Match value for subordinate user ID'),
-                    required=True,
-                )
-            elif option.name not in base_options:
-                # raw, version
-                yield option.clone()
-
-    def pre_callback(
-        self, ldap, filters, attrs_list, base_dn, scope, *args, **options
-    ):
-        # search for candidates in range
-        # Code assumes that no subordinate count is larger than SUBID_COUNT
-        filters = self.obj.get_subid_match_candidate_filter(
-            ldap, subuid=options["ipasubuidnumber"], subgid=None,
-        )
-        # always include subid attributes
-        for missing in self._subid_attrs.difference(attrs_list):
-            attrs_list.append(missing)
-
-        return filters, base_dn, scope
-
-    def post_callback(self, ldap, entries, truncated, *args, **options):
-        # filter out mismatches manually
-        osubuid = options["ipasubuidnumber"]
-        new_entries = []
-        for entry in entries:
-            esubuid = int(entry.single_value["ipasubuidnumber"])
-            esubcount = int(entry.single_value["ipasubuidcount"])
-            minsubuid = esubuid
-            maxsubuid = esubuid + esubcount - 1
-            if minsubuid <= osubuid <= maxsubuid:
-                new_entries.append(entry)
-
-        entries[:] = new_entries
-
-        return truncated

--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -17,9 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import random
 import six
 
-from ipalib import api, errors
+from ipalib import api, errors, output, constants
 from ipalib import (
     Flag, Int, Password, Str, Bool, StrEnum, DateTime, DNParam)
 from ipalib.parameters import Principal, Certificate
@@ -27,13 +28,13 @@ from ipalib.plugable import Registry
 from .baseldap import (
     DN, LDAPObject, LDAPCreate, LDAPUpdate, LDAPSearch, LDAPDelete,
     LDAPRetrieve, LDAPAddAttribute, LDAPModAttribute, LDAPRemoveAttribute,
-    LDAPAddMember, LDAPRemoveMember,
+    LDAPQuery, LDAPAddMember, LDAPRemoveMember,
     LDAPAddAttributeViaOption, LDAPRemoveAttributeViaOption,
-    add_missing_object_class)
+    add_missing_object_class, DNA_MAGIC, pkey_to_value, entry_to_dict
+)
 from ipaserver.plugins.service import (validate_realm, normalize_principal)
 from ipalib.request import context
 from ipalib import _
-from ipalib.constants import PATTERN_GROUPUSER_NAME
 from ipapython import kerberos
 from ipapython.ipautil import ipa_generate_password, TMP_PWD_ENTROPY_BITS
 from ipapython.ipavalidate import Email
@@ -161,7 +162,7 @@ class baseuser(LDAPObject):
     possible_objectclasses = [
         'meporiginentry', 'ipauserauthtypeclass', 'ipauser',
         'ipatokenradiusproxyuser', 'ipacertmapobject',
-        'ipantuserattrs'
+        'ipantuserattrs', 'ipasubordinateid',
     ]
     disallow_object_classes = ['krbticketpolicyaux']
     permission_filter_objectclasses = ['posixaccount']
@@ -175,13 +176,15 @@ class baseuser(LDAPObject):
         'krbprincipalexpiration', 'usercertificate;binary',
         'krbprincipalname', 'krbcanonicalname',
         'ipacertmapdata', 'ipantlogonscript', 'ipantprofilepath',
-        'ipanthomedirectory', 'ipanthomedirectorydrive'
+        'ipanthomedirectory', 'ipanthomedirectorydrive',
     ]
     search_display_attributes = [
         'uid', 'givenname', 'sn', 'homedirectory', 'krbcanonicalname',
         'krbprincipalname', 'loginshell',
         'mail', 'telephonenumber', 'title', 'nsaccountlock',
         'uidnumber', 'gidnumber', 'sshpubkeyfp',
+        'ipasubuidnumber', 'ipasubuidcount', 'ipasubgidnumber',
+        'ipasubgidcount',
     ]
     uuid_attribute = 'ipauniqueid'
     attribute_members = {
@@ -198,7 +201,7 @@ class baseuser(LDAPObject):
 
     takes_params = (
         Str('uid',
-            pattern=PATTERN_GROUPUSER_NAME,
+            pattern=constants.PATTERN_GROUPUSER_NAME,
             pattern_errmsg='may only include letters, numbers, _, -, . and $',
             maxlength=255,
             cli_name='login',
@@ -429,6 +432,41 @@ class baseuser(LDAPObject):
                     'J:', 'K:', 'L:', 'M:', 'N:', 'O:', 'P:', 'Q:', 'R:',
                     'S:', 'T:', 'U:', 'V:', 'W:', 'X:', 'Y:', 'Z:'),
                 ),
+        Int(
+            'ipasubuidnumber?',
+            label=_('SubUID range start'),
+            cli_name='subuid',
+            doc=_('Start value for subordinate user ID (subuid) range'),
+            minvalue=constants.SUBID_RANGE_START,
+            maxvalue=constants.SUBID_RANGE_MAX,
+        ),
+        Int(
+            'ipasubuidcount?',
+            label=_('SubUID range size'),
+            cli_name='subuidcount',
+            doc=_('Subordinate user ID count'),
+            flags={'no_create', 'no_update', 'no_search'},
+            minvalue=constants.SUBID_COUNT,
+            maxvalue=constants.SUBID_COUNT,
+        ),
+        Int(
+            'ipasubgidnumber?',
+            label=_('SubGID range start'),
+            cli_name='subgid',
+            doc=_('Start value for subordinate group ID (subgid) range'),
+            flags={'no_create', 'no_update'},
+            minvalue=constants.SUBID_RANGE_START,
+            maxvalue=constants.SUBID_RANGE_MAX,
+        ),
+        Int(
+            'ipasubgidcount?',
+            label=_('SubGID range size'),
+            cli_name='subgidcount',
+            doc=_('Subordinate group ID count'),
+            flags={'no_create', 'no_update', 'no_search'},
+            minvalue=constants.SUBID_COUNT,
+            maxvalue=constants.SUBID_COUNT,
+        ),
     )
 
     def normalize_and_validate_email(self, email, config=None):
@@ -526,6 +564,131 @@ class baseuser(LDAPObject):
         except KeyError:
             pass
 
+    def handle_subordinate_ids(self, ldap, dn, entry_attrs):
+        """Handle ipaSubordinateId object class
+        """
+        obj_classes = entry_attrs.get("objectclass")
+        new_subuid = entry_attrs.single_value.get("ipasubuidnumber")
+        new_subgid = entry_attrs.single_value.get("ipasubgidnumber")
+
+        # entry has object class ipaSubordinateId
+        # default to auto-assigment of subuids
+        if (
+            new_subuid is None
+            and obj_classes is not None
+            and self.has_objectclass(obj_classes, "ipasubordinateid")
+        ):
+            new_subuid = DNA_MAGIC
+
+        # neither auto-assignment nor explicit assignment
+        if new_subuid is None:
+            # nothing to do
+            return False
+
+        # enforce subuid == subgid
+        if new_subgid is not None and new_subgid != new_subuid:
+            raise errors.ValidationError(
+                name="ipasubgidnumber",
+                error=_("subgidnumber must be equal to subuidnumber")
+            )
+
+        self.set_subordinate_ids(ldap, dn, entry_attrs, new_subuid)
+        return True
+
+    def set_subordinate_ids(self, ldap, dn, entry_attrs, subuid):
+        """Set subuid value of an entry
+
+        Takes care of objectclass and sibbling attributes
+        """
+        if "objectclass" in entry_attrs:
+            obj_classes = entry_attrs["objectclass"]
+        else:
+            _entry_attrs = ldap.get_entry(dn, ["objectclass"])
+            entry_attrs["objectclass"] = _entry_attrs["objectclass"]
+            obj_classes = entry_attrs["objectclass"]
+
+        if not self.has_objectclass(obj_classes, "ipasubordinateid"):
+            # could append ipasubordinategid and ipasubordinateuid, too
+            obj_classes.append("ipasubordinateid")
+
+        # XXX HACK, remove later
+        if subuid == DNA_MAGIC:
+            subuid = self._fake_dna_plugin(ldap, dn, entry_attrs)
+
+        entry_attrs["ipasubuidnumber"] = subuid
+        # enforice subuid == subgid for now
+        entry_attrs["ipasubgidnumber"] = subuid
+        # hard-coded constants
+        entry_attrs["ipasubuidcount"] = constants.SUBID_COUNT
+        entry_attrs["ipasubgidcount"] = constants.SUBID_COUNT
+
+    def get_subid_match_candidate_filter(
+        self, ldap, *, subuid, subgid, extra_filters=(), offset=None,
+    ):
+        """Create LDAP filter to locate matching/overlapping subids
+        """
+        if subuid is None and subgid is None:
+            raise ValueError("subuid and subgid are both None")
+        if offset is None:
+            # assumes that no subordinate count is larger than SUBID_COUNT
+            offset = constants.SUBID_COUNT - 1
+
+        class_filters = "(objectclass=ipasubordinateid)"
+        subid_filters = []
+        if subuid is not None:
+            subid_filters.append(
+                ldap.combine_filters(
+                    [
+                        f"(ipasubuidnumber>={subuid - offset})",
+                        f"(ipasubuidnumber<={subuid + offset})",
+                    ],
+                    rules=ldap.MATCH_ALL
+                )
+            )
+        if subgid is not None:
+            subid_filters.append(
+                ldap.combine_filters(
+                    [
+                        f"(ipasubgidnumber>={subgid - offset})",
+                        f"(ipasubgidnumber<={subgid + offset})",
+                    ],
+                    rules=ldap.MATCH_ALL
+                )
+            )
+
+        subid_filters = ldap.combine_filters(
+            subid_filters, rules=ldap.MATCH_ANY
+        )
+        filters = [class_filters, subid_filters]
+        filters.extend(extra_filters)
+        return ldap.combine_filters(filters, rules=ldap.MATCH_ALL)
+
+    def _fake_dna_plugin(self, ldap, dn, entry_attrs):
+        """XXX HACK, remove when 389-DS DNA plugin supports steps"""
+        uidnumber = entry_attrs.single_value.get("uidnumber")
+        if uidnumber is None:
+            entry = ldap.get_entry(dn, ["uidnumber"])
+            uidnumber = entry.single_value["uidnumber"]
+        uidnumber = int(uidnumber)
+
+        if uidnumber == DNA_MAGIC:
+            return (
+                3221225472
+                + random.randint(1, 16382) * constants.SUBID_COUNT
+            )
+
+        if not hasattr(context, "idrange_ipabaseid"):
+            range_name = f"{self.api.env.realm}_id_range"
+            range = self.api.Command.idrange_show(range_name)["result"]
+            context.idrange_ipabaseid = int(range["ipabaseid"][0])
+
+        range_start = context.idrange_ipabaseid
+
+        assert uidnumber >= range_start
+        assert uidnumber < range_start + 2**14
+
+        return (uidnumber - range_start) * constants.SUBID_COUNT + 2**31
+
 
 class baseuser_add(LDAPCreate):
     """
@@ -536,6 +699,7 @@ class baseuser_add(LDAPCreate):
         assert isinstance(dn, DN)
         set_krbcanonicalname(entry_attrs)
         self.obj.convert_usercertificate_pre(entry_attrs)
+        self.obj.handle_subordinate_ids(ldap, dn, entry_attrs)
         if entry_attrs.get('ipatokenradiususername', None):
             add_missing_object_class(ldap, u'ipatokenradiusproxyuser', dn,
                                      entry_attrs, update=False)
@@ -688,6 +852,7 @@ class baseuser_mod(LDAPUpdate):
 
         self.check_objectclass(ldap, dn, entry_attrs)
         self.obj.convert_usercertificate_pre(entry_attrs)
+        self.obj.handle_subordinate_ids(ldap, dn, entry_attrs)
         self.preserve_krbprincipalname_pre(ldap, entry_attrs, *keys, **options)
         update_samba_attrs(ldap, dn, entry_attrs, **options)
 
@@ -968,3 +1133,98 @@ class baseuser_remove_certmapdata(ModCertMapData,
                                   LDAPRemoveAttribute):
     __doc__ = _("Remove one or more certificate mappings from the user entry.")
     msg_summary = _('Removed certificate mappings from user "%(value)s"')
+
+
+class baseuser_auto_subid(LDAPQuery):
+    __doc__ = _("Auto-assign subuid and subgid range to user entry")
+
+    has_output = output.standard_entry
+
+    def execute(self, cn, **options):
+        ldap = self.obj.backend
+        dn = self.obj.get_dn(cn)
+
+        try:
+            entry_attrs = ldap.get_entry(
+                dn, ["objectclass", "ipasubuidnumber"]
+            )
+        except errors.NotFound:
+            raise self.obj.handle_not_found(cn)
+
+        if "ipasubuidnumber" in entry_attrs:
+            raise errors.AlreadyContainsValueError(attr="ipasubuidnumber")
+
+        self.obj.set_subordinate_ids(ldap, dn, entry_attrs, subuid=DNA_MAGIC)
+        ldap.update_entry(entry_attrs)
+
+        # fetch updated entry (use search display attribute to show subids)
+        if options.get('all', False):
+            attrs_list = ['*'] + self.obj.search_display_attributes
+        else:
+            attrs_list = set(self.obj.search_display_attributes)
+            attrs_list.update(entry_attrs.keys())
+            if options.get('no_members', False):
+                attrs_list.difference_update(self.obj.attribute_members)
+            attrs_list = list(attrs_list)
+
+        entry = self._exc_wrapper((cn,), options, ldap.get_entry)(
+            dn, attrs_list
+        )
+        entry_attrs = entry_to_dict(entry, **options)
+        entry_attrs['dn'] = dn
+
+        return dict(result=entry_attrs, value=pkey_to_value(cn, options))
+
+
+class baseuser_match_subid(baseuser_find):
+    __doc__ = _("Match users by any subordinate uid in their range")
+
+    _subid_attrs = {
+        "ipasubuidnumber",
+        "ipasubuidcount",
+        "ipasubgidnumber",
+        "ipasubgidcount"
+    }
+
+    def get_options(self):
+        base_options = {p.name for p in self.obj.takes_params}
+        for option in super().get_options():
+            if option.name == "ipasubuidnumber":
+                yield option.clone(
+                    label=_('SubUID match'),
+                    doc=_('Match value for subordinate user ID'),
+                    required=True,
+                )
+            elif option.name not in base_options:
+                # raw, version
+                yield option.clone()
+
+    def pre_callback(
+        self, ldap, filters, attrs_list, base_dn, scope, *args, **options
+    ):
+        # search for candidates in range
+        # Code assumes that no subordinate count is larger than SUBID_COUNT
+        filters = self.obj.get_subid_match_candidate_filter(
+            ldap, subuid=options["ipasubuidnumber"], subgid=None,
+        )
+        # always include subid attributes
+        for missing in self._subid_attrs.difference(attrs_list):
+            attrs_list.append(missing)
+
+        return filters, base_dn, scope
+
+    def post_callback(self, ldap, entries, truncated, *args, **options):
+        # filter out mismatches manually
+        osubuid = options["ipasubuidnumber"]
+        new_entries = []
+        for entry in entries:
+            esubuid = int(entry.single_value["ipasubuidnumber"])
+            esubcount = int(entry.single_value["ipasubuidcount"])
+            minsubuid = esubuid
+            maxsubuid = esubuid + esubcount - 1
+            if minsubuid <= osubuid <= maxsubuid:
+                new_entries.append(entry)
+
+        entries[:] = new_entries
+
+        return truncated

--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -121,6 +121,7 @@ class config(LDAPObject):
         'ipapwdexpadvnotify', 'ipaselinuxusermaporder',
         'ipaselinuxusermapdefault', 'ipaconfigstring', 'ipakrbauthzdata',
         'ipauserauthtype', 'ipadomainresolutionorder', 'ipamaxhostnamelength',
+        'ipauserdefaultsubordinateid',
     ]
     container_dn = DN(('cn', 'ipaconfig'), ('cn', 'etc'))
     permission_filter_objectclasses = ['ipaguiconfig']
@@ -142,7 +143,7 @@ class config(LDAPObject):
                 'ipasearchrecordslimit', 'ipasearchtimelimit',
                 'ipauserauthtype', 'ipauserobjectclasses',
                 'ipausersearchfields', 'ipacustomfields',
-                'ipamaxhostnamelength',
+                'ipamaxhostnamelength', 'ipauserdefaultsubordinateid',
             },
         },
     }
@@ -261,6 +262,11 @@ class config(LDAPObject):
             values=(u'password', u'radius', u'otp',
                     u'pkinit', u'hardened', u'disabled'),
         ),
+        Bool('ipauserdefaultsubordinateid?',
+             cli_name='user_default_subid',
+             label=_('Enable adding subids to new users'),
+             doc=_('Enable adding subids to new users'),
+             ),
         Str(
             'ipa_master_server*',
             label=_('IPA masters'),

--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -205,6 +205,7 @@ class idrange(LDAPObject):
     # The commented range types are planned but not yet supported
     range_types = {
         u'ipa-local': unicode(_('local domain range')),
+        # u'ipa-local-subid': unicode(_('local domain subid range')),
         # u'ipa-ad-winsync': unicode(_('Active Directory winsync range')),
         u'ipa-ad-trust': unicode(_('Active Directory domain range')),
         u'ipa-ad-trust-posix': unicode(_('Active Directory trust range with '
@@ -221,10 +222,14 @@ class idrange(LDAPObject):
         Int('ipabaseid',
             cli_name='base_id',
             label=_("First Posix ID of the range"),
+            minvalue=1,
+            maxvalue=Int.MAX_UINT32
         ),
         Int('ipaidrangesize',
             cli_name='range_size',
             label=_("Number of IDs in the range"),
+            minvalue=1,
+            maxvalue=Int.MAX_UINT32
         ),
         Int('ipabaserid?',
             cli_name='rid_base',
@@ -669,7 +674,10 @@ class idrange_mod(LDAPUpdate):
         except errors.NotFound:
             raise self.obj.handle_not_found(*keys)
 
-        if old_attrs['iparangetype'][0] == 'ipa-local':
+        if (
+            old_attrs['iparangetype'][0] in {'ipa-local', 'ipa-local-subid'}
+            or old_attrs['cn'][0] == f'{self.api.env.realm}_subid_range'
+        ):
             raise errors.ExecutionError(
                 message=_('This command can not be used to change ID '
                           'allocation for local IPA domain. Run '

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1547,6 +1547,13 @@ class i18n_messages(Command):
                     "Drive to mount a home directory"
                 ),
             },
+            "subordinate": {
+                "identity": _("Subordinate user and group id"),
+                "subuidnumber": _("Subordinate user id"),
+                "subuidcount": _("Subordinate user id count"),
+                "subgidnumber": _("Subordinate group id"),
+                "subgidcount": _("Subordinate group id count"),
+            },
             "trustconfig": {
                 "options": _("Options"),
             },
@@ -1569,6 +1576,11 @@ class i18n_messages(Command):
                 ),
                 "add_into_sudo": _(
                     "Add user '${primary_key}' into sudo rules"
+                ),
+                "auto_subid": _("Auto assign subordinate ids"),
+                "auto_subid_confirm": _(
+                    "Are you sure you want to auto-assign a subordinate id "
+                    "to user ${object}?"
                 ),
                 "contact": _("Contact Settings"),
                 "delete_mode": _("Delete mode"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1547,7 +1547,7 @@ class i18n_messages(Command):
                     "Drive to mount a home directory"
                 ),
             },
-            "subordinate": {
+            "subid": {
                 "identity": _("Subordinate user and group id"),
                 "subuidnumber": _("Subordinate user id"),
                 "subuidcount": _("Subordinate user id count"),

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1364,6 +1364,20 @@ class i18n_messages(Command):
                 "undel_success": _("${count} user(s) restored"),
                 "user_categories": _("User categories"),
             },
+            "subid": {
+                "add": _("Add subid"),
+                "assigned_subids": _("Assigned subids"),
+                "baseid": _("Base ID"),
+                "dna_remaining": _("DNA remaining"),
+                "ipaowner": _("Owner"),
+                "ipasubgidcount": _("SubGID range size"),
+                "ipasubgidnumber": _("SubGID range start"),
+                "ipasubuidcount": _("SubUID range size"),
+                "ipasubuidnumber": _("SubUID range start"),
+                "rangesize": _("Range size"),
+                "remaining_subids": _("Remaining subids"),
+                "stats": _("Subordinate ID Statistics"),
+            },
             "sudocmd": {
                 "add": _("Add sudo command"),
                 "add_into_sudocmdgroups": _(
@@ -1546,13 +1560,6 @@ class i18n_messages(Command):
                 "ipanthomedirectorydrive_tooltip": _(
                     "Drive to mount a home directory"
                 ),
-            },
-            "subid": {
-                "identity": _("Subordinate user and group id"),
-                "subuidnumber": _("Subordinate user id"),
-                "subuidcount": _("Subordinate user id count"),
-                "subgidnumber": _("Subordinate group id"),
-                "subgidcount": _("Subordinate group id count"),
             },
             "trustconfig": {
                 "options": _("Options"),
@@ -1942,6 +1949,7 @@ class i18n_messages(Command):
             "network_services": _("Network Services"),
             "policy": _("Policy"),
             "role": _("Role-Based Access Control"),
+            "subid": _("Subordinate IDs"),
             "sudo": _("Sudo"),
             "topology": _("Topology"),
             "trust": _("Trusts"),

--- a/ipaserver/plugins/subid.py
+++ b/ipaserver/plugins/subid.py
@@ -1,0 +1,608 @@
+#
+# Copyright (C) 2021  FreeIPA Contributors see COPYING for license
+#
+
+import random
+import uuid
+
+from ipalib import api
+from ipalib import constants
+from ipalib import errors
+from ipalib import output
+from ipalib.plugable import Registry
+from ipalib.parameters import Int, Str
+from ipalib.request import context
+from ipalib.text import _, ngettext
+from ipapython.dn import DN
+
+from .baseldap import (
+    LDAPObject,
+    LDAPCreate,
+    LDAPDelete,
+    LDAPUpdate,
+    LDAPSearch,
+    LDAPRetrieve,
+    LDAPQuery,
+    DNA_MAGIC,
+)
+
+__doc__ = _(
+    """
+Subordinate ids
+
+Manage subordinate user and group ids for users
+
+EXAMPLES:
+
+ Auto-assign a subordinate id range to current user
+   ipa subid-generate
+
+ Auto-assign a subordinate id range to user alice:
+   ipa subid-generate --owner=alice
+
+ Find subordinate ids for user alice:
+   ipa subid-find --owner=alice
+
+ Match entry by any subordinate uid in range:
+   ipa subid-match --subuid=2147483649
+"""
+)
+
+register = Registry()
+
+
+@register()
+class subid(LDAPObject):
+    """Subordinate id object."""
+
+    container_dn = api.env.container_subids
+
+    object_name = _("Subordinate id")
+    object_name_plural = _("Subordinate ids")
+    label = _("Subordinate ids")
+    label_singular = _("Subordinate id")
+
+    object_class = ["ipasubordinateidentry"]
+    possible_objectclasses = [
+        "ipasubordinategid",
+        "ipasubordinateuid",
+        "ipasubordinateid",
+    ]
+    default_attributes = [
+        "ipauniqueid",
+        "ipaowner",
+        "ipasubuidnumber",
+        "ipasubuidcount",
+        "ipasubgidnumber",
+        "ipasubgidcount",
+    ]
+    allow_rename = False
+
+    permission_filter_objectclasses_string = (
+        "(objectclass=ipasubordinateidentry)"
+    )
+    managed_permissions = {
+        # all authenticated principals can read subordinate id information
+        "System: Read Subordinate Id Attributes": {
+            "ipapermbindruletype": "all",
+            "ipapermright": {"read", "search", "compare"},
+            "ipapermtargetfilter": [
+                permission_filter_objectclasses_string,
+            ],
+            "ipapermdefaultattr": {
+                "objectclass",
+                "ipauniqueid",
+                "description",
+                "ipaowner",
+                "ipasubuidnumber",
+                "ipasubuidcount",
+                "ipasubgidnumber",
+                "ipasubgidcount",
+            },
+        },
+        "System: Read Subordinate Id Count": {
+            "ipapermbindruletype": "all",
+            "ipapermright": {"read", "search", "compare"},
+            "ipapermtargetfilter": [],
+            "ipapermtarget": DN(container_dn, api.env.basedn),
+            "ipapermdefaultattr": {"numSubordinates"},
+        },
+        # user administrators can remove subordinate ids or update the
+        # ipaowner attribute. This enables user admins to remove users
+        # with assigned subids or move them to staging area (--preserve).
+        "System: Manage Subordinate Ids": {
+            "ipapermright": {"write"},
+            "ipapermtargetfilter": [
+                permission_filter_objectclasses_string,
+            ],
+            "ipapermdefaultattr": {
+                "description",
+                "ipaowner",  # allow user admins to preserve users
+            },
+            "default_privileges": {"User Administrators"},
+        },
+        "System: Remove Subordinate Ids": {
+            "ipapermright": {"delete"},
+            "ipapermtargetfilter": [
+                permission_filter_objectclasses_string,
+            ],
+            "default_privileges": {"User Administrators"},
+        },
+    }
+
+    takes_params = (
+        Str(
+            "ipauniqueid",
+            cli_name="id",
+            label=_("Unique ID"),
+            primary_key=True,
+            flags={"optional_create"},
+        ),
+        Str(
+            "description?",
+            cli_name="desc",
+            label=_("Description"),
+            doc=_("Subordinate id description"),
+        ),
+        Str(
+            "ipaowner",
+            cli_name="owner",
+            label=_("Owner"),
+            doc=_("Owning user of subordinate id entry"),
+            flags={"no_update"},
+        ),
+        Int(
+            "ipasubuidnumber?",
+            label=_("SubUID range start"),
+            cli_name="subuid",
+            doc=_("Start value for subordinate user ID (subuid) range"),
+            flags={"no_update"},
+            minvalue=constants.SUBID_RANGE_START,
+            maxvalue=constants.SUBID_RANGE_MAX,
+        ),
+        Int(
+            "ipasubuidcount?",
+            label=_("SubUID range size"),
+            cli_name="subuidcount",
+            doc=_("Subordinate user ID count"),
+            flags={"no_create", "no_update", "no_search"},  # auto-assigned
+            minvalue=constants.SUBID_COUNT,
+            maxvalue=constants.SUBID_COUNT,
+        ),
+        Int(
+            "ipasubgidnumber?",
+            label=_("SubGID range start"),
+            cli_name="subgid",
+            doc=_("Start value for subordinate group ID (subgid) range"),
+            flags={"no_create", "no_update"},  # auto-assigned
+            minvalue=constants.SUBID_RANGE_START,
+            maxvalue=constants.SUBID_RANGE_MAX,
+        ),
+        Int(
+            "ipasubgidcount?",
+            label=_("SubGID range size"),
+            cli_name="subgidcount",
+            doc=_("Subordinate group ID count"),
+            flags={"no_create", "no_update", "no_search"},  # auto-assigned
+            minvalue=constants.SUBID_COUNT,
+            maxvalue=constants.SUBID_COUNT,
+        ),
+    )
+
+    def fixup_objectclass(self, entry_attrs):
+        """Add missing object classes to entry"""
+        has_subuid = "ipasubuidnumber" in entry_attrs
+        has_subgid = "ipasubgidnumber" in entry_attrs
+
+        candicates = set(self.object_class)
+        if has_subgid:
+            candicates.add("ipasubordinategid")
+        if has_subuid:
+            candicates.add("ipasubordinateuid")
+        if has_subgid and has_subuid:
+            candicates.add("ipasubordinateid")
+
+        entry_oc = entry_attrs.setdefault("objectclass", [])
+        current_oc = {x.lower() for x in entry_oc}
+        for oc in candicates.difference(current_oc):
+            entry_oc.append(oc)
+
+    def handle_duplicate_entry(self, *keys):
+        if hasattr(context, "subid_owner_dn"):
+            uid = context.subid_owner_dn[0].value
+            msg = _(
+                '%(oname)s with with name "%(pkey)s" or for user "%(uid)s" '
+                "already exists."
+            ) % {
+                "uid": uid,
+                "pkey": keys[-1] if keys else "",
+                "oname": self.object_name,
+            }
+            raise errors.DuplicateEntry(message=msg) from None
+        else:
+            super().handle_duplicate_entry(*keys)
+
+    def convert_owner(self, entry_attrs, options):
+        """Change owner from DN to uid string"""
+        if not options.get("raw", False) and "ipaowner" in entry_attrs:
+            userobj = self.api.Object.user
+            entry_attrs["ipaowner"] = [
+                userobj.get_primary_key_from_dn(entry_attrs["ipaowner"][0])
+            ]
+
+    def get_owner_dn(self, *keys, **options):
+        """Get owning user entry entry (username or DN)"""
+        owner = keys[-1]
+        userobj = self.api.Object.user
+        if isinstance(owner, DN):
+            # it's already a DN, validate it's either an active or preserved
+            # user. Ref integrity plugin checks that it's not a dangling DN.
+            user_dns = (
+                DN(userobj.active_container_dn, self.api.env.basedn),
+                DN(userobj.delete_container_dn, self.api.env.basedn),
+            )
+            if not owner.endswith(user_dns):
+                raise errors.ValidationError(
+                    name="ipaowner",
+                    error=_("'%(dn)s is not a valid user") % {"dn": owner},
+                )
+            return owner
+
+        # similar to user.get_either_dn() but with error reporting and
+        # returns an entry
+        ldap = self.backend
+        try:
+            active_dn = userobj.get_dn(owner, **options)
+            entry = ldap.get_entry(active_dn, attrs_list=[])
+            return entry.dn
+        except errors.NotFound:
+            # fall back to deleted user
+            try:
+                delete_dn = userobj.get_delete_dn(owner, **options)
+                entry = ldap.get_entry(delete_dn, attrs_list=[])
+                return entry.dn
+            except errors.NotFound:
+                raise userobj.handle_not_found(owner)
+
+    def handle_subordinate_ids(self, ldap, dn, entry_attrs):
+        """Handle ipaSubordinateId object class"""
+        new_subuid = entry_attrs.single_value.get("ipasubuidnumber")
+        new_subgid = entry_attrs.single_value.get("ipasubgidnumber")
+
+        if new_subuid is None:
+            new_subuid = DNA_MAGIC
+
+        # enforce subuid == subgid
+        if new_subgid is not None and new_subgid != new_subuid:
+            raise errors.ValidationError(
+                name="ipasubgidnumber",
+                error=_("subgidnumber must be equal to subuidnumber"),
+            )
+
+        self.set_subordinate_ids(ldap, dn, entry_attrs, new_subuid)
+        return True
+
+    def set_subordinate_ids(self, ldap, dn, entry_attrs, subuid):
+        """Set subuid value of an entry
+
+        Takes care of objectclass and sibbling attributes
+        """
+        if "objectclass" not in entry_attrs:
+            _entry_attrs = ldap.get_entry(dn, ["objectclass"])
+            entry_attrs["objectclass"] = _entry_attrs["objectclass"]
+
+        # XXX HACK, remove later
+        if subuid == DNA_MAGIC:
+            subuid = self._fake_dna_plugin(ldap, dn, entry_attrs)
+
+        entry_attrs["ipasubuidnumber"] = subuid
+        # enforice subuid == subgid for now
+        entry_attrs["ipasubgidnumber"] = subuid
+        # hard-coded constants
+        entry_attrs["ipasubuidcount"] = constants.SUBID_COUNT
+        entry_attrs["ipasubgidcount"] = constants.SUBID_COUNT
+
+        self.fixup_objectclass(entry_attrs)
+
+    def get_subid_match_candidate_filter(
+        self,
+        ldap,
+        *,
+        subuid,
+        subgid,
+        extra_filters=(),
+        offset=None,
+    ):
+        """Create LDAP filter to locate matching/overlapping subids"""
+        if subuid is None and subgid is None:
+            raise ValueError("subuid and subgid are both None")
+        if offset is None:
+            # assumes that no subordinate count is larger than SUBID_COUNT
+            offset = constants.SUBID_COUNT - 1
+
+        class_filters = "(objectclass=ipasubordinateid)"
+        subid_filters = []
+        if subuid is not None:
+            subid_filters.append(
+                ldap.combine_filters(
+                    [
+                        f"(ipasubuidnumber>={subuid - offset})",
+                        f"(ipasubuidnumber<={subuid + offset})",
+                    ],
+                    rules=ldap.MATCH_ALL,
+                )
+            )
+        if subgid is not None:
+            subid_filters.append(
+                ldap.combine_filters(
+                    [
+                        f"(ipasubgidnumber>={subgid - offset})",
+                        f"(ipasubgidnumber<={subgid + offset})",
+                    ],
+                    rules=ldap.MATCH_ALL,
+                )
+            )
+
+        subid_filters = ldap.combine_filters(
+            subid_filters, rules=ldap.MATCH_ANY
+        )
+        filters = [class_filters, subid_filters]
+        filters.extend(extra_filters)
+        return ldap.combine_filters(filters, rules=ldap.MATCH_ALL)
+
+    def _fake_dna_plugin(self, ldap, dn, entry_attrs):
+        """XXX HACK, remove when 389-DS DNA plugin supports steps"""
+        return (
+            constants.SUBID_RANGE_START
+            + random.randint(1, 32764 - 2) * constants.SUBID_COUNT
+        )
+
+
+@register()
+class subid_add(LDAPCreate):
+    __doc__ = _("Add a new subordinate id.")
+    msg_summary = _('Added subordinate id "%(value)s"')
+
+    # internal command, use subid-auto to auto-assign subids
+    NO_CLI = True
+
+    def pre_callback(
+        self, ldap, dn, entry_attrs, attrs_list, *keys, **options
+    ):
+        # XXX let ref integrity plugin validate DN?
+        owner_dn = self.obj.get_owner_dn(entry_attrs["ipaowner"], **options)
+        context.subid_owner_dn = owner_dn
+        entry_attrs["ipaowner"] = owner_dn
+
+        self.obj.handle_subordinate_ids(ldap, dn, entry_attrs)
+        attrs_list.append("objectclass")
+
+        return dn
+
+    def execute(self, ipauniqueid=None, **options):
+        if ipauniqueid is None:
+            ipauniqueid = str(uuid.uuid4())
+        return super().execute(ipauniqueid, **options)
+
+    def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
+        self.obj.convert_owner(entry_attrs, options)
+        return super(subid_add, self).post_callback(
+            ldap, dn, entry_attrs, *keys, **options
+        )
+
+
+@register()
+class subid_del(LDAPDelete):
+    __doc__ = _("Delete a subordinate id.")
+    msg_summary = _('Deleted subordinate id "%(value)s"')
+
+    # internal command, subids cannot be removed
+    NO_CLI = True
+
+
+@register()
+class subid_mod(LDAPUpdate):
+    __doc__ = _("Modify a subordinate id.")
+    msg_summary = _('Modified subordinate id "%(value)s"')
+
+    def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
+        self.obj.convert_owner(entry_attrs, options)
+        return super(subid_mod, self).post_callback(
+            ldap, dn, entry_attrs, *keys, **options
+        )
+
+
+@register()
+class subid_find(LDAPSearch):
+    __doc__ = _("Search for subordinate id.")
+    msg_summary = ngettext(
+        "%(count)d subordinate id matched",
+        "%(count)d subordinate ids matched",
+        0,
+    )
+
+    def pre_callback(
+        self, ldap, filters, attrs_list, base_dn, scope, *args, **options
+    ):
+        attrs_list.append("objectclass")
+        return super(subid_find, self).pre_callback(
+            ldap, filters, attrs_list, base_dn, scope, *args, **options
+        )
+
+    def args_options_2_entry(self, *args, **options):
+        entry_attrs = super(subid_find, self).args_options_2_entry(
+            *args, **options
+        )
+        owner = entry_attrs.get("ipaowner")
+        if owner is not None:
+            owner_dn = self.obj.get_owner_dn(owner, **options)
+            entry_attrs["ipaowner"] = owner_dn
+        return entry_attrs
+
+    def post_callback(self, ldap, entries, truncated, *args, **options):
+        for entry in entries:
+            self.obj.convert_owner(entry, options)
+        return super(subid_find, self).post_callback(
+            ldap, entries, truncated, *args, **options
+        )
+
+
+@register()
+class subid_show(LDAPRetrieve):
+    __doc__ = _("Display information about a subordinate id.")
+
+    def pre_callback(self, ldap, dn, attrs_list, *keys, **options):
+        attrs_list.append("objectclass")
+        return super(subid_show, self).pre_callback(
+            ldap, dn, attrs_list, *keys, **options
+        )
+
+    def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
+        self.obj.convert_owner(entry_attrs, options)
+        return super(subid_show, self).post_callback(
+            ldap, dn, entry_attrs, *keys, **options
+        )
+
+
+@register()
+class subid_generate(LDAPQuery):
+    __doc__ = _(
+        "Generate and auto-assign subuid and subgid range to user entry"
+    )
+
+    has_output = output.standard_entry
+
+    takes_options = LDAPQuery.takes_options + (
+        Str(
+            "ipaowner?",
+            cli_name="owner",
+            label=_("Owner"),
+            doc=_("Owning user of subordinate id entry"),
+        ),
+    )
+
+    def get_args(self):
+        return []
+
+    def execute(self, *keys, **options):
+        owner_uid = options.get("ipaowner")
+        # default to current user
+        if owner_uid is None:
+            owner_dn = DN(self.api.Backend.ldap2.conn.whoami_s()[4:])
+            # validate it's a user and not a service or host
+            owner_dn = self.obj.get_owner_dn(owner_dn)
+            owner_uid = owner_dn[0].value
+
+        return self.api.Command.subid_add(
+            description="auto-assigned subid",
+            ipaowner=owner_uid,
+            version=options["version"],
+        )
+
+
+@register()
+class subid_match(subid_find):
+    __doc__ = _("Match users by any subordinate uid in their range")
+
+    def get_options(self):
+        base_options = {p.name for p in self.obj.takes_params}
+        for option in super().get_options():
+            if option.name == "ipasubuidnumber":
+                yield option.clone(
+                    label=_("SubUID match"),
+                    doc=_("Match value for subordinate user ID"),
+                    required=True,
+                )
+            elif option.name not in base_options:
+                # raw, version
+                yield option.clone()
+
+    def pre_callback(
+        self, ldap, filters, attrs_list, base_dn, scope, *args, **options
+    ):
+        # search for candidates in range
+        # Code assumes that no subordinate count is larger than SUBID_COUNT
+        filters = self.obj.get_subid_match_candidate_filter(
+            ldap,
+            subuid=options["ipasubuidnumber"],
+            subgid=None,
+        )
+        attrs_list.extend(self.obj.default_attributes)
+
+        return filters, base_dn, scope
+
+    def post_callback(self, ldap, entries, truncated, *args, **options):
+        # filter out mismatches manually
+        osubuid = options["ipasubuidnumber"]
+        new_entries = []
+        for entry in entries:
+            esubuid = int(entry.single_value["ipasubuidnumber"])
+            esubcount = int(entry.single_value["ipasubuidcount"])
+            minsubuid = esubuid
+            maxsubuid = esubuid + esubcount - 1
+            if minsubuid <= osubuid <= maxsubuid:
+                new_entries.append(entry)
+
+        entries[:] = new_entries
+
+        return truncated
+
+
+@register()
+class subid_stats(LDAPQuery):
+    __doc__ = _("Subordinate id statistics")
+
+    takes_options = ()
+    has_output = (
+        output.summary,
+        output.Entry("result"),
+    )
+
+    def get_args(self):
+        return ()
+
+    def get_remaining_dna(self, ldap, **options):
+        base_dn = DN(
+            self.api.env.container_dna_subordinate_ids, self.api.env.basedn
+        )
+        entries, _truncated = ldap.find_entries(
+            "(objectClass=dnaSharedConfig)",
+            attrs_list=["dnaRemainingValues"],
+            base_dn=base_dn,
+            scope=ldap.SCOPE_ONELEVEL,
+        )
+        return sum(
+            int(entry.single_value["dnaRemainingValues"]) for entry in entries
+        )
+
+    def get_idrange(self, ldap, **options):
+        cn = f"{self.api.env.realm}_subid_range"
+        result = self.api.Command.idrange_show(cn, version=options["version"])
+        baseid = int(result["result"]["ipabaseid"][0])
+        rangesize = int(result["result"]["ipaidrangesize"][0])
+        return baseid, rangesize
+
+    def get_subid_assigned(self, ldap, **options):
+        dn = DN(self.api.env.container_subids, self.api.env.basedn)
+        entry = ldap.get_entry(dn=dn, attrs_list=["numSubordinates"])
+        return int(entry.single_value["numSubordinates"])
+
+    def execute(self, *keys, **options):
+        ldap = self.obj.backend
+        dna_remaining = self.get_remaining_dna(ldap, **options)
+        baseid, rangesize = self.get_idrange(ldap, **options)
+        assigned_subids = self.get_subid_assigned(ldap, **options)
+        remaining_subids = dna_remaining // constants.SUBID_COUNT
+        return dict(
+            summary=_("%(remaining)i remaining subordinate id ranges")
+            % {
+                "remaining": remaining_subids,
+            },
+            result=dict(
+                baseid=baseid,
+                rangesize=rangesize,
+                dna_remaining=dna_remaining,
+                assigned_subids=assigned_subids,
+                remaining_subids=remaining_subids,
+            ),
+        )

--- a/ipaserver/plugins/subid.py
+++ b/ipaserver/plugins/subid.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2021  FreeIPA Contributors see COPYING for license
 #
 
-import random
 import uuid
 
 from ipalib import api
@@ -291,12 +290,8 @@ class subid(LDAPObject):
             _entry_attrs = ldap.get_entry(dn, ["objectclass"])
             entry_attrs["objectclass"] = _entry_attrs["objectclass"]
 
-        # XXX HACK, remove later
-        if subuid == DNA_MAGIC:
-            subuid = self._fake_dna_plugin(ldap, dn, entry_attrs)
-
         entry_attrs["ipasubuidnumber"] = subuid
-        # enforice subuid == subgid for now
+        # enforce subuid == subgid for now
         entry_attrs["ipasubgidnumber"] = subuid
         # hard-coded constants
         entry_attrs["ipasubuidcount"] = constants.SUBID_COUNT
@@ -349,13 +344,6 @@ class subid(LDAPObject):
         filters = [class_filters, subid_filters]
         filters.extend(extra_filters)
         return ldap.combine_filters(filters, rules=ldap.MATCH_ALL)
-
-    def _fake_dna_plugin(self, ldap, dn, entry_attrs):
-        """XXX HACK, remove when 389-DS DNA plugin supports steps"""
-        return (
-            constants.SUBID_RANGE_START
-            + random.randint(1, 32764 - 2) * constants.SUBID_COUNT
-        )
 
 
 @register()

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -50,7 +50,10 @@ from .baseuser import (
     baseuser_add_principal,
     baseuser_remove_principal,
     baseuser_add_certmapdata,
-    baseuser_remove_certmapdata)
+    baseuser_remove_certmapdata,
+    baseuser_auto_subid,
+    baseuser_match_subid,
+)
 from .idviews import remove_ipaobject_overrides
 from ipalib.plugable import Registry
 from .baseldap import (
@@ -202,6 +205,8 @@ class user(baseuser):
             'ipapermright': {'read', 'search', 'compare'},
             'ipapermdefaultattr': {
                 'ipauniqueid', 'ipasshpubkey', 'ipauserauthtype', 'userclass',
+                'ipasubuidnumber', 'ipasubuidcount', 'ipasubgidnumber',
+                'ipasubgidcount',
             },
             'fixup_function': fix_addressbook_permission_bindrule,
         },
@@ -1306,3 +1311,13 @@ class user_add_principal(baseuser_add_principal):
 class user_remove_principal(baseuser_remove_principal):
     __doc__ = _('Remove principal alias from the user entry')
     msg_summary = _('Removed aliases from user "%(value)s"')
+
+
+@register()
+class user_auto_subid(baseuser_auto_subid):
+    __doc__ = baseuser_auto_subid.__doc__
+
+
+@register()
+class user_match_subid(baseuser_match_subid):
+    __doc__ = baseuser_match_subid.__doc__

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -298,3 +298,15 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
+
+  fedora-latest/test_subids:
+    requires: [fedora-latest/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_subids.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/test_integration/test_subids.py
+++ b/ipatests/test_integration/test_subids.py
@@ -1,0 +1,201 @@
+#
+# Copyright (C) 2021  FreeIPA Contributors see COPYING for license
+#
+
+"""Tests for subordinate ids
+"""
+import os
+
+from ipalib.constants import SUBID_COUNT, SUBID_RANGE_START, SUBID_RANGE_MAX
+from ipaplatform.paths import paths
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestSubordinateId(IntegrationTest):
+    num_replicas = 0
+    topology = "star"
+
+    def _parse_result(self, result):
+        info = {}
+        for line in result.stdout_text.split("\n"):
+            line = line.strip()
+            if line:
+                if ":" not in line:
+                    continue
+                k, v = line.split(":", 1)
+                k = k.strip()
+                v = v.strip()
+                try:
+                    v = int(v, 10)
+                except ValueError:
+                    if v == "FALSE":
+                        v = False
+                    elif v == "TRUE":
+                        v = True
+                info.setdefault(k.lower(), []).append(v)
+
+        for k, v in info.items():
+            if len(v) == 1:
+                info[k] = v[0]
+            else:
+                info[k] = set(v)
+        return info
+
+    def get_user(self, uid):
+        cmd = ["ipa", "user-show", "--all", "--raw", uid]
+        result = self.master.run_command(cmd)
+        return self._parse_result(result)
+
+    def user_auto_subid(self, uid, **kwargs):
+        cmd = ["ipa", "user-auto-subid", uid]
+        return self.master.run_command(cmd, **kwargs)
+
+    def test_auto_subid(self):
+        tasks.kinit_admin(self.master)
+        uid = "testuser_auto1"
+        tasks.user_add(self.master, uid)
+        info = self.get_user(uid)
+        assert "ipasubuidcount" not in info
+
+        self.user_auto_subid(uid)
+        info = self.get_user(uid)
+        assert "ipasubuidcount" in info
+
+        subuid = info["ipasubuidnumber"]
+        result = self.master.run_command(
+            ["ipa", "user-match-subid", f"--subuid={subuid}", "--raw"]
+        )
+        match = self._parse_result(result)
+        assert match["uid"] == uid
+        assert match["ipasubuidnumber"] == info["ipasubuidnumber"]
+        assert match["ipasubuidnumber"] >= SUBID_RANGE_START
+        assert match["ipasubuidnumber"] <= SUBID_RANGE_MAX
+        assert match["ipasubuidcount"] == SUBID_COUNT
+        assert match["ipasubgidnumber"] == info["ipasubgidnumber"]
+        assert match["ipasubgidnumber"] == match["ipasubuidnumber"]
+        assert match["ipasubgidcount"] == SUBID_COUNT
+
+    def test_ipa_subid_script(self):
+        tasks.kinit_admin(self.master)
+
+        tool = os.path.join(paths.LIBEXEC_IPA_DIR, "ipa-subids")
+        users = []
+        for i in range(1, 11):
+            uid = f"testuser_script{i}"
+            users.append(uid)
+            tasks.user_add(self.master, uid)
+            info = self.get_user(uid)
+            assert "ipasubuidcount" not in info
+
+        cmd = [tool, "--verbose", "--group", "ipausers"]
+        self.master.run_command(cmd)
+
+        for uid in users:
+            info = self.get_user(uid)
+            assert info["ipasubuidnumber"] >= SUBID_RANGE_START
+            assert info["ipasubuidnumber"] <= SUBID_RANGE_MAX
+            assert info["ipasubuidnumber"] == info["ipasubgidnumber"]
+            assert info["ipasubuidcount"] == SUBID_COUNT
+            assert info["ipasubuidcount"] == info["ipasubgidcount"]
+
+    def test_subid_selfservice(self):
+        tasks.kinit_admin(self.master)
+
+        uid = "testuser_selfservice1"
+        password = "Secret123"
+        role = "Subordinate ID Selfservice User"
+
+        tasks.user_add(self.master, uid, password=password)
+        tasks.kinit_user(
+            self.master, uid, f"{password}\n{password}\n{password}\n"
+        )
+        info = self.get_user(uid)
+        assert "ipasubuidcount" not in info
+        result = self.user_auto_subid(uid, raiseonerr=False)
+        assert result.returncode > 0
+
+        tasks.kinit_admin(self.master)
+        self.master.run_command(
+            ["ipa", "role-add-member", role, "--groups=ipausers"]
+        )
+
+        try:
+            tasks.kinit_user(self.master, uid, password)
+            self.user_auto_subid(uid)
+            info = self.get_user(uid)
+            assert "ipasubuidcount" in info
+        finally:
+            tasks.kinit_admin(self.master)
+            self.master.run_command(
+                ["ipa", "role-remove-member", role, "--groups=ipausers"]
+            )
+
+    def test_subid_useradmin(self):
+        tasks.kinit_admin(self.master)
+
+        uid_useradmin = "testuser_usermgr_mgr1"
+        role = "User Administrator"
+        uid = "testuser_usermgr_user1"
+        password = "Secret123"
+
+        # create user administrator
+        tasks.user_add(self.master, uid_useradmin, password=password)
+        # add user to user admin group
+        tasks.kinit_admin(self.master)
+        self.master.run_command(
+            ["ipa", "role-add-member", role, f"--users={uid_useradmin}"],
+        )
+        # kinit as user admin
+        tasks.kinit_user(
+            self.master,
+            uid_useradmin,
+            f"{password}\n{password}\n{password}\n",
+        )
+        # create new user as user admin
+        tasks.user_add(self.master, uid)
+        # assign new subid to user (with useradmin credentials)
+        self.user_auto_subid(uid)
+
+    def test_subordinate_default_objclass(self):
+        tasks.kinit_admin(self.master)
+
+        result = self.master.run_command(
+            ["ipa", "config-show", "--raw", "--all"]
+        )
+        info = self._parse_result(result)
+        usercls = info["ipauserobjectclasses"]
+        assert "ipasubordinateid" not in usercls
+
+        cmd = [
+            "ipa",
+            "config-mod",
+            "--addattr",
+            "ipaUserObjectClasses=ipasubordinateid",
+        ]
+        self.master.run_command(cmd)
+
+        uid = "testuser_usercls1"
+        tasks.user_add(self.master, uid)
+        info = self.get_user(uid)
+        assert "ipasubuidcount" in info
+
+    def test_idrange_subid(self):
+        tasks.kinit_admin(self.master)
+
+        range_name = f"{self.master.domain.realm}_subid_range"
+
+        result = self.master.run_command(
+            ["ipa", "idrange-show", range_name, "--raw"]
+        )
+        info = self._parse_result(result)
+
+        # see https://github.com/SSSD/sssd/issues/5571
+        assert info["iparangetype"] == "ipa-ad-trust"
+        assert info["ipabaseid"] == SUBID_RANGE_START
+        assert info["ipaidrangesize"] == SUBID_RANGE_MAX - SUBID_RANGE_START
+        assert info["ipabaserid"] < SUBID_RANGE_START
+        assert "ipasecondarybaserid" not in info
+        assert info["ipanttrusteddomainsid"].startswith(
+            "S-1-5-21-738065-838566-"
+        )

--- a/ipatests/test_xmlrpc/test_range_plugin.py
+++ b/ipatests/test_xmlrpc/test_range_plugin.py
@@ -24,6 +24,7 @@ Test the `ipaserver/plugins/idrange.py` module, and XML-RPC in general.
 import six
 
 from ipalib import api, errors, messages
+from ipalib import constants
 from ipaplatform import services
 from ipatests.test_xmlrpc.xmlrpc_test import Declarative, fuzzy_uuid
 from ipatests.test_xmlrpc import objectclasses
@@ -46,6 +47,12 @@ rid_shift = 0
 for idrange in api.Command['idrange_find']()['result']:
     size = int(idrange['ipaidrangesize'][0])
     base_id = int(idrange['ipabaseid'][0])
+    rtype = idrange['iparangetype'][0]
+
+    if rtype == 'ipa-local-subid' or base_id == constants.SUBID_RANGE_START:
+        # ignore subordinate id range. It would push values beyond uint32_t.
+        # There is plenty of space below SUBUID_RANGE_START.
+        continue
 
     id_end = base_id + size
     rid_end = 0


### PR DESCRIPTION
New LDAP object class "ipaSubordinateIdEntry" + additional classes with five new attributes:
- ipasubuidnumber / ipasubuidcount
- ipasubgidnumber / ipasgbuidcount
- ipaOwner

New plugin ``subid`` to manage subordinate ids with public commands subid-generate, subid-match, subid-find, subid-show. The commands subid-add and subid-del are internal commands. Users lack permissions to add/del entries.

New permissions and self-service permissions

The code hard-codes counts to 65536, sets subgid equal to subuid, and
does not allow removal of subids. There is also a hack that emulates a
DNA plugin with step interval 65536 for testing.

## TODO

- [X] bike shed on command names ``subid-generate`` and ``subid-match``. Are these names self-explaining and easy to remember?
- [ ] Decide whether we should allow removing subids from users. I decided against it. Subid space is limited and we cannot safely recycle a subid any way.
- [ ] Include a helper script to import subuid and subgids from an existing databases? Customers may have existing ``/etc/subuid`` and ``/etc/subgid`` files.
- [ ] Enforce / check for subid interval overlaps? https://github.com/freeipa/freeipa/pull/5438 has some hacky code.
- [X] Add helper to show how many subid intervals are left, it's ``subid-stats``
- [ ] Should we add a unique check on ``ipaSubUidNumber`` and ``ipaSubGidNumber``?
- [x] explain that IPA's random baseid does not conflict with subid range start.
- [x] Add example how subids are allocated and assign.
- [x] Investigate new ID range type. First attempt to add ``ipa-local-subid`` failed.
- [x] sidgen task fails ``Failed to convert LDAP entry to range struct`` in ``ipa_sidgen_common.c`` because subid_range has no RIDs. Added hack to include RIDs by default.
- [x] Failing sudo test case ``test_domain_resolution_order`` is tracked at https://github.com/SSSD/sssd/issues/5571
- [ ] submit OIDs to RHANANA
- [ ] Mention that systemd's dynamic user feature uses range uids in range 61184 to 65519.
- [ ] Decide how to deal with ``user-del --preserve``. (see design doc for more details)
- [x] Improve WebUI
   - [x] Replace subid-add with subid-generate in user memberOf view
   - [x] Replace subid-add with subid-generate in subid view
   - [x] Show subid-stats
   - [x] Hide delete
   - [x] i18n

See: https://pagure.io/freeipa/issue/8361
Signed-off-by: Christian Heimes <cheimes@redhat.com>