### PR TITLE
[Backport][ipa-4-9] Add pkey_only to the service_find calls in the host plugin

### DIFF
--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -808,7 +808,7 @@ class host_del(LDAPDelete):
         truncated = True
         while truncated:
             try:
-                ret = api.Command['service_find'](fqdn)
+                ret = api.Command['service_find'](fqdn, pkey_only=True)
                 truncated = ret['truncated']
                 services = ret['result']
             except errors.NotFound:
@@ -1205,7 +1205,7 @@ class host_disable(LDAPQuery):
         truncated = True
         while truncated:
             try:
-                ret = api.Command['service_find'](fqdn)
+                ret = api.Command['service_find'](fqdn, pkey_only=True)
                 truncated = ret['truncated']
                 services = ret['result']
             except errors.NotFound:


### PR DESCRIPTION
This PR was opened automatically because PR #5690 was pushed to master and backport to ipa-4-9 is required.