### PR TITLE
WebUI: Handle assertion if multiple notifications are present

### DIFF
--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -2324,10 +2324,10 @@ class UI_driver:
         notification_type = 'div.notification-area .alert-{}'.format(type)
         # wait for a half sec for notification to appear
         self.wait(0.5)
-        is_present = self.find(notification_type, By.CSS_SELECTOR)
+        is_present = self.find(notification_type, By.CSS_SELECTOR, many=True)
         assert is_present, "Notification not present"
         if assert_text:
-            assert assert_text in is_present.text
+            assert any(map(lambda x: assert_text in x.text, is_present))
 
     def assert_last_error_dialog(self, expected_err, details=False,
                                  dialog_name='error_dialog'):


### PR DESCRIPTION
If multiple notifications of the same type are shown at the same
time, assertion works only for the first one. This change enables to
search for notification's content in all shown notifications.
    
Fixes: https://pagure.io/freeipa/issue/8641
    
Signed-off-by: Michal Polovka <mpolovka@redhat.com>
