### PR TITLE
ipa-otpd: handle LDAP timeout in a better way

### DIFF
--- a/daemons/ipa-otpd/bind.c
+++ b/daemons/ipa-otpd/bind.c
@@ -85,9 +85,11 @@ static void on_bind_readable(verto_ctx *vctx, verto_ev *ev)
         if (rslt <= 0)
             results = NULL;
         ldap_msgfree(results);
-        otpd_log_err(EIO, "IO error received on bind socket");
+        otpd_log_err(EIO, "IO error received on bind socket: %s", ldap_err2string(rslt));
         verto_break(ctx.vctx);
-        ctx.exitstatus = 1;
+        /* if result is -1 or 0, connection was closed by the server side
+	 * or the server is down and we should exit gracefully */
+        ctx.exitstatus = (rslt <= 0) ? 0 : 1;
         return;
     }
 


### PR DESCRIPTION
When LDAP server disconnects ipa-otpd client connection due to a
timeout, ipa-otpd instance would stop and report an issue. This confuses
systemd service reporting, so for these situations we better to shut
down gracefully.

Fixes: https://pagure.io/freeipa/issue/6587

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>