### PR TITLE
[Backport][ipa-4-9] Use PyCA crypto provider for KRAClient

### DIFF
--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -253,7 +253,7 @@ import six
 from ipalib import Backend, api, x509
 from ipapython.dn import DN
 import ipapython.cookie
-from ipapython import dogtag, ipautil, certdb
+from ipapython import dogtag, ipautil
 from ipaserver.masters import find_providing_server
 
 import pki
@@ -1957,11 +1957,10 @@ class kra(Backend):
             # TODO: replace this with a more specific exception
             raise RuntimeError('KRA service is not enabled')
 
-        tempdb = certdb.NSSDatabase()
-        tempdb.create_db()
-        crypto = cryptoutil.NSSCryptoProvider(
-            tempdb.secdir,
-            password_file=tempdb.pwd_file)
+        crypto = cryptoutil.CryptographyCryptoProvider(
+            transport_cert_nick="ra_agent",
+            transport_cert=x509.load_certificate_from_file(paths.RA_AGENT_PEM)
+        )
 
         # TODO: obtain KRA host & port from IPA service list or point to KRA load balancer
         # https://fedorahosted.org/freeipa/ticket/4557
@@ -1976,10 +1975,7 @@ class kra(Backend):
         connection.set_authentication_cert(paths.RA_AGENT_PEM,
                                            paths.RA_AGENT_KEY)
 
-        try:
-            yield KRAClient(connection, crypto)
-        finally:
-            tempdb.close()
+        yield KRAClient(connection, crypto)
 
 
 @register()


### PR DESCRIPTION
This PR was opened automatically because PR #5726 was pushed to master and backport to ipa-4-9 is required.