### PR TITLE
Revert the way hosts/services certs are searched for

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1860,7 +1860,9 @@ class cert_find(Search, CertMethod):
         # Do not execute the CA sub-search in CA-less deployment.
         # See https://pagure.io/freeipa/issue/8369.
         if ca_enabled:
-            searches = [self._cert_search, self._ca_search, self._ldap_search]
+            searches = [self._cert_search, self._ca_search]
+            if options.get('status') != 'REVOKED':
+                searches.append(self._ldap_search)
         else:
             searches = [self._cert_search, self._ldap_search]
 

--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -872,7 +872,7 @@ class host_del(LDAPDelete):
 
         if self.api.Command.ca_is_enabled()['result']:
             certs = self.api.Command.cert_find(
-                subject=fqdn, status='VALID'
+                host=fqdn, status='VALID'
             )['result']
             revoke_certs(certs)
 


### PR DESCRIPTION
Revert the way hosts/services certs are searched for
    
This reverts a change that caused all service certs to be
revoked if any other service was deleted.

There is special handling when passing in host, service or
user into cert_find. The _ldap_search method creates
filters for the object which later in cert_find removes
unrelated certificates.
    
https://pagure.io/freeipa/issue/7835

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
