### PR TITLE
pylint: Adapt to new Pylint 2.8

### DIFF
--- a/ipatests/azure/templates/autoconf-fedora.yml
+++ b/ipatests/azure/templates/autoconf-fedora.yml
@@ -7,6 +7,7 @@ steps:
     echo "Running autoconf generator"
     ./autogen.sh \
         ${{ parameters.options }} \
+        --enable-pylint \
         --enable-rpmlint \
 
   displayName: Configure the project

--- a/ipatests/azure/templates/prepare-lint-fedora.yml
+++ b/ipatests/azure/templates/prepare-lint-fedora.yml
@@ -2,6 +2,5 @@ steps:
 - script: |
     set -e
     sudo dnf -y install python3-pip
-    # https://pagure.io/freeipa/issue/8771
-    python3 -m pip install --user --upgrade astroid pylint==2.7.1
+    python3 -m pip install --user --ignore-installed pylint
   displayName: Install Lint dependencies

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -182,50 +182,6 @@ ipa_class_members = {
         'validatedns',
         'normalizedns',
     ],
-    'ipatests.test_integration.base.IntegrationTest': [
-        {'domain': [
-            {'name': dir(str)},
-        ]},
-        {'master': [
-            {'config': [
-                {'dirman_dn': dir(str)},
-                {'dirman_password': dir(str)},
-                {'admin_password': dir(str)},
-                {'admin_name': dir(str)},
-                {'dns_forwarder': dir(str)},
-                {'test_dir': dir(str)},
-                {'ad_admin_name': dir(str)},
-                {'ad_admin_password': dir(str)},
-                {'domain_level': dir(str)},
-                {'fips_mode': dir(bool)},
-            ]},
-            {'domain': [
-                {'basedn': dir(str)},
-                {'realm': dir(str)},
-                {'name': dir(str)},
-            ]},
-            {'external_hostname': dir(str)},
-            {'hostname': dir(str)},
-            'ip',
-            'collect_log',
-            {'run_command': [
-                {'stdout_text': dir(str)},
-                {'stderr_text': dir(str)},
-                'returncode',
-            ]},
-            {'transport': ['put_file', 'file_exists']},
-            'put_file_contents',
-            'get_file_contents',
-            'ldap_connect',
-            {'spawn_expect': ['__enter__', '__exit__']},
-        ]},
-        'replicas',
-        'clients',
-        'ad_domains',
-        {'ads': dir(list)},
-        {'ad_subdomains': dir(list)},
-        {'ad_treedomains': dir(list)},
-    ]
 }
 
 
@@ -576,3 +532,41 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     dns.rdatatype.URI = 0
     """
 ))
+
+AstroidBuilder(MANAGER).string_build(
+    textwrap.dedent(
+        """\
+    from ipatests.test_integration.base import IntegrationTest
+    from ipatests.pytest_ipa.integration.host import Host, WinHost
+    from ipatests.pytest_ipa.integration.config import Config, Domain
+
+
+    class PylintIPAHosts:
+        def __getitem__(self, key):
+            return Host()
+
+
+    class PylintWinHosts:
+        def __getitem__(self, key):
+            return WinHost()
+
+
+    class PylintADDomains:
+        def __getitem__(self, key):
+            return Domain()
+
+
+    Host.config = Config()
+    Host.domain = Domain()
+
+    IntegrationTest.domain = Domain()
+    IntegrationTest.master = Host()
+    IntegrationTest.replicas = PylintIPAHosts()
+    IntegrationTest.clients = PylintIPAHosts()
+    IntegrationTest.ads = PylintWinHosts()
+    IntegrationTest.ad_treedomains = PylintWinHosts()
+    IntegrationTest.ad_subdomains = PylintWinHosts()
+    IntegrationTest.ad_domains = PylintADDomains()
+    """
+    )
+)

--- a/pylintrc
+++ b/pylintrc
@@ -105,6 +105,9 @@ disable=
     f-string-without-interpolation,  # pylint 2.5.0, bare f-strings are ok
     super-with-arguments,  # pylint 2.6.0, zero-length form is syntactic sugar
     raise-missing-from,  # pylint 2.6.0, implicit exception chaining is ok
+    consider-using-with,  # pylint 2.8.0, contextmanager is not mandatory
+    consider-using-max-builtin,  # pylint 2.8.0, can be more readable
+    consider-using-min-builtin,  # pylint 2.8.0, can be more readable
 
 [REPORTS]
 


### PR DESCRIPTION
- globally ignore `consider-using-with`
- fix `consider-using-max-builtin`
- explicitly enable pylint on project configuration
- unpin Pylint
- added transformation for IntegrationTest attributes(will work
  unless explicitly defined)

Fixes: https://pagure.io/freeipa/issue/8818