### PR TITLE
Replace DS replication plugin name

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/nightly_latest_389ds.yaml

--- a/daemons/ipa-slapi-plugins/ipa-version/version-conf.ldif
+++ b/daemons/ipa-slapi-plugins/ipa-version/version-conf.ldif
@@ -13,5 +13,5 @@ nsslapd-pluginversion: 1.0
 nsslapd-pluginvendor: Red Hat, Inc.
 nsslapd-plugindescription: IPA Replication version plugin
 nsslapd-plugin-depends-on-type: database
-nsslapd-plugin-depends-on-named: Multimaster Replication Plugin
+nsslapd-plugin-depends-on-named: Multisupplier Replication Plugin
 

--- a/daemons/ipa-slapi-plugins/topology/ipa-topology-conf.ldif
+++ b/daemons/ipa-slapi-plugins/topology/ipa-topology-conf.ldif
@@ -15,7 +15,7 @@ nsslapd-topo-plugin-shared-binddngroup: cn=replication managers,cn=sysaccounts,c
 nsslapd-topo-plugin-startup-delay: 20
 nsslapd-pluginId: none
 nsslapd-plugin-depends-on-named: ldbm database
-nsslapd-plugin-depends-on-named: Multimaster Replication Plugin
+nsslapd-plugin-depends-on-named: Multisupplier Replication Plugin
 nsslapd-pluginVersion: 1.0
 nsslapd-pluginVendor: none
 nsslapd-pluginDescription: none

--- a/install/updates/10-enable-betxn.update
+++ b/install/updates/10-enable-betxn.update
@@ -18,7 +18,7 @@ only: nsslapd-pluginType: betxnpreoperation
 dn: cn=MemberOf Plugin,cn=plugins,cn=config
 only: nsslapd-pluginType: betxnpostoperation
 
-dn: cn=Multimaster Replication Plugin,cn=plugins,cn=config
+dn: cn=Multisupplier Replication Plugin,cn=plugins,cn=config
 only: nsslapd-pluginbetxn: on
 
 dn: cn=PAM Pass Through Auth,cn=plugins,cn=config

--- a/install/updates/20-enable_dirsrv_plugins.update
+++ b/install/updates/20-enable_dirsrv_plugins.update
@@ -50,8 +50,8 @@ replace: nsslapd-pluginEnabled:off::on
 dn: cn=Managed Entries,cn=plugins,cn=config
 replace: nsslapd-pluginEnabled:off::on
 
-# Multimaster Replication Plugin, plugins, config
-dn: cn=Multimaster Replication Plugin,cn=plugins,cn=config
+# Multisupplier Replication Plugin, plugins, config
+dn: cn=Multisupplier Replication Plugin,cn=plugins,cn=config
 replace: nsslapd-pluginEnabled:off::on
 
 # Roles Plugin, plugins, config

--- a/install/updates/20-replication.update
+++ b/install/updates/20-replication.update
@@ -58,7 +58,7 @@ default: nsslapd-topo-plugin-shared-binddngroup: cn=replication managers,cn=sysa
 default: nsslapd-topo-plugin-startup-delay: 20
 default: nsslapd-pluginId: none
 default: nsslapd-plugin-depends-on-named: ldbm database
-default: nsslapd-plugin-depends-on-named: Multimaster Replication Plugin
+default: nsslapd-plugin-depends-on-named: Multisupplier Replication Plugin
 default: nsslapd-pluginVersion: 1.0
 default: nsslapd-pluginVendor: none
 default: nsslapd-pluginDescription: none

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -738,7 +738,7 @@ class ReplicationManager:
         dn = mtent.dn
 
         plgent = self.conn.get_entry(
-            DN(('cn', 'Multimaster Replication Plugin'), ('cn', 'plugins'),
+            DN(('cn', 'Multisupplier Replication Plugin'), ('cn', 'plugins'),
                ('cn', 'config')),
             ['nsslapd-pluginPath'])
         path = plgent.single_value.get('nsslapd-pluginPath')

--- a/ipatests/test_ipaserver/test_topology_plugin.py
+++ b/ipatests/test_ipaserver/test_topology_plugin.py
@@ -40,7 +40,7 @@ class TestTopologyPlugin:
             u'nsslapd-pluginVendor': [u'freeipa'],
             u'cn': [u'IPA Topology Configuration'],
             u'nsslapd-plugin-depends-on-named':
-                [u'Multimaster Replication Plugin', u'ldbm database'],
+                [u'Multisupplier Replication Plugin', u'ldbm database'],
             u'nsslapd-topo-plugin-shared-replica-root': [u'dc=example,dc=com'],
             u'nsslapd-pluginVersion': [u'1.0'],
             u'nsslapd-topo-plugin-shared-config-base':


### PR DESCRIPTION
In efforts to remove problematic language, like master and slave,
DS is replacing "master" with "supplier" in the replication plugin
entry under cn=config.

DS should be able handle upgrades correctly as well.

relates: https://pagure.io/freeipa/issue/8799