### PR TITLE
Constrain pylint to supported versions 

### DIFF
--- a/.wheelconstraints.in
+++ b/.wheelconstraints.in
@@ -9,5 +9,7 @@ ipapython == @VERSION@
 ipaserver == @VERSION@
 ipatests == @VERSION@
 
-# upstream pylint 1.7.5 fixed bad python3 import of stat module
-pylint >= 1.7.5
+# keep pylint version in sync with current Fedora release
+# F34 has 2.6
+# https://pagure.io/freeipa/issue/8818 added pylint 2.8 support
+pylint < 2.9

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -347,12 +347,8 @@ BuildRequires:  python3-polib
 BuildRequires:  python3-pyasn1
 BuildRequires:  python3-pyasn1-modules
 BuildRequires:  python3-pycodestyle
-%if 0%{?fedora} || 0%{?rhel} > 8
-# https://bugzilla.redhat.com/show_bug.cgi?id=1648299
-BuildRequires:  python3-pylint >= 2.1.1-2
-%else
-BuildRequires:  python3-pylint >= 1.7
-%endif
+# .wheelconstraints.in limits pylint version in Azure and tox tests
+BuildRequires:  python3-pylint
 BuildRequires:  python3-pytest-multihost
 BuildRequires:  python3-pytest-sourceorder
 BuildRequires:  python3-qrcode-core >= 5.0.0

--- a/ipatests/azure/templates/prepare-lint-fedora.yml
+++ b/ipatests/azure/templates/prepare-lint-fedora.yml
@@ -2,5 +2,5 @@ steps:
 - script: |
     set -e
     sudo dnf -y install python3-pip
-    python3 -m pip install --user --ignore-installed pylint
+    python3 -m pip install --user --constraint .wheelconstraints.in --ignore-installed pylint
   displayName: Install Lint dependencies


### PR DESCRIPTION
Two, three times a year PR-CI starts failing because tox tests pull in a
newer version of pylint with new warnings. To reduce breakage this
change constraints pylint (and indirectly astroid) to latest tested
minor version. The constraint should be updated when FreeIPA starts to
support a new Fedora version with more recent pylint.

Related: pagure.io/freeipa/issue/8818
Signed-off-by: Christian Heimes <cheimes@redhat.com>