### PR TITLE
Spec file: bump augeas-libs version

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -160,6 +160,16 @@
 %global systemd_version 239
 %endif
 
+# augeas support for new chrony options
+# see https://pagure.io/freeipa/issue/8676
+# Note: will need to be updated for RHEL9 when a fix is available for
+# https://bugzilla.redhat.com/show_bug.cgi?id=1931787
+%if 0%{?fedora} >= 33
+%global augeas_version 1.12.0-6
+%else
+%global augeas_version 1.12.0-3
+%endif
+
 %global plugin_dir %{_libdir}/dirsrv/plugins
 %global etc_systemd_dir %{_sysconfdir}/systemd/system
 %global gettext_domain ipa
@@ -492,6 +502,7 @@ Requires: %{name}-common = %{version}-%{release}
 # we need pre-requires since earlier versions may break upgrade
 Requires(pre): python3-ldap >= %{python_ldap_version}
 Requires: python3-augeas
+Requires: augeas-libs >= %{augeas_version}
 Requires: python3-custodia >= 0.3.1
 Requires: python3-dbus
 Requires: python3-dns >= 1.15
@@ -715,6 +726,7 @@ Requires: %{name}-client-common = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 Requires: python3-ipalib = %{version}-%{release}
 Requires: python3-augeas
+Requires: augeas-libs >= %{augeas_version}
 Requires: python3-dns >= 1.15
 Requires: python3-jinja2
 


### PR DESCRIPTION
Older augeas does not support new options provided by chrony:
 sourcedir /run/chrony-dhcp
 ntsdumpdir /var/lib/chrony
and is failing to update /etc/chrony.conf in ipa installer.

Bump augeas-libs version to require the fix:
1.12.0-6 on fedora 33+
1.12.0-3 otherwise

Fixes: https://pagure.io/freeipa/issue/8676