### PR TITLE
pkispawn: override the AJP address

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -537,6 +537,11 @@ class CAInstance(DogtagInstance):
         if os.path.exists(paths.IPA_CA_CRT):
             cfg['pki_cert_chain_path'] = paths.IPA_CA_CRT
 
+        # Use IP address instead of default localhost4 and localhost6
+        # because /etc/hosts does not always define them
+        cfg['pki_ajp_host_ipv4'] = "127.0.0.1"
+        cfg['pki_ajp_host_ipv6'] = "::1"
+
         if self.clone:
             if self.no_db_setup:
                 cfg.update(


### PR DESCRIPTION
The /etc/hosts file currently defines the following:
```
127.0.0.1  localhost
::1  localhost
```

but pki defines AJP connectors using localhost4 and localhost6:
```
    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" address="localhost4" name="Connector1" secret="..."/>
    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" address="localhost6" name="Connector2" secret="..."/>
```
(since commit 1906afbeb3c8b7140601be7f9bee2f7fef5b0a5e, in order to fix
rhbz#1780082)

Override the definition with pki_ajp_host_ipv4 = 127.0.0.1 and pki_ajp_host_ipv6 = ::1 in the config file provided to pkispawn.

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>