### PR TITLE
azure: Re-group test envs

### DIFF
--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -17,14 +17,6 @@ vms:
     tests:
     - test_integration/test_forced_client_reenrollment.py
 
-  - container_job: external_ca_ExternalCAInstall
-    tests:
-    - test_integration/test_external_ca.py::TestExternalCAInstall
-
-  - container_job: membermanager
-    tests:
-    - test_integration/test_membermanager.py
-
 - vm_jobs:
   - container_job: InstallDNSSECFirst
     containers:
@@ -41,14 +33,6 @@ vms:
   - container_job: service_permissions
     tests:
     - test_integration/test_service_permissions.py
-
-  - container_job: netgroup
-    tests:
-    - test_integration/test_netgroup.py
-
-  - container_job: external_ca_ExternalCAProfileScenarios
-    tests:
-    - test_integration/test_external_ca.py::TestExternalCAProfileScenarios
 
   # requires external DNS configuration, this is not set up yet
   # - container_job: authselect
@@ -77,16 +61,6 @@ vms:
     - test_integration/test_topologies.py
     - test_integration/test_testconfig.py
 
-  - container_job: external_ca_SelfExternalSelf
-    tests:
-    - test_integration/test_external_ca.py::TestSelfExternalSelf
-
-  - container_job: external_ca_ExternalCAConstraints
-    containers:
-      clients: 1
-    tests:
-    - test_integration/test_external_ca.py::TestExternalCAConstraints
-
 - vm_jobs:
   # Requires more memory per container and fails reliably
   #  - container_job: commands
@@ -110,3 +84,31 @@ vms:
       clients: 1
     tests:
     - test_integration/test_advise.py
+
+- vm_jobs:
+  - container_job: membermanager
+    tests:
+    - test_integration/test_membermanager.py
+
+  - container_job: external_ca_ExternalCAProfileScenarios
+    tests:
+    - test_integration/test_external_ca.py::TestExternalCAProfileScenarios
+
+  - container_job: netgroup
+    tests:
+    - test_integration/test_netgroup.py
+
+  - container_job: external_ca_SelfExternalSelf
+    tests:
+    - test_integration/test_external_ca.py::TestSelfExternalSelf
+
+  - container_job: external_ca_ExternalCAInstall
+    tests:
+    - test_integration/test_external_ca.py::TestExternalCAInstall
+
+- vm_jobs:
+  - container_job: external_ca_ExternalCAConstraints
+    containers:
+      clients: 1
+    tests:
+    - test_integration/test_external_ca.py::TestExternalCAConstraints


### PR DESCRIPTION
This is the experimental fix to workaround the issue with
PKI component, which is sensitive to slow systems(at least,
appropriate delays and timeouts should be adjusted for such).

Somehow Azure's test envs became slower then they were earlier
(for example, CA subsystem start changed
~(20-30)sec -> ~(45-60)sec). This triggered various issues with
subsystems of PKI.

To release CPU resources(Azure VM provides 2 cores, 1 thread per
core) the extreme usage of swap was reduced to the limits provided
by Azure(7Gb + 4Gb swap). Server/replica container consumes ~2Gb,
client one ~0.5Gb.

Also this increases the number of Azure's Gating jobs from 4 to 6.

Related: https://lists.fedorahosted.org/archives/list/freeipa-devel@lists.fedorahosted.org/thread/AQRKHR56L3AHST2XGSNQGYS22ORYE5MI/