### PR TITLE
pkispawn: Make timeout consistent with IPA's startup_timeout

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -193,6 +193,10 @@ class DogtagInstance(service.Service):
         parameters.
         """
         subsystem = self.subsystem
+        spawn_env = os.environ.copy()
+        timeout = str(api.env.startup_timeout)
+        spawn_env["PKISPAWN_STARTUP_TIMEOUT_SECONDS"] = timeout
+
         args = [paths.PKISPAWN,
                 "-s", subsystem,
                 "-f", cfg_file,
@@ -204,7 +208,7 @@ class DogtagInstance(service.Service):
                 cfg_file, ipautil.nolog_replace(f.read(), nolog_list))
 
         try:
-            ipautil.run(args, nolog=nolog_list)
+            ipautil.run(args, nolog=nolog_list, env=spawn_env)
         except ipautil.CalledProcessError as e:
             self.handle_setup_error(e)
 


### PR DESCRIPTION
This is the experimental fix to workaround the issue with PKI on Azure Pipelines. PKI is sensitive to slow systems (at least, appropriate delays and timeouts should be adjusted for such).
    
Somehow Azure's test envs became slower then they were earlier (for example, CA subsystem start changed ~(20-30)sec -> ~(45-60)sec). This triggered various issues with subsystems of PKI in CI.
    
PKI honors `PKISPAWN_STARTUP_TIMEOUT_SECONDS` env variable (if not set the timeout is 60sec) for pkispawn tool. The default is inconsistent with IPA's one (startup_timeout=120sec), which in particular, is used in ipa-pki-wait-running tool).
 
Related: https://pagure.io/freeipa/issue/8830