### PR TITLE
Only attempt to upgrade ACME configuration files if deployed

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1122,7 +1122,8 @@ def ca_upgrade_schema(ca):
             acme_schema_ldif = path
             break
     else:
-        raise RuntimeError('ACME schema file not found')
+        logger.info('ACME schema is not available')
+        return False
 
     schema_files=[
         '/usr/share/pki/server/conf/schema-certProfile.ldif',
@@ -1530,6 +1531,16 @@ def ca_update_acme_configuration(ca, fqdn):
     """
     Re-apply the templates in case anyting has been updated.
     """
+    logger.info('[Updating ACME configuration]')
+    if not os.path.isdir(os.path.join(paths.PKI_TOMCAT, 'acme')):
+        logger.info('ACME is not deployed, skipping')
+        return
+
+    if not os.path.exists(paths.PKI_ACME_ISSUER_CONF):
+        logger.info('ACME configuration file %s is missing',
+                    paths.PKI_ACME_ISSUER_CONF)
+        return
+
     password = directivesetter.get_directive(
         paths.PKI_ACME_ISSUER_CONF,
         'password',


### PR DESCRIPTION
This can happen on upgrades from older deployments that lack
an ACME installation and don't meet the minimum requirements
to deploy one automatically.

Also don't consider missing ACME schema a total failure, just
log and skip it.

https://pagure.io/freeipa/issue/8832

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

TESTING: Testing is difficult because on upgrade IPA will deploy ACME if it isn't already configured. One way to avoid this is to twiddle with /usr/share/pki/VERSION and set the value < 10.10.0.

If ACME is already deployed you can remove it with:

```
# pki-server acme-undeploy
# rm -rf /etc/pki/pki-tomcat/acme
```