### PR TITLE
[ipa-4-9] ipatests: Bump PR-CI templates to Fedora 34

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.4
+          version: 0.0.5
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
-          name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.4
+          name: freeipa/ci-ipa-4-9-f34
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
-          name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.4
+          name: freeipa/ci-ipa-4-9-f34
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-previous
-          name: freeipa/ci-ipa-4-9-f32
-          version: 0.0.3
+          name: freeipa/ci-ipa-4-9-f33
+          version: 0.0.5
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,7 +57,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.4
+          version: 0.0.5
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Move 'latest' to Fedora 34 and 'previous' Fedora 33 for nightly runs.
Keep gating on Fedora 33 for now.

---
Known issues blocking gating to move to F34:
- `test_cert` timed out, blocked in the step `[8/11]: upgrading server`, under investigation with 389-ds
- `test_dnssec_TestInstallDNSSECFirst` reported at [8793](https://pagure.io/freeipa/issue/8793)

Gating run + some other jobs on Fedora 34: https://github.com/freeipa-pr-ci2/freeipa/pull/897