### PR TITLE
ipatests: kinit on server for test_proxycommand_invalid_shell

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1426,10 +1426,10 @@ class TestIPACommand(IntegrationTest):
 
         user_kinit = "{password}\n{password}\n{password}\n".format(
             password=password)
-        self.clients[0].run_command([
+        self.master.run_command([
             'kinit', regular_user],
             stdin_text=user_kinit)
-        self.clients[0].run_command([
+        self.master.run_command([
             'kinit', restricted_user],
             stdin_text=user_kinit)
         tasks.kdestroy_all(self.clients[0])


### PR DESCRIPTION
We've seen some intermittent failures of this test with warnings
about passwords about to expire. We suspect there may be a time
difference between the client and server so set the passwords
on the server instead to be sure that time is correct.

https://pagure.io/freeipa/issue/8785

Signed-off-by: Rob Crittenden <rcritten@redhat.com>