### PR TITLE
[Backport][ipa-4-9] ipatests: increase timeout for test_commands up to 1.5 hours

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -140,7 +140,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -143,7 +143,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-previous
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-previous-ipa-4-9/test_kerberos_flags:


### PR DESCRIPTION
This is a manual backport of #5748 