### PR TITLE
Fix the option to match in the ipa-client-automount usage and man-page

### DIFF
--- a/client/man/ipa-client-automount.1
+++ b/client/man/ipa-client-automount.1
@@ -57,7 +57,7 @@ Automount location.
 \fB\-S\fR, \fB\-\-no\-sssd\fR
 Do not configure the client to use SSSD for automount.
 .TP
-\fB\-S\fR, \fB\-\-idmap\-domain\fR=\fIIDMAP_DOMAIN\fR
+\fB\-\-idmap\-domain\fR=\fIIDMAP_DOMAIN\fR
 NFS domain for idmapd.conf. If unset, defaults to the IPA domain. If set to DNS, let idmapd or nfsidmap determine the domain from DNS (see idmapd(8) or nfsidmap(5) for details). If set to anything else, set idmapd.conf's Domain entry to that value.
 .TP
 \fB\-d\fR, \fB\-\-debug\fR

--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -90,6 +90,7 @@ def parse_options():
         help="nfs domain for idmapd.conf",
     )
     parser.add_option(
+        "-d",
         "--debug",
         dest="debug",
         action="store_true",


### PR DESCRIPTION
The command usage and man-page options may not match.
In ipa-client-automount, fix to match usage and man-page.