### PR TITLE
Add -d option to match in the ipa-client-samba usage and man-page

### DIFF
--- a/ipaclient/install/ipa_client_samba.py
+++ b/ipaclient/install/ipa_client_samba.py
@@ -102,6 +102,7 @@ def parse_options():
         help="force installation by redoing all steps",
     )
     parser.add_option(
+        "-d",
         "--debug",
         dest="debug",
         action="store_true",


### PR DESCRIPTION
The ipa-client-samba man-page describes the -d option, but the -d option cannot actually be used.
Fix ipa-client-samba to enable the -d option.