### PR TITLE
Add arguments to the description of OPTIONS in ipa-winsync-migrate.1

### DIFF
--- a/install/tools/man/ipa-winsync-migrate.1
+++ b/install/tools/man/ipa-winsync-migrate.1
@@ -20,7 +20,7 @@
 .SH "NAME"
 ipa\-winsync\-migrate \- Seamless migration of AD users created by winsync to native AD users.
 .SH "SYNOPSIS"
-ipa\-winsync\-migrate
+ipa\-winsync\-migrate [options]
 .SH "DESCRIPTION"
 Migrates AD users created by winsync agreement to ID overrides in
 the Default Trust View, thus preserving the actual POSIX attributes
@@ -42,11 +42,11 @@ on the IPA server.
 
 .SH "OPTIONS"
 .TP
-\fB\-\-realm\fR
+\fB\-\-realm\fR=\fIREALM_NAME\fR
 The Active Directory realm the winsynced users belong to.
 .TP
-\fB\-\-server\fR
+\fB\-\-server\fR=\fIHOST_NAME\fR
 The hostname of Active Directory Domain Controller the winsync replication agreement is established with.
 .TP
-\fB\-\-unattended\fR
+\fB\-U\fR, \fB\-\-unattended\fR
 Never prompts for user input.


### PR DESCRIPTION
ipa-winsync-migrate.1 has an explanation of options, but no arguments.
Therefore, add the arguments for --realm and --server.
Also, add a short option -U for --unattended.