### PR TITLE
[Backport][ipa-4-9] man: fix typos in ipa-epn.1

### DIFF
--- a/client/man/ipa-epn.1
+++ b/client/man/ipa-epn.1
@@ -17,14 +17,14 @@
 .\"
 .TH "IPA-EPN" "1" "April 24, 2020" "IPA" "IPA Manual Pages"
 .SH "NAME"
-ipa\-epn \- Send expiring password nofications
+ipa\-epn \- Send expiring password notifications
 .SH "SYNOPSIS"
 ipa\-epn \fR[options\fR]
 
 .SH "DESCRIPTION"
 ipa\-epn provides a method to warn users via email that their IPA account password is about to expire.
 
-It can be used in dry\-run mode which is recommmended during setup. The output is always JSON in this case.
+It can be used in dry\-run mode which is recommended during setup. The output is always JSON in this case.
 
 It can also be launched daily by its systemd timer.
 In this case it will parse its configuration file epn.conf(5) and send an email to users whose passwords are expiring within the defined future date ranges.
@@ -45,10 +45,10 @@ Together, these two CLI options can be used to determine how many emails would b
 The \fB\-\-to\-nbdays\fR CLI option implies \fB\-\-dry\-run\fR.
 .TP
 \fB\-\-from\-nbdays\fR \fI<number of days>\fR
-See \fB\-\-to\-nbdays\fR for an explanation. This option must be used in conjonction with \fB\-\-to\-nbdays\fR.
+See \fB\-\-to\-nbdays\fR for an explanation. This option must be used in conjunction with \fB\-\-to\-nbdays\fR.
 .TP
 \fB\-\-dry\-run\fR
-The \fB\-\-dry\-run\fR CLI option is intented to test ipa\-epn's configuration.
+The \fB\-\-dry\-run\fR CLI option is intended to test ipa\-epn's configuration.
 
 For instance, if notify_ttls is set to 21, 14, 3, \fB\-\-dry-run\fR would display the list of users whose passwords would expire in 21, 14, and 3 days in the future.
 .TP

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -140,7 +140,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -143,7 +143,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-previous
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-previous-ipa-4-9/test_kerberos_flags:


### PR DESCRIPTION
This PR was opened automatically because PR #5772 was pushed to master and backport to ipa-4-9 is required.