### PR TITLE
[Backport][ipa-4-9] Fix the option to match in the ipa-client-automount usage and man-page

### DIFF
--- a/client/man/ipa-client-automount.1
+++ b/client/man/ipa-client-automount.1
@@ -57,7 +57,7 @@ Automount location.
 \fB\-S\fR, \fB\-\-no\-sssd\fR
 Do not configure the client to use SSSD for automount.
 .TP
-\fB\-S\fR, \fB\-\-idmap\-domain\fR=\fIIDMAP_DOMAIN\fR
+\fB\-\-idmap\-domain\fR=\fIIDMAP_DOMAIN\fR
 NFS domain for idmapd.conf. If unset, defaults to the IPA domain. If set to DNS, let idmapd or nfsidmap determine the domain from DNS (see idmapd(8) or nfsidmap(5) for details). If set to anything else, set idmapd.conf's Domain entry to that value.
 .TP
 \fB\-d\fR, \fB\-\-debug\fR

--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -90,6 +90,7 @@ def parse_options():
         help="nfs domain for idmapd.conf",
     )
     parser.add_option(
+        "-d",
         "--debug",
         dest="debug",
         action="store_true",

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -140,7 +140,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -143,7 +143,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-previous
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-previous-ipa-4-9/test_kerberos_flags:


### PR DESCRIPTION
This PR was opened automatically because PR #5770 was pushed to master and backport to ipa-4-9 is required.