### PR TITLE
[Backport][ipa-4-9] Add arguments to the description of OPTIONS in ipa-winsync-migrate.1

### DIFF
--- a/install/tools/man/ipa-winsync-migrate.1
+++ b/install/tools/man/ipa-winsync-migrate.1
@@ -20,7 +20,7 @@
 .SH "NAME"
 ipa\-winsync\-migrate \- Seamless migration of AD users created by winsync to native AD users.
 .SH "SYNOPSIS"
-ipa\-winsync\-migrate
+ipa\-winsync\-migrate [options]
 .SH "DESCRIPTION"
 Migrates AD users created by winsync agreement to ID overrides in
 the Default Trust View, thus preserving the actual POSIX attributes
@@ -42,11 +42,11 @@ on the IPA server.
 
 .SH "OPTIONS"
 .TP
-\fB\-\-realm\fR
+\fB\-\-realm\fR=\fIREALM_NAME\fR
 The Active Directory realm the winsynced users belong to.
 .TP
-\fB\-\-server\fR
+\fB\-\-server\fR=\fIHOST_NAME\fR
 The hostname of Active Directory Domain Controller the winsync replication agreement is established with.
 .TP
-\fB\-\-unattended\fR
+\fB\-U\fR, \fB\-\-unattended\fR
 Never prompts for user input.

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -140,7 +140,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -143,7 +143,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-previous
-        timeout: 3600
+        timeout: 4800
         topology: *master_1repl_1client
 
   fedora-previous-ipa-4-9/test_kerberos_flags:


### PR DESCRIPTION
This PR was opened automatically because PR #5773 was pushed to master and backport to ipa-4-9 is required.