### PR TITLE
[Backport][ipa-4-9] Add ACME profile on replica install in non-ACME environment

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -477,12 +477,17 @@ class CAInstance(DogtagInstance):
                         self.step("exposing CA instance on LDAP",
                                   self.__expose_ca_in_ldap)
 
-                    self.step("migrating certificate profiles to LDAP",
-                              migrate_profiles_to_ldap)
                     self.step("importing IPA certificate profiles",
                               import_included_profiles)
+                    self.step("migrating certificate profiles to LDAP",
+                              migrate_profiles_to_ldap)
                     self.step("adding default CA ACL", ensure_default_caacl)
                     self.step("adding 'ipa' CA entry", ensure_ipa_authority_entry)
+                else:
+                    # Re-import profiles in the promote case to pick up any
+                    # that will only be triggered by an upgrade.
+                    self.step("importing IPA certificate profiles",
+                              import_included_profiles)
 
                 self.step("configuring certmonger renewal for lightweight CAs",
                           self.add_lightweight_ca_tracking_requests)

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1100,9 +1100,17 @@ def parse_updateCRL_xml(doc):
 #-------------------------------------------------------------------------------
 
 from ipalib import Registry, errors, SkipPluginModule
-if api.isdone('finalize') and api.env.ra_plugin != 'dogtag':
+
+# We only load the dogtag RA plugin if it is necessary to do so.
+# This is legacy code from when multiple RA backends were supported.
+#
+# If the plugins are loaded by the server then load the RA backend.
+#
+if api.isdone("finalize") and not (
+    api.env.ra_plugin == 'dogtag' or api.env.context == 'installer'
+):
     # In this case, abort loading this plugin module...
-    raise SkipPluginModule(reason='dogtag not selected as RA plugin')
+    raise SkipPluginModule(reason='Not loading dogtag RA plugin')
 import os
 from ipaserver.plugins import rabase
 from ipalib.constants import TYPE_ERROR


### PR DESCRIPTION
This PR was opened automatically because PR #5605 was pushed to master and backport to ipa-4-9 is required.