### PR TITLE
Add argument for --schema-file option in ipa-ldap-updater.1

### DIFF
--- a/install/tools/man/ipa-ldap-updater.1
+++ b/install/tools/man/ipa-ldap-updater.1
@@ -87,10 +87,10 @@ Schema files should be in LDIF format, and may only specify attributeTypes and o
 Enable debug logging when more verbose output is needed
 .TP
 \fB\-u\fR, \fB\-\-upgrade\fR
-Upgrade an installed server in offline mode (implies \-\-schema)
+Upgrade an installed server in offline mode
 .TP
-\fB\-S\fR, \fB\-\-schema\-file\fR
-Specify a schema file. May be used multiple times. Implies \-\-schema.
+\fB\-S\fR \fIFILE.ldif\fR, \fB\-\-schema\-file\fR=\fIFILE.ldif\fR
+Specify a schema file. May be used multiple times.
 .SH "EXIT STATUS"
 0 if the command was successful
 


### PR DESCRIPTION
There are no arguments in the --schema-file option,
but the Schema file in LDIF format must actually be specified.
Therefore, add FILE.ldif as an argument.