### PR TITLE
Add argument for --entry option in ipa-managed-entries.1

### DIFF
--- a/install/tools/man/ipa-managed-entries.1
+++ b/install/tools/man/ipa-managed-entries.1
@@ -40,7 +40,7 @@ Show a help message and exit
 \fB\-d\fR, \fB\-\-debug\fR
 Enable debug logging when more verbose output is needed
 .TP
-\fB\-e\fR, \fB\-\-entry\fR
+\fB\-e\fR \fIMANAGED_ENTRY\fR, \fB\-\-entry\fR=\fIMANAGED_ENTRY\fR
 DN for the Managed Entry Definition
 .TP
 \fB\-l\fR, \fB-\-list\fR


### PR DESCRIPTION
There are no arguments in the --entry option,
but DN for the managed entry definition must actually be specified.
Therefore, add MANAGED_ENTRY as an argument.