### PR TITLE
Revert "Only request VALID certs when revoking certs for a host/service"

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1687,6 +1687,8 @@ class cert_find(Search, CertMethod):
                 ra_options['subject'] = hosts[0]
             elif len(users) == 1 and not services and not hosts:
                 ra_options['subject'] = users[0]
+        if 'status' in options:
+            ra_options['status'] = options.get('status')
 
         try:
             ca_enabled_check(self.api)

--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -871,9 +871,7 @@ class host_del(LDAPDelete):
                 )
 
         if self.api.Command.ca_is_enabled()['result']:
-            certs = self.api.Command.cert_find(
-                subject=fqdn, status='VALID'
-            )['result']
+            certs = self.api.Command.cert_find(host=keys)['result']
             revoke_certs(certs)
 
         return dn

--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -825,16 +825,8 @@ class service_del(LDAPDelete):
         # custom services allow them to manage them.
         check_required_principal(ldap, keys[-1])
         if self.api.Command.ca_is_enabled()['result']:
-            # only try to revoke certs for valid principals
-            try:
-                subject = keys[-1].hostname
-            except ValueError:
-                pass
-            else:
-                certs = self.api.Command.cert_find(
-                    subject=subject, status='VALID'
-                )['result']
-                revoke_certs(certs)
+            certs = self.api.Command.cert_find(service=keys)['result']
+            revoke_certs(certs)
 
         return dn
 
@@ -1108,21 +1100,14 @@ class service_disable(LDAPQuery):
         done_work = False
 
         if self.api.Command.ca_is_enabled()['result']:
-            try:
-                subject = keys[-1].hostname
-            except ValueError:
-                pass
-            else:
-                certs = self.api.Command.cert_find(
-                    subject=subject, status='VALID'
-                )['result']
+            certs = self.api.Command.cert_find(service=keys)['result']
 
-                if len(certs) > 0:
-                    revoke_certs(certs)
-                    # Remove the usercertificate altogether
-                    entry_attrs['usercertificate'] = None
-                    ldap.update_entry(entry_attrs)
-                    done_work = True
+            if len(certs) > 0:
+                revoke_certs(certs)
+                # Remove the usercertificate altogether
+                entry_attrs['usercertificate'] = None
+                ldap.update_entry(entry_attrs)
+                done_work = True
 
         self.obj.get_password_attributes(ldap, dn, entry_attrs)
         if entry_attrs['has_keytab']:


### PR DESCRIPTION
This reverts commit aa1350384ad6a7d6b2f6056d99fbb43c5c5a6be7.

The search for certificates is a complex, three-step process,
which filters results in subsequent searches. This filters out
non-relevant certificates when deleting a host or service.

This patch breaks that so deleting one service of a host will
revoke *all* certificates for that host.

Another attempt will be made separately to implement this.

https://pagure.io/freeipa/issue/7835

Signed-off-by: Rob Crittenden rcritten@redhat.com