### PR TITLE
[Backport][ipa-4-9] Remove -s option from ipa-ldap-updater usage

### DIFF
--- a/ipaserver/install/ipa_ldap_updater.py
+++ b/ipaserver/install/ipa_ldap_updater.py
@@ -51,12 +51,13 @@ class LDAPUpdater(admintool.AdminTool):
     @classmethod
     def add_options(cls, parser):
         super(LDAPUpdater, cls).add_options(parser, debug_option=True)
-        parser.add_option("-u", '--upgrade', action="store_true",
-            dest="upgrade", default=False,
+        parser.add_option(
+            "-u", '--upgrade', action="store_true", dest="upgrade",
+            default=False,
             help="upgrade an installed server in offline mode")
-        parser.add_option("-S", '--schema-file', action="append",
-            dest="schema_files",
-            help="custom schema ldif file to use (implies -s)")
+        parser.add_option(
+            "-S", '--schema-file', action="append", dest="schema_files",
+            help="custom schema ldif file to use")
 
     @classmethod
     def get_command_class(cls, options, args):


### PR DESCRIPTION
This PR was opened automatically because PR #5782 was pushed to master and backport to ipa-4-9 is required.