### PR TITLE
[Backport][ipa-4-9] Add ability to search on certificate revocation status

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -754,7 +754,7 @@ output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
 command: cert_find/1
-args: 1,29,4
+args: 1,30,4
 arg: Str('criteria?')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('cacn?', cli_name='ca')
@@ -777,6 +777,7 @@ option: DateTime('revokedon_from?', autofill=False)
 option: DateTime('revokedon_to?', autofill=False)
 option: Principal('service*', cli_name='services')
 option: Int('sizelimit?')
+option: StrEnum('status?', values=[u'VALID', u'INVALID', u'REVOKED', u'EXPIRED', u'REVOKED_EXPIRED'])
 option: Str('subject?', autofill=False)
 option: Int('timelimit?')
 option: Str('user*', cli_name='users')

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -86,8 +86,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-define(IPA_API_VERSION_MINOR, 241)
-# Last change: add auto-private-groups option to idrange
+define(IPA_API_VERSION_MINOR, 242)
+# Last change: add status options for cert-find
 
 
 ########################################################

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -31,7 +31,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from dns import resolver, reversename
 import six
 
-from ipalib import Command, Str, Int, Flag
+from ipalib import Command, Str, Int, Flag, StrEnum
 from ipalib import api
 from ipalib import errors, messages
 from ipalib import x509
@@ -1559,6 +1559,12 @@ class cert_find(Search, CertMethod):
             normalizer=normalize_pkidate,
             autofill=False,
         ),
+        StrEnum(
+            'status?',
+            doc=_("Status of the certificate"),
+            values=(u'VALID', u'INVALID', u'REVOKED', u'EXPIRED',
+                    u'REVOKED_EXPIRED'),
+        ),
         Flag('pkey_only?',
             label=_("Primary key only"),
             doc=_("Results should contain primary key attribute only "
@@ -1644,7 +1650,8 @@ class cert_find(Search, CertMethod):
                      'validnotafter_from', 'validnotafter_to',
                      'validnotbefore_from', 'validnotbefore_to',
                      'issuedon_from', 'issuedon_to',
-                     'revokedon_from', 'revokedon_to'):
+                     'revokedon_from', 'revokedon_to',
+                     'status'):
             try:
                 value = options[name]
             except KeyError:
@@ -1680,6 +1687,8 @@ class cert_find(Search, CertMethod):
                 ra_options['subject'] = hosts[0]
             elif len(users) == 1 and not services and not hosts:
                 ra_options['subject'] = users[0]
+        if 'status' in options:
+            ra_options['status'] = options.get('status')
 
         try:
             ca_enabled_check(self.api)

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1785,6 +1785,10 @@ class ra(rabase.rabase, RestClient):
             node = etree.SubElement(page, 'serialTo')
             node.text = unicode(options['max_serial_number'])
 
+        if 'status' in options:
+            node = etree.SubElement(page, 'status')
+            node.text = unicode(options['status'])
+
         # date_types is a tuple that consists of:
         #   1. attribute name passed from IPA API
         #   2. attribute name used by REST API


### PR DESCRIPTION
This is a manual backport of one commit from PR https://github.com/freeipa/freeipa/pull/5701

This adds the ability to search for certificates based on status.

The other commit from that PR is in the process of being reverted.