### PR TITLE
[Backport][ipa-4-9] ipatests: kinit on server for test_proxycommand_invalid_shell

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1426,10 +1426,10 @@ class TestIPACommand(IntegrationTest):
 
         user_kinit = "{password}\n{password}\n{password}\n".format(
             password=password)
-        self.clients[0].run_command([
+        self.master.run_command([
             'kinit', regular_user],
             stdin_text=user_kinit)
-        self.clients[0].run_command([
+        self.master.run_command([
             'kinit', restricted_user],
             stdin_text=user_kinit)
         tasks.kdestroy_all(self.clients[0])


### PR DESCRIPTION
This PR was opened automatically because PR #5767 was pushed to master and backport to ipa-4-9 is required.