### PR TITLE
[Backport][ipa-4-9] pkispawn: override the AJP address

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -537,6 +537,11 @@ class CAInstance(DogtagInstance):
         if os.path.exists(paths.IPA_CA_CRT):
             cfg['pki_cert_chain_path'] = paths.IPA_CA_CRT
 
+        # Use IP address instead of default localhost4 and localhost6
+        # because /etc/hosts does not always define them
+        cfg['pki_ajp_host_ipv4'] = "127.0.0.1"
+        cfg['pki_ajp_host_ipv6'] = "::1"
+
         if self.clone:
             if self.no_db_setup:
                 cfg.update(


### PR DESCRIPTION
This PR was opened automatically because PR #5749 was pushed to master and backport to ipa-4-9 is required.