### PR TITLE
[Backport][ipa-4-9] Update IRC links to point to Libera.chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ Please see the file called COPYING.
 * If you want to participate in actively developing IPA please
   subscribe to the freeipa-devel mailing list at
   https://lists.fedoraproject.org/archives/list/freeipa-devel@lists.fedorahosted.org/ or join
-  us in IRC at <irc://irc.freenode.net/freeipa>
+  us in IRC at <irc://irc.libera.chat/freeipa>

--- a/doc/workshop/workshop.rst
+++ b/doc/workshop/workshop.rst
@@ -263,7 +263,7 @@ After the workshop
 Here are some contact details and resources that may help you after
 the workshop is over:
 
-- IRC: ``#freeipa`` and ``#sssd`` (Freenode)
+- IRC: ``#freeipa`` and ``#sssd`` (Libera.chat)
 
 - ``freeipa-users@lists.fedorahosted.org`` `mailing list
   <https://lists.fedoraproject.org/archives/list/freeipa-users@lists.fedorahosted.org/>`_


### PR DESCRIPTION
This PR was opened automatically because PR #5795 was pushed to master and backport to ipa-4-9 is required.