### PR TITLE
[Backport][ipa-4-9] Add --keyfile option to ipa-otptoken-import.1

### DIFF
--- a/install/tools/man/ipa-otptoken-import.1
+++ b/install/tools/man/ipa-otptoken-import.1
@@ -28,7 +28,7 @@ If the \fBinfile\fR contains encrypted token data, then the \fIkeyfile\fR (\fB-k
 
 .SH "OPTIONS"
 .TP
-\fB\-k\fR \fIkeyfile\fR
+\fB\-k\fR \fIkeyfile\fR, \fB\-\-keyfile\fR=\fIkeyfile\fR
 File containing the key used to decrypt the token data.
 .SH "EXIT STATUS"
 0 if the command was successful


### PR DESCRIPTION
This PR was opened automatically because PR #5791 was pushed to master and backport to ipa-4-9 is required.