### PR TITLE
ipatests: test_installation: move tracking_reqs dependency to ipalib constants

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -360,3 +360,11 @@ SUBID_RANGE_MAX = (2 ** 32) - (2 * SUBID_COUNT)
 SUBID_RANGE_SIZE = SUBID_RANGE_MAX - SUBID_RANGE_START
 # threshold before DNA plugin requests a new range
 SUBID_DNA_THRESHOLD = 500
+
+# moved from ipaserver/install/krainstance.py::KRAInstance to avoid duplication
+# as per https://pagure.io/freeipa/issue/8795
+KRA_TRACKING_REQS = {
+    'auditSigningCert cert-pki-kra': 'caAuditSigningCert',
+    'transportCert cert-pki-kra': 'caTransportCert',
+    'storageCert cert-pki-kra': 'caStorageCert',
+}

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -27,6 +27,7 @@ import base64
 
 from ipalib import api
 from ipalib import x509
+from ipalib.constants import KRA_TRACKING_REQS
 from ipaplatform.paths import paths
 from ipapython import directivesetter
 from ipapython import ipautil
@@ -64,11 +65,7 @@ class KRAInstance(DogtagInstance):
     # Mapping of nicknames for tracking requests, and the profile to
     # use for that certificate.  'configure_renewal()' reads this
     # dict.  The profile MUST be specified.
-    tracking_reqs = {
-        'auditSigningCert cert-pki-kra': 'caAuditSigningCert',
-        'transportCert cert-pki-kra': 'caTransportCert',
-        'storageCert cert-pki-kra': 'caStorageCert',
-    }
+    tracking_reqs = KRA_TRACKING_REQS
 
     def __init__(self, realm):
         super(KRAInstance, self).__init__(

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -20,7 +20,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography import x509 as crypto_x509
 
 from ipalib import x509
-from ipalib.constants import DOMAIN_LEVEL_0
+from ipalib.constants import DOMAIN_LEVEL_0, KRA_TRACKING_REQS
 from ipalib.constants import IPA_CA_RECORD
 from ipalib.sysrestore import SYSRESTORE_STATEFILE, SYSRESTORE_INDEXFILE
 from ipapython.dn import DN
@@ -34,7 +34,7 @@ from ipatests.pytest_ipa.integration.env_config import get_global_config
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.test_integration.test_caless import CALessBase, ipa_certs_cleanup
 from ipaplatform import services
-from ipaserver.install import krainstance
+
 
 config = get_global_config()
 
@@ -1282,8 +1282,7 @@ class TestInstallMasterKRA(IntegrationTest):
         """
         Test that the KRA subsystem certificates renew properly
         """
-        kra = krainstance.KRAInstance(self.master.domain.realm)
-        for nickname in kra.tracking_reqs:
+        for nickname in KRA_TRACKING_REQS:
             cert = tasks.certutil_fetch_cert(
                 self.master,
                 paths.PKI_TOMCAT_ALIAS_DIR,


### PR DESCRIPTION
ipatests: test_installation: move tracking_reqs dependency to ipalib
constants
ipaserver: krainstance: utilize moved tracking_reqs dependency
    
KRA instance import depends on lib389 package, which is not always
installed and that results in failure. Furthermore, test_installation
utilizes krainstance import. This fix moves relevant parts from
krainstance to ipalib constants where those are subsequently imported
from.
    
Related: https://pagure.io/freeipa/issue/8795
Signed-off-by: Michal Polovka <mpolovka@redhat.com>
