### PR TITLE
[ipa-4-9] ipatests: Bump PR-CI boxes

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.5
+          version: 0.0.6
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f34
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f34
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-previous
           name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.5
+          version: 0.0.6
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,7 +57,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.5
+          version: 0.0.6
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Update Fedora 34 and 33 boxes to include new packages.

Signed-off-by: Armando Neto <abiagion@redhat.com>