### PR TITLE
[Backport][ipa-4-9] ds: Support renaming of a replication plugin in 389-ds

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-version/version-conf.ldif
+++ b/daemons/ipa-slapi-plugins/ipa-version/version-conf.ldif
@@ -13,5 +13,5 @@ nsslapd-pluginversion: 1.0
 nsslapd-pluginvendor: Red Hat, Inc.
 nsslapd-plugindescription: IPA Replication version plugin
 nsslapd-plugin-depends-on-type: database
-nsslapd-plugin-depends-on-named: Multimaster Replication Plugin
+nsslapd-plugin-depends-on-named: $REPLICATION_PLUGIN
 

--- a/daemons/ipa-slapi-plugins/topology/ipa-topology-conf.ldif
+++ b/daemons/ipa-slapi-plugins/topology/ipa-topology-conf.ldif
@@ -15,7 +15,7 @@ nsslapd-topo-plugin-shared-binddngroup: cn=replication managers,cn=sysaccounts,c
 nsslapd-topo-plugin-startup-delay: 20
 nsslapd-pluginId: none
 nsslapd-plugin-depends-on-named: ldbm database
-nsslapd-plugin-depends-on-named: Multimaster Replication Plugin
+nsslapd-plugin-depends-on-named: $REPLICATION_PLUGIN
 nsslapd-pluginVersion: 1.0
 nsslapd-pluginVendor: none
 nsslapd-pluginDescription: none

--- a/install/updates/10-enable-betxn.update
+++ b/install/updates/10-enable-betxn.update
@@ -18,7 +18,7 @@ only: nsslapd-pluginType: betxnpreoperation
 dn: cn=MemberOf Plugin,cn=plugins,cn=config
 only: nsslapd-pluginType: betxnpostoperation
 
-dn: cn=Multimaster Replication Plugin,cn=plugins,cn=config
+dn: cn=$REPLICATION_PLUGIN,cn=plugins,cn=config
 only: nsslapd-pluginbetxn: on
 
 dn: cn=PAM Pass Through Auth,cn=plugins,cn=config

--- a/install/updates/20-enable_dirsrv_plugins.update
+++ b/install/updates/20-enable_dirsrv_plugins.update
@@ -50,8 +50,8 @@ replace: nsslapd-pluginEnabled:off::on
 dn: cn=Managed Entries,cn=plugins,cn=config
 replace: nsslapd-pluginEnabled:off::on
 
-# Multimaster Replication Plugin, plugins, config
-dn: cn=Multimaster Replication Plugin,cn=plugins,cn=config
+# Replication Plugin may be Multisupplier or Multimaster
+dn: cn=$REPLICATION_PLUGIN,cn=plugins,cn=config
 replace: nsslapd-pluginEnabled:off::on
 
 # Roles Plugin, plugins, config

--- a/install/updates/20-replication.update
+++ b/install/updates/20-replication.update
@@ -58,7 +58,7 @@ default: nsslapd-topo-plugin-shared-binddngroup: cn=replication managers,cn=sysa
 default: nsslapd-topo-plugin-startup-delay: 20
 default: nsslapd-pluginId: none
 default: nsslapd-plugin-depends-on-named: ldbm database
-default: nsslapd-plugin-depends-on-named: Multimaster Replication Plugin
+default: nsslapd-plugin-depends-on-named: $REPLICATION_PLUGIN
 default: nsslapd-pluginVersion: 1.0
 default: nsslapd-pluginVendor: none
 default: nsslapd-pluginDescription: none

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -571,6 +571,12 @@ class DsInstance(service.Service):
         inst.setup_ldapi()
         inst.open()
 
+        def get_entry(dn, attrs):
+            return inst.getEntry(dn, attrlist=attrs)
+
+        self.sub_dict['REPLICATION_PLUGIN'] = (
+            replication.get_replication_plugin_name(get_entry))
+
         try:
             ipadomain = IpaDomain(inst, dn=self.suffix.ldap_text())
             ipadomain.create(properties={
@@ -735,7 +741,7 @@ class DsInstance(service.Service):
         self._ldap_mod("pw-logging-conf.ldif")
 
     def __config_version_module(self):
-        self._ldap_mod("version-conf.ldif")
+        self._ldap_mod("version-conf.ldif", self.sub_dict)
 
     def __config_uuid_module(self):
         self._ldap_mod("uuid-conf.ldif")

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -232,6 +232,23 @@ def get_ds_version(conn):
     return vendor_version
 
 
+def get_replication_plugin_name(dirsrv_get_entry):
+    # Support renaming of a replication plugin in 389-ds
+    # IPA topology plugin depends on the replication plugin but
+    # 389-ds cannot handle older alias querying in the plugin
+    # configuration with 'nsslapd-plugin-depends-on-named: ..' attribute
+    #
+    # dirsrv_get_entry: function (dn, attrs) -> str
+    # returns entry dictionary
+    try:
+        entry = dirsrv_get_entry(
+            'cn=Multisupplier Replication Plugin,cn=plugins,cn=config',
+            ['cn'])
+        return str(entry['cn'], encoding='utf-8')
+    except Exception:
+        return 'Multimaster Replication Plugin'
+
+
 class ReplicationManager:
     """Manage replication agreements
 
@@ -737,8 +754,13 @@ class ReplicationManager:
         mtent = self.get_mapping_tree_entry()
         dn = mtent.dn
 
+        def get_entry(dn, attrs):
+            return self.conn.get_entry(DN(dn), attrs)
+
+        replication_plugin_name = get_replication_plugin_name(get_entry)
+
         plgent = self.conn.get_entry(
-            DN(('cn', 'Multimaster Replication Plugin'), ('cn', 'plugins'),
+            DN(('cn', replication_plugin_name), ('cn', 'plugins'),
                ('cn', 'config')),
             ['nsslapd-pluginPath'])
         path = plgent.single_value.get('nsslapd-pluginPath')

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -40,6 +40,7 @@ logger = logging.getLogger(__name__)
 
 DSE = 'dse.ldif'
 COMPAT_DN = "cn=Schema Compatibility,cn=plugins,cn=config"
+REPL_PLUGIN_DN_TEMPLATE = "cn=Multi%s Replication Plugin,cn=plugins,cn=config"
 
 
 class GetEntryFromLDIF(ldif.LDIFParser):
@@ -97,6 +98,7 @@ class IPAUpgrade(service.Service):
         self.modified = False
         self.serverid = serverid
         self.schema_files = schema_files
+        self.sub_dict = dict()
 
     def __start(self):
         srv = services.service(self.service_name, api)
@@ -169,6 +171,20 @@ class IPAUpgrade(service.Service):
                 pass
             else:
                 self.backup_state('nsslapd-global-backend-lock', global_lock)
+
+        # update self.sub_dict with the replication plugin name
+        # It may be different depending on 389-ds version
+        with open(self.filename, "r") as in_file:
+            parser = GetEntryFromLDIF(in_file, entries_dn=[])
+            parser.parse()
+
+        results = parser.get_results()
+
+        dn = REPL_PLUGIN_DN_TEMPLATE % "supplier"
+        if dn not in results:
+            dn = REPL_PLUGIN_DN_TEMPLATE % "master"
+
+        self.sub_dict['REPLICATION_PLUGIN'] = results[dn].get('cn')
 
         with open(self.filename, "r") as in_file:
             parser = GetEntryFromLDIF(in_file, entries_dn=[COMPAT_DN])
@@ -284,7 +300,7 @@ class IPAUpgrade(service.Service):
 
     def __upgrade(self):
         try:
-            ld = ldapupdate.LDAPUpdate(api=self.api)
+            ld = ldapupdate.LDAPUpdate(api=self.api, sub_dict=self.sub_dict)
             if len(self.files) == 0:
                 self.files = ld.get_all_files(ldapupdate.UPDATES_DIR)
             self.modified = (ld.update(self.files) or self.modified)


### PR DESCRIPTION
This PR was opened automatically because PR #5798 was pushed to master and backport to ipa-4-9 is required.