### PR TITLE
ipatests: Fetch sudo rules without time offset

### DIFF
--- a/ipatests/ipa-test-task
+++ b/ipatests/ipa-test-task
@@ -436,7 +436,7 @@ class TaskRunner(object):
 
     def setup_sssd_debugging(self, args):
         host = self.get_host(args.host, default=args.domain.master)
-        tasks.setup_sssd_debugging(host)
+        tasks.setup_sssd_conf(host)
 
     def sync_time(self, args):
         host = self.get_host(args.host, default=args.domain.master)

--- a/ipatests/test_integration/test_legacy_clients.py
+++ b/ipatests/test_integration/test_legacy_clients.py
@@ -543,7 +543,7 @@ class BaseTestSSSDMixin:
 
     def test_apply_advice(self):
         super(BaseTestSSSDMixin, self).test_apply_advice()
-        tasks.setup_sssd_debugging(self.legacy_client)
+        tasks.setup_sssd_conf(self.legacy_client)
 
 
 # Tests definitions themselves. Beauty. Just pure beauty.


### PR DESCRIPTION
As of 2.5.0 SSSD introduces a random timeout for the refresh of the SUDO rules \[0\]. With that change it's no longer possible to immediate fetch of SUDO rules unless the feature is disabled \[1\].

\[0\]: https://github.com/SSSD/sssd/issues/5609
\[1\]: https://github.com/SSSD/sssd/issues/5635

Related: https://pagure.io/freeipa/issue/8844