### PR TITLE
[Backport][ipa-4-9] ipatests: Fetch sudo rules without time offset

### DIFF
--- a/ipatests/ipa-test-task
+++ b/ipatests/ipa-test-task
@@ -436,7 +436,7 @@ class TaskRunner(object):
 
     def setup_sssd_debugging(self, args):
         host = self.get_host(args.host, default=args.domain.master)
-        tasks.setup_sssd_debugging(host)
+        tasks.setup_sssd_conf(host)
 
     def sync_time(self, args):
         host = self.get_host(args.host, default=args.domain.master)

--- a/ipatests/test_integration/test_legacy_clients.py
+++ b/ipatests/test_integration/test_legacy_clients.py
@@ -543,7 +543,7 @@ class BaseTestSSSDMixin:
 
     def test_apply_advice(self):
         super(BaseTestSSSDMixin, self).test_apply_advice()
-        tasks.setup_sssd_debugging(self.legacy_client)
+        tasks.setup_sssd_conf(self.legacy_client)
 
 
 # Tests definitions themselves. Beauty. Just pure beauty.


### PR DESCRIPTION
This PR was opened automatically because PR #5803 was pushed to master and backport to ipa-4-9 is required.