### PR TITLE
service: enforce keytab user when retrieving the keytab

### DIFF
--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -768,7 +768,7 @@ class Service:
         if keytab is None:
             keytab = self.keytab
         if owner is None:
-            owner = self.service_user
+            owner = self.keytab_user
         owner.chown(keytab)
 
     def run_getkeytab(self, ldap_uri, keytab, principal, retrieve=False):


### PR DESCRIPTION
HTTP service uses different user for keytab ownership than the service
user. On Fedora this leads to http.keytab being owned by 'apache' user
after IPA deployment while it should be owned by 'root' to allow
GSSPROXY configuration to work correctly.

The situation is fixed during upgrade (ipa-server-upgrade) but it means
for new deployments there might be a period of unexplained Web UI
authentication failures.

Fixes: https://pagure.io/freeipa/issue/8872

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>
Signed-off-by: Christian Heimes <cheimes@redhat.com>