### PR TITLE
[Backport][ipa-4-9] service: enforce keytab user when retrieving the keytab

### DIFF
--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -768,7 +768,7 @@ class Service:
         if keytab is None:
             keytab = self.keytab
         if owner is None:
-            owner = self.service_user
+            owner = self.keytab_user
         owner.chown(keytab)
 
     def run_getkeytab(self, ldap_uri, keytab, principal, retrieve=False):


### PR DESCRIPTION
This PR was opened automatically because PR #5805 was pushed to master and backport to ipa-4-9 is required.