### PR TITLE
[Backport][ipa-4-9] WebUI: Add support of 'ipaautoprivategroups' LDAP attribute on 'ID Ranges' page

### DIFF
--- a/install/ui/src/freeipa/idrange.js
+++ b/install/ui/src/freeipa/idrange.js
@@ -82,6 +82,13 @@ return {
                             name: 'ipanttrusteddomainsid',
                             label: '@i18n:objects.idrange.ipanttrusteddomainsid',
                             title: '@mo-param:idrange:ipanttrusteddomainsid:label'
+                        },
+                        {
+                            name: 'ipaautoprivategroups',
+                            $type: 'select',
+                            label: '@i18n:objects.idrange.ipaautoprivategroups',
+                            title: '@mo-param:idrange:ipaautoprivategroups:label',
+                            options: IPA.create_options(['', 'true', 'false', 'hybrid'])
                         }
                     ]
                 }
@@ -141,6 +148,13 @@ return {
             {
                 name: 'ipanttrusteddomainname',
                 enabled: false
+            },
+            {
+                name: 'ipaautoprivategroups',
+                $type: 'select',
+                label: '@i18n:objects.idrange.ipaautoprivategroups',
+                default_value: '',
+                options: IPA.create_options(['', 'true', 'false', 'hybrid'])
             }
         ],
         policies: [
@@ -210,6 +224,7 @@ IPA.idrange_adder_policy = function(spec) {
         var baserid_f = that.container.fields.get_field('ipabaserid');
         var secondarybaserid_f = that.container.fields.get_field('ipasecondarybaserid');
         var trusteddomainname_f = that.container.fields.get_field('ipanttrusteddomainname');
+        var autoprivategroups_f = that.container.fields.get_field('ipaautoprivategroups');
 
         var type_v = type_f.get_value()[0];
         var baserid_v = baserid_f.get_value()[0] || '';
@@ -224,9 +239,11 @@ IPA.idrange_adder_policy = function(spec) {
                 disable(baserid_f);
             }
             require(trusteddomainname_f);
+            enable(autoprivategroups_f);
             disable(secondarybaserid_f);
         } else {
             disable(trusteddomainname_f);
+            disable(autoprivategroups_f);
 
             if (IPA.trust_enabled) {
                 require(baserid_f);

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1236,6 +1236,7 @@ class i18n_messages(Command):
             "idrange": {
                 "add": _("Add ID range"),
                 "details": _("Range Settings"),
+                "ipaautoprivategroups": _("Auto private groups"),
                 "ipabaseid": _("Base ID"),
                 "ipabaserid": _("Primary RID base"),
                 "ipaidrangesize": _("Range size"),

--- a/ipatests/test_webui/task_range.py
+++ b/ipatests/test_webui/task_range.py
@@ -147,6 +147,7 @@ class range_tasks(UI_driver):
             range_type=range_type,
             size=size,
             domain=domain,
+            auto_private_groups=kwargs.get('auto_private_groups'),
             callback=self.check_range_type_mod
         )
 
@@ -173,7 +174,7 @@ class RangeAddFormData:
 
     def __init__(self, cn, base_id, base_rid=None, secondary_base_rid=None,
                  range_type=LOCAL_ID_RANGE, size=50, domain=None,
-                 callback=None):
+                 auto_private_groups='', callback=None):
         self.cn = cn
         self.base_id = base_id
         self.base_rid = base_rid
@@ -181,6 +182,7 @@ class RangeAddFormData:
         self.range_type = range_type
         self.size = size
         self.domain = domain
+        self.auto_private_groups = auto_private_groups
         self.callback = callback
 
     def serialize(self):
@@ -202,6 +204,11 @@ class RangeAddFormData:
             serialized.append(('textbox',
                                'ipasecondarybaserid',
                                str(self.secondary_base_rid)))
+
+        if self.range_type != LOCAL_ID_RANGE:
+            serialized.append(('selectbox',
+                               'ipaautoprivategroups',
+                               self.auto_private_groups))
 
         return serialized
 


### PR DESCRIPTION
This PR was opened automatically because PR #5769 was pushed to master and backport to ipa-4-9 is required.