### PR TITLE
Catch ValueError when trying to retrieve existing credentials

### DIFF
--- a/ipalib/krb_utils.py
+++ b/ipalib/krb_utils.py
@@ -175,7 +175,7 @@ def get_principal(ccache_name=None):
     try:
         creds = get_credentials(ccache_name=ccache_name)
         return unicode(creds.name)
-    except gssapi.exceptions.GSSError as e:
+    except ValueError as e:
         raise errors.CCacheError(message=unicode(e))
 
 def get_credentials_if_valid(name=None, ccache_name=None):
@@ -202,5 +202,5 @@ def get_credentials_if_valid(name=None, ccache_name=None):
         return None
     except gssapi.exceptions.ExpiredCredentialsError:
         return None
-    except gssapi.exceptions.GSSError:
+    except ValueError:
         return None


### PR DESCRIPTION
For WebUI users, catch ValueError from get_credentials_if_valid()
if their associated credentials cache is expired or missing.
This will in turn return an HTTP 401 so they can re-authenticate.

This was an uncaught exception due to changes made to sweep up
expired ccaches (https://pagure.io/freeipa/issue/8589)

https://pagure.io/freeipa/issue/8873

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

It's putting the cart before the horse but https://github.com/freeipa/freeipa/pull/5637 will eventually exercise this.

For reviewers: I did the least possible change. We could also not play with a creds variable and do the returns directly inside the exception but I found the current code easier to follow. YMMV.