### PR TITLE
ipatests: set selinux context for fips mode

### DIFF
--- a/ipatests/pytest_ipa/integration/fips.py
+++ b/ipatests/pytest_ipa/integration/fips.py
@@ -38,6 +38,9 @@ def enable_userspace_fips(host):
     host.run_command(["mkdir", "-p", FIPS_OVERLAY_DIR])
     host.put_file_contents(FIPS_OVERLAY, "1\n")
     host.run_command(
+        ["chcon", "-t", "sysctl_crypto_t", "-u", "system_u", FIPS_OVERLAY]
+    )
+    host.run_command(
         ["mount", "--bind", FIPS_OVERLAY, paths.PROC_FIPS_ENABLED]
     )
     # set crypto policy to FIPS mode


### PR DESCRIPTION
In order to test FIPS mode, the test is faking a user-space
FIPS environment by creating a file /var/tmp/userspace-fips
and bind-mounting this file as /proc/sys/crypto/fips_enabled

The security context needs to be properly set otherwise
/proc/sys/crypto/fips_enabled inherits the security context
unconfined_u:object_r:user_tmp_t:s0 and cannot be read,
resulting in the test seeing fips_mode=false.

Fixes: https://pagure.io/freeipa/issue/8868
