### PR TITLE
krb_utils: Simplify get_credentials

### DIFF
--- a/install/share/gssproxy.conf.template
+++ b/install/share/gssproxy.conf.template
@@ -11,7 +11,6 @@
 [service/ipa-api]
   mechs = krb5
   cred_store = keytab:$HTTP_KEYTAB
-  cred_store = client_keytab:$HTTP_KEYTAB
   allow_constrained_delegation = true
   allow_client_ccache_sync = true
   cred_usage = initiate

--- a/install/tools/ipa-ccache-sweeper.in
+++ b/install/tools/ipa-ccache-sweeper.in
@@ -43,13 +43,8 @@ def should_delete(fname, t, minlife):
     # is not provided in cred_store the result of gss_acquire_cred_from
     # is KRB5_FCC_NOFILE, which is mapped by gssproxy to
     # 0x04200000 + KRB5_FCC_NOFILE.
-    try:
-        creds = get_credentials_if_valid(ccache_name=fname)
-        return creds is None
-    except ValueError:
-        return True
-
-    return False
+    creds = get_credentials_if_valid(ccache_name=fname)
+    return creds is None
 
 
 if __name__ == "__main__":

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -913,6 +913,9 @@ class jsonserver_session(jsonserver, KerberosSession):
             else:
                 return self.service_unavailable(environ, start_response, msg)
 
+        except CCacheError:
+            return self.need_login(start_response)
+
         try:
             response = super(jsonserver_session, self).__call__(environ, start_response)
         finally:


### PR DESCRIPTION
Previously, `get_credentials` raises either `ValueError` or re-raises `GSSError`. The former makes the handling of this function more difficult without a good reason.
    
With this change:
- `get_credentials` no longer handles exceptions by itself, but delegates
    this to the callers (which already process GSS errors).
- `get_credentials_if_valid` doesn't raise any expected exceptions, but
    return valid credentials (on the moment of calling) or None. This makes
    it consistent with docs.
    
Related: https://pagure.io/freeipa/issue/8873

tested scenarios:
1. missing creds &&  ipa user-find xxx
2. expired creds && ipa user-find xxx
3. https://pagure.io/freeipa/issue/7752 (removed ccache on server + ipa user-find xxx)
4. ccache sweeper