### PR TITLE
ipatests: delete the replica before uninstallation

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -205,7 +205,7 @@ class TestInstallWithCA1(InstallTestBase1):
         ldap_conf = paths.OPENLDAP_LDAP_CONF
         base_dn = self.master.domain.basedn
         client = self.replicas[0]
-        tasks.uninstall_master(client)
+        tasks.uninstall_replica(self.master, client)
         expected_msg1 = "contains deprecated and unsupported " \
                         "entries: HOST, PORT"
         file_backup = client.get_file_contents(ldap_conf, encoding='utf-8')


### PR DESCRIPTION
The test
test_installation.py::TestInstallWithCA1::test_install_with_bad_ldap_conf
is uninstalling a replica by calling ipa-server-install --uninstall
directly, instead of deleting the replica first.
    
Use tasks.uninstall_replica instead of tasks.uninstall_master
to perform a proper uninstallation.
    
Fixes: https://pagure.io/freeipa/issue/8876
