### PR TITLE
[Backport][ipa-4-9] ipatests: set selinux context for fips mode

### DIFF
--- a/ipatests/pytest_ipa/integration/fips.py
+++ b/ipatests/pytest_ipa/integration/fips.py
@@ -38,6 +38,9 @@ def enable_userspace_fips(host):
     host.run_command(["mkdir", "-p", FIPS_OVERLAY_DIR])
     host.put_file_contents(FIPS_OVERLAY, "1\n")
     host.run_command(
+        ["chcon", "-t", "sysctl_crypto_t", "-u", "system_u", FIPS_OVERLAY]
+    )
+    host.run_command(
         ["mount", "--bind", FIPS_OVERLAY, paths.PROC_FIPS_ENABLED]
     )
     # set crypto policy to FIPS mode


### PR DESCRIPTION
This PR was opened automatically because PR #5812 was pushed to master and backport to ipa-4-9 is required.