### PR TITLE
[Backport][ipa-4-9] ipatests: delete the replica before uninstallation

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -205,7 +205,7 @@ class TestInstallWithCA1(InstallTestBase1):
         ldap_conf = paths.OPENLDAP_LDAP_CONF
         base_dn = self.master.domain.basedn
         client = self.replicas[0]
-        tasks.uninstall_master(client)
+        tasks.uninstall_replica(self.master, client)
         expected_msg1 = "contains deprecated and unsupported " \
                         "entries: HOST, PORT"
         file_backup = client.get_file_contents(ldap_conf, encoding='utf-8')


### PR DESCRIPTION
This PR was opened automatically because PR #5814 was pushed to master and backport to ipa-4-9 is required.