### PR TITLE
ipatests: temporary disable execution of test_nfs.py::TestNFS in nightly runs

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1450,17 +1450,17 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest/nfs:
-    requires: [fedora-latest/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_nfs.py::TestNFS
-        template: *ci-master-latest
-        timeout: 9000
-        topology: *master_3client
+#  fedora-latest/nfs:
+#    requires: [fedora-latest/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-latest/build_url}'
+#        test_suite: test_integration/test_nfs.py::TestNFS
+#        template: *ci-master-latest
+#        timeout: 9000
+#        topology: *master_3client
 
   fedora-latest/nfs_nsswitch_restore:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1564,18 +1564,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest/nfs:
-    requires: [fedora-latest/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-latest/build_url}'
-        selinux_enforcing: True
-        test_suite: test_integration/test_nfs.py::TestNFS
-        template: *ci-master-latest
-        timeout: 9000
-        topology: *master_3client
+#  fedora-latest/nfs:
+#    requires: [fedora-latest/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-latest/build_url}'
+#        selinux_enforcing: True
+#        test_suite: test_integration/test_nfs.py::TestNFS
+#        template: *ci-master-latest
+#        timeout: 9000
+#        topology: *master_3client
 
   fedora-latest/nfs_nsswitch_restore:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1564,18 +1564,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  testing-fedora/nfs:
-    requires: [testing-fedora/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{testing-fedora/build_url}'
-        update_packages: True
-        test_suite: test_integration/test_nfs.py::TestNFS
-        template: *testing-master-latest
-        timeout: 9000
-        topology: *master_3client
+#  testing-fedora/nfs:
+#    requires: [testing-fedora/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{testing-fedora/build_url}'
+#        update_packages: True
+#        test_suite: test_integration/test_nfs.py::TestNFS
+#        template: *testing-master-latest
+#        timeout: 9000
+#        topology: *master_3client
 
   testing-fedora/nfs_nsswitch_restore:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1678,19 +1678,19 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  testing-fedora/nfs:
-    requires: [testing-fedora/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{testing-fedora/build_url}'
-        update_packages: True
-        selinux_enforcing: True
-        test_suite: test_integration/test_nfs.py::TestNFS
-        template: *testing-master-latest
-        timeout: 9000
-        topology: *master_3client
+#  testing-fedora/nfs:
+#    requires: [testing-fedora/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{testing-fedora/build_url}'
+#        update_packages: True
+#        selinux_enforcing: True
+#        test_suite: test_integration/test_nfs.py::TestNFS
+#        template: *testing-master-latest
+#        timeout: 9000
+#        topology: *master_3client
 
   testing-fedora/nfs_nsswitch_restore:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1576,18 +1576,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-rawhide/nfs:
-    requires: [fedora-rawhide/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-rawhide/build_url}'
-        update_packages: True
-        test_suite: test_integration/test_nfs.py::TestNFS
-        template: *ci-master-frawhide
-        timeout: 9000
-        topology: *master_3client
+#  fedora-rawhide/nfs:
+#    requires: [fedora-rawhide/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-rawhide/build_url}'
+#        update_packages: True
+#        test_suite: test_integration/test_nfs.py::TestNFS
+#        template: *ci-master-frawhide
+#        timeout: 9000
+#        topology: *master_3client
 
   fedora-rawhide/nfs_nsswitch_restore:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
During test run on Fedora 34 and 35 sssd produces multi-gigabyte log file
which causes test runners to run out of disk space.

Related to https://pagure.io/freeipa/issue/8877