### PR TITLE
freeipa.spec: bump 389-ds version

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -105,11 +105,11 @@
 # fix for segfault in python3-ldap, https://pagure.io/freeipa/issue/7324
 %global python_ldap_version 3.1.0-1
 
-# Make sure to use 389-ds-base versions that fix https://github.com/389ds/389-ds-base/issues/4609
+# Make sure to use 389-ds-base versions that fix https://github.com/389ds/389-ds-base/issues/4700
 %if 0%{?fedora} < 34
-%global ds_version %{lua: local v={}; v['32']='1.4.3.20-2'; v['33']='1.4.4.13-2'; print(v[rpm.expand('%{fedora}')])}
+%global ds_version %{lua: local v={}; v['32']='1.4.3.20-2'; v['33']='1.4.4.16-1'; print(v[rpm.expand('%{fedora}')])}
 %else
-%global ds_version 2.0.3-3
+%global ds_version 2.0.5-1
 %endif
 
 # Fix for TLS 1.3 PHA, RHBZ#1775146


### PR DESCRIPTION
IPA depends on the 389-ds version with the fix for
https://github.com/389ds/389-ds-base/issues/4700
Regression in winsync replication agreement

The same 389-ds version also fixes
https://github.com/389ds/389-ds-base/issues/4670
389ds coredump in IPA nightly test
test_caless.py::TestReplicaInstall::test_wildcard_http

Fixes: https://pagure.io/freeipa/issue/8691
Fixes: https://pagure.io/freeipa/issue/8756
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>