### PR TITLE
[Backport][ipa-4-9] ipatests: temporary disable execution of test_nfs.py::TestNFS in nightly runs

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1450,17 +1450,17 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest-ipa-4-9/nfs:
-    requires: [fedora-latest-ipa-4-9/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-latest-ipa-4-9/build_url}'
-        test_suite: test_integration/test_nfs.py::TestNFS
-        template: *ci-ipa-4-9-latest
-        timeout: 9000
-        topology: *master_3client
+#  fedora-latest-ipa-4-9/nfs:
+#    requires: [fedora-latest-ipa-4-9/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-latest-ipa-4-9/build_url}'
+#        test_suite: test_integration/test_nfs.py::TestNFS
+#        template: *ci-ipa-4-9-latest
+#        timeout: 9000
+#        topology: *master_3client
 
   fedora-latest-ipa-4-9/nfs_nsswitch_restore:
     requires: [fedora-latest-ipa-4-9/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1564,18 +1564,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-latest-ipa-4-9/nfs:
-    requires: [fedora-latest-ipa-4-9/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-latest-ipa-4-9/build_url}'
-        selinux_enforcing: True
-        test_suite: test_integration/test_nfs.py::TestNFS
-        template: *ci-ipa-4-9-latest
-        timeout: 9000
-        topology: *master_3client
+#  fedora-latest-ipa-4-9/nfs:
+#    requires: [fedora-latest-ipa-4-9/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-latest-ipa-4-9/build_url}'
+#        selinux_enforcing: True
+#        test_suite: test_integration/test_nfs.py::TestNFS
+#        template: *ci-ipa-4-9-latest
+#        timeout: 9000
+#        topology: *master_3client
 
   fedora-latest-ipa-4-9/nfs_nsswitch_restore:
     requires: [fedora-latest-ipa-4-9/build]


### PR DESCRIPTION
This is a manual backport of #5818 