### PR TITLE
[ipa-4-6] CA less installation: non ASCII chars in CA subject

### DIFF
--- a/ipalib/install/certstore.py
+++ b/ipalib/install/certstore.py
@@ -294,7 +294,7 @@ def get_ca_certs(ldap, base_dn, compat_realm, compat_ipa_ca,
                         'cACertificate;binary'])
 
         for entry in result:
-            nickname = entry.single_value['cn']
+            nickname = entry.single_value['cn'].encode('utf-8')
             trusted = entry.single_value.get('ipaKeyTrust', 'unknown').lower()
             if trusted == 'trusted':
                 trusted = True

--- a/ipatests/pytest_ipa/integration/create_caless_pki.py
+++ b/ipatests/pytest_ipa/integration/create_caless_pki.py
@@ -550,7 +550,7 @@ def create_pki():
                 x509.NameAttribute(NameOID.COMMON_NAME, server2)
              ])
              )
-    ca1 = gen_subtree(u'ca1', u'Example Organization')
+    ca1 = gen_subtree(u'ca1', u'Example Organization Espa\xf1a')
     gen_subtree(u'subca', u'Subsidiary Example Organization', ca1)
     gen_subtree(u'ca2', u'Other Example Organization')
     ca3 = gen_subtree(u'ca3', u'Unknown Organization')


### PR DESCRIPTION
### CA less installation: non ASCII chars in CA subject
In CA-less installation, ipa-server-install fails when the CA
certificate contains a subject with non ASCII characters.

ipa-server-install is internally calling ipautil.run(...)
to launch a certutil -n nickname command, and the nickname is
provided as a unicode instead of a string.

The fix  makes sure the nickname is provided as a utf-8
encoded string.

Fixes: https://pagure.io/freeipa/issue/8879

### ipatests: use non-ascii chars in CA-less install

The CA-less installation creates an external CA with the
subject CN=CA,O=Example Organization.
In order to test non-ascii subjects, use
CN=CA,O=Example Organization España
instead.

Related: https://pagure.io/freeipa/issue/8879
