### PR TITLE
[Backport][ipa-4-9] freeipa.spec: bump 389-ds version

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -105,11 +105,11 @@
 # fix for segfault in python3-ldap, https://pagure.io/freeipa/issue/7324
 %global python_ldap_version 3.1.0-1
 
-# Make sure to use 389-ds-base versions that fix https://github.com/389ds/389-ds-base/issues/4609
+# Make sure to use 389-ds-base versions that fix https://github.com/389ds/389-ds-base/issues/4700
 %if 0%{?fedora} < 34
-%global ds_version %{lua: local v={}; v['32']='1.4.3.20-2'; v['33']='1.4.4.13-2'; print(v[rpm.expand('%{fedora}')])}
+%global ds_version %{lua: local v={}; v['32']='1.4.3.20-2'; v['33']='1.4.4.16-1'; print(v[rpm.expand('%{fedora}')])}
 %else
-%global ds_version 2.0.3-3
+%global ds_version 2.0.5-1
 %endif
 
 # Fix for TLS 1.3 PHA, RHBZ#1775146


### PR DESCRIPTION
This PR was opened automatically because PR #5819 was pushed to master and backport to ipa-4-9 is required.