### PR TITLE
ipa-cert-fix man page: add note about certmonger renewal

### DIFF
--- a/install/tools/man/ipa-cert-fix.1
+++ b/install/tools/man/ipa-cert-fix.1
@@ -39,6 +39,13 @@ for shared certificates via \fIgetcert-resubmit(1)\fR (on the other
 CA server).  This is to avoid unnecessary renewal of shared
 certificates.
 
+Important note: the \fIcertmonger\fR daemon does not immediately notice
+the updated certificates and may trigger a renewal after \fIipa-cert-fix\fR
+completes. As a consequence, \fIgetcert list\fR output may display
+that a renewal is in progress even if \fIipa-cert-fix\fR just
+finished. It is recommended to monitor the certmonger-initiated
+renewal and wait for its completion before any other administrative task.
+
 .SH "OPTIONS"
 .TP
 \fB\-\-version\fR

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -57,6 +57,12 @@ and keys, is STRONGLY RECOMMENDED.
 
 """
 
+renewal_note = """
+Note: Monitor the certmonger-initiated renewal of
+certificates after ipa-cert-fix and wait for its completion before
+any other administrative task.
+"""
+
 RENEWED_CERT_PATH_TEMPLATE = "/etc/pki/pki-tomcat/certs/{}-renewed.crt"
 
 logger = logging.getLogger(__name__)
@@ -175,6 +181,7 @@ class IPACertFix(AdminTool):
         print("Restarting IPA")
         ipautil.run(['ipactl', 'restart'], raiseonerr=True)
 
+        print(renewal_note)
         return 0
 
 


### PR DESCRIPTION
ipa-cert-fix man page needs to explain that certmonger may
trigger a renewal right after ipa-cert-fix completes because
certmonger does not notice the updated certificates.

Fixes: https://pagure.io/freeipa/issue/8702
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>