### PR TITLE
host: provide a better error message with updatedns when FQDN is not provided

### DIFF
--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -964,6 +964,10 @@ class host_mod(LDAPUpdate):
             try:
                 result = api.Command['dnszone_show'](domain)['result']
                 domain = result['idnsname'][0]
+            except errors.RequirementError:
+                raise errors.ValidationError(
+                    name="hostname",
+                    error="FQDN must be provided")
             except errors.NotFound:
                 raise self.obj.handle_not_found(*keys)
             update_sshfp_record(domain, unicode(parts[0]), entry_attrs)

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -331,6 +331,14 @@ class TestCRUD(XMLRPC_test):
                 name='sshpubkey', error=u'options are not allowed')):
             command()
 
+    def test_updatedns_with_shortname(self, host):
+        host.ensure_exists()
+        with raises_exact(errors.ValidationError(
+                name='hostname', error='FQDN must be provided')):
+            host.run_command('host_mod', host.shortname,
+                             updatedns=True,
+                             setattr='nshardwareplatform=linux')
+
     def test_delete_host(self, host):
         host.delete()
 


### PR DESCRIPTION
The --updatedns option for host-mod requires the FQDN to be passed,
otherwise an obscure error message is shown since the domain cannot be
found.

Fixes: https://pagure.io/freeipa/issue/8726
Signed-off-by: Antonio Torres <antorres@redhat.com>