### PR TITLE
ipatests: disable test_nfs.py::TestNFS in nightly runs on Fedora 33

### DIFF
--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1450,17 +1450,17 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-previous/nfs:
-    requires: [fedora-previous/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-previous/build_url}'
-        test_suite: test_integration/test_nfs.py::TestNFS
-        template: *ci-master-previous
-        timeout: 9000
-        topology: *master_3client
+#  fedora-previous/nfs:
+#    requires: [fedora-previous/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-previous/build_url}'
+#        test_suite: test_integration/test_nfs.py::TestNFS
+#        template: *ci-master-previous
+#        timeout: 9000
+#        topology: *master_3client
 
   fedora-previous/nfs_nsswitch_restore:
     requires: [fedora-previous/build]


### PR DESCRIPTION
Also disable in Fedora 33 as it also has the faulty version of sssd
which produces multi-gigabyte log file

Related to https://pagure.io/freeipa/issue/8877