### PR TITLE
[Backport][ipa-4-9] ipatests: disable test_nfs.py::TestNFS in nightly runs on Fedora 33

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1450,17 +1450,17 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
-  fedora-previous-ipa-4-9/nfs:
-    requires: [fedora-previous-ipa-4-9/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-previous-ipa-4-9/build_url}'
-        test_suite: test_integration/test_nfs.py::TestNFS
-        template: *ci-ipa-4-9-previous
-        timeout: 9000
-        topology: *master_3client
+#  fedora-previous-ipa-4-9/nfs:
+#    requires: [fedora-previous-ipa-4-9/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-previous-ipa-4-9/build_url}'
+#        test_suite: test_integration/test_nfs.py::TestNFS
+#        template: *ci-ipa-4-9-previous
+#        timeout: 9000
+#        topology: *master_3client
 
   fedora-previous-ipa-4-9/nfs_nsswitch_restore:
     requires: [fedora-previous-ipa-4-9/build]


### PR DESCRIPTION
This is a manual backport of #5827 