### PR TITLE
Allow PKINIT to be enabled when updating from a pre-PKINIT IPA CA server

### DIFF
--- a/ipaserver/install/ipa_pkinit_manage.py
+++ b/ipaserver/install/ipa_pkinit_manage.py
@@ -78,6 +78,8 @@ class PKINITManage(AdminTool):
             krb.enable_ssl()
 
         if setup_pkinit:
+            if not is_pkinit_enabled():
+                krb.setup_pkinit()
             krb.pkinit_enable()
         else:
             krb.pkinit_disable()


### PR DESCRIPTION
When upgrading from a server with IPA CA before PKINIT was introduced
(4.5), PKINIT would not be enabled and there wasn't any way to enable it
since upgrade code only issues self-signed certificates when
certificates are missing. With these change there is a way to enable
PKINIT when coming from a IPA server with a pre-PKINIT version (4.4 and
before).

Fixes: https://pagure.io/freeipa/issue/8532
Signed-off-by: Antonio Torres <antorres@redhat.com>