### PR TITLE
[Backport][ipa-4-9] krb_utils: Simplify get_credentials

### DIFF
--- a/install/share/gssproxy.conf.template
+++ b/install/share/gssproxy.conf.template
@@ -11,7 +11,6 @@
 [service/ipa-api]
   mechs = krb5
   cred_store = keytab:$HTTP_KEYTAB
-  cred_store = client_keytab:$HTTP_KEYTAB
   allow_constrained_delegation = true
   allow_client_ccache_sync = true
   cred_usage = initiate

--- a/install/tools/ipa-ccache-sweeper.in
+++ b/install/tools/ipa-ccache-sweeper.in
@@ -43,13 +43,8 @@ def should_delete(fname, t, minlife):
     # is not provided in cred_store the result of gss_acquire_cred_from
     # is KRB5_FCC_NOFILE, which is mapped by gssproxy to
     # 0x04200000 + KRB5_FCC_NOFILE.
-    try:
-        creds = get_credentials_if_valid(ccache_name=fname)
-        return creds is None
-    except ValueError:
-        return True
-
-    return False
+    creds = get_credentials_if_valid(ccache_name=fname)
+    return creds is None
 
 
 if __name__ == "__main__":

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -913,6 +913,9 @@ class jsonserver_session(jsonserver, KerberosSession):
             else:
                 return self.service_unavailable(environ, start_response, msg)
 
+        except CCacheError:
+            return self.need_login(start_response)
+
         try:
             response = super(jsonserver_session, self).__call__(environ, start_response)
         finally:


### PR DESCRIPTION
This PR was opened automatically because PR #5813 was pushed to master and backport to ipa-4-9 is required.