### PR TITLE
host: try to resolve FQDN before command execution

### DIFF
--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -331,6 +331,12 @@ class TestCRUD(XMLRPC_test):
                 name='sshpubkey', error=u'options are not allowed')):
             command()
 
+    def test_update_shortname(self, host):
+        host.ensure_exists()
+        host.run_command('host_mod', host.shortname,
+                         updatedns=True,
+                         setattr='nshardwareplatform=linux')
+
     def test_delete_host(self, host):
         host.delete()
 


### PR DESCRIPTION
Trying to resolve the FQDN before command execution (during
pre-callback) helps detect cases where the host specified by the user
does not exist, saving execution time. Aside from this, resolving the
FQDN is useful when only the shortname of the host is passed, as this
would cause issues when trying to update the DNS records during
modification of the entry.

Fixes: https://pagure.io/freeipa/issue/8726
Fixes: https://pagure.io/freeipa/issue/8884
Signed-off-by: Antonio Torres <antorres@redhat.com>