### PR TITLE
dnszone-add: deprecate option for setting SOA serial

### DIFF
--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -2432,6 +2432,7 @@ class dnszone(DNSZoneBase):
             autofill=True,
         ),
         Int('idnssoaserial',
+            # Deprecated
             cli_name='serial',
             label=_('SOA serial'),
             doc=_('SOA record serial number'),
@@ -2439,6 +2440,7 @@ class dnszone(DNSZoneBase):
             maxvalue=4294967295,
             default_from=_create_zone_serial,
             autofill=True,
+            flags=['no_option'],
         ),
         Int('idnssoarefresh',
             cli_name='refresh',
@@ -2776,6 +2778,14 @@ class dnszone_add(DNSZoneBase_add):
                     option='ip-address',
                     additional_info=u"Value will be ignored.")
             )
+        if 'idnssoaserial' in options:
+            messages.add_message(
+                options['version'],
+                result,
+                messages.OptionDeprecatedWarning(
+                    option='idnssoaserial',
+                    additional_info=u"Value will be ignored.")
+            )
 
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys, **options):
         assert isinstance(dn, DN)
@@ -2889,6 +2899,16 @@ class dnszone_mod(DNSZoneBase_mod):
              doc=_('Force nameserver change even if nameserver not in DNS')),
     )
 
+    def _warning_deprecated_option(self, result, **options):
+        if 'idnssoaserial' in options:
+            messages.add_message(
+                options['version'],
+                result,
+                messages.OptionDeprecatedWarning(
+                    option='idnssoaserial',
+                    additional_info=u"Value will be ignored.")
+            )
+
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list,
                      *keys, **options):
         if not _check_DN_objectclass(ldap, dn, self.obj.object_class):
@@ -2909,6 +2929,7 @@ class dnszone_mod(DNSZoneBase_mod):
 
     def execute(self, *keys, **options):
         result = super(dnszone_mod, self).execute(*keys, **options)
+        self._warning_deprecated_option(result, **options)
         self.obj._warning_forwarding(result, **options)
         self.obj._warning_name_server_option(result, context, **options)
         self.obj._warning_dnssec_master_is_not_installed(result, **options)

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -560,6 +560,16 @@ class test_dns(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -635,6 +645,15 @@ class test_dns(Declarative):
                     'objectclass': objectclasses.dnszone,
                 },
                 'messages': (
+                    {'message': "'idnssoaserial' option is deprecated."
+                                " Value will be ignored.",
+                     'code': 13004,
+                     'data': {
+                         'additional_info': 'Value will be ignored.',
+                         'option': 'idnssoaserial'
+                     },
+                     'name': 'OptionDeprecatedWarning',
+                     'type': 'warning'},
                     {'message': u"Semantic of setting Authoritative nameserver "
                                 u"was changed. "
                                 u"It is used only for setting the SOA MNAME "
@@ -696,6 +715,16 @@ class test_dns(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -731,6 +760,16 @@ class test_dns(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -965,6 +1004,16 @@ class test_dns(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -1803,6 +1852,16 @@ class test_dns(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -1837,6 +1896,16 @@ class test_dns(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -2023,6 +2092,16 @@ class test_dns(Declarative):
                                          u'grant %(realm)s krb5-self * SSHFP;'
                                          % dict(realm=api.env.realm)],
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -2276,6 +2355,16 @@ class test_dns(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -2323,6 +2412,16 @@ class test_dns(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -2355,6 +2454,16 @@ class test_dns(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -2462,6 +2571,16 @@ class test_dns(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -2656,6 +2775,16 @@ class test_dns(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -3507,6 +3636,16 @@ class test_root_zone(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -4789,6 +4928,16 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -4983,6 +5132,16 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -5189,6 +5348,15 @@ class test_forwardzone_delegation_warnings(Declarative):
                     'objectclass': objectclasses.dnszone,
                 },
                 'messages': (
+                    {'message': "'idnssoaserial' option is deprecated."
+                                " Value will be ignored.",
+                     'code': 13004,
+                     'data': {
+                         'additional_info': 'Value will be ignored.',
+                         'option': 'idnssoaserial'
+                     },
+                     'name': 'OptionDeprecatedWarning',
+                     'type': 'warning'},
                     {'message': u'forward zone "fw.sub.dnszone.test." is not '
                                  u'effective because of missing proper NS '
                                  u'delegation in authoritative zone '
@@ -5201,8 +5369,7 @@ class test_forwardzone_delegation_warnings(Declarative):
                         'authzone': zone1_absolute,
                         'fwzone': zone1_sub_fw,
                         'ns_rec': zone1_sub_fw[:-len(zone1_absolute) - 1]
-                     }},
-                ),
+                     }},),
             },
         ),
 
@@ -5235,6 +5402,15 @@ class test_forwardzone_delegation_warnings(Declarative):
                     'objectclass': objectclasses.dnszone,
                 },
                 'messages': (
+                    {'message': "'idnssoaserial' option is deprecated."
+                                " Value will be ignored.",
+                     'code': 13004,
+                     'data': {
+                         'additional_info': 'Value will be ignored.',
+                         'option': 'idnssoaserial'
+                     },
+                     'name': 'OptionDeprecatedWarning',
+                     'type': 'warning'},
                     {'message': u'forward zone "fw.sub.dnszone.test." is not '
                                 u'effective because of missing proper NS '
                                 u'delegation in authoritative zone '
@@ -5247,8 +5423,7 @@ class test_forwardzone_delegation_warnings(Declarative):
                         'authzone': zone1_sub,
                         'fwzone': zone1_sub_fw,
                         'ns_rec': zone1_sub_fw[:-len(zone1_sub) - 1]
-                     }},
-                ),
+                     }}),
             },
         ),
 
@@ -5687,6 +5862,16 @@ class test_dns_soa(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -5734,6 +5919,16 @@ class test_dns_soa(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
 
@@ -6163,6 +6358,16 @@ class test_dns_soa(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
         dict(
@@ -6206,6 +6411,16 @@ class test_dns_soa(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
+                'messages' : ({
+                    'code': 13004,
+                    'data': {
+                        'additional_info': 'Value will be ignored.',
+                        'option': 'idnssoaserial'
+                    },
+                    'message': "'idnssoaserial' option is deprecated."
+                               " Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
         ),
         dict(
@@ -6249,7 +6464,17 @@ class test_dns_soa(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
-                'messages': [{
+                'messages': [
+                    {'code': 13004,
+                     'data': {
+                         'additional_info': 'Value will be ignored.',
+                         'option': 'idnssoaserial'
+                     },
+                     'message': "'idnssoaserial' option is deprecated."
+                                " Value will be ignored.",
+                     'name': 'OptionDeprecatedWarning',
+                     'type': 'warning'},
+                    {
                     'message': u"Semantic of setting Authoritative nameserver "
                                u"was changed. "
                                u"It is used only for setting the SOA MNAME "
@@ -6265,8 +6490,7 @@ class test_dns_soa(Declarative):
                         'hint': u"NS record(s) can be edited in zone apex - "
                                 u"'@'. ",
                         'label': u"setting Authoritative nameserver",
-                    },
-                }], },
+                    }},], },
         ),
         dict(
             desc='Deleting a zone - %r' % zone6,
@@ -6312,7 +6536,17 @@ class test_dns_soa(Declarative):
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
                 },
-                'messages': [{
+                'messages': [
+                    {'code': 13004,
+                     'data': {
+                         'additional_info': 'Value will be ignored.',
+                         'option': 'idnssoaserial'
+                     },
+                     'message': "'idnssoaserial' option is deprecated."
+                                " Value will be ignored.",
+                     'name': 'OptionDeprecatedWarning',
+                     'type': 'warning'},
+                    {
                     'message': u"Semantic of setting Authoritative nameserver "
                                u"was changed. "
                                u"It is used only for setting the SOA MNAME "
@@ -6328,9 +6562,7 @@ class test_dns_soa(Declarative):
                         'hint': u"NS record(s) can be edited in zone apex - "
                                 u"'@'. ",
                         'label': u"setting Authoritative nameserver",
-                    },
-                }],
-            },
+                    }},], },
         ),
         dict(
             desc='Deleting a zone - %r' % zone6,

--- a/ipatests/test_xmlrpc/test_dns_realmdomains_integration.py
+++ b/ipatests/test_xmlrpc/test_dns_realmdomains_integration.py
@@ -130,8 +130,15 @@ class test_dns_realmdomains_integration(Declarative):
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
                     'objectclass': objectclasses.dnszone,
-
                 },
+                'messages': ({
+                    'code': 13004,
+                    'data': {'additional_info': 'Value will be ignored.',
+                             'option': 'idnssoaserial'},
+                    'message': "'idnssoaserial' option is deprecated. "
+                               "Value will be ignored.",
+                    'name': 'OptionDeprecatedWarning',
+                    'type': 'warning'},),
             },
             extra_check=assert_realmdomain_and_txt_record_present,
         ),
@@ -149,16 +156,26 @@ class test_dns_realmdomains_integration(Declarative):
             expected={
                 'value': DNSName(dnszone_2_absolute),
                 'summary': None,
-                'messages': ({
-                    u'message': u'DNS forwarder semantics changed since '
-                    u'IPA 4.0.\nYou may want to use forward zones '
-                    u'(dnsforwardzone-*) instead.\nFor more details read '
-                    u'the docs.',
-                    u'code': 13002,
-                    u'type': u'warning',
-                    u'name': u'ForwardersWarning',
-                    u'data': {}
-                },),
+                'messages': (
+                    {
+                        'code': 13004,
+                        'data': {'additional_info': 'Value will be ignored.',
+                                 'option': 'idnssoaserial'},
+                        'message': "'idnssoaserial' option is deprecated. "
+                                   "Value will be ignored.",
+                        'name': 'OptionDeprecatedWarning',
+                        'type': 'warning'
+                    },
+                    {
+                        u'message': u'DNS forwarder semantics changed since '
+                        u'IPA 4.0.\nYou may want to use forward zones '
+                        u'(dnsforwardzone-*) instead.\nFor more details read '
+                        u'the docs.',
+                        u'code': 13002,
+                        u'type': u'warning',
+                        u'name': u'ForwardersWarning',
+                        u'data': {}
+                    },),
                 'result': {
                     'dn': dnszone_2_dn,
                     'idnsname': [DNSName(dnszone_2_absolute)],


### PR DESCRIPTION
Since IPA 3 [1] SOA serial is managed automatically via autoincrement,
and the option of disabling this behavior was deprecated in IPA 3.3.3 [2].
As a result, the option `--serial` during DNS zone addition would be
ignored as it is set during the creation. This commit adds a deprecation
warning if this option is used. Setting the SOA serial manually would still
be useful in certain scenarios, so the option of doing it with dnszone-mod
is kept.

[1] https://www.freeipa.org/page/V3/DNS_SOA_serial_auto-incrementation
[2] https://www.freeipa.org/page/Releases/3.3.3

Fixes: https://pagure.io/freeipa/issue/8227
Signed-off-by: Antonio Torres <antorres@redhat.com>