### PR TITLE
[Backport][ipa-4-6] Allow PKINIT to be enabled when updating from a pre-PKINIT IPA CA server

### DIFF
--- a/ipaserver/install/ipa_pkinit_manage.py
+++ b/ipaserver/install/ipa_pkinit_manage.py
@@ -78,6 +78,8 @@ class PKINITManage(AdminTool):
             krb.enable_ssl()
 
         if setup_pkinit:
+            if not is_pkinit_enabled():
+                krb.setup_pkinit()
             krb.pkinit_enable()
         else:
             krb.pkinit_disable()


### PR DESCRIPTION
This PR was opened automatically because PR #5832 was pushed to master and backport to ipa-4-6 is required.