### PR TITLE
[Backport][ipa-4-9] host: try to resolve FQDN before command execution

### DIFF
--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -331,6 +331,12 @@ class TestCRUD(XMLRPC_test):
                 name='sshpubkey', error=u'options are not allowed')):
             command()
 
+    def test_update_shortname(self, host):
+        host.ensure_exists()
+        host.run_command('host_mod', host.shortname,
+                         updatedns=True,
+                         setattr='nshardwareplatform=linux')
+
     def test_delete_host(self, host):
         host.delete()
 


### PR DESCRIPTION
This PR was opened automatically because PR #5838 was pushed to master and backport to ipa-4-9 is required.