### PR TITLE
ipatests: Bump PR-CI rawhide template

### DIFF
--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-frawhide
           name: freeipa/ci-master-frawhide
-          version: 0.4.1
+          version: 0.4.2
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Update system's Python to 3.10

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/435

---

Testing template with `automember`: https://github.com/freeipa-pr-ci2/freeipa/pull/989