### PR TITLE
[Backport][ipa-4-9] Convert repl plugin name to single-value string on upgrades 

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -572,10 +572,11 @@ class DsInstance(service.Service):
         inst.open()
 
         def get_entry(dn, attrs):
-            return inst.getEntry(dn, attrlist=attrs)
+            return inst.getEntry(str(dn), attrlist=attrs)
 
         self.sub_dict['REPLICATION_PLUGIN'] = (
-            replication.get_replication_plugin_name(get_entry))
+            installutils.get_replication_plugin_name(get_entry)
+        )
 
         try:
             ipadomain = IpaDomain(inst, dn=self.suffix.ldap_text())

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -232,23 +232,6 @@ def get_ds_version(conn):
     return vendor_version
 
 
-def get_replication_plugin_name(dirsrv_get_entry):
-    # Support renaming of a replication plugin in 389-ds
-    # IPA topology plugin depends on the replication plugin but
-    # 389-ds cannot handle older alias querying in the plugin
-    # configuration with 'nsslapd-plugin-depends-on-named: ..' attribute
-    #
-    # dirsrv_get_entry: function (dn, attrs) -> str
-    # returns entry dictionary
-    try:
-        entry = dirsrv_get_entry(
-            'cn=Multisupplier Replication Plugin,cn=plugins,cn=config',
-            ['cn'])
-        return str(entry['cn'], encoding='utf-8')
-    except Exception:
-        return 'Multimaster Replication Plugin'
-
-
 class ReplicationManager:
     """Manage replication agreements
 
@@ -757,7 +740,9 @@ class ReplicationManager:
         def get_entry(dn, attrs):
             return self.conn.get_entry(DN(dn), attrs)
 
-        replication_plugin_name = get_replication_plugin_name(get_entry)
+        replication_plugin_name = (
+            installutils.get_replication_plugin_name(get_entry)
+        )
 
         plgent = self.conn.get_entry(
             DN(('cn', replication_plugin_name), ('cn', 'plugins'),

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -98,7 +98,6 @@ class IPAUpgrade(service.Service):
         self.modified = False
         self.serverid = serverid
         self.schema_files = schema_files
-        self.sub_dict = dict()
 
     def __start(self):
         srv = services.service(self.service_name, api)
@@ -171,20 +170,6 @@ class IPAUpgrade(service.Service):
                 pass
             else:
                 self.backup_state('nsslapd-global-backend-lock', global_lock)
-
-        # update self.sub_dict with the replication plugin name
-        # It may be different depending on 389-ds version
-        with open(self.filename, "r") as in_file:
-            parser = GetEntryFromLDIF(in_file, entries_dn=[])
-            parser.parse()
-
-        results = parser.get_results()
-
-        dn = REPL_PLUGIN_DN_TEMPLATE % "supplier"
-        if dn not in results:
-            dn = REPL_PLUGIN_DN_TEMPLATE % "master"
-
-        self.sub_dict['REPLICATION_PLUGIN'] = results[dn].get('cn')
 
         with open(self.filename, "r") as in_file:
             parser = GetEntryFromLDIF(in_file, entries_dn=[COMPAT_DN])
@@ -300,7 +285,7 @@ class IPAUpgrade(service.Service):
 
     def __upgrade(self):
         try:
-            ld = ldapupdate.LDAPUpdate(api=self.api, sub_dict=self.sub_dict)
+            ld = ldapupdate.LDAPUpdate(api=self.api)
             if len(self.files) == 0:
                 self.files = ld.get_all_files(ldapupdate.UPDATES_DIR)
             self.modified = (ld.update(self.files) or self.modified)


### PR DESCRIPTION
Manual backport of PR #5836 because a backport of ipa-4-9 is required.

The merged conflict was in the new subuid code only in master. Adding the ack since this change is so minor:

```
diff --cc ipaserver/install/ldapupdate.py
index 15c0ccb50,e7eb6c68f..000000000
--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@@ -296,6 -341,10 +311,13 @@@ class LDAPUpdate
              SELINUX_USERMAP_DEFAULT=platformconstants.SELINUX_USERMAP_DEFAULT,
              SELINUX_USERMAP_ORDER=platformconstants.SELINUX_USERMAP_ORDER,
              FIPS="#" if tasks.is_fips_enabled() else "",
++<<<<<<< HEAD
++=======
+             # uid / gid for autobind
+             NAMED_UID=platformconstants.NAMED_USER.uid,
+             NAMED_GID=platformconstants.NAMED_GROUP.gid,
+             REPLICATION_PLUGIN=replication_plugin,
++>>>>>>> 922357b74 (Use get_replication_plugin_name in LDAP updater)
          )
          for k, v in default_sub.items():
              self.sub_dict.setdefault(k, v)
```