### PR TITLE
[Backport][ipa-4-9] ipatests: Test to check that ResponseNotReady error is not displayed when user session cache is deleted #5637

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1466,3 +1466,36 @@ class TestIPACommand(IntegrationTest):
         if 'invalid option' not in nologin.stderr_text:
             assert 'This account is currently not available' in \
                 result.stdout_text
+
+
+class TestIPACommandWithoutReplica(IntegrationTest):
+    """
+    Execute tests with scenarios having only single
+    IPA server and no replica
+    """
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=True)
+
+    def test_client_doesnot_throw_responsenotready_error(self):
+        """
+        This testcase checks that ipa command
+        doesn't throw http.client.ResponseNotReady error
+        when current users session is deleted from the cache
+        """
+        user = 'ipauser1'
+        orig_pwd = 'Password123'
+
+        tasks.kinit_admin(self.master)
+        tasks.user_add(self.master, user, password=orig_pwd)
+        # kinit as admin on ipa-server and run ipa command
+        tasks.kinit_admin(self.master, raiseonerr=False)
+        self.master.run_command(['ipa', 'user-show', "ipauser1"])
+        # Delete the current user session cache on IPA server
+        self.master.run_command(
+            "rm -fv /run/ipa/ccaches/admin@{}-*".format(
+                self.master.domain.realm
+            )
+        )
+        # Run the command again after cache is removed
+        self.master.run_command(['ipa', 'user-show', 'ipauser1'])


### PR DESCRIPTION
This testcase checks that http.client.ResponseNotReady error is not displayed when
user session cache is deleted.

https://pagure.io/freeipa/issue/7752