### PR TITLE
Increase timeout for test_commands.py

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -140,7 +140,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -62,7 +62,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_commands.py
         template: *389ds-master-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   389ds-fedora/test_server_del:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -143,7 +143,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -143,7 +143,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_commands.py
         template: *testing-master-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   testing-fedora/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -150,7 +150,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_commands.py
         template: *testing-master-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   testing-fedora/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-master-previous
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-previous/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -143,7 +143,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_commands.py
         template: *ci-master-frawhide
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-rawhide/test_kerberos_flags:


### PR DESCRIPTION
test_commands.py testsuite is failing with the error 'RunPytest timed out after 4800s'
Hence the timeout has been increased from 4800 to 5400

Ref: https://github.com/freeipa-pr-ci2/freeipa/pull/996

Signed-off-by: Sudhir Menon <sumenon@redhat.com>