### PR TITLE
Don't return more attributes than requested from LDAP cache

### DIFF
--- a/ipatests/test_ipapython/test_ldap_cache.py
+++ b/ipatests/test_ipapython/test_ldap_cache.py
@@ -90,8 +90,16 @@ class TestLDAPCache:
 
     def test_get_testuser_again(self):
         assert self.userdn in self.cache.cache
+
+        # get the user again with with no attributes requested (so all)
         self.cache.get_entry(self.userdn)
         hits_and_misses(self.cache, 2, 2)
+
+        # Now get the user with a subset of cached attributes
+        entry = self.cache.get_entry(self.userdn, ('givenname', 'sn', 'cn'))
+        # Make sure we only got three attributes, as requested
+        assert len(entry.items()) == 3
+        hits_and_misses(self.cache, 3, 2)
 
     def test_update_testuser(self):
         entry = self.cache.cache[self.userdn].entry
@@ -100,7 +108,7 @@ class TestLDAPCache:
         except errors.EmptyModlist:
             pass
         assert self.userdn not in self.cache.cache
-        hits_and_misses(self.cache, 2, 2)
+        hits_and_misses(self.cache, 3, 2)
 
     def test_modify_testuser(self):
         self.cache.get_entry(self.userdn)
@@ -110,7 +118,7 @@ class TestLDAPCache:
         except errors.EmptyModlist:
             pass
         assert self.userdn not in self.cache.cache
-        hits_and_misses(self.cache, 2, 3)
+        hits_and_misses(self.cache, 3, 3)
 
     def test_delete_entry(self):
         # We don't care if this is successful or not, just that the
@@ -120,7 +128,7 @@ class TestLDAPCache:
         except Exception:
             pass
         assert self.userdn not in self.cache.cache
-        hits_and_misses(self.cache, 2, 3)
+        hits_and_misses(self.cache, 3, 3)
 
     def test_add_entry(self):
         # We don't care if this is successful or not, just that the
@@ -130,7 +138,7 @@ class TestLDAPCache:
         except Exception:
             pass
         assert self.userdn not in self.cache.cache
-        hits_and_misses(self.cache, 2, 3)
+        hits_and_misses(self.cache, 3, 3)
 
     def test_clear_cache(self):
         self.cache.clear_cache()


### PR DESCRIPTION
On a hit in the LDAP cache the entire cached entry was returned.
This caused problems because more attributes could be returned
than requested.

The automember condition add/remove calls only request the
inclusive/exclusive rule attributes and loop over the returned
values to look for duplicates. This was failing because the queried
entry contains attributes that the candidate entry does not contain.
The automember code is:

    old_entry = ldap.get_entry(dn, [attr])
    for regex in old_entry.keys():
        if not isinstance(entry_attrs[regex], (list, tuple)):

old_entry, returned from the cache, contained objectclass, cn,
description, etc. which don't exist in the candidate entry so
entry_attrs[regex] threw a KeyError.

Instead generate a new entry from the cache consisting of the
requested attributes only if all of the requested attributes are
cached.

Also be more careful when storing the attribbutes in the cache entry.
The returned attributes may not match the requested. So store the
attributes we actually have.

This issue was exposed by Ansible which maintains a larger and
longer-lived cache because commands are executed in the server context
one after another, giving the cache a chance to build up.

https://pagure.io/freeipa/issue/8897

Signed-off-by: Rob Crittenden <rcritten@redhat.com>