### PR TITLE
[Backport][ipa-4-9]: Increase timeout for test_commands.py #5856

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -140,7 +140,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -143,7 +143,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-9/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-9/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-9-previous
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-previous-ipa-4-9/test_kerberos_flags:


### PR DESCRIPTION
test_commands.py testsuite is failing due to
'RunPytest timed out after 4800s'
Hence the timeout has been increased from 4800 to 5400

Signed-off-by: Sudhir Menon <sumenon@redhat.com>