### PR TITLE
Remove unneeded dependency on python-coverage

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -872,7 +872,6 @@ BuildArch: noarch
 Requires: python3-ipaclient = %{version}-%{release}
 Requires: python3-ipaserver = %{version}-%{release}
 Requires: iptables
-Requires: python3-coverage
 Requires: python3-cryptography >= 1.6
 Requires: python3-pexpect
 %if 0%{?fedora}


### PR DESCRIPTION
The spec file requires python3-coverage although it is not
used in the project.

Fixes: https://pagure.io/freeipa/issue/8905
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>