### PR TITLE
[Backport][ipa-4-9] rpcserver.py: perf_counter_ns is Python 3.7+

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -71,6 +71,7 @@ class BasePathNamespace:
     IPA_DEFAULT_CONF = "/etc/ipa/default.conf"
     IPA_DNSKEYSYNCD_KEYTAB = "/etc/ipa/dnssec/ipa-dnskeysyncd.keytab"
     IPA_ODS_EXPORTER_KEYTAB = "/etc/ipa/dnssec/ipa-ods-exporter.keytab"
+    IPA_SERVER_CONF = "/etc/ipa/server.conf"
     DNSSEC_OPENSSL_CONF = "/etc/ipa/dnssec/openssl.cnf"
     DNSSEC_SOFTHSM2_CONF = "/etc/ipa/dnssec/softhsm2.conf"
     DNSSEC_SOFTHSM_PIN_SO = "/etc/ipa/dnssec/softhsm_pin_so"

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -31,6 +31,7 @@ import os
 import time
 import traceback
 from io import BytesIO
+from sys import version_info
 from urllib.parse import parse_qs
 from xmlrpc.client import Fault
 
@@ -71,6 +72,10 @@ from requests.auth import AuthBase
 
 if six.PY3:
     unicode = str
+
+# time.perf_counter_ns appeared in Python 3.7.
+if version_info < (3, 7):
+    time.perf_counter_ns = lambda: int(time.perf_counter() * 10**9)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR was opened automatically because PR #5852 was pushed to master and backport to ipa-4-9 is required.