### PR TITLE
stageuser: add ipauserauthtypeclass when required

### DIFF
--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -539,6 +539,9 @@ class baseuser_add(LDAPCreate):
         if entry_attrs.get('ipatokenradiususername', None):
             add_missing_object_class(ldap, u'ipatokenradiusproxyuser', dn,
                                      entry_attrs, update=False)
+        if entry_attrs.get('ipauserauthtype', None):
+            add_missing_object_class(ldap, u'ipauserauthtypeclass', dn,
+                                     entry_attrs, update=False)
 
     def post_common_callback(self, ldap, dn, entry_attrs, *keys, **options):
         assert isinstance(dn, DN)

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -617,10 +617,6 @@ class user_add(baseuser_add):
            'ipauser' not in entry_attrs['objectclass']:
             entry_attrs['objectclass'].append('ipauser')
 
-        if 'ipauserauthtype' in entry_attrs and \
-           'ipauserauthtypeclass' not in entry_attrs['objectclass']:
-            entry_attrs['objectclass'].append('ipauserauthtypeclass')
-
         rcl = entry_attrs.get('ipatokenradiusconfiglink', None)
         if rcl:
             if 'ipatokenradiusproxyuser' not in entry_attrs['objectclass']:

--- a/ipatests/test_xmlrpc/test_stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/test_stageuser_plugin.py
@@ -343,6 +343,12 @@ class TestStagedUser(XMLRPC_test):
         result = command()
         assert result['count'] == 1
 
+    def test_create_withuserauthtype(self, stageduser):
+        stageduser.ensure_missing()
+        command = stageduser.make_create_command(
+            options={u'ipauserauthtype': u'password'})
+        command()
+
 
 @pytest.mark.tier1
 class TestCreateInvalidAttributes(XMLRPC_test):


### PR DESCRIPTION
### stageuser: add ipauserauthtypeclass when required
The command
ipa stageuser-add --user-auth-type=xxx
is currently failing because the objectclass ipauserauthtypeclass
is missing from the created entry.

There is code adding the missing objectclass in the
pre_common_callback method of user_add, and this code should
be common to user_add and stageuser_add. In order to avoid code
duplication, it makes more sense to move the existing code to
pre_common_callback of baseuser_add, that is called by both
classes.

Fixes: https://pagure.io/freeipa/issue/8909

### XMLRPC test: add a test for stageuser-add --user-auth-type

Related: https://pagure.io/freeipa/issue/8909

