### PR TITLE
[Backport][ipa-4-9] Add checks to prevent adding auth indicators to internal IPA services

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -770,6 +770,15 @@ def promotion_check_ipa_domain(master_ldap_conn, basedn):
         ))
 
 
+def promotion_check_host_principal_auth_ind(conn, hostdn):
+    entry = conn.get_entry(hostdn, ['krbprincipalauthind'])
+    if 'krbprincipalauthind' in entry:
+        raise RuntimeError(
+            "Client cannot be promoted to a replica if the host principal "
+            "has an authentication indicator set."
+        )
+
+
 @common_cleanup
 @preserve_enrollment_state
 def promote_check(installer):
@@ -956,6 +965,10 @@ def promote_check(installer):
                                      config.master_host_name, None)
 
         promotion_check_ipa_domain(conn, remote_api.env.basedn)
+        hostdn = DN(('fqdn', api.env.host),
+                    api.env.container_host,
+                    api.env.basedn)
+        promotion_check_host_principal_auth_ind(conn, hostdn)
 
         # Make sure that domain fulfills minimal domain level
         # requirement

--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -38,7 +38,7 @@ from .baseldap import (LDAPQuery, LDAPObject, LDAPCreate,
                                      LDAPAddAttributeViaOption,
                                      LDAPRemoveAttributeViaOption)
 from .service import (
-    validate_realm, normalize_principal,
+    validate_realm, validate_auth_indicator, normalize_principal,
     set_certificate_attrs, ticket_flags_params, update_krbticketflags,
     set_kerberos_attrs, rename_ipaallowedtoperform_from_ldap,
     rename_ipaallowedtoperform_to_ldap, revoke_certs)
@@ -735,6 +735,8 @@ class host_add(LDAPCreate):
         update_krbticketflags(ldap, entry_attrs, attrs_list, options, False)
         if 'krbticketflags' in entry_attrs:
             entry_attrs['objectclass'].append('krbticketpolicyaux')
+        validate_auth_indicator(entry_attrs)
+
         return dn
 
     def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
@@ -993,6 +995,7 @@ class host_mod(LDAPUpdate):
             if 'krbprincipalaux' not in (item.lower() for item in
                                          entry_attrs['objectclass']):
                 entry_attrs['objectclass'].append('krbprincipalaux')
+            validate_auth_indicator(entry_attrs)
 
         add_sshpubkey_to_attrs_pre(self.context, attrs_list)
 

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -605,6 +605,16 @@ class TestProtectedMaster(XMLRPC_test):
                 error=u'An IPA master host cannot be deleted or disabled')):
             command()
 
+    def test_try_add_auth_ind_master(self, this_host):
+        command = this_host.make_update_command({
+            u'krbprincipalauthind': u'radius'})
+        with raises_exact(errors.ValidationError(
+            name='krbprincipalauthind',
+            error=u'authentication indicators not allowed '
+                'in service "host"'
+        )):
+            command()
+
 
 @pytest.mark.tier1
 class TestValidation(XMLRPC_test):


### PR DESCRIPTION
This PR was opened automatically because PR #5617 was pushed to master and backport to ipa-4-9 is required.