### PR TITLE
[Backport][ipa-4-9] Remove unneeded dependency on python-coverage

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -872,7 +872,6 @@ BuildArch: noarch
 Requires: python3-ipaclient = %{version}-%{release}
 Requires: python3-ipaserver = %{version}-%{release}
 Requires: iptables
-Requires: python3-coverage
 Requires: python3-cryptography >= 1.6
 Requires: python3-pexpect
 %if 0%{?fedora}


### PR DESCRIPTION
This PR was opened automatically because PR #5867 was pushed to master and backport to ipa-4-9 is required.