### PR TITLE
[Backport][ipa-4-9] stageuser: add ipauserauthtypeclass when required

### DIFF
--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -539,6 +539,9 @@ class baseuser_add(LDAPCreate):
         if entry_attrs.get('ipatokenradiususername', None):
             add_missing_object_class(ldap, u'ipatokenradiusproxyuser', dn,
                                      entry_attrs, update=False)
+        if entry_attrs.get('ipauserauthtype', None):
+            add_missing_object_class(ldap, u'ipauserauthtypeclass', dn,
+                                     entry_attrs, update=False)
 
     def post_common_callback(self, ldap, dn, entry_attrs, *keys, **options):
         assert isinstance(dn, DN)

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -617,10 +617,6 @@ class user_add(baseuser_add):
            'ipauser' not in entry_attrs['objectclass']:
             entry_attrs['objectclass'].append('ipauser')
 
-        if 'ipauserauthtype' in entry_attrs and \
-           'ipauserauthtypeclass' not in entry_attrs['objectclass']:
-            entry_attrs['objectclass'].append('ipauserauthtypeclass')
-
         rcl = entry_attrs.get('ipatokenradiusconfiglink', None)
         if rcl:
             if 'ipatokenradiusproxyuser' not in entry_attrs['objectclass']:

--- a/ipatests/test_xmlrpc/test_stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/test_stageuser_plugin.py
@@ -343,6 +343,12 @@ class TestStagedUser(XMLRPC_test):
         result = command()
         assert result['count'] == 1
 
+    def test_create_withuserauthtype(self, stageduser):
+        stageduser.ensure_missing()
+        command = stageduser.make_create_command(
+            options={u'ipauserauthtype': u'password'})
+        command()
+
 
 @pytest.mark.tier1
 class TestCreateInvalidAttributes(XMLRPC_test):


### PR DESCRIPTION
This PR was opened automatically because PR #5871 was pushed to master and backport to ipa-4-9 is required.