### PR TITLE
[ipa-4-6] Switch to external ca: fix certmonger script 

### DIFF
--- a/install/restart_scripts/renew_ca_cert
+++ b/install/restart_scripts/renew_ca_cert
@@ -181,7 +181,8 @@ def _main():
 
                 # Pass Dogtag's self-tests
                 for ca_nick in db.find_root_cert(nickname)[-2:-1]:
-                    ca_flags = dict(cc[1:] for cc in ca_certs)[ca_nick]
+                    ca_flags = dict(
+                        cc[1:] for cc in ca_certs)[ca_nick.encode('utf-8')]
                     usages = ca_flags.usages or set()
                     ca_flags_modified = TrustFlags(ca_flags.has_key,
                         True, True,


### PR DESCRIPTION
The script renew_ca_cert produces a Traceback when switching
from self-signed to external CA:
Traceback (most recent call last):
  File "/usr/libexec/ipa/certmonger/renew_ca_cert", line 224, in <module>
    main()
  File "/usr/libexec/ipa/certmonger/renew_ca_cert", line 218, in main
    _main()
  File "/usr/libexec/ipa/certmonger/renew_ca_cert", line 184, in _main
     ca_flags = dict(cc[1:] for cc in ca_certs)[ca_nick]
KeyError: 'CN=Cert Auth,O=FloAuth.

It is trying to find a cert in a dict using a str as key,
while the keys are bytes.

Related: https://pagure.io/freeipa/issue/8879
Fixes: https://pagure.io/freeipa/issue/8893

