### PR TITLE
Server install: do not use unchecked ip addr for ipa-ca record

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -491,6 +491,13 @@ def resolve_rrsets_nss(fqdn):
     ipv4 = []
     ipv6 = []
     for ip_address in ip_addresses:
+        # Skip reserved or link-local addresses
+        try:
+            ipautil.CheckedIPAddress(ip_address)
+        except ValueError as e:
+            logger.warning("Invalid IP address %s for %s: %s",
+                           ip_address, fqdn, unicode(e))
+            continue
         if ip_address.version == 4:
             ipv4.append(str(ip_address))
         elif ip_address.version == 6:


### PR DESCRIPTION
At the end of a server installation, the DNS records for
ipa-ca.$DOMAIN are created/updated with the IP addresses of the
new server.
The current code resolves the IP addresses of the new server
but doesn't check them. This can result in the addition of
a link-local address to ipa-ca record.

For each address, make sure that it's neither reserved nor a
link-local address.

Fixes: https://pagure.io/freeipa/issue/8810
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>