### PR TITLE
[Backport][ipa-4-9] Server install: do not use unchecked ip addr for ipa-ca record

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -491,6 +491,13 @@ def resolve_rrsets_nss(fqdn):
     ipv4 = []
     ipv6 = []
     for ip_address in ip_addresses:
+        # Skip reserved or link-local addresses
+        try:
+            ipautil.CheckedIPAddress(ip_address)
+        except ValueError as e:
+            logger.warning("Invalid IP address %s for %s: %s",
+                           ip_address, fqdn, unicode(e))
+            continue
         if ip_address.version == 4:
             ipv4.append(str(ip_address))
         elif ip_address.version == 6:


### PR DESCRIPTION
This PR was opened automatically because PR #5880 was pushed to master and backport to ipa-4-9 is required.