### PR TITLE
ipatests: use whole date when calling journalctl --since

### DIFF
--- a/ipatests/test_integration/test_external_ca.py
+++ b/ipatests/test_integration/test_external_ca.py
@@ -301,7 +301,7 @@ class TestSelfExternalSelf(IntegrationTest):
     def test_switch_back_to_self_signed(self):
 
         # for journalctl --since
-        switch_time = time.strftime('%H:%M:%S')
+        switch_time = time.strftime('%Y-%m-%d %H:%M:%S')
         # switch back to self-signed CA
         result = self.master.run_command([paths.IPA_CACERT_MANAGE, 'renew',
                                           '--self-signed'])


### PR DESCRIPTION
The test TestSelfExternalSelf::test_switch_back_to_self_signed
is checking the content of the journal using journalctl --since ...
but provides only the time, not the whole date with year-month-day.
As a consequence, if the test is executed around midnight it may
find nothing in the journal because it's looking for logs after 11:50PM,
which is a date in the future.
Fixes: https://pagure.io/freeipa/issue/8918

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>