### PR TITLE
[Backport][ipa-4-9] ipatests: use whole date when calling journalctl --since

### DIFF
--- a/ipatests/test_integration/test_external_ca.py
+++ b/ipatests/test_integration/test_external_ca.py
@@ -301,7 +301,7 @@ class TestSelfExternalSelf(IntegrationTest):
     def test_switch_back_to_self_signed(self):
 
         # for journalctl --since
-        switch_time = time.strftime('%H:%M:%S')
+        switch_time = time.strftime('%Y-%m-%d %H:%M:%S')
         # switch back to self-signed CA
         result = self.master.run_command([paths.IPA_CACERT_MANAGE, 'renew',
                                           '--self-signed'])


### PR DESCRIPTION
This PR was opened automatically because PR #5885 was pushed to master and backport to ipa-4-9 is required.