### PR TITLE
Fall back to krbprincipalname when validating host auth indicators

### DIFF
--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -209,6 +209,11 @@ def validate_auth_indicator(entry):
     # and shouldn't be allowed to have auth indicators.
     # https://pagure.io/freeipa/issue/8206
     pkey = api.Object['service'].get_primary_key_from_dn(entry.dn)
+    if pkey == str(entry.dn):
+        # krbcanonicalname may not be set yet if this is a host entry,
+        # try krbprincipalname
+        if 'krbprincipalname' in entry:
+            pkey = entry['krbprincipalname']
     principal = kerberos.Principal(pkey)
     server = api.Command.server_find(principal.hostname)['result']
     if server:

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -615,6 +615,17 @@ class TestProtectedMaster(XMLRPC_test):
         )):
             command()
 
+    def test_add_non_master_with_auth_ind(self, host5):
+        host5.ensure_missing()
+        command = host5.make_command(
+            'host_add', host5.fqdn, krbprincipalauthind=['radius'],
+            force=True
+        )
+        result = command()
+        # The fact that the command succeeds exercises the change but
+        # let's check the indicator as well.
+        assert result['result']['krbprincipalauthind'] == ('radius',)
+
 
 @pytest.mark.tier1
 class TestValidation(XMLRPC_test):


### PR DESCRIPTION
When adding a new host the principal cannot be determined because it
relies on either:

a) an entry to already exist
b) krbprincipalname be a component of the dn

As a result the full dn is being passed into ipapython.Kerberos
which can't parse it.

Look into the entry in validate_validate_auth_indicator() for
krbprincipalname in this case.

https://pagure.io/freeipa/issue/8206

Signed-off-by: Rob Crittenden <rcritten@redhat.com>