### PR TITLE
webui tests: close notification when revoking cert

### DIFF
--- a/ipatests/test_webui/test_cert.py
+++ b/ipatests/test_webui/test_cert.py
@@ -107,6 +107,7 @@ class test_cert(UI_driver):
         self.action_list_action('revoke_cert', False)
         self.select('select[name=revocation_reason]', reason)
         self.dialog_button_click('ok')
+        self.close_notifications()
         self.navigate_to_entity(ENTITY)
 
         return cert


### PR DESCRIPTION
When a cert is revoked, a notification is displayed
and may obscure the buttons. Make sure to close the
notification before moving to the next step.

Fixes: https://pagure.io/freeipa/issue/8911