### PR TITLE
[Backport][ipa-4-9] webui tests: close notification when revoking cert

### DIFF
--- a/ipatests/test_webui/test_cert.py
+++ b/ipatests/test_webui/test_cert.py
@@ -107,6 +107,7 @@ class test_cert(UI_driver):
         self.action_list_action('revoke_cert', False)
         self.select('select[name=revocation_reason]', reason)
         self.dialog_button_click('ok')
+        self.close_notifications()
         self.navigate_to_entity(ENTITY)
 
         return cert


### PR DESCRIPTION
This PR was opened automatically because PR #5895 was pushed to master and backport to ipa-4-9 is required.