### PR TITLE
spec file: Trust controller role should pull sssd-winbind-idmap package

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -597,6 +597,7 @@ Requires: %{name}-common = %{version}-%{release}
 
 Requires: samba >= %{samba_version}
 Requires: samba-winbind
+Requires: sssd-winbind-idmap
 Requires: libsss_idmap
 %if 0%{?rhel}
 Obsoletes: ipa-idoverride-memberof-plugin <= 0.1


### PR DESCRIPTION
ipa-server-trust-ad subpackage need to pull in sssd-winbind-idmap
Fixes: https://pagure.io/freeipa/issue/8923

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>