### PR TITLE
[Backport][ipa-4-9] spec file: Trust controller role should pull sssd-winbind-idmap package

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -597,6 +597,7 @@ Requires: %{name}-common = %{version}-%{release}
 
 Requires: samba >= %{samba_version}
 Requires: samba-winbind
+Requires: sssd-winbind-idmap
 Requires: libsss_idmap
 %if 0%{?rhel}
 Obsoletes: ipa-idoverride-memberof-plugin <= 0.1


### PR DESCRIPTION
This PR was opened automatically because PR #5898 was pushed to master and backport to ipa-4-9 is required.