### PR TITLE
rhel platform: add a named crypto-policy support

### DIFF
--- a/ipaplatform/rhel/paths.py
+++ b/ipaplatform/rhel/paths.py
@@ -30,6 +30,7 @@ from ipaplatform.rhel.constants import HAS_NFS_CONF
 
 
 class RHELPathNamespace(RedHatPathNamespace):
+    NAMED_CRYPTO_POLICY_FILE = "/etc/crypto-policies/back-ends/bind.config"
     if HAS_NFS_CONF:
         SYSCONFIG_NFS = '/etc/nfs.conf'
 


### PR DESCRIPTION
RHEL 8+ provides bind system-wide crypto policy support, enable it.

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>