### PR TITLE
Index: Fix definition for memberOf

### DIFF
--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -434,7 +434,7 @@ add:nsIndexType: eq
 add:nsIndexType: pres
 
 dn: cn=memberOf,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
-only:cn: member
+only:cn: memberOf
 add:nsIndexType: sub
 
 dn: cn=memberPrincipal,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config


### PR DESCRIPTION
The index definition for memberOf is inconsistent:

dn: cn=memberOf,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
cn: member
nsIndexType: eq
nsIndexType: sub
nsSystemIndex: false
objectClass: top
objectClass: nsIndex

The cn attribute should be memberOf, not member. Fix the definition.

Fixes: https://pagure.io/freeipa/issue/8920