### PR TITLE
webui tests: fix algo for finding available idrange

### DIFF
--- a/ipatests/test_webui/task_range.py
+++ b/ipatests/test_webui/task_range.py
@@ -64,6 +64,12 @@ class range_tasks(UI_driver):
         max_rid = 0
 
         for idrange in idranges:
+            # IPA.TEST_subid_range is automatically created near the end
+            # of the allowed ids, taking from 2,147,483,648 to 4,294,836,224
+            # Ignore this range when looking for available ids otherwise
+            # we won't find any value < max baseid 4,294,967,295
+            if idrange['cn'][0].endswith("_subid_range"):
+                continue
             size = int(idrange['ipaidrangesize'][0])
             base_id = int(idrange['ipabaseid'][0])
 


### PR DESCRIPTION
The webui tests for ID range evaluate a potentially free id range
by looking for existing ranges and picking a range = max value
\+ 1 million.

With the addition of subuid range this algorithm produces values
over the limit because the subuid range goes from
2,147,483,648 to 4,294,836,224 and the max base id is 4,294,967,295.

Ignore the subuid range when picking a potential range.
Fixes: https://pagure.io/freeipa/issue/8919
