### PR TITLE
[Backport][ipa-4-9] rhel platform: add a named crypto-policy support

### DIFF
--- a/ipaplatform/rhel/paths.py
+++ b/ipaplatform/rhel/paths.py
@@ -30,6 +30,7 @@ from ipaplatform.rhel.constants import HAS_NFS_CONF
 
 
 class RHELPathNamespace(RedHatPathNamespace):
+    NAMED_CRYPTO_POLICY_FILE = "/etc/crypto-policies/back-ends/bind.config"
     if HAS_NFS_CONF:
         SYSCONFIG_NFS = '/etc/nfs.conf'
 


### PR DESCRIPTION
This PR was opened automatically because PR #5900 was pushed to master and backport to ipa-4-9 is required.