### PR TITLE
[Backport][ipa-4-9] Index: Fix definition for memberOf

### DIFF
--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -434,7 +434,7 @@ add:nsIndexType: eq
 add:nsIndexType: pres
 
 dn: cn=memberOf,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
-only:cn: member
+only:cn: memberOf
 add:nsIndexType: sub
 
 dn: cn=memberPrincipal,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config


### PR DESCRIPTION
This PR was opened automatically because PR #5901 was pushed to master and backport to ipa-4-9 is required.