### PR TITLE
ipa-getkeytab: add option to discover servers using DNS SRV

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -58,6 +58,7 @@ ipa_getkeytab_LDADD = 		\
 	$(SASL_LIBS)		\
 	$(POPT_LIBS)		\
 	$(LIBINTL_LIBS)         \
+	$(RESOLV_LIBS)		\
 	$(INI_LIBS)		\
 	$(NULL)
 

--- a/client/ipa-getkeytab.c
+++ b/client/ipa-getkeytab.c
@@ -291,7 +291,7 @@ static int ldap_sasl_interact(LDAP *ld, unsigned flags, void *priv_data, void *s
 	return ret;
 }
 
-int filter_keys(krb5_context krbctx, struct keys_container *keys,
+static int filter_keys(krb5_context krbctx, struct keys_container *keys,
                 ber_int_t *enctypes)
 {
     struct krb_key_salt *ksdata;
@@ -507,7 +507,7 @@ static int ldap_set_keytab(krb5_context krbctx,
 	BerElement *sctrl = NULL;
 	struct berval *control = NULL;
 	LDAPControl **srvctrl = NULL;
-	int ret;
+	ber_tag_t ret;
 	int kvno, i;
 	ber_tag_t rtag;
 	ber_int_t *encs = NULL;
@@ -826,7 +826,7 @@ static int config_from_file(struct ini_cfgobj *cfgctx)
     return 0;
 }
 
-int read_ipa_config(struct ipa_config **ipacfg)
+static int read_ipa_config(struct ipa_config **ipacfg)
 {
     struct ini_cfgobj *cfgctx = NULL;
     struct value_obj *obj = NULL;

--- a/client/man/ipa-getkeytab.1
+++ b/client/man/ipa-getkeytab.1
@@ -78,7 +78,10 @@ arcfour\-hmac
 \fB\-s ipaserver\fR
 The IPA server to retrieve the keytab from (FQDN). If this option is not
 provided the server name is read from the IPA configuration file
-(/etc/ipa/default.conf). Cannot be used together with \fB\-H\fR.
+(/etc/ipa/default.conf). Cannot be used together with \fB\-H\fR. If the
+value is _srv_ then DNS discovery will be used to determine a server.
+If this discovery fails then it will fall back to using the configuration
+file.
 .TP
 \fB\-q\fR
 Quiet mode. Only errors are displayed.

--- a/configure.ac
+++ b/configure.ac
@@ -109,6 +109,16 @@ AC_SUBST(LDAP_LIBS)
 AC_SUBST(LDAP_CFLAGS)
 
 dnl ---------------------------------------------------------------------------
+dnl - Check for resolv library
+dnl ---------------------------------------------------------------------------
+
+SAVE_CPPFLAGS=$CPPFLAGS
+CPPFLAGS="$NSPR_CFLAGS $NSS_CFLAGS"
+AC_CHECK_LIB(resolv,main,RESOLV_LIBS=-lresolv)
+AC_CHECK_HEADERS(resolv.h)
+AC_SUBST(RESOLV_LIBS)
+
+dnl ---------------------------------------------------------------------------
 dnl - Check for OpenSSL Crypto library
 dnl ---------------------------------------------------------------------------
 PKG_CHECK_MODULES([CRYPTO], [libcrypto])


### PR DESCRIPTION
The basic flow is:

- If server is provided by the user then use it
- If server the magic value '_srv', check for _ldap._tcp SRV records for
  the domain in /etc/ipa/default.conf
- If no servers are found use the server from default.conf

https://pagure.io/freeipa/issue/8478

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
