### PR TITLE
Azure: temporarily disable problematic tests

### DIFF
--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -144,11 +144,11 @@ vms:
     containers:
       replicas: 1
 
-  - container_job: SubCAkeyReplication
-    containers:
-      replicas: 1
-    tests:
-    - test_integration/test_replica_promotion.py::TestSubCAkeyReplication
+#  - container_job: SubCAkeyReplication
+#    containers:
+#      replicas: 1
+#    tests:
+#    - test_integration/test_replica_promotion.py::TestSubCAkeyReplication
 
 #  - container_job: adtrust_install
 #    tests:
@@ -166,16 +166,16 @@ vms:
 #    tests:
 #    - test_integration/test_advise.py
 
-  - container_job: cert
-    tests:
-    - test_integration/test_cert.py
-    containers:
-      replicas: 1
-      clients: 1
-      resources:
-        replica:
-          mem_limit: "2300m"
-          memswap_limit: "3300m"
+#  - container_job: cert
+#    tests:
+#    - test_integration/test_cert.py
+#    containers:
+#      replicas: 1
+#      clients: 1
+#      resources:
+#        replica:
+#          mem_limit: "2300m"
+#          memswap_limit: "3300m"
 
   - container_job: external_ca_SelfExternalSelf
     tests:

--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -11,14 +11,14 @@ default_resources:
 
 vms:
 - vm_jobs:
-  - container_job: InstallMaster
-    containers:
-      resources:
-        server:
-          mem_limit: "3200m"
-          memswap_limit: "4800m"
-    tests:
-    - test_integration/test_installation.py::TestInstallMaster
+#  - container_job: InstallMaster
+#    containers:
+#      resources:
+#        server:
+#          mem_limit: "3200m"
+#          memswap_limit: "4800m"
+#    tests:
+#    - test_integration/test_installation.py::TestInstallMaster
 
   - container_job: kerberos_flags
     containers:
@@ -119,19 +119,19 @@ vms:
     - test_integration/test_external_ca.py::TestExternalCAConstraints
 
 - vm_jobs:
-  - container_job: commands
-    containers:
-      replicas: 1
-      clients: 1
-      resources:
-        server:
-          mem_limit: "3500m"
-          memswap_limit: "4000m"
-        client:
-          mem_limit: "768m"
-          memswap_limit: "1024m"
-    tests:
-    - test_integration/test_commands.py
+#  - container_job: commands
+#    containers:
+#      replicas: 1
+#      clients: 1
+#     resources:
+#        server:
+#          mem_limit: "3500m"
+#          memswap_limit: "4000m"
+#        client:
+#          mem_limit: "768m"
+#          memswap_limit: "1024m"
+#    tests:
+#    - test_integration/test_commands.py
 
   - container_job: membermanager
     tests:
@@ -150,22 +150,21 @@ vms:
     tests:
     - test_integration/test_replica_promotion.py::TestSubCAkeyReplication
 
-  - container_job: adtrust_install
-    tests:
-    - test_integration/test_adtrust_install.py
-    containers:
-      replicas: 1
+#  - container_job: adtrust_install
+#    tests:
+#    - test_integration/test_adtrust_install.py
+#    containers:
+#      replicas: 1
 
-- vm_jobs:
-  - container_job: advise
-    containers:
-      clients: 1
-      resources:
-        client:
-          mem_limit: "768m"
-          memswap_limit: "1024m"
-    tests:
-    - test_integration/test_advise.py
+#  - container_job: advise
+#    containers:
+#      clients: 1
+#      resources:
+#        client:
+#          mem_limit: "768m"
+#          memswap_limit: "1024m"
+#    tests:
+#    - test_integration/test_advise.py
 
   - container_job: cert
     tests:

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -44,7 +44,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMaster
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl
 
   fedora-latest/simple_replication:


### PR DESCRIPTION
Azure: temporarily disable problematic tests, #1
test_installation.TestInstallMaster, test_advise,
and test_integration.test_commands.TestIPACommand rely on DNS
forwarders and hit a known BIND bug:
https://gitlab.isc.org/isc-projects/bind9/-/issues/2728
quite often.
This is blocking gating nearly completely.
Disable these tests in gating until the bug is fixed and
the related build is available in Fedora.

+

Azure: temporarily disable problematic tests, #2
test_cert and test_SubCAkeyReplication are randomly failing.
The suspect for test_SubCAkeyReplication is an nss bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1985061

The reason for test_cert failures was not identified, the only
relevant line in the log contains:
2021-07-22T17:37:21.0873339Z tests: cert, result: 1, time: 30:08.98
2021-07-22T17:37:21.0874172Z Command exited with non-zero status 1

Disable these tests in gating until the NSS bug is fixed and
the related build is available in Fedora.


Related: https://pagure.io/freeipa/issue/8864
Signed-off-by: François Cami <fcami@redhat.com>