### PR TITLE
ipatests: Test ldapsearch with base scope works for compat tree.

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1581,6 +1581,19 @@ class TestIPACommandWithoutReplica(IntegrationTest):
         # Run the command again after cache is removed
         self.master.run_command(['ipa', 'user-show', 'ipauser1'])
 
+    def test_basesearch_compat_tree(self):
+        """Test ldapsearch against compat tree is working
+
+        This to ensure that ldapsearch with base scope is not failing.
+
+        related: https://bugzilla.redhat.com/show_bug.cgi?id=1958909
+        """
+        tasks.kinit_admin(self.master)
+        base_dn = str(self.master.domain.basedn)
+        base = "cn=admins,cn=groups,cn=compat,{basedn}".format(basedn=base_dn)
+        tasks.ldapsearch_dm(self.master, base, ldap_args=[], scope='sub')
+        tasks.ldapsearch_dm(self.master, base, ldap_args=[], scope='base')
+
 
 class TestIPAautomount(IntegrationTest):
     @classmethod

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -38,6 +38,7 @@ from ipatests.create_external_ca import ExternalCA
 from ipatests.test_ipalib.test_x509 import good_pkcs7, badcert
 from ipapython.ipautil import realm_to_suffix, ipa_generate_password
 from ipaserver.install.installutils import realm_to_serverid
+from pkg_resources import parse_version
 
 logger = logging.getLogger(__name__)
 
@@ -1588,6 +1589,12 @@ class TestIPACommandWithoutReplica(IntegrationTest):
 
         related: https://bugzilla.redhat.com/show_bug.cgi?id=1958909
         """
+        version = self.master.run_command(
+            ["rpm", "-qa", "--qf", "%{VERSION}", "slapi-nis"]
+        )
+        if tasks.get_platform(self.master) == "fedora" and parse_version(
+                version.stdout_text) <= parse_version("0.56.7"):
+            pytest.skip("Test requires slapi-nis with fix on fedora")
         tasks.kinit_admin(self.master)
         base_dn = str(self.master.domain.basedn)
         base = "cn=admins,cn=groups,cn=compat,{basedn}".format(basedn=base_dn)


### PR DESCRIPTION
Related: https://bugzilla.redhat.com/show_bug.cgi?id=1958909
