### PR TITLE
Display all orphaned keys in automountlocation-tofiles

### DIFF
--- a/ipaclient/plugins/automount.py
+++ b/ipaclient/plugins/automount.py
@@ -104,13 +104,15 @@ class automountlocation_tofiles(MethodOverride):
             textui.print_plain('/etc/%s:' % m['automountmapname'])
             for k in orphankeys:
                 if len(k) == 0: continue
-                dn = DN(k[0]['dn'])
-                if dn['automountmapname'] == m['automountmapname'][0]:
-                    textui.print_plain(
-                        '%s\t%s' % (
-                            k[0]['automountkey'][0], k[0]['automountinformation'][0]
+                for key in k:
+                    dn = DN(key['dn'])
+                    if dn['automountmapname'] == m['automountmapname'][0]:
+                        textui.print_plain(
+                            '%s\t%s' % (
+                                key['automountkey'][0],
+                                key['automountinformation'][0]
+                            )
                         )
-                    )
 
 
 @register()

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1522,3 +1522,51 @@ class TestIPACommandWithoutReplica(IntegrationTest):
         )
         # Run the command again after cache is removed
         self.master.run_command(['ipa', 'user-show', 'ipauser1'])
+
+
+class TestIPAautomount(IntegrationTest):
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=True)
+
+    def test_tofiles_orphan_keys(self):
+        """
+        Validate automountlocation-tofiles output
+
+        automount in LDAP is difficult to keep straight so a client-side
+        map generator was created.
+        """
+        tasks.kinit_admin(self.master)
+
+        self.master.run_command(
+            [
+                'ipa',
+                'automountmap-add', 'default',
+                'auto.test'
+            ]
+        )
+        self.master.run_command(
+            [
+                'ipa',
+                'automountkey-add', 'default',
+                'auto.test',
+                '--key', '/test',
+                '--info', 'nfs.example.com:/exports/test'
+            ]
+        )
+        self.master.run_command(
+            [
+                'ipa',
+                'automountkey-add', 'default',
+                'auto.test',
+                '--key', '/test2',
+                '--info', 'nfs.example.com:/exports/test2'
+            ]
+        )
+        result = self.master.run_command(
+            [
+                'ipa', 'automountlocation-tofiles', 'default'
+            ]
+        ).stdout_text
+        assert '/test' in result
+        assert '/test2' in result

--- a/ipatests/test_xmlrpc/test_automount_plugin.py
+++ b/ipatests/test_xmlrpc/test_automount_plugin.py
@@ -143,6 +143,7 @@ class test_automount(AutomountTest):
         ---------------------------
         /etc/testmap:
         testkey2\tro
+        testkey_rename\trw
         """).strip()
 
     def test_0_automountlocation_add(self):


### PR DESCRIPTION
Display all orphaned keys in automountlocation-tofiles

Only the first key was being displayed for any orphaned map.

https://pagure.io/freeipa/issue/7814

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
