### PR TITLE
[Backport][ipa-4-9] Display all orphaned keys in automountlocation-tofiles

### DIFF
--- a/ipaclient/plugins/automount.py
+++ b/ipaclient/plugins/automount.py
@@ -104,13 +104,15 @@ class automountlocation_tofiles(MethodOverride):
             textui.print_plain('/etc/%s:' % m['automountmapname'])
             for k in orphankeys:
                 if len(k) == 0: continue
-                dn = DN(k[0]['dn'])
-                if dn['automountmapname'] == m['automountmapname'][0]:
-                    textui.print_plain(
-                        '%s\t%s' % (
-                            k[0]['automountkey'][0], k[0]['automountinformation'][0]
+                for key in k:
+                    dn = DN(key['dn'])
+                    if dn['automountmapname'] == m['automountmapname'][0]:
+                        textui.print_plain(
+                            '%s\t%s' % (
+                                key['automountkey'][0],
+                                key['automountinformation'][0]
+                            )
                         )
-                    )
 
 
 @register()

--- a/ipatests/test_xmlrpc/test_automount_plugin.py
+++ b/ipatests/test_xmlrpc/test_automount_plugin.py
@@ -143,6 +143,7 @@ class test_automount(AutomountTest):
         ---------------------------
         /etc/testmap:
         testkey2\tro
+        testkey_rename\trw
         """).strip()
 
     def test_0_automountlocation_add(self):


### PR DESCRIPTION
This PR was opened automatically because PR #5920 was pushed to master and backport to ipa-4-9 is required.