### PR TITLE
ipa-advise: if p11-kit provides opensc, don't add to NSS db

### DIFF
--- a/ipaserver/advise/plugins/smart_card_auth.py
+++ b/ipaserver/advise/plugins/smart_card_auth.py
@@ -149,7 +149,7 @@ class config_server_for_smart_card_auth(common_smart_card_auth_config):
         self.log.exit_on_predicate(
             '[ -z "$ipaca_records" ]',
             [
-                'Can not resolve ipa-ca records for ${domain_name}',
+                f'Can not resolve ipa-ca records for {ipa_domain_name}',
                 'Please make sure to update your DNS infrastructure with ',
                 'ipa-ca record pointing to IP addresses of IPA CA masters'
             ])

--- a/ipaserver/advise/plugins/smart_card_auth.py
+++ b/ipaserver/advise/plugins/smart_card_auth.py
@@ -306,8 +306,9 @@ class config_client_for_smart_card_auth(common_smart_card_auth_config):
         shared_lib = self.pkcs11_shared_lib
 
         self.log.commands_on_predicate(
-            'modutil -dbdir {} -list | grep -q {}'.format(
-                nssdb, module_name),
+            'modutil -dbdir {nssdb} -list | grep -q {module_name} || '
+            'p11-kit list-modules | grep -i {module_name} -q'.format(
+                nssdb=nssdb, module_name=module_name),
             [
                 'echo "{} PKCS#11 module already configured"'.format(
                     module_name)


### PR DESCRIPTION
p11-kit-proxy in newer distributions handles loading the OpenSC
PKCS#11 library so don't try to add it to the NSS database in
/etc/pki/nssdb if it is already available in order to avoid a
potentially confusing error message.
    
https://pagure.io/freeipa/issue/8934
    
Signed-off-by: Rob Crittenden <rcritten@redhat.com>

NOTE:

1. A second patch fixes script error I noticed while working on the ticket.
2. There are no tests because it relies completely on the OS release and state of the client and we don't have that capacity in CI. I propose manual tests.
