### PR TITLE
[ipa-4-9] ipatests: bump prci boxes + move gating to f34

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -30,8 +30,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
-          name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.6
+          name: freeipa/ci-ipa-4-9-f34
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f34
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f34
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-previous
           name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.6
+          version: 0.0.7
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -56,8 +56,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
-          name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.6
+          name: freeipa/ci-ipa-4-9-f34
+          version: 0.0.3
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Bump template box version to latest to include recently updated
dependencies and move gating and temp definitions to latest Fedora
release.

Issue: https://pagure.io/freeipa/issue/8935