### PR TITLE
Fix ldapupdate.get_sub_dict() for missing named user

### DIFF
--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -64,6 +64,15 @@ def get_sub_dict(realm, domain, suffix, fqdn, idstart=None, idmax=None):
         idrange_size = idmax - idstart + 1
         subid_base_rid = constants.SUBID_RANGE_START - idrange_size
 
+    # uid / gid for autobind
+    # user is only defined when ipa-server-dns and bind are installed
+    try:
+        named_uid = platformconstants.NAMED_USER.uid
+        named_gid = platformconstants.NAMED_GROUP.gid
+    except ValueError:
+        named_uid = None
+        named_gid = None
+
     return dict(
         REALM=realm,
         DOMAIN=domain,
@@ -99,9 +108,8 @@ def get_sub_dict(realm, domain, suffix, fqdn, idstart=None, idmax=None):
         DEFAULT_ADMIN_SHELL=platformconstants.DEFAULT_ADMIN_SHELL,
         SELINUX_USERMAP_DEFAULT=platformconstants.SELINUX_USERMAP_DEFAULT,
         SELINUX_USERMAP_ORDER=platformconstants.SELINUX_USERMAP_ORDER,
-        # uid / gid for autobind
-        NAMED_UID=platformconstants.NAMED_USER.uid,
-        NAMED_GID=platformconstants.NAMED_GROUP.gid,
+        NAMED_UID=named_uid,
+        NAMED_GID=named_gid,
     )
 
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -547,6 +547,18 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  fedora-latest/test_installation_TestInstallWithoutNamed:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithoutNamed
+        template: *ci-master-latest
+        timeout: 4800
+        topology: *master_1repl
+
   fedora-latest/test_idviews:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -547,6 +547,18 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  fedora-previous/test_installation_TestInstallWithoutNamed:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithoutNamed
+        template: *ci-master-previous
+        timeout: 4800
+        topology: *master_1repl
+
   fedora-previous/test_idviews:
     requires: [fedora-previous/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -588,6 +588,19 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  fedora-rawhide/test_installation_TestInstallWithoutNamed:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallWithoutNamed
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl
+
   fedora-rawhide/test_idviews:
     requires: [fedora-rawhide/build]
     priority: 50

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1821,3 +1821,30 @@ class TestInstallWithoutSudo(IntegrationTest):
         result = tasks.install_client(self.master, self.clients[0])
         assert self.no_sudo_str not in result.stderr_text
         assert self.sudo_version_str not in result.stdout_text
+
+
+class TestInstallWithoutNamed(IntegrationTest):
+    num_replicas = 1
+
+    @classmethod
+    def remove_named(cls, host):
+        # remove the bind package and make sure the named user does not exist.
+        # https://pagure.io/freeipa/issue/8936
+        result = host.run_command(['id', 'named'], raiseonerr=False)
+        if result.returncode == 0:
+            tasks.uninstall_packages(host, ['bind'])
+            host.run_command(['userdel', constants.NAMED_USER])
+        assert host.run_command(
+            ['id', 'named'], raiseonerr=False
+        ).returncode == 1
+
+    @classmethod
+    def install(cls, mh):
+        for tgt in (cls.master, cls.replicas[0]):
+            cls.remove_named(tgt)
+        tasks.install_master(cls.master, setup_dns=False)
+
+    def test_replica0_install(self):
+        tasks.install_replica(
+            self.master, self.replicas[0], setup_ca=False, setup_dns=False
+        )


### PR DESCRIPTION
The named user may not be present when ipa-server-dns and bind are not
installed. NAMED_UID and NAMED_GID constants are only used with local
DNS support.

Fixes: https://pagure.io/freeipa/issue/8936
Signed-off-by: Christian Heimes <cheimes@redhat.com>