### PR TITLE
Parse getStatus as JSON not XML

### DIFF
--- a/install/tools/ipa-pki-wait-running.in
+++ b/install/tools/ipa-pki-wait-running.in
@@ -13,6 +13,7 @@ import logging
 import sys
 import time
 from xml.etree import ElementTree
+import json
 
 from ipalib import api
 from ipaplatform.paths import paths
@@ -74,10 +75,19 @@ def get_status(conn, timeout):
     """
     client = SystemStatusClient(conn)
     response = client.get_status(timeout=timeout)
-    root = ElementTree.fromstring(response)
-    status = root.findtext("Status")
-    error = root.findtext("Error")
-    logging.debug("Got status '%s', error '%s'", status, error)
+    status = None
+    error = None
+    try:
+        json_response = json.loads(response)
+        status = json_response['Response']['Status']
+    except KeyError as e:
+        error = repr(e)
+    except json.JSONDecodeError:
+        logger.debug("Response is not valid JSON, try XML")
+        root = ElementTree.fromstring(response)
+        status = root.findtext("Status")
+        error = root.findtext("Error")
+    logger.debug("Got status '%s', error '%s'", status, error)
     return status, error
 
 


### PR DESCRIPTION
On `dogtagpki/pki` master XML is being replaced by JSON, getStatus will return JSON in PKI 11.0+.

The PR for `dogtagpki/pki` that makes this change necessary is: https://github.com/dogtagpki/pki/pull/3674

To test, I forked the nightly copr build of `freeipa` and added in this patch. I then ran the `dogtagpki/pki` CI against my copr fork instead of the nightly freeipa copr. `dogtagpki/pki` CI fails against the nightly `freeipa` build, but succeeds with my patched build.

This is my first PR to this repo (hello everyone!) so if I need to do anything in addition, like bump a version or document that there is a breaking API change, then I would be grateful if someone could point me in the right direction!