### PR TITLE
Add index for sudoorder

### DIFF
--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -298,6 +298,15 @@ add:nsIndexType: eq
 add:nsIndexType: pres
 add:nsMatchingRule: integerOrderingMatch
 
+dn: cn=sudoorder,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+only:cn: sudoorder
+default:objectClass: nsIndex
+default:objectClass: top
+default:nsSystemIndex: false
+add:nsIndexType: eq
+add:nsIndexType: pres
+add:nsMatchingRule: integerOrderingMatch
+
 dn: cn=ipasudorunasgroup,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 only:cn: ipasudorunasgroup
 default:objectClass: nsIndex


### PR DESCRIPTION
sudorule-mod <rule> --order=<num> does a search for an existing
order and this search is unindexed.

https://pagure.io/freeipa/issue/8939

Signed-off-by: Rob Crittenden <rcritten@redhat.com>