### PR TITLE
Don't assume that plugin attributes and objectclasses are lowercase

### DIFF
--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -534,14 +534,14 @@ class config_mod(LDAPUpdate):
                     checked_attrs = checked_attrs + [self.api.Object[obj].uuid_attribute]
                 for obj_attr in checked_attrs:
                     obj_attr, _unused1, _unused2 = obj_attr.partition(';')
-                    if obj_attr in OPERATIONAL_ATTRIBUTES:
+                    if obj_attr.lower() in OPERATIONAL_ATTRIBUTES:
                         continue
-                    if obj_attr in self.api.Object[obj].params and \
+                    if obj_attr.lower() in self.api.Object[obj].params and \
                       'virtual_attribute' in \
-                      self.api.Object[obj].params[obj_attr].flags:
+                      self.api.Object[obj].params[obj_attr.lower()].flags:
                         # skip virtual attributes
                         continue
-                    if obj_attr not in new_allowed_attrs:
+                    if obj_attr.lower() not in new_allowed_attrs:
                         raise errors.ValidationError(name=attr,
                                 error=_('%(obj)s default attribute %(attr)s would not be allowed!') \
                                 % dict(obj=obj, attr=obj_attr))

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1713,3 +1713,15 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
+
+  fedora-latest/test_custom_plugins:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_custom_plugins.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1836,3 +1836,16 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
+
+  fedora-latest/test_custom_plugins:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_custom_plugins.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1836,3 +1836,16 @@ jobs:
         template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
+
+  testing-fedora/test_custom_plugins:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_custom_plugins.py
+        template: *testing-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1971,3 +1971,17 @@ jobs:
         template: *testing-master-latest
         timeout: 3600
         topology: *master_1repl
+
+  testing-fedora/test_custom_plugins:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        test_suite: test_integration/test_custom_plugins.py
+        template: *testing-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1713,3 +1713,15 @@ jobs:
         template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl
+
+  fedora-previous/test_custom_plugins:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_custom_plugins.py
+        template: *ci-master-previous
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1848,3 +1848,16 @@ jobs:
         template: *ci-master-frawhide
         timeout: 3600
         topology: *master_1repl
+
+  fedora-rawhide/test_custom_plugins:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_custom_plugins.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/test_integration/test_custom_plugins.py
+++ b/ipatests/test_integration/test_custom_plugins.py
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2021  FreeIPA Contributors see COPYING for license
+#
+"""Tests for custom plugins
+"""
+from __future__ import absolute_import
+
+import logging
+import os
+import site
+
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_ipa.integration import tasks
+
+logger = logging.getLogger(__name__)
+
+
+class TestCustomPlugin(IntegrationTest):
+    """
+    Tests for user-generated custom plugins
+    """
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=True)
+
+    def test_add_user_objectclass_with_custom_schema(self):
+        """Test adding a custom userclass to new users
+
+           Attributes should not be case-sensitive.
+
+           Based heavily on the custom plugin and schema at
+           https://github.com/Brandeis-CS-Systems/idm-unet-id-plugin
+        """
+        schema = (
+            "dn: cn=schema\n"
+            "attributeTypes: ( 2.16.840.1.113730.3.8.24.1.1 NAME 'customID' "
+            "EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX "
+            "1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'Testing' )\n"
+            "objectClasses: ( 2.16.840.1.113730.3.8.24.2.1 NAME 'customUser' "
+            "DESC 'custom user ID objectClass' AUXILIARY MAY ( customID ) "
+            "X-ORIGIN 'Testing' )\n"
+        )
+        plugin = (
+            "from ipalib.parameters import Str\n\n"
+            "from ipaserver.plugins.user import user\n\n"
+            "if 'customUser' not in user.possible_objectclasses:\n"
+            "    user.possible_objectclasses.append('customUser')\n"
+            "customuser_attributes = ['customID']\n"
+            "user.default_attributes.extend(customuser_attributes)\n"
+            "takes_params = (\n"
+            "    Str('customid?',\n"
+            "        cli_name='customid',\n"
+            "        maxlength=64,\n"
+            "        label='User custom uid'),\n"
+            ")\n"
+            "user.takes_params += takes_params\n"
+        )
+
+        tasks.kinit_admin(self.master)
+        self.master.put_file_contents('/tmp/schema.ldif', schema)
+        self.master.run_command(['ipa-ldap-updater', '-S', '/tmp/schema.ldif'])
+        self.master.put_file_contents('/tmp/schema.ldif', schema)
+
+        site_packages = site.getsitepackages()[-1]
+        site_file = os.path.join(
+            site_packages, "ipaserver", "plugins", "test.py"
+        )
+
+        self.master.put_file_contents(site_file, plugin)
+
+        self.master.run_command(['ipactl', 'restart'])
+
+        self.master.run_command([
+            'ipa', 'config-mod',
+            '--userobjectclasses', 'top',
+            '--userobjectclasses', 'person',
+            '--userobjectclasses', 'organizationalperson',
+            '--userobjectclasses', 'inetorgperson',
+            '--userobjectclasses', 'inetuser',
+            '--userobjectclasses', 'posixaccount',
+            '--userobjectclasses', 'krbprincipalaux',
+            '--userobjectclasses', 'krbticketpolicyaux',
+            '--userobjectclasses', 'ipaobject',
+            '--userobjectclasses', 'ipasshuser',
+            '--userobjectclasses', 'customuser',
+        ])
+
+        self.master.run_command(['rm', '-f', site_file])


### PR DESCRIPTION
Don't assume that plugin attributes and objectclasses are lowercase

A user wrote their own plugin to add custom attributes which was
failing with an incorrect error that the attribute wasn't allowed.

It wasn't allowed because it wasn't being treated as case-insensitive
so wasn't being found in the schema.

https://pagure.io/freeipa/issue/8415

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

**NOTE**: the new test file is not yet integrated into PR-CI. I think this is fine testing as part of the nightlies and not as gating but I'm open to suggestions.
