### PR TITLE
Provide more information in ipa-certupdate on ccache failure

### DIFF
--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -31,7 +31,7 @@ from ipaplatform import services
 from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks
 from ipalib import api, errors, x509
-from ipalib.constants import IPA_CA_NICKNAME, RENEWAL_CA_NAME
+from ipalib.constants import FQDN, IPA_CA_NICKNAME, RENEWAL_CA_NAME
 from ipalib.util import check_client_configuration
 
 logger = logging.getLogger(__name__)
@@ -62,6 +62,12 @@ class CertUpdate(admintool.AdminTool):
             api.Backend.rpcclient.connect()
             run_with_args(api)
             api.Backend.rpcclient.disconnect()
+        except errors.CCacheError:
+            logger.error(
+                "Unable to obtain credentials for %s from /etc/krb5.keytab",
+                FQDN
+            )
+            raise
         finally:
             if old_krb5ccname is None:
                 del os.environ['KRB5CCNAME']


### PR DESCRIPTION
ipa-certupdate obtains host credentials to operate. If this
fails with a ccache error this can be confusing if the user
executing it already has admin credentails.

Include the principal being retrieved and the keytab being
used.

This basically intercepts the exception to log additional
information and lets the exception be handled at a higher
level.

https://pagure.io/freeipa/issue/8257

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

I've only reproduced this with contrived use-cases but when I did run into it during development debugging the root cause was difficult so providing this information can be useful. As for test automation, I think it's overkill.