### PR TITLE
[Backport][ipa-4-9] Fix ldapupdate.get_sub_dict() for missing named user

### DIFF
--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -64,6 +64,15 @@ def get_sub_dict(realm, domain, suffix, fqdn, idstart=None, idmax=None):
         idrange_size = idmax - idstart + 1
         subid_base_rid = constants.SUBID_RANGE_START - idrange_size
 
+    # uid / gid for autobind
+    # user is only defined when ipa-server-dns and bind are installed
+    try:
+        named_uid = platformconstants.NAMED_USER.uid
+        named_gid = platformconstants.NAMED_GROUP.gid
+    except ValueError:
+        named_uid = None
+        named_gid = None
+
     return dict(
         REALM=realm,
         DOMAIN=domain,
@@ -99,9 +108,8 @@ def get_sub_dict(realm, domain, suffix, fqdn, idstart=None, idmax=None):
         DEFAULT_ADMIN_SHELL=platformconstants.DEFAULT_ADMIN_SHELL,
         SELINUX_USERMAP_DEFAULT=platformconstants.SELINUX_USERMAP_DEFAULT,
         SELINUX_USERMAP_ORDER=platformconstants.SELINUX_USERMAP_ORDER,
-        # uid / gid for autobind
-        NAMED_UID=platformconstants.NAMED_USER.uid,
-        NAMED_GID=platformconstants.NAMED_GROUP.gid,
+        NAMED_UID=named_uid,
+        NAMED_GID=named_gid,
     )
 
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -547,6 +547,18 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  fedora-latest-ipa-4-9/test_installation_TestInstallWithoutNamed:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithoutNamed
+        template: *ci-ipa-4-9-latest
+        timeout: 4800
+        topology: *master_1repl
+
   fedora-latest-ipa-4-9/test_idviews:
     requires: [fedora-latest-ipa-4-9/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -547,6 +547,18 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  fedora-previous-ipa-4-9/test_installation_TestInstallWithoutNamed:
+    requires: [fedora-previous-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-9/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithoutNamed
+        template: *ci-ipa-4-9-previous
+        timeout: 4800
+        topology: *master_1repl
+
   fedora-previous-ipa-4-9/test_idviews:
     requires: [fedora-previous-ipa-4-9/build]
     priority: 50


### PR DESCRIPTION
Manual backport of PR #5927

The named user may not be present when ipa-server-dns and bind are not
installed. NAMED_UID and NAMED_GID constants are only used with local
DNS support.

Fixes: https://pagure.io/freeipa/issue/8936
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Co-authored-by: François Cami <fcami@redhat.com>
Reviewed-By: Francois Cami <fcami@redhat.com>
Reviewed-By: Rob Crittenden <rcritten@redhat.com>