### PR TITLE
ipaserver: disable resolved' stub resolver

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -136,6 +136,8 @@ class BasePathNamespace:
     PKI_ACME_REALM_CONF = "/etc/pki/pki-tomcat/acme/realm.conf"
     ETC_REDHAT_RELEASE = "/etc/redhat-release"
     RESOLV_CONF = "/etc/resolv.conf"
+    RESOLV_CONF_STUB_RESOLVED = "/run/systemd/resolve/stub-resolv.conf"
+    RESOLV_CONF_RESOLVED = "/run/systemd/resolve/resolv.conf"
     SAMBA_KEYTAB = "/etc/samba/samba.keytab"
     SMB_CONF = "/etc/samba/smb.conf"
     LIMITS_CONF = "/etc/security/limits.conf"

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -322,6 +322,18 @@ class BaseTaskNamespace:
         """Tell systemd to reload config files"""
         raise NotImplementedError
 
+    def disable_resolved(self, sstore):
+        """
+        Disable systemd-resolved.
+        """
+        raise NotImplementedError()
+
+    def reenable_resolved(self, sstore):
+        """
+        The reverse of disable_resolved above.
+        """
+        raise NotImplementedError()
+
     def configure_dns_resolver(self, nameservers, searchdomains, *,
                                resolve1_enabled=False, fstore=None):
         """Configure global DNS resolver (e.g. /etc/resolv.conf)
@@ -546,5 +558,6 @@ class BaseTaskNamespace:
             statestore.delete_state(
                 'ipa-client-automount-nsswitch', 'previous-automount'
             )
+
 
 tasks = BaseTaskNamespace()

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -42,6 +42,8 @@ from ipaserver.install import dnskeysyncinstance
 from ipaserver.install import odsexporterinstance
 from ipaserver.install import opendnssecinstance
 from ipaserver.install import service
+from ipaplatform.tasks import tasks
+
 
 if six.PY3:
     unicode = str
@@ -120,8 +122,12 @@ def install_check(standalone, api, replica, options, hostname):
     global ip_addresses
     global reverse_zones
     fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    sstore = sysrestore.StateFile(paths.SYSRESTORE)
 
     package_check(RuntimeError)
+
+    # https://pagure.io/freeipa/issue/8700
+    tasks.disable_resolved(sstore)
 
     # when installing first DNS instance we need to check zone overlap
     if replica or standalone:

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1197,6 +1197,7 @@ def uninstall(installer):
     otpdinstance.OtpdInstance().uninstall()
     tasks.restore_hostname(fstore, sstore)
     tasks.restore_pkcs11_modules(fstore)
+    tasks.reenable_resolved(sstore)
     fstore.restore_all_files()
     try:
         os.remove(paths.ROOT_IPA_CACHE)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -513,6 +513,14 @@ def ca_initialize_hsm_state(ca):
         ca.set_hsm_state(config)
 
 
+def disable_resolved():
+    """
+    Disable resolved and switch back to the glibc stub resolver.
+    """
+    sstore = sysrestore.StateFile(paths.SYSRESTORE)
+    tasks.disable_resolved(sstore)
+
+
 def dnssec_set_openssl_engine(dnskeysyncd):
     """
     Setup OpenSSL engine for BIND

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,27 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_installation_TestInstallWithCA_DNS3:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl
+
+  fedora-latest/test_upgrade:
+    requires: [fedora-latest/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_upgrade.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -462,7 +462,7 @@ class TestInstallCA(IntegrationTest):
 
         # Tweak sysrestore.state to drop installation section
         self.master.run_command(
-            ['sed','-i', r's/\[installation\]/\[badinstallation\]/',
+            ['sed', '-i', r's/\[installation\]/\[badinstallation\]/',
              os.path.join(paths.SYSRESTORE, SYSRESTORE_STATEFILE)])
 
         # Re-run installation check and it should fall back to old method
@@ -472,7 +472,7 @@ class TestInstallCA(IntegrationTest):
 
         # Restore installation section.
         self.master.run_command(
-            ['sed','-i', r's/\[badinstallation\]/\[installation\]/',
+            ['sed', '-i', r's/\[badinstallation\]/\[installation\]/',
              os.path.join(paths.SYSRESTORE, SYSRESTORE_STATEFILE)])
 
         # Uninstall and confirm that the old method reports correctly
@@ -577,14 +577,74 @@ class TestInstallWithCA_DNS3(CALessBase):
         self.create_pkcs12('ca1/server')
         self.prepare_cacert('ca1')
 
+        # Clean NM DNS configuration.
+        # Then apply revolved.
+        if osinfo.id == 'fedora' and osinfo.version_number >= (33,):
+
+            nmcli_script_file = "/root/nmcli_script"
+            nmcli_script = ("nmcli -g name,type connection  show  --active "
+                            "| awk -F: '/ethernet|wireless/ { print $1 }'"
+                            "| while read connection\n"
+                            "do\n"
+                            "  nmcli con mod \"$connection\" "
+                            "ipv6.ignore-auto-dns yes\n"
+                            "  nmcli con mod \"$connection\" "
+                            "ipv4.ignore-auto-dns yes\n"
+                            "  nmcli con down \"$connection\" "
+                            "&& nmcli con up \"$connection\"\n"
+                            "done\n")
+            self.master.put_file_contents(nmcli_script_file , nmcli_script)
+            self.master.run_command(["bash", nmcli_script_file])
+
+            # remove all resolved netif-specific configuration
+            result = self.master.run_command(
+                ["ls", "/run/systemd/resolve/netif/"]
+            )
+            for netif in result.stdout_text.splitlines():
+                self.master.run_command(
+                    ["resolvconf", "-d", f"{netif}"]
+                )
+
+            # force using 127.0.0.2
+            self.master.run_command(
+                "echo \"DNS=127.0.0.2\" >> /etc/systemd/resolved.conf"
+            )
+            self.master.run_command(
+                ["cat", "/etc/systemd/resolved.conf"]
+            )
+
+            # restart NM + resolved
+            self.master.run_command(
+                ["systemctl", "restart", "NetworkManager"]
+            )
+            self.master.run_command(
+                ["systemctl", "restart", "systemd-resolved"]
+            )
+
+        # check that resolv.conf contains exactly what we expect,
+        # because otherwise the test results cannot be interpreted.
+        resolv_conf = self.master.get_file_contents(
+            '/run/systemd/resolve/resolv.conf',
+            encoding='utf-8'
+        )
+        assert resolv_conf.count("nameserver") == 1
+        assert "nameserver 127.0.0.2" in resolv_conf
+
         self.install_server(extra_args=['--allow-zone-overlap'])
 
-        result = self.master.run_command([
-            'ipa', 'dnszone-find'])
-
+        # actual checks
+        result = self.master.run_command(['ipa', 'dnszone-find'])
         assert "in-addr.arpa." in result.stdout_text
-
         assert "returned 2" in result.stdout_text
+
+        # check that resolv.conf only points to the local IPA instance
+        resolv_conf = self.master.get_file_contents(
+            '/etc/resolv.conf',
+            encoding='utf-8'
+        )
+        assert resolv_conf.count("nameserver") == 1
+        assert "nameserver 127.0.0.1" in resolv_conf
+
 
 
 class TestInstallWithCA_DNS4(CALessBase):
@@ -672,6 +732,7 @@ def get_pki_tomcatd_pid(host):
             pid = line.split()[2]
             break
     return(pid)
+
 
 def get_ipa_services_pids(host):
     ipa_services_name = [


### PR DESCRIPTION
Disable systemd-resolved stub resolver at install time.
Use systemd-resolved' maintained list of upstream DNS servers instead.

Rationale: systemd-resolved always resolves the FQDN to the local IP
and vice-versa. This breaks DNS zone detection and especially reverse
zone detection. This results in --auto-reverse being broken.

On systemd-resolved enabled systems, there are four ways to
configure resolv.conf:
* a symlink to /run/systemd/resolve/stub-resolv.conf
    This is the default and uses both the 127.0.0.53 DNS stub plus
    the search domains.
* a symlink to /usr/lib/systemd/resolv.conf
    This only contains the 127.0.0.53 DNS stub.
* a symlink to /run/systemd/resolve/resolv.conf
    This contains the upstream DNS IPs and bypasses systemd-resolved.
* Create and maintain /etc/resolv.conf directly.

Solutions #1 and #2 break DNS zone detection.
Solution #4 is not straightforward.
Combine Solution3 and 4: copy the file containing the upstream DNS IPs
so that it is properly maintained by NetworkManager after installation.

Fixes: https://pagure.io/freeipa/issue/8700
Signed-off-by: François Cami <fcami@redhat.com>

+

ipatests: xfail TestInstallWithCA_DNS3
    
TestInstallWithCA_DNS3 cannot succeed in PR-CI due to libvirt's
dnsmasq auto-maintaining the reverse zone for the networks it belongs
to. Mark the test as xfail on Fedora.
    
Related: https://pagure.io/freeipa/issue/8700
Signed-off-by: François Cami <fcami@redhat.com>
