### PR TITLE
[Backport][ipa-4-9] ipatests: use krb5_trace in TestIpaAdTrustInstall

### DIFF
--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -257,8 +257,11 @@ class TestIpaAdTrustInstall(IntegrationTest):
         user_princ = '@'.join([user, self.master.domain.realm])
         passwd = 'Secret123'
         # Create a user with a password
-        tasks.create_active_user(self.master, user, passwd, extra_args=[
-            '--homedir', '/home/{}'.format(user)])
+        tasks.create_active_user(
+            self.master, user, passwd,
+            extra_args=["--homedir", "/home/{}".format(user)],
+            krb5_trace=True
+        )
         try:
             # Defaults: host/... principal for service
             # keytab in /etc/krb5.keytab
@@ -282,8 +285,11 @@ class TestIpaAdTrustInstall(IntegrationTest):
         user_princ = '@'.join([user, self.master.domain.realm])
         passwd = 'Secret123'
         # Create a user with a password
-        tasks.create_active_user(self.master, user, passwd, extra_args=[
-            '--homedir', '/home/{}'.format(user)])
+        tasks.create_active_user(
+            self.master, user, passwd,
+            extra_args=["--homedir", "/home/{}".format(user)],
+            krb5_trace=True
+        )
         try:
             # Defaults: host/... principal for service
             # keytab in /etc/krb5.keytab


### PR DESCRIPTION
This PR was opened automatically because PR #5953 was pushed to master and backport to ipa-4-9 is required.