### PR TITLE
Add index for dnahostname

### DIFF
--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -107,6 +107,13 @@ default:nsSystemIndex: false
 add:nsIndexType: eq
 add:nsIndexType: sub
 
+dn: cn=dnahostname,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+only:cn: dnahostname
+default:objectClass: nsIndex
+default:objectClass: top
+default:nsSystemIndex: false
+add:nsIndexType: eq
+
 dn: cn=fqdn,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 only:cn: fqdn
 default:objectClass: nsIndex


### PR DESCRIPTION
There are 60+ searches for:
Filter:   (dnahostname=FQDN)
at startup.

Fixes: https://pagure.io/freeipa/issue/8945
Signed-off-by: François Cami <fcami@redhat.com>