### PR TITLE
[Backport][ipa-4-9] Don't assume that plugin attributes and objectclasses are lowercase

### DIFF
--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -534,14 +534,14 @@ class config_mod(LDAPUpdate):
                     checked_attrs = checked_attrs + [self.api.Object[obj].uuid_attribute]
                 for obj_attr in checked_attrs:
                     obj_attr, _unused1, _unused2 = obj_attr.partition(';')
-                    if obj_attr in OPERATIONAL_ATTRIBUTES:
+                    if obj_attr.lower() in OPERATIONAL_ATTRIBUTES:
                         continue
-                    if obj_attr in self.api.Object[obj].params and \
+                    if obj_attr.lower() in self.api.Object[obj].params and \
                       'virtual_attribute' in \
-                      self.api.Object[obj].params[obj_attr].flags:
+                      self.api.Object[obj].params[obj_attr.lower()].flags:
                         # skip virtual attributes
                         continue
-                    if obj_attr not in new_allowed_attrs:
+                    if obj_attr.lower() not in new_allowed_attrs:
                         raise errors.ValidationError(name=attr,
                                 error=_('%(obj)s default attribute %(attr)s would not be allowed!') \
                                 % dict(obj=obj, attr=obj_attr))

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1713,3 +1713,15 @@ jobs:
         template: *ci-ipa-4-9-latest
         timeout: 3600
         topology: *master_1repl
+
+  fedora-latest-ipa-4-9/test_custom_plugins:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        test_suite: test_integration/test_custom_plugins.py
+        template: *ci-ipa-4-9-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1836,3 +1836,16 @@ jobs:
         template: *ci-ipa-4-9-latest
         timeout: 3600
         topology: *master_1repl
+
+  fedora-latest-ipa-4-9/test_custom_plugins:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_custom_plugins.py
+        template: *ci-ipa-4-9-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1713,3 +1713,15 @@ jobs:
         template: *ci-ipa-4-9-previous
         timeout: 3600
         topology: *master_1repl
+
+  fedora-previous-ipa-4-9/test_custom_plugins:
+    requires: [fedora-previous-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-9/build_url}'
+        test_suite: test_integration/test_custom_plugins.py
+        template: *ci-ipa-4-9-previous
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/test_integration/test_custom_plugins.py
+++ b/ipatests/test_integration/test_custom_plugins.py
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2021  FreeIPA Contributors see COPYING for license
+#
+"""Tests for custom plugins
+"""
+from __future__ import absolute_import
+
+import logging
+import os
+import site
+
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_ipa.integration import tasks
+
+logger = logging.getLogger(__name__)
+
+
+class TestCustomPlugin(IntegrationTest):
+    """
+    Tests for user-generated custom plugins
+    """
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=True)
+
+    def test_add_user_objectclass_with_custom_schema(self):
+        """Test adding a custom userclass to new users
+
+           Attributes should not be case-sensitive.
+
+           Based heavily on the custom plugin and schema at
+           https://github.com/Brandeis-CS-Systems/idm-unet-id-plugin
+        """
+        schema = (
+            "dn: cn=schema\n"
+            "attributeTypes: ( 2.16.840.1.113730.3.8.24.1.1 NAME 'customID' "
+            "EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX "
+            "1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'Testing' )\n"
+            "objectClasses: ( 2.16.840.1.113730.3.8.24.2.1 NAME 'customUser' "
+            "DESC 'custom user ID objectClass' AUXILIARY MAY ( customID ) "
+            "X-ORIGIN 'Testing' )\n"
+        )
+        plugin = (
+            "from ipalib.parameters import Str\n\n"
+            "from ipaserver.plugins.user import user\n\n"
+            "if 'customUser' not in user.possible_objectclasses:\n"
+            "    user.possible_objectclasses.append('customUser')\n"
+            "customuser_attributes = ['customID']\n"
+            "user.default_attributes.extend(customuser_attributes)\n"
+            "takes_params = (\n"
+            "    Str('customid?',\n"
+            "        cli_name='customid',\n"
+            "        maxlength=64,\n"
+            "        label='User custom uid'),\n"
+            ")\n"
+            "user.takes_params += takes_params\n"
+        )
+
+        tasks.kinit_admin(self.master)
+        self.master.put_file_contents('/tmp/schema.ldif', schema)
+        self.master.run_command(['ipa-ldap-updater', '-S', '/tmp/schema.ldif'])
+        self.master.put_file_contents('/tmp/schema.ldif', schema)
+
+        site_packages = site.getsitepackages()[-1]
+        site_file = os.path.join(
+            site_packages, "ipaserver", "plugins", "test.py"
+        )
+
+        self.master.put_file_contents(site_file, plugin)
+
+        self.master.run_command(['ipactl', 'restart'])
+
+        self.master.run_command([
+            'ipa', 'config-mod',
+            '--userobjectclasses', 'top',
+            '--userobjectclasses', 'person',
+            '--userobjectclasses', 'organizationalperson',
+            '--userobjectclasses', 'inetorgperson',
+            '--userobjectclasses', 'inetuser',
+            '--userobjectclasses', 'posixaccount',
+            '--userobjectclasses', 'krbprincipalaux',
+            '--userobjectclasses', 'krbticketpolicyaux',
+            '--userobjectclasses', 'ipaobject',
+            '--userobjectclasses', 'ipasshuser',
+            '--userobjectclasses', 'customuser',
+        ])
+
+        self.master.run_command(['rm', '-f', site_file])


### PR DESCRIPTION
Manual backport of #5935

Only the nightly PR-CI configuration needed to be updated.

Don't assume that plugin attributes and objectclasses are lowercase

A user wrote their own plugin to add custom attributes which was
failing with an incorrect error that the attribute wasn't allowed.

It wasn't allowed because it wasn't being treated as case-insensitive
so wasn't being found in the schema.

https://pagure.io/freeipa/issue/8415

Signed-off-by: Rob Crittenden rcritten@redhat.com