### PR TITLE
ipatests: test_ipahealthcheck: Test if check for FIPS is present

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -504,6 +504,26 @@ class TestIpaHealthCheck(IntegrationTest):
         assert data[0]["kw"]["ipa_version"] in result.stdout_text
         assert data[0]["kw"]["ipa_api_version"] in result.stdout_text
 
+    def test_fips_mode_check_exists(self):
+        """
+        Testcase to verify whether FIPS mode check exists
+        in ipahealthcheck.meta.core
+        """
+        returncode, data = run_healthcheck(self.master,
+                                           "ipahealthcheck.meta.core",
+                                           "MetaCheck")
+        assert returncode == 0
+
+        cmd = self.master.run_command(['fips-mode-setup', '--is-enabled'],
+                                      raiseonerr=False)
+        fips_enabled = cmd.returncode == 0
+        for check in data:
+            if check["kw"].get("fips", None):
+                if fips_enabled:
+                    assert check["kw"]["fips"] == "enabled"
+                else:
+                    assert check["kw"]["fips"] == "disabled"
+
     def test_source_ipahealthcheck_ipa_host_check_ipahostkeytab(self):
         """
         Testcase checks behaviour of check IPAHostKeytab in source


### PR DESCRIPTION
Test if the check for FIPS mode status is present in ipahealthcheck.meta.core
   
Resolves: https://pagure.io/freeipa/issue/8951
    
Signed-off-by: Michal Polovka <mpolovka@redhat.com>
