### PR TITLE
ipatests: Additional tests for ipa subordinate ids

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_subids.py::TestSubordinateId
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_subids.py
+++ b/ipatests/test_integration/test_subids.py
@@ -253,3 +253,21 @@ class TestSubordinateId(IntegrationTest):
     def test_subid_stats(self):
         tasks.kinit_admin(self.master)
         self.master.run_command(["ipa", "subid-stats"])
+
+    def test_add_subid_range_as_regular_ipauser(self):
+        '''
+        Test checks that when regular ipauser tries to add
+        subid range it generates an error
+        '''
+        password = 'Secret123'
+        error_msg = (
+            "ipa: ERROR: Insufficient access: "
+            "Insufficient 'add' privilege to add the entry"
+        )
+        tasks.kinit_admin(self.master)
+        uid = 'ipauser1'
+        tasks.create_active_user(self.master, uid, password=password)
+        self.master.run_command(["kdestroy", "-A"])
+        tasks.kinit_as_user(self.master, uid, password=password)
+        cmd = self.subid_generate(uid, raiseonerr=False)
+        assert error_msg in cmd.stderr_text


### PR DESCRIPTION
1. Test check that when no subid is provided in ipa subid-show command error message is displayed on the console.
2. Test check that when regular ipa user tries to generate subid an error is displayed
