### PR TITLE
schema plugin: Generate stable fingerprint

### DIFF
--- a/ipaserver/plugins/schema.py
+++ b/ipaserver/plugins/schema.py
@@ -839,7 +839,7 @@ class schema(Command):
         langs = "".join(getattr(context, "languages", []))
 
         if getattr(self.api, "_schema", None) is None:
-            setattr(self.api, "_schema", {})
+            object.__setattr__(self.api, "_schema", {})
 
         schema = self.api._schema.get(langs)
         if schema is None:

--- a/ipaserver/plugins/schema.py
+++ b/ipaserver/plugins/schema.py
@@ -592,7 +592,7 @@ class param(BaseParam):
                 obj[key] = unicode(value)
             elif key in ('exclude',
                          'include'):
-                obj[key] = list(unicode(v) for v in value)
+                obj[key] = sorted(list(unicode(v) for v in value))
             if isinstance(metaobj, Command):
                 if key == 'alwaysask':
                     obj.setdefault(key, value)


### PR DESCRIPTION
If some Param defines several values for `exclude` or `include` attributes then API schema hash will be unstable.
    
First, these Param's attributes are converted to frozenset (`ipalib.parameters`), then `ipaserver.plugins.schema` plugin converts `exclude` and `include` attrs to list. Set/frozenset in turn, is unordered collection \[0\]. So, the end order of values is undefined.

But due to the nature of sets:
> two sets are equal if and only if every element of each set is contained in the other (each is a subset of the other)
    
the order of values can be ignored.
    
Note: other Param's attrs with type frozenset are not affected because they are not processed by the schema plugin.
    
\[0\]: https://docs.python.org/3/library/stdtypes.html#set-types-set-frozenset
    
Fixes: https://pagure.io/freeipa/issue/8955