### PR TITLE
Only call add_agent_to_security_domain_admins() when CA is installed

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1843,11 +1843,11 @@ def upgrade_configuration():
         ca.setup_acme()
         ca_update_acme_configuration(ca, fqdn)
         ca_initialize_hsm_state(ca)
+        add_agent_to_security_domain_admins()
 
     migrate_to_authselect()
     add_systemd_user_hbac()
     add_admin_root_alias()
-    add_agent_to_security_domain_admins()
 
     sssd_update()
 


### PR DESCRIPTION
Only call add_agent_to_security_domain_admins() when CA is installed

This allows the RA agent to manage the pki security domain and is
only needed if a CA has been configured. Only call it in a CA-ful
installation.

https://pagure.io/freeipa/issue/8956

Signed-off-by: Rob Crittenden <rcritten@redhat.com>