### PR TITLE
[Backport][ipa-4-9] Only call add_agent_to_security_domain_admins() when CA is installed

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1840,11 +1840,11 @@ def upgrade_configuration():
         ca.setup_acme()
         ca_update_acme_configuration(ca, fqdn)
         ca_initialize_hsm_state(ca)
+        add_agent_to_security_domain_admins()
 
     migrate_to_authselect()
     add_systemd_user_hbac()
     add_admin_root_alias()
-    add_agent_to_security_domain_admins()
 
     sssd_update()
 


### PR DESCRIPTION
This PR was opened automatically because PR #5980 was pushed to master and backport to ipa-4-9 is required.