### PR TITLE
Azure: Run pycodestyle check in Lint job

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -230,6 +230,8 @@ fasttest: $(GENERATED_PYTHON_FILES) ipasetup.py
 	    --ignore $(abspath $(top_srcdir))/ipatests/test_xmlrpc
 
 fastcodestyle: $(GENERATED_PYTHON_FILES) ipasetup.py
+	@ # keep Python files in sync to pycodestyle configuration in
+	@ # tox.ini(filename=)
 	@echo "Fast code style checking with $(PYTHON) from branch '$(GIT_BRANCH)'"
 
 	@MERGEBASE=$$(git merge-base --fork-point $(GIT_BRANCH)); \
@@ -250,8 +252,8 @@ fastcodestyle: $(GENERATED_PYTHON_FILES) ipasetup.py
 	    echo -e "Fast code style checking for files:\n$${FILES}\n"; \
 	    echo "pycodestyle"; \
 	    echo "-----------"; \
-	    git diff -U0 $${MERGEBASE} | \
-	        $(PYTHON) -m pycodestyle --diff || exit $$?; \
+	    git diff -U0 $${MERGEBASE} -- $${FILES} | \
+	        $(PYTHON) -m pycodestyle -v --diff || exit $$?; \
 	else \
 	    echo "No modified Python files found"; \
 	fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -216,7 +216,7 @@ endif
 	$(MAKE) $(AM_MAKEFLAGS) acilint apilint polint pylint jslint $(RPMLINT_TARGET) yamllint check
 	@echo "All tests passed."
 
-.PHONY: fastcheck fasttest fastlint
+.PHONY: fastcheck fasttest fastlint fastcodestyle
 fastcheck:
 	@$(MAKE) -j1 $(AM_MAKEFLAGS) fastlint $(RPMLINT_TARGET) yamllint fasttest apilint acilint
 
@@ -229,7 +229,34 @@ fasttest: $(GENERATED_PYTHON_FILES) ipasetup.py
 	    --ignore $(abspath $(top_srcdir))/ipatests/test_integration \
 	    --ignore $(abspath $(top_srcdir))/ipatests/test_xmlrpc
 
-fastlint: $(GENERATED_PYTHON_FILES) ipasetup.py acilint apilint
+fastcodestyle: $(GENERATED_PYTHON_FILES) ipasetup.py
+	@echo "Fast code style checking with $(PYTHON) from branch '$(GIT_BRANCH)'"
+
+	@MERGEBASE=$$(git merge-base --fork-point $(GIT_BRANCH)); \
+	PYFILES=$$(git diff --name-only --diff-filter=d $${MERGEBASE} \
+	    | grep -E '\.py$$' ); \
+	INFILES=$$(git diff --name-only --diff-filter=d $${MERGEBASE} \
+	    | grep -E '\.in$$' \
+	    | xargs -n1 file 2>/dev/null | grep Python \
+	    | cut -d':' -f1; ); \
+	if [ -n "$${PYFILES}" ] && [ -n "$${INFILES}" ]; then \
+	    FILES="$$( printf $${PYFILES}\\n$${INFILES} )" ; \
+	elif [ -n "$${PYFILES}" ]; then \
+	    FILES="$${PYFILES}" ; \
+	else \
+	    FILES="$${INFILES}" ; \
+	fi ; \
+	if [ -n "$${FILES}" ]; then \
+	    echo -e "Fast code style checking for files:\n$${FILES}\n"; \
+	    echo "pycodestyle"; \
+	    echo "-----------"; \
+	    git diff -U0 $${MERGEBASE} | \
+	        $(PYTHON) -m pycodestyle --diff || exit $$?; \
+	else \
+	    echo "No modified Python files found"; \
+	fi
+
+fastlint: $(GENERATED_PYTHON_FILES) ipasetup.py fastcodestyle acilint apilint
 if ! WITH_PYLINT
 	@echo "ERROR: pylint not available"; exit 1
 endif
@@ -251,10 +278,6 @@ endif
 	fi ; \
 	if [ -n "$${FILES}" ]; then \
 	    echo -e "Fast linting files:\n$${FILES}\n"; \
-	    echo "pycodestyle"; \
-	    echo "-----------"; \
-	    git diff -U0 $${MERGEBASE} | \
-	        $(PYTHON) -m pycodestyle --diff || exit $$?; \
 	    echo -e "\npylint"; \
 	    echo "------"; \
 	    $(PYTHON) -m pylint --version; \

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -20,12 +20,6 @@ jobs:
   steps:
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - template: templates/${{ variables.AUTOCONF_TEMPLATE }}
-    - script: |
-        set -e
-        git update-ref refs/heads/$(System.PullRequest.TargetBranch) origin/$(System.PullRequest.TargetBranch)
-        make V=0 "GIT_BRANCH=$(System.PullRequest.TargetBranch)" fastlint
-      displayName: Quick code style check
-      condition: eq(variables['Build.Reason'], 'PullRequest')
     - template: templates/${{ variables.BUILD_TEMPLATE }}
     - template: templates/publish-build.yml
       parameters:
@@ -75,6 +69,12 @@ jobs:
         echo "Running make target 'lint'"
         make V=0 lint
       displayName: Lint sources
+    - script: |
+        set -e
+        git update-ref refs/heads/$(System.PullRequest.TargetBranch) origin/$(System.PullRequest.TargetBranch)
+        make V=0 "GIT_BRANCH=$(System.PullRequest.TargetBranch)" fastcodestyle
+      displayName: Quick code style check
+      condition: eq(variables['Build.Reason'], 'PullRequest')
 
 - job: Docs
   pool:
@@ -144,7 +144,9 @@ jobs:
 - job: BASE_XMLRPC
   pool:
     vmImage: $(VM_IMAGE)
-  dependsOn: Build
+  dependsOn:
+    - Build
+    - Lint
   variables:
     IPA_IMAGE_ARTIFACT: $[ dependencies.Build.outputs['artifacts_image.image'] ]
     IPA_PACKAGES_ARTIFACT: $[ dependencies.Build.outputs['artifacts_packages.packages'] ]
@@ -158,7 +160,9 @@ jobs:
 - job: GATING
   pool:
     vmImage: $(VM_IMAGE)
-  dependsOn: Build
+  dependsOn:
+    - Build
+    - Lint
   variables:
     IPA_IMAGE_ARTIFACT: $[ dependencies.Build.outputs['artifacts_image.image'] ]
     IPA_PACKAGES_ARTIFACT: $[ dependencies.Build.outputs['artifacts_packages.packages'] ]

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ ignore = E203, E402, E231, W503, E731, E741
 max-line-length = 80
 # exclude auto-generated remote plugins
 exclude=.git,.venv,build,_build,rpmbuild,2_49,2_114,2_156,2_164
+filename=*.py,*.in
 
 [pytest]
 addopts = -ra -v


### PR DESCRIPTION
- previously, fastlint make's target includes both the Pylint task
and pycodestyle one. The purpose of this target is a fast checking
only for changed Python files. This makes sense for pycodestyle, but
limits Pylint due to a context(file) checking. The clients which
call the code being linted are not checked at all. In Azure Pylint
(for the whole codebase) is run in the Lint task, this makes fastlint
extra for Azure.

- `Quick code style check` task used distro's Pylint, while `Lint`
task PyPI's one. This may cause different results and confuse a
user.

- `Build` task takes time longer than `Lint` one, so this change
doesn't lead to increased CI time.

- all Azure tests depend on Build and Lint tasks. Mostly it's no need
to run tests due to a probably broken code.

Fixes: https://pagure.io/freeipa/issue/8961