### PR TITLE
ipatests: use whole date for journalctl --since

### DIFF
--- a/ipatests/test_integration/test_cert.py
+++ b/ipatests/test_integration/test_cert.py
@@ -69,7 +69,7 @@ class TestInstallMasterClient(IntegrationTest):
 
         # time to look into journal logs in
         # test_certmonger_ipa_responder_jsonrpc
-        cls.since = time.strftime('%H:%M:%S')
+        cls.since = time.strftime('%Y-%m-%d %H:%M:%S')
 
     def test_cacert_file_appear_with_option_F(self):
         """Test if getcert creates cacert file with -F option

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1208,7 +1208,8 @@ class TestIPACommand(IntegrationTest):
         # start to look at logs a bit before "now"
         # https://pagure.io/freeipa/issue/8432
         since = time.strftime(
-            '%H:%M:%S', (datetime.now() - timedelta(seconds=10)).timetuple()
+            '%Y-%m-%d %H:%M:%S',
+            (datetime.now() - timedelta(seconds=10)).timetuple()
         )
 
         password = 'WrongPassword'

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -130,7 +130,7 @@ class TestNFS(IntegrationTest):
         nfsclt = self.clients[1]
 
         # for journalctl --since
-        since = time.strftime('%H:%M:%S')
+        since = time.strftime('%Y-%m-%d %H:%M:%S')
         nfsclt.run_command(["systemctl", "restart", "rpc-gssd"])
         time.sleep(WAIT_AFTER_INSTALL)
         mountpoints = ("/mnt/krb", "/mnt/std", "/home")


### PR DESCRIPTION
When a test is executed around midnight and is checking the
journal content with --since=date, it needs to specify the
whole date (with day and time) to avoid missing entries.

If for instance --since=23:59:00 is used and the current time is
now 00:01:00, --since=23:59:00 would refer to a date in the
future and no journal entry will be found.

Fixes: https://pagure.io/freeipa/issue/8953