### PR TITLE
Increase default limit on LDAP searches to 100k

### DIFF
--- a/install/updates/10-config.update
+++ b/install/updates/10-config.update
@@ -16,7 +16,7 @@ only: nsslapd-pluginPrecedence: 60
 # Set limits to suite better IPA deployment sizes, defaults are too
 # conservative
 dn: cn=config
-default: nsslapd-sizelimit:100000
+replace: nsslapd-sizelimit:2000::100000
 
 dn: cn=config,cn=ldbm database,cn=plugins,cn=config
 replace: nsslapd-lookthroughlimit:5000::100000

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -765,6 +765,7 @@ class LDAPClient:
         'nsslapd-logging-hr-timestamps-enabled': True,
         'nsslapd-ldapientrysearchbase': True,
         'nsslapd-ldapidnmappingbase': True,
+        'nsslapd-sizelimit': True,
     })
 
     time_limit = -1.0   # unlimited


### PR DESCRIPTION
A similar change was attempted years ago in commit
9724251292e4c0797367fcc351a9f16f30c6aefe but it was
never applied because it used the wrong DN and because
nsslapd-timelimit is already present in the entry
the default keyword won't trigger.

Use replace instead to increase the value to 100k from
the default as originally intended.

https://pagure.io/freeipa/issue/8962

Signed-off-by: Rob Crittenden <rcritten@redhat.com>