### PR TITLE
[Backport][ipa-4-9] freeipa.spec.in: update 389-DS version

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -110,7 +110,7 @@
 %if 0%{?fedora} < 34
 %global ds_version 1.4.4.16-1
 %else
-%global ds_version 2.0.5-1
+%global ds_version 2.0.7-1
 %endif
 
 # Fix for TLS 1.3 PHA, RHBZ#1775146


### PR DESCRIPTION
This PR was opened automatically because PR #5986 was pushed to master and backport to ipa-4-9 is required.