### PR TITLE
Avoid double encryption of LDAP connections

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -164,17 +164,6 @@ class ldap2(CrudBackend, LDAPCache):
             cacert=cacert)
         conn = client._conn
 
-        with client.error_handler():
-            minssf = conn.get_option(_ldap.OPT_X_SASL_SSF_MIN)
-            maxssf = conn.get_option(_ldap.OPT_X_SASL_SSF_MAX)
-            # Always connect with at least an SSF of 56, confidentiality
-            # This also protects us from a broken ldap.conf
-            if minssf < 56:
-                minssf = 56
-                conn.set_option(_ldap.OPT_X_SASL_SSF_MIN, minssf)
-                if maxssf < minssf:
-                    conn.set_option(_ldap.OPT_X_SASL_SSF_MAX, minssf)
-
         ldapi = self.ldap_uri.startswith('ldapi://')
 
         if bind_pw:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/simple_replication:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_simple_replication.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl


### PR DESCRIPTION
The default settings of FreeIPA and OpenLDAP's libldap result in double
encryption of LDAPS and StartTLS connections. The outer layer is TLS and
the inner layer is SASL data security layer with GSSAPI encryption.
Double encryption is a waste of resources and can impact performance.

libldap does not install the SASL data security layer when a connection
uses a minimum and maximum security strength factor of 0.

Fixes: https://pagure.io/freeipa/issue/8970
Signed-off-by: Christian Heimes <cheimes@redhat.com>