### PR TITLE
selinux policy: allow custodia to access /proc/cpuinfo

### DIFF
--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -364,6 +364,7 @@ files_tmp_filetrans(ipa_custodia_t, ipa_custodia_tmp_t, { dir file })
 
 kernel_dgram_send(ipa_custodia_t)
 kernel_read_network_state(ipa_custodia_t)
+kernel_read_system_state(ipa_custodia_t)
 
 auth_read_passwd(ipa_custodia_t)
 


### PR DESCRIPTION
On aarch64, custodia creates AVC when accessing /proc/cpuinfo.

According to gcrypt manual
(https://gnupg.org/documentation/manuals/gcrypt/Configuration.html),
/proc/cpuinfo is used on ARM architecture to read the hardware
capabilities of the CPU. This explains why the issue happens only
on aarch64.

audit2allow suggests to add the following:
allow ipa_custodia_t proc_t:file { getattr open read };

but this policy would be too broad. Instead, the patch is using
the interface kernel_read_system_state.

Fixes: https://pagure.io/freeipa/issue/8972
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>