### PR TITLE
Catch and log errors when adding CA profiles

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1973,8 +1973,17 @@ def import_included_profiles():
 
             # Create the profile, replacing any existing profile of same name
             profile_data = __get_profile_config(profile_id)
-            _create_dogtag_profile(profile_id, profile_data, overwrite=True)
-            logger.debug("Imported profile '%s'", profile_id)
+            try:
+                _create_dogtag_profile(profile_id, profile_data,
+                                       overwrite=True)
+            except errors.HTTPRequestError as e:
+                logger.warning("Failed to import profile '%s': %s. Running "
+                               "ipa-server-upgrade when installation is "
+                               "completed may resolve this issue.",
+                               profile_id, e)
+                conn.delete_entry(entry)
+            else:
+                logger.debug("Imported profile '%s'", profile_id)
         else:
             logger.debug(
                 "Profile '%s' is already in LDAP; skipping", profile_id


### PR DESCRIPTION
Rather than stopping the installer entirely, catch and report
errors adding new certificate profiles.

It was discovered that installing a newer IPA that has the
ACME profile which requires sanToCNDefault will fail when
installing a new server against a very old one that lacks
this class.

Deleting the LDAP profile in cn=certprofiles,cn=ca,$SUFFIX
and then running ipa-server-install on the newer server
will add the missing profile.

https://pagure.io/freeipa/issue/8974

Signed-off-by: Rob Crittenden <rcritten@redhat.com>