### PR TITLE
[Backport][ipa-4-9] selinux policy: allow custodia to access /proc/cpuinfo

### DIFF
--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -364,6 +364,7 @@ files_tmp_filetrans(ipa_custodia_t, ipa_custodia_tmp_t, { dir file })
 
 kernel_dgram_send(ipa_custodia_t)
 kernel_read_network_state(ipa_custodia_t)
+kernel_read_system_state(ipa_custodia_t)
 
 auth_read_passwd(ipa_custodia_t)
 


### PR DESCRIPTION
This PR was opened automatically because PR #5994 was pushed to master and backport to ipa-4-9 is required.