### PR TITLE
[Backport][ipa-4-9] extdom: return LDAP_NO_SUCH_OBJECT if domains differ

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_common.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_common.c
@@ -542,7 +542,9 @@ int pack_ber_user(struct ipa_extdom_ctx *ctx,
         if (strcasecmp(locat+1, domain_name) == 0  ) {
             locat[0] = '\0';
         } else {
-            ret = LDAP_INVALID_SYNTAX;
+            /* The found object is from a different domain than requested,
+             * that means it does not exist in the requested domain */
+            ret = LDAP_NO_SUCH_OBJECT;
             goto done;
         }
     }
@@ -655,7 +657,9 @@ int pack_ber_group(enum response_types response_type,
         if (strcasecmp(locat+1, domain_name) == 0  ) {
             locat[0] = '\0';
         } else {
-            ret = LDAP_INVALID_SYNTAX;
+            /* The found object is from a different domain than requested,
+             * that means it does not exist in the requested domain */
+            ret = LDAP_NO_SUCH_OBJECT;
             goto done;
         }
     }


### PR DESCRIPTION
This PR was opened automatically because PR #5991 was pushed to master and backport to ipa-4-9 is required.