### PR TITLE
subid: subid-match: display the owner's ID not DN

### DIFF
--- a/ipaserver/plugins/subid.py
+++ b/ipaserver/plugins/subid.py
@@ -524,6 +524,7 @@ class subid_match(subid_find):
         osubuid = options["ipasubuidnumber"]
         new_entries = []
         for entry in entries:
+            self.obj.convert_owner(entry, options)
             esubuid = int(entry.single_value["ipasubuidnumber"])
             esubcount = int(entry.single_value["ipasubuidcount"])
             minsubuid = esubuid


### PR DESCRIPTION
Previously, the subid-match command would output the full
DN of the owner of the matched range.
With this change, the UID of the owner is displayed, just like
for other subid- commands.

Fixes: https://pagure.io/freeipa/issue/8977
Signed-off-by: François Cami <fcami@redhat.com>