### PR TITLE
[Backport][ipa-4-9] subid: subid-match: display the owner's ID not DN

### DIFF
--- a/ipaserver/plugins/subid.py
+++ b/ipaserver/plugins/subid.py
@@ -524,6 +524,7 @@ class subid_match(subid_find):
         osubuid = options["ipasubuidnumber"]
         new_entries = []
         for entry in entries:
+            self.obj.convert_owner(entry, options)
             esubuid = int(entry.single_value["ipasubuidnumber"])
             esubcount = int(entry.single_value["ipasubuidcount"])
             minsubuid = esubuid


### PR DESCRIPTION
This PR was opened automatically because PR #6001 was pushed to master and backport to ipa-4-9 is required.