### PR TITLE
[Backport][ipa-4-9] Increase default limit on LDAP searches to 100k

### DIFF
--- a/install/updates/10-config.update
+++ b/install/updates/10-config.update
@@ -16,7 +16,7 @@ only: nsslapd-pluginPrecedence: 60
 # Set limits to suite better IPA deployment sizes, defaults are too
 # conservative
 dn: cn=config
-default: nsslapd-sizelimit:100000
+replace: nsslapd-sizelimit:2000::100000
 
 dn: cn=config,cn=ldbm database,cn=plugins,cn=config
 replace: nsslapd-lookthroughlimit:5000::100000

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -763,6 +763,7 @@ class LDAPClient:
         'nsslapd-enable-upgrade-hash': True,
         'nsslapd-db-locks': True,
         'nsslapd-logging-hr-timestamps-enabled': True,
+        'nsslapd-sizelimit': True,
     })
 
     time_limit = -1.0   # unlimited


### PR DESCRIPTION
This PR was opened manually because PR #5985 was pushed to master and backport to ipa-4-9 is required.

There was a merge conflict in the attribute overrides in ipapython/ipaldap.py but the resulting change, plus or minus a few line numbers, is identical to the change in master. Adding the ack flag.