### PR TITLE
ipatests: fix logic waiting for repl in TestIPACommand

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1375,7 +1375,9 @@ class TestIPACommand(IntegrationTest):
             stdin_text='{0}\n{0}\n'.format(original_passwd)
         )
 
-        ldap = self.master.ldap_connect()
+        # Wait for the password update to be replicated from replicas[0]
+        # to other servers
+        ldap = self.replicas[0].ldap_connect()
         tasks.wait_for_replication(ldap)
 
         # The user can log in again


### PR DESCRIPTION
The logic of test_reset_password_unlock is twisted.
Currently it's doing:
- reset password on replicas[0]
- wait for replication on master
- kinit on master

The call to wait_for_replication should be done on
replicas[0], not on master, according to the method doc:
    Note that this waits for updates originating on this host, not those
    coming from other hosts.

Fixes: https://pagure.io/freeipa/issue/8975

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>