### PR TITLE
azure: Ignore tar errors

### DIFF
--- a/ipatests/azure/scripts/azure-run-base-tests.sh
+++ b/ipatests/azure/scripts/azure-run-base-tests.sh
@@ -22,7 +22,8 @@ function collect_logs() {
         /var/log/pki \
         /var/log/samba \
         "$BIND_DATADIR" \
-        systemd_journal.log
+        systemd_journal.log \
+        ||:
 }
 
 server_password=Secret123
@@ -95,6 +96,8 @@ if [ "$install_result" -eq 0 ] ; then
 else
     echo "ipa-server-install failed with code ${install_result}, skip IPA tests"
 fi
+# let the services gracefully flush their logs
+ipactl stop ||:
 collect_logs ipaserver_install_logs.tar.gz
 
 echo "Potential Python 3 incompatibilities in the IPA framework:"


### PR DESCRIPTION
Sometimes tar fails on changed in process files:
```
[2021-09-07 11:03:33] + tar --ignore-failed-read -czf ipaserver_install_logs.tar.gz --warning=no-failed-read /var/log/dirsrv /var/log/httpd2 /var/log/ipa /var/log/ipaclient-install.log /var/log/ipa-custodia.audit.log /var/log/ipaserver-install.log /var/log/krb5kdc.log /var/log/pki /var/log/samba /var/lib/bind/data systemd_journal.log
[2021-09-07 11:03:33] tar: Removing leading `/' from member names
[2021-09-07 11:03:33] tar: Removing leading `/' from hard link targets
[2021-09-07 11:03:33] tar: /var/log/dirsrv/slapd-IPA-TEST/access: file changed as we read it
[2021-09-07 11:03:33] + tests_result=1
```

This is expected failure since processes are not stopped during logs
collection and can flush their logs.

Fixes: https://pagure.io/freeipa/issue/8983