### PR TITLE
migrate-ds: workaround to detect compat tree

### DIFF
--- a/ipaserver/plugins/migration.py
+++ b/ipaserver/plugins/migration.py
@@ -922,7 +922,8 @@ migration process might be incomplete\n''')
         # check whether the compat plugin is enabled
         if not options.get('compat'):
             try:
-                ldap.get_entry(DN(('cn', 'compat'), (api.env.basedn)))
+                ldap.get_entry(DN(('cn', 'users'), ('cn', 'compat'),
+                                  (api.env.basedn)))
                 return dict(result={}, failed={}, enabled=True, compat=False)
             except errors.NotFound:
                 pass


### PR DESCRIPTION
Migrate-ds needs to check if compat tree is enabled before
migrating users and groups. The check is doing a base
search on cn=compat,$SUFFIX and considers the compat tree
enabled when the entry exists.

Due to a bug in slapi-nis, the base search may return NotFound
even though the compat tree is enabled. The workaround is to
perform a base search on cn=users,cn=compat,$SUFFIX instead.

Fixes: https://pagure.io/freeipa/issue/8984