### PR TITLE
[Backport][ipa-4-9] migrate-ds: workaround to detect compat tree

### DIFF
--- a/ipaserver/plugins/migration.py
+++ b/ipaserver/plugins/migration.py
@@ -922,7 +922,8 @@ migration process might be incomplete\n''')
         # check whether the compat plugin is enabled
         if not options.get('compat'):
             try:
-                ldap.get_entry(DN(('cn', 'compat'), (api.env.basedn)))
+                ldap.get_entry(DN(('cn', 'users'), ('cn', 'compat'),
+                                  (api.env.basedn)))
                 return dict(result={}, failed={}, enabled=True, compat=False)
             except errors.NotFound:
                 pass


### PR DESCRIPTION
This PR was opened automatically because PR #6008 was pushed to master and backport to ipa-4-9 is required.