### PR TITLE
Make Dogtag return XML for ipa cert-find

### DIFF
--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1832,7 +1832,8 @@ class ra(rabase.rabase, RestClient):
             method='POST',
             headers={'Accept-Encoding': 'gzip, deflate',
                      'User-Agent': 'IPA',
-                     'Content-Type': 'application/xml'},
+                     'Content-Type': 'application/xml',
+                     'Accept': 'application/xml'},
             body=payload
         )
 


### PR DESCRIPTION
Using JSON by default within Dogtag appears to cause `ipa cert-find` to
return JSON, when the request was made with XML. We can request that XML
is returned as before by specifying so in the request header.