### PR TITLE
ipatests: fix expected msg in tasks.run_ssh_cmd

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2767,8 +2767,11 @@ def run_ssh_cmd(
 
     if auth_method == "password":
         if expect_auth_success is True:
-            assert "Authentication succeeded (keyboard-interactive)" in \
-                stderr
+            patterns = [
+                r'Authenticated to .* using "keyboard-interactive"',
+                r'Authentication succeeded \(keyboard-interactive\)'
+            ]
+            assert any(re.search(pattern, stderr) for pattern in patterns)
             # do not assert the return code:
             # it can be >0 if the command failed.
         elif expect_auth_failure is True:
@@ -2777,7 +2780,11 @@ def run_ssh_cmd(
             assert "Authentication succeeded" not in stderr
     elif auth_method == "key":
         if expect_auth_success is True:
-            assert "Authentication succeeded (publickey)" in stderr
+            patterns = [
+                r'Authenticated to .* using "publickey"',
+                r'Authentication succeeded \(publickey\)'
+            ]
+            assert any(re.search(pattern, stderr) for pattern in patterns)
             # do not assert the return code:
             # it can be >0 if the command failed.
         elif expect_auth_failure is True:


### PR DESCRIPTION
OpenSSH 8.7p1 changed the message logged on successful
authentication (see commit [9e1882ef6489a7dd16b6d7794af96629cae61a53](https://github.com/openssh/openssh-portable/commit/9e1882ef6489a7dd16b6d7794af96629cae61a53#diff-9b68b8ea7f8914f8a6ecc452a600d0e886b13f3b5af14fa80261d66c4723b8fd)).

As a result, the method run_ssh_cmd is failing and needs to be
adapted in order to be compatible with old and new openssh versions.

Fixes: https://pagure.io/freeipa/issue/8989

