### PR TITLE
krb5: Pin kpasswd server to a primary one

### DIFF
--- a/install/share/krb5.conf.template
+++ b/install/share/krb5.conf.template
@@ -19,6 +19,7 @@ $OTHER_LIBDEFAULTS
  $REALM = {
   kdc = $FQDN:88
   master_kdc = $FQDN:88
+  kpasswd_server = $FQDN:464
   admin_server = $FQDN:749
   default_domain = $DOMAIN
   pkinit_anchors = FILE:$KDC_CA_BUNDLE_PEM

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1262,6 +1262,29 @@ def enable_server_snippet():
     tasks.restore_context(paths.KRB5_FREEIPA_SERVER)
 
 
+def setup_kpasswd_server(krb):
+    logger.info("[Setup kpasswd_server]")
+    aug = Augeas(
+        flags=Augeas.NO_LOAD | Augeas.NO_MODL_AUTOLOAD,
+        loadpath=paths.USR_SHARE_IPA_DIR,
+    )
+    try:
+        aug.transform("IPAKrb5", paths.KRB5_CONF)
+        aug.load()
+
+        kpass_srv_path = "/files{}/realms/{}/kpasswd_server"
+        kpass_srv_path = kpass_srv_path.format(paths.KRB5_CONF, krb.realm)
+
+        if aug.match(kpass_srv_path):
+            return
+
+        aug.set(kpass_srv_path, f"{krb.fqdn}:464")
+        aug.save()
+
+    finally:
+        aug.close()
+
+
 def ntpd_cleanup(fqdn, fstore):
     sstore = sysrestore.StateFile(paths.SYSRESTORE)
     timeconf.restore_forced_timeservices(sstore, 'ntpd')
@@ -1874,6 +1897,7 @@ def upgrade_configuration():
     setup_spake(krb)
     setup_pkinit(krb)
     enable_server_snippet()
+    setup_kpasswd_server(krb)
 
     # Must be executed after certificate_renewal_update
     # (see function docstring for details)

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2127,7 +2127,7 @@ def create_active_user(host, login, password, first='test', last='user',
         # Note raiseonerr=False:
         # the assert is located after kdcinfo retrieval.
         result = host.run_command(
-            "KRB5_TRACE=/dev/stdout kinit %s" % login,
+            f"KRB5_TRACE=/dev/stdout SSSD_KRB5_LOCATOR_DEBUG=1 kinit {login}",
             stdin_text='{0}\n{1}\n{1}\n'.format(
                 temp_password, password
             ), raiseonerr=False
@@ -2164,8 +2164,8 @@ def run_command_as_user(host, user, command, *args, **kwargs):
 
 def kinit_as_user(host, user, password, krb5_trace=False, raiseonerr=True):
     """Launch kinit as user on host.
-    If krb5_trace, then set KRB5_TRACE=/dev/stdout and collect
-    /var/lib/sss/pubconf/kdcinfo.$REALM
+    If krb5_trace, then set KRB5_TRACE=/dev/stdout, SSSD_KRB5_LOCATOR_DEBUG=1
+    and collect /var/lib/sss/pubconf/kdcinfo.$REALM
     as this file contains the list of KRB5KDC IPs SSSD uses.
     https://pagure.io/freeipa/issue/8510
     """
@@ -2181,7 +2181,7 @@ def kinit_as_user(host, user, password, krb5_trace=False, raiseonerr=True):
         # Note raiseonerr=False:
         # the assert is located after kdcinfo retrieval.
         result = host.run_command(
-            "KRB5_TRACE=/dev/stdout kinit %s" % user,
+            f"KRB5_TRACE=/dev/stdout SSSD_KRB5_LOCATOR_DEBUG=1 kinit {user}",
             stdin_text='{0}\n'.format(password),
             raiseonerr=False
         )


### PR DESCRIPTION
There are time gaps in which kinit requests may fail due to offlined SSSD's locator and replication delays.
    
Since `IPA` provider or SSSD offline the locator plugin for libkrb5 (man 8 sssd_krb5_locator_plugin) can do nothing about this and knit fallbacks to the standard libkrb5 algorithm described in `man 5 krb5.conf`.
`krb5.conf` on IPA server doesn't include `kpasswd_server` and kinit fallbacks to DNS way. DNS (URI or SRV) RRs don't preserve any order and kinit may contact either master or replica kpasswd servers. This may result in a password was changed on a replica but was not replicated to master:
master(kinit)->master(initial)->replica(kpasswd)->master(can't  obtain initial creds with new password)
    
So, `kpasswd_server` serves as a fallback for the offlined locator.
    
Note: primary_kdc(the former master_kdc) doesn't help here because it is only used if the initial credentials obtaining fail (see `krb5_get_init_creds_password` in libkrb5) and not a password change.
    
Fixes: https://pagure.io/freeipa/issue/8353
