### PR TITLE
ipatests: fix TestInstallWithCA_DNS3's resolv.conf

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,27 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_installation_TestInstallWithCA_DNS3:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl
+
+  fedora-latest/test_upgrade:
+    requires: [fedora-latest/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_upgrade.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -570,6 +570,11 @@ class TestInstallWithCA_DNS3(CALessBase):
     ticket 7239
     """
 
+    @pytest.mark.skipif(
+        osinfo.id == 'fedora',
+        reason='https://pagure.io/freeipa/issue/8700',
+        strict=True
+    )
     @server_install_setup
     def test_number_of_zones(self):
         """There should be two zones: one forward, one reverse"""


### PR DESCRIPTION
TestInstallWithCA_DNS3 uses the Resolved resolver class which
does not configure resolv.conf correctly.

Unconfigure NetworkManager first and then reconfigure systemd-resolved.

Fixes: https://pagure.io/freeipa/issue/8993
Signed-off-by: François Cami <fcami@redhat.com>
