### PR TITLE
[Backport][ipa-4-9] Don't store entries with a usercertificate in the LDAP cache

### DIFF
--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -1821,9 +1821,17 @@ class LDAPCache(LDAPClient):
                         entry=None, exception=None):
         # idnsname - caching prevents delete when mod value to None
         # cospriority - in a Class of Service object, uncacheable
-        # TODO - usercertificate was banned at one point and I don't remember
-        #        why...
-        BANNED_ATTRS = {'idnsname', 'cospriority'}
+        # usercertificate* - caching subtypes is tricky, trade less
+        #                    complexity for performance
+        #
+        # TODO: teach the cache about subtypes
+
+        BANNED_ATTRS = {
+            'idnsname',
+            'cospriority',
+            'usercertificate',
+            'usercertificate;binary'
+        }
         if not self._enable_cache:
             return
 


### PR DESCRIPTION
This PR was opened automatically because PR #6015 was pushed to master and backport to ipa-4-9 is required.