### PR TITLE
[Backport][ipa-4-9] schema plugin: Fix commands without metaobject argument

### DIFF
--- a/ipaserver/plugins/schema.py
+++ b/ipaserver/plugins/schema.py
@@ -129,8 +129,8 @@ class BaseMetaSearch(Search):
                   "(\"%s\")") % 'name',
         )
 
-    def execute(self, command, criteria=None, **options):
-        result = list(self.obj.search(command, criteria, **options))
+    def execute(self, criteria=None, **options):
+        result = list(self.obj.search(criteria, **options))
         return dict(result=result, count=len(result), truncated=False)
 
 
@@ -494,7 +494,9 @@ class BaseParamRetrieve(BaseParamMethod, BaseMetaRetrieve):
 
 
 class BaseParamSearch(BaseParamMethod, BaseMetaSearch):
-    pass
+    def execute(self, command, criteria=None, **options):
+        result = list(self.obj.search(command, criteria, **options))
+        return dict(result=result, count=len(result), truncated=False)
 
 
 @register()

--- a/ipaserver/plugins/schema.py
+++ b/ipaserver/plugins/schema.py
@@ -292,6 +292,13 @@ class command_defaults(PKQuery):
     )
 
     def execute(self, name, **options):
+        if name not in self.api.Command:
+            raise errors.NotFound(
+                reason=_("{oname}: {command_name} not found").format(
+                    oname=self.name, command_name=name
+                )
+            )
+
         command = self.api.Command[name]
 
         params = options.get('params') or []

--- a/ipatests/test_xmlrpc/test_schema_plugin.py
+++ b/ipatests/test_xmlrpc/test_schema_plugin.py
@@ -9,21 +9,22 @@ Test the `ipaserver/plugins/schema.py` module.
 import pytest
 
 from ipalib import api, errors
-from ipatests.test_xmlrpc.tracker.base import Tracker
 from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test
 
 
 @pytest.mark.tier1
 class TestParamFindAndShowCommand(XMLRPC_test):
     """Test functionality of the ipa param-{find,show} command"""
-
-    tracker = Tracker()
+    def run_command(self, command, *args, **options):
+        cmd = api.Command[command]
+        cmd_result = cmd(*args, **options)
+        return cmd_result
 
     def test_param_find(self):
         """Test param-find command"""
-
+        cmd = "param_find"
         # right command without criteria
-        result = self.tracker.run_command('param_find', u'user-add')
+        result = self.run_command(cmd, "user-add")
         assert len(result['result']) != 0, result
         assert result['result'][0]['name'] == 'uid', result
         assert result['result'][0]['cli_name'] == 'login', result
@@ -31,26 +32,30 @@ class TestParamFindAndShowCommand(XMLRPC_test):
 
         # right command, right criteria
         criteria = u'postalcode'
-        result = self.tracker.run_command('param_find', u'user-add', criteria)
+        result = self.run_command(cmd, "user-add", criteria)
         assert len(result['result']) != 0, result
         for item in result['result']:
             assert (criteria in item['name'].lower() or
                     criteria in item['doc'].lower()), item
 
         # right command, wrong criteria
-        result = self.tracker.run_command('param_find', u'user-add', u'fake')
+        result = self.run_command(cmd, "user-add", "fake")
         assert len(result['result']) == 0, result
 
         # wrong command, wrong criteria
-        result = self.tracker.run_command('param_find', u'fake', u'fake')
+        result = self.run_command(cmd, "fake", "fake")
         assert len(result['result']) == 0, result
+
+        # too many args
+        with pytest.raises(errors.MaxArgumentError):
+            self.run_command(cmd, "arg1", "arg2", "arg3")
 
     def test_param_show(self):
         """Test param-show command"""
-
         # right command, right criteria
-        criteria = u'uid'
-        result = self.tracker.run_command('param_show', u'user-add', criteria)
+        criteria = "uid"
+        cmd = "param_show"
+        result = self.run_command(cmd, "user-add", criteria)
         assert result['result'] is not None, result
         assert result['result']['name'] == 'uid', result
         assert result['result']['cli_name'] == 'login', result
@@ -58,26 +63,33 @@ class TestParamFindAndShowCommand(XMLRPC_test):
 
         # right command without criteria
         with pytest.raises(errors.RequirementError):
-            self.tracker.run_command('param_show', u'user-add')
+            self.run_command(cmd, "user-add")
 
         # right command, wrong criteria
         with pytest.raises(errors.NotFound):
-            self.tracker.run_command('param_show', u'user-add', u'fake')
+            self.run_command(cmd, "user-add", "fake")
 
         # wrong command, wrong criteria
         with pytest.raises(errors.NotFound):
-            self.tracker.run_command('param_show', u'fake', u'fake')
+            self.run_command(cmd, "fake", "fake")
+
+        # too many args
+        with pytest.raises(errors.MaxArgumentError):
+            self.run_command(cmd, "arg1", "arg2", "arg3")
 
 
 class TestOutputFindAndShowCommand(XMLRPC_test):
     """Test functionality of the ipa output-{find,show} command"""
-    tracker = Tracker()
+    def run_command(self, command, *args, **options):
+        cmd = api.Command[command]
+        cmd_result = cmd(*args, **options)
+        return cmd_result
 
     def test_output_find(self):
         """Test output-find command"""
-
+        cmd = "output_find"
         # right command without criteria
-        result = self.tracker.run_command('output_find', u'user-add')
+        result = self.run_command(cmd, "user-add")
         assert len(result['result']) != 0, result
         assert result['result'][0]['name'] == 'summary', result
         assert result['result'][0]['doc'] == \
@@ -85,24 +97,29 @@ class TestOutputFindAndShowCommand(XMLRPC_test):
 
         # right command, right criteria
         criteria = u'result'
-        result = self.tracker.run_command('output_find', u'user-add', criteria)
+        result = self.run_command(cmd, "user-add", criteria)
         assert len(result['result']) == 1, result
         assert criteria in result['result'][0]['name'].lower(), result
 
         # right command, wrong criteria
-        result = self.tracker.run_command('output_find', u'user-add', u'fake')
+        result = self.run_command(cmd, "user-add", "fake")
         assert len(result['result']) == 0, result
 
         # wrong command, wrong criteria
-        result = self.tracker.run_command('output_find', u'fake', u'fake')
+        result = self.run_command(cmd, "fake", "fake")
         assert len(result['result']) == 0, result
+
+        # too many args
+        with pytest.raises(errors.MaxArgumentError):
+            self.run_command(cmd, "arg1", "arg2", "arg3")
 
     def test_output_show(self):
         """Test output-show command"""
 
         # right command, right criteria
-        criteria = u'value'
-        result = self.tracker.run_command('output_show', u'user-add', criteria)
+        criteria = "value"
+        cmd = "output_show"
+        result = self.run_command(cmd, "user-add", criteria)
         assert len(result['result']) != 0, result
         assert criteria in result['result']['name'].lower(), result
         assert result['result']['doc'] == \
@@ -110,15 +127,19 @@ class TestOutputFindAndShowCommand(XMLRPC_test):
 
         # right command without criteria
         with pytest.raises(errors.RequirementError):
-            self.tracker.run_command('output_show', u'user-add')
+            self.run_command(cmd, "user-add")
 
         # right command, wrong criteria
         with pytest.raises(errors.NotFound):
-            self.tracker.run_command('output_show', u'user-add', u'fake')
+            self.run_command(cmd, "user-add", "fake")
 
         # wrong command, wrong criteria
         with pytest.raises(errors.NotFound):
-            self.tracker.run_command('output_show', u'fake', u'fake')
+            self.run_command(cmd, "fake", "fake")
+
+        # too many args
+        with pytest.raises(errors.MaxArgumentError):
+            self.run_command(cmd, "arg1", "arg2", "arg3")
 
 
 class TestSchemaCommand(XMLRPC_test):

--- a/ipatests/test_xmlrpc/test_schema_plugin.py
+++ b/ipatests/test_xmlrpc/test_schema_plugin.py
@@ -9,6 +9,7 @@ Test the `ipaserver/plugins/schema.py` module.
 import pytest
 
 from ipalib import api, errors
+from ipapython.dnsutil import DNSName
 from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test
 
 
@@ -180,3 +181,276 @@ class TestSchemaCommand(XMLRPC_test):
         """Test schema with too many args"""
         with pytest.raises(errors.ZeroArgumentError):
             self.run_command("schema", "arg1")
+
+
+class TestCommandCommand(XMLRPC_test):
+    """Test functionality of the ipa 'command' command"""
+    expected_keys = {
+        "doc",
+        "full_name",
+        "name",
+        "topic_topic",
+        "version",
+    }
+
+    def run_command(self, command, *args, **options):
+        cmd = api.Command[command]
+        cmd_result = cmd(*args, **options)
+        return cmd_result
+
+    def test_command_find_all(self):
+        """Test command-find without any args"""
+        cmd_result = self.run_command("command_find")
+        result = cmd_result["result"]
+        assert len(result) != 0, result
+        for item in result:
+            assert self.expected_keys.issubset(item.keys()), item
+
+    def test_command_find_existent_command(self):
+        """Test 'command' with existent command as arg"""
+        criteria = "user_add"
+        cmd_result = self.run_command("command_find", criteria)
+        result = cmd_result["result"]
+        assert len(result) != 0, result
+        for item in result:
+            assert self.expected_keys.issubset(item.keys()), item
+            name = item["name"].lower()
+            doc = item.get("doc", "").lower()
+            assert criteria in name or criteria in doc, item
+
+    def test_command_find_nonexistent_command(self):
+        """Test command-find with nonexistent command as arg"""
+        cmd_result = self.run_command("command_find", "nonextentcommand")
+        result = cmd_result["result"]
+        assert len(result) == 0, result
+
+    def test_command_find_too_many_args(self):
+        """Test command-find with too many args"""
+        with pytest.raises(errors.MaxArgumentError):
+            self.run_command("command_find", "arg1", "arg2")
+
+    def test_command_show_no_args(self):
+        """Test command-show without args"""
+        with pytest.raises(errors.RequirementError):
+            self.run_command("command_show")
+
+    def test_command_show_existent_command(self):
+        """Test command-show with existent command as arg"""
+        criteria = "user_add"
+        cmd_result = self.run_command("command_show", criteria)
+        result = cmd_result["result"]
+        assert self.expected_keys.issubset(result.keys()), result
+        assert result["name"] == criteria
+
+    def test_command_show_nonexistent_command(self):
+        """Test command-show with nonexistent command as arg"""
+        with pytest.raises(errors.NotFound):
+            self.run_command("command_show", "nonextentcommand")
+
+    def test_command_show_too_many_args(self):
+        """Test command-show with too many args"""
+        with pytest.raises(errors.MaxArgumentError):
+            self.run_command("command_show", "arg1", "arg2")
+
+    def test_command_defaults_no_args(self):
+        """Test command_defaults without args"""
+        with pytest.raises(errors.RequirementError):
+            self.run_command("command_defaults")
+
+    def test_command_defaults_existent_command(self):
+        """Test command_defaults with existent command as arg"""
+        criteria = "user_add"
+        cmd_result = self.run_command("command_defaults", criteria)
+        # 9c19dd350: do not validate unrequested params in command_defaults
+        result = cmd_result["result"]
+        assert len(result) == 0, result
+
+    def test_command_defaults_existent_command_params(self):
+        """Test command_defaults with existent command as arg with params"""
+        criteria = "user_add"
+        params = ["all"]
+        cmd_result = self.run_command(
+            "command_defaults", criteria, params=params
+        )
+        result = cmd_result["result"]
+        assert len(result) == len(params), result
+        assert isinstance(result["all"], bool)
+
+    def test_command_defaults_existent_command_several_params(self):
+        """
+        Test command_defaults with existent command as arg with several params
+        """
+        criteria = "user_add"
+        params = ["all", "raw"]
+        cmd_result = self.run_command(
+            "command_defaults", criteria, params=params
+        )
+        result = cmd_result["result"]
+        assert len(result) == len(params), result
+        assert isinstance(result["all"], bool), result
+        assert isinstance(result["raw"], bool), result
+
+    def test_command_defaults_existent_command_kw(self):
+        """Test command_defaults with existent command as arg with kw"""
+        criteria = "dnszone_add"
+        params = ["idnsname"]
+        kw = {"name_from_ip": "127.0.0.1"}
+        cmd_result = self.run_command(
+            "command_defaults", criteria, params=params
+        )
+        result = cmd_result["result"]
+        assert len(result) == 0, result
+
+        cmd_result = self.run_command(
+            "command_defaults", criteria, params=params, kw=kw
+        )
+        result = cmd_result["result"]
+        assert len(result) == len(params), result
+        assert isinstance(result["idnsname"], DNSName)
+
+    def test_command_defaults_nonexistent_command(self):
+        """Test command-show with nonexistent command as arg"""
+        with pytest.raises(errors.NotFound):
+            self.run_command("command_defaults", "nonextentcommand")
+
+    def test_command_defaults_too_many_args(self):
+        """Test command-show with too many args"""
+        with pytest.raises(errors.MaxArgumentError):
+            self.run_command("command_defaults", "arg1", "arg2")
+
+
+class TestClassCommand(XMLRPC_test):
+    """Test functionality of the ipa 'class' command"""
+    expected_keys = {
+        "name",
+        "full_name",
+        "version",
+    }
+
+    def run_command(self, command, *args, **options):
+        cmd = api.Command[command]
+        cmd_result = cmd(*args, **options)
+        return cmd_result
+
+    def test_class_find_all(self):
+        """Test class-find without any args"""
+        cmd_result = self.run_command("class_find")
+        result = cmd_result["result"]
+        assert len(result) != 0, result
+        for item in result:
+            assert item.keys() == self.expected_keys, item
+
+    def test_class_find_existent_class(self):
+        """Test class-find with existent class as arg"""
+        criteria = "user"
+        cmd_result = self.run_command("class_find", criteria)
+        result = cmd_result["result"]
+        assert len(result) != 0, result
+        for item in result:
+            assert item.keys() == self.expected_keys, item
+            name = item["name"].lower()
+            doc = item.get("doc", "").lower()
+            assert criteria in name or criteria in doc, item
+
+    def test_class_find_nonexistent_class(self):
+        """Test class-find with nonexistent class as arg"""
+        cmd_result = self.run_command("class_find", "nonextentclass")
+        result = cmd_result["result"]
+        assert len(result) == 0, result
+
+    def test_class_find_too_many_args(self):
+        """Test class-find with too many args"""
+        with pytest.raises(errors.MaxArgumentError):
+            self.run_command("class_find", "arg1", "arg2")
+
+    def test_class_show_no_args(self):
+        """Test class-show without args"""
+        with pytest.raises(errors.RequirementError):
+            self.run_command("class_show")
+
+    def test_class_show_existent_class(self):
+        """Test class-show with existent class as arg"""
+        criteria = "user"
+        cmd_result = self.run_command("class_show", criteria)
+        result = cmd_result["result"]
+        assert result.keys() == self.expected_keys, result
+        assert result["name"] == criteria
+
+    def test_class_show_nonexistent_class(self):
+        """Test class-show with nonexistent class as arg"""
+        with pytest.raises(errors.NotFound):
+            self.run_command("class_show", "nonextentclass")
+
+    def test_class_show_too_many_args(self):
+        """Test class-show with too many args"""
+        with pytest.raises(errors.MaxArgumentError):
+            self.run_command("class_show", "arg1", "arg2")
+
+
+class TestTopicCommand(XMLRPC_test):
+    """Test functionality of the ipa 'topic' command"""
+    expected_keys = {
+        "name",
+        "full_name",
+        "version",
+        "doc",
+    }
+
+    def run_command(self, command, *args, **options):
+        cmd = api.Command[command]
+        cmd_result = cmd(*args, **options)
+        return cmd_result
+
+    def test_topic_find_all(self):
+        """Test topic-find without any args"""
+        cmd_result = self.run_command("topic_find")
+        result = cmd_result["result"]
+        assert len(result) != 0, result
+        for item in result:
+            assert self.expected_keys.issubset(item.keys()), item
+
+    def test_topic_find_existent_topic(self):
+        """Test topic-find with existent topic as arg"""
+        criteria = "user"
+        cmd_result = self.run_command("topic_find", criteria)
+        result = cmd_result["result"]
+        assert len(result) != 0, result
+        for item in result:
+            assert self.expected_keys.issubset(item.keys()), item
+            name = item["name"].lower()
+            doc = item.get("doc", "").lower()
+            assert criteria in name or criteria in doc, item
+
+    def test_topic_find_nonexistent_topic(self):
+        """Test topic-find with nonexistent topic as arg"""
+        cmd_result = self.run_command("topic_find", "nonextenttopic")
+        result = cmd_result["result"]
+        assert len(result) == 0, result
+
+    def test_topic_find_too_many_args(self):
+        """Test topic-find with too many args"""
+        with pytest.raises(errors.MaxArgumentError):
+            self.run_command("topic_find", "arg1", "arg2")
+
+    def test_topic_show_no_args(self):
+        """Test topic-show without args"""
+        with pytest.raises(errors.RequirementError):
+            self.run_command("topic_show")
+
+    def test_topic_show_existent_topic(self):
+        """Test topic-show with existent topic as arg"""
+        criteria = "user"
+        cmd_result = self.run_command("topic_show", criteria)
+        result = cmd_result["result"]
+        assert self.expected_keys.issubset(result.keys()), result
+        assert result["name"] == criteria
+
+    def test_topic_show_nonexistent_topic(self):
+        """Test topic-show with nonexistent topic as arg"""
+        with pytest.raises(errors.NotFound):
+            self.run_command("topic_show", "nonextenttopic")
+
+    def test_topic_show_too_many_args(self):
+        """Test topic-show with too many args"""
+        with pytest.raises(errors.MaxArgumentError):
+            self.run_command("topic_show", "arg1", "arg2")


### PR DESCRIPTION
This PR was opened automatically because PR #5975 was pushed to master and backport to ipa-4-9 is required.