### PR TITLE
selinux: Fix file context definition for /var/run

### DIFF
--- a/selinux/ipa.fc
+++ b/selinux/ipa.fc
@@ -23,7 +23,7 @@
 
 /var/log/ipareplica-conncheck.log.*	--	gen_context(system_u:object_r:ipa_log_t,s0)
 
-/run/ipa(/.*)?              gen_context(system_u:object_r:ipa_var_run_t,s0)
+/var/run/ipa(/.*)?              gen_context(system_u:object_r:ipa_var_run_t,s0)
 
 /usr/libexec/ipa/ipa-custodia					--	gen_context(system_u:object_r:ipa_custodia_exec_t,s0)
 /usr/libexec/ipa/custodia/ipa-custodia-dmldap			--	gen_context(system_u:object_r:ipa_custodia_dmldap_exec_t,s0)


### PR DESCRIPTION
There is a file context equivalence rule assigning /run the same
contexts as /var/run. Because of it it's necessary to use /var/run
instead of /run in file context definitions.

See:
https://fedoraproject.org/wiki/SELinux/IndependentPolicy#File_contexts_and_equivalency_rules

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>