### PR TITLE
Improve sudooption docs, make the option multi-value

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -5569,7 +5569,7 @@ command: sudorule_add_option/1
 args: 1,5,3
 arg: Str('cn', cli_name='sudorule_name')
 option: Flag('all', autofill=True, cli_name='all', default=False)
-option: Str('ipasudoopt', cli_name='sudooption')
+option: Str('ipasudoopt+', cli_name='sudooption')
 option: Flag('no_members', autofill=True, default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Str('version?')
@@ -5724,7 +5724,7 @@ command: sudorule_remove_option/1
 args: 1,5,3
 arg: Str('cn', cli_name='sudorule_name')
 option: Flag('all', autofill=True, cli_name='all', default=False)
-option: Str('ipasudoopt', cli_name='sudooption')
+option: Str('ipasudoopt+', cli_name='sudooption')
 option: Flag('no_members', autofill=True, default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Str('version?')

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -86,8 +86,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-# Last change: add subordinate id feature
-define(IPA_API_VERSION_MINOR, 243)
+# Last change: make sudorule option multivalue
+define(IPA_API_VERSION_MINOR, 244)
 
 
 ########################################################

--- a/ipaclient/plugins/sudorule.py
+++ b/ipaclient/plugins/sudorule.py
@@ -39,9 +39,11 @@ class sudorule_disable(MethodOverride):
 @register(override=True, no_fail=True)
 class sudorule_add_option(MethodOverride):
     def output_for_cli(self, textui, result, cn, **options):
+        opts = self.normalize(**options)
         textui.print_dashed(
             _('Added option "%(option)s" to Sudo Rule "%(rule)s"')
-              % dict(option=options['ipasudoopt'], rule=cn))
+            % dict(option=','.join(opts['ipasudoopt']), rule=cn)
+        )
 
         super(sudorule_add_option, self).output_for_cli(textui, result, cn,
                                                         **options)
@@ -50,8 +52,10 @@ class sudorule_add_option(MethodOverride):
 @register(override=True, no_fail=True)
 class sudorule_remove_option(MethodOverride):
     def output_for_cli(self, textui, result, cn, **options):
+        opts = self.normalize(**options)
         textui.print_dashed(
             _('Removed option "%(option)s" from Sudo Rule "%(rule)s"')
-              % dict(option=options['ipasudoopt'], rule=cn))
+            % dict(option=','.join(opts['ipasudoopt']), rule=cn)
+        )
         super(sudorule_remove_option, self).output_for_cli(textui, result, cn,
                                                            **options)


### PR DESCRIPTION
I don't know why this wasn't always multi-value but if one wanted
to set multiple options they needed to call add-option multiple
times. The LDAP attribute is already multi-value.

This shouldn't cause API issues as it understood the attribute as
multi-value just didn't expose it. Client output on the CLI will
look a bit different:

Added option "('one', 'two')" to Sudo Rule "test"

or

Added option "(u'one', u'Two')" to Sudo Rule "test"

instead of with this change:

Added option "one,two" to Sudo Rule "test"

https://pagure.io/freeipa/issue/2278

Signed-off-by: Rob Crittenden <rcritten@redhat.com>