### PR TITLE
ipatests: increase sosreport verbosity 

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1221,7 +1221,7 @@ class TestIpaHealthCheck(IntegrationTest):
                 "--case-id",
                 caseid,
                 "--batch",
-                "-v",
+                "-vv",
                 "--build",
             ]
         )


### PR DESCRIPTION
With the new version sos-4.2-1, sos report -v prints the
debug messages into sos.log only. In order to see the debug
messages in the console, -vv is needed.
For more info refer to sos report commit
sosreport/sos@1d0729a

Since the test is looking for messages in stdout, use -vv to
make sure the expected messages are printed in the console.

Fixes: https://pagure.io/freeipa/issue/9000