### PR TITLE
[Backport][ipa-4-9] ipatests: increase sosreport verbosity 

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1221,7 +1221,7 @@ class TestIpaHealthCheck(IntegrationTest):
                 "--case-id",
                 caseid,
                 "--batch",
-                "-v",
+                "-vv",
                 "--build",
             ]
         )


### PR DESCRIPTION
This PR was opened automatically because PR #6032 was pushed to master and backport to ipa-4-9 is required.