### PR TITLE
webui test: close notification after selinux user map update

### DIFF
--- a/ipatests/test_webui/test_selinuxusermap.py
+++ b/ipatests/test_webui/test_selinuxusermap.py
@@ -356,6 +356,7 @@ class test_selinuxusermap(UI_driver):
         self.fill_fields(selinuxmap.DATA['mod'], undo=True)
         self.click_on_link('SELinux User Maps')
         self.dialog_button_click('save')
+        self.close_notifications()
         self.navigate_to_record(selinuxmap.PKEY)
         self.verify_btn_action(mod_description, negative=True)
         self.wait_for_request(n=2)


### PR DESCRIPTION
The test test_undo_refresh_reset_update_cancel is sometimes
failing because a notification obscures the selinuxmap record.

After saving the modification on the record, close any notification
to make sure the test succeeds.

Fixes: https://pagure.io/freeipa/issue/8846
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>

