### PR TITLE
[Backport][ipa-4-9] ipatests: fix failure in test_trust/test_extdom_plugin

### DIFF
--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -571,9 +571,6 @@ class TestTrust(BaseTestTrust):
 
         client = self.clients[0]
         tasks.backup_file(self.master, paths.SSSD_CONF)
-        log_file = '{0}/sssd_{1}.log'.format(paths.VAR_LOG_SSSD_DIR,
-                                             client.domain.name)
-        logsize = len(client.get_file_contents(log_file))
         res = self.master.run_command(['pidof', 'sssd_be'])
         pid = res.stdout_text.strip()
         test_id = 'id testuser@%s' % self.ad_domain
@@ -594,6 +591,10 @@ class TestTrust(BaseTestTrust):
         remove_cache = 'sss_cache -E'
         self.master.run_command(remove_cache)
         client.run_command(remove_cache)
+
+        log_file = '{0}/sssd_{1}.log'.format(paths.VAR_LOG_SSSD_DIR,
+                                             client.domain.name)
+        logsize = len(client.get_file_contents(log_file))
 
         try:
             # stop sssd_be, needed to simulate a timeout in the extdom plugin.

--- a/ipatests/test_webui/test_selinuxusermap.py
+++ b/ipatests/test_webui/test_selinuxusermap.py
@@ -356,6 +356,7 @@ class test_selinuxusermap(UI_driver):
         self.fill_fields(selinuxmap.DATA['mod'], undo=True)
         self.click_on_link('SELinux User Maps')
         self.dialog_button_click('save')
+        self.close_notifications()
         self.navigate_to_record(selinuxmap.PKEY)
         self.verify_btn_action(mod_description, negative=True)
         self.wait_for_request(n=2)


### PR DESCRIPTION
This PR was opened automatically because PR #6022 was pushed to master and backport to ipa-4-9 is required.