### PR TITLE
Test to check ipa ca-show <authority ID> error handling

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_cert.py::TestCAShowErrorHandling
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl

--- a/ipatests/test_integration/test_cert.py
+++ b/ipatests/test_integration/test_cert.py
@@ -546,3 +546,43 @@ class TestCertmongerInterruption(IntegrationTest):
 
         assert ca_error is None
         assert state == 'CA_WORKING'
+
+
+class TestCAShowErrorHandling(IntegrationTest):
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master)
+        tasks.install_replica(cls.master, cls.replicas[0])
+
+    def test_ca_show_error_handling(self):
+        """
+        Test to verify if the case of a request
+        for /ca/rest/authority/{id}/cert (or .../chain)
+        where {id} is an unknown authority ID.
+
+        Test Steps:
+        1. Setup a freeipa server and a replica
+        2. Stop ipa-custodia service on replica
+        3. Create a LWCA on the replica
+        4. Verify LWCA is recognized on the server
+        5. Run `ipa ca-show <LWCA>`
+
+        PKI Github Link: https://github.com/dogtagpki/pki/pull/3605/
+        """
+        self.replicas[0].run_command(['systemctl', 'stop', 'ipa-custodia'])
+        lwca = 'lwca1'
+        result = self.replicas[0].run_command([
+            'ipa', 'ca-add', lwca, '--subject', 'CN=LWCA 1'
+        ])
+        assert 'Created CA "{}"'.format(lwca) in result.stdout_text
+        result = self.master.run_command(['ipa', 'ca-find'])
+        assert 'Name: {}'.format(lwca) in result.stdout_text
+        result = self.master.run_command(
+            ['ipa', 'ca-show', lwca, ],
+            raiseonerr=False
+        )
+        error_msg = 'ipa: ERROR: The certificate for ' \
+                    '{} is not available on this server.'.format(lwca)
+        assert error_msg in result.stderr_text


### PR DESCRIPTION
Test to verify if the case of a request for /ca/rest/authority/{id}/c…ert (or .../chain)

where {id} is an unknown authority ID.

Test Steps:
1. Setup a freeipa server and a replica
2. Stop ipa-custodia service on replica
3. Create a LWCA on the replica
4. Verify LWCA is recognized on the server
5. Run `ipa ca-show <LWCA>`

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>