### PR TITLE
On redhat-based platforms rely on authselect to enable sudo

### DIFF
--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -756,6 +756,9 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                                   "{}.module".format(name))
                      for name, _module, _disabled in PKCS11_MODULES)
 
+    def enable_sssd_sudo(self, _fstore):
+        """sudo enablement is handled by authselect"""
+
     def enable_ldap_automount(self, statestore):
         """
         Point automount to ldap in nsswitch.conf.


### PR DESCRIPTION
The default platform task enable_sssd_sudo() writes directly
to nsswitch.conf to enable sudo. This isn't necessary to do on
systems with authselect where we already pass in with-sudo as a
profile option.

Override the default function with does a direct write with a no-op.

https://pagure.io/freeipa/issue/8755

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

I think the existing tests will exercise whether the client is configured properly and sudo works.