### PR TITLE
ipatests: webui: Specify configuration loader

### DIFF
--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -191,7 +191,7 @@ class UI_driver:
         if not NO_YAML and os.path.isfile(path):
             try:
                 with open(path, 'r') as conf:
-                    cls.config = yaml.load(conf)
+                    cls.config = yaml.load(stream=conf, Loader=yaml.FullLoader)
             except yaml.YAMLError as e:
                 pytest.skip("Invalid Web UI config.\n%s" % e)
             except IOError as e:


### PR DESCRIPTION
Default YAML loader has been deprecated in PyYAML-6.0, specify loader explicitly.

Fixes: https://pagure.io/freeipa/issue/9009

Signed-off-by: Michal Polovka <mpolovka@redhat.com>