### PR TITLE
[Backport][ipa-4-9] seccomp profile: Default to ENOSYS instead of EPERM

### DIFF
--- a/ipatests/azure/Dockerfiles/seccomp.json
+++ b/ipatests/azure/Dockerfiles/seccomp.json
@@ -1,6 +1,7 @@
 {
 	"__defaultAction": "Change defaultAction to SCMP_ACT_LOG and then check Host's journal for SECCOMP",
-        "defaultAction": "SCMP_ACT_ERRNO",
+	"defaultAction": "SCMP_ACT_ERRNO",
+	"defaultErrnoRet": 38,
 	"archMap": [
 		{
 			"architecture": "SCMP_ARCH_X86_64",
@@ -53,6 +54,46 @@
 	"syscalls": [
 		{
 			"names": [
+				"bdflush",
+				"io_pgetevents",
+				"kexec_file_load",
+				"kexec_load",
+				"migrate_pages",
+				"move_pages",
+				"nfsservctl",
+				"nice",
+				"oldfstat",
+				"oldlstat",
+				"oldolduname",
+				"oldstat",
+				"olduname",
+				"pciconfig_iobase",
+				"pciconfig_read",
+				"pciconfig_write",
+				"sgetmask",
+				"ssetmask",
+				"swapcontext",
+				"swapoff",
+				"swapon",
+				"sysfs",
+				"uselib",
+				"userfaultfd",
+				"ustat",
+				"vm86",
+				"vm86old",
+				"vmsplice"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {},
+			"errnoRet": 1
+		},
+		{
+			"names": [
+				"_llseek",
+				"_newselect",
 				"accept",
 				"accept4",
 				"access",
@@ -67,10 +108,17 @@
 				"chown",
 				"chown32",
 				"clock_adjtime",
+				"clock_adjtime64",
 				"clock_getres",
+				"clock_getres_time64",
 				"clock_gettime",
+				"clock_gettime64",
 				"clock_nanosleep",
+				"clock_nanosleep_time64",
+				"clone",
+				"clone3",
 				"close",
+				"close_range",
 				"connect",
 				"copy_file_range",
 				"creat",
@@ -82,6 +130,7 @@
 				"epoll_ctl",
 				"epoll_ctl_old",
 				"epoll_pwait",
+				"epoll_pwait2",
 				"epoll_wait",
 				"epoll_wait_old",
 				"eventfd",
@@ -110,7 +159,11 @@
 				"flock",
 				"fork",
 				"fremovexattr",
+				"fsconfig",
 				"fsetxattr",
+				"fsmount",
+				"fsopen",
+				"fspick",
 				"fstat",
 				"fstat64",
 				"fstatat64",
@@ -120,7 +173,10 @@
 				"ftruncate",
 				"ftruncate64",
 				"futex",
+				"futex_time64",
 				"futimesat",
+				"get_robust_list",
+				"get_thread_area",
 				"getcpu",
 				"getcwd",
 				"getdents",
@@ -134,6 +190,7 @@
 				"getgroups",
 				"getgroups32",
 				"getitimer",
+				"get_mempolicy",
 				"getpeername",
 				"getpgid",
 				"getpgrp",
@@ -146,12 +203,10 @@
 				"getresuid",
 				"getresuid32",
 				"getrlimit",
-				"get_robust_list",
 				"getrusage",
 				"getsid",
 				"getsockname",
 				"getsockopt",
-				"get_thread_area",
 				"gettid",
 				"gettimeofday",
 				"getuid",
@@ -162,14 +217,15 @@
 				"inotify_init1",
 				"inotify_rm_watch",
 				"io_cancel",
-				"ioctl",
 				"io_destroy",
 				"io_getevents",
-				"ioprio_get",
-				"ioprio_set",
 				"io_setup",
 				"io_submit",
+				"ioctl",
+				"ioprio_get",
+				"ioprio_set",
 				"ipc",
+				"keyctl",
 				"kill",
 				"lchown",
 				"lchown32",
@@ -179,14 +235,15 @@
 				"listen",
 				"listxattr",
 				"llistxattr",
-				"_llseek",
 				"lremovexattr",
 				"lseek",
 				"lsetxattr",
 				"lstat",
 				"lstat64",
 				"madvise",
+				"mbind",
 				"memfd_create",
+				"memfd_secret",
 				"mincore",
 				"mkdir",
 				"mkdirat",
@@ -197,12 +254,16 @@
 				"mlockall",
 				"mmap",
 				"mmap2",
+				"mount",
+				"move_mount",
 				"mprotect",
 				"mq_getsetattr",
 				"mq_notify",
 				"mq_open",
 				"mq_timedreceive",
+				"mq_timedreceive_time64",
 				"mq_timedsend",
+				"mq_timedsend_time64",
 				"mq_unlink",
 				"mremap",
 				"msgctl",
@@ -213,33 +274,47 @@
 				"munlock",
 				"munlockall",
 				"munmap",
+				"name_to_handle_at",
 				"nanosleep",
 				"newfstatat",
-				"_newselect",
 				"open",
 				"openat",
+				"openat2",
+				"open_tree",
 				"pause",
+				"pidfd_getfd",
+				"pidfd_open",
+				"pidfd_send_signal",
 				"pipe",
 				"pipe2",
+				"pivot_root",
+				"pkey_alloc",
+				"pkey_free",
+				"pkey_mprotect",
 				"poll",
 				"ppoll",
+				"ppoll_time64",
 				"prctl",
 				"pread64",
 				"preadv",
 				"preadv2",
 				"prlimit64",
 				"pselect6",
+				"pselect6_time64",
 				"pwrite64",
 				"pwritev",
 				"pwritev2",
 				"read",
 				"readahead",
+				"readdir",
 				"readlink",
 				"readlinkat",
 				"readv",
+				"reboot",
 				"recv",
 				"recvfrom",
 				"recvmmsg",
+				"recvmmsg_time64",
 				"recvmsg",
 				"remap_file_pages",
 				"removexattr",
@@ -248,6 +323,7 @@
 				"renameat2",
 				"restart_syscall",
 				"rmdir",
+				"rseq",
 				"rt_sigaction",
 				"rt_sigpending",
 				"rt_sigprocmask",
@@ -255,14 +331,16 @@
 				"rt_sigreturn",
 				"rt_sigsuspend",
 				"rt_sigtimedwait",
+				"rt_sigtimedwait_time64",
 				"rt_tgsigqueueinfo",
+				"sched_get_priority_max",
+				"sched_get_priority_min",
 				"sched_getaffinity",
 				"sched_getattr",
 				"sched_getparam",
-				"sched_get_priority_max",
-				"sched_get_priority_min",
 				"sched_getscheduler",
 				"sched_rr_get_interval",
+				"sched_rr_get_interval_time64",
 				"sched_setaffinity",
 				"sched_setattr",
 				"sched_setparam",
@@ -274,12 +352,18 @@
 				"semget",
 				"semop",
 				"semtimedop",
+				"semtimedop_time64",
 				"send",
 				"sendfile",
 				"sendfile64",
 				"sendmmsg",
 				"sendmsg",
 				"sendto",
+				"setns",
+				"set_mempolicy",
+				"set_robust_list",
+				"set_thread_area",
+				"set_tid_address",
 				"setfsgid",
 				"setfsgid32",
 				"setfsuid",
@@ -300,11 +384,8 @@
 				"setreuid",
 				"setreuid32",
 				"setrlimit",
-				"set_robust_list",
 				"setsid",
 				"setsockopt",
-				"set_thread_area",
-				"set_tid_address",
 				"setuid",
 				"setuid32",
 				"setxattr",
@@ -317,7 +398,6 @@
 				"signalfd",
 				"signalfd4",
 				"sigreturn",
-				"socket",
 				"socketcall",
 				"socketpair",
 				"splice",
@@ -332,41 +412,44 @@
 				"sync_file_range",
 				"syncfs",
 				"sysinfo",
+				"syslog",
 				"tee",
 				"tgkill",
 				"time",
 				"timer_create",
 				"timer_delete",
-				"timerfd_create",
-				"timerfd_gettime",
-				"timerfd_settime",
 				"timer_getoverrun",
 				"timer_gettime",
+				"timer_gettime64",
 				"timer_settime",
+				"timer_settime64",
+				"timerfd_create",
+				"timerfd_gettime",
+				"timerfd_gettime64",
+				"timerfd_settime",
+				"timerfd_settime64",
 				"times",
 				"tkill",
 				"truncate",
 				"truncate64",
 				"ugetrlimit",
 				"umask",
+				"umount",
+				"umount2",
 				"uname",
 				"unlink",
 				"unlinkat",
+				"unshare",
 				"utime",
 				"utimensat",
+				"utimensat_time64",
 				"utimes",
 				"vfork",
-				"vmsplice",
 				"wait4",
 				"waitid",
 				"waitpid",
 				"write",
-				"writev",
-				"mount",
-				"umount2",
-				"reboot",
-				"name_to_handle_at",
-				"unshare"
+				"writev"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],
@@ -557,21 +640,29 @@
 		},
 		{
 			"names": [
+				"open_by_handle_at"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_DAC_READ_SEARCH"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"bpf",
-				"clone",
 				"fanotify_init",
 				"lookup_dcookie",
-				"mount",
-				"name_to_handle_at",
 				"perf_event_open",
 				"quotactl",
 				"setdomainname",
 				"sethostname",
-				"setns",
-				"syslog",
-				"umount",
-				"umount2",
-				"unshare"
+				"setns"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],
@@ -585,68 +676,25 @@
 		},
 		{
 			"names": [
-				"clone"
+				"bpf",
+				"fanotify_init",
+				"lookup_dcookie",
+				"perf_event_open",
+				"quotactl",
+				"setdomainname",
+				"sethostname",
+				"setns"
 			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 2080505856,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_MASKED_EQ"
-				}
-			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
 			"comment": "",
 			"includes": {},
 			"excludes": {
 				"caps": [
 					"CAP_SYS_ADMIN"
-				],
-				"arches": [
-					"s390",
-					"s390x"
-				]
-			}
-		},
-		{
-			"names": [
-				"clone"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 1,
-					"value": 2080505856,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_MASKED_EQ"
-				}
-			],
-			"comment": "s390 parameter ordering for clone is different",
-			"includes": {
-				"arches": [
-					"s390",
-					"s390x"
 				]
 			},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_ADMIN"
-				]
-			}
-		},
-		{
-			"names": [
-				"reboot"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_SYS_BOOT"
-				]
-			},
-			"excludes": {}
+			"errnoRet": 1
 		},
 		{
 			"names": [
@@ -661,6 +709,21 @@
 				]
 			},
 			"excludes": {}
+		},
+		{
+			"names": [
+				"chroot"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_CHROOT"
+				]
+			},
+			"errnoRet": 1
 		},
 		{
 			"names": [
@@ -681,6 +744,24 @@
 		},
 		{
 			"names": [
+				"delete_module",
+				"init_module",
+				"finit_module",
+				"query_module"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_MODULE"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"acct"
 			],
 			"action": "SCMP_ACT_ALLOW",
@@ -695,7 +776,23 @@
 		},
 		{
 			"names": [
+				"acct"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_PACCT"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"kcmp",
+				"process_madvise",
 				"process_vm_readv",
 				"process_vm_writev",
 				"ptrace"
@@ -709,6 +806,25 @@
 				]
 			},
 			"excludes": {}
+		},
+		{
+			"names": [
+				"kcmp",
+				"process_madvise",
+				"process_vm_readv",
+				"process_vm_writev",
+				"ptrace"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_PTRACE"
+				]
+			},
+			"errnoRet": 1
 		},
 		{
 			"names": [
@@ -727,9 +843,26 @@
 		},
 		{
 			"names": [
+				"iopl",
+				"ioperm"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_RAWIO"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"settimeofday",
 				"stime",
-				"clock_settime"
+				"clock_settime",
+				"clock_settime64"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],
@@ -740,6 +873,24 @@
 				]
 			},
 			"excludes": {}
+		},
+		{
+			"names": [
+				"settimeofday",
+				"stime",
+				"clock_settime",
+				"clock_settime64"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_TIME"
+				]
+			},
+			"errnoRet": 1
 		},
 		{
 			"names": [
@@ -757,30 +908,120 @@
 		},
 		{
 			"names": [
-				"get_mempolicy",
-				"mbind",
-				"set_mempolicy"
+				"vhangup"
 			],
-			"action": "SCMP_ACT_ALLOW",
+			"action": "SCMP_ACT_ERRNO",
 			"args": [],
 			"comment": "",
-			"includes": {
+			"includes": {},
+			"excludes": {
 				"caps": [
-					"CAP_SYS_NICE"
+					"CAP_SYS_TTY_CONFIG"
 				]
 			},
-			"excludes": {}
+			"errnoRet": 1
 		},
 		{
 			"names": [
-				"syslog"
+				"socket"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [
+				{
+					"index": 0,
+					"value": 16,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				},
+				{
+					"index": 2,
+					"value": 9,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			},
+			"errnoRet": 22
+		},
+		{
+			"names": [
+				"socket"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": [],
+			"args": [
+				{
+					"index": 2,
+					"value": 9,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 16,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 2,
+					"value": 9,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": null,
 			"comment": "",
 			"includes": {
 				"caps": [
-					"CAP_SYSLOG"
+					"CAP_AUDIT_WRITE"
 				]
 			},
 			"excludes": {}


### PR DESCRIPTION
This PR was opened automatically because PR #6048 was pushed to master and backport to ipa-4-9 is required.