### PR TITLE
azure: Don't customize pip's builddir

### DIFF
--- a/.tox-install.sh
+++ b/.tox-install.sh
@@ -4,9 +4,8 @@ set -ex
 FLAVOR="$1"
 ENVPYTHON="$(realpath -s "$2")"
 ENVSITEPACKAGESDIR="$(realpath -s "$3")"
-ENVDIR="$4"
-# 4...end are package requirements
-shift 4
+# 3...end are package requirements
+shift 3
 
 TOXINIDIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -26,20 +25,9 @@ if [ ! -f "${TOXINIDIR}/tox.ini" ]; then
     exit 3
 fi
 
-if [ ! -d "${ENVDIR}" ]; then
-    echo "${ENVDIR}: no such directory"
-    exit 4
-fi
-
 # https://pip.pypa.io/en/stable/user_guide/#environment-variables
 export PIP_CACHE_DIR="${TOXINIDIR}/.tox/cache"
 mkdir -p "${PIP_CACHE_DIR}"
-
-# /tmp could be mounted with noexec option.
-# pip checks if path is executable and if not then doesn't set such
-# permission bits
-export PIP_BUILD="${ENVDIR}/pip_build"
-rm -rf "${PIP_BUILD}"
 
 DISTBUNDLE="${TOXINIDIR}/dist/bundle"
 mkdir -p "${DISTBUNDLE}"

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ skipsdist=true
 # always re-create virtual env. A special install helper is used to configure,
 # build and install packages.
 recreate=True
-install_command={toxinidir}/.tox-install.sh wheel_bundle {envpython} {envsitepackagesdir} {envdir} {packages}
+install_command={toxinidir}/.tox-install.sh wheel_bundle {envpython} {envsitepackagesdir} {packages}
 changedir={envdir}
 setenv=
     HOME={envtmpdir}
@@ -34,7 +34,7 @@ commands=
 
 [testenv:pypi]
 recreate=True
-install_command={toxinidir}/.tox-install.sh pypi_packages {envpython} {envsitepackagesdir} {envdir} {packages}
+install_command={toxinidir}/.tox-install.sh pypi_packages {envpython} {envsitepackagesdir} {packages}
 changedir={envdir}
 setenv=
     HOME={envtmpdir}


### PR DESCRIPTION
As of 21.3 pip:

> Remove the --build-dir option and aliases, one last time. (pypa/pip#10485)

https://pip.pypa.io/en/stable/news/#v21-3

Previous versions warn about deprecation.

The builddir is provided to pip via env variable PIP_BUILD in Tox task.
The purpose of changing of default builddir was noexec mount option for
/tmp in Travis (see 17d571c961). Since Travis is no longer used and
Azure lacks this issue the PIP_BUILD can be safely removed.

Note: pip 21.3 just ignores this env variable, which is more than can be
said for the command line option. It's better to clean it up, since the
behaviour may be changed in future.

Fixes: https://pagure.io/freeipa/issue/9011
Signed-off-by: Stanislav Levin <slev@altlinux.org>