### PR TITLE
ipatests: TestMultipleExternalCA: Create tempfiles on remote host

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2099,13 +2099,15 @@ def ldapsearch_dm(host, base, ldap_args, scope='sub', **kwargs):
     return host.run_command(args, **kwargs)
 
 
-def create_temp_file(host, directory=None, create_file=True):
-    """Creates temporary file using mktemp."""
+def create_temp_file(host, directory=None, suffix=None, create_file=True):
+    """Creates temporary file using mktemp. See `man 1 mktemp`."""
     cmd = ['mktemp']
     if create_file is False:
         cmd += ['--dry-run']
     if directory is not None:
         cmd += ['-p', directory]
+    if suffix is not None:
+        cmd.extend(["--suffix", suffix])
     return host.run_command(cmd).stdout_text.strip()
 
 

--- a/ipatests/test_integration/test_external_ca.py
+++ b/ipatests/test_integration/test_external_ca.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 import os
 import re
 import time
-import tempfile
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -464,8 +463,12 @@ class TestMultipleExternalCA(IntegrationTest):
     def test_master_install_ca1(self):
         install_server_external_ca_step1(self.master)
         # Sign CA, transport it to the host and get ipa a root ca paths.
-        root_ca_fname1 = tempfile.mkdtemp(suffix='root_ca.crt', dir=paths.TMP)
-        ipa_ca_fname1 = tempfile.mkdtemp(suffix='ipa_ca.crt', dir=paths.TMP)
+        root_ca_fname1 = tasks.create_temp_file(
+            self.master, directory=paths.TMP, suffix="root_ca.crt"
+        )
+        ipa_ca_fname1 = tasks.create_temp_file(
+            self.master, directory=paths.TMP, suffix="ipa_ca.crt"
+        )
 
         ipa_csr = self.master.get_file_contents(paths.ROOT_IPA_CSR)
 
@@ -485,8 +488,12 @@ class TestMultipleExternalCA(IntegrationTest):
         assert "CN=RootCA1" in result.stdout_text
 
     def test_master_install_ca2(self):
-        root_ca_fname2 = tempfile.mkdtemp(suffix='root_ca.crt', dir=paths.TMP)
-        ipa_ca_fname2 = tempfile.mkdtemp(suffix='ipa_ca.crt', dir=paths.TMP)
+        root_ca_fname2 = tasks.create_temp_file(
+            self.master, directory=paths.TMP, suffix="root_ca.crt"
+        )
+        ipa_ca_fname2 = tasks.create_temp_file(
+            self.master, directory=paths.TMP, suffix="ipa_ca.crt"
+        )
 
         self.master.run_command([
             paths.IPA_CACERT_MANAGE, 'renew', '--external-ca'])


### PR DESCRIPTION
Previously, `test_master_install_ca1` and `test_master_install_ca2`
attempt to create tempdirs on local host and later write some
content into the returned paths on remote host. This fails if
a remote host is a local one.

The existent `create_temp_file` function has been extended to
support `suffix` option of `mktemp`.

Fixes: https://pagure.io/freeipa/issue/9013
Signed-off-by: Stanislav Levin <slev@altlinux.org>