### PR TITLE
[Backport][ipa-4-9] azure: Don't customize pip's builddir

### DIFF
--- a/.tox-install.sh
+++ b/.tox-install.sh
@@ -4,9 +4,8 @@ set -ex
 FLAVOR="$1"
 ENVPYTHON="$(realpath -s "$2")"
 ENVSITEPACKAGESDIR="$(realpath -s "$3")"
-ENVDIR="$4"
-# 4...end are package requirements
-shift 4
+# 3...end are package requirements
+shift 3
 
 TOXINIDIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -26,20 +25,9 @@ if [ ! -f "${TOXINIDIR}/tox.ini" ]; then
     exit 3
 fi
 
-if [ ! -d "${ENVDIR}" ]; then
-    echo "${ENVDIR}: no such directory"
-    exit 4
-fi
-
 # https://pip.pypa.io/en/stable/user_guide/#environment-variables
 export PIP_CACHE_DIR="${TOXINIDIR}/.tox/cache"
 mkdir -p "${PIP_CACHE_DIR}"
-
-# /tmp could be mounted with noexec option.
-# pip checks if path is executable and if not then doesn't set such
-# permission bits
-export PIP_BUILD="${ENVDIR}/pip_build"
-rm -rf "${PIP_BUILD}"
 
 DISTBUNDLE="${TOXINIDIR}/dist/bundle"
 mkdir -p "${DISTBUNDLE}"

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ skipsdist=true
 # always re-create virtual env. A special install helper is used to configure,
 # build and install packages.
 recreate=True
-install_command={toxinidir}/.tox-install.sh wheel_bundle {envpython} {envsitepackagesdir} {envdir} {packages}
+install_command={toxinidir}/.tox-install.sh wheel_bundle {envpython} {envsitepackagesdir} {packages}
 changedir={envdir}
 setenv=
     HOME={envtmpdir}
@@ -34,7 +34,7 @@ commands=
 
 [testenv:pypi]
 recreate=True
-install_command={toxinidir}/.tox-install.sh pypi_packages {envpython} {envsitepackagesdir} {envdir} {packages}
+install_command={toxinidir}/.tox-install.sh pypi_packages {envpython} {envsitepackagesdir} {packages}
 changedir={envdir}
 setenv=
     HOME={envtmpdir}


### PR DESCRIPTION
This PR was opened automatically because PR #6053 was pushed to master and backport to ipa-4-9 is required.