### PR TITLE
ipatests: Bump rawhide template for PR-CI 

### DIFF
--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-frawhide
           name: freeipa/ci-master-frawhide
-          version: 0.4.2
+          version: 0.5.1
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
New PR-CI template based on compose `Fedora-Rawhide-20211021.n.0`, future Fedora 36.