### PR TITLE
[Backport][ipa-4-9] On redhat-based platforms rely on authselect to enable sudo

### DIFF
--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -756,6 +756,9 @@ class RedHatTaskNamespace(BaseTaskNamespace):
                                   "{}.module".format(name))
                      for name, _module, _disabled in PKCS11_MODULES)
 
+    def enable_sssd_sudo(self, _fstore):
+        """sudo enablement is handled by authselect"""
+
     def enable_ldap_automount(self, statestore):
         """
         Point automount to ldap in nsswitch.conf.


### PR DESCRIPTION
This PR was opened automatically because PR #6047 was pushed to master and backport to ipa-4-9 is required.