### PR TITLE
[Backport][ipa-4-6] ipatests: use AD domain name from config instead of hardcoded value

### DIFF
--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -641,12 +641,12 @@ class TestTrust(BaseTestTrust):
             ['chown', '--reference', paths.NAMED_CONF, ad_zone_file])
         named_conf = self.master.get_file_contents(paths.NAMED_CONF,
                                                    encoding='utf-8')
-        named_conf += textwrap.dedent('''
-            zone "ad.test" {{
+        named_conf += textwrap.dedent(f'''
+            zone "{self.ad.domain.name}" {{
                 type master;
-                file "{}";
+                file "{ad_zone_file}";
             }};
-        '''.format(ad_zone_file))
+        ''')
         self.master.put_file_contents(paths.NAMED_CONF, named_conf)
         tasks.restart_named(self.master)
         try:


### PR DESCRIPTION
This PR was opened automatically because PR #6061 was pushed to master and backport to ipa-4-6 is required.