### PR TITLE
ipa-4-6: ipatests: Update PR-CI template

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f27
           name: freeipa/ci-ipa-4-6-f27
-          version: 1.0.3
+          version: 1.0.5
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
New template without vagrant left-overs that were causing the test to fail.

Template notes: https://app.vagrantup.com/freeipa/boxes/ci-ipa-4-6-f27/versions/1.0.5
Issue: https://pagure.io/freeipa/issue/8959
