### PR TITLE
ipatests: revert wrong commit on gating definition

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/temp_commit.yaml
+ipatests/prci_definitions/gating.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_cert.py::TestCAShowErrorHandling
+        test_suite: test_integration/test_REPLACEME.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client


### PR DESCRIPTION
Commit ebe838c overwrote the PRCI definition with temp commit
and needs to be reverted.