### PR TITLE
[Backport][ipa-4-9] Integrate SID configuration into base IPA installers

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -1076,11 +1076,13 @@ args: 0,1,1
 option: Str('version?')
 output: Output('result')
 command: config_mod/1
-args: 0,29,3
+args: 0,32,3
+option: Flag('add_sids?', autofill=True, default=False)
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('ca_renewal_master_server?', autofill=False)
 option: Str('delattr*', cli_name='delattr')
+option: Flag('enable_sid?', autofill=True, default=False)
 option: StrEnum('ipaconfigstring*', autofill=False, cli_name='ipaconfigstring', values=[u'AllowNThash', u'KDC:Disable Last Success', u'KDC:Disable Lockout', u'KDC:Disable Default Preauth for SPNs'])
 option: Str('ipadefaultemaildomain?', autofill=False, cli_name='emaildomain')
 option: Str('ipadefaultloginshell?', autofill=False, cli_name='defaultshell')
@@ -1102,6 +1104,7 @@ option: StrEnum('ipauserauthtype*', autofill=False, cli_name='user_auth_type', v
 option: Bool('ipauserdefaultsubordinateid?', autofill=False, cli_name='user_default_subid')
 option: Str('ipauserobjectclasses*', autofill=False, cli_name='userobjectclasses')
 option: IA5Str('ipausersearchfields?', autofill=False, cli_name='usersearch')
+option: Str('netbios_name?', autofill=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Flag('rights', autofill=True, default=False)
 option: Str('setattr*', cli_name='setattr')

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -86,8 +86,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-# Last change: add subordinate id feature
-define(IPA_API_VERSION_MINOR, 243)
+# Last change: add enable_sid to config
+define(IPA_API_VERSION_MINOR, 245)
 
 
 ########################################################

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1378,6 +1378,7 @@ fi
 %dir %{_libexecdir}/ipa/oddjob
 %attr(0755,root,root) %{_libexecdir}/ipa/oddjob/org.freeipa.server.conncheck
 %attr(0755,root,root) %{_libexecdir}/ipa/oddjob/org.freeipa.server.trust-enable-agent
+%attr(0755,root,root) %{_libexecdir}/ipa/oddjob/org.freeipa.server.config-enable-sid
 %config(noreplace) %{_sysconfdir}/dbus-1/system.d/org.freeipa.server.conf
 %config(noreplace) %{_sysconfdir}/oddjobd.conf.d/ipa-server.conf
 %dir %{_libexecdir}/ipa/certmonger

--- a/install/oddjob/Makefile.am
+++ b/install/oddjob/Makefile.am
@@ -7,6 +7,7 @@ dbusconfdir = $(sysconfdir)/dbus-1/system.d
 dist_noinst_DATA =		\
 	com.redhat.idm.trust-fetch-domains.in	\
 	org.freeipa.server.trust-enable-agent.in	\
+	org.freeipa.server.config-enable-sid.in \
 	etc/oddjobd.conf.d/oddjobd-ipa-trust.conf.in	\
 	etc/oddjobd.conf.d/ipa-server.conf.in		\
 	$(NULL)
@@ -18,6 +19,7 @@ dist_oddjob_SCRIPTS =				\
 nodist_oddjob_SCRIPTS =				\
 	com.redhat.idm.trust-fetch-domains	\
 	org.freeipa.server.trust-enable-agent	\
+	org.freeipa.server.config-enable-sid \
 	$(NULL)
 
 

--- a/install/oddjob/etc/oddjobd.conf.d/ipa-server.conf.in
+++ b/install/oddjob/etc/oddjobd.conf.d/ipa-server.conf.in
@@ -17,6 +17,12 @@
                   prepend_user_name="no"
                   argument_passing_method="cmdline"/>
         </method>
+        <method name="config_enable_sid">
+          <helper exec="@ODDJOBDIR@/org.freeipa.server.config-enable-sid"
+                  arguments="10"
+                  prepend_user_name="no"
+                  argument_passing_method="cmdline"/>
+        </method>
       </interface>
       <interface name="org.freedesktop.DBus.Introspectable">
         <allow min_uid="0" max_uid="0"/>

--- a/install/oddjob/org.freeipa.server.config-enable-sid.in
+++ b/install/oddjob/org.freeipa.server.config-enable-sid.in
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2021  FreeIPA Contributors see COPYING for license
+#
+
+import logging
+
+from ipalib import api
+from ipalib.install import sysrestore
+from ipaplatform.paths import paths
+from ipapython import ipaldap
+from ipapython.admintool import AdminTool
+from ipaserver.install import adtrust, adtrustinstance
+
+logger = logging.getLogger(__name__)
+
+class IPAConfigEnableSid(AdminTool):
+    command_name = "ipa-enable-sid"
+    log_file_name = paths.IPASERVER_ENABLESID_LOG
+    usage = "%prog"
+    description = "Enable SID generation"
+
+    @classmethod
+    def add_options(cls, parser):
+        super(IPAConfigEnableSid, cls).add_options(parser)
+
+        parser.add_option(
+            "--add-sids",
+            dest="add_sids", default=False, action="store_true",
+            help="Add SIDs for existing users and groups as the final step"
+        )
+
+        parser.add_option(
+            "--netbios-name",
+            dest="netbios_name", default=None,
+            help="NetBIOS name of the IPA domain"
+        )
+
+        parser.add_option(
+            "--reset-netbios-name",
+            dest="reset_netbios_name", default=False, action="store_true",
+            help="Force reset of the existing NetBIOS name"
+        )
+
+
+    def validate_options(self):
+        super(IPAConfigEnableSid, self).validate_options(needs_root=True)
+
+    def run(self):
+        api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
+        api.finalize()
+
+        try:
+            api.Backend.ldap2.connect()
+            fstore = sysrestore.FileStore(paths.SYSRESTORE)
+
+            smb = adtrustinstance.ADTRUSTInstance(fstore, False)
+            smb.realm = api.env.realm
+            smb.autobind = ipaldap.AUTOBIND_ENABLED
+            smb.setup(api.env.host, api.env.realm,
+                      self.options.netbios_name,
+                      self.options.reset_netbios_name,
+                      adtrust.DEFAULT_PRIMARY_RID_BASE,
+                      adtrust.DEFAULT_SECONDARY_RID_BASE,
+                      self.options.add_sids,
+                      enable_compat=False)
+            smb.find_local_id_range()
+            smb.create_instance()
+
+        finally:
+            if api.Backend.ldap2.isconnected():
+                api.Backend.ldap2.disconnect()
+
+        return 0
+
+IPAConfigEnableSid.run_cli()

--- a/install/tools/ipa-adtrust-install.in
+++ b/install/tools/ipa-adtrust-install.in
@@ -64,10 +64,11 @@ def parse_options():
     parser.add_option("--no-msdcs", dest="no_msdcs", action="store_true",
                       default=False, help=SUPPRESS_HELP)
 
-    parser.add_option("--rid-base", dest="rid_base", type=int, default=1000,
+    parser.add_option("--rid-base", dest="rid_base", type=int,
+                      default=adtrust.DEFAULT_PRIMARY_RID_BASE,
                       help="Start value for mapping UIDs and GIDs to RIDs")
     parser.add_option("--secondary-rid-base", dest="secondary_rid_base",
-                      type=int, default=100000000,
+                      type=int, default=adtrust.DEFAULT_SECONDARY_RID_BASE,
                       help="Start value of the secondary range for mapping "
                            "UIDs and GIDs to RIDs")
     parser.add_option("-U", "--unattended", dest="unattended",

--- a/install/tools/ipa-adtrust-install.in
+++ b/install/tools/ipa-adtrust-install.in
@@ -209,6 +209,8 @@ def main():
         raise ScriptError(
             "Unrecognized error during check of admin rights: %s" % e)
 
+    # Force options.setup_adtrust
+    options.setup_adtrust = True
     adtrust.install_check(True, options, api)
     adtrust.install(True, options, fstore, api)
 

--- a/install/tools/man/ipa-replica-install.1
+++ b/install/tools/man/ipa-replica-install.1
@@ -205,10 +205,7 @@ Do not automatically create DNS SSHFP records.
 \fB\-\-no\-dnssec\-validation\fR
 Disable DNSSEC validation on this server.
 
-.SS "AD TRUST OPTIONS"
-.TP
-\fB\-\-setup\-adtrust\fR
-Configure AD Trust capability on a replica.
+.SS "SID GENERATION OPTIONS"
 .TP
 \fB\-\-netbios\-name\fR=\fINETBIOS_NAME\fR
 The NetBIOS name for the IPA domain. If not provided then this is determined
@@ -227,6 +224,21 @@ ipa\-adtrust\-install is run and scheduled independently. To start this task
 you have to load an edited version of ipa-sidgen-task-run.ldif with the
 ldapmodify command info the directory server.
 .TP
+\fB\-\-rid-base\fR=\fIRID_BASE\fR
+First RID value of the local domain. The first Posix ID of the local domain will
+be assigned to this RID, the second to RID+1 etc. See the online help of the
+idrange CLI for details.
+.TP
+\fB\-\-secondary-rid-base\fR=\fISECONDARY_RID_BASE\fR
+Start value of the secondary RID range, which is only used in the case a user
+and a group share numerically the same Posix ID. See the online help of the
+idrange CLI for details.
+
+.SS "AD TRUST OPTIONS"
+.TP
+\fB\-\-setup\-adtrust\fR
+Configure AD Trust capability on a replica.
+.TP
 \fB\-\-add\-agents\fR
 Add IPA masters to the list that allows to serve information about
 users from trusted forests. Starting with IPA 4.2, a regular IPA master
@@ -239,16 +251,6 @@ Note that IPA masters where ipa\-adtrust\-install wasn't run, can serve
 information about users from trusted forests only if they are enabled
 via \ipa-adtrust\-install run on any other IPA master. At least SSSD
 version 1.13 on IPA master is required to be able to perform as a trust agent.
-.TP
-\fB\-\-rid-base\fR=\fIRID_BASE\fR
-First RID value of the local domain. The first Posix ID of the local domain will
-be assigned to this RID, the second to RID+1 etc. See the online help of the
-idrange CLI for details.
-.TP
-\fB\-\-secondary-rid-base\fR=\fISECONDARY_RID_BASE\fR
-Start value of the secondary RID range, which is only used in the case a user
-and a group share numerically the same Posix ID. See the online help of the
-idrange CLI for details.
 .TP
 \fB\-\-enable\-compat\fR
 Enables support for trusted domains users for old clients through Schema Compatibility plugin.

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -230,11 +230,7 @@ Disable DNSSEC validation on this server.
 \fB\-\-allow\-zone\-overlap\fR
 Allow creation of (reverse) zone even if the zone is already resolvable. Using this option is discouraged as it result in later problems with domain name resolution.
 
-.SS "AD TRUST OPTIONS"
-
-.TP
-\fB\-\-setup\-adtrust\fR
-Configure AD Trust capability.
+.SS "SID GENERATION OPTIONS"
 .TP
 \fB\-\-netbios\-name\fR=\fINETBIOS_NAME\fR
 The NetBIOS name for the IPA domain. If not provided, this is determined
@@ -252,6 +248,11 @@ idrange CLI for details.
 Start value of the secondary RID range, which is only used in the case a user
 and a group share numerically the same POSIX ID. See the online help of the
 idrange CLI for details.
+
+.SS "AD TRUST OPTIONS"
+.TP
+\fB\-\-setup\-adtrust\fR
+Configure AD Trust capability.
 .TP
 \fB\-\-enable\-compat\fR
 Enables support for trusted domains users for old clients through Schema Compatibility plugin.

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -23,6 +23,7 @@ All constants centralised in one file.
 """
 
 import os
+import string
 
 from ipaplatform.constants import constants as _constants
 from ipapython.dn import DN
@@ -368,3 +369,5 @@ KRA_TRACKING_REQS = {
     'transportCert cert-pki-kra': 'caTransportCert',
     'storageCert cert-pki-kra': 'caStorageCert',
 }
+
+ALLOWED_NETBIOS_CHARS = string.ascii_uppercase + string.digits + '-'

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -364,6 +364,7 @@ class BasePathNamespace:
     IPAREPLICA_CONNCHECK_LOG = "/var/log/ipareplica-conncheck.log"
     IPAREPLICA_INSTALL_LOG = "/var/log/ipareplica-install.log"
     IPARESTORE_LOG = "/var/log/iparestore.log"
+    IPASERVER_ENABLESID_LOG = "/var/log/ipaserver-enable-sid.log"
     IPASERVER_INSTALL_LOG = "/var/log/ipaserver-install.log"
     IPASERVER_ADTRUST_INSTALL_LOG = "/var/log/ipaserver-adtrust-install.log"
     IPASERVER_DNS_INSTALL_LOG = "/var/log/ipaserver-dns-install.log"

--- a/ipaserver/install/adtrust.py
+++ b/ipaserver/install/adtrust.py
@@ -39,6 +39,9 @@ logger = logging.getLogger(__name__)
 netbios_name = None
 reset_netbios_name = False
 
+DEFAULT_PRIMARY_RID_BASE = 1000
+DEFAULT_SECONDARY_RID_BASE = 100000000
+
 
 def netbios_name_error(name):
     logger.error("\nIllegal NetBIOS name [%s].\n", name)
@@ -553,12 +556,12 @@ class SIDInstallInterface(ServiceAdminInstallInterface):
     )
     rid_base = knob(
         int,
-        1000,
+        DEFAULT_PRIMARY_RID_BASE,
         description="Start value for mapping UIDs and GIDs to RIDs"
     )
     secondary_rid_base = knob(
         int,
-        100000000,
+        DEFAULT_SECONDARY_RID_BASE,
         description="Start value of the secondary range for mapping "
                     "UIDs and GIDs to RIDs"
     )

--- a/ipaserver/install/adtrust.py
+++ b/ipaserver/install/adtrust.py
@@ -530,7 +530,41 @@ def generate_dns_service_records_help(api):
 
 
 @group
-class ADTrustInstallInterface(ServiceAdminInstallInterface):
+class SIDInstallInterface(ServiceAdminInstallInterface):
+    """
+    Interface for the SID generation Installer
+
+    Knobs defined here will be available in:
+    * ipa-server-install
+    * ipa-replica-install
+    * ipa-adtrust-install
+    """
+    description = "SID generation"
+    add_sids = knob(
+        None,
+        description="Add SIDs for existing users and groups as the final step"
+    )
+    add_sids = replica_install_only(add_sids)
+    netbios_name = knob(
+        str,
+        None,
+        description="NetBIOS name of the IPA domain"
+    )
+    rid_base = knob(
+        int,
+        1000,
+        description="Start value for mapping UIDs and GIDs to RIDs"
+    )
+    secondary_rid_base = knob(
+        int,
+        100000000,
+        description="Start value of the secondary range for mapping "
+                    "UIDs and GIDs to RIDs"
+    )
+
+
+@group
+class ADTrustInstallInterface(SIDInstallInterface):
     """
     Interface for the AD trust installer
 
@@ -543,10 +577,6 @@ class ADTrustInstallInterface(ServiceAdminInstallInterface):
 
     # the following knobs are provided on top of those specified for
     # admin credentials
-    add_sids = knob(
-        None,
-        description="Add SIDs for existing users and groups as the final step"
-    )
     add_agents = knob(
         None,
         description="Add IPA masters to a list of hosts allowed to "
@@ -557,24 +587,8 @@ class ADTrustInstallInterface(ServiceAdminInstallInterface):
         None,
         description="Enable support for trusted domains for old clients"
     )
-    netbios_name = knob(
-        str,
-        None,
-        description="NetBIOS name of the IPA domain"
-    )
     no_msdcs = knob(
         None,
         description="Deprecated: has no effect",
         deprecated=True
-    )
-    rid_base = knob(
-        int,
-        1000,
-        description="Start value for mapping UIDs and GIDs to RIDs"
-    )
-    secondary_rid_base = knob(
-        int,
-        100000000,
-        description="Start value of the secondary range for mapping "
-                    "UIDs and GIDs to RIDs"
     )

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -25,7 +25,6 @@ import errno
 import ldap
 import tempfile
 import uuid
-import string
 import struct
 import re
 import socket
@@ -36,7 +35,8 @@ from ipaserver.install import service
 from ipaserver.install import installutils
 from ipaserver.install.replication import wait_for_task
 from ipalib import errors, api
-from ipalib.constants import SUBID_RANGE_START
+from ipalib.constants import SUBID_RANGE_START, ALLOWED_NETBIOS_CHARS
+
 from ipalib.util import normalize_zone
 from ipapython.dn import DN
 from ipapython import ipachangeconf
@@ -53,8 +53,6 @@ if six.PY3:
     unicode = str
 
 logger = logging.getLogger(__name__)
-
-ALLOWED_NETBIOS_CHARS = string.ascii_uppercase + string.digits + '-'
 
 UPGRADE_ERROR = """
 Entry %(dn)s does not exist.

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -335,6 +335,8 @@ class ADTRUSTInstance(service.Service):
         # _ldap_mod does not return useful error codes, so we must check again
         # if the fallback group was created properly.
         try:
+            # Remove entry from cache otherwise get_entry won't find it
+            api.Backend.ldap2.remove_cache_entry(fb_group_dn)
             api.Backend.ldap2.get_entry(fb_group_dn)
         except errors.NotFound:
             self.print_msg("Failed to add fallback group.")

--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -432,11 +432,6 @@ class ServerInstallInterface(ServerCertificateInstallInterface,
                     "You cannot specify an --enable-compat option without the "
                     "--setup-adtrust option")
 
-            if self.netbios_name:
-                raise RuntimeError(
-                    "You cannot specify a --netbios-name option without the "
-                    "--setup-adtrust option")
-
             if self.no_msdcs:
                 raise RuntimeError(
                     "You cannot specify a --no-msdcs option without the "

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -443,6 +443,7 @@ def install_check(installer):
         print("  * Configure KRA (dogtag) for secret management")
     if options.setup_dns:
         print("  * Configure DNS (bind)")
+    print("  * Configure SID generation")
     if options.setup_adtrust:
         print("  * Configure Samba (smb) and winbind for managing AD trusts")
     if not options.no_pkinit:
@@ -703,8 +704,9 @@ def install_check(installer):
         logger.debug('Starting Directory Server')
         services.knownservices.dirsrv.start(instance_name)
 
-    if options.setup_adtrust:
-        adtrust.install_check(False, options, api)
+    # Always call adtrust.install_check
+    # if --setup-adtrust is not specified, only the SID part is executed
+    adtrust.install_check(False, options, api)
 
     # installer needs to update hosts file when DNS subsystem will be
     # installed or custom addresses are used
@@ -966,8 +968,9 @@ def install(installer):
     if options.setup_dns:
         dns.install(False, False, options)
 
-    if options.setup_adtrust:
-        adtrust.install(False, options, fstore, api)
+    # Always call adtrust installer to configure SID generation
+    # if --setup-adtrust is not specified, only the SID part is executed
+    adtrust.install(False, options, fstore, api)
 
     # Set the admin user kerberos password
     ds.change_admin_password(admin_password)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1158,8 +1158,9 @@ def promote_check(installer):
             # check addresses here, dns module is doing own check
             no_matching_interface_for_ip_address_warning(config.ips)
 
-        if options.setup_adtrust:
-            adtrust.install_check(False, options, remote_api)
+        # Always call adtrust.install_check
+        # if --setup-adtrust is not specified, only the SID part is executed
+        adtrust.install_check(False, options, remote_api)
 
     except errors.ACIError:
         logger.debug("%s", traceback.format_exc())
@@ -1365,8 +1366,9 @@ def install(installer):
     if options.setup_dns:
         dns.install(False, True, options, api)
 
-    if options.setup_adtrust:
-        adtrust.install(False, options, fstore, api)
+    # Always call adtrust.install
+    # if --setup-adtrust is not specified, only the SID part is executed
+    adtrust.install(False, options, fstore, api)
 
     if options.hidden_replica:
         # Set services to hidden

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -659,6 +659,10 @@ class user_add(baseuser_add):
 
         entry_attrs.update(newentry)
 
+        # delete ipantsecurityidentifier if present
+        if ('ipantsecurityidentifier' in entry_attrs):
+            del entry_attrs['ipantsecurityidentifier']
+
         if options.get('random', False):
             try:
                 entry_attrs['randompassword'] = unicode(getattr(context, 'randompassword'))

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -1002,6 +1002,7 @@ class user_stage(LDAPMultiQuery):
                     u'ipauniqueid', u'krbcanonicalname',
                     u'sshpubkeyfp', u'krbextradata',
                     u'ipacertmapdata',
+                    'ipantsecurityidentifier',
                     u'nsaccountlock']
 
     def execute(self, *keys, **options):

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -383,6 +383,8 @@ class WSGIExecutioner(Executioner):
         if self.api.env.debug:
             time_start = time.perf_counter_ns()
         try:
+            if 'KRB5CCNAME' in environ:
+                setattr(context, "ccache_name", environ['KRB5CCNAME'])
             if ('HTTP_ACCEPT_LANGUAGE' in environ):
                 lang_reg_w_q = environ['HTTP_ACCEPT_LANGUAGE'].split(',')[0]
                 lang_reg = lang_reg_w_q.split(';')[0]

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -311,6 +311,11 @@ class BaseBackupAndRestoreWithDNS(IntegrationTest):
                 tasks.install_master(self.master, setup_dns=True)
             self.master.run_command(['ipa-restore', backup_path],
                                     stdin_text=dirman_password + '\nyes')
+            if reinstall:
+                # If the server was reinstalled, reinstall may have changed
+                # the uid and restore reverts to the original value.
+                # clear the cache to make sure we get up-to-date values
+                tasks.clear_sssd_cache(self.master)
             tasks.resolve_record(self.master.ip, self.example_test_zone)
 
             tasks.kinit_admin(self.master)
@@ -379,6 +384,12 @@ class BaseBackupAndRestoreWithDNSSEC(IntegrationTest):
             dirman_password = self.master.config.dirman_password
             self.master.run_command(['ipa-restore', backup_path],
                                     stdin_text=dirman_password + '\nyes')
+
+            if reinstall:
+                # If the server was reinstalled, reinstall may have changed
+                # the uid and restore reverts to the original value.
+                # clear the cache to make sure we get up-to-date values
+                tasks.clear_sssd_cache(self.master)
 
             assert (
                 wait_until_record_is_signed(
@@ -463,6 +474,12 @@ class BaseBackupAndRestoreWithKRA(IntegrationTest):
             dirman_password = self.master.config.dirman_password
             self.master.run_command(['ipa-restore', backup_path],
                                     stdin_text=dirman_password + '\nyes')
+
+            if reinstall:
+                # If the server was reinstalled, reinstall may have changed
+                # the uid and restore reverts to the original value.
+                # clear the cache to make sure we get up-to-date values
+                tasks.clear_sssd_cache(self.master)
 
             tasks.kinit_admin(self.master)
             # retrieve secret after restore

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -60,6 +60,7 @@ def get_install_stdin(cert_passwords=()):
         '',  # Server host name (has default)
     ]
     lines.extend(cert_passwords)  # Enter foo.p12 unlock password
+    lines.extend('IPA') # NetBios name
     lines += [
         'no',   # configure chrony with NTP server or pool address?
         'yes',  # Continue with these values?

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1579,6 +1579,46 @@ class TestIPACommandWithoutReplica(IntegrationTest):
         tasks.ldapsearch_dm(self.master, base, ldap_args=[], scope='sub')
         tasks.ldapsearch_dm(self.master, base, ldap_args=[], scope='base')
 
+    def test_sid_generation(self):
+        """
+        Test SID generation
+
+        Check that new users are created with a SID and PAC data is
+        added in their Kerberos tickets.
+        """
+        user = "pacuser"
+        passwd = "Secret123"
+
+        try:
+            # Create a nonadmin user
+            tasks.create_active_user(
+                self.master, user, passwd, first=user, last=user,
+                krb5_trace=True)
+
+            # Check SID is present in the new entry
+            base_dn = str(self.master.domain.basedn)
+            result = tasks.ldapsearch_dm(
+                self.master,
+                'uid={user},cn=users,cn=accounts,{base_dn}'.format(
+                    user=user, base_dn=base_dn),
+                ['ipantsecurityidentifier'],
+                scope='base'
+            )
+            assert 'ipantsecurityidentifier' in result.stdout_text
+
+            # Defaults: host/... principal for service
+            # keytab in /etc/krb5.keytab
+            self.master.run_command(["kinit", '-k'])
+            result = self.master.run_command(
+                [os.path.join(paths.LIBEXEC_IPA_DIR, "ipa-print-pac"),
+                 "ticket", user],
+                stdin_text=(passwd + '\n')
+            )
+            assert "PAC_DATA" in result.stdout_text
+        finally:
+            tasks.kinit_admin(self.master)
+            self.master.run_command(['ipa', 'user-del', user])
+
 
 class TestIPAautomount(IntegrationTest):
     @classmethod

--- a/ipatests/test_integration/test_ntp_options.py
+++ b/ipatests/test_integration/test_ntp_options.py
@@ -260,6 +260,8 @@ class TestNTPoptions(IntegrationTest):
             "No\n"
             # Server host name [hostname]:
             "\n"
+            # Enter the NetBIOS name for the IPA domain
+            "IPA\n"
             # Do you want to configure chrony with NTP server
             #   or pool address? [no]:
             "Yes\n"
@@ -372,6 +374,7 @@ class TestNTPoptions(IntegrationTest):
         server_input = (
             "\n" +
             "\n"
+            "IPA\n"
             "No\n"
             "Yes"
         )

--- a/ipatests/test_webui/test_range.py
+++ b/ipatests/test_webui/test_range.py
@@ -297,8 +297,13 @@ class test_range(range_tasks):
 
         # Without primary and secondary RID bases
         data = self.get_data(pkey, base_rid='', secondary_base_rid='')
-        self.add_record(ENTITY, data, navigate=False)
-        self.delete_record(pkey)
+        self.add_record(ENTITY, data, navigate=False, negative=True)
+        try:
+            assert self.has_form_error('ipabaserid')
+        finally:
+            self.delete_record(pkey)
+
+        self.dialog_button_click('cancel')
 
     @screenshot
     def test_modify_range_with_invalid_or_missing_values(self):

--- a/ipatests/test_xmlrpc/mock_trust.py
+++ b/ipatests/test_xmlrpc/mock_trust.py
@@ -2,55 +2,10 @@
 #
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
-from contextlib import contextmanager
 import six
 
 from ipalib import api
-from ipatests.util import MockLDAP
 
-trust_container_dn = "cn=ad,cn=trusts,{basedn}".format(
-    basedn=api.env.basedn)
-trust_container_add = dict(
-    objectClass=[b"nsContainer", b"top"]
-    )
-
-smb_cont_dn = "{cifsdomains},{basedn}".format(
-    cifsdomains=api.env.container_cifsdomains,
-    basedn=api.env.basedn)
-smb_cont_add = dict(
-    objectClass=[b"nsContainer", b"top"]
-    )
-
-
-def create_mock_trust_containers():
-    with MockLDAP() as ldap:
-        ldap.add_entry(trust_container_dn, trust_container_add)
-        ldap.add_entry(smb_cont_dn, smb_cont_add)
-
-
-def remove_mock_trust_containers():
-    with MockLDAP() as ldap:
-        ldap.del_entry(trust_container_dn)
-        ldap.del_entry(smb_cont_dn)
-
-
-@contextmanager
-def mocked_trust_containers():
-    """Mocked trust containers
-
-    Provides containers for the RPC tests:
-    cn=ad,cn=trusts,BASEDN
-    cn=ad,cn=etc,BASEDN
-
-    Upon exiting, it tries to remove the container entries.
-    If the user of the context manager failed to remove
-    all child entries, exiting the context manager will fail.
-    """
-    create_mock_trust_containers()
-    try:
-        yield
-    finally:
-        remove_mock_trust_containers()
 
 def get_range_dn(name):
     format_str = "cn={name},cn=ranges,cn=etc,{basedn}"

--- a/ipatests/test_xmlrpc/objectclasses.py
+++ b/ipatests/test_xmlrpc/objectclasses.py
@@ -35,7 +35,7 @@ user_base = [
     u'ipaSshGroupOfPubKeys',
 ]
 
-user = user_base + [u'mepOriginEntry']
+user = user_base + [u'mepOriginEntry', 'ipantuserattrs',]
 
 group = [
     u'top',
@@ -46,7 +46,7 @@ group = [
 ]
 
 externalgroup = group + [u'ipaexternalgroup']
-posixgroup = group + [u'posixgroup']
+posixgroup = group + [u'posixgroup', 'ipantgroupattrs']
 
 host = [
     u'ipasshhost',

--- a/ipatests/test_xmlrpc/test_batch_plugin.py
+++ b/ipatests/test_xmlrpc/test_batch_plugin.py
@@ -25,6 +25,7 @@ from ipalib import api
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.util import Fuzzy, assert_deepequal
 from ipatests.test_xmlrpc.xmlrpc_test import (Declarative, fuzzy_digits,
+                                              fuzzy_set_optional_oc,
                                               fuzzy_uuid)
 from ipapython.dn import DN
 import pytest
@@ -97,7 +98,8 @@ class test_batch(Declarative):
                         result=dict(
                             cn=[group1],
                             description=[u'Test desc 1'],
-                            objectclass=objectclasses.group + [u'posixgroup'],
+                            objectclass=fuzzy_set_optional_oc(
+                                objectclasses.posixgroup, 'ipantgroupattrs'),
                             ipauniqueid=[fuzzy_uuid],
                             gidnumber=[fuzzy_digits],
                             dn=DN(('cn', 'testgroup1'),
@@ -168,7 +170,8 @@ class test_batch(Declarative):
                         result=dict(
                             cn=[group1],
                             description=[u'Test desc 1'],
-                            objectclass=objectclasses.group + [u'posixgroup'],
+                            objectclass=fuzzy_set_optional_oc(
+                                objectclasses.posixgroup, 'ipantgroupattrs'),
                             ipauniqueid=[fuzzy_uuid],
                             gidnumber=[fuzzy_digits],
                             dn=DN(('cn', 'testgroup1'),

--- a/ipatests/test_xmlrpc/test_idviews_plugin.py
+++ b/ipatests/test_xmlrpc/test_idviews_plugin.py
@@ -217,7 +217,8 @@ class test_idviews(Declarative):
                     u'Test',
                     u'User1',
                     'add',
-                    objectclass=objectclasses.user,
+                    objectclass=fuzzy_set_optional_oc(
+                        objectclasses.user, 'ipantuserattrs'),
                 ),
             ),
         ),
@@ -1623,7 +1624,8 @@ class test_idviews(Declarative):
                     u'Removed',
                     u'User',
                     'add',
-                    objectclass=objectclasses.user,
+                    objectclass=fuzzy_set_optional_oc(
+                        objectclasses.user, 'ipantuserattrs'),
                 ),
             ),
         ),

--- a/ipatests/test_xmlrpc/test_idviews_plugin.py
+++ b/ipatests/test_xmlrpc/test_idviews_plugin.py
@@ -27,7 +27,8 @@ import six
 
 from ipalib import api, errors
 from ipatests.test_xmlrpc import objectclasses
-from ipatests.test_xmlrpc.xmlrpc_test import (Declarative, uuid_re, add_oc,
+from ipatests.test_xmlrpc.xmlrpc_test import (Declarative, uuid_re,
+                                              fuzzy_set_optional_oc,
                                               fuzzy_uuid, fuzzy_digits)
 from ipatests.test_xmlrpc.test_user_plugin import get_user_result
 from ipatests.test_xmlrpc.test_group_plugin import get_group_dn
@@ -216,10 +217,7 @@ class test_idviews(Declarative):
                     u'Test',
                     u'User1',
                     'add',
-                    objectclass=add_oc(
-                        objectclasses.user,
-                        u'ipantuserattrs'
-                    )
+                    objectclass=objectclasses.user,
                 ),
             ),
         ),
@@ -237,7 +235,8 @@ class test_idviews(Declarative):
                 result=dict(
                     cn=[idoverridegroup1],
                     description=[u'Test desc 1'],
-                    objectclass=objectclasses.posixgroup,
+                    objectclass=fuzzy_set_optional_oc(
+                        objectclasses.posixgroup, 'ipantgroupattrs'),
                     ipauniqueid=[fuzzy_uuid],
                     gidnumber=[fuzzy_digits],
                     dn=get_group_dn(idoverridegroup1),
@@ -1624,10 +1623,7 @@ class test_idviews(Declarative):
                     u'Removed',
                     u'User',
                     'add',
-                    objectclass=add_oc(
-                        objectclasses.user,
-                        u'ipantuserattrs'
-                    )
+                    objectclass=objectclasses.user,
                 ),
             ),
         ),
@@ -1645,7 +1641,8 @@ class test_idviews(Declarative):
                 result=dict(
                     cn=[idoverridegroup_removed],
                     description=[u'Removed group'],
-                    objectclass=objectclasses.posixgroup,
+                    objectclass=fuzzy_set_optional_oc(
+                        objectclasses.posixgroup, 'ipantgroupattrs'),
                     ipauniqueid=[fuzzy_uuid],
                     gidnumber=[fuzzy_digits],
                     dn=get_group_dn(idoverridegroup_removed),

--- a/ipatests/test_xmlrpc/test_kerberos_principal_aliases.py
+++ b/ipatests/test_xmlrpc/test_kerberos_principal_aliases.py
@@ -19,7 +19,7 @@ from ipatests.test_xmlrpc.tracker.host_plugin import HostTracker
 from ipatests.test_xmlrpc.tracker.service_plugin import ServiceTracker
 from ipatests.test_xmlrpc.tracker.stageuser_plugin import StageUserTracker
 from ipatests.test_xmlrpc.mock_trust import (
-    mocked_trust_containers, get_trust_dn, get_trusted_dom_dict,
+    get_trust_dn, get_trusted_dom_dict,
     encode_mockldap_value)
 from ipatests.util import unlock_principal_password, change_principal
 
@@ -62,7 +62,7 @@ def trusted_domain():
     trusted_dom = TRUSTED_DOMAIN_MOCK
 
     # Write the changes
-    with mocked_trust_containers(), MockLDAP() as ldap:
+    with MockLDAP() as ldap:
         ldap.add_entry(trusted_dom['dn'], trusted_dom['ldif'])
         yield trusted_dom
         ldap.del_entry(trusted_dom['dn'])
@@ -83,7 +83,7 @@ def trusted_domain_with_suffix():
     )
 
     # Write the changes
-    with mocked_trust_containers(), MockLDAP() as ldap:
+    with MockLDAP() as ldap:
         ldap.add_entry(trusted_dom['dn'], trusted_dom['ldif'])
         yield trusted_dom
         ldap.del_entry(trusted_dom['dn'])

--- a/ipatests/test_xmlrpc/test_netgroup_plugin.py
+++ b/ipatests/test_xmlrpc/test_netgroup_plugin.py
@@ -24,6 +24,7 @@ Test the `ipaserver/plugins/netgroup.py` module.
 from ipalib import api
 from ipalib import errors
 from ipatests.test_xmlrpc.xmlrpc_test import (Declarative, fuzzy_digits,
+                                              fuzzy_set_optional_oc,
                                               fuzzy_uuid, fuzzy_netgroupdn)
 from ipatests.test_xmlrpc import objectclasses
 from ipapython.dn import DN
@@ -300,7 +301,8 @@ class test_netgroup(Declarative):
                     cn=[group1],
                     description=[u'Test desc 1'],
                     gidnumber=[fuzzy_digits],
-                    objectclass=objectclasses.group + [u'posixgroup'],
+                    objectclass=fuzzy_set_optional_oc(
+                        objectclasses.posixgroup, 'ipantgroupattrs'),
                     ipauniqueid=[fuzzy_uuid],
                     dn=DN(('cn',group1),('cn','groups'),('cn','accounts'),
                           api.env.basedn),

--- a/ipatests/test_xmlrpc/test_range_plugin.py
+++ b/ipatests/test_xmlrpc/test_range_plugin.py
@@ -503,7 +503,6 @@ class test_range(Declarative):
                     uidnumber=[unicode(user1_uid)],
                     gidnumber=[unicode(user1_uid)],
                     objectclass=objectclasses.user_base + [u'mepOriginEntry'],
-                    omit=['ipantsecurityidentifier'],
                 ),
             ),
         ),

--- a/ipatests/test_xmlrpc/test_range_plugin.py
+++ b/ipatests/test_xmlrpc/test_range_plugin.py
@@ -502,6 +502,8 @@ class test_range(Declarative):
                     user1, u'Test', u'User1', 'add',
                     uidnumber=[unicode(user1_uid)],
                     gidnumber=[unicode(user1_uid)],
+                    objectclass=objectclasses.user_base + [u'mepOriginEntry'],
+                    omit=['ipantsecurityidentifier'],
                 ),
             ),
         ),

--- a/ipatests/test_xmlrpc/test_selinuxusermap_plugin.py
+++ b/ipatests/test_xmlrpc/test_selinuxusermap_plugin.py
@@ -25,6 +25,7 @@ from ipaplatform.constants import constants as platformconstants
 
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.test_xmlrpc.xmlrpc_test import (Declarative, fuzzy_digits,
+                                              fuzzy_set_optional_oc,
                                               fuzzy_uuid)
 from ipapython.dn import DN
 from ipatests.util import Fuzzy
@@ -230,7 +231,8 @@ class test_selinuxusermap(Declarative):
                     cn=[group1],
                     description=[u'Test desc 1'],
                     gidnumber=[fuzzy_digits],
-                    objectclass=objectclasses.group + [u'posixgroup'],
+                    objectclass=fuzzy_set_optional_oc(
+                        objectclasses.posixgroup, 'ipantgroupattrs'),
                     ipauniqueid=[fuzzy_uuid],
                     dn=DN(('cn', group1), ('cn', 'groups'), ('cn', 'accounts'),
                           api.env.basedn),

--- a/ipatests/test_xmlrpc/test_service_plugin.py
+++ b/ipatests/test_xmlrpc/test_service_plugin.py
@@ -25,6 +25,7 @@ from ipalib import api, errors
 from ipatests.test_xmlrpc.xmlrpc_test import Declarative, fuzzy_uuid, fuzzy_hash
 from ipatests.test_xmlrpc.xmlrpc_test import fuzzy_digits, fuzzy_date, fuzzy_issuer
 from ipatests.test_xmlrpc.xmlrpc_test import fuzzy_hex, XMLRPC_test
+from ipatests.test_xmlrpc.xmlrpc_test import fuzzy_set_optional_oc
 from ipatests.test_xmlrpc.xmlrpc_test import raises_exact
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.test_xmlrpc.testcert import get_testcert, subject_base
@@ -1113,7 +1114,8 @@ class test_service_allowed_to(Declarative):
                 summary=u'Added group "%s"' % group1,
                 result=dict(
                     cn=[group1],
-                    objectclass=objectclasses.group + [u'posixgroup'],
+                    objectclass=fuzzy_set_optional_oc(
+                        objectclasses.posixgroup, 'ipantgroupattrs'),
                     ipauniqueid=[fuzzy_uuid],
                     gidnumber=[fuzzy_digits],
                     dn=group1_dn
@@ -1165,7 +1167,8 @@ class test_service_allowed_to(Declarative):
                 summary=u'Added group "%s"' % group2,
                 result=dict(
                     cn=[group2],
-                    objectclass=objectclasses.group + [u'posixgroup'],
+                    objectclass=fuzzy_set_optional_oc(
+                        objectclasses.posixgroup, 'ipantgroupattrs'),
                     ipauniqueid=[fuzzy_uuid],
                     gidnumber=[fuzzy_digits],
                     dn=group2_dn

--- a/ipatests/test_xmlrpc/test_trust_plugin.py
+++ b/ipatests/test_xmlrpc/test_trust_plugin.py
@@ -27,6 +27,7 @@ from ipapython.dn import DN
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.test_xmlrpc.xmlrpc_test import (
     Declarative, fuzzy_guid, fuzzy_domain_sid, fuzzy_string, fuzzy_uuid,
+    fuzzy_set_optional_oc,
     fuzzy_digits)
 import pytest
 
@@ -110,7 +111,8 @@ class test_trustconfig(Declarative):
                     cn=[testgroup],
                     description=[u'Test group'],
                     gidnumber=[fuzzy_digits],
-                    objectclass=objectclasses.group + [u'posixgroup'],
+                    objectclass=fuzzy_set_optional_oc(
+                        objectclasses.posixgroup, 'ipantgroupattrs'),
                     ipauniqueid=[fuzzy_uuid],
                     dn=testgroup_dn,
                 ),

--- a/ipatests/test_xmlrpc/test_user_plugin.py
+++ b/ipatests/test_xmlrpc/test_user_plugin.py
@@ -1182,6 +1182,9 @@ def get_user_result(uid, givenname, sn, operation='show', omit=[],
             objectclass=objectclasses.user,
             krbprincipalname=[u'%s@%s' % (uid, api.env.realm)],
             krbcanonicalname=[u'%s@%s' % (uid, api.env.realm)],
+        )
+    if operation == 'show-all':
+        result.update(
             ipantsecurityidentifier=[fuzzy_user_or_group_sid],
         )
     if operation in ('show', 'show-all', 'find', 'mod'):

--- a/ipatests/test_xmlrpc/tracker/group_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/group_plugin.py
@@ -4,6 +4,8 @@
 
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.test_xmlrpc.xmlrpc_test import fuzzy_digits, fuzzy_uuid
+from ipatests.test_xmlrpc.xmlrpc_test import fuzzy_user_or_group_sid
+from ipatests.test_xmlrpc.xmlrpc_test import fuzzy_set_optional_oc
 
 from ipatests.test_xmlrpc.tracker.base import Tracker
 from ipatests.util import assert_deepequal, get_group_dn
@@ -21,9 +23,10 @@ class GroupTracker(Tracker):
         'idoverrideuser'
     }
 
-    retrieve_all_keys = retrieve_keys | {u'ipauniqueid', u'objectclass'}
+    retrieve_all_keys = retrieve_keys | {u'ipauniqueid', u'objectclass',
+                                         'ipantsecurityidentifier'}
 
-    create_keys = retrieve_all_keys
+    create_keys = retrieve_all_keys - {u'ipantsecurityidentifier'}
     update_keys = retrieve_keys - {u'dn'}
 
     add_member_keys = retrieve_keys | {u'description'}
@@ -91,7 +94,9 @@ class GroupTracker(Tracker):
             description=[self.description],
             gidnumber=[fuzzy_digits],
             ipauniqueid=[fuzzy_uuid],
-            objectclass=objectclasses.posixgroup,
+            objectclass=fuzzy_set_optional_oc(
+                objectclasses.posixgroup, 'ipantgroupattrs'),
+            ipantsecurityidentifier=[fuzzy_user_or_group_sid],
             )
         self.exists = True
 

--- a/ipatests/test_xmlrpc/tracker/user_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/user_plugin.py
@@ -11,7 +11,7 @@ import six
 from ipatests.util import assert_deepequal, get_group_dn
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.test_xmlrpc.xmlrpc_test import (
-    fuzzy_digits, fuzzy_uuid, raises_exact)
+    fuzzy_digits, fuzzy_uuid, fuzzy_user_or_group_sid, raises_exact)
 from ipatests.test_xmlrpc.tracker.base import Tracker
 from ipatests.test_xmlrpc.tracker.kerberos_aliases import KerberosAliasMixin
 from ipatests.test_xmlrpc.tracker.certmapdata import CertmapdataMixin
@@ -40,7 +40,8 @@ class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
         u'l', u'mobile', u'krbextradata', u'krblastpwdchange',
         u'krbpasswordexpiration', u'pager', u'st', u'manager', u'cn',
         u'ipauniqueid', u'objectclass', u'mepmanagedentry',
-        u'displayname', u'gecos', u'initials', u'preserved'}
+        u'displayname', u'gecos', u'initials', u'preserved',
+        'ipantsecurityidentifier'}
 
     retrieve_preserved_keys = (retrieve_keys - {u'memberof_group'}) | {
         u'preserved'}
@@ -122,7 +123,8 @@ class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
                 api.env.container_deleteuser,
                 api.env.basedn
                 )
-            self.attrs[u'objectclass'] = objectclasses.user_base
+            self.attrs[u'objectclass'] = objectclasses.user_base \
+                + ['ipantuserattrs']
 
         return self.make_command(
             'user_del', self.uid,
@@ -188,6 +190,7 @@ class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
             mepmanagedentry=[get_group_dn(self.uid)],
             memberof_group=[u'ipausers'],
             nsaccountlock=[u'false'],
+            ipantsecurityidentifier=[fuzzy_user_or_group_sid],
             )
 
         for key in self.kwargs:

--- a/ipatests/test_xmlrpc/tracker/user_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/user_plugin.py
@@ -11,6 +11,7 @@ import six
 from ipatests.util import assert_deepequal, get_group_dn
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.test_xmlrpc.xmlrpc_test import (
+    fuzzy_set_optional_oc,
     fuzzy_digits, fuzzy_uuid, fuzzy_user_or_group_sid, raises_exact)
 from ipatests.test_xmlrpc.tracker.base import Tracker
 from ipatests.test_xmlrpc.tracker.kerberos_aliases import KerberosAliasMixin
@@ -51,6 +52,7 @@ class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
         u'krbextradata', u'krbpasswordexpiration', u'krblastpwdchange',
         u'krbprincipalkey', u'userpassword', u'randompassword'}
     create_keys = create_keys - {u'nsaccountlock'}
+    create_keys = create_keys - {'ipantsecurityidentifier'}
 
     update_keys = retrieve_keys - {u'dn'}
     activate_keys = retrieve_keys
@@ -175,7 +177,8 @@ class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
             displayname=[u'%s %s' % (self.givenname, self.sn)],
             cn=[u'%s %s' % (self.givenname, self.sn)],
             initials=[u'%s%s' % (self.givenname[0], self.sn[0])],
-            objectclass=objectclasses.user,
+            objectclass=fuzzy_set_optional_oc(
+                objectclasses.user, 'ipantuserattrs'),
             description=[u'__no_upg__'],
             ipauniqueid=[fuzzy_uuid],
             uidnumber=[fuzzy_digits],

--- a/ipatests/test_xmlrpc/xmlrpc_test.py
+++ b/ipatests/test_xmlrpc/xmlrpc_test.py
@@ -137,6 +137,12 @@ fuzzy_bytes = Fuzzy(type=bytes)
 def fuzzy_set_ci(s):
     return Fuzzy(test=lambda other: set(x.lower() for x in other) == set(y.lower() for y in s))
 
+
+def fuzzy_set_optional_oc(s, oc):
+    return Fuzzy(test=lambda other: set(x.lower() for x in other if x != oc)
+                 == set(y.lower() for y in s if y != oc))
+
+
 try:
     if not api.Backend.rpcclient.isconnected():
         api.Backend.rpcclient.connect()
@@ -150,12 +156,6 @@ except errors.NotFound:
 
 adtrust_is_enabled = api.Command['adtrust_is_enabled']()['result']
 sidgen_was_run = api.Command['sidgen_was_run']()['result']
-
-
-def add_sid(d, check_sidgen=False):
-    if adtrust_is_enabled and (not check_sidgen or sidgen_was_run):
-        d['ipantsecurityidentifier'] = (fuzzy_user_or_group_sid,)
-    return d
 
 
 def add_oc(l, oc, check_sidgen=False):

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -155,6 +155,9 @@ manage_dirs_pattern(ipa_helper_t, ipa_var_run_t, ipa_var_run_t)
 manage_files_pattern(ipa_helper_t, ipa_var_run_t, ipa_var_run_t)
 files_pid_filetrans(ipa_helper_t, ipa_var_run_t, { dir file })
 
+manage_files_pattern(ipa_helper_t, ipa_tmp_t, ipa_tmp_t)
+files_tmp_filetrans(ipa_helper_t, ipa_tmp_t, { file })
+
 kernel_read_system_state(ipa_helper_t)
 kernel_read_network_state(ipa_helper_t)
 


### PR DESCRIPTION
This is a manual backport of PR #6045 to ipa-4-9 branch.

There was a conflict on VERSION.m4 file because ipa-4-9 doesn't contain the `make sudorule option multivalue` update.