### PR TITLE
ipatests: update packages in rawhide test test_installation_client.py

### DIFF
--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1220,6 +1220,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
         test_suite: test_integration/test_installation_client.py
         template: *ci-master-frawhide
         timeout: 3600


### PR DESCRIPTION
The test definition is missing the instruction to update
the packages.

Fixes: https://pagure.io/freeipa/issue/9035
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>