### PR TITLE
freeipa.spec.in: -server subpackage should require samba-client-libs

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1,3 +1,5 @@
+%define ipa_requires_gt()  %(LC_ALL="C" echo '%*' | xargs -r rpm -q --qf 'Requires: %%{name} >= %%{epoch}:%%{version}-%%{release}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not")
+
 # ipatests enabled by default, can be disabled with --without ipatests
 %bcond_without ipatests
 # default to not use XML-RPC in Rawhide, can be turned around with --with ipa_join_xml
@@ -473,6 +475,8 @@ Requires: gssproxy >= 0.7.0-2
 Requires: sssd-dbus >= %{sssd_version}
 Requires: libpwquality
 Requires: cracklib-dicts
+# NDR libraries are internal in Samba and change with version without changing SONAME
+%ipa_requires_gt samba-client-libs
 
 Provides: %{alt_name}-server = %{version}
 Conflicts: %{alt_name}-server


### PR DESCRIPTION
KDB driver extensively uses NDR parsing and marshalling code provided by
Samba libraries. Since these libraries are internal to Samba, they often
change structures without updating SONAME. Typical changes include
adding new structures, so we should require samba-client-libs we were
built against.

Related: https://pagure.io/freeipa/issue/9031

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>