### PR TITLE
fix(webui): create correct PTR record when navigated from host page

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1,3 +1,5 @@
+%define ipa_requires_gt()  %(LC_ALL="C" echo '%*' | xargs -r rpm -q --qf 'Requires: %%{name} >= %%{epoch}:%%{version}-%%{release}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not")
+
 # ipatests enabled by default, can be disabled with --without ipatests
 %bcond_without ipatests
 # default to not use XML-RPC in Rawhide, can be turned around with --with ipa_join_xml
@@ -473,6 +475,8 @@ Requires: gssproxy >= 0.7.0-2
 Requires: sssd-dbus >= %{sssd_version}
 Requires: libpwquality
 Requires: cracklib-dicts
+# NDR libraries are internal in Samba and change with version without changing SONAME
+%ipa_requires_gt samba-client-libs
 
 Provides: %{alt_name}-server = %{version}
 Conflicts: %{alt_name}-server

--- a/install/ui/src/freeipa/host.js
+++ b/install/ui/src/freeipa/host.js
@@ -840,7 +840,22 @@ IPA.host_dnsrecord_entity_link_widget = function(spec) {
         var first_dot = pkey.search(/\./);
         var pkeys = [];
         pkeys[1] = pkey.substring(0,first_dot);
-        pkeys[0] = pkey.substring(first_dot+1);
+        var dnszone = pkey.substring(first_dot+1);
+        pkeys[0] = dnszone;
+
+        // Check whether DNS record associated with the host belongs to a
+        // fully qualified DNS zone (has trailing '.'). If so, modify the
+        // pkey to be correct in the link.
+        if (that.check_data && dnszone[dnszone.length-1] !== '.') {
+            var avas = that.check_data.dn.split(',');
+            for (var i=0, j=avas.length; i<j; i++) {
+                var ava = avas[i];
+                if (ava.indexOf('idnsname') === 0 && ava.indexOf(dnszone + '.') > 0) {
+                    pkeys[0] = dnszone + '.';
+                }
+            }
+        }
+
         return pkeys;
     };
 

--- a/install/ui/src/freeipa/widget.js
+++ b/install/ui/src/freeipa/widget.js
@@ -5223,6 +5223,9 @@ IPA.link_widget = function(spec) {
             retry: false,
             on_success: function(data) {
                 that.is_link = data.result && data.result.result;
+                if (that.is_link) {
+                    that.check_data = data.result.result;
+                }
                 that.update_link();
             },
             on_error: function() {

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -30,8 +30,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f34
-          version: 0.0.5
+          name: freeipa/ci-master-f35
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f34
-          version: 0.0.5
+          name: freeipa/ci-master-f35
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -34,7 +34,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &389ds-master-latest
-          name: freeipa/389ds-master-f34
+          name: freeipa/389ds-master-f35
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -38,7 +38,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &pki-master-latest
-          name: freeipa/pki-master-f34
+          name: freeipa/pki-master-f35
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f34
-          version: 0.0.5
+          name: freeipa/ci-master-f35
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &testing-master-latest
-          name: freeipa/testing-master-f34
+          name: freeipa/testing-master-f35
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &testing-master-latest
-          name: freeipa/testing-master-f34
+          name: freeipa/testing-master-f35
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-previous
-          name: freeipa/ci-master-f33
-          version: 0.0.11
+          name: freeipa/ci-master-f34
+          version: 0.0.7
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-frawhide
           name: freeipa/ci-master-frawhide
-          version: 0.5.1
+          version: 0.5.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -56,8 +56,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f34
-          version: 0.0.5
+          name: freeipa/ci-master-f35
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -582,6 +582,9 @@ class TestInstallWithCA_DNS3(CALessBase):
     ticket 7239
     """
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora' and osinfo.version_number >= (33,),
+        reason='freeipa ticket 8700', strict=True)
     @server_install_setup
     def test_number_of_zones(self):
         """There should be two zones: one forward, one reverse"""

--- a/ipatests/test_webui/test_dns.py
+++ b/ipatests/test_webui/test_dns.py
@@ -24,7 +24,7 @@ DNS tests
 from ipatests.test_webui.ui_driver import UI_driver
 from ipatests.test_webui.ui_driver import screenshot
 from ipatests.test_webui.data_dns import (
-    ZONE_ENTITY, FORWARD_ZONE_ENTITY, CONFIG_ENTITY,
+    ZONE_ENTITY, FORWARD_ZONE_ENTITY, CONFIG_ENTITY, RECORD_ENTITY,
     ZONE_DEFAULT_FACET, ZONE_PKEY, ZONE_DATA, FORWARD_ZONE_PKEY,
     FORWARD_ZONE_DATA, RECORD_PKEY, A_IP, RECORD_ADD_DATA, RECORD_MOD_DATA,
     CONFIG_MOD_DATA
@@ -113,3 +113,69 @@ class test_dns(UI_driver):
         self.init_app()
         self.navigate_by_menu('network_services/dns/dnsconfig')
         self.mod_record(CONFIG_ENTITY, CONFIG_MOD_DATA)
+
+    def test_ptr_from_host_creation(self):
+        """
+        Test scenario for RHBZ 2009114 - a PTR record is created correctly
+        with trailing dot when navigated to DNS Records page from host details
+        page.
+        """
+        self.init_app()
+
+        zone = "ptrzone.test."
+        reverse_zone = "12.168.192.in-addr.arpa."
+        hostname = "server"
+        fqdn = "server.ptrzone.test"
+        dns_fqdn = fqdn + "."
+        ip = "192.168.12.20"
+        zone_add_data = {
+            "add": [
+                ("textbox", "idnsname", zone),
+            ],
+        }
+        reverse_zone_add_data = {
+            "add": [
+                ("radio", "dnszone_name_type", "name_from_ip"),
+                ("textbox", "name_from_ip", ip + "/24"),
+            ],
+        }
+        record_add_data = {
+            "add": [
+                ("textbox", "idnsname", "server"),
+                ("textbox", "a_part_ip_address", ip),
+            ]
+        }
+        host_add_data = {
+            "add": [
+                ("textbox", "hostname", hostname),
+                ("combobox", "dnszone", zone),
+            ],
+        }
+
+        # Create needed DNS zones and record
+        self.add_record(ZONE_ENTITY, zone_add_data, navigate=True)
+        self.add_record(ZONE_ENTITY, reverse_zone_add_data, navigate=False)
+        self.navigate_to_record(zone)
+        self.add_record(ZONE_ENTITY, record_add_data,
+                        facet=ZONE_DEFAULT_FACET)
+
+        # Create host record
+        self.navigate_by_menu("identity/host")
+        self.add_record("host", host_add_data, navigate=False)
+        self.navigate_to_record(fqdn)
+        self.click_on_link(fqdn)
+        self.wait_for_request(n=2, d=0.5)
+        self.assert_facet(RECORD_ENTITY, "details")
+        self.click_on_link(ip)
+        self.wait_for_request(n=2, d=0.5)
+        self.assert_dialog()
+        self.click_on_link("Create dns record")
+        self.wait_for_request(n=3, d=0.5)
+        self.assert_facet(RECORD_ENTITY, "details")
+        self.assert_record(dns_fqdn, table_name="ptrrecord")
+
+        # Cleanup
+        self.navigate_to_entity(ZONE_ENTITY)
+        self.delete_record([zone, reverse_zone])
+        self.navigate_to_entity("host")
+        self.delete_record([fqdn])

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -1056,7 +1056,7 @@ class UI_driver:
 
         # Chrome does not close search area on click
         if list_cnt.is_displayed():
-            self.driver.switch_to_active_element().send_keys(Keys.RETURN)
+            self.driver.switch_to.active_element.send_keys(Keys.RETURN)
 
         self.wait()
 

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -1460,10 +1460,6 @@ class UI_driver:
 
         last_element = data[len(data) - 1]
 
-        pkeys = []
-
-        for record in data:
-            pkeys.append(record['pkey'])
         if navigate:
             self.navigate_to_entity(entity, facet)
 


### PR DESCRIPTION

In scenario:
1. make sure that reverse zone doesn't have the desired PTR record
2. open host page of the host with matchnig the A record, e.g.: https://server.pvoborni.test/ipa/ui/#/e/host/details/test2.pvoborni.test
3. click on the "Host name" link, it will bring us to it's DNS record page. E.g., https://server.pvoborni.test/ipa/ui/#/e/dnsrecord/details/pvoborni.test&test2
! notice the missing '.' in the URL after zone name (pvoborni.test)
4. click on the A record , dialog will show up, saying "record not found"
5. click on the "create DNS record"

PTR record created by Web UI doesn't have trailing '.' (is not fully
qualified record) even if the DNS zone is.

This patch is fixing the link to the DNS Record page so that the
page then correctly gets the DNS Zone name and thus creates a correct
fully qualified PTR record.

https://bugzilla.redhat.com/show_bug.cgi?id=2009114
https://pagure.io/freeipa/issue/9036

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>