### PR TITLE
pwpolicy: change lifetime error message

### DIFF
--- a/ipaserver/plugins/pwpolicy.py
+++ b/ipaserver/plugins/pwpolicy.py
@@ -491,7 +491,10 @@ class pwpolicy(LDAPObject):
             if minlife > maxlife:
                 raise errors.ValidationError(
                     name='maxlife',
-                    error=_('Maximum password life must be greater than minimum.'),
+                    error=_(
+                        "Maximum password life must be equal to "
+                        "or greater than the minimum."
+                    ),
                 )
 
     def add_cospriority(self, entry, pwpolicy_name, rights=True):


### PR DESCRIPTION
ipa pwpolicy-mod --minlife $min --maxlife $max
accepts $max >= $min, yet the error message says:
"Maximum password life must be greater than minimum."

Change the error message so that it conveys the
actual logic.

Fixes: https://pagure.io/freeipa/issue/9038
Signed-off-by: François Cami <fcami@redhat.com>