### PR TITLE
[master] ipatests: Bump PR-CI latest templates to Fedora 35

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -30,8 +30,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f34
-          version: 0.0.5
+          name: freeipa/ci-master-f35
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f34
-          version: 0.0.5
+          name: freeipa/ci-master-f35
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -34,7 +34,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &389ds-master-latest
-          name: freeipa/389ds-master-f34
+          name: freeipa/389ds-master-f35
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -38,7 +38,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &pki-master-latest
-          name: freeipa/pki-master-f34
+          name: freeipa/pki-master-f35
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f34
-          version: 0.0.5
+          name: freeipa/ci-master-f35
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &testing-master-latest
-          name: freeipa/testing-master-f34
+          name: freeipa/testing-master-f35
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &testing-master-latest
-          name: freeipa/testing-master-f34
+          name: freeipa/testing-master-f35
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-previous
-          name: freeipa/ci-master-f33
-          version: 0.0.11
+          name: freeipa/ci-master-f34
+          version: 0.0.7
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-frawhide
           name: freeipa/ci-master-frawhide
-          version: 0.5.1
+          version: 0.5.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -56,8 +56,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f34
-          version: 0.0.5
+          name: freeipa/ci-master-f35
+          version: 0.0.2
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Moving 'latest' to Fedora 35 and 'previous' to Fedora 34.
Update Rawhide template.

Based on https://github.com/freeipa/freeipa-pr-ci/pull/445.

Signed-off-by: Armando Neto <abiagion@redhat.com>

---

ipa-4-9: https://github.com/freeipa/freeipa/pull/6088