### PR TITLE
[ipa-4-9] ipatests: Bump PR-CI latest templates to Fedora 35

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -30,8 +30,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
-          name: freeipa/ci-ipa-4-9-f34
-          version: 0.0.3
+          name: freeipa/ci-ipa-4-9-f35
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
-          name: freeipa/ci-ipa-4-9-f34
-          version: 0.0.3
+          name: freeipa/ci-ipa-4-9-f35
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
-          name: freeipa/ci-ipa-4-9-f34
-          version: 0.0.3
+          name: freeipa/ci-ipa-4-9-f35
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -50,8 +50,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-previous
-          name: freeipa/ci-ipa-4-9-f33
-          version: 0.0.7
+          name: freeipa/ci-ipa-4-9-f34
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -56,8 +56,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
-          name: freeipa/ci-ipa-4-9-f34
-          version: 0.0.3
+          name: freeipa/ci-ipa-4-9-f35
+          version: 0.0.1
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Moving 'latest' to Fedora 35 and 'previous' to Fedora 34.

Based on https://github.com/freeipa/freeipa-pr-ci/pull/445.

Signed-off-by: Armando Neto <abiagion@redhat.com>

---
master: https://github.com/freeipa/freeipa/pull/6087