### PR TITLE
ipatests: Fix UI_driver method after Selenium upgrade

### DIFF
--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -1056,7 +1056,7 @@ class UI_driver:
 
         # Chrome does not close search area on click
         if list_cnt.is_displayed():
-            self.driver.switch_to_active_element().send_keys(Keys.RETURN)
+            self.driver.switch_to.active_element.send_keys(Keys.RETURN)
 
         self.wait()
 


### PR DESCRIPTION
`WebDriver.switch_to_active_element()` was deprecated in favour of `driver.switch_to.active_element`.

Method was deprecated a long time ago; however, deprecation message and proxy method were removed recently and are not present in latest version.

* https://selenium-python.readthedocs.io/api.html#selenium.webdriver.remote.webdriver.WebDriver.switch_to_active_element
* https://www.selenium.dev/selenium/docs/api/py/webdriver_remote/selenium.webdriver.remote.webdriver.html#selenium.webdriver.remote.webdriver.WebDriver.switch_to

Issue: https://pagure.io/freeipa/issue/9029