### PR TITLE
ipatests: mark test_installation_TestInstallWithCA_DNS3 as xfail

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -582,6 +582,9 @@ class TestInstallWithCA_DNS3(CALessBase):
     ticket 7239
     """
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora' and osinfo.version_number >= (33,),
+        reason='freeipa ticket 8700', strict=True)
     @server_install_setup
     def test_number_of_zones(self):
         """There should be two zones: one forward, one reverse"""


### PR DESCRIPTION
The test failure is a known issue, happening on f33+. Mark as xfail
until 8700 is fixed.

Related: https://pagure.io/freeipa/issue/8700
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>