### PR TITLE
subid: test with podman

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_subids:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_subids.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -47,7 +47,7 @@ topologies:
     memory: 14500
 
 jobs:
-  fedora-latest/build:
+  fedora-rawhide/build:
     requires: []
     priority: 100
     job:
@@ -55,20 +55,21 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-latest
-          name: freeipa/ci-master-f35
-          version: 0.0.2
+        template: &ci-master-frawhide
+          name: freeipa/ci-master-frawhide
+          version: 0.5.2
         timeout: 1800
         topology: *build
 
-  fedora-latest/test_subids:
-    requires: [fedora-latest/build]
+  fedora-rawhide/test_subids:
+    requires: [fedora-rawhide/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-latest/build_url}'
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
         test_suite: test_integration/test_subids.py
-        template: *ci-master-latest
+        template: *ci-master-frawhide
         timeout: 3600
         topology: *master_1repl

--- a/ipatests/test_integration/test_subids.py
+++ b/ipatests/test_integration/test_subids.py
@@ -157,6 +157,10 @@ class TestSubordinateId(IntegrationTest):
         info = self.assert_subid(uid, match=True)
         subuid = info["ipasubuidnumber"]
 
+        # debug
+        print("subuid: {subuid}".format(subuid=str(subuid)))
+        # end debug
+
         # add "subid: sss" to nsswitch.conf to use SSSD as subid provider
         nsswitch_conf = self.master.get_file_contents(
             paths.NSSWITCH_CONF,
@@ -173,13 +177,21 @@ class TestSubordinateId(IntegrationTest):
                 "apply-changes"
             ])
 
+        # debug
+        conf = self.master.get_file_contents(
+            "/etc/nsswitch.conf",
+            encoding="utf-8"
+        )
+        print(conf)
+        # end debug
+
         # install podman
         tasks.install_packages(self.master, ["podman"])
 
         # these two commands:
         # - retrieve subids
         # - must be executed as the user owning the subids
-        # Warning: "su" will not cut it, only ssh will
+        # Warning: "su" will not cut it
         cmds = (
             "podman unshare cat /proc/self/uid_map",
             "podman unshare cat /proc/self/gid_map"
@@ -193,6 +205,10 @@ class TestSubordinateId(IntegrationTest):
                 password=passwd,
                 verbose=True
             )
+            # debug
+            print(result[1])
+            print(result[2])
+            # end debug
             assert result[0] == 0
             assert "65536" in result[1]
             assert str(subuid) in result[1]

--- a/ipatests/test_integration/test_subids.py
+++ b/ipatests/test_integration/test_subids.py
@@ -6,9 +6,12 @@
 """
 import os
 
+import pytest
+
 from ipalib.constants import (
     SUBID_COUNT, SUBID_RANGE_START, SUBID_RANGE_MAX, SUBID_DNA_THRESHOLD
 )
+from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipatests.pytest_ipa.integration import tasks
@@ -135,6 +138,11 @@ class TestSubordinateId(IntegrationTest):
             match = self._parse_result(result)
             self.assert_subid_info(uid, match)
 
+    @pytest.mark.xfail(
+        osinfo.id == "fedora" and osinfo.version_number <= (34,),
+        reason='shadow-utils-subid is shipped in f35+',
+        strict=True
+    )
     def test_podman(self):
         """
         Test that podman can retrieve subuid+subgid created for a user.


### PR DESCRIPTION
podman can leverage FreeIPA-managed subids provided:
- nsswitch.conf contains "subid: sss"
- a real session is opened for that user (not su)

podman provides also a way to test whether subids can be retrieved:
$ podman unshare cat /proc/self/uid_map
$ podman unshare cat /proc/self/gid_map

Fixes: TBD
Signed-off-by: François Cami <fcami@redhat.com>