### PR TITLE
[Backport][ipa-4-9] ipatests: Fix UI_driver method after Selenium upgrade

### DIFF
--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -1057,7 +1057,7 @@ class UI_driver:
 
         # Chrome does not close search area on click
         if list_cnt.is_displayed():
-            self.driver.switch_to_active_element().send_keys(Keys.RETURN)
+            self.driver.switch_to.active_element.send_keys(Keys.RETURN)
 
         self.wait()
 


### PR DESCRIPTION
This PR was opened automatically because PR #6089 was pushed to master and backport to ipa-4-9 is required.