### PR TITLE
Remove duplicate _() in the error path

### DIFF
--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -479,7 +479,7 @@ class server_del(LDAPDelete):
                     )
                 )
             else:
-                raise errors.ServerRemovalError(reason=_(msg))
+                raise errors.ServerRemovalError(reason=msg)
 
         ipa_config = self.api.Command.config_show()['result']
 


### PR DESCRIPTION
When running IPA in locale de_DE.UTF-8 I got an internal error:

jochen@freeipa1:~$ ipa server-del freeipa4.example.org
Removing freeipa4.example.org from replication topology, please wait...
ipa: ERROR: Ein interner Fehler ist aufgetreten

This is not the complete messages. Using en_US.UTF-8 would be ok.
In the httpd error_log:

] ipa: ERROR: non-public: TypeError: unhashable type: 'Gettext'
] Traceback (most recent call last):
]   File "/usr/lib/python3.10/site-packags/ipaserver/rpcserver.py", line 407, in wsgi_execute
]     result = command(*args, **options)
]   File "/usr/lib/python3.10/site-packages/ipalib/frontend.py", line 471, in __call__
]     return self.__do_call(*args, **options)
]   File "/usr/lib/python3.10/site-packages/ipalib/frontend.py", line 499, in __do_call
]     ret = self.run(*args, **options)
]   File "/usr/lib/python3.10/site-packages/ipalib/frontend.py", line 821, in run
]     return self.execute(*args, **options)
]   File "/usr/lib/python3.10/site-packages/ipaserver/plugins/baseldap.py", line 1686, in execute]     return self.execute(*args, **options)
]   File "/usr/lib/python3.10/site-packages/ipaserver/plugins/baseldap.py", line 1686, in execute
]     delete_entry(pkey)
]   File "/usr/lib/python3.10/site-packages/ipaserver/plugins/baseldap.py", line 1637, in delete_entry
]     dn = callback(self, ldap, dn, *nkeys, **options)
]   File "/usr/lib/python3.10/site-packages/ipaserver/plugins/server.py", line 755, in pre_callback
]     self._ensure_last_of_role(
] File
"/usr/lib/python3.10/site-packages/ipaserver/plugins/server.py", line
520, in _ensure_last_of_role
]     handler(
]   File "/usr/lib/python3.10/site-packages/ipaserver/plugins/server.py", line 482, in handler
]     raise errors.ServerRemovalError(reason=_(msg))
]   File "/usr/lib/python3.10/site-packages/ipalib/errors.py", line 269, in __init__
]     messages.process_message_arguments(self, format, message, **kw)
]   File "/usr/lib/python3.10/site-packages/ipalib/messages.py", line 55, in process_message_arguments
]     kw[key] = unicode(value)
]   File "/usr/lib/python3.10/site-packages/ipalib/text.py", line 296, in __str__
]     return unicode(self.as_unicode())
]   File "/usr/lib/python3.10/site-packages/ipalib/text.py", line 293, in as_unicode
]     return t.gettext(self.msg)
]   File "/usr/lib64/python3.10/gettext.py", line 498, in gettext
]     tmsg = self._catalog.get(message, missing)
] TypeError: unhashable type: 'Gettext'
] ipa: INFO: [jsonserver_session] admin@EXAMPLE.ORG:
server_del/1(['freeipa4.example.org'], version='2.245'): InternalError

Alexander suggested to remove _() in local handler() function in
_ensure_last_of_role():

            else:
                raise errors.ServerRemovalError(reason=_(msg))

Looks like all the callers give already gettext-enabled message (wrapped
with _() already).

At least for my case I now get a complete error message.