### PR TITLE
[Backport][ipa-4-9] pwpolicy: change lifetime error message

### DIFF
--- a/ipaserver/plugins/pwpolicy.py
+++ b/ipaserver/plugins/pwpolicy.py
@@ -491,7 +491,10 @@ class pwpolicy(LDAPObject):
             if minlife > maxlife:
                 raise errors.ValidationError(
                     name='maxlife',
-                    error=_('Maximum password life must be greater than minimum.'),
+                    error=_(
+                        "Maximum password life must be equal to "
+                        "or greater than the minimum."
+                    ),
                 )
 
     def add_cospriority(self, entry, pwpolicy_name, rights=True):


### PR DESCRIPTION
This PR was opened automatically because PR #6086 was pushed to master and backport to ipa-4-9 is required.