### PR TITLE
Don't limit role-find by hostname when searching for last KRA

### DIFF
--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -509,7 +509,6 @@ class server_del(LDAPDelete):
         if self.api.Command.ca_is_enabled()['result']:
             try:
                 roles = self.api.Command.server_role_find(
-                    server_server=hostname,
                     role_servrole='KRA server',
                     status='enabled',
                     include_master=True,


### PR DESCRIPTION
The "is this the last KRA" test did a role-find including the
current server. This skewed the result if the server to be
removed has a KRA installed, it would always return "not allowed"
because len(roles) == 1 and the name matched, regardless of
whether other servers also provided a KRA.

https://pagure.io/freeipa/issue/8397

Signed-off-by: Rob Crittenden <rcritten@redhat.com>