### PR TITLE
[Backport][ipa-4-9] Don't limit role-find by hostname when searching for last KRA

### DIFF
--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -509,7 +509,6 @@ class server_del(LDAPDelete):
         if self.api.Command.ca_is_enabled()['result']:
             try:
                 roles = self.api.Command.server_role_find(
-                    server_server=hostname,
                     role_servrole='KRA server',
                     status='enabled',
                     include_master=True,


### PR DESCRIPTION
This PR was opened automatically because PR #6101 was pushed to master and backport to ipa-4-9 is required.