### PR TITLE
ipatests: remove xfail on f35+ for test_number_of_zones

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -583,7 +583,8 @@ class TestInstallWithCA_DNS3(CALessBase):
     """
 
     @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (33,),
+        osinfo.id == 'fedora' and osinfo.version_number >= (33,)
+        and osinfo.version_number < (35,),
         reason='freeipa ticket 8700', strict=True)
     @server_install_setup
     def test_number_of_zones(self):


### PR DESCRIPTION
systemd-resolved fixed the issue on f35+
Related: https://pagure.io/freeipa/issue/8700