### PR TITLE
[Backport][ipa-4-9] Remove duplicate _() in the error path

### DIFF
--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -479,7 +479,7 @@ class server_del(LDAPDelete):
                     )
                 )
             else:
-                raise errors.ServerRemovalError(reason=_(msg))
+                raise errors.ServerRemovalError(reason=msg)
 
         ipa_config = self.api.Command.config_show()['result']
 


### PR DESCRIPTION
This PR was opened automatically because PR #6097 was pushed to master and backport to ipa-4-9 is required.