### PR TITLE
Extend test to see if replica is not shown when running `ipa-replica-manage list -v FQDN`

### DIFF
--- a/ipatests/test_integration/test_simple_replication.py
+++ b/ipatests/test_integration/test_simple_replication.py
@@ -111,5 +111,6 @@ class TestSimpleReplication(IntegrationTest):
         # has to be run with --force, there is no --unattended
         self.master.run_command(['ipa-replica-manage', 'del',
                                  self.replicas[0].hostname, '--force'])
-        result = self.master.run_command(['ipa-replica-manage', 'list'])
+        result = self.master.run_command(
+            ['ipa-replica-manage', 'list', '-v', self.master.hostname])
         assert self.replicas[0].hostname not in result.stdout_text


### PR DESCRIPTION


Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>