### PR TITLE
[Backport][ipa-4-9] freeipa.spec: depend on bind-pkcs11-utils

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -576,9 +576,11 @@ Requires: %{name}-server = %{version}-%{release}
 Requires: bind-dyndb-ldap >= 11.2-2
 Requires: bind >= %{bind_version}
 Requires: bind-utils >= %{bind_version}
+# bind-dnssec-utils is required by the OpenDNSSec integration
+# https://pagure.io/freeipa/issue/9026
+Requires: bind-dnssec-utils >= %{bind_version}
 %if %{with bind_pkcs11}
 Requires: bind-pkcs11 >= %{bind_version}
-Requires: bind-pkcs11-utils >= %{bind_version}
 %else
 Requires: softhsm >= %{softhsm_version}
 Requires: openssl-pkcs11 >= %{openssl_pkcs11_version}

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -259,7 +259,7 @@ class BasePathNamespace:
     IPA_PKI_RETRIEVE_KEY = "/usr/libexec/ipa/ipa-pki-retrieve-key"
     IPA_HTTPD_PASSWD_READER = "/usr/libexec/ipa/ipa-httpd-pwdreader"
     IPA_PKI_WAIT_RUNNING = "/usr/libexec/ipa/ipa-pki-wait-running"
-    DNSSEC_KEYFROMLABEL = "/usr/sbin/dnssec-keyfromlabel-pkcs11"
+    DNSSEC_KEYFROMLABEL = "/usr/sbin/dnssec-keyfromlabel"
     GETSEBOOL = "/usr/sbin/getsebool"
     GROUPADD = "/usr/sbin/groupadd"
     USERMOD = "/usr/sbin/usermod"

--- a/ipaplatform/fedora/paths.py
+++ b/ipaplatform/fedora/paths.py
@@ -36,7 +36,6 @@ class FedoraPathNamespace(RedHatPathNamespace):
     NAMED_CRYPTO_POLICY_FILE = "/etc/crypto-policies/back-ends/bind.config"
     if HAS_NFS_CONF:
         SYSCONFIG_NFS = '/etc/nfs.conf'
-    DNSSEC_KEYFROMLABEL = "/usr/sbin/dnssec-keyfromlabel"
 
 
 paths = FedoraPathNamespace()

--- a/ipaserver/dnssec/bindmgr.py
+++ b/ipaserver/dnssec/bindmgr.py
@@ -127,6 +127,7 @@ class BINDMgr:
         )
         cmd = [
             paths.DNSSEC_KEYFROMLABEL,
+            '-E', 'pkcs11',
             '-K', workdir,
             '-a', attrs['idnsSecAlgorithm'][0],
             '-l', uri


### PR DESCRIPTION
This PR was opened automatically because PR #6074 was pushed to master and backport to ipa-4-9 is required.