### PR TITLE
ipatests : local ca is not generated under fips

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_fips.py
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client


### PR DESCRIPTION
Certmonger uses default OpenSSL encryption algorithms
to generate the PKCS12 object used for the local CA.
This uses operations that are disallowed under fips,
and so the local ca pkcs12 creds file is not generated.

Bugzilla Link:  https://bugzilla.redhat.com/show_bug.cgi?id=1950132

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>