### PR TITLE
[Backport][ipa-4-9] PAC fixes for Windows Server November 2021 security release

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -1148,7 +1148,8 @@ static krb5_error_code ipadb_get_pac(krb5_context kcontext,
 #endif
 
 #ifdef HAVE_PAC_REQUESTER_SID
-    {
+    /* MS-KILE 3.3.5.6.4.8: add PAC_REQUESTER_SID only in TGT case */
+    if ((flags & KRB5_KDB_FLAG_CLIENT_REFERRALS_ONLY) != 0) {
         union PAC_INFO pac_requester_sid;
         /* == Package PAC_REQUESTER_SID == */
         memset(&pac_requester_sid, 0, sizeof(pac_requester_sid));


### PR DESCRIPTION
This PR was opened automatically because PR #6113 was pushed to master and backport to ipa-4-9 is required.