### PR TITLE
Remove deprecation warning when installing a CA replica

### DIFF
--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -81,7 +81,6 @@ pki_skip_installation=False
 pki_skip_sd_verify=False
 
 pki_sslserver_token=internal
-pki_ssl_server_token=%(pki_sslserver_token)s
 pki_sslserver_nickname=Server-Cert cert-pki-ca
 pki_sslserver_subject_dn=cn=%(ipa_fqdn)s,%(ipa_subject_base)s
 


### PR DESCRIPTION
I got the following message when installing a replica with CA:

2021-11-22T21:15:35Z DEBUG   [5/30]: configuring certificate server instance

...
WARNING: The 'pki_ssl_server_token' in [CA] has been deprecated. Use 'pki_sslserver_token' instead.
Installation log: /var/log/pki/pki-ca-spawn.20211122221535.log
Installing CA into /var/lib/pki/pki-tomcat.

With the following change the message no longer appears when installing a replica.

Signed-off-by: Jochen Kellner <jochen@jochen.org>