### PR TITLE
[Backport][ipa-4-9] ipatests: fix TestOTPToken::test_check_otpd_after_idle_timeout

### DIFF
--- a/ipatests/test_integration/test_otp.py
+++ b/ipatests/test_integration/test_otp.py
@@ -354,6 +354,9 @@ class TestOTPToken(IntegrationTest):
             otpvalue = totp.generate(int(time.time())).decode("ascii")
             kinit_otp(self.master, USER, password=PASSWORD, otp=otpvalue)
             time.sleep(60)
+            # ldapsearch will wake up slapd and force walking through
+            # the connection list, in order to spot the idle connections
+            tasks.ldapsearch_dm(self.master, "", ldap_args=[], scope="base")
 
             def test_cb(cmd_jornalctl):
                 # check if LDAP connection is timed out


### PR DESCRIPTION
This PR was opened automatically because PR #6119 was pushed to master and backport to ipa-4-9 is required.