### PR TITLE
Added test automation for SHA384withRSA CSR support

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -559,6 +559,18 @@ jobs:
         timeout: 4800
         topology: *master_1repl
 
+  fedora-latest/test_installation_TestInstallwithSHA384withRSA:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-latest/test_idviews:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -329,6 +329,19 @@ jobs:
         timeout: 10800
         topology: *master_1repl
 
+  pki-fedora/test_installation_TestInstallwithSHA384withRSA:
+    requires: [pki-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{pki-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
+        template: *pki-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   pki-fedora/test_caless_TestServerInstall:
     requires: [pki-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -588,6 +588,19 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  fedora-latest/test_installation_TestInstallwithSHA384withRSA:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-latest/test_idviews:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -588,6 +588,19 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  testing-fedora/test_installation_TestInstallwithSHA384withRSA:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
+        template: *testing-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   testing-fedora/test_idviews:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -629,6 +629,20 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  testing-fedora/test_installation_TestInstallwithSHA384withRSA:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
+        template: *testing-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   testing-fedora/test_idviews:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -559,6 +559,18 @@ jobs:
         timeout: 4800
         topology: *master_1repl
 
+  fedora-previous/test_installation_TestInstallwithSHA384withRSA:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
+        template: *ci-master-previous
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-previous/test_idviews:
     requires: [fedora-previous/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -601,6 +601,19 @@ jobs:
         timeout: 4800
         topology: *master_1repl
 
+  fedora-rawhide/test_installation_TestInstallwithSHA384withRSA:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-rawhide/test_idviews:
     requires: [fedora-rawhide/build]
     priority: 50


### PR DESCRIPTION
Setup master with --ca-signing-algorithm=SHA384withRSA
Run certutil and check Signing Algorithm

Pagure Link: https://pagure.io/freeipa/issue/8906

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>