### PR TITLE
ipatests: webui: Use YAML SafeLoader

### DIFF
--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -191,7 +191,7 @@ class UI_driver:
         if not NO_YAML and os.path.isfile(path):
             try:
                 with open(path, 'r') as conf:
-                    cls.config = yaml.load(stream=conf, Loader=yaml.FullLoader)
+                    cls.config = yaml.safe_load(stream=conf)
             except yaml.YAMLError as e:
                 pytest.skip("Invalid Web UI config.\n%s" % e)
             except IOError as e:


### PR DESCRIPTION
FullLoader class for YAML loader was introduced in version 5.1 which
also deprecated default loader. SafeLoader, however, stays consistent
across the versions and brings added security.

Related: https://pagure.io/freeipa/issue/9009

Signed-off-by: Michal Polovka <mpolovka@redhat.com>