### PR TITLE
Support building against OpenLDAP 2.6+

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,9 +101,13 @@ dnl ---------------------------------------------------------------------------
 
 SAVE_CPPFLAGS=$CPPFLAGS
 CPPFLAGS="$NSPR_CFLAGS $NSS_CFLAGS"
-AC_CHECK_LIB([ldap_r], [ldap_search], [ ], AC_MSG_ERROR([libldap_r not found]))
-AC_CHECK_LIB([lber], [ber_peek_tag], [ ], AC_MSG_ERROR([liblber not found]))
-LDAP_LIBS="-lldap_r -llber"
+SAVE_LIBS="$LIBS"
+LIBS=
+AC_SEARCH_LIBS([ldap_search], [ldap_r ldap], [], [AC_MSG_ERROR([libldap or libldap_r not found])])
+AC_SEARCH_LIBS([ber_peek_tag], [lber], [], [AC_MSG_ERROR([liblber not found])])
+LDAP_LIBS="$LIBS"
+LDAP_CFLAGS=""
+LIBS="$SAVE_LIBS"
 LDAP_CFLAGS=""
 AC_SUBST(LDAP_LIBS)
 AC_SUBST(LDAP_CFLAGS)


### PR DESCRIPTION
OpenLDAP 2.6 deprecated separate libldap/libldap_r and
liblber/liblber_r, there is only one (reentrant) variant for each
library.

Attempt to use _r variant by default. In case it is missing, assume we
are using OpenLDAP 2.6 which has libraries without _r suffix. The
functions are still reentrant so there is not functional difference.

Fixes: https://pagure.io/freeipa/issue/9080

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>