### PR TITLE
ipatests: fix expected automount config in nsswitch.conf 

### DIFF
--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -323,7 +323,9 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
         if no_sssd:
             assert after_ipa_client_automount == ['files', 'ldap']
         else:
-            assert after_ipa_client_automount == ['sss', 'files']
+            # The default order depends on the authselect version
+            # but we only care about the list of sources, not their order
+            assert sorted(after_ipa_client_automount) == ['files', 'sss']
 
         cmd = self.clients[0].run_command(grep_automount_command)
         assert cmd.stdout_text.split() == after_ipa_client_automount


### PR DESCRIPTION
The test TestIpaClientAutomountFileRestore expects a
specific order for the automount sources to query
in /etc/nsswitch.conf.

With authselect update 1.3.0, the databases are sorted in
order of likelihood and the following line in seen:
automount: files sss
instead of
automount: sss files

Since the test doesn't care about the order but rather about
the list of sources, ignore the order.

Fixes: https://pagure.io/freeipa/issue/9067