### PR TITLE
[Backport][ipa-4-9] automember default group: remove --desc parameter

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -136,9 +136,8 @@ output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
 command: automember_default_group_remove/1
-args: 0,5,3
+args: 0,4,3
 option: Flag('all', autofill=True, cli_name='all', default=False)
-option: Str('description?', autofill=False, cli_name='desc')
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: StrEnum('type', values=[u'group', u'hostgroup'])
 option: Str('version?')
@@ -146,10 +145,9 @@ output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: Output('value', type=[<type 'unicode'>])
 command: automember_default_group_set/1
-args: 0,6,3
+args: 0,5,3
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('automemberdefaultgroup', cli_name='default_group')
-option: Str('description?', autofill=False, cli_name='desc')
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: StrEnum('type', values=[u'group', u'hostgroup'])
 option: Str('version?')

--- a/ipaserver/plugins/automember.py
+++ b/ipaserver/plugins/automember.py
@@ -566,7 +566,7 @@ class automember_default_group(automember):
 
     def get_params(self):
         for param in super(automember_default_group, self).get_params():
-            if param.name == 'cn':
+            if param.name == 'cn' or param.name == 'description':
                 continue
             yield param
 


### PR DESCRIPTION
This PR was opened automatically because PR #6129 was pushed to master and backport to ipa-4-9 is required.