### PR TITLE
[Backport][ipa-4-9] Config plugin: return EmptyModlist when no change is applied

### DIFF
--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -707,7 +707,7 @@ class config_mod(LDAPUpdate):
         if (isinstance(exc, errors.EmptyModlist) and
                 call_func.__name__ == 'update_entry' and
                 ('ca_renewal_master_server' in options or
-                 'enable_sid' in options)):
+                 options['enable_sid'])):
             return
 
         super(config_mod, self).exc_callback(

--- a/ipatests/test_xmlrpc/test_config_plugin.py
+++ b/ipatests/test_xmlrpc/test_config_plugin.py
@@ -312,4 +312,13 @@ class test_config(Declarative):
                 'value': None,
             },
         ),
+        dict(
+            desc='Set the value to the already set value, no modifications',
+            command=(
+                'config_mod', [], {
+                    'ipasearchrecordslimit': u'100',
+                },
+            ),
+            expected=errors.EmptyModlist(),
+        ),
     ]


### PR DESCRIPTION
This PR was opened automatically because PR #6126 was pushed to master and backport to ipa-4-9 is required.