### PR TITLE
[Backport][ipa-4-9] ipatests: webui: Use YAML SafeLoader

### DIFF
--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -192,7 +192,7 @@ class UI_driver:
         if not NO_YAML and os.path.isfile(path):
             try:
                 with open(path, 'r') as conf:
-                    cls.config = yaml.load(stream=conf, Loader=yaml.FullLoader)
+                    cls.config = yaml.safe_load(stream=conf)
             except yaml.YAMLError as e:
                 pytest.skip("Invalid Web UI config.\n%s" % e)
             except IOError as e:


### PR DESCRIPTION
This PR was opened automatically because PR #6132 was pushed to master and backport to ipa-4-9 is required.