### PR TITLE
[Backport][ipa-4-9][manual] ipatests: Added test automation for SHA384withRSA CSR support

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -559,6 +559,18 @@ jobs:
         timeout: 4800
         topology: *master_1repl
 
+  fedora-latest-ipa-4-9/test_installation_TestInstallwithSHA384withRSA:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
+        template: *ci-ipa-4-9-latest
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-latest-ipa-4-9/test_idviews:
     requires: [fedora-latest-ipa-4-9/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -588,6 +588,19 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  fedora-latest-ipa-4-9/test_installation_TestInstallwithSHA384withRSA:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
+        template: *ci-ipa-4-9-latest
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-latest-ipa-4-9/test_idviews:
     requires: [fedora-latest-ipa-4-9/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -559,6 +559,18 @@ jobs:
         timeout: 4800
         topology: *master_1repl
 
+  fedora-previous-ipa-4-9/test_installation_TestInstallwithSHA384withRSA:
+    requires: [fedora-previous-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-9/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
+        template: *ci-ipa-4-9-previous
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-previous-ipa-4-9/test_idviews:
     requires: [fedora-previous-ipa-4-9/build]
     priority: 50


### PR DESCRIPTION
Scenario 1:
Setup master with --ca-signing-algorithm=SHA384withRSA
Run certutil and check Signing Algorithm

Scenario 2:
Setup a master
Stop services
Modify default.params.signingAlg in CS.cfg
Restart services
Resubmit cert (Resubmitted cert should have new Algorithm)

Pagure Link: https://pagure.io/freeipa/issue/8906

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>