### PR TITLE
[Backport][ipa-4-9] Remove deprecation warning when installing a CA replica

### DIFF
--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -81,7 +81,6 @@ pki_skip_installation=False
 pki_skip_sd_verify=False
 
 pki_sslserver_token=internal
-pki_ssl_server_token=%(pki_sslserver_token)s
 pki_sslserver_nickname=Server-Cert cert-pki-ca
 pki_sslserver_subject_dn=cn=%(ipa_fqdn)s,%(ipa_subject_base)s
 


### PR DESCRIPTION
This PR was opened automatically because PR #6122 was pushed to master and backport to ipa-4-9 is required.