### PR TITLE
Tests for Autoprivate group.

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1627,7 +1627,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_trust.py
         template: *ci-master-latest
-        timeout: 9000
+        timeout: 10000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1743,7 +1743,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_trust.py
         template: *ci-master-latest
-        timeout: 9000
+        timeout: 10000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1743,7 +1743,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_trust.py
         template: *testing-master-latest
-        timeout: 9000
+        timeout: 10000
         topology: *adroot_adchild_adtree_master_1client
 
   testing-fedora/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1871,7 +1871,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_trust.py
         template: *testing-master-latest
-        timeout: 9000
+        timeout: 10000
         topology: *adroot_adchild_adtree_master_1client
 
   testing-fedora/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1627,7 +1627,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_trust.py
         template: *ci-master-previous
-        timeout: 9000
+        timeout: 10000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-previous/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1756,7 +1756,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_trust.py
         template: *ci-master-frawhide
-        timeout: 9000
+        timeout: 10000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-rawhide/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -1169,9 +1169,12 @@ class TestPosixAutoPrivateGroup(BaseTestTrust):
                                                  raiseonerr=False)
             tasks.assert_error(result, "no such user")
         else:
-            (uid, gid) = self.get_user_id(self.clients[0], posixuser)
-            assert uid == gid
-            assert uid == '10060'
+            sssd_version = tasks.get_sssd_version(self.clients[0])
+            with xfail_context(sssd_version <= tasks.parse_version('2.6.3'),
+                               'https://github.com/SSSD/sssd/issues/5988'):
+                (uid, gid) = self.get_user_id(self.clients[0], posixuser)
+                assert uid == gid
+                assert uid == '10060'
 
     @pytest.mark.parametrize('type', ['hybrid', 'true', "false"])
     def test_only_uid_number_auto_private_group_default(self, type):


### PR DESCRIPTION
Added tests using posix AD trust and non posix AD trust.
For option --auto-private-groups=[hybrid/true/false]    
Related : https://pagure.io/freeipa/issue/8807
