### PR TITLE
[Backport][ipa-4-9] ipatests: fix expected automount config in nsswitch.conf 

### DIFF
--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -323,7 +323,9 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
         if no_sssd:
             assert after_ipa_client_automount == ['files', 'ldap']
         else:
-            assert after_ipa_client_automount == ['sss', 'files']
+            # The default order depends on the authselect version
+            # but we only care about the list of sources, not their order
+            assert sorted(after_ipa_client_automount) == ['files', 'sss']
 
         cmd = self.clients[0].run_command(grep_automount_command)
         assert cmd.stdout_text.split() == after_ipa_client_automount


### PR DESCRIPTION
This PR was opened automatically because PR #6141 was pushed to master and backport to ipa-4-9 is required.