### PR TITLE
WIP: Instrumenting test to see if it runs differently in CI

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *master_2repl_1client

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -1146,6 +1146,14 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         """Exercises backup+restore and hidden replica uninstall
         """
         self._check_server_role(self.replicas[0], 'hidden')
+        tasks.ldapsearch_dm(
+            self.replicas[0],
+            "cn=KDC,cn={},cn=masters,cn=ipa,cn=etc,{}".format(
+                self.replicas[0].hostname, self.replicas[0].domain.basedn
+            ),
+            ldap_args=["ipaConfigString"],
+            scope="base"
+        )
         # backup
         backup_path = tasks.get_backup_dir(self.replicas[0])
         # uninstall
@@ -1156,6 +1164,14 @@ class TestHiddenReplicaPromotion(IntegrationTest):
             ['ipa-restore', backup_path],
             stdin_text=dirman_password + '\nyes'
         )
+        tasks.ldapsearch_dm(
+            self.replicas[0],
+            "cn=KDC,cn={},cn=masters,cn=ipa,cn=etc,{}".format(
+                self.replicas[0].hostname, self.replicas[0].domain.basedn
+            ),
+            ldap_args=["ipaConfigString"],
+            scope="base"
+        )
 
         tasks.kinit_admin(self.master)
         tasks.kinit_admin(self.replicas[0])
@@ -1163,7 +1179,26 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         # restore turns a hidden replica into an enabled replica
         # https://pagure.io/freeipa/issue/7894
         self._check_config([self.master, self.replicas[0]])
+
+        tasks.ldapsearch_dm(
+            self.replicas[0],
+            "cn=KDC,cn={},cn=masters,cn=ipa,cn=etc,{}".format(
+                self.replicas[0].hostname, self.replicas[0].domain.basedn
+            ),
+            ldap_args=["ipaConfigString"],
+            scope="base"
+        )
+
         self._check_server_role(self.replicas[0], 'enabled')
+
+        tasks.ldapsearch_dm(
+            self.replicas[0],
+            "cn=KDC,cn={},cn=masters,cn=ipa,cn=etc,{}".format(
+                self.replicas[0].hostname, self.replicas[0].domain.basedn
+            ),
+            ldap_args=["ipaConfigString"],
+            scope="base"
+        )
 
     def test_hidden_replica_automatic_crl(self):
         """Exercises if automatic CRL configuration works with


### PR DESCRIPTION
Apparently a hidden service becomes unhidden on restoration
but I can't reproduce it manually. Run with some instrumentation
to see what is going on in CI.

Next run will be against latest 389-ds.