### PR TITLE
Turn off interpolation to avoid issues with special characters

### DIFF
--- a/ipalib/sysrestore.py
+++ b/ipalib/sysrestore.py
@@ -82,7 +82,7 @@ class FileStore:
 
         self.files = {}
 
-        p = SafeConfigParser()
+        p = SafeConfigParser(interpolation=None)
         p.optionxform = str
         p.read(self._index)
 
@@ -103,7 +103,7 @@ class FileStore:
                 os.remove(self._index)
             return
 
-        p = SafeConfigParser()
+        p = SafeConfigParser(interpolation=None)
         p.optionxform = str
 
         p.add_section('files')
@@ -344,7 +344,7 @@ class StateFile:
 
         self.modules = {}
 
-        p = SafeConfigParser()
+        p = SafeConfigParser(interpolation=None)
         p.optionxform = str
         p.read(self._path)
 
@@ -373,7 +373,7 @@ class StateFile:
                 os.remove(self._path)
             return
 
-        p = SafeConfigParser()
+        p = SafeConfigParser(interpolation=None)
         p.optionxform = str
 
         for module in self.modules:


### PR DESCRIPTION
This fixes https://pagure.io/freeipa/issue/9085

The Python `configparser.ConfigParser` class enables string interpolation by default which throws errors if `%` signs are used in any values that don't interpolate correctly. The majority of the code base uses `configparser.RawConfigParser` which has interpolation disabled by default so `ipalib/sysrestore.py` can match this functionality by setting `interpolation=None` on instantiation.