### PR TITLE
ipa-pki-proxy.conf: provide access to /kra/admin/kra/getStatus

### DIFF
--- a/install/share/ipa-pki-proxy.conf.template
+++ b/install/share/ipa-pki-proxy.conf.template
@@ -1,4 +1,4 @@
-# VERSION 16 - DO NOT REMOVE THIS LINE
+# VERSION 17 - DO NOT REMOVE THIS LINE
 
 ProxyRequests Off
 
@@ -11,7 +11,7 @@ ProxyRequests Off
 </LocationMatch>
 
 # matches for admin port and installer
-<LocationMatch "^/ca/admin/ca/getCertChain|^/ca/admin/ca/getConfigEntries|^/ca/admin/ca/getCookie|^/ca/admin/ca/getStatus|^/ca/admin/ca/securityDomainLogin|^/ca/admin/ca/getDomainXML|^/ca/admin/ca/updateNumberRange|^/ca/admin/ca/tokenAuthenticate|^/ca/admin/ca/updateNumberRange|^/ca/admin/ca/updateDomainXML|^/ca/admin/ca/updateConnector|^/ca/admin/ca/getSubsystemCert|^/kra/admin/kra/updateNumberRange|^/kra/admin/kra/getConfigEntries">
+<LocationMatch "^/ca/admin/ca/getCertChain|^/ca/admin/ca/getConfigEntries|^/ca/admin/ca/getCookie|^/ca/admin/ca/getStatus|^/ca/admin/ca/securityDomainLogin|^/ca/admin/ca/getDomainXML|^/ca/admin/ca/updateNumberRange|^/ca/admin/ca/tokenAuthenticate|^/ca/admin/ca/updateNumberRange|^/ca/admin/ca/updateDomainXML|^/ca/admin/ca/updateConnector|^/ca/admin/ca/getSubsystemCert|^/kra/admin/kra/updateNumberRange|^/kra/admin/kra/getConfigEntries|^/kra/admin/kra/getStatus">
     SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
     SSLVerifyClient none
     ProxyPassMatch ajp://localhost:$DOGTAG_PORT $DOGTAG_AJP_SECRET


### PR DESCRIPTION
The access to /kra/admin/kra/getStatus will be needed
in order to fix pki-healthcheck.
Note that this commit is a pre-requisite for the fix
to be done on PKI side. No test added since the full
integration test already exists in test_replica_promotion.py,
in TestHiddenReplicaPromotion::test_ipahealthcheck_hidden_replica

Fixes: https://pagure.io/freeipa/issue/9099
Related: https://pagure.io/freeipa/issue/8582

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>