### PR TITLE
[Backport][ipa-4-9] Custodia: use a stronger encryption algo when exporting keys

### DIFF
--- a/ipaserver/secrets/handlers/pemfile.py
+++ b/ipaserver/secrets/handlers/pemfile.py
@@ -31,6 +31,9 @@ def export_key(args, tmpdir):
         '-out', pk12file,
         '-inkey', args.keyfile,
         '-password', 'file:{pk12pwfile}'.format(pk12pwfile=pk12pwfile),
+        '-keypbe', 'AES-256-CBC',
+        '-certpbe', 'AES-256-CBC',
+        '-macalg', 'sha384',
     ])
 
     with open(pk12file, 'rb') as f:


### PR DESCRIPTION
This PR was opened automatically because PR #6155 was pushed to master and backport to ipa-4-9 is required.