### PR TITLE
Enable the ccache sweep timer during installation

### DIFF
--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -140,6 +140,8 @@ class HTTPInstance(service.Service):
         self.step("publish CA cert", self.__publish_ca_cert)
         self.step("clean up any existing httpd ccaches",
                   self.remove_httpd_ccaches)
+        self.step("enable ccache sweep",
+                  self.enable_ccache_sweep)
         self.step("configuring SELinux for httpd", self.configure_selinux_for_httpd)
         if not self.is_kdcproxy_configured():
             self.step("create KDC proxy config", self.create_kdcproxy_conf)
@@ -175,6 +177,11 @@ class HTTPInstance(service.Service):
         shutil.rmtree(paths.IPA_CCACHES)
         ipautil.run(
             [paths.SYSTEMD_TMPFILES, '--create', '--prefix', paths.IPA_CCACHES]
+        )
+
+    def enable_ccache_sweep(self):
+        ipautil.run(
+            [paths.SYSTEMCTL, 'enable', 'ipa-ccache-sweep.timer']
         )
 
     def __configure_http(self):

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -475,7 +475,7 @@ class TestInstallCA(IntegrationTest):
 
         # Tweak sysrestore.state to drop installation section
         self.master.run_command(
-            ['sed','-i', r's/\[installation\]/\[badinstallation\]/',
+            ['sed', '-i', r's/\[installation\]/\[badinstallation\]/',
              os.path.join(paths.SYSRESTORE, SYSRESTORE_STATEFILE)])
 
         # Re-run installation check and it should fall back to old method
@@ -485,7 +485,7 @@ class TestInstallCA(IntegrationTest):
 
         # Restore installation section.
         self.master.run_command(
-            ['sed','-i', r's/\[badinstallation\]/\[installation\]/',
+            ['sed', '-i', r's/\[badinstallation\]/\[installation\]/',
              os.path.join(paths.SYSRESTORE, SYSRESTORE_STATEFILE)])
 
         # Uninstall and confirm that the old method reports correctly
@@ -689,6 +689,7 @@ def get_pki_tomcatd_pid(host):
             pid = line.split()[2]
             break
     return(pid)
+
 
 def get_ipa_services_pids(host):
     ipa_services_name = [
@@ -1308,6 +1309,20 @@ class TestInstallMasterKRA(IntegrationTest):
 
     def test_install_master(self):
         tasks.install_master(self.master, setup_dns=False, setup_kra=True)
+
+    def test_ipa_ccache_sweep_timer_enabled(self):
+        """Test ipa-ccache-sweep.timer enabled by default during installation
+
+        This test checks that ipa-ccache-sweep.timer is enabled by default
+        during the ipa installation.
+
+        related: https://pagure.io/freeipa/issue/9107
+        """
+        result = self.master.run_command(
+            ['systemctl', 'is-enabled', 'ipa-ccache-sweep.timer'],
+            raiseonerr=False
+        )
+        assert 'enabled' in result.stdout_text
 
     def test_install_dns(self):
         tasks.install_dns(self.master)


### PR DESCRIPTION
The timer was only being enabled during package installation
if IPA was configured. So effectively only on upgrade.

Add as a separate installation step after the ccache directory
is configured.

https://pagure.io/freeipa/issue/9107

Signed-off-by: Rob Crittenden <rcritten@redhat.com>