### PR TITLE
ipatests: Test if local CA uses proper DER encoding

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -314,6 +314,7 @@ class BasePathNamespace:
     CERTMONGER_CAS_DIR = "/var/lib/certmonger/cas/"
     CERTMONGER_CAS_CA_RENEWAL = "/var/lib/certmonger/cas/ca_renewal"
     CERTMONGER_REQUESTS_DIR = "/var/lib/certmonger/requests/"
+    CERTMONGER_LOCAL_CA = "/var/lib/certmonger/local/creds"
     VAR_LIB_DIRSRV = "/var/lib/dirsrv"
     DIRSRV_BOOT_LDIF = "/var/lib/dirsrv/boot.ldif"
     VAR_LIB_IPA = "/var/lib/ipa"

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_cert.py::TestInstallMasterClient
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client


### PR DESCRIPTION
The automatically generated local certificate authority (CA) used
improper DER-encoding for the CA Basic Constraint boolean. As a
consequence, the certificate was in some cases rejected as invalid.
This test is to check if the local CA uses proper DER-encoding
boolean.

related: https://bugzilla.redhat.com/show_bug.cgi?id=1560961

Signed-off-by: Mohammad Rizwan <myusuf@redhat.com>