### PR TITLE
[ipa-4-9] ipatests: update images for f34 and f35

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f35
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f35
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f35
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-previous
           name: freeipa/ci-ipa-4-9-f34
-          version: 0.0.6
+          version: 0.0.7
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,7 +57,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-9-latest
           name: freeipa/ci-ipa-4-9-f35
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
The new images include 389-ds-base 2.0.14-1
which contains the fixes for  the following tickets:

389-ds-base https://github.com/freeipa/freeipa/pull/5079 Freeipa nightly test failure with winsync agreement
389-ds-base https://github.com/freeipa/freeipa/pull/5031 ipa-restore broken in selinux enforcing mode

Fixes: https://pagure.io/freeipa/issue/9069
Fixes: https://pagure.io/freeipa/issue/9051

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>