### PR TITLE
Remove the --no-sssd option from ipa-client-automount

### DIFF
--- a/client/man/ipa-client-automount.1
+++ b/client/man/ipa-client-automount.1
@@ -24,14 +24,12 @@ ipa\-client\-automount [\fIOPTION\fR]... <location>
 .SH "DESCRIPTION"
 Configures automount for IPA.
 
-The automount configuration consists of three files:
+The automount configuration consists of two files:
 .PP
 .IP  o
 /etc/nsswitch.conf
 .IP  o
 /etc/sysconfig/autofs
-.IP  o
-/etc/autofs_ldap_auth.conf
 
 .TP
 By default this will use DNS discovery to attempt to determine the IPA server(s) to use. If IPA servers are discovered then the automount client will be configured to use DNS discovery.
@@ -42,9 +40,9 @@ The default automount location is named default. To specify a different one use 
 .TP
 The IPA client must already be configured in order to configure automount. The IPA client is configured as part of a server installation.
 .TP
-There are two ways to configure automount. The default is to use sssd to manage the automount maps. Alternatively autofs can configured to bind to LDAP over GSSAPI and authenticate using the machine's host principal.
+SSSD is configured to manage the automount maps.
 .TP
-The nsswitch automount service is configured to use either sss or ldap and files depending on whether SSSD is configured or not.
+The nss automount service is configured to use sss and files.
 .TP
 NFSv4 is also configured. The rpc.gssd and rpc.idmapd are started on clients to support Kerberos\-secured mounts.
 .SH "OPTIONS"
@@ -53,9 +51,6 @@ Set the FQDN of the IPA server to connect to.
 .TP
 \fB\-\-location\fR=\fILOCATION\fR
 Automount location.
-.TP
-\fB\-S\fR, \fB\-\-no\-sssd\fR
-Do not configure the client to use SSSD for automount.
 .TP
 \fB\-\-idmap\-domain\fR=\fIIDMAP_DOMAIN\fR
 NFS domain for idmapd.conf. If unset, defaults to the IPA domain. If set to DNS, let idmapd or nfsidmap determine the domain from DNS (see idmapd(8) or nfsidmap(5) for details). If set to anything else, set idmapd.conf's Domain entry to that value.
@@ -71,20 +66,11 @@ Restore the automount configuration files.
 
 .SH "FILES"
 .TP
-Files that will be always be configured:
+Files that will be configured:
 
 /etc/nsswitch.conf
-.TP
-Files that will be configured when SSSD is the automount client (default):
 
 /etc/sssd/sssd.conf
-
-.TP
-Files that will be configured when using the ldap automount client:
-
-/etc/sysconfig/autofs
-
-/etc/autofs_ldap_auth.conf
 
 .SH "EXIT STATUS"
 0 if the installation was successful

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -36,7 +36,6 @@ class BasePathNamespace:
     SYSTEMD_DETECT_VIRT = "/usr/bin/systemd-detect-virt"
     SYSTEMD_TMPFILES = "/bin/systemd-tmpfiles"
     TAR = "/bin/tar"
-    AUTOFS_LDAP_AUTH_CONF = "/etc/autofs_ldap_auth.conf"
     ETC_FEDORA_RELEASE = "/etc/fedora-release"
     GROUP = "/etc/group"
     ETC_HOSTNAME = "/etc/hostname"

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -472,43 +472,6 @@ class BaseTaskNamespace:
             fstore, 'sudoers', ['sss'],
             default_value=['files'])
 
-    def enable_ldap_automount(self, statestore):
-        """
-        Point automount to ldap in nsswitch.conf.
-        This function is for non-SSSD setups only.
-        """
-        conf = IPAChangeConf("IPA Installer")
-        conf.setOptionAssignment(':')
-
-        with open(paths.NSSWITCH_CONF, 'r') as f:
-            current_opts = conf.parse(f)
-            current_nss_value = conf.findOpts(
-                current_opts, name='automount', type='option'
-            )[1]
-            if current_nss_value is None:
-                # no automount database present
-                current_nss_value = False  # None cannot be backed up
-            else:
-                current_nss_value = current_nss_value['value']
-            statestore.backup_state(
-                'ipa-client-automount-nsswitch', 'previous-automount',
-                current_nss_value
-            )
-
-        nss_value = ' files ldap'
-        opts = [
-            {
-                'name': 'automount',
-                'type': 'option',
-                'action': 'set',
-                'value': nss_value,
-            },
-            {'name': 'empty', 'type': 'empty'},
-        ]
-        conf.changeConf(paths.NSSWITCH_CONF, opts)
-
-        logger.info("Configured %s", paths.NSSWITCH_CONF)
-
     def disable_ldap_automount(self, statestore):
         """Disable automount using LDAP"""
         if statestore.get_state(

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -17,7 +17,6 @@ MULTIARCH = sysconfig.get_config_var('MULTIARCH')
 
 class DebianPathNamespace(BasePathNamespace):
     BIN_HOSTNAMECTL = "/usr/bin/hostnamectl"
-    AUTOFS_LDAP_AUTH_CONF = "/etc/autofs_ldap_auth.conf"
     ETC_HTTPD_DIR = "/etc/apache2"
     HTTPD_ALIAS_DIR = "/etc/apache2/ipa"
     HTTPD_CONF_D_DIR = "/etc/apache2/conf-enabled/"

--- a/ipaplatform/debian/tasks.py
+++ b/ipaplatform/debian/tasks.py
@@ -202,11 +202,7 @@ Serial Number (hex): {cert.serial_number:#x}
 
         return True
 
-    # Debian doesn't use authselect, so call enable/disable_ldap_automount
-    # from BaseTaskNamespace.
-    def enable_ldap_automount(self, statestore):
-        return BaseTaskNamespace.enable_ldap_automount(self, statestore)
-
+    # Debian doesn't use authselect, so call disable_ldap_automount
     def disable_ldap_automount(self, statestore):
         return BaseTaskNamespace.disable_ldap_automount(self, statestore)
 

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -759,17 +759,6 @@ class RedHatTaskNamespace(BaseTaskNamespace):
     def enable_sssd_sudo(self, _fstore):
         """sudo enablement is handled by authselect"""
 
-    def enable_ldap_automount(self, statestore):
-        """
-        Point automount to ldap in nsswitch.conf.
-        This function is for non-SSSD setups only.
-        """
-        super(RedHatTaskNamespace, self).enable_ldap_automount(statestore)
-
-        authselect_cmd = [paths.AUTHSELECT, "enable-feature",
-                          "with-custom-automount"]
-        ipautil.run(authselect_cmd)
-
     def disable_ldap_automount(self, statestore):
         """Disable ldap-based automount"""
         super(RedHatTaskNamespace, self).disable_ldap_automount(statestore)


### PR DESCRIPTION
This makes automount configurable only using sssd and not LDAP.
The reason is that authselect 1.3 no longer supports
user-nsswitch.conf which is where we made direct changes to the
nss configuration on Fedora/RHEL.

The equivalent option was removed from ipa-client-install in
https://pagure.io/freeipa/issue/7671

Fixes: https://pagure.io/freeipa/issue/9084

Signed-off-by: Rob Crittenden <rcritten@redhat.com>