### PR TITLE
ipatests: Test ipa-ccache-sweep.timer enabled by default during installation

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_installation.py::TestInstallMasterKRA
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -475,7 +475,7 @@ class TestInstallCA(IntegrationTest):
 
         # Tweak sysrestore.state to drop installation section
         self.master.run_command(
-            ['sed','-i', r's/\[installation\]/\[badinstallation\]/',
+            ['sed', '-i', r's/\[installation\]/\[badinstallation\]/',
              os.path.join(paths.SYSRESTORE, SYSRESTORE_STATEFILE)])
 
         # Re-run installation check and it should fall back to old method
@@ -485,7 +485,7 @@ class TestInstallCA(IntegrationTest):
 
         # Restore installation section.
         self.master.run_command(
-            ['sed','-i', r's/\[badinstallation\]/\[installation\]/',
+            ['sed', '-i', r's/\[badinstallation\]/\[installation\]/',
              os.path.join(paths.SYSRESTORE, SYSRESTORE_STATEFILE)])
 
         # Uninstall and confirm that the old method reports correctly
@@ -689,6 +689,7 @@ def get_pki_tomcatd_pid(host):
             pid = line.split()[2]
             break
     return(pid)
+
 
 def get_ipa_services_pids(host):
     ipa_services_name = [
@@ -1308,6 +1309,19 @@ class TestInstallMasterKRA(IntegrationTest):
 
     def test_install_master(self):
         tasks.install_master(self.master, setup_dns=False, setup_kra=True)
+
+    def test_ipa_ccache_sweep_timer_enabled(self):
+        """Test ipa-ccache-sweep.timer enabled by default during installation
+
+        This test checks that ipa-ccache-sweep.timer is enabled by default
+        during the ipa installation.
+
+        related: https://pagure.io/freeipa/issue/9107
+        """
+        result = self.master.run_command(
+            ['systemctl', 'is-enabled', 'ipa-ccache-sweep.timer']
+        )
+        assert 'enabled' in result.stdout_text
 
     def test_install_dns(self):
         tasks.install_dns(self.master)


### PR DESCRIPTION
This test checks that ipa-ccache-sweep.timer is enabled by default
during the ipa installation.

related: https://pagure.io/freeipa/issue/9107

Signed-off-by: Mohammad Rizwan <myusuf@redhat.com>