### PR TITLE
ipatests: Remove certmonger tracking before uninstall in cert tests

### DIFF
--- a/ipatests/test_integration/test_ipa_cert_fix.py
+++ b/ipatests/test_integration/test_ipa_cert_fix.py
@@ -118,6 +118,13 @@ def expire_cert_critical():
     yield _expire_cert_critical
 
     host = hosts.pop('host')
+    # Prior to uninstall remove all the cert tracking to prevent
+    # errors from certmonger trying to check the status of certs
+    # that don't matter because we are uninstalling.
+    host.run_command(['systemctl', 'stop', 'certmonger'])
+    host.run_command(
+        ['rm', '-f', paths.CERTMONGER_REQUESTS_DIR + '/*']
+    )
     tasks.uninstall_master(host)
     tasks.move_date(host, 'start', '-3Years-1day')
 


### PR DESCRIPTION
There is some contention between certmonger starting during the
uninstallation process in order to stop the tracking and activity
going on within certmonger helpers.

As near as I can tell certmonger is not running, then IPA is
stopped in order to uninstall, then certmonger is started to stop
the tracking. certmonger checks cert status on startup but since
IPA isn't running it can't get a host ticket. During this time any
request over DBus may time out, causing a test to fail when we're
just trying to clean up.

https://pagure.io/freeipa/issue/8506

Signed-off-by: Rob Crittenden <rcritten@redhat.com>