### PR TITLE
ipa_cldap: fix memory leak

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-cldap/ipa_cldap_worker.c
+++ b/daemons/ipa-slapi-plugins/ipa-cldap/ipa_cldap_worker.c
@@ -287,6 +287,7 @@ done:
     ipa_cldap_respond(ctx, req, &reply);
 
     ipa_cldap_free_kvps(&req->kvps);
+    free(reply.bv_val);
     free(req);
     return;
 }


### PR DESCRIPTION
ipa_cldap_encode_netlogon() allocates memory to store binary data as part of
berval (bv_val) when processing a CLDAP packet request from a worker. The
data is used by ipa_cldap_respond() but bv_val is not freed later on.

This commit is adding the corresponding free() after ipa_cldap_respond()
is completed.

Discovered by LeakSanitizer

Fixes: https://pagure.io/freeipa/issue/9110
Signed-off-by: Francisco Trivino <ftrivino@redhat.com>