### PR TITLE
[Backport][ipa-4-9] ipa_cldap: fix memory leak

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-cldap/ipa_cldap_worker.c
+++ b/daemons/ipa-slapi-plugins/ipa-cldap/ipa_cldap_worker.c
@@ -287,6 +287,7 @@ done:
     ipa_cldap_respond(ctx, req, &reply);
 
     ipa_cldap_free_kvps(&req->kvps);
+    free(reply.bv_val);
     free(req);
     return;
 }


### PR DESCRIPTION
This PR was opened automatically because PR #6180 was pushed to master and backport to ipa-4-9 is required.