### PR TITLE
[Backport][ipa-4-9] ipatests: remove additional check for failed units.

### DIFF
--- a/ipatests/test_integration/test_otp.py
+++ b/ipatests/test_integration/test_otp.py
@@ -316,7 +316,6 @@ class TestOTPToken(IntegrationTest):
         check_services = self.master.run_command(
             ['systemctl', 'list-units', '--state=failed']
         )
-        assert "0 loaded units listed" in check_services.stdout_text
         assert "ipa-otpd" not in check_services.stdout_text
         # Be sure no services are running and failed units
         self.master.run_command(['killall', 'ipa-otpd'], raiseonerr=False)


### PR DESCRIPTION
This PR was opened automatically because PR #6178 was pushed to master and backport to ipa-4-9 is required.