### PR TITLE
Convert values using _SYNTAX_MAPPING with --delattr

### DIFF
--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -1135,7 +1135,11 @@ last, after all sets and adds."""),
 
                 for delval in deldict.get(attr, []):
                     try:
-                        entry_attrs[attr].remove(delval)
+                        try:
+                            val = ldap.decode(delval.encode('utf-8'), attr)
+                            entry_attrs[attr].remove(val)
+                        except ValueError:
+                            entry_attrs[attr].remove(delval)
                     except ValueError:
                         if isinstance(delval, bytes):
                             # This is a Binary value, base64 encode it


### PR DESCRIPTION
When an entry is loaded the incoming values are converted
into python datatypes automatically based on the _SYNTAX_MAPPING
value in ipaldap.

When using delattr to remove a mapped value it will fail because
the datatypes do not match up. For example date types are
datetime.datetime structions and won't match a generalized time
string.

So try to map the value to delete using _SYNTAX_MAPPING before
trying to remove the value. Fall back to trying to remove the
raw value if the mapping fails.

This won't work for some mapping types, DNs for example. Providing
only the RDN value for a DN-type, manager for example, lacks the
context to know how to construct the DN (RDN and contaner).

Fixes: https://pagure.io/freeipa/issue/9004

Signed-off-by: Rob Crittenden <rcritten@redhat.com>