### PR TITLE
Fix hostname input in server installer

### DIFF
--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -502,7 +502,7 @@ def install_check(installer):
         host_name = host_default
 
     try:
-        verify_fqdn(host_default, options.no_host_dns)
+        verify_fqdn(host_name, options.no_host_dns)
     except BadHostError as e:
         raise ScriptError(e)
 

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -186,13 +186,16 @@ def read_host_name(host_default):
     print("Enter the fully qualified domain name of the computer")
     print("on which you're setting up server software. Using the form")
     print("<hostname>.<domainname>")
-    print("Example: master.example.com.")
+    print("Example: master.example.com")
     print("")
     print("")
     if host_default == "":
         host_default = "master.example.com"
     host_name = user_input("Server host name", host_default, allow_empty=False)
     print("")
+
+    if host_name.endswith('.'):
+        host_name = host_name[:-1]
 
     return host_name
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1522,6 +1522,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-latest/hostname_validator:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_installation.py::TestHostnameValidator
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-latest/automember:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1629,6 +1629,19 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-latest/hostname_validator:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestHostnameValidator
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-latest/automember:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1629,6 +1629,19 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  testing-fedora/hostname_validator:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestHostnameValidator
+        template: *testing-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   testing-fedora/automember:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1748,6 +1748,20 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  testing-fedora/hostname_validator:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestHostnameValidator
+        template: *testing-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   testing-fedora/automember:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1522,6 +1522,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-previous/hostname_validator:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_installation.py::TestHostnameValidator
+        template: *ci-master-previous
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-previous/automember:
     requires: [fedora-previous/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1616,6 +1616,19 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-rawhide/hostname_validator:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestHostnameValidator
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
 #  fedora-rawhide/nfs:
 #    requires: [fedora-rawhide/build]
 #    priority: 50


### PR DESCRIPTION
The refactor change 9094dfc had a slight error where the
user-input provided value in input wasn't being validated. Only
the command-line or the current FQDN was being verified so
if the FQDN was bad any value input by the user was being skipped.

Fixes: https://pagure.io/freeipa/issue/9111

And strip off a trailing '.' in a user-provided hostname.