### PR TITLE
Set the mode on ipaupgrade.log during RPM %post snipppet

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1236,6 +1236,7 @@ if [ $1 -gt 1 ] ; then
 
         %{__python3} -c 'from ipaclient.install.client import configure_krb5_snippet; configure_krb5_snippet()' >>/var/log/ipaupgrade.log 2>&1
         %{__python3} -c 'from ipaclient.install.client import update_ipa_nssdb; update_ipa_nssdb()' >>/var/log/ipaupgrade.log 2>&1
+        chmod 0600 /var/log/ipaupgrade.log
         SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config"
         if [ -f "$SSH_CLIENT_SYSTEM_CONF" ]; then
             sed -E --in-place=.orig 's/^(HostKeyAlgorithms ssh-rsa,ssh-dss)$/# disabled by ipa-client update\n# \1/' "$SSH_CLIENT_SYSTEM_CONF"


### PR DESCRIPTION
The IPA tools will create /var/log/ipaupgrade.log with mode
0600. If for some reason this file doesn't exist during
upgrade then it will be created by the RPM transaction with
mode 0644 (because of umask).

So always set the mode once the snippets are done. This
will ensure that a newly created log will have the expected
mode and also fix any previous incorrectly set mode.

Fixes: https://pagure.io/freeipa/issue/8899

Signed-off-by: Rob Crittenden <rcritten@redhat.com>