### PR TITLE
ipa-restore: Mark a restored server as enabled

### DIFF
--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -235,6 +235,15 @@ class Restore(admintool.AdminTool):
                 raise admintool.ScriptError(
                     "Directory Manager password required")
 
+    def enable_server(self):
+        """Make sure the current server is marked as enabled"""
+        if not api.Backend.ldap2.isconnected():
+            api.Backend.ldap2.connect()
+
+        try:
+            api.Command.server_state(api.env.host, state='enabled')
+        except errors.EmptyModlist:
+            pass
 
     def run(self):
         options = self.options
@@ -483,6 +492,7 @@ class Restore(admintool.AdminTool):
                 result = run([paths.IPACTL, 'restart'], raiseonerr=False)
                 if result.returncode != 0:
                     logger.error('Restarting IPA failed: %s', result.error_log)
+                self.enable_server()
         finally:
             shutil.rmtree(self.top_dir)
             logger.info("Restoring umask to %s", old_umask)


### PR DESCRIPTION
There is no use-case to keep a restored server in a hidden
state. It can be re-marked as hidden once the installation is
recovered from the restore. So mark all restored services as
enabled so they are visible to existing clients during the
remaining recovery.

Fixes: https://pagure.io/freeipa/issue/9095

Signed-off-by: Rob Crittenden <rcritten@redhat.com>