### PR TITLE
[Manual][Backport] Tests for Autoprivate group.

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1627,7 +1627,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_trust.py
         template: *ci-ipa-4-9-latest
-        timeout: 9000
+        timeout: 10000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest-ipa-4-9/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1743,7 +1743,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_trust.py
         template: *ci-ipa-4-9-latest
-        timeout: 9000
+        timeout: 10000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest-ipa-4-9/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1627,7 +1627,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-9/build_url}'
         test_suite: test_integration/test_trust.py
         template: *ci-ipa-4-9-previous
-        timeout: 9000
+        timeout: 10000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-previous-ipa-4-9/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -1169,9 +1169,12 @@ class TestPosixAutoPrivateGroup(BaseTestTrust):
                                                  raiseonerr=False)
             tasks.assert_error(result, "no such user")
         else:
-            (uid, gid) = self.get_user_id(self.clients[0], posixuser)
-            assert uid == gid
-            assert uid == '10060'
+            sssd_version = tasks.get_sssd_version(self.clients[0])
+            with xfail_context(sssd_version <= tasks.parse_version('2.6.3'),
+                               'https://github.com/SSSD/sssd/issues/5988'):
+                (uid, gid) = self.get_user_id(self.clients[0], posixuser)
+                assert uid == gid
+                assert uid == '10060'
 
     @pytest.mark.parametrize('type', ['hybrid', 'true', "false"])
     def test_only_uid_number_auto_private_group_default(self, type):


### PR DESCRIPTION
Added tests using posix AD trust and non posix AD trust.
For option --auto-private-groups=[hybrid/true/false]
Related : https://pagure.io/freeipa/issue/8807