### PR TITLE
Pylint 2.12.2 fixes

### DIFF
--- a/.wheelconstraints.in
+++ b/.wheelconstraints.in
@@ -10,6 +10,6 @@ ipaserver == @VERSION@
 ipatests == @VERSION@
 
 # keep pylint version in sync with current Fedora release
-# F34 has 2.6
+# F36 has 2.12.2
 # https://pagure.io/freeipa/issue/8818 added pylint 2.8 support
-pylint < 2.9
+pylint ~= 2.12.2

--- a/daemons/ipa-otpd/test.py
+++ b/daemons/ipa-otpd/test.py
@@ -59,7 +59,7 @@ def main():
     rsp.DecodePacket(buf)
     pkt.VerifyReply(rsp)
 
-    proc.terminate()  # pylint: disable=E1101
+    proc.terminate()
     proc.wait()
 
 if __name__ == '__main__':

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
@@ -220,7 +220,7 @@ def request_cert(reuse_existing, **kwargs):
         sys.stderr.write(result.raw_error_output)
     else:
         # Write bytes directly
-        sys.stderr.buffer.write(result.raw_error_output)  #pylint: disable=no-member
+        sys.stderr.buffer.write(result.raw_error_output)
     sys.stderr.flush()
 
     syslog.syslog(syslog.LOG_NOTICE,

--- a/install/certmonger/ipa-server-guard.in
+++ b/install/certmonger/ipa-server-guard.in
@@ -36,8 +36,8 @@ def run_operation(cmd):
 
     result = ipautil.run(cmd, raiseonerr=False, env=os.environ)
     # Write bytes directly
-    sys.stdout.buffer.write(result.raw_output)  #pylint: disable=no-member
-    sys.stderr.buffer.write(result.raw_error_output)  #pylint: disable=no-member
+    sys.stdout.buffer.write(result.raw_output)
+    sys.stderr.buffer.write(result.raw_error_output)
     sys.stdout.flush()
     sys.stderr.flush()
 

--- a/install/tools/ipa-adtrust-install.in
+++ b/install/tools/ipa-adtrust-install.in
@@ -202,7 +202,7 @@ def main():
         if not (user['uid'][0] in group['member_user'] and
                 group['cn'][0] in user['memberof_group']):
             raise errors.RequirementError(name='admins group membership')
-    except errors.RequirementError as e:
+    except errors.RequirementError:
         raise ScriptError(
             "Must have administrative privileges to setup AD trusts on server"
         )

--- a/install/tools/ipa-compat-manage.in
+++ b/install/tools/ipa-compat-manage.in
@@ -131,6 +131,8 @@ def main():
             else:
                 print("Enabling plugin")
 
+                # https://github.com/PyCQA/pylint/issues/872
+                # pylint: disable=unsupported-assignment-operation
                 if entry is None:
                     ld = LDAPUpdate()
                     if not ld.update(files):
@@ -139,6 +141,7 @@ def main():
                 else:
                     entry['nsslapd-pluginenabled'] = ['on']
                     api.Backend.ldap2.update_entry(entry)
+                # pylint: enable=unsupported-assignment-operation
         except errors.ExecutionError as lde:
             print("An error occurred while talking to the server.")
             print(lde)
@@ -168,7 +171,9 @@ def main():
                 else:
                     print("Disabling plugin")
 
+                    # pylint: disable=unsupported-assignment-operation
                     entry['nsslapd-pluginenabled'] = ['off']
+                    # pylint: enable=unsupported-assignment-operation
                     api.Backend.ldap2.update_entry(entry)
             except errors.DatabaseError as dbe:
                 print("An error occurred while talking to the server.")

--- a/install/tools/ipa-csreplica-manage.in
+++ b/install/tools/ipa-csreplica-manage.in
@@ -71,18 +71,21 @@ def parse_options():
 
     if len(args):
         n = len(args) - 1
-        for cmd in commands:
+        for cmd, args_info in commands.items():
             if cmd == args[0]:
-                v = commands[cmd]
                 err = None
-                if n < v[0]:
-                    err = v[3]
-                elif n > v[1]:
+                if n < args_info[0]:
+                    err = args_info[3]
+                elif n > args_info[1]:
                     err = "too many arguments"
                 else:
                     valid_syntax = True
                 if err:
-                    parser.error("Invalid syntax: %s\nUsage: %s [options] %s" % (err, cmd, v[2]))
+                    parser.error(
+                        "Invalid syntax: %s\nUsage: %s [options] %s" % (
+                            err, cmd, args_info[2]
+                        )
+                    )
 
     if not valid_syntax:
         cmdstr = " | ".join(commands.keys())

--- a/install/tools/ipa-custodia-check.in
+++ b/install/tools/ipa-custodia-check.in
@@ -184,7 +184,7 @@ class IPACustodiaTester:
             pkey = JWK(**dictkeys[usage_id])
             local_pubkey = json_decode(pkey.export_public())
         except Exception:
-            raise self.error(
+            raise self.error(  # pylint: disable=raising-bad-type, #4772
                 "Failed to load and parse local JWK.", fatal=True
             )
         else:
@@ -193,7 +193,7 @@ class IPACustodiaTester:
             ))
 
         if pkey.key_id != self.host_spn:
-            raise self.error(
+            raise self.error(  # pylint: disable=raising-bad-type, #4772
                 "KID '{}' != host service principal name '{}' "
                 "(usage: {})".format(pkey.key_id, self.host_spn, usage),
                 fatal=True
@@ -210,7 +210,7 @@ class IPACustodiaTester:
         try:
             host_pubkey = json_decode(find_key(self.host_spn, usage_id))
         except Exception:
-            raise self.error(
+            raise self.error(  # pylint: disable=raising-bad-type, #4772
                 "Fetching host keys {} (usage: {}) failed.".format(
                     self.host_spn, usage),
                 fatal=True
@@ -223,7 +223,7 @@ class IPACustodiaTester:
         if host_pubkey != local_pubkey:
             self.debug("LDAP: '{}'".format(host_pubkey))
             self.debug("Local: '{}'".format(local_pubkey))
-            raise self.error(
+            raise self.error(  # pylint: disable=raising-bad-type, #4772
                 "Host key in LDAP does not match local key.",
                 fatal=True
             )
@@ -235,7 +235,7 @@ class IPACustodiaTester:
         try:
             server_pubkey = json_decode(find_key(self.server_spn, usage_id))
         except Exception:
-            raise self.error(
+            raise self.error(  # pylint: disable=raising-bad-type, #4772
                 "Fetching server keys {} (usage: {}) failed.".format(
                     self.server_spn, usage),
                 fatal=True

--- a/install/tools/ipa-nis-manage.in
+++ b/install/tools/ipa-nis-manage.in
@@ -155,7 +155,9 @@ def main():
         elif entry.get('nsslapd-pluginenabled', [''])[0].lower() == 'off':
             print("Enabling plugin")
             # Already configured, just enable the plugin
+            # pylint: disable=unsupported-assignment-operation
             entry['nsslapd-pluginenabled'] = ['on']
+            # pylint: enable=unsupported-assignment-operation
             api.Backend.ldap2.update_entry(entry)
         else:
             print("Plugin already Enabled")

--- a/install/tools/ipa-pki-retrieve-key.in
+++ b/install/tools/ipa-pki-retrieve-key.in
@@ -34,7 +34,6 @@ def main():
                 "File '{}' missing or not readable.\n".format(filename)
             )
 
-    # pylint: disable=no-member
     client = CustodiaClient(
         client_service="{}@{}".format(service, env.host),
         server=args.servername,

--- a/install/tools/ipa-replica-conncheck.in
+++ b/install/tools/ipa-replica-conncheck.in
@@ -319,7 +319,7 @@ class PortResponder(threading.Thread):
             logger.debug('%d %s: Stopped listening', port, proto)
 
     def _is_closing(self):
-        with self._close_lock:  # pylint: disable=not-context-manager
+        with self._close_lock:
             return self._close
 
     def _bind_to_port(self, port, socket_type):
@@ -370,7 +370,7 @@ class PortResponder(threading.Thread):
     def stop(self):
         logger.debug('Stopping listening thread.')
 
-        with self._close_lock:  # pylint: disable=not-context-manager
+        with self._close_lock:
             self._close = True
 
 

--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -116,18 +116,21 @@ def parse_options():
 
     if len(args):
         n = len(args) - 1
-        for cmd in commands:
+        for cmd, args_info in commands.items():
             if cmd == args[0]:
-                v = commands[cmd]
                 err = None
-                if n < v[0]:
-                    err = v[3]
-                elif n > v[1]:
+                if n < args_info[0]:
+                    err = args_info[3]
+                elif n > args_info[1]:
                     err = "too many arguments"
                 else:
                     valid_syntax = True
                 if err:
-                    parser.error("Invalid syntax: %s\nUsage: %s [options] %s" % (err, cmd, v[2]))
+                    parser.error(
+                        "Invalid syntax: %s\nUsage: %s [options] %s" % (
+                            err, cmd, args_info[2]
+                        )
+                    )
 
     if not valid_syntax:
         cmdstr = " | ".join(commands.keys())

--- a/ipaclient/frontend.py
+++ b/ipaclient/frontend.py
@@ -126,25 +126,25 @@ class CommandOverride(Command):
         return api.get_plugin_next(cls)
 
     @classmethod
-    def __doc_getter(cls):
+    def __doc_getter(cls):  # pylint: disable=unused-private-member, #4756
         return cls.__get_next().doc
 
     doc = classproperty(__doc_getter)
 
     @classmethod
-    def __summary_getter(cls):
+    def __summary_getter(cls):  # pylint: disable=unused-private-member, #4756
         return cls.__get_next().summary
 
     summary = classproperty(__summary_getter)
 
     @classmethod
-    def __NO_CLI_getter(cls):
+    def __NO_CLI_getter(cls):  # pylint: disable=unused-private-member, #4756
         return cls.__get_next().NO_CLI
 
     NO_CLI = classproperty(__NO_CLI_getter)
 
     @classmethod
-    def __topic_getter(cls):
+    def __topic_getter(cls):  # pylint: disable=unused-private-member, #4756
         return cls.__get_next().topic
 
     topic = classproperty(__topic_getter)

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1549,8 +1549,8 @@ def verify_dns_update(fqdn, ips):
                        ', '.join(missing_reverse))
     if wrong_reverse:
         logger.warning('Incorrect reverse record(s):')
-        for ip in wrong_reverse:
-            for target in wrong_reverse[ip]:
+        for ip, targets in wrong_reverse.items():
+            for target in targets:
                 logger.warning('%s is pointing to %s instead of %s',
                                ip, target, fqdn_name)
 

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1922,8 +1922,12 @@ def get_ca_certs(fstore, options, server, basedn, realm):
                         reason=u"Unable to load existing CA cert '%s': %s" %
                                (paths.IPA_CA_CRT, e))
             else:
-                raise errors.FileError(reason=u"Existing ca cert '%s' is " +
-                                       "not a plain file" % (paths.IPA_CA_CRT))
+                raise errors.FileError(
+                    reason=(
+                        f"Existing ca cert '{paths.IPA_CA_CRT}' is not a plain "
+                        "file"
+                    ),
+                )
 
         if otp_auth:
             if existing_ca_certs:

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3667,7 +3667,7 @@ def init(installer):
     root_logger = logging.getLogger()
     for handler in root_logger.handlers:
         if (isinstance(handler, logging.StreamHandler) and
-                handler.stream is sys.stderr):  # pylint: disable=no-member
+                handler.stream is sys.stderr):
             installer.debug = handler.level == logging.DEBUG
             break
     else:
@@ -3749,7 +3749,6 @@ class ClientInstallInterface(hostname_.HostNameInstallInterface,
     force_join = enroll_only(force_join)
 
     ntp_servers = knob(
-        # pylint: disable=invalid-sequence-index
         typing.List[str], None,
         description="ntp server to use. This option can be used multiple "
                     "times",

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3336,7 +3336,7 @@ def uninstall(options):
                     ipa_domain = domain.get_option('ipa_domain')
                 except SSSDConfig.NoOptionError:
                     pass
-    except Exception as e:
+    except Exception:
         # We were unable to read existing SSSD config. This might mean few
         # things:
         # - sssd wasn't installed

--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -113,9 +113,9 @@ def run_with_args(api):
 
         update_server(certs)
 
-        # pylint: disable=import-error,ipa-forbidden-import
+        # pylint: disable=ipa-forbidden-import
         from ipaserver.install import cainstance, custodiainstance
-        # pylint: enable=import-error,ipa-forbidden-import
+        # pylint: enable=ipa-forbidden-import
 
         # Add LWCA tracking requests.  Only execute if *this server*
         # has CA installed (ca_enabled indicates CA-ful topology).

--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -37,10 +37,8 @@ except ImportError:
     from xml.etree import ElementTree as etree
 import SSSDConfig
 
-# pylint: disable=import-error
 from six.moves.urllib.parse import urlsplit
 
-# pylint: enable=import-error
 from optparse import OptionParser  # pylint: disable=deprecated-module
 from ipapython import ipachangeconf
 from ipaclient.install import ipadiscovery

--- a/ipaclient/install/ipa_client_samba.py
+++ b/ipaclient/install/ipa_client_samba.py
@@ -173,8 +173,8 @@ def retrieve_domain_information(api):
         return []
 
     l_domain = dict()
-    for key in trust_keymap:
-        l_domain[key] = result.get(trust_keymap[key], [None])[0]
+    for key, val in trust_keymap.items():
+        l_domain[key] = result.get(val, [None])[0]
 
     # Pull down ID range and other details of our domain
     #

--- a/ipaclient/plugins/automount.py
+++ b/ipaclient/plugins/automount.py
@@ -54,7 +54,7 @@ class _fake_automountlocation_show(Method):
 @register(override=True, no_fail=True)
 class automountlocation_tofiles(MethodOverride):
     @classmethod
-    def __NO_CLI_getter(cls):
+    def __NO_CLI_getter(cls):  # pylint: disable=unused-private-member, #4756
         return (api.Command.get_plugin('automountlocation_show') is
                 _fake_automountlocation_show)
 

--- a/ipaclient/plugins/automount.py
+++ b/ipaclient/plugins/automount.py
@@ -218,8 +218,8 @@ class automountlocation_import(Command):
         # Now iterate over the map files and add the keys. To handle
         # continuation lines I'll make a pass through it to skip comments
         # etc and also to combine lines.
-        for m in maps:
-            map = self.__read_mapfile(maps[m])
+        for m, filename in maps.items():
+            map = self.__read_mapfile(filename)
             lines = []
             cont = ''
             for x in map:
@@ -227,7 +227,7 @@ class automountlocation_import(Command):
                     continue
                 x = x.rstrip()
                 if x.startswith('+'):
-                    result['skipped'].append([m, maps[m]])
+                    result['skipped'].append([m, filename])
                     continue
                 if len(x) == 0:
                     continue

--- a/ipaclient/plugins/otptoken.py
+++ b/ipaclient/plugins/otptoken.py
@@ -129,7 +129,6 @@ class HTTPSHandler(urllib.request.HTTPSHandler):
         return create_https_connection(host, **tmp)
 
     def https_open(self, req):
-        # pylint: disable=no-member
         return self.do_open(self.__inner, req)
 
 @register()
@@ -156,8 +155,6 @@ class otptoken_sync(Local):
         segments = list(urllib.parse.urlparse(self.api.env.xmlrpc_uri))
         assert segments[0] == 'https' # Ensure encryption.
         segments[2] = segments[2].replace('/xml', '/session/sync_token')
-        # urlunparse *can* take one argument
-        # pylint: disable=too-many-function-args
         sync_uri = urllib.parse.urlunparse(segments)
 
         # Prepare the query.
@@ -170,7 +167,6 @@ class otptoken_sync(Local):
         query = query.encode('utf-8')
 
         # Sync the token.
-        # pylint: disable=E1101
         handler = HTTPSHandler(
             cafile=api.env.tls_ca_cert,
             tls_version_min=api.env.tls_version_min,

--- a/ipaclient/plugins/otptoken_yubikey.py
+++ b/ipaclient/plugins/otptoken_yubikey.py
@@ -81,7 +81,7 @@ class otptoken_add_yubikey(Command):
     has_output_params = takes_options
 
     @classmethod
-    def __NO_CLI_getter(cls):
+    def __NO_CLI_getter(cls):  # pylint: disable=unused-private-member, #4756
         return api.Command.get_plugin('otptoken_add') is _fake_otptoken_add
 
     NO_CLI = classproperty(__NO_CLI_getter)

--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -199,7 +199,7 @@ class vault_add(Local):
     )
 
     @classmethod
-    def __NO_CLI_getter(cls):
+    def __NO_CLI_getter(cls):  # pylint: disable=unused-private-member, #4756
         return (api.Command.get_plugin('vault_add_internal') is
                 _fake_vault_add_internal)
 
@@ -410,7 +410,7 @@ class vault_mod(Local):
     )
 
     @classmethod
-    def __NO_CLI_getter(cls):
+    def __NO_CLI_getter(cls):  # pylint: disable=unused-private-member, #4756
         return (api.Command.get_plugin('vault_mod_internal') is
                 _fake_vault_mod_internal)
 
@@ -739,7 +739,7 @@ class vault_archive(ModVaultData):
     )
 
     @classmethod
-    def __NO_CLI_getter(cls):
+    def __NO_CLI_getter(cls):  # pylint: disable=unused-private-member, #4756
         return (api.Command.get_plugin('vault_archive_internal') is
                 _fake_vault_archive_internal)
 
@@ -985,7 +985,7 @@ class vault_retrieve(ModVaultData):
     )
 
     @classmethod
-    def __NO_CLI_getter(cls):
+    def __NO_CLI_getter(cls):  # pylint: disable=unused-private-member, #4756
         return (api.Command.get_plugin('vault_retrieve_internal') is
                 _fake_vault_retrieve_internal)
 

--- a/ipaclient/remote_plugins/__init__.py
+++ b/ipaclient/remote_plugins/__init__.py
@@ -41,7 +41,7 @@ class ServerInfo(MutableMapping):
         try:
             self._language = locale.setlocale(
                 locale.LC_MESSAGES, ''
-            ).split('.')[0].lower()
+            ).split('.', maxsplit=1)[0].lower()
         except locale.Error:
             self._language = 'en_us'
 

--- a/ipaclient/remote_plugins/__init__.py
+++ b/ipaclient/remote_plugins/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
 
+from collections.abc import MutableMapping
 import errno
 import json
 import locale
@@ -9,20 +10,11 @@ import logging
 import os
 import time
 
-import six
-
 from . import compat
 from . import schema
 from ipaclient.plugins.rpcclient import rpcclient
 from ipalib.constants import USER_CACHE_PATH
 from ipapython.dnsutil import DNSName
-
-# pylint: disable=no-name-in-module, import-error
-if six.PY3:
-    from collections.abc import MutableMapping
-else:
-    from collections import MutableMapping
-# pylint: enable=no-name-in-module, import-error
 
 logger = logging.getLogger(__name__)
 

--- a/ipaclient/remote_plugins/__init__.py
+++ b/ipaclient/remote_plugins/__init__.py
@@ -109,9 +109,12 @@ class ServerInfo(MutableMapping):
 
 def get_package(api):
     if api.env.in_tree:
+        # server packages are not published on pypi.org
+        # pylint: disable=useless-suppression
         # pylint: disable=import-error,ipa-forbidden-import
         from ipaserver import plugins
         # pylint: enable=import-error,ipa-forbidden-import
+        # pylint: enable=useless-suppression
     else:
         try:
             plugins = api._remote_plugins

--- a/ipaclient/remote_plugins/schema.py
+++ b/ipaclient/remote_plugins/schema.py
@@ -526,7 +526,7 @@ class Schema:
     def get_help(self, namespace, member):
         if isinstance(self._help, bytes):
             self._help = json.loads(
-                self._help.decode('utf-8')  # pylint: disable=no-member
+                self._help.decode('utf-8')
             )
 
         return self._help[namespace][member]
@@ -585,7 +585,7 @@ def get_package(server_info, client):
     for plugin_cls in (_SchemaCommandPlugin, _SchemaObjectPlugin):
         for full_name in schema[plugin_cls.schema_key]:
             plugin = plugin_cls(schema, str(full_name))
-            plugin = module.register()(plugin)  # pylint: disable=no-member
+            plugin = module.register()(plugin)
     sys.modules[module_name] = module
 
     for full_name, topic in six.iteritems(schema['topics']):

--- a/ipaclient/remote_plugins/schema.py
+++ b/ipaclient/remote_plugins/schema.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2016  FreeIPA Contributors see COPYING for license
 #
 
+from collections.abc import Mapping, Sequence
 import errno
 import json
 import logging
@@ -26,13 +27,6 @@ from ipapython import ipautil
 from ipapython.ipautil import fsdecode
 from ipapython.dn import DN
 from ipapython.dnsutil import DNSName
-
-# pylint: disable=no-name-in-module, import-error
-if six.PY3:
-    from collections.abc import Mapping, Sequence
-else:
-    from collections import Mapping, Sequence
-# pylint: enable=no-name-in-module, import-error
 
 logger = logging.getLogger(__name__)
 

--- a/ipalib/__init__.py
+++ b/ipalib/__init__.py
@@ -890,7 +890,7 @@ def _enable_warnings(error=False):
     import warnings
 
     # get reference to Py_BytesWarningFlag from Python CAPI
-    byteswarnings = ctypes.c_int.in_dll(  # pylint: disable=no-member
+    byteswarnings = ctypes.c_int.in_dll(
         ctypes.pythonapi, 'Py_BytesWarningFlag')
 
     if byteswarnings.value >= 2:
@@ -936,9 +936,12 @@ class API(plugable.API):
     @property
     def packages(self):
         if self.env.in_server:
+            # server packages are not published on pypi.org
+            # pylint: disable=useless-suppression
             # pylint: disable=import-error,ipa-forbidden-import
             import ipaserver.plugins
             # pylint: enable=import-error,ipa-forbidden-import
+            # pylint: enable=useless-suppression
             result = (
                 ipaserver.plugins,
             )
@@ -951,9 +954,12 @@ class API(plugable.API):
             )
 
         if self.env.context in ('installer', 'updates'):
+            # server packages are not published on pypi.org
+            # pylint: disable=useless-suppression
             # pylint: disable=import-error,ipa-forbidden-import
             import ipaserver.install.plugins
             # pylint: enable=import-error,ipa-forbidden-import
+            # pylint: enable=useless-suppression
             result += (ipaserver.install.plugins,)
 
         return result

--- a/ipalib/backend.py
+++ b/ipalib/backend.py
@@ -139,7 +139,7 @@ class Executioner(Backend):
             if _name not in self.Command:
                 raise CommandError(name=_name)
             return self.Command[_name](*args, **options)
-        except PublicError:  # pylint: disable=try-except-raise
+        except PublicError:
             raise
         except Exception as e:
             logger.exception(

--- a/ipalib/backend.py
+++ b/ipalib/backend.py
@@ -63,7 +63,7 @@ class Connectible(Backend):
                 "{0} is already connected ({1} in {2})".format(
                     self.name,
                     self.id,
-                    threading.currentThread().getName()
+                    threading.current_thread().name,
                 )
             )
         conn = self.create_connection(*args, **kw)
@@ -80,7 +80,7 @@ class Connectible(Backend):
                 "{0} is not connected ({1} in {2})".format(
                     self.name,
                     self.id,
-                    threading.currentThread().getName()
+                    threading.current_thread().name,
                 )
             )
         self.destroy_connection()
@@ -105,7 +105,7 @@ class Connectible(Backend):
                 "{0} is not connected ({1} in {2})".format(
                     self.name,
                     self.id,
-                    threading.currentThread().getName()
+                    threading.current_thread().name,
                 )
             )
         return getattr(context, self.id).conn

--- a/ipalib/backend.py
+++ b/ipalib/backend.py
@@ -96,7 +96,7 @@ class Connectible(Backend):
         """
         return hasattr(context, self.id)
 
-    def __get_conn(self):
+    def __get_conn(self):  # pylint: disable=unused-private-member, #4756
         """
         Return thread-local connection.
         """

--- a/ipalib/base.py
+++ b/ipalib/base.py
@@ -469,7 +469,7 @@ class NameSpace(ReadOnly):
         if isinstance(key, str):
             return self.__map[key]
         if type(key) in (int, slice):
-            return self.__members[key]
+            return self.__members[key]  # pylint: disable=invalid-sequence-index
         raise TypeError(
             TYPE_ERROR % ('key', (str, int, slice, 'object with __name__'),
                           key, type(key))

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -68,7 +68,7 @@ from ipalib.errors import (PublicError, CommandError, HelpError, InternalError,
 from ipalib.constants import CLI_TAB, LDAP_GENERALIZED_TIME_FORMAT
 from ipalib.parameters import File, BinaryFile, Str, Enum, Any, Flag
 from ipalib.text import _
-from ipalib import api  # pylint: disable=unused-import
+from ipalib import api
 from ipapython.dnsutil import DNSName
 from ipapython.admintool import ScriptError
 
@@ -609,7 +609,7 @@ class textui(backend.Backend):
             prompt = u'%s Yes/No: ' % label
 
         while True:
-            data = self.prompt_helper(prompt, label).lower() #pylint: disable=E1103
+            data = self.prompt_helper(prompt, label).lower()
 
             if data in (u'yes', u'y'):
                 return True
@@ -680,9 +680,9 @@ class textui(backend.Backend):
             except EOFError:
                 return -2
 
-            if resp.lower() == "q": #pylint: disable=E1103
+            if resp.lower() == "q":
                 return -2
-            if resp.lower() == "a": #pylint: disable=E1103
+            if resp.lower() == "a":
                 return -1
             try:
                 selection = int(resp) - 1
@@ -1411,9 +1411,7 @@ class cli(backend.Executioner):
                 elif p.stdin_if_missing:
                     try:
                         if six.PY3 and p.type is bytes:
-                            # pylint: disable=no-member
                             raw = sys.stdin.buffer.read()
-                            # pylint: enable=no-member
                         else:
                             raw = sys.stdin.read()
                     except IOError as e:

--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -890,13 +890,13 @@ class help(frontend.Local):
                 commands = self._topics[topic][2]
             else:
                 commands = []
-                for t in self._topics:
-                    if type(self._topics[t][2]) is not dict:
+                for v in self._topics.values():
+                    if not isinstance(v[2], dict):
                         continue
-                    if topic not in self._topics[t][2]:
+                    if topic not in v[2]:
                         continue
-                    mcl = self._topics[t][2][topic][1]
-                    commands = self._topics[t][2][topic][2]
+                    mcl = v[2][topic][1]
+                    commands = v[2][topic][2]
                     break
 
             doc, _topic = self._get_topic(topic)

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -270,9 +270,9 @@ class Env:
         if type(value) not in (unicode, int, float, bool, type(None), DN):
             raise TypeError(key, value)
         object.__setattr__(self, key, value)
-        # pylint: disable=unsupported-assignment-operation, no-member
+        # pylint: disable=no-member
         self.__d[key] = value
-        # pylint: enable=unsupported-assignment-operation, no-member
+        # pylint: enable=no-member
 
     def __getitem__(self, key):
         """
@@ -600,12 +600,10 @@ class Env:
         # and server from jsonrpc_uri so that when only server or xmlrpc_uri
         # is specified, all 3 keys have a value.)
         if 'xmlrpc_uri' not in self and 'server' in self:
-            # pylint: disable=no-member, access-member-before-definition
             self.xmlrpc_uri = 'https://{}/ipa/xml'.format(self.server)
 
         # Derive ldap_uri from server
         if 'ldap_uri' not in self and 'server' in self:
-            # pylint: disable=no-member, access-member-before-definition
             self.ldap_uri = 'ldap://{}'.format(self.server)
 
         # Derive jsonrpc_uri from xmlrpc_uri

--- a/ipalib/frontend.py
+++ b/ipalib/frontend.py
@@ -693,11 +693,6 @@ class Command(HasParam):
             (k, self.params[k].convert(v)) for (k, v) in kw.items()
         )
 
-    def __convert_iter(self, kw):
-        for param in self.params():
-            if kw.get(param.name, None) is None:
-                continue
-
     def get_default(self, _params=None, **kw):
         """
         Return a dictionary of defaults for all missing required values.

--- a/ipalib/frontend.py
+++ b/ipalib/frontend.py
@@ -429,7 +429,7 @@ class Command(HasParam):
     api_version = API_VERSION
 
     @classmethod
-    def __topic_getter(cls):
+    def __topic_getter(cls):  # pylint: disable=unused-private-member, #4756
         return cls.__module__.rpartition('.')[2]
 
     topic = classproperty(__topic_getter)

--- a/ipalib/install/hostname.py
+++ b/ipalib/install/hostname.py
@@ -21,7 +21,6 @@ class HostNameInstallInterface(service.ServiceInstallInterface):
     """
 
     ip_addresses = knob(
-        # pylint: disable=invalid-sequence-index
         typing.List[CheckedIPAddress], None,
         description="Specify IP address that should be added to DNS. This "
                     "option can be used multiple times",

--- a/ipalib/install/service.py
+++ b/ipalib/install/service.py
@@ -115,7 +115,6 @@ class ServiceInstallInterface(common.Installable,
         validate_domain_name(value)
 
     servers = knob(
-        # pylint: disable=invalid-sequence-index
         typing.List[str], None,
         description="FQDN of IPA server",
         cli_names='--server',
@@ -143,7 +142,6 @@ class ServiceInstallInterface(common.Installable,
     )
 
     ca_cert_files = knob(
-        # pylint: disable=invalid-sequence-index
         typing.List[str], None,
         description="load the CA certificate from this file",
         cli_names='--ca-cert-file',

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -454,7 +454,7 @@ class API(ReadOnly):
         if root_logger.handlers or self.env.validate_api:
             return
 
-        if self.env.debug:  # pylint: disable=using-constant-test
+        if self.env.debug:
             level = logging.DEBUG
         else:
             level = logging.INFO
@@ -478,7 +478,7 @@ class API(ReadOnly):
 
         # Add stderr handler:
         level = logging.INFO
-        if self.env.debug:  # pylint: disable=using-constant-test
+        if self.env.debug:
             level = logging.DEBUG
         else:
             if self.env.context == 'cli':
@@ -510,7 +510,7 @@ class API(ReadOnly):
                 return
 
         level = logging.INFO
-        if self.env.debug:  # pylint: disable=using-constant-test
+        if self.env.debug:
             level = logging.DEBUG
         if self.env.log is not None:
             try:
@@ -663,7 +663,7 @@ class API(ReadOnly):
                 continue
             except Exception:
                 tb = self.env.startup_traceback
-                if tb:  # pylint: disable=using-constant-test
+                if tb:
                     logger.exception("could not load plugin module %s", name)
                 raise
 

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -804,8 +804,6 @@ class API(ReadOnly):
                 if not production_mode:
                     assert islocked(instance)
 
-        self.__finalized = True
-
         if not production_mode:
             lock(self)
 

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -822,10 +822,10 @@ class API(ReadOnly):
 
 
 class IPAHelpFormatter(optparse.IndentedHelpFormatter):
-    def format_epilog(self, text):
+    def format_epilog(self, epilog):
         text_width = self.width - self.current_indent
         indent = " " * self.current_indent
-        lines = text.splitlines()
+        lines = epilog.splitlines()
         result = '\n'.join(
             textwrap.fill(line, text_width, initial_indent=indent,
                 subsequent_indent=indent)

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -146,32 +146,32 @@ class Plugin(ReadOnly):
         self.__finalize_lock = threading.RLock()
 
     @classmethod
-    def __name_getter(cls):
+    def __name_getter(cls):  # pylint: disable=unused-private-member, #4756
         return cls.__name__
 
     # you know nothing, pylint
     name = classproperty(__name_getter)
 
     @classmethod
-    def __full_name_getter(cls):
+    def __full_name_getter(cls):  # pylint: disable=unused-private-member
         return '{}/{}'.format(cls.name, cls.version)
 
     full_name = classproperty(__full_name_getter)
 
     @classmethod
-    def __bases_getter(cls):
+    def __bases_getter(cls):  # pylint: disable=unused-private-member, #4756
         return cls.__bases__
 
     bases = classproperty(__bases_getter)
 
     @classmethod
-    def __doc_getter(cls):
+    def __doc_getter(cls):  # pylint: disable=unused-private-member, #4756
         return cls.__doc__
 
     doc = classproperty(__doc_getter)
 
     @classmethod
-    def __summary_getter(cls):
+    def __summary_getter(cls):  # pylint: disable=unused-private-member, #4756
         doc = cls.doc
         if not _(doc).msg:
             return '<%s.%s>' % (cls.__module__, cls.__name__)

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -25,6 +25,7 @@ you are unfamiliar with this Python feature, see
 http://docs.python.org/ref/sequence-types.html
 """
 
+from collections.abc import Mapping
 import logging
 import operator
 import re
@@ -50,13 +51,6 @@ from ipapython.ipa_log_manager import (
     LOGGING_FORMAT_FILE,
     LOGGING_FORMAT_STDERR)
 from ipapython.version import VERSION, API_VERSION, DEFAULT_PLUGINS
-
-# pylint: disable=no-name-in-module, import-error
-if six.PY3:
-    from collections.abc import Mapping
-else:
-    from collections import Mapping
-# pylint: enable=no-name-in-module, import-error
 
 if six.PY3:
     unicode = str

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -661,7 +661,7 @@ class API(ReadOnly):
             except errors.SkipPluginModule as e:
                 logger.debug("skipping plugin module %s: %s", name, e.reason)
                 continue
-            except Exception as e:
+            except Exception:
                 tb = self.env.startup_traceback
                 if tb:  # pylint: disable=using-constant-test
                     logger.exception("could not load plugin module %s", name)

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -77,7 +77,6 @@ try:
     from xmlrpclib import (Binary, Fault, DateTime, dumps, loads, ServerProxy,
             Transport, ProtocolError, MININT, MAXINT)
 except ImportError:
-    # pylint: disable=import-error
     from xmlrpc.client import (Binary, Fault, DateTime, dumps, loads, ServerProxy,
             Transport, ProtocolError, MININT, MAXINT)
 
@@ -763,7 +762,7 @@ class KerbTransport(SSLTransport):
             else:
                 connection.putrequest("POST", handler)
             headers.append(("User-Agent", self.user_agent))
-            self.send_headers(connection, headers)  # pylint: disable=E1101
+            self.send_headers(connection, headers)
             self.send_content(connection, request_body)
             return connection
 
@@ -996,8 +995,6 @@ class RPCClient(Connectible):
         # Form the session URL by substituting the session path into the original URL
         scheme, netloc, path, params, query, fragment = urllib.parse.urlparse(original_url)
         path = self.session_path
-        # urlencode *can* take one argument
-        # pylint: disable=too-many-function-args
         session_url = urllib.parse.urlunparse((scheme, netloc, path, params, query, fragment))
 
         return session_url
@@ -1078,11 +1075,9 @@ class RPCClient(Connectible):
                             )
                     # We don't care about the response, just that we got one
                     return serverproxy
-                # pylint: disable=try-except-raise
                 except errors.KerberosError:
                     # kerberos error on one server is likely on all
                     raise
-                # pylint: enable=try-except-raise
                 except ProtocolError as e:
                     if hasattr(context, 'session_cookie') and e.errcode == 401:
                         # Unauthorized. Remove the session and try again.

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -742,7 +742,7 @@ class KerbTransport(SSLTransport):
             self.close()
             logger.debug("HTTP server has closed connection (%s)", host)
             raise
-        except BaseException as e:
+        except BaseException:
             # Unexpected exception may leave connections in a bad state.
             self.close()
             logger.debug("HTTP connection destroyed (%s)",
@@ -837,7 +837,7 @@ class KerbTransport(SSLTransport):
                      cookie_string, principal)
         try:
             update_persistent_client_session_data(principal, cookie_string)
-        except Exception as e:
+        except Exception:
             # Not fatal, we just can't use the session cookie we were sent.
             pass
 
@@ -977,7 +977,7 @@ class RPCClient(Connectible):
                          principal, e)
             try:
                 delete_persistent_client_session_data(principal)
-            except Exception as e:
+            except Exception:
                 pass
             return original_url
         except Cookie.URLMismatch as e:

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -533,7 +533,7 @@ class LanguageAwareTransport(MultiProtocolTransport):
         try:
             lang = locale.setlocale(
                 locale.LC_MESSAGES, ''
-            ).split('.')[0].lower()
+            ).split('.', maxsplit=1)[0].lower()
         except locale.Error:
             # fallback to default locale
             lang = 'en_us'

--- a/ipalib/sysrestore.py
+++ b/ipalib/sysrestore.py
@@ -376,9 +376,9 @@ class StateFile:
         p = SafeConfigParser(interpolation=None)
         p.optionxform = str
 
-        for module in self.modules:
+        for module, vals in self.modules.items():
             p.add_section(module)
-            for (key, value) in self.modules[module].items():
+            for (key, value) in vals.items():
                 p.set(module, key, str(value))
 
         with open(self._path, "w") as f:

--- a/ipalib/text.py
+++ b/ipalib/text.py
@@ -288,7 +288,7 @@ class Gettext(LazyText):
         else:
             t = create_translation(self.key)
         if six.PY2:
-            return t.ugettext(self.msg)  # pylint: disable=no-member
+            return t.ugettext(self.msg)
         else:
             return t.gettext(self.msg)
 
@@ -296,10 +296,10 @@ class Gettext(LazyText):
         return unicode(self.as_unicode())
 
     def __json__(self):
-        return unicode(self)   #pylint: disable=no-member
+        return unicode(self)
 
     def __mod__(self, kw):
-        return unicode(self) % kw  #pylint: disable=no-member
+        return unicode(self) % kw
 
     def format(self, *args, **kwargs):
         return unicode(self).format(*args, **kwargs)
@@ -481,9 +481,7 @@ class NGettext(LazyText):
         else:
             t = create_translation(self.key)
         if six.PY2:
-            # pylint: disable=no-member
             return t.ungettext(self.singular, self.plural, count)
-            # pylint: enable=no-member
         else:
             return t.ngettext(self.singular, self.plural, count)
 

--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -60,7 +60,6 @@ from ipalib.constants import (
     TLS_VERSIONS, TLS_VERSION_MINIMAL, TLS_VERSION_MAXIMAL,
     TLS_VERSION_DEFAULT_MIN, TLS_VERSION_DEFAULT_MAX,
 )
-# pylint: disable=ipa-forbidden-import
 from ipalib.facts import is_ipa_client_configured
 from ipalib.text import _
 from ipaplatform.constants import constants
@@ -77,7 +76,7 @@ from ipapython.dnsutil import (
 from ipapython.admintool import ScriptError
 
 if sys.version_info >= (3, 2):
-    import reprlib  # pylint: disable=import-error
+    import reprlib
 else:
     reprlib = None
 
@@ -321,7 +320,6 @@ def create_https_connection(
             is not encrypted.
     :returns An established HTTPS connection to host:port
     """
-    # pylint: disable=no-member
     tls_cutoff_map = {
         "ssl2": ssl.OP_NO_SSLv2,
         "ssl3": ssl.OP_NO_SSLv3,
@@ -330,7 +328,6 @@ def create_https_connection(
         "tls1.2": ssl.OP_NO_TLSv1_2,
         "tls1.3": getattr(ssl, "OP_NO_TLSv1_3", 0),
     }
-    # pylint: enable=no-member
 
     if cafile is None:
         raise RuntimeError("cafile argument is required to perform server "
@@ -343,7 +340,6 @@ def create_https_connection(
     # official Python documentation states that the best option to get
     # TLSv1 and later is to setup SSLContext with PROTOCOL_SSLv23
     # and then negate the insecure SSLv2 and SSLv3
-    # pylint: disable=no-member
     ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
     ctx.options |= (
         ssl.OP_ALL | ssl.OP_NO_COMPRESSION | ssl.OP_SINGLE_DH_USE |
@@ -357,7 +353,6 @@ def create_https_connection(
     # remove the slice of negating protocol options according to options
     tls_span = get_proper_tls_version_span(tls_version_min, tls_version_max)
 
-    # pylint: enable=no-member
     # set up the correct TLS version flags for the SSL context
     if tls_span is not None:
         for version in TLS_VERSIONS:

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -397,7 +397,10 @@ class IPACertificate:
             for value in values:
                 match_san.append(('DNS', value))
 
-        ssl.match_hostname(match_cert, DNSName(hostname).ToASCII())
+        # deprecated in Python3.7 without replacement
+        ssl.match_hostname(  # pylint: disable=deprecated-method
+            match_cert, DNSName(hostname).ToASCII()
+        )
 
 
 def load_pem_x509_certificate(data):

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -809,12 +809,10 @@ class ExternalCAProfile:
             _oid = univ.ObjectIdentifier(parts[0])
 
             # It is; construct a V2 template
-            # pylint: disable=too-many-function-args
             return MSCSTemplateV2.__new__(MSCSTemplateV2, s)
 
         except pyasn1.error.PyAsn1Error:
             # It is not an OID; treat as a template name
-            # pylint: disable=too-many-function-args
             return MSCSTemplateV1.__new__(MSCSTemplateV1, s)
 
     def __getstate__(self):

--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -37,12 +37,7 @@ from ipapython import ipautil
 from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks
 
-# pylint: disable=no-name-in-module, import-error
-if six.PY3:
-    from collections.abc import Mapping
-else:
-    from collections import Mapping
-# pylint: enable=no-name-in-module, import-error
+from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
 

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -513,14 +513,14 @@ class RedHatTaskNamespace(BaseTaskNamespace):
         """Tell systemd to reload config files"""
         ipautil.run([paths.SYSTEMCTL, "--system", "daemon-reload"])
 
-    def configure_http_gssproxy_conf(self, ipaapi_user):
+    def configure_http_gssproxy_conf(self, ipauser):
         ipautil.copy_template_file(
             os.path.join(paths.USR_SHARE_IPA_DIR, 'gssproxy.conf.template'),
             paths.GSSPROXY_CONF,
             dict(
                 HTTP_KEYTAB=paths.HTTP_KEYTAB,
                 HTTPD_USER=constants.HTTPD_USER,
-                IPAAPI_USER=ipaapi_user,
+                IPAAPI_USER=ipauser,
                 SWEEPER_SOCKET=paths.IPA_CCACHE_SWEEPER_GSSPROXY_SOCK,
             )
         )

--- a/ipapython/admintool.py
+++ b/ipapython/admintool.py
@@ -180,9 +180,8 @@ class AdminTool:
             return_value = self.run()
         except BaseException as exception:
             if isinstance(exception, ScriptError):
-                # pylint: disable=no-member
                 if exception.rval and exception.rval > return_value:
-                    return_value = exception.rval  # pylint: disable=no-member
+                    return_value = exception.rval
             traceback = sys.exc_info()[2]
             error_message, return_value = self.handle_error(exception)
             if return_value:
@@ -244,7 +243,7 @@ class AdminTool:
         root_logger = logging.getLogger()
         for handler in root_logger.handlers:
             if (isinstance(handler, logging.StreamHandler) and
-                    handler.stream is sys.stderr):  # pylint: disable=no-member
+                    handler.stream is sys.stderr):
                 root_logger.removeHandler(handler)
                 break
 

--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -611,7 +611,7 @@ class NSSDatabase:
         try:
             self.run_pk12util(args)
         except ipautil.CalledProcessError as e:
-            if e.returncode == 17 or e.returncode == 18:
+            if e.returncode in (17, 18):
                 raise Pkcs12ImportIncorrectPasswordError(
                     "incorrect password for pkcs#12 file %s" % pkcs12_filename)
             elif e.returncode == 10:

--- a/ipapython/cookie.py
+++ b/ipapython/cookie.py
@@ -444,7 +444,7 @@ class Cookie:
             except Exception:
                 raise ValueError("Max-Age value '%s' not convertable to integer" % value)
 
-    def __set_attr(self, name, value):
+    def __set_attr(self, name, value):  # pylint: disable=unused-private-member
         '''
         Sets one of the predefined cookie attributes.
         '''

--- a/ipapython/dnsutil.py
+++ b/ipapython/dnsutil.py
@@ -162,7 +162,6 @@ class DNSName(dns.name.Name):
     def __init__(self, labels, origin=None):
         try:
             if isinstance(labels, str):
-                #pylint: disable=E1101
                 labels = dns.name.from_text(unicode(labels), origin).labels
             elif isinstance(labels, dns.name.Name):
                 labels = labels.labels

--- a/ipapython/dogtag.py
+++ b/ipapython/dogtag.py
@@ -41,7 +41,6 @@ from ipapython import ipautil
 try:
     import httplib
 except ImportError:
-    # pylint: disable=import-error
     import http.client as httplib
 
 if six.PY3:
@@ -67,7 +66,7 @@ KDC_PROFILE = u'KDCs_PKINIT_Certs'
 
 
 if six.PY3:
-    gzip_decompress = gzip.decompress  # pylint: disable=no-member
+    gzip_decompress = gzip.decompress
 else:
     # note: gzip.decompress available in Python >= 3.2
     def gzip_decompress(data):

--- a/ipapython/install/cli.py
+++ b/ipapython/install/cli.py
@@ -131,7 +131,9 @@ class ConfigureTool(admintool.AdminTool):
         raise NotImplementedError
 
     @classmethod
-    def add_options(cls, parser, positional=False):
+    def add_options(  # pylint: disable=arguments-renamed
+        cls, parser, positional=False
+    ):
         transformed_cls = cls._transform(cls.configurable_class)
 
         if issubclass(transformed_cls, common.Interactive):

--- a/ipapython/ipachangeconf.py
+++ b/ipapython/ipachangeconf.py
@@ -216,7 +216,7 @@ class IPAChangeConf:
         if value:
             return {'name': 'comment',
                     'type': 'comment',
-                    'value': value.rstrip()}  # pylint: disable=E1103
+                    'value': value.rstrip()}
 
         o = dict()
         parts = line.split(self.dassign, 1)

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -84,7 +84,7 @@ if six.PY2 and hasattr(ldap, 'LDAPBytesWarning'):
     # XXX silence python-ldap's BytesWarnings
     warnings.filterwarnings(
         action="ignore",
-        category=ldap.LDAPBytesWarning,  # pylint: disable=no-member
+        category=ldap.LDAPBytesWarning,
     )
 
 
@@ -255,7 +255,7 @@ class LDAPEntry(MutableMapping):
 
         Keyword arguments can be used to override values of specific attributes.
         """
-        super(LDAPEntry, self).__init__()  # pylint: disable=no-member
+        super(LDAPEntry, self).__init__()
 
         if isinstance(_conn, LDAPEntry):
             assert _dn is None
@@ -284,7 +284,6 @@ class LDAPEntry(MutableMapping):
         self._single_value_view = None
 
         if isinstance(_obj, LDAPEntry):
-            #pylint: disable=E1103
             self._not_list = set(_obj._not_list)
             self._orig_raw = dict(_obj._orig_raw)
             if _obj.conn is _conn:
@@ -1933,7 +1932,6 @@ class LDAPCache(LDAPClient):
 
     def get_entry(self, dn, attrs_list=None, time_limit=None,
                   size_limit=None, get_effective_rights=False):
-        # pylint: disable=no-member
         if not self._enable_cache:
             return super(LDAPCache, self).get_entry(
                 dn, attrs_list, time_limit, size_limit, get_effective_rights
@@ -1971,7 +1969,6 @@ class LDAPCache(LDAPClient):
             get_all = True
 
         if entry and entry.all and get_all:
-            # self.hit  # pylint: disable=pointless-statement
             hits = self._cache_hits + 1  # pylint: disable=no-member
             object.__setattr__(self, '_cache_hits', hits)
             self.cache_status('HIT')

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -53,12 +53,7 @@ from ipapython.dn import DN, RDN
 from ipapython.dnsutil import DNSName
 from ipapython.kerberos import Principal
 
-# pylint: disable=no-name-in-module, import-error
-if six.PY3:
-    from collections.abc import MutableMapping
-else:
-    from collections import MutableMapping
-# pylint: enable=no-name-in-module, import-error
+from collections.abc import MutableMapping
 
 if six.PY3:
     unicode = str

--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -544,7 +544,7 @@ def run(args, stdin=None, raiseonerr=True, nolog=(), env=None,
         raise
     finally:
         if skip_output:
-            p_out.close()   # pylint: disable=E1103
+            p_out.close()
 
     logger.debug('Process finished, return code=%s', p.returncode)
 
@@ -1513,7 +1513,7 @@ if six.PY2:
                 str.__name__,
                 type(value).__name__))
 else:
-    fsdecode = os.fsdecode  #pylint: disable=no-member
+    fsdecode = os.fsdecode
 
 
 def unescape_seq(seq, *args):

--- a/ipapython/ssh.py
+++ b/ipapython/ssh.py
@@ -26,7 +26,7 @@ import base64
 import re
 import struct
 from hashlib import sha1
-from hashlib import sha256  # pylint: disable=E0611
+from hashlib import sha256
 
 import six
 

--- a/ipaserver/advise/base.py
+++ b/ipaserver/advise/base.py
@@ -458,6 +458,7 @@ class IpaAdvise(admintool.AdminTool):
         installutils.check_server_configuration()
 
         if len(self.args) > 1:
+            # pylint: disable=raising-bad-type, #4772
             raise self.option_parser.error("You can only provide one "
                                            "positional argument.")
 

--- a/ipaserver/custodia/httpd/authenticators.py
+++ b/ipaserver/custodia/httpd/authenticators.py
@@ -41,7 +41,6 @@ class SimpleHeaderAuth(HTTPAuthenticator):
             return None
         value = request['headers'][self.header]
         if self.value is not None:
-            # pylint: disable=unsupported-membership-test
             if value not in self.value:
                 self.audit_svc_access(log.AUDIT_SVC_AUTH_FAIL,
                                       request['client_id'], value)

--- a/ipaserver/custodia/httpd/authorizers.py
+++ b/ipaserver/custodia/httpd/authorizers.py
@@ -22,7 +22,7 @@ class SimplePathAuthz(HTTPAuthorizer):
 
         # if an authorized path does not end in /
         # check if it matches fullpath for strict match
-        for authz in self.paths:  # pylint: disable=not-an-iterable
+        for authz in self.paths:
             if authz.endswith('/'):
                 continue
             if authz.endswith('.'):
@@ -34,7 +34,6 @@ class SimplePathAuthz(HTTPAuthorizer):
                 return True
 
         while path != '':
-            # pylint: disable=unsupported-membership-test
             if path in self.paths:
                 self.audit_svc_access(log.AUDIT_SVC_AUTHZ_PASS,
                                       request['client_id'], path)

--- a/ipaserver/custodia/httpd/server.py
+++ b/ipaserver/custodia/httpd/server.py
@@ -20,7 +20,7 @@ from ipaserver.custodia import log
 from ipaserver.custodia.plugin import HTTPError
 
 try:
-    from systemd import daemon as sd  # pylint: disable=import-error
+    from systemd import daemon as sd
 except ImportError:
     sd = None
     if 'NOTIFY_SOCKET' in os.environ:
@@ -61,7 +61,7 @@ class ForkingHTTPServer(ForkingTCPServer):
 
     def __init__(self, server_address, handler_class, config,
                  bind_and_activate=True):
-        # pylint: disable=super-init-not-called, non-parent-init-called
+        # pylint: disable=non-parent-init-called
         # Init just BaseServer, TCPServer creates a socket.
         BaseServer.__init__(self, server_address, handler_class)
 

--- a/ipaserver/custodia/log.py
+++ b/ipaserver/custodia/log.py
@@ -55,7 +55,6 @@ class CustodiaLoggingAdapter(logging.LoggerAdapter):
         extra = {'origin': plugin.origin}
         super(CustodiaLoggingAdapter, self).__init__(logger, extra=extra)
 
-    # pylint: disable=arguments-differ
     def exception(self, msg, *args, **kwargs):
         """Like standard exception() logger but only print stack in debug mode
         """

--- a/ipaserver/custodia/plugin.py
+++ b/ipaserver/custodia/plugin.py
@@ -8,7 +8,6 @@ import inspect
 import json
 import pwd
 import re
-import sys
 
 from jwcrypto.common import json_encode
 
@@ -262,17 +261,12 @@ class CustodiaPluginMeta(abc.ABCMeta):
         ncls = super(CustodiaPluginMeta, cls).__new__(
             cls, name, bases, namespace, **kwargs)
 
-        if sys.version_info < (3, 0):
-            # pylint: disable=deprecated-method
-            args = inspect.getargspec(ncls.__init__).args
-            # pylint: enable=deprecated-method
-        else:
-            sig = inspect.signature(ncls.__init__)  # pylint: disable=no-member
-            args = list(sig.parameters)
+        sig = inspect.signature(ncls.__init__)
+        args = list(sig.parameters)
 
         if args[1:3] != ['config', 'section']:
             # old-style plugin class
-            ncls._options = None  # pylint: disable=protected-access
+            ncls._options = None
             return ncls
 
         # new-style plugin class
@@ -288,7 +282,7 @@ class CustodiaPluginMeta(abc.ABCMeta):
             value.name = name
             options.append(value)
 
-        ncls._options = tuple(options)  # pylint: disable=protected-access
+        ncls._options = tuple(options)
         return ncls
 
 
@@ -315,7 +309,6 @@ class CustodiaPlugin:
         if section is not None and self._options is not None:
             # new style configuration
             opt = OptionHandler(config, section)
-            # pylint: disable=not-an-iterable
             for option in self._options:
                 value = opt.get(option)
                 # special case for store
@@ -359,9 +352,7 @@ class CustodiaPlugin:
             raise ValueError(
                 "'{}' references non-existing store '{}'".format(
                     self.section, self.store_name))
-        # pylint: disable=attribute-defined-outside-init
         self.store = store_plugin
-        # pylint: enable=attribute-defined-outside-init
         store_plugin.finalize_init(config, cfgparser, context=self)
 
     def finalize_init(self, config, cfgparser, context=None):

--- a/ipaserver/custodia/server/__init__.py
+++ b/ipaserver/custodia/server/__init__.py
@@ -67,11 +67,11 @@ def _create_plugin(cfgparser, section, menu):
         handler = _load_plugin_class(menu, handler_name)
         classname = handler.__name__
         hconf['facility_name'] = '%s-[%s]' % (classname, section)
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as e:
         raise ValueError('Invalid format for "handler" option '
                          '[%r]: %s' % (e, handler_name))
 
-    if handler._options is not None:  # pylint: disable=protected-access
+    if handler._options is not None:
         # new-style plugin with parser and section
         plugin = handler(cfgparser, section)
     else:

--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -277,7 +277,7 @@ class DomainValidator:
                 result[t_partner] = (fname_norm,
                                      security.dom_sid(trusted_sid))
             return result
-        except errors.NotFound as exc:
+        except errors.NotFound:
             return []
 
     def set_trusted_domains(self):
@@ -816,7 +816,7 @@ class DomainValidator:
 
             try:
                 answers = query_srv(gc_name)
-            except DNSException as e:
+            except DNSException:
                 answers = []
 
             for answer in answers:

--- a/ipaserver/dnssec/ldapkeydb.py
+++ b/ipaserver/dnssec/ldapkeydb.py
@@ -180,8 +180,8 @@ class Key(MutableMapping):
         """remove default values from LDAP entry"""
         default_attrs = get_default_attrs(self.entry['objectclass'])
         empty = object()
-        for attr in default_attrs:
-            if self.get(attr, empty) == default_attrs[attr]:
+        for attr, attr_val in default_attrs.items():
+            if self.get(attr, empty) == attr_val:
                 del self[attr]
 
     def _update_key(self):
@@ -299,8 +299,8 @@ class LdapKeyDB(AbstractHSM):
             # add default values not present in LDAP
             key = key_type(o, self.ldap, self)
             default_attrs = get_default_attrs(key.entry['objectclass'])
-            for attr in default_attrs:
-                key.setdefault(attr, default_attrs[attr])
+            for attr, attr_val in default_attrs.items():
+                key.setdefault(attr, attr_val)
 
             if 'ipk11id' not in key:
                 raise ValueError(

--- a/ipaserver/dnssec/ldapkeydb.py
+++ b/ipaserver/dnssec/ldapkeydb.py
@@ -5,10 +5,9 @@
 from __future__ import print_function, absolute_import
 
 from binascii import hexlify
+from collections.abc import MutableMapping
 import logging
 from pprint import pprint
-
-import six
 
 import ipalib
 from ipaplatform.paths import paths
@@ -23,13 +22,6 @@ from ipaserver.dnssec.abshsm import (
     populate_pkcs11_metadata)
 from ipaserver import p11helper as _ipap11helper
 import uuid
-
-# pylint: disable=no-name-in-module, import-error
-if six.PY3:
-    from collections.abc import MutableMapping
-else:
-    from collections import MutableMapping
-# pylint: enable=no-name-in-module, import-error
 
 logger = logging.getLogger(__name__)
 

--- a/ipaserver/dnssec/ldapkeydb.py
+++ b/ipaserver/dnssec/ldapkeydb.py
@@ -32,7 +32,6 @@ def uri_escape(val):
         raise ValueError("zero-length URI component detected")
     hexval = str_hexlify(val)
     out = '%'
-    # pylint: disable=E1127
     out += '%'.join(hexval[i:i+2] for i in range(0, len(hexval), 2))
     return out
 

--- a/ipaserver/dnssec/localhsm.py
+++ b/ipaserver/dnssec/localhsm.py
@@ -4,10 +4,9 @@
 
 from __future__ import print_function, absolute_import
 
+from collections.abc import MutableMapping
 import os
 from pprint import pprint
-
-import six
 
 from ipalib.constants import SOFTHSM_DNSSEC_TOKEN_LABEL
 from ipaplatform.paths import paths
@@ -16,13 +15,6 @@ from ipaserver.dnssec.abshsm import (attrs_name2id, attrs_id2name, AbstractHSM,
                                      keytype_id2name, keytype_name2id,
                                      ldap2p11helper_api_params)
 from ipaserver.dnssec.ldapkeydb import str_hexlify
-
-# pylint: disable=no-name-in-module, import-error
-if six.PY3:
-    from collections.abc import MutableMapping
-else:
-    from collections import MutableMapping
-# pylint: enable=no-name-in-module, import-error
 
 
 private_key_api_params = set(["label", "id", "data", "unwrapping_key",

--- a/ipaserver/dnssec/syncrepl.py
+++ b/ipaserver/dnssec/syncrepl.py
@@ -48,8 +48,8 @@ class SyncReplConsumer(ReconnectLDAPObject, SyncreplConsumer):
         logger.debug('New cookie is: %s', cookie)
         self.__data['cookie'] = cookie
 
-    def syncrepl_entry(self, dn, attributes, uuid):
-        attributes = cidict(attributes)
+    def syncrepl_entry(self, dn, attrs, uuid):
+        attributes = cidict(attrs)
         # First we determine the type of change we have here
         # (and store away the previous data for later if needed)
         previous_attributes = cidict()

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -491,7 +491,6 @@ class CAInstallInterface(dogtag.DogtagInstallInterface,
     external_ca_profile = master_install_only(external_ca_profile)
 
     external_cert_files = knob(
-        # pylint: disable=invalid-sequence-index
         typing.List[str], None,
         description=("File containing the IPA CA certificate and the external "
                      "CA certificate chain"),

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -27,7 +27,6 @@ import enum
 import logging
 
 import dbus
-import ldap
 import os
 import re
 import shutil
@@ -1304,21 +1303,6 @@ class CAInstance(DogtagInstance):
         keystore.generate_keys(self.service_prefix)
         os.chmod(keyfile, 0o600)
         self.service_user.chown(keyfile)
-
-    def __remove_lightweight_ca_key_retrieval_custodia(self):
-        keyfile = os.path.join(paths.PKI_TOMCAT,
-                               self.service_prefix + '.keys')
-        keystore = IPAKEMKeys({'server_keys': keyfile})
-        # Call remove_server_keys_file explicitly to ensure that the key
-        # file is always removed.
-        keystore.remove_server_keys_file()
-        try:
-            keystore.remove_keys(self.service_prefix)
-        except (ldap.CONNECT_ERROR, ldap.SERVER_DOWN):
-            logger.debug(
-                "Cannot remove custodia keys now, server_del takes care of "
-                "them later."
-            )
 
     def add_lightweight_ca_tracking_requests(self):
         try:

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -774,7 +774,7 @@ class _CrossProcessLock:
         if six.PY2:
             p.readfp(fileobj)  # pylint: disable=deprecated-method
         else:
-            p.read_file(fileobj)  # pylint: disable=no-member
+            p.read_file(fileobj)
 
         try:
             self._locked = p.getboolean('lock', 'locked')

--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -303,9 +303,3 @@ class CustodiaInstance(SimpleServiceInstance):
         data = {'prefix': 'ca',
                 'list': certlist}
         self._get_keys(cacerts_file, cacerts_pwd, data)
-
-    def __start(self):
-        super(CustodiaInstance, self).__start()
-
-    def __enable(self):
-        super(CustodiaInstance, self).__enable()

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -444,7 +444,6 @@ class DNSInstallInterface(hostname.HostNameInstallInterface):
     allow_zone_overlap = prepare_only(allow_zone_overlap)
 
     reverse_zones = knob(
-        # pylint: disable=invalid-sequence-index
         typing.List[str], [],
         description=("The reverse DNS zone to use. This option can be used "
                      "multiple times"),
@@ -506,7 +505,6 @@ class DNSInstallInterface(hostname.HostNameInstallInterface):
                 raise ValueError(error)
 
     forwarders = knob(
-        # pylint: disable=invalid-sequence-index
         typing.List[ipautil.CheckedIPAddressLoopback], None,
         description=("Add a DNS forwarder. This option can be used multiple "
                      "times"),

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -500,7 +500,7 @@ class DogtagInstance(service.Service):
     def configure_renewal(self):
         """ Configure certmonger to renew system certs """
 
-        for nickname in self.tracking_reqs:
+        for nickname, profile in self.tracking_reqs.items():
             token_name = self.get_token_name(nickname)
             pin = self.__get_pin(token_name)
             try:
@@ -512,7 +512,7 @@ class DogtagInstance(service.Service):
                     pin=pin,
                     pre_command='stop_pkicad',
                     post_command='renew_ca_cert "%s"' % nickname,
-                    profile=self.tracking_reqs[nickname],
+                    profile=profile,
                 )
             except RuntimeError as e:
                 logger.error(

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -993,7 +993,6 @@ class DsInstance(service.Service):
 
     def __setup_s4u2proxy(self):
 
-        # pylint: disable=unused-private-member
         def __add_principal(last_cn, principal, self):
             dn = DN(('cn', last_cn), ('cn', 's4u2proxy'),
                     ('cn', 'etc'), self.suffix)

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -458,7 +458,7 @@ def resolve_ip_addresses_nss(fqdn):
         addrinfos = socket.getaddrinfo(fqdn, None,
                                        socket.AF_UNSPEC, socket.SOCK_STREAM)
     except socket.error as ex:
-        if ex.errno == socket.EAI_NODATA or ex.errno == socket.EAI_NONAME:
+        if ex.errno in (socket.EAI_NODATA, socket.EAI_NONAME):
             logger.debug('Name %s does not have any address: %s', fqdn, ex)
             return set()
         else:

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -171,7 +171,7 @@ def verify_fqdn(host_name, no_host_dns=False, local_hostname=True):
         except socket.error as e:
             logger.debug(
                 'socket.gethostbyaddr() error: %d: %s',
-                e.errno, e.strerror)  # pylint: disable=no-member
+                e.errno, e.strerror)
 
     if no_host_dns:
         print("Warning: skipping DNS resolution of host", host_name)

--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -75,7 +75,6 @@ def convertDate(value):
 
     dt = dateutil.parser.parse(value)
 
-    # pylint: disable=E1101
     if dt.tzinfo is None:
         dt = datetime.datetime(*dt.timetuple()[0:6],
                                tzinfo=dateutil.tz.tzlocal())
@@ -535,11 +534,11 @@ class OTPTokenImport(admintool.AdminTool):
 
         # Verify a key is provided if one is needed.
         if self.doc.keyname is not None:
-            if self.safe_options.keyfile is None:  # pylint: disable=no-member
+            if self.safe_options.keyfile is None:
                 raise admintool.ScriptError("Encryption key required: %s!" % self.doc.keyname)
 
             # Load the keyfile.
-            keyfile = self.safe_options.keyfile  # pylint: disable=no-member
+            keyfile = self.safe_options.keyfile
             with open(keyfile) as f:
                 self.doc.setKey(f.read())
 

--- a/ipaserver/install/ipa_replica_install.py
+++ b/ipaserver/install/ipa_replica_install.py
@@ -47,14 +47,12 @@ class CompatServerReplicaInstall(ServerReplicaInstall):
         self.__dm_password = value
 
     ip_addresses = extend_knob(
-        ServerReplicaInstall.ip_addresses,  # pylint: disable=no-member
+        ServerReplicaInstall.ip_addresses,
         description="Replica server IP Address. This option can be used "
                     "multiple times",
     )
 
-    admin_password = (
-        ServerReplicaInstall.admin_password     # pylint: disable=no-member
-    )
+    admin_password = ServerReplicaInstall.admin_password
     admin_password = extend_knob(
         admin_password,
         cli_names=list(admin_password.cli_names) + ['-w'],

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -642,7 +642,7 @@ class Restore(admintool.AdminTool):
             template_dir = paths.VAR_LOG_DIRSRV_INSTANCE_TEMPLATE % instance
             try:
                 os.makedirs(template_dir)
-            except OSError as e:
+            except OSError:
                 pass
 
             constants.DS_USER.chown(template_dir)

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -798,11 +798,9 @@ class Restore(admintool.AdminTool):
         self.backup_host = config.get('ipa', 'host')
         self.backup_ipa_version = config.get('ipa', 'ipa_version')
         self.backup_version = config.get('ipa', 'version')
-        # pylint: disable=no-member
         # we can assume that returned object is string and it has .split()
         # method
         self.backup_services = config.get('ipa', 'services').split(',')
-        # pylint: enable=no-member
 
     def extract_backup(self):
         '''

--- a/ipaserver/install/ipa_server_install.py
+++ b/ipaserver/install/ipa_server_install.py
@@ -18,19 +18,18 @@ class CompatServerMasterInstall(ServerMasterInstall):
     request_cert = False
 
     dm_password = extend_knob(
-        ServerMasterInstall.dm_password,    # pylint: disable=no-member
+        ServerMasterInstall.dm_password,
         cli_names=['--ds-password', '-p'],
     )
 
     admin_password = ServerMasterInstall.admin_password
     admin_password = extend_knob(
         admin_password,
-        # pylint: disable=no-member
         cli_names=list(admin_password.cli_names) + ['-a'],
     )
 
     ip_addresses = extend_knob(
-        ServerMasterInstall.ip_addresses,   # pylint: disable=no-member
+        ServerMasterInstall.ip_addresses,
         description="Master Server IP Address. This option can be used "
                     "multiple times",
     )

--- a/ipaserver/install/ipa_subids.py
+++ b/ipaserver/install/ipa_subids.py
@@ -52,7 +52,7 @@ class IPASubids(AdminTool):
             help="Dry run mode.",
         )
 
-    def validate_options(self, neends_root=False):
+    def validate_options(self, needs_root=False):
         super().validate_options(needs_root=True)
         opt = self.safe_options
 

--- a/ipaserver/install/ipactl.py
+++ b/ipaserver/install/ipactl.py
@@ -395,7 +395,7 @@ def ipa_start(options):
 
         if isinstance(e, IpactlError):
             # do not display any other error message
-            raise IpactlError(rval=e.rval)  # pylint: disable=no-member
+            raise IpactlError(rval=e.rval)
         else:
             raise IpactlError()
 
@@ -509,7 +509,7 @@ def ipa_restart(options):
             pass
         if isinstance(e, IpactlError):
             # do not display any other error message
-            raise IpactlError(rval=e.rval)  # pylint: disable=no-member
+            raise IpactlError(rval=e.rval)
         else:
             raise IpactlError()
 

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -605,14 +605,6 @@ class KrbInstance(service.Service):
         except errors.AlreadyActive:
             pass
 
-    def __convert_to_gssapi_replication(self):
-        repl = replication.ReplicationManager(self.realm,
-                                              self.fqdn,
-                                              self.dm_password)
-        repl.convert_to_gssapi_replication(self.master_fqdn,
-                                           r_binddn=DN(('cn', 'Directory Manager')),
-                                           r_bindpw=self.dm_password)
-
     def stop_tracking_certs(self):
         certmonger.stop_tracking(certfile=paths.KDC_CERT)
 

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -645,7 +645,7 @@ class LDAPUpdate:
         while True:
             try:
                 entry = self.conn.get_entry(dn, attrlist)
-            except errors.NotFound as e:
+            except errors.NotFound:
                 logger.error("Task not found: %s", dn)
                 return
             except errors.DatabaseError as e:

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1366,7 +1366,7 @@ class ReplicationManager:
 
         try:
             self.conn.add_entry(entry)
-        except Exception as e:
+        except Exception:
             logger.info("Failed to create public entry for winsync replica")
 
         # For winsync, unhashed passwords needs to be in replication changelog

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1593,12 +1593,12 @@ class ReplicationManager:
             pass
         except Exception as e:
             if force and err:
-                raise err   #pylint: disable=E0702
+                raise err
             else:
                 raise e
 
         if err:
-            raise err   #pylint: disable=E0702
+            raise err
 
     def set_readonly(self, readonly, critical=False):
         """

--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -60,7 +60,6 @@ class ServerCertificateInstallInterface(service.ServiceInstallInterface):
     description = "SSL certificate"
 
     dirsrv_cert_files = knob(
-        # pylint: disable=invalid-sequence-index
         typing.List[str], None,
         description=("File containing the Directory Server SSL certificate "
                      "and private key"),
@@ -71,7 +70,6 @@ class ServerCertificateInstallInterface(service.ServiceInstallInterface):
     dirsrv_cert_files = prepare_only(dirsrv_cert_files)
 
     http_cert_files = knob(
-        # pylint: disable=invalid-sequence-index
         typing.List[str], None,
         description=("File containing the Apache Server SSL certificate and "
                      "private key"),
@@ -82,7 +80,6 @@ class ServerCertificateInstallInterface(service.ServiceInstallInterface):
     http_cert_files = prepare_only(http_cert_files)
 
     pkinit_cert_files = knob(
-        # pylint: disable=invalid-sequence-index
         typing.List[str], None,
         description=("File containing the Kerberos KDC SSL certificate and "
                      "private key"),
@@ -171,7 +168,6 @@ class ServerInstallInterface(ServerCertificateInstallInterface,
     domain_name = client.ClientInstallInterface.domain_name
     domain_name = extend_knob(
         domain_name,
-        # pylint: disable=no-member
         cli_names=list(domain_name.cli_names) + ['-n'],
     )
 
@@ -453,7 +449,7 @@ class ServerInstallInterface(ServerCertificateInstallInterface,
                     "You cannot specify --external-ca-profile without "
                     "--external-ca")
 
-            if self.uninstalling:  # pylint: disable=using-constant-test
+            if self.uninstalling:
                 if (self.realm_name or self.admin_password or
                         self.master_password):
                     raise RuntimeError(

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -132,7 +132,7 @@ def read_cache(dm_password):
                                   fname,
                                   dm_password,
                                   top_dir)
-    except Exception as e:
+    except Exception:
         shutil.rmtree(top_dir)
         raise Exception("Decryption of answer cache in %s failed, please "
                         "check your password." % paths.ROOT_IPA_CACHE)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -823,14 +823,12 @@ def promote_check(installer):
     env._bootstrap(context='installer', confdir=paths.ETC_IPA, log=None)
     env._finalize_core(**dict(constants.DEFAULT_CONFIG))
 
-    # pylint: disable=no-member
     xmlrpc_uri = 'https://{}/ipa/xml'.format(ipautil.format_netloc(env.host))
     api.bootstrap(in_server=True,
                   context='installer',
                   confdir=paths.ETC_IPA,
                   ldap_uri=ipaldap.realm_to_ldapi_uri(env.realm),
                   xmlrpc_uri=xmlrpc_uri)
-    # pylint: enable=no-member
     api.finalize()
 
     config = ReplicaConfig()

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1311,7 +1311,7 @@ def ntpd_cleanup(fqdn, fstore):
         try:
             instance.disable()
             instance.stop()
-        except Exception as e:
+        except Exception:
             logger.debug("Service ntpd was not disabled or stopped")
 
     for ntpd_file in [paths.NTP_CONF, paths.NTP_STEP_TICKERS,

--- a/ipaserver/plugins/aci.py
+++ b/ipaserver/plugins/aci.py
@@ -377,7 +377,7 @@ def _aci_to_kw(ldap, a, test=False, pkey_only=False):
             entry = ldap.make_entry(dn)
             try:
                 entry = ldap.get_entry(groupdn, ['cn'])
-            except errors.NotFound as e:
+            except errors.NotFound:
                 # FIXME, use real name here
                 if test:
                     dn = DN(('cn', 'test'), api.env.container_permission,

--- a/ipaserver/plugins/automember.py
+++ b/ipaserver/plugins/automember.py
@@ -566,7 +566,7 @@ class automember_default_group(automember):
 
     def get_params(self):
         for param in super(automember_default_group, self).get_params():
-            if param.name == 'cn' or param.name == 'description':
+            if param.name in ('cn', 'description'):
                 continue
             yield param
 

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -1788,7 +1788,7 @@ class LDAPAddMember(LDAPModMember):
         completed = 0
         for (attr, objs) in member_dns.items():
             for ldap_obj_name in objs:
-                for m_dn in member_dns[attr][ldap_obj_name]:
+                for m_dn in objs[ldap_obj_name]:
                     assert isinstance(m_dn, DN)
                     if not m_dn:
                         continue

--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -733,7 +733,7 @@ class LDAPObject(Object):
         container_dns = {}
         new_attrs = {}
 
-        for attr in self.attribute_members:
+        for attr, members in self.attribute_members.items():
             try:
                 value = entry_attrs.raw[attr]
             except KeyError:
@@ -742,7 +742,7 @@ class LDAPObject(Object):
 
             for member in value:
                 memberdn = DN(member.decode('utf-8'))
-                for ldap_obj_name in self.attribute_members[attr]:
+                for ldap_obj_name in members:
                     ldap_obj = self.api.Object[ldap_obj_name]
                     try:
                         container_dn = container_dns[ldap_obj_name]

--- a/ipaserver/plugins/batch.py
+++ b/ipaserver/plugins/batch.py
@@ -185,13 +185,13 @@ class batch(Command):
                         isinstance(e, errors.ConversionError)):
                     logger.info(
                         '%s: batch: %s',
-                        context.principal,  # pylint: disable=no-member
+                        context.principal,
                         e.__class__.__name__
                     )
                 else:
                     logger.info(
                         '%s: batch: %s(%s): %s',
-                        context.principal, name,  # pylint: disable=no-member
+                        context.principal, name,
                         ', '.join(api.Command[name]._repr_iter(**params)),
                         e.__class__.__name__
                     )

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1380,7 +1380,7 @@ class cert_show(Retrieve, CertMethod, VirtualCommand):
             logger.debug("Not granted by ACI to retrieve certificate, "
                          "looking at principal")
             if not bind_principal_can_manage_cert(cert):
-                raise acierr  # pylint: disable=E0702
+                raise acierr
 
         ca_obj = api.Command.ca_show(
             options['cacn'],

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -3132,11 +3132,11 @@ class dnsrecord(LDAPObject):
             addr = keys[-1]
 
         zone_len = 0
-        for valid_zone in REVERSE_DNS_ZONES:
+        for valid_zone, zone_num_components in REVERSE_DNS_ZONES.items():
             if zone.is_subdomain(valid_zone):
                 zone = zone.relativize(valid_zone)
                 zone_name = valid_zone
-                zone_len = REVERSE_DNS_ZONES[valid_zone]
+                zone_len = zone_num_components
 
         if not zone_len:
             # PTR records in zones other than in-addr.arpa and ip6.arpa are
@@ -3608,7 +3608,7 @@ class dnsrecord_add(LDAPCreate):
         assert isinstance(dn, DN)
         precallback_attrs = []
         processed_attrs = []
-        for option in options:
+        for option, option_val in options.items():
             try:
                 param = self.params[option]
             except KeyError:
@@ -3636,7 +3636,7 @@ class dnsrecord_add(LDAPCreate):
 
             if get_extra_rrtype(param.name):
                 # do not run precallback for unset flags
-                if isinstance(param, Flag) and not options[option]:
+                if isinstance(param, Flag) and not option_val:
                     continue
                 # extra option is passed, run per-type pre_callback for given RR type
                 precallback_attrs.append(rrparam.name)
@@ -3785,9 +3785,9 @@ class dnsrecord_mod(LDAPUpdate):
             raise self.obj.handle_not_found(*keys)
 
         if updated_attrs:
-            for attr in updated_attrs:
+            for attr, attr_vals in updated_attrs.items():
                 param = self.params[attr]
-                old_dnsvalue, new_parts = updated_attrs[attr]
+                old_dnsvalue, new_parts = attr_vals
 
                 if old_dnsvalue not in old_entry.get(attr, []):
                     attr_name = unicode(param.label or param.name)

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1813,9 +1813,9 @@ class ra(rabase.rabase, RestClient):
                 booloptions[battr] = True
 
         # Add the boolean options to our XML document
-        for opt in booloptions:
+        for opt, value in booloptions.items():
             e = etree.SubElement(page, opt)
-            e.text = str(booloptions[opt]).lower()
+            e.text = str(value).lower()
 
         payload = etree.tostring(doc, pretty_print=False,
                                  xml_declaration=True, encoding='UTF-8')

--- a/ipaserver/plugins/hbactest.py
+++ b/ipaserver/plugins/hbactest.py
@@ -247,7 +247,7 @@ def _convert_to_ipa_rule(rule):
             if attr_name in rule:
                 element[4].groups = rule[attr_name]
     if 'externalhost' in rule:
-            ipa_rule.srchosts.names.extend(rule['externalhost']) #pylint: disable=E1101
+            ipa_rule.srchosts.names.extend(rule['externalhost'])
     return ipa_rule
 
 

--- a/ipaserver/plugins/idviews.py
+++ b/ipaserver/plugins/idviews.py
@@ -178,6 +178,7 @@ class idview(LDAPObject):
         try:
             orig_entry_attrs = ldap.get_entry(dn, ['objectclass'])
         except errors.NotFound:
+            # pylint: disable=raising-bad-type, #4772
             raise self.handle_not_found(*keys)
 
         orig_objectclasses = {

--- a/ipaserver/plugins/migration.py
+++ b/ipaserver/plugins/migration.py
@@ -216,7 +216,7 @@ def _pre_migrate_user(ldap, pkey, dn, entry_attrs, failed, config, ctx, **kwargs
                 logger.warning('GID number %s of migrated user %s should '
                                'match 1 group, but it matched %d groups',
                                entry_attrs['gidnumber'][0], pkey, e.found)
-            except errors.LimitsExceeded as e:
+            except errors.LimitsExceeded:
                 logger.warning('Search limit exceeded searching for GID %s',
                                entry_attrs['gidnumber'][0])
 

--- a/ipaserver/plugins/permission.py
+++ b/ipaserver/plugins/permission.py
@@ -658,7 +658,7 @@ class permission(baseldap.LDAPObject):
             permission_entry, old_name, notfound_ok=True)
 
         # (pylint thinks `acientry` is just a dict, but it's an LDAPEntry)
-        acidn = acientry.dn  # pylint: disable=E1103
+        acidn = acientry.dn
 
         if acistring is not None:
             logger.debug('Removing ACI %r from %s', acistring, acidn)
@@ -746,7 +746,7 @@ class permission(baseldap.LDAPObject):
 
         # The DN of old permissions is always basedn
         # (pylint thinks `base` is just a dict, but it's an LDAPEntry)
-        assert base.dn == self.api.env.basedn, base  # pylint: disable=E1103
+        assert base.dn == self.api.env.basedn, base
 
         aci = ACI(acistring)
 

--- a/ipaserver/plugins/privilege.py
+++ b/ipaserver/plugins/privilege.py
@@ -87,7 +87,7 @@ def principal_has_privilege(api, principal, privilege):
     privilege_dn = api.Object.privilege.get_dn(privilege)
     ldap = api.Backend.ldap2
     filter = ldap.make_filter({
-        'krbprincipalname': principal,  # pylint: disable=no-member
+        'krbprincipalname': principal,
         'memberof': privilege_dn},
         rules=ldap.MATCH_ALL)
     try:

--- a/ipaserver/plugins/schema.py
+++ b/ipaserver/plugins/schema.py
@@ -214,10 +214,10 @@ class command(metaobject):
         ),
     )
 
-    def _iter_params(self, cmd):
-        for arg in cmd.args():
+    def _iter_params(self, metaobj):
+        for arg in metaobj.args():
             yield arg
-        for option in cmd.options():
+        for option in metaobj.options():
             if option.name == 'version':
                 continue
             yield option
@@ -412,8 +412,8 @@ class topic_(MetaObject):
                     else:
                         topic.pop('topic_topic', None)
 
-    def _get_obj(self, topic, **kwargs):
-        return topic
+    def _get_obj(self, obj, **kwargs):
+        return obj
 
     def _retrieve(self, full_name, **kwargs):
         self.__make_topics()
@@ -564,8 +564,8 @@ class param(BaseParam):
     def parent(self):
         return self.api.Object.metaobject
 
-    def _get_obj(self, metaobj_param, **kwargs):
-        metaobj, param = metaobj_param
+    def _get_obj(self, obj, **kwargs):
+        metaobj, param = obj
 
         obj = dict()
         obj['name'] = unicode(param.name)
@@ -693,8 +693,8 @@ class output(BaseParam):
     def parent(self):
         return self.api.Object.command
 
-    def _get_obj(self, cmd_output, **kwargs):
-        cmd, output = cmd_output
+    def _get_obj(self, obj, **kwargs):
+        cmd, output = obj
         required = True
         multivalue = False
 

--- a/ipaserver/plugins/trust.py
+++ b/ipaserver/plugins/trust.py
@@ -614,6 +614,7 @@ class trust(LDAPObject):
                     ldap.SCOPE_SUBTREE, trustfilter, ['']
                 )
             except errors.NotFound:
+                # pylint: disable=raising-bad-type, #4772
                 raise self.handle_not_found(keys[-1])
 
             if len(result) > 1:

--- a/ipaserver/plugins/vault.py
+++ b/ipaserver/plugins/vault.py
@@ -39,13 +39,11 @@ from ipaserver.masters import is_service_enabled
 if api.env.in_server:
     import pki.account
     import pki.key
-    # pylint: disable=no-member
     try:
         # pki >= 10.4.0
         from pki.crypto import DES_EDE3_CBC_OID
     except ImportError:
         DES_EDE3_CBC_OID = pki.key.KeyClient.DES_EDE3_CBC_OID
-    # pylint: enable=no-member
 
 
 if six.PY3:

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -1095,7 +1095,7 @@ class login_password(Backend, KerberosSession):
                     armor_path,
                     pkinit_anchors=[paths.KDC_CERT, paths.KDC_CA_BUNDLE_PEM],
                 )
-            except RuntimeError as e:
+            except RuntimeError:
                 logger.error("Failed to obtain armor cache")
                 # We try to continue w/o armor, 2FA will be impacted
                 armor_path = None
@@ -1159,8 +1159,10 @@ class change_password(Backend, HTTP_Status):
 
         try:
             query_dict = parse_qs(query_string)
-        except Exception as e:
-            return self.bad_request(environ, start_response, "cannot parse query data")
+        except Exception:
+            return self.bad_request(
+                environ, start_response, "cannot parse query data"
+            )
 
         data = {}
         for field in ('user', 'old_password', 'new_password', 'otp'):
@@ -1264,8 +1266,10 @@ class sync_token(Backend, HTTP_Status):
         # Parse the query string to a dictionary.
         try:
             query_dict = parse_qs(query_string)
-        except Exception as e:
-            return self.bad_request(environ, start_response, "cannot parse query data")
+        except Exception:
+            return self.bad_request(
+                environ, start_response, "cannot parse query data"
+            )
         data = {}
         for field in ('user', 'password', 'first_code', 'second_code', 'token'):
             value = query_dict.get(field, None)

--- a/ipaserver/topology.py
+++ b/ipaserver/topology.py
@@ -104,12 +104,11 @@ def _create_topology_graphs(api_instance):
 
     topology_graphs = {}
 
-    for suffix_name in suffix_to_masters:
+    for suffix_name, masters in suffix_to_masters.items():
         segments = api_instance.Command.topologysegment_find(
             suffix_name, sizelimit=0).get('result')
 
-        topology_graphs[suffix_name] = create_topology_graph(
-            suffix_to_masters[suffix_name], segments)
+        topology_graphs[suffix_name] = create_topology_graph(masters, segments)
 
     return topology_graphs
 
@@ -165,8 +164,7 @@ class TopologyConnectivity:
 
     def check_current_state(self):
         err_msg = ""
-        for suffix in self.errors:
-            errors = self.errors[suffix]
+        for suffix, errors in self.errors.items():
             if errors:
                 err_msg = "\n".join([
                     err_msg,
@@ -182,8 +180,7 @@ class TopologyConnectivity:
         err_msg = ""
         errors_after_removal = self.errors_after_master_removal(master_cn)
 
-        for suffix in errors_after_removal:
-            errors = errors_after_removal[suffix]
+        for suffix, errors in errors_after_removal.items():
             if errors:
                 err_msg = "\n".join([
                     err_msg,

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -63,12 +63,6 @@ VERSION = '@VERSION@'
 
 SETUPTOOLS_VERSION = tuple(int(v) for v in setuptools.__version__.split("."))
 
-# backwards compatibility with setuptools 0.9.8, split off +gitHASH suffix
-# PEP 440 was introduced in setuptools 8.
-if SETUPTOOLS_VERSION < (8, 0, 0):
-    VERSION = VERSION.split('+')[0]
-
-
 PACKAGE_VERSION = {
     'cryptography': 'cryptography >= 1.6',
     'custodia': 'custodia >= 0.3.1',

--- a/ipatests/azure/scripts/setup_containers.py
+++ b/ipatests/azure/scripts/setup_containers.py
@@ -34,7 +34,7 @@ IPA_TESTS_ENV_DIR = os.path.join(IPA_TESTS_ENV_WORKING_DIR, IPA_TESTS_ENV_NAME)
 IPA_TEST_CONFIG = "ipa-test-config.yaml"
 
 
-class ExecRunReturn(NamedTuple):  # pylint: disable=inherit-non-class #3876
+class ExecRunReturn(NamedTuple):
     exit_code: int
     output: Tuple[bytes, bytes]
 

--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -151,11 +151,9 @@ def pytest_cmdline_main(config):
 def pytest_runtest_setup(item):
     if isinstance(item, pytest.Function):
         if item.get_closest_marker('skip_ipaclient_unittest'):
-            # pylint: disable=no-member
             if item.config.option.ipaclient_unittests:
                 pytest.skip("Skip in ipaclient unittest mode")
         if item.get_closest_marker('needs_ipaapi'):
-            # pylint: disable=no-member
             if item.config.option.skip_ipaapi:
                 pytest.skip("Skip tests that needs an IPA API")
     if osinfo is not None:

--- a/ipatests/i18n.py
+++ b/ipatests/i18n.py
@@ -624,10 +624,8 @@ def test_translations(po_file, lang, domain, locale_dir):
     t = gettext.translation(domain, locale_dir)
 
     if six.PY2:
-        # pylint: disable=no-member
         get_msgstr = t.ugettext
         get_msgstr_plural = t.ungettext
-        # pylint: enable=no-member
     else:
         get_msgstr = t.gettext
         get_msgstr_plural = t.ngettext

--- a/ipatests/pytest_ipa/declarative.py
+++ b/ipatests/pytest_ipa/declarative.py
@@ -29,7 +29,7 @@ def pytest_generate_tests(metafunc):
             if callable(test):
                 description = '%s: %s' % (
                     str(i).zfill(4),
-                    test.__name__,  # test is not a dict. pylint: disable=E1103
+                    test.__name__,
                 )
             else:
                 description = '%s: %s: %s' % (str(i).zfill(4),

--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -294,8 +294,8 @@ class IntegrationLogs:
     def init_method_logs(self):
         """Initilize method logs with the class ones"""
         self._method_logs = {}
-        for k in self._class_logs:
-            self._method_logs[k] = list(self._class_logs[k])
+        for host, logs in self._class_logs.items():
+            self._method_logs[host] = list(logs)
 
     def collect_class_log(self, host, filename):
         """Add class scope log

--- a/ipatests/pytest_ipa/integration/resolver.py
+++ b/ipatests/pytest_ipa/integration/resolver.py
@@ -104,7 +104,8 @@ class Resolver(abc.ABC):
         logger.info('Applying resolver state for host %s: %s', self.host, state)
         self.current_state = state
 
-    @abc.abstractclassmethod
+    @classmethod
+    @abc.abstractmethod
     def is_our_resolver(cls, host):
         """Checks if the class is appropriate for managing resolver on the host.
         """

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1904,7 +1904,7 @@ def ldappasswd_user_change(user, oldpw, newpw, master, use_dirman=False,
 
     if use_dirman:
         args = [paths.LDAPPASSWD, '-D',
-                str(master.config.dirman_dn),  # pylint: disable=no-member
+                str(master.config.dirman_dn),
                 '-w', master.config.dirman_password,
                 '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri, userdn]
     else:
@@ -1922,7 +1922,7 @@ def ldappasswd_sysaccount_change(user, oldpw, newpw, master, use_dirman=False):
 
     if use_dirman:
         args = [paths.LDAPPASSWD, '-D',
-                str(master.config.dirman_dn),  # pylint: disable=no-member
+                str(master.config.dirman_dn),
                 '-w', master.config.dirman_password,
                 '-a', oldpw,
                 '-s', newpw, '-x', '-ZZ', '-H', master_ldap_uri,

--- a/ipatests/test_custodia/test_server.py
+++ b/ipatests/test_custodia/test_server.py
@@ -10,8 +10,6 @@ from ipaserver.custodia.server.config import parse_config
 HERE = os.path.dirname(os.path.abspath(__file__))
 EMPTY_CONF = os.path.join(HERE, 'empty.conf')
 
-# pylint: disable=redefined-outer-name
-
 
 @pytest.fixture()
 def args():

--- a/ipatests/test_integration/base.py
+++ b/ipatests/test_integration/base.py
@@ -77,7 +77,7 @@ class IntegrationTest:
         else:
             domain_level = cls.master.config.domain_level
 
-        if cls.master.config.fips_mode:  # pylint: disable=using-constant-test
+        if cls.master.config.fips_mode:
             cls.fips_mode = True
         if cls.fips_mode:
             cls.enable_fips_mode()

--- a/ipatests/test_integration/test_automember.py
+++ b/ipatests/test_integration/test_automember.py
@@ -102,15 +102,15 @@ class TestAutounmembership(IntegrationTest):
     def check_autounmembership_in_ldap(self, state='on'):
         """Check autounmembership state."""
         conn = self.master.ldap_connect()
-        entry = conn.get_entry(self.dn)  # pylint: disable=no-member
+        entry = conn.get_entry(self.dn)
         assert state == entry.single_value['automemberprocessmodifyops']
 
     def disable_autounmembership_in_ldap(self):
         """Disable autounmembership."""
         conn = self.master.ldap_connect()
-        entry = conn.get_entry(self.dn)  # pylint: disable=no-member
+        entry = conn.get_entry(self.dn)
         entry.single_value['automemberprocessmodifyops'] = 'off'
-        conn.update_entry(entry)  # pylint: disable=no-member
+        conn.update_entry(entry)
         self.master.run_command(['ipactl', 'restart'])
 
     def test_modify_user_entry_unmembership(self):

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -131,11 +131,11 @@ class CALessBase(IntegrationTest):
         cls.cert_password = cls.master.config.admin_password
         cls.crl_path = os.path.join(cls.master.config.test_dir, 'crl')
 
-        if cls.replicas:  # pylint: disable=using-constant-test
+        if cls.replicas:
             replica_hostname = cls.replicas[0].hostname
         else:
             replica_hostname = 'unused-replica.test'
-        if cls.clients:  # pylint: disable=using-constant-test
+        if cls.clients:
             client_hostname = cls.clients[0].hostname
         else:
             client_hostname = 'unused-client.test'

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -363,7 +363,7 @@ class TestIPACommand(IntegrationTest):
         master = self.master
 
         # Add a system account and add it to a group managed by the policy
-        base_dn = str(master.domain.basedn)  # pylint: disable=no-member
+        base_dn = str(master.domain.basedn)
         entry_ldif = textwrap.dedent("""
             dn: uid={account_name},cn=sysaccounts,cn=etc,{base_dn}
             changetype: add
@@ -877,7 +877,7 @@ class TestIPACommand(IntegrationTest):
         )
 
         conn = self.master.ldap_connect()
-        entry = conn.get_entry(dn)  # pylint: disable=no-member
+        entry = conn.get_entry(dn)
 
         # original setting and all settings without state
         orig_cfg = list(entry['ipaConfigString'])
@@ -888,19 +888,19 @@ class TestIPACommand(IntegrationTest):
             cfg = [HIDDEN_SERVICE]
             cfg.extend(other_cfg)
             entry['ipaConfigString'] = cfg
-            conn.update_entry(entry)  # pylint: disable=no-member
+            conn.update_entry(entry)
             self.master.run_command(['ipa', 'config-show'])
 
             # test with configured
             cfg = [CONFIGURED_SERVICE]
             cfg.extend(other_cfg)
             entry['ipaConfigString'] = cfg
-            conn.update_entry(entry)  # pylint: disable=no-member
+            conn.update_entry(entry)
             self.master.run_command(['ipa', 'config-show'])
         finally:
             # reset
             entry['ipaConfigString'] = orig_cfg
-            conn.update_entry(entry)  # pylint: disable=no-member
+            conn.update_entry(entry)
 
     def test_ssh_from_controller(self):
         """https://pagure.io/SSSD/sssd/issue/3979
@@ -1255,9 +1255,9 @@ class TestIPACommand(IntegrationTest):
         )
         assert console_msg in result.stdout_text
         # verify using backend
-        conn = self.master.ldap_connect()  # pylint: disable=no-member
+        conn = self.master.ldap_connect()
         dn = DN(('cn', 'NIS Server'), ('cn', 'plugins'), ('cn', 'config'))
-        entry = conn.get_entry(dn)  # pylint: disable=no-member
+        entry = conn.get_entry(dn)
         nispluginstring = entry.get('nsslapd-pluginEnabled')
         assert 'on' in nispluginstring
         # restart for changes to take effect
@@ -1289,9 +1289,9 @@ class TestIPACommand(IntegrationTest):
         )
         assert msg in result.stdout_text
         # verify using backend
-        conn = self.master.ldap_connect()  # pylint: disable=no-member
+        conn = self.master.ldap_connect()
         dn = DN(('cn', 'NIS Server'), ('cn', 'plugins'), ('cn', 'config'))
-        entry = conn.get_entry(dn)  # pylint: disable=no-member
+        entry = conn.get_entry(dn)
         nispluginstring = entry.get('nsslapd-pluginEnabled')
         assert 'off' in nispluginstring
         # restart dirsrv for changes to take effect

--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -499,13 +499,13 @@ class TestEPN(IntegrationTest):
                 ),
             )
 
-        for key in users:
+        for user_info in users.values():
             tasks.user_add(
                 self.master,
-                users[key]["uid"],
+                user_info["uid"],
                 extra_args=[
                     "--password-expiration",
-                    users[key]["krbpasswordexpiration"],
+                    user_info["krbpasswordexpiration"],
                 ],
                 password=None,
             )

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -757,7 +757,7 @@ class TestInstallMaster(IntegrationTest):
         related: https://pagure.io/freeipa/issue/8193
         """
         conn = self.master.ldap_connect()
-        entry = conn.get_entry(DN(             # pylint: disable=no-member
+        entry = conn.get_entry(DN(
             "cn=groups,cn=Schema Compatibility,cn=plugins,cn=config"))
 
         entry_list = list(entry['schema-compat-entry-attribute'])

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1719,8 +1719,8 @@ def modify_permissions():
 
     # Restore the previous state
     host = state.pop('host')
-    for path in state:
-        (owner, group, mode) = state[path].split(':')
+    for path, path_state in state.items():
+        (owner, group, mode) = path_state.split(":", maxsplit=2)
         host.run_command(["chown", "%s:%s" % (owner, group), path])
         host.run_command(["chmod", mode, path])
 

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -964,15 +964,15 @@ class TestIpaHealthCheck(IntegrationTest):
         dn = DN(
             ("cn", "config"),
         )
-        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        entry = ldap.get_entry(dn)
         entry.single_value["nsslapd-logging-hr-timestamps-enabled"] = 'off'
-        ldap.update_entry(entry)  # pylint: disable=no-member
+        ldap.update_entry(entry)
 
         yield
 
-        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        entry = ldap.get_entry(dn)
         entry.single_value["nsslapd-logging-hr-timestamps-enabled"] = 'on'
-        ldap.update_entry(entry)  # pylint: disable=no-member
+        ldap.update_entry(entry)
 
     def test_ipahealthcheck_ds_configcheck(self, update_logging):
         """
@@ -1104,15 +1104,15 @@ class TestIpaHealthCheck(IntegrationTest):
             ("cn", "plugins"),
             ("cn", "config"),
         )
-        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        entry = ldap.get_entry(dn)
         entry.single_value["referint-update-delay"] = -1
-        ldap.update_entry(entry)  # pylint: disable=no-member
+        ldap.update_entry(entry)
 
         yield
 
-        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        entry = ldap.get_entry(dn)
         entry.single_value["referint-update-delay"] = 0
-        ldap.update_entry(entry)  # pylint: disable=no-member
+        ldap.update_entry(entry)
 
     def test_ipahealthcheck_ds_riplugincheck(self, update_riplugin):
         """
@@ -1140,15 +1140,15 @@ class TestIpaHealthCheck(IntegrationTest):
         """
         ldap = self.master.ldap_connect()
         dn = DN(("cn", "config"),)
-        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        entry = ldap.get_entry(dn)
         entry.single_value["nsslapd-rootpwstoragescheme"] = "MD5"
-        ldap.update_entry(entry)  # pylint: disable=no-member
+        ldap.update_entry(entry)
 
         yield
 
-        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        entry = ldap.get_entry(dn)
         entry.single_value["nsslapd-rootpwstoragescheme"] = "PBKDF2_SHA256"
-        ldap.update_entry(entry)  # pylint: disable=no-member
+        ldap.update_entry(entry)
 
     def test_ds_configcheck_passwordstorage(self, modify_pwdstoragescheme):
         """
@@ -1563,16 +1563,16 @@ class TestIpaHealthCheckWithADtrust(IntegrationTest):
             ("cn", "etc"),
             basedn,
         )
-        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        entry = ldap.get_entry(dn)
         krbprinc = entry['member']
         entry['member'] = ''
-        ldap.update_entry(entry)  # pylint: disable=no-member
+        ldap.update_entry(entry)
 
         yield
 
         # Add the entry back
         entry['member'] = krbprinc
-        ldap.update_entry(entry)  # pylint: disable=no-member
+        ldap.update_entry(entry)
 
     def test_trustcontroller_principalcheck(self, modify_cifs_princ):
         """
@@ -2643,19 +2643,19 @@ class TestIpaHealthCheckWithExternalCA(IntegrationTest):
         """
         ldap = self.master.ldap_connect()
         dn = DN(("uid", "ipara"), ("ou", "People"), ("o", "ipaca"))
-        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        entry = ldap.get_entry(dn)
         ldap_cert_desc = entry.single_value.get("description")
 
         def _update_entry(description):
-            entry = ldap.get_entry(dn)  # pylint: disable=no-member
+            entry = ldap.get_entry(dn)
             entry.single_value['description'] = description
-            ldap.update_entry(entry)  # pylint: disable=no-member
+            ldap.update_entry(entry)
 
         yield _update_entry
 
-        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        entry = ldap.get_entry(dn)
         entry.single_value['description'] = ldap_cert_desc
-        ldap.update_entry(entry)  # pylint: disable=no-member
+        ldap.update_entry(entry)
 
     def test_ipahealthcheck_iparaagent_ldap(self, update_ra_cert_desc):
         """

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -73,11 +73,11 @@ class TestNFS(IntegrationTest):
             "euripides": "s"
         }
         temp_pass = 'temppass'
-        for user in users:
+        for user, last in users.items():
             self.master.run_command([
                 "ipa", "user-add",
-                "%s" % user, "--first", "%s" % user,
-                "--last", "%s" % users[user],
+                user, "--first", user,
+                "--last", last,
                 '--password'], stdin_text="%s\n%s\n" % (temp_pass, temp_pass)
             )
             self.master.run_command(["kdestroy", "-A"])
@@ -111,12 +111,12 @@ class TestNFS(IntegrationTest):
             "stdnfs": "*(ro)",
             "home": "*(sec=krb5p,rw)"
         }
-        for export in exports:
+        for export, options in exports.items():
             exportpath = os.sep.join(('', basedir, export))
             exportfile = os.sep.join((
                 '', 'etc', 'exports.d', "%s.exports" % export
             ))
-            exportline = " ".join((exportpath, exports[export]))
+            exportline = " ".join((exportpath, options))
             nfssrv.run_command(["mkdir", "-p", exportpath])
             nfssrv.run_command(["chmod", "770", exportpath])
             nfssrv.put_file_contents(exportfile, exportline)

--- a/ipatests/test_integration/test_otp.py
+++ b/ipatests/test_integration/test_otp.py
@@ -276,7 +276,7 @@ class TestOTPToken(IntegrationTest):
         This requires paramiko until the 2-prompt sshpass RFE is
         fulfilled: https://sourceforge.net/p/sshpass/feature-requests/5/
         """
-        if self.master.is_fips_mode:  # pylint: disable=no-member
+        if self.master.is_fips_mode:
             pytest.skip("paramiko is not compatible with FIPS mode")
 
         master = self.master
@@ -323,7 +323,7 @@ class TestOTPToken(IntegrationTest):
         new_limit = 30
         conn = self.master.ldap_connect()
         dn = DN(('cn', 'config'))
-        entry = conn.get_entry(dn)  # pylint: disable=no-member
+        entry = conn.get_entry(dn)
         orig_limit = entry.single_value.get('nsslapd-idletimeout')
         ldap_query = textwrap.dedent("""
             dn: cn=config

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -783,8 +783,8 @@ class TestSubCAkeyReplication(IntegrationTest):
         # give replication some time
         time.sleep(15)
 
-        for name in subcas:
-            self.check_subca(replica, name, subcas[name])
+        for name, cert_nick in subcas.items():
+            self.check_subca(replica, name, cert_nick)
             self.del_subca(replica, name)
 
 

--- a/ipatests/test_integration/test_server_del.py
+++ b/ipatests/test_integration/test_server_del.py
@@ -83,12 +83,11 @@ def check_removal_disconnects_topology(
         )
     }
 
-    for suffix in err_messages_by_suffix:
+    for suffix, err_str in err_messages_by_suffix.items():
         if suffix in affected_suffixes:
-            tasks.assert_error(
-                result, err_messages_by_suffix[suffix], returncode=1)
+            tasks.assert_error(result, err_str, returncode=1)
         else:
-            assert err_messages_by_suffix[suffix] not in result.stderr_text
+            assert err_str not in result.stderr_text
 
 
 class ServerDelBase(IntegrationTest):

--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -211,13 +211,11 @@ class TestSMB(IntegrationTest):
             \s*SID:\s*S-1-5-21-\d+-\d+-\d+\n
             \s+ID\ range:\s*\d+\s*-\s*\d+
         '''
-        # pylint: disable=no-member
         ipa_regexp = domain_regexp_tpl.format(
             domain=re.escape(self.master.domain.name),
             netbios=self.master.netbios)
         ad_regexp = domain_regexp_tpl.format(
             domain=re.escape(self.ad.domain.name), netbios=self.ad.netbios)
-        # pylint: enable=no-member
         output_regexp = r'''
             Discovered\ domains.*
             {}

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -221,7 +221,7 @@ class TestSSSDWithAdTrust(IntegrationTest):
         master = self.master
         conn = master.ldap_connect()
         dn = DN(('cn', 'config'))
-        entry = conn.get_entry(dn)  # pylint: disable=no-member
+        entry = conn.get_entry(dn)
         orig_limit = entry.single_value.get('nsslapd-sizelimit')
         ldap_query = textwrap.dedent("""
             dn: cn=config

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -636,12 +636,12 @@ class TestTrust(BaseTestTrust):
         client.run_command(test_id)
 
         conn = self.master.ldap_connect()
-        entry = conn.get_entry(extdom_dn)  # pylint: disable=no-member
+        entry = conn.get_entry(extdom_dn)
         orig_extdom_timeout = entry.single_value.get('ipaextdommaxnsstimeout')
 
         # set the extdom plugin timeout to 1s (1000)
         entry.single_value['ipaextdommaxnsstimeout'] = 1000
-        conn.update_entry(entry)  # pylint: disable=no-member
+        conn.update_entry(entry)
         self.master.run_command(['ipactl', 'restart'])
 
         with tasks.remote_sssd_config(self.master) as sssd_conf:
@@ -667,9 +667,9 @@ class TestTrust(BaseTestTrust):
                 self.master.run_command('kill -CONT %s' % pid)
             # reconnect and set back to default extdom plugin
             conn = self.master.ldap_connect()
-            entry = conn.get_entry(extdom_dn)  # pylint: disable=no-member
+            entry = conn.get_entry(extdom_dn)
             entry.single_value['ipaextdommaxnsstimeout'] = orig_extdom_timeout
-            conn.update_entry(entry)  # pylint: disable=no-member
+            conn.update_entry(entry)
             tasks.restore_files(self.master)
             self.master.run_command(['ipactl', 'restart'])
 

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -129,14 +129,14 @@ class TestUpgrade(IntegrationTest):
         ldap = self.master.ldap_connect()
         basedn = self.master.domain.basedn
         dn = DN(('cn', 'CAcert'), ('cn', 'ipa'), ('cn', 'etc'), basedn)
-        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        entry = ldap.get_entry(dn)
         # Extract the certificate as DER then double-encode
         cacert = entry['cacertificate;binary'][0]
         cacert_der = cacert.public_bytes(serialization.Encoding.DER)
         cacert_b64 = base64.b64encode(cacert_der)
         # overwrite the value with double-encoded cert
         entry.single_value['cACertificate;binary'] = cacert_b64
-        ldap.update_entry(entry)  # pylint: disable=no-member
+        ldap.update_entry(entry)
 
         # try the upgrade
         self.master.run_command(['ipa-server-upgrade'])
@@ -144,7 +144,7 @@ class TestUpgrade(IntegrationTest):
         # reconnect to the master (upgrade stops 389-ds)
         ldap = self.master.ldap_connect()
         # read the value after upgrade, should be fixed
-        entry = ldap.get_entry(dn)  # pylint: disable=no-member
+        entry = ldap.get_entry(dn)
         try:
             _cacert = entry['cacertificate;binary']
         except ValueError:

--- a/ipatests/test_integration/test_winsyncmigrate.py
+++ b/ipatests/test_integration/test_winsyncmigrate.py
@@ -59,7 +59,9 @@ class TestWinsyncMigrate(IntegrationTest):
     ipa_group = 'ipa_group'
     ad_user = 'testuser'
     default_shell = platformconstants.DEFAULT_SHELL
-    selinuxuser = platformconstants.SELINUX_USERMAP_ORDER.split("$")[0]
+    selinuxuser = platformconstants.SELINUX_USERMAP_ORDER.split(
+        "$", maxsplit=1
+    )[0]
     test_role = 'test_role'
     test_hbac_rule = 'test_hbac_rule'
     test_selinux_map = 'test_selinux_map'

--- a/ipatests/test_ipalib/test_backend.py
+++ b/ipatests/test_ipalib/test_backend.py
@@ -83,8 +83,10 @@ class test_Connectible(ClassChecker):
         assert o.connect(*args, **kw) is None
         conn = context.example
         assert type(conn) is Connection
+        # pylint: disable=no-member
         assert o.args == args
         assert o.kw == kw
+        # pylint: enable=no-member
         assert conn.conn == 'The connection.'
         assert conn.disconnect == o.disconnect
 

--- a/ipatests/test_ipalib/test_backend.py
+++ b/ipatests/test_ipalib/test_backend.py
@@ -94,7 +94,8 @@ class test_Connectible(ClassChecker):
         m = "{0} is already connected ({1} in {2})"
         e = raises(Exception, o.connect, *args, **kw)
         assert str(e) == m.format(
-            'example', o.id, threading.currentThread().getName())
+            "example", o.id, threading.current_thread().name
+        )
 
         # Double check that it works after deleting context.example:
         del context.example
@@ -124,7 +125,8 @@ class test_Connectible(ClassChecker):
         m = "{0} is not connected ({1} in {2})"
         e = raises(Exception, o.disconnect)
         assert str(e) == m.format(
-            'example', o.id, threading.currentThread().getName())
+            "example", o.id, threading.current_thread().name
+        )
 
         context.example = 'The connection.'
         assert o.disconnect() is None
@@ -169,7 +171,7 @@ class test_Connectible(ClassChecker):
             o = klass(api, shared_instance=True)
             e = raises(AttributeError, getattr, o, 'conn')
             assert str(e) == msg.format(
-                klass.__name__, o.id, threading.currentThread().getName()
+                klass.__name__, o.id, threading.current_thread().name
             )
             conn = Connection('The connection.', Disconnect())
             setattr(context, klass.__name__, conn)

--- a/ipatests/test_ipalib/test_cli.py
+++ b/ipatests/test_ipalib/test_cli.py
@@ -80,7 +80,7 @@ class DummyCommand:
     def __init__(self, name):
         self.__name = name
 
-    def __get_name(self):
+    def __get_name(self):  # pylint: disable=unused-private-member, #4756
         return self.__name
     name = property(__get_name)
 
@@ -89,7 +89,7 @@ class DummyAPI:
     def __init__(self, cnt):
         self.__cmd = plugable.APINameSpace(self.__cmd_iter(cnt), DummyCommand)
 
-    def __get_cmd(self):
+    def __get_cmd(self):  # pylint: disable=unused-private-member, #4756
         return self.__cmd
     Command = property(__get_cmd)
 

--- a/ipatests/test_ipalib/test_config.py
+++ b/ipatests/test_ipalib/test_config.py
@@ -403,12 +403,15 @@ class test_Env(ClassChecker):
         assert o._merge_from_file(good) == (6, 6)
         added = ('string', 'null', 'yes', 'no', 'number', 'floating')
         assert list(o) == sorted(keys + added)
+
+        # pylint: disable=no-member
         assert o.string == 'Hello world!'
         assert o.null is None
         assert o.yes is True
         assert o.no is False
         assert o.number == 42
         assert o.floating == '3.14'
+        # pylint: enable=no-member
 
     def new(self, in_tree=False):
         """
@@ -573,10 +576,12 @@ class test_Env(ClassChecker):
         assert o.in_server is True
         assert o.logdir == home.join('.ipa', 'log')
         assert o.log == home.join('.ipa', 'log', 'server.log')
+        # pylint: disable=no-member
         assert o.yes is True
         assert o.no is False
         assert o.number == 42
         assert o.not_in_other == 'foo_bar'
+        # pylint: enable=no-member
 
         # Test using DEFAULT_CONFIG:
         defaults = dict(constants.DEFAULT_CONFIG)

--- a/ipatests/test_ipalib/test_errors.py
+++ b/ipatests/test_ipalib/test_errors.py
@@ -57,7 +57,7 @@ class PrivateExceptionTester:
     def new(self, **kw):
         for (key, value) in kw.items():
             assert not hasattr(self.klass, key), key
-        inst = self.klass(**kw)
+        inst = self.klass(**kw)  # pylint: disable=not-callable
         assert isinstance(inst, Exception)
         assert isinstance(inst, errors.PrivateError)
         # pylint: disable=isinstance-second-argument-not-valid-type
@@ -218,7 +218,9 @@ class PublicExceptionTester:
         # Test the instance:
         for (key, value) in kw.items():
             assert not hasattr(self.klass, key), key
+        # pylint: disable=not-callable
         inst = self.klass(format=format, message=message, **kw)
+        # pylint: enable=not-callable
         for required_class in self.required_classes:
             assert isinstance(inst, required_class)
         # pylint: disable=isinstance-second-argument-not-valid-type

--- a/ipatests/test_ipalib/test_errors.py
+++ b/ipatests/test_ipalib/test_errors.py
@@ -45,7 +45,7 @@ class PrivateExceptionTester:
     _klass = None
     __klass = None
 
-    def __get_klass(self):
+    def __get_klass(self):  # pylint: disable=unused-private-member, #4756
         if self.__klass is None:
             self.__klass = self._klass
         assert issubclass(self.__klass, Exception)
@@ -197,7 +197,7 @@ class PublicExceptionTester:
     _klass = None
     __klass = None
 
-    def __get_klass(self):
+    def __get_klass(self):  # pylint: disable=unused-private-member, #4756
         if self.__klass is None:
             self.__klass = self._klass
         assert issubclass(self.__klass, Exception)

--- a/ipatests/test_ipalib/test_errors.py
+++ b/ipatests/test_ipalib/test_errors.py
@@ -60,7 +60,9 @@ class PrivateExceptionTester:
         inst = self.klass(**kw)
         assert isinstance(inst, Exception)
         assert isinstance(inst, errors.PrivateError)
+        # pylint: disable=isinstance-second-argument-not-valid-type
         assert isinstance(inst, self.klass)
+        # pylint: enable=isinstance-second-argument-not-valid-type
         assert not isinstance(inst, errors.PublicError)
         for (key, value) in kw.items():
             assert getattr(inst, key) is value
@@ -219,7 +221,9 @@ class PublicExceptionTester:
         inst = self.klass(format=format, message=message, **kw)
         for required_class in self.required_classes:
             assert isinstance(inst, required_class)
+        # pylint: disable=isinstance-second-argument-not-valid-type
         assert isinstance(inst, self.klass)
+        # pylint: enable=isinstance-second-argument-not-valid-type
         assert not isinstance(inst, errors.PrivateError)
         for (key, value) in kw.items():
             assert getattr(inst, key) is value

--- a/ipatests/test_ipalib/test_frontend.py
+++ b/ipatests/test_ipalib/test_frontend.py
@@ -365,7 +365,9 @@ class test_Command(ClassChecker):
         inst.finalize()
         assert type(inst.output) is NameSpace
         assert list(inst.output) == ['result']
+        # pylint: disable=no-member
         assert type(inst.output.result) is output.Output
+        # pylint: enable=no-member
 
     def test_iter_output(self):
         """

--- a/ipatests/test_ipalib/test_frontend.py
+++ b/ipatests/test_ipalib/test_frontend.py
@@ -463,7 +463,7 @@ class test_Command(ClassChecker):
         api.finalize()
         o = my_cmd(api)
         o.finalize()
-        e = o.get_default(**kw)  # pylint: disable=not-callable
+        e = o.get_default(**kw)
         assert type(e) is dict
         assert 'option2' in e
         assert e['option2'] == u'some value'

--- a/ipatests/test_ipalib/test_parameters.py
+++ b/ipatests/test_ipalib/test_parameters.py
@@ -605,7 +605,7 @@ class test_Param(ClassChecker):
 
             def __init__(self, name, **kw):
                 # (Pylint complains because the superclass is unknowm)
-                # pylint: disable=bad-super-call, super-on-old-class
+                # pylint: disable=super-on-old-class
                 self._convert_scalar = PassThrough()
                 super(Str, self).__init__(name, **kw)
 

--- a/ipatests/test_ipalib/test_rpc.py
+++ b/ipatests/test_ipalib/test_rpc.py
@@ -390,7 +390,5 @@ class test_rpcclient_context(PluginTester):
             r'^ipa_session=MagBearerToken=[A-Za-z0-9+\/]+=*;$')
 
         session_cookie = getattr(context, 'session_cookie', None)
-        # pylint-2 is incorrectly spewing Too many positional arguments
-        # pylint: disable=E1121
         unquoted = urllib.parse.unquote(session_cookie)
         assert(unquoted == fuzzy_cookie)

--- a/ipatests/test_ipapython/test_dn.py
+++ b/ipatests/test_ipapython/test_dn.py
@@ -531,7 +531,6 @@ class TestRDN:
     def test_assignments(self):
         rdn = RDN((self.attr1, self.value1))
         with pytest.raises(TypeError):
-            # pylint: disable=unsupported-assignment-operation
             rdn[0] = self.ava2
 
     def test_iter(self):
@@ -997,10 +996,8 @@ class TestDN:
     def test_assignments(self):
         dn = DN('t=0,t=1,t=2,t=3,t=4,t=5,t=6,t=7,t=8,t=9')
         with pytest.raises(TypeError):
-            # pylint: disable=unsupported-assignment-operation
             dn[0] = RDN('t=a')
         with pytest.raises(TypeError):
-            # pylint: disable=unsupported-assignment-operation
             dn[0:1] = [RDN('t=a'), RDN('t=b')]
 
     def test_iter(self):

--- a/ipatests/test_ipaserver/httptest.py
+++ b/ipatests/test_ipaserver/httptest.py
@@ -44,8 +44,6 @@ class Unauthorized_HTTP_test:
         """
         if params is not None:
             if self.content_type == 'application/x-www-form-urlencoded':
-                # urlencode *can* take two arguments
-                # pylint: disable=too-many-function-args
                 params = urllib.parse.urlencode(params, True)
         url = 'https://' + self.host + self.app_uri
 

--- a/ipatests/test_ipaserver/test_install/test_installer.py
+++ b/ipatests/test_ipaserver/test_install/test_installer.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import six
 
-from abc import ABCMeta, abstractproperty
+from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 import itertools
 
@@ -21,7 +21,8 @@ class InstallerTestBase(six.with_metaclass(ABCMeta, object)):
     OPTS_DICT = {}
 
     # don't allow creating classes with tested_cls unspecified
-    @abstractproperty
+    @property
+    @abstractmethod
     def tested_cls(self):
         return None
 

--- a/ipatests/test_ipaserver/test_install/test_installer.py
+++ b/ipatests/test_ipaserver/test_install/test_installer.py
@@ -48,7 +48,6 @@ class InstallerTestBase(six.with_metaclass(ABCMeta, object)):
                                "class first.")
 
         # add all options from the option groups
-        # pylint: disable=no-member
         for opt_group in cls.tested_cls.option_parser.option_groups:
             for opt in opt_group.option_list:
                 cls.OPTS_DICT[opt.dest] = opt._short_opts + opt._long_opts

--- a/ipatests/test_util.py
+++ b/ipatests/test_util.py
@@ -41,17 +41,17 @@ class Prop:
         self.__ops = frozenset(ops)
         self.__prop = 'prop value'
 
-    def __get_prop(self):
+    def __get_prop(self):  # pylint: disable=unused-private-member, #4756
         if 'get' not in self.__ops:
             raise AttributeError('get prop')
         return self.__prop
 
-    def __set_prop(self, value):
+    def __set_prop(self, value):  # pylint: disable=unused-private-member, #4756
         if 'set' not in self.__ops:
             raise AttributeError('set prop')
         self.__prop = value
 
-    def __del_prop(self):
+    def __del_prop(self):  # pylint: disable=unused-private-member, #4756
         if 'del' not in self.__ops:
             raise AttributeError('del prop')
         self.__prop = None

--- a/ipatests/test_webui/data_selinuxusermap.py
+++ b/ipatests/test_webui/data_selinuxusermap.py
@@ -5,8 +5,9 @@
 from ipaplatform.constants import constants as platformconstants
 
 # for example, user_u:s0
-selinuxuser1 = platformconstants.SELINUX_USERMAP_ORDER.split("$")[0]
-selinuxuser2 = platformconstants.SELINUX_USERMAP_ORDER.split("$")[1]
+selunux_users = platformconstants.SELINUX_USERMAP_ORDER.split("$")
+selinuxuser1 = selunux_users[0]
+selinuxuser2 = selunux_users[1]
 
 selinux_mcs_max = platformconstants.SELINUX_MCS_MAX
 selinux_mls_max = platformconstants.SELINUX_MLS_MAX

--- a/ipatests/test_xmlrpc/test_automount_plugin.py
+++ b/ipatests/test_xmlrpc/test_automount_plugin.py
@@ -106,7 +106,7 @@ class AutomountTest(XMLRPC_test):
                     skipped=(),
                     duplicatemaps=(),
                     duplicatekeys=(),
-                )), res)  # pylint: disable=used-before-assignment
+                )), res)
             self.check_tofiles()
         finally:
             res = api.Command['automountlocation_del'](self.locname)['result']

--- a/ipatests/test_xmlrpc/test_baseldap_plugin.py
+++ b/ipatests/test_xmlrpc/test_baseldap_plugin.py
@@ -53,7 +53,7 @@ def test_exc_wrapper():
     # Test with one callback first
 
     @test_callback.register_exc_callback
-    def handle_exception(  # pylint: disable=unused-variable
+    def handle_exception(
             self, keys, options, e, call_func, *args, **kwargs):
         assert args == (1, 2)
         assert kwargs == dict(a=1, b=2)
@@ -151,7 +151,7 @@ def test_exc_callback_registration():
         pass
 
     @callbacktest_subclass.register_exc_callback
-    def exc_callback(  # pylint: disable=unused-variable
+    def exc_callback(
             self, keys, options, exc, call_func, *args, **kwargs):
         """Subclass's private exception callback"""
         messages.append('Subclass registered callback')
@@ -165,7 +165,7 @@ def test_exc_callback_registration():
 
 
     @callbacktest_base.register_exc_callback
-    def exc_callback_2(  # pylint: disable=unused-variable
+    def exc_callback_2(
             self, keys, options, exc, call_func, *args, **kwargs):
         """Callback on super class; doesn't affect the subclass"""
         messages.append('Superclass registered callback')

--- a/ipatests/test_xmlrpc/test_cert_plugin.py
+++ b/ipatests/test_xmlrpc/test_cert_plugin.py
@@ -281,7 +281,7 @@ class test_cert_find(XMLRPC_test):
 
         is_db_configured()
 
-    short = api.env.host.split('.')[0]
+    short = api.env.host.split('.', maxsplit=1)[0]
 
     def test_0001_find_all(self):
         """

--- a/ipatests/test_xmlrpc/test_selinuxusermap_plugin.py
+++ b/ipatests/test_xmlrpc/test_selinuxusermap_plugin.py
@@ -33,8 +33,9 @@ from ipatests.test_xmlrpc.test_user_plugin import get_user_result
 import pytest
 
 rule1 = u'selinuxrule1'
-selinuxuser1 = platformconstants.SELINUX_USERMAP_ORDER.split("$")[0]
-selinuxuser2 = platformconstants.SELINUX_USERMAP_ORDER.split("$")[1]
+selinux_users = platformconstants.SELINUX_USERMAP_ORDER.split("$")
+selinuxuser1 = selinux_users[0]
+selinuxuser2 = selinux_users[1]
 
 INVALID_MCS = "Invalid MCS value, must match {}, where max category {}".format(
     platformconstants.SELINUX_MCS_REGEX,

--- a/ipatests/test_xmlrpc/tracker/base.py
+++ b/ipatests/test_xmlrpc/tracker/base.py
@@ -155,9 +155,7 @@ class ModificationTracker(BaseTracker):
         result = command()
         self.attrs.update(updates)
         self.attrs.update(expected_updates)
-        for key, value in self.attrs.items():
-            if value is None:
-                del self.attrs[key]
+        self.attrs = {k: v for k, v in self.attrs.items() if v is not None}
 
         self.check_update(
             result,

--- a/ipatests/test_xmlrpc/tracker/user_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/user_plugin.py
@@ -196,24 +196,26 @@ class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
             ipantsecurityidentifier=[fuzzy_user_or_group_sid],
             )
 
-        for key in self.kwargs:
-            if key == u'krbprincipalname':
+        for key, value in self.kwargs.items():
+            if key == "krbprincipalname":
                 try:
-                    self.attrs[key] = [u'%s@%s' % (
-                        (self.kwargs[key].split('@'))[0].lower(),
-                        (self.kwargs[key].split('@'))[1]
-                    )]
+                    princ_splitted = value.split("@", maxsplit=1)
+                    self.attrs[key] = [
+                        "{}@{}".format(
+                            princ_splitted[0].lower(),
+                            princ_splitted[1],
+                        )
+                    ]
                 except IndexError:
                     # we can provide just principal part
-                    self.attrs[key] = [u'%s@%s' % (
-                        (self.kwargs[key].lower(),
-                         self.api.env.realm)
-                    )]
+                    self.attrs[key] = [
+                        "{}@{}".format(value.lower(), self.api.env.realm)
+                    ]
             else:
-                if type(self.kwargs[key]) is not list:
-                    self.attrs[key] = [self.kwargs[key]]
+                if not isinstance(value, list):
+                    self.attrs[key] = [value]
                 else:
-                    self.attrs[key] = self.kwargs[key]
+                    self.attrs[key] = value
 
         self.exists = True
 

--- a/ipatests/test_xmlrpc/xmlrpc_test.py
+++ b/ipatests/test_xmlrpc/xmlrpc_test.py
@@ -22,23 +22,16 @@ Base class for all XML-RPC tests
 """
 from __future__ import print_function
 
+from collections.abc import Sequence
 import datetime
 import inspect
 
 import contextlib
 import pytest
-import six
 
 from ipatests.util import assert_deepequal, Fuzzy
 from ipalib import api, request as ipa_request, errors
 from ipapython.version import API_VERSION
-
-# pylint: disable=no-name-in-module, import-error
-if six.PY3:
-    from collections.abc import Sequence
-else:
-    from collections import Sequence
-# pylint: enable=no-name-in-module, import-error
 
 # Matches a gidnumber like '1391016742'
 # FIXME: Does it make more sense to return gidnumber, uidnumber, etc. as `int`

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -94,7 +94,7 @@ class TempDir:
         self.__path = tempfile.mkdtemp(prefix='ipa.tests.')
         assert self.path == self.__path
 
-    def __get_path(self):
+    def __get_path(self):  # pylint: disable=unused-private-member, pylint#4756
         assert path.abspath(self.__path) == self.__path
         assert self.__path.startswith(path.join(tempfile.gettempdir(),
                                                 'ipa.tests.'))
@@ -517,14 +517,14 @@ class ClassChecker:
     __cls = None
     __subcls = None
 
-    def __get_cls(self):
+    def __get_cls(self):  # pylint: disable=unused-private-member, #4756
         if self.__cls is None:
             self.__cls = self._cls  # pylint: disable=E1101
         assert inspect.isclass(self.__cls)
         return self.__cls
     cls = property(__get_cls)
 
-    def __get_subcls(self):
+    def __get_subcls(self):  # pylint: disable=unused-private-member, #4756
         if self.__subcls is None:
             self.__subcls = self.get_subcls()
         assert inspect.isclass(self.__subcls)
@@ -577,7 +577,7 @@ def create_test_api(**kw):
 class PluginTester:
     __plugin = None
 
-    def __get_plugin(self):
+    def __get_plugin(self):  # pylint: disable=unused-private-member, #4756
         if self.__plugin is None:
             self.__plugin = self._plugin  # pylint: disable=E1101
         assert issubclass(self.__plugin, Plugin)

--- a/ipatests/util.py
+++ b/ipatests/util.py
@@ -146,7 +146,6 @@ class TempDir:
 class TempHome(TempDir):
     def __init__(self):
         super(TempHome, self).__init__()
-        self.__home = os.environ['HOME']
         os.environ['HOME'] = self.path
 
 

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -406,6 +406,7 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.container_automount = DN()
     api.env.container_ca = DN()
     api.env.container_ca_renewal = DN()
+    api.env.container_subids = DN()
     api.env.container_caacl = DN()
     api.env.container_certmap = DN()
     api.env.container_certmaprules = DN()
@@ -470,10 +471,6 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.interactive = True
     api.env.ipalib = ''  # object
     api.env.kinit_lifetime = None
-    api.env.lite_pem = ''
-    api.env.lite_profiler = ''
-    api.env.lite_host = ''
-    api.env.lite_port = 0
     api.env.log = ''  # object
     api.env.logdir = ''  # object
     api.env.mode = ''
@@ -500,6 +497,32 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.version = ''
     api.env.wait_for_dns = 0
     api.env.webui_prod = True
+
+    # defined in ipaclient/install/ipa_epn.py
+    api.env.smtp_server = ""
+    api.env.smtp_port = 0
+    api.env.smtp_user = None
+    api.env.smtp_password = None
+    api.env.smtp_client_cert = None
+    api.env.smtp_client_key = None
+    api.env.smtp_client_key_pass = None
+    api.env.smtp_timeout = 0
+    api.env.smtp_security = ""
+    api.env.smtp_admin = ""
+    api.env.smtp_delay = None
+    api.env.mail_from = None
+    api.env.notify_ttls = ""
+    api.env.msg_charset = ""
+    api.env.msg_subtype = ""
+    api.env.msg_subject = ""
+
+    # defined in contrib/lite-server.py
+    api.env.lite_pem = ''
+    api.env.lite_profiler = ''
+    api.env.lite_host = ''
+    api.env.lite_port = 0
+    api.env.lite_tracemalloc = False
+
     """
 ))
 

--- a/pylintrc
+++ b/pylintrc
@@ -28,10 +28,18 @@ valid-metaclass-classmethod-first-arg=cls
 
 enable=
     all,
-    python3
+    python3,
+    useless-suppression,
 
 disable=
-    I,
+    bad-inline-option,
+    c-extension-no-member,
+    deprecated-pragma,
+    file-ignored,
+    locally-disabled,
+    raw-checker-failed,
+    suppressed-message,
+    use-symbolic-message-instead,
     duplicate-code,
     interface-not-implemented,
     no-self-use,

--- a/pylintrc
+++ b/pylintrc
@@ -108,6 +108,7 @@ disable=
     consider-using-with,  # pylint 2.8.0, contextmanager is not mandatory
     consider-using-max-builtin,  # pylint 2.8.0, can be more readable
     consider-using-min-builtin,  # pylint 2.8.0, can be more readable
+    redundant-u-string-prefix,  # pylint 2.10.0, too many unessential changes
 
 [REPORTS]
 

--- a/pylintrc
+++ b/pylintrc
@@ -109,6 +109,7 @@ disable=
     consider-using-max-builtin,  # pylint 2.8.0, can be more readable
     consider-using-min-builtin,  # pylint 2.8.0, can be more readable
     redundant-u-string-prefix,  # pylint 2.10.0, too many unessential changes
+    consider-using-f-string,  # pylint 2.11.0, format can be more readable
 
 [REPORTS]
 

--- a/pylintrc
+++ b/pylintrc
@@ -110,6 +110,8 @@ disable=
     consider-using-min-builtin,  # pylint 2.8.0, can be more readable
     redundant-u-string-prefix,  # pylint 2.10.0, too many unessential changes
     consider-using-f-string,  # pylint 2.11.0, format can be more readable
+    use-dict-literal,  # pylint 2.10.0 dict vs {}
+    use-list-literal,  # pylint 2.10.0 list() vs []
 
 [REPORTS]
 

--- a/pylintrc
+++ b/pylintrc
@@ -121,6 +121,7 @@ disable=
     use-dict-literal,  # pylint 2.10.0 dict vs {}
     use-list-literal,  # pylint 2.10.0 list() vs []
     unspecified-encoding,  # pylint 2.10.0, ASCII or UTF8 and platform-specific
+    use-implicit-booleaness-not-comparison,  # pylint 2.12.2, weak comparison
 
 [REPORTS]
 

--- a/pylintrc
+++ b/pylintrc
@@ -112,6 +112,7 @@ disable=
     consider-using-f-string,  # pylint 2.11.0, format can be more readable
     use-dict-literal,  # pylint 2.10.0 dict vs {}
     use-list-literal,  # pylint 2.10.0 list() vs []
+    unspecified-encoding,  # pylint 2.10.0, ASCII or UTF8 and platform-specific
 
 [REPORTS]
 


### PR DESCRIPTION
disabled new checkers:
- `redundant-u-string-prefix`
- `consider-using-f-string`
- `use-dict-literal`
- `use-list-literal`
- `unspecified-encoding`
- `use-implicit-booleaness-not-comparison`


fixed:
- `use-maxsplit-arg`
- `unused-private-member`
- `deprecated-class`
- `unnecessary-dict-index-lookup`
- `deprecated-decorator`
- `no-member`
- `unused-variable`
- `consider-using-dict-items`
- `useless-suppression`
- `arguments-renamed`
- `consider-using-in`
- `deprecated-method`
- `format-string-without-interpolation`

Fixes: https://pagure.io/freeipa/issue/9117

