### PR TITLE
KRB instance: make provision to work with crypto policy without SHA-1…

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -695,6 +695,12 @@ Provides: %{name}-admintools = %{version}-%{release}
 Conflicts: crypto-policies < 20200629-1
 %endif
 
+%if 0%{?rhel} == 9
+# Conflict with crypto-policies < 20220223-1 to get upgraded AD-SUPPORT and
+# AD-SUPPORT-LEGACY policy modules
+Conflicts: crypto-policies < 20220223-1
+%endif
+
 %description client
 IPA is an integrated solution to provide centrally managed Identity (users,
 hosts, services), Authentication (SSO, 2FA), and Authorization

--- a/install/share/kdc.conf.template
+++ b/install/share/kdc.conf.template
@@ -6,7 +6,8 @@
 
 [realms]
  $REALM = {
-  master_key_type = aes256-cts
+  master_key_type = $MASTER_KEY_TYPE
+  supported_enctypes = $SUPPORTED_ENCTYPES
   max_life = 7d
   max_renewable_life = 14d
   acl_file = $KRB5KDC_KADM5_ACL

--- a/install/share/kerberos.ldif
+++ b/install/share/kerberos.ldif
@@ -28,6 +28,8 @@ ${FIPS}krbSupportedEncSaltTypes: camellia256-cts-cmac:normal
 ${FIPS}krbSupportedEncSaltTypes: camellia256-cts-cmac:special
 krbMaxTicketLife: 86400
 krbMaxRenewableAge: 604800
+krbDefaultEncSaltTypes: aes256-sha2:special
+krbDefaultEncSaltTypes: aes128-sha2:special
 krbDefaultEncSaltTypes: aes256-cts:special
 krbDefaultEncSaltTypes: aes128-cts:special
 

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -51,6 +51,14 @@ logger = logging.getLogger(__name__)
 
 PKINIT_ENABLED = 'pkinitEnabled'
 
+MASTER_KEY_TYPE = 'aes256-sha1'
+SUPPORTED_ENCTYPES = ('aes256-sha2:special', 'aes128-sha2:special',
+                      'aes256-sha2:normal', 'aes128-sha2:normal',
+                      'aes256-cts:special', 'aes128-cts:special',
+                      'aes256-cts:normal', 'aes128-cts:normal',
+                      'camellia256-cts:special', 'camellia128-cts:special',
+                      'camellia256-cts:normal', 'camellia128-cts:normal')
+
 
 def get_pkinit_request_ca():
     """
@@ -252,6 +260,7 @@ class KrbInstance(service.Service):
         else:
             includes = ''
 
+        fips_enabled = tasks.is_fips_enabled()
         self.sub_dict = dict(FQDN=self.fqdn,
                              IP=self.ip,
                              PASSWORD=self.kdc_password,
@@ -269,7 +278,17 @@ class KrbInstance(service.Service):
                              KDC_CA_BUNDLE_PEM=paths.KDC_CA_BUNDLE_PEM,
                              CA_BUNDLE_PEM=paths.CA_BUNDLE_PEM,
                              INCLUDES=includes,
-                             FIPS='#' if tasks.is_fips_enabled() else '')
+                             FIPS='#' if fips_enabled else '')
+
+        if fips_enabled:
+            supported_enctypes = list(
+                filter(lambda e: not e.startswith('camelia'),
+                       SUPPORTED_ENCTYPES))
+        else:
+            supported_enctypes = SUPPORTED_ENCTYPES
+        self.sub_dict['SUPPORTED_ENCTYPES'] = ' '.join(supported_enctypes)
+
+        self.sub_dict['MASTER_KEY_TYPE'] = MASTER_KEY_TYPE
 
         # IPA server/KDC is not a subdomain of default domain
         # Proper domain-realm mapping needs to be specified

--- a/ipaserver/install/plugins/adtrust.py
+++ b/ipaserver/install/plugins/adtrust.py
@@ -754,7 +754,8 @@ class update_host_cifs_keytabs(Updater):
     """
 
     host_princ_template = "host/{master}@{realm}"
-    valid_etypes = ['aes256-cts-hmac-sha1-96', 'aes128-cts-hmac-sha1-96']
+    valid_etypes = ['aes256-cts-hmac-sha384-192', 'aes128-cts-hmac-sha256-128',
+                    'aes256-cts-hmac-sha1-96', 'aes128-cts-hmac-sha1-96']
 
     def extract_key_refs(self, keytab):
         host_princ = self.host_princ_template.format(

--- a/ipatests/pytest_ipa/integration/fips.py
+++ b/ipatests/pytest_ipa/integration/fips.py
@@ -68,3 +68,9 @@ def disable_userspace_fips(host):
     # sanity check
     assert not is_fips_enabled(host)
     host.run_command(["openssl", "md5", "/dev/null"])
+
+
+def enable_crypto_subpolicy(host, subpolicy):
+    result = host.run_command(["update-crypto-policies", "--show"])
+    policy = result.stdin_text.strip() + ":" + subpolicy
+    host.run_command(["update-crypto-policies", "--set", policy])

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -66,6 +66,7 @@ from .env_config import env_to_script
 from .host import Host
 from .firewall import Firewall
 from .resolver import ResolvedResolver
+from .fips import is_fips_enabled, enable_crypto_subpolicy
 
 logger = logging.getLogger(__name__)
 
@@ -362,6 +363,8 @@ def install_master(host, setup_dns=True, setup_kra=False, setup_adtrust=False,
     if setup_adtrust:
         args.append('--setup-adtrust')
         fw_services.append("freeipa-trust")
+        if is_fips_enabled(host):
+            enable_crypto_subpolicy(host, "AD-SUPPORT")
     if external_ca:
         args.append('--external-ca')
 

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2261,7 +2261,8 @@ class KerberosKeyCopier:
        copier.copy_keys('/etc/krb5.keytab', tmpname, replacement=replacement)
     """
     host_princ_template = "host/{master}@{realm}"
-    valid_etypes = ['aes256-cts-hmac-sha1-96', 'aes128-cts-hmac-sha1-96']
+    valid_etypes = ['aes256-cts-hmac-sha384-192', 'aes128-cts-hmac-sha256-128',
+                    'aes256-cts-hmac-sha1-96', 'aes128-cts-hmac-sha1-96']
 
     def __init__(self, host):
         self.host = host


### PR DESCRIPTION
… HMAC types

RHEL 9 system-wide crypto policies aim at eventual removal of SHA-1 use.

Due to bootstrapping process, force explicitly supported encryption
types in kdc.conf or we may end up with AES128-CTS and AES256-CTS only
in FIPS mode at bootstrap time which then fails to initialize kadmin
principals requiring use of AES256-SHA2 and AES128-SHA2.

Camellia ciphers must be filtered out in FIPS mode, we do that already
in the kerberos.ldif.

Fixes: https://pagure.io/freeipa/issue/9119

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>