### PR TITLE
[Backport][ipa-4-9] Fix hostname input in server installer

### DIFF
--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -502,7 +502,7 @@ def install_check(installer):
         host_name = host_default
 
     try:
-        verify_fqdn(host_default, options.no_host_dns)
+        verify_fqdn(host_name, options.no_host_dns)
     except BadHostError as e:
         raise ScriptError(e)
 

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -186,13 +186,16 @@ def read_host_name(host_default):
     print("Enter the fully qualified domain name of the computer")
     print("on which you're setting up server software. Using the form")
     print("<hostname>.<domainname>")
-    print("Example: master.example.com.")
+    print("Example: master.example.com")
     print("")
     print("")
     if host_default == "":
         host_default = "master.example.com"
     host_name = user_input("Server host name", host_default, allow_empty=False)
     print("")
+
+    if host_name.endswith('.'):
+        host_name = host_name[:-1]
 
     return host_name
 

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1522,6 +1522,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-latest-ipa-4-9/hostname_validator:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        test_suite: test_integration/test_installation.py::TestHostnameValidator
+        template: *ci-ipa-4-9-latest
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-latest-ipa-4-9/automember:
     requires: [fedora-latest-ipa-4-9/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1629,6 +1629,19 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-latest-ipa-4-9/hostname_validator:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestHostnameValidator
+        template: *ci-ipa-4-9-latest
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-latest-ipa-4-9/automember:
     requires: [fedora-latest-ipa-4-9/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1522,6 +1522,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-previous-ipa-4-9/hostname_validator:
+    requires: [fedora-previous-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-9/build_url}'
+        test_suite: test_integration/test_installation.py::TestHostnameValidator
+        template: *ci-ipa-4-9-previous
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-previous-ipa-4-9/automember:
     requires: [fedora-previous-ipa-4-9/build]
     priority: 50


### PR DESCRIPTION
This is a manual backport of PR#6185 to ipa-4-9 branch.
Automated backport failed because of the nightly test definitions which have a different filename in the 4-9 branch.
PR was ACKed automatically because this is backport of PR #6185. Wait for CI to finish before pushing. In case of questions or problems contact @rcritten who is author of the original PR.