### PR TITLE
ipatests: add missing test in the nightly defs

### DIFF
--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -588,6 +588,19 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  fedora-latest/test_installation_TestInstallWithoutNamed:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestInstallWithoutNamed
+        template: *ci-master-latest
+        timeout: 4800
+        topology: *master_1repl
+
   fedora-latest/test_installation_TestInstallwithSHA384withRSA:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -588,6 +588,19 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  testing-fedora/test_installation_TestInstallWithoutNamed:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallWithoutNamed
+        template: *testing-master-latest
+        timeout: 4800
+        topology: *master_1repl
+
   testing-fedora/test_installation_TestInstallwithSHA384withRSA:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -629,6 +629,20 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  testing-fedora/test_installation_TestInstallWithoutNamed:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestInstallWithoutNamed
+        template: *testing-master-latest
+        timeout: 4800
+        topology: *master_1repl
+
   testing-fedora/test_installation_TestInstallwithSHA384withRSA:
     requires: [testing-fedora/build]
     priority: 50


### PR DESCRIPTION
The test
test_integration/test_installation.py::TestInstallWithoutNamed
was missing in some nightly definitions.
Add the job definition for:
- nightly_latest_selinux.yaml
- nightly_latest_testing.yaml
- nightly_latest_testing_selinux.yaml

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>