### PR TITLE
[ipa-4-9] ipatests: add missing test in the nightly defs

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -588,6 +588,19 @@ jobs:
         timeout: 4800
         topology: *master_1repl_1client
 
+  fedora-latest-ipa-4-9/test_installation_TestInstallWithoutNamed:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestInstallWithoutNamed
+        template: *ci-ipa-4-9-latest
+        timeout: 4800
+        topology: *master_1repl
+
   fedora-latest-ipa-4-9/test_installation_TestInstallwithSHA384withRSA:
     requires: [fedora-latest-ipa-4-9/build]
     priority: 50


### PR DESCRIPTION
The test
test_integration/test_installation.py::TestInstallWithoutNamed
was missing in some nightly definitions.
Add the job definition for nightly_ipa-4-9_latest_selinux.yaml

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>