### PR TITLE
ipatests: remove certmonger tracking before uninstall

### DIFF
--- a/ipatests/test_integration/test_ipa_cert_fix.py
+++ b/ipatests/test_integration/test_ipa_cert_fix.py
@@ -122,9 +122,10 @@ def expire_cert_critical():
     # errors from certmonger trying to check the status of certs
     # that don't matter because we are uninstalling.
     host.run_command(['systemctl', 'stop', 'certmonger'])
-    host.run_command(
-        ['rm', '-f', paths.CERTMONGER_REQUESTS_DIR + '/*']
-    )
+    # Important: run_command with a str argument is able to
+    # perform shell expansion but run_command with a list of
+    # arguments is not
+    host.run_command('rm -fv ' + paths.CERTMONGER_REQUESTS_DIR + '*')
     tasks.uninstall_master(host)
     tasks.move_date(host, 'start', '-3Years-1day')
 


### PR DESCRIPTION
test_ipahealthcheck_expiring is moving the date in the future
in order to check that certmonger properly warns about expiring
certificates, then uninstalls the master.

The uninstallation randomly fails with a DBus error communicating
with certmonger because of a contention between certmonger being
waken up by the call to stop tracking certs and the certmonger
helpers trying to renew the certs.

To avoid the contention, manually remove the tracking before
calling uninstall.

Fixes: https://pagure.io/freeipa/issue/9123
