### PR TITLE
allow overriding systemd-tmpfiles program

### DIFF
--- a/ipaplatform/fedora_container/paths.py
+++ b/ipaplatform/fedora_container/paths.py
@@ -29,5 +29,15 @@ class FedoraContainerPathNamespace(FedoraPathNamespace):
     HTTPD_IPA_WSGI_MODULES_CONF = None
     HTTPD_PASSWD_FILE_FMT = data(FedoraPathNamespace.HTTPD_PASSWD_FILE_FMT)
 
+    # In some contexts, filesystem mounts may be owned by unmapped users
+    # (e.g. "emptyDir" mounts in Kubernetes / OpenShift when using user
+    # namespaces).  This causes systemd-tmpfiles(8) to fail, as a
+    # consequence of systemd's path processing routines which reject
+    # this scenario.  Therefore we provide a way to substitute
+    # systemd-tmpfiles with a "clone" program.
+    #
+    SYSTEMD_TMPFILES = os.environ.get(
+        'IPA_TMPFILES_PROG', FedoraPathNamespace.SYSTEMD_TMPFILES)
+
 
 paths = FedoraContainerPathNamespace()

--- a/ipaplatform/rhel_container/paths.py
+++ b/ipaplatform/rhel_container/paths.py
@@ -29,5 +29,15 @@ class RHELContainerPathNamespace(RHELPathNamespace):
     HTTPD_IPA_WSGI_MODULES_CONF = None
     HTTPD_PASSWD_FILE_FMT = data(RHELPathNamespace.HTTPD_PASSWD_FILE_FMT)
 
+    # In some contexts, filesystem mounts may be owned by unmapped users
+    # (e.g. "emptyDir" mounts in Kubernetes / OpenShift when using user
+    # namespaces).  This causes systemd-tmpfiles(8) to fail, as a
+    # consequence of systemd's path processing routines which reject
+    # this scenario.  Therefore we provide a way to substitute
+    # systemd-tmpfiles with a "clone" program.
+    #
+    SYSTEMD_TMPFILES = os.environ.get(
+        'IPA_TMPFILES_PROG', RHELPathNamespace.SYSTEMD_TMPFILES)
+
 
 paths = RHELContainerPathNamespace()


### PR DESCRIPTION
In some contexts, filesystem mounts may be owned by unmapped users
(e.g. `emptyDir` mounts in Kubernetes / OpenShift when using user
namespaces).  This causes `systemd-tmpfiles(8)` to fail, as a
consequence of systemd's path processing routines which reject this
scenario.  Therefore, in Fedora container context, if the
`IPA_TMPFILES_PROG` environment value is set, use the program
specified by its value instead of `/bin/systemd-tmpfiles`.