### PR TITLE
Kerberos instance: default to AES256-SHA2 for master key encryption

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 PKINIT_ENABLED = 'pkinitEnabled'
 
-MASTER_KEY_TYPE = 'aes256-sha1'
+MASTER_KEY_TYPE = 'aes256-sha2'
 SUPPORTED_ENCTYPES = ('aes256-sha2:special', 'aes128-sha2:special',
                       'aes256-sha2:normal', 'aes128-sha2:normal',
                       'aes256-cts:special', 'aes128-cts:special',

--- a/ipatests/test_integration/test_krbtpolicy.py
+++ b/ipatests/test_integration/test_krbtpolicy.py
@@ -105,6 +105,9 @@ class TestPWPolicy(IntegrationTest):
 
     def test_krbtpolicy_password_and_hardended(self):
         """Test a pwd and hardened kerberos ticket policy with 10min tickets"""
+        if self.master.is_fips_mode:
+            pytest.skip("SPAKE pre-auth is not compatible with FIPS mode")
+
         master = self.master
         master.run_command(['ipa', 'user-mod', USER1,
                             '--user-auth-type', 'password',
@@ -133,6 +136,9 @@ class TestPWPolicy(IntegrationTest):
 
     def test_krbtpolicy_hardended(self):
         """Test a hardened kerberos ticket policy with 30min tickets"""
+        if self.master.is_fips_mode:
+            pytest.skip("SPAKE pre-auth is not compatible with FIPS mode")
+
         master = self.master
         master.run_command(['ipa', 'user-mod', USER1,
                             '--user-auth-type', 'hardened'])

--- a/ipatests/test_integration/test_otp.py
+++ b/ipatests/test_integration/test_otp.py
@@ -5,7 +5,6 @@
 """
 import base64
 import logging
-import paramiko
 import pytest
 import re
 import time
@@ -102,6 +101,8 @@ def ssh_2f(hostname, username, answers_dict, port=22):
             logger.info(
                 "Answer to ssh prompt is: '%s'", answers_dict[prmpt_str])
         return resp
+
+    import paramiko
     trans = paramiko.Transport((hostname, port))
     trans.connect()
     trans.auth_interactive(username, answer_handler)


### PR DESCRIPTION
KDC configuration in /var/kerberos/krb5kdc/kdc.conf is generated from
the template in install/share/kdc.conf.template. Master key encryption
type specified there is used to bootstrap the master key in LDAP
database. Once it is done, actual deployment does not rely on the
master_key_type value anymore. The actual master key(s) get loaded from
LDAP database where they stored in a BER-encoded format, preserving all
parameters, including encryption type.

This means we can safely migrate to AES256-SHA2 as the default master
key encryption type for new installations. Replicas will get their
master key encryption type details from the server they were provisioned
from.

MIT Kerberos supports AES256-SHA2 since 1.15 (2015), meaning RHEL 7.4 is
the earliest supported version as it provides krb5 1.15.1. Current
supported RHEL 7 version is RHEL 7.9. Since RHEL 6 already cannot be
used as a replica to IPA 4.5+ due to a domain level 1 upgrade, this
change does not affect old releases.

Migration from the previously deployed master key encryption type is
described by MIT Kerberos upstream in
http://web.mit.edu/kerberos/krb5-latest/doc/admin/advanced/retiring-des.html#the-database-master-key

One would need to use '-x ipa-setup-override-restrictions' to allow
the `kdb5_util` utility to modify the data over IPA KDB driver.

Fixes: https://pagure.io/freeipa/issue/9119

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>