### PR TITLE
[Backport][ipa-4-9] Kerberos instance: default to AES256-SHA2 for master key encryption

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 PKINIT_ENABLED = 'pkinitEnabled'
 
-MASTER_KEY_TYPE = 'aes256-sha1'
+MASTER_KEY_TYPE = 'aes256-sha2'
 SUPPORTED_ENCTYPES = ('aes256-sha2:special', 'aes128-sha2:special',
                       'aes256-sha2:normal', 'aes128-sha2:normal',
                       'aes256-cts:special', 'aes128-cts:special',

--- a/ipatests/test_integration/test_krbtpolicy.py
+++ b/ipatests/test_integration/test_krbtpolicy.py
@@ -105,6 +105,9 @@ class TestPWPolicy(IntegrationTest):
 
     def test_krbtpolicy_password_and_hardended(self):
         """Test a pwd and hardened kerberos ticket policy with 10min tickets"""
+        if self.master.is_fips_mode:
+            pytest.skip("SPAKE pre-auth is not compatible with FIPS mode")
+
         master = self.master
         master.run_command(['ipa', 'user-mod', USER1,
                             '--user-auth-type', 'password',
@@ -133,6 +136,9 @@ class TestPWPolicy(IntegrationTest):
 
     def test_krbtpolicy_hardended(self):
         """Test a hardened kerberos ticket policy with 30min tickets"""
+        if self.master.is_fips_mode:
+            pytest.skip("SPAKE pre-auth is not compatible with FIPS mode")
+
         master = self.master
         master.run_command(['ipa', 'user-mod', USER1,
                             '--user-auth-type', 'hardened'])

--- a/ipatests/test_integration/test_otp.py
+++ b/ipatests/test_integration/test_otp.py
@@ -5,7 +5,6 @@
 """
 import base64
 import logging
-import paramiko
 import pytest
 import re
 import time
@@ -102,6 +101,8 @@ def ssh_2f(hostname, username, answers_dict, port=22):
             logger.info(
                 "Answer to ssh prompt is: '%s'", answers_dict[prmpt_str])
         return resp
+
+    import paramiko
     trans = paramiko.Transport((hostname, port))
     trans.connect()
     trans.auth_interactive(username, answer_handler)


### PR DESCRIPTION
This PR was opened automatically because PR #6209 was pushed to master and backport to ipa-4-9 is required.