### PR TITLE
ipa-kdb: fix make check

### DIFF
--- a/daemons/ipa-kdb/Makefile.am
+++ b/daemons/ipa-kdb/Makefile.am
@@ -90,6 +90,12 @@ ipa_kdb_tests_SOURCES =        \
        ipa_kdb_audit_as.c      \
        $(NULL)
 
+if BUILD_IPA_ISSUE_PAC
+ipa_kdb_tests_SOURCES += ipa_kdb_mspac_v9.c
+else
+ipa_kdb_tests_SOURCES += ipa_kdb_mspac_v6.c
+endif
+
 if BUILD_IPA_CERTAUTH_PLUGIN
 ipa_kdb_tests_SOURCES += ipa_kdb_certauth.c
 endif


### PR DESCRIPTION
The recent refactoring split out code into two new files which are
needed for the test binary as well.

Related: https://pagure.io/freeipa/issue/9083