### PR TITLE
kdb: Inherit default ticket policy, don't reset values if set

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -222,6 +222,10 @@ void ipadb_parse_user_auth(LDAP *lcontext, LDAPMessage *le,
             }
         }
     }
+    /* If password auth is enabled, enable hardened policy too. */
+    if (*userauth & IPADB_USER_AUTH_PASSWORD) {
+        *userauth |= IPADB_USER_AUTH_HARDENED;
+    }
 
     ldap_value_free_len(vals);
 }

--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -40,7 +40,7 @@ jitter(krb5_deltat baseline, krb5_deltat *lifetime_out)
         return;
     }
 
-    *lifetime_out = baseline - offset % JITTER_WINDOW_SECONDS;
+    *lifetime_out = baseline - abs(offset) % JITTER_WINDOW_SECONDS;
 }
 
 static krb5_error_code

--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -161,7 +161,7 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
         if (pol_limits->max_life != 0) {
             jitter(pol_limits->max_life, lifetime_out);
         } else {
-            jitter(ONE_DAY_SECONDS, lifetime_out);
+            jitter(client->max_life, lifetime_out);
         }
 
         if (pol_limits->max_renewable_life != 0) {


### PR DESCRIPTION
A principal may go through multiple passes of ipadb_parse_authind_policies
so don't replace values already set.

If an auth indicator-specific policy is missing then apply the
default policy.

Patch by Alexander Bokovoy

Fixes: https://pagure.io/freeipa/issue/9121
