### PR TITLE
tests: ensure AD-SUPPORT subpolicy is active in more cases

### DIFF
--- a/ipatests/pytest_ipa/integration/fips.py
+++ b/ipatests/pytest_ipa/integration/fips.py
@@ -72,5 +72,5 @@ def disable_userspace_fips(host):
 
 def enable_crypto_subpolicy(host, subpolicy):
     result = host.run_command(["update-crypto-policies", "--show"])
-    policy = result.stdin_text.strip() + ":" + subpolicy
+    policy = result.stdout_text.strip() + ":" + subpolicy
     host.run_command(["update-crypto-policies", "--set", policy])

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -499,6 +499,8 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
     if setup_adtrust:
         args.append('--setup-adtrust')
         fw_services.append("freeipa-trust")
+        if is_fips_enabled(replica):
+            enable_crypto_subpolicy(replica, "AD-SUPPORT")
     if master_authoritative_for_client_domain(master, replica):
         args.extend(['--ip-address', replica.ip])
 
@@ -568,6 +570,8 @@ def install_client(master, client, extra_args=[], user=None,
 
     args.extend(extra_args)
 
+    if is_fips_enabled(client) and 'ad' in master:
+        enable_crypto_subpolicy(client, "AD-SUPPORT")
     result = client.run_command(args, stdin_text=stdin_text)
 
     setup_sssd_conf(client)
@@ -582,6 +586,8 @@ def install_adtrust(host):
     Configures the compat tree for the legacy clients.
     """
     kinit_admin(host)
+    if is_fips_enabled(host):
+        enable_crypto_subpolicy(host, "AD-SUPPORT")
     host.run_command(['ipa-adtrust-install', '-U',
                       '--enable-compat',
                       '--netbios-name', host.netbios,


### PR DESCRIPTION
Continuation of the commit 2eee5931d714ca237290be7dc2fb7233ce747eca:

    Use AD-SUPPORT subpolicy when testing trust to Active Directory in FIPS
    mode. This is required in FIPS mode due to AD not supporting Kerberos
    AES-bases encryption types using FIPS-compliant PBKDF2 and KDF, as
    defined in RFC 8009.

Fixes: https://pagure.io/freeipa/issue/9119

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>