### PR TITLE
[Backport][ipa-4-9] ipatests: fix check for AD topology being present

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -570,7 +570,7 @@ def install_client(master, client, extra_args=[], user=None,
 
     args.extend(extra_args)
 
-    if is_fips_enabled(client) and 'ad' in master:
+    if is_fips_enabled(client) and getattr(master.config, 'ad_domains', False):
         enable_crypto_subpolicy(client, "AD-SUPPORT")
     result = client.run_command(args, stdin_text=stdin_text)
 


### PR DESCRIPTION
This PR was opened automatically because PR #6227 was pushed to master and backport to ipa-4-9 is required.