### PR TITLE
ipa-pwd-extop: allow ipasam to request RC4-HMAC in Kerberos keys for trusted domain objects

### DIFF
--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -99,6 +99,7 @@ CLASS_LOGFILES = [
     paths.NETWORK_MANAGER_CONFIG_DIR,
     paths.SYSTEMD_RESOLVED_CONF,
     paths.SYSTEMD_RESOLVED_CONF_DIR,
+    '/var/log/samba',
 ]
 
 

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -594,6 +594,7 @@ def install_adtrust(host):
                       '-a', host.config.admin_password,
                       '--add-sids'])
 
+    host.run_command(['net', 'conf', 'setparm', 'global', 'log level', '10'])
     Firewall(host).enable_service("freeipa-trust")
 
     # Restart named because it lost connection to dirsrv


### PR DESCRIPTION
This is a problem since we added commit b5fbbd1 in 2019. Its logic allowed to add RC4-HMAC keys for cifs/.. service principal but it didn't account for the case when cifs/.. principal initiates the request. The latter is when ipasam PDB module for Samba attempts to create a trust account. We rely on system-wide crypto policy to disallow clients using RC4-HMAC but we need this key to be able to retrieve NTLM hash on-demand for the trusted domain objects in ipasam.  Trust validation process triggers a request ServerAuthenticate3 from the AD DC side which relies on NTLM hash availability to mutually authenticate both parties    (https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/3a9ed16f-8014-45ae-80af-c0ecb06e2db9):

> The server MUST compute or retrieve the NTOWFv1 (as specified in NTLM v1
> Authentication in [MS-NLMP] section 3.3.1) of the client computer
> password and use it to compute a session key, as specified in section
> 3.1.4.3. If the server cannot compute or retrieve the NTOWFv1 of the
> client computer password, it MUST return STATUS_NO_TRUST_SAM_ACCOUNT.
>
> The server MUST compute the client Netlogon credential as specified in
> section 3.1.4.4 and compare the result with the client Netlogon
> credential passed from the client for verification. The computation is
> performed using the ClientChallenge from the ChallengeTable. If the
> comparison fails, session-key negotiation fails, and the server MUST
> return STATUS_ACCESS_DENIED.
    
Since ipasam only uses GETKEYTAB control, provide this extension only here and don't allow the same for SETKEYTAB. At the point of check for the bind DN, we already have verified that the DN is allowed to write to the krbPrincipalKey attribute so there is no leap of faith to 'any cifs/... principal' here.
    
A principal must be member of `cn=adtrust agents,cn=sysaccounts,cn=etc,$SUFFIX` to allow perform this operation
    
Fixes: https://pagure.io/freeipa/issue/9134
