### PR TITLE
ipatests: Test certmonger rekey command fails for DSA key type

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_cert.py::TestCertmongerRekey::test_rekey_keytype_DSA
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl


### PR DESCRIPTION
DSA is disabled in DEFAULT crypto policy in F30+, hence
the command with DSA key type will fail.

related: https://bugzilla.redhat.com/show_bug.cgi?id=2066439

Signed-off-by: Mohammad Rizwan <myusuf@redhat.com>