### PR TITLE
[Backport][ipa-4-9] ipa-pwd-extop: allow ipasam to request RC4-HMAC in Kerberos keys for trusted domain objects

### DIFF
--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -99,6 +99,7 @@ CLASS_LOGFILES = [
     paths.NETWORK_MANAGER_CONFIG_DIR,
     paths.SYSTEMD_RESOLVED_CONF,
     paths.SYSTEMD_RESOLVED_CONF_DIR,
+    '/var/log/samba',
 ]
 
 

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -594,6 +594,7 @@ def install_adtrust(host):
                       '-a', host.config.admin_password,
                       '--add-sids'])
 
+    host.run_command(['net', 'conf', 'setparm', 'global', 'log level', '10'])
     Firewall(host).enable_service("freeipa-trust")
 
     # Restart named because it lost connection to dirsrv


### PR DESCRIPTION
This PR was opened automatically because PR #6232 was pushed to master and backport to ipa-4-9 is required.