### PR TITLE
ipatests: bump PR-CI rawhide template

### DIFF
--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-frawhide
           name: freeipa/ci-master-frawhide
-          version: 0.5.2
+          version: 0.6.0
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Based on compose `20220413.n.0`.

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/457

Signed-off-by: Armando Neto <abiagion@redhat.com>

---

New template is future Fedora 37.
Temp run results available here: https://github.com/freeipa-pr-ci2/freeipa/pull/1652