### PR TITLE
ipatests: ipahealthcheck tests to check change in permission  of ipaserver-upgrade.log file

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1290,6 +1290,23 @@ class TestIpaHealthCheck(IntegrationTest):
         )
         assert msg in cmd.stdout_text
 
+    def modify_perms_run_healthcheck(self, filename, modify_permissions,
+                                     expected_permissions):
+        """
+        Modify the ipa logfile permissions and run
+        healthcheck command to check the status.
+        """
+        modify_permissions(self.master, path=filename, mode="0644")
+        returncode, data = run_healthcheck(
+            self.master, "ipahealthcheck.ipa.files", failures_only=True
+        )
+        assert returncode == 1
+        assert len(data) == 1
+        assert data[0]["result"] == "WARNING"
+        assert data[0]["kw"]["path"] == filename
+        assert data[0]["kw"]["type"] == "mode"
+        assert data[0]["kw"]["expected"] == expected_permissions
+
     def test_ipahealthcheck_verify_perms_for_source_files(self,
                                                           modify_permissions):
         """
@@ -1297,21 +1314,26 @@ class TestIpaHealthCheck(IntegrationTest):
         source.
         The test modifies permissions of ipainstall log file and checks the
         response from healthcheck.
-
         https://pagure.io/freeipa/issue/8949
         """
-        modify_permissions(self.master, path=paths.IPASERVER_INSTALL_LOG,
-                           mode="0644")
-        returncode, data = run_healthcheck(
-            self.master, "ipahealthcheck.ipa.files", failures_only=True)
+        self.modify_perms_run_healthcheck(
+            paths.IPASERVER_INSTALL_LOG, modify_permissions,
+            expected_permissions="0600"
+        )
 
-        assert returncode == 1
-        assert len(data) == 1
-        assert data[0]["result"] == "WARNING"
-        assert data[0]["kw"]["path"] == paths.IPASERVER_INSTALL_LOG
-        assert data[0]["kw"]["type"] == "mode"
-        assert data[0]["kw"]["expected"] == "0600"
-
+    def test_ipahealthcheck_verify_perms_upgrade_log_file(self,
+                                                          modify_permissions):
+        """
+        This testcase creates /var/log/ipaupgrade.log file.
+        Once the file is generated the permissions are modified
+        to check that correct status message is displayed
+        by healthcheck tool
+        """
+        self.master.run_command(["touch", paths.IPAUPGRADE_LOG])
+        self.modify_perms_run_healthcheck(
+            paths.IPAUPGRADE_LOG, modify_permissions,
+            expected_permissions="0600"
+        )
 
     @pytest.fixture
     def remove_healthcheck(self):


### PR DESCRIPTION
This testscase checks that when permission of ipaserver-upgrade.log is changed healthcheck tool reports the correct warning message.