### PR TITLE
[Backport][ipa-4-9] EPN: document missing option msg_subject

### DIFF
--- a/client/man/epn.conf.5
+++ b/client/man/epn.conf.5
@@ -89,6 +89,9 @@ Specifies the From: e-mail address value in the e-mails sent. The default is nor
 .B notify_ttls <list of days>
 This is the list of days before a password expiration when ipa-epn should notify a user that their password will soon require a reset. If this value is not specified then the default list will be used: 28, 14, 7, 3, 1.
 .TP
+.B msg_subject <subject>
+Specifies the subject of the e-mails sent. The default is "Your password will expire soon."
+.TP
 .B msg_charset <type>
 Set the character set of the message. The default is utf8. This will result in he body of the message being base64-encoded.
 .TP

--- a/client/share/epn.conf
+++ b/client/share/epn.conf
@@ -64,6 +64,9 @@ smtp_delay = 0
 # a user that their password will soon require a reset.
 notify_ttls = 28, 14, 7, 3, 1
 
+# Set the subject of the message
+# msg_subject =
+
 # Set the character set of the message.
 msg_charset = utf8
 


### PR DESCRIPTION
This PR was opened automatically because PR #6241 was pushed to master and backport to ipa-4-9 is required.