### PR TITLE
ipatests: update the expected sha256sum of epn.conf file

### DIFF
--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -358,7 +358,7 @@ class TestEPN(IntegrationTest):
         assert epn_conf in cmd1.stdout_text
         assert epn_template in cmd1.stdout_text
         cmd2 = self.master.run_command(["sha256sum", epn_conf])
-        ck = "9977d846539d4945900bd04bae25bf746ac75fb561d3769014002db04e1790b8"
+        ck = "5e56a0f8010ff4f399b206c9e45004823bc05bf6577b34b3e701e4a2935df989"
         assert cmd2.stdout_text.find(ck) == 0
 
     def test_EPN_connection_refused(self):


### PR DESCRIPTION
The file epn.conf has been updated when fixing issue 9145
and the test test_epn.py::TestEPN::test_EPN_config_file
is comparing its sha256sum with the checksum of the
shipped file from the package ipa-client-epn.

The expected checksum needs to be updated.

Fixes: https://pagure.io/freeipa/issue/9146