### PR TITLE
web ui: do not provide Remove button in subid page

### DIFF
--- a/install/ui/src/freeipa/subid.js
+++ b/install/ui/src/freeipa/subid.js
@@ -16,12 +16,30 @@ define([
 
 var exp = IPA.subid = {};
 
+exp.search_facet_control_buttons_pre_op = function(spec, context) {
+    spec.control_buttons = [
+        {
+            name: 'add',
+            label: '@i18n:buttons.add',
+            icon: 'fa-plus'
+        },
+        {
+            name: 'refresh',
+            label: '@i18n:buttons.refresh',
+            icon: 'fa-refresh'
+        }
+    ];
+
+    return spec;
+};
+
 var make_spec = function() {
 return {
     name: 'subid',
     facets: [
         {
             $type: 'search',
+            $pre_ops: [ exp.search_facet_control_buttons_pre_op ],
             columns: [
                 'ipauniqueid',
                 'ipaowner',

--- a/ipatests/test_webui/test_subid.py
+++ b/ipatests/test_webui/test_subid.py
@@ -125,17 +125,3 @@ class test_subid(UI_driver):
         self.assert_no_error_dialog()
         after_count = self.get_rows()
         assert len(before_count) < len(after_count)
-
-    @screenshot
-    def test_subid_del(self):
-        """
-        Test to remove subordinate id for given user.
-        """
-        self.init_app()
-        self.navigate_to_entity('subid', facet='search')
-        user_uid = self.get_record_pkey("some-user", "ipaowner",
-                                        table_name="ipauniqueid")
-        before_count = self.get_rows()
-        self.delete_record(user_uid, table_name="ipauniqueid")
-        after_count = self.get_rows()
-        assert len(before_count) > len(after_count)


### PR DESCRIPTION
subid range management does not allow to delete ranges

If subid range was allocated, it cannot be removed because there might
be file objects associated with it on one of IPA clients.

In Web UI a button to remove the range should not be shown.

Remove corresponding test from the Web UI test for subid as the button
to remove the subid range is not present anymore.

Fixes: https://pagure.io/freeipa/issue/9150

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>