### PR TITLE
[Backport][ipa-4-9] Switch Azure CI to Fedora 36 pre-release

### DIFF
--- a/install/ui/src/freeipa/package.json
+++ b/install/ui/src/freeipa/package.json
@@ -41,9 +41,9 @@
     "path": "install/ui/js/freeipa"
   },
   "devDependencies": {
-    "grunt": "^1.0.1",
-    "grunt-contrib-qunit": "^2.0.0",
-    "grunt-qunit-junit": "^0.3.1"
+    "grunt": "",
+    "grunt-contrib-qunit": "",
+    "grunt-qunit-junit": ""
   },
   "dependencies": {
     "dojo": "~1.16.2"

--- a/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
+++ b/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM registry.fedoraproject.org/fedora-toolbox:36
 MAINTAINER [FreeIPA Developers freeipa-devel@lists.fedorahosted.org]
 ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -130,7 +130,7 @@ jobs:
         echo "Running WebUI unit tests"
         # PhantomJS is not compatible with OpenSSL 1.1.1
         # https://github.com/wch/webshot/pull/93
-        export OPENSSL_CONF=whatever
+        # export OPENSSL_CONF=whatever
         cd $(builddir)/install/ui/js/libs && make
         cd $(builddir)/install/ui && npm install
         cd $(builddir)/install/ui && node_modules/grunt/bin/grunt --verbose test

--- a/ipatests/azure/templates/prepare-tox-fedora.yml
+++ b/ipatests/azure/templates/prepare-tox-fedora.yml
@@ -2,5 +2,6 @@ steps:
 - script: |
     set -e
     sudo dnf -y install nss-tools python3-pip git
+    sudo ln -s /usr/lib64/libldap.so /usr/lib64/libldap_r.so
     python3 -m pip install --user --upgrade pip setuptools pycodestyle
   displayName: Install Tox prerequisites

--- a/ipatests/azure/templates/prepare-webui-fedora.yml
+++ b/ipatests/azure/templates/prepare-webui-fedora.yml
@@ -1,5 +1,5 @@
 steps:
 - script: |
     set -e
-    sudo dnf -y install npm fontconfig
+    sudo dnf -y install npm fontconfig gtk3 atk at-spi2-atk
   displayName: Install WebUI Unit tests prerequisites

--- a/ipatests/azure/templates/variables-fedora.yml
+++ b/ipatests/azure/templates/variables-fedora.yml
@@ -1,7 +1,7 @@
 variables:
   IPA_PLATFORM: fedora
   # the Docker public image to build IPA packages (rpms)
-  DOCKER_BUILD_IMAGE: 'fedora:34'
+  DOCKER_BUILD_IMAGE: 'registry.fedoraproject.org/fedora-toolbox:36'
 
   # the Dockerfile to build Docker image for running IPA tests
   DOCKER_DOCKERFILE: ${{ format('Dockerfile.build.{0}', variables.IPA_PLATFORM) }}


### PR DESCRIPTION
This PR was opened automatically because PR #6188 was pushed to master and backport to ipa-4-9 is required.