### PR TITLE
ipatests: --no-dnssec-validation requires --setup-dns

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1459,8 +1459,7 @@ class TestIpaHealthCheckWithoutDNS(IntegrationTest):
         tasks.uninstall_replica(cls.master, cls.replicas[0])
         tasks.uninstall_master(cls.master)
         tasks.install_master(
-            cls.master, setup_dns=False, extra_args=['--no-dnssec-validation']
-        )
+            cls.master, setup_dns=False)
 
     def test_ipa_dns_systemrecords_check(self):
         """


### PR DESCRIPTION
The test test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS
is installing the server without DNS but calls the installer
with --no-dnssec-validation option.

Remove the --no-dnssec-validation option as it is incompatible
with a non-DNS setup.

Fixes: https://pagure.io/freeipa/issue/9152