### PR TITLE
client uninstall: handle uninstall with authconfig

### DIFF
--- a/ipaplatform/redhat/authconfig.py
+++ b/ipaplatform/redhat/authconfig.py
@@ -129,7 +129,14 @@ class RedHatAuthSelect(RedHatAuthToolBase):
     def unconfigure(
         self, fstore, statestore, was_sssd_installed, was_sssd_configured
     ):
-        if not statestore.has_state('authselect') and was_sssd_installed:
+        # If the installation failed before doing the authselect part
+        # nothing to do here
+        complete = statestore.get_state('installation', 'complete')
+        if complete is not None and not complete and \
+           not statestore.has_state('authselect'):
+            return
+
+        if not statestore.has_state('authselect'):
             logger.warning(
                 "WARNING: Unable to revert to the pre-installation state "
                 "('authconfig' tool has been deprecated in favor of "

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -765,6 +765,12 @@ class RedHatTaskNamespace(BaseTaskNamespace):
 
         authselect_cmd = [paths.AUTHSELECT, "disable-feature",
                           "with-custom-automount"]
-        ipautil.run(authselect_cmd)
+        try:
+            ipautil.run(authselect_cmd)
+        except ipautil.CalledProcessError:
+            logger.info("Unable to disable with-custom-automount feature")
+            logger.info("It may happen if the configuration was done "
+                        "using authconfig instead of authselect")
+
 
 tasks = RedHatTaskNamespace()


### PR DESCRIPTION
If the client was installed with authconfig, with
automount configured to use ldap (--no-sssd), and later
updated to a version using authselect, the uninstaller
tries to disable the authselect feature with-custom-automount
but fails because there is no authselect profile in use.

(Upgrade of a client does not transform authconfig settings
into authselect settings because we don't have any client
upgrader, as opposed to the ipa-server-upgrade for the
servers).

To avoid uninstallation failure, ignore the error and log a
warning.

The second part of the commit fixes a wrong assumption
introduced by commit e59ee60, trying to fix issues when
a client installation fails and the installation is reverted
by the ipa-client-install tool itself.
The original fix's intention was to detect when unconfigure
is called from a failed ipa-client-install, and relied on
the variable was_sssd_installed.
This variable is True when there was an SSSD config file
before ipa-client-install was called, but does not allow to
detect if unconfigure is called from a failed installation.
The fix checks instead if the statestore shows an incomplete
installation. If the install was incomplete and failed before
any attempt to configure authselect, then unconfigure doesn't
need to do anything. In the other cases, unconfigure needs
to revert to the pre-ipa state.

Fixes: https://pagure.io/freeipa/issue/9147