### PR TITLE
dnssec daemons: read the dns context config file for debug state

### DIFF
--- a/client/man/default.conf.5
+++ b/client/man/default.conf.5
@@ -78,7 +78,7 @@ Specifies the insecure CA end user port. The default is 8080.
 The time to wait for a certmonger request to complete during installation. The default value is 300 seconds.
 .TP
 .B context <context>
-Specifies the context that IPA is being executed in. IPA may operate differently depending on the context. The current defined contexts are cli and server. Additionally this value is used to load /etc/ipa/\fBcontext\fR.conf to provide context\-specific configuration. For example, if you want to always perform client requests in verbose mode but do not want to have verbose enabled on the server, add the verbose option to \fI/etc/ipa/cli.conf\fR.
+Specifies the context that IPA is being executed in. IPA may operate differently depending on the context. The current defined contexts are cli, server and dns. Additionally this value is used to load /etc/ipa/\fBcontext\fR.conf to provide context\-specific configuration. For example, if you want to always perform client requests in verbose mode but do not want to have verbose enabled on the server, add the verbose option to \fI/etc/ipa/cli.conf\fR.
 .TP
 .B debug <boolean>
 When True provides detailed information. Specifically this set the global log level to "debug". Default is False.
@@ -250,12 +250,20 @@ system\-wide IPA configuration file
 .I $HOME/.ipa/default.conf
 user IPA configuration file
 .TP
-It is also possible to define context\-specific configuration files. The \fBcontext\fR is set when the IPA api is initialized. The two currently defined contexts in IPA are \fBcli\fR and \fBserver\fR. This is helpful, for example, if you only want \fBdebug\fR enabled on the server and not in the client. If this is set to True in \fIdefault.conf\fR it will affect both the ipa client tool and the IPA server. If it is only set in \fIserver.conf\fR then only the server will have \fBdebug\fR set. These files will be loaded if they exist:
+It is also possible to define context\-specific configuration files. The \fBcontext\fR is set when the IPA api is initialized. The currently defined contexts in IPA are \fBcli\fR, \fBserver\fR and \fBdns\fR. This is helpful, for example, if you only want \fBdebug\fR enabled on the server and not in the client. If this is set to True in \fIdefault.conf\fR it will affect both the ipa client tool and the IPA server. If it is only set in \fIserver.conf\fR then only the server will have \fBdebug\fR set. These files will be loaded if they exist:
 .TP
 .I /etc/ipa/cli.conf
 system\-wide IPA client configuration file
 .TP
 .I /etc/ipa/server.conf
 system\-wide IPA server configuration file
+.SH "EXAMPLES"
+.TP
+An example of a context-specific configuration file is \fB/etc/ipa/dns.conf\fR to be used to increase debug output of the IPA DNSSEC daemons.
+.TP
+.RS L
+[global]
+debug = True
+.RE
 .SH "SEE ALSO"
 .BR ipa (1)

--- a/daemons/dnssec/ipa-dnskeysync-replica.in
+++ b/daemons/dnssec/ipa-dnskeysync-replica.in
@@ -19,6 +19,7 @@ from ipalib.constants import SOFTHSM_DNSSEC_TOKEN_LABEL
 from ipalib.install.kinit import kinit_keytab
 from ipapython.dn import DN
 from ipapython.ipa_log_manager import standard_logging_setup
+from ipapython.ipautil import get_config_debug
 from ipapython import ipaldap
 from ipaplatform.paths import paths
 from ipaserver.dnssec.abshsm import (sync_pkcs11_metadata,
@@ -145,7 +146,11 @@ def ldap2replica_zone_keys_sync(ldapkeydb, localhsm):
 
 
 # IPA framework initialization
-standard_logging_setup(debug=True)
+debug = get_config_debug('dns')
+standard_logging_setup(debug=debug, verbose=True)
+if not debug:
+    logger.info("To increase debugging set debug=True in dns.conf "
+                "See default.conf(5) for details")
 ipalib.api.bootstrap(context='dns', confdir=paths.ETC_IPA, in_server=True)
 ipalib.api.finalize()
 

--- a/daemons/dnssec/ipa-dnskeysyncd.in
+++ b/daemons/dnssec/ipa-dnskeysyncd.in
@@ -16,6 +16,7 @@ from ipalib.install.kinit import kinit_keytab
 from ipapython.dn import DN
 from ipapython.ipa_log_manager import standard_logging_setup
 from ipapython import ipaldap
+from ipapython.ipautil import get_config_debug
 from ipaplatform.paths import paths
 from ipaserver.dnssec.keysyncer import KeySyncer
 
@@ -35,7 +36,11 @@ def fixup_dnssec_utils(self):
 
 fixup_dnssec_utils(paths)
 # IPA framework initialization
-standard_logging_setup(debug=True)
+debug = get_config_debug('dns')
+standard_logging_setup(debug=debug, verbose=True)
+if not debug:
+    logger.info("To increase debugging set debug=True in dns.conf "
+                "See default.conf(5) for details")
 api.bootstrap(context='dns', confdir=paths.ETC_IPA, in_server=True)
 api.finalize()
 

--- a/daemons/dnssec/ipa-ods-exporter.in
+++ b/daemons/dnssec/ipa-ods-exporter.in
@@ -36,6 +36,7 @@ from ipalib.install.kinit import kinit_keytab
 from ipapython.dn import DN
 from ipapython.ipa_log_manager import standard_logging_setup
 from ipapython import ipaldap
+from ipapython.ipautil import get_config_debug
 from ipaplatform.paths import paths
 from ipaserver import p11helper
 from ipaserver.dnssec.abshsm import sync_pkcs11_metadata, wrappingmech_name2id
@@ -675,7 +676,11 @@ def cleanup_ldap_zone(ldap, dns_dn, zone_name):
 
 
 # IPA framework initialization
-standard_logging_setup(debug=True)
+debug = get_config_debug('dns')
+standard_logging_setup(debug=debug, verbose=True)
+if not debug:
+    logger.info("To increase debugging set debug=True in dns.conf "
+                "See default.conf(5) for details")
 ipalib.api.bootstrap(context='dns', confdir=paths.ETC_IPA, in_server=True)
 ipalib.api.finalize()
 


### PR DESCRIPTION
This had been hardcoded to debug=True but it spams the logs
with a lot of unnecessary information.

Allow it to be enabled for troubleshooting purposes but keep it
disabled by default.

Enabling debug would involve created /etc/ipa/dns.conf:

[global]
debug = True

I didn't add a more generic mechanism because for now we only need
the value of debug and it introduces a lot of type conversion
headaches. ipalib handles this automatically but to duplicate this
would be corner-case city.

Fixes: https://pagure.io/freeipa/issue/9128

Signed-off-by: Rob Crittenden <rcritten@redhat.com>