### PR TITLE
freeipa.spec.in: Depend on sssd-idp directly to help RHEL BaseOS/AppS…

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -665,6 +665,7 @@ Requires: xmlrpc-c >= 1.27.4
 Requires: jansson
 %endif
 Requires: sssd-ipa >= %{sssd_version}
+Requires: sssd-idp >= %{sssd_version}
 Requires: certmonger >= %{certmonger_version}
 Requires: nss-tools >= %{nss_version}
 Requires: bind-utils


### PR DESCRIPTION
…tream repository split

In RHEL there is a split of packages between Base OS and AppStream
repositories. While both repositories are accessible and enabled by
default, there are different requirements towards binary packages in
both. Namely, Base OS packages cannot have runtime dependencies to
AppStream packages and they should have a stricter lifecycle promises in
terms of API and ABI stability.

SSSD 2.7.0 adds sssd-idp package which provides actual implementation of
OAuth 2.0 integration. Since SSSD is provided as part of Base OS, if
sssd-idp is placed there, then all its dependencies would have to be in
Base OS. Unfortunately, libjose is already part of AppStream.

SSSD team currently pulls sssd-idp as a dependency of sssd-ipa so
FreeIPA didn't need to change anything. However, Base OS requirements
will force SSSD team to drop sssd-idp dependency from sssd-ipa. This
means FreeIPA will have to explicitly depend on sssd-idp.

Fixes:https://pagure.io/freeipa/issue/9155

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>