### PR TITLE
[Backport][ipa-4-9] freeipa.spec.in: Depend on sssd-idp directly to help RHEL BaseOS/AppS…

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -665,6 +665,7 @@ Requires: xmlrpc-c >= 1.27.4
 Requires: jansson
 %endif
 Requires: sssd-ipa >= %{sssd_version}
+Requires: sssd-idp >= %{sssd_version}
 Requires: certmonger >= %{certmonger_version}
 Requires: nss-tools >= %{nss_version}
 Requires: bind-utils


### PR DESCRIPTION
This PR was opened automatically because PR #6259 was pushed to master and backport to ipa-4-9 is required.