### PR TITLE
ipatests: Fix for ipahealtcheck testsuites failure

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -274,6 +274,7 @@ class TestIpaHealthCheck(IntegrationTest):
         valid_msg = (
             'IPA is not configured\n', 'IPA server is not configured\n'
         )
+        self.clients[0].run_command(["dnf", "module", "enable", "-y", "idm:DL1"])
         tasks.install_packages(self.clients[0], HEALTHCHECK_PKG)
         cmd = self.clients[0].run_command(
             ["ipa-healthcheck"], raiseonerr=False


### PR DESCRIPTION
ipa-healthcheck packages is not getting installed on an ipa-client and throwing an error as below.
    
"All matches were filtered out by modular filtering for argument: *ipa-healthcheck
Error: Unable to find a match: *ipa-healthcheck"
    
After testing the same scenario manually on a test system found that once the idm:DL1 module was enabled the
ipa-healthcheck package was getting installed