### PR TITLE
[Backport][ipa-4-9] client uninstall: handle uninstall with authconfig

### DIFF
--- a/ipaplatform/redhat/authconfig.py
+++ b/ipaplatform/redhat/authconfig.py
@@ -129,7 +129,14 @@ class RedHatAuthSelect(RedHatAuthToolBase):
     def unconfigure(
         self, fstore, statestore, was_sssd_installed, was_sssd_configured
     ):
-        if not statestore.has_state('authselect') and was_sssd_installed:
+        # If the installation failed before doing the authselect part
+        # nothing to do here
+        complete = statestore.get_state('installation', 'complete')
+        if complete is not None and not complete and \
+           not statestore.has_state('authselect'):
+            return
+
+        if not statestore.has_state('authselect'):
             logger.warning(
                 "WARNING: Unable to revert to the pre-installation state "
                 "('authconfig' tool has been deprecated in favor of "

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -765,6 +765,12 @@ class RedHatTaskNamespace(BaseTaskNamespace):
 
         authselect_cmd = [paths.AUTHSELECT, "disable-feature",
                           "with-custom-automount"]
-        ipautil.run(authselect_cmd)
+        try:
+            ipautil.run(authselect_cmd)
+        except ipautil.CalledProcessError:
+            logger.info("Unable to disable with-custom-automount feature")
+            logger.info("It may happen if the configuration was done "
+                        "using authconfig instead of authselect")
+
 
 tasks = RedHatTaskNamespace()


### PR DESCRIPTION
This PR was opened automatically because PR #6256 was pushed to master and backport to ipa-4-9 is required.