### PR TITLE
Fix handling of forwarders addresses with custom port.

### DIFF
--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -801,7 +801,15 @@ def _resolve_record(owner, rtype, nameserver_ip=None, edns0=False,
 
     res = DNSResolver()
     if nameserver_ip:
+        # When validating forwarders, nameserver_ip takes the format
+        # '<ip> port <port>', which is not a vaild IP address. In this
+        # case, split the string and add the IP part to res.nameservers,
+        # and the ip:port pair to res.nameserver_ports dict.
+        nameserver_ip = re.sub(r'\s+', ' ', nameserver_ip.strip())
+        nameserver_ip, *port = nameserver_ip.split(" port ")
         res.nameservers = [nameserver_ip]
+        if port:
+            res.nameserver_ports = {nameserver_ip: int(*port)}
     res.lifetime = timeout
 
     # Recursion Desired,

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -289,6 +289,7 @@ arec3 = u'172.16.250.123'
 aaaarec1 = u'ff02::1'
 
 fwd_ip = u'172.16.31.80'
+fwd_ip_port = u'172.16.31.80 port 8053'
 allowtransfer_tofwd = u'%s;' % fwd_ip
 
 # 198.18.0.0/15 testing range reserved by RFC2544
@@ -1975,6 +1976,43 @@ class test_dns(Declarative):
                 'result': {
                     'dns_server_server': [api.env.host],
                     'idnsforwarders': [fwd_ip],
+                },
+            },
+        ),
+
+        dict(
+            desc='Update global DNS settings with forwarder in custom port',
+            command=('dnsconfig_mod', [], {'idnsforwarders' : [fwd_ip_port],}),
+            expected={
+                'value': None,
+                'summary': None,
+                u'messages': (
+                    {
+                        u'message': lambda x: x.startswith(
+                            u"Forwarding policy conflicts with some "
+                            "automatic empty zones."
+                        ),
+                        u'code': 13021,
+                        u'type': u'warning',
+                        u'name': u'DNSForwardPolicyConflictWithEmptyZone',
+                        u'data': {}
+                    },
+                    {
+                        u'message': lambda x: x.startswith(
+                            u"DNS server %s: query '. SOA':" % fwd_ip_port
+                        ),
+                        u'code': 13006,
+                        u'type':u'warning',
+                        u'name': u'DNSServerValidationWarning',
+                        u'data': {
+                            u'error': lambda x: x.startswith(u"query '. SOA':"),
+                            u'server': u"%s" % fwd_ip_port
+                        }
+                    },
+                ),
+                'result': {
+                    'dns_server_server': [api.env.host],
+                    'idnsforwarders': [fwd_ip_port],
                 },
             },
         ),

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -4197,7 +4197,7 @@ class test_forward_zones(Declarative):
                     'data': {
                         'error': lambda x: x.startswith(
                             "query '%s SOA':" % fwzone_custom_port
-                        ) and x.endswith("[Errno 22] Invalid argument."),
+                        ),
                         'server': u"%s" % forwarder1_custom_port
                     }
                 },),
@@ -4246,16 +4246,51 @@ class test_forward_zones(Declarative):
 
         dict(
             desc=(
-                'Create forward zone %r with invalid forwarder %s'
+                'Create forward zone %r with forwarder using port 0: %s'
                 % (fwzone_custom_port, forwarder_custom_port_inv1)
             ),
             command=(
                 'dnsforwardzone_add', [fwzone_custom_port],
                 {'idnsforwarders': [forwarder_custom_port_inv1]}
             ),
-            expected=errors.ValidationError(
-                name='idnsforwarders',
-                error=u'Please specify forwarders.')
+            expected={
+                'value': fwzone_custom_port_dnsname,
+                'summary': None,
+                u'messages': ({
+                    u'message': lambda x: x.startswith(
+                        u"DNS server %s: query '%s SOA':"
+                        % (forwarder1_custom_port, fwzone_custom_port)
+                    ),
+                    u'code': 13006,
+                    u'type':u'warning',
+                    u'name': u'DNSServerValidationWarning',
+                    u'data': {
+                        u'error': lambda x: x.startswith(
+                            u"query '%s SOA':" % fwzone_custom_port
+                        ) and x.endswith(u"[Errno 22] Invalid argument."),
+                        u'server': u"%s" % forwarder_custom_port_inv1
+                    }
+                },),
+                'result': {
+                    'dn': fwzone_custom_port_dn,
+                    'idnsname': [fwzone_custom_port_dnsname],
+                    'idnszoneactive': [u'TRUE'],
+                    'idnsforwardpolicy': [u'first'],
+                    'idnsforwarders': [forwarder1_custom_port],
+                    'objectclass': objectclasses.dnsforwardzone,
+                },
+            },
+        ),
+
+        dict(
+            desc='Delete forward zone %r (cleanup)' % fwzone_custom_port,
+            command=('dnsforwardzone_del', [fwzone_custom_port], {}),
+            expected={
+                'value': [fwzone_custom_port_dnsname],
+                'summary':
+                    u'Deleted DNS forward zone "%s"' % fwzone_custom_port,
+                'result': {'failed': []},
+            },
         ),
 
         dict(

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -379,6 +379,9 @@ forwarder4 = u'172.16.15.4'
 
 forwarder1_custom_port = u'172.16.15.253 port 8053'
 forwarder2_custom_port = u'172.16.15.254 port 8053'
+forwarder3_custom_port = u'172.16.15.254   port 8053'
+forwarder4_custom_port = u'172.16.15.254 port   8053'
+forwarder5_custom_port = u'172.16.15.254  port  8053'
 
 fwzone_custom_port = u'fwzone-custom.test.'
 fwzone_custom_port_dnsname = DNSName(fwzone_custom_port)
@@ -4183,6 +4186,37 @@ class test_forward_zones(Declarative):
                     'idnszoneactive': [u'TRUE'],
                     'idnsforwardpolicy': [u'first'],
                     'idnsforwarders': [forwarder2_custom_port],
+                },
+            },
+        ),
+
+        dict(
+            desc=(
+                'Modify forward zone %r change three forwarders'
+                % fwzone_custom_port
+            ),
+            command=(
+                'dnsforwardzone_mod', [fwzone_custom_port], {
+                    'idnsforwarders': [
+                        forwarder3_custom_port,
+                        forwarder4_custom_port,
+                        forwarder5_custom_port
+                    ],
+                }
+            ),
+            expected={
+                'value': fwzone_custom_port_dnsname,
+                'summary': None,
+                'messages': lambda x: True,  # fake forwarders - ignore message
+                'result': {
+                    'idnsname': [fwzone_custom_port_dnsname],
+                    'idnszoneactive': [u'TRUE'],
+                    'idnsforwardpolicy': [u'first'],
+                    'idnsforwarders': [
+                        forwarder3_custom_port,
+                        forwarder4_custom_port,
+                        forwarder5_custom_port
+                    ],
                 },
             },
         ),

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -382,6 +382,12 @@ forwarder2_custom_port = u'172.16.15.254 port 8053'
 forwarder3_custom_port = u'172.16.15.254   port 8053'
 forwarder4_custom_port = u'172.16.15.254 port   8053'
 forwarder5_custom_port = u'172.16.15.254  port  8053'
+forwarder_custom_port_inv1 = u'172.16.15.253 port 0'
+forwarder_custom_port_inv2 = u'172.16.15.253 port 1000000000'
+forwarder_custom_port_inv3 = u'172.16.15.253 port a'
+forwarder_custom_port_inv4 = u'172.16.15.253 8053'
+forwarder_custom_port_inv5 = u'a.b.c.d port 8053'
+forwarder_custom_port_inv6 = u'172.16.15.253 prot 8053'
 
 fwzone_custom_port = u'fwzone-custom.test.'
 fwzone_custom_port_dnsname = DNSName(fwzone_custom_port)
@@ -4230,6 +4236,20 @@ class test_forward_zones(Declarative):
                     u'Deleted DNS forward zone "%s"' % fwzone_custom_port,
                 'result': {'failed': []},
             },
+        ),
+
+        dict(
+            desc=(
+                'Create forward zone %r with invalid forwarder %s'
+                % (fwzone_custom_port, forwarder_custom_port_inv1)
+            ),
+            command=(
+                'dnsforwardzone_add', [fwzone_custom_port],
+                {'idnsforwarders': [forwarder_custom_port_inv1]}
+            ),
+            expected=errors.ValidationError(
+                name='idnsforwarders',
+                error=u'Please specify forwarders.')
         ),
 
         dict(

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -4189,7 +4189,7 @@ class test_forward_zones(Declarative):
                 'messages': ({
                     'message': lambda x: x.startswith(
                         "DNS server %s: query '%s SOA':"
-                        % (forwarder1_custom_port, fwzone_custom_port)
+                        % (forwarder2_custom_port, fwzone_custom_port)
                     ),
                     'code': 13006,
                     'type': 'warning',
@@ -4198,7 +4198,7 @@ class test_forward_zones(Declarative):
                         'error': lambda x: x.startswith(
                             "query '%s SOA':" % fwzone_custom_port
                         ),
-                        'server': u"%s" % forwarder1_custom_port
+                        'server': u"%s" % forwarder2_custom_port
                     }
                 },),
                 'result': {
@@ -4259,7 +4259,7 @@ class test_forward_zones(Declarative):
                 u'messages': ({
                     u'message': lambda x: x.startswith(
                         u"DNS server %s: query '%s SOA':"
-                        % (forwarder1_custom_port, fwzone_custom_port)
+                        % (forwarder_custom_port_inv1, fwzone_custom_port)
                     ),
                     u'code': 13006,
                     u'type':u'warning',
@@ -4267,7 +4267,7 @@ class test_forward_zones(Declarative):
                     u'data': {
                         u'error': lambda x: x.startswith(
                             u"query '%s SOA':" % fwzone_custom_port
-                        ) and x.endswith(u"[Errno 22] Invalid argument."),
+                        ) and u"[Errno 22] Invalid argument" in x,
                         u'server': u"%s" % forwarder_custom_port_inv1
                     }
                 },),
@@ -4276,7 +4276,7 @@ class test_forward_zones(Declarative):
                     'idnsname': [fwzone_custom_port_dnsname],
                     'idnszoneactive': [u'TRUE'],
                     'idnsforwardpolicy': [u'first'],
-                    'idnsforwarders': [forwarder1_custom_port],
+                    'idnsforwarders': [forwarder_custom_port_inv1],
                     'objectclass': objectclasses.dnsforwardzone,
                 },
             },


### PR DESCRIPTION
When setting a DNS forwarder, IPA allows the use of a custom port using
the format '<ip> port <port>', and this configuration is validated with
dnspython to ensure the forwarder is resolvable.

Starting with dnspython 2.2.0 the Resolver.nameservers property, used
to resolve the forwarders IP address, validates the IP address when
the value is assigned to property, and as the forwarder format is not
an IP address, it fails and a ValueError exception is raised.

Modifying the way forwarders are handled when validating them prevents
the exception to be raised, and test for the correct port.

Fixes: https://pagure.io/freeipa/issue/9158