### PR TITLE
ipatests: update definitions for custom "COPR" nightlies

### DIFF
--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -31,11 +31,12 @@ jobs:
     job:
       class: Build
       args:
+        copr: '@389ds/389-ds-base-nightly'
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &389ds-master-latest
-          name: freeipa/389ds-master-f35
-          version: 0.0.1
+        template: &ci-master-latest
+          name: freeipa/ci-master-f36
+          version: 0.0.5
         timeout: 1800
         topology: *build
 
@@ -47,8 +48,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_simple_replication.py
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -60,8 +62,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_commands.py
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl_1client
 
@@ -73,8 +76,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_server_del.py
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -86,8 +90,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -99,8 +104,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_caless.py::TestServerInstall
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 12000
         topology: *master_1repl
 
@@ -112,8 +118,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -125,8 +132,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_caless.py::TestClientInstall
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 5400
         # actually master_1client
         topology: *master_1repl_1client
@@ -139,8 +147,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_caless.py::TestCertInstall
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -152,8 +161,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -165,8 +175,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -178,8 +189,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -191,8 +203,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -204,8 +217,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -217,8 +231,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -230,8 +245,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -243,8 +259,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -256,8 +273,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -269,8 +287,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -282,8 +301,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -295,8 +315,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_dnssec.py
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -308,8 +329,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -321,8 +343,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -334,8 +357,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -347,8 +371,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_upgrade.py
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -360,8 +385,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -373,8 +399,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_topology.py::TestTopologyOptions
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -386,8 +413,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -399,8 +427,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -412,8 +441,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -425,8 +455,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -438,8 +469,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -451,8 +483,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -464,8 +497,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -477,8 +511,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -490,8 +525,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -503,8 +539,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_uninstallation.py
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
@@ -516,8 +553,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_customized_ds_config_install.py
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -529,8 +567,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_dns_locations.py
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_2repl_1client
 
@@ -542,8 +581,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -555,8 +595,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_installation.py::TestMaskInstall
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -568,8 +609,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_automember.py
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -581,8 +623,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_fips.py
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
@@ -594,8 +637,9 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_pwpolicy.py
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -607,7 +651,8 @@ jobs:
       args:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_idp.py
-        template: *389ds-master-latest
+        template: *ci-master-latest
         timeout: 5000
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -35,11 +35,12 @@ jobs:
     job:
       class: Build
       args:
+        copr: '@pki/master'
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &pki-master-latest
-          name: freeipa/pki-master-f35
-          version: 0.0.1
+        template: &ci-master-latest
+          name: freeipa/ci-master-f36
+          version: 0.0.5
         timeout: 1800
         topology: *build
 
@@ -51,8 +52,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_simple_replication.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -64,8 +66,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_external_ca.py::TestExternalCA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
@@ -77,8 +80,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -90,8 +94,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -103,8 +108,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_vault.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 6300
         topology: *master_1repl
 
@@ -116,8 +122,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
@@ -129,8 +136,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -142,8 +150,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -155,8 +164,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallCA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -168,8 +178,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -181,8 +192,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -194,8 +206,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -207,8 +220,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -220,8 +234,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -233,8 +248,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -246,8 +262,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -259,8 +276,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -272,8 +290,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallMaster
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -285,8 +304,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -298,8 +318,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -311,8 +332,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallMasterDNSRepeatedly
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -324,8 +346,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -337,8 +360,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -350,8 +374,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_caless.py::TestServerInstall
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 12000
         topology: *master_1repl
 
@@ -363,8 +388,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -376,8 +402,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_caless.py::TestClientInstall
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 5400
         # actually master_1client
         topology: *master_1repl_1client
@@ -390,8 +417,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_caless.py::TestIPACommands
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -403,8 +431,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_caless.py::TestCertInstall
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -416,8 +445,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_caless.py::TestPKINIT
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -429,8 +459,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -442,8 +473,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -455,8 +487,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -468,8 +501,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -481,8 +515,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -494,8 +529,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -507,8 +543,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -520,8 +557,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -533,8 +571,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -546,8 +585,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -559,8 +599,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -572,8 +613,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_upgrade.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -585,8 +627,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -598,8 +641,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -611,8 +655,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -624,8 +669,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -637,8 +683,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -650,8 +697,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -663,8 +711,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -676,8 +725,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -689,8 +739,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -702,8 +753,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -715,8 +767,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_uninstallation.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
@@ -728,8 +781,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_webui/test_cert.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 2400
         topology: *ipaserver
 
@@ -741,10 +795,11 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -756,8 +811,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_dns_locations.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_2repl_1client
 
@@ -769,8 +825,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -782,8 +839,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -795,8 +853,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -808,8 +867,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl_1client
 
@@ -821,8 +881,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFileCheck
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -834,8 +895,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_pkinit_manage.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -847,8 +909,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_crlgen_manage.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -860,8 +923,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_ca_custom_sdn.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -873,8 +937,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_fips.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
@@ -886,8 +951,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_acme.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
@@ -899,8 +965,9 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_ipa_cert_fix.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -912,7 +979,8 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
+        copr: '@pki/master'
         test_suite: test_integration/test_idp.py
-        template: *pki-master-latest
+        template: *ci-master-latest
         timeout: 5000
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -47,11 +47,12 @@ jobs:
     job:
       class: Build
       args:
+        enable_testing_repo: True
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &testing-master-latest
-          name: freeipa/testing-master-f35
-          version: 0.0.1
+        template: &ci-master-latest
+          name: freeipa/ci-master-f36
+          version: 0.0.5
         timeout: 1800
         topology: *build
 
@@ -63,8 +64,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_simple_replication.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -76,8 +78,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
@@ -89,8 +92,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -102,8 +106,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -115,8 +120,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_topologies.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -128,8 +134,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_sudo.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
@@ -141,8 +148,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_commands.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl_1client
 
@@ -154,8 +162,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_kerberos_flags.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
@@ -167,8 +176,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_http_kdc_proxy.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *ad_master_2client
 
@@ -180,8 +190,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_fips.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
@@ -193,8 +204,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
@@ -206,8 +218,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_advise.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
@@ -219,8 +232,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_testconfig.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -232,8 +246,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_service_permissions.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -245,8 +260,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_netgroup.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -258,8 +274,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_vault.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 6300
         topology: *master_1repl
 
@@ -271,8 +288,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_authselect.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
@@ -284,8 +302,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_smb.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *ad_master_2client
 
@@ -297,8 +316,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_server_del.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -310,8 +330,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -323,8 +344,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -336,8 +358,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -349,8 +372,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -362,8 +386,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -375,8 +400,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -388,8 +414,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -401,8 +428,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -414,8 +442,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -427,8 +456,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -440,8 +470,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -453,8 +484,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallMaster
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -466,8 +498,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -479,8 +512,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -492,8 +526,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallMasterDNSRepeatedly
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -505,8 +540,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -518,8 +554,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallMasterReplica
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -531,8 +568,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallReplicaAgainstSpecificServer
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -544,8 +582,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestADTrustInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -557,8 +596,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestADTrustInstallWithDNS_KRA_ADTrust
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -570,8 +610,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestKRAinstallAfterCertRenew
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -583,8 +624,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithoutSudo
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
@@ -596,8 +638,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithoutNamed
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl
 
@@ -609,8 +652,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -622,8 +666,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_idviews.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *ad_master_2client
 
@@ -635,8 +680,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestServerInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 12000
         topology: *master_1repl
 
@@ -648,8 +694,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -661,8 +708,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestClientInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         # actually master_1client
         topology: *master_1repl_1client
@@ -675,8 +723,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestIPACommands
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -688,8 +737,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestCertInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -701,8 +751,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestPKINIT
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -714,8 +765,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -727,8 +779,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -740,8 +793,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -753,8 +807,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -766,8 +821,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -779,8 +835,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -792,8 +849,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -805,8 +863,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -818,8 +877,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -831,8 +891,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -844,8 +905,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -857,8 +919,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -870,8 +933,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -883,8 +947,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -896,8 +961,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupRoles
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -909,8 +975,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_dnssec.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -922,8 +989,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -935,8 +1003,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -948,8 +1017,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -961,8 +1031,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestWrongClientDomain
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -974,8 +1045,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -987,8 +1059,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallWithExistingEntry
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1000,8 +1073,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1013,8 +1087,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -1026,8 +1101,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInForwardZone
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1039,8 +1115,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -1052,8 +1129,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -1065,8 +1143,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_upgrade.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1078,8 +1157,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1091,8 +1171,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_topology.py::TestTopologyOptions
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1104,8 +1185,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1117,8 +1199,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -1130,8 +1213,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -1143,8 +1227,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1156,8 +1241,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1169,8 +1255,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -1182,8 +1269,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1195,8 +1283,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1208,8 +1297,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1221,8 +1311,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_uninstallation.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
@@ -1234,8 +1325,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation_client.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_3client
 
@@ -1247,8 +1339,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_user_permissions.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
@@ -1260,8 +1353,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_webui/test_cert.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 2400
         topology: *ipaserver
 
@@ -1273,12 +1367,13 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_loginscreen.py
           test_webui/test_misc_cases.py
           test_webui/test_navigation.py
           test_webui/test_translation.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1290,8 +1385,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_webui/test_host.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1303,10 +1399,11 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1318,10 +1415,11 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1333,11 +1431,12 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_automount.py
           test_webui/test_dns.py
           test_webui/test_vault.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1349,13 +1448,14 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_hbac.py
           test_webui/test_krbtpolicy.py
           test_webui/test_pwpolicy.py
           test_webui/test_selinuxusermap.py
           test_webui/test_sudo.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1367,11 +1467,12 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_delegation.py
           test_webui/test_rbac.py
           test_webui/test_selfservice.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1383,13 +1484,14 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
           test_webui/test_topology.py
           test_webui/test_trust.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *ipaserver
 
@@ -1401,8 +1503,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_webui/test_service.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 2400
         topology: *ipaserver
 
@@ -1414,10 +1517,11 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_group.py
           test_webui/test_user.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *ipaserver
 
@@ -1429,8 +1533,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_webui/test_subid.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 2400
         topology: *ipaserver
 
@@ -1442,8 +1547,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_customized_ds_config_install.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1455,8 +1561,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_dns_locations.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_2repl_1client
 
@@ -1468,8 +1575,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1481,8 +1589,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert test_integration/test_external_ca.py::TestExternalCAInvalidIntermediate
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1494,8 +1603,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1507,8 +1617,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
-        template: *testing-master-latest
+        template: *ci-master-latest
         topology: *master_1repl_1client
         timeout: 5400
 
@@ -1520,8 +1631,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFileCheck
-        template: *testing-master-latest
+        template: *ci-master-latest
         topology: *master_1repl
         timeout: 5400
 
@@ -1533,8 +1645,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCLI test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFilesystemSpace
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1546,8 +1659,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithADtrust
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *adroot_adchild_adtree_master_1client
 
@@ -1559,8 +1673,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl_1client
 
@@ -1572,8 +1687,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_otp.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1585,8 +1701,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_pkinit_manage.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1598,8 +1715,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_pki_config_override.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1611,8 +1729,9 @@ jobs:
 #      args:
 #        build_url: '{testing-fedora/build_url}'
 #        update_packages: True
+#        enable_testing_repo: True
 #        test_suite: test_integration/test_nfs.py::TestNFS
-#        template: *testing-master-latest
+#        template: *ci-master-latest
 #        timeout: 9000
 #        topology: *master_3client
 
@@ -1624,8 +1743,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_3client
 
@@ -1637,8 +1757,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestMaskInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1650,8 +1771,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestHostnameValidator
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1663,8 +1785,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_automember.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1676,8 +1799,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_crlgen_manage.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1689,8 +1813,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -1702,8 +1827,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_sssd.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
@@ -1715,8 +1841,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ca_custom_sdn.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1728,8 +1855,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_membermanager.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 1800
         topology: *master_1repl
 
@@ -1741,8 +1869,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_krbtpolicy.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl
 
@@ -1754,8 +1883,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_winsyncmigrate.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *ad_master
 
@@ -1767,8 +1897,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_trust.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10000
         topology: *adroot_adchild_adtree_master_1client
 
@@ -1780,8 +1911,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreTrust
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1793,8 +1925,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_adtrust_install.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1806,8 +1939,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_cert.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl_1client
 
@@ -1819,8 +1953,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_epn.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3client
 
@@ -1832,8 +1967,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_acme.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
@@ -1845,8 +1981,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_dns.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1858,8 +1995,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_pwpolicy.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1871,8 +2009,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ipa_cert_fix.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -1884,8 +2023,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_subids.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1897,8 +2037,9 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_custom_plugins.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1910,7 +2051,8 @@ jobs:
       args:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
+        enable_testing_repo: True
         test_suite: test_integration/test_idp.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5000
         topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -47,11 +47,12 @@ jobs:
     job:
       class: Build
       args:
+        enable_testing_repo: True
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &testing-master-latest
-          name: freeipa/testing-master-f35
-          version: 0.0.1
+        template: &ci-master-latest
+          name: freeipa/ci-master-f36
+          version: 0.0.5
         timeout: 1800
         topology: *build
 
@@ -64,8 +65,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_simple_replication.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -78,8 +80,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
@@ -92,8 +95,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -106,8 +110,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -120,8 +125,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_topologies.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -134,8 +140,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_sudo.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
@@ -148,8 +155,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_commands.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl_1client
 
@@ -162,8 +170,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_kerberos_flags.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
@@ -176,8 +185,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_http_kdc_proxy.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *ad_master_2client
 
@@ -190,8 +200,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_fips.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
@@ -204,8 +215,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
@@ -218,8 +230,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_advise.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
@@ -232,8 +245,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_testconfig.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -246,8 +260,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_service_permissions.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -260,8 +275,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_netgroup.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -274,8 +290,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_vault.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 6300
         topology: *master_1repl
 
@@ -288,8 +305,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_authselect.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
@@ -302,8 +320,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_smb.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *ad_master_2client
 
@@ -316,8 +335,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_server_del.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -330,8 +350,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -344,8 +365,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -358,8 +380,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -372,8 +395,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -386,8 +410,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -400,8 +425,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -414,8 +440,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -428,8 +455,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -442,8 +470,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -456,8 +485,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -470,8 +500,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -484,8 +515,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallMaster
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -498,8 +530,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -512,8 +545,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -526,8 +560,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallMasterDNSRepeatedly
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -540,8 +575,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -554,8 +590,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallMasterReplica
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -568,8 +605,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallReplicaAgainstSpecificServer
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -582,8 +620,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestADTrustInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -596,8 +635,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestADTrustInstallWithDNS_KRA_ADTrust
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -610,8 +650,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestKRAinstallAfterCertRenew
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -624,8 +665,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithoutSudo
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl_1client
 
@@ -638,8 +680,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallWithoutNamed
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl
 
@@ -652,8 +695,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -666,8 +710,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_idviews.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *ad_master_2client
 
@@ -680,8 +725,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestServerInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 12000
         topology: *master_1repl
 
@@ -694,8 +740,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestReplicaInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -708,8 +755,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestClientInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         # actually master_1client
         topology: *master_1repl_1client
@@ -723,8 +771,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestIPACommands
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -737,8 +786,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestCertInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -751,8 +801,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestPKINIT
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -765,8 +816,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -779,8 +831,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -793,8 +846,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
 
@@ -807,8 +861,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -821,8 +876,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -835,8 +891,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -849,8 +906,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -863,8 +921,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -877,8 +936,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -891,8 +951,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -905,8 +966,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -919,8 +981,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -933,8 +996,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -947,8 +1011,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -961,8 +1026,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupRoles
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -975,8 +1041,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_dnssec.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_2repl_1client
 
@@ -989,8 +1056,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1003,8 +1071,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1017,8 +1086,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -1031,8 +1101,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestWrongClientDomain
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1045,8 +1116,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1059,8 +1131,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallWithExistingEntry
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1073,8 +1146,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1087,8 +1161,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -1101,8 +1176,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInForwardZone
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1115,8 +1191,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -1129,8 +1206,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
 
@@ -1143,8 +1221,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_upgrade.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1157,8 +1236,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1171,8 +1251,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_topology.py::TestTopologyOptions
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1185,8 +1266,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1199,8 +1281,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -1213,8 +1296,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -1227,8 +1311,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1241,8 +1326,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1255,8 +1341,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_3repl_1client
 
@@ -1269,8 +1356,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1283,8 +1371,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1297,8 +1386,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3repl_1client
 
@@ -1311,8 +1401,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_uninstallation.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
@@ -1325,8 +1416,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation_client.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_3client
 
@@ -1339,8 +1431,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_user_permissions.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
 
@@ -1353,8 +1446,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_webui/test_cert.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 2400
         topology: *ipaserver
 
@@ -1367,12 +1461,13 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_loginscreen.py
           test_webui/test_misc_cases.py
           test_webui/test_navigation.py
           test_webui/test_translation.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1385,8 +1480,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_webui/test_host.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1399,10 +1495,11 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1415,10 +1512,11 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1431,11 +1529,12 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_automount.py
           test_webui/test_dns.py
           test_webui/test_vault.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1448,13 +1547,14 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_hbac.py
           test_webui/test_krbtpolicy.py
           test_webui/test_pwpolicy.py
           test_webui/test_selinuxusermap.py
           test_webui/test_sudo.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1467,11 +1567,12 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_delegation.py
           test_webui/test_rbac.py
           test_webui/test_selfservice.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *ipaserver
 
@@ -1484,13 +1585,14 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
           test_webui/test_topology.py
           test_webui/test_trust.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *ipaserver
 
@@ -1503,8 +1605,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_webui/test_service.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 2400
         topology: *ipaserver
 
@@ -1517,10 +1620,11 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: >-
           test_webui/test_group.py
           test_webui/test_user.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *ipaserver
 
@@ -1533,8 +1637,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_webui/test_subid.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 2400
         topology: *ipaserver
 
@@ -1547,8 +1652,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_customized_ds_config_install.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1561,8 +1667,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_dns_locations.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_2repl_1client
 
@@ -1575,8 +1682,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1589,8 +1697,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert test_integration/test_external_ca.py::TestExternalCAInvalidIntermediate
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1603,8 +1712,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1617,8 +1727,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
-        template: *testing-master-latest
+        template: *ci-master-latest
         topology: *master_1repl_1client
         timeout: 5400
 
@@ -1631,8 +1742,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFileCheck
-        template: *testing-master-latest
+        template: *ci-master-latest
         topology: *master_1repl
         timeout: 5400
 
@@ -1645,8 +1757,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCLI test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFilesystemSpace
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1659,8 +1772,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithADtrust
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *adroot_adchild_adtree_master_1client
 
@@ -1673,8 +1787,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl_1client
 
@@ -1687,8 +1802,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_otp.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1701,8 +1817,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_pkinit_manage.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1715,8 +1832,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_pki_config_override.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1729,8 +1847,9 @@ jobs:
 #        build_url: '{testing-fedora/build_url}'
 #        update_packages: True
 #        selinux_enforcing: True
+#        enable_testing_repo: True
 #        test_suite: test_integration/test_nfs.py::TestNFS
-#        template: *testing-master-latest
+#        template: *ci-master-latest
 #        timeout: 9000
 #        topology: *master_3client
 
@@ -1743,8 +1862,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_nfs.py::TestIpaClientAutomountFileRestore
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_3client
 
@@ -1757,8 +1877,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestMaskInstall
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1771,8 +1892,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_installation.py::TestHostnameValidator
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1785,8 +1907,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_automember.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1799,8 +1922,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_crlgen_manage.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1813,8 +1937,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -1827,8 +1952,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_sssd.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
@@ -1841,8 +1967,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ca_custom_sdn.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1855,8 +1982,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_membermanager.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 1800
         topology: *master_1repl
 
@@ -1869,8 +1997,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_krbtpolicy.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *master_1repl
 
@@ -1883,8 +2012,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_winsyncmigrate.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 4800
         topology: *ad_master
 
@@ -1897,8 +2027,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_trust.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10000
         topology: *adroot_adchild_adtree_master_1client
 
@@ -1911,8 +2042,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreTrust
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl
 
@@ -1925,8 +2057,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_adtrust_install.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1939,8 +2072,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_cert.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl_1client
 
@@ -1953,8 +2087,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_epn.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_3client
 
@@ -1967,8 +2102,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_acme.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 7200
         topology: *master_1repl_1client
 
@@ -1981,8 +2117,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_dns.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -1994,9 +2131,10 @@ jobs:
       args:
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         build_url: '{testing-fedora/build_url}'
         test_suite: test_integration/test_pwpolicy.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -2009,8 +2147,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_ipa_cert_fix.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
 
@@ -2023,8 +2162,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_subids.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -2037,8 +2177,9 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_custom_plugins.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl
 
@@ -2051,7 +2192,8 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         selinux_enforcing: True
+        enable_testing_repo: True
         test_suite: test_integration/test_idp.py
-        template: *testing-master-latest
+        template: *ci-master-latest
         timeout: 5000
         topology: *master_1repl


### PR DESCRIPTION
Vagrant templates for `pki-`, `389ds-` and `testing-` are no longer needed after feature added by https://github.com/freeipa/freeipa-pr-ci/pull/463.

This updates the test definitions to use PR-CI's custom arguments with standard `ci-master-f36` vagrant box.