### PR TITLE
Update ipa-replica-install replication agreement error message

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1023,8 +1023,8 @@ def promote_check(installer):
         if replman.get_replication_agreement(config.host_name):
             msg = ("A replication agreement for this host already exists. "
                    "It needs to be removed.\n"
-                   "Run this command:\n"
-                   "    %% ipa-replica-manage del {host} --force"
+                   "Run this command on any working server:\n"
+                   "    %% ipa server-del {host} --force"
                    .format(host=config.host_name))
             raise ScriptError(msg, rval=3)
 


### PR DESCRIPTION
So that it prints out a valid command:
- replace "ipa-replica-manage del" by "ipa server-del" (only domain-level1 is now supported)
- the commands needs to be run on a working server, not on the host where ipa-replica-install failed

Fixes: https://pagure.io/freeipa/issue/9162