### PR TITLE
[Backport][ipa-4-9] Installer: add option to configure SSSD as subid data source

### DIFF
--- a/client/man/ipa-client-install.1
+++ b/client/man/ipa-client-install.1
@@ -136,6 +136,9 @@ Do not configure OpenSSH server.
 \fB\-\-no\-sudo\fR
 Do not configure SSSD as a data source for sudo.
 .TP
+\fB\-\-subid\fR
+Configure SSSD as data source for subid.
+.TP
 \fB\-\-no\-dns\-sshfp\fR
 Do not automatically create DNS SSHFP records.
 .TP

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -653,7 +653,12 @@ Requires: python3-sssdconfig >= %{sssd_version}
 Requires: cyrus-sasl-gssapi%{?_isa}
 Requires: chrony
 Requires: krb5-workstation >= %{krb5_version}
-Requires: authselect >= 0.4-2
+# authselect: sssd profile with-subid
+%if 0%{?fedora} >= 36
+Requires: authselect >= 1.4.0
+%else
+Requires: authselect >= 1.2.5
+%endif
 Requires: curl
 # NIS domain name config: /usr/lib/systemd/system/*-domainname.service
 # All Fedora 28+ and RHEL8+ contain the service in hostname package

--- a/install/tools/man/ipa-replica-install.1
+++ b/install/tools/man/ipa-replica-install.1
@@ -92,6 +92,9 @@ Do not configure OpenSSH client.
 \fB\-\-no\-sshd\fR
 Do not configure OpenSSH server.
 .TP
+\fB\-\-subid\fR
+Configure SSSD as data source for subid.
+.TP
 \fB\-\-skip\-conncheck\fR
 Skip connection check to remote master
 .TP

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -80,6 +80,9 @@ Do not configure OpenSSH client.
 \fB\-\-no\-sshd\fR
 Do not configure OpenSSH server.
 .TP
+\fB\-\-subid\fR
+Configure SSSD as data source for subid.
+.TP
 \fB\-d\fR, \fB\-\-debug\fR
 Enable debug logging when more verbose output is needed.
 .TP

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3157,7 +3157,8 @@ def _install(options):
             sssd=options.sssd,
             mkhomedir=options.mkhomedir,
             statestore=statestore,
-            sudo=options.conf_sudo
+            sudo=options.conf_sudo,
+            subid=options.subid
         )
         # if mkhomedir, make sure oddjobd is enabled and started
         if options.mkhomedir:
@@ -3813,6 +3814,12 @@ class ClientInstallInterface(hostname_.HostNameInstallInterface,
         description="do not configure SSSD as data source for sudo",
     )
     no_sudo = enroll_only(no_sudo)
+
+    subid = knob(
+        None,
+        description="configure SSSD as data source for subid",
+    )
+    subid = enroll_only(subid)
 
     no_dns_sshfp = knob(
         None,

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -200,7 +200,7 @@ class BaseTaskNamespace:
         raise NotImplementedError()
 
     def modify_nsswitch_pam_stack(self, sssd, mkhomedir, statestore,
-                                  sudo=True):
+                                  sudo=True, subid=False):
         """
         If sssd flag is true, configure pam and nsswitch so that SSSD is used
         for retrieving user information and authentication.

--- a/ipaplatform/debian/tasks.py
+++ b/ipaplatform/debian/tasks.py
@@ -42,7 +42,8 @@ class DebianTaskNamespace(RedHatTaskNamespace):
         return True
 
     @staticmethod
-    def modify_nsswitch_pam_stack(sssd, mkhomedir, statestore, sudo=True):
+    def modify_nsswitch_pam_stack(sssd, mkhomedir, statestore, sudo=True,
+                                  subid=False):
         if mkhomedir:
             try:
                 ipautil.run(["pam-auth-update",

--- a/ipaplatform/fedora_container/tasks.py
+++ b/ipaplatform/fedora_container/tasks.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 class FedoraContainerTaskNamespace(FedoraTaskNamespace):
     def modify_nsswitch_pam_stack(
-        self, sssd, mkhomedir, statestore, sudo=True
+        self, sssd, mkhomedir, statestore, sudo=True, subid=False
     ):
         # freeipa-container images are preconfigured
         # authselect select sssd with-sudo --force

--- a/ipaplatform/redhat/authconfig.py
+++ b/ipaplatform/redhat/authconfig.py
@@ -101,7 +101,8 @@ class RedHatAuthSelect(RedHatAuthToolBase):
         features = output_items[1:]
         return profile, features
 
-    def configure(self, sssd, mkhomedir, statestore, sudo=True):
+    def configure(self, sssd, mkhomedir, statestore, sudo=True,
+                  subid=False):
         # In the statestore, the following keys are used for the
         # 'authselect' module:
         # Old method:
@@ -121,6 +122,8 @@ class RedHatAuthSelect(RedHatAuthToolBase):
             statestore.backup_state('authselect', 'mkhomedir', True)
         if sudo:
             cmd.append("with-sudo")
+        if subid:
+            cmd.append("with-subid")
         cmd.append("--force")
         cmd.append("--backup={}".format(backup_name))
 

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -245,9 +245,9 @@ class RedHatTaskNamespace(BaseTaskNamespace):
             f.writelines(content)
 
     def modify_nsswitch_pam_stack(self, sssd, mkhomedir, statestore,
-                                  sudo=True):
+                                  sudo=True, subid=False):
         auth_config = get_auth_tool()
-        auth_config.configure(sssd, mkhomedir, statestore, sudo)
+        auth_config.configure(sssd, mkhomedir, statestore, sudo, subid)
 
     def is_nosssd_supported(self):
         # The flag --no-sssd is not supported any more for rhel-based distros

--- a/ipaplatform/rhel_container/tasks.py
+++ b/ipaplatform/rhel_container/tasks.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 class RHELContainerTaskNamespace(RHELTaskNamespace):
     def modify_nsswitch_pam_stack(
-        self, sssd, mkhomedir, statestore, sudo=True
+        self, sssd, mkhomedir, statestore, sudo=True, subid=False
     ):
         # freeipa-container images are preconfigured
         # authselect select sssd with-sudo --force

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -994,6 +994,8 @@ def install(installer):
             args.append("--no-sshd")
         if options.mkhomedir:
             args.append("--mkhomedir")
+        if options.subid:
+            args.append("--subid")
         start = time.time()
         run(args, redirect_output=True)
         dur = time.time() - start

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -720,6 +720,8 @@ def ensure_enrolled(installer):
         args.append("--no-sshd")
     if installer.mkhomedir:
         args.append("--mkhomedir")
+    if installer.subid:
+        args.append("--subid")
     if installer.force_join:
         args.append("--force-join")
     if installer.no_ntp:

--- a/ipatests/test_integration/test_authselect.py
+++ b/ipatests/test_integration/test_authselect.py
@@ -192,6 +192,17 @@ class TestClientInstallation(IntegrationTest):
         result = self._uninstall_client()
         assert result.returncode == 0
 
+    def test_install_client_subid(self):
+        """
+        Test client installation with --subid option
+        """
+        result = self._install_client(extraargs=['-f', '--subid'])
+        assert result.returncode == 0
+        # Client installation must configure the 'sssd' profile
+        # with subid feature
+        check_authselect_profile(
+            self.client, default_profile, ('with-sudo', 'with-subid'))
+
     @classmethod
     def uninstall(cls, mh):
         super(TestClientInstallation, cls).uninstall(mh)
@@ -234,6 +245,23 @@ class TestServerInstallation(IntegrationTest):
         """
         Test server uninstallation when a different profile was present
         before server installation
+        """
+        # uninstall must revert to the preconfigured profile
+        tasks.uninstall_master(self.master)
+        check_authselect_profile(
+            self.master, preconfigured_profile, preconfigured_options)
+
+    def test_install_with_subid(self):
+        """
+        Test server installation when --subid option is specified
+        """
+        tasks.install_master(self.master, extra_args=["--subid"])
+        check_authselect_profile(
+            self.master, default_profile, ('with-sudo', 'with-subid'))
+
+    def test_uninstall_with_subid(self):
+        """
+        Test server uninstallation when --subid option was configured
         """
         # uninstall must revert to the preconfigured profile
         tasks.uninstall_master(self.master)


### PR DESCRIPTION
This PR was opened automatically because PR #6266 was pushed to master and backport to ipa-4-9 is required.