### PR TITLE
[ipa-4-9] Implement support for bind 9.18+

### DIFF
--- a/daemons/dnssec/ipa-dnskeysyncd.in
+++ b/daemons/dnssec/ipa-dnskeysyncd.in
@@ -22,6 +22,18 @@ from ipaserver.dnssec.keysyncer import KeySyncer
 logger = logging.getLogger(os.path.basename(__file__))
 
 
+def fixup_dnssec_utils(self):
+   try:
+       os.stat(self.DNSSEC_KEYFROMLABEL)
+   except FileNotFoundError:
+       try:
+           os.stat(self.DNSSEC_KEYFROMLABEL_9_17)
+       except FileNotFoundError:
+           pass
+       else:
+           self.DNSSEC_KEYFROMLABEL = self.DNSSEC_KEYFROMLABEL_9_17
+
+fixup_dnssec_utils(paths)
 # IPA framework initialization
 standard_logging_setup(debug=True)
 api.bootstrap(context='dns', confdir=paths.ETC_IPA, in_server=True)

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -259,6 +259,7 @@ class BasePathNamespace:
     IPA_HTTPD_PASSWD_READER = "/usr/libexec/ipa/ipa-httpd-pwdreader"
     IPA_PKI_WAIT_RUNNING = "/usr/libexec/ipa/ipa-pki-wait-running"
     DNSSEC_KEYFROMLABEL = "/usr/sbin/dnssec-keyfromlabel"
+    DNSSEC_KEYFROMLABEL_9_17 = "/usr/bin/dnssec-keyfromlabel"
     GETSEBOOL = "/usr/sbin/getsebool"
     GROUPADD = "/usr/sbin/groupadd"
     USERMOD = "/usr/sbin/usermod"


### PR DESCRIPTION
Manual backport of PR https://github.com/freeipa/freeipa/pull/6264 to ipa-4-9 is required.