### PR TITLE
ipa-kdb: avoid additional checks for a well-known anonymous principal

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -89,8 +89,9 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
 
     ua = ied->user_auth;
 
-    /* If no mechanisms are set, allow every auth method */
-    if (ua == IPADB_USER_AUTH_NONE) {
+    /* If no mechanisms are set, or it is anonymous PKINIT, allow every auth method */
+    if ((ua == IPADB_USER_AUTH_NONE) ||
+        (request->kdc_options & KDC_OPT_REQUEST_ANONYMOUS)) {
         jitter(ONE_DAY_SECONDS, lifetime_out);
         kerr = 0;
         goto done;


### PR DESCRIPTION
For a well-known anonymous principal an Anonymous PKINIT method is used which ignores the password set in the principal entry. For these principals any defined user auth type is irrelevant, their use is defined in RFC 6112. This gets confusing when a default user auth type requires a particular authentication method.

When AS request for Anonymous PKINIT is used, a TGT would contain no authentication indicator. It means we cannot apply any specific indicator policy and must skip the checks.
    
Fixes: https://pagure.io/freeipa/issue/9165