### PR TITLE
[Backport][ipa-4-9] ipa-kdb: avoid additional checks for a well-known anonymous principal

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -89,8 +89,9 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
 
     ua = ied->user_auth;
 
-    /* If no mechanisms are set, allow every auth method */
-    if (ua == IPADB_USER_AUTH_NONE) {
+    /* If no mechanisms are set, or it is anonymous PKINIT, allow every auth method */
+    if ((ua == IPADB_USER_AUTH_NONE) ||
+        (request->kdc_options & KDC_OPT_REQUEST_ANONYMOUS)) {
         jitter(ONE_DAY_SECONDS, lifetime_out);
         kerr = 0;
         goto done;


### PR DESCRIPTION
This PR was opened automatically because PR #6279 was pushed to master and backport to ipa-4-9 is required.