### PR TITLE
[Backport][ipa-4-9] Configure and enable the graceperiod plugin on upgrades

### DIFF
--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -247,7 +247,7 @@ class DsInstance(service.Service):
         self.step("enabling entryUSN plugin", self.__enable_entryusn)
         self.step("configuring lockout plugin", self.__config_lockout_module)
         self.step("configuring graceperiod plugin",
-                  self.__config_graceperiod_module)
+                  self.config_graceperiod_module)
         self.step("configuring topology plugin", self.__config_topology_module)
         self.step("creating indices", self.__create_indices)
         self.step("enabling referential integrity plugin", self.__add_referint_module)
@@ -753,8 +753,14 @@ class DsInstance(service.Service):
     def __config_lockout_module(self):
         self._ldap_mod("lockout-conf.ldif")
 
-    def __config_graceperiod_module(self):
-        self._ldap_mod("graceperiod-conf.ldif")
+    def config_graceperiod_module(self):
+        if not api.Backend.ldap2.isconnected():
+            api.Backend.ldap2.connect()
+        dn = DN('cn=IPA Graceperiod,cn=plugins,cn=config')
+        try:
+            api.Backend.ldap2.get_entry(dn)
+        except errors.NotFound:
+            self._ldap_mod("graceperiod-conf.ldif")
 
     def __config_topology_module(self):
         self._ldap_mod("ipa-topology-conf.ldif", self.sub_dict)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1114,11 +1114,24 @@ def ds_enable_sidgen_extdom_plugins(ds):
 
     if sysupgrade.get_upgrade_state('ds', 'enable_ds_sidgen_extdom_plugins'):
         logger.debug('sidgen and extdom plugins are enabled already')
-        return
+        return False
 
     ds.add_sidgen_plugin(api.env.basedn)
     ds.add_extdom_plugin(api.env.basedn)
     sysupgrade.set_upgrade_state('ds', 'enable_ds_sidgen_extdom_plugins', True)
+    return True
+
+
+def ds_enable_graceperiod_plugin(ds):
+    """Graceperiod is a newer DS plugin so needs to be enabled on upgrade"""
+    if sysupgrade.get_upgrade_state('ds', 'enable_ds_graceperiod_plugin'):
+        logger.debug('graceperiod is enabled already')
+        return False
+
+    ds.config_graceperiod_module()
+    sysupgrade.set_upgrade_state('ds', 'enable_ds_graceperiod_plugin', True)
+    return True
+
 
 def ca_upgrade_schema(ca):
     logger.info('[Upgrading CA schema]')
@@ -1605,6 +1618,21 @@ def ca_update_acme_configuration(ca, fqdn):
                                   template_name))
 
 
+def set_default_grace_time():
+    dn = DN(
+        ('cn', 'global_policy'), ('cn', api.env.realm),
+        ('cn', 'kerberos'), api.env.basedn
+    )
+    entry = api.Backend.ldap2.get_entry(dn)
+    for (a,_v) in entry.items():
+        if a.lower() == 'passwordgracelimit':
+            return
+
+    entry['objectclass'].append('ipapwdpolicy')
+    entry['passwordgracelimit'] = -1
+    api.Backend.ldap2.update_entry(entry)
+
+
 def upgrade_configuration():
     """
     Execute configuration upgrade of the IPA services
@@ -1789,7 +1817,13 @@ def upgrade_configuration():
     ds.realm = api.env.realm
     ds.suffix = ipautil.realm_to_suffix(api.env.realm)
 
-    ds_enable_sidgen_extdom_plugins(ds)
+    if any([
+        ds_enable_sidgen_extdom_plugins(ds),
+        ds_enable_graceperiod_plugin(ds)
+    ]):
+        ds.restart(ds.serverid)
+
+    set_default_grace_time()
 
     if not http.is_kdcproxy_configured():
         logger.info('[Enabling KDC Proxy]')

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -290,6 +290,8 @@ class TestUpgrade(IntegrationTest):
         entry_ldif = textwrap.dedent("""
             dn: cn=global_policy,cn={realm},cn=kerberos,{base_dn}
             changetype: modify
+            delete: passwordGraceLimit
+            -
             delete: objectclass
             objectclass: ipapwdpolicy
         """).format(


### PR DESCRIPTION
This PR was opened automatically because PR #6283 was pushed to master and backport to ipa-4-9 is required.