### PR TITLE
ipaldap: fix conversion from boolean OID to Python

### DIFF
--- a/install/ui/src/freeipa/dns.js
+++ b/install/ui/src/freeipa/dns.js
@@ -184,12 +184,8 @@ return {
                         measurement_unit: 'seconds'
                     },
                     {
-                        $type: 'radio',
+                        $type: 'checkbox',
                         name: 'idnsallowdynupdate',
-                        options: [
-                            { value: 'TRUE', label: '@i18n:true' },
-                            { value: 'FALSE', label: '@i18n:false' }
-                        ]
                     },
                     {
                         $type: 'textarea',

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -683,6 +683,7 @@ class LDAPClient:
         '1.3.6.1.4.1.1466.115.121.1.1'   : bytes, # ACI item
         '1.3.6.1.4.1.1466.115.121.1.4'   : bytes, # Audio
         '1.3.6.1.4.1.1466.115.121.1.5'   : bytes, # Binary
+        '1.3.6.1.4.1.1466.115.121.1.7'   : bool,  # Boolean
         '1.3.6.1.4.1.1466.115.121.1.8'   : bytes, # Certificate
         '1.3.6.1.4.1.1466.115.121.1.9'   : bytes, # Certificate List
         '1.3.6.1.4.1.1466.115.121.1.10'  : bytes, # Certificate Pair
@@ -1009,6 +1010,8 @@ class LDAPClient:
                     return val
                 elif target_type is unicode:
                     return val.decode('utf-8')
+                elif target_type is bool:
+                    return val.decode('utf-8') == 'TRUE'
                 elif target_type is datetime.datetime:
                     return datetime.datetime.strptime(
                         val.decode('utf-8'), LDAP_GENERALIZED_TIME_FORMAT)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -2018,7 +2018,7 @@ def import_included_profiles():
                 objectclass=['ipacertprofile'],
                 cn=[profile_id],
                 description=[desc],
-                ipacertprofilestoreissued=['TRUE' if store_issued else 'FALSE'],
+                ipacertprofilestoreissued=[store_issued],
             )
             conn.add_entry(entry)
 

--- a/ipaserver/plugins/caacl.py
+++ b/ipaserver/plugins/caacl.py
@@ -247,7 +247,7 @@ class caacl_add(LDAPCreate):
 
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys, **options):
         # CA ACLs are enabled by default
-        entry_attrs['ipaenabledflag'] = ['TRUE']
+        entry_attrs['ipaenabledflag'] = [True]
         return dn
 
 
@@ -334,7 +334,7 @@ class caacl_enable(LDAPQuery):
         except errors.NotFound:
             raise self.obj.handle_not_found(cn)
 
-        entry_attrs['ipaenabledflag'] = ['TRUE']
+        entry_attrs['ipaenabledflag'] = [True]
 
         try:
             ldap.update_entry(entry_attrs)
@@ -363,7 +363,7 @@ class caacl_disable(LDAPQuery):
         except errors.NotFound:
             raise self.obj.handle_not_found(cn)
 
-        entry_attrs['ipaenabledflag'] = ['FALSE']
+        entry_attrs['ipaenabledflag'] = [False]
 
         try:
             ldap.update_entry(entry_attrs)

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -957,7 +957,7 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
         # Success? Then add it to the principal's entry
         # (unless the profile tells us not to)
         profile = api.Command['certprofile_show'](profile_id)
-        store = profile['result']['ipacertprofilestoreissued'][0] == 'TRUE'
+        store = profile['result']['ipacertprofilestoreissued'][0]
         if store and 'certificate' in result:
             cert = result.get('certificate')
             kwargs = dict(addattr=u'usercertificate={}'.format(cert))

--- a/ipaserver/plugins/certmap.py
+++ b/ipaserver/plugins/certmap.py
@@ -426,7 +426,7 @@ class certmaprule_enable(LDAPQuery):
         except errors.NotFound:
             raise self.obj.handle_not_found(cn)
 
-        entry_attrs['ipaenabledflag'] = ['TRUE']
+        entry_attrs['ipaenabledflag'] = [True]
 
         try:
             ldap.update_entry(entry_attrs)
@@ -455,7 +455,7 @@ class certmaprule_disable(LDAPQuery):
         except errors.NotFound:
             raise self.obj.handle_not_found(cn)
 
-        entry_attrs['ipaenabledflag'] = ['FALSE']
+        entry_attrs['ipaenabledflag'] = [False]
 
         try:
             ldap.update_entry(entry_attrs)

--- a/ipaserver/plugins/dns.py
+++ b/ipaserver/plugins/dns.py
@@ -2169,7 +2169,7 @@ class DNSZoneBase_add(LDAPCreate):
                     message=_(u'Only one zone type is allowed per zone name')
                 )
 
-        entry_attrs['idnszoneactive'] = 'TRUE'
+        entry_attrs['idnszoneactive'] = True
 
         if not options['skip_overlap_check']:
             try:
@@ -2272,7 +2272,7 @@ class DNSZoneBase_disable(LDAPQuery):
         if not _check_entry_objectclass(entry, self.obj.object_class):
             raise self.obj.handle_not_found(*keys)
 
-        entry['idnszoneactive'] = ['FALSE']
+        entry['idnszoneactive'] = [False]
 
         try:
             ldap.update_entry(entry)
@@ -2297,7 +2297,7 @@ class DNSZoneBase_enable(LDAPQuery):
         if not _check_entry_objectclass(entry, self.obj.object_class):
             raise self.obj.handle_not_found(*keys)
 
-        entry['idnszoneactive'] = ['TRUE']
+        entry['idnszoneactive'] = [True]
 
         try:
             ldap.update_entry(entry)

--- a/ipaserver/plugins/hbacrule.py
+++ b/ipaserver/plugins/hbacrule.py
@@ -304,7 +304,7 @@ class hbacrule_add(LDAPCreate):
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys, **options):
         assert isinstance(dn, DN)
         # HBAC rules are enabled by default
-        entry_attrs['ipaenabledflag'] = 'TRUE'
+        entry_attrs['ipaenabledflag'] = True
         return dn
 
 
@@ -392,7 +392,7 @@ class hbacrule_enable(LDAPQuery):
         except errors.NotFound:
             raise self.obj.handle_not_found(cn)
 
-        entry_attrs['ipaenabledflag'] = ['TRUE']
+        entry_attrs['ipaenabledflag'] = [True]
 
         try:
             ldap.update_entry(entry_attrs)
@@ -422,7 +422,7 @@ class hbacrule_disable(LDAPQuery):
         except errors.NotFound:
             raise self.obj.handle_not_found(cn)
 
-        entry_attrs['ipaenabledflag'] = ['FALSE']
+        entry_attrs['ipaenabledflag'] = [False]
 
         try:
             ldap.update_entry(entry_attrs)

--- a/ipaserver/plugins/migration.py
+++ b/ipaserver/plugins/migration.py
@@ -901,7 +901,7 @@ migration process might be incomplete\n''')
             assert isinstance(ds_base_dn, DN)
 
         # check if migration mode is enabled
-        if config.get('ipamigrationenabled', ('FALSE', ))[0] == 'FALSE':
+        if not config.get('ipamigrationenabled', (False,))[0]:
             return dict(result={}, failed={}, enabled=False, compat=True)
 
         # connect to DS

--- a/ipaserver/plugins/pwpolicy.py
+++ b/ipaserver/plugins/pwpolicy.py
@@ -456,7 +456,7 @@ class pwpolicy(LDAPObject):
             for attr in ['ipapwdmaxrepeat', 'ipapwdmaxsequence',
                          'ipapwddictcheck', 'ipapwdusercheck']:
                 val = get_val(entry, attr)
-                if val not in ('FALSE', '0', 0, None):
+                if val not in (False, 'FALSE', '0', 0, None):
                     return True
             return False
 

--- a/ipaserver/plugins/selinuxusermap.py
+++ b/ipaserver/plugins/selinuxusermap.py
@@ -332,7 +332,7 @@ class selinuxusermap_add(LDAPCreate):
     def pre_callback(self, ldap, dn, entry_attrs, attrs_list, *keys, **options):
         assert isinstance(dn, DN)
         # rules are enabled by default
-        entry_attrs['ipaenabledflag'] = 'TRUE'
+        entry_attrs['ipaenabledflag'] = True
         validate_selinuxuser_inlist(ldap, entry_attrs['ipaselinuxuser'])
 
         def is_to_be_set(x):
@@ -508,7 +508,7 @@ class selinuxusermap_enable(LDAPQuery):
         except errors.NotFound:
             raise self.obj.handle_not_found(cn)
 
-        entry_attrs['ipaenabledflag'] = ['TRUE']
+        entry_attrs['ipaenabledflag'] = [True]
 
         try:
             ldap.update_entry(entry_attrs)
@@ -538,7 +538,7 @@ class selinuxusermap_disable(LDAPQuery):
         except errors.NotFound:
             raise self.obj.handle_not_found(cn)
 
-        entry_attrs['ipaenabledflag'] = ['FALSE']
+        entry_attrs['ipaenabledflag'] = [False]
 
         try:
             ldap.update_entry(entry_attrs)

--- a/ipaserver/plugins/sudorule.py
+++ b/ipaserver/plugins/sudorule.py
@@ -397,7 +397,7 @@ class sudorule_add(LDAPCreate):
         assert isinstance(dn, DN)
         self.obj.check_order_uniqueness(*keys, **options)
         # Sudo Rules are enabled by default
-        entry_attrs['ipaenabledflag'] = 'TRUE'
+        entry_attrs['ipaenabledflag'] = True
         return dn
 
     msg_summary = _('Added Sudo Rule "%(value)s"')
@@ -503,7 +503,7 @@ class sudorule_enable(LDAPQuery):
         except errors.NotFound:
             raise self.obj.handle_not_found(cn)
 
-        entry_attrs['ipaenabledflag'] = ['TRUE']
+        entry_attrs['ipaenabledflag'] = [True]
 
         try:
             ldap.update_entry(entry_attrs)
@@ -526,7 +526,7 @@ class sudorule_disable(LDAPQuery):
         except errors.NotFound:
             raise self.obj.handle_not_found(cn)
 
-        entry_attrs['ipaenabledflag'] = ['FALSE']
+        entry_attrs['ipaenabledflag'] = [False]
 
         try:
             ldap.update_entry(entry_attrs)

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -680,9 +680,9 @@ class user_add(baseuser_add):
 
         # generate subid
         default_subid = config.single_value.get(
-            'ipaUserDefaultSubordinateId', 'FALSE'
+            'ipaUserDefaultSubordinateId', False
         )
-        if default_subid == 'TRUE':
+        if default_subid:
             result = self.api.Command.subid_generate(
                 ipaowner=entry_attrs.single_value['uid'],
                 version=options['version']

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -819,7 +819,7 @@ class TestIPACommand(IntegrationTest):
         lines = set(l.strip() for l in result.stdout_text.split('\n'))
         assert 'User category: all' in lines
         assert 'Host category: all' in lines
-        assert 'Enabled: TRUE' in lines
+        assert 'Enabled: True' in lines
         assert 'HBAC Services: systemd-user' in lines
         assert 'accessruletype: allow' in lines
 
@@ -843,7 +843,7 @@ class TestIPACommand(IntegrationTest):
         lines = set(l.strip() for l in result.stdout_text.split('\n'))
         assert 'User category: all' in lines
         assert 'Host category: all' in lines
-        assert 'Enabled: TRUE' in lines
+        assert 'Enabled: True' in lines
         assert 'HBAC Services: systemd-user' in lines
         assert 'accessruletype: allow' in lines
 

--- a/ipatests/test_xmlrpc/test_certmap_plugin.py
+++ b/ipatests/test_xmlrpc/test_certmap_plugin.py
@@ -53,7 +53,7 @@ certmaprule_optional_params = (
     'ipacertmappriority',
 )
 
-certmapconfig_update_params = {u'ipacertmappromptusername': u'TRUE'}
+certmapconfig_update_params = {u'ipacertmappromptusername': True}
 
 CREATE_PERM = u'System: Add Certmap Rules'
 READ_PERM = u'System: Read Certmap Rules'
@@ -459,7 +459,7 @@ class TestPermission(XMLRPC_test):
             api.env.container_certmaprules,
             api.env.basedn,
         )
-        expected_ok[u'result'][0][u'ipaenabledflag'] = (u'TRUE',)
+        expected_ok[u'result'][0][u'ipaenabledflag'] = (True,)
         with self.execute_with_expected(
             certmap_user_permissions,
             [

--- a/ipatests/test_xmlrpc/test_certprofile_plugin.py
+++ b/ipatests/test_xmlrpc/test_certprofile_plugin.py
@@ -160,7 +160,7 @@ class TestProfileCRUD(XMLRPC_test):
                 ipacertprofilestoreissued=False
             ),
             expected_updates=dict(
-                ipacertprofilestoreissued=[u'FALSE']
+                ipacertprofilestoreissued=[False]
             )
         )
 

--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -542,7 +542,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': zone1_dn,
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone1_rname_dnsname],
@@ -551,7 +551,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -626,7 +626,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': zone2_sub_dn,
                     'idnsname': [zone2_sub_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [zone2_sub_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone2_sub_rname_dnsname],
@@ -635,7 +635,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -697,7 +697,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': zone4_dn,
                     'idnsname': [zone4_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone4_rname_dnsname],
@@ -706,7 +706,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -742,7 +742,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': zone5_dn,
                     'idnsname': [zone5_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone5_rname_dnsname],
@@ -751,7 +751,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -797,7 +797,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': zone1_dn,
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [zone1_rname_dnsname],
@@ -807,7 +807,7 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -826,7 +826,7 @@ class test_dns(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [zone1_rname_dnsname],
@@ -836,7 +836,7 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -911,7 +911,7 @@ class test_dns(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [zone1_rname_dnsname],
@@ -921,7 +921,7 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -941,7 +941,7 @@ class test_dns(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [zone1_rname_dnsname],
@@ -951,7 +951,7 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -988,7 +988,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': revzone1_dn,
                     'idnsname': [revzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone1_rname_dnsname],
@@ -997,7 +997,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-subdomain %(zone)s PTR;'
                                          % dict(realm=api.env.realm, zone=revzone1)],
                     'idnsallowtransfer': [u'none;'],
@@ -1028,7 +1028,7 @@ class test_dns(Declarative):
                 'result': [{
                     'dn': revzone1_dn,
                     'idnsname': [revzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [zone1_rname_dnsname],
@@ -1037,7 +1037,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy':
                         [u'grant %(realm)s krb5-subdomain %(zone)s PTR;'
                             % dict(
@@ -1049,7 +1049,7 @@ class test_dns(Declarative):
                 {
                     'dn': zone1_dn,
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [zone1_rname_dnsname],
@@ -1060,7 +1060,7 @@ class test_dns(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -1080,7 +1080,7 @@ class test_dns(Declarative):
                 'result': [{
                     'dn': zone1_dn,
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [zone1_rname_dnsname],
@@ -1091,7 +1091,7 @@ class test_dns(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -1836,7 +1836,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': revzone1_dn,
                     'idnsname': [revzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone1_rname_dnsname],
@@ -1845,7 +1845,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-subdomain %(zone)s PTR;'
                                          % dict(realm=api.env.realm, zone=revzone1)],
                     'idnsallowtransfer': [u'none;'],
@@ -1880,7 +1880,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': revzone2_dn,
                     'idnsname': [revzone2_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone1_rname_dnsname],
@@ -1889,7 +1889,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-subdomain %(zone)s PTR;'
                                          % dict(realm=api.env.realm, zone=revzone2)],
                     'idnsallowtransfer': [u'none;'],
@@ -2004,7 +2004,7 @@ class test_dns(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'mxrecord': [u'0 ns1.dnszone.test.'],
                     'locrecord': [u"49 11 42.400 N 16 36 29.600 E 227.64 10.00 10.00 0.10"],
@@ -2017,7 +2017,7 @@ class test_dns(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowquery': [allowquery_restricted_out],
                     'idnsallowtransfer': [u'none;'],
-                    'idnsallowdynupdate': ('FALSE',),
+                    'idnsallowdynupdate': (False,),
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -2042,7 +2042,7 @@ class test_dns(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'mxrecord': [u'0 ns1.dnszone.test.'],
                     'locrecord': [u"49 11 42.400 N 16 36 29.600 E 227.64 10.00 10.00 0.10"],
@@ -2055,7 +2055,7 @@ class test_dns(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowquery': [allowquery_restricted_out],
                     'idnsallowtransfer': [allowtransfer_tofwd],
-                    'idnsallowdynupdate': ('FALSE',),
+                    'idnsallowdynupdate': (False,),
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -2073,7 +2073,7 @@ class test_dns(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'mxrecord': [u'0 ns1.dnszone.test.'],
                     'locrecord': [u"49 11 42.400 N 16 36 29.600 E 227.64 10.00 10.00 0.10"],
@@ -2086,7 +2086,7 @@ class test_dns(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowquery': [allowquery_restricted_out],
                     'idnsallowtransfer': [allowtransfer_tofwd],
-                    'idnsallowdynupdate': ('FALSE',),
+                    'idnsallowdynupdate': (False,),
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -2337,7 +2337,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': zone3_dn,
                     'idnsname': [zone3_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone3_rname_dnsname],
@@ -2346,7 +2346,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -2396,7 +2396,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': revzone3_classless1_dn,
                     'idnsname': [revzone3_classless1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone3_rname_dnsname],
@@ -2405,7 +2405,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-subdomain %(zone)s PTR;'
                                          % dict(realm=api.env.realm, zone=revzone3_classless1)],
                     'idnsallowtransfer': [u'none;'],
@@ -2438,7 +2438,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': revzone3_classless2_dn,
                     'idnsname': [revzone3_classless2_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone3_rname_dnsname],
@@ -2447,7 +2447,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-subdomain %(zone)s PTR;'
                                          % dict(realm=api.env.realm, zone=revzone3_classless2)],
                     'idnsallowtransfer': [u'none;'],
@@ -2553,7 +2553,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': idnzone1_dn,
                     'idnsname': [idnzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [idnzone1_rname_dnsname],
@@ -2562,7 +2562,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -2595,7 +2595,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': idnzone1_dn,
                     'idnsname': [idnzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [idnzone1_rname_dnsname],
@@ -2606,7 +2606,7 @@ class test_dns(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -2626,7 +2626,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': idnzone1_dn,
                     'idnsname': [idnzone1_punycoded],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': ['TRUE'],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns],
                     'idnssoarname': [idnzone1_rname_punycoded],
@@ -2637,7 +2637,7 @@ class test_dns(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': ['FALSE'],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -2659,7 +2659,7 @@ class test_dns(Declarative):
                 'result': [
                     {   'dn': idnzone1_dn,
                         'idnsname': [idnzone1_dnsname],
-                        'idnszoneactive': [u'TRUE'],
+                        'idnszoneactive': [True],
                         'nsrecord': nameservers,
                         'idnssoamname': [self_server_ns_dnsname],
                         'idnssoarname': [idnzone1_rname_dnsname],
@@ -2670,7 +2670,7 @@ class test_dns(Declarative):
                         'idnssoaminimum': [fuzzy_digits],
                         'idnsallowtransfer': [u'none;'],
                         'idnsallowquery': [u'any;'],
-                        'idnsallowdynupdate': [u'FALSE'],
+                        'idnsallowdynupdate': [False],
                         'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                              u'grant %(realm)s krb5-self '
                                              u'* AAAA; '
@@ -2695,7 +2695,7 @@ class test_dns(Declarative):
                 'result': [
                     {   'dn': idnzone1_dn,
                         'idnsname': [idnzone1_punycoded],
-                        'idnszoneactive': [u'TRUE'],
+                        'idnszoneactive': ['TRUE'],
                         'nsrecord': nameservers,
                         'idnssoamname': [self_server_ns],
                         'idnssoarname': [idnzone1_rname_punycoded],
@@ -2706,7 +2706,7 @@ class test_dns(Declarative):
                         'idnssoaminimum': [fuzzy_digits],
                         'idnsallowtransfer': [u'none;'],
                         'idnsallowquery': [u'any;'],
-                        'idnsallowdynupdate': [u'FALSE'],
+                        'idnsallowdynupdate': ['FALSE'],
                         'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                              u'grant %(realm)s krb5-self '
                                              u'* AAAA; '
@@ -2726,7 +2726,7 @@ class test_dns(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [idnzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [idnzone1_rname_dnsname],
@@ -2737,7 +2737,7 @@ class test_dns(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -2759,7 +2759,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': revidnzone1_dn,
                     'idnsname': [revidnzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [idnzone1_rname_dnsname],
@@ -2768,7 +2768,7 @@ class test_dns(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-subdomain %(zone)s PTR;'
                                          % dict(realm=api.env.realm, zone=revidnzone1)],
                     'idnsallowtransfer': [u'none;'],
@@ -2808,7 +2808,7 @@ class test_dns(Declarative):
                 'result': [{
                     'dn': idnzone1_dn,
                     'idnsname': [idnzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [idnzone1_rname_dnsname],
@@ -2819,7 +2819,7 @@ class test_dns(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -3389,7 +3389,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': zone1_dn,
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'FALSE'],
+                    'idnszoneactive': [False],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [zone1_rname_dnsname],
@@ -3399,7 +3399,7 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'172.16.31.80;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -3432,7 +3432,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': zone1_dn,
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [zone1_rname_dnsname],
@@ -3442,7 +3442,7 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'172.16.31.80;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -3474,7 +3474,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': idnzone1_dn,
                     'idnsname': [idnzone1_dnsname],
-                    'idnszoneactive': [u'FALSE'],
+                    'idnszoneactive': [False],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [idnzone1_rname_dnsname],
@@ -3484,7 +3484,7 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -3517,7 +3517,7 @@ class test_dns(Declarative):
                 'result': {
                     'dn': idnzone1_dn,
                     'idnsname': [idnzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': nameservers,
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnssoarname': [idnzone1_rname_dnsname],
@@ -3527,7 +3527,7 @@ class test_dns(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -3618,7 +3618,7 @@ class test_root_zone(Declarative):
                 'result': {
                     'dn': zone_root_dn,
                     'idnsname': [zone_root_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone_root_rname_dnsname],
@@ -3627,7 +3627,7 @@ class test_root_zone(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -3842,7 +3842,7 @@ class test_forward_zones(Declarative):
                 'result': {
                     'dn': fwzone1_dn,
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'none'],
                     'objectclass': objectclasses.dnsforwardzone,
                 },
@@ -3883,7 +3883,7 @@ class test_forward_zones(Declarative):
                 'result': {
                     'dn': fwzone2_dn,
                     'idnsname': [fwzone2_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'first'],
                     'idnsforwarders': [forwarder1],
                     'objectclass': objectclasses.dnsforwardzone,
@@ -3918,7 +3918,7 @@ class test_forward_zones(Declarative):
                 'result': {
                     'dn': fwzone2_dn,
                     'idnsname': [fwzone2_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'only'],
                     'idnsforwarders': [forwarder1, forwarder2, forwarder3],
                     'objectclass': objectclasses.dnsforwardzone,
@@ -3952,7 +3952,7 @@ class test_forward_zones(Declarative):
                 'result': {
                     'dn': fwzone2_dn,
                     'idnsname': [fwzone2_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'only'],
                     'idnsforwarders': [forwarder2],
                     'objectclass': objectclasses.dnsforwardzone,
@@ -3976,7 +3976,7 @@ class test_forward_zones(Declarative):
                 'result': {
                     'dn': fwzone3_dn,
                     'idnsname': [fwzone3_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'first'],
                     'idnsforwarders': [forwarder1, forwarder2, forwarder3],
                     'objectclass': objectclasses.dnsforwardzone,
@@ -4010,7 +4010,7 @@ class test_forward_zones(Declarative):
                 'result': {
                     'dn': fwzone3_dn,
                     'idnsname': [fwzone3_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'first'],
                     'idnsforwarders': [forwarder3],
                     'objectclass': objectclasses.dnsforwardzone,
@@ -4033,7 +4033,7 @@ class test_forward_zones(Declarative):
                 'messages': lambda x: True,  # fake forwarders - ignore message
                 'result': {
                     'idnsname': [fwzone3_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'first'],
                     'idnsforwarders': [forwarder1],
                 },
@@ -4054,7 +4054,7 @@ class test_forward_zones(Declarative):
                 'messages': lambda x: True,  # fake forwarders - ignore message
                 'result': {
                     'idnsname': [fwzone3_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'first'],
                     'idnsforwarders': [forwarder1, forwarder2],
                 },
@@ -4075,7 +4075,7 @@ class test_forward_zones(Declarative):
                 'messages': lambda x: True,  # fake forwarders - ignore message
                 'result': {
                     'idnsname': [fwzone3_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'first'],
                     'idnsforwarders': [forwarder1, forwarder3],
                 },
@@ -4096,7 +4096,7 @@ class test_forward_zones(Declarative):
                 'messages': lambda x: True,  # fake forwarders - ignore message
                 'result': {
                     'idnsname': [fwzone3_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'first'],
                     'idnsforwarders': [forwarder2, forwarder4],
                 },
@@ -4118,7 +4118,7 @@ class test_forward_zones(Declarative):
                 'messages': lambda x: True,  # fake forwarders - ignore message
                 'result': {
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'none'],
                     'idnsforwarders': [forwarder3],
                 },
@@ -4138,7 +4138,7 @@ class test_forward_zones(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [fwzone2_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'none'],
                     'idnsforwarders': [forwarder2],
                 },
@@ -4158,7 +4158,7 @@ class test_forward_zones(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [fwzone2_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'only'],
                     'idnsforwarders': [forwarder2],
                 },
@@ -4180,7 +4180,7 @@ class test_forward_zones(Declarative):
                 'messages': lambda x: True,  # fake forwarders - ignore message
                 'result': {
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'first'],
                     'idnsforwarders': [forwarder3],
                 },
@@ -4201,7 +4201,7 @@ class test_forward_zones(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'none'],
                 },
             },
@@ -4222,7 +4222,7 @@ class test_forward_zones(Declarative):
                 'messages': lambda x: True,  # fake forwarders - ignore message
                 'result': {
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'only'],
                     'idnsforwarders': [forwarder1, forwarder2],
                 },
@@ -4242,7 +4242,7 @@ class test_forward_zones(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'first'],
                     'idnsforwarders': [forwarder1, forwarder2],
                 },
@@ -4262,7 +4262,7 @@ class test_forward_zones(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'only'],
                     'idnsforwarders': [forwarder1, forwarder2],
                 },
@@ -4283,7 +4283,7 @@ class test_forward_zones(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'none'],
                 },
             },
@@ -4402,7 +4402,7 @@ class test_forward_zones(Declarative):
                 'result': {
                     'dn': fwzone1_dn,
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'none'],
                 },
             },
@@ -4430,20 +4430,20 @@ class test_forward_zones(Declarative):
                     {
                         'dn': fwzone1_dn,
                         'idnsname': [fwzone1_dnsname],
-                        'idnszoneactive': [u'TRUE'],
+                        'idnszoneactive': [True],
                         'idnsforwardpolicy': [u'none'],
                     },
                     {
                         'dn': fwzone2_dn,
                         'idnsname': [fwzone2_dnsname],
-                        'idnszoneactive': [u'TRUE'],
+                        'idnszoneactive': [True],
                         'idnsforwardpolicy': [u'only'],
                         'idnsforwarders': [forwarder2],
                     },
                     {
                         'dn': fwzone3_dn,
                         'idnsname': [fwzone3_dnsname],
-                        'idnszoneactive': [u'TRUE'],
+                        'idnszoneactive': [True],
                         'idnsforwardpolicy': [u'first'],
                         'idnsforwarders': [forwarder2, forwarder4],
                     },
@@ -4487,7 +4487,7 @@ class test_forward_zones(Declarative):
                 'result': [{
                     'dn': fwzone1_dn,
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'none'],
                 }],
             },
@@ -4505,20 +4505,20 @@ class test_forward_zones(Declarative):
                     {
                         'dn': fwzone1_dn,
                         'idnsname': [fwzone1_dnsname],
-                        'idnszoneactive': [u'TRUE'],
+                        'idnszoneactive': [True],
                         'idnsforwardpolicy': [u'none'],
                     },
                     {
                         'dn': fwzone2_dn,
                         'idnsname': [fwzone2_dnsname],
-                        'idnszoneactive': [u'TRUE'],
+                        'idnszoneactive': [True],
                         'idnsforwardpolicy': [u'only'],
                         'idnsforwarders': [forwarder2],
                     },
                     {
                         'dn': fwzone3_dn,
                         'idnsname': [fwzone3_dnsname],
-                        'idnszoneactive': [u'TRUE'],
+                        'idnszoneactive': [True],
                         'idnsforwardpolicy': [u'first'],
                         'idnsforwarders': [forwarder2, forwarder4],
                     },
@@ -4538,7 +4538,7 @@ class test_forward_zones(Declarative):
                     {
                         'dn': fwzone1_dn,
                         'idnsname': [fwzone1_dnsname],
-                        'idnszoneactive': [u'TRUE'],
+                        'idnszoneactive': [True],
                         'idnsforwardpolicy': [u'none'],
                     }
                 ],
@@ -4557,7 +4557,7 @@ class test_forward_zones(Declarative):
                     {
                         'dn': fwzone1_dn,
                         'idnsname': [fwzone1_dnsname],
-                        'idnszoneactive': [u'TRUE'],
+                        'idnszoneactive': [True],
                         'idnsforwardpolicy': [u'none'],
                     }
                 ],
@@ -4576,7 +4576,7 @@ class test_forward_zones(Declarative):
                     {
                         'dn': fwzone2_dn,
                         'idnsname': [fwzone2_dnsname],
-                        'idnszoneactive': [u'TRUE'],
+                        'idnszoneactive': [True],
                         'idnsforwardpolicy': [u'only'],
                         'idnsforwarders': [forwarder2],
                     }
@@ -4596,7 +4596,7 @@ class test_forward_zones(Declarative):
                     {
                         'dn': fwzone3_dn,
                         'idnsname': [fwzone3_dnsname],
-                        'idnszoneactive': [u'TRUE'],
+                        'idnszoneactive': [True],
                         'idnsforwardpolicy': [u'first'],
                         'idnsforwarders': [forwarder2, forwarder4],
                     }
@@ -4795,7 +4795,7 @@ class test_forward_zones(Declarative):
                 'result': {
                     'dn': fwzone1_dn,
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'FALSE'],
+                    'idnszoneactive': [False],
                     'idnsforwardpolicy': [u'none'],
                 },
             },
@@ -4842,7 +4842,7 @@ class test_forward_zones(Declarative):
                 'result': {
                     'dn': fwzone1_dn,
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'none'],
                 },
             },
@@ -4913,7 +4913,7 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
                 'result': {
                     'dn': zone1_dn,
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': lambda x: True,  # don't care in this test
                     'nsrecord': lambda x: True,  # don't care in this test
                     'idnssoarname': lambda x: True,  # don't care in this test
@@ -4922,7 +4922,7 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': lambda x: True,  # don't care in this test
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
@@ -4953,7 +4953,7 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
                 'result': {
                     'dn': fwzone1_dn,
                     'idnsname': [fwzone1_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'none'],
                     'objectclass': objectclasses.dnsforwardzone,
                 },
@@ -5117,7 +5117,7 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
                 'result': {
                     'dn': zone_findtest_master_dn,
                     'idnsname': [zone_findtest_master_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': lambda x: True,  # don't care in this test
                     'nsrecord': lambda x: True,  # don't care in this test
                     'idnssoarname': lambda x: True,  # don't care in this test
@@ -5126,7 +5126,7 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': lambda x: True,  # don't care in this test
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
@@ -5159,7 +5159,7 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
                 'result': {
                     'dn': zone_findtest_forward_dn,
                     'idnsname': [zone_findtest_forward_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'first'],
                     'idnsforwarders': [forwarder1],
                     'objectclass': objectclasses.dnsforwardzone,
@@ -5178,7 +5178,7 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
                 'result': [{
                     'dn': zone_findtest_forward_dn,
                     'idnsname': [zone_findtest_forward_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'first'],
                     'idnsforwarders': [forwarder1],
                 }],
@@ -5196,7 +5196,7 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
                 'result': [{
                     'dn': zone_findtest_master_dn,
                     'idnsname': [zone_findtest_master_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'nsrecord': lambda x: True,  # don't care in this test
                     'idnssoamname': lambda x: True,  # don't care in this test
                     'idnssoarname': lambda x: True,  # don't care in this test
@@ -5206,7 +5206,7 @@ class test_forward_master_zones_mutual_exlusion(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -5312,7 +5312,7 @@ class test_forwardzone_delegation_warnings(Declarative):
                 'result': {
                     'dn': zone1_sub_fw_dn,
                     'idnsname': [zone1_sub_fw_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'none'],
                     'objectclass': objectclasses.dnsforwardzone,
                 },
@@ -5332,7 +5332,7 @@ class test_forwardzone_delegation_warnings(Declarative):
                 'result': {
                     'dn': zone1_dn,
                     'idnsname': [zone1_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': lambda x: True,  # don't care in this test
                     'nsrecord': lambda x: True,  # don't care in this test
                     'idnssoarname': lambda x: True,  # don't care in this test
@@ -5341,7 +5341,7 @@ class test_forwardzone_delegation_warnings(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': lambda x: True,  # don't care in this test
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
@@ -5386,7 +5386,7 @@ class test_forwardzone_delegation_warnings(Declarative):
                 'result': {
                     'dn': zone1_sub_dn,
                     'idnsname': [zone1_sub_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': lambda x: True,  # don't care in this test
                     'nsrecord': lambda x: True,  # don't care in this test
                     'idnssoarname': lambda x: True,  # don't care in this test
@@ -5395,7 +5395,7 @@ class test_forwardzone_delegation_warnings(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': lambda x: True,  # don't care in this test
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
@@ -5632,7 +5632,7 @@ class test_forwardzone_delegation_warnings(Declarative):
                 'result': {
                     'dn': zone1_sub2_fw_dn,
                     'idnsname': [zone1_sub2_fw_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnsforwardpolicy': [u'none'],
                     'objectclass': objectclasses.dnsforwardzone,
                 },
@@ -5844,7 +5844,7 @@ class test_dns_soa(Declarative):
                 'result': {
                     'dn': zone6b_absolute_dn,
                     'idnsname': [zone6b_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6b_rname_dnsname],
@@ -5853,7 +5853,7 @@ class test_dns_soa(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -5901,7 +5901,7 @@ class test_dns_soa(Declarative):
                 'result': {
                     'dn': zone6_absolute_dn,
                     'idnsname': [zone6_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6_rname_default_dnsname],
@@ -5910,7 +5910,7 @@ class test_dns_soa(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -5946,7 +5946,7 @@ class test_dns_soa(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone6_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6_rname_relative_dnsname],
@@ -5956,7 +5956,7 @@ class test_dns_soa(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -5980,7 +5980,7 @@ class test_dns_soa(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone6_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6_rname_absolute_dnsname],
@@ -5990,7 +5990,7 @@ class test_dns_soa(Declarative):
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -6012,7 +6012,7 @@ class test_dns_soa(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone6_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6_rname_default_dnsname],
@@ -6023,7 +6023,7 @@ class test_dns_soa(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -6044,7 +6044,7 @@ class test_dns_soa(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone6_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [zone6b_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6b_rname_dnsname],
@@ -6055,7 +6055,7 @@ class test_dns_soa(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -6111,7 +6111,7 @@ class test_dns_soa(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone6_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [zone6_ns_arec_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6_rname_default_dnsname],
@@ -6122,7 +6122,7 @@ class test_dns_soa(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -6164,7 +6164,7 @@ class test_dns_soa(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone6_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [zone6_unresolvable_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6_rname_default_dnsname],
@@ -6175,7 +6175,7 @@ class test_dns_soa(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -6217,7 +6217,7 @@ class test_dns_soa(Declarative):
                 'summary': None,
                 'result': {
                     'idnsname': [zone6_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [zone6_unresolvable_ns_relative_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6_rname_default_dnsname],
@@ -6228,7 +6228,7 @@ class test_dns_soa(Declarative):
                     'idnssoaminimum': [fuzzy_digits],
                     'idnsallowtransfer': [u'none;'],
                     'idnsallowquery': [u'any;'],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -6340,7 +6340,7 @@ class test_dns_soa(Declarative):
                 'result': {
                     'dn': zone6_absolute_dn,
                     'idnsname': [zone6_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6_rname_relative_dnsname],
@@ -6349,7 +6349,7 @@ class test_dns_soa(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -6393,7 +6393,7 @@ class test_dns_soa(Declarative):
                 'result': {
                     'dn': zone6_absolute_dn,
                     'idnsname': [zone6_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6_rname_absolute_dnsname],
@@ -6402,7 +6402,7 @@ class test_dns_soa(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -6446,7 +6446,7 @@ class test_dns_soa(Declarative):
                 'result': {
                     'dn': zone6_absolute_dn,
                     'idnsname': [zone6_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [zone6b_ns_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6b_rname_dnsname],
@@ -6455,7 +6455,7 @@ class test_dns_soa(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -6518,7 +6518,7 @@ class test_dns_soa(Declarative):
                 'result': {
                     'dn': zone6_absolute_dn,
                     'idnsname': [zone6_absolute_dnsname],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [zone6_unresolvable_ns_relative_dnsname],
                     'nsrecord': nameservers,
                     'idnssoarname': [zone6_rname_default_dnsname],
@@ -6527,7 +6527,7 @@ class test_dns_soa(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'

--- a/ipatests/test_xmlrpc/test_dns_realmdomains_integration.py
+++ b/ipatests/test_xmlrpc/test_dns_realmdomains_integration.py
@@ -113,7 +113,7 @@ class test_dns_realmdomains_integration(Declarative):
                 'result': {
                     'dn': dnszone_1_dn,
                     'idnsname': [DNSName(dnszone_1_absolute)],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': lambda x: True,
                     'idnssoarname': [DNSName(idnssoarname)],
@@ -122,7 +122,7 @@ class test_dns_realmdomains_integration(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'
@@ -179,7 +179,7 @@ class test_dns_realmdomains_integration(Declarative):
                 'result': {
                     'dn': dnszone_2_dn,
                     'idnsname': [DNSName(dnszone_2_absolute)],
-                    'idnszoneactive': [u'TRUE'],
+                    'idnszoneactive': [True],
                     'idnssoamname': [self_server_ns_dnsname],
                     'idnsforwarders': [u'198.18.19.20'],
                     'idnsforwardpolicy': [u'only'],
@@ -190,7 +190,7 @@ class test_dns_realmdomains_integration(Declarative):
                     'idnssoaretry': [fuzzy_digits],
                     'idnssoaexpire': [fuzzy_digits],
                     'idnssoaminimum': [fuzzy_digits],
-                    'idnsallowdynupdate': [u'FALSE'],
+                    'idnsallowdynupdate': [False],
                     'idnsupdatepolicy': [u'grant %(realm)s krb5-self * A; '
                                          u'grant %(realm)s krb5-self * AAAA; '
                                          u'grant %(realm)s krb5-self * SSHFP;'

--- a/ipatests/test_xmlrpc/test_hbac_plugin.py
+++ b/ipatests/test_xmlrpc/test_hbac_plugin.py
@@ -64,7 +64,7 @@ class test_hbac(XMLRPC_test):
         entry = ret['result']
         assert_attr_equal(entry, 'cn', self.rule_name)
         assert_attr_equal(entry, 'accessruletype', self.rule_type)
-        assert_attr_equal(entry, 'ipaenabledflag', 'TRUE')
+        assert_attr_equal(entry, 'ipaenabledflag', True)
         assert_attr_equal(entry, 'description', self.rule_desc)
 
     def test_1_hbacrule_add(self):
@@ -82,7 +82,7 @@ class test_hbac(XMLRPC_test):
         """
         entry = api.Command['hbacrule_show'](self.rule_name)['result']
         assert_attr_equal(entry, 'cn', self.rule_name)
-        assert_attr_equal(entry, 'ipaenabledflag', 'TRUE')
+        assert_attr_equal(entry, 'ipaenabledflag', True)
         assert_attr_equal(entry, 'description', self.rule_desc)
 
     def test_3_hbacrule_mod(self):
@@ -327,8 +327,7 @@ class test_hbac(XMLRPC_test):
         """
         assert api.Command['hbacrule_disable'](self.rule_name)['result'] is True
         entry = api.Command['hbacrule_show'](self.rule_name)['result']
-        # FIXME: Should this be 'disabled' or 'FALSE'?
-        assert_attr_equal(entry, 'ipaenabledflag', 'FALSE')
+        assert_attr_equal(entry, 'ipaenabledflag', False)
 
     def test_e_hbacrule_enabled(self):
         """
@@ -337,8 +336,7 @@ class test_hbac(XMLRPC_test):
         assert api.Command['hbacrule_enable'](self.rule_name)['result'] is True
         # check it's really enabled
         entry = api.Command['hbacrule_show'](self.rule_name)['result']
-         # FIXME: Should this be 'enabled' or 'TRUE'?
-        assert_attr_equal(entry, 'ipaenabledflag', 'TRUE')
+        assert_attr_equal(entry, 'ipaenabledflag', True)
 
     def test_ea_hbacrule_disable_setattr(self):
         """
@@ -346,9 +344,9 @@ class test_hbac(XMLRPC_test):
         """
         command_result = api.Command['hbacrule_mod'](
             self.rule_name, setattr=u'ipaenabledflag=false')
-        assert command_result['result']['ipaenabledflag'] == (u'FALSE',)
+        assert command_result['result']['ipaenabledflag'] == (False,)
         entry = api.Command['hbacrule_show'](self.rule_name)['result']
-        assert_attr_equal(entry, 'ipaenabledflag', 'FALSE')
+        assert_attr_equal(entry, 'ipaenabledflag', False)
 
     def test_eb_hbacrule_enable_setattr(self):
         """
@@ -356,10 +354,10 @@ class test_hbac(XMLRPC_test):
         """
         command_result = api.Command['hbacrule_mod'](
             self.rule_name, setattr=u'ipaenabledflag=1')
-        assert command_result['result']['ipaenabledflag'] == (u'TRUE',)
+        assert command_result['result']['ipaenabledflag'] == (True,)
         # check it's really enabled
         entry = api.Command['hbacrule_show'](self.rule_name)['result']
-        assert_attr_equal(entry, 'ipaenabledflag', 'TRUE')
+        assert_attr_equal(entry, 'ipaenabledflag', True)
 
     def test_f_hbacrule_exclusiveuser(self):
         """

--- a/ipatests/test_xmlrpc/test_selinuxusermap_plugin.py
+++ b/ipatests/test_xmlrpc/test_selinuxusermap_plugin.py
@@ -119,7 +119,7 @@ class test_selinuxusermap(Declarative):
                     ipaselinuxuser=[selinuxuser1],
                     objectclass=objectclasses.selinuxusermap,
                     ipauniqueid=[fuzzy_uuid],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     dn=fuzzy_selinuxusermapdn,
                 ),
             ),
@@ -146,7 +146,7 @@ class test_selinuxusermap(Declarative):
                 result=dict(
                     cn=[rule1],
                     ipaselinuxuser=[selinuxuser1],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     dn=fuzzy_selinuxusermapdn,
                 ),
             ),
@@ -163,7 +163,7 @@ class test_selinuxusermap(Declarative):
                 result=dict(
                     cn=[rule1],
                     ipaselinuxuser=[selinuxuser2],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                 ),
                 summary=u'Modified SELinux User Map "%s"' % rule1,
                 value=rule1,
@@ -179,7 +179,7 @@ class test_selinuxusermap(Declarative):
                 result=dict(
                     cn=[rule1],
                     ipaselinuxuser=[selinuxuser2],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     dn=fuzzy_selinuxusermapdn,
                 ),
                 summary=None,
@@ -197,7 +197,7 @@ class test_selinuxusermap(Declarative):
                     dict(
                         cn=[rule1],
                         ipaselinuxuser=[selinuxuser2],
-                        ipaenabledflag=[u'TRUE'],
+                        ipaenabledflag=[True],
                         dn=fuzzy_selinuxusermapdn,
                     ),
                 ],
@@ -311,7 +311,7 @@ class test_selinuxusermap(Declarative):
                     objectclass=objectclasses.hbacrule,
                     ipauniqueid=[fuzzy_uuid],
                     accessruletype=[u'allow'],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     dn=fuzzy_hbacruledn,
                 ),
             ),
@@ -331,7 +331,7 @@ class test_selinuxusermap(Declarative):
                     objectclass=objectclasses.hbacrule,
                     ipauniqueid=[fuzzy_uuid],
                     accessruletype=[u'allow'],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     dn=fuzzy_hbacruledn,
                 ),
             ),
@@ -349,7 +349,7 @@ class test_selinuxusermap(Declarative):
                 result=dict(
                     cn=[rule1],
                     ipaselinuxuser=[selinuxuser2],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     memberuser_user=[user1],
                     dn=fuzzy_selinuxusermapdn,
                 ),
@@ -370,7 +370,7 @@ class test_selinuxusermap(Declarative):
                 result=dict(
                     cn=[rule1],
                     ipaselinuxuser=[selinuxuser2],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     memberuser_user=[user1],
                     dn=fuzzy_selinuxusermapdn,
                 ),
@@ -387,7 +387,7 @@ class test_selinuxusermap(Declarative):
                 result=dict(
                     cn=[rule1],
                     ipaselinuxuser=[selinuxuser2],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     dn=fuzzy_selinuxusermapdn,
                 ),
             )
@@ -408,7 +408,7 @@ class test_selinuxusermap(Declarative):
                 result=dict(
                     cn=[rule1],
                     ipaselinuxuser=[selinuxuser2],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     dn=fuzzy_selinuxusermapdn,
                 ),
             )
@@ -424,7 +424,7 @@ class test_selinuxusermap(Declarative):
                 result=dict(
                     cn=[rule1],
                     ipaselinuxuser=[selinuxuser2],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     memberuser_group=[group1],
                     dn=fuzzy_selinuxusermapdn,
                 ),
@@ -441,7 +441,7 @@ class test_selinuxusermap(Declarative):
                 result=dict(
                     cn=[rule1],
                     ipaselinuxuser=[selinuxuser2],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     memberhost_host=[host1],
                     memberuser_group=[group1],
                     dn=fuzzy_selinuxusermapdn,
@@ -508,7 +508,7 @@ class test_selinuxusermap(Declarative):
                 result=dict(
                     cn=[rule1],
                     ipaselinuxuser=[selinuxuser2],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     memberuser_group=[group1],
                     dn=fuzzy_selinuxusermapdn,
                 ),
@@ -526,7 +526,7 @@ class test_selinuxusermap(Declarative):
                 result=dict(
                     cn=[rule1],
                     ipaselinuxuser=[selinuxuser2],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     dn=fuzzy_selinuxusermapdn,
                 ),
             )
@@ -552,7 +552,7 @@ class test_selinuxusermap(Declarative):
                 result=dict(
                     cn=[rule1],
                     ipaselinuxuser=[selinuxuser2],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     seealso=hbacrule1,
                 ),
                 summary=u'Modified SELinux User Map "%s"' % rule1,
@@ -754,7 +754,7 @@ class test_selinuxusermap(Declarative):
                     ipaselinuxuser=[selinuxuser1],
                     objectclass=objectclasses.selinuxusermap,
                     ipauniqueid=[fuzzy_uuid],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     dn=fuzzy_selinuxusermapdn,
                     seealso=hbacrule1
                 ),
@@ -825,7 +825,7 @@ class test_selinuxusermap(Declarative):
                     ipaselinuxuser=[selinuxuser1],
                     objectclass=objectclasses.selinuxusermap,
                     ipauniqueid=[fuzzy_uuid],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     dn=fuzzy_selinuxusermapdn,
                     usercategory=[u'all'],
                     hostcategory=[u'all']
@@ -866,7 +866,7 @@ class test_selinuxusermap(Declarative):
                     ipaselinuxuser=[selinuxuser1],
                     objectclass=objectclasses.selinuxusermap,
                     ipauniqueid=[fuzzy_uuid],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     dn=fuzzy_selinuxusermapdn,
                 ),
             ),
@@ -911,7 +911,7 @@ class test_selinuxusermap(Declarative):
                     ipaselinuxuser=[selinuxuser1],
                     objectclass=objectclasses.selinuxusermap,
                     ipauniqueid=[fuzzy_uuid],
-                    ipaenabledflag=[u'TRUE'],
+                    ipaenabledflag=[True],
                     dn=fuzzy_selinuxusermapdn,
                     seealso=u'allow_all',
                 ),

--- a/ipatests/test_xmlrpc/tracker/caacl_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/caacl_plugin.py
@@ -105,7 +105,7 @@ class CAACLTracker(Tracker):
             ipauniqueid=[fuzzy_uuid],
             cn=[self.name],
             objectclass=objectclasses.caacl,
-            ipaenabledflag=[u'TRUE'])
+            ipaenabledflag=[True])
 
         self.attrs.update(self.create_categories)
         if self.description:
@@ -374,10 +374,10 @@ class CAACLTracker(Tracker):
 
     def enable(self):
         command = self.make_command(u'caacl_enable', self.name)
-        self.attrs.update({u'ipaenabledflag': [u'TRUE']})
+        self.attrs.update({u'ipaenabledflag': [True]})
         command()
 
     def disable(self):
         command = self.make_command(u'caacl_disable', self.name)
-        self.attrs.update({u'ipaenabledflag': [u'FALSE']})
+        self.attrs.update({u'ipaenabledflag': [False]})
         command()

--- a/ipatests/test_xmlrpc/tracker/certmap_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/certmap_plugin.py
@@ -52,7 +52,7 @@ class CertmapruleTracker(Tracker, EnableTracker):
         self.attrs = {
             'dn': self.dn,
             'cn': [self.name],
-            'ipaenabledflag': [u'TRUE'],
+            'ipaenabledflag': [True],
             'objectclass': objectclasses.certmaprule,
         }
         self.attrs.update({

--- a/ipatests/test_xmlrpc/tracker/certprofile_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/certprofile_plugin.py
@@ -86,7 +86,7 @@ class CertprofileTracker(Tracker):
             dn=unicode(self.dn),
             cn=[self.name],
             description=[self.description],
-            ipacertprofilestoreissued=[unicode(self.store).upper()],
+            ipacertprofilestoreissued=[self.store],
             objectclass=objectclasses.certprofile
         )
         self.exists = True


### PR DESCRIPTION
In IPA framework we don't properly convert to Python bool type and just
return a string (TRUE or FALSE). This can be seen with many boolean
attributes, like

        Bool('idnsallowdynupdate?',
            cli_name='dynamic_update',
            label=_('Dynamic update'),
            doc=_('Allow dynamic updates.'),
            attribute=True,
            default=False,
            autofill=True
        ),

in 'ipa dnszone-show':

> > > api.Command.dnszone_show('ipa.test')['result']['idnsallowdynupdate']
['TRUE']

This is because we don't have the reverse (from LDAP to Python) mapping
for the LDAP boolean OID 1.3.6.1.4.1.1466.115.121.1.7.

When Web UI asks for the entry, it gets back JSON output that contains
this 'TRUE' value:

            "idnsallowdynupdate": [
                "TRUE"
            ],

In Web UI we accustomed to this by adding a logic in boolean_formatter
and enable/disable callback handlers but it is awkward and certainly
complicates life of third-party vendors.

Add proper mapping from LDAP to Python bool type.

Fixes: ...

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>