### PR TITLE
Create missing SSSD_PUBCONF_KRB5_INCLUDE_D_DIR

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -677,6 +677,8 @@ def configure_krb5_conf(
 
     # SSSD include dir
     if configure_sssd:
+        if not os.path.exists(paths.SSSD_PUBCONF_KRB5_INCLUDE_D_DIR):
+            os.makedirs(paths.SSSD_PUBCONF_KRB5_INCLUDE_D_DIR, mode=0o755)
         opts.extend([
             {
                 'name': 'includedir',


### PR DESCRIPTION
One some distributions, namely Suse, the SSSD_PUBCONF_KRB5_INCLUDE_D_DIR
does not exist by default. Ipa-client-install will fail to initialize
the kerberos ticket and error when this directory does not exist.

This patch simply creates the directory if it does not exist before
adding the include statement into /etc/krb5.conf