### PR TITLE
Update Suse compatibility

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -462,6 +462,7 @@ class BasePathNamespace:
     IPA_CCACHE_SWEEPER_GSSPROXY_SOCK = (
         "/var/lib/gssproxy/ipa_ccache_sweeper.sock"
     )
+    PAM_CONFIG = None
 
     def check_paths(self):
         """Check paths for missing files

--- a/ipaplatform/suse/paths.py
+++ b/ipaplatform/suse/paths.py
@@ -86,7 +86,7 @@ class SusePathNamespace(BasePathNamespace):
     KDESTROY = "/usr/lib/mit/bin/kdestroy"
     BIN_KVNO = "/usr/lib/mit/bin/kvno"
     UPDATE_CA_TRUST = "/usr/sbin/update-ca-certificates"
-    AUTHSELECT = "/usr/bin/authselect"
+    PAM_CONFIG = "/usr/sbin/pam-config"
 
 
 paths = SusePathNamespace()

--- a/ipaplatform/suse/services.py
+++ b/ipaplatform/suse/services.py
@@ -17,7 +17,6 @@ suse_system_units = dict(
     (x, "%s.service" % x) for x in base_services.wellknownservices
 )
 suse_system_units["httpd"] = "apache2.service"
-
 suse_system_units["dirsrv"] = "dirsrv@.service"
 suse_system_units["pki-tomcatd"] = "pki-tomcatd@pki-tomcat.service"
 suse_system_units["pki_tomcatd"] = suse_system_units["pki-tomcatd"]
@@ -163,9 +162,25 @@ class SuseCAService(SuseService):
         return False
 
 
+# For services which have no SUSE counterpart
+class SuseNoService(base_services.PlatformService):
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def restart(self):
+        pass
+
+    def disable(self):
+        pass
+
 def suse_service_class_factory(name, api):
     if name == "dirsrv":
         return SuseDirectoryService(name, api)
+    if name == 'domainname':
+        return SuseNoService(name, api)
     if name == "ipa":
         return SuseIPAService(name, api)
     if name in ("pki-tomcatd", "pki_tomcatd"):
@@ -189,6 +204,6 @@ class SuseServices(base_services.KnownServices):
         super().__init__(services)
 
 
-timedate_services = ["ntpd"]
+timedate_services = base_services.timedate_services
 service = suse_service_class_factory
 knownservices = SuseServices()


### PR DESCRIPTION
Suse compatibility is not working.  This patch provides a working ipa
configuration after a ipa-client-install

* Removes authselect requirement for Suse
* Use Suse 'pam-config' to configure PAM
* Configures nsswitch.conf
* Removes domainname service since it does not exist on Suse

Ticket https://pagure.io/freeipa/issue/9174
