### PR TITLE
ipatests: Healthcheck: Adjust expected error message

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -489,10 +489,10 @@ class TestIpaHealthCheck(IntegrationTest):
         DogtagCertsConnectivityCheck displays the result as ERROR.
         """
         error_msg = (
-            "Request for certificate failed, "
-            "Certificate operation cannot be completed: "
-            "Request failed with status 503: "
-            "Non-2xx response from CA REST API: 503.  (503)"
+            "Request for certificate failed"
+        )
+        error_desc = (
+            "Non - 2xx response from CA REST API: 503"
         )
         returncode, data = run_healthcheck(
             self.master, "ipahealthcheck.dogtag.ca",
@@ -501,7 +501,8 @@ class TestIpaHealthCheck(IntegrationTest):
         assert returncode == 1
         for check in data:
             assert check["result"] == "ERROR"
-            assert check["kw"]["msg"] == error_msg
+            assert error_msg in check["kw"]["msg"]
+            assert error_desc in check["kw"]["error"]
 
     def test_source_ipahealthcheck_meta_core_metacheck(self):
         """


### PR DESCRIPTION
Adjust expected error message for the test test_ipahealthcheck_dogtag_ca_connectivity_check
as this has changed with https://github.com/freeipa/freeipa-healthcheck/commit/6359917748fa38fa19d08b1c2a6facb3a4710ac2

Related: https://pagure.io/freeipa/issue/9175

Signed-off-by: Michal Polovka <mpolovka@redhat.com>