### PR TITLE
Fixes for the new bool mapping

### DIFF
--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1096,7 +1096,7 @@ class ReplicationManager:
                 elif status.find("Total update succeeded") > -1:
                     print("\nUpdate succeeded")
                     done = True
-                elif inprogress.lower() == 'true':
+                elif inprogress:
                     print("\nUpdate in progress yet not in progress")
                 else:
                     print("\n[%s] reports: Update failed! Status: [%s]"

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1465,7 +1465,7 @@ class TestInstallMasterDNS(IntegrationTest):
             ['ipa', 'dnszone-show', self.master.domain.name]
         ).stdout_text
 
-        assert 'Active zone: TRUE' in result
+        assert 'Active zone: True' in result
 
 
 class TestInstallMasterDNSRepeatedly(IntegrationTest):


### PR DESCRIPTION
### ipa-replica-install: nsds5replicaUpdateInProgress is a Boolean

nsds5replicaUpdateInProgress is defined in LDAP schema as a boolean.
Now that IPA API is able to properly map booleans to the python
bool type, this attribute is not a string any more and
comparisons can be done directly based on its real type.

The code in ipa-replica-install was reading nsds5replicaUpdateInProgress
and calling value.tolower() == 'true' but should now use
value == True instead.

### ipatests: update expected output for boolean attribute

Now that IPA API properly maps LDAP boolean attributes to the
python bool type, they are displayed as True/False instead
of TRUE/FALSE in the ipa *-show outputs.

Update the expected output for DNS Active Zone.

Related: https://pagure.io/freeipa/issue/9171