### PR TITLE
Remove pytest.xfail as the pagure issue has been fixed

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion::test_ipahealthcheck_hidden_replica
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -1031,9 +1031,6 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         self._check_dnsrecords([self.master], [self.replicas[0]])
         self._check_config([self.master], [self.replicas[0]])
 
-    @pytest.mark.xfail(
-        reason='https://pagure.io/freeipa/issue/8582', strict=True
-    )
     def test_ipahealthcheck_hidden_replica(self):
         """Ensure that ipa-healthcheck runs successfully on all members
         of an IPA cluster that includes a hidden replica.


### PR DESCRIPTION
Remove pytest.xfail as the pagure issue has been fixed
Pagure Issue: https://pagure.io/freeipa/issue/8582

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>