### PR TITLE
[Backport][ipa-4-9] Add switch for LDAP cache debug output

### DIFF
--- a/client/man/default.conf.5
+++ b/client/man/default.conf.5
@@ -119,6 +119,9 @@ Enable a per-request LDAP cache. The default is True.
 .B ldap_cache_size <integer>
 The maximum number of entries cached if ldap_cache is True. Since this cache is per-request it is not expected to be very large. The default is 100. Setting the value < 1 effectively disables the cache regardless of the ldap_cache setting
 .TP
+.B ldap_cache_debug <boolean>
+Log details on hits, misses, etc. for the LDAP cache if the cache is enabled.
+.TP
 .B ldap_uri <URI>
 Specifies the URI of the IPA LDAP server to connect to. The URI scheme may be one of \fBldap\fR or \fBldapi\fR. The default is to use ldapi, e.g. ldapi://%2fvar%2frun%2fslapd\-EXAMPLE\-COM.socket
 .TP

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -170,6 +170,7 @@ DEFAULT_CONFIG = (
 
     ('ldap_cache', True),
     ('ldap_cache_size', 100),
+    ('ldap_cache_debug', False),
 
     # Define an inclusive range of SSL/TLS version support
     ('tls_version_min', TLS_VERSION_DEFAULT_MIN),

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -1766,15 +1766,18 @@ class LDAPCache(LDAPClient):
 
     def __init__(self, ldap_uri, start_tls=False, force_schema_updates=False,
                  no_schema=False, decode_attrs=True, cacert=None,
-                 sasl_nocanon=True, enable_cache=True, cache_size=100):
+                 sasl_nocanon=True, enable_cache=True, cache_size=100,
+                 debug_cache=False):
 
         self.cache = OrderedDict()
         self._enable_cache = True  # initialize to zero to satisfy pylint
+        self._debug_cache = False  # initialize to zero to satisfy pylint
 
         object.__setattr__(self, '_cache_misses', 0)
         object.__setattr__(self, '_cache_hits', 0)
         object.__setattr__(self, '_enable_cache',
                            enable_cache and cache_size > 0)
+        object.__setattr__(self, '_debug_cache', debug_cache)
         object.__setattr__(self, '_cache_size', cache_size)
 
         super(LDAPCache, self).__init__(
@@ -1795,7 +1798,7 @@ class LDAPCache(LDAPClient):
         return self._cache_size  # pylint: disable=no-member
 
     def emit(self, msg, *args, **kwargs):
-        if self._enable_cache:
+        if self._enable_cache and self._debug_cache:
             logger.debug(msg, *args, **kwargs)
 
     def copy_entry(self, dn, entry, attrs=[]):

--- a/ipaserver/plugins/ldap2.py
+++ b/ipaserver/plugins/ldap2.py
@@ -66,6 +66,7 @@ class ldap2(CrudBackend, LDAPCache):
             force_schema_updates=force_schema_updates,
             enable_cache=api.env.ldap_cache and not force_schema_updates,
             cache_size=api.env.ldap_cache_size,
+            debug_cache=api.env.ldap_cache_debug,
         )
 
         self._time_limit = float(LDAPCache.time_limit)


### PR DESCRIPTION
This PR was opened automatically because PR #6315 was pushed to master and backport to ipa-4-9 is required.