### PR TITLE
[Backport][ipa-4-6] Idoverride cache resolve

### DIFF
--- a/ipaserver/plugins/idviews.py
+++ b/ipaserver/plugins/idviews.py
@@ -746,8 +746,12 @@ class baseidoverride(LDAPObject):
 
     def convert_anchor_to_human_readable_form(self, entry_attrs, **options):
         if not options.get('raw'):
-            anchor = entry_attrs.single_value['ipaanchoruuid']
+            if 'ipaoriginaluid' in entry_attrs:
+                originaluid = entry_attrs.single_value['ipaoriginaluid']
+                entry_attrs.single_value['ipaanchoruuid'] = originaluid
+                return
 
+            anchor = entry_attrs.single_value['ipaanchoruuid']
             if anchor:
                 try:
                     object_name = resolve_anchor_to_object_name(
@@ -991,7 +995,7 @@ class idoverrideuser(baseidoverride):
             original_uid = resolve_anchor_to_object_name(self.backend,
                                                          self.override_object,
                                                          anchor)
-            entry_attrs['ipaOriginalUid'] = original_uid
+            entry_attrs['ipaoriginaluid'] = original_uid
 
         except (errors.NotFound, errors.ValidationError):
             # Anchor could not be resolved, this means we had to specify the


### PR DESCRIPTION
This PR was opened automatically because PR #6302 was pushed to master and backport to ipa-4-6 is required.