### PR TITLE
[Backport][ipa-4-9] Create missing SSSD_PUBCONF_KRB5_INCLUDE_D_DIR

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -677,6 +677,8 @@ def configure_krb5_conf(
 
     # SSSD include dir
     if configure_sssd:
+        if not os.path.exists(paths.SSSD_PUBCONF_KRB5_INCLUDE_D_DIR):
+            os.makedirs(paths.SSSD_PUBCONF_KRB5_INCLUDE_D_DIR, mode=0o755)
         opts.extend([
             {
                 'name': 'includedir',


### PR DESCRIPTION
This PR was opened automatically because PR #6296 was pushed to master and backport to ipa-4-9 is required.