### PR TITLE
[Backport][ipa-4-9] ipatests: xfail for test_ipahealthcheck_hidden_replica to respect pki version

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2452,6 +2452,18 @@ def get_platform(host):
     return result.stdout_text.strip()
 
 
+def get_platform_version(host):
+    result = host.run_command([
+        'python3', '-c',
+        'from ipaplatform.osinfo import OSInfo; print(OSInfo().version_number)'
+    ], raiseonerr=False)
+    assert result.returncode == 0
+    # stdout_text is a str in format "(X, Y)" and needs to be
+    # converted back to a functional tuple. This approach works with
+    # any number of version numbers filled, e.g. (34, ) or (8, 6) etc.
+    return tuple(map(int, re.findall(r'[0-9]+', result.stdout_text.strip())))
+
+
 def install_packages(host, pkgs):
     """Install packages on a remote host.
     :param host: the host where the installation takes place


### PR DESCRIPTION
This PR was opened automatically because PR #6190 was pushed to master and backport to ipa-4-9 is required.