### PR TITLE
ipatests: Increase expect timeout for interactive mode

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1208,7 +1208,7 @@ class TestInstallMaster(IntegrationTest):
 
         try:
             cmd = ['ipa-server-install', '--hostname', new_hostname]
-            with self.master.spawn_expect(cmd) as e:
+            with self.master.spawn_expect(cmd, default_timeout=100) as e:
                 e.expect_exact('Do you want to configure integrated '
                                'DNS (BIND)? [no]: ')
                 e.sendline('no')
@@ -1419,7 +1419,7 @@ class TestInstallMasterDNS(IntegrationTest):
         """
         cmd = ['ipa-server-install']
         netbios = create_netbios_name(self.master)
-        with self.master.spawn_expect(cmd) as e:
+        with self.master.spawn_expect(cmd, default_timeout=100) as e:
             e.expect_exact('Do you want to configure integrated '
                            'DNS (BIND)? [no]: ')
             e.sendline('yes')


### PR DESCRIPTION
Increase the default timeout for expect function when testing
interactive mode to mitigate an issue when the tests are failing
on the slow systems.

Fixes: https://pagure.io/freeipa/issue/9183

Signed-off-by: Michal Polovka <mpolovka@redhat.com>