### PR TITLE
[Backport][ipa-4-9] ipatests: Increase expect timeout for interactive mode

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1206,7 +1206,7 @@ class TestInstallMaster(IntegrationTest):
 
         try:
             cmd = ['ipa-server-install', '--hostname', new_hostname]
-            with self.master.spawn_expect(cmd) as e:
+            with self.master.spawn_expect(cmd, default_timeout=100) as e:
                 e.expect_exact('Do you want to configure integrated '
                                'DNS (BIND)? [no]: ')
                 e.sendline('no')
@@ -1417,7 +1417,7 @@ class TestInstallMasterDNS(IntegrationTest):
         """
         cmd = ['ipa-server-install']
         netbios = create_netbios_name(self.master)
-        with self.master.spawn_expect(cmd) as e:
+        with self.master.spawn_expect(cmd, default_timeout=100) as e:
             e.expect_exact('Do you want to configure integrated '
                            'DNS (BIND)? [no]: ')
             e.sendline('yes')


### PR DESCRIPTION
This PR was opened automatically because PR #6324 was pushed to master and backport to ipa-4-9 is required.