### PR TITLE
ipatests: Enforce MTU for all AD machines

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -65,10 +65,10 @@ jobs:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_http_kdc_proxy.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *ad_master_2client


### PR DESCRIPTION
Implement a method to change MTU in Windows Server 2019 and newer.
Add a check on what MTU changing method to use.

Related: https://pagure.io/freeipa/issue/8967

Signed-off-by: Michal Polovka <mpolovka@redhat.com>