### PR TITLE
Some path fixes for Debian

### DIFF
--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -79,6 +79,7 @@ class DebianPathNamespace(BasePathNamespace):
     UPDATE_CA_TRUST = "/usr/sbin/update-ca-certificates"
     BIND_LDAP_DNS_IPA_WORKDIR = "/var/cache/bind/dyndb-ldap/ipa/"
     BIND_LDAP_DNS_ZONE_WORKDIR = "/var/cache/bind/dyndb-ldap/ipa/master/"
+    BIND_LDAP_SO = "ldap.so"
     LIBARCH = "/{0}".format(MULTIARCH)
     LIBSOFTHSM2_SO = "/usr/lib/{0}/softhsm/libsofthsm2.so".format(MULTIARCH)
     PAM_KRB5_SO = "/usr/lib/{0}/security/pam_krb5.so".format(MULTIARCH)

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -80,7 +80,7 @@ class DebianPathNamespace(BasePathNamespace):
     BIND_LDAP_DNS_IPA_WORKDIR = "/var/cache/bind/dyndb-ldap/ipa/"
     BIND_LDAP_DNS_ZONE_WORKDIR = "/var/cache/bind/dyndb-ldap/ipa/master/"
     LIBARCH = "/{0}".format(MULTIARCH)
-    LIBSOFTHSM2_SO = "/usr/lib/softhsm/libsofthsm2.so"
+    LIBSOFTHSM2_SO = "/usr/lib/{0}/softhsm/libsofthsm2.so".format(MULTIARCH)
     PAM_KRB5_SO = "/usr/lib/{0}/security/pam_krb5.so".format(MULTIARCH)
     LIB_SYSTEMD_SYSTEMD_DIR = "/lib/systemd/system/"
     LIBEXEC_CERTMONGER_DIR = "/usr/lib/certmonger"


### PR DESCRIPTION
libsofthsm2 should use a multiarch path

named.conf should drop the path to ldap.so, since it's redundant as named is able to find the plugin just fine, assuming it's installed in the plugindir