### PR TITLE
[Backport][ipa-4-9] Preserve user: fix the confusing summary

### DIFF
--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -56,6 +56,7 @@ from .idviews import remove_ipaobject_overrides
 from ipalib.plugable import Registry
 from .baseldap import (
     LDAPObject,
+    pkey_to_unicode,
     pkey_to_value,
     LDAPCreate,
     LDAPSearch,
@@ -701,6 +702,7 @@ class user_del(baseuser_del):
     __doc__ = _('Delete a user.')
 
     msg_summary = _('Deleted user "%(value)s"')
+    msg_summary_preserved = _('Preserved user "%(value)s"')
 
     takes_options = baseuser_del.takes_options + (
         Bool('preserve?',
@@ -831,6 +833,8 @@ class user_del(baseuser_del):
                     failed.append(pkey_to_value(pkey, options))
 
             val = dict(result=dict(failed=failed), value=preserved)
+            val['summary'] = self.msg_summary_preserved % dict(
+                value=pkey_to_unicode(preserved))
             return val
         else:
             return super(user_del, self).execute(*keys, **options)

--- a/ipatests/test_xmlrpc/test_stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/test_stageuser_plugin.py
@@ -479,11 +479,12 @@ class TestActive(XMLRPC_test):
 
     def test_delete_preserve(self, user):
         user.ensure_exists()
-        user.track_delete()
+        user.track_delete(preserve=True)
         command = user.make_delete_command(no_preserve=False, preserve=True)
         result = command()
         user.check_delete(result)
 
+        user.track_delete(preserve=False)
         command = user.make_delete_command()
         result = command()
         user.check_delete(result)
@@ -622,6 +623,7 @@ class TestCustomAttr(XMLRPC_test):
         assert 'BusinessCat' in result['result'][u'businesscategory']
 
         # delete the user with --preserve
+        user_customattr.track_delete(preserve=True)
         command = user_customattr.make_delete_command(no_preserve=False,
                                                       preserve=True)
         result = command()
@@ -763,6 +765,7 @@ class TestGroups(XMLRPC_test):
         result = command()
         group.check_retrieve(result)
 
+        user.track_delete(preserve=True)
         command = user.make_delete_command(no_preserve=False, preserve=True)
         result = command()
         user.check_delete(result)

--- a/ipatests/test_xmlrpc/tracker/user_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/user_plugin.py
@@ -273,9 +273,14 @@ class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
 
     def check_delete(self, result):
         """ Check 'user-del' command result """
+        if u'preserved' in self.attrs and self.attrs[u'preserved']:
+            summary = u'Preserved user "%s"' % self.uid
+        else:
+            summary = u'Deleted user "%s"' % self.uid
+
         assert_deepequal(dict(
             value=[self.uid],
-            summary=u'Deleted user "%s"' % self.uid,
+            summary=summary,
             result=dict(failed=[]),
             ), result)
 


### PR DESCRIPTION
This PR was opened automatically because PR #6329 was pushed to master and backport to ipa-4-9 is required.