### PR TITLE
ipatests: ipa-client-install --subid adds entry in nsswitch.conf

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -309,4 +309,4 @@ jobs:
         test_suite: test_integration/test_subids.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1748,7 +1748,7 @@ jobs:
         test_suite: test_integration/test_subids.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-latest/test_custom_plugins:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1887,7 +1887,7 @@ jobs:
         test_suite: test_integration/test_subids.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-latest/test_custom_plugins:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -2027,7 +2027,7 @@ jobs:
         test_suite: test_integration/test_subids.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   testing-fedora/test_custom_plugins:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2166,7 +2166,7 @@ jobs:
         test_suite: test_integration/test_subids.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   testing-fedora/test_custom_plugins:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1748,7 +1748,7 @@ jobs:
         test_suite: test_integration/test_subids.py
         template: *ci-master-previous
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-previous/test_custom_plugins:
     requires: [fedora-previous/build]


### PR DESCRIPTION
This testcase checks that when ipa-client-install command is run with --subid option, /etc/nsswitch.conf file is updated
with the below entry  
subid: nss
