### PR TITLE
Fix test_secure_ajp_connector.py failing with Python 3.6.8

### DIFF
--- a/ipatests/test_ipaserver/test_secure_ajp_connector.py
+++ b/ipatests/test_ipaserver/test_secure_ajp_connector.py
@@ -214,8 +214,8 @@ class TestAJPSecretUpgrade:
                 as mocked_file:
             dogtag.secure_ajp_connector()
             if rewrite:
-                newdata = mocked_file().write.call_args.args
-                f = BytesIO(newdata[0])
+                newdata = mocked_file().write.call_args
+                f = BytesIO(newdata[0][0])
                 server_xml = myparse(f)
                 doc = server_xml.getroot()
                 connectors = doc.xpath('//Connector[@protocol="AJP/1.3"]')


### PR DESCRIPTION
Some of the test data are not expected to cause a rewrite in
the upgrade code. Those that do will set the rewrite flag.

In that case there is a new server.xml to be read. This is
handled with mock_open(). The contents can be retrieved via
mocked_file().write.call_args but the repr() of it is:

call(b'<Server port="1234" shutdown="SHUTDOWN">\n  ...')

In at least Python 3.10 one can use write.call_args.args to get
just the raw data. This does not work with Python 3.6.8 and
returns the string 'args' instead results in a TypeError.

TypeError: a bytes-like object is required, not 'str'

Instead drop the args and use the data directly.

For the case of x = mocked_file().write.call_args:

   x[0] is a tuple with the first element being the data
   x[0][0] is the raw data

So use x[0][0] to get at the data instead of x.args[0]

Fixes: https://pagure.io/freeipa/issue/9190

Signed-off-by: Rob Crittenden <rcritten@redhat.com>