### PR TITLE
[Backport][ipa-4-9] ipatests: Fix install_master for test_idp.py

### DIFF
--- a/ipatests/test_integration/test_idp.py
+++ b/ipatests/test_integration/test_idp.py
@@ -80,7 +80,7 @@ class TestIDPKeycloak(IntegrationTest):
     def install(cls, mh):
         cls.client = cls.replicas[0]
         cls.replica = cls.replicas[1]
-        tasks.install_master(cls.master)
+        tasks.install_master(cls.master, extra_args=['--no-dnssec-validation'])
         tasks.install_client(cls.master, cls.replicas[0],
                              extra_args=["--mkhomedir"])
         tasks.install_replica(cls.master, cls.replicas[1])


### PR DESCRIPTION
This PR was opened automatically because PR #6334 was pushed to master and backport to ipa-4-9 is required.