### PR TITLE
[Backport][ipa-4-9] Add missing parameter to Suse modify_nsswitch_pam_stack

### DIFF
--- a/ipaplatform/suse/tasks.py
+++ b/ipaplatform/suse/tasks.py
@@ -45,7 +45,7 @@ class SuseTaskNamespace(RedHatTaskNamespace):
         return False  # FIXME: Implement after libexec move
 
     def modify_nsswitch_pam_stack(self, sssd, mkhomedir, statestore,
-                                  sudo=True):
+                                  sudo=True, subid=False):
         # pylint: disable=ipa-forbidden-import
         from ipalib import sysrestore  # FixMe: break import cycle
         # pylint: enable=ipa-forbidden-import


### PR DESCRIPTION
This PR was opened automatically because PR #6326 was pushed to master and backport to ipa-4-9 is required.