### PR TITLE
[Backport][ipa-4-9] Fix test_secure_ajp_connector.py failing with Python 3.6.8

### DIFF
--- a/ipatests/test_ipaserver/test_secure_ajp_connector.py
+++ b/ipatests/test_ipaserver/test_secure_ajp_connector.py
@@ -214,8 +214,8 @@ class TestAJPSecretUpgrade:
                 as mocked_file:
             dogtag.secure_ajp_connector()
             if rewrite:
-                newdata = mocked_file().write.call_args.args
-                f = BytesIO(newdata[0])
+                newdata = mocked_file().write.call_args
+                f = BytesIO(newdata[0][0])
                 server_xml = myparse(f)
                 doc = server_xml.getroot()
                 connectors = doc.xpath('//Connector[@protocol="AJP/1.3"]')


### PR DESCRIPTION
This PR was opened automatically because PR #6336 was pushed to master and backport to ipa-4-9 is required.