### PR TITLE
RSN v3 tests

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1821,3 +1821,27 @@ jobs:
         template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
+
+  fedora-latest/test_random_serial_numbers_TestRSNPKIConfig:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNPKIConfig
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_random_serial_numbers_TestRSNVault:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNVault
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -1040,3 +1040,31 @@ jobs:
         template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
+
+  pki-fedora/test_random_serial_numbers_TestRSNPKIConfig:
+    requires: [pki-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{pki-fedora/build_url}'
+        update_packages: True
+        copr: '@pki/master'
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNPKIConfig
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  pki-fedora/test_random_serial_numbers_TestRSNVault:
+    requires: [pki-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{pki-fedora/build_url}'
+        update_packages: True
+        copr: '@pki/master'
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNVault
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1966,3 +1966,29 @@ jobs:
         template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
+
+  fedora-latest/test_random_serial_numbers_TestRSNPKIConfig:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNPKIConfig
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest/test_random_serial_numbers_TestRSNVault:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNVault
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -2112,3 +2112,31 @@ jobs:
         template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
+
+  testing-fedora/test_random_serial_numbers_TestRSNPKIConfig:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNPKIConfig
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  testing-fedora/test_random_serial_numbers_TestRSNVault:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNVault
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2257,3 +2257,33 @@ jobs:
         template: *ci-master-latest
         timeout: 5400
         topology: *master_1repl
+
+  testing-fedora/test_random_serial_numbers_TestRSNPKIConfig:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNPKIConfig
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  testing-fedora/test_caless_TestRSNVault:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNVault
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1821,3 +1821,27 @@ jobs:
         template: *ci-master-previous
         timeout: 5400
         topology: *master_1repl
+
+  fedora-previous/test_random_serial_numbers_TestRSNPKIConfig:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNPKIConfig
+        template: *ci-master-previous
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-previous/test_random_serial_numbers_TestRSNVault:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNVault
+        template: *ci-master-previous
+        timeout: 10800
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1966,3 +1966,29 @@ jobs:
         template: *ci-master-frawhide
         timeout: 5400
         topology: *master_1repl
+
+  fedora-rawhide/test_random_serial_numbers_TestRSNPKIConfig:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNPKIConfig
+        template: *ci-master-frawhide
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-rawhide/test_random_serial_numbers_TestRSNVault:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNVault
+        template: *ci-master-frawhide
+        timeout: 10800
+        topology: *master_1repl

--- a/ipatests/test_integration/test_random_serial_numbers.py
+++ b/ipatests/test_integration/test_random_serial_numbers.py
@@ -4,12 +4,15 @@
 
 import pytest
 
+from ipaplatform.paths import paths
+
+from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_installation import (
     TestInstallWithCA_DNS1,
     TestInstallWithCA_KRA1,
 )
 from ipatests.test_integration.test_caless import TestServerCALessToExternalCA
-
+from ipatests.test_integration.test_vault import TestInstallKRA
 from ipatests.test_integration.test_commands import TestIPACommand
 
 
@@ -24,6 +27,18 @@ def pki_supports_RSNv3(host):
     if 'true' in result.stdout_text.strip().lower():
         return True
     return False
+
+
+def check_pki_config_params(host):
+    # Check CS.cfg
+    try:
+        cs_cfg = host.get_file_contents(paths.CA_CS_CFG_PATH)
+        kra_cfg = host.get_file_contents(paths.KRA_CS_CFG_PATH)
+        assert "dbs.cert.id.generator=random".encode() in cs_cfg
+        assert "dbs.request.id.generator=random".encode() in cs_cfg
+        assert "dbs.key.id.generator=random".encode() in kra_cfg
+    except IOError:
+        pytest.skip("PKI config not present.Skipping test")
 
 
 class TestInstallWithCA_DNS1_RSN(TestInstallWithCA_DNS1):
@@ -70,3 +85,37 @@ class TestServerCALessToExternalCA_RSN(TestServerCALessToExternalCA):
         if not pki_supports_RSNv3(mh.master):
             raise pytest.skip("RSNv3 not supported")
         super(TestServerCALessToExternalCA_RSN, cls).uninstall(mh)
+
+
+class TestRSNPKIConfig(TestInstallWithCA_KRA1):
+    random_serial = True
+    num_replicas = 3
+
+    @classmethod
+    def install(cls, mh):
+        if not pki_supports_RSNv3(mh.master):
+            raise pytest.skip("RSNv3 not supported")
+        super(TestRSNPKIConfig, cls).install(mh)
+
+    def test_check_pki_config(self):
+        check_pki_config_params(self.master)
+        check_pki_config_params(self.replicas[0])
+        check_pki_config_params(self.replicas[1])
+
+    def test_check_rsn_version(self):
+        tasks.kinit_admin(self.master)
+        res = self.master.run_command(['ipa', 'ca-find'])
+        assert 'RSN Version: 3' in res.stdout_text
+        tasks.kinit_admin(self.replicas[0])
+        res = self.replicas[0].run_command(['ipa', 'ca-find'])
+        assert 'RSN Version: 3' in res.stdout_text
+
+
+class TestRSNVault(TestInstallKRA):
+    random_serial = True
+
+    @classmethod
+    def install(cls, mh):
+        if not pki_supports_RSNv3(mh.master):
+            raise pytest.skip("RSNv3 not supported")
+        super(TestRSNVault, cls).install(mh)

--- a/ipatests/test_integration/test_vault.py
+++ b/ipatests/test_integration/test_vault.py
@@ -33,7 +33,9 @@ class TestInstallKRA(IntegrationTest):
 
     @classmethod
     def install(cls, mh):
-        tasks.install_master(cls.master, setup_kra=True)
+        tasks.install_master(cls.master,
+                             setup_kra=True,
+                             random_serial=cls.random_serial)
         # do not install KRA on replica, it is part of test
         tasks.install_replica(cls.master, cls.replicas[0], setup_kra=False)
 


### PR DESCRIPTION
Additional tests for random serial numbers v3
New Tests include
TestRSNPKIConfig
TestRSNVault

The new tests are just extending existing classes to be run
with random serial numbers enabled

The tests also include a new method to check params set in CS.cfg for both CA and
KRA

Related Ticket: https://pagure.io/freeipa/issue/2016

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>