### PR TITLE
BUILD.txt: remove redundant dnf-builddep option

### DIFF
--- a/BUILD.txt
+++ b/BUILD.txt
@@ -7,7 +7,7 @@ For more information, see http://www.freeipa.org/page/Build
 
 The quickest way to get the dependencies needed for building is:
 
-# dnf builddep -b -D "with_wheels 1" -D "with_lint 1" -D "with_doc 1" --spec freeipa.spec.in --best --allowerasing --setopt=install_weak_deps=False
+# dnf builddep -D "with_wheels 1" -D "with_lint 1" -D "with_doc 1" --spec freeipa.spec.in --best --allowerasing --setopt=install_weak_deps=False
 
 TIP: For building with latest dependencies for freeipa master enable copr repo:
 


### PR DESCRIPTION
-b and --best are the same option (see dnf(8)).  Remove -b and keep
--best, because --best is more descriptive.