### PR TITLE
[Backport][ipa-4-9] install: improve --skip-mem-check documentation

### DIFF
--- a/install/tools/man/ipa-replica-install.1
+++ b/install/tools/man/ipa-replica-install.1
@@ -98,6 +98,9 @@ Configure SSSD as data source for subid.
 \fB\-\-skip\-conncheck\fR
 Skip connection check to remote master
 .TP
+\fB\-\-skip\-mem\-check\fR
+Skip checking for minimum required memory
+.TP
 \fB\-d\fR, \fB\-\-debug
 Enable debug logging when more verbose output is needed
 .TP

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -83,6 +83,9 @@ Do not configure OpenSSH server.
 \fB\-\-subid\fR
 Configure SSSD as data source for subid.
 .TP
+\fB\-\-skip\-mem\-check\fR
+Skip checking for minimum required memory
+.TP
 \fB\-d\fR, \fB\-\-debug\fR
 Enable debug logging when more verbose output is needed.
 .TP

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1132,7 +1132,8 @@ def check_available_memory(ca=False):
     if available < minimum_suggested:
         raise ScriptError(
             "Less than the minimum 1.2GB of RAM is available, "
-            "%.2fGB available" % (available / (1024 * 1024 * 1024))
+            "%.2fGB available.  Use --skip-mem-check to suppress this check."
+            % (available / (1024 * 1024 * 1024))
         )
 
 def load_external_cert(files, ca_subject):


### PR DESCRIPTION
This PR was opened automatically because PR #6350 was pushed to master and backport to ipa-4-9 is required.