### PR TITLE
ipatests: Ensure admin principal is active in TestSSSDWithAdTrust

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        selinux_enforcing: True
+        test_suite: test_integration/test_sssd.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -64,6 +64,17 @@ class TestSSSDWithAdTrust(IntegrationTest):
         cls.ad = cls.ads[0]
         cls.child_ad = cls.ad_subdomains[0]
 
+        cls.master.run_command(
+            [
+                "/usr/bin/dnf",
+                "-y",
+                "update",
+                "selinux-policy",
+                "selinux-policy-targeted",
+                "--enablerepo=updates-testing",
+            ]
+        )
+
         tasks.install_adtrust(cls.master)
         tasks.configure_dns_for_trust(cls.master, cls.ad)
         tasks.establish_trust_with_ad(cls.master, cls.ad.domain.name)


### PR DESCRIPTION
ipatests: Ensure admin principal is active in TestSSSDWithAdTrust

It is implicit that the current principal is admin when adding
the intermediate user (user2). Add an explicit kinit prior
to this to ensure it is the case.

A nightly test failed with a permission error because the active
principal was cifs/master.ipa.test@IPA.TEST. It is unclear how
this doesn't fail more often but being explicit about who is
doing an operation is better in general.

Fixes: https://pagure.io/freeipa/issue/9198

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
