### PR TITLE
ipatests: fix SSSD nightly definition

### DIFF
--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -11,6 +11,10 @@ topologies:
     name: master_1repl_1client
     cpu: 4
     memory: 7400
+  master_2repl_1client: &master_2repl_1client
+    name: master_2repl_1client
+    cpu: 5
+    memory: 10150
   ad_master_2client: &ad_master_2client
     name: ad_master_2client
     cpu: 4
@@ -66,7 +70,7 @@ jobs:
         test_suite: test_integration/test_idp.py
         template: *ci-master-latest
         timeout: 5000
-        topology: *master_1repl
+        topology: *master_2repl_1client
 
   sssd-fedora/test_idviews:
     requires: [sssd-fedora/build]


### PR DESCRIPTION
The nightly test test_external_idp requires a topology
with 2 replicas. Fix the definition in nightly_latest_sssd.

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>