### PR TITLE
[ipa-4-10] Nightly tests: fix template for nightly_ipa-4-10_latest.yaml

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
-          name: freeipa/ci-master-f36
+          name: freeipa/ci-ipa-4-10-f36
           version: 0.0.1
         timeout: 1800
         topology: *build


### PR DESCRIPTION
The vagrant box must be freeipa/ci-ipa-4-10-f36 on this branch
instead of freeipa/ci-master-f36.

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>