### PR TITLE
[Backport][ipa-4-9] Warn for permissions with read/write/search/compare and no attrs

### DIFF
--- a/ipalib/messages.py
+++ b/ipalib/messages.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Custom message (debug, info, wraning) classes passed through RPC.
+Custom message (debug, info, warning) classes passed through RPC.
 
 These are added to the "messages" entry in a RPC response, and printed to the
 user as log messages.
@@ -27,7 +27,7 @@ Each message class has a unique numeric "errno" attribute from the 10000-10999
 range, so that it does not clash with PublicError numbers.
 
 Messages also have the 'type' argument, set to one of 'debug', 'info',
-'warning', 'error'. This determines the severity of themessage.
+'warning', 'error'. This determines the severity of the message.
 """
 from __future__ import print_function
 
@@ -494,6 +494,16 @@ class LightweightCACertificateNotAvailable(PublicMessage):
     errno = 13031
     type = "error"
     format = _("The certificate for %(ca)s is not available on this server.")
+
+
+class MissingTargetAttributesinPermission(PublicMessage):
+    """
+    **13032** A permission was added with no target attributes
+    """
+    errno = 13032
+    type = "warning"
+    format = _("The permission has %(right)s rights but no attributes "
+               "are set.")
 
 
 def iter_messages(variables, base):

--- a/ipatests/test_xmlrpc/test_old_permission_plugin.py
+++ b/ipatests/test_xmlrpc/test_old_permission_plugin.py
@@ -152,6 +152,18 @@ class test_old_permission(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Added permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -493,6 +505,18 @@ class test_old_permission(Declarative):
             expected=dict(
                 value=permission2,
                 summary=u'Added permission "%s"' % permission2,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission2_dn,
                     cn=[permission2],
@@ -801,6 +825,18 @@ class test_old_permission(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Modified permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has read rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'read',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -921,6 +957,18 @@ class test_old_permission(Declarative):
             expected=dict(
                 value=permission1_renamed,
                 summary=u'Modified permission "%s"' % permission1_renamed,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result={
                     'dn': permission1_renamed_ucase_dn,
                     'cn': [permission1_renamed_ucase],
@@ -947,6 +995,18 @@ class test_old_permission(Declarative):
             expected=dict(
                 value=permission1_renamed_ucase,
                 summary=u'Modified permission "%s"' % permission1_renamed_ucase,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_renamed_ucase_dn,
                     cn=[permission1_renamed_ucase],
@@ -1175,6 +1235,18 @@ class test_old_permission(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Added permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -1206,6 +1278,18 @@ class test_old_permission(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Modified permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -1229,6 +1313,18 @@ class test_old_permission(Declarative):
             ),
             expected=dict(
                 summary=u'Modified permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 value=permission1,
                 result=dict(
                     dn=permission1_dn,
@@ -1266,6 +1362,18 @@ class test_old_permission(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Added permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],

--- a/ipatests/test_xmlrpc/test_permission_plugin.py
+++ b/ipatests/test_xmlrpc/test_permission_plugin.py
@@ -3167,6 +3167,18 @@ class test_permission_bindtype(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Added permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -3228,6 +3240,18 @@ class test_permission_bindtype(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Modified permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -3319,6 +3343,18 @@ class test_permission_bindtype(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Modified permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_renamed_dn,
                     cn=[permission1_renamed],
@@ -3350,6 +3386,18 @@ class test_permission_bindtype(Declarative):
             expected=dict(
                 value=permission1_renamed,
                 summary=u'Modified permission "%s"' % permission1_renamed,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_renamed_dn,
                     cn=[permission1_renamed],
@@ -3379,6 +3427,18 @@ class test_permission_bindtype(Declarative):
             expected=dict(
                 value=permission1_renamed,
                 summary=u'Modified permission "%s"' % permission1_renamed,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -4010,6 +4070,18 @@ class test_permission_filters(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Added permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -4054,6 +4126,18 @@ class test_permission_filters(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Modified permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -4093,6 +4177,18 @@ class test_permission_filters(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Modified permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -4132,6 +4228,18 @@ class test_permission_filters(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Modified permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -4172,6 +4280,18 @@ class test_permission_filters(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Modified permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -4205,6 +4325,18 @@ class test_permission_filters(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Modified permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],
@@ -4254,6 +4386,18 @@ class test_permission_filters(Declarative):
             expected=dict(
                 value=permission1,
                 summary=u'Added permission "%s"' % permission1,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission1_dn,
                     cn=[permission1],

--- a/ipatests/test_xmlrpc/test_privilege_plugin.py
+++ b/ipatests/test_xmlrpc/test_privilege_plugin.py
@@ -255,6 +255,18 @@ class test_privilege(Declarative):
             expected=dict(
                 value=permission2,
                 summary=u'Added permission "%s"' % permission2,
+                messages=(
+                    {
+                        'message': ('The permission has write rights but no '
+                                    'attributes are set.'),
+                        'code': 13032,
+                        'type': 'warning',
+                        'name': 'MissingTargetAttributesinPermission',
+                        'data': {
+                            'right': 'write',
+                        }
+                    },
+                ),
                 result=dict(
                     dn=permission2_dn,
                     cn=[permission2],

--- a/makeaci.in
+++ b/makeaci.in
@@ -61,7 +61,7 @@ def generate_aci_lines(api):
             anonymous_read_aci=None,
             is_new=True,
         )
-        aci = perm_plugin.make_aci(entry)
+        aci, _msg = perm_plugin.make_aci(entry)
         yield 'dn: %s\n' % entry.single_value['ipapermlocation']
         yield f'aci: {aci}\n'
 


### PR DESCRIPTION
This PR was opened automatically because PR #6343 was pushed to master and backport to ipa-4-9 is required.