### PR TITLE
ipatests: Test of output while preserving a user account

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_commands.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 5400
         topology: *master_1repl_1client

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2062,8 +2062,10 @@ def user_add(host, login, first='test', last='user', extra_args=(),
     return host.run_command(cmd, stdin_text=stdin_text)
 
 
-def user_del(host, login):
+def user_del(host, login, preserve=False):
     cmd = ["ipa", "user-del", login]
+    if preserve:
+        cmd.extend(["--preserve"])
     return host.run_command(cmd)
 
 


### PR DESCRIPTION
To preserve a user account, the administrator can use the `ipa user-del` command with the `--preserve` option, which works as intended.
This test is testing if preserving and deleting a user account produces correct output message.

Related: https://pagure.io/freeipa/issue/9187

Signed-off-by: Erik Belko <ebelko@redhat.com>