### PR TITLE
ipatest: fix prci checker target masked return code & add pylint

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,8 @@ PYTHON_SCRIPT_SUBDIRS = \
         $(top_builddir)/install/tools \
         $(NULL)
 
+PRCI_DEFINITIONS_DIR = $(top_srcdir)/ipatests/prci_definitions
+
 AZURE_PYTHON_SCRIPT_SUBDIR = $(top_builddir)/ipatests/azure
 
 IPA_PLACEHOLDERS = freeipa ipa ipaserver ipatests
@@ -359,10 +361,10 @@ yamllint:
 		echo $${YAML}; \
 		$(PYTHON) -c "import yaml; f = open('$${YAML}'); yaml.safe_load(f); f.close()" || { echo Your YAML file: $${YAML} has a wrong syntax or this is a Jinja template. In the latter clause, consider to add your YAML file to the YAML_TEMPLATE_FILES list in Makefile.am.; exit 1; } \
 	done; \
-	echo -e "\nCheck PRCI definitions"; \
-	echo "-----------"; \
-	$(PYTHON) $(top_srcdir)/ipatests/prci_definitions/prci_checker.py -d $(top_srcdir)/ipatests/prci_definitions -s $(top_srcdir)/ipatests/prci_definitions/prci_jobs_spec.yaml; \
-	echo "-----------"
+	echo -e "\nCheck PRCI definitions";
+	@echo "-----------"
+	$(PYTHON) $(PRCI_DEFINITIONS_DIR)/prci_checker.py -d $(PRCI_DEFINITIONS_DIR) -s $(PRCI_DEFINITIONS_DIR)/prci_jobs_spec.yaml;
+	@echo "-----------"
 
 # Build & lint documentation.
 #
@@ -394,7 +396,7 @@ pylint: $(GENERATED_PYTHON_FILES) ipasetup.py python_scripts
 		-name '*~' -o \
 		-name '*.py' -print -o \
 		-type f -exec grep -qsm1 '^#!.*\bpython' '{}' \; -print`; \
-	FILES=`echo -e "$${FILES}\n$(AZURE_PYTHON_SCRIPT_SUBDIR)"`; \
+	FILES=`echo -e "$${FILES}\n$(AZURE_PYTHON_SCRIPT_SUBDIR)\n$(PRCI_DEFINITIONS_DIR)"`; \
 	echo -e "Pylint on $(PYTHON) is running over files:\n$${FILES}\nPlease wait ...\n"; \
 	$(PYTHON) -m pylint --version; \
 	PYTHONPATH=$(top_srcdir) $(PYTHON) -m pylint \

--- a/ipatests/prci_definitions/prci_checker.py
+++ b/ipatests/prci_definitions/prci_checker.py
@@ -266,7 +266,7 @@ def process_def_file(file, jobs_spec, supported_classes):
             "the format."
         )
         return False, "", -1
-    topologies = [value for value in topologies_def.values()]
+    topologies = list(topologies_def.values())
 
     # Print file to be analyzed and its number of jobs
     n_jobs = len(jobs_def)


### PR DESCRIPTION
In the yamllint target of makefile, prci_checker result was being masked by echo statement.
Aditionally, prci_checker script has been added to the list of Python sources to be Pylinted.

Addressing comments of recently merged PR:
https://github.com/freeipa/freeipa/pull/6301#discussion_r923163970
https://github.com/freeipa/freeipa/pull/6301#issuecomment-1187037261

Signed-off-by: David Pascual <davherna@redhat.com>