### PR TITLE
Disabling gracelimit does not prevent LDAP binds

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-graceperiod/ipa_graceperiod.c
+++ b/daemons/ipa-slapi-plugins/ipa-graceperiod/ipa_graceperiod.c
@@ -479,7 +479,7 @@ static int ipagraceperiod_preop(Slapi_PBlock *pb)
         if (pwresponse_requested) {
             slapi_pwpolicy_make_response_control(pb, -1, grace_limit - grace_user_time , -1);
         }
-    } else if ((grace_limit > 0) && (grace_user_time >= grace_limit)) {
+    } else if (grace_user_time >= grace_limit) {
         LOG_TRACE("%s password is expired and out of grace limit\n", dn);
         errstr = "Password is expired.\n";
         ret = LDAP_INVALID_CREDENTIALS;


### PR DESCRIPTION
Originally the code treated 0 as disabled. This was
changed during the review process to -1 but one remnant
was missed effetively allowing gracelimit 0 to also mean
disabled.

Add explicit tests for testing with gracelimit = 0 and
gracelimit = -1.

Also remove some extranous "str(self.master.domain.basedn)"
lines from some of the tests.

Fixes: https://pagure.io/freeipa/issue/9206

Signed-off-by: Rob Crittenden <rcritten@redhat.com>