### PR TITLE
WIP: ipatests:  allow to query the AD specific attributes for a user or a group directly

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_trust.py::TestADUserGroupMgmt
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *ad_master_2client


### PR DESCRIPTION
The testscase adds an additional attribute info: mytest for AD group which is similar to the user name 'mytest'
and make sure that the getent group should display the output on ipa-client
