### PR TITLE
upgrades: Don't restart the CA on ACME and profile schema change

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1888,9 +1888,12 @@ def upgrade_configuration():
     custodia = custodiainstance.CustodiaInstance(api.env.host, api.env.realm)
     custodia.upgrade_instance()
 
+    # Don't include schema upgrades in restart consideration, see
+    # https://pagure.io/freeipa/issue/9204
+    ca_upgrade_schema(ca)
+
     ca_restart = any([
         ca_restart,
-        ca_upgrade_schema(ca),
         certificate_renewal_update(ca, kra, ds, http),
         ca_enable_pkix(ca),
         ca_configure_profiles_acl(ca),


### PR DESCRIPTION
There are currently three sets of CA schema changes applied
in ipa-server-upgrade:

* addition of ACME schema
* addition of certificate profile schema
* addition of lightweight CA schema

None of these require a restart of the CA to be supported.

There is an issue in schema parsing such that it doesn't handle
X-ORIGIN properly. A difference is detected and a change applied
but no change is recorded in LDAP so every time upgrade is
run it thinks a CA restart is needed. The CA is not quick to
restart so avoiding one is best, particularly when the update is
run as part of an rpm transaction where a user with an itchy finger
may think things have hung and break out of it.

https://github.com/389ds/389-ds-base/issues/5366 was
filed to track this.

Related: https://pagure.io/freeipa/issue/9204

Signed-off-by: Rob Crittenden <rcritten@redhat.com>