### PR TITLE
Explicitly use legacy ID generators by default

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -529,6 +529,9 @@ class CAInstance(DogtagInstance):
         if self.random_serial_numbers:
             cfg['pki_request_id_generator'] = 'random'
             cfg['pki_cert_id_generator'] = 'random'
+        else:
+            cfg['pki_request_id_generator'] = 'legacy'
+            cfg['pki_cert_id_generator'] = 'legacy'
 
         if not (os.path.isdir(paths.PKI_TOMCAT_ALIAS_DIR) and
                 os.path.isfile(paths.PKI_TOMCAT_PASSWORD_CONF)):
@@ -576,6 +579,8 @@ class CAInstance(DogtagInstance):
             else:
                 cfg.update(
                     pki_random_serial_numbers_enable=False,
+                    pki_request_id_generator="legacy",
+                    pki_cert_id_generator="legacy",
                 )
 
             self._configure_clone(

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -169,6 +169,9 @@ class KRAInstance(DogtagInstance):
         if lookup_random_serial_number_version(api) > 0:
             cfg['pki_key_id_generator'] = 'random'
             cfg['pki_request_id_generator'] = 'random'
+        else:
+            cfg['pki_key_id_generator'] = 'legacy'
+            cfg['pki_request_id_generator'] = 'legacy'
 
         if not (os.path.isdir(paths.PKI_TOMCAT_ALIAS_DIR) and
                 os.path.isfile(paths.PKI_TOMCAT_PASSWORD_CONF)):


### PR DESCRIPTION
The default ID generators used by PKI might change in the future, so to preserve the current behavior the installation code has been updated to explicitly use the legacy ID generators by default.