### PR TITLE
webui: Allow grace login limit

### DIFF
--- a/install/ui/src/freeipa/policy.js
+++ b/install/ui/src/freeipa/policy.js
@@ -72,6 +72,9 @@ return {
                         {
                             name: 'cospriority',
                             required: true
+                        },
+                        {
+                            name: 'passwordgracelimit'
                         }
                     ]
                 }]

--- a/install/ui/src/freeipa/user.js
+++ b/install/ui/src/freeipa/user.js
@@ -318,6 +318,11 @@ return {
                             label: '@mo-param:pwpolicy:krbpwdlockoutduration:label',
                             read_only: true,
                             measurement_unit: 'seconds'
+                        },
+                        {
+                            name: 'passwordgracelimit',
+                            label: '@mo-param:pwpolicy:passwordgracelimit:label',
+                            read_only: true
                         }
                     ]
                 },


### PR DESCRIPTION
There was no support for setting the grace login limit on the WebUI. The
only way to so was only via CLI:

   `ipa pwpolicy-mod --gracelimit=2 global_policy`

Thus, the grace login limit must be updated from the policy section and
this will reflect also on the user settings (under the 'Password Policy'
section)

Fixes: https://pagure.io/freeipa/issue/9211

Signed-off-by: Carla Martinez <carlmart@redhat.com>