### PR TITLE
[Backport][ipa-4-10]ipatests: ipa-client-install --subid adds entry in nsswitch.conf 

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -309,4 +309,4 @@ jobs:
         test_suite: test_integration/test_subids.py
         template: *ci-ipa-4-10-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
@@ -1748,7 +1748,7 @@ jobs:
         test_suite: test_integration/test_subids.py
         template: *ci-ipa-4-10-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-latest-ipa-4-10/test_custom_plugins:
     requires: [fedora-latest-ipa-4-10/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
@@ -1887,7 +1887,7 @@ jobs:
         test_suite: test_integration/test_subids.py
         template: *ci-ipa-4-10-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-latest-ipa-4-10/test_custom_plugins:
     requires: [fedora-latest-ipa-4-10/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
@@ -1748,7 +1748,7 @@ jobs:
         test_suite: test_integration/test_subids.py
         template: *ci-ipa-4-10-previous
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-previous-ipa-4-10/test_custom_plugins:
     requires: [fedora-previous-ipa-4-10/build]


### PR DESCRIPTION
This PR was opened automatically because PR https://github.com/freeipa/freeipa/pull/6335 was pushed to master and backport to ipa-4-10 is required.