### PR TITLE
ipatests: fixes for test_subid webui testsuite

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -65,10 +65,10 @@ jobs:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_webui/test_subid.py::test_subid
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *ipaserver

--- a/ipatests/test_webui/test_subid.py
+++ b/ipatests/test_webui/test_subid.py
@@ -142,11 +142,6 @@ class test_subid(UI_driver):
         """
         self.init_app()
         self.navigate_to_entity('subid', facet='search')
-        self.facet_button_click('add')
-        self.select_combobox('ipaowner', 'admin')
-        self.dialog_button_click('add')
-        self.wait(0.3)
-        self.assert_no_error_dialog()
         self.get_field_checked('ipauniqueid')
         with pytest.raises(NoSuchElementException):
             self.facet_button_click('remove')


### PR DESCRIPTION
    Since the admin user already has the subid generated
    in the previous tests removed the steps which added the
    subid.
    
    Fixes: https://pagure.io/freeipa/issue/9214
