### PR TITLE
[Backport][ipa-4-10]ipatests: Additional tests for RSN v3

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
@@ -1821,3 +1821,27 @@ jobs:
         template: *ci-ipa-4-10-latest
         timeout: 5400
         topology: *master_1repl
+
+  fedora-latest-ipa-4-10/test_random_serial_numbers_TestRSNPKIConfig:
+    requires: [fedora-latest-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-10/build_url}'
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNPKIConfig
+        template: *ci-ipa-4-10-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-10/test_random_serial_numbers_TestRSNVault:
+    requires: [fedora-latest-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-10/build_url}'
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNVault
+        template: *ci-ipa-4-10-latest
+        timeout: 10800
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
@@ -1966,3 +1966,29 @@ jobs:
         template: *ci-ipa-4-10-latest
         timeout: 5400
         topology: *master_1repl
+
+  fedora-latest-ipa-4-10/test_random_serial_numbers_TestRSNPKIConfig:
+    requires: [fedora-latest-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-10/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNPKIConfig
+        template: *ci-ipa-4-10-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-latest-ipa-4-10/test_random_serial_numbers_TestRSNVault:
+    requires: [fedora-latest-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-10/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNVault
+        template: *ci-ipa-4-10-latest
+        timeout: 10800
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
@@ -1821,3 +1821,27 @@ jobs:
         template: *ci-ipa-4-10-previous
         timeout: 5400
         topology: *master_1repl
+
+  fedora-previous-ipa-4-10/test_random_serial_numbers_TestRSNPKIConfig:
+    requires: [fedora-previous-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-10/build_url}'
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNPKIConfig
+        template: *ci-ipa-4-10-previous
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-previous-ipa-4-10/test_random_serial_numbers_TestRSNVault:
+    requires: [fedora-previous-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-10/build_url}'
+        test_suite: test_integration/test_random_serial_numbers.py::TestRSNVault
+        template: *ci-ipa-4-10-previous
+        timeout: 10800
+        topology: *master_1repl

--- a/ipatests/test_integration/test_random_serial_numbers.py
+++ b/ipatests/test_integration/test_random_serial_numbers.py
@@ -4,12 +4,15 @@
 
 import pytest
 
+from ipaplatform.paths import paths
+
+from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_installation import (
     TestInstallWithCA_DNS1,
     TestInstallWithCA_KRA1,
 )
 from ipatests.test_integration.test_caless import TestServerCALessToExternalCA
-
+from ipatests.test_integration.test_vault import TestInstallKRA
 from ipatests.test_integration.test_commands import TestIPACommand
 
 
@@ -24,6 +27,18 @@ def pki_supports_RSNv3(host):
     if 'true' in result.stdout_text.strip().lower():
         return True
     return False
+
+
+def check_pki_config_params(host):
+    # Check CS.cfg
+    try:
+        cs_cfg = host.get_file_contents(paths.CA_CS_CFG_PATH)
+        kra_cfg = host.get_file_contents(paths.KRA_CS_CFG_PATH)
+        assert "dbs.cert.id.generator=random".encode() in cs_cfg
+        assert "dbs.request.id.generator=random".encode() in cs_cfg
+        assert "dbs.key.id.generator=random".encode() in kra_cfg
+    except IOError:
+        pytest.skip("PKI config not present.Skipping test")
 
 
 class TestInstallWithCA_DNS1_RSN(TestInstallWithCA_DNS1):
@@ -70,3 +85,37 @@ class TestServerCALessToExternalCA_RSN(TestServerCALessToExternalCA):
         if not pki_supports_RSNv3(mh.master):
             raise pytest.skip("RSNv3 not supported")
         super(TestServerCALessToExternalCA_RSN, cls).uninstall(mh)
+
+
+class TestRSNPKIConfig(TestInstallWithCA_KRA1):
+    random_serial = True
+    num_replicas = 3
+
+    @classmethod
+    def install(cls, mh):
+        if not pki_supports_RSNv3(mh.master):
+            raise pytest.skip("RSNv3 not supported")
+        super(TestRSNPKIConfig, cls).install(mh)
+
+    def test_check_pki_config(self):
+        check_pki_config_params(self.master)
+        check_pki_config_params(self.replicas[0])
+        check_pki_config_params(self.replicas[1])
+
+    def test_check_rsn_version(self):
+        tasks.kinit_admin(self.master)
+        res = self.master.run_command(['ipa', 'ca-find'])
+        assert 'RSN Version: 3' in res.stdout_text
+        tasks.kinit_admin(self.replicas[0])
+        res = self.replicas[0].run_command(['ipa', 'ca-find'])
+        assert 'RSN Version: 3' in res.stdout_text
+
+
+class TestRSNVault(TestInstallKRA):
+    random_serial = True
+
+    @classmethod
+    def install(cls, mh):
+        if not pki_supports_RSNv3(mh.master):
+            raise pytest.skip("RSNv3 not supported")
+        super(TestRSNVault, cls).install(mh)

--- a/ipatests/test_integration/test_vault.py
+++ b/ipatests/test_integration/test_vault.py
@@ -33,7 +33,9 @@ class TestInstallKRA(IntegrationTest):
 
     @classmethod
     def install(cls, mh):
-        tasks.install_master(cls.master, setup_kra=True)
+        tasks.install_master(cls.master,
+                             setup_kra=True,
+                             random_serial=cls.random_serial)
         # do not install KRA on replica, it is part of test
         tasks.install_replica(cls.master, cls.replicas[0], setup_kra=False)
 


### PR DESCRIPTION
New Tests include
TestRSNPKIConfig
TestRSNVault

The new tests are just extending existing classes to be run
with random serial numbers enabled

The tests also include a new method to check params set in CS.cfg for both CA and
KRA, and another test to check Random Serial Number version while
running `ipa ca-find`

Added nightly definitions

Related Ticket: https://pagure.io/freeipa/issue/2016

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>