### PR TITLE
Tests fixes: fix yaml and disable azure test TestInstallDNSSECFirst

### DIFF
--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -45,15 +45,16 @@ vms:
     - test_integration/test_external_ca.py::TestExternalCAInstall
 
 - vm_jobs:
-  - container_job: InstallDNSSECFirst
-    containers:
-      replicas: 1
-      resources:
-        replica:
-          mem_limit: "2400m"
-          memswap_limit: "3500m"
-    tests:
-    - test_integration/test_dnssec.py::TestInstallDNSSECFirst
+# Temporary disable - see https://pagure.io/freeipa/issue/9216
+#  - container_job: InstallDNSSECFirst
+#    containers:
+#      replicas: 1
+#      resources:
+#        replica:
+#          mem_limit: "2400m"
+#          memswap_limit: "3500m"
+#    tests:
+#    - test_integration/test_dnssec.py::TestInstallDNSSECFirst
 
   - container_job: simple_replication
     containers:

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -210,7 +210,7 @@ jobs:
         test_suite: test_integration/test_subids.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   sssd-fedora/test_sudo:
     requires: [sssd-fedora/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1887,7 +1887,7 @@ jobs:
         test_suite: test_integration/test_subids.py
         template: *ci-master-frawhide
         timeout: 3600
-        topology: *master_1repl
+        topology: *master_1repl_1client
 
   fedora-rawhide/test_custom_plugins:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
### ipatests: fix the topology for rawhide/test_subids

The test test_integration/test_subids.py::TestSubordinateId
needs a master and a client but the yaml definition for rawhide
is currently using master_1repl. Replace with
master_1repl_1client to fulfill the requirement.

Fixes: https://pagure.io/freeipa/issue/9217

### azure tests: disable TestInstallDNSSECFirst

The test TestInstallDNSSECFirst is failing because of one of its
dependencies (the most likely suspect is the update of openssl-pkcs11).
Disable the test from azure gating until the issue is solved.

Related: https://pagure.io/freeipa/issue/9216