### PR TITLE
check_repl_update: in progress is a boolean

### DIFF
--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -1152,7 +1152,7 @@ class ReplicationManager:
             except (ValueError, TypeError, KeyError):
                 end = 0
             # incremental update is done if inprogress is false and end >= start
-            done = inprogress and inprogress.lower() == 'false' and start <= end
+            done = inprogress is not None and not inprogress and start <= end
             logger.info("Replication Update in progress: %s: status: %s: "
                         "start: %d: end: %d",
                         inprogress, status, start, end)


### PR DESCRIPTION
With the fix for https://pagure.io/freeipa/issue/9171,
nsds5replicaUpdateInProgress is now handled as a boolean.
One remaining occurrence was still handling it as a string
and calling lower() on its value.

Replace with direct boolean comparison.

Fixes: https://pagure.io/freeipa/issue/9218