### PR TITLE
WIP: Add compat tree rebuild support

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -4572,6 +4572,15 @@ option: Str('version?')
 output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
+command: server_compat_tree_refresh/1
+args: 0,4,3
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('no_wait?', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
 command: server_conncheck/1
 args: 2,1,3
 arg: Str('cn', cli_name='name')
@@ -7260,6 +7269,7 @@ default: selinuxusermap_remove_host/1
 default: selinuxusermap_remove_user/1
 default: selinuxusermap_show/1
 default: server/1
+default: server_compat_tree_refresh/1
 default: server_conncheck/1
 default: server_del/1
 default: server_find/1

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -86,8 +86,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-# Last change: add Random Serial Numbers v3
-define(IPA_API_VERSION_MINOR, 249)
+# Last change: add Compat Tree Refresh server command
+define(IPA_API_VERSION_MINOR, 250)
 
 ########################################################
 # Following values are auto-generated from values above

--- a/doc/designs/compat-tree-rebuild.md
+++ b/doc/designs/compat-tree-rebuild.md
@@ -1,0 +1,95 @@
+# Compat Tree Rebuild
+
+**DESIGN STAGE**
+
+## Overview
+
+For different reasons, the compat tree maps might get corrupted and some entries
+would be missing, as a consequence the compat tree is not updating after adding
+or removing users from groups. 
+
+This RFE allows to rebuild the compat tree without having to restart the LDAP
+server. It provides a way to rebuild online the whole compat tree on demand via
+a DS task.
+
+## Use Cases
+
+Many IPA users have asked for a mechanism that allows to rebuild the compat tree
+after making changes without the need to restart LDAP server.
+
+## How to Use
+
+A new server command is available `ipa server-compat-tree-refresh`. After
+adding/removing users, the admin can issue the command to make sure that the
+compat tree is updated and and the changes are reflected, this way the LDAP
+queries should show the modifications.
+
+The command can	be issued in two different modes depending if the --no-wait flag is
+added or not, if so, the command will return immediately, default is to wait for the
+task to be completed.
+
+## Design
+
+During installation/upgrade process the following container in tree is added to LDAP:
+
+    dn: cn=Schema compatibility refresh task,cn=tasks,cn=config
+    objectClass: top
+    objectClass: extensibleObject
+    cn: Schema compatibility refresh task
+
+Then, the admin can issue the command `ipa server-compat-tree-refresh`. This call
+internally builds an entry cn=task,cn=Schema compatibility refresh task,cn=tasks,cn=config
+and adds the entry to the previous container. The addition of this entry will provoke
+the rebuild of the compat tree via a 389-ds task. This is following the standard behavior
+for any 389-ds task [Task Invocation Via LDAP Design](https://www.port389.org/docs/389ds/design/task-invocation-via-ldap.html).
+
+In addition to the container in tree, the implementation must contain the proper ACIs
+allowing to create the task below the container. This way, it is possible to maintain
+the permission and privilege to define who is allowed to create this task including
+specific users/groups.
+
+## Implementation
+
+The server commands are extended to handle compat tree rebuild. The server plugin class grows
+two additional sub commands, one for launching the task and one for listing the tasks in
+progress. The show command prints the list of tasks and also accepts the name of the task.
+
+As default, any member of the admins group is allowed to create the refresh task but any
+specific user/group should be able to trigger the task if the privilege is granted.
+
+### UI
+
+This option is not visible through the Web UI as there is no compat tree view available.
+
+### CLI
+
+Overview of the CLI commands. Example:
+
+| Command |	Options |
+| --- | ----- |
+| server-compat-tree-refresh | --no-wait |
+| server-compat-tree-refresh-show | --task |
+
+
+### Configuration
+
+The new plugin will be registered on new installations.
+
+## Upgrade
+
+The plugin will be registered on upgrades.
+
+## Test plan
+
+TBD
+
+## Troubleshooting and debugging
+
+TBD
+
+Include as much information as possible that would help troubleshooting:
+- Does the feature rely on existing files (keytabs, config file...)
+- Does the feature produce logs? in a file or in the journal?
+- Does the feature create/rely on LDAP entries? 
+- How to enable debug logs?
+- When the feature doesn't work, is it possible to diagnose which step failed? Are there intermediate steps that produce logs?

--- a/doc/designs/index.rst
+++ b/doc/designs/index.rst
@@ -26,3 +26,4 @@ FreeIPA design documentation
    external-idp/external-idp.md
    external-idp/idp-api.md
    random-serial-numbers.md
+   compat-tree-rebuild.md

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -73,7 +73,8 @@
 # Require 4.7.0 which brings Python 3 bindings
 %global samba_version 4.12.3-12
 %global selinux_policy_version 3.14.3-52
-%global slapi_nis_version 0.56.4
+# Allow to rebuild the compat tree requires:
+%global slapi_nis_version 0.60.0-1
 %global python_ldap_version 3.1.0-1
 %if 0%{?rhel} < 9
 # Bug 1929067 - PKI instance creation failed with new 389-ds-base build
@@ -100,7 +101,8 @@
 
 # 3.14.5-45 or later includes a number of interfaces fixes for IPA interface
 %global selinux_policy_version 3.14.5-45
-%global slapi_nis_version 0.56.5
+# Allow to rebuild the compat tree requires:
+%global slapi_nis_version 0.60.0-1
 
 %global krb5_kdb_version 8.0
 

--- a/install/updates/80-schema_compat.update
+++ b/install/updates/80-schema_compat.update
@@ -225,3 +225,28 @@ add:schema-compat-entry-attribute: %ifeq("ipaanchoruuid","%{ipaanchoruuid}","obj
 dn: cn=users,cn=Schema Compatibility,cn=plugins,cn=config
 add:schema-compat-entry-attribute: uid=%{uid}
 replace:schema-compat-entry-rdn: uid=%{uid}::uid=%first("%{uid}")
+
+# Add container on tree to expose compat tree rebuild task
+dn: cn=Schema compatibility refresh task,cn=tasks,cn=config
+default:objectClass: top
+default:objectClass: extensibleObject
+default:cn: Schema compatibility refresh task
+
+# Schema compatibility refresh task
+dn: cn=Schema Compatibility Refresh Task Administrator,cn=privileges,cn=pbac,$SUFFIX
+default:objectClass: nestedgroup
+default:objectClass: groupofnames
+default:objectClass: top
+default:cn: Schema Compatibility Refresh Task Administrator
+default:description: Schema Compatibility Refresh Task Administrator
+
+dn: cn=Add Schema Compatibility Refresh Membership Task,cn=permissions,cn=pbac,$SUFFIX
+default:objectClass: groupofnames
+default:objectClass: ipapermission
+default:objectClass: top
+default:cn: Add Schema Compatibility Refresh Membership Task
+default:member: cn=Schema Compatibility Refresh Task Administrator,cn=privileges,cn=pbac,$SUFFIX
+default:ipapermissiontype: SYSTEM
+
+dn: cn=config
+add:aci: (target = "ldap:///cn=schema compatibility refresh membership,cn=tasks,cn=config")(targetattr = "*")(version 3.0;acl "permission:Add Schema Compatibility Refresh Membership Task";allow (add) groupdn = "ldap:///cn=Add Schema Compatibility Refresh Membership Task,cn=permissions,cn=pbac,$SUFFIX";)

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -156,6 +156,11 @@ DEFAULT_CONFIG = (
         DN(('cn', 'ca_renewal'), ('cn', 'ipa'), ('cn', 'etc'))),
     ('container_subids', DN(('cn', 'subids'), ('cn', 'accounts'))),
     ('container_idp', DN(('cn', 'idp'))),
+    ('container_compat_tree_refresh', DN(
+        ('cn', 'Schema compatibility refresh task'),
+        ('cn', 'tasks'),
+        ('cn', 'config')
+    )),
 
     # Ports, hosts, and URIs:
     # Following values do not have any reasonable default.

--- a/ipatests/test_xmlrpc/xmlrpc_test.py
+++ b/ipatests/test_xmlrpc/xmlrpc_test.py
@@ -48,6 +48,11 @@ fuzzy_automember_dn = Fuzzy(
     '^cn=%s,cn=automember rebuild membership,cn=tasks,cn=config$' % uuid_re
 )
 
+# Matches a server compat tree refresh
+fuzzy_server_compat_tree_refresh_dn = Fuzzy(
+    '^cn=%s,cn=Schema compatibility refresh task,cn=tasks,cn=config$' % uuid_re
+)
+
 # base64-encoded value
 fuzzy_base64 = Fuzzy('^[0-9A-Za-z/+]+={0,2}$')
 


### PR DESCRIPTION
For different reasons, the compat tree might get corrupted and some entries would be missing.

This PR implements a new IPA server command: "ipa server-compat-tree-refresh" that allows the admin to rebuild the compat tree without having to restart the LDAP server.

Fixes: https://pagure.io/freeipa/issue/9219

Todo:
- [x] Add new IPA command "ipa server-compat-tree-refresh"
- [x] Create dn container during install/upgrade as well as the proper ACI allowing to create the task below the new container.
- [x] Design page
- [x] Merge slapi-nis PR https://pagure.io/slapi-nis/pull-request/46
- [x] Spec file changes to make sure slapi-nis supports the refresh of the compat tree
- [ ] Implement XMLRPC tests
