### PR TITLE
[Backport][ipa-4-9] azure tests: disable TestInstallDNSSECFirst

### DIFF
--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -45,15 +45,16 @@ vms:
     - test_integration/test_external_ca.py::TestExternalCAInstall
 
 - vm_jobs:
-  - container_job: InstallDNSSECFirst
-    containers:
-      replicas: 1
-      resources:
-        replica:
-          mem_limit: "2400m"
-          memswap_limit: "3500m"
-    tests:
-    - test_integration/test_dnssec.py::TestInstallDNSSECFirst
+# Temporary disable - see https://pagure.io/freeipa/issue/9216
+#  - container_job: InstallDNSSECFirst
+#    containers:
+#      replicas: 1
+#      resources:
+#        replica:
+#          mem_limit: "2400m"
+#          memswap_limit: "3500m"
+#    tests:
+#    - test_integration/test_dnssec.py::TestInstallDNSSECFirst
 
   - container_job: simple_replication
     containers:


### PR DESCRIPTION
This is a manual backport of PR https://github.com/freeipa/freeipa/pull/6401 as the fix is also needed on ipa-4-9 branch.

The test TestInstallDNSSECFirst is failing because of one of its
dependencies (the most likely suspect is the update of openssl-pkcs11).
Disable the test from azure gating until the issue is solved.

Related: https://pagure.io/freeipa/issue/9216
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>
Reviewed-By: Francisco Trivino <ftrivino@redhat.com>