### PR TITLE
[Backport][ipa-4-9] ipatests: WebUI: do not allow subid range deletion #6379

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -65,10 +65,10 @@ jobs:
     requires: [fedora-latest-ipa-4-9/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_webui/test_subid.py::test_subid::test_subid_range_deletion_not_allowed
         template: *ci-ipa-4-9-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_webui/test_subid.py
+++ b/ipatests/test_webui/test_subid.py
@@ -7,7 +7,15 @@ from ipatests.test_webui.ui_driver import UI_driver
 import ipatests.test_webui.data_config as config_data
 import ipatests.test_webui.data_user as user_data
 from ipatests.test_webui.ui_driver import screenshot
+
 import re
+import pytest
+
+try:
+    from selenium.common.exceptions import NoSuchElementException
+    from selenium.webdriver.common.by import By
+except ImportError:
+    pass
 
 
 class test_subid(UI_driver):
@@ -125,3 +133,26 @@ class test_subid(UI_driver):
         self.assert_no_error_dialog()
         after_count = self.get_rows()
         assert len(before_count) < len(after_count)
+
+    @screenshot
+    def test_subid_range_deletion_not_allowed(self):
+        """
+        Test to check that subid range delete is not
+        allowed from WebUI i.e Delete button is not available.
+        """
+        self.init_app()
+        self.navigate_to_entity('subid', facet='search')
+        self.facet_button_click('add')
+        self.select_combobox('ipaowner', 'admin')
+        self.dialog_button_click('add')
+        self.wait(0.3)
+        self.assert_no_error_dialog()
+        self.get_field_checked('ipauniqueid')
+        with pytest.raises(NoSuchElementException):
+            self.facet_button_click('remove')
+        buttons_s = 'div.control-buttons button'
+        facet_buttons = self.find(buttons_s, By.CSS_SELECTOR,
+                                  many=True, strict=True)
+        assert len(facet_buttons) == 2
+        assert facet_buttons[0].get_attribute('name') in ['add', 'refresh']
+        assert facet_buttons[1].get_attribute('name') in ['add', 'refresh']


### PR DESCRIPTION
This PR was opened manually because PR https://github.com/freeipa/freeipa/pull/6379 was pushed to master and backport to ipa-4-9 is required.