### PR TITLE
Fix dns resolver for nameservers with ports

### DIFF
--- a/ipatests/test_ipapython/test_dnsutil.py
+++ b/ipatests/test_ipapython/test_dnsutil.py
@@ -101,3 +101,43 @@ class TestSortURI:
         assert dnsutil.sort_prio_weight([h3, h2, h1]) == [h1, h2, h3]
         assert dnsutil.sort_prio_weight([h3, h3, h3]) == [h3]
         assert dnsutil.sort_prio_weight([h2, h2, h1, h1]) == [h1, h2]
+
+
+class TestDNSResolver:
+    def test_nameservers(self):
+        res = dnsutil.DNSResolver()
+        res.nameservers = ["4.4.4.4", "8.8.8.8"]
+        assert res.nameservers == ["4.4.4.4", "8.8.8.8"]
+
+    def test_nameservers_with_ports(self):
+        res = dnsutil.DNSResolver()
+        res.nameservers = ["4.4.4.4 port 53", "8.8.8.8 port 8053"]
+        assert res.nameservers == ["4.4.4.4", "8.8.8.8"]
+        assert res.nameserver_ports == {"4.4.4.4": 53, "8.8.8.8": 8053}
+
+        res.nameservers = ["4.4.4.4 port 53", "8.8.8.8  port  8053"]
+        assert res.nameservers == ["4.4.4.4", "8.8.8.8"]
+        assert res.nameserver_ports == {"4.4.4.4": 53, "8.8.8.8": 8053}
+
+    def test_nameservers_with_bad_ports(self):
+        res = dnsutil.DNSResolver()
+        try:
+            res.nameservers = ["4.4.4.4 port a"]
+        except ValueError:
+            pass
+        else:
+            pytest.fail("No fail on bad port a")
+
+        try:
+            res.nameservers = ["4.4.4.4 port -1"]
+        except ValueError:
+            pass
+        else:
+            pytest.fail("No fail on bad port -1")
+
+        try:
+            res.nameservers = ["4.4.4.4 port 65536"]
+        except ValueError:
+            pass
+        else:
+            pytest.fail("No fail on bad port 65536")


### PR DESCRIPTION
DNSResolver: Fix use of nameservers with ports

IPA DNS zone and forwardzone commands allow to use nameservers with ports
as "SERVER_IP port PORT_NUMBER". bind is supporting this syntax, but the
Resolver in dnspython that is used to verify the list of forwarders
(nameservers) is only allowing to have IP addresses in this list. With
dnspython version 2.20 there is a new validator in dns.resolver.BaseResolver
that ensures this.

Refs:
- https://bind9.readthedocs.io/en/v9_18_4/reference.html#zone-statement-grammar
- https://github.com/rthalley/dnspython/blob/master/dns/resolver.py#L1094

ipapython/dnsutil.DNSResolver derives from dns.resolver.Resolver. The setter
for nameservers has been overloaded in the DNSResolver class to split out the
port numbers into the nameserver_ports dict { SERVER_IP: PORT_NUMBER }.
After the setter for nameservers succeeded, nameserver_ports is set.

Additional tests have been added to verify that nameservers and also
nameserver_ports are properly set and also valid.

Fixes: https://pagure.io/freeipa/issue/9158