### PR TITLE
[Backport][ipa-4-10] upgrades: Don't restart the CA on ACME and profile schema change

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1888,9 +1888,12 @@ def upgrade_configuration():
     custodia = custodiainstance.CustodiaInstance(api.env.host, api.env.realm)
     custodia.upgrade_instance()
 
+    # Don't include schema upgrades in restart consideration, see
+    # https://pagure.io/freeipa/issue/9204
+    ca_upgrade_schema(ca)
+
     ca_restart = any([
         ca_restart,
-        ca_upgrade_schema(ca),
         certificate_renewal_update(ca, kra, ds, http),
         ca_enable_pkix(ca),
         ca_configure_profiles_acl(ca),


### PR DESCRIPTION
This PR was opened automatically because PR #6386 was pushed to master and backport to ipa-4-10 is required.