### PR TITLE
[Backport][ipa-4-10] Remove pki_restart_configured_instance

### DIFF
--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -67,7 +67,6 @@ pki_replication_password=
 
 pki_enable_proxy=True
 pki_ajp_secret=%(ipa_ajp_secret)s
-pki_restart_configured_instance=False
 pki_security_domain_hostname=%(ipa_fqdn)s
 pki_security_domain_https_port=443
 pki_security_domain_name=IPA


### PR DESCRIPTION
This PR was opened automatically because PR #6389 was pushed to master and backport to ipa-4-10 is required.