### PR TITLE
Fix ipa-ccache-sweeper activation timer and clean up service file

### DIFF
--- a/init/systemd/ipa-ccache-sweep.service.in
+++ b/init/systemd/ipa-ccache-sweep.service.in
@@ -8,6 +8,3 @@ Environment=LC_ALL=C.UTF-8
 ExecStart=@libexecdir@/ipa/ipa-ccache-sweeper
 PrivateTmp=yes
 User=ipaapi
-
-[Install]
-WantedBy=multi-user.target

--- a/init/systemd/ipa-ccache-sweep.timer.in
+++ b/init/systemd/ipa-ccache-sweep.timer.in
@@ -2,6 +2,7 @@
 Description=Remove Expired Kerberos Credential Caches
 
 [Timer]
+OnActiveSec=12h
 OnUnitActiveSec=12h
 
 [Install]


### PR DESCRIPTION
Added OnActiveSec=12h to start the timer cycle because OnUnitActiveSec setting alone never triggers the timer after boot as there has not been transition between active and inactive state.
Removed [Install] section from sweeper.service as it is not needed

Fixes: https://pagure.io/freeipa/issue/9231
Signed-off-by: Jesse Sandberg <jesse.sandberg@netcode.fi>