### PR TITLE
[ipatests] Set pkeys in test_selinuxusermap.py::test_misc::delete_record

### DIFF
--- a/ipatests/test_webui/test_selinuxusermap.py
+++ b/ipatests/test_webui/test_selinuxusermap.py
@@ -146,7 +146,7 @@ class test_selinuxusermap(UI_driver):
         self.add_record(selinuxmap.ENTITY, [selinuxmap.DATA, selinuxmap.DATA2])
 
         # test delete multiple records
-        self.delete_record([selinuxmap.DATA, selinuxmap.DATA2])
+        self.delete_record([selinuxmap.PKEY, selinuxmap.PKEY2])
 
         # test add and cancel adding record
         self.add_record(selinuxmap.ENTITY, selinuxmap.DATA,


### PR DESCRIPTION
The test_selinuxusermap.py::test_selinuxusermap::test_misc is failing
because the 'delete_record' function (located in the same file) is passing
incorrect parameters: it should take the 'pkeys' instead of the full
data.

The changes will take the right 'pkeys' parameters in the 'test_misc()'
function.

Fixes: https://pagure.io/freeipa/issue/9161

Signed-off-by: Carla Martinez <carlmart@redhat.com>