### PR TITLE
[Backport][ipa-4-10] Fix ipa-ccache-sweeper activation timer and clean up service file

### DIFF
--- a/init/systemd/ipa-ccache-sweep.service.in
+++ b/init/systemd/ipa-ccache-sweep.service.in
@@ -8,6 +8,3 @@ Environment=LC_ALL=C.UTF-8
 ExecStart=@libexecdir@/ipa/ipa-ccache-sweeper
 PrivateTmp=yes
 User=ipaapi
-
-[Install]
-WantedBy=multi-user.target

--- a/init/systemd/ipa-ccache-sweep.timer.in
+++ b/init/systemd/ipa-ccache-sweep.timer.in
@@ -2,6 +2,7 @@
 Description=Remove Expired Kerberos Credential Caches
 
 [Timer]
+OnActiveSec=12h
 OnUnitActiveSec=12h
 
 [Install]


### PR DESCRIPTION
This PR was opened automatically because PR #6430 was pushed to master and backport to ipa-4-10 is required.