### PR TITLE
[Backport][ipa-4-9] [ipatests] Set pkeys in test_selinuxusermap.py::test_misc::delete_record

### DIFF
--- a/ipatests/test_webui/test_selinuxusermap.py
+++ b/ipatests/test_webui/test_selinuxusermap.py
@@ -146,7 +146,7 @@ class test_selinuxusermap(UI_driver):
         self.add_record(selinuxmap.ENTITY, [selinuxmap.DATA, selinuxmap.DATA2])
 
         # test delete multiple records
-        self.delete_record([selinuxmap.DATA, selinuxmap.DATA2])
+        self.delete_record([selinuxmap.PKEY, selinuxmap.PKEY2])
 
         # test add and cancel adding record
         self.add_record(selinuxmap.ENTITY, selinuxmap.DATA,


### PR DESCRIPTION
This PR was opened automatically because PR #6431 was pushed to master and backport to ipa-4-9 is required.