### PR TITLE
[ipa-4-6] ipatests: backport tasks.ldapsearch_dm

### DIFF
--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -58,7 +58,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f27
           name: freeipa/ci-ipa-4-6-f27
-          version: 1.0.3
+          version: 1.0.5
         timeout: 1800
         topology: *build
 

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1770,6 +1770,31 @@ def group_add(host, groupname, extra_args=()):
     return host.run_command(cmd)
 
 
+def ldapsearch_dm(host, base, ldap_args, scope='sub', **kwargs):
+    """Run ldapsearch as Directory Manager
+
+    :param host: host object
+    :param base: Base DN
+    :param ldap_args: additional arguments to ldapsearch (filter, attributes)
+    :param scope: search scope (base, sub, one)
+    :param kwargs: additional keyword arguments to run_command()
+    :return: result object
+    """
+    args = [
+        'ldapsearch',
+        '-x', '-ZZ',
+        '-H', "ldap://{}".format(host.hostname),
+        '-D', str(host.config.dirman_dn),
+        '-w', host.config.dirman_password,
+        '-s', scope,
+        '-b', base,
+        '-o', 'ldif-wrap=no',
+        '-LLL',
+    ]
+    args.extend(ldap_args)
+    return host.run_command(args, **kwargs)
+
+
 def create_temp_file(host, directory=None, create_file=True):
     """Creates temproray file using mktemp."""
     cmd = ['mktemp']


### PR DESCRIPTION
This method is needed by the backport fix for
TestOTPToken::test_check_otpd_after_idle_timeout

Related: https://pagure.io/freeipa/issue/9044