### PR TITLE
docs: pin package version for cryptography

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -19,7 +19,7 @@ requests
 
 ## C libraries with binary wheels
 cffi
-cryptography
+cryptography==37.0.4  # Issue: https://pagure.io/freeipa/issue/9160
 lxml
 
 ## C libraries without binaries wheels


### PR DESCRIPTION
Sphinx install packages from pypi, so there's a mismatch between pypi and fedora packages. 
**This is a temporary solution to unblock CI** while a new implementation of the custom X509 Certificate class addresses the problem.

Issue: https://pagure.io/freeipa/issue/9160
