### PR TITLE
webui: Show 'Sudo order' column

### DIFF
--- a/install/ui/src/freeipa/sudo.js
+++ b/install/ui/src/freeipa/sudo.js
@@ -47,6 +47,7 @@ var spec = {
             row_enabled_attribute: 'ipaenabledflag',
             columns: [
                 'cn',
+                'sudoorder',
                 {
                     name: 'ipaenabledflag',
                     label: '@i18n:status.label',


### PR DESCRIPTION
In the 'Sudo rules' page, the 'Sudo order' column should be visible in the list so the users can easily see which rules override other rules based on their order.

Fixes: https://pagure.io/freeipa/issue/9237
Signed-off-by: Carla Martinez <carlmart@redhat.com>