### PR TITLE
Fix 389-ds healthcheck output message

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1306,9 +1306,6 @@ class TestIpaHealthCheck(IntegrationTest):
         """
         error_msg = (
             "\n\nIn Directory Server, we offer one hash suitable for this "
-            "(PBKDF2_SHA256) and one hash\nfor \"legacy\" support (SSHA512)."
-            "\n\nYour configuration does not use these for password storage "
-            "or the root password storage\nscheme.\n"
         )
         returncode, data = run_healthcheck(
             self.master, "ipahealthcheck.ds.config", "ConfigCheck",


### PR DESCRIPTION
With the commit #99a74d7, 389-ds changed the message returned in ipa-healthcheck.

Previously the message was:

"\n\nIn Directory Server, we offer one hash suitable for this " "(PBKDF2_SHA256) and one hash\nfor \"legacy\" support (SSHA512)." "\n\nYour configuration does not use these for password storage " "or the root password storage\nscheme.\n"

but now the message is:

\n\nIn Directory Server, we offer one hash suitable for this " "(PBKDF2-SHA512) and one hash\nfor \"legacy\" support (SSHA512)." "\n\nYour configuration does not use these for password storage " "or the root password storage\nscheme.\n"

PBKDF2_SHA256 has been replaced with PBKDF2-SHA512

Pagure: https://pagure.io/freeipa/issue/9238

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>