### PR TITLE
[ipa-4-10] Tests: test on f37 and f36

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -30,7 +30,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
-          name: freeipa/ci-ipa-4-10-f36
+          name: freeipa/ci-ipa-4-10-f37
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
-          name: freeipa/ci-ipa-4-10-f36
+          name: freeipa/ci-ipa-4-10-f37
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
-          name: freeipa/ci-ipa-4-10-f36
+          name: freeipa/ci-ipa-4-10-f37
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-previous
-          name: freeipa/ci-ipa-4-10-f35
+          name: freeipa/ci-ipa-4-10-f36
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -56,7 +56,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
-          name: freeipa/ci-ipa-4-10-f36
+          name: freeipa/ci-ipa-4-10-f37
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -6,8 +6,10 @@
 
 import re
 import os
+import pytest
 import textwrap
 
+from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipatests.pytest_ipa.integration import tasks
@@ -50,6 +52,9 @@ class TestIpaAdTrustInstall(IntegrationTest):
         res = self.master.run_command(['testparm', '-s'])
         assert 'ERROR' not in (res.stdout_text + res.stderr_text)
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
+        reason='freeipa ticket 9234', strict=True)
     def test_add_agent_not_allowed(self):
         """Check that add-agents can be run only by Admins."""
         user = "nonadmin"
@@ -251,6 +256,9 @@ class TestIpaAdTrustInstall(IntegrationTest):
                  '"member","ipaexternalmember")')
         assert value in entry_list
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
+        reason='freeipa ticket 9234', strict=True)
     def test_ipa_user_pac(self):
         """Test that a user can request a service ticket with PAC"""
         user = 'testpacuser'
@@ -279,6 +287,9 @@ class TestIpaAdTrustInstall(IntegrationTest):
             tasks.kinit_admin(self.master)
             self.master.run_command(['ipa', 'user-del', user])
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
+        reason='freeipa ticket 9234', strict=True)
     def test_ipa_user_s4u2self_pac(self):
         """Test that a service can request S4U2Self ticket with PAC"""
         user = 'tests4u2selfuser'

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -24,6 +24,7 @@ from datetime import datetime, timedelta
 
 from ipalib.constants import IPAAPI_USER
 
+from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 
 from ipapython.dn import DN
@@ -1606,6 +1607,9 @@ class TestIPACommandWithoutReplica(IntegrationTest):
         tasks.ldapsearch_dm(self.master, base, ldap_args=[], scope='sub')
         tasks.ldapsearch_dm(self.master, base, ldap_args=[], scope='base')
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
+        reason='freeipa ticket 9234', strict=True)
     def test_sid_generation(self):
         """
         Test SID generation

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -20,6 +20,7 @@ from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.firewall import Firewall
 from ipaplatform.tasks import tasks as platform_tasks
+from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 from ipapython.dnsutil import DNSResolver
 
@@ -324,6 +325,9 @@ class TestInstallDNSSECFirst(IntegrationTest):
 
         super(TestInstallDNSSECFirst, cls).uninstall(mh)
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
+        reason='freeipa ticket 9216', strict=True)
     def test_sign_root_zone(self):
         dnszone_add_dnssec(self.master, root_zone)
 
@@ -355,6 +359,9 @@ class TestInstallDNSSECFirst(IntegrationTest):
             self.replicas[0].ip, root_zone, timeout=300
         ), "Zone %s is not signed (replica)" % root_zone
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
+        reason='freeipa ticket 9216', strict=True)
     def test_delegation(self):
         dnszone_add_dnssec(self.master, example_test_zone)
 
@@ -420,6 +427,9 @@ class TestInstallDNSSECFirst(IntegrationTest):
             rtype="DS"
         ), "No DS record of '%s' returned from replica" % example_test_zone
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
+        reason='freeipa ticket 9216', strict=True)
     def test_chain_of_trust_drill(self):
         """
         Validate signed DNS records, using our own signed root zone
@@ -467,6 +477,9 @@ class TestInstallDNSSECFirst(IntegrationTest):
         self.master.run_command(args)
         self.replicas[0].run_command(args)
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
+        reason='freeipa ticket 9216', strict=True)
     def test_chain_of_trust_delv(self):
         """
         Validate signed DNS records, using our own signed root zone


### PR DESCRIPTION
Fedora 37 beta is now available, move the testing pipelines to

    fedora 37 for the _latest definitions
    fedora 36 for the _previous definition
