### PR TITLE
Fix upper bound of password policy grace limit

### DIFF
--- a/ipaserver/plugins/pwpolicy.py
+++ b/ipaserver/plugins/pwpolicy.py
@@ -406,7 +406,7 @@ class pwpolicy(LDAPObject):
             label=_('Grace login limit'),
             doc=_('Number of LDAP authentications allowed after expiration'),
             minvalue=-1,
-            maxvalue=Int.MAX_UINT32,
+            maxvalue=Int.MAXINT,
             default=-1,
             autofill=True,
         ),

--- a/ipatests/test_xmlrpc/test_pwpolicy_plugin.py
+++ b/ipatests/test_xmlrpc/test_pwpolicy_plugin.py
@@ -25,6 +25,7 @@ import pytest
 
 from ipalib import api
 from ipalib import errors
+from ipalib.parameters import Int
 from ipapython.dn import DN
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.test_xmlrpc.xmlrpc_test import (XMLRPC_test, assert_attr_equal,
@@ -218,6 +219,17 @@ class test_pwpolicy(XMLRPC_test):
         entry = api.Command['pwpolicy_mod'](self.group,
                                             krbminpwdlife=50)['result']
         assert_attr_equal(entry, 'krbminpwdlife', '50')
+
+        # Test upper bound
+        entry = api.Command['pwpolicy_mod'](
+            self.group, passwordgracelimit=Int.MAXINT)['result']
+        assert_attr_equal(entry, 'passwordgracelimit', str(Int.MAXINT))
+
+        # Test bad values
+        for value in (Int.MAXINT + 1, -2):
+            with pytest.raises(errors.ValidationError):
+                entry = api.Command['pwpolicy_mod'](
+                    self.group, passwordgracelimit=value)['result']
 
     def test_maxlife_pwpolicy(self):
         """Check maxlife error message where minlife > maxlife specified


### PR DESCRIPTION
It was defined as an unsigned value (2**32) because it originally was. During the review an additional setting of disabled (-1) was added so the value needed to be signed. The upper bound needs to be 2**31 which is provided by the xmlrpc client MAXINT import.

Fixes: https://pagure.io/freeipa/issue/9243

Signed-off-by: Rob Crittenden <rcritten@redhat.com>