### PR TITLE
[Backport][ipa-4-10] webui: Show 'Sudo order' column

### DIFF
--- a/install/ui/src/freeipa/sudo.js
+++ b/install/ui/src/freeipa/sudo.js
@@ -47,6 +47,7 @@ var spec = {
             row_enabled_attribute: 'ipaenabledflag',
             columns: [
                 'cn',
+                'sudoorder',
                 {
                     name: 'ipaenabledflag',
                     label: '@i18n:status.label',


### PR DESCRIPTION
This PR was opened automatically because PR #6446 was pushed to master and backport to ipa-4-10 is required.