### PR TITLE
extdom: make sure result doesn't miss domain part

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_cmocka_tests.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_cmocka_tests.c
@@ -503,8 +503,8 @@ void test_pack_ber_user_timeout(void **state)
     oldgetgrgid_r = test_data->ctx->nss_ctx->getgrgid_r;
     test_data->ctx->nss_ctx->getgrgid_r = getgrgid_r_timeout;
 
-    ret = pack_ber_user(test_data->ctx, RESP_USER_GROUPLIST,
-                        TEST_DOMAIN_NAME, "member001", 12345, 54321,
+    ret = pack_ber_user(test_data->ctx, RESP_USER_GROUPLIST, TEST_DOMAIN_NAME,
+                        "member001@"TEST_DOMAIN_NAME, 12345, 54321,
                         "gecos", "homedir", "shell", NULL, &resp_val);
     test_data->ctx->nss_ctx->getgrgid_r = oldgetgrgid_r;
     assert_int_equal(ret, LDAP_TIMELIMIT_EXCEEDED);
@@ -548,15 +548,17 @@ void test_encode(void **state)
     assert_memory_equal(res_nam, resp_val->bv_val, resp_val->bv_len);
     ber_bvfree(resp_val);
 
-    ret = pack_ber_user(ctx, RESP_USER, TEST_DOMAIN_NAME, "test", 12345, 54321,
-                        NULL, NULL, NULL, NULL, &resp_val);
+    ret = pack_ber_user(ctx, RESP_USER, TEST_DOMAIN_NAME,
+                        "test@"TEST_DOMAIN_NAME, 12345, 54321, NULL, NULL,
+                        NULL, NULL, &resp_val);
     assert_int_equal(ret, LDAP_SUCCESS);
     assert_int_equal(sizeof(res_uid), resp_val->bv_len);
     assert_memory_equal(res_uid, resp_val->bv_val, resp_val->bv_len);
     ber_bvfree(resp_val);
 
-    ret = pack_ber_group(RESP_GROUP, TEST_DOMAIN_NAME, "test_group", 54321,
-                         NULL, NULL, &resp_val);
+    ret = pack_ber_group(RESP_GROUP, TEST_DOMAIN_NAME,
+                         "test_group@"TEST_DOMAIN_NAME, 54321, NULL, NULL,
+                         &resp_val);
     assert_int_equal(ret, LDAP_SUCCESS);
     assert_int_equal(sizeof(res_gid), resp_val->bv_len);
     assert_memory_equal(res_gid, resp_val->bv_val, resp_val->bv_len);

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_common.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_common.c
@@ -526,6 +526,20 @@ int pack_ber_sid(const char *sid, struct berval **berval)
     return LDAP_SUCCESS;
 }
 
+static char *get_short_name(const char *fqdn, const char *domain_name)
+{
+    const char *pos = strrchr(fqdn, SSSD_DOMAIN_SEPARATOR);
+    if (pos == NULL) {
+        return NULL;
+    }
+
+    if (strcasecmp(pos + 1, domain_name) != 0) {
+        return NULL;
+    }
+
+    return strndup(fqdn, pos - fqdn);
+}
+
 int pack_ber_user(struct ipa_extdom_ctx *ctx,
                   enum response_types response_type,
                   const char *domain_name, const char *user_name,
@@ -542,19 +556,13 @@ int pack_ber_user(struct ipa_extdom_ctx *ctx,
     char *buf = NULL;
     struct group grp;
     size_t c;
-    char *locat;
     char *short_user_name = NULL;
 
-    short_user_name = strdup(user_name);
-    if ((locat = strrchr(short_user_name, SSSD_DOMAIN_SEPARATOR)) != NULL) {
-        if (strcasecmp(locat+1, domain_name) == 0  ) {
-            locat[0] = '\0';
-        } else {
-            /* The found object is from a different domain than requested,
-             * that means it does not exist in the requested domain */
-            ret = LDAP_NO_SUCH_OBJECT;
-            goto done;
-        }
+    short_user_name = get_short_name(user_name, domain_name);
+    if (short_user_name == NULL) {
+        /* domain mismatch */
+        ret = LDAP_NO_SUCH_OBJECT;
+        goto done;
     }
 
     ber = ber_alloc_t( LBER_USE_DER );
@@ -657,19 +665,13 @@ int pack_ber_group(enum response_types response_type,
     BerElement *ber = NULL;
     int ret;
     size_t c;
-    char *locat;
     char *short_group_name = NULL;
 
-    short_group_name = strdup(group_name);
-    if ((locat = strrchr(short_group_name, SSSD_DOMAIN_SEPARATOR)) != NULL) {
-        if (strcasecmp(locat+1, domain_name) == 0  ) {
-            locat[0] = '\0';
-        } else {
-            /* The found object is from a different domain than requested,
-             * that means it does not exist in the requested domain */
-            ret = LDAP_NO_SUCH_OBJECT;
-            goto done;
-        }
+    short_group_name = get_short_name(group_name, domain_name);
+    if (short_group_name == NULL) {
+        /* domain mismatch */
+        ret = LDAP_NO_SUCH_OBJECT;
+        goto done;
     }
 
     ber = ber_alloc_t( LBER_USE_DER );

--- a/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_common.c
+++ b/daemons/ipa-slapi-plugins/ipa-extdom-extop/ipa_extdom_common.c
@@ -106,7 +106,7 @@ static int inc_buffer(size_t buf_max, size_t *_buf_len, char **_buf)
     return 0;
 }
 
-int __nss_to_err(enum nss_status errcode)
+static int __nss_to_err(enum nss_status errcode)
 {
     switch(errcode) {
     case NSS_STATUS_SUCCESS:
@@ -735,8 +735,8 @@ done:
     return ret;
 }
 
-int pack_ber_name_list(struct extdom_req *req, char **fq_name_list,
-                       struct berval **berval)
+static int pack_ber_name_list(struct extdom_req *req, char **fq_name_list,
+                              struct berval **berval)
 {
     BerElement *ber = NULL;
     int ret;


### PR DESCRIPTION
`extdom`: make sure result doesn't miss domain part. This is required to ensure that only objects from requested domain
are returned.