### PR TITLE
ipa otptoken-sync: return error when sync fails

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -1513,6 +1513,9 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
         }
     }
 
+    /* Reset rc to make sure errors are reported*/
+    rc = LDAP_INVALID_CREDENTIALS;
+
     /* Authenticate the user. */
     ret = ipapwd_authenticate(dn, entry, credentials);
     if (ret) {

--- a/ipaclient/plugins/otptoken.py
+++ b/ipaclient/plugins/otptoken.py
@@ -22,6 +22,7 @@ import sys
 
 from ipaclient.frontend import MethodOverride
 from ipalib import api, Str, Password, _
+from ipalib import errors
 from ipalib.messages import add_message, ResultFormattingError
 from ipalib.plugable import Registry
 from ipalib.frontend import Local
@@ -176,11 +177,13 @@ class otptoken_sync(Local):
             status['result'][self.header] = rsp.info().get(self.header, 'unknown')
         rsp.close()
 
+        if status['result'][self.header] != "ok":
+            msg = {'error': 'Error contacting server!',
+                   'invalid-credentials': 'Invalid Credentials!',
+                   }.get(status['result'][self.header], 'Unknown Error!')
+            raise errors.ExecutionError(
+                message=_("Unable to synchronize token: %s") % msg)
         return status
 
     def output_for_cli(self, textui, result, *keys, **options):
-        textui.print_plain({
-            'ok': 'Token synchronized.',
-            'error': 'Error contacting server!',
-            'invalid-credentials': 'Invalid Credentials!',
-        }.get(result['result'][self.header], 'Unknown Error!'))
+        textui.print_plain('Token synchronized.')


### PR DESCRIPTION
The command ipa otptoken-sync does not properly handle
errors happening during the synchronization step.

- Even if an error is detected (such as invalid password
provided), the command exits with return code = 0. An
error message is displayed but the exit code should be 1.

- When an invalid token is provided, the token is not
synchronized but the error is not reported back to the
ipa otptoken-sync command.

The first issue can be fixed by raising an exception when
the HTTP response contains an header with an error.
The second issue is fixed by returning LDAP_INVALID_CREDENTIALS
to ldap bind with the sync control if synchronization fails.

Fixes: https://pagure.io/freeipa/issue/9248