### PR TITLE
Move client certificate request after krb5.conf is created

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3089,8 +3089,6 @@ def _install(options, tdict):
 
     if not options.on_master:
         client_dns(cli_server[0], hostname, options)
-        configure_certmonger(fstore, subject_base, cli_realm, hostname,
-                             options, ca_enabled)
 
     update_ssh_keys(hostname, paths.SSH_CONFIG_DIR, options.create_sshfp)
 
@@ -3288,6 +3286,11 @@ def _install(options, tdict):
             force=options.force)
 
         logger.info("Configured /etc/krb5.conf for IPA realm %s", cli_realm)
+
+        # Configure certmonger after krb5.conf is created and last
+        # to give higher chance that the new client is replicated.
+        configure_certmonger(fstore, subject_base, cli_realm, hostname,
+                             options, ca_enabled)
 
     statestore.delete_state('installation', 'complete')
     statestore.backup_state('installation', 'complete', True)


### PR DESCRIPTION
Move client certificate request after krb5.conf is created

The creation of krb5.conf was moved to the end of the script
as part of maintaining server affinity during ipa-client-install.
If the installation is faster than replication then requests
against some IPA servers may fail because the client entry is
not yet present.

This is more difficult with certmonger as it will only use
/etc/krb5.conf. There is no way of knowing, even at the end
of the client installation, that replication has finished.

Certificate issuance may fail during ipa-client-install but
certmonger will re-try the request.

Fixes: https://pagure.io/freeipa/issue/9246

Signed-off-by: Rob Crittenden <rcritten@redhat.com>