### PR TITLE
ipatests: add keycloak user login to ipa test

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2165,6 +2165,17 @@ def create_active_user(host, login, password, first='test', last='user',
     kdestroy_all(host)
 
 
+def set_user_password(host, username, password):
+    temppass = "redhat\nredhat"
+    sendpass = f"redhat\n{password}\n{password}"
+    kdestroy_all(host)
+    kinit_admin(host)
+    host.run_command(["ipa", "passwd", username],stdin_text=temppass)
+    host.run_command(["kinit", username], stdin_text=sendpass)
+    kdestroy_all(host)
+    kinit_admin(host)
+
+
 def kdestroy_all(host):
     return host.run_command(['kdestroy', '-A'])
 


### PR DESCRIPTION
Adding test case to test_sso.py to cover login to IPA client as Keycloak user without relying on external IdP.

create_bridge.py:
- getkeytab in setup_scim_server to allow bridge to use IPA API.
- fix unintstall to remove plugin by version instead of main

test_sso.py:
- add keycloak_add_user function
- add ipa_set_user_password to only set password
- add test_ipa_login_with_sso_user

Fixes: https://pagure.io/freeipa/issue/9250
Signed-off-by: Scott Poore <spoore@redhat.com>