### PR TITLE
[Backport][ipa-4-6] ipa otptoken-sync: return error when sync fails

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -1502,6 +1502,9 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
         }
     }
 
+    /* Reset rc to make sure errors are reported*/
+    rc = LDAP_INVALID_CREDENTIALS;
+
     /* Authenticate the user. */
     ret = ipapwd_authenticate(dn, entry, credentials);
     if (ret) {

--- a/ipaclient/plugins/otptoken.py
+++ b/ipaclient/plugins/otptoken.py
@@ -27,7 +27,6 @@ from ipalib.messages import add_message, ResultFormattingError
 from ipalib.plugable import Registry
 from ipalib.frontend import Local
 from ipalib.util import create_https_connection
-from ipapython.dn import DN
 from ipapython.version import API_VERSION
 
 import locale
@@ -162,13 +161,13 @@ class otptoken_sync(Local):
         sync_uri = urllib.parse.urlunparse(segments)
 
         # Prepare the query.
-        query = {k: v for k, v in kwargs.items()
-                    if k in {x.name for x in self.takes_options}}
+        options = {x.name for x in self.takes_options}
+        query = {k: v for k, v in kwargs.items() if k in options}
         if args and args[0] is not None:
-            obj = self.api.Object.otptoken
-            query['token'] = DN((obj.primary_key.name, args[0]),
-                                obj.container_dn, self.api.env.basedn)
+            # sync_token converts token name to token DN
+            query['token'] = args[0]
         query = urllib.parse.urlencode(query)
+        query = query.encode('utf-8')
 
         # Sync the token.
         # pylint: disable=E1101

--- a/ipaclient/plugins/otptoken.py
+++ b/ipaclient/plugins/otptoken.py
@@ -22,6 +22,7 @@ import sys
 
 from ipaclient.frontend import MethodOverride
 from ipalib import api, Str, Password, _
+from ipalib import errors
 from ipalib.messages import add_message, ResultFormattingError
 from ipalib.plugable import Registry
 from ipalib.frontend import Local
@@ -180,11 +181,13 @@ class otptoken_sync(Local):
             status['result'][self.header] = rsp.info().get(self.header, 'unknown')
         rsp.close()
 
+        if status['result'][self.header] != "ok":
+            msg = {'error': 'Error contacting server!',
+                   'invalid-credentials': 'Invalid Credentials!',
+                   }.get(status['result'][self.header], 'Unknown Error!')
+            raise errors.ExecutionError(
+                message=_("Unable to synchronize token: %s") % msg)
         return status
 
     def output_for_cli(self, textui, result, *keys, **options):
-        textui.print_plain({
-            'ok': 'Token synchronized.',
-            'error': 'Error contacting server!',
-            'invalid-credentials': 'Invalid Credentials!',
-        }.get(result['result'][self.header], 'Unknown Error!'))
+        textui.print_plain('Token synchronized.')

--- a/ipatests/test_integration/test_otp.py
+++ b/ipatests/test_integration/test_otp.py
@@ -32,6 +32,7 @@ from ipapython.dn import DN
 PASSWORD = "DummyPassword123"
 USER = "opttestuser"
 ARMOR = "/tmp/armor"
+OTP_SYNC_INPUT="{}\n{}\n{}\n"
 logger = logging.getLogger(__name__)
 
 
@@ -210,7 +211,8 @@ class TestOTPToken(IntegrationTest):
         # Try to sync with a wrong password
         result = self.master.run_command(
             ["ipa", "otptoken-sync", "--user", USER, otpuid],
-            stdin_text=f"invalidpwd\n{otp2}\n{otp3}\n", raiseonerr=False
+            stdin_text=OTP_SYNC_INPUT.format("invalidpwd", otp2, otp3),
+            raiseonerr=False
         )
         assert result.returncode == 1
         assert "Invalid Credentials!" in result.stderr_text
@@ -218,7 +220,7 @@ class TestOTPToken(IntegrationTest):
         # Now sync with the right values
         self.master.run_command(
             ["ipa", "otptoken-sync", "--user", USER, otpuid],
-            stdin_text=f"{PASSWORD}\n{otp2}\n{otp3}\n"
+            stdin_text=OTP_SYNC_INPUT.format(PASSWORD, otp2, otp3)
         )
 
     def test_otptoken_sync_incorrect_first_value(self, desynchronized_hotp):
@@ -232,7 +234,8 @@ class TestOTPToken(IntegrationTest):
         # Try to sync with a wrong first value (contains non-digit)
         result = self.master.run_command(
             ["ipa", "otptoken-sync", "--user", USER, otpuid],
-            stdin_text=f"{PASSWORD}\n{otp2}\n{otp3}\n", raiseonerr=False
+            stdin_text=OTP_SYNC_INPUT.format(PASSWORD, otp2, otp3),
+            raiseonerr=False
         )
         assert result.returncode == 1
         assert "Invalid Credentials!" in result.stderr_text
@@ -240,7 +243,7 @@ class TestOTPToken(IntegrationTest):
         # Now sync with the right values
         self.master.run_command(
             ["ipa", "otptoken-sync", "--user", USER, otpuid],
-            stdin_text=f"{PASSWORD}\n{otp3}\n{otp4}\n"
+            stdin_text=OTP_SYNC_INPUT.format(PASSWORD, otp3, otp4)
         )
 
     def test_otptoken_sync_incorrect_second_value(self, desynchronized_hotp):
@@ -252,7 +255,8 @@ class TestOTPToken(IntegrationTest):
         # Try to sync with wrong order
         result = self.master.run_command(
             ["ipa", "otptoken-sync", "--user", USER, otpuid],
-            stdin_text=f"{PASSWORD}\n{otp3}\n{otp2}\n", raiseonerr=False
+            stdin_text=OTP_SYNC_INPUT.format(PASSWORD, otp3, otp2),
+            raiseonerr=False
         )
         assert result.returncode == 1
         assert "Invalid Credentials!" in result.stderr_text
@@ -260,7 +264,7 @@ class TestOTPToken(IntegrationTest):
         # Now sync with the right order
         self.master.run_command(
             ["ipa", "otptoken-sync", "--user", USER, otpuid],
-            stdin_text=f"{PASSWORD}\n{otp2}\n{otp3}\n"
+            stdin_text=OTP_SYNC_INPUT.format(PASSWORD, otp2, otp3)
         )
 
     def test_totp(self):

--- a/ipatests/test_integration/test_otp.py
+++ b/ipatests/test_integration/test_otp.py
@@ -186,6 +186,83 @@ class TestOTPToken(IntegrationTest):
 
         del_otptoken(master, otpuid)
 
+    @pytest.fixture
+    def desynchronized_hotp(self):
+        """ Create an hotp token for user """
+        tasks.kinit_admin(self.master)
+        otpuid, hotp = add_otptoken(self.master, USER, otptype="hotp")
+
+        # skipping too many OTP fails
+        otp1 = hotp.generate(10).decode("ascii")
+        kinit_otp(self.master, USER, password=PASSWORD, otp=otp1, success=False)
+        # Now the token is desynchronized
+        yield (otpuid, hotp)
+
+        del_otptoken(self.master, otpuid)
+
+    def test_otptoken_sync_incorrect_password(self, desynchronized_hotp):
+        """ Test if sync fails when incorrect password is provided """
+        otpuid, hotp = desynchronized_hotp
+
+        otp2 = hotp.generate(20).decode("ascii")
+        otp3 = hotp.generate(21).decode("ascii")
+
+        # Try to sync with a wrong password
+        result = self.master.run_command(
+            ["ipa", "otptoken-sync", "--user", USER, otpuid],
+            stdin_text=f"invalidpwd\n{otp2}\n{otp3}\n", raiseonerr=False
+        )
+        assert result.returncode == 1
+        assert "Invalid Credentials!" in result.stderr_text
+
+        # Now sync with the right values
+        self.master.run_command(
+            ["ipa", "otptoken-sync", "--user", USER, otpuid],
+            stdin_text=f"{PASSWORD}\n{otp2}\n{otp3}\n"
+        )
+
+    def test_otptoken_sync_incorrect_first_value(self, desynchronized_hotp):
+        """ Test if sync fails when incorrect 1st token value is provided """
+        otpuid, hotp = desynchronized_hotp
+
+        otp2 = "12345a"
+        otp3 = hotp.generate(20).decode("ascii")
+        otp4 = hotp.generate(21).decode("ascii")
+
+        # Try to sync with a wrong first value (contains non-digit)
+        result = self.master.run_command(
+            ["ipa", "otptoken-sync", "--user", USER, otpuid],
+            stdin_text=f"{PASSWORD}\n{otp2}\n{otp3}\n", raiseonerr=False
+        )
+        assert result.returncode == 1
+        assert "Invalid Credentials!" in result.stderr_text
+
+        # Now sync with the right values
+        self.master.run_command(
+            ["ipa", "otptoken-sync", "--user", USER, otpuid],
+            stdin_text=f"{PASSWORD}\n{otp3}\n{otp4}\n"
+        )
+
+    def test_otptoken_sync_incorrect_second_value(self, desynchronized_hotp):
+        """ Test if sync fails when incorrect 2nd token value is provided """
+        otpuid, hotp = desynchronized_hotp
+
+        otp2 = hotp.generate(20).decode("ascii")
+        otp3 = hotp.generate(21).decode("ascii")
+        # Try to sync with wrong order
+        result = self.master.run_command(
+            ["ipa", "otptoken-sync", "--user", USER, otpuid],
+            stdin_text=f"{PASSWORD}\n{otp3}\n{otp2}\n", raiseonerr=False
+        )
+        assert result.returncode == 1
+        assert "Invalid Credentials!" in result.stderr_text
+
+        # Now sync with the right order
+        self.master.run_command(
+            ["ipa", "otptoken-sync", "--user", USER, otpuid],
+            stdin_text=f"{PASSWORD}\n{otp2}\n{otp3}\n"
+        )
+
     def test_totp(self):
         master = self.master
 


### PR DESCRIPTION
This PR was opened automatically because PR #6472 was pushed to master and backport to ipa-4-6 is required.