### PR TITLE
ipa man page: format the EXAMPLES section

### DIFF
--- a/client/man/ipa.1
+++ b/client/man/ipa.1
@@ -136,8 +136,10 @@ O \- self\-obliterate
 .TP
 \fBipa help commands\fR
 Display a list of available commands
+.TP
 \fBipa help topics\fR
 Display a high\-level list of help topics
+.TP
 \fBipa help user\fR
 Display documentation and list of commands in the "user" topic.
 .TP


### PR DESCRIPTION
The EXAMPLES section is missing .TP macros before some of the provided examples, and they are displayed in the same paragraph.

Add .TP (tagged, indented paragraph) before each example.

Fixes: https://pagure.io/freeipa/issue/9252
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>