### PR TITLE
Exclude installed policy module file from RPM verification

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1726,7 +1726,7 @@ fi
 %if %{with selinux}
 %files selinux
 %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.*
-%ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}
+%ghost %verify(not md5 size mode mtime) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}
 # with selinux
 %endif
 


### PR DESCRIPTION
selinux: Update based on latest packaging guide
https://fedoraproject.org/wiki/SELinux/IndependentPolicy

Signed-off-by: Nikola Knazekova <nknazeko@redhat.com>