### PR TITLE
ipatests : Test for aduser-group management with posix AD trust

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_sssd:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_sssd.py::TestSSSDWithAdTrust
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -26,7 +26,6 @@ from ipapython.dn import DN
 
 
 class TestSSSDWithAdTrust(IntegrationTest):
-
     topology = 'star'
     num_ad_domains = 1
     num_ad_subdomains = 1
@@ -148,7 +147,7 @@ class TestSSSDWithAdTrust(IntegrationTest):
         try:
             with tasks.remote_sssd_config(self.master) as sssd_conf:
                 sssd_conf.edit_service("nss",
-                                      'filter_users', self.users[user]['name'])
+                                       'filter_users', self.users[user]['name'])
             tasks.clear_sssd_cache(self.master)
             yield
         finally:
@@ -266,6 +265,7 @@ class TestSSSDWithAdTrust(IntegrationTest):
 
         Regression test for https://pagure.io/SSSD/sssd/issue/4012
         """
+
         def get_cache_update_time(obj_kind, obj_name):
             res = self.master.run_command(
                 ['sssctl', '{}-show'.format(obj_kind), obj_name])
@@ -515,6 +515,44 @@ class TestSSSDWithAdTrust(IntegrationTest):
             with xfail_context(sssd_version < tasks.parse_version('2.3.0'),
                                'https://pagure.io/SSSD/sssd/issue/4061'):
                 assert 'gid={id}'.format(id=gid) in test_gid.stdout_text
+
+    def test_aduser_mgmt(self):
+        """Test for aduser-group management with posix AD trust
+
+        Verify that query to the AD specific attributes for a
+        user or a group directly is successful.
+
+        Related : https://pagure.io/freeipa/issue/9127
+        """
+        tasks.remove_trust_with_ad(self.master, self.ad.domain.name,
+                                   self.ad.hostname)
+        tasks.configure_windows_dns_for_trust(self.ad, self.master)
+        tasks.establish_trust_with_ad(
+            self.master, self.ad.domain.name,
+            extra_args=['--range-type', 'ipa-ad-trust-posix',
+                        '--two-way=true'])
+        aduser = 'mytestuser@%s' % self.ad.domain.name
+        tasks.clear_sssd_cache(self.master)
+        self.master.run_command(
+            ['getent', 'group', aduser],
+            ok_returncode=2)
+        sssd_conf_backup = tasks.FileBackup(self.master, paths.SSSD_CONF)
+        content = self.master.get_file_contents(paths.SSSD_CONF,
+                                                encoding='utf-8')
+        conf = content + "\n[domain/{0}/{1}]\nldap_group_name = info".format(
+            self.master.domain.name, self.ad.domain.name
+        )
+        self.master.put_file_contents(paths.SSSD_CONF, conf)
+        tasks.clear_sssd_cache(self.master)
+        tasks.clear_sssd_cache(self.clients[0])
+        try:
+            for host in [self.master, self.clients[0]]:
+                host.run_command(["id", aduser])
+                host.run_command(["getent", "passwd", aduser])
+                host.run_command(["getent", "group", aduser])
+        finally:
+            sssd_conf_backup.restore()
+            tasks.clear_sssd_cache(self.master)
 
 
 class TestNestedMembers(IntegrationTest):


### PR DESCRIPTION
 Verify that query to the AD specific attributes for a
 user or a group directly is successful.
    
 Related : https://pagure.io/freeipa/issue/9127
