### PR TITLE
Generate CNAME records pointing to location-aware TXT and URI Kerberos records

### DIFF
--- a/install/updates/90-post_upgrade_plugins.update
+++ b/install/updates/90-post_upgrade_plugins.update
@@ -42,3 +42,4 @@ plugin: update_dnsserver_configuration_into_ldap
 plugin: update_ldap_server_list
 plugin: update_dna_shared_config
 plugin: update_unhashed_password
+plugin: update_krb_uri_txt_records_for_locations


### PR DESCRIPTION
The IPA location system relies on DNS record priorities in order to give higher precedence to servers from the same location. For Kerberos, this is done by redirecting generic SRV records (e.g. `_kerberos._udp.[domain].`) to location-aware records (e.g. `_kerberos._udp.[location]._locations.[domain].`) using CNAMEs.

This commit applies the same logic for URI records. URI location-aware record were created, but there were no redirection from generic URI records. It was causing them to be ignored in practice.

Kerberos URI and TXT records have the same name: `_kerberos`. However, CNAME records cannot coexist with any other record type. To avoid this conflict, the generic TXT realm record was replaced by location-aware records, even if the content of these records is the same for all locations.

Fixes: https://pagure.io/freeipa/issue/9257