### PR TITLE
ipaclient: do not set TLS CA options in ldap.conf anymore

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -549,7 +549,7 @@ def configure_openldap_conf(fstore, cli_basedn, cli_server):
         {
             'name': 'comment',
             'type': 'comment',
-            'value': '   URI, BASE, TLS_CACERT and SASL_MECH'
+            'value': '   URI, BASE, and SASL_MECH'
         },
         {
             'name': 'comment',
@@ -598,12 +598,6 @@ def configure_openldap_conf(fstore, cli_basedn, cli_server):
             'name': 'BASE',
             'type': 'option',
             'value': str(cli_basedn)
-        },
-        {
-            'action': 'addifnotset',
-            'name': 'TLS_CACERT',
-            'type': 'option',
-            'value': paths.IPA_CA_CRT
         },
         {
             'action': 'addifnotset',

--- a/ipatests/test_ipaclient/test_ldapconf.py
+++ b/ipatests/test_ipaclient/test_ldapconf.py
@@ -84,7 +84,6 @@ def test_openldap_conf_empty():
     assert settings == {
         'BASE': [BASEDN],
         'URI': ['ldaps://{}'.format(SERVER)],
-        'TLS_CACERT': ['/etc/ipa/ca.crt'],
         'SASL_MECH': ['GSSAPI']
     }
 
@@ -96,7 +95,6 @@ def test_openldap_conf_spaces():
         'BASE': ['dc=example,dc=com'],
         'URI': ['ldap://ldap.example.com'],
         'SASL_NOCANON': ['on'],
-        'TLS_CACERT': ['/etc/ipa/ca.crt'],
         'SASL_MECH': ['GSSAPI']
     }
 
@@ -109,6 +107,5 @@ def test_openldap_conf_mixed():
         'BASE': ['dc=example,dc=com'],
         'URI': ['ldap://ldap.example.com ldap://ldap-master.example.com:666'],
         'SASL_NOCANON': ['on'],
-        'TLS_CACERT': ['/etc/ipa/ca.crt'],
         'SASL_MECH': ['GSSAPI']
     }


### PR DESCRIPTION
OpenLDAP has made it explicit to use default CA store as provided by OpenSSL in 2016:

	branches 2.5 and later:
	commit 4962dd6083ae0fe722eb23a618ad39e47611429b
	Author: Howard Guo <hguo@suse.com>
	Date:   Thu Nov 10 15:39:03 2016 +0100

	branch 2.4:
	commit e3affc71e05b33bfac43833c7b95fd7b7c3188f8
	Author: Howard Guo <hguo@suse.com>
	Date:   Thu Nov 10 15:39:03 2016 +0100

This means starting with OpenLDAP 2.4.45 we can drop the explicit CA configuration in ldap.conf.

There are several use cases where an explicit IPA CA should be specified in the configuration. These mostly concern situations where a higher security level must be maintained. For these configurations an administrator would need to add an explicit CA configuration to ldap.conf if we wouldn't add it during the ipa-client-install setup.

RN: FreeIPA client installer does not add explicit TLS CA configuration RN: to OpenLDAP's ldap.conf anymore. Since OpenLDAP 2.4.45, explicit CA RN: configuration is not required as OpenLDAP uses the default CA store RN: provided by OpenSSL and IPA CA is installed in the default store RN: by the installer already.

Fixes: https://pagure.io/freeipa/issue/9258

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>