### PR TITLE
[Backport][ipa-4-9] ipapython: Support openldap 2.6

### DIFF
--- a/ipapython/dn_ctypes.py
+++ b/ipapython/dn_ctypes.py
@@ -12,12 +12,15 @@ import six
 
 __all__ = ("str2dn", "dn2str", "DECODING_ERROR", "LDAPError")
 
-# load reentrant ldap client library (libldap_r-*.so.2)
-ldap_r_lib = ctypes.util.find_library("ldap_r-2")
-if ldap_r_lib is None:
-    raise ImportError("libldap_r shared library missing")
+# load reentrant ldap client library (libldap_r-*.so.2 or libldap.so.2)
+ldap_lib_filename = next(
+    filter(None, map(ctypes.util.find_library, ["ldap_r-2", "ldap"])), None
+)
+
+if ldap_lib_filename is None:
+    raise ImportError("libldap_r or libldap shared library missing")
 try:
-    lib = ctypes.CDLL(ldap_r_lib)
+    lib = ctypes.CDLL(ldap_lib_filename)
 except OSError as e:
     raise ImportError(str(e))
 

--- a/ipatests/azure/templates/prepare-tox-fedora.yml
+++ b/ipatests/azure/templates/prepare-tox-fedora.yml
@@ -2,6 +2,5 @@ steps:
 - script: |
     set -e
     sudo dnf -y install nss-tools python3-pip git
-    sudo ln -s /usr/lib64/libldap.so /usr/lib64/libldap_r.so
     python3 -m pip install --user --upgrade pip setuptools pycodestyle
   displayName: Install Tox prerequisites


### PR DESCRIPTION
This PR was opened automatically because PR #6494 was pushed to master and backport to ipa-4-9 is required.