### PR TITLE
Spec file: bump bind version on f37+

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -125,7 +125,12 @@
 # Fix for TLS 1.3 PHA, RHBZ#1775146
 %global httpd_version 2.4.41-9
 
+# Fix for RHBZ#2117342
+%if 0%{?fedora} < 37
 %global bind_version 9.11.24-1
+%else
+%global bind_version 32:9.18.7-1
+%endif
 # Don't use Fedora's Python dependency generator on Fedora 30/rawhide yet.
 # Some packages don't provide new dist aliases.
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/

--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -45,16 +45,15 @@ vms:
     - test_integration/test_external_ca.py::TestExternalCAInstall
 
 - vm_jobs:
-# Temporary disable - see https://pagure.io/freeipa/issue/9216
-#  - container_job: InstallDNSSECFirst
-#    containers:
-#      replicas: 1
-#      resources:
-#        replica:
-#          mem_limit: "2400m"
-#          memswap_limit: "3500m"
-#    tests:
-#    - test_integration/test_dnssec.py::TestInstallDNSSECFirst
+  - container_job: InstallDNSSECFirst
+    containers:
+      replicas: 1
+      resources:
+        replica:
+          mem_limit: "2400m"
+          memswap_limit: "3500m"
+    tests:
+    - test_integration/test_dnssec.py::TestInstallDNSSECFirst
 
   - container_job: simple_replication
     containers:

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -20,7 +20,6 @@ from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.firewall import Firewall
 from ipaplatform.tasks import tasks as platform_tasks
-from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 from ipapython.dnsutil import DNSResolver
 
@@ -325,9 +324,6 @@ class TestInstallDNSSECFirst(IntegrationTest):
 
         super(TestInstallDNSSECFirst, cls).uninstall(mh)
 
-    @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
-        reason='freeipa ticket 9216', strict=True)
     def test_sign_root_zone(self):
         dnszone_add_dnssec(self.master, root_zone)
 
@@ -359,9 +355,6 @@ class TestInstallDNSSECFirst(IntegrationTest):
             self.replicas[0].ip, root_zone, timeout=300
         ), "Zone %s is not signed (replica)" % root_zone
 
-    @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
-        reason='freeipa ticket 9216', strict=True)
     def test_delegation(self):
         dnszone_add_dnssec(self.master, example_test_zone)
 
@@ -427,9 +420,6 @@ class TestInstallDNSSECFirst(IntegrationTest):
             rtype="DS"
         ), "No DS record of '%s' returned from replica" % example_test_zone
 
-    @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
-        reason='freeipa ticket 9216', strict=True)
     def test_chain_of_trust_drill(self):
         """
         Validate signed DNS records, using our own signed root zone
@@ -477,9 +467,6 @@ class TestInstallDNSSECFirst(IntegrationTest):
         self.master.run_command(args)
         self.replicas[0].run_command(args)
 
-    @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
-        reason='freeipa ticket 9216', strict=True)
     def test_chain_of_trust_delv(self):
         """
         Validate signed DNS records, using our own signed root zone


### PR DESCRIPTION
### Spec file: bump bind version on f37+

On fedora37+, require at least bind 9.18.7-1 to avoid
dnssec regression (see BZ#2117342) related to bind and
OpenSSL 3.0 engine support.

Fixes: https://pagure.io/freeipa/issue/9216

### ipatests: re-enable dnssec tests

On fedora 37+ the dnssec tests were broken. The tests
launched for each pull request were disabled or marked
as xfail.
With the bump of bind version, they should now succeed
and can be re-enabled.

Related: https://pagure.io/freeipa/issue/9216