### PR TITLE
[Backport][ipa-4-9] ipaclient: do not set TLS CA options in ldap.conf anymore

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -549,7 +549,7 @@ def configure_openldap_conf(fstore, cli_basedn, cli_server):
         {
             'name': 'comment',
             'type': 'comment',
-            'value': '   URI, BASE, TLS_CACERT and SASL_MECH'
+            'value': '   URI, BASE, and SASL_MECH'
         },
         {
             'name': 'comment',
@@ -598,12 +598,6 @@ def configure_openldap_conf(fstore, cli_basedn, cli_server):
             'name': 'BASE',
             'type': 'option',
             'value': str(cli_basedn)
-        },
-        {
-            'action': 'addifnotset',
-            'name': 'TLS_CACERT',
-            'type': 'option',
-            'value': paths.IPA_CA_CRT
         },
         {
             'action': 'addifnotset',

--- a/ipatests/test_ipaclient/test_ldapconf.py
+++ b/ipatests/test_ipaclient/test_ldapconf.py
@@ -84,7 +84,6 @@ def test_openldap_conf_empty():
     assert settings == {
         'BASE': [BASEDN],
         'URI': ['ldaps://{}'.format(SERVER)],
-        'TLS_CACERT': ['/etc/ipa/ca.crt'],
         'SASL_MECH': ['GSSAPI']
     }
 
@@ -96,7 +95,6 @@ def test_openldap_conf_spaces():
         'BASE': ['dc=example,dc=com'],
         'URI': ['ldap://ldap.example.com'],
         'SASL_NOCANON': ['on'],
-        'TLS_CACERT': ['/etc/ipa/ca.crt'],
         'SASL_MECH': ['GSSAPI']
     }
 
@@ -109,6 +107,5 @@ def test_openldap_conf_mixed():
         'BASE': ['dc=example,dc=com'],
         'URI': ['ldap://ldap.example.com ldap://ldap-master.example.com:666'],
         'SASL_NOCANON': ['on'],
-        'TLS_CACERT': ['/etc/ipa/ca.crt'],
         'SASL_MECH': ['GSSAPI']
     }


### PR DESCRIPTION
This PR was opened automatically because PR #6496 was pushed to master and backport to ipa-4-9 is required.