### PR TITLE
[Backport][ipa-4-10] Fix 389-ds healthcheck output message

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1306,9 +1306,6 @@ class TestIpaHealthCheck(IntegrationTest):
         """
         error_msg = (
             "\n\nIn Directory Server, we offer one hash suitable for this "
-            "(PBKDF2_SHA256) and one hash\nfor \"legacy\" support (SSHA512)."
-            "\n\nYour configuration does not use these for password storage "
-            "or the root password storage\nscheme.\n"
         )
         returncode, data = run_healthcheck(
             self.master, "ipahealthcheck.ds.config", "ConfigCheck",


### PR DESCRIPTION
This PR was opened automatically because PR #6450 was pushed to master and backport to ipa-4-10 is required.