### PR TITLE
webui tests: fix test_subid suite

### DIFF
--- a/ipatests/test_webui/test_subid.py
+++ b/ipatests/test_webui/test_subid.py
@@ -13,7 +13,6 @@ import pytest
 
 try:
     from selenium.common.exceptions import NoSuchElementException
-    from selenium.webdriver.common.by import By
 except ImportError:
     pass
 
@@ -142,17 +141,10 @@ class test_subid(UI_driver):
         """
         self.init_app()
         self.navigate_to_entity('subid', facet='search')
-        self.facet_button_click('add')
-        self.select_combobox('ipaowner', 'admin')
-        self.dialog_button_click('add')
-        self.wait(0.3)
-        self.assert_no_error_dialog()
-        self.get_field_checked('ipauniqueid')
-        with pytest.raises(NoSuchElementException):
-            self.facet_button_click('remove')
-        buttons_s = 'div.control-buttons button'
-        facet_buttons = self.find(buttons_s, By.CSS_SELECTOR,
-                                  many=True, strict=True)
-        assert len(facet_buttons) == 2
-        assert facet_buttons[0].get_attribute('name') in ['add', 'refresh']
-        assert facet_buttons[1].get_attribute('name') in ['add', 'refresh']
+        admin_uid = self.get_record_pkey("admin", "ipaowner",
+                                         table_name="ipauniqueid")
+        with pytest.raises(NoSuchElementException) as excinfo:
+            self.delete_record(admin_uid, table_name="ipauniqueid")
+        # Ensure that the exception is really related to missing remove button
+        msg = "Unable to locate element: .facet-controls button[name=remove]"
+        assert msg in str(excinfo)


### PR DESCRIPTION
The webui test test_subid_range_deletion_not_allowed is
adding a new subid for the admin user but a previous
test already took care of that step.
Remove the call adding the subid.

2nd issue: a given record has to be selected in
order to check that there is no "delete" button.

Fixes: https://pagure.io/freeipa/issue/9214

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>