### PR TITLE
[Backport][ipa-4-10] Exclude installed policy module file from RPM verification

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1726,7 +1726,7 @@ fi
 %if %{with selinux}
 %files selinux
 %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.*
-%ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}
+%ghost %verify(not md5 size mode mtime) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}
 # with selinux
 %endif
 


### PR DESCRIPTION
This PR was opened automatically because PR #6483 was pushed to master and backport to ipa-4-10 is required.