### PR TITLE
[Backport][ipa-4-10] Spec file: bump the selinux-policy version

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -72,14 +72,16 @@
 %global python_netaddr_version 0.7.19
 # Require 4.7.0 which brings Python 3 bindings
 %global samba_version 4.12.3-12
-%global selinux_policy_version 3.14.3-52
 %global slapi_nis_version 0.56.4
 %global python_ldap_version 3.1.0-1
 %if 0%{?rhel} < 9
 # Bug 1929067 - PKI instance creation failed with new 389-ds-base build
 %global ds_version 1.4.3.16-12
+%global selinux_policy_version 3.14.3-107
 %else
 %global ds_version 2.0.3-3
+# TBD update selinux_policy_version when BZ#2114902 is fixed
+%global selinux_policy_version 3.14.3-52
 %endif
 
 # Fix for TLS 1.3 PHA, RHBZ#1775158
@@ -99,7 +101,12 @@
 %global samba_version 2:4.12.10
 
 # 3.14.5-45 or later includes a number of interfaces fixes for IPA interface
+# 36.16-1 fixes BZ#2115691
+%if 0%{?fedora} < 36
 %global selinux_policy_version 3.14.5-45
+%else
+%global selinux_policy_version 36.16-1
+%endif
 %global slapi_nis_version 0.56.5
 
 %global krb5_kdb_version 8.0


### PR DESCRIPTION
This is a manual backport of PR #6518 to ipa-4-10 branch. Cherry-pick didn't raise any issue.