### PR TITLE
ipatests: xfail test_ipa_login_with_sso_user

### DIFF
--- a/ipatests/test_integration/test_sso.py
+++ b/ipatests/test_integration/test_sso.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
 
+import pytest
 import textwrap
+from ipaplatform.osinfo import osinfo
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks, create_keycloak
 from ipatests.pytest_ipa.integration import create_bridge
@@ -120,6 +122,9 @@ class TestSsoBridge(IntegrationTest):
         password = self.keycloak.config.admin_password
         keycloak_login(self.keycloak, username, password, username_fl)
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
+        reason='freeipa ticket 9264', strict=True)
     def test_ipa_login_with_sso_user(self):
         """
         Test case to authenticate via ssh to IPA client as Keycloak


### PR DESCRIPTION
There is a crash occurring that causes Keycloak to be unable to communicate with ipa-tuura on the bridge server (replica0).  This is much more prevalent in Fedora 37 so we need to xfail that test case until the crash is resolved.

Related: https://pagure.io/freeipa/issue/9264

Signed-off-by: Scott Poore <spoore@redhat.com>