### PR TITLE
Test adding sleep to wait for cleanallruv task

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,124 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_topology_TestCASpecificRUVs:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest/test_topology_TestCASpecificRUVs_2:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest/test_topology_TestCASpecificRUVs_3:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest/test_topology_TestCASpecificRUVs_4:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest/test_topology_TestCASpecificRUVs_5:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest/test_topology_TestCASpecificRUVs_6:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest/test_topology_TestCASpecificRUVs_7:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest/test_topology_TestCASpecificRUVs_8:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest/test_topology_TestCASpecificRUVs_9:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  fedora-latest/test_topology_TestCASpecificRUVs_10:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1552,6 +1552,7 @@ def wait_for_cleanallruv_tasks(ldap, timeout=30):
             for e in entries
         ):
             logger.debug("All cleanallruv tasks finished successfully")
+            time.sleep(1)  # Give some time for RUV to be updated
             break
         logger.debug("cleanallruv task in progress, (waited %s/%ss)",
                      i, timeout)


### PR DESCRIPTION
This is just to see if a sleep helps the replica install/uninstall test case with cleanAllRuv.  Do not review this at this time.