### PR TITLE
[Backport][ipa-4-9] Add test for user root using admin password

### DIFF
--- a/ipatests/test_webui/data_loginscreen.py
+++ b/ipatests/test_webui/data_loginscreen.py
@@ -8,6 +8,9 @@ PKEY = 'itest-user'
 PASSWD_ITEST_USER = '12345678'
 PASSWD_ITEST_USER_NEW = '87654321'
 
+ROOT_PKEY = 'root'
+PASSWD_ADMIN = 'Secret.123'
+
 # used for add/delete fixture test user
 DATA_ITEST_USER = {
     'pkey': PKEY,

--- a/ipatests/test_webui/test_loginscreen.py
+++ b/ipatests/test_webui/test_loginscreen.py
@@ -401,3 +401,17 @@ class TestLoginScreen(UI_driver):
         self.wait(0.5)
         self.check_elements_of_form(loginscreen.LOGIN_FORM)
         self.check_alerts(loginscreen.LOGIN_FORM)
+
+    @screenshot
+    def test_root_login(self):
+        """
+        Verify logging as root, using admin password.
+        Root should be recognized as an alias for admin user.
+
+        Related: https://pagure.io/freeipa/issue/9226
+        """
+        self.load()
+        assert self.login_screen_visible()
+        self.login(loginscreen.ROOT_PKEY, loginscreen.PASSWD_ADMIN)
+
+        assert self.logged_in()


### PR DESCRIPTION
This PR was opened automatically because PR #6534 was pushed to master and backport to ipa-4-9 is required.