### PR TITLE
ipa-kdb: for delegation check, use different error codes before and a…

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_delegation.c
+++ b/daemons/ipa-kdb/ipa_kdb_delegation.c
@@ -273,7 +273,11 @@ krb5_error_code ipadb_check_allowed_to_delegate(krb5_context kcontext,
 
 done:
     if (kerr) {
+#if KRB5_KDB_DAL_MAJOR_VERSION < 9
+        kerr = KRB5KDC_ERR_POLICY;
+#else
         kerr = KRB5KDC_ERR_BADOPTION;
+#endif
     }
     ipadb_free_principal(kcontext, proxy_entry);
     krb5_free_unparsed_name(kcontext, srv_principal);


### PR DESCRIPTION
…fter krb5 1.20

With MIT krb5 1.20, a call to krb5_db_check_allowed_to_delegate() and krb5_db_check_allowed_to_delegate_from() expects to return either KRB5KDC_ERR_BADOPTION for a policy denial or KRB5_PLUGIN_OP_NOTSUPP in case plugin does not handle the policy case. This is part of the MIT krb5 commit a441fbe329ebbd7775eb5d4ccc4a05eef370f08b which added a minimal MS-PAC generator.

Prior to MIT krb5 1.20, the same call was expected to return either KRB5KDC_ERR_POLICY or KRB5_PLUGIN_OP_NOTSUPP errors.

Related: https://pagure.io/freeipa/issue/9083
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>