### PR TITLE
[Backport][ipa-4-10] ipa-kdb: for delegation check, use different error codes before and a…

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_delegation.c
+++ b/daemons/ipa-kdb/ipa_kdb_delegation.c
@@ -273,7 +273,11 @@ krb5_error_code ipadb_check_allowed_to_delegate(krb5_context kcontext,
 
 done:
     if (kerr) {
+#if KRB5_KDB_DAL_MAJOR_VERSION < 9
+        kerr = KRB5KDC_ERR_POLICY;
+#else
         kerr = KRB5KDC_ERR_BADOPTION;
+#endif
     }
     ipadb_free_principal(kcontext, proxy_entry);
     krb5_free_unparsed_name(kcontext, srv_principal);


### PR DESCRIPTION
This PR was opened automatically because PR #6541 was pushed to master and backport to ipa-4-10 is required.