### PR TITLE
Support tokens and optional password files when opening an NSS db

### DIFF
--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -256,7 +256,7 @@ class NSSDatabase:
     # BaseCertDB is a class that knows nothing about IPA.
     # Generic NSS DB code should be moved here.
 
-    def __init__(self, nssdir=None, dbtype='auto'):
+    def __init__(self, nssdir=None, dbtype='auto', token=None, pwd_file=None):
         if nssdir is not None:
             self.secdir = nssdir
             self._is_temporary = False
@@ -273,9 +273,13 @@ class NSSDatabase:
             self.secdir = tempfile.mkdtemp()
             self._is_temporary = True
 
-        self.pwd_file = os.path.join(self.secdir, 'pwdfile.txt')
+        if pwd_file is None:
+            self.pwd_file = os.path.join(self.secdir, 'pwdfile.txt')
+        else:
+            self.pwd_file = pwd_file
         self.dbtype = None
         self.certdb = self.keydb = self.secmod = None
+        self.token = token
         # files in actual db
         self.filenames = ()
         # all files that are handled by create_db(backup=True)
@@ -340,6 +344,8 @@ class NSSDatabase:
             "-d", '{}:{}'.format(self.dbtype, self.secdir)
         ]
         new_args.extend(args)
+        if self.token:
+            new_args.extend(["-h", self.token])
         new_args.extend(['-f', self.pwd_file])
         # When certutil makes a request it creates a file in the cwd, make
         # sure we are in a unique place when this happens.


### PR DESCRIPTION
Each token in an NSS database is likely to have its own password/PIN. This allows the password to be set per token available in the PKI password file.

This is necessary for HSM devices where the password is necessary to access information about the private key (e.g. presence)

This may mean that to see all certificates in a given NSS database one will need multiple instances of the NSSDatabase class, one for each desired token (include None for the native token).

https://pagure.io/freeipa/issue/9273

Signed-off-by: Rob Crittenden <rcritten@redhat.com>