### PR TITLE
Pass the curl write callback by name instead of address

### DIFF
--- a/client/ipa-join.c
+++ b/client/ipa-join.c
@@ -57,6 +57,8 @@
 
 char * read_config_file(const char *filename);
 char * get_config_entry(char * data, const char *section, const char *key);
+static size_t
+jsonrpc_handle_response(char *ptr, size_t size, size_t nmemb, void *userdata);
 
 static int debug = 0;
 
@@ -642,7 +644,7 @@ curl_slist_append_log(struct curl_slist *list, char *string, bool quiet) {
         goto cleanup; \
     }
 
-size_t
+static size_t
 jsonrpc_handle_response(char *ptr, size_t size, size_t nmemb, void *userdata) {
     size_t realsize = size * nmemb;
     curl_buffer *cb = (curl_buffer *) userdata;
@@ -722,7 +724,7 @@ jsonrpc_request(const char *ipaserver, const json_t *json, curl_buffer *response
 
     CURL_SETOPT(curl, CURLOPT_CAINFO, DEFAULT_CA_CERT_FILE);
 
-    CURL_SETOPT(curl, CURLOPT_WRITEFUNCTION, &jsonrpc_handle_response);
+    CURL_SETOPT(curl, CURLOPT_WRITEFUNCTION, jsonrpc_handle_response);
     CURL_SETOPT(curl, CURLOPT_WRITEDATA, response);
 
     CURL_SETOPT(curl, CURLOPT_HTTPAUTH, CURLAUTH_NEGOTIATE);


### PR DESCRIPTION
This was reported by Coverity as a potential issue. Passing by name is the example that curl uses so switch to that to quiet the warning.

Also change to a static function and pre-declare it to quiet a compile-time warning.

https://pagure.io/freeipa/issue/9274

Signed-off-by: Rob Crittenden <rcritten@redhat.com>