### PR TITLE
[ipa-4-10] ipatests: update vagrant boxes

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -31,7 +31,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
           name: freeipa/ci-ipa-4-10-f37
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
           name: freeipa/ci-ipa-4-10-f37
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
           name: freeipa/ci-ipa-4-10-f37
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-previous
           name: freeipa/ci-ipa-4-10-f36
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -57,7 +57,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
           name: freeipa/ci-ipa-4-10-f37
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Use new versions of vagrant boxes:
ci-ipa-4-10-f36 0.0.2
ci-ipa-4-10-f37 0.0.2

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>