### PR TITLE
spec file: bump sssd version

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -88,6 +88,9 @@
 %global httpd_version 2.4.37-21
 %global bind_version 9.11.20-6
 
+# Fix for https://github.com/SSSD/sssd/issues/6331
+%global sssd_version 2.8.0
+
 %else
 # Fedora
 %global package_name freeipa
@@ -135,6 +138,15 @@
 # Some packages don't provide new dist aliases.
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/
 %{?python_disable_dependency_generator}
+
+%if 0%{?fedora} < 37
+# F35+, adds IdP integration
+%global sssd_version 2.7.0
+%else
+# Fix for https://github.com/SSSD/sssd/issues/6331
+%global sssd_version 2.8.0
+%endif
+
 # Fedora
 %endif
 
@@ -161,8 +173,6 @@
 # RHEL 8.2+, F32+ has 3.58
 %global nss_version 3.44.0-4
 
-# RHEL 8.7+, F35+, adds IdP integration
-%global sssd_version 2.7.0
 
 %define krb5_base_version %(LC_ALL=C /usr/bin/pkgconf --modversion krb5 | grep -Eo '^[^.]+\.[^.]+' || echo %krb5_version)
 %global kdcproxy_version 0.4-3

--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -6,10 +6,8 @@
 
 import re
 import os
-import pytest
 import textwrap
 
-from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipatests.pytest_ipa.integration import tasks
@@ -52,9 +50,6 @@ class TestIpaAdTrustInstall(IntegrationTest):
         res = self.master.run_command(['testparm', '-s'])
         assert 'ERROR' not in (res.stdout_text + res.stderr_text)
 
-    @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
-        reason='freeipa ticket 9234', strict=True)
     def test_add_agent_not_allowed(self):
         """Check that add-agents can be run only by Admins."""
         user = "nonadmin"
@@ -256,9 +251,6 @@ class TestIpaAdTrustInstall(IntegrationTest):
                  '"member","ipaexternalmember")')
         assert value in entry_list
 
-    @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
-        reason='freeipa ticket 9234', strict=True)
     def test_ipa_user_pac(self):
         """Test that a user can request a service ticket with PAC"""
         user = 'testpacuser'
@@ -287,9 +279,6 @@ class TestIpaAdTrustInstall(IntegrationTest):
             tasks.kinit_admin(self.master)
             self.master.run_command(['ipa', 'user-del', user])
 
-    @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
-        reason='freeipa ticket 9234', strict=True)
     def test_ipa_user_s4u2self_pac(self):
         """Test that a service can request S4U2Self ticket with PAC"""
         user = 'tests4u2selfuser'

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -24,7 +24,6 @@ from datetime import datetime, timedelta
 
 from ipalib.constants import IPAAPI_USER
 
-from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 
 from ipapython.dn import DN
@@ -1607,9 +1606,6 @@ class TestIPACommandWithoutReplica(IntegrationTest):
         tasks.ldapsearch_dm(self.master, base, ldap_args=[], scope='sub')
         tasks.ldapsearch_dm(self.master, base, ldap_args=[], scope='base')
 
-    @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
-        reason='freeipa ticket 9234', strict=True)
     def test_sid_generation(self):
         """
         Test SID generation


### PR DESCRIPTION
### spec file: bump sssd version
Bump sssd version to 2.8.0 on fedora37+ and RHEL
to ensure the fix for SSSD #6631 is present.

No need to bump the version on fedora 36 as the issue
is not seen on versions < 37.

Fixes: https://pagure.io/freeipa/issue/9234
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>

### ipatests: remove xfail for tests using sssctl domain-status

The tests calling sssctl domain-status were marked xfail
because of SSSD issue https://github.com/freeipa/freeipa/pull/6331. Now that the issue is fixed
and freeipa bumped sssd required version, remove the xfail
annotation.

Related: https://pagure.io/freeipa/issue/9234