### PR TITLE
Fixes: ipa-otpd@.service: deprecated syslog setting

### DIFF
--- a/daemons/ipa-otpd/ipa-otpd@.service.in
+++ b/daemons/ipa-otpd/ipa-otpd@.service.in
@@ -7,4 +7,4 @@ EnvironmentFile=@sysconfdir@/ipa/default.conf
 ExecStart=@libexecdir@/ipa/ipa-otpd $ldap_uri
 StandardInput=socket
 StandardOutput=socket
-StandardError=syslog
+StandardError=journal


### PR DESCRIPTION
This patch updates the deprecated syslog setting i.e StandardError=syslog with StandardError=journal

Pagure: https://pagure.io/freeipa/issue/9279
Ref: https://github.com/systemd/systemd/pull/15812

Signed-off-by: Sudhir Menon <sumenon@redhat.com>