### PR TITLE
[Backport][ipa-4-9] Generate CNAMEs for TXT+URI location krb records

### DIFF
--- a/install/updates/90-post_upgrade_plugins.update
+++ b/install/updates/90-post_upgrade_plugins.update
@@ -42,3 +42,4 @@ plugin: update_dnsserver_configuration_into_ldap
 plugin: update_ldap_server_list
 plugin: update_dna_shared_config
 plugin: update_unhashed_password
+plugin: update_krb_uri_txt_records_for_locations


### PR DESCRIPTION
This PR was opened manually because PR https://github.com/freeipa/freeipa/pull/6495 was pushed to master and the automatic backport to ipa-4-9 failed but it's required.