### PR TITLE
API reference: update doc

### DIFF
--- a/doc/api/dnszone_add.md
+++ b/doc/api/dnszone_add.md
@@ -10,7 +10,6 @@ Create new DNS zone (SOA record).
 ### Options
 * idnssoarname : :ref:`DNSNameParam<DNSNameParam>` **(Required)**
  * Default: hostmaster
-* idnssoaserial : :ref:`Int<Int>` **(Required)**
 * idnssoarefresh : :ref:`Int<Int>` **(Required)**
  * Default: 3600
 * idnssoaretry : :ref:`Int<Int>` **(Required)**
@@ -34,6 +33,7 @@ Create new DNS zone (SOA record).
 * idnsforwardpolicy : :ref:`StrEnum<StrEnum>`
  * Values: ('only', 'first', 'none')
 * idnssoamname : :ref:`DNSNameParam<DNSNameParam>`
+* idnssoaserial : :ref:`Int<Int>`
 * dnsttl : :ref:`Int<Int>`
 * dnsdefaultttl : :ref:`Int<Int>`
 * dnsclass : :ref:`StrEnum<StrEnum>`

--- a/doc/api/vault_archive_internal.md
+++ b/doc/api/vault_archive_internal.md
@@ -20,7 +20,7 @@ Archive data into a vault.
  * Default: False
 * username : :ref:`Str<Str>`
 * wrapping_algo : :ref:`StrEnum<StrEnum>`
- * Default: aes-128-cbc
+ * Default: des-ede3-cbc
  * Values: ('aes-128-cbc', 'des-ede3-cbc')
 * version : :ref:`Str<Str>`
 

--- a/doc/api/vault_retrieve_internal.md
+++ b/doc/api/vault_retrieve_internal.md
@@ -18,7 +18,7 @@ Retrieve data from a vault.
  * Default: False
 * username : :ref:`Str<Str>`
 * wrapping_algo : :ref:`StrEnum<StrEnum>`
- * Default: aes-128-cbc
+ * Default: des-ede3-cbc
  * Values: ('aes-128-cbc', 'des-ede3-cbc')
 * version : :ref:`Str<Str>`
 


### PR DESCRIPTION
### API reference: update vault doc

Update doc/api/vault_archive_internal.md and
doc/api/vault_retrieve_internal.md
after the change from commit https://github.com/freeipa/freeipa/commit/93548f2569e11a49ffbb5d0f5957be420820f501
(default wrapping algo is now des-ede3-cbc instead of aes-128-cbc).

Related: https://pagure.io/freeipa/issue/9259

### API reference: update dnszone_add generated doc

Update doc/api/dnszone_add.md after commit c74c701
(Set 'idnssoaserial' to deprecated)

Related: https://pagure.io/freeipa/issue/9249