### PR TITLE
webui tests: fix assertion in test_subid.py

### DIFF
--- a/ipatests/test_webui/test_subid.py
+++ b/ipatests/test_webui/test_subid.py
@@ -146,5 +146,5 @@ class test_subid(UI_driver):
         with pytest.raises(NoSuchElementException) as excinfo:
             self.delete_record(admin_uid, table_name="ipauniqueid")
         # Ensure that the exception is really related to missing remove button
-        msg = "Unable to locate element: .facet-controls button[name=remove]"
-        assert msg in str(excinfo)
+        msg = r"Unable to locate element: .facet-controls button\[name=remove\]"
+        assert excinfo.match(msg)


### PR DESCRIPTION
The test wants to check the error related to an
exception obtained inside a "with pytest.raises" instruction.
The object is an ExceptionInfo and offers a match method
to check the content of the string representation.
Use this match() method instead of str(excinfo) which now
returns
'<ExceptionInfo NoSuchElementException() tblen=10>'

Fixes: https://pagure.io/freeipa/issue/9282

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>