### PR TITLE
ipatests: xfail on all fedora for test_ipa_login_with_sso_user

### DIFF
--- a/ipatests/test_integration/test_sso.py
+++ b/ipatests/test_integration/test_sso.py
@@ -123,7 +123,7 @@ class TestSsoBridge(IntegrationTest):
         keycloak_login(self.keycloak, username, password, username_fl)
 
     @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (37,),
+        osinfo.id == 'fedora',
         reason='freeipa ticket 9264', strict=True)
     def test_ipa_login_with_sso_user(self):
         """


### PR DESCRIPTION
With the new fedora36 vagrant image, the test is also failing.
Mark xfail for all fedora versions.
Related: https://pagure.io/freeipa/issue/9264

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>