### PR TITLE
ipatests: update the xfail annotation for test_number_of_zones

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -586,9 +586,8 @@ class TestInstallWithCA_DNS3(CALessBase):
     """
 
     @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (33,)
-        and osinfo.version_number < (35,),
-        reason='freeipa ticket 8700', strict=True)
+        osinfo.id == 'fedora' and osinfo.version_number >= (36,),
+        reason='freeipa ticket 9135', strict=True)
     @server_install_setup
     def test_number_of_zones(self):
         """There should be two zones: one forward, one reverse"""


### PR DESCRIPTION
The test is failing on fedora 36+, update and simplify the
xfail condition.

Related: https://pagure.io/freeipa/issue/9135

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>