### PR TITLE
[Backport][ipa-4-9] PRCI: update memory reqs for each topology

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -6,19 +6,19 @@ topologies:
   master_1repl: &master_1repl
     name: master_1repl
     cpu: 4
-    memory: 6450
+    memory: 6750
   master_1repl_1client: &master_1repl_1client
     name: master_1repl_1client
     cpu: 4
-    memory: 7400
+    memory: 8000
   ad_master_2client: &ad_master_2client
     name: ad_master_2client
     cpu: 4
-    memory: 12000
+    memory: 10596
   ipaserver: &ipaserver
     name: ipaserver
     cpu: 2
-    memory: 2400
+    memory: 2750
 
 jobs:
   fedora-latest-ipa-4-9/build:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -6,39 +6,39 @@ topologies:
   master_3client: &master_3client
     name: master_3client
     cpu: 5
-    memory: 10150
+    memory: 7750
   master_1repl: &master_1repl
     name: master_1repl
     cpu: 4
-    memory: 6450
+    memory: 6750
   master_1repl_1client: &master_1repl_1client
     name: master_1repl_1client
     cpu: 4
-    memory: 7400
+    memory: 8000
   ipaserver: &ipaserver
     name: ipaserver
     cpu: 2
-    memory: 2400
+    memory: 2750
   master_2repl_1client: &master_2repl_1client
     name: master_2repl_1client
     cpu: 5
-    memory: 10150
+    memory: 10750
   master_3repl_1client: &master_3repl_1client
     name: master_3repl_1client
     cpu: 6
-    memory: 12900
+    memory: 13500
   ad_master_2client: &ad_master_2client
     name: ad_master_2client
     cpu: 4
-    memory: 12000
+    memory: 10596
   ad_master: &ad_master
     name: ad_master
     cpu: 4
-    memory: 12000
+    memory: 8096
   adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
     name: adroot_adchild_adtree_master_1client
     cpu: 8
-    memory: 14500
+    memory: 14466
 
 jobs:
   fedora-latest-ipa-4-9/build:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -6,39 +6,39 @@ topologies:
   master_3client: &master_3client
     name: master_3client
     cpu: 5
-    memory: 10150
+    memory: 7750
   master_1repl: &master_1repl
     name: master_1repl
     cpu: 4
-    memory: 6450
+    memory: 6750
   master_1repl_1client: &master_1repl_1client
     name: master_1repl_1client
     cpu: 4
-    memory: 7400
+    memory: 8000
   ipaserver: &ipaserver
     name: ipaserver
     cpu: 2
-    memory: 2400
+    memory: 2750
   master_2repl_1client: &master_2repl_1client
     name: master_2repl_1client
     cpu: 5
-    memory: 10150
+    memory: 10750
   master_3repl_1client: &master_3repl_1client
     name: master_3repl_1client
     cpu: 6
-    memory: 12900
+    memory: 13500
   ad_master_2client: &ad_master_2client
     name: ad_master_2client
     cpu: 4
-    memory: 12000
+    memory: 10596
   ad_master: &ad_master
     name: ad_master
     cpu: 4
-    memory: 12000
+    memory: 8096
   adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
     name: adroot_adchild_adtree_master_1client
     cpu: 8
-    memory: 14500
+    memory: 14466
 
 jobs:
   fedora-latest-ipa-4-9/build:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -6,39 +6,39 @@ topologies:
   master_3client: &master_3client
     name: master_3client
     cpu: 5
-    memory: 10150
+    memory: 7750
   master_1repl: &master_1repl
     name: master_1repl
     cpu: 4
-    memory: 6450
+    memory: 6750
   master_1repl_1client: &master_1repl_1client
     name: master_1repl_1client
     cpu: 4
-    memory: 7400
+    memory: 8000
   ipaserver: &ipaserver
     name: ipaserver
     cpu: 2
-    memory: 2400
+    memory: 2750
   master_2repl_1client: &master_2repl_1client
     name: master_2repl_1client
     cpu: 5
-    memory: 10150
+    memory: 10750
   master_3repl_1client: &master_3repl_1client
     name: master_3repl_1client
     cpu: 6
-    memory: 12900
+    memory: 13500
   ad_master_2client: &ad_master_2client
     name: ad_master_2client
     cpu: 4
-    memory: 12000
+    memory: 10596
   ad_master: &ad_master
     name: ad_master
     cpu: 4
-    memory: 12000
+    memory: 8096
   adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
     name: adroot_adchild_adtree_master_1client
     cpu: 8
-    memory: 14500
+    memory: 14466
 
 jobs:
   fedora-previous-ipa-4-9/build:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -12,39 +12,39 @@ topologies:
   master_3client: &master_3client
     name: master_3client
     cpu: 5
-    memory: 10150
+    memory: 7750
   master_1repl: &master_1repl
     name: master_1repl
     cpu: 4
-    memory: 6450
+    memory: 6750
   master_1repl_1client: &master_1repl_1client
     name: master_1repl_1client
     cpu: 4
-    memory: 7400
+    memory: 8000
   ipaserver: &ipaserver
     name: ipaserver
     cpu: 2
-    memory: 2400
+    memory: 2750
   master_2repl_1client: &master_2repl_1client
     name: master_2repl_1client
     cpu: 5
-    memory: 10150
+    memory: 10750
   master_3repl_1client: &master_3repl_1client
     name: master_3repl_1client
     cpu: 6
-    memory: 12900
+    memory: 13500
   ad_master_2client: &ad_master_2client
     name: ad_master_2client
     cpu: 4
-    memory: 12000
+    memory: 10596
   ad_master: &ad_master
     name: ad_master
     cpu: 4
-    memory: 12000
+    memory: 8096
   adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
     name: adroot_adchild_adtree_master_1client
     cpu: 8
-    memory: 14500
+    memory: 14466
 
 jobs:
   fedora-latest-ipa-4-9/build:


### PR DESCRIPTION
The memory requirements are defined in the vagrant templates in https://github.com/freeipa/freeipa-pr-ci/tree/master/templates/vagrantfiles

They have been updated and the corresponding values must be kept consistent in the topologies for PRCI.

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>