### PR TITLE
WIP: netgroup: do not display hostgroups as part of netgroup-show as default

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -3568,10 +3568,12 @@ output: Output('completed', type=[<type 'int'>])
 output: Output('failed', type=[<type 'dict'>])
 output: Entry('result')
 command: netgroup_show/1
-args: 1,5,3
+args: 1,7,3
 arg: Str('cn', cli_name='name')
 option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('managed', autofill=True, cli_name='managed', default=False)
 option: Flag('no_members', autofill=True, default=False)
+option: Flag('private', autofill=True, default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Flag('rights', autofill=True, default=False)
 option: Str('version?')

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -86,8 +86,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-# Last change: fix vault interoperability issues.
-define(IPA_API_VERSION_MINOR, 251)
+# Last change: do not display hostgroups when netgroup-show.
+define(IPA_API_VERSION_MINOR, 252)
 
 ########################################################
 # Following values are auto-generated from values above


### PR DESCRIPTION
This commit fixes an inconsistency between netgroup-show and netgroup-find where the first one is displaying hostgroups as netgroups while the second one is not.

With this commit, both ipa commands netgroup-show and netgroup-find behaves in the same way. Option "--managed" has been added to netgroup-show to be able to display managed hostgroups.

Fixes: https://pagure.io/freeipa/issue/9284
Signed-off-by: Francisco Trivino <ftrivino@redhat.com>

TODO:

[ ] Add/Modify netgroup xmlrpc
