### PR TITLE
[Backport][ipa-4-9] ipa-certupdate: Update client certs before KDC/HTTPd restart

### DIFF
--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -103,9 +103,10 @@ def run_with_args(api):
     else:
         lwcas = []
 
-    ipa_configured = is_ipa_configured()
+    # update client certs before KDC and HTTPd are restarted.
+    update_client(certs)
 
-    if ipa_configured:
+    if is_ipa_configured():
         # look up CA servers before service restarts
         resp = api.Command.server_role_find(
             role_servrole=u'CA server',
@@ -141,12 +142,10 @@ def run_with_args(api):
         if services.knownservices.httpd.is_running():
             services.knownservices.httpd.restart()
 
-    update_client(certs)
-
-    # update_client() may have updated KDC cert bundle; restart KDC to pick
-    # up changes.
-    if ipa_configured and services.knownservices.krb5kdc.is_running():
-        services.knownservices.krb5kdc.restart()
+        # update_client() may have updated KDC cert bundle; restart KDC to pick
+        # up changes.
+        if services.knownservices.krb5kdc.is_running():
+            services.knownservices.krb5kdc.restart()
 
 
 def update_client(certs):


### PR DESCRIPTION
This PR was opened automatically because PR #6573 was pushed to master and backport to ipa-4-9 is required.