### PR TITLE
ipatests: WebUI: Warning for deprecated feature should not show for DNS

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -65,10 +65,10 @@ jobs:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_webui/test_dns.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *ipaserver

--- a/ipatests/test_webui/data_dns.py
+++ b/ipatests/test_webui/data_dns.py
@@ -10,6 +10,7 @@ CONFIG_ENTITY = 'dnsconfig'
 ZONE_DEFAULT_FACET = 'records'
 
 ZONE_PKEY = 'foo.itest.'
+REVERSE_ZONE_IP = '192.0.2.0/24'
 
 ZONE_DATA = {
     'pkey': ZONE_PKEY,
@@ -20,6 +21,14 @@ ZONE_DATA = {
         ('checkbox', 'idnsallowsyncptr', 'checked'),
     ],
 }
+
+REVERSE_ZONE_DATA = {
+    'pkey': ZONE_PKEY,
+    'add': [
+        ('textbox', 'idnsname', REVERSE_ZONE_IP),
+    ]
+}
+
 
 FORWARD_ZONE_PKEY = 'forward.itest.'
 

--- a/ipatests/test_webui/test_dns.py
+++ b/ipatests/test_webui/test_dns.py
@@ -21,15 +21,16 @@
 DNS tests
 """
 
-from ipatests.test_webui.ui_driver import UI_driver
-from ipatests.test_webui.ui_driver import screenshot
+import pytest
+
 from ipatests.test_webui.data_dns import (
     ZONE_ENTITY, FORWARD_ZONE_ENTITY, CONFIG_ENTITY, RECORD_ENTITY,
     ZONE_DEFAULT_FACET, ZONE_PKEY, ZONE_DATA, FORWARD_ZONE_PKEY,
     FORWARD_ZONE_DATA, RECORD_PKEY, A_IP, RECORD_ADD_DATA, RECORD_MOD_DATA,
-    CONFIG_MOD_DATA
+    CONFIG_MOD_DATA, REVERSE_ZONE_DATA
 )
-import pytest
+from ipatests.test_webui.ui_driver import UI_driver
+from ipatests.test_webui.ui_driver import screenshot
 
 
 @pytest.mark.tier1
@@ -62,6 +63,15 @@ class test_dns(UI_driver):
         self.navigate_by_breadcrumb(ZONE_PKEY)
         self.delete_record(RECORD_PKEY)
         self.navigate_by_breadcrumb("DNS Zones")
+        self.delete_record(ZONE_PKEY)
+
+        # add reverse zone
+        self.basic_crud(ZONE_ENTITY, REVERSE_ZONE_DATA,
+                        default_facet=ZONE_DEFAULT_FACET, delete=False)
+        # test for https://pagure.io/freeipa/issue/9249
+        # Deprecated feature idnssoaserial must not show
+        with pytest.raises(AssertionError):
+            self.assert_notification(type="warning")
         self.delete_record(ZONE_PKEY)
 
     @screenshot


### PR DESCRIPTION
When adding a reverse dns zone, the message 'idnssoaserial' option is deprecated should not appear as it is not possible to set it through the UI. This commit introduces test for this behaviour.

Related: https://pagure.io/freeipa/issue/9249

Signed-off-by: Michal Polovka <mpolovka@redhat.com>