### PR TITLE
FIPS mode

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -95,8 +95,6 @@
 # Fedora
 %global package_name freeipa
 %global alt_name ipa
-# Fix for CVE-2020-28196
-%global krb5_version 1.18.2-29
 # 0.7.16: https://github.com/drkjam/netaddr/issues/71
 %global python_netaddr_version 0.7.16
 # Require 4.7.0 which brings Python 3 bindings
@@ -112,7 +110,15 @@
 %endif
 %global slapi_nis_version 0.56.5
 
+%if 0%{?fedora} < 38
+# Fix for CVE-2020-28196
+%global krb5_version 1.18.2-29
 %global krb5_kdb_version 8.0
+%else
+# Fix for CVE-2020-28196
+%global krb5_version 1.20.1-3
+%global krb5_kdb_version 9.0
+%endif
 
 # fix for segfault in python3-ldap, https://pagure.io/freeipa/issue/7324
 %global python_ldap_version 3.1.0-1

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -282,7 +282,7 @@ class KrbInstance(service.Service):
 
         if fips_enabled:
             supported_enctypes = list(
-                filter(lambda e: not e.startswith('camelia'),
+                filter(lambda e: not e.startswith('camellia'),
                        SUPPORTED_ENCTYPES))
         else:
             supported_enctypes = SUPPORTED_ENCTYPES

--- a/ipatests/pytest_ipa/integration/fips.py
+++ b/ipatests/pytest_ipa/integration/fips.py
@@ -52,7 +52,7 @@ def enable_userspace_fips(host):
         ["openssl", "md5", "/dev/null"], raiseonerr=False
     )
     assert result.returncode == 1
-    assert "EVP_DigestInit_ex:disabled for FIPS" in result.stderr_text
+    assert "Error setting digest" in result.stderr_text
 
 
 def disable_userspace_fips(host):

--- a/ipatests/test_integration/test_fips.py
+++ b/ipatests/test_integration/test_fips.py
@@ -3,6 +3,9 @@
 #
 """Smoke tests for FreeIPA installation in (fake) userspace FIPS mode
 """
+import pytest
+
+from ipaplatform.osinfo import osinfo
 from ipapython.dn import DN
 from ipapython.ipautil import ipa_generate_password, realm_to_suffix
 
@@ -18,6 +21,9 @@ from .test_dnssec import (
 )
 
 
+@pytest.mark.xfail(
+    osinfo.id == 'fedora' and osinfo.version_number > (35,),
+    reason='freeipa ticket 9002', strict=True)
 class TestInstallFIPS(IntegrationTest):
     num_replicas = 1
     num_clients = 1


### PR DESCRIPTION
### ipatests: update the fake fips mode expected message

The test ipatests/test_integration/test_fips.py is faking
FIPS mode and calls "openssl md5" to ensure the algo is
not available in the fake FIPS mode.

The error message has been updated with openssl-3.0.5-5.
In the past the command used to return:
$ openssl md5 /dev/null
Error setting digest
140640350118336:error:060800C8:digital envelope routines:EVP_DigestInit_ex:disabled for FIPS:crypto/evp/digest.c:147:

And now it returns:
$ openssl md5 /dev/null
Error setting digest
00C224822E7F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:349:Global default library context, Algorithm (MD5 : 97), Properties ()
00C224822E7F0000:error:03000086:digital envelope routines:evp_md_init_internal:initialization error:crypto/evp/digest.c:252:

To be compatible with all versions, only check the common part:
Error setting digest

Mark the test as xfail since installation is currently not working.

### cert utilities: MAC verification is incompatible with FIPS mode

The PKCS12 MAC requires PKCS12KDF which is not an approved FIPS
algorithm and cannot be supported by the FIPS provider.
Do not require mac verification in FIPS mode: append the option
--nomacver to the command openssl pkcs12 used to extract a pem file
or a key from a p12 file.

### FIPS setup: fix typo filtering camellia encryption

The config file /var/kerberos/krb5kdc/kdc.conf is customized
during IPA server installation with a list of supported
encryption types.
In FIPS mode, camellia encryption is not supported and should
be filtered out. Because of a typo in the filtering method,
the camellia encryptions are appended while they should not.

Fix the typo (camelia vs camellia) in order to filter properly.