### PR TITLE
[Backport][ipa-4-9] Fixes: ipa-otpd@.service: deprecated syslog setting

### DIFF
--- a/daemons/ipa-otpd/ipa-otpd@.service.in
+++ b/daemons/ipa-otpd/ipa-otpd@.service.in
@@ -7,4 +7,4 @@ EnvironmentFile=@sysconfdir@/ipa/default.conf
 ExecStart=@libexecdir@/ipa/ipa-otpd $ldap_uri
 StandardInput=socket
 StandardOutput=socket
-StandardError=syslog
+StandardError=journal


### PR DESCRIPTION
This PR was opened automatically because PR #6564 was pushed to master and backport to ipa-4-9 is required.