### PR TITLE
[Backport][ipa-4-10] ipatests: update the xfail annotation for test_number_of_zones

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -586,9 +586,8 @@ class TestInstallWithCA_DNS3(CALessBase):
     """
 
     @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (33,)
-        and osinfo.version_number < (35,),
-        reason='freeipa ticket 8700', strict=True)
+        osinfo.id == 'fedora' and osinfo.version_number >= (36,),
+        reason='freeipa ticket 9135', strict=True)
     @server_install_setup
     def test_number_of_zones(self):
         """There should be two zones: one forward, one reverse"""


### PR DESCRIPTION
This PR was opened automatically because PR #6580 was pushed to master and backport to ipa-4-10 is required.