### PR TITLE
ipaplatform: add initial nixos support

### DIFF
--- a/ipaplatform/nixos/__init__.py
+++ b/ipaplatform/nixos/__init__.py
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+#
+
+'''
+This module contains Nixos specific platform files.
+'''
+import sys
+import warnings
+
+NAME = 'nixos'
+
+if sys.version_info < (3, 6):
+    warnings.warn(
+        "Support for Python 2.7 and 3.5 is deprecated. Python version "
+        "3.6 or newer will be required in the next major release.",
+        category=DeprecationWarning
+    )

--- a/ipaplatform/nixos/constants.py
+++ b/ipaplatform/nixos/constants.py
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+#
+
+'''
+This nixos base platform module exports platform related constants.
+'''
+
+# Fallback to default constant definitions
+from __future__ import absolute_import
+
+from ipaplatform.redhat.constants import (
+    RedHatConstantsNamespace, User, Group
+)
+
+HAS_NFS_CONF = True
+
+
+__all__ = ("constants", "User", "Group")
+
+
+class NixosConstantsNamespace(RedHatConstantsNamespace):
+    MOD_WSGI_PYTHON2 = "modules/mod_wsgi.so"
+    MOD_WSGI_PYTHON3 = "modules/mod_wsgi_python3.so"
+
+    if HAS_NFS_CONF:
+        SECURE_NFS_VAR = None
+
+    NAMED_OPENSSL_ENGINE = "pkcs11"
+
+
+constants = NixosConstantsNamespace()

--- a/ipaplatform/nixos/paths.py
+++ b/ipaplatform/nixos/paths.py
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+#
+
+from ipaplatform.fedora.paths import FedoraPathNamespace
+
+# Note that we cannot use real paths, as they will be meaningless on nixos, as
+# nixos stores all its packages in the nixstore under version/hash specific
+# paths. The `@xxx@` are placeholders which will be instantiated to the correct
+# nixstore paths at build time, by the nixpkgs freeipa derivation.
+
+
+class NixOSPathNamespace(FedoraPathNamespace):
+    SBIN_IPA_JOIN = "@out@/bin/ipa-join"
+    IPA_GETCERT = "@out@/bin/ipa-getcert"
+    IPA_RMKEYTAB = "@out@/bin/ipa-rmkeytab"
+    IPA_GETKEYTAB = "@out@/bin/ipa-getkeytab"
+    NSUPDATE = "@bind@/bin/nsupdate"
+    BIN_CURL = "@curl@/bin/curl"
+    KINIT = "@kerberos@/bin/kinit"
+    KDESTROY = "@kerberos@/bin/kdestroy"
+
+
+paths = NixOSPathNamespace()

--- a/ipaplatform/nixos/services.py
+++ b/ipaplatform/nixos/services.py
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Contains Nixos-specific service class implementations.
+"""
+
+from __future__ import absolute_import
+
+from ipaplatform.redhat import services as redhat_services
+
+# Mappings from service names as FreeIPA code references to these services
+# to their actual systemd service names
+nixos_system_units = redhat_services.redhat_system_units.copy()
+nixos_system_units['named'] = nixos_system_units['named-regular']
+nixos_system_units['named-conflict'] = nixos_system_units['named-pkcs11']
+
+
+# Service classes that implement nixos-specific behaviour
+
+class nixosService(redhat_services.RedHatService):
+    system_units = nixos_system_units
+
+
+# Function that constructs proper nixos-specific server classes for services
+# of specified name
+
+def nixos_service_class_factory(name, api=None):
+    if name in ['named', 'named-conflict']:
+        return nixosService(name, api)
+    return redhat_services.redhat_service_class_factory(name, api)
+
+
+# Magicdict containing nixosService instances.
+
+class NixosServices(redhat_services.RedHatServices):
+    def service_class_factory(self, name, api=None):
+        return nixos_service_class_factory(name, api)
+
+
+# Objects below are expected to be exported by platform module
+
+timedate_services = redhat_services.timedate_services
+service = nixos_service_class_factory
+knownservices = NixosServices()

--- a/ipaplatform/nixos/tasks.py
+++ b/ipaplatform/nixos/tasks.py
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+#
+
+'''
+This module contains default nixos-specific implementations of system tasks.
+'''
+
+from __future__ import absolute_import
+
+from ipapython import directivesetter
+from ipaplatform.redhat.tasks import RedHatTaskNamespace
+from ipaplatform.paths import paths
+
+
+class NixosTaskNamespace(RedHatTaskNamespace):
+
+    def configure_httpd_protocol(self):
+        # On nixos 31 and earlier DEFAULT crypto-policy has TLS 1.0 and 1.1
+        # enabled.
+        directivesetter.set_directive(
+            paths.HTTPD_SSL_CONF,
+            'SSLProtocol',
+            "all -SSLv3 -TLSv1 -TLSv1.1",
+            False
+        )
+
+
+tasks = NixosTaskNamespace()

--- a/ipaplatform/setup.py
+++ b/ipaplatform/setup.py
@@ -37,6 +37,7 @@ if __name__ == '__main__':
             "ipaplatform.debian",
             "ipaplatform.fedora",
             "ipaplatform.fedora_container",
+            "ipaplatform.nixos",
             "ipaplatform.redhat",
             "ipaplatform.rhel",
             "ipaplatform.rhel_container",


### PR DESCRIPTION
This PR adds initial nixos support to freeipa.

Once this lands, we will modify https://github.com/NixOS/nixpkgs/pull/207115 to use the nixos ipaplatform from here, rather than patching in it's own support.