### PR TITLE
Add trusted CA as first class object

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -6257,6 +6257,31 @@ option: Str('version?')
 output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
+command: trustedca_find/1
+args: 1,8,4
+arg: Str('criteria?')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Certificate('cacertificate?', autofill=False)
+option: Str('cn?', autofill=False, cli_name='name')
+option: Flag('pkey_only?', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Int('sizelimit?', autofill=False)
+option: Int('timelimit?', autofill=False)
+option: Str('version?')
+output: Output('count', type=[<type 'int'>])
+output: ListOfEntries('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: Output('truncated', type=[<type 'bool'>])
+command: trustedca_show/1
+args: 1,4,3
+arg: Str('cn', cli_name='name')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Flag('rights', autofill=True, default=False)
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
 command: user_add/1
 args: 1,48,3
 arg: Str('uid', cli_name='login')
@@ -7402,6 +7427,9 @@ default: trustdomain_disable/1
 default: trustdomain_enable/1
 default: trustdomain_find/1
 default: trustdomain_mod/1
+default: trustedca/1
+default: trustedca_find/1
+default: trustedca_show/1
 default: user/1
 default: user_add/1
 default: user_add_cert/1

--- a/API.txt
+++ b/API.txt
@@ -6272,6 +6272,20 @@ output: Output('count', type=[<type 'int'>])
 output: ListOfEntries('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: Output('truncated', type=[<type 'bool'>])
+command: trustedca_mod/1
+args: 1,8,3
+arg: Str('cn', cli_name='name')
+option: Str('addattr*', cli_name='addattr')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Str('delattr*', cli_name='delattr')
+option: StrEnum('ipacerttrustscope*', autofill=False, cli_name='trustscope', values=[u'http_client_auth', u'pkinit'])
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Flag('rights', autofill=True, default=False)
+option: Str('setattr*', cli_name='setattr')
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
 command: trustedca_show/1
 args: 1,4,3
 arg: Str('cn', cli_name='name')
@@ -7429,6 +7443,7 @@ default: trustdomain_find/1
 default: trustdomain_mod/1
 default: trustedca/1
 default: trustedca_find/1
+default: trustedca_mod/1
 default: trustedca_show/1
 default: user/1
 default: user_add/1

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -86,8 +86,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-# Last change: fix vault interoperability issues.
-define(IPA_API_VERSION_MINOR, 251)
+# Last change: added trustedca plugin.
+define(IPA_API_VERSION_MINOR, 252)
 
 ########################################################
 # Following values are auto-generated from values above

--- a/doc/api/commands.rst
+++ b/doc/api/commands.rst
@@ -453,6 +453,7 @@ IPA API Commands
    trustdomain_find.md
    trustdomain_mod.md
    trustedca_find.md
+   trustedca_mod.md
    trustedca_show.md
    user_add.md
    user_add_cert.md

--- a/doc/api/commands.rst
+++ b/doc/api/commands.rst
@@ -452,6 +452,8 @@ IPA API Commands
    trustdomain_enable.md
    trustdomain_find.md
    trustdomain_mod.md
+   trustedca_find.md
+   trustedca_show.md
    user_add.md
    user_add_cert.md
    user_add_certmapdata.md

--- a/doc/api/trustedca_find.md
+++ b/doc/api/trustedca_find.md
@@ -1,0 +1,36 @@
+[//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
+# trustedca_find
+Search for trusted CAs certificates.
+
+### Arguments
+|Name|Type|Required
+|-|-|-
+|criteria|:ref:`Str<Str>`|False
+
+### Options
+* all : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* raw : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* cn : :ref:`Str<Str>`
+* cacertificate : :ref:`Certificate<Certificate>`
+* timelimit : :ref:`Int<Int>`
+* sizelimit : :ref:`Int<Int>`
+* version : :ref:`Str<Str>`
+* pkey_only : :ref:`Flag<Flag>`
+ * Default: False
+
+### Output
+|Name|Type
+|-|-
+|count|Output
+|result|ListOfEntries
+|summary|Output
+|truncated|Output
+
+[//]: # (ADD YOUR NOTES BELOW. THESE WILL BE PICKED EVERY TIME THE DOCS ARE REGENERATED. //end)
+### Semantics
+
+### Notes
+
+### Version differences

--- a/doc/api/trustedca_mod.md
+++ b/doc/api/trustedca_mod.md
@@ -1,0 +1,36 @@
+[//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
+# trustedca_mod
+Modify trusted CA certificate
+
+### Arguments
+|Name|Type|Required
+|-|-|-
+|cn|:ref:`Str<Str>`|True
+
+### Options
+* rights : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* all : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* raw : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* ipacerttrustscope : :ref:`StrEnum<StrEnum>`
+ * Values: ('http_client_auth', 'pkinit')
+* setattr : :ref:`Str<Str>`
+* addattr : :ref:`Str<Str>`
+* delattr : :ref:`Str<Str>`
+* version : :ref:`Str<Str>`
+
+### Output
+|Name|Type
+|-|-
+|result|Entry
+|summary|Output
+|value|PrimaryKey
+
+[//]: # (ADD YOUR NOTES BELOW. THESE WILL BE PICKED EVERY TIME THE DOCS ARE REGENERATED. //end)
+### Semantics
+
+### Notes
+
+### Version differences

--- a/doc/api/trustedca_show.md
+++ b/doc/api/trustedca_show.md
@@ -1,0 +1,31 @@
+[//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
+# trustedca_show
+Display the properties of a trusted CA certificate.
+
+### Arguments
+|Name|Type|Required
+|-|-|-
+|cn|:ref:`Str<Str>`|True
+
+### Options
+* rights : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* all : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* raw : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* version : :ref:`Str<Str>`
+
+### Output
+|Name|Type
+|-|-
+|result|Entry
+|summary|Output
+|value|PrimaryKey
+
+[//]: # (ADD YOUR NOTES BELOW. THESE WILL BE PICKED EVERY TIME THE DOCS ARE REGENERATED. //end)
+### Semantics
+
+### Notes
+
+### Version differences

--- a/install/share/65ipacertstore.ldif
+++ b/install/share/65ipacertstore.ldif
@@ -4,5 +4,7 @@ attributeTypes: (2.16.840.1.113730.3.8.11.57 NAME 'ipaCertIssuerSerial' DESC 'Is
 attributeTypes: (2.16.840.1.113730.3.8.11.58 NAME 'ipaKeyTrust' DESC 'Key trust (unknown, trusted, distrusted)' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'IPA v4.1' )
 attributeTypes: (2.16.840.1.113730.3.8.11.59 NAME 'ipaKeyUsage' DESC 'Allowed key usage' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'IPA v4.1' )
 attributeTypes: (2.16.840.1.113730.3.8.11.60 NAME 'ipaKeyExtUsage' DESC 'Allowed extended key usage' EQUALITY objectIdentifierMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 X-ORIGIN 'IPA v4.1' )
+attributeTypes: (2.16.840.1.113730.3.8.11.78 NAME 'ipaCertTrustScope' DESC 'Trust scope for CA certificates' EQUALITY objectIdentifierMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 X-ORIGIN 'IPA v4.9' )
 objectClasses: (2.16.840.1.113730.3.8.12.27 NAME 'ipaCertificate' SUP top STRUCTURAL MUST ( cn $ ipaCertIssuerSerial $ ipaCertSubject $ ipaPublicKey ) MAY ( ipaConfigString ) X-ORIGIN 'IPA v4.1' )
 objectClasses: (2.16.840.1.113730.3.8.12.28 NAME 'ipaKeyPolicy' SUP top AUXILIARY MAY ( ipaKeyTrust $ ipaKeyUsage $ ipaKeyExtUsage ) X-ORIGIN 'IPA v4.1' )
+objectClasses: (2.16.840.1.113730.3.8.12.40 NAME 'ipaScopedCertificate' SUP top AUXILIARY MUST ( caCertificate $ ipaCertTrustScope ) X-ORIGIN 'IPA v4.9' )

--- a/install/ui/src/freeipa/app.js
+++ b/install/ui/src/freeipa/app.js
@@ -34,6 +34,7 @@ define([
     './plugins/certprofile',
     './plugins/certmap',
     './plugins/certmapmatch',
+    './plugins/trustedca',
     './dns',
     './group',
     './hbac',

--- a/install/ui/src/freeipa/certificate.js
+++ b/install/ui/src/freeipa/certificate.js
@@ -1589,7 +1589,8 @@ exp.facet_group = {
         certificates: 'cert_search',
         profiles: 'certprofile_search',
         acls: 'caacl_search',
-        ca_search: 'ca_search'
+        ca_search: 'ca_search',
+        trustedca: 'trustedca_search'
     }
 };
 

--- a/install/ui/src/freeipa/navigation/menu_spec.js
+++ b/install/ui/src/freeipa/navigation/menu_spec.js
@@ -180,6 +180,11 @@ var nav = {};
                             entity: 'ca',
                             facet: 'search',
                             hidden: true
+                        },
+                        {
+                            entity: 'trustedca',
+                            facet: 'search',
+                            hidden: true
                         }
                     ]
                 },

--- a/install/ui/src/freeipa/plugins/trustedca.js
+++ b/install/ui/src/freeipa/plugins/trustedca.js
@@ -1,0 +1,90 @@
+//
+// Copyright (C) 2023  FreeIPA Contributors see COPYING for license
+//
+
+define([
+    '../ipa',
+    '../jquery',
+    '../phases',
+    '../reg',
+    '../certificate'
+],
+function(IPA, $, phases, reg, cert) {
+/**
+ * trustedca module
+ * @class plugins.trustedca
+ * @singleton
+ */
+var trustedca = IPA.trustedca = {
+};
+
+var make_trustedca_spec = function() {
+return {
+    name: 'trustedca',
+    facets: [
+        {
+            $type: 'search',
+            disable_facet_tabs: false,
+            tabs_in_sidebar: true,
+            tab_label: '@mo:trustedca.label',
+            facet_groups: [cert.facet_group],
+            facet_group: 'certificates',
+            no_update: true,
+            columns: [
+                'cn',
+                'subject'
+            ]
+        },
+        {
+            $type: 'details',
+            $factory: IPA.cert.details_facet,
+            no_update: true,
+            disable_facet_tabs: true,
+            // TODO: add 'cacertificate' text field and download feature
+            sections: [
+                {
+                    name: 'details',
+                    label: '@i18n:objects.cert.certificate',
+                    fields: [
+                        'cn',
+                        'serial_number',
+                        'serial_number_hex',
+                        'subject',
+                        'issuer',
+                        'valid_not_before',
+                        'valid_not_after',
+                        'sha1_fingerprint',
+                        'sha256_fingerprint',
+                        'ipakeytrust',
+                        {
+                            $type: 'multivalued',
+                            name: 'ipakeyextusage'
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};};
+
+
+/**
+ * Certificate profile entity specification object
+ * @member plugins.trustedca
+ */
+trustedca.trustedca_spec = make_trustedca_spec();
+
+
+/**
+ * Register entity
+ * @member plugins.trustedca
+ */
+trustedca.register = function() {
+    var e = reg.entity;
+    e.register({type: 'trustedca', spec: trustedca.trustedca_spec});
+};
+
+phases.on('registration', trustedca.register);
+
+return trustedca;
+});

--- a/install/ui/src/freeipa/plugins/trustedca.js
+++ b/install/ui/src/freeipa/plugins/trustedca.js
@@ -38,7 +38,6 @@ return {
         {
             $type: 'details',
             $factory: IPA.cert.details_facet,
-            no_update: true,
             disable_facet_tabs: true,
             // TODO: add 'cacertificate' text field and download feature
             sections: [
@@ -59,7 +58,25 @@ return {
                         {
                             $type: 'multivalued',
                             name: 'ipakeyextusage'
-                        }
+                        },
+                        {
+                            $type: 'checkboxes',
+                            label: '@i18n:objects.trustedca.trustscope',
+                            name: 'ipacerttrustscope',
+                            options: [
+                                {
+                                    label: '@i18n:objects.trustedca.type_http_client_auth',
+                                    value: 'http_client_auth'
+                                },
+                                {
+                                    label: '@i18n:objects.trustedca.type_pkinit',
+                                    value: 'pkinit'
+                                }
+                            ],
+                            tooltip: {
+                                title: '@mc-opt:trustedca_mod:ipacerttrustscope:doc'
+                            }
+                        },
                     ]
                 }
             ]

--- a/ipaclient/plugins/trustedca.py
+++ b/ipaclient/plugins/trustedca.py
@@ -1,0 +1,63 @@
+#
+# Copyright (C) 2023  FreeIPA Contributors see COPYING for license
+#
+
+from ipaclient.frontend import MethodOverride
+from ipalib import errors
+from ipalib import x509
+from ipalib import util
+from ipalib.parameters import Str
+from ipalib.plugable import Registry
+from ipalib.text import _
+
+register = Registry()
+
+
+class CACertRetrieveOverride(MethodOverride):
+    takes_options = (
+        Str(
+            'cacertificate_out?',
+            doc=_('Write CA certificates to file'),
+            include='cli',
+            cli_metavar='FILE',
+        ),
+    )
+
+    def forward(self, *args, **options):
+        if 'cacertificate_out' in options:
+            cacertificate_out = options.pop('cacertificate_out')
+            try:
+                util.check_writable_file(cacertificate_out)
+            except errors.FileError as e:
+                raise errors.ValidationError(name='cacertificate-out',
+                                             error=str(e))
+        else:
+            cacertificate_out = None
+
+        result = super(CACertRetrieveOverride, self).forward(*args, **options)
+
+        if cacertificate_out is not None:
+            if isinstance(result['result'], (list, tuple)):
+                cacerts_der = [
+                    entry['cacertificate;binary'][0]
+                    for entry in result['result']
+                ]
+            else:
+                cacerts_der = [result['result']['cacertificate;binary'][0]]
+            cacerts = [
+                x509.load_der_x509_certificate(der)
+                for der in cacerts_der
+            ]
+            x509.write_certificate_list(cacerts, cacertificate_out)
+
+        return result
+
+
+@register(override=True, no_fail=True)
+class trustedca_show(CACertRetrieveOverride):
+    pass
+
+
+@register(override=True, no_fail=True)
+class trustedca_find(CACertRetrieveOverride):
+    pass

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -156,6 +156,10 @@ DEFAULT_CONFIG = (
         DN(('cn', 'ca_renewal'), ('cn', 'ipa'), ('cn', 'etc'))),
     ('container_subids', DN(('cn', 'subids'), ('cn', 'accounts'))),
     ('container_idp', DN(('cn', 'idp'))),
+    ('container_trustedca', DN(
+        ('cn', 'certificates'), ('cn', 'ipa'), ('cn', 'etc')
+    )),
+
 
     # Ports, hosts, and URIs:
     # Following values do not have any reasonable default.

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -83,6 +83,17 @@ EKU_PKINIT_KDC = '1.3.6.1.5.2.3.5'
 EKU_ANY = '2.5.29.37.0'
 EKU_PLACEHOLDER = '1.3.6.1.4.1.3319.6.10.16'
 
+EKU_NAMES = {
+    EKU_SERVER_AUTH: "server auth",
+    EKU_CLIENT_AUTH: "client auth",
+    EKU_CODE_SIGNING: "code signing",
+    EKU_EMAIL_PROTECTION: "email protection",
+    EKU_PKINIT_CLIENT_AUTH: "PKINIT client auth",
+    EKU_PKINIT_KDC: "PKINIT KDC",
+    EKU_ANY: "any",
+    # EKU_PLACEHOLDER
+}
+
 SAN_UPN = '1.3.6.1.4.1.311.20.2.3'
 SAN_KRB5PRINCIPALNAME = '1.3.6.1.5.2.2'
 

--- a/ipaserver/install/plugins/upload_cacrt.py
+++ b/ipaserver/install/plugins/upload_cacrt.py
@@ -77,8 +77,11 @@ class update_upload_cacrt(Updater):
                 trust_flags = certdb.IPA_CA_TRUST_FLAGS
             trust, _ca, eku = certstore.trust_flags_to_key_policy(trust_flags)
 
-            dn = DN(('cn', nickname), ('cn', 'certificates'), ('cn', 'ipa'),
-                    ('cn','etc'), self.api.env.basedn)
+            dn = DN(
+                ('cn', nickname),
+                self.api.env.container_trustedca,
+                self.api.env.basedn
+            )
             entry = ldap.make_entry(dn)
 
             try:

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1555,6 +1555,11 @@ class i18n_messages(Command):
                 "trusttype": _("Trust type"),
                 "ipantadditionalsuffixes": _("Alternative UPN suffixes"),
             },
+            "trustedca": {
+                "trustscope": _("Trust scope"),
+                "type_http_client_auth": _("HTTP client auth"),
+                "type_pkinit": _("PKINIT"),
+            },
             'smb_attributes': {
                 "title": _(
                     "User attributes for SMB services"

--- a/ipaserver/plugins/trustedca.py
+++ b/ipaserver/plugins/trustedca.py
@@ -1,0 +1,137 @@
+#
+# Copyright (C) 2023  FreeIPA Contributors see COPYING for license
+#
+
+
+from ipalib import api
+from ipalib import Bytes, DNParam, Str
+from ipalib.parameters import Certificate
+from ipalib.plugable import Registry
+from ipalib import x509
+from ipaserver.plugins.baseldap import LDAPObject, LDAPSearch, LDAPRetrieve
+from ipaserver.plugins.cert import AbstractCertObject
+from ipalib import _, ngettext
+
+
+__doc__ = _("""
+Manage trusted Certificate Authorities (ipa-catrust-manage)
+""")
+
+
+register = Registry()
+
+
+@register()
+class trustedca(LDAPObject, AbstractCertObject):
+    """Trusted CA object
+    """
+    container_dn = api.env.container_trustedca
+    object_name = _('Trusted CA certificate')
+    object_name_plural = _('Trusted CAs certificates')
+    object_class = ['ipacertificate', 'pkiCA']
+    permission_filter_objectclasses = ['ipacertificate']
+    default_attributes = [
+        'cn', 'cacertificate', 'ipakeyextusage', ' ipakeytrust',
+    ]
+    rdn_attribute = 'cn'
+    allow_rename = True
+    label = _('Trusted CA certificates')
+    label_singular = _('Trusted CA certificate')
+
+    takes_params = (
+        Str(
+            'cn',
+            primary_key=True,
+            cli_name='name',
+            label=_('Name'),
+            doc=_('Name for referencing the CA'),
+        ),
+        Str(
+            'ipacertissuerserial',
+            cli_name='issuerserial',
+            label=_('Issuer & Serial'),
+            doc=_('Certificate issuer and serial number'),
+            flags={'no_display', 'no_create', 'no_update', 'no_search'},
+        ),
+        DNParam(
+            'ipacertsubject',
+            cli_name='subject',
+            label=_('Subject DN'),
+            doc=_('Subject Distinguished Name'),
+            flags={'no_display', 'no_create', 'no_update', 'no_search'},
+        ),
+        Bytes(
+            'ipapublickey',
+            label=_("public key"),
+            doc=_("Base-64 encoded public key of the certificate."),
+            flags={'no_display', 'no_create', 'no_update', 'no_search'},
+        ),
+        Certificate(
+            'cacertificate',
+            label=_("CA Certificate"),
+            doc=_("Base-64 encoded certificate."),
+            flags={'no_create', 'no_update', 'no_search'},
+        ),
+    ) + AbstractCertObject.x509v1_params + AbstractCertObject.san_params + (
+        Str(
+            'ipakeyextusage*',
+            cli_name='eku',
+            label=_('Extended key usage'),
+            doc=_('Extended key usage'),
+            flags={'no_create', 'no_update', 'no_search'},
+        ),
+        Str(
+            'ipakeytrust',
+            cli_name='keytrust',
+            label=_('Trust'),
+            doc=_('Trust'),
+            flags={'no_create', 'no_update', 'no_search'},
+        ),
+    )
+
+    managed_permissions = {}
+
+    def _parse_cacertificate(self, obj, full=True):
+        if "cacertificate" in obj:
+            cert = obj["cacertificate"][0]
+            self._parse_x509v1(cert, obj, full=full)
+            self._parse_san(cert, obj, full=full)
+        # human readable EKU, sorted by OID
+        if "ipakeyextusage" in obj:
+            obj["ipakeyextusage"] = [
+                x509.EKU_NAMES.get(eku, eku)
+                for eku in sorted(obj["ipakeyextusage"])
+            ]
+
+    def get_params(self):
+        for param in super(trustedca, self).get_params():
+            if param.name == 'cacertificate':
+                param = param.clone(flags=param.flags - {'no_search'})
+            yield param
+
+
+@register()
+class trustedca_find(LDAPSearch):
+    __doc__ = _("Search for trusted CAs certificates.")
+    msg_summary = ngettext(
+        '%(count)d CA matched', '%(count)d CAs matched', 0
+    )
+
+    def post_callback(self, ldap, entries, truncated, *args, **options):
+        if not options.get("raw"):
+            all = options.get("all")
+            for entry in entries:
+                self.obj._parse_cacertificate(entry, all)
+
+        return truncated
+
+
+@register()
+class trustedca_show(LDAPRetrieve):
+    __doc__ = _("Display the properties of a trusted CA certificate.")
+
+    def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
+        if not options.get("raw"):
+            all = options.get("all")
+            self.obj._parse_cacertificate(entry_attrs, all)
+        return dn

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -449,6 +449,7 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.container_sudorule = DN()
     api.env.container_sysaccounts = DN()
     api.env.container_topology = DN()
+    api.env.container_trustedca = DN()
     api.env.container_trusts = DN()
     api.env.container_user = DN()
     api.env.container_vault = DN()


### PR DESCRIPTION
IPA now has an API to return trusted CA certificates (`ipa-cacert-manage`). The trusted CA certificates are listed in the web UI.

- [ ] Create ticket
- [x] Add tests
- [ ] Add download button to UI