### PR TITLE
Refactor certstore API

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -70,7 +70,6 @@ from ipapython import version
 
 from . import automount, timeconf, sssd
 from ipaclient import discovery
-from ipaclient.install import ipa_certupdate
 from ipapython.ipachangeconf import IPAChangeConf
 
 NoneType = type(None)
@@ -3095,7 +3094,7 @@ def _install(options, tdict):
                                                   ca_subject)
 
     # install CA certs in system cert store, KDC, and NSSDB
-    ipa_certupdate.update_client(ca_certs)
+    certstore.update_cert_stores(ca_certs, certstore.StoreInstallation.CLIENT)
 
     if not options.on_master:
         client_dns(cli_server[0], hostname, options)

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -517,7 +517,7 @@ class KrbInstance(service.Service):
                                           self.api.env.basedn,
                                           self.api.env.realm,
                                           False)
-        ca_certs = [c for c, _n, t, _u in ca_certs if t is not False]
+        ca_certs = [ci.cert for ci in ca_certs if ci.trusted is not False]
         x509.write_certificate_list(ca_certs, paths.CACERT_PEM, mode=0o644)
 
     def issue_selfsigned_pkinit_certs(self):

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -435,8 +435,8 @@ class KrbInstance(service.Service):
         krbtgt = "krbtgt/" + self.realm + "@" + self.realm
         certpath = (paths.KDC_CERT, paths.KDC_KEY)
 
+        prev_helper = None
         try:
-            prev_helper = None
             # on the first CA-ful master without '--no-pkinit', we issue the
             # certificate by contacting Dogtag directly
             ca_instances = find_providing_servers(
@@ -516,7 +516,12 @@ class KrbInstance(service.Service):
                                           self.api.env.basedn,
                                           self.api.env.realm,
                                           False)
-        certstore.write_trusted_ca_certs(paths.CACERT_PEM, ca_certs)
+        # update paths.CACERT_PEM
+        certstore.update_cert_stores(
+            ca_certs,
+            certstore.StoreInstallation.SERVER,
+            service=self.service_name
+        )
 
     def issue_selfsigned_pkinit_certs(self):
         self._call_certmonger(certmonger_ca="SelfSign")

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -27,7 +27,6 @@ import dbus
 
 import dns.name
 
-from ipalib import x509
 from ipalib.install import certstore
 from ipaserver.install import service
 from ipaserver.install import installutils
@@ -517,8 +516,7 @@ class KrbInstance(service.Service):
                                           self.api.env.basedn,
                                           self.api.env.realm,
                                           False)
-        ca_certs = [ci.cert for ci in ca_certs if ci.trusted is not False]
-        x509.write_certificate_list(ca_certs, paths.CACERT_PEM, mode=0o644)
+        certstore.write_trusted_ca_certs(paths.CACERT_PEM, ca_certs)
 
     def issue_selfsigned_pkinit_certs(self):
         self._call_certmonger(certmonger_ca="SelfSign")

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -143,7 +143,7 @@ def install_ca_cert(ldap, base_dn, realm, cafile, destfile=paths.IPA_CA_CRT):
                 # cafile == IPA_CA_CRT
                 pass
         else:
-            certs = [c[0] for c in certs if c[2] is not False]
+            certs = [ci.cert for ci in certs if ci.trusted is not False]
             x509.write_certificate_list(certs, destfile, mode=0o644)
     except Exception as e:
         raise ScriptError("error copying files: " + str(e))

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -32,7 +32,7 @@ from ipapython.ipachangeconf import IPAChangeConf
 from ipaplatform import services
 from ipaplatform.tasks import tasks
 from ipaplatform.paths import paths
-from ipalib import api, constants, create_api, errors, rpc, x509
+from ipalib import api, constants, create_api, errors, rpc
 from ipalib.config import Env
 from ipalib.facts import is_ipa_configured, is_ipa_client_configured
 from ipalib.util import no_matching_interface_for_ip_address_warning
@@ -143,8 +143,7 @@ def install_ca_cert(ldap, base_dn, realm, cafile, destfile=paths.IPA_CA_CRT):
                 # cafile == IPA_CA_CRT
                 pass
         else:
-            certs = [ci.cert for ci in certs if ci.trusted is not False]
-            x509.write_certificate_list(certs, destfile, mode=0o644)
+            certstore.write_trusted_ca_certs(destfile, certs)
     except Exception as e:
         raise ScriptError("error copying files: " + str(e))
     return destfile

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -531,16 +531,15 @@ class Service:
         if conn is None:
             conn = api.Backend.ldap2
 
-        ca_certs = None
         try:
-            ca_certs = certstore.get_ca_certs(
-                conn, self.suffix, self.realm, ca_is_configured)
+            certs = certstore.get_ca_certs(
+                conn, self.suffix, self.realm, ca_is_configured
+            )
         except errors.NotFound:
             pass
         else:
-            with open(cafile, 'wb') as fd:
-                for cert, _unused1, _unused2, _unused3 in ca_certs:
-                    fd.write(cert.public_bytes(x509.Encoding.PEM))
+            certs = [ci.cert for ci in certs if ci.trusted is not False]
+            x509.write_certificate_list(certs, cafile, mode=0o644)
 
     def export_ca_certs_nssdb(self, db, ca_is_configured, conn=None):
         """

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -33,7 +33,7 @@ from ipalib.install import certstore, sysrestore
 from ipapython import ipautil
 from ipapython.dn import DN
 from ipapython import kerberos
-from ipalib import api, errors, x509
+from ipalib import api, errors
 from ipalib.constants import FQDN
 from ipaplatform import services
 from ipaplatform.constants import User
@@ -538,8 +538,7 @@ class Service:
         except errors.NotFound:
             pass
         else:
-            certs = [ci.cert for ci in certs if ci.trusted is not False]
-            x509.write_certificate_list(certs, cafile, mode=0o644)
+            certstore.write_trusted_ca_certs(cafile, certs)
 
     def export_ca_certs_nssdb(self, db, ca_is_configured, conn=None):
         """


### PR DESCRIPTION
The certstore module now uses a rich CACertInfo object instead of a simple tuple to return CA certificate information. The new object is a named tuple that behaves like the previous result from `get_ca_certs`. The change prepares the API for further changes to scope and limit CA certificates to subsystems.

The client installer now reuses code from `ipa-certupdate` to install CA certs into various cert stores. This changes behavior slightly in two ways: `/etc/ipa/ca.crt` is updated a second time and failure to add a cert to NSSDB no longer aborts the installer.

- [ ] `dsinstance` `__import_ca_certs` does not use new API
- [x] `replicainstall` `install_ca_cert` does not use new API, see https://github.com/freeipa/freeipa/pull/6620
- [ ] drop `service` `export_ca_certs_file`
- [ ] drop `service` `export_ca_certs_nssdb`

Related: https://pagure.io/freeipa/issue/9272