### PR TITLE
ipatests: mark test_smb as xfail 

### DIFF
--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -349,6 +349,7 @@ class TestSMB(IntegrationTest):
     @pytest.mark.skipif(
         osinfo.id == 'fedora' and osinfo.version_number <= (31,),
         reason='Test requires krb 1.18')
+    @pytest.mark.xfail(reason="Pagure ticket 9124", strict=True)
     def test_smb_service_s4u2self(self):
         """Test S4U2Self operation by IPA service
            against both AD and IPA users


### PR DESCRIPTION
Mark the test test_smb.py::TestSMB::test_smb_service_s4u2self as xfail.

Related: https://pagure.io/freeipa/issue/9124