### PR TITLE
[Backport][ipa-4-9] ipatests: mark test_smb as xfail 

### DIFF
--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -349,6 +349,7 @@ class TestSMB(IntegrationTest):
     @pytest.mark.skipif(
         osinfo.id == 'fedora' and osinfo.version_number <= (31,),
         reason='Test requires krb 1.18')
+    @pytest.mark.xfail(reason="Pagure ticket 9124", strict=True)
     def test_smb_service_s4u2self(self):
         """Test S4U2Self operation by IPA service
            against both AD and IPA users


### PR DESCRIPTION
This PR was opened automatically because PR #6617 was pushed to master and backport to ipa-4-9 is required.