### PR TITLE
Refactor CA file handling in replica installer

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -22,7 +22,7 @@ import six
 
 from ipaclient.install.client import check_ldap_conf, sssd_enable_ifp
 import ipaclient.install.timeconf
-from ipalib.install import certstore, sysrestore
+from ipalib.install import sysrestore
 from ipalib.install.kinit import kinit_keytab
 from ipapython import ipaldap, ipautil
 from ipapython.dn import DN
@@ -32,7 +32,7 @@ from ipapython.ipachangeconf import IPAChangeConf
 from ipaplatform import services
 from ipaplatform.tasks import tasks
 from ipaplatform.paths import paths
-from ipalib import api, constants, create_api, errors, rpc, x509
+from ipalib import api, constants, create_api, errors, rpc
 from ipalib.config import Env
 from ipalib.facts import is_ipa_configured, is_ipa_client_configured
 from ipalib.util import no_matching_interface_for_ip_address_warning
@@ -130,24 +130,6 @@ def install_krb(config, setup_pkinit=False, pkcs12_info=None, fstore=None):
                        subject_base=config.subject_base)
 
     return krb
-
-
-def install_ca_cert(ldap, base_dn, realm, cafile, destfile=paths.IPA_CA_CRT):
-    try:
-        try:
-            certs = certstore.get_ca_certs(ldap, base_dn, realm, False)
-        except errors.NotFound:
-            try:
-                shutil.copy(cafile, destfile)
-            except shutil.Error:
-                # cafile == IPA_CA_CRT
-                pass
-        else:
-            certs = [c[0] for c in certs if c[2] is not False]
-            x509.write_certificate_list(certs, destfile, mode=0o644)
-    except Exception as e:
-        raise ScriptError("error copying files: " + str(e))
-    return destfile
 
 
 def install_http(config, auto_redirect, ca_is_configured, ca_file,
@@ -797,7 +779,8 @@ def promote_check(installer):
         raise ScriptError("--setup-ca and --*-cert-file options are "
                           "mutually exclusive")
 
-    if not is_ipa_client_configured(on_master=True):
+    ipa_client_installed = is_ipa_client_configured(on_master=True)
+    if not ipa_client_installed:
         # One-step replica installation
         if options.password and options.admin_password:
             raise ScriptError("--password and --admin-password options are "
@@ -935,10 +918,13 @@ def promote_check(installer):
                  paths.KRB5_KEYTAB,
                  ccache)
 
-    cafile = paths.IPA_CA_CRT
-    if not os.path.isfile(cafile):
-        raise RuntimeError("CA cert file is not available! Please reinstall"
-                           "the client and try again.")
+    if ipa_client_installed:
+        # host was already an IPA client, refresh client cert stores to
+        # ensure we have up to date CA certs.
+        try:
+            ipautil.run([paths.IPA_CERTUPDATE])
+        except ipautil.CalledProcessError:
+            raise RuntimeError("ipa-certupdate failed to refresh certs.")
 
     ldapuri = 'ldaps://%s' % ipautil.format_netloc(config.master_host_name)
     xmlrpc_uri = 'https://{}/ipa/xml'.format(
@@ -1193,14 +1179,14 @@ def promote_check(installer):
                 config.master_host_name, config.host_name, config.realm_name,
                 options.setup_ca, 389,
                 options.admin_password, principal=options.principal,
-                ca_cert_file=cafile)
+                ca_cert_file=paths.IPA_CA_CRT)
         finally:
             if add_to_ipaservers:
                 os.environ['KRB5CCNAME'] = ccache
 
     installer._ca_enabled = ca_enabled
     installer._kra_enabled = kra_enabled
-    installer._ca_file = cafile
+    installer._ca_file = paths.IPA_CA_CRT
     installer._fstore = fstore
     installer._sstore = sstore
     installer._config = config
@@ -1221,7 +1207,6 @@ def install(installer):
     fstore = installer._fstore
     sstore = installer._sstore
     config = installer._config
-    cafile = installer._ca_file
     dirsrv_pkcs12_info = installer._dirsrv_pkcs12_info
     http_pkcs12_info = installer._http_pkcs12_info
     pkinit_pkcs12_info = installer._pkinit_pkcs12_info
@@ -1255,18 +1240,10 @@ def install(installer):
 
     try:
         conn.connect(ccache=ccache)
-
-        # Update and istall updated CA file
-        cafile = install_ca_cert(conn, api.env.basedn, api.env.realm, cafile)
-        install_ca_cert(conn, api.env.basedn, api.env.realm, cafile,
-                        destfile=paths.KDC_CA_BUNDLE_PEM)
-        install_ca_cert(conn, api.env.basedn, api.env.realm, cafile,
-                        destfile=paths.CA_BUNDLE_PEM)
-
         # Configure dirsrv
         ds = install_replica_ds(config, options, ca_enabled,
                                 remote_api,
-                                ca_file=cafile,
+                                ca_file=paths.IPA_CA_CRT,
                                 pkcs12_info=dirsrv_pkcs12_info,
                                 fstore=fstore)
 
@@ -1317,7 +1294,7 @@ def install(installer):
         auto_redirect=not options.no_ui_redirect,
         pkcs12_info=http_pkcs12_info,
         ca_is_configured=ca_enabled,
-        ca_file=cafile,
+        ca_file=paths.IPA_CA_CRT,
         fstore=fstore)
 
     # Need to point back to ourself after the cert for HTTP is obtained


### PR DESCRIPTION
Clean up and remove obsolete code from ipa-replica-install. For several versions replica installer first ensures that a host is an IPA client, then promotes the client to a replica. The client installer code sets up CA stores like IPA_CA_CRT already.

Related: https://pagure.io/freeipa/issue/9272