### PR TITLE
[Backport][ipa-4-10] server install: remove error log about missing bkup file

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -124,10 +124,9 @@ def cleanup(func):
             os.rmdir(ccache_dir)
         except OSError:
             pass
-        try:
-            os.remove(krb_name + ".ipabkp")
-        except OSError:
-            logger.error("Could not remove %s.ipabkp", krb_name)
+        # During master installation, the .ipabkp file is not created
+        # Ignore the delete error if it is "file does not exist"
+        remove_file(krb_name + ".ipabkp")
 
     return inner
 


### PR DESCRIPTION
This PR was opened automatically because PR #6621 was pushed to master and backport to ipa-4-10 is required.