### PR TITLE
Tests: force key type in ACME tests

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -131,6 +131,7 @@ def certbot_standalone_cert(host, acme_server):
             'certonly',
             '--domain', host.hostname,
             '--standalone',
+            '--key-type', 'rsa',
         ]
     )
 
@@ -305,6 +306,7 @@ class TestACME(CALessBase):
             '--manual-public-ip-logging-ok',
             '--manual-auth-hook', CERTBOT_DNS_IPA_SCRIPT,
             '--manual-cleanup-hook', CERTBOT_DNS_IPA_SCRIPT,
+            '--key-type', 'rsa',
         ])
 
     ##############


### PR DESCRIPTION
PKI can issue ACME certs only when the key type is rsa.

With version 2.0.0, certbot defaults to ecdsa key type,
and this causes test failures.
For now, force rsa when requesting an ACME certificate.
This change can be reverted when PKI fixes the issue
on their side (https://github.com/dogtagpki/pki/issues/4273)

Related: https://pagure.io/freeipa/issue/9298
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>