### PR TITLE
Installer: create RID base before domain object 

### DIFF
--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -862,6 +862,7 @@ class ADTRUSTInstance(service.Service):
             self.step("validate server hostname",
                       self.__validate_server_hostname)
             self.step("stopping smbd", self.__stop)
+        self.step("adding RID bases", self.__add_rid_bases)
         self.step("creating samba domain object", \
                   self.__create_samba_domain_object)
         if self.fulltrust:
@@ -880,7 +881,6 @@ class ADTRUSTInstance(service.Service):
             self.step("adding cifs principal to S4U2Proxy targets",
                       self.__add_s4u2proxy_target)
         self.step("adding admin(group) SIDs", self.__add_admin_sids)
-        self.step("adding RID bases", self.__add_rid_bases)
         self.step("updating Kerberos config", self.__update_krb5_conf)
         if self.fulltrust:
             self.step("activating CLDAP plugin", self.__add_cldap_module)


### PR DESCRIPTION
The installer is currently creating the samba domain object
before it adds the RID base and secondary RID base. As a consequence,
there is a window during which the sidgen plugin is active but
unable to generate SIDs (it requires the samba domain object to
find the domain SID and RID base to know where to start from).
There is no direct impact except the error log of 389ds that reports
ERR - get_ranges - [file ipa_sidgen_common.c, line 276]: Failed to convert LDAP entry to range struct.

This fix configures the RID base and secondary RID base before the
domain object is created, thus removing this window.

Fixes: https://pagure.io/freeipa/issue/9309
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>