### PR TITLE
[Backport][ipa-4-10] Tests: force key type in ACME tests

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -131,6 +131,7 @@ def certbot_standalone_cert(host, acme_server):
             'certonly',
             '--domain', host.hostname,
             '--standalone',
+            '--key-type', 'rsa',
         ]
     )
 
@@ -305,6 +306,7 @@ class TestACME(CALessBase):
             '--manual-public-ip-logging-ok',
             '--manual-auth-hook', CERTBOT_DNS_IPA_SCRIPT,
             '--manual-cleanup-hook', CERTBOT_DNS_IPA_SCRIPT,
+            '--key-type', 'rsa',
         ])
 
     ##############


### PR DESCRIPTION
This PR was opened automatically because PR #6625 was pushed to master and backport to ipa-4-10 is required.