### PR TITLE
doc: Fix incorrect URL format

### DIFF
--- a/doc/workshop/12-external-idp-support.rst
+++ b/doc/workshop/12-external-idp-support.rst
@@ -41,7 +41,7 @@ experience. Emulating the login pages as part of line- and packet-oriented SSH
 protocol or console login script is not possible.
 
 OAuth 2.0 Device Authorization Grant is defined in
-[RFC 8628](https://www.rfc-editor.org/rfc/rfc8628) and allows devices that either
+`RFC 8628 <https://www.rfc-editor.org/rfc/rfc8628>`_ and allows devices that either
 lack a browser or input constrained to obtain user authorization to access
 protected resources. Instead of performing the authorization flow right at the
 device where OAuth authorization grant is requested, a user would perform it at


### PR DESCRIPTION
Replaced URL in Markdown Format with the proper reStructuredText markup in file doc/workshop/12-external-idp-support.rst

Signed-off-by: Lenz Grimmer <lenz.grimmer@percona.com>