### PR TITLE
[Backport][ipa-4-9] trust-add: handle missing msSFU30MaxGidNumber

### DIFF
--- a/ipaserver/plugins/trust.py
+++ b/ipaserver/plugins/trust.py
@@ -379,7 +379,10 @@ def add_range(myapi, trustinstance, range_name, dom_sid, *keys, **options):
                 range_type = u'ipa-ad-trust-posix'
 
                 max_uid = info.get('msSFU30MaxUidNumber')
-                max_gid = info.get('msSFU30MaxGidNumber', None)
+                # if max_gid is missing, assume 0 and the max will
+                # be obtained from max_uid. We just checked that
+                # msSFU30MaxUidNumber is defined
+                max_gid = info.get('msSFU30MaxGidNumber', [b'0'])
                 max_id = int(max(max_uid, max_gid)[0])
 
                 base_id = int(info.get('msSFU30OrderNumber')[0])


### PR DESCRIPTION
This PR was opened automatically because PR #6634 was pushed to master and backport to ipa-4-9 is required.