### PR TITLE
spec: Drop no longer used build dependency on paste

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -388,7 +388,6 @@ BuildRequires:  python3-libsss_nss_idmap
 BuildRequires:  python3-lxml
 BuildRequires:  python3-netaddr >= %{python_netaddr_version}
 BuildRequires:  python3-netifaces
-BuildRequires:  python3-paste
 BuildRequires:  python3-pki >= %{pki_version}
 BuildRequires:  python3-polib
 BuildRequires:  python3-pyasn1


### PR DESCRIPTION
With ff6e701b0077d9c8e2aacdcaecf70f885018db92 it was replaced with `werkzeug`.

https://pypi.org/project/Paste/
> Paste is in maintenance mode and recently moved from bitbucket to
  github. Patches are accepted to keep it on life support, but for the
  most part, please consider using other options.

Fixes: https://pagure.io/freeipa/issue/9314