### PR TITLE
fastlint: Correct concatenation of file lists

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -244,7 +244,7 @@ fastcodestyle: $(GENERATED_PYTHON_FILES) ipasetup.py
 	    | xargs -n1 file 2>/dev/null | grep Python \
 	    | cut -d':' -f1; ); \
 	if [ -n "$${PYFILES}" ] && [ -n "$${INFILES}" ]; then \
-	    FILES="$$( printf $${PYFILES}\\n$${INFILES} )" ; \
+	    FILES="$$( printf '%s\n' "$${PYFILES}" "$${INFILES}" )" ; \
 	elif [ -n "$${PYFILES}" ]; then \
 	    FILES="$${PYFILES}" ; \
 	else \
@@ -274,7 +274,7 @@ endif
 	    | xargs -n1 file 2>/dev/null | grep Python \
 	    | cut -d':' -f1; ); \
 	if [ -n "$${PYFILES}" ] && [ -n "$${INFILES}" ]; then \
-	    FILES="$$( printf $${PYFILES}\\n$${INFILES} )" ; \
+	    FILES="$$( printf '%s\n' "$${PYFILES}" "$${INFILES}" )" ; \
 	elif [ -n "$${PYFILES}" ]; then \
 	    FILES="$${PYFILES}" ; \
 	else \


### PR DESCRIPTION
`printf` ignores excessive arguments unused in formatting.
This resulted in only the first file from two file lists was
linted/stylechecked if both Python template files and Python
modules were changed.

Make use of formatting instead:
> The format is reused as necessary to consume all of the arguments

Fixes: https://pagure.io/freeipa/issue/9318