### PR TITLE
tests: Configure DNSResolver as platform agnostic resolver

### DIFF
--- a/ipatests/test_ipapython/test_dnsutil.py
+++ b/ipatests/test_ipapython/test_dnsutil.py
@@ -104,13 +104,19 @@ class TestSortURI:
 
 
 class TestDNSResolver:
-    def test_nameservers(self):
-        res = dnsutil.DNSResolver()
+    @pytest.fixture(name="res")
+    def resolver(self):
+        """Resolver that doesn't read /etc/resolv.conf
+
+        /etc/resolv.conf is not mandatory on systems
+        """
+        return dnsutil.DNSResolver(configure=False)
+
+    def test_nameservers(self, res):
         res.nameservers = ["4.4.4.4", "8.8.8.8"]
         assert res.nameservers == ["4.4.4.4", "8.8.8.8"]
 
-    def test_nameservers_with_ports(self):
-        res = dnsutil.DNSResolver()
+    def test_nameservers_with_ports(self, res):
         res.nameservers = ["4.4.4.4 port 53", "8.8.8.8 port 8053"]
         assert res.nameservers == ["4.4.4.4", "8.8.8.8"]
         assert res.nameserver_ports == {"4.4.4.4": 53, "8.8.8.8": 8053}
@@ -119,8 +125,7 @@ class TestDNSResolver:
         assert res.nameservers == ["4.4.4.4", "8.8.8.8"]
         assert res.nameserver_ports == {"4.4.4.4": 53, "8.8.8.8": 8053}
 
-    def test_nameservers_with_bad_ports(self):
-        res = dnsutil.DNSResolver()
+    def test_nameservers_with_bad_ports(self, res):
         try:
             res.nameservers = ["4.4.4.4 port a"]
         except ValueError:


### PR DESCRIPTION
Avoid reading platform specific `/etc/resolv.conf` in `TestDNSResolver` unit tests. Systems (e.g. sandboxes) may not have `/etc/resolv.conf` or this file may not contain any configured name servers.

`TestDNSResolver` unit tests check only customized `nameservers` property and should not depend on existence of `/etc/resolv.conf`.

Resolver accepts `configure` option.
https://dnspython.readthedocs.io/en/latest/resolver-class.html :
> configure, a bool. If True (the default), the resolver instance is
  configured in the normal fashion for the operating system the resolver
  is running on. (I.e. by reading a /etc/resolv.conf file on POSIX
  systems and from the registry on Windows systems.)

Fixes: https://pagure.io/freeipa/issue/9319