### PR TITLE
[Backport][ipa-4-10] spec: Drop no longer used build dependency on paste

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -388,7 +388,6 @@ BuildRequires:  python3-libsss_nss_idmap
 BuildRequires:  python3-lxml
 BuildRequires:  python3-netaddr >= %{python_netaddr_version}
 BuildRequires:  python3-netifaces
-BuildRequires:  python3-paste
 BuildRequires:  python3-pki >= %{pki_version}
 BuildRequires:  python3-polib
 BuildRequires:  python3-pyasn1


### PR DESCRIPTION
This PR was opened automatically because PR #6641 was pushed to master and backport to ipa-4-10 is required.