### PR TITLE
[Backport][ipa-4-9] Address test failures related to the freeipa-healthcheck 0.12 release

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1617,12 +1617,21 @@ class TestIpaHealthCheckWithoutDNS(IntegrationTest):
         Test checks the result of IPADNSSystemRecordsCheck
         when ipa-server is configured without DNS.
         """
-        expected_msgs = {
-            "Expected SRV record missing",
-            "Got {count} ipa-ca A records, expected {expected}",
-            "Got {count} ipa-ca AAAA records, expected {expected}",
-            "Expected URI record missing",
-        }
+        version = tasks.get_healthcheck_version(self.master)
+        if (parse_version(version) < parse_version('0.12')):
+            expected_msgs = {
+                "Expected SRV record missing",
+                "Got {count} ipa-ca A records, expected {expected}",
+                "Got {count} ipa-ca AAAA records, expected {expected}",
+                "Expected URI record missing",
+            }
+        else:
+            expected_msgs = {
+                "Expected SRV record missing",
+                "Unexpected ipa-ca address {ipaddr}",
+                "expected ipa-ca to contain {ipaddr} for {server}",
+                "Expected URI record missing",
+            }
 
         tasks.install_packages(self.master, HEALTHCHECK_PKG)
         returncode, data = run_healthcheck(

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -810,7 +810,9 @@ class TestIpaHealthCheck(IntegrationTest):
             + [str(ip) for ip in resolve_ip_addresses_nss(h.external_hostname)]
         ]
         SYSTEM_RECORDS.append(f'"{self.master.domain.realm.upper()}"')
-
+        version = tasks.get_healthcheck_version(self.master)
+        if parse_version(version) >= parse_version("0.12"):
+            SYSTEM_RECORDS.append('ipa_ca_check')
 
         returncode, data = run_healthcheck(
             self.master,


### PR DESCRIPTION
This PR was opened automatically because PR #6646 was pushed to master and backport to ipa-4-9 is required.