### PR TITLE
[Backport][ipa-4-9] Fix 389-ds healthcheck output message

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1310,9 +1310,6 @@ class TestIpaHealthCheck(IntegrationTest):
         """
         error_msg = (
             "\n\nIn Directory Server, we offer one hash suitable for this "
-            "(PBKDF2_SHA256) and one hash\nfor \"legacy\" support (SSHA512)."
-            "\n\nYour configuration does not use these for password storage "
-            "or the root password storage\nscheme.\n"
         )
         returncode, data = run_healthcheck(
             self.master, "ipahealthcheck.ds.config", "ConfigCheck",


### PR DESCRIPTION
This is a manual backport of PR#6450 to ipa-4-9 branch.

389-ds-base-2.1.6-1.fc36 contains the fix for issue #[5356](https://github.com/389ds/389-ds-base/commit/99a74d7) and ipa-4-9 is still available on fedora 36 => the test fix is needed on ipa-4-9.