### PR TITLE
[Backport][ipa-4-10] automember-rebuild: add a notice about high CPU use

### DIFF
--- a/install/ui/test/data/i18n_messages.json
+++ b/install/ui/test/data/i18n_messages.json
@@ -7,7 +7,7 @@
             "actions": {
                 "apply": "Apply", 
                 "automember_rebuild": "Rebuild auto membership", 
-                "automember_rebuild_confirm": "Are you sure you want to rebuild auto membership?", 
+                "automember_rebuild_confirm": "Are you sure you want to rebuild auto membership? In case of a high number of users, hosts or groups, the operation may require high CPU usage.",
                 "automember_rebuild_success": "Automember rebuild membership task completed", 
                 "confirm": "Are you sure you want to proceed with the action?", 
                 "delete_confirm": "Are you sure you want to delete ${object}?", 

--- a/ipaclient/plugins/automember.py
+++ b/ipaclient/plugins/automember.py
@@ -34,3 +34,11 @@ class automember_add_condition(MethodOverride):
             flags=['suppress_empty'],
         ),
     )
+
+
+@register(override=True, no_fail=True)
+class automember_rebuild(MethodOverride):
+    def interactive_prompt_callback(self, kw):
+        msg = _('IMPORTANT: In case of a high number of users, hosts or '
+                'groups, the operation may require high CPU usage.')
+        self.Backend.textui.print_plain(msg)

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -160,7 +160,11 @@ class i18n_messages(Command):
         "actions": {
             "apply": _("Apply"),
             "automember_rebuild": _("Rebuild auto membership"),
-            "automember_rebuild_confirm": _("Are you sure you want to rebuild auto membership?"),
+            "automember_rebuild_confirm": _(
+                "Are you sure you want to rebuild auto membership? In case of "
+                "a high number of users, hosts or groups, the operation "
+                "may require high CPU usage."
+            ),
             "automember_rebuild_success": _("Automember rebuild membership task completed"),
             "confirm": _("Are you sure you want to proceed with the action?"),
             "delete_confirm": _("Are you sure you want to delete ${object}?"),


### PR DESCRIPTION
This PR was opened automatically because PR #6653 was pushed to master and backport to ipa-4-10 is required.