### PR TITLE
[Backport][ipa-4-9] ipatests: (prci_checker) fix duplicated check & error return code

### DIFF
--- a/ipatests/prci_definitions/prci_checker.py
+++ b/ipatests/prci_definitions/prci_checker.py
@@ -115,6 +115,7 @@ def check_jobs(filename, jobs_def, topologies, current_spec, supported_classes):
         if "timeout" not in args:
             msg = "'timeout' field should be defined in args section"
             print_field_error(job_name, custom_msg=msg)
+            correct_fields = False
         if args.get("topology") not in topologies:
             msg = (
                 "'topology' field should be defined with one of the "
@@ -171,10 +172,6 @@ def check_jobs(filename, jobs_def, topologies, current_spec, supported_classes):
         # Check template field against build target
         if args.get("template") != template:
             print_field_error(job_name, "template", template)
-            correct_fields = False
-        if "timeout" not in args:
-            msg = "'timeout' field should be defined in args section"
-            print_field_error(job_name, custom_msg=msg)
             correct_fields = False
         # If build target has a copr repo, check that the job also defines it
         if args.get("copr") != copr:
@@ -391,7 +388,7 @@ def main():
     jobs_spec, supported_classes, f_fixed_jobs = process_spec_file(args.spec)
 
     if args.file:
-        result = process_def_file(args.file, jobs_spec, supported_classes)
+        result = process_def_file(args.file, jobs_spec, supported_classes)[0]
     else:
         # Get all yaml files in default dir, except those in IGNORE_FILES
         def_files_dir = os.path.join(args.defs, "*.y*ml")


### PR DESCRIPTION
This PR was opened automatically because PR #6654 was pushed to master and backport to ipa-4-9 is required.