### PR TITLE
tests: add wrapper around ACME RSNv3 test

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -393,7 +393,14 @@ class TestACME(CALessBase):
 
     def test_acme_pruning_no_random_serial(self):
         """This ACME install is configured without random serial
-           numbers. Verify that we can't enable pruning on it."""
+           numbers. Verify that we can't enable pruning on it.
+
+           This test is located here because by default installs
+           don't enable RSNv3.
+        """
+        if (tasks.get_pki_version(self.master)
+           < tasks.parse_version('11.3.0')):
+            raise pytest.skip("Certificate pruning is not available")
         self.master.run_command(['ipa-acme-manage', 'enable'])
         result = self.master.run_command(
             ['ipa-acme-manage', 'pruning', '--enable'],


### PR DESCRIPTION
tests: add wrapper around ACME RSNv3 test

This test is located outside of the TestACMEPrune because
it enables RSNv3 while the server installed by TestACME doesn't.

It still needs a wrapper to enforce a version of PKI that
supports pruning because that is checked first in the tool.
Re-ordering that wouldn't be a good user experience.

https://pagure.io/freeipa/issue/9322

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
