### PR TITLE
API doc: add note about ipa show-mappings to usage guide

### DIFF
--- a/doc/api/basic_usage.md
+++ b/doc/api/basic_usage.md
@@ -92,6 +92,10 @@ kw = {
 api.Command.user_show(*args, **kw)
 ```
 
+The full list of available arguments and options for each command can be found
+in the API Reference. Alternatively, it is possible to see the mapping of CLI
+option to API attribute through `ipa show-mappings`.
+
 ## Retrieving output
 
 Command output is returned as a Python dictionary. Example shown is the output


### PR DESCRIPTION
As discussed in PR #6664, `ipa show-mappings` can be used as a handy way to list command arguments and options directly through the CLI.

Signed-off-by: Antonio Torres <antorres@redhat.com>