### PR TITLE
ipatests: increase timeout for test_acme

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1721,9 +1721,25 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_acme.py
+        test_suite: >-
+            test_integration/test_acme.py::TestACME
+            test_integration/test_acme.py::TestACMECALess
+            test_integration/test_acme.py::TestACMEwithExternalCA
+            test_integration/test_acme.py::TestACMERenew
         template: *ci-master-latest
-        timeout: 7200
+        timeout: 8100
+        topology: *master_1repl_1client
+
+  fedora-latest/test_acme_prune:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_acme.py::TestACMEPrune
+        template: *ci-master-latest
+        timeout: 3600
         topology: *master_1repl_1client
 
   fedora-latest/test_dns:

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -966,9 +966,27 @@ jobs:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
         copr: '@pki/master'
-        test_suite: test_integration/test_acme.py
+        test_suite: >-
+            test_integration/test_acme.py::TestACME
+            test_integration/test_acme.py::TestACMECALess
+            test_integration/test_acme.py::TestACMEwithExternalCA
+            test_integration/test_acme.py::TestACMERenew
         template: *ci-master-latest
-        timeout: 7200
+        timeout: 8100
+        topology: *master_1repl_1client
+
+  pki-fedora/test_acme_prune:
+    requires: [pki-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{pki-fedora/build_url}'
+        update_packages: True
+        copr: '@pki/master'
+        test_suite: test_integration/test_acme.py::TestACMEPrune
+        template: *ci-master-latest
+        timeout: 3600
         topology: *master_1repl_1client
 
   pki-fedora/test_cert_fix:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1858,9 +1858,26 @@ jobs:
       args:
         build_url: '{fedora-latest/build_url}'
         selinux_enforcing: True
-        test_suite: test_integration/test_acme.py
+        test_suite:  >-
+            test_integration/test_acme.py::TestACME
+            test_integration/test_acme.py::TestACMECALess
+            test_integration/test_acme.py::TestACMEwithExternalCA
+            test_integration/test_acme.py::TestACMERenew
         template: *ci-master-latest
-        timeout: 7200
+        timeout: 8100
+        topology: *master_1repl_1client
+
+  fedora-latest/test_acme_prune:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite:  test_integration/test_acme.py::TestACMEPrune
+        template: *ci-master-latest
+        timeout: 3600
         topology: *master_1repl_1client
 
   fedora-latest/test_dns:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1996,9 +1996,27 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         enable_testing_repo: True
-        test_suite: test_integration/test_acme.py
+        test_suite: >-
+            test_integration/test_acme.py::TestACME
+            test_integration/test_acme.py::TestACMECALess
+            test_integration/test_acme.py::TestACMEwithExternalCA
+            test_integration/test_acme.py::TestACMERenew
         template: *ci-master-latest
-        timeout: 7200
+        timeout: 8100
+        topology: *master_1repl_1client
+
+  testing-fedora/test_acme_prune:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_acme.py::TestACMEPrune
+        template: *ci-master-latest
+        timeout: 3600
         topology: *master_1repl_1client
 
   testing-fedora/test_dns:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2133,9 +2133,28 @@ jobs:
         update_packages: True
         selinux_enforcing: True
         enable_testing_repo: True
-        test_suite: test_integration/test_acme.py
+        test_suite: >-
+            test_integration/test_acme.py::TestACME
+            test_integration/test_acme.py::TestACMECALess
+            test_integration/test_acme.py::TestACMEwithExternalCA
+            test_integration/test_acme.py::TestACMERenew
         template: *ci-master-latest
-        timeout: 7200
+        timeout: 8100
+        topology: *master_1repl_1client
+
+  testing-fedora/test_acme_prune:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_acme.py::TestACMEPrune
+        template: *ci-master-latest
+        timeout: 3600
         topology: *master_1repl_1client
 
   testing-fedora/test_dns:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1721,9 +1721,25 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-previous/build_url}'
-        test_suite: test_integration/test_acme.py
+        test_suite: >-
+            test_integration/test_acme.py::TestACME
+            test_integration/test_acme.py::TestACMECALess
+            test_integration/test_acme.py::TestACMEwithExternalCA
+            test_integration/test_acme.py::TestACMERenew
         template: *ci-master-previous
-        timeout: 7200
+        timeout: 8100
+        topology: *master_1repl_1client
+
+  fedora-previous/test_acme_prune:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_acme.py::TestACMEPrune
+        template: *ci-master-previous
+        timeout: 3600
         topology: *master_1repl_1client
 
   fedora-previous/test_dns:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1858,9 +1858,26 @@ jobs:
       args:
         build_url: '{fedora-rawhide/build_url}'
         update_packages: True
-        test_suite: test_integration/test_acme.py
+        test_suite: >-
+            test_integration/test_acme.py::TestACME
+            test_integration/test_acme.py::TestACMECALess
+            test_integration/test_acme.py::TestACMEwithExternalCA
+            test_integration/test_acme.py::TestACMERenew
         template: *ci-master-frawhide
-        timeout: 7200
+        timeout: 8100
+        topology: *master_1repl_1client
+
+  fedora-rawhide/test_acme_prune:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_acme.py::TestACMEPrune
+        template: *ci-master-frawhide
+        timeout: 3600
         topology: *master_1repl_1client
 
   fedora-rawhide/test_dns:


### PR DESCRIPTION
The test test_integration/test_acme.py times out frequently
and has a current timeout set to 2h, which is roughly
the average time for a successful run.

Increase by 15 minutes, so that even the tests requiring
packages update have enough time (for instance rawhide
run needs to update all the packages to the latest version).

Also create a separate job for the new test TestACMEPrune.

Fixes: https://pagure.io/freeipa/issue/9324

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>