### PR TITLE
PRCI: update test_trust.py for nightly pipelines.

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1649,9 +1649,21 @@ jobs:
       class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_trust.py
+        test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-latest
-        timeout: 10000
+        timeout: 6000
+        topology: *adroot_adchild_adtree_master_1client
+
+  fedora-latest/test_trust_autoprivate:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_trust.py::TestNonPosixAutoPrivateGroup test_integration/test_trust.py::TestPosixAutoPrivateGroup
+        template: *ci-master-latest
+        timeout: 6000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1780,9 +1780,22 @@ jobs:
       args:
         build_url: '{fedora-latest/build_url}'
         selinux_enforcing: True
-        test_suite: test_integration/test_trust.py
+        test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-latest
-        timeout: 10000
+        timeout: 6000
+        topology: *adroot_adchild_adtree_master_1client
+
+  fedora-latest/test_trust_autoprivate:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_trust.py::TestNonPosixAutoPrivateGroup test_integration/test_trust.py::TestPosixAutoPrivateGroup
+        template: *ci-master-latest
+        timeout: 6000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -230,14 +230,28 @@ jobs:
     requires: [sssd-fedora/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{sssd-fedora/build_url}'
         update_packages: True
         copr: '@sssd/nightly'
-        test_suite: test_integration/test_trust.py
+        test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-latest
-        timeout: 10000
+        timeout: 6000
+        topology: *adroot_adchild_adtree_master_1client
+
+  sssd-fedora/test_trust_autoprivate:
+    requires: [sssd-fedora/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{sssd-fedora/build_url}'
+        update_packages: True
+        copr: '@sssd/nightly'
+        test_suite: test_integration/test_trust.py::TestNonPosixAutoPrivateGroup test_integration/test_trust.py::TestPosixAutoPrivateGroup
+        template: *ci-master-latest
+        timeout: 6000
         topology: *adroot_adchild_adtree_master_1client
 
   sssd-fedora/test_user_permissions_TestUserPermissions:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1912,9 +1912,23 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         enable_testing_repo: True
-        test_suite: test_integration/test_trust.py
+        test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-latest
-        timeout: 10000
+        timeout: 6000
+        topology: *adroot_adchild_adtree_master_1client
+
+  testing-fedora/test_trust_autoprivate:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_trust.py::TestNonPosixAutoPrivateGroup test_integration/test_trust.py::TestPosixAutoPrivateGroup
+        template: *ci-master-latest
+        timeout: 6000
         topology: *adroot_adchild_adtree_master_1client
 
   testing-fedora/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2043,9 +2043,24 @@ jobs:
         update_packages: True
         selinux_enforcing: True
         enable_testing_repo: True
-        test_suite: test_integration/test_trust.py
+        test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-latest
-        timeout: 10000
+        timeout: 6000
+        topology: *adroot_adchild_adtree_master_1client
+
+  testing-fedora/test_trust_autoprivate:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_trust.py::TestNonPosixAutoPrivateGroup test_integration/test_trust.py::TestPosixAutoPrivateGroup
+        template: *ci-master-latest
+        timeout: 6000
         topology: *adroot_adchild_adtree_master_1client
 
   testing-fedora/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1649,9 +1649,21 @@ jobs:
       class: RunADTests
       args:
         build_url: '{fedora-previous/build_url}'
-        test_suite: test_integration/test_trust.py
+        test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-previous
-        timeout: 10000
+        timeout: 6000
+        topology: *adroot_adchild_adtree_master_1client
+
+  fedora-previous/test_trust_autoprivate:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_trust.py::TestNonPosixAutoPrivateGroup test_integration/test_trust.py::TestPosixAutoPrivateGroup
+        template: *ci-master-previous
+        timeout: 6000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-previous/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1780,9 +1780,22 @@ jobs:
       args:
         build_url: '{fedora-rawhide/build_url}'
         update_packages: True
-        test_suite: test_integration/test_trust.py
+        test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-frawhide
-        timeout: 10000
+        timeout: 6000
+        topology: *adroot_adchild_adtree_master_1client
+
+  fedora-rawhide/test_trust_autoprivate:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_trust.py::TestNonPosixAutoPrivateGroup test_integration/test_trust.py::TestPosixAutoPrivateGroup
+        template: *ci-master-frawhide
+        timeout: 6000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-rawhide/test_backup_and_restore_TestBackupAndRestoreTrust:


### PR DESCRIPTION
In nightly pipelines test_trust is failing with timeout thus, 
test_integration/test_trust.py is divided into two parts. 
1: class TestTrust
2: class TestNonPosixAutoPrivateGroup, class TestPosixAutoPrivateGroup
Latest failure observed in https://github.com/freeipa-pr-ci2/freeipa/pull/2423

Fixes: https://pagure.io/freeipa/issue/9326

Signed-off-by: Anuja More <amore@redhat.com>