### PR TITLE
[Backport][ipa-4-9]PRCI: update test_trust.py for nightly pipelines.

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1649,9 +1649,21 @@ jobs:
       class: RunADTests
       args:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
-        test_suite: test_integration/test_trust.py
+        test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-ipa-4-9-latest
-        timeout: 10000
+        timeout: 6000
+        topology: *adroot_adchild_adtree_master_1client
+
+  fedora-latest-ipa-4-9/test_trust_autoprivate:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        test_suite: test_integration/test_trust.py::TestNonPosixAutoPrivateGroup test_integration/test_trust.py::TestPosixAutoPrivateGroup
+        template: *ci-ipa-4-9-latest
+        timeout: 6000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest-ipa-4-9/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1780,9 +1780,22 @@ jobs:
       args:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         selinux_enforcing: True
-        test_suite: test_integration/test_trust.py
+        test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-ipa-4-9-latest
-        timeout: 10000
+        timeout: 6000
+        topology: *adroot_adchild_adtree_master_1client
+
+  fedora-latest-ipa-4-9/test_trust_autoprivate:
+    requires: [fedora-latest-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest-ipa-4-9/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_trust.py::TestNonPosixAutoPrivateGroup test_integration/test_trust.py::TestPosixAutoPrivateGroup
+        template: *ci-ipa-4-9-latest
+        timeout: 6000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest-ipa-4-9/test_backup_and_restore_TestBackupAndRestoreTrust:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1649,9 +1649,21 @@ jobs:
       class: RunADTests
       args:
         build_url: '{fedora-previous-ipa-4-9/build_url}'
-        test_suite: test_integration/test_trust.py
+        test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-ipa-4-9-previous
-        timeout: 10000
+        timeout: 6000
+        topology: *adroot_adchild_adtree_master_1client
+
+  fedora-previous-ipa-4-9/test_trust_autoprivate:
+    requires: [fedora-previous-ipa-4-9/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-previous-ipa-4-9/build_url}'
+        test_suite: test_integration/test_trust.py::TestNonPosixAutoPrivateGroup test_integration/test_trust.py::TestPosixAutoPrivateGroup
+        template: *ci-ipa-4-9-previous
+        timeout: 6000
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-previous-ipa-4-9/test_backup_and_restore_TestBackupAndRestoreTrust:


### PR DESCRIPTION
Manual backport of https://github.com/freeipa/freeipa/pull/6686
test_integration/test_trust.py is divided into two parts. 1: class TestTrust
2: class TestNonPosixAutoPrivateGroup, class TestPosixAutoPrivateGroup

Fixes: https://pagure.io/freeipa/issue/9326