### PR TITLE
Disable web security and enable local file access for WebUI tests

### DIFF
--- a/install/ui/Gruntfile.js
+++ b/install/ui/Gruntfile.js
@@ -4,6 +4,16 @@ module.exports = function(grunt) {
             options: {}
         },
         qunit: {
+            options: {
+                puppeteer: {
+                    ignoreDefaultArgs: true,
+                    args: [
+                        "--headless",
+                        "--disable-web-security",
+                        "--allow-file-access-from-files"
+                    ]
+                },
+            },
             all: [
                 'test/all_tests.html'
             ]


### PR DESCRIPTION
Disable CORS to allow local file access for WebUI tests.

Resolves: https://pagure.io/freeipa/issue/9329