### PR TITLE
install: Fix missing dyndb keytab directive

### DIFF
--- a/install/share/bind.named.conf.template
+++ b/install/share/bind.named.conf.template
@@ -58,4 +58,5 @@ dyndb "ipa" "$BIND_LDAP_SO" {
 	server_id "$FQDN";
 	auth_method "sasl";
 	sasl_mech "EXTERNAL";
+	krb5_keytab "FILE:$NAMED_KEYTAB";
 };


### PR DESCRIPTION
bind-dyndb-ldap uses the krb5_keytab directive to set the path to the keytab to use. This directive was not being used in the configuration template, resulting in a failure to start named if the keytab path differed from the defaults.

This issue was discovered when packaging FreeIPA for Debian, which is one of the platforms where the path is customized. 

No issue for this was found on pagure.io, so I elected to open a PR directly.