### PR TITLE
Don't block when kinit_pkinit() fails

### DIFF
--- a/ipalib/install/kinit.py
+++ b/ipalib/install/kinit.py
@@ -172,4 +172,6 @@ def kinit_pkinit(
 
     # this workaround enables us to capture stderr and put it
     # into the raised exception in case of unsuccessful authentication
-    run(args, env=env, raiseonerr=True, capture_error=True)
+    # Unsuccessful pkinit can lead to a password prompt. Send \n to skip
+    # prompt.
+    run(args, env=env, stdin="\n", raiseonerr=True, capture_error=True)


### PR DESCRIPTION
Installation of ipa-client with PKINIT authentication can block when there is a problem with PKINIT, e.g. KDC does not accept the cert or the anchor chain is incomplete. `kinit` falls back to password authentication and asks the user to enter a password.

`kinit` does not have an option to force non-interactive mode. Sending `\n` to stdin seems to be the only solution here.

Fixes: https://pagure.io/freeipa/issue/9333