### PR TITLE
ipaplatform/debian: fix path to ldap.so

### DIFF
--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -79,7 +79,7 @@ class DebianPathNamespace(BasePathNamespace):
     UPDATE_CA_TRUST = "/usr/sbin/update-ca-certificates"
     BIND_LDAP_DNS_IPA_WORKDIR = "/var/cache/bind/dyndb-ldap/ipa/"
     BIND_LDAP_DNS_ZONE_WORKDIR = "/var/cache/bind/dyndb-ldap/ipa/master/"
-    BIND_LDAP_SO = "ldap.so"
+    BIND_LDAP_SO = "/usr/lib/{0}/bind/ldap.so".format(MULTIARCH)
     LIBARCH = "/{0}".format(MULTIARCH)
     LIBSOFTHSM2_SO = "/usr/lib/{0}/softhsm/libsofthsm2.so".format(MULTIARCH)
     PAM_KRB5_SO = "/usr/lib/{0}/security/pam_krb5.so".format(MULTIARCH)


### PR DESCRIPTION
bind-dyndb-ldap on Debian installs ldap.so in a subdirectory of /usr/lib to prevent unintentional usage of an unversioned .so. The default settings for FreeIPA on Debian used an incomplete path, resulting in a failure to find ldap.so when bind attempts to start with bind-dyndb-ldap configured.

This fixes the default path to use the appropriate location in its multiarch-qualified path.

No issue for this was found on pagure.io, so I elected to open a PR directly.

This is a reopened continuation of #6706; see https://github.com/freeipa/freeipa/pull/6706#issuecomment-1439013796.