### PR TITLE
[Backport][ipa-4-10] ipatests: increase timeout for test_acme

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
@@ -1721,9 +1721,25 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest-ipa-4-10/build_url}'
-        test_suite: test_integration/test_acme.py
+        test_suite: >-
+            test_integration/test_acme.py::TestACME
+            test_integration/test_acme.py::TestACMECALess
+            test_integration/test_acme.py::TestACMEwithExternalCA
+            test_integration/test_acme.py::TestACMERenew
         template: *ci-ipa-4-10-latest
-        timeout: 7200
+        timeout: 8100
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-10/test_acme_prune:
+    requires: [fedora-latest-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-10/build_url}'
+        test_suite: test_integration/test_acme.py::TestACMEPrune
+        template: *ci-ipa-4-10-latest
+        timeout: 3600
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-10/test_dns:

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
@@ -1858,9 +1858,26 @@ jobs:
       args:
         build_url: '{fedora-latest-ipa-4-10/build_url}'
         selinux_enforcing: True
-        test_suite: test_integration/test_acme.py
+        test_suite: >-
+            test_integration/test_acme.py::TestACME
+            test_integration/test_acme.py::TestACMECALess
+            test_integration/test_acme.py::TestACMEwithExternalCA
+            test_integration/test_acme.py::TestACMERenew
         template: *ci-ipa-4-10-latest
-        timeout: 7200
+        timeout: 8100
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-10/test_acme_prune:
+    requires: [fedora-latest-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-10/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_acme.py::TestACMEPrune
+        template: *ci-ipa-4-10-latest
+        timeout: 3600
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-10/test_dns:

--- a/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
@@ -1721,9 +1721,25 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-previous-ipa-4-10/build_url}'
-        test_suite: test_integration/test_acme.py
+        test_suite: >-
+            test_integration/test_acme.py::TestACME
+            test_integration/test_acme.py::TestACMECALess
+            test_integration/test_acme.py::TestACMEwithExternalCA
+            test_integration/test_acme.py::TestACMERenew
         template: *ci-ipa-4-10-previous
-        timeout: 7200
+        timeout: 8100
+        topology: *master_1repl_1client
+
+  fedora-previous-ipa-4-10/test_acme_prune:
+    requires: [fedora-previous-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-10/build_url}'
+        test_suite: test_integration/test_acme.py::TestACMEPrune
+        template: *ci-ipa-4-10-previous
+        timeout: 3600
         topology: *master_1repl_1client
 
   fedora-previous-ipa-4-10/test_dns:


### PR DESCRIPTION
The test test_integration/test_acme.py times out frequently and has a current timeout set to 2h, which is roughly the average time for a successful run.

Increase by 15 minutes, so that even the tests requiring packages update have enough time (for instance rawhide run needs to update all the packages to the latest version).

Also create a separate job for the new test TestACMEPrune.

Fixes: https://pagure.io/freeipa/issue/9324