### PR TITLE
Add support for Hardware Security Module (HSM)

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ACI.txt
+++ b/ACI.txt
@@ -29,7 +29,7 @@ aci: (targetfilter = "(objectclass=ipaca)")(version 3.0;acl "permission:System: 
 dn: cn=cas,cn=ca,dc=ipa,dc=example
 aci: (targetattr = "cn || description")(targetfilter = "(objectclass=ipaca)")(version 3.0;acl "permission:System: Modify CA";allow (write) groupdn = "ldap:///cn=System: Modify CA,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=cas,cn=ca,dc=ipa,dc=example
-aci: (targetattr = "cn || createtimestamp || description || entryusn || ipacaid || ipacaissuerdn || ipacarandomserialnumberversion || ipacasubjectdn || modifytimestamp || objectclass")(targetfilter = "(objectclass=ipaca)")(version 3.0;acl "permission:System: Read CAs";allow (compare,read,search) userdn = "ldap:///all";)
+aci: (targetattr = "cn || createtimestamp || description || entryusn || ipacahsmconfiguration || ipacaid || ipacaissuerdn || ipacarandomserialnumberversion || ipacasubjectdn || modifytimestamp || objectclass")(targetfilter = "(objectclass=ipaca)")(version 3.0;acl "permission:System: Read CAs";allow (compare,read,search) userdn = "ldap:///all";)
 dn: cn=caacls,cn=ca,dc=ipa,dc=example
 aci: (targetfilter = "(objectclass=ipacaacl)")(version 3.0;acl "permission:System: Add CA ACL";allow (add) groupdn = "ldap:///cn=System: Add CA ACL,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=caacls,cn=ca,dc=ipa,dc=example

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ SUBDIRS = \
         pypi \
         selinux \
         selinux/nfast \
+        selinux/luna \
         $(PYTHON_SUBDIRS) \
         $(SERVER_SUBDIRS) \
         $(NULL)

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,6 +36,7 @@ SUBDIRS = \
         po \
         pypi \
         selinux \
+        selinux/nfast \
         $(PYTHON_SUBDIRS) \
         $(SERVER_SUBDIRS) \
         $(NULL)

--- a/configure.ac
+++ b/configure.ac
@@ -688,6 +688,7 @@ AC_CONFIG_FILES([
     po/Makefile.in
     po/Makefile.hack
     selinux/Makefile
+    selinux/nfast/Makefile
     util/Makefile
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -689,6 +689,7 @@ AC_CONFIG_FILES([
     po/Makefile.hack
     selinux/Makefile
     selinux/nfast/Makefile
+    selinux/luna/Makefile
     util/Makefile
 ])
 

--- a/doc/designs/hsm.md
+++ b/doc/designs/hsm.md
@@ -57,6 +57,10 @@ are generated and stored in the HSM.
 | --token-name             | NSS name for the token          |
 | --library-path           | Path to PKCS#11 shared library  |
 | --token-password         | Password for the token          |
+| --token-password-file    | File containing the token password |
+
+If neither --token-password nor --token-password-file are provided
+then the password will be obtained interactively.
 
 This information will be stored in new schema so that replicas can auto-detect when an HSM is configured.
 
@@ -64,7 +68,7 @@ ipa-ca-install will accept the same options.
 
 ```
 attributeTypes: (
-  2.16.840.1.113730.3.8.21.1.TBD
+  2.16.840.1.113730.3.8.21.1.10
   NAME 'ipaCaHSMConfiguration'
   DESC 'HSM Configuration'
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
@@ -78,11 +82,11 @@ This attribute will be semi-colon delimited and contain the HSM information need
 
 token-name;library-path
 
-The token password will be prompted by ipa-replica-install or passed on the cli.
+On a replica installation the token password will be prompted by ipa-replica-install or passed using the cli options.
 
 The presence of this attribute is enough to indicate that an HSM is present in the installation and the options will automatically be used for additional servers and/or services. The password will not be stored and the user must provide them on the cli. Whenever a replica, replica CA, KRA or replica KRA is added this attribute will be examined to determine whether an HSM is available or not, and what the options are.
 
-A user can override library-path on the command-line in case it is in a different location or architecture. A different token name would mean a different token and they cannot be mixed.
+A user can override library-path on the command-line in case it is in a different location or architecture. A different token name would mean a different token and they cannot be mixed. If not provided on the command-line then the stored value will be used.
 
 The NSS module name will be the basepath of the library minus .so*.
 

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -994,6 +994,16 @@ Requires(post):      selinux-policy-%{selinuxtype}
 
 %description selinux
 Custom SELinux policy module for FreeIPA
+
+%package selinux-nfast
+Summary:             FreeIPA SELinux policy for nCipher nfast HSMs
+BuildArch:           noarch
+Requires:            selinux-policy-%{selinuxtype}
+Requires(post):      selinux-policy-%{selinuxtype}
+%{?selinux_requires}
+
+%description selinux-nfast
+Custom SELinux policy module for nCipher nfast HSMs
 # with selinux
 %endif
 
@@ -1301,10 +1311,18 @@ fi
 semodule -d ipa_custodia &> /dev/null || true;
 %selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.bz2
 
+%post selinux-nfast
+%selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}-nfast.pp.bz2
+
 %postun selinux
 if [ $1 -eq 0 ]; then
     %selinux_modules_uninstall -s %{selinuxtype} %{modulename}
     semodule -e ipa_custodia &> /dev/null || true;
+fi
+
+%postun selinux-nfast
+if [ $1 -eq 0 ]; then
+    %selinux_modules_uninstall -s %{selinuxtype} %{modulename}-nfast
 fi
 
 %posttrans selinux
@@ -1758,6 +1776,10 @@ fi
 %files selinux
 %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.*
 %ghost %verify(not md5 size mode mtime) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}
+
+%files selinux-nfast
+%{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}-nfast.pp.*
+%ghost %verify(not md5 size mode mtime) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}-nfast
 # with selinux
 %endif
 

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1004,6 +1004,16 @@ Requires(post):      selinux-policy-%{selinuxtype}
 
 %description selinux-nfast
 Custom SELinux policy module for nCipher nfast HSMs
+
+%package selinux-luna
+Summary:             FreeIPA SELinux policy for Thales Luna HSMs
+BuildArch:           noarch
+Requires:            selinux-policy-%{selinuxtype}
+Requires(post):      selinux-policy-%{selinuxtype}
+%{?selinux_requires}
+
+%description selinux-luna
+Custom SELinux policy module for Thales Luna HSMs
 # with selinux
 %endif
 
@@ -1314,6 +1324,9 @@ semodule -d ipa_custodia &> /dev/null || true;
 %post selinux-nfast
 %selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}-nfast.pp.bz2
 
+%post selinux-luna
+%selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}-luna.pp.bz2
+
 %postun selinux
 if [ $1 -eq 0 ]; then
     %selinux_modules_uninstall -s %{selinuxtype} %{modulename}
@@ -1324,6 +1337,10 @@ fi
 if [ $1 -eq 0 ]; then
     %selinux_modules_uninstall -s %{selinuxtype} %{modulename}-nfast
 fi
+
+%postun selinux-luna
+if [ $1 -eq 0 ]; then
+    %selinux_modules_uninstall -s %{selinuxtype} %{modulename}-luna
 
 %posttrans selinux
 %selinux_relabel_post -s %{selinuxtype}
@@ -1780,6 +1797,10 @@ fi
 %files selinux-nfast
 %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}-nfast.pp.*
 %ghost %verify(not md5 size mode mtime) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}-nfast
+
+%files selinux-luna
+%{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}-luna.pp.*
+%ghost %verify(not md5 size mode mtime) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}-luna
 # with selinux
 %endif
 

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
@@ -42,7 +42,7 @@ import six
 from ipalib.install.kinit import kinit_keytab
 from ipapython import ipautil
 from ipapython.dn import DN
-from ipalib import api, errors, x509
+from ipalib import api, errors, x509, sysrestore
 from ipaplatform.paths import paths
 from ipaserver.plugins.ldap2 import ldap2
 from ipaserver.install import ca, cainstance, dsinstance, certs
@@ -384,6 +384,16 @@ def retrieve_cert_continuous(reuse_existing, **kwargs):
 
     new_cert = x509.load_pem_x509_certificate(result[1].encode('ascii'))
     if new_cert == old_cert:
+        sstore = sysrestore.StateFile(paths.SYSRESTORE)
+        if (
+            sstore.has_state('pki_hsm')
+            and sstore.get_state('pki_hsm', 'token_name')
+        ):
+            # HSMs must be networked so the cert is already present
+            return (
+                ISSUED,
+                new_cert.public_bytes(x509.Encoding.PEM).decode("ascii"),
+            )
         syslog.syslog(syslog.LOG_INFO, "Updated certificate not available")
         # No cert available yet, tell certmonger to wait another 8 hours
         return (WAIT_WITH_DELAY, 8 * 60 * 60, '')

--- a/install/restart_scripts/renew_ca_cert.in
+++ b/install/restart_scripts/renew_ca_cert.in
@@ -36,7 +36,7 @@ from ipaserver.install import certs, cainstance
 from ipaserver.plugins.ldap2 import ldap2
 from ipaplatform import services
 from ipaplatform.paths import paths
-from ipapython.certdb import TrustFlags
+from ipapython.certdb import TrustFlags, get_ca_nickname
 
 
 def _main():
@@ -50,8 +50,6 @@ def _main():
     dogtag_service = services.knownservices['pki_tomcatd']
 
     ca = cainstance.CAInstance(host_name=api.env.host)
-    if ca.token_name:
-        nickname = f"{ca.token_name}:{nickname}"
 
     # dogtag opens its NSS database in read/write mode so we need it
     # shut down so certmonger can open it read/write mode. This avoids
@@ -70,28 +68,8 @@ def _main():
             syslog.syslog(
                 syslog.LOG_NOTICE, "Stopped %s" % dogtag_service.service_name)
 
-    pwdfile = None
-    if ca.hsm_enabled:
-        token_pw = None
-        with open(paths.PKI_TOMCAT_PASSWORD_CONF, "r") as passfile:
-            contents = passfile.readlines()
-        for line in contents:
-            data = line.split('=', 1)
-            if data[0] == 'hardware-' + ca.token_name:
-                token_pw = data[1]
-                break
-        if token_pw:
-            pwfile = ipautil.write_tmp_file(token_pw)
-            pwdfile = pwfile.name
-        else:
-            syslog.syslog(
-                syslog.LOG_ERR,
-                'Unable to find pin for token %s' % ca.token_name
-            )
-
     # Fetch the new certificate
-    db = certs.CertDB(api.env.realm, nssdir=paths.PKI_TOMCAT_ALIAS_DIR,
-                      pwd_file=pwdfile)
+    db = certs.CertDB(api.env.realm, nssdir=paths.PKI_TOMCAT_ALIAS_DIR)
     cert = db.get_cert_from_db(nickname)
     if not cert:
         syslog.syslog(syslog.LOG_ERR, 'No certificate %s found.' % nickname)
@@ -129,7 +107,7 @@ def _main():
         elif nickname == 'caSigningCert cert-pki-ca':
             # Remove old external CA certificates
             for ca_nick, ca_flags in db.list_certs():
-                if ca_flags.has_key:
+                if ca_flags.has_key or not ca_flags.ca:
                     continue
                 # Delete *all* certificates that use the nickname
                 while True:
@@ -173,8 +151,11 @@ def _main():
                         "%s" % e)
                     ca_certs = []
 
+                realm_nickname = get_ca_nickname(api.env.realm)
                 for ca_cert, ca_nick, ca_flags in ca_certs:
                     try:
+                        if ca_nick == realm_nickname:
+                            ca_nick = 'caSigningCert cert-pki-ca'
                         db.add_cert(ca_cert, ca_nick, ca_flags)
                     except ipautil.CalledProcessError as e:
                         syslog.syslog(

--- a/install/restart_scripts/renew_ca_cert.in
+++ b/install/restart_scripts/renew_ca_cert.in
@@ -49,6 +49,10 @@ def _main():
 
     dogtag_service = services.knownservices['pki_tomcatd']
 
+    ca = cainstance.CAInstance(host_name=api.env.host)
+    if ca.token_name:
+        nickname = f"{ca.token_name}:{nickname}"
+
     # dogtag opens its NSS database in read/write mode so we need it
     # shut down so certmonger can open it read/write mode. This avoids
     # database corruption. It should already be stopped by the pre-command
@@ -66,8 +70,28 @@ def _main():
             syslog.syslog(
                 syslog.LOG_NOTICE, "Stopped %s" % dogtag_service.service_name)
 
+    pwdfile = None
+    if ca.hsm_enabled:
+        token_pw = None
+        with open(paths.PKI_TOMCAT_PASSWORD_CONF, "r") as passfile:
+            contents = passfile.readlines()
+        for line in contents:
+            data = line.split('=', 1)
+            if data[0] == 'hardware-' + ca.token_name:
+                token_pw = data[1]
+                break
+        if token_pw:
+            pwfile = ipautil.write_tmp_file(token_pw)
+            pwdfile = pwfile.name
+        else:
+            syslog.syslog(
+                syslog.LOG_ERR,
+                'Unable to find pin for token %s' % ca.token_name
+            )
+
     # Fetch the new certificate
-    db = certs.CertDB(api.env.realm, nssdir=paths.PKI_TOMCAT_ALIAS_DIR)
+    db = certs.CertDB(api.env.realm, nssdir=paths.PKI_TOMCAT_ALIAS_DIR,
+                      pwd_file=pwdfile)
     cert = db.get_cert_from_db(nickname)
     if not cert:
         syslog.syslog(syslog.LOG_ERR, 'No certificate %s found.' % nickname)
@@ -82,7 +106,6 @@ def _main():
 
         api.Backend.ldap2.connect()
 
-        ca = cainstance.CAInstance(host_name=api.env.host)
         ca.update_cert_config(nickname, cert)
         if ca.is_renewal_master():
             cainstance.update_people_entry(cert)

--- a/install/restart_scripts/renew_ca_cert.in
+++ b/install/restart_scripts/renew_ca_cert.in
@@ -89,7 +89,10 @@ def _main():
             cainstance.update_people_entry(cert)
             cainstance.update_authority_entry(cert)
 
-        if nickname == 'auditSigningCert cert-pki-ca':
+        if nickname in (
+            'auditSigningCert cert-pki-ca',
+            'auditSigningCert cert-pki-kra',
+        ):
             # Fix trust on the audit cert
             try:
                 db.run_certutil(['-M',

--- a/install/share/60certificate-profiles.ldif
+++ b/install/share/60certificate-profiles.ldif
@@ -8,6 +8,7 @@ attributeTypes: (2.16.840.1.113730.3.8.21.1.6 NAME 'ipaCaId' DESC 'Dogtag Author
 attributeTypes: (2.16.840.1.113730.3.8.21.1.7 NAME 'ipaCaIssuerDN' DESC 'Issuer DN' SUP distinguishedName X-ORIGIN 'IPA v4.4 Lightweight CAs' )
 attributeTypes: (2.16.840.1.113730.3.8.21.1.8 NAME 'ipaCaSubjectDN' DESC 'Subject DN' SUP distinguishedName X-ORIGIN 'IPA v4.4 Lightweight CAs' )
 attributeTypes: (2.16.840.1.113730.3.8.21.1.9 NAME 'ipaCaRandomSerialNumberVersion' DESC 'Random Serial Number Version' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'IPA v4.9 RSNv3' )
+attributeTypes: (2.16.840.1.113730.3.8.21.1.10 NAME 'ipaCaHSMConfiguration' DESC 'HSM Configuration' EQUALITY caseIgnoreMatch ORDERING caseIgnoreOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'IPA v4.10 HSM' )
 objectClasses: (2.16.840.1.113730.3.8.21.2.1 NAME 'ipaCertProfile' SUP top STRUCTURAL MUST ( cn $ description $ ipaCertProfileStoreIssued ) X-ORIGIN 'IPA v4.2' )
 objectClasses: (2.16.840.1.113730.3.8.21.2.2 NAME 'ipaCaAcl' SUP ipaAssociation STRUCTURAL MUST cn MAY ( ipaCaCategory $ ipaCertProfileCategory $ userCategory $ hostCategory $ serviceCategory $ ipaMemberCa $ ipaMemberCertProfile $ memberService ) X-ORIGIN 'IPA v4.2' )
-objectClasses: (2.16.840.1.113730.3.8.21.2.3 NAME 'ipaCa' SUP top STRUCTURAL MUST ( cn $ ipaCaId $ ipaCaSubjectDN $ ipaCaIssuerDN ) MAY ( description $ ipaCaRandomSerialNumberVersion ) X-ORIGIN 'IPA v4.4 Lightweight CAs' )
+objectClasses: (2.16.840.1.113730.3.8.21.2.3 NAME 'ipaCa' SUP top STRUCTURAL MUST ( cn $ ipaCaId $ ipaCaSubjectDN $ ipaCaIssuerDN ) MAY ( description $ ipaCaRandomSerialNumberVersion $ ipaCaHSMConfiguration) X-ORIGIN 'IPA v4.4 Lightweight CAs' )

--- a/install/tools/ipa-ca-install.in
+++ b/install/tools/ipa-ca-install.in
@@ -101,6 +101,25 @@ def parse_options():
                           "The CA certificate subject DN "
                           "(default CN=Certificate Authority,O=<realm-name>). "
                           "RDNs are in LDAP order (most specific RDN first)."))
+    parser.add_option("--token-name", dest="token_name",
+                      default=None,
+                      help=(
+                          "The PKCS#11 token name if using an HSM to store "
+                          "and generate private keys."))
+    parser.add_option("--token-library-path", dest="token_library_path",
+                      default=None,
+                      help=(
+                          "The full path to the PKCS#11 shared library "
+                          "needed to access the HSM device."))
+    parser.add_option("--token-password", dest="token_password",
+                      default=None,
+                      help=(
+                          "The PKCS#11 token password for the HSM."))
+    parser.add_option("--token-password-file", dest="token_password_file",
+                      default=None,
+                      help=(
+                          "The full path to a file containing the PKCS#11 "
+                          " token password."))
 
     parser.add_option("--pki-config-override", dest="pki_config_override",
                       default=None,

--- a/install/tools/man/ipa-ca-install.1
+++ b/install/tools/man/ipa-ca-install.1
@@ -85,6 +85,18 @@ Do not use DNS for hostname lookup during installation
 \fB\-\-random\-serial\-numbers\fR
 Enable Random Serial Numbers. Random serial numbers cannot be used in a mixed environment. Either all CA's have it enabled or none do.
 .TP
+\fB\-\-token\-name\fR=\fITOKEN_NAME\fR
+The PKCS#11 token name if using an HSM to store and generate private keys.
+.TP
+\fB\-\-token\-library\-path\fR=\fITOKEN_LIBRARY_PATH\fR
+The full path to the PKCS#11 shared library needed to access the HSM device.
+.TP
+\fB\-\-token\-password\fR=\fITOKEN_PASSWORD\fR
+The PKCS#11 token password for the HSM.
+.TP
+\fB\-\-token\-password\-file\fR=\fITOKEN_PASSWORD_FILE\fR
+The full path to a file containing the PKCS#11 token password.
+.TP
 \fB\-\-skip\-conncheck\fR
 Skip connection check to remote master
 .TP

--- a/install/tools/man/ipa-replica-install.1
+++ b/install/tools/man/ipa-replica-install.1
@@ -152,6 +152,19 @@ File containing overrides for CA and KRA installation.
 \fB\-\-skip\-schema\-check\fR
 Skip check for updated CA DS schema on the remote master
 
+.SS "HSM OPTIONS"
+The token name will be used from the existing topology.
+.TP
+\fB\-\-token\-library\-path\fR=\fITOKEN_LIBRARY_PATH\fR
+The full path to the PKCS#11 shared library needed to access the HSM device. If the path is identical to the original install then this does not need to be provided.
+.TP
+\fB\-\-token\-password\fR=\fITOKEN_PASSWORD\fR
+The PKCS#11 token password for the HSM.
+.TP
+\fB\-\-token\-password\-file\fR=\fITOKEN_PASSWORD_FILE\fR
+The full path to a file containing the PKCS#11 token password.
+
+
 .SS "SECRET MANAGEMENT OPTIONS"
 .TP
 \fB\-\-setup\-kra\fR

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -173,6 +173,20 @@ The subject base for certificates issued by IPA (default O=REALM.NAME). RDNs are
 \fB\-\-ca\-signing\-algorithm\fR=\fIALGORITHM\fR
 Signing algorithm of the IPA CA certificate. Possible values are SHA1withRSA, SHA256withRSA, SHA384withRSA, SHA512withRSA. Default value is SHA256withRSA. Use this option with --external-ca if the external CA does not support the default signing algorithm.
 
+.SS "HSM OPTIONS"
+.TP
+\fB\-\-token\-name\fR=\fITOKEN_NAME\fR
+The PKCS#11 token name if using an HSM to store and generate private keys.
+.TP
+\fB\-\-token\-library\-path\fR=\fITOKEN_LIBRARY_PATH\fR
+The full path to the PKCS#11 shared library needed to access the HSM device.
+.TP
+\fB\-\-token\-password\fR=\fITOKEN_PASSWORD\fR
+The PKCS#11 token password for the HSM.
+.TP
+\fB\-\-token\-password\-file\fR=\fITOKEN_PASSWORD_FILE\fR
+The full path to a file containing the PKCS#11 token password.
+
 .SS "SECRET MANAGEMENT OPTIONS"
 .TP
 \fB\-\-setup\-kra\fR

--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -511,7 +511,8 @@ class NSSDatabase:
 
         :return: List of (name, trust_flags) tuples
         """
-        result = self.run_certutil(["-L"], capture_output=True)
+        args = ["-L"]
+        result = self.run_certutil(args, capture_output=True)
         certs = result.output.splitlines()
 
         # FIXME, this relies on NSS never changing the formatting of certutil

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -351,7 +351,7 @@ def install_check(standalone, replica_config, options):
         (token_name, token_library_path) = lookup_hsm_configuration(_api)
         # IPA version and dependency checking should prevent this but
         # better to be safe and avoid a failed install.
-        if token_name:
+        if replica_config.setup_ca and token_name:
             try:
                 hsm_validator(
                     True,
@@ -364,6 +364,19 @@ def install_check(standalone, replica_config, options):
                 raise ScriptError(str(e))
             if not options.token_library_path:
                 options.token_library_path = token_library_path
+            if (
+                not options.token_password_file
+                and not options.token_password
+            ):
+                if options.unattended:
+                    raise ScriptError("HSM token password required")
+                token_password = installutils.read_password(
+                    f"{token_name}", confirm=False
+                )
+                if token_password is None:
+                    raise ScriptError("HSM token password required")
+                else:
+                    options.token_password = token_password
 
     if replica_config is not None and not replica_config.setup_ca:
         return

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -386,11 +386,13 @@ def install_step_0(standalone, replica_config, options, custodia):
         ra_only = False
         promote = False
     else:
-        cafile = os.path.join(replica_config.dir, 'cacert.p12')
-        if replica_config.setup_ca:
+        if not cainstance.hsm_enabled():
+            cafile = os.path.join(replica_config.dir, 'cacert.p12')
             custodia.get_ca_keys(
                 cafile,
                 replica_config.dirman_password)
+        else:
+            cafile = None
 
         ca_signing_algorithm = None
         ca_type = None

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -182,12 +182,55 @@ def hsm_version(enabled):
     return pki_version >= pki.util.Version("11.3.0"), pki_version
 
 
-def hsm_validator(enabled):
+def hsm_validator(enabled, token_name, token_library):
     val, pki_version = hsm_version(enabled)
     if val is False:
         raise ValueError(
             "HSM is not supported in PKI version %s" % pki_version
         )
+    if ':' in token_name:
+        raise ValueError(
+            "Colon is not allowed in a token name, it confuses NSS."
+        )
+    if not os.path.exists(token_library):
+        raise ValueError(
+            "Token library path '%s' does not exist" % token_library
+        )
+    with certdb.NSSDatabase() as tempnssdb:
+        tempnssdb.create_db()
+        # Try adding the token library to the temporary database in
+        # case it isn't already available. Ignore all errors.
+        command = [
+            paths.MODUTIL,
+            '-dbdir', '{}:{}'.format(tempnssdb.dbtype, tempnssdb.secdir),
+            '-nocertdb',
+            '-add', 'test',
+            '-libfile', token_library,
+            '-force',
+        ]
+        # It may fail if p11-kit has already registered the library, that's
+        # ok.
+        ipautil.run(command, stdin='\n', cwd=tempnssdb.secdir,
+                    raiseonerr=False)
+
+        command = [
+            paths.MODUTIL,
+            '-dbdir', '{}:{}'.format(tempnssdb.dbtype, tempnssdb.secdir),
+            '-list',
+            '-force'
+        ]
+        lines = ipautil.run(
+            command, cwd=tempnssdb.secdir, capture_output=True).output
+        found = False
+        token_line = f'token: {token_name}'
+        for line in lines.split('\n'):
+            if token_line in line.strip():
+                found = True
+                break
+        if not found:
+            raise ValueError(
+                "Token named '%s' was not found" % token_name
+            )
 
 
 def set_subject_base_in_config(subject_base):
@@ -276,7 +319,8 @@ def install_check(standalone, replica_config, options):
     if replica_config is None:
         if options.token_name:
             try:
-                hsm_validator(True)
+                hsm_validator(
+                    True, options.token_name, options.token_library_path)
             except ValueError as e:
                 raise ScriptError(str(e))
         options._subject_base = options.subject_base
@@ -309,7 +353,13 @@ def install_check(standalone, replica_config, options):
         # better to be safe and avoid a failed install.
         if token_name:
             try:
-                hsm_validator(True)
+                hsm_validator(
+                    True,
+                    token_name,
+                    options.token_library_path
+                    if options.token_library_path
+                    else token_library_path,
+                )
             except ValueError as e:
                 raise ScriptError(str(e))
             if not options.token_library_path:

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -141,6 +141,55 @@ def lookup_random_serial_number_version(api):
     return version
 
 
+def lookup_hsm_configuration(api):
+    """
+    If an HSM was configured on the initial install then return the
+    token name and PKCS#11 library path from that install.
+
+    Returns a tuple of (token_name, token_library_path) or (None, None)
+    """
+    dn = DN(('cn', IPA_CA_CN), api.env.container_ca, api.env.basedn)
+    token_name = None
+    token_library_path = None
+    try:
+        # we do not use api.Command.ca_show because it attempts to
+        # talk to the CA (to read certificate / chain), but the RA
+        # backend may be unavailable (ipa-replica-install) or unusable
+        # due to RA Agent cert not yet created (ipa-ca-install).
+        entry = api.Backend.ldap2.get_entry(dn)
+
+        # If the attribute doesn't exist then the remote didn't
+        # enable RSN.
+        if 'ipacahsmconfiguration' in entry:
+            val = entry['ipacahsmconfiguration'][0]
+            (token_name, token_library_path) = val.split(';')
+    except (errors.NotFound, KeyError):
+        # if the entry doesn't exist then the remote doesn't support
+        # HSM so there is nothing to do.
+        pass
+
+    return (token_name, token_library_path)
+
+
+def hsm_version(enabled):
+    """Return True if PKI supports working HSM code
+
+       The caller is responsible for raising the exception.
+    """
+    if not enabled:
+        return None, None
+    pki_version = pki.util.Version(pki.specification_version())
+    return pki_version >= pki.util.Version("11.3.0"), pki_version
+
+
+def hsm_validator(enabled):
+    val, pki_version = hsm_version(enabled)
+    if val is False:
+        raise ValueError(
+            "HSM is not supported in PKI version %s" % pki_version
+        )
+
+
 def set_subject_base_in_config(subject_base):
     entry_attrs = api.Backend.ldap2.get_ipa_config()
     entry_attrs['ipacertificatesubjectbase'] = [str(subject_base)]
@@ -225,9 +274,15 @@ def install_check(standalone, replica_config, options):
     host_name = options.host_name
 
     if replica_config is None:
+        if options.token_name:
+            try:
+                hsm_validator(True)
+            except ValueError as e:
+                raise ScriptError(str(e))
         options._subject_base = options.subject_base
         options._ca_subject = options.ca_subject
         options._random_serial_numbers = options.random_serial_numbers
+        token_name = options.token_name
     else:
         # during replica install, this gets invoked before local DS is
         # available, so use the remote api.
@@ -248,6 +303,17 @@ def install_check(standalone, replica_config, options):
                 )
             except ValueError as e:
                 raise ScriptError(str(e))
+
+        (token_name, token_library_path) = lookup_hsm_configuration(_api)
+        # IPA version and dependency checking should prevent this but
+        # better to be safe and avoid a failed install.
+        if token_name:
+            try:
+                hsm_validator(True)
+            except ValueError as e:
+                raise ScriptError(str(e))
+            if not options.token_library_path:
+                options.token_library_path = token_library_path
 
     if replica_config is not None and not replica_config.setup_ca:
         return
@@ -363,6 +429,12 @@ def install_step_0(standalone, replica_config, options, custodia):
     subject_base = options._subject_base
     external_ca_profile = None
 
+    if options.token_password_file:
+        with open(options.token_password_file, "r") as fd:
+            token_password = fd.readline().strip()
+    else:
+        token_password = options.token_password
+
     if replica_config is None:
         ca_signing_algorithm = options.ca_signing_algorithm
         if options.external_ca:
@@ -378,6 +450,7 @@ def install_step_0(standalone, replica_config, options, custodia):
         else:
             cert_file = None
             cert_chain_file = None
+        token_name = options.token_name
 
         pkcs12_info = None
         master_host = None
@@ -386,7 +459,9 @@ def install_step_0(standalone, replica_config, options, custodia):
         ra_only = False
         promote = False
     else:
-        if not cainstance.hsm_enabled():
+        _api = api if standalone else options._remote_api
+        (token_name, _token_library_path) = lookup_hsm_configuration(api)
+        if not token_name:
             cafile = os.path.join(replica_config.dir, 'cacert.p12')
             custodia.get_ca_keys(
                 cafile,
@@ -441,6 +516,9 @@ def install_step_0(standalone, replica_config, options, custodia):
         use_ldaps=use_ldaps,
         pki_config_override=options.pki_config_override,
         random_serial_numbers=options._random_serial_numbers,
+        token_name=token_name,
+        token_library_path=options.token_library_path,
+        token_password=token_password,
     )
 
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -567,9 +567,13 @@ class CAInstance(DogtagInstance):
             # if paths.TMP_CA_P12 exists and is not owned by root,
             # shutil.copy will fail if when fs.protected_regular=1
             # so remove the file first
-            ipautil.remove_file(paths.TMP_CA_P12)
-            shutil.copy(cafile, paths.TMP_CA_P12)
-            self.service_user.chown(paths.TMP_CA_P12)
+            if os.path.exists(paths.TMP_CA_P12):
+                ipautil.remove_file(paths.TMP_CA_P12)
+                shutil.copy(cafile, paths.TMP_CA_P12)
+                self.service_user.chown(paths.TMP_CA_P12)
+                clone_pkcs12_path = paths.TMP_CA_P12
+            else:
+                clone_pkcs12_path = None
 
             if self.random_serial_numbers:
                 cfg.update(
@@ -587,7 +591,7 @@ class CAInstance(DogtagInstance):
             self._configure_clone(
                 cfg,
                 security_domain_hostname=self.master_host,
-                clone_pkcs12_path=paths.TMP_CA_P12,
+                clone_pkcs12_path=clone_pkcs12_path,
             )
 
         # External CA

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -345,7 +345,9 @@ class CAInstance(DogtagInstance):
                            ra_p12=None, ra_only=False,
                            promote=False, use_ldaps=False,
                            pki_config_override=None,
-                           random_serial_numbers=False):
+                           random_serial_numbers=False,
+                           token_name=None, token_library_path=None,
+                           token_password=None):
         """Create a CA instance.
 
            To create a clone, pass in pkcs12_info.
@@ -390,6 +392,10 @@ class CAInstance(DogtagInstance):
         self.no_db_setup = promote
         self.use_ldaps = use_ldaps
         self.pki_config_override = pki_config_override
+
+        self.tokenname = token_name
+        self.token_library_path = token_library_path
+        self.token_password = token_password
 
         # Determine if we are installing as an externally-signed CA and
         # what stage we're in.
@@ -487,6 +493,8 @@ class CAInstance(DogtagInstance):
                     if not self.clone:
                         self.step("Recording random serial number state",
                                   self.__store_random_serial_number_state)
+                        self.step("Recording HSM configuration state",
+                                  self.__store_hsm_configuration_state)
                 else:
                     # Re-import profiles in the promote case to pick up any
                     # that will only be triggered by an upgrade.
@@ -522,6 +530,19 @@ class CAInstance(DogtagInstance):
         cfg = dict(
             pki_ds_secure_connection=self.use_ldaps
         )
+
+        # FIXME: don't forget about reading from token-password-file
+        #        (not here)
+        if self.tokenname:
+            module_name = os.path.basename(
+                self.token_library_path
+            ).split('.', 1)[0]
+            cfg['pki_hsm_enable'] = True
+            cfg['pki_hsm_modulename'] = module_name
+            cfg['pki_hsm_libfile'] = self.token_library_path
+            cfg['pki_token_name'] = self.tokenname
+            cfg['pki_token_password'] = self.token_password
+            cfg['pki_sslserver_token'] = 'internal'
 
         if self.ca_signing_algorithm is not None:
             cfg['ipa_ca_signing_algorithm'] = self.ca_signing_algorithm
@@ -567,7 +588,7 @@ class CAInstance(DogtagInstance):
             # if paths.TMP_CA_P12 exists and is not owned by root,
             # shutil.copy will fail if when fs.protected_regular=1
             # so remove the file first
-            if os.path.exists(paths.TMP_CA_P12):
+            if cafile:
                 ipautil.remove_file(paths.TMP_CA_P12)
                 shutil.copy(cafile, paths.TMP_CA_P12)
                 self.service_user.chown(paths.TMP_CA_P12)
@@ -621,6 +642,7 @@ class CAInstance(DogtagInstance):
                 ext_cert = x509.load_unknown_x509_certificate(f.read())
             cert_file.write(ext_cert.public_bytes(x509.Encoding.PEM))
             ipautil.flush_sync(cert_file)
+            self.service_user.chown(cert_file.name)
 
             result = ipautil.run(
                 [paths.OPENSSL, 'crl2pkcs7',
@@ -643,6 +665,8 @@ class CAInstance(DogtagInstance):
             )
 
         nolog_list = [self.dm_password, self.admin_password, pki_pin]
+        if self.token_password:
+            nolog_list.append(self.token_password)
 
         config = self._create_spawn_config(cfg)
         self.set_hsm_state(config)
@@ -1599,6 +1623,22 @@ class CAInstance(DogtagInstance):
                 api.env.basedn)
         entry_attrs = api.Backend.ldap2.get_entry(dn)
         entry_attrs['ipaCaRandomSerialNumberVersion'] = value
+        api.Backend.ldap2.update_entry(entry_attrs)
+
+    def __store_hsm_configuration_state(self):
+        """
+        Save the HSM token configuration.
+
+        This data is used during replica install to determine whether
+        the remote server uses an HSM.
+        """
+        if not self.token_name or self.token_name == 'internal':
+            return
+        dn = DN(('cn', ipalib.constants.IPA_CA_CN), api.env.container_ca,
+                api.env.basedn)
+        entry_attrs = api.Backend.ldap2.get_entry(dn)
+        entry_attrs['ipaCaHSMConfiguration'] = '{};{}'.format(
+            self.token_name, self.token_library_path)
         api.Backend.ldap2.update_entry(entry_attrs)
 
 

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -161,8 +161,8 @@ class CertDB:
     def __init__(self, realm, nssdir, fstore=None,
                  host_name=None, subject_base=None, ca_subject=None,
                  user=None, group=None, mode=None, create=False,
-                 dbtype='auto'):
-        self.nssdb = NSSDatabase(nssdir, dbtype=dbtype)
+                 dbtype='auto', pwd_file=None):
+        self.nssdb = NSSDatabase(nssdir, dbtype=dbtype, pwd_file=pwd_file)
 
         self.realm = realm
 
@@ -377,8 +377,14 @@ class CertDB:
         """
         Retrieve a certificate from the current NSS database for nickname.
         """
+        if ':' in nickname:
+            token = nickname.split(':', 1)[0]
+        else:
+            token = None
         try:
             args = ["-L", "-n", nickname, "-a"]
+            if token:
+                args.extend(['-h', token])
             result = self.run_certutil(args, capture_output=True)
             return x509.load_pem_x509_certificate(result.raw_output)
         except ipautil.CalledProcessError:

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -510,6 +510,10 @@ class DogtagInstance(service.Service):
     def configure_renewal(self):
         """ Configure certmonger to renew system certs """
 
+        if self.hsm_enabled:
+            nss_user = constants.PKI_USER
+        else:
+            nss_user = None
         for nickname, profile in self.tracking_reqs.items():
             token_name = self.get_token_name(nickname)
             pin = self.__get_pin(token_name)
@@ -523,6 +527,7 @@ class DogtagInstance(service.Service):
                     pre_command='stop_pkicad',
                     post_command='renew_ca_cert "%s"' % nickname,
                     profile=profile,
+                    nss_user=nss_user,
                 )
             except RuntimeError as e:
                 logger.error(

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -907,8 +907,6 @@ class DogtagInstance(service.Service):
             pki_security_domain_password=self.admin_password,
             # Clone
             pki_clone=True,
-            pki_clone_pkcs12_path=clone_pkcs12_path,
-            pki_clone_pkcs12_password=self.dm_password,
             pki_clone_replication_security="TLS",
             pki_clone_replication_master_port=self.master_replication_port,
             pki_clone_replication_clone_port=389,
@@ -916,6 +914,11 @@ class DogtagInstance(service.Service):
             pki_clone_uri="https://%s" % ipautil.format_netloc(
                 self.master_host, 443),
         )
+        if clone_pkcs12_path:
+            subsystem_config.update(
+                pki_clone_pkcs12_path=clone_pkcs12_path,
+                pki_clone_pkcs12_password=self.dm_password,
+            )
 
     def _create_spawn_config(self, subsystem_config):
         loader = PKIIniLoader(

--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -80,6 +80,18 @@ class KRAInstall(admintool.AdminTool):
             default=None,
             help="Path to ini file with config overrides.")
 
+        parser.add_option(
+            "--token-password", dest="token_password",
+            default=None,
+            help=(
+                "The password to the PKCS#11 token."))
+        parser.add_option(
+            "--token_password-file", dest="token_password_file",
+            default=None,
+            help=(
+                "The full path containing the PKCS#11 token "
+                "password."))
+
     def validate_options(self, needs_root=True):
         super(KRAInstall, self).validate_options(needs_root=True)
 
@@ -135,6 +147,17 @@ class KRAInstaller(KRAInstall):
             if self.options.password is None:
                 raise admintool.ScriptError(
                     "Directory Manager password required")
+
+        cai = cainstance.CAInstance()
+        if (
+            not self.options.unattended
+            and cai.hsm_enabled
+            and self.options.token_password is None
+            and self.options.token_password_file is None
+        ):
+            self.options.token_password = installutils.read_password(
+                f"{cai.token_name}", confirm=False,
+                validate=False, retry=False)
 
     def run(self):
         super(KRAInstaller, self).run()

--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -60,6 +60,11 @@ def install_check(api, replica_config, options):
 
 
 def install(api, replica_config, options, custodia):
+    if options.token_password_file:
+        with open(options.token_password_file, "r") as fd:
+            token_password = fd.readline().strip()
+    else:
+        token_password = options.token_password
     if replica_config is None:
         if not options.setup_kra:
             return
@@ -74,7 +79,8 @@ def install(api, replica_config, options, custodia):
     else:
         if not replica_config.setup_kra:
             return
-        if cainstance.hsm_enabled():
+        cai = cainstance.CAInstance()
+        if not cai.hsm_enabled:
             krafile = os.path.join(replica_config.dir, 'kracert.p12')
             with ipautil.private_ccache():
                 ccache = os.environ['KRB5CCNAME']
@@ -108,6 +114,7 @@ def install(api, replica_config, options, custodia):
         master_host=master_host,
         promote=promote,
         pki_config_override=options.pki_config_override,
+        token_password=token_password
     )
 
     _service.print_msg("Restarting the directory server")

--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -74,16 +74,19 @@ def install(api, replica_config, options, custodia):
     else:
         if not replica_config.setup_kra:
             return
-        krafile = os.path.join(replica_config.dir, 'kracert.p12')
-        with ipautil.private_ccache():
-            ccache = os.environ['KRB5CCNAME']
-            kinit_keytab(
-                'host/{env.host}@{env.realm}'.format(env=api.env),
-                paths.KRB5_KEYTAB,
-                ccache)
-            custodia.get_kra_keys(
-                krafile,
-                replica_config.dirman_password)
+        if cainstance.hsm_enabled():
+            krafile = os.path.join(replica_config.dir, 'kracert.p12')
+            with ipautil.private_ccache():
+                ccache = os.environ['KRB5CCNAME']
+                kinit_keytab(
+                    'host/{env.host}@{env.realm}'.format(env=api.env),
+                    paths.KRB5_KEYTAB,
+                    ccache)
+                custodia.get_kra_keys(
+                    krafile,
+                    replica_config.dirman_password)
+        else:
+            krafile = None
 
         realm_name = replica_config.realm_name
         dm_password = replica_config.dirman_password

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -79,7 +79,8 @@ class KRAInstance(DogtagInstance):
     def configure_instance(self, realm_name, host_name, dm_password,
                            admin_password, pkcs12_info=None, master_host=None,
                            subject_base=None, ca_subject=None,
-                           promote=False, pki_config_override=None):
+                           promote=False, pki_config_override=None,
+                           token_password=None):
         """Create a KRA instance.
 
            To create a clone, pass in pkcs12_info.
@@ -93,6 +94,8 @@ class KRAInstance(DogtagInstance):
             self.clone = True
         self.master_host = master_host
         self.pki_config_override = pki_config_override
+        # The remaining token values are available via sysrestore
+        self.token_password = token_password
 
         self.subject_base = \
             subject_base or installutils.default_subject_base(realm_name)
@@ -180,6 +183,13 @@ class KRAInstance(DogtagInstance):
             cfg['pki_server_database_password'] = pki_pin
         else:
             pki_pin = None
+
+        ca = cainstance.CAInstance(self.realm)
+        if ca.hsm_enabled:
+            cfg['pki_hsm_enable'] = True
+            cfg['pki_token_name'] = ca.token_name
+            cfg['pki_token_password'] = self.token_password
+            cfg['pki_sslserver_token'] = 'internal'
 
         p12_tmpfile_name = None
 

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -181,12 +181,16 @@ class KRAInstance(DogtagInstance):
         else:
             pki_pin = None
 
-        _p12_tmpfile_handle, p12_tmpfile_name = tempfile.mkstemp(dir=paths.TMP)
+        p12_tmpfile_name = None
 
         if self.clone:
             krafile = self.pkcs12_info[0]
-            shutil.copy(krafile, p12_tmpfile_name)
-            self.service_user.chown(p12_tmpfile_name)
+            if krafile:
+                _p12_tmpfile_handle, p12_tmpfile_name = tempfile.mkstemp(
+                    dir=paths.TMP
+                )
+                shutil.copy(krafile, p12_tmpfile_name)
+                self.service_user.chown(p12_tmpfile_name)
 
             self._configure_clone(
                 cfg,
@@ -225,7 +229,8 @@ class KRAInstance(DogtagInstance):
                 nolog_list=nolog_list
             )
         finally:
-            os.remove(p12_tmpfile_name)
+            if p12_tmpfile_name:
+                os.remove(p12_tmpfile_name)
             os.remove(cfg_file)
             os.remove(admin_p12_file)
 

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -234,7 +234,10 @@ class KRAInstance(DogtagInstance):
             os.remove(cfg_file)
             os.remove(admin_p12_file)
 
-        shutil.move(paths.KRA_BACKUP_KEYS_P12, paths.KRACERT_P12)
+        if config.getboolean(
+            self.subsystem, 'pki_backup_keys', fallback=True
+        ):
+            shutil.move(paths.KRA_BACKUP_KEYS_P12, paths.KRACERT_P12)
         logger.debug("completed creating KRA instance")
 
     def __create_kra_agent(self):

--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -139,7 +139,48 @@ class ServerCertificateInstallInterface(service.ServiceInstallInterface):
 
 
 @group
+class ServerHSMInstallInterface(service.ServiceInstallInterface):
+    description = "HSM"
+
+    token_name = knob(
+        str, None,
+        description=(
+            "The PKCS#11 token name if using an HSM to store and generate "
+            "private keys."
+        ),
+        cli_metavar='NAME',
+    )
+    token_name = master_install_only(token_name)
+
+    token_library_path = knob(
+        str, None,
+        description=(
+            "The full path to the PKCS#11 shared library needed to"
+            "access an HSM device."
+        ),
+        cli_metavar='NAME',
+    )
+    token_library_path = prepare_only(token_library_path)
+
+    token_password = knob(
+        str, None,
+        description=("The PKCS#11 token password for the HSM."),
+        cli_metavar='NAME',
+    )
+    token_password = prepare_only(token_password)
+
+    token_password_file = knob(
+        str, None,
+        description=("The full path to a file containing the password to "
+                     "the PKCS#11 token password."),
+        cli_metavar='NAME',
+    )
+    token_password_file = prepare_only(token_password_file)
+
+
+@group
 class ServerInstallInterface(ServerCertificateInstallInterface,
+                             ServerHSMInstallInterface,
                              client.ClientInstallInterface,
                              ca.CAInstallInterface,
                              kra.KRAInstallInterface,

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -427,6 +427,23 @@ def install_check(installer):
     if not setup_ca and options.setup_kra:
         raise ScriptError(
             "--setup-kra cannot be used with CA-less installation")
+    if setup_ca:
+        if any(
+            (
+                options.token_name is not None,
+                options.token_library_path is not None,
+                options.token_password is not None,
+                options.token_password_file is not None,
+            )
+        ):
+            if any(
+                (
+                    options.token_name is None,
+                    options.token_library_path is None)
+            ):
+                raise ScriptError(
+                    "Both token name and library path are required."
+                )
 
     print("======================================="
           "=======================================")
@@ -626,6 +643,19 @@ def install_check(installer):
             raise ScriptError("IPA admin password required")
     else:
         admin_password = options.admin_password
+
+    if all(
+        (
+            options.token_password is None,
+            options.token_password_file is None,
+            options.token_name is not None
+        )
+    ):
+        token_password = read_password(f"{options.token_name}" , confirm=False)
+        if token_password is None:
+            raise ScriptError("HSM token password required")
+        else:
+            options.token_password = token_password
 
     # Configuration for ipalib, we will bootstrap and finalize later, after
     # we are sure we have the configuration file ready.
@@ -1060,7 +1090,7 @@ def install(installer):
               "enabling chronyd.")
 
     print("")
-    if setup_ca:
+    if setup_ca and not options.token_name:
         print(("Be sure to back up the CA certificates stored in " +
               paths.CACERT_P12))
         print("These files are required to create replicas. The password for "

--- a/ipaserver/plugins/ca.py
+++ b/ipaserver/plugins/ca.py
@@ -72,7 +72,7 @@ class ca(LDAPObject):
     permission_filter_objectclasses = ['ipaca']
     default_attributes = [
         'cn', 'description', 'ipacaid', 'ipacaissuerdn', 'ipacasubjectdn',
-        'ipacarandomserialnumberversion',
+        'ipacarandomserialnumberversion', 'ipacahsmconfiguration',
     ]
     rdn_attribute = 'cn'
     allow_rename = True
@@ -143,6 +143,7 @@ class ca(LDAPObject):
                 'ipacaissuerdn',
                 'ipacasubjectdn',
                 'ipacarandomserialnumberversion',
+                'ipacahsmconfiguration',
                 'objectclass',
             },
         },

--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -24,7 +24,7 @@ import logging
 from ipalib import api
 from ipalib import Bool, Int, Str, IA5Str, StrEnum, DNParam, Flag
 from ipalib import errors
-from ipalib.constants import MAXHOSTNAMELEN
+from ipalib.constants import MAXHOSTNAMELEN, IPA_CA_CN
 from ipalib.plugable import Registry
 from ipalib.request import context
 from ipalib.util import validate_domain_name
@@ -366,6 +366,12 @@ class config(LDAPObject):
             label=_('NetBIOS name of the IPA domain'),
             doc=_('NetBIOS name of the IPA domain'),
             flags={'virtual_attribute', 'no_create'}
+        ),
+        Str(
+            'hsm_token_name?',
+            label=_('HSM token name'),
+            doc=_('The HSM token name storing the CA private keys'),
+            flags={'virtual_attribute', 'no_create', 'no_update'}
         ),
     )
 
@@ -725,6 +731,16 @@ class config_show(LDAPRetrieve):
     __doc__ = _('Show the current configuration.')
 
     def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
+        ca_dn = DN(('cn', IPA_CA_CN), api.env.container_ca, api.env.basedn)
+        try:
+            ca_entry = ldap.get_entry(ca_dn, ['ipacahsmconfiguration'])
+        except errors.NotFound:
+            pass
+        else:
+            if 'ipacahsmconfiguration' in ca_entry:
+                val = ca_entry['ipacahsmconfiguration'][0]
+                (token_name, _token_library_path) = val.split(';')
+                entry_attrs.update({'hsm_token_name': token_name})
         self.obj.show_servroles_attributes(
             entry_attrs, "CA server", "KRA server", "IPA master",
             "DNS server", **options)

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,28 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/temp_TestHSMcertRenewal:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        update_packages: True
+        test_suite: test_integration/test_hsm.py::TestHSMcertRenewal
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 12000
+        topology: *master_1repl
+
+  fedora-latest/temp_TestHSMExternalToSelfSignedCA:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_hsm.py::TestHSMExternalToSelfSignedCA
+        template: *ci-master-latest
+        timeout: 12000
+        topology: *master_1repl

--- a/ipatests/pytest_ipa/integration/config.py
+++ b/ipatests/pytest_ipa/integration/config.py
@@ -44,6 +44,9 @@ class Config(pytest_multihost.config.Config):
         'domain_level',
         'log_journal_since',
         'fips_mode',
+        'token_name',
+        'token_password',
+        'token_library',
     }
 
     def __init__(self, **kwargs):
@@ -69,6 +72,9 @@ class Config(pytest_multihost.config.Config):
         if self.domain_level is None:
             self.domain_level = MAX_DOMAIN_LEVEL
         self.fips_mode = kwargs.get('fips_mode', False)
+        self.token_name = kwargs.get('token_name', None)
+        self.token_password = kwargs.get('token_password', None)
+        self.token_library = kwargs.get('token_library', None)
 
     def get_domain_class(self):
         return Domain

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2914,3 +2914,15 @@ def move_date(host, chrony_cmd, date_str):
     """
     host.run_command(['systemctl', chrony_cmd, 'chronyd'])
     host.run_command(['date', '-s', date_str])
+
+
+def copy_files(source_host, dest_host, filelist):
+    """Helper to copy a file from one host to another
+    :param source_host: source host of the file to copy
+    :param dest_host: destination host
+    :param filelist: list of full path of files to copy
+    """
+    for file in filelist:
+        dest_host.transport.mkdir_recursive(os.path.dirname(file))
+        data = source_host.get_file_contents(file)
+        dest_host.transport.put_file_contents(file, data)

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -435,7 +435,8 @@ def master_authoritative_for_client_domain(master, client):
 def install_replica(master, replica, setup_ca=True, setup_dns=False,
                     setup_kra=False, setup_adtrust=False, extra_args=(),
                     domain_level=None, unattended=True, stdin_text=None,
-                    raiseonerr=True, promote=True, nameservers='master'):
+                    raiseonerr=True, promote=True, nameservers='master',
+                    token_password=None):
     """
     This task installs client and then promote it to the replica
 
@@ -508,6 +509,8 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
             enable_crypto_subpolicy(replica, "AD-SUPPORT")
     if master_authoritative_for_client_domain(master, replica):
         args.extend(['--ip-address', replica.ip])
+    if token_password:
+        args.extend(['--token-password', token_password])
 
     args.extend(replica_args)  # append extra arguments to installation
 
@@ -1424,7 +1427,7 @@ def double_circle_topo(master, replicas, site_size=6):
 def install_topo(topo, master, replicas, clients, domain_level=None,
                  skip_master=False, setup_replica_cas=True,
                  setup_replica_kras=False, clients_extra_args=(),
-                 random_serial=False):
+                 random_serial=False, token_password=None):
     """Install IPA servers and clients in the given topology"""
     if setup_replica_kras and not setup_replica_cas:
         raise ValueError("Option 'setup_replica_kras' requires "
@@ -1452,6 +1455,7 @@ def install_topo(topo, master, replicas, clients, domain_level=None,
                 setup_ca=setup_replica_cas,
                 setup_kra=setup_replica_kras,
                 nameservers=master.ip,
+                token_password=token_password
             )
         installed.add(child)
     install_clients([master] + replicas, clients, clients_extra_args)
@@ -1678,11 +1682,14 @@ def ipa_restore(master, backup_path):
 
 
 def install_kra(host, domain_level=None,
-                first_instance=False, raiseonerr=True):
+                first_instance=False, token_password=None,
+                raiseonerr=True):
     if domain_level is None:
         domain_level = domainlevel(host)
     check_domain_level(domain_level)
     command = ["ipa-kra-install", "-U", "-p", host.config.dirman_password]
+    if token_password:
+        command.extend(['--token-password', token_password])
     result = host.run_command(command, raiseonerr=raiseonerr)
     return result
 
@@ -1690,7 +1697,7 @@ def install_kra(host, domain_level=None,
 def install_ca(
         host, domain_level=None, first_instance=False, external_ca=False,
         cert_files=None, raiseonerr=True, extra_args=(),
-        random_serial=False,
+        random_serial=False, token_password=None,
 ):
     if domain_level is None:
         domain_level = domainlevel(host)
@@ -1699,6 +1706,8 @@ def install_ca(
                "-P", 'admin', "-w", host.config.admin_password]
     if random_serial:
         command.append('--random-serial-numbers')
+    if token_password:
+        command.extend(['--token-password', token_password])
     if not isinstance(extra_args, (tuple, list)):
         raise TypeError("extra_args must be tuple or list")
     command.extend(extra_args)

--- a/ipatests/test_integration/base.py
+++ b/ipatests/test_integration/base.py
@@ -40,6 +40,7 @@ class IntegrationTest:
     domain_level = None
     fips_mode = None
     random_serial = False
+    token_password = None
 
     @classmethod
     def host_by_role(cls, role):
@@ -89,7 +90,8 @@ class IntegrationTest:
             tasks.install_topo(cls.topology,
                                cls.master, cls.replicas,
                                cls.clients, domain_level,
-                               random_serial=cls.random_serial)
+                               random_serial=cls.random_serial,
+                               token_password=cls.token_password)
     @classmethod
     def uninstall(cls, mh):
         for replica in cls.replicas:

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -184,7 +184,7 @@ class CALessBase(IntegrationTest):
                        http_pin=_DEFAULT, dirsrv_pin=_DEFAULT, pkinit_pin=None,
                        root_ca_file='root.pem', pkinit_pkcs12_exists=False,
                        pkinit_pkcs12='server-kdc.p12', unattended=True,
-                       stdin_text=None, extra_args=None):
+                       stdin_text=None, extra_args=[]):
         """Install a CA-less server
 
         Return value is the remote ipa-server-install command

--- a/ipatests/test_integration/test_external_ca.py
+++ b/ipatests/test_integration/test_external_ca.py
@@ -81,6 +81,7 @@ def install_server_external_ca_step1(host, extra_args=(), raiseonerr=True):
 
 
 def install_server_external_ca_step2(host, ipa_ca_cert, root_ca_cert,
+                                     extra_args=(),
                                      raiseonerr=True):
     """Step 2 to install the ipa server with external ca"""
     args = ['ipa-server-install', '-U', '-r', host.domain.realm,
@@ -88,7 +89,7 @@ def install_server_external_ca_step2(host, ipa_ca_cert, root_ca_cert,
             '-p', host.config.dirman_password,
             '--external-cert-file', ipa_ca_cert,
             '--external-cert-file', root_ca_cert]
-
+    args.extend(extra_args)
     cmd = host.run_command(args, raiseonerr=raiseonerr)
     return cmd
 

--- a/ipatests/test_integration/test_hsm.py
+++ b/ipatests/test_integration/test_hsm.py
@@ -1,0 +1,1127 @@
+#
+# Copyright (C) 2023 FreeIPA Contributors see COPYING for license
+#
+
+import os.path
+import pytest
+import random
+import re
+import string
+import time
+
+from ipalib.constants import KRA_TRACKING_REQS
+from ipapython.ipaldap import realm_to_serverid
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.test_integration.test_acme import (
+    prepare_acme_client,
+    certbot_register,
+    certbot_standalone_cert,
+    get_selinux_status,
+    skip_certbot_tests,
+    skip_mod_md_tests,
+
+)
+from ipatests.test_integration.test_caless import CALessBase
+from ipatests.test_integration.test_cert import get_certmonger_fs_id
+from ipatests.test_integration.test_external_ca import (
+    install_server_external_ca_step1,
+    install_server_external_ca_step2,
+    check_CA_flag,
+    verify_caentry
+)
+from ipatests.test_integration.test_ipa_cert_fix import (
+    check_status,
+    needs_resubmit,
+    get_cert_expiry
+)
+from ipatests.test_integration.test_ipahealthcheck import run_healthcheck
+from ipatests.pytest_ipa.integration import tasks
+from ipalib import x509 as ipa_x509
+from ipaplatform.paths import paths
+
+
+hsm_lib_path = '/usr/lib64/pkcs11/libsofthsm2.so'
+
+
+def create_hsm_token(host):
+    """Helper method to create an hsm token using softhsm"""
+    token_name = ''.join(
+        random.choice(string.ascii_letters) for i in range(10)
+    )
+    token_passwd = ''.join(
+        random.choice(string.ascii_letters) for i in range(10)
+    )
+    # remove the token if already exist
+    host.run_command(
+        ['softhsm2-util', '--delete-token', '--token', token_name],
+        raiseonerr=False
+    )
+    host.run_command(
+        ['runuser', '-u', 'pkiuser', '--', 'softhsm2-util', '--init-token',
+         '--free', '--pin', token_passwd, '--so-pin', token_passwd,
+         '--label', token_name]
+    )
+    return (token_name, token_passwd)
+
+
+def find_softhsm_token_files(host, token):
+    if not host.transport.file_exists(paths.PKI_TOMCAT_ALIAS_DIR):
+        return None, []
+
+    result = host.run_command([
+        paths.MODUTIL, '-list', 'libsofthsm2',
+        '-dbdir', paths.PKI_TOMCAT_ALIAS_DIR
+    ])
+
+    serial = None
+    state = 'token_name'
+    for line in result.stdout_text.split('\n'):
+        if state == 'token_name' and 'Token Name:' in line.strip():
+            (_label, tokenname) = line.split(':', 1)
+            if tokenname.strip() == token:
+                state = 'serial'
+        elif state == 'serial' and 'Token Serial Number' in line.strip():
+            (_label, serial) = line.split(':', 1)
+            serial = serial.strip()
+            serial = "{}-{}".format(serial[0:4], serial[4:])
+            break
+
+    if serial is None:
+        raise RuntimeError("can't find softhsm token serial for %s"
+                           % token)
+
+    result = host.run_command(
+        ['ls', '-l', '/var/lib/softhsm/tokens/'])
+    serialdir = None
+    for r in result.stdout_text.split('\n'):
+        if serial in r:
+            dirname = r.split()[-1:][0]
+            serialdir = f'/var/lib/softhsm/tokens/{dirname}'
+            break
+    if serialdir is None:
+        raise RuntimeError("can't find softhsm token directory for %s"
+                           % serial)
+    result = host.run_command(['ls', '-1', serialdir])
+    return serialdir, [
+        os.path.join(serialdir, file)
+        for file in result.stdout_text.strip().split('\n')
+    ]
+
+
+def check_version(host):
+    if tasks.get_pki_version(host) < tasks.parse_version('11.3.0'):
+        raise pytest.skip("PKI HSM support is not available")
+
+
+class TestHSMInstall(IntegrationTest):
+
+    num_replicas = 3
+    num_clients = 1
+    topology = 'star'
+
+    @classmethod
+    def install(cls, mh):
+        check_version(cls.master)
+        # Enable pkiuser to read softhsm tokens
+        cls.master.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+
+        token_name, token_passwd = create_hsm_token(cls.master)
+        cls.token_password = token_passwd
+        cls.token_name = token_name
+        tasks.install_master(
+            cls.master, setup_dns=True,
+            extra_args=(
+                '--token-name', token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', token_passwd
+            )
+        )
+        # copy the token files to replicas
+        serialdir, token_files = find_softhsm_token_files(
+            cls.master, token_name
+        )
+        if serialdir:
+            for replica in cls.replicas:
+                tasks.copy_files(cls.master, replica, token_files)
+                replica.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+                replica.run_command(
+                    ['chown', '-R', 'pkiuser:pkiuser', serialdir]
+                )
+
+    @classmethod
+    def uninstall(cls, mh):
+        check_version(cls.master)
+        super(TestHSMInstall, cls).uninstall(mh)
+        for host in [cls.master] + cls.replicas:
+            host.run_command(
+                ['softhsm2-util', '--delete-token', '--token', cls.token_name],
+                raiseonerr=False
+            )
+
+    def test_hsm_install_replica0_ca_less_install(self):
+        check_version(self.master)
+        tasks.install_replica(
+            self.master, self.replicas[0], setup_ca=False,
+            setup_dns=True,
+            token_password=self.token_password)
+
+    def test_hsm_install_replica0_ipa_ca_install(self):
+        check_version(self.master)
+        tasks.install_ca(self.replicas[0], token_password=self.token_password)
+
+    def test_hsm_install_replica0_ipa_kra_install(self):
+        check_version(self.master)
+        tasks.install_kra(self.replicas[0], first_instance=True,
+                          token_password=self.token_password)
+
+        # Copy the new KRA key material to the other servers.
+        serialdir, token_files = find_softhsm_token_files(
+            self.replicas[0], self.token_name
+        )
+        for server in (self.replicas[1], self.replicas[2], self.master):
+            tasks.copy_files(self.replicas[0], server, token_files)
+            server.run_command(
+                ['chown', '-R', 'pkiuser:pkiuser', serialdir]
+            )
+
+    def test_hsm_install_replica0_ipa_dns_install(self):
+        tasks.install_dns(self.replicas[0])
+
+    def test_hsm_install_replica1_with_ca_install(self):
+        check_version(self.master)
+        tasks.install_replica(
+            self.master, self.replicas[1], setup_ca=True,
+            token_password=self.token_password)
+
+    def test_hsm_install_replica1_ipa_kra_install(self):
+        check_version(self.master)
+        tasks.install_kra(
+            self.replicas[1],
+            token_password=self.token_password
+        )
+
+    def test_hsm_install_replica1_ipa_dns_install(self):
+        check_version(self.master)
+        tasks.install_dns(self.replicas[1])
+
+    def test_hsm_install_replica2_with_ca_kra_dns_install(self):
+        check_version(self.master)
+        tasks.install_replica(
+            self.master, self.replicas[2], setup_ca=True, setup_kra=True,
+            setup_dns=True, token_password=self.token_password)
+
+    def test_hsm_install_client(self):
+        check_version(self.master)
+        tasks.install_client(self.master, self.clients[0])
+
+    def test_hsm_install_issue_user_cert(self):
+        check_version(self.master)
+        user = 'testuser1'
+        csr_file = f'{user}.csr'
+        key_file = f'{user}.key'
+        cert_file = f'{user}.crt'
+
+        tasks.kinit_admin(self.master)
+        tasks.user_add(self.master, user)
+        openssl_cmd = [
+            'openssl', 'req', '-newkey', 'rsa:2048', '-keyout', key_file,
+            '-nodes', '-out', csr_file, '-subj', '/CN=' + user]
+        self.master.run_command(openssl_cmd)
+
+        cmd_args = ['ipa', 'cert-request', '--principal', user,
+                    '--certificate-out', cert_file, csr_file]
+        self.master.run_command(cmd_args)
+
+    def test_hsm_install_healthcheck(self):
+        check_version(self.master)
+        tasks.install_packages(self.master, ['*ipa-healthcheck'])
+        returncode, output = run_healthcheck(
+            self.master, output_type="human", failures_only=True
+        )
+        assert returncode == 0
+        assert output == "No issues found."
+
+
+class TestHSMInstallADTrustBase(IntegrationTest):
+    """
+    Base test for builtin AD trust installation in combination with other
+    components with HSM support
+    """
+    num_replicas = 1
+    master_with_dns = False
+
+    @classmethod
+    def install(cls, mh):
+        check_version(cls.master)
+        # Enable pkiuser to read softhsm tokens
+        cls.master.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+
+        token_name, token_passwd = create_hsm_token(cls.master)
+        cls.token_password = token_passwd
+        cls.token_name = token_name
+        tasks.install_master(
+            cls.master, setup_dns=cls.master_with_dns,
+            setup_kra=True,
+            extra_args=(
+                '--token-name', token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', token_passwd
+            )
+        )
+        serialdir, token_files = find_softhsm_token_files(
+            cls.master, token_name
+        )
+        if serialdir:
+            for replica in cls.replicas:
+                tasks.copy_files(cls.master, replica, token_files)
+                replica.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+                replica.run_command(
+                    ['chown', '-R', 'pkiuser:pkiuser', serialdir]
+                )
+
+    @classmethod
+    def uninstall(cls, mh):
+        check_version(cls.master)
+        super(TestHSMInstallADTrustBase, cls).uninstall(mh)
+        for host in [cls.master] + cls.replicas:
+            host.run_command(
+                ['softhsm2-util', '--delete-token', '--token', cls.token_name],
+                raiseonerr=False
+            )
+
+    def test_hsm_adtrust_replica0_all_components(self):
+        check_version(self.master)
+        tasks.install_replica(
+            self.master, self.replicas[0], setup_ca=True,
+            setup_adtrust=True, setup_kra=True, setup_dns=True,
+            nameservers='master' if self.master_with_dns else None,
+            token_password=self.token_password)
+
+
+class TestADTrustInstallWithDNS_KRA_ADTrust(IntegrationTest):
+
+    num_replicas = 1
+    master_with_dns = True
+
+    @classmethod
+    def install(cls, mh):
+        check_version(cls.master)
+        # Enable pkiuser to read softhsm tokens
+        cls.master.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+
+        token_name, token_passwd = create_hsm_token(cls.master)
+        cls.token_password = token_passwd
+        cls.token_name = token_name
+        tasks.install_master(
+            cls.master, setup_dns=cls.master_with_dns,
+            setup_adtrust=True, setup_kra=True,
+            extra_args=(
+                '--token-name', token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', token_passwd
+            )
+        )
+        serialdir, token_files = find_softhsm_token_files(
+            cls.master, token_name
+        )
+
+        if serialdir:
+            for replica in cls.replicas:
+                tasks.copy_files(cls.master, replica, token_files)
+                replica.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+                replica.run_command(
+                    ['chown', '-R', 'pkiuser:pkiuser', serialdir]
+                )
+
+    @classmethod
+    def uninstall(cls, mh):
+        check_version(cls.master)
+        super(TestADTrustInstallWithDNS_KRA_ADTrust, cls).uninstall(mh)
+        for host in [cls.master] + cls.replicas:
+            host.run_command(
+                ['softhsm2-util', '--delete-token', '--token', cls.token_name],
+                raiseonerr=False
+            )
+
+    def test_hsm_adtrust_replica0(self):
+        check_version(self.master)
+        tasks.install_replica(
+            self.master, self.replicas[0], setup_ca=True, setup_kra=True,
+            token_password=self.token_password
+        )
+
+
+class TestHSMcertRenewal(IntegrationTest):
+
+    @classmethod
+    def install(cls, mh):
+        check_version(cls.master)
+        # Enable pkiuser to read softhsm tokens
+        cls.master.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+
+        token_name, token_passwd = create_hsm_token(cls.master)
+        cls.token_password = token_passwd
+        cls.token_name = token_name
+        tasks.install_master(
+            cls.master, setup_dns=True, setup_kra=True,
+            extra_args=(
+                '--token-name', token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', token_passwd
+            )
+        )
+
+    @classmethod
+    def uninstall(cls, mh):
+        check_version(cls.master)
+        super(TestHSMcertRenewal, cls).uninstall(mh)
+        for host in [cls.master] + cls.replicas:
+            host.run_command(
+                ['softhsm2-util', '--delete-token', '--token', cls.token_name],
+                raiseonerr=False
+            )
+
+    def test_certs_renewal(self):
+        """
+        Test that the KRA subsystem certificates renew properly
+        """
+        check_version(self.master)
+        CA_TRACKING_REQS = {
+            'caSigningCert cert-pki-ca': 'cacaSigningCert',
+            'ocspSigningCert cert-pki-ca': 'caocspSigningCert',
+            'subsystemCert cert-pki-ca': 'casubsystemCert',
+            'auditSigningCert cert-pki-ca': 'caauditSigningCert'
+        }
+        CA_TRACKING_REQS.update(KRA_TRACKING_REQS)
+        self.master.put_file_contents('/tmp/token_passwd', self.token_password)
+        for nickname in CA_TRACKING_REQS:
+            cert = tasks.certutil_fetch_cert(
+                self.master,
+                paths.PKI_TOMCAT_ALIAS_DIR,
+                '/tmp/token_passwd',
+                nickname,
+                token_name=self.token_name,
+            )
+            starting_serial = int(cert.serial_number)
+            cmd_arg = [
+                'ipa-getcert', 'resubmit', '-v', '-w',
+                '-d', paths.PKI_TOMCAT_ALIAS_DIR,
+                '-n', nickname,
+            ]
+            result = self.master.run_command(cmd_arg)
+            request_id = re.findall(r'\d+', result.stdout_text)
+
+            status = tasks.wait_for_request(self.master, request_id[0], 120)
+            assert status == "MONITORING"
+
+            args = ['-L', '-h', self.token_name, '-f', '/tmp/token_passwd']
+            tasks.run_certutil(self.master, args, paths.PKI_TOMCAT_ALIAS_DIR)
+
+            cert = tasks.certutil_fetch_cert(
+                self.master,
+                paths.PKI_TOMCAT_ALIAS_DIR,
+                '/tmp/token_passwd',
+                nickname,
+                token_name=self.token_name,
+            )
+            assert starting_serial != int(cert.serial_number)
+
+
+class TestHSMCALessToExternalToSelfSignedCA(CALessBase):
+    """Test server caless to extarnal CA to self signed scenario"""
+
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        check_version(cls.master)
+        super(TestHSMCALessToExternalToSelfSignedCA, cls).install(mh)
+        # Enable pkiuser to read softhsm tokens
+        cls.master.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+
+        token_name, token_passwd = create_hsm_token(cls.master)
+        cls.token_password = token_passwd
+        cls.token_name = token_name
+
+    @classmethod
+    def uninstall(cls, mh):
+        check_version(cls.master)
+        super(TestHSMCALessToExternalToSelfSignedCA, cls).uninstall(mh)
+        for host in [cls.master] + cls.replicas:
+            host.run_command(
+                ['softhsm2-util', '--delete-token', '--token', cls.token_name],
+                raiseonerr=False
+            )
+
+    def test_hsm_caless_server(self):
+        """Install CA-less master"""
+        check_version(self.master)
+        self.create_pkcs12('ca1/server')
+        self.prepare_cacert('ca1')
+
+        master = self.install_server(
+            extra_args=[
+                '--token-name', self.token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', self.token_password
+            ]
+        )
+        assert master.returncode == 0
+
+        # copy the token files to replicas
+        serialdir, token_files = find_softhsm_token_files(
+            self.master, self.token_name
+        )
+
+        if serialdir:
+            for replica in self.replicas:
+                tasks.copy_files(self.master, replica, token_files)
+                replica.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+                replica.run_command(
+                    ['chown', '-R', 'pkiuser:pkiuser', serialdir]
+                )
+
+    def test_hsm_caless_to_ca_full(self):
+        check_version(self.master)
+        tasks.install_ca(self.master, token_password=self.token_password)
+
+        ca_show = self.master.run_command(['ipa', 'ca-show', 'ipa'])
+        assert 'Subject DN: CN=Certificate Authority,O={}'.format(
+            self.master.domain.realm) in ca_show.stdout_text
+
+    def test_hsm_caless_to_external_ca_install(self):
+        """Install external CA on master"""
+        result = self.master.run_command([paths.IPA_CACERT_MANAGE, 'renew',
+                                         '--external-ca'])
+        assert result.returncode == 0
+
+        # Sign CA, transport it to the host and get ipa a root ca paths.
+        root_ca_fname, ipa_ca_fname = tasks.sign_ca_and_transport(
+            self.master, paths.IPA_CA_CSR, ROOT_CA, IPA_CA)
+
+        # renew CA with externally signed one
+        result = self.master.run_command([paths.IPA_CACERT_MANAGE, 'renew',
+                                          '--external-cert-file={}'.
+                                          format(ipa_ca_fname),
+                                          '--external-cert-file={}'.
+                                          format(root_ca_fname)])
+        assert result.returncode == 0
+
+        # update IPA certificate databases
+        result = self.master.run_command([paths.IPA_CERTUPDATE])
+        assert result.returncode == 0
+
+        # Check if external CA have "C" flag after the switch
+        result = check_CA_flag(self.master)
+        assert bool(result), ('External CA does not have "C" flag')
+
+        # Check that ldap entries for the CA have been updated
+        remote_cacrt = self.master.get_file_contents(ipa_ca_fname)
+        cacrt = ipa_x509.load_pem_x509_certificate(remote_cacrt)
+        verify_caentry(self.master, cacrt)
+
+    def test_hsm_caless_external_to_self_signed_ca(self):
+        check_version(self.master)
+        self.master.run_command([paths.IPA_CACERT_MANAGE, 'renew',
+                                 '--self-signed'])
+        self.master.run_command([paths.IPA_CERTUPDATE])
+
+    def test_hsm_caless_replica0_with_ca_install(self):
+        check_version(self.master)
+        tasks.install_replica(
+            self.master, self.replicas[0], setup_ca=True,
+            token_password=self.token_password)
+
+
+IPA_CA = "ipa_ca.crt"
+ROOT_CA = "root_ca.crt"
+
+
+class TestHSMExternalToSelfSignedCA(IntegrationTest):
+    """
+    Test of FreeIPA server installation with external CA then
+    renew it to self-signed
+    """
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        check_version(cls.master)
+        # Enable pkiuser to read softhsm tokens
+        cls.master.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+
+        token_name, token_passwd = create_hsm_token(cls.master)
+        cls.token_password = token_passwd
+        cls.token_name = token_name
+
+    @classmethod
+    def uninstall(cls, mh):
+        check_version(cls.master)
+        super(TestHSMExternalToSelfSignedCA, cls).uninstall(mh)
+        for host in [cls.master] + cls.replicas:
+            host.run_command(
+                ['softhsm2-util', '--delete-token', '--token', cls.token_name],
+                raiseonerr=False
+            )
+
+    def test_hsm_external_ca_install(self):
+        check_version(self.master)
+        # Step 1 of ipa-server-install.
+        result = install_server_external_ca_step1(
+            self.master,
+            extra_args=[
+                '--external-ca-type=ms-cs',
+                '--token-name', self.token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', self.token_password
+            ]
+        )
+        assert result.returncode == 0
+
+        root_ca_fname, ipa_ca_fname = tasks.sign_ca_and_transport(
+            self.master, paths.ROOT_IPA_CSR, ROOT_CA, IPA_CA
+        )
+
+        # Step 2 of ipa-server-install.
+        result = install_server_external_ca_step2(
+            self.master, ipa_ca_fname, root_ca_fname,
+            extra_args=[
+                '--token-name', self.token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', self.token_password
+            ]
+        )
+        assert result.returncode == 0
+
+        # copy token files to replicas
+        serialdir, token_files = find_softhsm_token_files(
+            self.master, self.token_name
+        )
+
+        if serialdir:
+            for replica in self.replicas:
+                tasks.copy_files(self.master, replica, token_files)
+                replica.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+                replica.run_command(
+                    ['chown', '-R', 'pkiuser:pkiuser', serialdir]
+                )
+
+    def test_hsm_external_kra_install(self):
+        check_version(self.master)
+        tasks.install_kra(self.master, first_instance=True,
+                          token_password=self.token_password)
+
+    def test_hsm_external_to_self_signed_ca(self):
+        check_version(self.master)
+        self.master.run_command([paths.IPA_CACERT_MANAGE, 'renew',
+                                 '--self-signed'])
+        self.master.run_command([paths.IPA_CERTUPDATE])
+
+    def test_hsm_external_ca_replica0_install(self):
+        check_version(self.master)
+        tasks.install_replica(
+            self.master, self.replicas[0], setup_kra=True,
+            token_password=self.token_password)
+
+
+@pytest.fixture
+def expire_cert_critical():
+    """
+    Fixture to expire the certs by moving the system date using
+    date -s command and revert it back
+    """
+
+    hosts = dict()
+
+    def _expire_cert_critical(host):
+        hosts['host'] = host
+        # move date to expire certs
+        tasks.move_date(host, 'stop', '+3Years+1day')
+
+    yield _expire_cert_critical
+
+    host = hosts.pop('host')
+    # Prior to uninstall remove all the cert tracking to prevent
+    # errors from certmonger trying to check the status of certs
+    # that don't matter because we are uninstalling.
+    host.run_command(['systemctl', 'stop', 'certmonger'])
+    # Important: run_command with a str argument is able to
+    # perform shell expansion but run_command with a list of
+    # arguments is not
+    host.run_command('rm -fv ' + paths.CERTMONGER_REQUESTS_DIR + '*')
+    tasks.uninstall_master(host)
+    tasks.move_date(host, 'start', '-3Years-1day')
+
+
+class TestHSMcertFix(IntegrationTest):
+
+    master_with_dns = False
+
+    @classmethod
+    def install(cls, mh):
+        check_version(cls.master)
+        # Enable pkiuser to read softhsm tokens
+        cls.master.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+
+        token_name, token_passwd = create_hsm_token(cls.master)
+        cls.token_password = token_passwd
+        cls.token_name = token_name
+        tasks.install_master(
+            cls.master, setup_dns=cls.master_with_dns,
+            extra_args=(
+                '--token-name', token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', token_passwd,
+                '--no-ntp'
+            )
+        )
+
+    @classmethod
+    def uninstall(cls, mh):
+        check_version(cls.master)
+        super(TestHSMcertFix, cls).uninstall(mh)
+        for host in [cls.master] + cls.replicas:
+            host.run_command(
+                ['softhsm2-util', '--delete-token', '--token', cls.token_name],
+                raiseonerr=False
+            )
+
+    def test_hsm_renew_expired_cert_on_master(self, expire_cert_critical):
+        check_version(self.master)
+        expire_cert_critical(self.master)
+
+        # wait for cert expiry
+        check_status(self.master, 8, "CA_UNREACHABLE")
+
+        self.master.run_command(['ipa-cert-fix', '-v'], stdin_text='yes\n')
+
+        check_status(self.master, 9, "MONITORING")
+
+        # second iteration of ipa-cert-fix
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v'],
+            stdin_text='yes\n'
+        )
+        assert "Nothing to do" in result.stdout_text
+        check_status(self.master, 9, "MONITORING")
+
+
+class TestHSMcertFixKRA(IntegrationTest):
+
+    master_with_dns = False
+
+    @classmethod
+    def install(cls, mh):
+        check_version(cls.master)
+        # Enable pkiuser to read softhsm tokens
+        cls.master.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+
+        token_name, token_passwd = create_hsm_token(cls.master)
+        cls.token_password = token_passwd
+        cls.token_name = token_name
+        tasks.install_master(
+            cls.master, setup_dns=cls.master_with_dns,
+            setup_kra=True,
+            extra_args=(
+                '--token-name', token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', token_passwd,
+                '--no-ntp'
+            )
+        )
+
+    @classmethod
+    def uninstall(cls, mh):
+        check_version(cls.master)
+        super(TestHSMcertFixKRA, cls).uninstall(mh)
+        for host in [cls.master] + cls.replicas:
+            host.run_command(
+                ['softhsm2-util', '--delete-token', '--token', cls.token_name],
+                raiseonerr=False
+            )
+
+    def test_hsm_renew_expired_cert_with_kra(self, expire_cert_critical):
+        check_version(self.master)
+        expire_cert_critical(self.master)
+
+        # check if all subsystem cert expired
+        check_status(self.master, 11, "CA_UNREACHABLE")
+
+        self.master.run_command(['ipa-cert-fix', '-v'], stdin_text='yes\n')
+
+        check_status(self.master, 12, "MONITORING")
+
+
+class TestHSMcertFixReplica(IntegrationTest):
+
+    num_replicas = 1
+    master_with_dns = False
+
+    @classmethod
+    def install(cls, mh):
+        check_version(cls.master)
+        # Enable pkiuser to read softhsm tokens
+        cls.master.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+
+        token_name, token_passwd = create_hsm_token(cls.master)
+        cls.token_password = token_passwd
+        cls.token_name = token_name
+        tasks.install_master(
+            cls.master, setup_dns=cls.master_with_dns,
+            extra_args=(
+                '--token-name', token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', token_passwd,
+                '--no-ntp'
+            )
+        )
+        # copy the token files to replicas
+        serialdir, token_files = find_softhsm_token_files(
+            cls.master, token_name
+        )
+
+        if serialdir:
+            for replica in cls.replicas:
+                tasks.copy_files(cls.master, replica, token_files)
+                replica.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+                replica.run_command(
+                    ['chown', '-R', 'pkiuser:pkiuser', serialdir]
+                )
+
+        tasks.install_replica(
+            cls.master, cls.replicas[0], setup_ca=False,
+            nameservers='master' if cls.master_with_dns else None,
+            token_password=token_passwd
+        )
+
+    @classmethod
+    def uninstall(cls, mh):
+        check_version(cls.master)
+        super(TestHSMcertFixReplica, cls).uninstall(mh)
+        for host in [cls.master] + cls.replicas:
+            host.run_command(
+                ['softhsm2-util', '--delete-token', '--token', cls.token_name],
+                raiseonerr=False
+            )
+
+    @pytest.fixture
+    def expire_certs(self):
+        # move system date to expire certs
+        for host in self.master, self.replicas[0]:
+            tasks.move_date(host, 'stop', '+3years+1days')
+
+        yield
+
+        # move date back on replica and master
+        for host in self.replicas[0], self.master:
+            tasks.uninstall_master(host)
+            tasks.move_date(host, 'start', '-3years-1days')
+
+    def test_hsm_renew_expired_cert_replica(self, expire_certs):
+        check_version(self.master)
+        # wait for cert expiry
+        check_status(self.master, 8, "CA_UNREACHABLE")
+
+        self.master.run_command(['ipa-cert-fix', '-v'], stdin_text='yes\n')
+
+        check_status(self.master, 9, "MONITORING")
+
+        # replica operations
+        # 'Server-Cert cert-pki-ca' cert will be in CA_UNREACHABLE state
+        cmd = self.replicas[0].run_command(
+            ['getcert', 'list',
+             '-d', paths.PKI_TOMCAT_ALIAS_DIR,
+             '-n', 'Server-Cert cert-pki-ca']
+        )
+        req_id = get_certmonger_fs_id(cmd.stdout_text)
+        tasks.wait_for_certmonger_status(
+            self.replicas[0], ('CA_UNREACHABLE'), req_id, timeout=600
+        )
+        # get initial expiry date to compare later with renewed cert
+        initial_expiry = get_cert_expiry(
+            self.replicas[0],
+            paths.PKI_TOMCAT_ALIAS_DIR,
+            'Server-Cert cert-pki-ca'
+        )
+
+        # check that HTTP,LDAP,PKINIT are renewed and in MONITORING state
+        instance = realm_to_serverid(self.master.domain.realm)
+        dirsrv_cert = paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % instance
+        for cert in (paths.KDC_CERT, paths.HTTPD_CERT_FILE):
+            cmd = self.replicas[0].run_command(
+                ['getcert', 'list', '-f', cert]
+            )
+            req_id = get_certmonger_fs_id(cmd.stdout_text)
+            tasks.wait_for_certmonger_status(
+                self.replicas[0], ('MONITORING'), req_id, timeout=600
+            )
+
+        cmd = self.replicas[0].run_command(
+            ['getcert', 'list', '-d', dirsrv_cert]
+        )
+        req_id = get_certmonger_fs_id(cmd.stdout_text)
+        tasks.wait_for_certmonger_status(
+            self.replicas[0], ('MONITORING'), req_id, timeout=600
+        )
+
+        # check if replication working fine
+        testuser = 'testuser1'
+        password = 'Secret@123'
+        stdin = (f"{self.master.config.admin_password}\n"
+                 f"{self.master.config.admin_password}\n"
+                 f"{self.master.config.admin_password}\n")
+        self.master.run_command(['kinit', 'admin'], stdin_text=stdin)
+        tasks.user_add(self.master, testuser, password=password)
+        self.replicas[0].run_command(['kinit', 'admin'], stdin_text=stdin)
+        self.replicas[0].run_command(['ipa', 'user-show', testuser])
+
+        # renew shared certificates by resubmitting to certmonger
+        cmd = self.replicas[0].run_command(
+            ['getcert', 'list', '-f', paths.RA_AGENT_PEM]
+        )
+        req_id = get_certmonger_fs_id(cmd.stdout_text)
+        if needs_resubmit(self.replicas[0], req_id):
+            self.replicas[0].run_command(
+                ['getcert', 'resubmit', '-i', req_id]
+            )
+            tasks.wait_for_certmonger_status(
+                self.replicas[0], ('MONITORING'), req_id, timeout=600
+            )
+        for cert_nick in ('auditSigningCert cert-pki-ca',
+                          'ocspSigningCert cert-pki-ca',
+                          'subsystemCert cert-pki-ca'):
+            cmd = self.replicas[0].run_command(
+                ['getcert', 'list',
+                 '-d', paths.PKI_TOMCAT_ALIAS_DIR,
+                 '-n', cert_nick]
+            )
+            req_id = get_certmonger_fs_id(cmd.stdout_text)
+            if needs_resubmit(self.replicas[0], req_id):
+                self.replicas[0].run_command(
+                    ['getcert', 'resubmit', '-i', req_id]
+                )
+                tasks.wait_for_certmonger_status(
+                    self.replicas[0], ('MONITORING'), req_id, timeout=600
+                )
+
+        self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+
+        check_status(self.replicas[0], 9, "MONITORING")
+
+        # Sometimes certmonger takes time to update the cert status
+        # So check in nssdb instead of relying on getcert command
+        renewed_expiry = get_cert_expiry(
+            self.replicas[0],
+            paths.PKI_TOMCAT_ALIAS_DIR,
+            'Server-Cert cert-pki-ca'
+        )
+        assert renewed_expiry > initial_expiry
+
+
+class TestHSMNegative(IntegrationTest):
+
+    master_with_dns = False
+
+    @classmethod
+    def install(cls, mh):
+        check_version(cls.master)
+        # Enable pkiuser to read softhsm tokens
+        cls.master.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+
+        token_name, token_passwd = create_hsm_token(cls.master)
+        cls.token_password = token_passwd
+        cls.token_name = token_name
+
+    def test_hsm_negative_wrong_token_details(self):
+        check_version(self.master)
+        # wrong token name
+        result = tasks.install_master(
+            self.master, raiseonerr=False,
+            extra_args=(
+                '--token-name', 'random_token',
+                '--token-library-path', hsm_lib_path,
+                '--token-password', self.token_password
+            )
+        )
+        # assert 'error message non existing token name' in result.stderr_text
+        assert result.returncode != 0
+
+        # wrong token password
+        result = tasks.install_master(
+            self.master, raiseonerr=False,
+            extra_args=(
+                '--token-name', self.token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', 'token_passwd'
+            )
+        )
+        # assert 'error message wrong  passwd' in result.stderr_text
+        assert result.returncode != 0
+
+        # wrong token lib
+        result = tasks.install_master(
+            self.master, raiseonerr=False,
+            extra_args=(
+                '--token-name', self.token_name,
+                '--token-library-path', '/tmp/non_existing_hsm_lib_path',
+                '--token-password', self.token_password
+            )
+        )
+        # assert 'error message non existing token lib' in result.stderr_text
+        assert result.returncode != 0
+
+    def test_hsm_negative_special_char_token_name(self):
+        check_version(self.master)
+        token_name = 'hsm token'
+        token_passwd = 'Secret123'
+        self.master.run_command(
+            ['softhsm2-util', '--delete-token', '--token', token_name],
+            raiseonerr=False
+        )
+        self.master.run_command(
+            ['runuser', '-u', 'pkiuser', '--', 'softhsm2-util', '--init-token',
+             '--free', '--pin', token_passwd, '--so-pin', token_passwd,
+             '--label', token_name]
+        )
+
+        # special character in token name
+        result = tasks.install_master(
+            self.master, raiseonerr=False,
+            extra_args=(
+                '--token-name', token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', token_passwd
+            )
+        )
+        # assert 'error message non existing token lib' in result.stderr_text
+        assert result.returncode != 0
+
+
+class TestHSMACME(CALessBase):
+
+    num_clients = 1
+
+    @classmethod
+    def install(cls, mh):
+        check_version(cls.master)
+        super(TestHSMACME, cls).install(mh)
+
+        # install packages before client install in case of IPA DNS problems
+        cls.acme_server = prepare_acme_client(cls.master, cls.clients[0])
+
+        # Enable pkiuser to read softhsm tokens
+        cls.master.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+
+        token_name, token_passwd = create_hsm_token(cls.master)
+        cls.token_password = token_passwd
+        cls.token_name = token_name
+        tasks.install_master(
+            cls.master, setup_dns=True,
+            extra_args=(
+                '--token-name', token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', token_passwd
+            )
+        )
+
+        tasks.install_client(cls.master, cls.clients[0])
+
+    @pytest.mark.skipif(skip_certbot_tests, reason='certbot not available')
+    def test_certbot_certonly_standalone(self):
+        check_version(self.master)
+        # enable ACME on server
+        tasks.kinit_admin(self.master)
+        self.master.run_command(['ipa-acme-manage', 'enable'])
+        # register account to certbot
+        certbot_register(self.clients[0], self.acme_server)
+        # request ACME cert with certbot
+        certbot_standalone_cert(self.clients[0], self.acme_server)
+
+    @pytest.mark.skipif(skip_mod_md_tests, reason='mod_md not available')
+    def test_mod_md(self):
+        check_version(self.master)
+        if get_selinux_status(self.clients[0]):
+            # mod_md requires its own SELinux policy to grant perms to
+            # maintaining ACME registration and cert state.
+            raise pytest.skip("SELinux is enabled, this will fail")
+        # write config
+        self.clients[0].run_command(['mkdir', '-p', '/etc/httpd/conf.d'])
+        self.clients[0].run_command(['mkdir', '-p', '/etc/httpd/md'])
+        self.clients[0].put_file_contents(
+            '/etc/httpd/conf.d/md.conf',
+            '\n'.join([
+                f'MDCertificateAuthority {self.acme_server}',
+                'MDCertificateAgreement accepted',
+                'MDStoreDir  /etc/httpd/md',
+                f'MDomain {self.clients[0].hostname}',
+                '<VirtualHost *:443>',
+                f'    ServerName {self.clients[0].hostname}',
+                '    SSLEngine on',
+                '</VirtualHost>\n',
+            ]),
+        )
+
+        # To check for successful cert issuance means knowing how mod_md
+        # stores certificates, or looking for specific log messages.
+        # If the thing we are inspecting changes, the test will break.
+        # So I prefer a conservative sleep.
+        #
+        self.clients[0].run_command(['systemctl', 'restart', 'httpd'])
+        time.sleep(15)
+
+        # We expect mod_md has acquired the certificate by now.
+        # Perform a graceful restart to begin using the cert.
+        # (If mod_md ever learns to start using newly acquired
+        # certificates /without/ the second restart, then both
+        # of these sleeps can be replaced by "loop until good".)
+        #
+        self.clients[0].run_command(['systemctl', 'reload', 'httpd'])
+        time.sleep(3)
+
+        # HTTPS request from server to client (should succeed)
+        self.master.run_command(
+            ['curl', f'https://{self.clients[0].hostname}'])
+
+        # clean-up
+        self.clients[0].run_command(['rm', '-rf', '/etc/httpd/md'])
+        self.clients[0].run_command(['rm', '-f', '/etc/httpd/conf.d/md.conf'])
+
+
+class TestHSMBackupRestore(IntegrationTest):
+
+    @classmethod
+    def install(cls, mh):
+        check_version(cls.master)
+        # Enable pkiuser to read softhsm tokens
+        cls.master.run_command(['usermod', 'pkiuser', '-a', '-G', 'ods'])
+
+        token_name, token_passwd = create_hsm_token(cls.master)
+        cls.token_password = token_passwd
+        cls.token_name = token_name
+        tasks.install_master(
+            cls.master,
+            extra_args=(
+                '--token-name', token_name,
+                '--token-library-path', hsm_lib_path,
+                '--token-password', token_passwd
+            )
+        )
+
+    def test_hsm_backup_restore(self):
+        check_version(self.master)
+        backup_path = tasks.get_backup_dir(self.master)
+
+        self.master.run_command(['ipa-server-install',
+                                 '--uninstall',
+                                 '-U'])
+        assert not self.master.transport.file_exists(
+            paths.IPA_CUSTODIA_KEYS)
+        assert not self.master.transport.file_exists(
+            paths.IPA_CUSTODIA_CONF)
+
+        self.master.run_command(
+            ['ipa-restore', backup_path],
+            stdin_text=f'{self.master.config.dirman_password}\nyes'
+        )

--- a/ipatests/test_integration/test_hsm.py
+++ b/ipatests/test_integration/test_hsm.py
@@ -387,7 +387,6 @@ class TestHSMcertRenewal(IntegrationTest):
         """
         check_version(self.master)
         CA_TRACKING_REQS = {
-            'caSigningCert cert-pki-ca': 'cacaSigningCert',
             'ocspSigningCert cert-pki-ca': 'caocspSigningCert',
             'subsystemCert cert-pki-ca': 'casubsystemCert',
             'auditSigningCert cert-pki-ca': 'caauditSigningCert'

--- a/ipatests/test_integration/test_hsm.py
+++ b/ipatests/test_integration/test_hsm.py
@@ -611,6 +611,16 @@ class TestHSMExternalToSelfSignedCA(IntegrationTest):
         tasks.install_kra(self.master, first_instance=True,
                           token_password=self.token_password)
 
+        # Copy the new KRA key material to the other server(s).
+        serialdir, token_files = find_softhsm_token_files(
+            self.master, self.token_name
+        )
+        for server in (self.replicas[0],):
+            tasks.copy_files(self.master, server, token_files)
+            server.run_command(
+                ['chown', '-R', 'pkiuser:pkiuser', serialdir]
+            )
+
     def test_hsm_external_to_self_signed_ca(self):
         check_version(self.master)
         self.master.run_command([paths.IPA_CACERT_MANAGE, 'renew',

--- a/ipatests/test_integration/test_hsm.py
+++ b/ipatests/test_integration/test_hsm.py
@@ -578,11 +578,7 @@ class TestHSMExternalToSelfSignedCA(IntegrationTest):
                           token_password=self.token_password)
 
         # Copy the new KRA key material to the other server(s).
-        copy_token_files(
-            self.replicas[0],
-            [self.replicas[1], self.replicas[2], self.master],
-            self.token_name
-        )
+        copy_token_files(self.master, self.replicas, self.token_name)
 
     def test_hsm_external_to_self_signed_ca(self):
         check_version(self.master)

--- a/ipatests/test_integration/test_testconfig.py
+++ b/ipatests/test_integration/test_testconfig.py
@@ -47,6 +47,9 @@ DEFAULT_OUTPUT_DICT = {
     "domain_level": MAX_DOMAIN_LEVEL,
     "log_journal_since": "-1h",
     "fips_mode": False,
+    "token_name": None,
+    "token_password": None,
+    "token_library": None,
 }
 
 DEFAULT_OUTPUT_ENV = {

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -504,3 +504,15 @@ optional_policy(`
     ')
 	ipa_helper_noatsecure(oddjob_t)
 ')
+
+optional_policy(`
+    gen_require(` #selint-disable:S-001
+        type certmonger_t;
+        type pki_tomcat_etc_rw_t;
+        class file getattr;
+        class file ioctl;
+        class file open;
+        class file read;
+    ')
+    allow certmonger_t pki_tomcat_etc_rw_t:file { getattr ioctl open read };
+')

--- a/selinux/luna/Makefile.am
+++ b/selinux/luna/Makefile.am
@@ -1,0 +1,33 @@
+SELINUXTYPE = targeted
+NULL =
+
+if BUILD_SELINUX_POLICY
+MODULE = ipa-luna.pp.bz2
+MODULE_IF = ipa-luna.if
+else
+MODULE =
+MODULE_IF =
+endif
+
+dist_noinst_DATA =	\
+	ipa-luna.te	\
+	$(NULL)
+
+# selinuxincludedir = $(datarootdir)/selinux/devel/include/contrib
+# nodist_selinuxinclude_DATA = \
+#	$(MODULE_IF)			\
+#	$(NULL)
+
+selinuxpolicydir = $(datarootdir)/selinux/packages/$(SELINUXTYPE)
+nodist_selinuxpolicy_DATA =	\
+	$(MODULE)				\
+	$(NULL)
+
+%.pp.bz2: %.pp
+	bzip2 -f -9 $^
+
+%.pp: %.te
+	make -f $(selinux_makefile) $@
+
+clean-local:
+	rm -f *~  *.tc *.pp *.pp.bz2

--- a/selinux/luna/ipa-luna.te
+++ b/selinux/luna/ipa-luna.te
@@ -1,0 +1,9 @@
+policy_module(ipa-luna, 1.0.0)
+
+require {
+    type certmonger_t;
+    type ibm_dt_2_port_t;
+    class tcp_socket name_connect;
+}
+
+allow certmonger_t ibm_dt_2_port_t:tcp_socket name_connect;

--- a/selinux/nfast/Makefile.am
+++ b/selinux/nfast/Makefile.am
@@ -1,0 +1,33 @@
+SELINUXTYPE = targeted
+NULL =
+
+if BUILD_SELINUX_POLICY
+MODULE = ipa-nfast.pp.bz2
+MODULE_IF = ipa-nfast.if
+else
+MODULE =
+MODULE_IF =
+endif
+
+dist_noinst_DATA =	\
+	ipa-nfast.te	\
+	$(NULL)
+
+# selinuxincludedir = $(datarootdir)/selinux/devel/include/contrib
+# nodist_selinuxinclude_DATA = \
+#	$(MODULE_IF)			\
+#	$(NULL)
+
+selinuxpolicydir = $(datarootdir)/selinux/packages/$(SELINUXTYPE)
+nodist_selinuxpolicy_DATA =	\
+	$(MODULE)				\
+	$(NULL)
+
+%.pp.bz2: %.pp
+	bzip2 -f -9 $^
+
+%.pp: %.te
+	make -f $(selinux_makefile) $@
+
+clean-local:
+	rm -f *~  *.tc *.pp *.pp.bz2

--- a/selinux/nfast/ipa-nfast.te
+++ b/selinux/nfast/ipa-nfast.te
@@ -1,0 +1,23 @@
+policy_module(ipa-nfast, 1.0.0)
+
+#
+# A transition can't be used here because it would apply to all
+# certmonger processes and it really just needs access to
+# /opt/nfast/kmdata/local/world to read the private key material.
+#
+
+require {
+    type certmonger_t;
+    type pki_common_t;
+    type initrc_t;
+    class file { create rename unlink write execute getattr open read map };
+    class dir { getattr open read search add_name remove_name write };
+    class sock_file write;
+    class unix_stream_socket connectto;
+}
+
+allow certmonger_t initrc_t:unix_stream_socket connectto;
+allow certmonger_t pki_common_t:dir { getattr open read search add_name remove_name write };
+allow certmonger_t pki_common_t:file { create rename unlink write execute getattr open read };
+allow certmonger_t pki_common_t:file map;
+allow certmonger_t pki_common_t:sock_file write;


### PR DESCRIPTION
Implement the design for HSM support.

This PR set adds options for HSM token, library path and token password to the CA/KRA-related installers.

The intention is to test this in CI using a SoftHSM2 token. This is not recommended for production since it lacks the Hardware part of HSM.

It has additionally been smoke-tested using an nCipher HSM with CA installation.

The HSM code requires PKI 11.3.0+.

Non-HSM installations should not be affected.