### PR TITLE
Update 'Auth indicators' doc string

### DIFF
--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -574,6 +574,9 @@ class service(LDAPObject):
                   " Use 'pkinit' to allow PKINIT-based 2FA authentications."
                   " Use 'hardened' to allow brute-force hardened password"
                   " authentication by SPAKE or FAST."
+                  " Use 'idp' to allow authentication against an external"
+                  " Identity Provider supporting OAuth 2.0 Device"
+                  " Authorization Flow (RFC 8628)."
                   " With no indicator specified,"
                   " all authentication mechanisms are allowed."),
             values=(u'radius', u'otp', u'pkinit', u'hardened', u'idp'),


### PR DESCRIPTION
The doc string located in the 'Authentication indicators' ('Services' settings page) was missing the usage explanation for the 'ipd' checkbox option.

Fixes: https://pagure.io/freeipa/issue/9338
Signed-off-by: Carla Martinez <carlmart@redhat.com>