### PR TITLE
[ipa-4-9] ipatests: remove wrong job definition TestACMEPrune

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1730,18 +1730,6 @@ jobs:
         timeout: 8100
         topology: *master_1repl_1client
 
-  fedora-latest-ipa-4-9/test_acme_prune:
-    requires: [fedora-latest-ipa-4-9/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-latest-ipa-4-9/build_url}'
-        test_suite: test_integration/test_acme.py::TestACMEPrune
-        template: *ci-ipa-4-9-latest
-        timeout: 3600
-        topology: *master_1repl_1client
-
   fedora-latest-ipa-4-9/test_dns:
     requires: [fedora-latest-ipa-4-9/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1867,19 +1867,6 @@ jobs:
         timeout: 8100
         topology: *master_1repl_1client
 
-  fedora-latest-ipa-4-9/test_acme_prune:
-    requires: [fedora-latest-ipa-4-9/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-latest-ipa-4-9/build_url}'
-        selinux_enforcing: True
-        test_suite: test_integration/test_acme.py::TestACMEPrune
-        template: *ci-ipa-4-9-latest
-        timeout: 3600
-        topology: *master_1repl_1client
-
   fedora-latest-ipa-4-9/test_dns:
     requires: [fedora-latest-ipa-4-9/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1730,18 +1730,6 @@ jobs:
         timeout: 8100
         topology: *master_1repl_1client
 
-  fedora-previous-ipa-4-9/test_acme_prune:
-    requires: [fedora-previous-ipa-4-9/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-previous-ipa-4-9/build_url}'
-        test_suite: test_integration/test_acme.py::TestACMEPrune
-        template: *ci-ipa-4-9-previous
-        timeout: 3600
-        topology: *master_1repl_1client
-
   fedora-previous-ipa-4-9/test_dns:
     requires: [fedora-previous-ipa-4-9/build]
     priority: 50


### PR DESCRIPTION
In ipa-4-9 branch, there is no TestACMEPrune in the test test_integration/test_acme.py.
The nightly job was introduced by mistake by a
backport. Remove the nightly job definition.

Related: https://pagure.io/freeipa/issue/9324