### PR TITLE
ipatests: add missing automember-cli tests

### DIFF
--- a/ipatests/test_xmlrpc/tracker/automember_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/automember_plugin.py
@@ -189,6 +189,17 @@ class AutomemberTracker(Tracker):
         result = command()
         self.check_add_condition(result)
 
+    def add_condition_exclusive(self, key, type, exclusiveregex):
+        """ Add a condition with given exclusive regex and check for result.
+        Only one condition can be added. For more specific uses please
+        use make_add_condition_command instead. """
+        command = self.make_add_condition_command(
+            key=key, type=type, automemberexclusiveregex=exclusiveregex)
+        self.attrs['automemberexclusiveregex'] = [u'%s=%s' %
+                                                  (key, exclusiveregex[0])]
+        result = command()
+        self.check_add_condition(result)
+
     def rebuild(self, no_wait=False):
         """ Rebuild automember conditions and check for result """
         command = self.make_rebuild_command(type=self.membertype,


### PR DESCRIPTION
Revisit bash ipa-automember-cli and port to upstream.
As of now, focusing on negative tests.

Related: https://pagure.io/freeipa/issue/9332

Signed-off-by: mbhalodi <mbhalodi@redhat.com>
