### PR TITLE
Migrated to SPDX license.

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -226,7 +226,7 @@ Version:        %{IPA_VERSION}
 Release:        0%{?rc_version:.%rc_version}%{?dist}
 Summary:        The Identity, Policy and Audit system
 
-License:        GPLv3+
+License:        GPL-3.0-or-later
 URL:            http://www.freeipa.org/
 Source0:        https://releases.pagure.org/freeipa/freeipa-%{version}%{?rc_version}.tar.gz
 # Only use detached signature for the distribution builds. If it is a developer build, skip it


### PR DESCRIPTION
According to [1] all Fedora packages need to be updated to use a SPDX expression. This patch updates the freeipa spec template to comply with this change.

[1] https://fedoraproject.org/wiki/Changes/SPDX_Licenses_Phase_1

Fixes: https://pagure.io/freeipa/issue/9342
