### PR TITLE
[Backport][ipa-4-9] external-idp: change idp server name to reference name

### DIFF
--- a/doc/api/idp_add.md
+++ b/doc/api/idp_add.md
@@ -1,6 +1,6 @@
 [//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
 # idp_add
-Add a new Identity Provider server.
+Add a new Identity Provider reference.
 
 ### Arguments
 |Name|Type|Required

--- a/doc/api/idp_del.md
+++ b/doc/api/idp_del.md
@@ -1,6 +1,6 @@
 [//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
 # idp_del
-Delete an Identity Provider server.
+Delete an Identity Provider reference.
 
 ### Arguments
 |Name|Type|Required

--- a/doc/api/idp_find.md
+++ b/doc/api/idp_find.md
@@ -1,6 +1,6 @@
 [//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
 # idp_find
-Search for Identity Provider servers.
+Search for Identity Provider references.
 
 ### Arguments
 |Name|Type|Required

--- a/doc/api/idp_mod.md
+++ b/doc/api/idp_mod.md
@@ -1,6 +1,6 @@
 [//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
 # idp_mod
-Modify an Identity Provider server.
+Modify an Identity Provider reference.
 
 ### Arguments
 |Name|Type|Required

--- a/doc/api/idp_show.md
+++ b/doc/api/idp_show.md
@@ -1,6 +1,6 @@
 [//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
 # idp_show
-Display information about an Identity Provider server.
+Display information about an Identity Provider reference.
 
 ### Arguments
 |Name|Type|Required

--- a/doc/workshop/12-external-idp-support.rst
+++ b/doc/workshop/12-external-idp-support.rst
@@ -112,7 +112,7 @@ suitable, individual parameters can also be added::
   ipa help idp-add
   Usage: ipa [global-options] idp-add NAME [options]
 
-  Add a new Identity Provider server.
+  Add a new Identity Provider reference.
   Options:
     -h, --help            show this help message and exit
     --auth-uri=STR        OAuth 2.0 authorization endpoint
@@ -370,9 +370,9 @@ The following command adds IdP reference named ``keycloak`` as IPA administrator
         --client-id ipa_oidc_client \
         --secret
   -----------------------------------------
-  Added Identity Provider server "keycloak"
+  Added Identity Provider reference "keycloak"
   -----------------------------------------
-    Identity Provider server name: keycloak
+    Identity Provider reference name: keycloak
     Authorization URI: https://client.ipademo.local:8443/auth/realms/master/protocol/openid-connect/auth
     Device authorization URI: https://client.ipademo.local:8443/auth/realms/master/protocol/openid-connect/auth/device
     Token URI: https://client.ipademo.local:8443/auth/realms/master/protocol/openid-connect/token

--- a/ipaserver/plugins/idp.py
+++ b/ipaserver/plugins/idp.py
@@ -22,34 +22,35 @@ from itertools import chain
 logger = logging.getLogger(__name__)
 
 __doc__ = _("""
-External Identity Provider Servers
+External Identity Provider References
 """) + _("""
-Manage External Identity Provider Servers.
+Manage External Identity Provider References.
 """) + _("""
-IPA supports the use of an external Identity Provider for Oauth2.0 Device Flow
+IPA supports the use of an external Identity Provider for OAuth2.0 Device Flow
 authentication.
 """) + _("""
 EXAMPLES:
 """) + _("""
- Add a new external Identity Provider server:
+ Add a new external Identity Provider reference:
    ipa idp-add MyIdP --client-id jhkQty13 \
       --auth-uri https://oauth2.idp.com/auth \
       --token-uri https://oauth2.idp.com/token --secret
 """) + _("""
- Add a new external Identity Provider server using github predefined endpoints:
+ Add a new external Identity Provider reference using github predefined
+ endpoints:
    ipa idp-add MyIdp --client-id jhkQty13 --provider github --secret
 """) + _("""
- Find all external Identity Provider servers whose entries include the string
+ Find all external Identity Provider references whose entries include the string
  "test.com":
    ipa idp-find test.com
 """) + _("""
- Examine the configuration of an external Identity Provider server:
+ Examine the configuration of an external Identity Provider reference:
    ipa idp-show MyIdP
 """) + _("""
  Change the secret:
    ipa idp-mod MyIdP --secret
 """) + _("""
- Delete an external Identity Provider server:
+ Delete an external Identity Provider reference:
    ipa idp-del MyIdP
 """)
 
@@ -80,8 +81,8 @@ class idp(LDAPObject):
     Identity Provider object.
     """
     container_dn = api.env.container_idp
-    object_name = _('Identity Provider server')
-    object_name_plural = _('Identity Provider servers')
+    object_name = _('Identity Provider reference')
+    object_name_plural = _('Identity Provider references')
     object_class = ['ipaidp']
     default_attributes = [
         'cn', 'ipaidpauthendpoint', 'ipaidpdevauthendpoint',
@@ -95,13 +96,13 @@ class idp(LDAPObject):
         'ipaidpkeysendpoint', 'ipaidpscope', 'ipaidpsub',
     ]
     allow_rename = True
-    label = _('Identity Provider servers')
-    label_singular = _('Identity Provider server')
+    label = _('Identity Provider references')
+    label_singular = _('Identity Provider reference')
 
     takes_params = (
         Str('cn',
             cli_name='name',
-            label=_('Identity Provider server name'),
+            label=_('Identity Provider reference name'),
             primary_key=True,
             ),
         Str('ipaidpauthendpoint?',
@@ -225,8 +226,8 @@ class idp(LDAPObject):
 
 @register()
 class idp_add(LDAPCreate):
-    __doc__ = _('Add a new Identity Provider server.')
-    msg_summary = _('Added Identity Provider server "%(value)s"')
+    __doc__ = _('Add a new Identity Provider reference.')
+    msg_summary = _('Added Identity Provider reference "%(value)s"')
 
     # List of pre-populated idp endpoints
     # key = provider,
@@ -409,22 +410,22 @@ class idp_add(LDAPCreate):
 
 @register()
 class idp_del(LDAPDelete):
-    __doc__ = _('Delete an Identity Provider server.')
-    msg_summary = _('Deleted Identity Provider server "%(value)s"')
+    __doc__ = _('Delete an Identity Provider reference.')
+    msg_summary = _('Deleted Identity Provider reference "%(value)s"')
 
 
 @register()
 class idp_mod(LDAPUpdate):
-    __doc__ = _('Modify an Identity Provider server.')
-    msg_summary = _('Modified Identity Provider server "%(value)s"')
+    __doc__ = _('Modify an Identity Provider reference.')
+    msg_summary = _('Modified Identity Provider reference "%(value)s"')
 
 
 @register()
 class idp_find(LDAPSearch):
-    __doc__ = _('Search for Identity Provider servers.')
+    __doc__ = _('Search for Identity Provider references.')
     msg_summary = ngettext(
-        '%(count)d Identity Provider server matched',
-        '%(count)d Identity Provider servers matched', 0
+        '%(count)d Identity Provider reference matched',
+        '%(count)d Identity Provider references matched', 0
     )
 
     def get_options(self):
@@ -439,4 +440,4 @@ class idp_find(LDAPSearch):
 @register()
 class idp_show(LDAPRetrieve):
     __doc__ = _('Display information about an Identity Provider '
-                'server.')
+                'reference.')

--- a/ipatests/test_xmlrpc/test_idp_plugin.py
+++ b/ipatests/test_xmlrpc/test_idp_plugin.py
@@ -55,7 +55,7 @@ class TestNonexistentIdp(XMLRPC_test):
         idp.ensure_missing()
         command = idp.make_retrieve_command()
         with raises_exact(errors.NotFound(
-                reason='%s: Identity Provider server not found' % idp.cn)):
+                reason='%s: Identity Provider reference not found' % idp.cn)):
             command()
 
     def test_update_nonexistent(self, idp):
@@ -64,7 +64,7 @@ class TestNonexistentIdp(XMLRPC_test):
         command = idp.make_update_command(
             updates=dict(ipaidpclientid='idpclient2'))
         with raises_exact(errors.NotFound(
-                reason='%s: Identity Provider server not found' % idp.cn)):
+                reason='%s: Identity Provider reference not found' % idp.cn)):
             command()
 
     def test_delete_nonexistent(self, idp):
@@ -72,7 +72,7 @@ class TestNonexistentIdp(XMLRPC_test):
         idp.ensure_missing()
         command = idp.make_delete_command()
         with raises_exact(errors.NotFound(
-                reason='%s: Identity Provider server not found' % idp.cn)):
+                reason='%s: Identity Provider reference not found' % idp.cn)):
             command()
 
     def test_rename_nonexistent(self, idp, renamedidp):
@@ -81,7 +81,7 @@ class TestNonexistentIdp(XMLRPC_test):
         command = idp.make_update_command(
             updates=dict(setattr='cn=%s' % renamedidp.cn))
         with raises_exact(errors.NotFound(
-                reason='%s: Identity Provider server not found' % idp.cn)):
+                reason='%s: Identity Provider reference not found' % idp.cn)):
             command()
 
 

--- a/ipatests/test_xmlrpc/tracker/idp_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/idp_plugin.py
@@ -64,7 +64,7 @@ class IdpTracker(Tracker):
         assert_deepequal(
             dict(
                 value=self.cn,
-                summary='Added Identity Provider server "%s"' % self.cn,
+                summary='Added Identity Provider reference "%s"' % self.cn,
                 result=self.filter_attrs(expected),
             ), result)
 
@@ -77,7 +77,7 @@ class IdpTracker(Tracker):
         assert_deepequal(
             dict(
                 value=[self.cn],
-                summary='Deleted Identity Provider server "%s"' % self.cn,
+                summary='Deleted Identity Provider reference "%s"' % self.cn,
                 result=dict(failed=[]),
             ), result)
 
@@ -113,7 +113,7 @@ class IdpTracker(Tracker):
         assert_deepequal(dict(
             count=1,
             truncated=False,
-            summary='1 Identity Provider server matched',
+            summary='1 Identity Provider reference matched',
             result=[expected],
         ), result)
 
@@ -165,6 +165,6 @@ class IdpTracker(Tracker):
         expected = self.filter_attrs(self.update_keys | set(extra_keys))
         assert_deepequal(dict(
             value=self.cn,
-            summary='Modified Identity Provider server "%s"' % self.cn,
+            summary='Modified Identity Provider reference "%s"' % self.cn,
             result=expected
         ), result)


### PR DESCRIPTION
This PR was opened automatically because PR #6689 was pushed to master and backport to ipa-4-9 is required.