### PR TITLE
ipatests: Test MemberManager ACI to allow managers from a specified group after upgrade scenario

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2081,6 +2081,25 @@ def group_add(host, groupname, extra_args=()):
     return host.run_command(cmd)
 
 
+def group_del(host, groupname):
+    cmd = [
+        "ipa", "group-del", groupname,
+    ]
+    return host.run_command(cmd)
+
+
+def group_add_member(host, groupname, users=None,
+                     raiseonerr=True, extra_args=()):
+    cmd = [
+        "ipa", "group-add-member", groupname
+    ]
+    if users:
+        cmd.append("--users")
+        cmd.append(users)
+    cmd.extend(extra_args)
+    return host.run_command(cmd, raiseonerr=raiseonerr)
+
+
 def ldapmodify_dm(host, ldif_text, **kwargs):
     """Run ldapmodify as Directory Manager
 


### PR DESCRIPTION
Testing if manager whose rights defined by the group membership is able to add group members, after upgrade of ipa server. Using ACI modification to demonstrate unability before upgrading ipa server.
Related: https://pagure.io/freeipa/issue/9286

Also added some generally helpful functions to tasks.py

This is duplicated PR, because it was accidentally merged without ipatool. 
https://github.com/freeipa/freeipa/pull/6685