### PR TITLE
[Backport][ipa-4-6] Defer creating the final krb5.conf on clients

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -116,10 +116,9 @@ def cleanup(func):
             os.rmdir(ccache_dir)
         except OSError:
             pass
-        try:
-            os.remove(krb_name + ".ipabkp")
-        except OSError:
-            logger.error("Could not remove %s.ipabkp", krb_name)
+        # During master installation, the .ipabkp file is not created
+        # Ignore the delete error if it is "file does not exist"
+        remove_file(krb_name + ".ipabkp")
 
     return inner
 

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -2836,8 +2836,6 @@ def _install(options, tdict):
 
     if not options.on_master:
         client_dns(cli_server[0], hostname, options)
-        configure_certmonger(fstore, subject_base, cli_realm, hostname,
-                             options, ca_enabled)
 
     update_ssh_keys(hostname, paths.SSH_CONFIG_DIR, options.create_sshfp)
 
@@ -3034,6 +3032,11 @@ def _install(options, tdict):
             force=options.force)
 
         logger.info("Configured /etc/krb5.conf for IPA realm %s", cli_realm)
+
+        # Configure certmonger after krb5.conf is created and last
+        # to give higher chance that the new client is replicated. 
+        configure_certmonger(fstore, subject_base, cli_realm, hostname,
+                             options, ca_enabled)
 
     logger.info('Client configuration complete.')
 


### PR DESCRIPTION
This is a manual backport of the following PRs to ipa-4-6 branch:
- PR #[6429](https://github.com/freeipa/freeipa/pull/6429) Defer creating the final krb5.conf on clients
- PR #[6473](https://github.com/freeipa/freeipa/pull/6473) Move client certificate request after krb5.conf is created
- PR #[6621](https://github.com/freeipa/freeipa/pull/6621) server install: remove error log about missing bkup file