### PR TITLE
[Backport][ipa-4-6] ipaserver: deepcopy objectclasses list from IPA config

### DIFF
--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -796,9 +796,9 @@ class LDAPObject(Object):
         objectclasses = self.object_class
         if self.object_class_config:
             config = ldap.get_ipa_config()
-            objectclasses = config.get(
+            objectclasses = deepcopy(config.get(
                 self.object_class_config, objectclasses
-            )
+            ))
         objectclasses = objectclasses + self.possible_objectclasses
         # Get list of available attributes for this object for use
         # in the ACI UI.
@@ -1157,9 +1157,9 @@ class LDAPCreate(BaseLDAPCommand, crud.Create):
 
         if self.obj.object_class_config:
             config = ldap.get_ipa_config()
-            entry_attrs['objectclass'] = config.get(
+            entry_attrs['objectclass'] = deepcopy(config.get(
                 self.obj.object_class_config, entry_attrs['objectclass']
-            )
+            ))
 
         if self.obj.uuid_attribute:
             entry_attrs[self.obj.uuid_attribute] = 'autogenerate'

--- a/ipaserver/plugins/stageuser.py
+++ b/ipaserver/plugins/stageuser.py
@@ -557,9 +557,9 @@ class stageuser_activate(LDAPQuery):
 
         if self.obj.object_class_config:
             config = ldap.get_ipa_config()
-            entry_attrs['objectclass'] = config.get(
+            entry_attrs['objectclass'] = deepcopy(config.get(
                 self.obj.object_class_config, entry_attrs['objectclass']
-            )
+            ))
 
         return(entry_attrs)
 


### PR DESCRIPTION
This PR was opened automatically because PR #6741 was pushed to master and backport to ipa-4-6 is required.