### PR TITLE
ipatests: increase timeout for test_trust

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1651,7 +1651,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-latest
-        timeout: 6000
+        timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest/test_trust_autoprivate:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1782,7 +1782,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-latest
-        timeout: 6000
+        timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest/test_trust_autoprivate:

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -237,7 +237,7 @@ jobs:
         copr: '@sssd/nightly'
         test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-latest
-        timeout: 6000
+        timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
   sssd-fedora/test_trust_autoprivate:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1914,7 +1914,7 @@ jobs:
         enable_testing_repo: True
         test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-latest
-        timeout: 6000
+        timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
   testing-fedora/test_trust_autoprivate:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2045,7 +2045,7 @@ jobs:
         enable_testing_repo: True
         test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-latest
-        timeout: 6000
+        timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
   testing-fedora/test_trust_autoprivate:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1651,7 +1651,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-previous
-        timeout: 6000
+        timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-previous/test_trust_autoprivate:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1782,7 +1782,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-frawhide
-        timeout: 6000
+        timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-rawhide/test_trust_autoprivate:


### PR DESCRIPTION
The timeout for test_trust is too short (6000s) and
the nightly tests often fail. Increase to 7200s.

Fixes: https://pagure.io/freeipa/issue/9326

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>