### PR TITLE
[Backport][ipa-4-9] ipatests: increase timeout for test_trust

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1651,7 +1651,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-9/build_url}'
         test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-ipa-4-9-latest
-        timeout: 6000
+        timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest-ipa-4-9/test_trust_autoprivate:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1782,7 +1782,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-ipa-4-9-latest
-        timeout: 6000
+        timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest-ipa-4-9/test_trust_autoprivate:

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1651,7 +1651,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-9/build_url}'
         test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-ipa-4-9-previous
-        timeout: 6000
+        timeout: 7200
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-previous-ipa-4-9/test_trust_autoprivate:


### PR DESCRIPTION
This is a manual backport of PR https://github.com/freeipa/freeipa/pull/6752 to ipa-4-9 branch. Auto-ACK since it's a simple backport.