### PR TITLE
[Backport][ipa-4-10] fastlint: Correct concatenation of file lists

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -244,7 +244,7 @@ fastcodestyle: $(GENERATED_PYTHON_FILES) ipasetup.py
 	    | xargs -n1 file 2>/dev/null | grep Python \
 	    | cut -d':' -f1; ); \
 	if [ -n "$${PYFILES}" ] && [ -n "$${INFILES}" ]; then \
-	    FILES="$$( printf $${PYFILES}\\n$${INFILES} )" ; \
+	    FILES="$$( printf '%s\n' "$${PYFILES}" "$${INFILES}" )" ; \
 	elif [ -n "$${PYFILES}" ]; then \
 	    FILES="$${PYFILES}" ; \
 	else \
@@ -274,7 +274,7 @@ endif
 	    | xargs -n1 file 2>/dev/null | grep Python \
 	    | cut -d':' -f1; ); \
 	if [ -n "$${PYFILES}" ] && [ -n "$${INFILES}" ]; then \
-	    FILES="$$( printf $${PYFILES}\\n$${INFILES} )" ; \
+	    FILES="$$( printf '%s\n' "$${PYFILES}" "$${INFILES}" )" ; \
 	elif [ -n "$${PYFILES}" ]; then \
 	    FILES="$${PYFILES}" ; \
 	else \


### PR DESCRIPTION
This PR was opened automatically because PR #6647 was pushed to master and backport to ipa-4-10 is required.