### PR TITLE
ipatests: client install - add tests scenarios

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -44,6 +44,7 @@ topologies:
   adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
     name: adroot_adchild_adtree_master_1client
     cpu: 8
+
     memory: 14466
 
 jobs:
@@ -68,7 +69,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_installation_client.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_installation_client.py
+++ b/ipatests/test_integration/test_installation_client.py
@@ -17,6 +17,8 @@ from ipaplatform.paths import paths
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.firewall import Firewall
+from ipatests.test_integration.test_authselect import (check_authselect_profile,
+                                                       default_profile)
 
 
 class TestInstallClient(IntegrationTest):
@@ -71,10 +73,72 @@ class TestInstallClient(IntegrationTest):
 
         related: https://pagure.io/freeipa/issue/8082
         """
-        tasks.install_client(self.master, self.clients[0],
-                             extra_args=['--ssh-trust-dns'])
-        result = self.clients[0].run_command(['cat', '/etc/ssh/ssh_config'])
-        assert 'HostKeyAlgorithms' not in result.stdout_text
+        try:
+            tasks.install_client(self.master, self.clients[0],
+                                 extra_args=['--ssh-trust-dns'])
+            result = self.clients[0].run_command(['cat', '/etc/ssh/ssh_config'])
+            assert 'HostKeyAlgorithms' not in result.stdout_text
+        finally:
+            tasks.uninstall_client(self.clients[0])
+
+
+class TestClientInstallParams(IntegrationTest):
+    num_clients = 1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=True)
+
+    def test_client_install_sssd_params(self):
+        """
+        --permit
+        Configure  SSSD  to  permit all access.
+        Otherwise, the machine will be controlled
+        by the Host-based Access Controls (HBAC) on the IPA server.
+        """
+        client = self.clients[0]
+        tasks.install_client(self.master, client,
+                             extra_args=['--permit',
+                                         '--enable-dns-updates',
+                                         '--no-krb5-offline-passwords'])
+        try:
+            sssd_conf = client.transport.get_file_contents(paths.SSSD_CONF,
+                                                           encoding='utf-8')
+            exp_val_permit = "access_provider = permit"
+            assert exp_val_permit in sssd_conf
+
+            """
+            --enable-dns-updates
+            This option tells SSSD to automatically update DNS with
+            the  IP  address  of  this client.
+            """
+            exp_val_dyndns_update = "dyndns_update = True"
+            assert exp_val_dyndns_update in sssd_conf
+
+            """
+            --no-krb5-offline-passwords
+            Configure SSSD not to store user
+            password when the server is offline.
+            """
+            unexp_val_krb5_pass = "krb5_store_password_if_offline = True"
+            assert unexp_val_krb5_pass not in sssd_conf
+        finally:
+            tasks.uninstall_client(client)
+
+    def test_client_install_authconfig_params(self):
+        """
+        --mkhomedir
+        Configure PAM to create a users home directory
+        if it does not exist
+        """
+        client = self.clients[0]
+        tasks.install_client(self.master, client,
+                             extra_args=['--mkhomedir'])
+
+        options = ('with-mkhomedir',)
+        check_authselect_profile(client,
+                                 default_profile,
+                                 expected_options=options)
 
     def test_client_install_with_krb5(self):
         """Test that SSSD_PUBCONF_KRB5_INCLUDE_D_DIR is not added in krb5.conf
@@ -203,3 +267,208 @@ class TestClientInstallBind(IntegrationTest):
             assert "ANSWER: 0" not in dig_after.stdout_text.strip()
         finally:
             self.client.resolver.restore()
+
+
+class TestClientInstallNegative(IntegrationTest):
+    num_clients = 1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=True)
+
+    def test_client_install_no_params(self):
+        """Installation with no parameters"""
+        cmd = self.clients[0].run_command("ipa-client-install -U",
+                                          raiseonerr=False)
+        assert cmd.returncode != 0
+        exp_msg = ["password", "principal", "keytab", "required"]
+        assert all(x in cmd.stderr_text.lower() for x in exp_msg)
+
+    def test_install_invalid_domain(self):
+        """Installation with invalid domain"""
+        client = self.clients[0]
+        cmd = client.run_command(
+            "ipa-client-install "
+            "--domain=xxx.xx "
+            f"-p {client.config.admin_name} "
+            f"-w {client.config.admin_password} "
+            "-U",
+            raiseonerr=False)
+        assert cmd.returncode != 0
+        exp_msg = "Unable to find IPA Server to join"
+        assert exp_msg.lower() in cmd.stderr_text.lower()
+
+    def test_client_install_no_domain(self):
+        """
+        Installation with the server but without
+        the required param domain specified
+        """
+        client = self.clients[0]
+        cmd = client.run_command(
+            "ipa-client-install --server=xxx",
+            raiseonerr=False)
+        assert cmd.returncode != 0
+        exp_msg = "--server cannot be used without providing --domain"
+        assert exp_msg.lower() in cmd.stderr_text.lower()
+
+    def test_client_install_invalid_server(self):
+        """Installation with invalid server"""
+        client = self.clients[0]
+        cmd = client.run_command(
+            "ipa-client-install --server=xxx --domain=xxx.xx",
+            raiseonerr=False)
+        assert cmd.returncode != 0
+        exp_msg = "failed to verify that xxx is an ipa server"
+        assert exp_msg.lower() in cmd.stderr_text.lower()
+
+    def test_client_install_invalid_hostname(self):
+        cmd = tasks.install_client(
+            self.master, self.clients[0],
+            extra_args=['--hostname', 'nonexistent'],
+            raiseonerr=False
+        )
+        exp_msg = "invalid hostname"
+        assert cmd.returncode != 0
+        assert exp_msg.lower() in cmd.stderr_text.lower()
+
+    def test_client_install_password_no_principal(self):
+        cmd = self.clients[0].run_command(
+            "ipa-client-install --password=random123 -U",
+            raiseonerr=False)
+        exp_msg = "invalid credentials"
+        assert cmd.returncode != 0
+        assert exp_msg.lower() in cmd.stderr_text.lower()
+
+    def test_client_install_nonexistent_principal(self):
+        cmd = tasks.install_client(
+            self.master, self.clients[0],
+            user="nonexistentprincipal",
+            raiseonerr=False
+        )
+        exp_msg = "not found in Kerberos database"
+        assert cmd.returncode != 0
+        assert exp_msg.lower() in cmd.stderr_text.lower()
+
+    def test_client_install_non_admin_principal(self):
+        non_admin_user = "testuser"
+        tasks.create_active_user(self.master,
+                                 non_admin_user,
+                                 "RandomPassword123")
+        cmd = tasks.install_client(
+            self.master, self.clients[0],
+            user=non_admin_user,
+            raiseonerr=False
+        )
+        exp_msg = "Password incorrect while getting initial credentials"
+        assert cmd.returncode != 0
+        assert exp_msg.lower() in cmd.stderr_text.lower()
+
+    def test_client_install_invalid_password(self):
+        cmd = tasks.install_client(
+            self.master, self.clients[0],
+            password="incorrect+password",
+            raiseonerr=False
+        )
+        exp_msg = "Password incorrect while getting initial credentials"
+        assert cmd.returncode != 0
+        assert exp_msg.lower() in cmd.stderr_text.lower()
+
+    def test_client_force_parameter(self):
+        """
+        Second installation should fail except when --force
+        parameter is provided
+        """
+        tasks.install_client(self.master, self.clients[0])
+
+        try:
+            # second installation
+            exp_msg = "IPA client is already configured on this system"
+
+            result = tasks.install_client(self.master,
+                                          self.clients[0],
+                                          raiseonerr=False)
+            assert result.returncode != 0
+            assert exp_msg.lower() in result.stderr_text.lower()
+
+            # second installation, but with force - should still fail
+            result = tasks.install_client(self.master, self.clients[0],
+                                          extra_args=['--force'],
+                                          raiseonerr=False)
+            assert result.returncode != 0
+            assert exp_msg.lower() in result.stderr_text.lower()
+        finally:
+            tasks.uninstall_client(self.clients[0], raiseonerr=False)
+
+    def test_client_install_hostname_localhost(self):
+        def modify_local_hostname(hostname):
+            # first modify using hostnamectl
+            client.run_command(['hostnamectl',
+                                'set-hostname',
+                                hostname],
+                               raiseonerr=True)
+
+            # then modify entry in /etc/hosts
+            orig_hosts = client.get_file_contents(paths.HOSTS,
+                                                  encoding='utf-8')
+            new_hosts = []
+            for line in orig_hosts.split('\n'):
+                if client.hostname in line:
+                    curr_ip = line.split(' ')[0]
+                    new_hosts.append(f"{curr_ip}   {hostname}")
+                else:
+                    new_hosts.append(line)
+            client.put_file_contents(paths.HOSTS, '\n'.join(new_hosts))
+
+        client = self.clients[0]
+        hosts_bcp = tasks.FileBackup(client, paths.HOSTS)
+        exp_msg = "Invalid hostname"
+
+        try:
+            modify_local_hostname('localhost.localdomain')
+            # client_install method fixes the hostname,
+            # so we cannot use it here
+            client_install_command = ['ipa-client-install', '-U',
+                                      '--domain', client.domain.name,
+                                      '--realm', client.domain.realm,
+                                      '-p', client.config.admin_name,
+                                      '-w', client.config.admin_password,
+                                      '--server', self.master.hostname]
+            result = client.run_command(client_install_command,
+                                        raiseonerr=False)
+            assert result.returncode != 0
+            assert exp_msg.lower() in result.stderr_text.lower()
+
+            modify_local_hostname('localhost')
+            result = client.run_command(client_install_command,
+                                        raiseonerr=False)
+            assert result.returncode != 0
+            assert exp_msg.lower() in result.stderr_text.lower()
+        finally:
+            hosts_bcp.restore()
+
+
+class TestClientInstallReplica(IntegrationTest):
+    num_clients = 1
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=True)
+        tasks.install_replica(cls.master, cls.replicas[0], setup_dns=True)
+
+    def test_client_install_join_replica(self):
+        try:
+            result = tasks.install_client(self.replicas[0], self.clients[0])
+            assert result.returncode == 0
+        finally:
+            # now uninstall
+            tasks.uninstall_client(self.clients[0], raiseonerr=True)
+
+    def test_client_install_replica_with_master_down(self):
+        self.master.run_command(['ipactl', 'stop'], raiseonerr=True)
+        try:
+            result = tasks.install_client(self.replicas[0], self.clients[0])
+            assert result.returncode == 0
+            tasks.uninstall_client(self.clients[0], raiseonerr=True)
+        finally:
+            self.master.run_command(['ipactl', 'start'], raiseonerr=True)


### PR DESCRIPTION
Add negative tests scenarios, parameter testing, replica joining tests, and other scenarios from downstream.