### PR TITLE
[Backport][ipa-4-10] ipatests: fix test definition for test_trust

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
@@ -1649,7 +1649,7 @@ jobs:
       class: RunADTests
       args:
         build_url: '{fedora-previous-ipa-4-10/build_url}'
-        test_suite: test_integration/test_trust.py
+        test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-ipa-4-10-previous
         timeout: 7200
         topology: *adroot_adchild_adtree_master_1client


### PR DESCRIPTION
The nightly test test_trust.py has been split into 2 jobs, one for test_trust.py::TestTrust (test_trust) and the other for the remaining test classes from the same file
(test_trust_autoprivate).

The backport forgot to narrow down the first job definition to the class test_trust.py::TestTrust in the 4-10_previous pipeline. Fix this omission.

Related: https://pagure.io/freeipa/issue/9326