### PR TITLE
[Backport][ipa-4-10] install: Fix missing dyndb keytab directive

### DIFF
--- a/install/share/bind.named.conf.template
+++ b/install/share/bind.named.conf.template
@@ -58,4 +58,5 @@ dyndb "ipa" "$BIND_LDAP_SO" {
 	server_id "$FQDN";
 	auth_method "sasl";
 	sasl_mech "EXTERNAL";
+	krb5_keytab "FILE:$NAMED_KEYTAB";
 };


### PR DESCRIPTION
This PR was opened automatically because PR #6705 was pushed to master and backport to ipa-4-10 is required.