### PR TITLE
[Backport][ipa-4-10] ipatests: add missing automember-cli tests

### DIFF
--- a/ipatests/test_xmlrpc/tracker/automember_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/automember_plugin.py
@@ -189,6 +189,17 @@ class AutomemberTracker(Tracker):
         result = command()
         self.check_add_condition(result)
 
+    def add_condition_exclusive(self, key, type, exclusiveregex):
+        """ Add a condition with given exclusive regex and check for result.
+        Only one condition can be added. For more specific uses please
+        use make_add_condition_command instead. """
+        command = self.make_add_condition_command(
+            key=key, type=type, automemberexclusiveregex=exclusiveregex)
+        self.attrs['automemberexclusiveregex'] = [u'%s=%s' %
+                                                  (key, exclusiveregex[0])]
+        result = command()
+        self.check_add_condition(result)
+
     def rebuild(self, no_wait=False):
         """ Rebuild automember conditions and check for result """
         command = self.make_rebuild_command(type=self.membertype,


### PR DESCRIPTION
This PR was opened automatically because PR #6718 was pushed to master and backport to ipa-4-10 is required.