### PR TITLE
ipatests: add remove automember condition tests

### DIFF
--- a/ipatests/test_xmlrpc/tracker/automember_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/automember_plugin.py
@@ -87,6 +87,11 @@ class AutomemberTracker(Tracker):
         return self.make_command('automember_add_condition', self.cn,
                                  *args, **kwargs)
 
+    def make_remove_condition_command(self, *args, **kwargs):
+        """ Make function that issues automember_remove_condition """
+        return self.make_command('automember_remove_condition', self.cn,
+                                 *args, **kwargs)
+
     def track_create(self):
         """ Updates expected state for automember creation"""
         self.attrs = dict(


### PR DESCRIPTION
`remove_condition` tests were not written in [PR 6718](https://github.com/freeipa/freeipa/pull/6718), as the function was not defined in the upstream, for example in base.py or anywhere in the plugins.

So, in this PR, in _automember_plugin.py_, I am adding the `make_remove_condition_command`function in the `class AutomemberTracker` and using it for the tests.

Related: https://pagure.io/freeipa/issue/9332

~~Still, I believe it's WIP as some more tests can be added (so please don't review this PR as I have opened a draft PR to track the progress; whenever I would require it, I will mark it as Ready for Review PR).~~

Signed-off-by: mbhalodi [mbhalodi@redhat.com](mailto:mbhalodi@redhat.com)