### PR TITLE
Enable affinity during server installation

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -781,6 +781,20 @@ def promotion_check_host_principal_auth_ind(conn, hostdn):
         )
 
 
+def remote_connection(config):
+    ldapuri = 'ldaps://%s' % ipautil.format_netloc(config.master_host_name)
+    xmlrpc_uri = 'https://{}/ipa/xml'.format(
+        ipautil.format_netloc(config.master_host_name))
+    remote_api = create_api(mode=None)
+    remote_api.bootstrap(in_server=True,
+                         context='installer',
+                         confdir=paths.ETC_IPA,
+                         ldap_uri=ldapuri,
+                         xmlrpc_uri=xmlrpc_uri)
+    remote_api.finalize()
+    return remote_api
+
+
 @common_cleanup
 @preserve_enrollment_state
 def promote_check(installer):
@@ -940,16 +954,7 @@ def promote_check(installer):
         raise RuntimeError("CA cert file is not available! Please reinstall"
                            "the client and try again.")
 
-    ldapuri = 'ldaps://%s' % ipautil.format_netloc(config.master_host_name)
-    xmlrpc_uri = 'https://{}/ipa/xml'.format(
-        ipautil.format_netloc(config.master_host_name))
-    remote_api = create_api(mode=None)
-    remote_api.bootstrap(in_server=True,
-                         context='installer',
-                         confdir=paths.ETC_IPA,
-                         ldap_uri=ldapuri,
-                         xmlrpc_uri=xmlrpc_uri)
-    remote_api.finalize()
+    remote_api = remote_connection(config)
     installer._remote_api = remote_api
 
     with rpc_client(remote_api) as client:
@@ -1079,7 +1084,16 @@ def promote_check(installer):
             'CA', conn, preferred_cas
         )
         if ca_host is not None:
+            if config.master_host_name != ca_host:
+                conn.disconnect()
+                del remote_api
+                config.master_host_name = ca_host
+                remote_api = remote_connection(config)
+                installer._remote_api = remote_api
+                conn = remote_api.Backend.ldap2
+                conn.connect(ccache=installer._ccache)
             config.ca_host_name = ca_host
+            config.master_host_name = ca_host
             ca_enabled = True
             if options.dirsrv_cert_files:
                 logger.error("Certificates could not be provided when "
@@ -1118,7 +1132,17 @@ def promote_check(installer):
             'KRA', conn, preferred_kras
         )
         if kra_host is not None:
+            if config.master_host_name != kra_host:
+                conn.disconnect()
+                del remote_api
+                config.master_host_name = kra_host
+                remote_api = remote_connection(config)
+                installer._remote_api = remote_api
+                conn = remote_api.Backend.ldap2
+                conn.connect(ccache=installer._ccache)
             config.kra_host_name = kra_host
+            config.ca_host_name = kra_host
+            config.master_host_name = kra_host
             kra_enabled = True
             if options.setup_kra and options.server and \
                kra_host != options.server:
@@ -1235,6 +1259,24 @@ def install(installer):
 
     if tasks.configure_pkcs11_modules(fstore):
         print("Disabled p11-kit-proxy")
+
+    _hostname, _sep, host_domain = config.host_name.partition('.')
+    fstore.backup_file(paths.KRB5_CONF)
+
+    # Write a new krb5.conf in case any values changed finding the
+    # right server to configure against (for CA, KRA).
+    logger.debug("Installing against server %s", config.master_host_name)
+    configure_krb5_conf(
+        cli_realm=api.env.realm,
+        cli_domain=api.env.domain,
+        cli_server=[config.master_host_name],
+        cli_kdc=[config.master_host_name],
+        dnsok=False,
+        filename=paths.KRB5_CONF,
+        client_domain=host_domain,
+        client_hostname=config.host_name,
+        configure_sssd=False
+    )
 
     if installer._add_to_ipaservers:
         try:

--- a/ipaserver/masters.py
+++ b/ipaserver/masters.py
@@ -127,6 +127,8 @@ def find_providing_servers(svcname, conn=None, preferred_hosts=(), api=api):
             )
         else:
             servers.insert(0, host_name)
+    logger.debug("Discovery: available servers for service '%s' are %s",
+                 svcname, ', '.join(servers))
     return servers
 
 
@@ -143,8 +145,11 @@ def find_providing_server(svcname, conn=None, preferred_hosts=(), api=api):
         svcname, conn=conn, preferred_hosts=preferred_hosts, api=api
     )
     if not servers:
+        logger.debug("Discovery: no '%s' service found.", svcname)
         return None
     else:
+        logger.debug("Discovery: using %s for '%s' service",
+                     servers[0], svcname)
         return servers[0]
 
 


### PR DESCRIPTION
In order to prevent installation racing against replication pick a server to install against and do all operations against that server.

This gets tricky when it comes to installing the optional CA and KRA services when promoting a client. It will attempt to use the currently defined api.env.server to install against but if that server does not provide all the necessary services then the installer will switch to one that does.

Notably, if both a CA and KRA are being installed it is possible it may pick a server with a CA and then pick another if that server doesn't also have a KRA.

This will make topology management...interesting. It can be corrected post-install.

Non-promotion installs will fail if the provided --server does not provide the required services (CA/KRA).

Also use the new service discovery code in ipa-ca-install and ipa-kra-install.

Fixes: https://pagure.io/freeipa/issue/9289