### PR TITLE
[Backport][ipa-4-10] ipatest: loginscreen: do not use hardcoded password

### DIFF
--- a/ipatests/test_webui/data_loginscreen.py
+++ b/ipatests/test_webui/data_loginscreen.py
@@ -9,7 +9,6 @@ PASSWD_ITEST_USER = '12345678'
 PASSWD_ITEST_USER_NEW = '87654321'
 
 ROOT_PKEY = 'root'
-PASSWD_ADMIN = 'Secret.123'
 
 # used for add/delete fixture test user
 DATA_ITEST_USER = {

--- a/ipatests/test_webui/test_loginscreen.py
+++ b/ipatests/test_webui/test_loginscreen.py
@@ -412,6 +412,6 @@ class TestLoginScreen(UI_driver):
         """
         self.load()
         assert self.login_screen_visible()
-        self.login(loginscreen.ROOT_PKEY, loginscreen.PASSWD_ADMIN)
+        self.login(loginscreen.ROOT_PKEY, self.config['ipa_password'])
 
         assert self.logged_in()


### PR DESCRIPTION
This PR was opened automatically because PR #6784 was pushed to master and backport to ipa-4-10 is required.