### PR TITLE
ipasphinx: Correct import of progress_message for Sphinx 6.1.0+

### DIFF
--- a/ipasphinx/ipabase.py
+++ b/ipasphinx/ipabase.py
@@ -7,7 +7,11 @@ import os
 import re
 import sys
 
-from sphinx.util import progress_message
+try:
+    from sphinx.util.display import progress_message
+except ImportError:
+    # sphinx < 6.1.0
+    from sphinx.util import progress_message
 from sphinx.ext.autodoc import mock as autodoc_mock
 
 HERE = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Pylint reports false-negative result for Sphinx 6.1.0+:

```
************* Module ipasphinx.ipabase
ipasphinx/ipabase.py:10: [E0611(no-name-in-module), ] No name 'progress_message' in module 'sphinx.util')
```

Actually `sphinx.util.progress_message` is still available in Sphinx 6.1 but it's deprecated and will be removed in 8.0:
https://www.sphinx-doc.org/en/master/extdev/deprecated.html#deprecated-apis

Related change:
https://github.com/sphinx-doc/sphinx/commit/8c5e7013ea5f6a50e3cc3130b22205a85ba87fab

Fixes: https://pagure.io/freeipa/issue/9361