### PR TITLE
[Backport][ipa-4-9] Drop duplicate includedir from krb5.conf

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -685,6 +685,7 @@ Requires: jansson
 %endif
 Requires: sssd-ipa >= %{sssd_version}
 Requires: sssd-idp >= %{sssd_version}
+Requires: sssd-krb5 >= %{sssd_version}
 Requires: certmonger >= %{certmonger_version}
 Requires: nss-tools >= %{nss_version}
 Requires: bind-utils
@@ -1249,10 +1250,8 @@ if [ $1 -gt 1 ] ; then
     test -f '/var/lib/ipa-client/sysrestore/sysrestore.index' && restore=$(wc -l '/var/lib/ipa-client/sysrestore/sysrestore.index' | awk '{print $1}')
 
     if [ -f '/etc/sssd/sssd.conf' -a $restore -ge 2 ]; then
-        if ! grep -E -q '/var/lib/sss/pubconf/krb5.include.d/' /etc/krb5.conf  2>/dev/null ; then
-            echo "includedir /var/lib/sss/pubconf/krb5.include.d/" > /etc/krb5.conf.ipanew
-            cat /etc/krb5.conf >> /etc/krb5.conf.ipanew
-            mv -Z /etc/krb5.conf.ipanew /etc/krb5.conf
+        if grep -E -q '/var/lib/sss/pubconf/krb5.include.d/' /etc/krb5.conf  2>/dev/null ; then
+            sed -i '\;includedir /var/lib/sss/pubconf/krb5.include.d;d' /etc/krb5.conf
         fi
     fi
 

--- a/install/share/krb5.conf.template
+++ b/install/share/krb5.conf.template
@@ -1,5 +1,4 @@
 $INCLUDES
-includedir /var/lib/sss/pubconf/krb5.include.d/
 
 [logging]
  default = FILE:/var/log/krb5libs.log

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -699,19 +699,6 @@ def configure_krb5_conf(
             }
         ])
 
-    # SSSD include dir
-    if configure_sssd:
-        if not os.path.exists(paths.SSSD_PUBCONF_KRB5_INCLUDE_D_DIR):
-            os.makedirs(paths.SSSD_PUBCONF_KRB5_INCLUDE_D_DIR, mode=0o755)
-        opts.extend([
-            {
-                'name': 'includedir',
-                'type': 'option',
-                'value': paths.SSSD_PUBCONF_KRB5_INCLUDE_D_DIR,
-                'delim': ' '
-            },
-            krbconf.emptyLine()])
-
     # [libdefaults]
     libopts = [
         krbconf.setOption('default_realm', cli_realm)


### PR DESCRIPTION
This PR was opened automatically because PR #6791 was pushed to master and backport to ipa-4-9 is required.