### PR TITLE
Fix "no entry" condition when searching PAC info.

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -1086,7 +1086,7 @@ krb5_error_code ipadb_get_pac(krb5_context kcontext,
                 }
 
                 sentry = ldap_first_entry(ipactx->lcontext, sresults);
-                if (!lentry) {
+                if (!sentry) {
                     kerr = ENOENT;
                     goto done;
                 }


### PR DESCRIPTION
When sarching for PAC info, the wrong condition was being evaluated when entry is a trusted domain object.

Fixes: https://pagure.io/freeipa/issue/9368