### PR TITLE
cert-find: fix call with --all

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1827,6 +1827,7 @@ class cert_find(Search, CertMethod):
                             # For the case of CA-less we need to keep
                             # the certificate because getting it again later
                             # would require unnecessary LDAP searches.
+                            cert = cert.to_cryptography()
                             obj['certificate'] = (
                                 base64.b64encode(
                                     cert.public_bytes(x509.Encoding.DER))


### PR DESCRIPTION
When ipa cert-find --all is called, the function prints the
certificate public bytes. The code recently switched to OpenSSL.crypto
and the objects OpenSSL.crypto.X509 do not have the method
public_bytes(). Use to_cryptography() to transform into a
cryptography.x509.Certificate before calling public_bytes().

Related: https://pagure.io/freeipa/issue/9331

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>
