### PR TITLE
[Backport][ipa-4-9] Fix "no entry" condition when searching PAC info.

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -1086,7 +1086,7 @@ krb5_error_code ipadb_get_pac(krb5_context kcontext,
                 }
 
                 sentry = ldap_first_entry(ipactx->lcontext, sresults);
-                if (!lentry) {
+                if (!sentry) {
                     kerr = ENOENT;
                     goto done;
                 }


### PR DESCRIPTION
This PR was opened automatically because PR #6799 was pushed to master and backport to ipa-4-9 is required.