### PR TITLE
[Backport][ipa-4-9] cert-find: fix call with --all

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1832,6 +1832,7 @@ class cert_find(Search, CertMethod):
                             # For the case of CA-less we need to keep
                             # the certificate because getting it again later
                             # would require unnecessary LDAP searches.
+                            cert = cert.to_cryptography()
                             obj['certificate'] = (
                                 base64.b64encode(
                                     cert.public_bytes(x509.Encoding.DER))


### PR DESCRIPTION
This PR was opened automatically because PR #6800 was pushed to master and backport to ipa-4-9 is required.