### PR TITLE
[Backport][ipa-4-10] ipasphinx: Correct import of progress_message for Sphinx 6.1.0+

### DIFF
--- a/ipasphinx/ipabase.py
+++ b/ipasphinx/ipabase.py
@@ -7,7 +7,11 @@ import os
 import re
 import sys
 
-from sphinx.util import progress_message
+try:
+    from sphinx.util.display import progress_message
+except ImportError:
+    # sphinx < 6.1.0
+    from sphinx.util import progress_message
 from sphinx.ext.autodoc import mock as autodoc_mock
 
 HERE = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
This PR was opened automatically because PR #6792 was pushed to master and backport to ipa-4-10 is required.