### PR TITLE
idview: improve performance of idview-show

### DIFF
--- a/ipaserver/plugins/idviews.py
+++ b/ipaserver/plugins/idviews.py
@@ -269,13 +269,20 @@ class idview_show(LDAPRetrieve):
             try:
                 overrides, _truncated = ldap.find_entries(
                     filter="objectclass=%s" % objectclass,
-                    attrs_list=['ipaanchoruuid'],
+                    attrs_list=['ipaanchoruuid', 'ipaoriginaluid'],
                     base_dn=dn,
                     scope=ldap.SCOPE_ONELEVEL,
                     paged_search=True)
 
                 resolved_overrides = []
                 for override in overrides:
+                    if 'ipaoriginaluid' in override:
+                        # No need to resolve the anchor, we already know
+                        # the value
+                        resolved_overrides.append(
+                            override.single_value['ipaoriginaluid'])
+                        continue
+
                     anchor = override.single_value['ipaanchoruuid']
 
                     try:


### PR DESCRIPTION
The command ipa idview-show NAME has a post callback
method that replaces the ID override anchor with the corresponding
user name.
For instance the anchor
ipaanchoruuid=:SID:S-1-5-21-3951964782-819614989-3867706637-1114
is replaced with the name of the ad user aduser@ad.test.

The method loops on all the anchors and for each one performs the
resolution, which can be a costly operation if the anchor is for
a trusted user. Instead of doing a search for each anchor, it is
possible to read the 'ipaOriginalUid' value from the ID override
entry.

Fixes: https://pagure.io/freeipa/issue/9372

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>