### PR TITLE
Nightly test: add +15min for test_ipahealthcheck

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1399,7 +1399,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6300
         topology: *master_1repl_1client
 
   fedora-latest/test_ipahealthcheck_nodns_extca_file:

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -870,7 +870,7 @@ jobs:
         copr: '@pki/master'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6300
         topology: *master_1repl_1client
 
   pki-fedora/test_ipahealthcheck_nodns_extca_file:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1509,7 +1509,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6300
         topology: *master_1repl_1client
 
   fedora-latest/test_ipahealthcheck_nodns_extca_file:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1621,7 +1621,7 @@ jobs:
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
         topology: *master_1repl_1client
-        timeout: 5400
+        timeout: 6300
 
   testing-fedora/test_ipahealthcheck_nodns_extca_file:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1731,7 +1731,7 @@ jobs:
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
         topology: *master_1repl_1client
-        timeout: 5400
+        timeout: 6300
 
   testing-fedora/test_ipahealthcheck_nodns_extca_file:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1399,7 +1399,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-previous
-        timeout: 5400
+        timeout: 6300
         topology: *master_1repl_1client
 
   fedora-previous/test_ipahealthcheck_nodns_extca_file:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1509,7 +1509,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-frawhide
-        timeout: 5400
+        timeout: 6300
         topology: *master_1repl_1client
 
   fedora-rawhide/test_ipahealthcheck_nodns_extca_file:


### PR DESCRIPTION
The test test_ipahealthcheck.py::TestIpaHealthcheck frequently
hits its 90min timeout. Extend by 15min to allow completion.
    
Fixes: https://pagure.io/freeipa/issue/9362
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>
