### PR TITLE
updates: add ACIs for RBCD self-management

### DIFF
--- a/install/updates/73-service-rbcd.update
+++ b/install/updates/73-service-rbcd.update
@@ -1,0 +1,5 @@
+dn: $SUFFIX
+add:aci: (targetattr = "memberPrincipal")(targattrfilters="add=objectclass:(objectclass=resourcedelegation)")(version 3.0;acl "permission:RBCD:Kerberos principals can manage resource-based constrained delegation for themselves";allow (write) userdn = "ldap:///self";)
+add:aci: (targetattr = "memberPrincipal")(targattrfilters="add=objectclass:(objectclass=resourcedelegation)")(version 3.0;acl "permission:RBCD:Managing principals can manage resource-based constrained delegation for other principals";allow (write) userattr = "managedby#GROUPDN" or userattr = "managedby#USERDN";)
+add:aci: (targetattr = "memberPrincipal")(targattrfilters="add=objectclass:(objectclass=resourcedelegation)")(version 3.0;acl "permission:RBCD:Delegated permission to manage resource-based constrained delegation for other principals";allow (write) userattr="ipaAllowedToPerform;write_delegation#GROUPDN" or userattr="ipaAllowedToPerform;write_delegation#USERDN" ;)
+

--- a/install/updates/Makefile.am
+++ b/install/updates/Makefile.am
@@ -67,6 +67,7 @@ app_DATA =				\
 	73-winsync.update		\
 	73-certmap.update		\
 	73-passkey.update		\
+	73-service-rbcd.update		\
 	75-user-trust-attributes.update	\
 	80-schema_compat.update 	\
 	81-externalmembers.update	\


### PR DESCRIPTION
Somehow, I forgot this update file...

Fixes: https://pagure.io/freeipa/issue/9354