### PR TITLE
spec file: force nodejs < 20 on fedora < 39

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -306,7 +306,12 @@ BuildRequires:  libpwquality-devel
 BuildRequires:  libsss_idmap-devel
 BuildRequires:  libsss_certmap-devel
 BuildRequires:  libsss_nss_idmap-devel >= %{sssd_version}
+%if 0%{?fedora} >= 39 || 0%{?rhel} >= 10
+# Do not use nodejs20 on fedora < 39, https://pagure.io/freeipa/issue/9374
 BuildRequires:  nodejs(abi)
+%else
+BuildRequires:  nodejs(abi) < 111
+%endif
 # use old dependency on RHEL 8 for now
 %if 0%{?fedora} >= 31 || 0%{?rhel} >= 9
 BuildRequires:  python3-rjsmin


### PR DESCRIPTION
On fedora < 39, nodejs 20 is not the default version. As
a consequence, the installation of nodejs20 adds the command
/usr/bin/node-20 instead of /usr/bin/node.
FreeIPA build is using the node command and fails if the
command is missing.

Force nodejs < 20 on fedora < 39 to make sure the node
command is installed.

Fixes: https://pagure.io/freeipa/issue/9374

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>