### PR TITLE
[Backport][ipa-4-10] Nightly test: add +15min for test_ipahealthcheck

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
@@ -1399,7 +1399,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-10/build_url}'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-ipa-4-10-latest
-        timeout: 5400
+        timeout: 6300
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-10/test_ipahealthcheck_nodns_extca_file:

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
@@ -1509,7 +1509,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-ipa-4-10-latest
-        timeout: 5400
+        timeout: 6300
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-10/test_ipahealthcheck_nodns_extca_file:

--- a/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
@@ -1399,7 +1399,7 @@ jobs:
         build_url: '{fedora-previous-ipa-4-10/build_url}'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-ipa-4-10-previous
-        timeout: 5400
+        timeout: 6300
         topology: *master_1repl_1client
 
   fedora-previous-ipa-4-10/test_ipahealthcheck_nodns_extca_file:


### PR DESCRIPTION
This is a manual backport of PR#[6811](https://github.com/freeipa/freeipa/pull/6811) to ipa-4-10 branch.
PR was ACKed automatically because this is backport. Wait for CI to finish before pushing. In case of questions or problems contact @flo-renaud who is author of the original PR.