### PR TITLE
[ipa-4-10] Tests: test on f37 and f38

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -30,7 +30,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
-          name: freeipa/ci-ipa-4-10-f37
+          name: freeipa/ci-ipa-4-10-f38
           version: 0.0.2
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
-          name: freeipa/ci-ipa-4-10-f37
+          name: freeipa/ci-ipa-4-10-f38
           version: 0.0.2
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
-          name: freeipa/ci-ipa-4-10-f37
+          name: freeipa/ci-ipa-4-10-f38
           version: 0.0.2
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-previous
-          name: freeipa/ci-ipa-4-10-f36
+          name: freeipa/ci-ipa-4-10-f37
           version: 0.0.2
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -56,7 +56,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-10-latest
-          name: freeipa/ci-ipa-4-10-f37
+          name: freeipa/ci-ipa-4-10-f38
           version: 0.0.2
         timeout: 1800
         topology: *build


### PR DESCRIPTION
Fedora 38 is now available, move the testing pipelines to
- fedora 38 for the _latest definitions
- fedora 37 for the _previous definitions