### PR TITLE
ipatests: commands: Wait for the SSSD to become available

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -645,6 +645,9 @@ class TestIPACommand(IntegrationTest):
             (datetime.now() - timedelta(seconds=10)).timetuple()
         )
 
+        # Wait for sssd to be back online, hence test-user to become available
+        tasks.wait_for_sssd_domain_status_online(self.master)
+
         tasks.run_ssh_cmd(
             to_host=self.master.external_hostname, username=test_user,
             auth_method="key", private_key_path=first_priv_key_path


### PR DESCRIPTION
Previous test to test_ssh_key_connection is calling ipa-server-upgrade command, which restarts all the associated services. Especially on slower machine, SSSD is not yet online when the SSH connection is attempted. This results to only cached users being available.
Wait for SSSD to become available before the SSH connection is attempted.

Fixes: https://pagure.io/freeipa/issue/9377