### PR TITLE
azure pipeline: disable the upgrade test

### DIFF
--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -182,15 +182,15 @@ vms:
     tests:
     - test_integration/test_external_ca.py::TestSelfExternalSelf
 
-- vm_jobs:
-  - container_job: upgrade
-    containers:
-      resources:
-        server:
-          mem_limit: "2200m"
-          memswap_limit: "3300m"
-    tests:
-    - test_integration/test_upgrade.py
+#- vm_jobs:
+#  - container_job: upgrade
+#    containers:
+#      resources:
+#        server:
+#          mem_limit: "2200m"
+#          memswap_limit: "3300m"
+#    tests:
+#    - test_integration/test_upgrade.py
 
 
   # requires external DNS configuration, this is not set up yet


### PR DESCRIPTION
The test test_integration/test_upgrade.py is too unstable in azure, probably because of memory issues.

Disable the test for now, as it is executed in PRCI anyway.