### PR TITLE
[ipa-4-9] kdb: Use krb5_pac_full_sign_compat() when available

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_mspac_v6.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac_v6.c
@@ -176,11 +176,21 @@ static krb5_error_code ipadb_sign_pac(krb5_context context,
 
     /* only pass with_realm TRUE when it is cross-realm ticket and S4U2Self
      * was requested */
+#ifdef HAVE_KRB5_PAC_FULL_SIGN_COMPAT
+    kerr = krb5_pac_full_sign_compat(
+        context, pac, authtime, client_princ, server->princ, server_key,
+        right_krbtgt_signing_key,
+        (is_issuing_referral && (flags & KRB5_KDB_FLAG_PROTOCOL_TRANSITION)),
+        pac_data
+    );
+#else
+    /* Use standard function, PAC extended KDC signature not supported */
     kerr = krb5_pac_sign_ext(context, pac, authtime, client_princ, server_key,
                              right_krbtgt_signing_key,
                              (is_issuing_referral &&
                               (flags & KRB5_KDB_FLAG_PROTOCOL_TRANSITION)),
                              pac_data);
+#endif
 
 done:
     free(princ);

--- a/server.m4
+++ b/server.m4
@@ -91,6 +91,15 @@ AC_CHECK_MEMBER([kdb_vftabl.issue_pac],
                 [have_kdb_issue_pac=no], [#include <kdb.h>])
 
 dnl ---------------------------------------------------------------------------
+dnl - Check for KRB5 krb5_kdc_sign_ticket function
+dnl ---------------------------------------------------------------------------
+
+AC_CHECK_LIB(krb5, krb5_pac_full_sign_compat,
+             [AC_DEFINE([HAVE_KRB5_PAC_FULL_SIGN_COMPAT], [1],
+                        [krb5_pac_full_sign_compat() is available.])],
+             [AC_MSG_NOTICE([krb5_pac_full_sign_compat() is not available])])
+
+dnl ---------------------------------------------------------------------------
 dnl - Check for UUID library
 dnl ---------------------------------------------------------------------------
 PKG_CHECK_MODULES([UUID], [uuid])


### PR DESCRIPTION
In November 2022, Microsoft introduced a new PAC signature type called "extended KDC signature" (or "full PAC checksum"). This new PAC signature will be required by default by Active Directory in July 2023 for S4U requests, and opt-out will no longer be possible after October 2023.

Support for this new signature type was added to MIT krb5, but it relies on the new KDB API introduced in krb5 1.20. For older MIT krb5 versions, the code generating extended KDC signatures cannot be backported as it is without backporting the full new KDB API code too. This would have too much impact to be done.

As a consequence, krb5 packages for Fedora 37, CentOS 8 Stream, and RHEL 8 will include a downstream-only update adding the krb5_pac_full_sign_compat() function, which can be used in combination with the prior to 1.20 KDB API to generate PAC extended KDC signatures.

Fixes: https://pagure.io/freeipa/issue/9373