### PR TITLE
Differentiate location meaning between host and server

### DIFF
--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -500,7 +500,7 @@ class host(LDAPObject):
         Str('nshostlocation?',
             cli_name='location',
             label=_('Location'),
-            doc=_('Host location (e.g. "Lab 2")'),
+            doc=_('Host physical location hint (e.g. "Lab 2")'),
         ),
         Str('nshardwareplatform?',
             cli_name='platform',

--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -130,7 +130,7 @@ class server(LDAPObject):
             'ipalocation_location?',
             cli_name='location',
             label=_('Location'),
-            doc=_('Server location'),
+            doc=_('Server DNS location'),
             only_relative=True,
             flags={'no_search'},
         ),


### PR DESCRIPTION
A host uses Location (nshostlocation) as an optional hint where a host may phsyically be located (e.g. Lab 2). This will result in an attribute in the host entry like:
nshostlocation: Lab 2

A server uses location (ipalocation) to identify which DNS location the server is part of (e.g. prague). This will result in an attribute in the server entry like:
ipalocation: idnsname=prague,cn=locations,cn=etc,dc=example,dc=test

They are completely different animals.

https://pagure.io/freeipa/issue/9317