### PR TITLE
[Backport][ipa-4-10] Fontawesome spec changes

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -493,7 +493,7 @@ Requires: policycoreutils >= 2.1.12-5
 Requires: tar
 Requires(pre): certmonger >= %{certmonger_version}
 Requires(pre): 389-ds-base >= %{ds_version}
-Requires: fontawesome-fonts
+Requires: font(fontawesome)
 Requires: open-sans-fonts
 %if 0%{?fedora} >= 32 || 0%{?rhel} >= 9
 # https://pagure.io/freeipa/issue/8632


### PR DESCRIPTION
This PR was opened automatically because PR #6841 was pushed to master and backport to ipa-4-10 is required.