### PR TITLE
ipa-kdb: hint KDC to use aes256-sha1 for forest trust TGT

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -529,52 +529,6 @@ static krb5_principal ipadb_create_local_tgs(krb5_context kcontext,
     return tgtp;
 }
 
-static char *no_attrs[] = {
-    LDAP_NO_ATTRS,
-
-    NULL
-};
-
-static krb5_error_code
-should_support_pac_tkt_sign(krb5_context kcontext, bool *result)
-{
-    struct ipadb_context *ipactx;
-    krb5_error_code kerr;
-    LDAPMessage *res = NULL;
-    char *masters_dn = NULL;
-    int count;
-
-    char *kdc_filter = "(&(cn=KDC)(objectClass=ipaConfigObject)"
-                       "(!(ipaConfigString=pacTktSignSupported)))";
-
-    ipactx = ipadb_get_context(kcontext);
-    if (!ipactx) {
-        kerr = KRB5_KDB_DBNOTINITED;
-        goto done;
-    }
-
-    count = asprintf(&masters_dn, "cn=masters,cn=ipa,cn=etc,%s", ipactx->base);
-    if (count < 0) {
-        kerr = ENOMEM;
-        goto done;
-    }
-
-    kerr = ipadb_simple_search(ipactx, masters_dn, LDAP_SCOPE_SUBTREE,
-                               kdc_filter, no_attrs, &res);
-    if (kerr)
-        goto done;
-
-    count = ldap_count_entries(ipactx->lcontext, res);
-
-    if (result)
-        *result = (count == 0);
-
-done:
-    free(masters_dn);
-    ldap_msgfree(res);
-    return kerr;
-}
-
 /* INTERFACE */
 
 static krb5_error_code ipadb_init_library(void)
@@ -595,7 +549,6 @@ static krb5_error_code ipadb_init_module(krb5_context kcontext,
     krb5_error_code kerr;
     int ret;
     int i;
-    bool pac_tkt_sign_supported;
 
     /* make sure the context is freed to avoid leaking it */
     ipactx = ipadb_get_context(kcontext);
@@ -667,6 +620,8 @@ static krb5_error_code ipadb_init_module(krb5_context kcontext,
         goto fail;
     }
 
+    ipactx->optional_pac_tkt_chksum = IPADB_TRISTATE_UNDEFINED;
+
     ret = ipadb_get_connection(ipactx);
     if (ret != 0) {
         /* Not a fatal failure, as the LDAP server may be temporarily down. */
@@ -680,13 +635,6 @@ static krb5_error_code ipadb_init_module(krb5_context kcontext,
         goto fail;
     }
 
-    /* Enforce PAC ticket signature verification if supported by all KDCs */
-    kerr = should_support_pac_tkt_sign(kcontext, &pac_tkt_sign_supported);
-    if (kerr) {
-        ret = kerr;
-        goto fail;
-    }
-    ipactx->optional_pac_tkt_chksum = !pac_tkt_sign_supported;
 
     return 0;
 

--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -49,6 +49,11 @@ static void ipadb_context_free(krb5_context kcontext,
     size_t c;
 
     if (*ctx != NULL) {
+        if ((*ctx)->magic != IPA_CONTEXT_MAGIC) {
+            krb5_klog_syslog(LOG_ERR, "IPA context is corrupted");
+            *ctx = NULL;
+            return;
+        }
         free((*ctx)->uri);
         free((*ctx)->base);
         free((*ctx)->realm_base);

--- a/daemons/ipa-kdb/ipa_kdb.h
+++ b/daemons/ipa-kdb/ipa_kdb.h
@@ -126,6 +126,12 @@ struct ipadb_global_config {
     bool disable_preauth_for_spns;
 };
 
+enum ipadb_tristate_option {
+	IPADB_TRISTATE_FALSE = FALSE,
+	IPADB_TRISTATE_TRUE = TRUE,
+	IPADB_TRISTATE_UNDEFINED,
+};
+
 #define IPA_CONTEXT_MAGIC 0x0c027ea7
 struct ipadb_context {
     int magic;
@@ -143,7 +149,7 @@ struct ipadb_context {
     krb5_key_salt_tuple *def_encs;
     int n_def_encs;
     struct ipadb_mspac *mspac;
-    bool optional_pac_tkt_chksum;
+    enum ipadb_tristate_option optional_pac_tkt_chksum;
 #ifdef HAVE_KRB5_CERTAUTH_PLUGIN
     krb5_certauth_moddata certauth_moddata;
 #endif

--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -2367,7 +2367,10 @@ krb5_error_code ipadb_common_verify_pac(krb5_context context,
     for (i = 0; i < num_buffers; i++) {
         if (types[i] == KRB5_PAC_SERVER_CHECKSUM ||
             types[i] == KRB5_PAC_PRIVSVR_CHECKSUM ||
-            types[i] == KRB5_PAC_CLIENT_INFO) {
+#ifdef KRB5_PAC_FULL_CHECKSUM
+            types[i] == KRB5_PAC_FULL_CHECKSUM ||
+#endif
+	    types[i] == KRB5_PAC_CLIENT_INFO) {
             continue;
         }
 

--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -114,12 +114,12 @@ static char *std_principal_obj_classes[] = {
 
 #define DEFAULT_TL_DATA_CONTENT "\x00\x00\x00\x00principal@UNINITIALIZED"
 
-#define OPT_PAC_TKT_CHKSUM_STR_ATTR_NAME "optional_pac_tkt_chksum"
+#ifndef KRB5_KDB_SK_OPTIONAL_PAC_TKT_CHKSUM
+#define KRB5_KDB_SK_OPTIONAL_PAC_TKT_CHKSUM "optional_pac_tkt_chksum"
+#endif
 
 #ifndef KRB5_KDB_SK_PAC_PRIVSVR_ENCTYPE
-#define OPT_PAC_PRIVSVR_CHKSUM_STR_ATTR_NAME "pac_privsvr_enctype"
-#else
-#define OPT_PAC_PRIVSVR_CHKSUM_STR_ATTR_NAME KRB5_KDB_SK_PAC_PRIVSVR_ENCTYPE
+#define KRB5_KDB_SK_PAC_PRIVSVR_ENCTYPE "pac_privsvr_enctype"
 #endif
 
 static int ipadb_ldap_attr_to_tl_data(LDAP *lcontext, LDAPMessage *le,
@@ -1748,10 +1748,14 @@ krb5_error_code ipadb_get_principal(krb5_context kcontext,
          */
         if (!is_local_tgs_princ) {
             kerr = krb5_dbe_set_string(kcontext, *entry,
-                                       OPT_PAC_PRIVSVR_CHKSUM_STR_ATTR_NAME,
+                                       KRB5_KDB_SK_PAC_PRIVSVR_ENCTYPE,
                                        "aes256-sha1");
         }
 
+        /* We should have been initialized at this point already */
+        if (ipactx->optional_pac_tkt_chksum == IPADB_TRISTATE_UNDEFINED) {
+                return KRB5_KDB_SERVER_INTERNAL_ERR;
+        }
         /* PAC ticket signature should be optional for foreign realms, and local
          * realm if not supported by all servers
          */
@@ -1761,7 +1765,7 @@ krb5_error_code ipadb_get_principal(krb5_context kcontext,
             opt_pac_tkt_chksum_val = "false";
 
         kerr = krb5_dbe_set_string(kcontext, *entry,
-                                   OPT_PAC_TKT_CHKSUM_STR_ATTR_NAME,
+                                   KRB5_KDB_SK_OPTIONAL_PAC_TKT_CHKSUM,
                                    opt_pac_tkt_chksum_val);
     }
 
@@ -2878,8 +2882,8 @@ remove_virtual_str_attrs(krb5_context kcontext, krb5_db_entry *entry)
     char *str_attr_val;
     krb5_error_code kerr;
     const char *str_attrs[] = {
-        OPT_PAC_TKT_CHKSUM_STR_ATTR_NAME,
-        OPT_PAC_PRIVSVR_CHKSUM_STR_ATTR_NAME,
+        KRB5_KDB_SK_OPTIONAL_PAC_TKT_CHKSUM,
+        KRB5_KDB_SK_PAC_PRIVSVR_ENCTYPE,
         NULL};
 
     for(int i = 0; str_attrs[i] != NULL; i++) {

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -239,6 +239,12 @@ class IPACertificate(crypto_x509.Certificate):
         """
         return self._cert.signature_algorithm_oid
 
+    if hasattr(crypto_x509.Certificate, "signature_algorithm_parameters"):
+        # added in python-cryptography 41.0
+        @property
+        def signature_algorithm_parameters(self):
+            return self._cert.signature_algorithm_parameters
+
     @property
     def signature(self):
         """


### PR DESCRIPTION
From https://krbdev.mit.edu/rt/Ticket/Display.html?id=9089 

> The KDC uses the first local TGT key for the privsvr and full PAC checksums.  If this key is of an aes-sha2 enctype in a cross-realm TGT, a Microsoft KDC in the target realm may reject the ticket because it has an unexpectedly large privsvr checksum buffer.  This behavior is unnecessarily picky as the target realm KDC cannot and does not need to very the privsvr checksum, but [MS-PAC] 2.8.2 does limit the checksum key to three specific enctypes.

Use MIT Kerberos 1.21+ facility to hint about proper enctype for cross-realm TGT.

Fixes: https://pagure.io/freeipa/issue/9124