### PR TITLE
Replace usage of #!/usr/bin/env python3 with #!/usr/bin/python3

### DIFF
--- a/contrib/lite-server.py
+++ b/contrib/lite-server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 #
 # Copyright (C) 2017 FreeIPA Contributors see COPYING for license
 #

--- a/contrib/lite-setup.py
+++ b/contrib/lite-setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 #
 # Copyright (C) 2020 FreeIPA Contributors see COPYING for license
 #

--- a/install/tools/ipa-ccache-sweeper.in
+++ b/install/tools/ipa-ccache-sweeper.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 # Based heavily on
 # https://github.com/gssapi/mod_auth_gssapi/blob/master/contrib/sweeper.py


### PR DESCRIPTION
Only three remaining scripts used this form, two of which are for developers only and not shipped.

The shebang in ipa-ccache-sweeper will be converted to "#!$(PYTHON) -I" in the build process.

Fixes: https://pagure.io/freeipa/issue/8941