### PR TITLE
PRCI: update rawhide box

### DIFF
--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -51,7 +51,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-frawhide
           name: freeipa/ci-master-frawhide
-          version: 0.8.2
+          version: 0.8.3
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Update the rawhide Vagrant box to 0.8.3
(built May 26 2023 using fedora-39)

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>