### PR TITLE
[Backport][ipa-4-10] Don't allow a group to be converted to POSIX and external

### DIFF
--- a/ipaserver/plugins/group.py
+++ b/ipaserver/plugins/group.py
@@ -505,6 +505,9 @@ class group_mod(LDAPUpdate):
             else:
                 old_entry_attrs['objectclass'].append('ipaexternalgroup')
                 entry_attrs['objectclass'] = old_entry_attrs['objectclass']
+            if 'gidnumber' in entry_attrs:
+                raise errors.MutuallyExclusiveError(reason=_(
+                    'An external group cannot be POSIX'))
 
         # Can't check for this in a validator because we lack context
         if 'gidnumber' in options and options['gidnumber'] is None:

--- a/ipatests/test_xmlrpc/test_group_plugin.py
+++ b/ipatests/test_xmlrpc/test_group_plugin.py
@@ -466,6 +466,21 @@ class TestNonposixGroup(XMLRPC_test):
             ],
         ), result)
 
+    def test_upgrade_nonposix_to_posix_and_external(self, group):
+        """ Update non-posix group to promote it to posix group & external"""
+        command = group.make_update_command(dict(posix=True, external=True))
+        with raises_exact(errors.MutuallyExclusiveError(
+                reason=u"An external group cannot be POSIX")):
+            command()
+
+    def test_upgrade_nonposix_with_gid_and_external(self, group):
+        """ Update non-posix group to promote it to posix group & external"""
+        command = group.make_update_command(dict(gidnumber=12345,
+                                                 external=True))
+        with raises_exact(errors.MutuallyExclusiveError(
+                reason=u"An external group cannot be POSIX")):
+            command()
+
     def test_upgrade_nonposix_to_posix(self, group):
         """ Update non-posix group to promote it to posix group """
         group.attrs.update(gidnumber=[fuzzy_digits])


### PR DESCRIPTION
This PR was opened automatically because PR #6855 was pushed to master and backport to ipa-4-10 is required.