### PR TITLE
ipatest: remove xfail from test_smb

### DIFF
--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -349,7 +349,6 @@ class TestSMB(IntegrationTest):
     @pytest.mark.skipif(
         osinfo.id == 'fedora' and osinfo.version_number <= (31,),
         reason='Test requires krb 1.18')
-    @pytest.mark.xfail(reason="Pagure ticket 9124", strict=True)
     def test_smb_service_s4u2self(self):
         """Test S4U2Self operation by IPA service
            against both AD and IPA users


### PR DESCRIPTION
test_smb is now successful because the windows server version
has been updated to windows-server-2022 with
- KB5012170
- KB5025230
- KB5022507
- servicing stack 10.0.20348.1663
in freeipa-pr-ci commit 3ba4151.

Remove the xfail.

Fixes: https://pagure.io/freeipa/issue/9124
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>