### PR TITLE
[Backport][ipa-4-9] ipalib/x509.py: Add signature_algorithm_parameters

### DIFF
--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -239,6 +239,12 @@ class IPACertificate(crypto_x509.Certificate):
         """
         return self._cert.signature_algorithm_oid
 
+    if hasattr(crypto_x509.Certificate, "signature_algorithm_parameters"):
+        # added in python-cryptography 41.0
+        @property
+        def signature_algorithm_parameters(self):
+            return self._cert.signature_algorithm_parameters
+
     @property
     def signature(self):
         """


### PR DESCRIPTION
Python-cryptography 41.0.0 new abstract method.

Signed-off-by: Christian Heimes <cheimes@redhat.com>
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>
Reviewed-By: Julien Rische <jrische@redhat.com>
(cherry picked from commit 18bf495ce88fbb032f23f7db7f941458ecf55c7a)

This is a manual backport to ipa-4-9 branch.

PR was ACKed automatically because this is a partial backport of PR https://github.com/freeipa/freeipa/pull/6852. Wait for CI to finish before pushing. In case of questions or problems contact @abbra who is author of the original PR.