### PR TITLE
nis server: limit group.byname and group.bygid maps to POSIX groups

### DIFF
--- a/install/share/nis-update.uldif
+++ b/install/share/nis-update.uldif
@@ -36,3 +36,9 @@ default:nis-filter: (&(macAddress=*)(fqdn=*)(objectClass=ipaHost))
 default:nis-keys-format: %mregsub("%{macAddress} %{fqdn}","(..)[:\\\|-](..)[:\\\|-](..)[:\\\|-](..)[:\\\|-](..)[:\\\|-](..) (.*)","%7")
 default:nis-values-format: %mregsub("%{macAddress} %{fqdn}","(..)[:\\\|-](..)[:\\\|-](..)[:\\\|-](..)[:\\\|-](..)[:\\\|-](..) (.*)","%1:%2:%3:%4:%5:%6 %7")
 default:nis-secure: no
+
+dn: nis-domain=$DOMAIN+nis-map=group.byname, cn=NIS Server, cn=plugins, cn=config
+onlyifexist:nis-filter: (objectClass=posixGroup)
+
+dn: nis-domain=$DOMAIN+nis-map=group.bygid, cn=NIS Server, cn=plugins, cn=config
+onlyifexist:nis-filter: (objectClass=posixGroup)

--- a/install/share/nis.uldif
+++ b/install/share/nis.uldif
@@ -37,6 +37,7 @@ default:nis-domain: $DOMAIN
 default:nis-map: group.byname
 default:nis-base: cn=groups, cn=accounts, $SUFFIX
 default:nis-secure: no
+default:nis-filter: (objectClass=posixGroup)
 
 dn: nis-domain=$DOMAIN+nis-map=group.bygid, cn=NIS Server, cn=plugins, cn=config
 default:objectclass: top
@@ -45,6 +46,7 @@ default:nis-domain: $DOMAIN
 default:nis-map: group.bygid
 default:nis-base: cn=groups, cn=accounts, $SUFFIX
 default:nis-secure: no
+default:nis-filter: (objectClass=posixGroup)
 
 dn: nis-domain=$DOMAIN+nis-map=netid.byname, cn=NIS Server, cn=plugins, cn=config
 default:objectclass: top


### PR DESCRIPTION
For NIS maps only POSIX groups make sense. Limit searches to those. This should avoid pulling groups like 'ipausers' into NIS maps. It also will help with large non-POSIX groups being rebuilt when a new member is added because then NIS maps wouldn't need to be rebuilt.

In a real life scenario this reduced time spent on adding a user from 45 seconds to 15 seconds: 'ipausers' group membership change does not trigger a rebuild of NIS maps anymore.

Fixes: https://pagure.io/freeipa/issue/9388