### PR TITLE
webuitests: close notification which hides Add button

### DIFF
--- a/ipatests/test_webui/test_service.py
+++ b/ipatests/test_webui/test_service.py
@@ -296,6 +296,7 @@ class test_service(sevice_tasks):
         cert_widget_sel = "div.certificate-widget"
 
         self.add_record(ENTITY, data)
+        self.close_notifications()
         self.navigate_to_record(pkey)
 
         # check whether certificate section is present


### PR DESCRIPTION
The webui test test_service.py::test_service::test_arbitrary_certificates
randomly fails.
The test is creating a new service then navigates to the Service page
and clicks on the Add Certificate button.
The notification area may still be present and hide the button, with
the message "Service successfully added".
Close all notifications before navigating to the Service page.

Fixes: https://pagure.io/freeipa/issue/9389
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>