### PR TITLE
[Backport][ipa-4-10] webuitests: close notification which hides Add button

### DIFF
--- a/ipatests/test_webui/test_service.py
+++ b/ipatests/test_webui/test_service.py
@@ -296,6 +296,7 @@ class test_service(sevice_tasks):
         cert_widget_sel = "div.certificate-widget"
 
         self.add_record(ENTITY, data)
+        self.close_notifications()
         self.navigate_to_record(pkey)
 
         # check whether certificate section is present


### PR DESCRIPTION
This PR was opened automatically because PR #6871 was pushed to master and backport to ipa-4-10 is required.