### PR TITLE
test: add tests for descriptive error message in ipa user-add

### DIFF
--- a/ipatests/test_xmlrpc/test_group_plugin.py
+++ b/ipatests/test_xmlrpc/test_group_plugin.py
@@ -183,10 +183,10 @@ class TestGroup(XMLRPC_test):
         testgroup.create()
         testgroup.delete()
 
-    def test_create_with_numeric_only_group_name(self):
+    def test_create_with_numeric_only_groupname(self):
         """Try to create a group with name only contains numeric chars"""
         testgroup = GroupTracker(
-            name=u'1234', description=u'Numeric only group name',
+            name=invalidgroup2, description=u'Numeric only group name',
         )
         with raises_exact(errors.ValidationError(
             name='group_name',
@@ -205,6 +205,17 @@ class TestGroup(XMLRPC_test):
         )):
             command()
 
+    def test_rename_to_invalid_groupname(self, group):
+        """ Try to rename group using an invalid name """
+        group.ensure_exists()
+        command = group.make_update_command(
+            updates=dict(rename=invalidgroup1))
+        with raises_exact(errors.ValidationError(
+            name='rename',
+            error=ERRMSG_GROUPUSER_NAME.format('group'),
+        )):
+            command()
+
     def test_rename_setattr_to_numeric_only_groupname(self, group):
         """ Try to rename using an invalid numeric only name  with setattr"""
         group.ensure_exists()
@@ -216,6 +227,16 @@ class TestGroup(XMLRPC_test):
         )):
             command()
 
+    def test_rename_to_numeric_only_groupname(self, group):
+        """ Try to rename group using an invalid numeric only name """
+        group.ensure_exists()
+        command = group.make_update_command(
+            updates=dict(rename=invalidgroup2))
+        with raises_exact(errors.ValidationError(
+            name='rename',
+            error=ERRMSG_GROUPUSER_NAME.format('group'),
+        )):
+            command()
 
 @pytest.mark.tier1
 class TestFindGroup(XMLRPC_test):

--- a/ipatests/test_xmlrpc/test_stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/test_stageuser_plugin.py
@@ -41,6 +41,7 @@ invalidrealm2 = u'suser1@BAD@NOTFOUND.ORG'
 
 invaliduser1 = u'+tuser1'
 invaliduser2 = u'tuser1234567890123456789012345678901234567890'
+invaliduser3 = u'1234'
 
 sshpubkey = (u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGAX3xAeLeaJggwTqMjxNwa6X'
              'HBUAikXPGMzEpVrlLDCZtv00djsFTBi38PkgxBJVkgRWMrcBsr/35lq7P6w8KGI'
@@ -358,7 +359,18 @@ class TestCreateInvalidAttributes(XMLRPC_test):
         command = invalid.make_create_command()
         with raises_exact(errors.ValidationError(
             name='login',
-                error=ERRMSG_GROUPUSER_NAME.format('user'))):
+            error=ERRMSG_GROUPUSER_NAME.format('user'),
+        )):
+            command()
+
+    def test_create_numeric_only_uid(self):
+        invalid = StageUserTracker(invaliduser3, u'NumFirst1234',
+                                   u'NumSurname1234')
+        command = invalid.make_create_command()
+        with raises_exact(errors.ValidationError(
+            name='login',
+            error=ERRMSG_GROUPUSER_NAME.format('user'),
+        )):
             command()
 
     def test_create_long_uid(self):

--- a/ipatests/test_xmlrpc/test_user_plugin.py
+++ b/ipatests/test_xmlrpc/test_user_plugin.py
@@ -504,8 +504,9 @@ class TestUpdate(XMLRPC_test):
             updates=dict(rename=invaliduser1)
         )
         with raises_exact(errors.ValidationError(
-                name='rename',
-                error=ERRMSG_GROUPUSER_NAME.format('user'))):
+            name='rename',
+            error=ERRMSG_GROUPUSER_NAME.format('user'),
+        )):
             command()
 
     def test_rename_setattr_to_numeric_only_username(self, user):
@@ -519,6 +520,19 @@ class TestUpdate(XMLRPC_test):
             error=ERRMSG_GROUPUSER_NAME.format('user'),
         )):
             command()
+
+    def test_rename_to_numeric_only_username(self, user):
+        """ Try to change user name to name containing only numeric chars"""
+        user.ensure_exists()
+        command = user.make_update_command(
+            updates=dict(rename=invaliduser3)
+        )
+        with raises_exact(errors.ValidationError(
+            name='rename',
+            error=ERRMSG_GROUPUSER_NAME.format('user'),
+        )):
+            command()
+
 
     def test_add_radius_username(self, user):
         """ Test for ticket 7569: Try to add --radius-username """
@@ -570,8 +584,9 @@ class TestCreate(XMLRPC_test):
         )
         command = testuser.make_create_command()
         with raises_exact(errors.ValidationError(
-                name=u'login',
-                error=ERRMSG_GROUPUSER_NAME.format('user'))):
+            name=u'login',
+            error=ERRMSG_GROUPUSER_NAME.format('user'),
+        )):
             command()
 
     def test_create_with_too_long_login(self):
@@ -741,11 +756,11 @@ class TestCreate(XMLRPC_test):
     def test_create_with_numeric_only_username(self):
         """Try to create a user with name only contains numeric chars"""
         testuser = UserTracker(
-            name=u'1234', givenname=u'NumFirst1234', sn=u'NumSurname1234',
+            name=invaliduser3, givenname=u'NumFirst1234', sn=u'NumSurname1234',
         )
         with raises_exact(errors.ValidationError(
-                name=u'login',
-                error=ERRMSG_GROUPUSER_NAME.format('user'),
+            name=u'login',
+            error=ERRMSG_GROUPUSER_NAME.format('user'),
         )):
             testuser.create()
 


### PR DESCRIPTION
Add tests for renaming existing user and group with invalid name or only numeric name
Related: https://pagure.io/freeipa/issue/9378