### PR TITLE
Use the python-cryptography parser directly in cert-find

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -412,7 +412,6 @@ BuildRequires:  python3-pylint
 BuildRequires:  python3-pytest-multihost
 BuildRequires:  python3-pytest-sourceorder
 BuildRequires:  python3-qrcode-core >= 5.0.0
-BuildRequires:  python3-pyOpenSSL
 BuildRequires:  python3-samba
 BuildRequires:  python3-six
 BuildRequires:  python3-sss
@@ -887,7 +886,6 @@ Requires: python3-netifaces >= 0.10.4
 Requires: python3-pyasn1 >= 0.3.2-2
 Requires: python3-pyasn1-modules >= 0.3.2-2
 Requires: python3-pyusb
-Requires: python3-pyOpenSSL
 Requires: python3-qrcode-core >= 5.0.0
 Requires: python3-requests
 Requires: python3-six

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1807,7 +1807,6 @@ class cert_find(Search, CertMethod):
                             # For the case of CA-less we need to keep
                             # the certificate because getting it again later
                             # would require unnecessary LDAP searches.
-                            cert = cert.to_cryptography()
                             obj['certificate'] = (
                                 base64.b64encode(
                                     cert.public_bytes(x509.Encoding.DER))

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -30,7 +30,6 @@ import cryptography.x509
 from cryptography.hazmat.primitives import hashes, serialization
 from dns import resolver, reversename
 import six
-import sys
 
 from ipalib import Command, Str, Int, Flag, StrEnum, SerialNumber
 from ipalib import api
@@ -1618,19 +1617,7 @@ class cert_find(Search, CertMethod):
             )
 
     def _get_cert_key(self, cert):
-        # for cert-find with a certificate value
-        if isinstance(cert, x509.IPACertificate):
-            return (DN(cert.issuer), cert.serial_number)
-
-        issuer = []
-        for oid, value in cert.get_issuer().get_components():
-            issuer.append(
-                '{}={}'.format(oid.decode('utf-8'), value.decode('utf-8'))
-            )
-        issuer = ','.join(issuer)
-        # Use this to flip from OpenSSL reverse to X500 ordering
-        issuer = DN(issuer).x500_text()
-        return (DN(issuer), cert.get_serial_number())
+        return (DN(cert.issuer), cert.serial_number)
 
     def _cert_search(self, pkey_only, **options):
         result = collections.OrderedDict()
@@ -1750,11 +1737,6 @@ class cert_find(Search, CertMethod):
         return result, False, complete
 
     def _ldap_search(self, all, pkey_only, no_members, **options):
-        # defer import of the OpenSSL module to not affect the requests
-        # module which will use pyopenssl if this is available.
-        if sys.modules.get('OpenSSL.SSL', False) is None:
-            del sys.modules["OpenSSL.SSL"]
-        import OpenSSL.crypto
         ldap = self.api.Backend.ldap2
 
         filters = []
@@ -1813,14 +1795,12 @@ class cert_find(Search, CertMethod):
         ca_enabled = getattr(context, 'ca_enabled')
         for entry in entries:
             for attr in ('usercertificate', 'usercertificate;binary'):
-                for der in entry.raw.get(attr, []):
-                    cert = OpenSSL.crypto.load_certificate(
-                        OpenSSL.crypto.FILETYPE_ASN1, der)
+                for cert in entry.get(attr, []):
                     cert_key = self._get_cert_key(cert)
                     try:
                         obj = result[cert_key]
                     except KeyError:
-                        obj = {'serial_number': cert.get_serial_number()}
+                        obj = {'serial_number': cert.serial_number}
                         if not pkey_only and (all or not ca_enabled):
                             # Retrieving certificate details is now deferred
                             # until after all certificates are collected.

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1795,7 +1795,8 @@ class cert_find(Search, CertMethod):
         ca_enabled = getattr(context, 'ca_enabled')
         for entry in entries:
             for attr in ('usercertificate', 'usercertificate;binary'):
-                for cert in entry.get(attr, []):
+                for der in entry.raw.get(attr, []):
+                    cert = cryptography.x509.load_der_x509_certificate(der)
                     cert_key = self._get_cert_key(cert)
                     try:
                         obj = result[cert_key]

--- a/ipatests/test_xmlrpc/test_cert_plugin.py
+++ b/ipatests/test_xmlrpc/test_cert_plugin.py
@@ -254,6 +254,16 @@ class test_cert(BaseCert):
         result = _emails_are_valid(email_addrs, [])
         assert not result
 
+    def test_00012_cert_find_all(self):
+        """
+        Test that cert-find --all returns successfully.
+
+        We don't know how many we'll get but there should be at least 10
+        by default.
+        """
+        res = api.Command['cert_find'](all=True)
+        assert 'count' in res and res['count'] >= 10
+
     def test_99999_cleanup(self):
         """
         Clean up cert test data
@@ -283,7 +293,7 @@ class test_cert_find(XMLRPC_test):
 
     short = api.env.host.split('.', maxsplit=1)[0]
 
-    def test_0001_find_all(self):
+    def test_0001_find_all_certs(self):
         """
         Search for all certificates.
 


### PR DESCRIPTION
**Jump to the bottom of this description for a test program to demonstrate the issue in isolation.**

This is take-two of cert-find performance improvement. I identified part of the problem in take one (reverted here) which was that the certificate was being processed as an IPACertificate. I incorrectly chalked the problem up to python-cryptography and not the IPACertificate class itself. This PR corrects that.

To generate a ton of certificates I did this as root:

kinit admin
ipa service-add test/ipa.example.test
for in in {0..5000}; do  ipa-getcert request -f /etc/pki/test/test.pem -k /etc/pki/test/test.key  -K test/ipa.example.test -v -w; getcert stop-tracking -f /etc/pki/test/test.pem; ipa service-mod --certificate='' test/ipa.example.test ; rm -f /etc/pki/test/test.pem; done

And let that sucker run in the background while I did other work. Because of the service-mod it takes 1.5-2 seconds for each cert but it's still pretty fast.

commit message:

cert-find is a rather complex beast because it not only
looks for certificates in the optional CA but within the
IPA LDAP database as well. It has a process to deduplicate
the certificates since any PKI issued certificates will
also be associated with an IPA record.

In order to obtain the data to deduplicate the certificates
the cert from LDAP must be parser for issuer and serial number.
ipaldap has automation to determine the datatype of an
attribute and will use the ipalib.x509 IPACertificate class to
decode a certificate automatically if you access
entry['usercertificate'].

The downside is that this is comparatively slow. Here is the
parse time in microseconds:

cryptography 0.0081
OpenSSL.crypto 0.2271
ipalib.x509 2.6814

Since only issuer and subject are required there is no need to
make the expensive IPACertificate call.

The IPACertificate parsing time is fine if you're parsing one
certificate but if the LDAP search returns a lot of certificates,
say in the thousands, then those microseconds add up quickly.
In testing it took ~17 seconds to parse 5k certificates (excluding
transmission overhead, etc).

cert-find when there are a lot of certificates has been
historically slow. It isn't related to the CA which returns
large sets (well, 5k anyway) in a second or two. It was the
LDAP comparision adding tens of seconds to the runtime.

When searching with the default sizelimit of 100 the time is
~10s without this patch. With it the time is 1.5s.

CLI times from before and after searching for all certs:

original:

 Number of entries returned 5038

real    0m15.507s
user    0m0.828s
sys     0m0.241s

using cryptography:

real    0m4.037s
user    0m0.816s
sys     0m0.193s

Fixes: https://pagure.io/freeipa/issue/9331

```
# time loading of certificates using various libraries

import base64
import timeit

from cryptography import x509 as crypto_x509
import OpenSSL.crypto
from ipalib import x509


with open("/etc/ipa/ca.crt", "r") as fd:
    data = fd.read()

certs = x509.PEM_CERT_REGEX.findall(data.encode('utf-8'))
raw = base64.b64decode(certs[0][1])

# number of iterations to run
n = 1000

print("cryptography")
result = timeit.timeit(stmt='crypto_x509.load_der_x509_certificate(raw)', globals=globals(), number=n)
print(f"Execution time is {(result / n) * 1000} ms\n")

print("OpenSSL")
result = timeit.timeit(stmt='OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_ASN1, raw)', globals=globals(), number=n)
print(f"Execution time is {(result / n) * 1000} ms\n")

print("ipalib")
result = timeit.timeit(stmt='x509.load_der_x509_certificate(raw)', globals=globals(), number=n)
print(f"Execution time is {(result / n) * 1000} ms")
```