### PR TITLE
[Backport][ipa-4-10] Don't allow the FQDN to match the domain on server installs

### DIFF
--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -525,6 +525,9 @@ def install_check(installer):
 
     domain_name = domain_name.lower()
 
+    if host_name.lower() == domain_name:
+        raise ScriptError("hostname cannot be the same as the domain name")
+
     if not options.realm_name:
         realm_name = read_realm_name(domain_name, not installer.interactive)
         logger.debug("read realm_name: %s\n", realm_name)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -930,6 +930,9 @@ def promote_check(installer):
     installutils.verify_fqdn(config.master_host_name, options.no_host_dns,
                              local_hostname=not container_environment)
 
+    if config.host_name.lower() == config.domain_name.lower():
+        raise ScriptError("hostname cannot be the same as the domain name")
+
     ccache = os.environ['KRB5CCNAME']
     kinit_keytab('host/{env.host}@{env.realm}'.format(env=api.env),
                  paths.KRB5_KEYTAB,

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -2100,3 +2100,17 @@ class TestHostnameValidator(IntegrationTest):
                 hostname = m.group(1)
                 break
         assert hostname == self.master.hostname
+
+    def test_hostname_matching_domain(self):
+        # https://pagure.io/freeipa/issue/9003
+        # Prevent hostname from matching the domain
+        self.master.run_command(['hostname', self.master.hostname])
+        args = self.get_args(self.master)
+        args.extend(['--hostname', self.master.domain.name])
+        result = self.master.run_command(
+            args, raiseonerr=False,
+        )
+
+        assert result.returncode == 1
+        assert 'hostname cannot be the same as the domain name' \
+            in result.stderr_text


### PR DESCRIPTION
This PR was opened automatically because PR #6853 was pushed to master and backport to ipa-4-10 is required.