### PR TITLE
Uninstaller: uninstall PKI before shutting down services

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -305,7 +305,7 @@ class DogtagInstance(service.Service):
             self.print_msg("Unconfiguring %s" % self.subsystem)
 
         args = [paths.PKIDESTROY,
-                "-i", "pki-tomcat",
+                "-i", "pki-tomcat", "--force",
                 "-s", self.subsystem]
 
         # specify --log-file <path> on PKI 11.0.0 or later

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -184,7 +184,7 @@ class DogtagInstance(service.Service):
                 ['pki-server', 'subsystem-show', self.subsystem.lower()],
                 capture_output=True)
             # parse the command output
-            return 'Enabled: True' in result.output
+            return 'Enabled: ' in result.output
         except ipautil.CalledProcessError:
             return False
 

--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -132,6 +132,8 @@ def uninstall_check(options):
 
     if result.returncode not in [0, 4]:
         try:
+            logger.info(
+                "Starting services to unregister KRA from security domain")
             ipautil.run([paths.IPACTL, 'start'])
         except Exception:
             logger.info("Re-starting IPA failed, continuing uninstall")

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1110,6 +1110,7 @@ def uninstall_check(installer):
             raise ScriptError("Aborting uninstall operation.")
 
     kra.uninstall_check(options)
+    ca.uninstall_check(options)
 
     try:
         api.Backend.ldap2.connect(autobind=True)
@@ -1132,7 +1133,7 @@ def uninstall_check(installer):
     else:
         dns.uninstall_check(options)
 
-        ca.uninstall_check(options)
+        ca.uninstall_crl_check(options)
 
         cleanup_dogtag_server_specific_data()
 
@@ -1181,6 +1182,9 @@ def uninstall(installer):
     # Uninstall the KRA prior to shutting the services down so it
     # can un-register with the CA.
     kra.uninstall()
+    # Uninstall the CA priori to shutting the services down so it
+    # can unregister from the security domain
+    ca.uninstall()
 
     print("Shutting down all IPA services")
     try:
@@ -1193,8 +1197,6 @@ def uninstall(installer):
             pass
 
     restore_time_sync(sstore, fstore)
-
-    ca.uninstall()
 
     dns.uninstall()
 


### PR DESCRIPTION
The uninstaller is stopping all the services before
calling pkidestroy to uninstall the CA.
With PKI 11.4+ this sequence fails as pkidestroy tries
to connect to PKI server in order to unregister from the
security domain. The error interrupts the full completion
of pkidestroy, is logged but doesn't make ipa uninstallation
fail.
The issue is that trying to re-install later on would fail because
pkidestroy did not completely uninstall the CA.

To avoid this, call pkidestroy before shutting down the services.

Fixes: https://pagure.io/freeipa/issue/9330

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>