### PR TITLE
User and groups: rename with --setattr must check format

### DIFF
--- a/ipatests/test_xmlrpc/test_group_plugin.py
+++ b/ipatests/test_xmlrpc/test_group_plugin.py
@@ -39,6 +39,7 @@ from ipatests.util import assert_deepequal, get_group_dn
 notagroup = u'notagroup'
 renamedgroup1 = u'renamedgroup'
 invalidgroup1 = u'+tgroup1'
+invalidgroup2 = u'1234'
 external_sid1 = u'S-1-1-123456-789-1'
 
 
@@ -192,6 +193,28 @@ class TestGroup(XMLRPC_test):
             error=ERRMSG_GROUPUSER_NAME.format('group'),
         )):
             testgroup.create()
+
+    def test_rename_setattr_to_invalid_groupname(self, group):
+        """ Try to rename group using an invalid name with settatr cn= """
+        group.ensure_exists()
+        command = group.make_update_command(
+            updates=dict(setattr='cn=%s' % invalidgroup1))
+        with raises_exact(errors.ValidationError(
+            name='cn',
+            error=ERRMSG_GROUPUSER_NAME.format('group'),
+        )):
+            command()
+
+    def test_rename_setattr_to_numeric_only_groupname(self, group):
+        """ Try to rename using an invalid numeric only name  with setattr"""
+        group.ensure_exists()
+        command = group.make_update_command(
+            updates=dict(setattr='cn=%s' % invalidgroup2))
+        with raises_exact(errors.ValidationError(
+            name='cn',
+            error=ERRMSG_GROUPUSER_NAME.format('group'),
+        )):
+            command()
 
 
 @pytest.mark.tier1

--- a/ipatests/test_xmlrpc/test_user_plugin.py
+++ b/ipatests/test_xmlrpc/test_user_plugin.py
@@ -53,6 +53,7 @@ admin_group = u'admins'
 
 invaliduser1 = u'+tuser1'
 invaliduser2 = u''.join(['a' for n in range(256)])
+invaliduser3 = u'1234'
 
 sshpubkey = (u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGAX3xAeLeaJggwTqMjxNwa6X'
              'HBUAikXPGMzEpVrlLDCZtv00djsFTBi38PkgxBJVkgRWMrcBsr/35lq7P6w8KGI'
@@ -505,6 +506,18 @@ class TestUpdate(XMLRPC_test):
         with raises_exact(errors.ValidationError(
                 name='rename',
                 error=ERRMSG_GROUPUSER_NAME.format('user'))):
+            command()
+
+    def test_rename_setattr_to_numeric_only_username(self, user):
+        """ Try to change name to name with only numeric chars with setattr"""
+        user.ensure_exists()
+        command = user.make_update_command(
+            updates=dict(setattr='uid=%s' % invaliduser3)
+        )
+        with raises_exact(errors.ValidationError(
+            name='uid',
+            error=ERRMSG_GROUPUSER_NAME.format('user'),
+        )):
             command()
 
     def test_add_radius_username(self, user):


### PR DESCRIPTION
### User and groups: rename with --setattr must check format

There are 2 possible methods to rename users and groups:
- either use ipa user|group-mod oldname --rename newname
- or use settattr:
   ipa user-mod oldname --setattr uid=newname
   ipa group-mod oldname --setattr cn=newname

The first method validates the new name but the second method
doesn't. Add a validation to make both methods consistent

Fixes: https://pagure.io/freeipa/issue/9396

### xmlrpc tests: add test renaming user or group with setattr

Add a new test renaming user or group using --setattr.
The new name must be validated and invalid names must be
refused.

Related: https://pagure.io/freeipa/issue/9396