### PR TITLE
[Backport][ipa-4-10] Use the python-cryptography parser directly in cert-find

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -412,7 +412,6 @@ BuildRequires:  python3-pylint
 BuildRequires:  python3-pytest-multihost
 BuildRequires:  python3-pytest-sourceorder
 BuildRequires:  python3-qrcode-core >= 5.0.0
-BuildRequires:  python3-pyOpenSSL
 BuildRequires:  python3-samba
 BuildRequires:  python3-six
 BuildRequires:  python3-sss
@@ -884,7 +883,6 @@ Requires: python3-netifaces >= 0.10.4
 Requires: python3-pyasn1 >= 0.3.2-2
 Requires: python3-pyasn1-modules >= 0.3.2-2
 Requires: python3-pyusb
-Requires: python3-pyOpenSSL
 Requires: python3-qrcode-core >= 5.0.0
 Requires: python3-requests
 Requires: python3-six

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1807,7 +1807,6 @@ class cert_find(Search, CertMethod):
                             # For the case of CA-less we need to keep
                             # the certificate because getting it again later
                             # would require unnecessary LDAP searches.
-                            cert = cert.to_cryptography()
                             obj['certificate'] = (
                                 base64.b64encode(
                                     cert.public_bytes(x509.Encoding.DER))

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -30,7 +30,6 @@ import cryptography.x509
 from cryptography.hazmat.primitives import hashes, serialization
 from dns import resolver, reversename
 import six
-import sys
 
 from ipalib import Command, Str, Int, Flag, StrEnum, SerialNumber
 from ipalib import api
@@ -1618,19 +1617,7 @@ class cert_find(Search, CertMethod):
             )
 
     def _get_cert_key(self, cert):
-        # for cert-find with a certificate value
-        if isinstance(cert, x509.IPACertificate):
-            return (DN(cert.issuer), cert.serial_number)
-
-        issuer = []
-        for oid, value in cert.get_issuer().get_components():
-            issuer.append(
-                '{}={}'.format(oid.decode('utf-8'), value.decode('utf-8'))
-            )
-        issuer = ','.join(issuer)
-        # Use this to flip from OpenSSL reverse to X500 ordering
-        issuer = DN(issuer).x500_text()
-        return (DN(issuer), cert.get_serial_number())
+        return (DN(cert.issuer), cert.serial_number)
 
     def _cert_search(self, pkey_only, **options):
         result = collections.OrderedDict()
@@ -1750,11 +1737,6 @@ class cert_find(Search, CertMethod):
         return result, False, complete
 
     def _ldap_search(self, all, pkey_only, no_members, **options):
-        # defer import of the OpenSSL module to not affect the requests
-        # module which will use pyopenssl if this is available.
-        if sys.modules.get('OpenSSL.SSL', False) is None:
-            del sys.modules["OpenSSL.SSL"]
-        import OpenSSL.crypto
         ldap = self.api.Backend.ldap2
 
         filters = []
@@ -1813,14 +1795,12 @@ class cert_find(Search, CertMethod):
         ca_enabled = getattr(context, 'ca_enabled')
         for entry in entries:
             for attr in ('usercertificate', 'usercertificate;binary'):
-                for der in entry.raw.get(attr, []):
-                    cert = OpenSSL.crypto.load_certificate(
-                        OpenSSL.crypto.FILETYPE_ASN1, der)
+                for cert in entry.get(attr, []):
                     cert_key = self._get_cert_key(cert)
                     try:
                         obj = result[cert_key]
                     except KeyError:
-                        obj = {'serial_number': cert.get_serial_number()}
+                        obj = {'serial_number': cert.serial_number}
                         if not pkey_only and (all or not ca_enabled):
                             # Retrieving certificate details is now deferred
                             # until after all certificates are collected.

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1795,7 +1795,8 @@ class cert_find(Search, CertMethod):
         ca_enabled = getattr(context, 'ca_enabled')
         for entry in entries:
             for attr in ('usercertificate', 'usercertificate;binary'):
-                for cert in entry.get(attr, []):
+                for der in entry.raw.get(attr, []):
+                    cert = cryptography.x509.load_der_x509_certificate(der)
                     cert_key = self._get_cert_key(cert)
                     try:
                         obj = result[cert_key]

--- a/ipatests/test_xmlrpc/test_cert_plugin.py
+++ b/ipatests/test_xmlrpc/test_cert_plugin.py
@@ -254,6 +254,16 @@ class test_cert(BaseCert):
         result = _emails_are_valid(email_addrs, [])
         assert not result
 
+    def test_00012_cert_find_all(self):
+        """
+        Test that cert-find --all returns successfully.
+
+        We don't know how many we'll get but there should be at least 10
+        by default.
+        """
+        res = api.Command['cert_find'](all=True)
+        assert 'count' in res and res['count'] >= 10
+
     def test_99999_cleanup(self):
         """
         Clean up cert test data
@@ -283,7 +293,7 @@ class test_cert_find(XMLRPC_test):
 
     short = api.env.host.split('.', maxsplit=1)[0]
 
-    def test_0001_find_all(self):
+    def test_0001_find_all_certs(self):
         """
         Search for all certificates.
 


### PR DESCRIPTION
This PR was opened automatically because PR #6875 was pushed to master and backport to ipa-4-10 is required.