### PR TITLE
[Backport][ipa-4-9] User and groups: rename with --setattr must check format

### DIFF
--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
 import six
 
 from ipalib import api, errors, constants
@@ -588,6 +589,8 @@ class baseuser_mod(LDAPUpdate):
     """
     Prototype command plugin to be implemented by real plugin
     """
+    NAME_PATTERN = re.compile(constants.PATTERN_GROUPUSER_NAME)
+
     def check_namelength(self, ldap, **options):
         if options.get('rename') is not None:
             config = ldap.get_ipa_config()
@@ -599,6 +602,14 @@ class baseuser_mod(LDAPUpdate):
                             len = int(config.get('ipamaxusernamelength')[0])
                         )
                     )
+
+    def check_name(self, entry_attrs):
+        if 'uid' in entry_attrs:
+            # Check the pattern if the user is renamed
+            if self.NAME_PATTERN.match(entry_attrs.single_value['uid']) is None:
+                raise errors.ValidationError(
+                    name='uid',
+                    error=constants.ERRMSG_GROUPUSER_NAME.format('user'))
 
     def preserve_krbprincipalname_pre(self, ldap, entry_attrs, *keys, **options):
         """
@@ -715,6 +726,7 @@ class baseuser_mod(LDAPUpdate):
         add_sshpubkey_to_attrs_pre(self.context, attrs_list)
 
         self.check_namelength(ldap, **options)
+        self.check_name(entry_attrs)
 
         self.check_mail(entry_attrs)
 

--- a/ipatests/test_xmlrpc/test_group_plugin.py
+++ b/ipatests/test_xmlrpc/test_group_plugin.py
@@ -39,6 +39,7 @@ from ipatests.util import assert_deepequal, get_group_dn
 notagroup = u'notagroup'
 renamedgroup1 = u'renamedgroup'
 invalidgroup1 = u'+tgroup1'
+invalidgroup2 = u'1234'
 external_sid1 = u'S-1-1-123456-789-1'
 
 
@@ -192,6 +193,28 @@ class TestGroup(XMLRPC_test):
             error=ERRMSG_GROUPUSER_NAME.format('group'),
         )):
             testgroup.create()
+
+    def test_rename_setattr_to_invalid_groupname(self, group):
+        """ Try to rename group using an invalid name with settatr cn= """
+        group.ensure_exists()
+        command = group.make_update_command(
+            updates=dict(setattr='cn=%s' % invalidgroup1))
+        with raises_exact(errors.ValidationError(
+            name='cn',
+            error=ERRMSG_GROUPUSER_NAME.format('group'),
+        )):
+            command()
+
+    def test_rename_setattr_to_numeric_only_groupname(self, group):
+        """ Try to rename using an invalid numeric only name  with setattr"""
+        group.ensure_exists()
+        command = group.make_update_command(
+            updates=dict(setattr='cn=%s' % invalidgroup2))
+        with raises_exact(errors.ValidationError(
+            name='cn',
+            error=ERRMSG_GROUPUSER_NAME.format('group'),
+        )):
+            command()
 
 
 @pytest.mark.tier1

--- a/ipatests/test_xmlrpc/test_user_plugin.py
+++ b/ipatests/test_xmlrpc/test_user_plugin.py
@@ -53,6 +53,7 @@ admin_group = u'admins'
 
 invaliduser1 = u'+tuser1'
 invaliduser2 = u''.join(['a' for n in range(256)])
+invaliduser3 = u'1234'
 
 sshpubkey = (u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGAX3xAeLeaJggwTqMjxNwa6X'
              'HBUAikXPGMzEpVrlLDCZtv00djsFTBi38PkgxBJVkgRWMrcBsr/35lq7P6w8KGI'
@@ -504,6 +505,18 @@ class TestUpdate(XMLRPC_test):
         with raises_exact(errors.ValidationError(
                 name='rename',
                 error=ERRMSG_GROUPUSER_NAME.format('user'))):
+            command()
+
+    def test_rename_setattr_to_numeric_only_username(self, user):
+        """ Try to change name to name with only numeric chars with setattr"""
+        user.ensure_exists()
+        command = user.make_update_command(
+            updates=dict(setattr='uid=%s' % invaliduser3)
+        )
+        with raises_exact(errors.ValidationError(
+            name='uid',
+            error=ERRMSG_GROUPUSER_NAME.format('user'),
+        )):
             command()
 
     def test_add_radius_username(self, user):


### PR DESCRIPTION
This PR was opened automatically because PR #6883 was pushed to master and backport to ipa-4-9 is required.