### PR TITLE
Upgrade: add PKI drop-in file if missing

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1742,6 +1742,10 @@ def upgrade_configuration():
                      os.path.join(paths.USR_SHARE_IPA_DIR,
                                   "ipa-kdc-proxy.conf.template"))
         if ca.is_configured():
+            # Ensure that the drop-in file is present
+            if not os.path.isfile(paths.SYSTEMD_PKI_TOMCAT_IPA_CONF):
+                ca.add_ipa_wait()
+
             # Handle upgrade of AJP connector configuration
             rewrite = ca.secure_ajp_connector()
             if ca.ajp_secret:


### PR DESCRIPTION
### Upgrade: add PKI drop-in file if missing

During the installation of IPA server, the installer adds a drop-in
file in /etc/systemd/system/pki-tomcatd@pki-tomcat.service.d/ipa.conf
that ensures the CA is reachable before the start command returns.
If the file is missing (for instance because the server was installed
with an old version before this drop-in was created), the upgrade
should add the file.

Fixes: https://pagure.io/freeipa/issue/9381

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>

### Integration test: add a test for upgrade and PKI drop-in file

Add an upgrade test with the following scenario:
- remove PKI drop-in file (to simulate an upgrade from an old
version)
- remove caECServerCertWithSCT profile from LDAP
- launch the ipa-server-upgrade command
- check that the upgrade added the file

Related: https://pagure.io/freeipa/issue/9381

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>