### PR TITLE
[Backport][ipa-4-9] Upgrade: add PKI drop-in file if missing

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1737,6 +1737,10 @@ def upgrade_configuration():
                      os.path.join(paths.USR_SHARE_IPA_DIR,
                                   "ipa-kdc-proxy.conf.template"))
         if ca.is_configured():
+            # Ensure that the drop-in file is present
+            if not os.path.isfile(paths.SYSTEMD_PKI_TOMCAT_IPA_CONF):
+                ca.add_ipa_wait()
+
             # Handle upgrade of AJP connector configuration
             rewrite = ca.secure_ajp_connector()
             if ca.ajp_secret:


### PR DESCRIPTION
This PR was opened automatically because PR #6889 was pushed to master and backport to ipa-4-9 is required.