### PR TITLE
[Backport][ipa-4-9] Differentiate location meaning between host and server

### DIFF
--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -481,7 +481,7 @@ class host(LDAPObject):
         Str('nshostlocation?',
             cli_name='location',
             label=_('Location'),
-            doc=_('Host location (e.g. "Lab 2")'),
+            doc=_('Host physical location hint (e.g. "Lab 2")'),
         ),
         Str('nshardwareplatform?',
             cli_name='platform',

--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -130,7 +130,7 @@ class server(LDAPObject):
             'ipalocation_location?',
             cli_name='location',
             label=_('Location'),
-            doc=_('Server location'),
+            doc=_('Server DNS location'),
             only_relative=True,
             flags={'no_search'},
         ),


### PR DESCRIPTION
This PR was opened automatically because PR #6840 was pushed to master and backport to ipa-4-9 is required.