### PR TITLE
ipatests: enable firewall rule for http service on acme client

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -10,6 +10,7 @@ import pytest
 
 from ipalib.constants import IPA_CA_RECORD
 from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_ipa.integration.firewall import Firewall
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_caless import CALessBase, ipa_certs_cleanup
 from ipatests.test_integration.test_random_serial_numbers import (
@@ -84,6 +85,9 @@ def prepare_acme_client(master, client):
     # cache the acme service uri
     acme_host = f'{IPA_CA_RECORD}.{master.domain.name}'
     acme_server = f'https://{acme_host}/acme/directory'
+
+    # enable firewall rule on client
+    Firewall(client).enable_services(["http", "https"])
 
     # install acme client packages
     if not skip_certbot_tests:


### PR DESCRIPTION
when system hardning done i.e in case of STIG, sometimes http challanges
can't be validated by CA if port 80 is not open. This fix enable it to facilitate
the communication.

Signed-off-by: Mohammad Rizwan <myusuf@redhat.com>