### PR TITLE
Fix memory leak in the OTP last token plugin

### DIFF
--- a/daemons/ipa-slapi-plugins/libotp/otp_token.c
+++ b/daemons/ipa-slapi-plugins/libotp/otp_token.c
@@ -398,6 +398,7 @@ static struct otp_token **find(const struct otp_config *cfg, const char *user_dn
     }
 
 error:
+    slapi_free_search_results_internal(pb);
     slapi_pblock_destroy(pb);
     return tokens;
 }


### PR DESCRIPTION
Three memory leaks are addressed:

1. String values retrieved from the pblock need to be manually freed.

2. The list of objectclasses retreived from the pblock need to be freed.

3. Internal search results need to be freed.

Fixes: https://pagure.io/freeipa/issue/9403