### PR TITLE
tests: fix backup-restore scenario with replica

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -602,6 +602,12 @@ class TestBackupAndRestoreWithReplica(IntegrationTest):
             tasks.user_add(self.replica1, 'test2_replica')
 
             # simulate master crash
+            # the replica is stopped to make sure master uninstallation
+            # does not delete any entry on the replica. In case of a
+            # real master crash there would not be any communication between
+            # master and replica
+            self.replica1.run_command(['ipactl', 'stop'])
+
             self.master.run_command(['ipactl', 'stop'])
             tasks.uninstall_master(self.master, clean=False)
 
@@ -612,6 +618,7 @@ class TestBackupAndRestoreWithReplica(IntegrationTest):
             self.master.run_command([
                 "systemctl", "disable", "oddjobd"
             ])
+            self.replica1.run_command(['ipactl', 'start'])
 
             self.master.run_command(['ipa-restore', '-U', backup_path])
 


### PR DESCRIPTION
The test TestBackupAndRestoreWithReplica is simulating a
master crash in order to check the behavior after ipa-restore.

Since commit https://github.com/freeipa/freeipa/commit/67a33e5a305c7510fb182f84e46f304043f6ab37, the uninstaller restarts the services in
order to unregister the server from PKI security domain. An
indirect consequence is that master/replica communication is re-
established and operations removing entries (done by the uninstaller)
are replicated to the replica.
This means that the scenario does not really simulate a server crash.

To make sure that no replication happens during this "crash", stop
the replica first, then uninstall the master, and finally restart
the replica before calling the ipa-restore command on the master.

Fixes: https://pagure.io/freeipa/issue/9404

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>