### PR TITLE
Remove all references to deleted indirect map from parent map

### DIFF
--- a/ipaserver/plugins/automount.py
+++ b/ipaserver/plugins/automount.py
@@ -412,7 +412,7 @@ class automountmap_del(LDAPDelete):
         # delete optional parental connection (direct maps may not have this)
         try:
             entry_attrs = ldap.find_entry_by_attr(
-                'automountinformation', keys[0], 'automount',
+                'automountinformation', keys[1], 'automount',
                 base_dn=DN(self.obj.container_dn, api.env.basedn)
             )
             ldap.delete_entry(entry_attrs)

--- a/ipatests/test_xmlrpc/test_automount_plugin.py
+++ b/ipatests/test_xmlrpc/test_automount_plugin.py
@@ -479,7 +479,32 @@ class test_automount_indirect(AutomountTest):
         with pytest.raises(errors.NotFound):
             api.Command['automountmap_show'](self.locname, self.mapname)
 
-    def test_5_automountlocation_del(self):
+    def test_5_automountmap_add_indirect(self):
+        """
+        Add back the indirect map
+        """
+        res = api.Command['automountmap_add_indirect'](
+            self.locname, self.mapname, **self.map_kw)['result']
+        assert res
+        assert_attr_equal(res, 'automountmapname', self.mapname)
+
+    def test_6_automountmap_del(self):
+        """
+        Remove the indirect map without removing the key first.
+        """
+        res = api.Command['automountmap_del'](
+            self.locname, self.mapname)['result']
+        assert res
+        assert not res['failed']
+
+        # Verify that it is gone
+        with pytest.raises(errors.NotFound):
+            api.Command['automountmap_show'](self.locname, self.mapname)
+
+        # automountlocation-tofiles should succeed if the map was removed
+        api.Command['automountlocation_tofiles'](self.locname)
+
+    def test_7_automountlocation_del(self):
         """
         Remove the location.
         """


### PR DESCRIPTION
An attempt to do this was already coded but the wrong
argument was used. It was passing in the location name and
not the map name so the map wouldn't be completely removed.

Include a test to verify that the map is gone after removing
it by calling automountlocation-tofiles which will fail if the
map wasn't properly removed.

Fixes: https://pagure.io/freeipa/issue/9397

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
