### PR TITLE
[Backport][ipa-4-9] OTP: fix data type to avoid endianness issue

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -1433,7 +1433,7 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
     Slapi_DN *target_sdn = NULL;
     Slapi_DN *sdn = NULL;
     const char *dn = NULL;
-    int method = 0;
+    ber_tag_t method = 0;
     bool syncreq;
     bool otpreq;
     int ret = 0;
@@ -1454,8 +1454,10 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
     }
 
     /* We're only interested in simple authentication. */
-    if (method != LDAP_AUTH_SIMPLE || credentials->bv_len == 0)
+    if (method != LDAP_AUTH_SIMPLE || credentials->bv_len == 0) {
+        LOG("Not handled (not simple bind or NULL dn/credentials)\n");
         return 0;
+    }
 
     /* Retrieve the user's entry. */
     sdn = slapi_sdn_dup(target_sdn);


### PR DESCRIPTION
This PR was opened automatically because PR #6898 was pushed to master and backport to ipa-4-9 is required.