### PR TITLE
Use ssl.match_hostname from urllib3 as it was removed from Python 3.12

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -565,11 +565,11 @@ Requires: python3-pyasn1 >= 0.3.2-2
 Requires: python3-sssdconfig >= %{sssd_version}
 Requires: python3-psutil
 Requires: rpm-libs
-# Indirect dependency: use newer urllib3 with TLS 1.3 PHA support
 %if 0%{?rhel}
 Requires: python3-urllib3 >= 1.24.2-3
 %else
-Requires: python3-urllib3 >= 1.25.7
+# For urllib3.util.ssl_match_hostname
+Requires: python3-urllib3 >= 1.25.8
 %endif
 
 %description -n python3-ipaserver
@@ -895,6 +895,12 @@ Requires: python3-yubico >= 1.3.2-7
 Requires: platform-python-setuptools
 %else
 Requires: python3-setuptools
+%endif
+%if 0%{?rhel}
+Requires: python3-urllib3 >= 1.24.2-3
+%else
+# For urllib3.util.ssl_match_hostname
+Requires: python3-urllib3 >= 1.25.8
 %endif
 
 %description -n python3-ipalib

--- a/ipalib/setup.py
+++ b/ipalib/setup.py
@@ -42,6 +42,7 @@ if __name__ == '__main__':
             "pyasn1",
             "pyasn1-modules",
             "six",
+            "urllib3",
         ],
         extras_require={
             "install": ["dbus-python"],  # for certmonger and resolve1

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -30,7 +30,6 @@ import dbus
 import os
 import re
 import shutil
-import ssl
 import sys
 import syslog
 import time
@@ -2378,7 +2377,7 @@ def check_ipa_ca_san(cert):
 
     try:
         cert.match_hostname(expect)
-    except ssl.CertificateError:
+    except x509.ssl_match_hostname.CertificateError:
         raise errors.ValidationError(
             name='certificate',
             error='Does not have a \'{}\' SAN'.format(expect)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -12,7 +12,6 @@ import os
 import glob
 import shutil
 import fileinput
-import ssl
 import stat
 import sys
 import tempfile
@@ -717,7 +716,7 @@ def http_certificate_ensure_ipa_ca_dnsname(http):
 
     try:
         cert.match_hostname(expect)
-    except ssl.CertificateError:
+    except x509.ssl_match_hostname.CertificateError:
         if certs.is_ipa_issued_cert(api, cert):
             request_id = certmonger.get_request_id(
                 {'cert-file': paths.HTTPD_CERT_FILE})


### PR DESCRIPTION
See https://pagure.io/freeipa/issue/9409
and https://github.com/python/cpython/pull/94224#issuecomment-1621097418