### PR TITLE
User plugin: improve error related to non existing idp

### DIFF
--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -755,7 +755,11 @@ class baseuser_mod(LDAPUpdate):
                     if 'ipaidpuser' not in obj_classes:
                         entry_attrs['objectclass'].append('ipaidpuser')
 
-                    answer = self.api.Object['idp'].get_dn_if_exists(cl)
+                    try:
+                        answer = self.api.Object['idp'].get_dn_if_exists(cl)
+                    except errors.NotFound:
+                        reason = "External IdP configuration {} not found"
+                        raise errors.NotFound(reason=_(reason).format(cl))
                     entry_attrs['ipaidpconfiglink'] = answer
 
             # Note: we could have used the method add_missing_object_class

--- a/ipaserver/plugins/stageuser.py
+++ b/ipaserver/plugins/stageuser.py
@@ -406,7 +406,11 @@ class stageuser_add(baseuser_add):
                 if 'ipaidpuser' not in entry_attrs['objectclass']:
                     entry_attrs['objectclass'].append('ipaidpuser')
 
-                answer = self.api.Object['idp'].get_dn_if_exists(cl)
+                try:
+                    answer = self.api.Object['idp'].get_dn_if_exists(cl)
+                except errors.NotFound:
+                    reason = "External IdP configuration {} not found"
+                    raise errors.NotFound(reason=_(reason).format(cl))
                 entry_attrs['ipaidpconfiglink'] = answer
 
         self.pre_common_callback(ldap, dn, entry_attrs, attrs_list, *keys,

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -649,7 +649,11 @@ class user_add(baseuser_add):
             if 'ipaidpuser' not in entry_attrs['objectclass']:
                 entry_attrs['objectclass'].append('ipaidpuser')
 
-            answer = self.api.Object['idp'].get_dn_if_exists(rcl)
+            try:
+                answer = self.api.Object['idp'].get_dn_if_exists(rcl)
+            except errors.NotFound:
+                reason = "External IdP configuration {} not found"
+                raise errors.NotFound(reason=_(reason).format(rcl))
             entry_attrs['ipaidpconfiglink'] = answer
 
         self.pre_common_callback(ldap, dn, entry_attrs, attrs_list, *keys,

--- a/ipatests/test_xmlrpc/test_stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/test_stageuser_plugin.py
@@ -39,6 +39,8 @@ gid = u'456'
 invalidrealm1 = u'suser1@NOTFOUND.ORG'
 invalidrealm2 = u'suser1@BAD@NOTFOUND.ORG'
 
+nonexistentidp = 'IdPDoesNotExist'
+
 invaliduser1 = u'+tuser1'
 invaliduser2 = u'tuser1234567890123456789012345678901234567890'
 invaliduser3 = u'1234'
@@ -431,6 +433,15 @@ class TestCreateInvalidAttributes(XMLRPC_test):
                     invalidrealm2))):
             command()
 
+    def test_create_invalid_idp(self, stageduser):
+        stageduser.ensure_missing()
+        command = stageduser.make_create_command(
+            options={u'ipaidpconfiglink': nonexistentidp})
+        with raises_exact(errors.NotFound(
+                reason="External IdP configuration {} not found".format(
+                    nonexistentidp))):
+            command()
+
 
 @pytest.mark.tier1
 class TestUpdateInvalidAttributes(XMLRPC_test):
@@ -464,6 +475,15 @@ class TestUpdateInvalidAttributes(XMLRPC_test):
             updates={u'gidnumber': u'-123'})
         with raises_exact(errors.ValidationError(
                 message=u'invalid \'gidnumber\': must be at least 1')):
+            command()
+
+    def test_update_invalididp(self, stageduser):
+        stageduser.ensure_exists()
+        command = stageduser.make_update_command(
+            updates={u'ipaidpconfiglink': nonexistentidp})
+        with raises_exact(errors.NotFound(
+                reason="External IdP configuration {} not found".format(
+                    nonexistentidp))):
             command()
 
 


### PR DESCRIPTION
### User plugin: improve error related to non existing idp

The user and stageuser commands return the following error
when the user is created/updated with a non existing idp:
$ ipa user-add testuser --first test --last user --idp dummy
ipa: ERROR: no such entry

The error is not descriptive enough and has been modified to
display instead:
$ ipa user-add testuser --first test --last user --idp dummy
ipa: ERROR: External IdP configuration dummy not found

Fixes: https://pagure.io/freeipa/issue/9416

### xmlrpc tests: add a test for user plugin with non-existing idp

Add new tests checking the error returned for
ipa user-add ... --idp nonexistingidp
ipa user-mod ... --idp nonexistingidp
ipa stageuser-add ... --idp nonexistingidp
ipa stageuser-mod ... --idp nonexistingidp

The expected error message is:
ipa: ERROR: External IdP configuration nonexistingidp not found

Related: https://pagure.io/freeipa/issue/9416

