### PR TITLE
Fix typo in "Subordinate ID Selfservice User" role

### DIFF
--- a/install/updates/73-subid.update
+++ b/install/updates/73-subid.update
@@ -16,7 +16,8 @@ default:objectClass: groupofnames
 default:objectClass: nestedgroup
 default:objectClass: top
 default:cn: Subordinate ID Selfservice User
-default:description: User that can self-request subordiante ids
+default:description: User that can self-request subordinate ids
+replace:description: User that can self-request subordiante ids::User that can self-request subordinate ids
 # default: member: cn=ipausers,cn=groups,cn=accounts,$SUFFIX
 
 dn: cn=Subordinate ID Selfservice Users,cn=privileges,cn=pbac,$SUFFIX


### PR DESCRIPTION
The description of "Subordinate ID Selfservice User" role had 'subordiante' instead of 'subordinate'.

Related: https://pagure.io/freeipa/issue/9418