### PR TITLE
[Backport][ipa-4-9] User plugin: improve error related to non existing idp

### DIFF
--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -708,7 +708,11 @@ class baseuser_mod(LDAPUpdate):
                     if 'ipaidpuser' not in obj_classes:
                         entry_attrs['objectclass'].append('ipaidpuser')
 
-                    answer = self.api.Object['idp'].get_dn_if_exists(cl)
+                    try:
+                        answer = self.api.Object['idp'].get_dn_if_exists(cl)
+                    except errors.NotFound:
+                        reason = "External IdP configuration {} not found"
+                        raise errors.NotFound(reason=_(reason).format(cl))
                     entry_attrs['ipaidpconfiglink'] = answer
 
             # Note: we could have used the method add_missing_object_class

--- a/ipaserver/plugins/stageuser.py
+++ b/ipaserver/plugins/stageuser.py
@@ -404,7 +404,11 @@ class stageuser_add(baseuser_add):
                 if 'ipaidpuser' not in entry_attrs['objectclass']:
                     entry_attrs['objectclass'].append('ipaidpuser')
 
-                answer = self.api.Object['idp'].get_dn_if_exists(cl)
+                try:
+                    answer = self.api.Object['idp'].get_dn_if_exists(cl)
+                except errors.NotFound:
+                    reason = "External IdP configuration {} not found"
+                    raise errors.NotFound(reason=_(reason).format(cl))
                 entry_attrs['ipaidpconfiglink'] = answer
 
         self.pre_common_callback(ldap, dn, entry_attrs, attrs_list, *keys,

--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -638,7 +638,11 @@ class user_add(baseuser_add):
             if 'ipaidpuser' not in entry_attrs['objectclass']:
                 entry_attrs['objectclass'].append('ipaidpuser')
 
-            answer = self.api.Object['idp'].get_dn_if_exists(rcl)
+            try:
+                answer = self.api.Object['idp'].get_dn_if_exists(rcl)
+            except errors.NotFound:
+                reason = "External IdP configuration {} not found"
+                raise errors.NotFound(reason=_(reason).format(rcl))
             entry_attrs['ipaidpconfiglink'] = answer
 
         self.pre_common_callback(ldap, dn, entry_attrs, attrs_list, *keys,

--- a/ipatests/test_xmlrpc/test_stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/test_stageuser_plugin.py
@@ -39,6 +39,8 @@ gid = u'456'
 invalidrealm1 = u'suser1@NOTFOUND.ORG'
 invalidrealm2 = u'suser1@BAD@NOTFOUND.ORG'
 
+nonexistentidp = 'IdPDoesNotExist'
+
 invaliduser1 = u'+tuser1'
 invaliduser2 = u'tuser1234567890123456789012345678901234567890'
 invaliduser3 = u'1234'
@@ -431,6 +433,15 @@ class TestCreateInvalidAttributes(XMLRPC_test):
                     invalidrealm2))):
             command()
 
+    def test_create_invalid_idp(self, stageduser):
+        stageduser.ensure_missing()
+        command = stageduser.make_create_command(
+            options={u'ipaidpconfiglink': nonexistentidp})
+        with raises_exact(errors.NotFound(
+                reason="External IdP configuration {} not found".format(
+                    nonexistentidp))):
+            command()
+
 
 @pytest.mark.tier1
 class TestUpdateInvalidAttributes(XMLRPC_test):
@@ -464,6 +475,15 @@ class TestUpdateInvalidAttributes(XMLRPC_test):
             updates={u'gidnumber': u'-123'})
         with raises_exact(errors.ValidationError(
                 message=u'invalid \'gidnumber\': must be at least 1')):
+            command()
+
+    def test_update_invalididp(self, stageduser):
+        stageduser.ensure_exists()
+        command = stageduser.make_update_command(
+            updates={u'ipaidpconfiglink': nonexistentidp})
+        with raises_exact(errors.NotFound(
+                reason="External IdP configuration {} not found".format(
+                    nonexistentidp))):
             command()
 
 

--- a/ipatests/test_xmlrpc/test_user_plugin.py
+++ b/ipatests/test_xmlrpc/test_user_plugin.py
@@ -86,6 +86,8 @@ expired_expiration_string = "1991-12-07T19:54:13Z"
 # Date in ISO format (2013-12-10T12:00:00)
 isodate_re = re.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$')
 
+nonexistentidp = 'IdPDoesNotExist'
+
 
 @pytest.fixture(scope='class')
 def user_min(request, xmlrpc_setup):
@@ -542,6 +544,18 @@ class TestUpdate(XMLRPC_test):
         command()
         user.delete()
 
+    def test_update_invalid_idp(self, user):
+        """ Test user-mod --idp with a non-existent idp """
+        user.ensure_exists()
+        command = user.make_update_command(
+            updates=dict(ipaidpconfiglink=nonexistentidp)
+        )
+        with raises_exact(errors.NotFound(
+            reason="External IdP configuration {} not found".format(
+                nonexistentidp)
+        )):
+            command()
+
 
 @pytest.mark.tier1
 class TestCreate(XMLRPC_test):
@@ -769,6 +783,17 @@ class TestCreate(XMLRPC_test):
         result = command()
         user_radius.check_create(result)
         user_radius.delete()
+
+    def test_create_with_invalididp(self):
+        testuser = UserTracker(
+            name='idpuser', givenname='idp', sn='user',
+            ipaidpconfiglink=nonexistentidp
+        )
+        with raises_exact(errors.NotFound(
+            reason="External IdP configuration {} not found".format(
+                nonexistentidp)
+        )):
+            testuser.create()
 
 
 @pytest.mark.tier1


### PR DESCRIPTION
This PR was opened automatically because PR #6916 was pushed to master and backport to ipa-4-9 is required.