### PR TITLE
Replace service certificates with ipa-server-certinstall

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipaserver/install/ipa_server_certinstall.py
+++ b/ipaserver/install/ipa_server_certinstall.py
@@ -32,7 +32,7 @@ from ipapython.dn import DN
 from ipapython import ipaldap
 from ipalib import api, errors
 from ipaserver.install import certs, dsinstance, installutils, krbinstance
-from ipaserver.install import cainstance
+from ipaserver.install import cainstance, httpinstance
 
 
 class ServerCertInstall(admintool.AdminTool):
@@ -137,6 +137,8 @@ class ServerCertInstall(admintool.AdminTool):
         api.Backend.ldap2.disconnect()
 
     def install_dirsrv_cert(self):
+        from ipaserver.plugins.service import revoke_certs
+
         serverid = ipaldap.realm_to_serverid(api.env.realm)
         dirname = dsinstance.config_dirname(serverid)
 
@@ -146,21 +148,35 @@ class ServerCertInstall(admintool.AdminTool):
                                ['nssslpersonalityssl'])
         old_cert = entry.single_value['nssslpersonalityssl']
 
-        server_cert = self.import_cert(dirname, self.options.pin,
-                                       old_cert, 'ldap/%s' % api.env.host,
-                                       'restart_dirsrv %s' % serverid)
+        nickname, cert = self.import_cert(dirname, self.options.pin,
+                                          old_cert, 'ldap/%s' % api.env.host,
+                                          'restart_dirsrv %s' % serverid)
 
-        entry['nssslpersonalityssl'] = [server_cert]
+        entry['nssslpersonalityssl'] = [nickname]
         try:
             conn.update_entry(entry)
         except errors.EmptyModlist:
             pass
+
+        ds = dsinstance.DsInstance()
+        ds.suffix = api.env.basedn
+        ds.realm = api.env.realm
+        ds.fqdn = api.env.host
+        ds.service_prefix = 'ldap'
+        ds.cert = cert
+        name = f'{ds.service_prefix}/{ds.fqdn}'
+        oldcerts = api.Command.cert_find(service=name)['result']
+        ds.add_cert_to_service(append=False)
+
+        revoke_certs(oldcerts)
 
     def replace_http_cert(self):
         """
         Replace the current HTTP cert-key pair with another one
         from a PKCS#12 file
         """
+        from ipaserver.plugins.service import revoke_certs
+
         # pass in `host_name` to perform
         # `NSSDatabase.verify_server_cert_validity()``
         cert, key, ca_cert = self.load_pkcs12(
@@ -182,6 +198,18 @@ class ServerCertInstall(admintool.AdminTool):
             certmonger.add_principal(
                 req_id, 'HTTP/{host}'.format(host=api.env.host))
             certmonger.add_subject(req_id, str(DN(cert.subject)))
+
+        http = httpinstance.HTTPInstance()
+        http.suffix = api.env.basedn
+        http.realm = api.env.realm
+        http.fqdn = api.env.host
+        http.service_prefix = 'HTTP'
+        http.cert = cert
+        name = f'{http.service_prefix}/{http.fqdn}'
+        oldcerts = api.Command.cert_find(service=name)['result']
+        http.add_cert_to_service(append=False)
+
+        revoke_certs(oldcerts)
 
     def replace_kdc_cert(self):
         # pass in `realm` to perform `NSSDatabase.verify_kdc_cert_validity()`
@@ -314,7 +342,8 @@ class ServerCertInstall(admintool.AdminTool):
             cdb.import_pkcs12(pkcs12_file.name, pin)
             news = cdb.find_server_certs()
             server_certs = [item for item in news if item not in prevs]
-            server_cert = server_certs[0][0]
+            nickname = server_certs[0][0]
+            cert = cdb.get_cert_from_db(nickname)
 
             if ca_enabled:
                 # Start tracking only if the cert was issued by IPA CA
@@ -323,11 +352,11 @@ class ServerCertInstall(admintool.AdminTool):
                     get_ca_nickname(api.env.realm))
                 # And compare with the CA which signed this certificate
                 if ca_cert == ipa_ca_cert:
-                    cdb.track_server_cert(server_cert,
+                    cdb.track_server_cert(nickname,
                                           principal,
                                           cdb.passwd_fname,
                                           command)
         except RuntimeError as e:
             raise admintool.ScriptError(str(e))
 
-        return server_cert
+        return nickname, cert

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -505,7 +505,7 @@ class Service:
 
         return dn
 
-    def add_cert_to_service(self):
+    def add_cert_to_service(self, append=True):
         """
         Add a certificate to a service
 
@@ -515,7 +515,10 @@ class Service:
             raise ValueError("{} has no cert".format(self.service_name))
         dn = self.get_principal_dn()
         entry = api.Backend.ldap2.get_entry(dn)
-        entry.setdefault('userCertificate', []).append(self.cert)
+        if append:
+            entry.setdefault('userCertificate', []).append(self.cert)
+        else:
+            entry['userCertificate'] = self.cert
         try:
             api.Backend.ldap2.update_entry(entry)
         except Exception as e:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -76,7 +76,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_caless.py::TestCertInstall
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 5400
+        topology: *master_1repl

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -1546,6 +1546,62 @@ class TestCertInstall(CALessBase):
         result = self.master.run_command(['kinit', '-n'])
         assert result.returncode == 0
 
+    # The previous install will be lost with this test
+    def test_services_are_updated(self):
+        "Test that IPA service entries get updated & old certs revoked"
+
+        tasks.uninstall_master(self.master, clean=False)
+        ipa_certs_cleanup(self.master)
+        tasks.install_master(self.master, setup_dns=False)
+
+        test_dir = self.master.config.test_dir
+        for filename in ('ca1.crt', 'ca1/server.crt'):
+            self.master.transport.put_file(
+                os.path.join(self.cert_dir, filename),
+                os.path.join(test_dir, os.path.basename(filename))
+            )
+        result = self.master.run_command(
+            ['ipa-cacert-manage', 'install',
+             os.path.join(self.master.config.test_dir,'ca1.crt')]
+        )
+        assert result.returncode == 0
+        result = self.master.run_command(['ipa-certupdate'])
+        assert result.returncode == 0
+
+        result = self.master.run_command([
+            'openssl', 'x509', '-serial', '-noout', '-in',
+            os.path.join(self.master.config.test_dir, 'server.crt')
+        ])
+        new_serial = str(int(result.stdout_text.split('=')[1].strip()))
+
+        serials = {}
+        for service in ('HTTP', 'ldap',):
+            result = self.master.run_command(
+                'ipa service-show %s/%s --raw | grep serial_number:' %
+                (service, self.master.hostname)
+            )
+            serial_number = result.stdout_text.split(':')[1].strip()
+            serials[service] = serial_number
+
+        # import pdb; pdb.set_trace()
+        for service in ('w', 'd',):
+            result = self.certinstall(service, 'ca1/server')
+            assert result.returncode == 0
+
+        for service in ('HTTP', 'ldap',):
+            result = self.master.run_command(
+                'ipa service-show %s/%s --raw | grep serial_number:' %
+                (service, self.master.hostname)
+            )
+            serial_number = result.stdout_text.split(':')[1].strip()
+            assert serial_number == new_serial
+
+            result = self.master.run_command(
+                ['ipa', 'cert-show', serials[service], '--raw']
+            )
+            assert 'revocation_reason:' in result.stdout_text
+
+
 
 def verify_kdc_cert_perms(host):
     """Verify that the KDC cert pem file has 0644 perms"""


### PR DESCRIPTION
Replace service certificates with ipa-server-certinstall

Also revoke existing IPA-issued certificates.

ipa-server-certinstall does not update the HTTP or ldap service
entries when the the new certificates. This is confusing when
looking at the service entries because it looks like the new
certificates are not active, when they are.

Fixes: https://pagure.io/freeipa/issue/9417
