### PR TITLE
[Backport][ipa-4-10] component: mail_from_realname config setting added to IPA-EPN

### DIFF
--- a/client/man/epn.conf.5
+++ b/client/man/epn.conf.5
@@ -86,6 +86,9 @@ Time to wait, in milliseconds, between each e-mail sent to try to avoid overload
 Specifies the From: e-mail address value in the e-mails sent. The default is noreply@ipadefaultemaildomain. This value can be found by running
 .I ipa config-show
 .TP
+.B mail_from_name <name>
+Specifies the From: name value in the e-mails sent. The default is IPA-EPN.
+.TP
 .B notify_ttls <list of days>
 This is the list of days before a password expiration when ipa-epn should notify a user that their password will soon require a reset. If this value is not specified then the default list will be used: 28, 14, 7, 3, 1.
 .TP

--- a/client/share/epn.conf
+++ b/client/share/epn.conf
@@ -60,6 +60,10 @@ smtp_delay = 0
 # This value can be found by running ipa config-show.
 # mail_from =
 
+# Specifies the From: name value in the e-mails-sent.
+# The default when unset is IPA-EPN.
+# mail_from_name =
+
 # The list of days before a password expiration when ipa-epn should notify
 # a user that their password will soon require a reset.
 notify_ttls = 28, 14, 7, 3, 1

--- a/ipaclient/install/ipa_epn.py
+++ b/ipaclient/install/ipa_epn.py
@@ -64,6 +64,7 @@ EPN_CONFIG = {
     "smtp_admin": "root@localhost",
     "smtp_delay": None,
     "mail_from": None,
+    "mail_from_name": "IPA-EPN",
     "notify_ttls": "28,14,7,3,1",
     "msg_charset": "utf8",
     "msg_subtype": "plain",
@@ -565,6 +566,7 @@ class EPN(admintool.AdminTool):
                     mail_body=body,
                     subscribers=ast.literal_eval(entry["mail"]),
                     mail_from=mail_from,
+                    mail_from_name=api.env.mail_from_name,
                 )
                 now = datetime.utcnow()
                 expdate = datetime.strptime(
@@ -799,12 +801,13 @@ class MailUserAgent:
 
     def send_message(
         self, mail_subject=None, mail_body=None, subscribers=None,
-        mail_from=None
+        mail_from=None, mail_from_name=None
     ):
         """Given mail_subject, mail_body, and subscribers, composes
            the message and sends it.
         """
-        if None in [mail_subject, mail_body, subscribers, mail_from]:
+        if None in [mail_subject, mail_body, subscribers,
+                    mail_from, mail_from_name]:
             logger.error("IPA-EPN: Tried to send an empty message.")
             return False
         self._compose_message(
@@ -812,6 +815,7 @@ class MailUserAgent:
             mail_body=mail_body,
             subscribers=subscribers,
             mail_from=mail_from,
+            mail_from_name=mail_from_name,
         )
         self._mta_client.send_message(
             message_str=self._message_str, subscribers=subscribers
@@ -819,7 +823,8 @@ class MailUserAgent:
         return True
 
     def _compose_message(
-        self, mail_subject, mail_body, subscribers, mail_from
+        self, mail_subject, mail_body, subscribers,
+        mail_from, mail_from_name
     ):
         """The composer creates a MIME multipart message.
         """
@@ -829,7 +834,7 @@ class MailUserAgent:
         self._subscribers = subscribers
 
         self._msg = MIMEMultipart(_charset=self._charset)
-        self._msg["From"] = formataddr(("IPA-EPN", mail_from))
+        self._msg["From"] = formataddr((mail_from_name, mail_from))
         self._msg["To"] = ", ".join(self._subscribers)
         self._msg["Date"] = formatdate(localtime=True)
         self._msg["Subject"] = Header(self._subject, self._charset)

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -512,6 +512,7 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.smtp_admin = ""
     api.env.smtp_delay = None
     api.env.mail_from = None
+    api.env.mail_from_name = None
     api.env.notify_ttls = ""
     api.env.msg_charset = ""
     api.env.msg_subtype = ""


### PR DESCRIPTION
This PR was opened automatically because PR #6913 was pushed to master and backport to ipa-4-10 is required.