### PR TITLE
ipatests: update expected cksum for epn.conf

### DIFF
--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -358,7 +358,7 @@ class TestEPN(IntegrationTest):
         assert epn_conf in cmd1.stdout_text
         assert epn_template in cmd1.stdout_text
         cmd2 = self.master.run_command(["sha256sum", epn_conf])
-        ck = "5e56a0f8010ff4f399b206c9e45004823bc05bf6577b34b3e701e4a2935df989"
+        ck = "06a73f15562686516c984dd9fe61689c5268ff1c5a13e69f8b347afef41b3277"
         assert cmd2.stdout_text.find(ck) == 0
 
     def test_EPN_connection_refused(self):


### PR DESCRIPTION
The test test_epn.py::TestEPN::test_EPN_config_file ensures that
/etc/ipa/epn.conf is installed and compares its checksum with an
expected value.
Commit fcad9c9 has changed the content of the file and the cksum
must be updated to reflect the new content.

Fixes: https://pagure.io/freeipa/issue/9419

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>
