### PR TITLE
[Backport][ipa-4-10] ipatests: update expected cksum for epn.conf

### DIFF
--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -358,7 +358,7 @@ class TestEPN(IntegrationTest):
         assert epn_conf in cmd1.stdout_text
         assert epn_template in cmd1.stdout_text
         cmd2 = self.master.run_command(["sha256sum", epn_conf])
-        ck = "5e56a0f8010ff4f399b206c9e45004823bc05bf6577b34b3e701e4a2935df989"
+        ck = "06a73f15562686516c984dd9fe61689c5268ff1c5a13e69f8b347afef41b3277"
         assert cmd2.stdout_text.find(ck) == 0
 
     def test_EPN_connection_refused(self):


### PR DESCRIPTION
This PR was opened automatically because PR #6925 was pushed to master and backport to ipa-4-10 is required.