### PR TITLE
idp: when adding an IdP allow to override IdP options

### DIFF
--- a/ipaserver/plugins/idp.py
+++ b/ipaserver/plugins/idp.py
@@ -350,6 +350,9 @@ class idp_add(LDAPCreate):
                                 name=self.options[s].cli_name,
                                 error=_('value is missing'))
                     points[k] = template_str(v, elements)
+                elif k in elements:
+                    points[k] = elements[k]
+
             entry_attrs.update(points)
 
     def get_options(self):


### PR DESCRIPTION
Use of 'ipa idp-add --provider' was supposed to allow override scope and other IdP options. The defaults are provided by the IdP template and were actually not overridden. Fix this.

Fixes: https://pagure.io/freeipa/issue/9421