### PR TITLE
[Backport][ipa-4-10] Fix memory leak in the OTP last token plugin

### DIFF
--- a/daemons/ipa-slapi-plugins/libotp/otp_token.c
+++ b/daemons/ipa-slapi-plugins/libotp/otp_token.c
@@ -398,6 +398,7 @@ static struct otp_token **find(const struct otp_config *cfg, const char *user_dn
     }
 
 error:
+    slapi_free_search_results_internal(pb);
     slapi_pblock_destroy(pb);
     return tokens;
 }


### PR DESCRIPTION
This PR was opened automatically because PR #6900 was pushed to master and backport to ipa-4-10 is required.