### PR TITLE
[Backport][ipa-4-10] idp: when adding an IdP allow to override IdP options

### DIFF
--- a/ipaserver/plugins/idp.py
+++ b/ipaserver/plugins/idp.py
@@ -350,6 +350,9 @@ class idp_add(LDAPCreate):
                                 name=self.options[s].cli_name,
                                 error=_('value is missing'))
                     points[k] = template_str(v, elements)
+                elif k in elements:
+                    points[k] = elements[k]
+
             entry_attrs.update(points)
 
     def get_options(self):


### PR DESCRIPTION
This PR was opened automatically because PR #6928 was pushed to master and backport to ipa-4-10 is required.