### PR TITLE
ipatests: update expected webui msg for admin deletion

### DIFF
--- a/ipatests/test_webui/test_user.py
+++ b/ipatests/test_webui/test_user.py
@@ -50,8 +50,7 @@ INV_FIRSTNAME = ("invalid 'first': Leading and trailing spaces are "
 FIELD_REQ = 'Required field'
 ERR_INCLUDE = 'may only include letters, numbers, _, -, . and $'
 ERR_MISMATCH = 'Passwords must match'
-ERR_ADMIN_DEL = ('admin cannot be deleted or disabled because it is the last '
-                 'member of group admins')
+ERR_ADMIN_DEL = ('user admin cannot be deleted/modified: privileged user')
 USR_EXIST = 'user with name "{}" already exists'
 ENTRY_EXIST = 'This entry already exists'
 ACTIVE_ERR = 'active user with name "{}" already exists'


### PR DESCRIPTION
The deletion of the admin is now forbidden (even if it is
not the last member of the admins group) and the error
message has changed from "admin cannot be deleted or
disabled because it is the last member of group admins"
to " user admin cannot be deleted/modified: privileged user".

Update the expected message in the webui test.

Related: https://pagure.io/freeipa/issue/8878

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>