### PR TITLE
Remove non-existent default pki_cert_chain_path

### DIFF
--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -94,7 +94,7 @@ pki_group=pkiuser
 pki_user=pkiuser
 pki_existing=False
 
-pki_cert_chain_path=%(pki_instance_configuration_path)s/external_ca_chain.cert
+pki_cert_chain_path=
 pki_cert_chain_nickname=caSigningCert External CA
 
 pki_pkcs12_path=


### PR DESCRIPTION
In the future `pkispawn` will validate all path params so the default value for `pki_cert_chain_path` needs to be removed since it points to a non-existent file. When the param is actually used (e.g. for installing with an external CA) `CAInstance.__spawn_instance()` will configure the param to point to the actual cert chain.

**Note:** This patch does not need to be backported to older IPA versions.