### PR TITLE
Add pki_share_dbuser_dn for CA

### DIFF
--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -130,6 +130,7 @@ pki_audit_signing_nickname=auditSigningCert cert-pki-ca
 pki_audit_signing_subject_dn=cn=CA Audit,%(ipa_subject_base)s
 
 pki_share_db=False
+pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=ipaca
 pki_master_crl_enable=True
 
 pki_default_ocsp_uri=%(ipa_ocsp_uri)s


### PR DESCRIPTION
In the future the default value for `pki_share_dbuser_dn` might change. To ensure that CA and KRA in IPA will use the same database user, the `pki_share_dbuser_dn` needs to be defined for CA to match the same param for KRA.

**Note:** This patch does not need to be backported to older IPA versions.