### PR TITLE
Remove unused subsystem.count

### DIFF
--- a/install/restart_scripts/renew_ca_cert.in
+++ b/install/restart_scripts/renew_ca_cert.in
@@ -115,15 +115,9 @@ def _main():
                     directivesetter.set_directive(
                         cfg_path, 'hierarchy.select', 'Root',
                         quotes=False, separator='=')
-                    directivesetter.set_directive(
-                        cfg_path, 'subsystem.count', '1',
-                        quotes=False, separator='=')
                 else:
                     directivesetter.set_directive(
                         cfg_path, 'hierarchy.select', 'Subordinate',
-                        quotes=False, separator='=')
-                    directivesetter.set_directive(
-                        cfg_path, 'subsystem.count', '0',
                         quotes=False, separator='=')
             else:
                 syslog.syslog(syslog.LOG_NOTICE, "Not updating CS.cfg")


### PR DESCRIPTION
The `subsystem.count` param has actually been removed since PKI 10.10 so it doesn't need to be set in `renew_ca_cert.in`.

**Note:** This patch does not need to be backported to older IPA versions.