### PR TITLE
ipa-epn: include timezone info

### DIFF
--- a/ipaclient/install/ipa_epn.py
+++ b/ipaclient/install/ipa_epn.py
@@ -571,7 +571,7 @@ class EPN(admintool.AdminTool):
                 now = datetime.now(tz=UTC)
                 expdate = datetime.strptime(
                     entry["krbpasswordexpiration"],
-                    '%Y-%m-%d %H:%M:%S')
+                    '%Y-%m-%d %H:%M:%S').replace(tzinfo=UTC)
                 logger.debug(
                     "Notified %s (%s). Password expiring in %d days at %s.",
                     entry["mail"], entry["uid"], (expdate - now).days,

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -799,7 +799,8 @@ class _CrossProcessLock:
                 expire = p.get('lock', 'expire')
                 try:
                     self._expire = datetime.datetime.strptime(
-                        expire, self._DATETIME_FORMAT)
+                        expire, self._DATETIME_FORMAT).replace(
+                        tzinfo=datetime.UTC)
                 except ValueError:
                     raise configparser.Error
         except configparser.Error:

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -128,7 +128,9 @@ class IPACertFix(AdminTool):
 
         ca_subject_dn = ca.lookup_ca_subject(api, subject_base)
 
-        now = datetime.datetime.now() + datetime.timedelta(weeks=2)
+        now = (
+            datetime.datetime.now(tz=datetime.UTC)
+            + datetime.timedelta(weeks=2))
         certs, extra_certs, non_renewed = expired_certs(now)
 
         if not certs and not extra_certs:


### PR DESCRIPTION
ipa-epn is using timezone-aware timestamps for "now"
but converts krbpasswordexpiration attribute into
a naive datetime object that is missing the tzinfo.

It is not possible to substract timezone aware and
naive values. Convert krbpasswordexpiration attribute
into an UTC value before doing the substration.

Related: https://pagure.io/freeipa/issue/9425