### PR TITLE
ipatests: fixture can produce IndexError

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -633,9 +633,13 @@ def issue_and_expire_acme_cert():
         tasks.move_date(host, 'start', '-90days-60minutes')
 
     # restart ipa services as date moved and wait to get things settle
-    time.sleep(10)
-    hosts[0].run_command(['ipactl', 'restart'])
-    time.sleep(10)
+    # if the internal fixture was not called (for instance because the test
+    # was skipped), hosts = [] and hosts[0] would produce an IndexError
+    # exception.
+    if hosts:
+        time.sleep(10)
+        hosts[0].run_command(['ipactl', 'restart'])
+        time.sleep(10)
 
 
 class TestACMERenew(IntegrationTest):


### PR DESCRIPTION
The fixture issue_and_expire_acme_cert returns a function
that fills the hosts array. If the function is not called in
the test (for instance because a test is skipped, as in
TestACMEPrune::test_prune_cert_search_size_limit), hosts = []
and hosts[0] raises an IndexError.

Fix the fixture to check first that hosts is not empty.

Related: https://pagure.io/freeipa/issue/9348
