### PR TITLE
Remove default values for pki_ca_signing_*_path

### DIFF
--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -40,7 +40,7 @@ pki_ca_port=%(pki_security_domain_https_port)s
 
 # nickname and subject are hard-coded
 pki_ca_signing_nickname=caSigningCert cert-pki-ca
-pki_ca_signing_cert_path=%(pki_instance_configuration_path)s/external_ca.cert
+pki_ca_signing_cert_path=
 
 pki_client_admin_cert_p12=%(ipa_admin_cert_p12)s
 pki_client_database_password=
@@ -108,7 +108,7 @@ pki_ca_signing_record_create=True
 pki_ca_signing_serial_number=1
 pki_ca_signing_subject_dn=%(ipa_ca_subject)s
 
-pki_ca_signing_csr_path=/root/ipa.csr
+pki_ca_signing_csr_path=
 
 pki_ca_starting_crl_number=0
 


### PR DESCRIPTION
In the future `pkispawn` will validate all path params so the default values for `pki_ca_signing_csr_path` and
`pki_ca_signing_cert_path` need to be removed since they point to non-existent files. When the params are actually used for installing an external CA, `CAInstance.__spawn_instance()` will initialize them with the correct paths.

**Note:** This patch does not need to be backported to older IPA versions.