### PR TITLE
Installer: activate nss and pam services in sssd.conf

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -969,6 +969,9 @@ def configure_sssd_conf(
         nss_service.set_option('memcache_timeout', 600)
         sssdconfig.save_service(nss_service)
 
+    sssd_enable_service(sssdconfig, 'nss')
+    sssd_enable_service(sssdconfig, 'pam')
+
     domain.set_option('ipa_domain', cli_domain)
     domain.set_option('ipa_hostname', client_hostname)
     if cli_domain.lower() != cli_realm.lower():


### PR DESCRIPTION
If there is already a sssd.conf file before the installer is executed, the nss and pam services may not be enabled by the installer. This happens for instance if the machine is hardened for STIG and sssd.conf does not define services=... in the [sssd] section.

The consequence is that trust cannot be established with an AD domain.

The installer must enable nss and pam services even if there is a pre-existing sssd.conf file.

Fixes: https://pagure.io/freeipa/issue/9427