### PR TITLE
Vault: Migrate to RSA-OAEP

### DIFF
--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -164,3 +164,6 @@ pki_audit_signing_subject_dn=cn=KRA Audit,%(ipa_subject_base)s
 # We will use the dbuser created for the CA.
 pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=ipaca
+
+# KRA padding, set RSA-OAEP in FIPS mode
+pki_use_oaep_rsa_keywrap=%(fips_use_oaep_rsa_keywrap)s

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -1020,7 +1020,9 @@ class PKIIniLoader:
             # for softhsm2 testing
             softhsm2_so=paths.LIBSOFTHSM2_SO,
             # Configure a more secure AJP password by default
-            ipa_ajp_secret=ipautil.ipa_generate_password(special=None)
+            ipa_ajp_secret=ipautil.ipa_generate_password(special=None),
+            # in FIPS mode use RSA-OAEP wrapping padding algo as default
+            fips_use_oaep_rsa_keywrap=tasks.is_fips_enabled()
         )
 
     @classmethod

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -284,6 +284,18 @@ class KRAInstance(DogtagInstance):
 
         # A restart is required
 
+    def enable_oaep_wrap_algo(self):
+        """
+        Enable KRA OAEP key wrap algorithm
+        """
+        with installutils.stopped_service('pki-tomcatd', 'pki-tomcat'):
+            directivesetter.set_directive(
+                self.config,
+                'keyWrap.useOAEP',
+                'true', quotes=False, separator='=')
+
+        # A restart is required
+
     def update_cert_config(self, nickname, cert):
         """
         When renewing a KRA subsystem certificate the configuration file

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1794,6 +1794,18 @@ def upgrade_configuration():
             else:
                 logger.info('ephemeralRequest is already enabled')
 
+            if tasks.is_fips_enabled():
+                logger.info('[Ensuring KRA OAEP wrap algo is enabled in FIPS]')
+                value = directivesetter.get_directive(
+                    paths.KRA_CS_CFG_PATH,
+                    'keyWrap.useOAEP',
+                    separator='=')
+                if value is None or value.lower() != 'true':
+                    logger.info('Use the OAEP key wrap algo')
+                    kra.enable_oaep_wrap_algo()
+                else:
+                    logger.info('OAEP key wrap algo is already enabled')
+
     # several upgrade steps require running CA.  If CA is configured,
     # always run ca.start() because we need to wait until CA is really ready
     # by checking status using http


### PR DESCRIPTION
PKCS#1 v1.5 padding support has been removed as it will not be allowed in FIPS mode after 2023.
None of the FIPS certified modules in RHEL will support it as a FIPS approved mechanism.

This commit migrates PKCS#1 v1.5 padding to RSA-OAEP. Mew installations of KRA will use RSA-OAEP
as default key wrapping algorithm.

Fixes: https://pagure.io/freeipa/issue/9191
