### PR TITLE
Replace subsystem.select with CAInstance.is_crlgen_enabled()

### DIFF
--- a/install/restart_scripts/renew_ca_cert.in
+++ b/install/restart_scripts/renew_ca_cert.in
@@ -28,7 +28,6 @@ import shutil
 import traceback
 
 from ipalib.install import certstore
-from ipapython import directivesetter
 from ipapython import ipautil
 from ipalib import api, errors
 from ipalib import x509
@@ -105,23 +104,6 @@ def _main():
                     "Updating trust on certificate %s failed in %s" %
                     (nickname, db.secdir))
         elif nickname == 'caSigningCert cert-pki-ca':
-            # Update CS.cfg
-            cfg_path = paths.CA_CS_CFG_PATH
-            config = directivesetter.get_directive(
-                cfg_path, 'subsystem.select', '=')
-            if config == 'New':
-                syslog.syslog(syslog.LOG_NOTICE, "Updating CS.cfg")
-                if cert.is_self_signed():
-                    directivesetter.set_directive(
-                        cfg_path, 'hierarchy.select', 'Root',
-                        quotes=False, separator='=')
-                else:
-                    directivesetter.set_directive(
-                        cfg_path, 'hierarchy.select', 'Subordinate',
-                        quotes=False, separator='=')
-            else:
-                syslog.syslog(syslog.LOG_NOTICE, "Not updating CS.cfg")
-
             # Remove old external CA certificates
             for ca_nick, ca_flags in db.list_certs():
                 if ca_flags.has_key:

--- a/ipaserver/install/plugins/ca_renewal_master.py
+++ b/ipaserver/install/plugins/ca_renewal_master.py
@@ -28,7 +28,6 @@ from ipalib.install import certmonger
 from ipalib.plugable import Registry
 from ipaplatform.paths import paths
 from ipapython.dn import DN
-from ipapython import directivesetter
 
 logger = logging.getLogger(__name__)
 
@@ -108,18 +107,9 @@ class update_ca_renewal_master(Updater):
         else:
             logger.debug("certmonger request for RA cert not found")
 
-            config = directivesetter.get_directive(
-                paths.CA_CS_CFG_PATH, 'subsystem.select', '=')
-
-            if config == 'New':
-                pass
-            elif config == 'Clone':
+            if not ca.is_crlgen_enabled():
+                # CA is not a renewal master
                 return False, []
-            else:
-                logger.warning(
-                    "CS.cfg has unknown subsystem.select value '%s', "
-                    "assuming local CA is not a renewal master", config)
-                return (False, False, [])
 
         update = {
                 'dn': dn,


### PR DESCRIPTION
The `subsystem.select` is not a reliable indicator to determine whether the CA is a renewal master since there is no process in PKI to update the param when the role of the instance changes (from master to clone and vice versa) so the param has been removed in PKI 11.5.

Instead, it's better to use `CAInstance.is_crlgen_enabled()` since CRL generation is only enabled in a renewal master.

The `hierarchy.select` param has been removed in PKI 11.5 so it doesn't need to be updated in `renew_ca_cert.in`.

**Note:** This patch does not need to be backported to older IPA versions.