### PR TITLE
Fix ca.crl.MasterCRL.enable on clone

### DIFF
--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -131,7 +131,11 @@ pki_audit_signing_subject_dn=cn=CA Audit,%(ipa_subject_base)s
 
 pki_share_db=False
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=ipaca
-pki_master_crl_enable=True
+
+# Set ca.crl.MasterCRL.enable to false initially, then later
+# CAInstance.__enable_crl_publish() will set the param to
+# true/false depending on whether it's a master or a clone.
+pki_master_crl_enable=False
 
 pki_default_ocsp_uri=%(ipa_ocsp_uri)s
 

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -536,6 +536,35 @@ def ca_disable_publish_cert(ca):
     return True  # restart needed
 
 
+def ca_configure_master_crl(ca):
+    logger.info('[Configuring Master CRL]')
+    if not ca.is_configured():
+        logger.info('CA is not configured')
+        return False
+
+    enable = directivesetter.get_directive(
+        paths.CA_CS_CFG_PATH,
+        'ca.crl.MasterCRL.enable',
+        separator='=')
+
+    enableCRLUpdates = directivesetter.get_directive(
+        paths.CA_CS_CFG_PATH,
+        'ca.crl.MasterCRL.enableCRLUpdates',
+        separator='=')
+
+    if enable == enableCRLUpdates:
+        return False  # already consistent; restart not needed
+
+    # update enable to match enableCRLUpdates
+    directivesetter.set_directive(
+        paths.CA_CS_CFG_PATH,
+        'ca.crl.MasterCRL.enable',
+        enableCRLUpdates,
+        quotes=False,
+        separator='=')
+    return True  # restart needed
+
+
 def ca_initialize_hsm_state(ca):
     """Initializse HSM state as False / internal token
     """
@@ -1917,6 +1946,7 @@ def upgrade_configuration():
         ca_enable_lightweight_ca_monitor(ca),
         ca_add_default_ocsp_uri(ca),
         ca_disable_publish_cert(ca),
+        ca_configure_master_crl(ca),
     ])
 
     if ca_restart:


### PR DESCRIPTION
Currently the following params are not set consistently on a clone:
- `ca.crl.MasterCRL.enable=true`
- `ca.crl.MasterCRL.enableCRLCache=false`
- `ca.crl.MasterCRL.enableCRLUpdates=false`

To ensure that CRL is fully disabled on the clone the `ca.crl.MasterCRL.enable` should be set to `false` as well.

To fix the problem on new installations, `pkispawn` will create the clone with `ca.crl.MasterCRL.enable=false` initially, then later `CAInstance.__enable_crl_publish()` will set the param to `true`/`false` properly depending on whether it's a master or a clone.

To fix the problem on existing installations, during upgrade the `ca.crl.MasterCRL.enable` will be updated to match the `ca.crl.MasterCRL.enableCRLUpdates`.

The `ipa-crlgen-manage` will now set the params consistently, and the `CAInstance.is_crlgen_enabled()` will verify that the params are set consistently.

The documentation should be updated accordingly:
https://www.freeipa.org/page/Howto/Promote_CA_to_Renewal_and_CRL_Master.html
