### PR TITLE
ipa-client-install: enable SELinux for SSSD

### DIFF
--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -151,6 +151,9 @@ class BaseConstantsNamespace:
             'samba_share_nfs': 'on',
         },
     }
+    SELINUX_BOOLEAN_SSSD = {
+        'sssd_use_usb': 'on',
+    }
     SELINUX_MCS_MAX = 1023
     SELINUX_MCS_REGEX = r"^c(\d+)([.,-]c(\d+))*$"
     SELINUX_MLS_MAX = 15


### PR DESCRIPTION
For passkeys (FIDO2) support, SSSD uses libfido2 library which needs access to USB devices. Add SELinux booleans handling to ipa-client-install so that correct SELinux booleans can be enabled and disabled during install and uninstall. Ignore and record a warning when SELinux policy does not support the boolean.

Fixes: https://pagure.io/freeipa/issue/9434