### PR TITLE
[Backport][ipa-4-10] idp: add the ipaidpuser objectclass when needed

### DIFF
--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -565,7 +565,10 @@ class baseuser_add(LDAPCreate):
         if entry_attrs.get('ipauserauthtype', None):
             add_missing_object_class(ldap, u'ipauserauthtypeclass', dn,
                                      entry_attrs, update=False)
-        if entry_attrs.get('ipaidpconfiglink', None):
+        if (
+            entry_attrs.get('ipaidpconfiglink', None)
+            or entry_attrs.get('ipaidpsub', None)
+        ):
             add_missing_object_class(ldap, 'ipaidpuser', dn,
                                      entry_attrs, update=False)
 
@@ -673,7 +676,7 @@ class baseuser_mod(LDAPUpdate):
         # Some attributes may require additional object classes
         special_attrs = {'ipasshpubkey', 'ipauserauthtype', 'userclass',
                          'ipatokenradiusconfiglink', 'ipatokenradiususername',
-                         'ipaidpconfiglink'}
+                         'ipaidpconfiglink', 'ipaidpsub'}
         if special_attrs.intersection(entry_attrs):
             if 'objectclass' in entry_attrs:
                 obj_classes = entry_attrs['objectclass']
@@ -701,6 +704,10 @@ class baseuser_mod(LDAPUpdate):
 
                     answer = self.api.Object['radiusproxy'].get_dn_if_exists(cl)
                     entry_attrs['ipatokenradiusconfiglink'] = answer
+
+            if 'ipaidpsub' in entry_attrs:
+                if 'ipaidpuser' not in obj_classes:
+                    entry_attrs['objectclass'].append('ipaidpuser')
 
             if 'ipaidpconfiglink' in entry_attrs:
                 cl = entry_attrs['ipaidpconfiglink']

--- a/ipatests/test_xmlrpc/test_user_plugin.py
+++ b/ipatests/test_xmlrpc/test_user_plugin.py
@@ -167,6 +167,20 @@ def user_radius(request, xmlrpc_setup):
 
 
 @pytest.fixture(scope='class')
+def user_idp(request, xmlrpc_setup):
+    """ User tracker fixture for testing users with idp user id """
+    tracker = UserTracker(name='idpuser', givenname='idp',
+                          sn='user', ipaidpsub='myidpuserid')
+    tracker.track_create()
+    tracker.attrs.update(ipaidpsub=['myidpuserid'])
+    tracker.attrs.update(objectclass=fuzzy_set_optional_oc(
+        objectclasses.user + [u'ipaidpuser'],
+        'ipantuserattrs'),
+    )
+    return tracker.make_fixture(request)
+
+
+@pytest.fixture(scope='class')
 def group(request, xmlrpc_setup):
     tracker = GroupTracker(name=u'group1')
     return tracker.make_fixture(request)
@@ -556,6 +570,15 @@ class TestUpdate(XMLRPC_test):
         )):
             command()
 
+    def test_update_add_idpsub(self, user):
+        """ Test user-mod --idp-user-id"""
+        user.ensure_exists()
+        command = user.make_update_command(
+            updates=dict(ipaidpsub=u'myidp_user_id')
+        )
+        command()
+        user.delete()
+
 
 @pytest.mark.tier1
 class TestCreate(XMLRPC_test):
@@ -794,6 +817,13 @@ class TestCreate(XMLRPC_test):
                 nonexistentidp)
         )):
             testuser.create()
+
+    def test_create_with_idpsub(self, user_idp):
+        """ Test creation of a user with --idp-user-id"""
+        command = user_idp.make_create_command()
+        result = command()
+        user_idp.check_create(result, ['ipaidpsub'])
+        user_idp.delete()
 
 
 @pytest.mark.tier1


### PR DESCRIPTION
This PR was opened automatically because PR #6975 was pushed to master and backport to ipa-4-10 is required.