### PR TITLE
Add 'cache_dir' option to api.env

### DIFF
--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -550,10 +550,8 @@ class vault_mod(Local):
 class _KraConfigCache:
     """The KRA config cache stores vaultconfig-show result.
     """
-    def __init__(self):
-        self._dirname = os.path.join(
-            constants.USER_CACHE_PATH, 'ipa', 'kra-config'
-        )
+    def __init__(self, api):
+        self._dirname = os.path.join(api.env.cache_dir, 'kra-config')
 
     def _get_filename(self, domain):
         basename = DNSName(domain).ToASCII() + '.json'
@@ -629,7 +627,7 @@ class _KraConfigCache:
             return True
 
 
-_kra_config_cache = _KraConfigCache()
+_kra_config_cache = _KraConfigCache(api)
 
 
 @register(override=True, no_fail=True)

--- a/ipaclient/remote_plugins/__init__.py
+++ b/ipaclient/remote_plugins/__init__.py
@@ -13,18 +13,16 @@ import time
 from . import compat
 from . import schema
 from ipaclient.plugins.rpcclient import rpcclient
-from ipalib.constants import USER_CACHE_PATH
 from ipapython.dnsutil import DNSName
 
 logger = logging.getLogger(__name__)
 
 
 class ServerInfo(MutableMapping):
-    _DIR = os.path.join(USER_CACHE_PATH, 'ipa', 'servers')
-
     def __init__(self, api):
+        self._dir = os.path.join(api.env.cache_dir, "servers")
         hostname = DNSName(api.env.server).ToASCII()
-        self._path = os.path.join(self._DIR, hostname)
+        self._filename = os.path.join(self._dir, hostname)
         self._force_check = api.env.force_schema_check
         self._now = time.time()
         self._dict = {}
@@ -41,7 +39,7 @@ class ServerInfo(MutableMapping):
 
     def _read(self):
         try:
-            with open(self._path, 'r') as sc:
+            with open(self._filename, 'r') as sc:
                 self._dict = json.load(sc)
         except Exception as e:
             if (isinstance(e, EnvironmentError) and
@@ -56,11 +54,11 @@ class ServerInfo(MutableMapping):
     def _write(self):
         try:
             try:
-                os.makedirs(self._DIR)
+                os.makedirs(self._dir)
             except EnvironmentError as e:
                 if e.errno != errno.EEXIST:
                     raise
-            with open(self._path, 'w') as sc:
+            with open(self._filename, 'w') as sc:
                 json.dump(self._dict, sc)
         except EnvironmentError as e:
             logger.warning('Failed to write server info: %s', e)

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -45,6 +45,7 @@ from ipalib.constants import (
     CONFIG_SECTION,
     OVERRIDE_ERROR, SET_ERROR, DEL_ERROR,
     TLS_VERSIONS, TLS_VERSION_DEFAULT_MIN, TLS_VERSION_DEFAULT_MAX,
+    USER_CACHE_PATH
 )
 from ipalib import errors
 
@@ -506,6 +507,11 @@ class Env:
 
         if 'nss_dir' not in self:
             self.nss_dir = self._join('confdir', 'nssdb')
+
+        # user cache dir for IPA, defaults to '$XDG_CACHE_HOME/ipa' or
+        # '~/.cache/ipa'. XDG_CACHE_HOME env var is cached at import time.
+        if 'cache_dir' not in self:
+            self.cache_dir = os.path.join(USER_CACHE_PATH, 'ipa')
 
         if 'tls_ca_cert' not in self:
             self.tls_ca_cert = self._join('confdir', 'ca.crt')

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -273,6 +273,7 @@ DEFAULT_CONFIG = (
     ('conf_default', object),  # File containing context independent config
     ('plugins_on_demand', object),  # Whether to finalize plugins on-demand (bool)
     ('nss_dir', object),  # Path to nssdb, default {confdir}/nssdb
+    ('cache_dir', object),  # ~/.cache/ipa directory, may use XDG_CACHE_HOME env
     ('tls_ca_cert', object),  # Path to CA cert file
 
     # Set in Env._finalize_core():

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -395,6 +395,7 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.ca_host = ''
     api.env.ca_install_port = None
     api.env.ca_port = 0
+    api.env.cache_dir = ''  # object
     api.env.certmonger_wait_timeout = 0
     api.env.conf = ''  # object
     api.env.conf_default = ''  # object


### PR DESCRIPTION
`api.env` now has a `cache_dir` option, which defaults to `os.path.join(USER_CACHE_PATH, 'ipa')`. Schema cache, server info, and KRA key cache use `api.env.cache_dir` as base directory. The option allows application to set a custom cache directory.

Related: https://pagure.io/freeipa/issue/9438