### PR TITLE
[Backport][ipa-4-11] ipatests: rename 'ipatuura' directory to 'scim' in bridge tests

### DIFF
--- a/ipatests/pytest_ipa/integration/create_bridge.py
+++ b/ipatests/pytest_ipa/integration/create_bridge.py
@@ -36,7 +36,7 @@ def setup_scim_server(host, version="main"):
     host.run_command(["pip", "install", "-r", f"{django_reqs}"])
 
     # Prepare models and database
-    host.run_command(["python", "manage.py", "makemigrations", "ipatuura"],
+    host.run_command(["python", "manage.py", "makemigrations", "scim"],
                      cwd=f"{dir}/src/ipa-tuura")
     host.run_command(["python", "manage.py", "migrate"],
                      cwd=f"{dir}/src/ipa-tuura")


### PR DESCRIPTION
This PR was opened automatically because PR #6991 was pushed to master and backport to ipa-4-11 is required.