### PR TITLE
[Backport][ipa-4-11] ipa-client-install: enable SELinux for SSSD

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3624,7 +3624,7 @@ def uninstall(options):
                 "Failed to disable automatic startup of the SSSD daemon: %s",
                 e)
 
-    if was_sssd_installed and selinux_works:
+    if statestore.has_state('selinux'):
         # Restore SELinux boolean states
         boolean_states = {name: statestore.restore_state('selinux', name)
                           for name in constants.SELINUX_BOOLEAN_SSSD}

--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -151,6 +151,9 @@ class BaseConstantsNamespace:
             'samba_share_nfs': 'on',
         },
     }
+    SELINUX_BOOLEAN_SSSD = {
+        'sssd_use_usb': 'on',
+    }
     SELINUX_MCS_MAX = 1023
     SELINUX_MCS_REGEX = r"^c(\d+)([.,-]c(\d+))*$"
     SELINUX_MLS_MAX = 15


### PR DESCRIPTION
This PR was opened automatically because PR #6978 was pushed to master and backport to ipa-4-11 is required.