### PR TITLE
Don't assume KRB5CCNAME is in the environment in replica install

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -988,7 +988,7 @@ def promote_check(installer):
                 raise errors.ACIError(info="Not authorized")
 
             if installer._ccache is None:
-                del os.environ['KRB5CCNAME']
+                os.environ.pop('KRB5CCNAME', None)
             else:
                 os.environ['KRB5CCNAME'] = installer._ccache
 
@@ -1197,7 +1197,7 @@ def promote_check(installer):
         if add_to_ipaservers:
             # use user's credentials when the server host is not ipaservers
             if installer._ccache is None:
-                del os.environ['KRB5CCNAME']
+                os.environ.pop('KRB5CCNAME', None)
             else:
                 os.environ['KRB5CCNAME'] = installer._ccache
 


### PR DESCRIPTION
The replica install was unilaterally removing KRB5CCNAME from os.environ in some cases. Instead check first to see if it is present and only remove in that case.

Fixes: https://pagure.io/freeipa/issue/9446

IMPORTANT: There are backports for ipa-4-11, 10 and 9 pending push. I'm not pushing them because without (potentially) this patch it was cause more test failures.