### PR TITLE
[Backport][ipa-4-11] [Doc] typo in API basic_usage.md

### DIFF
--- a/doc/api/basic_usage.md
+++ b/doc/api/basic_usage.md
@@ -63,7 +63,7 @@ else:
 This will connect to LDAP directly if we are running our script in server, or
 use a RPC client if we are running it from a FreeIPA client.
 
-After we have initialized the API and stablished a connection, we are ready to
+After we have initialized the API and established a connection, we are ready to
 issue commands.
 
 ## Running commands


### PR DESCRIPTION
This PR was opened automatically because PR #6990 was pushed to master and backport to ipa-4-11 is required.