### PR TITLE
Add context manager to ipalib.API

### DIFF
--- a/ipatests/test_integration/example_cli.py
+++ b/ipatests/test_integration/example_cli.py
@@ -1,0 +1,19 @@
+import os
+
+import ipalib
+from ipaplatform.paths import paths
+
+# authenticate with host keytab and custom ccache
+os.environ.update(
+    KRB5_CLIENT_KTNAME=paths.KRB5_KEYTAB,
+)
+
+# custom options
+overrides = {"context": "example_cli"}
+ipalib.api.bootstrap(**overrides)
+
+with ipalib.api as api:
+    user = api.Command.user_show("admin")
+    print(user)
+
+assert not api.Backend.rpcclient.isconnected()


### PR DESCRIPTION
`ipalib.API` instances like `ipalib.api` now provide a context manager that connects and disconnects the API object. Users no longer have to deal with different types of backends or finalize the API correctly.

```python
import ipalib

with ipalib.api as api:
    api.Commands.ping()
```

See: https://pagure.io/freeipa/issue/9443