### PR TITLE
ipatests: restart ipa services after moving date

### DIFF
--- a/ipatests/test_integration/test_ipa_cert_fix.py
+++ b/ipatests/test_integration/test_ipa_cert_fix.py
@@ -408,6 +408,9 @@ class TestCertFixReplica(IntegrationTest):
         # move system date to expire certs
         for host in self.master, self.replicas[0]:
             tasks.move_date(host, 'stop', '+3years+1days')
+            host.run_command(
+                ['ipactl', 'restart', '--ignore-service-failures']
+            )
 
         yield
 


### PR DESCRIPTION
When system date is moved into future, it have unprecedented behavior i.e CA becomes irresponsive or unexpected certificcate state. Hence restart the ipa service after moving the date to gracefully serve the request.

Fixes: https://pagure.io/freeipa/issue/9379