### PR TITLE
Allow ipa-otpd to access USB devices for passkeys

### DIFF
--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -106,6 +106,8 @@ corenet_tcp_connect_radius_port(ipa_otpd_t)
 
 dev_read_urand(ipa_otpd_t)
 dev_read_rand(ipa_otpd_t)
+dev_read_sysfs(ipa_otpd_t)
+dev_rw_generic_usb_dev(ipa_otpd_t)
 
 sysnet_dns_name_resolve(ipa_otpd_t)
 


### PR DESCRIPTION
Main SELinux policy will allow transition of passkey_child (SSSD) to ipa_otpd_t context to perform FIDO2 operations with USB devices. This means ipa-otpd will need to be able to read data from sysfs and connect to USB devices.

Add required permissions to IPA subpolicy as well. See rhbz#2238224 for discussion.

Related: https://pagure.io/freeipa/issue/9434