### PR TITLE
[Backport][ipa-4-11] ipatests: restart ipa services after moving date

### DIFF
--- a/ipatests/test_integration/test_ipa_cert_fix.py
+++ b/ipatests/test_integration/test_ipa_cert_fix.py
@@ -408,6 +408,9 @@ class TestCertFixReplica(IntegrationTest):
         # move system date to expire certs
         for host in self.master, self.replicas[0]:
             tasks.move_date(host, 'stop', '+3years+1days')
+            host.run_command(
+                ['ipactl', 'restart', '--ignore-service-failures']
+            )
 
         yield
 


### PR DESCRIPTION
This PR was opened automatically because PR #7005 was pushed to master and backport to ipa-4-11 is required.