### PR TITLE
ipatests: fix healthcheck test for --indent option

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -2405,12 +2405,19 @@ class TestIpaHealthCLI(IntegrationTest):
             cmd = self.base_cmd + ["--indent", option]
             result = self.master.run_command(cmd, raiseonerr=False)
             assert result.returncode == 2
-            assert 'invalid int value' in result.stderr_text
+            assert ('invalid int value' in result.stderr_text
+                    or 'is not an integer' in result.stderr_text)
 
-        # unusual success, arguably odd but not invalid :-)
+        version = tasks.get_healthcheck_version(self.master)
         for option in ('-1', '5000'):
             cmd = self.base_cmd + ["--indent", option]
-            result = self.master.run_command(cmd)
+            result = self.master.run_command(cmd, raiseonerr=False)
+            if parse_version(version) >= parse_version('0.13'):
+                assert result.returncode == 2
+                assert 'is not in the range 0-32' in result.stderr_text
+            else:
+                # Older versions did not check for a given allowed range
+                assert result.returncode == 0
 
     def test_severity(self):
         """


### PR DESCRIPTION
ipa-healthcheck --indent option expects an integer. The error
message changed with ipa-healthcheck 0.13.
Recent versions also check that the value is in the range 0-32.

The test must be compatible with old and new versions.

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>
