### PR TITLE
ipatests: fix healthcheck test without DNS

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1639,12 +1639,18 @@ class TestIpaHealthCheckWithoutDNS(IntegrationTest):
                 "Got {count} ipa-ca AAAA records, expected {expected}",
                 "Expected URI record missing",
             }
-        else:
+        elif (parse_version(version) < parse_version('0.13')):
             expected_msgs = {
                 "Expected SRV record missing",
                 "Unexpected ipa-ca address {ipaddr}",
                 "expected ipa-ca to contain {ipaddr} for {server}",
                 "Expected URI record missing",
+            }
+        else:
+            expected_msgs = {
+                "Expected SRV record missing",
+                "Expected URI record missing",
+                "missing IP address for ipa-ca server {server}",
             }
 
         tasks.install_packages(self.master, HEALTHCHECK_PKG)


### PR DESCRIPTION
ipa-healthcheck has added a new check for ipa-ca record
missing. The test needs to be adapted to handle the new check.

Fixes: https://pagure.io/freeipa/issue/9459
    
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>