### PR TITLE
[Backport][ipa-4-10] Covscan issues: deadcode and Use after free

### DIFF
--- a/daemons/ipa-kdb/ipa-print-pac.c
+++ b/daemons/ipa-kdb/ipa-print-pac.c
@@ -494,7 +494,7 @@ init_with_password(const char *name, const char *password)
 
 done:
     if (service_creds != GSS_C_NO_CREDENTIAL)
-        gss_release_cred(&min, &client_creds);
+        gss_release_cred(&min, &service_creds);
 
     if (client_creds != GSS_C_NO_CREDENTIAL)
         gss_release_cred(&min, &client_creds);

--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -1808,6 +1808,9 @@ krb5_error_code ipadb_get_principal(krb5_context kcontext,
             kerr = krb5_dbe_set_string(kcontext, *entry,
                                        KRB5_KDB_SK_PAC_PRIVSVR_ENCTYPE,
                                        "aes256-sha1");
+            if (kerr)
+                return kerr;
+
         }
 
         /* We should have been initialized at this point already */


### PR DESCRIPTION
This PR was opened automatically because PR #7014 was pushed to master and backport to ipa-4-10 is required.