### PR TITLE
 [Backport][ipa-4-9] Covscan issues: Use after free

### DIFF
--- a/daemons/ipa-kdb/ipa-print-pac.c
+++ b/daemons/ipa-kdb/ipa-print-pac.c
@@ -494,7 +494,7 @@ init_with_password(const char *name, const char *password)
 
 done:
     if (service_creds != GSS_C_NO_CREDENTIAL)
-        gss_release_cred(&min, &client_creds);
+        gss_release_cred(&min, &service_creds);
 
     if (client_creds != GSS_C_NO_CREDENTIAL)
         gss_release_cred(&min, &client_creds);


### PR DESCRIPTION
This is a manual backport of PR #7014 into ipa-4-9 branch (only picked the changes on ipa-print-pac.c, the other file ipa_kdb_principals.c did not contain the same code in 4.9 branch).