### PR TITLE
[Backport][ipa-4-11] Use datetime.timezone.utc instead of newer datetime.UTC alias

### DIFF
--- a/ipaclient/install/ipa_epn.py
+++ b/ipaclient/install/ipa_epn.py
@@ -33,7 +33,8 @@ import ssl
 import time
 
 from collections import deque
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta, timezone
+UTC = timezone.utc
 from email.utils import formataddr, formatdate
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText

--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -1836,7 +1836,7 @@ class DateTime(Param):
     def _convert_scalar(self, value, index=None):
         if isinstance(value, str):
             if value == u'now':
-                time = datetime.datetime.now(tz=datetime.UTC)
+                time = datetime.datetime.now(tz=datetime.timezone.utc)
                 return time
             else:
                 for date_format in self.accepted_formats:

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -819,7 +819,8 @@ class KerbTransport(SSLTransport):
                 session_cookie = (
                     Cookie.get_named_cookie_from_string(
                         cookie, COOKIE_NAME, request_url,
-                        timestamp=datetime.datetime.now(tz=datetime.UTC))
+                        timestamp=datetime.datetime.now(
+                            tz=datetime.timezone.utc))
                     )
                 if session_cookie is not None:
                     break
@@ -922,7 +923,7 @@ class RPCClient(Connectible):
         try:
             session_cookie = Cookie.get_named_cookie_from_string(
                 cookie_string, COOKIE_NAME,
-                timestamp=datetime.datetime.now(tz=datetime.UTC))
+                timestamp=datetime.datetime.now(tz=datetime.timezone.utc))
         except Exception as e:
             logger.debug(
                 'Error retrieving cookie from the persistent storage: %s',

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -267,12 +267,12 @@ class IPACertificate(crypto_x509.Certificate):
     @property
     def not_valid_before(self):
         return datetime.datetime.fromtimestamp(
-            self._cert.not_valid_before.timestamp(), tz=datetime.UTC)
+            self._cert.not_valid_before.timestamp(), tz=datetime.timezone.utc)
 
     @property
     def not_valid_after(self):
         return datetime.datetime.fromtimestamp(
-            self._cert.not_valid_after.timestamp(), tz=datetime.UTC)
+            self._cert.not_valid_after.timestamp(), tz=datetime.timezone.utc)
 
     @property
     def tbs_certificate_bytes(self):

--- a/ipapython/certdb.py
+++ b/ipapython/certdb.py
@@ -943,7 +943,7 @@ class NSSDatabase:
     def _verify_cert_validity(self, cert):
         """Common checks for cert validity
         """
-        utcnow = datetime.datetime.now(tz=datetime.UTC)
+        utcnow = datetime.datetime.now(tz=datetime.timezone.utc)
         if cert.not_valid_before > utcnow:
             raise ValueError(
                 f"not valid before {cert.not_valid_before} UTC is in the "

--- a/ipapython/cookie.py
+++ b/ipapython/cookie.py
@@ -652,7 +652,7 @@ class Cookie:
 
         cookie_expiration = self.get_expiration()
         if cookie_expiration is not None:
-            now = datetime.datetime.now(tz=datetime.UTC)
+            now = datetime.datetime.now(tz=datetime.timezone.utc)
             if cookie_expiration < now:
                 raise Cookie.Expired("cookie named '%s'; expired at %s'" % \
                                      (cookie_name,

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -740,7 +740,7 @@ class _CrossProcessLock:
         self._do(self._release, owner)
 
     def _acquire(self, owner):
-        now = datetime.datetime.now(tz=datetime.UTC)
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
 
         if self._locked and now >= self._expire:
             self._locked = False
@@ -800,7 +800,7 @@ class _CrossProcessLock:
                 try:
                     self._expire = datetime.datetime.strptime(
                         expire, self._DATETIME_FORMAT).replace(
-                        tzinfo=datetime.UTC)
+                        tzinfo=datetime.timezone.utc)
                 except ValueError:
                     raise configparser.Error
         except configparser.Error:

--- a/ipaserver/install/ipa_cacert_manage.py
+++ b/ipaserver/install/ipa_cacert_manage.py
@@ -556,7 +556,7 @@ class CACertManage(admintool.AdminTool):
                                               api.env.realm,
                                               False)
 
-        now = datetime.datetime.now(tz=datetime.UTC)
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
         for ca_cert, ca_nickname, _ca_trust_flags in ca_certs:
             if ca_cert.not_valid_after < now:
                 expired_certs.append(ca_nickname)

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -129,7 +129,7 @@ class IPACertFix(AdminTool):
         ca_subject_dn = ca.lookup_ca_subject(api, subject_base)
 
         now = (
-            datetime.datetime.now(tz=datetime.UTC)
+            datetime.datetime.now(tz=datetime.timezone.utc)
             + datetime.timedelta(weeks=2))
         certs, extra_certs, non_renewed = expired_certs(now)
 

--- a/ipatests/create_external_ca.py
+++ b/ipatests/create_external_ca.py
@@ -35,7 +35,7 @@ class ExternalCA:
     """
 
     def __init__(self, days=365, key_size=None):
-        self.now = datetime.datetime.now(tz=datetime.UTC)
+        self.now = datetime.datetime.now(tz=datetime.timezone.utc)
         self.delta = datetime.timedelta(days=days)
         self.ca_key = None
         self.ca_public_key = None

--- a/ipatests/pytest_ipa/integration/create_caless_pki.py
+++ b/ipatests/pytest_ipa/integration/create_caless_pki.py
@@ -102,7 +102,7 @@ class KRB5PrincipalName(univ.Sequence):
 
 
 def profile_ca(builder, ca_nick, ca):
-    now = datetime.datetime.now(tz=datetime.UTC)
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
 
     builder = builder.not_valid_before(now)
     builder = builder.not_valid_after(now + 10 * YEAR)
@@ -174,7 +174,7 @@ def profile_ca(builder, ca_nick, ca):
 def profile_server(builder, ca_nick, ca,
                    warp=datetime.timedelta(days=0), dns_name=None,
                    badusage=False, wildcard=False):
-    now = datetime.datetime.now(tz=datetime.UTC) + warp
+    now = datetime.datetime.now(tz=datetime.timezone.utc) + warp
 
     builder = builder.not_valid_before(now)
     builder = builder.not_valid_after(now + YEAR)
@@ -231,7 +231,7 @@ def profile_server(builder, ca_nick, ca,
 def profile_kdc(builder, ca_nick, ca,
                 warp=datetime.timedelta(days=0), dns_name=None,
                 badusage=False):
-    now = datetime.datetime.now(tz=datetime.UTC) + warp
+    now = datetime.datetime.now(tz=datetime.timezone.utc) + warp
 
     builder = builder.not_valid_before(now)
     builder = builder.not_valid_after(now + YEAR)
@@ -347,7 +347,7 @@ def gen_cert(profile, nick_base, subject, ca=None, **kwargs):
 
 
 def revoke_cert(ca, serial):
-    now = datetime.datetime.now(tz=datetime.UTC)
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
 
     crl_builder = x509.CertificateRevocationListBuilder()
     crl_builder = crl_builder.issuer_name(ca.cert.subject)

--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -467,7 +467,8 @@ class TestEPN(IntegrationTest):
             extra_args=[
                 "--password-expiration",
                 datetime_to_generalized_time(
-                    datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(
+                    datetime.datetime.now(
+                        tz=datetime.timezone.utc) + datetime.timedelta(
                         days=7)
                 ),
             ],
@@ -496,7 +497,8 @@ class TestEPN(IntegrationTest):
                 uid=uid,
                 days=i,
                 krbpasswordexpiration=datetime_to_generalized_time(
-                    datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(
+                    datetime.datetime.now(
+                        tz=datetime.timezone.utc) + datetime.timedelta(
                         days=i)
                 ),
             )
@@ -812,7 +814,8 @@ class TestEPN(IntegrationTest):
         self.master.run_command(
             ['ipa', 'user-mod', 'admin', '--password-expiration',
              datetime_to_generalized_time(
-                 datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(
+                 datetime.datetime.now(
+                     tz=datetime.timezone.utc) + datetime.timedelta(
                      days=7)
              )]
         )

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -8,7 +8,8 @@ Tests to verify that the ipa-healthcheck scenarios
 from __future__ import absolute_import
 
 from configparser import RawConfigParser, NoOptionError
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta, timezone
+UTC = timezone.utc
 import json
 import os
 import re

--- a/ipatests/test_ipalib/test_x509.py
+++ b/ipatests/test_ipalib/test_x509.py
@@ -234,8 +234,10 @@ class test_x509:
         # Verify certificate contents. This exercises python-cryptography
         # more than anything but confirms our usage of it.
 
-        not_before = datetime.datetime(2010, 6, 25, 13, 0, 42, 0, datetime.UTC)
-        not_after = datetime.datetime(2015, 6, 25, 13, 0, 42, 0, datetime.UTC)
+        not_before = datetime.datetime(2010, 6, 25, 13, 0, 42, 0,
+                                       datetime.timezone.utc)
+        not_after = datetime.datetime(2015, 6, 25, 13, 0, 42, 0,
+                                      datetime.timezone.utc)
         cert = x509.load_pem_x509_certificate(goodcert_headers)
 
         assert DN(cert.subject) == DN(('CN', 'ipa.example.com'), ('O', 'IPA'))
@@ -279,8 +281,10 @@ class test_x509:
         assert DN(cert.issuer) == DN(
             "CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US")
         assert cert.serial_number == 0x03ad42a2a5ada59a131327cb0979623cb605
-        not_before = datetime.datetime(2018, 7, 25, 5, 36, 59, 0, datetime.UTC)
-        not_after = datetime.datetime(2018, 10, 23, 5, 36, 59, 0, datetime.UTC)
+        not_before = datetime.datetime(2018, 7, 25, 5, 36, 59, 0,
+                                       datetime.timezone.utc)
+        not_after = datetime.datetime(2018, 10, 23, 5, 36, 59, 0,
+                                      datetime.timezone.utc)
         assert cert.not_valid_before == not_before
         assert cert.not_valid_after == not_after
         assert cert.san_general_names == [DNSName('ipa.demo1.freeipa.org')]

--- a/ipatests/test_ipapython/test_cookie.py
+++ b/ipatests/test_ipapython/test_cookie.py
@@ -402,7 +402,9 @@ class TestHTTPReturn:
             assert cookie.http_return_ok(self.url)
 
     def test_expires(self):
-        now = datetime.datetime.now(tz=datetime.UTC).replace(microsecond=0)
+        now = datetime.datetime.now(
+            tz=datetime.timezone.utc).replace(
+            microsecond=0)
 
         # expires 1 day from now
         expires = now + datetime.timedelta(days=1)

--- a/ipatests/test_webui/crypto_utils.py
+++ b/ipatests/test_webui/crypto_utils.py
@@ -2,8 +2,8 @@
 # Copyright (C) 2018  FreeIPA Contributors see COPYING for license
 #
 
-from datetime import datetime, timedelta, UTC
-
+from datetime import datetime, timedelta, timezone
+UTC = timezone.utc
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization, hashes


### PR DESCRIPTION
This PR was opened automatically because PR #7018 was pushed to master and backport to ipa-4-11 is required.