### PR TITLE
Increase memory usage for Azure CI upgrade test

### DIFF
--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -32,10 +32,10 @@ vms:
       clients: 1
       resources:
         replica:
-          mem_limit: "2200m"
+          mem_limit: "2300m"
           memswap_limit: "3300m"
         client:
-          mem_limit: "768m"
+          mem_limit: "805m"
           memswap_limit: "1024m"
     tests:
     - test_integration/test_forced_client_reenrollment.py

--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -187,7 +187,7 @@ vms:
     containers:
       resources:
         server:
-          mem_limit: "2200m"
+          mem_limit: "2450m"
           memswap_limit: "3300m"
     tests:
     - test_integration/test_upgrade.py


### PR DESCRIPTION
The test often fails when running in parallel to other tests as very little memory is left. 389-ds memory autotuning causes database backend to refuse working in such cases. 389-ds team suggested more memory has to be made available.

Increate RAM for this test to 2.5GB instead of 2.2GB.