### PR TITLE
Enable LWCA monitor explicitly

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -435,6 +435,8 @@ class CAInstance(DogtagInstance):
                       configure_lightweight_ca_acls)
             self.step("Ensure lightweight CAs container exists",
                       ensure_lightweight_cas_container)
+            self.step("Enable lightweight CA monitor",
+                      enable_lightweight_ca_monitor)
             self.step(
                 "Ensuring backward compatibility",
                 self.__dogtag10_migration)
@@ -1781,6 +1783,28 @@ def ensure_lightweight_cas_container():
         objectclass=['top', 'organizationalUnit'],
         ou=['authorities'],
     )
+
+
+def enable_lightweight_ca_monitor():
+
+    # Check LWCA monitor
+    value = directivesetter.get_directive(
+        paths.CA_CS_CFG_PATH,
+        'ca.authorityMonitor.enable',
+        separator='=')
+
+    if value == 'true':
+        return False  # already enabled; restart not needed
+
+    # Enable LWCA monitor
+    directivesetter.set_directive(
+        paths.CA_CS_CFG_PATH,
+        'ca.authorityMonitor.enable',
+        'true',
+        quotes=False,
+        separator='=')
+
+    return True  # restart needed
 
 
 def minimum_acme_support(data=None):

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -482,6 +482,16 @@ def ca_ensure_lightweight_cas_container(ca):
     return cainstance.ensure_lightweight_cas_container()
 
 
+def ca_enable_lightweight_ca_monitor(ca):
+    logger.info('[Enabling LWCA monitor]')
+
+    if not ca.is_configured():
+        logger.info('CA is not configured')
+        return False
+
+    return cainstance.enable_lightweight_ca_monitor()
+
+
 def ca_add_default_ocsp_uri(ca):
     logger.info('[Adding default OCSP URI configuration]')
     if not ca.is_configured():
@@ -1904,6 +1914,7 @@ def upgrade_configuration():
         ca_configure_profiles_acl(ca),
         ca_configure_lightweight_ca_acls(ca),
         ca_ensure_lightweight_cas_container(ca),
+        ca_enable_lightweight_ca_monitor(ca),
         ca_add_default_ocsp_uri(ca),
         ca_disable_publish_cert(ca),
     ])


### PR DESCRIPTION
Currently LWCA is only supported in IPA since the key replication depends on Custodia, so LWCA is not actually supported in regular PKI installation. However, currently the `AuthorityMonitor` is enabled by default and it executes a persistent search to monitor LWCA replication so it is wasting resources in non-IPA environment.

To reduce unnecessary resource consumption the LWCA monitor will be disabled by default in PKI, so IPA will need to enable it explicitly for new and existing installations.