### PR TITLE
[Backport][ipa-4-10] Increase memory usage for Azure CI upgrade test

### DIFF
--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -32,10 +32,10 @@ vms:
       clients: 1
       resources:
         replica:
-          mem_limit: "2200m"
+          mem_limit: "2300m"
           memswap_limit: "3300m"
         client:
-          mem_limit: "768m"
+          mem_limit: "805m"
           memswap_limit: "1024m"
     tests:
     - test_integration/test_forced_client_reenrollment.py

--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -187,7 +187,7 @@ vms:
     containers:
       resources:
         server:
-          mem_limit: "2200m"
+          mem_limit: "2450m"
           memswap_limit: "3300m"
     tests:
     - test_integration/test_upgrade.py


### PR DESCRIPTION
This PR was opened automatically because PR #7029 was pushed to master and backport to ipa-4-10 is required.