### PR TITLE
[Backport][ipa-4-10] ipatests: fix healthcheck test without DNS

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1639,12 +1639,18 @@ class TestIpaHealthCheckWithoutDNS(IntegrationTest):
                 "Got {count} ipa-ca AAAA records, expected {expected}",
                 "Expected URI record missing",
             }
-        else:
+        elif (parse_version(version) < parse_version('0.13')):
             expected_msgs = {
                 "Expected SRV record missing",
                 "Unexpected ipa-ca address {ipaddr}",
                 "expected ipa-ca to contain {ipaddr} for {server}",
                 "Expected URI record missing",
+            }
+        else:
+            expected_msgs = {
+                "Expected SRV record missing",
+                "Expected URI record missing",
+                "missing IP address for ipa-ca server {server}",
             }
 
         tasks.install_packages(self.master, HEALTHCHECK_PKG)


### PR DESCRIPTION
This PR was opened automatically because PR #7021 was pushed to master and backport to ipa-4-10 is required.