### PR TITLE
[Backport][ipa-4-10] ipatests: fix test_ipactl_scenario_check

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -695,7 +695,7 @@ def get_pki_tomcatd_pid(host):
 def get_ipa_services_pids(host):
     ipa_services_name = [
         "krb5kdc", "kadmin", "named", "httpd", "ipa-custodia",
-        "pki_tomcatd", "ipa-dnskeysyncd"
+        "pki_tomcatd"
     ]
     pids_of_ipa_services = {}
     for name in ipa_services_name:


### PR DESCRIPTION
This PR was opened automatically because PR #7012 was pushed to master and backport to ipa-4-10 is required.