### PR TITLE
ipalib: fix the IPACertificate validity dates

### DIFF
--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -266,13 +266,11 @@ class IPACertificate(crypto_x509.Certificate):
 
     @property
     def not_valid_before(self):
-        return datetime.datetime.fromtimestamp(
-            self._cert.not_valid_before.timestamp(), tz=datetime.timezone.utc)
+        return self._cert.not_valid_before.replace(tzinfo=datetime.timezone.utc)
 
     @property
     def not_valid_after(self):
-        return datetime.datetime.fromtimestamp(
-            self._cert.not_valid_after.timestamp(), tz=datetime.timezone.utc)
+        return self._cert.not_valid_after.replace(tzinfo=datetime.timezone.utc)
 
     @property
     def tbs_certificate_bytes(self):


### PR DESCRIPTION
The class IPACertificate builds objects from x509 Certificate objects and creates the not_valid_before and not_valid_after values by converting to a timestamp + applying timezone delta to UTC + reading from the timestamp. This results in applying twice the delta.

Use a simpler method that replaces the timezone info with UTC in the datetime object.

Fixes: https://pagure.io/freeipa/issue/9462