### PR TITLE
ipatests: Skip the test failing due to FIPS policy

### DIFF
--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -180,7 +180,6 @@ def configure_starttls(host):
     postconf(host, 'smtpd_tls_session_cache_timeout = 3600s')
     # announce STARTTLS support to remote SMTP clients, not require
     postconf(host, 'smtpd_tls_security_level = may')
-
     host.run_command(["systemctl", "restart", "postfix"])
 
 
@@ -207,6 +206,9 @@ def configure_ssl_client_cert(host):
     postconf(host, "smtpd_tls_req_ccert = yes")
     # CA certificates of root CAs trusted to sign remote SMTP client cert
     postconf(host, f"smtpd_tls_CAfile = {paths.IPA_CA_CRT}")
+
+    if host.is_fips_mode:
+        postconf(host, 'smtpd_tls_fingerprint_digest = sha256')
 
     host.run_command(["systemctl", "restart", "postfix"])
 

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -35,6 +35,7 @@ from ipatests.pytest_ipa.integration.env_config import get_global_config
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.test_integration.test_caless import CALessBase, ipa_certs_cleanup
 from ipatests.test_integration.test_cert import get_certmonger_fs_id
+from ipatests.pytest_ipa.integration import skip_if_fips
 from ipaplatform import services
 
 
@@ -298,6 +299,7 @@ class TestInstallCA(IntegrationTest):
         tasks.install_replica(self.master, self.replicas[1], setup_ca=False)
         tasks.install_ca(self.replicas[1], extra_args=["--skip-schema-check"])
 
+    @skip_if_fips()
     def test_certmonger_reads_token_HSM(self):
         """Test if certmonger reads the token in HSM
 


### PR DESCRIPTION
 1. test_certmonger_reads_token_HSM test in test_installaton.py is failing in FIPS/STIG mode with the below error. 
 SEC_ERROR_PKCS12_UNABLE_TO_IMPORT_KEY: Unable to import. Error attempting to import private key in STIG mode
    
2. Some of the test_epn  related tests are also failing due to FIPS policy hence skipping those tests.
ipa: ERROR: stderr: IPA-EPN: Unable to create an encrypted session: Connection unexpectedly closed: [Errno 104] Connection reset by peer