### PR TITLE
[Backport][ipa-4-11] ipalib: fix the IPACertificate validity dates

### DIFF
--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -266,13 +266,11 @@ class IPACertificate(crypto_x509.Certificate):
 
     @property
     def not_valid_before(self):
-        return datetime.datetime.fromtimestamp(
-            self._cert.not_valid_before.timestamp(), tz=datetime.timezone.utc)
+        return self._cert.not_valid_before.replace(tzinfo=datetime.timezone.utc)
 
     @property
     def not_valid_after(self):
-        return datetime.datetime.fromtimestamp(
-            self._cert.not_valid_after.timestamp(), tz=datetime.timezone.utc)
+        return self._cert.not_valid_after.replace(tzinfo=datetime.timezone.utc)
 
     @property
     def tbs_certificate_bytes(self):


### PR DESCRIPTION
This PR was opened automatically because PR #7044 was pushed to master and backport to ipa-4-11 is required.