### PR TITLE
[Backport][ipa-4-11] ipa-client: correct directory location by using constants instead

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3697,9 +3697,12 @@ def uninstall(options):
         logger.warning(
             'Some installation state has not been restored.\n'
             'This may cause re-installation to fail.\n'
-            'It should be safe to remove /var/lib/ipa-client/sysrestore.state '
+            'It should be safe to remove %s '
             'but it may\n mean your system hasn\'t been restored '
-            'to its pre-installation state.')
+            'to its pre-installation state.',
+            os.path.join(paths.IPA_CLIENT_SYSRESTORE,
+                         sysrestore.SYSRESTORE_STATEFILE)
+        )
 
     # Remove the IPA configuration file
     remove_file(paths.IPA_DEFAULT_CONF)


### PR DESCRIPTION
This PR was opened automatically because PR #7053 was pushed to master and backport to ipa-4-11 is required.