### PR TITLE
group-add-member fails with an external member

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -303,7 +303,7 @@ class DomainValidator:
         # Parse sid string to see if it is really in a SID format
         try:
             test_sid = security.dom_sid(sid)
-        except TypeError:
+        except (TypeError, ValueError):
             raise errors.ValidationError(name='sid',
                                          error=_('SID is not valid'))
 


### PR DESCRIPTION
The command ipa group-add-member --external aduser@addomain.test fails with an internal error when used with samba 4.19.

The command internally calls samba.security.dom_sid(sid) which used to raise a TypeError but now raises a ValueError (commit 9abdd67 on https://github.com/samba-team/samba).

IPA source code needs to handle properly both exception types.

Fixes: https://pagure.io/freeipa/issue/9466