### PR TITLE
/run/ipa/services.list: force perms to 644

### DIFF
--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -140,6 +140,7 @@ class PlatformService:
 
         with open(paths.SVC_LIST_FILE, 'w') as f:
             json.dump(svc_list, f)
+        os.chmod(paths.SVC_LIST_FILE, 0o644)
 
     def stop(self, instance_name="", capture_output=True,
              update_service_list=True):
@@ -161,6 +162,7 @@ class PlatformService:
 
         with open(paths.SVC_LIST_FILE, 'w') as f:
             json.dump(svc_list, f)
+        os.chmod(paths.SVC_LIST_FILE, 0o644)
 
     def reload_or_restart(self, instance_name="", capture_output=True,
                           wait=True):


### PR DESCRIPTION
Force permissions of /run/ipa/services.list to be 644 at creation time.

If leftover from a failed install due to the wrong umask, its mode might be more strict, leading to an IPAFileCheck error in freeipa-healthcheck.