### PR TITLE
[Backport][ipa-4-11] group-add-member fails with an external member

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -303,7 +303,7 @@ class DomainValidator:
         # Parse sid string to see if it is really in a SID format
         try:
             test_sid = security.dom_sid(sid)
-        except TypeError:
+        except (TypeError, ValueError):
             raise errors.ValidationError(name='sid',
                                          error=_('SID is not valid'))
 


### PR DESCRIPTION
This PR was opened automatically because PR #7061 was pushed to master and backport to ipa-4-11 is required.