### PR TITLE
Handle samba changes in samba.security.dom_sid()

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -97,7 +97,7 @@ logger = logging.getLogger(__name__)
 def is_sid_valid(sid):
     try:
         security.dom_sid(sid)
-    except TypeError:
+    except (TypeError, ValueError):
         return False
     else:
         return True
@@ -457,7 +457,7 @@ class DomainValidator:
         try:
             test_sid = security.dom_sid(sid)
             return unicode(test_sid)
-        except TypeError:
+        except (TypeError, ValueError):
             raise errors.ValidationError(name=_('trusted domain object'),
                                          error=_('Trusted domain did not '
                                                  'return a valid SID for '


### PR DESCRIPTION
samba.security.dom_sid() in 4.19 now raises ValueError instead of TypeError. Fix the expected exception.

Related: https://pagure.io/freeipa/issue/9466