### PR TITLE
[Backport][ipa-4-11] Handle samba changes in samba.security.dom_sid()

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -97,7 +97,7 @@ logger = logging.getLogger(__name__)
 def is_sid_valid(sid):
     try:
         security.dom_sid(sid)
-    except TypeError:
+    except (TypeError, ValueError):
         return False
     else:
         return True
@@ -457,7 +457,7 @@ class DomainValidator:
         try:
             test_sid = security.dom_sid(sid)
             return unicode(test_sid)
-        except TypeError:
+        except (TypeError, ValueError):
             raise errors.ValidationError(name=_('trusted domain object'),
                                          error=_('Trusted domain did not '
                                                  'return a valid SID for '


### PR DESCRIPTION
This PR was opened automatically because PR #7064 was pushed to master and backport to ipa-4-11 is required.