### PR TITLE
Fixes: Python SyntaxWarnings about invalid escape sequences

### DIFF
--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -390,7 +390,10 @@ def get_ruv(realm, host, dirman_passwd, nolookup=False, ca=False):
         for ruv in e['nsds50ruv']:
             if ruv.startswith('{replicageneration'):
                 continue
-            data = re.match('\{replica (\d+) (ldap://.*:\d+)\}(\s+\w+\s+\w*){0,1}', ruv)
+            data = re.match(
+                r'\{replica (\d+) (ldap://.*:\d+)\}(\s+\w+\s+\w*){0,1}',
+                ruv
+            )
             if data:
                 rid = data.group(1)
                 (
@@ -718,12 +721,12 @@ def clean_dangling_ruvs(realm, host, options):
             # This needs needs to be split off
             if ruv_dict.get('domain'):
                 master_info['ruvs'] = {
-                    (re.sub(':\d+', '', x), y)
+                    (re.sub(r':\d+', '', x), y)
                     for (x, y) in ruv_dict['domain']
                 }
             if ruv_dict.get('ca'):
                 master_info['csruvs'] = {
-                    (re.sub(':\d+', '', x), y)
+                    (re.sub(r':\d+', '', x), y)
                     for (x, y) in ruv_dict['ca']
                 }
         except Exception as e:


### PR DESCRIPTION
Otherwise we get some SyntaxWarnings about invalid escape sequences such as '\d' and '\{', e.g.:
```console
/usr/sbin/ipa-replica-manage:393: SyntaxWarning: invalid escape sequence '\{'
  data = re.match('\{replica (\d+) (ldap://.*:\d+)\}(\s+\w+\s+\w*){0,1}', ruv)
/usr/sbin/ipa-replica-manage:721: SyntaxWarning: invalid escape sequence '\d'
  (re.sub(':\d+', '', x), y)
/usr/sbin/ipa-replica-manage:726: SyntaxWarning: invalid escape sequence '\d'
  (re.sub(':\d+', '', x), y)
```


Fixes: https://pagure.io/freeipa/issue/9483