### PR TITLE
[Backport][ipa-4-10] ipatests: ignore nsslapd-accesslog-logbuffering WARN in healthcheck

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -635,9 +635,15 @@ class TestIpaHealthCheck(IntegrationTest):
         ipahealthcheck.ipa.host when GSSAPI credentials cannot be obtained
         from host's keytab.
         """
-        msg = (
-            "Minor (2529639107): No credentials cache found"
-        )
+        version = tasks.get_healthcheck_version(self.master)
+        if parse_version(version) >= parse_version("0.15"):
+            msg = (
+                "Service {service} keytab {path} does not exist."
+            )
+        else:
+            msg = (
+                "Minor (2529639107): No credentials cache found"
+            )
 
         with tasks.FileBackup(self.master, paths.KRB5_KEYTAB):
             self.master.run_command(["rm", "-f", paths.KRB5_KEYTAB])

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -13,7 +13,7 @@ import pytest
 
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.test_integration.test_ipahealthcheck import (
-    run_healthcheck, HEALTHCHECK_PKG
+    run_healthcheck, set_excludes, HEALTHCHECK_PKG
 )
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.tasks import (
@@ -982,6 +982,9 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         )
         # manually install KRA to verify that hidden state is synced
         tasks.install_kra(cls.replicas[0])
+
+        set_excludes(cls.master, "key", "DSCLE0004")
+        set_excludes(cls.replicas[0], "key", "DSCLE0004")
 
     def _check_dnsrecords(self, hosts_expected, hosts_unexpected=()):
         domain = DNSName(self.master.domain.name).make_absolute()


### PR DESCRIPTION
This PR was opened automatically because PR #7074 was pushed to master and backport to ipa-4-10 is required.