### PR TITLE
ipaserver/dcerpc: avoid logging stack trace in retrieve_anonymously

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -935,7 +935,12 @@ class TrustDomainInstance:
             else:
                 result = netrc.finddc(address=remote_host, flags=flags)
         except RuntimeError as e:
-            raise assess_dcerpc_error(e)
+            dcerpc_error = assess_dcerpc_error(e)
+            logger.error(
+                getattr(dcerpc_error, "info", None)
+                or getattr(dcerpc_error, "reason", str(dcerpc_error))
+            )
+            return False
 
         if not result:
             return False


### PR DESCRIPTION
If an error occured when searching foc a DC a stack trace was logged, and execution was aborted.

This patch allows execution to continue and log the error message that caused the 'finddc' do fail.

Fixes: https://pagure.io/freeipa/issue/9484
Related: https://issues.redhat.com/browse/RHEL-12149