### PR TITLE
Kdc fix userauth defaults

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -26,6 +26,7 @@
 #include "ipa_kdb.h"
 #include "ipa_krb5.h"
 #include "ipa_hostname.h"
+#include <kadm5/admin.h>
 
 #define IPADB_GLOBAL_CONFIG_CACHE_TIME 60
 
@@ -207,6 +208,19 @@ static const struct {
     { "idp", IPADB_USER_AUTH_IDP },
     { "passkey", IPADB_USER_AUTH_PASSKEY },
     { }
+},
+  objclass_table[] = {
+    { "ipaservice", IPADB_USER_AUTH_PASSWORD },
+    { "ipahost", IPADB_USER_AUTH_PASSWORD },
+    { }
+},
+  princname_table[] = {
+    { KRB5_TGS_NAME, IPADB_USER_AUTH_PASSWORD },
+    { KRB5_KDB_M_NAME, IPADB_USER_AUTH_PASSWORD },
+    { KADM5_ADMIN_SERVICE, IPADB_USER_AUTH_PASSWORD },
+    { KADM5_CHANGEPW_SERVICE, IPADB_USER_AUTH_PASSWORD },
+    { KADM5_HIST_PRINCIPAL, IPADB_USER_AUTH_PASSWORD },
+    { }
 };
 
 void ipadb_parse_user_auth(LDAP *lcontext, LDAPMessage *le,
@@ -217,16 +231,48 @@ void ipadb_parse_user_auth(LDAP *lcontext, LDAPMessage *le,
 
     *userauth = IPADB_USER_AUTH_NONE;
     vals = ldap_get_values_len(lcontext, le, IPA_USER_AUTH_TYPE);
-    if (!vals)
-        return;
+    if (!vals) {
+        /* if there is no explicit ipaUserAuthType set, use objectclass */
+        vals = ldap_get_values_len(lcontext, le, "objectclass");
+        if (!vals)
+            return;
 
-    for (i = 0; vals[i]; i++) {
-        for (j = 0; userauth_table[j].name; j++) {
-            if (strcasecmp(vals[i]->bv_val, userauth_table[j].name) == 0) {
-                *userauth |= userauth_table[j].flag;
-                break;
+        for (i = 0; vals[i]; i++) {
+            for (j = 0; objclass_table[j].name; j++) {
+                if (strcasecmp(vals[i]->bv_val, objclass_table[j].name) == 0) {
+                    *userauth |= objclass_table[j].flag;
+                    break;
+                }
             }
         }
+    } else {
+        for (i = 0; vals[i]; i++) {
+            for (j = 0; userauth_table[j].name; j++) {
+                if (strcasecmp(vals[i]->bv_val, userauth_table[j].name) == 0) {
+                    *userauth |= userauth_table[j].flag;
+                    break;
+                }
+            }
+        }
+    }
+
+    /* If neither ipaUserAuthType nor objectClass were definitive,
+     * check the krbPrincipalName to see if it is krbtgt/ or K/M one */
+    if (*userauth == IPADB_USER_AUTH_NONE) {
+        ldap_value_free_len(vals);
+        vals = ldap_get_values_len(lcontext, le, "krbprincipalname");
+        if (!vals)
+            return;
+        for (i = 0; vals[i]; i++) {
+            for (j = 0; princname_table[j].name; j++) {
+                if (strncmp(vals[i]->bv_val, princname_table[j].name,
+                            strlen(princname_table[j].name)) == 0) {
+                    *userauth |= princname_table[j].flag;
+                    break;
+                }
+            }
+        }
+
     }
     /* If password auth is enabled, enable hardened policy too. */
     if (*userauth & IPADB_USER_AUTH_PASSWORD) {

--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -195,6 +195,9 @@ done:
     return base;
 }
 
+/* In this table all _AUTH_PASSWORD entries will be
+ * expanded to include _AUTH_HARDENED in ipadb_parse_user_auth()
+ * which means there is no need to explicitly add it here */
 static const struct {
     const char *name;
     enum ipadb_user_auth flag;

--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -119,11 +119,8 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
             pol_limits = &(ied->pol_limits[IPADB_USER_AUTH_IDX_RADIUS]);
         } else if (strcmp(auth_indicator, "pkinit") == 0) {
             valid_auth_indicators++;
-            if (!(ua & IPADB_USER_AUTH_PKINIT)) {
-                *status = "PKINIT pre-authentication not allowed for this user.";
-                kerr = KRB5KDC_ERR_POLICY;
-                goto done;
-            }
+            /* allow PKINIT unconditionally -- it has passed already at this
+             * point so some certificate was useful, only apply the limits */
             pol_limits = &(ied->pol_limits[IPADB_USER_AUTH_IDX_PKINIT]);
         } else if (strcmp(auth_indicator, "hardened") == 0) {
             valid_auth_indicators++;


### PR DESCRIPTION
If default user authentication type is set to a list that does not include a password or a hardened credential, the resulting configuration might be incorrect for service principals, including a krbtgt/.. one.

Add detection of service principals to avoid these situations and always allow password or hardened for services.

Fixes: https://pagure.io/freeipa/issue/9485