### PR TITLE
Remove ipaserver.custodia.__init__.py

### DIFF
--- a/ipaserver/custodia/__init__.py
+++ b/ipaserver/custodia/__init__.py
@@ -1,3 +1,0 @@
-# custodia namespace
-# You must NOT include any other code and data in __init__.py
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
Use native Python namespaces instead.

Related: https://pagure.io/freeipa/issue/9467