### PR TITLE
[Backport][ipa-4-11] Remove ipaserver.custodia.__init__.py

### DIFF
--- a/ipaserver/custodia/__init__.py
+++ b/ipaserver/custodia/__init__.py
@@ -1,3 +1,0 @@
-# custodia namespace
-# You must NOT include any other code and data in __init__.py
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
This PR was opened automatically because PR #7085 was pushed to master and backport to ipa-4-11 is required.