### PR TITLE
[Backport][ipa-4-10] group-add-member fails with an external member

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -303,7 +303,7 @@ class DomainValidator:
         # Parse sid string to see if it is really in a SID format
         try:
             test_sid = security.dom_sid(sid)
-        except TypeError:
+        except (TypeError, ValueError):
             raise errors.ValidationError(name='sid',
                                          error=_('SID is not valid'))
 

--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -97,7 +97,7 @@ logger = logging.getLogger(__name__)
 def is_sid_valid(sid):
     try:
         security.dom_sid(sid)
-    except TypeError:
+    except (TypeError, ValueError):
         return False
     else:
         return True
@@ -457,7 +457,7 @@ class DomainValidator:
         try:
             test_sid = security.dom_sid(sid)
             return unicode(test_sid)
-        except TypeError:
+        except (TypeError, ValueError):
             raise errors.ValidationError(name=_('trusted domain object'),
                                          error=_('Trusted domain did not '
                                                  'return a valid SID for '


### PR DESCRIPTION
This is backport of PR #7061 and PR #7064 to ipa-4-10 branch.
PR was ACKed automatically because this is backport. Wait for CI to finish before pushing. In case of questions or problems contact @flo-renaud who is author of the original PR.