### PR TITLE
Fix ipa-client-automount install/uninstall with new install states

### DIFF
--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -340,14 +340,16 @@ def configure_nfs(fstore, statestore, options):
 
 
 def configure_automount():
-    try:
-        check_client_configuration()
-    except ScriptError as e:
-        print(e.msg)
-        sys.exit(e.rval)
+    statestore = sysrestore.StateFile(paths.IPA_CLIENT_SYSRESTORE)
+    if not statestore.get_state('installation', 'automount'):
+        # not called from ipa-client-install
+        try:
+            check_client_configuration()
+        except ScriptError as e:
+            print(e.msg)
+            sys.exit(e.rval)
 
     fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
-    statestore = sysrestore.StateFile(paths.IPA_CLIENT_SYSRESTORE)
 
     options, _args = parse_options()
 

--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -36,7 +36,7 @@ from six.moves.urllib.parse import urlsplit
 
 from optparse import OptionParser  # pylint: disable=deprecated-module
 from ipapython import ipachangeconf
-from ipaclient.install import ipadiscovery
+from ipaclient import discovery
 from ipaclient.install.client import (
     CLIENT_NOT_CONFIGURED,
     CLIENT_ALREADY_CONFIGURED,
@@ -384,12 +384,12 @@ def configure_automount():
         sys.exit(CLIENT_ALREADY_CONFIGURED)
 
     autodiscover = False
-    ds = ipadiscovery.IPADiscovery()
+    ds = discovery.IPADiscovery()
     if not options.server:
         print("Searching for IPA server...")
         ret = ds.search(ca_cert_path=ca_cert_path)
         logger.debug('Executing DNS discovery')
-        if ret == ipadiscovery.NO_LDAP_SERVER:
+        if ret == discovery.NO_LDAP_SERVER:
             logger.debug('Autodiscovery did not find LDAP server')
             s = urlsplit(api.env.xmlrpc_uri)
             server = [s.netloc]
@@ -409,14 +409,14 @@ def configure_automount():
         server = options.server
         logger.debug("Verifying that %s is an IPA server", server)
         ldapret = ds.ipacheckldap(server, api.env.realm, ca_cert_path)
-        if ldapret[0] == ipadiscovery.NO_ACCESS_TO_LDAP:
+        if ldapret[0] == discovery.NO_ACCESS_TO_LDAP:
             print("Anonymous access to the LDAP server is disabled.")
             print("Proceeding without strict verification.")
             print(
                 "Note: This is not an error if anonymous access has been "
                 "explicitly restricted."
             )
-        elif ldapret[0] == ipadiscovery.NO_TLS_LDAP:
+        elif ldapret[0] == discovery.NO_TLS_LDAP:
             logger.warning("Unencrypted access to LDAP is not supported.")
         elif ldapret[0] != 0:
             sys.exit('Unable to confirm that %s is an IPA server' % server)


### PR DESCRIPTION
Issue 8384 introduced a new installation state for the statestore
to identify when client/server installation is completely finished
rather than relying on has_files().

The problem is that ipa-client-automount may be called during
ipa-client-install and since installation is not complete at that
point the automount install was failing with "IPA client not
configured".

Add a new state, 'automount', to designate that automount installation
is in process. If check_client_configuration() fails it checks to
see if [installation] automount is True. If so it continues with the
installation.

This also addresses an issue where the filestore and statestore are
shared between the client and automount installers but the client
wasn't refreshing state after automount completed. This resulted in
an incomplete state and index file of backed-up files which caused
files to not be restored on uninstall and the state file to be
orphaned.

Fixes: https://pagure.io/freeipa/issue/9487

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
