### PR TITLE
[Backport][ipa-4-11] Integration tests: disable test_sso

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1814,17 +1814,17 @@ jobs:
         timeout: 5000
         topology: *master_2repl_1client
 
-  fedora-latest/test_sso:
-    requires: [fedora-latest/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_sso.py
-        template: *ci-master-latest
-        timeout: 5000
-        topology: *master_2repl_1client
+#  fedora-latest/test_sso:
+#    requires: [fedora-latest/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-latest/build_url}'
+#        test_suite: test_integration/test_sso.py
+#        template: *ci-master-latest
+#        timeout: 5000
+#        topology: *master_2repl_1client
 
   fedora-latest/test_random_serial_numbers_TestInstallWithCA_DNS1_RSN:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1958,18 +1958,18 @@ jobs:
         timeout: 5000
         topology: *master_2repl_1client
 
-  fedora-latest/test_sso:
-    requires: [fedora-latest/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-latest/build_url}'
-        selinux_enforcing: True
-        test_suite: test_integration/test_sso.py
-        template: *ci-master-latest
-        timeout: 5000
-        topology: *master_2repl_1client
+#  fedora-latest/test_sso:
+#    requires: [fedora-latest/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-latest/build_url}'
+#        selinux_enforcing: True
+#        test_suite: test_integration/test_sso.py
+#        template: *ci-master-latest
+#        timeout: 5000
+#        topology: *master_2repl_1client
 
   fedora-latest/test_random_serial_numbers_TestInstallWithCA_DNS1_RSN:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -2103,19 +2103,19 @@ jobs:
         timeout: 5000
         topology: *master_2repl_1client
 
-  testing-fedora/test_sso:
-    requires: [testing-fedora/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{testing-fedora/build_url}'
-        update_packages: True
-        enable_testing_repo: True
-        test_suite: test_integration/test_sso.py
-        template: *ci-master-latest
-        timeout: 5000
-        topology: *master_2repl_1client
+#  testing-fedora/test_sso:
+#    requires: [testing-fedora/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{testing-fedora/build_url}'
+#        update_packages: True
+#        enable_testing_repo: True
+#        test_suite: test_integration/test_sso.py
+#        template: *ci-master-latest
+#        timeout: 5000
+#        topology: *master_2repl_1client
 
   testing-fedora/test_random_serial_numbers_TestInstallWithCA_DNS1_RSN:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2247,20 +2247,20 @@ jobs:
         timeout: 5000
         topology: *master_2repl_1client
 
-  testing-fedora/test_sso:
-    requires: [testing-fedora/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{testing-fedora/build_url}'
-        update_packages: True
-        selinux_enforcing: True
-        enable_testing_repo: True
-        test_suite: test_integration/test_sso.py
-        template: *ci-master-latest
-        timeout: 5000
-        topology: *master_2repl_1client
+#  testing-fedora/test_sso:
+#    requires: [testing-fedora/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{testing-fedora/build_url}'
+#        update_packages: True
+#        selinux_enforcing: True
+#        enable_testing_repo: True
+#        test_suite: test_integration/test_sso.py
+#        template: *ci-master-latest
+#        timeout: 5000
+#        topology: *master_2repl_1client
 
   testing-fedora/test_random_serial_numbers_TestInstallWithCA_DNS1_RSN:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1814,17 +1814,17 @@ jobs:
         timeout: 5000
         topology: *master_2repl_1client
 
-  fedora-previous/test_sso:
-    requires: [fedora-previous/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-previous/build_url}'
-        test_suite: test_integration/test_sso.py
-        template: *ci-master-previous
-        timeout: 5000
-        topology: *master_2repl_1client
+#  fedora-previous/test_sso:
+#    requires: [fedora-previous/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-previous/build_url}'
+#        test_suite: test_integration/test_sso.py
+#        template: *ci-master-previous
+#        timeout: 5000
+#        topology: *master_2repl_1client
 
   fedora-previous/test_random_serial_numbers_TestInstallWithCA_DNS1_RSN:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1958,18 +1958,18 @@ jobs:
         timeout: 5000
         topology: *master_2repl_1client
 
-  fedora-rawhide/test_sso:
-    requires: [fedora-rawhide/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-rawhide/build_url}'
-        update_packages: True
-        test_suite: test_integration/test_sso.py
-        template: *ci-master-frawhide
-        timeout: 5000
-        topology: *master_2repl_1client
+#  fedora-rawhide/test_sso:
+#    requires: [fedora-rawhide/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-rawhide/build_url}'
+#        update_packages: True
+#        test_suite: test_integration/test_sso.py
+#        template: *ci-master-frawhide
+#        timeout: 5000
+#        topology: *master_2repl_1client
 
   fedora-rawhide/test_random_serial_numbers_TestInstallWithCA_DNS1_RSN:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
This PR was opened automatically because PR #7099 was pushed to master and backport to ipa-4-11 is required.