### PR TITLE
[Backport][ipa-4-10] Integration tests: disable test_sso

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
@@ -1814,17 +1814,17 @@ jobs:
         timeout: 5000
         topology: *master_2repl_1client
 
-  fedora-latest-ipa-4-10/test_sso:
-    requires: [fedora-latest-ipa-4-10/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-latest-ipa-4-10/build_url}'
-        test_suite: test_integration/test_sso.py
-        template: *ci-ipa-4-10-latest
-        timeout: 5000
-        topology: *master_2repl_1client
+#  fedora-latest-ipa-4-10/test_sso:
+#    requires: [fedora-latest-ipa-4-10/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-latest-ipa-4-10/build_url}'
+#        test_suite: test_integration/test_sso.py
+#        template: *ci-ipa-4-10-latest
+#        timeout: 5000
+#        topology: *master_2repl_1client
 
   fedora-latest-ipa-4-10/test_random_serial_numbers_TestInstallWithCA_DNS1_RSN:
     requires: [fedora-latest-ipa-4-10/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
@@ -1958,18 +1958,18 @@ jobs:
         timeout: 5000
         topology: *master_2repl_1client
 
-  fedora-latest-ipa-4-10/test_sso:
-    requires: [fedora-latest-ipa-4-10/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-latest-ipa-4-10/build_url}'
-        selinux_enforcing: True
-        test_suite: test_integration/test_sso.py
-        template: *ci-ipa-4-10-latest
-        timeout: 5000
-        topology: *master_2repl_1client
+#  fedora-latest-ipa-4-10/test_sso:
+#    requires: [fedora-latest-ipa-4-10/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-latest-ipa-4-10/build_url}'
+#        selinux_enforcing: True
+#        test_suite: test_integration/test_sso.py
+#        template: *ci-ipa-4-10-latest
+#        timeout: 5000
+#        topology: *master_2repl_1client
 
   fedora-latest-ipa-4-10/test_random_serial_numbers_TestInstallWithCA_DNS1_RSN:
     requires: [fedora-latest-ipa-4-10/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
@@ -1814,17 +1814,17 @@ jobs:
         timeout: 5000
         topology: *master_2repl_1client
 
-  fedora-previous-ipa-4-10/test_sso:
-    requires: [fedora-previous-ipa-4-10/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-previous-ipa-4-10/build_url}'
-        test_suite: test_integration/test_sso.py
-        template: *ci-ipa-4-10-previous
-        timeout: 5000
-        topology: *master_2repl_1client
+#  fedora-previous-ipa-4-10/test_sso:
+#    requires: [fedora-previous-ipa-4-10/build]
+#    priority: 50
+#    job:
+#      class: RunPytest
+#      args:
+#        build_url: '{fedora-previous-ipa-4-10/build_url}'
+#        test_suite: test_integration/test_sso.py
+#        template: *ci-ipa-4-10-previous
+#        timeout: 5000
+#        topology: *master_2repl_1client
 
   fedora-previous-ipa-4-10/test_random_serial_numbers_TestInstallWithCA_DNS1_RSN:
     requires: [fedora-previous-ipa-4-10/build]


### PR DESCRIPTION
This is a manual backport of PR https://github.com/freeipa/freeipa/pull/7099 to ipa-4-10.
PR was ACKed automatically because this is backport of PR https://github.com/freeipa/freeipa/pull/7099. Wait for CI to finish before pushing. In case of questions or problems contact @flo-renaud who is author of the original PR.