### PR TITLE
ipatests: Test ipaIdpSub attribute

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_idp.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_2repl_1client


### PR DESCRIPTION
Test case to check if ipaIdpSub is correctly created
for IdP and non-IdP users
    
Related: https://pagure.io/freeipa/issue/9433
    
Signed-off-by: Michal Polovka <mpolovka@redhat.com>
