### PR TITLE
Remove unused pki_theme_* params

### DIFF
--- a/install/share/ipaca_default.ini
+++ b/install/share/ipaca_default.ini
@@ -87,8 +87,6 @@ pki_sslserver_subject_dn=cn=%(ipa_fqdn)s,%(ipa_subject_base)s
 pki_subsystem_nickname=subsystemCert cert-pki-ca
 pki_subsystem_subject_dn=cn=CA Subsystem,%(ipa_subject_base)s
 
-pki_theme_enable=True
-pki_theme_server_dir=/usr/share/pki/common-ui
 pki_audit_group=pkiaudit
 pki_group=pkiuser
 pki_user=pkiuser


### PR DESCRIPTION
The `pki_theme_enable` and `pki_theme_server_dir` params are not used by `pkispawn` so they can be removed.

**Note:** It's not necessary to backport this change to older IPA versions.