### PR TITLE
[Backport][ipa-4-10] ipatests: disable dnssec validation in tests using dnf

### DIFF
--- a/ipatests/test_integration/test_advise.py
+++ b/ipatests/test_integration/test_advise.py
@@ -50,6 +50,16 @@ class TestAdvice(IntegrationTest):
     num_replicas = 0
     num_clients = 1
 
+    @classmethod
+    def install(cls, mh):
+        # Install without dnssec validation because the test is
+        # calling dnf install on the client and mirrors.fedoraproject.org
+        # has a broken trust chain
+        tasks.install_master(
+            cls.master, setup_dns=True, extra_args=['--no-dnssec-validation']
+        )
+        tasks.install_client(cls.master, cls.clients[0])
+
     def execute_advise(self, host, advice_id, *args):
         # ipa-advise script is only available on a server
         tasks.kinit_admin(self.master)

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1262,7 +1262,10 @@ class TestInstallMaster(IntegrationTest):
             tasks.uninstall_packages(self.master, [package_name])
             reinstall = True
         try:
-            tasks.install_master(self.master)
+            # Disable dnssec-validation as the test is calling dnf install
+            # and mirrors.fedoraproject.org have a broken trust chain
+            tasks.install_master(self.master,
+                                 extra_args=['--no-dnssec-validation'])
         finally:
             if reinstall:
                 tasks.install_packages(self.master, [package_name])


### PR DESCRIPTION
This PR was opened automatically because PR #7119 was pushed to master and backport to ipa-4-10 is required.