### PR TITLE
[ipa-4-9] ipa-kdb: Ensure Bronze-Bit check can be enabled

### DIFF
--- a/.wheelconstraints.in
+++ b/.wheelconstraints.in
@@ -13,3 +13,4 @@ ipatests == @VERSION@
 # F36 has 2.12.2
 # https://pagure.io/freeipa/issue/8818 added pylint 2.8 support
 pylint ~= 2.12.2
+netaddr == 0.8.0

--- a/daemons/ipa-kdb/ipa_kdb.h
+++ b/daemons/ipa-kdb/ipa_kdb.h
@@ -367,6 +367,8 @@ krb5_error_code ipadb_is_princ_from_trusted_realm(krb5_context kcontext,
                                                   const char *test_realm, size_t size,
                                                   char **trusted_realm);
 
+#if KRB5_KDB_DAL_MAJOR_VERSION <= 8
+#  ifdef HAVE_KRB5_PAC_FULL_SIGN_COMPAT
 /* Try to detect a Bronze-Bit attack based on the content of the request and
  * data from the KDB.
  *
@@ -379,6 +381,8 @@ krb5_error_code ipadb_is_princ_from_trusted_realm(krb5_context kcontext,
 krb5_error_code
 ipadb_check_for_bronze_bit_attack(krb5_context context, krb5_kdc_req *request,
                                   bool *detected, const char **status);
+#  endif
+#endif
 
 /* DELEGATION CHECKS */
 

--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -185,11 +185,18 @@ ipa_kdcpolicy_check_tgs(krb5_context context, krb5_kdcpolicy_moddata moddata,
                         const char **status, krb5_deltat *lifetime_out,
                         krb5_deltat *renew_lifetime_out)
 {
+#if KRB5_KDB_DAL_MAJOR_VERSION <= 8
+#  ifdef HAVE_KRB5_PAC_FULL_SIGN_COMPAT
     krb5_error_code kerr;
 
     kerr = ipadb_check_for_bronze_bit_attack(context, request, NULL, status);
     if (kerr)
         return KRB5KDC_ERR_POLICY;
+#  else
+#    warning Support for Kerberos PAC extended KDC signature is missing.\
+             This makes FreeIPA vulnerable to the Bronze-Bit exploit (CVE-2020-17049).
+#  endif
+#endif
 
     *status = NULL;
     *lifetime_out = 0;

--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -3299,6 +3299,8 @@ krb5_error_code ipadb_is_princ_from_trusted_realm(krb5_context kcontext,
 	return KRB5_KDB_NOENTRY;
 }
 
+#if KRB5_KDB_DAL_MAJOR_VERSION <= 8
+#  ifdef HAVE_KRB5_PAC_FULL_SIGN_COMPAT
 krb5_error_code
 ipadb_check_for_bronze_bit_attack(krb5_context context, krb5_kdc_req *request,
                                   bool *detected, const char **status)
@@ -3471,3 +3473,5 @@ end:
     ipadb_free_principal(context, proxy_entry);
     return kerr;
 }
+#  endif
+#endif


### PR DESCRIPTION
MIT krb5 1.19 and older do not implement support for PAC ticket signature to protect the encrypted part of tickets. This is the cause of the Bronze-Bit vulnerability (CVE-2020-17043). The Bronze-Bit attack detection mechanism introduced in a847e248 relies on the content of the PAC.

However, since CVE-2022-37967, the content of the PAC can no longer be trusted if the KDC does not support PAC extended KDC signature (aka. PAC full checksum). This signature is supported in MIT krb5 since version 1.21.

Support for the PAC extended KDC signature was backported downstream to krb5 1.18.2 for CentOS 8 Stream ([dist-git commit `7d215a54`](https://gitlab.com/redhat/centos-stream/rpms/krb5/-/commit/7d215a54da9cdaade54a6e2a9f502a29095d0a25)). This makes the content of the PAC still trustworthy there.

This commit disables the Bronze-Bit attack detection mechanism at build time in case krb5 does not provide the `krb5_pac_full_sign_compat()` function.