### PR TITLE
[Backport][ipa-4-10] ipatests: Skip ds_encryption tests on RHEL9 SUT

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -158,7 +158,6 @@ TOMCAT_CONFIG_FILES = (
     paths.CA_CS_CFG_PATH,
 )
 
-
 def run_healthcheck(host, source=None, check=None, output_type="json",
                     failures_only=False, config=None):
     """
@@ -1262,6 +1261,10 @@ class TestIpaHealthCheck(IntegrationTest):
         )
         self.master.run_command(cmd)
 
+    @pytest.mark.skipif((osinfo.id == 'rhel'
+                         and osinfo.version_number >= (9,0)),
+                        reason=" TLS versions below 1.2 are not "
+                        "supported anymore in RHEL9.0 and above.")
     def test_ipahealthcheck_ds_encryption(self, modify_tls):
         """
         This testcase modifies the default TLS version of


### PR DESCRIPTION
This PR was opened automatically because PR #7125 was pushed to master and backport to ipa-4-10 is required.