### PR TITLE
[ipa-4-10] azure tests: pin netaddr version

### DIFF
--- a/.wheelconstraints.in
+++ b/.wheelconstraints.in
@@ -12,3 +12,4 @@ ipatests == @VERSION@
 # keep pylint version in sync with current Fedora release
 # F37 has 2.15.5
 pylint ~= 2.15.5
+netaddr == 0.8.0


### PR DESCRIPTION
python3-netaddr 0.10 breaks azure tests.
Pin the version to 0.8, which is the default version on f38