### PR TITLE
[Backport][ipa-4-10] Fix ipa-client-automount install/uninstall with new install states

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1271,7 +1271,7 @@ def create_sshd_ipa_config(options):
     logger.info('Configured %s', paths.SSHD_IPA_CONFIG)
 
 
-def configure_automount(options):
+def configure_automount(options, statestore):
     logger.info('\nConfiguring automount:')
 
     args = [
@@ -1284,12 +1284,15 @@ def configure_automount(options):
     if not options.sssd:
         args.append('--no-sssd')
 
+    statestore.backup_state('installation', 'automount', True)
     try:
         result = run(args)
     except Exception as e:
         logger.error('Automount configuration failed: %s', str(e))
     else:
         logger.info('%s', result.output_log)
+    finally:
+        statestore.delete_state('installation', 'automount')
 
 
 def configure_nisdomain(options, domain, statestore):
@@ -3285,7 +3288,11 @@ def _install(options, tdict):
         configure_sshd_config(fstore, options)
 
     if options.location:
-        configure_automount(options)
+        configure_automount(options, statestore)
+
+        # Reload the state as automount install may have modified it
+        fstore._load()
+        statestore._load()
 
     if options.configure_firefox:
         configure_firefox(options, statestore, cli_domain)
@@ -3344,12 +3351,15 @@ def uninstall(options):
     fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
     statestore = sysrestore.StateFile(paths.IPA_CLIENT_SYSRESTORE)
 
+    statestore.backup_state('installation', 'automount', True)
     try:
         run([paths.IPA_CLIENT_AUTOMOUNT, "--uninstall", "--debug"])
     except CalledProcessError as e:
         if e.returncode != CLIENT_NOT_CONFIGURED:
             logger.error(
                 "Unconfigured automount client failed: %s", str(e))
+    finally:
+        statestore.delete_state('installation', 'automount')
 
     # Reload the state as automount unconfigure may have modified it
     fstore._load()

--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -340,14 +340,16 @@ def configure_nfs(fstore, statestore, options):
 
 
 def configure_automount():
-    try:
-        check_client_configuration()
-    except ScriptError as e:
-        print(e.msg)
-        sys.exit(e.rval)
+    statestore = sysrestore.StateFile(paths.IPA_CLIENT_SYSRESTORE)
+    if not statestore.get_state('installation', 'automount'):
+        # not called from ipa-client-install
+        try:
+            check_client_configuration()
+        except ScriptError as e:
+            print(e.msg)
+            sys.exit(e.rval)
 
     fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
-    statestore = sysrestore.StateFile(paths.IPA_CLIENT_SYSRESTORE)
 
     options, _args = parse_options()
 

--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -36,7 +36,7 @@ from six.moves.urllib.parse import urlsplit
 
 from optparse import OptionParser  # pylint: disable=deprecated-module
 from ipapython import ipachangeconf
-from ipaclient.install import ipadiscovery
+from ipaclient import discovery
 from ipaclient.install.client import (
     CLIENT_NOT_CONFIGURED,
     CLIENT_ALREADY_CONFIGURED,
@@ -384,12 +384,12 @@ def configure_automount():
         sys.exit(CLIENT_ALREADY_CONFIGURED)
 
     autodiscover = False
-    ds = ipadiscovery.IPADiscovery()
+    ds = discovery.IPADiscovery()
     if not options.server:
         print("Searching for IPA server...")
         ret = ds.search(ca_cert_path=ca_cert_path)
         logger.debug('Executing DNS discovery')
-        if ret == ipadiscovery.NO_LDAP_SERVER:
+        if ret == discovery.NO_LDAP_SERVER:
             logger.debug('Autodiscovery did not find LDAP server')
             s = urlsplit(api.env.xmlrpc_uri)
             server = [s.netloc]
@@ -409,14 +409,14 @@ def configure_automount():
         server = options.server
         logger.debug("Verifying that %s is an IPA server", server)
         ldapret = ds.ipacheckldap(server, api.env.realm, ca_cert_path)
-        if ldapret[0] == ipadiscovery.NO_ACCESS_TO_LDAP:
+        if ldapret[0] == discovery.NO_ACCESS_TO_LDAP:
             print("Anonymous access to the LDAP server is disabled.")
             print("Proceeding without strict verification.")
             print(
                 "Note: This is not an error if anonymous access has been "
                 "explicitly restricted."
             )
-        elif ldapret[0] == ipadiscovery.NO_TLS_LDAP:
+        elif ldapret[0] == discovery.NO_TLS_LDAP:
             logger.warning("Unencrypted access to LDAP is not supported.")
         elif ldapret[0] != 0:
             sys.exit('Unable to confirm that %s is an IPA server' % server)


### PR DESCRIPTION
This PR was opened automatically because PR #7100 was pushed to master and backport to ipa-4-10 is required.