### PR TITLE
[Backport][ipa-4-10] ipaplatform: add opencloudos/tencentos support

### DIFF
--- a/ipaplatform/opencloudos/__init__.py
+++ b/ipaplatform/opencloudos/__init__.py
@@ -1,0 +1,9 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+"""
+This module contains OpenCloudOS family-specific platform files.
+"""
+
+NAME = "opencloudos"

--- a/ipaplatform/opencloudos/constants.py
+++ b/ipaplatform/opencloudos/constants.py
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+"""
+This OpenCloudOS family base platform module exports platform related constants.
+"""
+
+# Fallback to default path definitions
+from __future__ import absolute_import
+
+from ipaplatform.redhat.constants import RedHatConstantsNamespace, User, Group
+
+
+__all__ = ("constants", "User", "Group")
+
+
+class OpenCloudOSConstantsNamespace(RedHatConstantsNamespace):
+    SECURE_NFS_VAR = None
+    NAMED_OPENSSL_ENGINE = "pkcs11"
+
+
+constants = OpenCloudOSConstantsNamespace()

--- a/ipaplatform/opencloudos/paths.py
+++ b/ipaplatform/opencloudos/paths.py
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+"""
+This OpenCloudOS family base platform module exports default filesystem paths
+as common in OpenCloudOS family-based systems.
+"""
+
+from __future__ import absolute_import
+
+from ipaplatform.redhat.paths import RedHatPathNamespace
+
+
+class OpenCloudOSPathNamespace(RedHatPathNamespace):
+    NAMED_CRYPTO_POLICY_FILE = "/etc/crypto-policies/back-ends/bind.config"
+    SYSCONFIG_NFS = "/etc/nfs.conf"
+
+
+paths = OpenCloudOSPathNamespace()

--- a/ipaplatform/opencloudos/services.py
+++ b/ipaplatform/opencloudos/services.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+
+"""
+Contains OpenCloudOS family-specific service class implementations.
+"""
+
+from __future__ import absolute_import
+
+from ipaplatform.redhat import services as redhat_services
+
+# Mappings from service names as FreeIPA code references to these services
+# to their actual systemd service names
+opencloudos_system_units = redhat_services.redhat_system_units.copy()
+opencloudos_system_units["named"] = opencloudos_system_units["named-regular"]
+opencloudos_system_units["named-conflict"] = \
+    opencloudos_system_units["named-pkcs11"]
+
+
+# Service classes that implement OpenCloudOS family-specific behaviour
+
+
+class OpenCloudOSService(redhat_services.RedHatService):
+    system_units = opencloudos_system_units
+
+
+# Function that constructs proper OpenCloudOS family-specific server classes
+# for services of specified name
+
+
+def opencloudos_service_class_factory(name, api=None):
+    if name in ["named", "named-conflict"]:
+        return OpenCloudOSService(name, api)
+    return redhat_services.redhat_service_class_factory(name, api)
+
+
+# Magicdict containing OpenCloudOSService instances.
+
+
+class OpenCloudOSServices(redhat_services.RedHatServices):
+    def service_class_factory(self, name, api=None):
+        return opencloudos_service_class_factory(name, api)
+
+
+# Objects below are expected to be exported by platform module
+
+timedate_services = redhat_services.timedate_services
+service = opencloudos_service_class_factory
+knownservices = OpenCloudOSServices()

--- a/ipaplatform/opencloudos/tasks.py
+++ b/ipaplatform/opencloudos/tasks.py
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+"""
+This module contains default OpenCloudOS family-specific implementations of
+system tasks.
+"""
+
+from __future__ import absolute_import
+
+from ipaplatform.redhat.tasks import RedHatTaskNamespace
+
+
+class OpenCloudOSTaskNamespace(RedHatTaskNamespace):
+    pass
+
+
+tasks = OpenCloudOSTaskNamespace()

--- a/ipaplatform/setup.py
+++ b/ipaplatform/setup.py
@@ -41,7 +41,9 @@ if __name__ == '__main__':
             "ipaplatform.redhat",
             "ipaplatform.rhel",
             "ipaplatform.rhel_container",
-            "ipaplatform.suse"
+            "ipaplatform.suse",
+            "ipaplatform.opencloudos",
+            "ipaplatform.tencentos"
         ],
         install_requires=[
             "cffi",

--- a/ipaplatform/tencentos/__init__.py
+++ b/ipaplatform/tencentos/__init__.py
@@ -1,0 +1,10 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+"""
+This module contains TencentOS specific platform files.
+
+"""
+
+NAME = "tencentos"

--- a/ipaplatform/tencentos/constants.py
+++ b/ipaplatform/tencentos/constants.py
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+"""
+This TencentOS base platform module exports platform related constants.
+"""
+
+# Fallback to default path definitions
+from __future__ import absolute_import
+
+from ipaplatform.redhat.constants import RedHatConstantsNamespace, User, Group
+
+
+__all__ = ("constants", "User", "Group")
+
+
+class TencentOSConstantsNamespace(RedHatConstantsNamespace):
+    SECURE_NFS_VAR = None
+    NAMED_OPENSSL_ENGINE = "pkcs11"
+
+
+constants = TencentOSConstantsNamespace()

--- a/ipaplatform/tencentos/paths.py
+++ b/ipaplatform/tencentos/paths.py
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+"""
+This TencentOS base platform module exports default filesystem paths
+as common in TencentOS-based systems.
+"""
+
+from __future__ import absolute_import
+
+from ipaplatform.redhat.paths import RedHatPathNamespace
+
+
+class TencentOSPathNamespace(RedHatPathNamespace):
+    NAMED_CRYPTO_POLICY_FILE = "/etc/crypto-policies/back-ends/bind.config"
+    SYSCONFIG_NFS = "/etc/nfs.conf"
+
+
+paths = TencentOSPathNamespace()

--- a/ipaplatform/tencentos/services.py
+++ b/ipaplatform/tencentos/services.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+
+"""
+Contains TencentOS specific service class implementations.
+"""
+
+from __future__ import absolute_import
+
+from ipaplatform.redhat import services as redhat_services
+
+# Mappings from service names as FreeIPA code references to these services
+# to their actual systemd service names
+tencentos_system_units = redhat_services.redhat_system_units.copy()
+tencentos_system_units["named"] = tencentos_system_units["named-regular"]
+tencentos_system_units["named-conflict"] = \
+    tencentos_system_units["named-pkcs11"]
+
+
+# Service classes that implement TencentOS-specific behaviour
+
+
+class TencentOSService(redhat_services.RedHatService):
+    system_units = tencentos_system_units
+
+
+# Function that constructs proper TencentOS-specific server classes for
+# services of specified name
+
+
+def tencentos_service_class_factory(name, api=None):
+    if name in ["named", "named-conflict"]:
+        return TencentOSService(name, api)
+    return redhat_services.redhat_service_class_factory(name, api)
+
+
+# Magicdict containing TencentOSService instances.
+
+
+class TencentOSServices(redhat_services.RedHatServices):
+    def service_class_factory(self, name, api=None):
+        return tencentos_service_class_factory(name, api)
+
+
+# Objects below are expected to be exported by platform module
+
+timedate_services = redhat_services.timedate_services
+service = tencentos_service_class_factory
+knownservices = TencentOSServices()

--- a/ipaplatform/tencentos/tasks.py
+++ b/ipaplatform/tencentos/tasks.py
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+"""
+This module contains default TencentOS-specific implementations of system tasks.
+"""
+
+from __future__ import absolute_import
+
+from ipaplatform.redhat.tasks import RedHatTaskNamespace
+
+
+class TencentOSTaskNamespace(RedHatTaskNamespace):
+    pass
+
+
+tasks = TencentOSTaskNamespace()


### PR DESCRIPTION
This PR was opened automatically because PR #7132 was pushed to master and backport to ipa-4-10 is required.