### PR TITLE
[Backport][ipa-4-9] azure tests: pin netaddr version

### DIFF
--- a/.wheelconstraints.in
+++ b/.wheelconstraints.in
@@ -13,3 +13,4 @@ ipatests == @VERSION@
 # F36 has 2.12.2
 # https://pagure.io/freeipa/issue/8818 added pylint 2.8 support
 pylint ~= 2.12.2
+netaddr == 0.8.0


### PR DESCRIPTION
python3-netaddr 0.10 breaks azure tests.
Pin the version to 0.8, which is the default version on f38

This is a manual backport of #7143 from the ipa-4-10 branch to ipa-4-9.