### PR TITLE
adtrustinstance: make sure NetBIOS name defaults are set properly

### DIFF
--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -189,6 +189,8 @@ class ADTRUSTInstance(service.Service):
         self.fqdn = self.fqdn or api.env.host
         self.host_netbios_name = make_netbios_name(self.fqdn)
         self.realm = self.realm or api.env.realm
+        if not self.netbios_name:
+            self.netbios_name = make_netbios_name(self.realm)
 
         self.suffix = ipautil.realm_to_suffix(self.realm)
         self.ldapi_socket = "%%2fvar%%2frun%%2fslapd-%s.socket" % \


### PR DESCRIPTION
Some tools may pass None as NetBIOS name if not put explicitly by a user. This meant to use default NetBIOS name generator based on the domain (realm) name. However, this wasn't done properly, so None is passed later to python-ldap and it rejects such LDAP entry.

Fixes: https://pagure.io/freeipa/issue/9514