### PR TITLE
[Backport][ipa-4-9] Server affinity: Don't rely just on [ca|kra]_enabled for installs

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1143,7 +1143,8 @@ def promote_check(installer):
                 installer._remote_api = remote_api
                 conn = remote_api.Backend.ldap2
                 conn.connect(ccache=installer._ccache)
-                config.kra_host_name = kra_host
+            config.kra_host_name = kra_host
+            if options.setup_kra:  # only reset ca_host if KRA is requested
                 config.ca_host_name = kra_host
             kra_enabled = True  # There is a KRA somewhere in the topology
             if options.setup_kra and options.server and \
@@ -1381,7 +1382,7 @@ def install(installer):
     custodia = custodiainstance.get_custodia_instance(config, mode)
     custodia.create_instance()
 
-    if ca_enabled:
+    if options.setup_ca and ca_enabled:
         options.realm_name = config.realm_name
         options.domain_name = config.domain_name
         options.host_name = config.host_name
@@ -1397,7 +1398,7 @@ def install(installer):
     service.print_msg("Finalize replication settings")
     ds.finalize_replica_config()
 
-    if kra_enabled:
+    if options.setup_kra and kra_enabled:
         kra.install(api, config, options, custodia=custodia)
 
     service.print_msg("Restarting the KDC")


### PR DESCRIPTION
This PR was opened automatically because PR #7159 was pushed to master and backport to ipa-4-9 is required.