### PR TITLE
[Backport][ipa-4-9] Server affinity: call ca.install() if there is a CA in the topology

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -303,9 +303,10 @@ def install_step_0(standalone, replica_config, options, custodia):
         promote = False
     else:
         cafile = os.path.join(replica_config.dir, 'cacert.p12')
-        custodia.get_ca_keys(
-            cafile,
-            replica_config.dirman_password)
+        if replica_config.setup_ca:
+            custodia.get_ca_keys(
+                cafile,
+                replica_config.dirman_password)
 
         ca_signing_algorithm = None
         ca_type = None

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1382,11 +1382,13 @@ def install(installer):
     custodia = custodiainstance.get_custodia_instance(config, mode)
     custodia.create_instance()
 
-    if options.setup_ca and ca_enabled:
+    if ca_enabled:
         options.realm_name = config.realm_name
         options.domain_name = config.domain_name
         options.host_name = config.host_name
         options.dm_password = config.dirman_password
+        # Always call ca.install() if there is a CA in the topology
+        # to ensure the RA agent is present.
         ca.install(False, config, options, custodia=custodia)
 
     # configure PKINIT now that all required services are in place
@@ -1398,7 +1400,8 @@ def install(installer):
     service.print_msg("Finalize replication settings")
     ds.finalize_replica_config()
 
-    if options.setup_kra and kra_enabled:
+    if kra_enabled:
+        # The KRA installer checks for itself the status of setup_kra
         kra.install(api, config, options, custodia=custodia)
 
     service.print_msg("Restarting the KDC")


### PR DESCRIPTION
This PR was opened automatically because PR #7170 was pushed to master and backport to ipa-4-9 is required.