### PR TITLE
[ipa-4-10] azure pipeline: pin cryptography version to 37.0.2

### DIFF
--- a/.wheelconstraints.in
+++ b/.wheelconstraints.in
@@ -13,3 +13,5 @@ ipatests == @VERSION@
 # F37 has 2.15.5
 pylint ~= 2.15.5
 netaddr == 0.8.0
+# f37 and f38 have python-cryptography 37.0.2
+cryptography == 37.0.2


### PR DESCRIPTION
The azure pipeline is running tox tests, which install cryptography using pip. The latest version is not compatible, so we need to pin it to 37.0.2 which is the default version shipped as a rpm package in fedora 37 and fedora 38.

Fixes: https://pagure.io/freeipa/issue/9518