### PR TITLE
[ipa-4-9] ipa-kdb: Disable Bronze-Bit check if PAC not available

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.h
+++ b/daemons/ipa-kdb/ipa_kdb.h
@@ -370,17 +370,21 @@ krb5_error_code ipadb_is_princ_from_trusted_realm(krb5_context kcontext,
 #if KRB5_KDB_DAL_MAJOR_VERSION <= 8
 #  ifdef HAVE_KRB5_PAC_FULL_SIGN_COMPAT
 /* Try to detect a Bronze-Bit attack based on the content of the request and
- * data from the KDB.
+ * data from the KDB. This check will work only if the domain supports MS-PAC.
  *
  *   context     krb5 context
  *   request     KDB request
- *   detected    Set to "true" if a bronze bit attack is detected and the
- *               pointer is not NULL. Remains unset otherwise.
+ *   supported   If not NULL, set to "false" in case the Bronze-Bit exploit
+ *               detection process silently failed to complete because the
+ *               domain does not meet requirements. Set to "true" otherwise.
+ *   detected    If not NULL, set to "true" if a Bronze-Bit attack is detected.
+ *               Set to "false" otherwise.
  *   status      If the call fails and the pointer is not NULL, set it with a
  *               message describing the cause of the failure. */
 krb5_error_code
 ipadb_check_for_bronze_bit_attack(krb5_context context, krb5_kdc_req *request,
-                                  bool *detected, const char **status);
+                                  bool *supported, bool *detected,
+                                  const char **status);
 #  endif
 #endif
 

--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -188,10 +188,18 @@ ipa_kdcpolicy_check_tgs(krb5_context context, krb5_kdcpolicy_moddata moddata,
 #if KRB5_KDB_DAL_MAJOR_VERSION <= 8
 #  ifdef HAVE_KRB5_PAC_FULL_SIGN_COMPAT
     krb5_error_code kerr;
+    bool supported;
 
-    kerr = ipadb_check_for_bronze_bit_attack(context, request, NULL, status);
+    kerr = ipadb_check_for_bronze_bit_attack(context, request, supported, NULL,
+                                             status);
     if (kerr)
         return KRB5KDC_ERR_POLICY;
+
+    if (!supported)
+        krb5_klog_syslog(LOG_WARNING, "MS-PAC not available. This makes "
+                         "FreeIPA vulnerable to the Bronze-Bit exploit "
+                         "(CVE-2020-17049). Please generate SIDs to enable "
+                         "PAC support.");
 #  else
 #    warning Support for Kerberos PAC extended KDC signature is missing.\
              This makes FreeIPA vulnerable to the Bronze-Bit exploit (CVE-2020-17049).


### PR DESCRIPTION
The Bronze-Bit check introduced in commit a847e2483b4c4832ee5129901da169f4eb0d1392 requires the MS-PAC to be present in the evidence ticket in order for S4U2Proxy requests to be accepted. This actually requires SIDs to be set.

However, domains that were initialized before commit e527857d000e558b3288a7a210400abaf2171237 may still not have SIDs configured. This would results in all S4U2Proxy requests to fail (including all the HTTP API requests).

This present commit disables the check for the Bronze-Bit exploit (CVE-2020-17049) in case the domain is not able to generate PACs. Instead, it prints a warning message in the KDC logs each time a S4U2Proxy request is processed.

Fixes: https://pagure.io/freeipa/issue/9521