### PR TITLE
[Backport][ipa-4-10] test_acme: Use ipalib.x509

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -4,11 +4,10 @@
 
 import time
 
-from cryptography.hazmat.backends import default_backend
-from cryptography import x509
 import pytest
 
 from ipalib.constants import IPA_CA_RECORD
+from ipalib import x509
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration.firewall import Firewall
 from ipatests.pytest_ipa.integration import tasks
@@ -278,7 +277,7 @@ class TestACME(CALessBase):
         cert_path = \
             f'/etc/letsencrypt/live/{self.clients[0].hostname}/cert.pem'
         data = self.clients[0].get_file_contents(cert_path)
-        cert = x509.load_pem_x509_certificate(data, backend=default_backend())
+        cert = x509.load_pem_x509_certificate(data)
 
         # revoke cert via ACME
         self.clients[0].run_command(
@@ -669,7 +668,7 @@ class TestACMERenew(IntegrationTest):
         data = self.clients[0].get_file_contents(
             f'/etc/letsencrypt/live/{self.clients[0].hostname}/cert.pem'
         )
-        cert = x509.load_pem_x509_certificate(data, backend=default_backend())
+        cert = x509.load_pem_x509_certificate(data)
         initial_expiry = cert.not_valid_after_utc
 
         self.clients[0].run_command(['certbot', 'renew'])
@@ -677,7 +676,7 @@ class TestACMERenew(IntegrationTest):
         data = self.clients[0].get_file_contents(
             f'/etc/letsencrypt/live/{self.clients[0].hostname}/cert.pem'
         )
-        cert = x509.load_pem_x509_certificate(data, backend=default_backend())
+        cert = x509.load_pem_x509_certificate(data)
         renewed_expiry = cert.not_valid_after_utc
 
         assert initial_expiry != renewed_expiry

--- a/ipatests/test_integration/test_ipa_cert_fix.py
+++ b/ipatests/test_integration/test_ipa_cert_fix.py
@@ -5,13 +5,12 @@
 """
 Module provides tests for ipa-cert-fix CLI.
 """
-from cryptography.hazmat.backends import default_backend
-from cryptography import x509
 from datetime import datetime, date
 import pytest
 import time
 
 import logging
+from ipalib import x509
 from ipaplatform.paths import paths
 from ipapython.ipaldap import realm_to_serverid
 from ipatests.pytest_ipa.integration import tasks
@@ -91,7 +90,7 @@ def get_cert_expiry(host, nssdb_path, cert_nick):
         '-o', '/root/cert.pem'
     ])
     data = host.get_file_contents('/root/cert.pem')
-    cert = x509.load_pem_x509_certificate(data, backend=default_backend())
+    cert = x509.load_pem_x509_certificate(data)
     return cert.not_valid_after_utc
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #7188 was pushed to master and backport to ipa-4-10 is required.