### PR TITLE
ipatests: test_idp fails calling yum list wget

### DIFF
--- a/ipatests/test_integration/test_idp.py
+++ b/ipatests/test_integration/test_idp.py
@@ -217,7 +217,7 @@ class TestIDPKeycloak(IntegrationTest):
             assert "User keycloakuser may run the following commands" in test
             assert "/usr/bin/yum" in test
             kinit_idp(self.client, 'keycloakuser', self.client)
-            test_sudo = 'su -c "sudo yum list wget" keycloakuser'
+            test_sudo = 'su -c "sudo yum list yum" keycloakuser'
             self.client.run_command(test_sudo)
             list_fail = self.master.run_command(cmd).stdout_text
             assert "User keycloakuser is not allowed to run sudo" in list_fail


### PR DESCRIPTION
On rawhide, the package wget has been replaced with wget2
(more info in https://bugzilla.redhat.com/show_bug.cgi?id=2254790).

The test test_idp is checking that the sudo command is working
for a keycloak user, by creating a sudo rule for the yum command
and calling sudo yum list wget.
As the wget package does not exist any more on Rawhide, the command
returns an error:
Error: No matching Packages to list
and the test fails.

Replace the call "sudo yum list wget" with a call to "sudo yum list yum"
as the yum package is always present.

Fixes: https://pagure.io/freeipa/issue/9522