### PR TITLE
[Backport][ipa-4-11] ipa-backup: adapt for 389ds switch to LMDB

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -78,8 +78,8 @@
 %global ds_version 1.4.3.16-12
 %global selinux_policy_version 3.14.3-107
 %else
-# DNA interval enabled
-%global ds_version 2.0.5-1
+# version supporting LMDB and lib389.cli_ctl.dblib.run_dbscan utility
+%global ds_version 2.1.0
 %global selinux_policy_version 38.1.1-1
 %endif
 
@@ -124,10 +124,11 @@
 
 # Make sure to use 389-ds-base versions that fix https://github.com/389ds/389-ds-base/issues/4700
 # and has DNA interval enabled
+# version supporting LMDB and lib389.cli_ctl.dblib.run_dbscan utility
 %if 0%{?fedora} < 34
 %global ds_version 1.4.4.16-1
 %else
-%global ds_version 2.0.7-1
+%global ds_version 2.1.0
 %endif
 
 # Fix for TLS 1.3 PHA, RHBZ#1775146

--- a/ipaserver/install/ipa_backup.py
+++ b/ipaserver/install/ipa_backup.py
@@ -41,6 +41,7 @@ from ipaserver.install import installutils
 from ipapython import ipaldap
 from ipaplatform.constants import constants
 from ipaplatform.tasks import tasks
+from lib389.cli_ctl.dblib import run_dbscan
 
 # pylint: disable=import-error
 if six.PY3:
@@ -337,8 +338,11 @@ class Backup(admintool.AdminTool):
             instance = ipaldap.realm_to_serverid(api.env.realm)
             if os.path.exists(paths.VAR_LIB_SLAPD_INSTANCE_DIR_TEMPLATE %
                               instance):
-                if os.path.exists(paths.SLAPD_INSTANCE_DB_DIR_TEMPLATE %
-                                  (instance, 'ipaca')):
+                # Check existence of ipaca backend
+                dbpath = (paths.SLAPD_INSTANCE_DB_DIR_TEMPLATE %
+                          (instance, ""))
+                output = run_dbscan(['-L', dbpath])
+                if 'ipaca/' in output:
                     self.db2ldif(instance, 'ipaca', online=options.online)
                 self.db2ldif(instance, 'userRoot', online=options.online)
                 self.db2bak(instance, online=options.online)


### PR DESCRIPTION
This PR was opened automatically because PR #7192 was pushed to master and backport to ipa-4-11 is required.