### PR TITLE
[Backport][ipa-4-11] ipatests: test_idp fails calling yum list wget

### DIFF
--- a/ipatests/test_integration/test_idp.py
+++ b/ipatests/test_integration/test_idp.py
@@ -217,7 +217,7 @@ class TestIDPKeycloak(IntegrationTest):
             assert "User keycloakuser may run the following commands" in test
             assert "/usr/bin/yum" in test
             kinit_idp(self.client, 'keycloakuser', self.client)
-            test_sudo = 'su -c "sudo yum list wget" keycloakuser'
+            test_sudo = 'su -c "sudo yum list yum" keycloakuser'
             self.client.run_command(test_sudo)
             list_fail = self.master.run_command(cmd).stdout_text
             assert "User keycloakuser is not allowed to run sudo" in list_fail


### PR DESCRIPTION
This PR was opened automatically because PR #7191 was pushed to master and backport to ipa-4-11 is required.