### PR TITLE
ipa-kdb: support Samba 4.20 private libraries

### DIFF
--- a/daemons/ipa-kdb/Makefile.am
+++ b/daemons/ipa-kdb/Makefile.am
@@ -116,7 +116,7 @@ ipa_kdb_tests_LDADD =          \
        $(top_builddir)/util/libutil.la	\
        -lkdb5                  \
        -lsss_idmap             \
-       -lsamba-security-samba4 \
+       -l$(SAMBA_SECURITY_LIBS)\
        -lsamba-errors          \
        $(NULL)
 

--- a/server.m4
+++ b/server.m4
@@ -182,6 +182,14 @@ AC_CHECK_LIB([smbldap],[smbldap_set_bind_callback],
              [AC_DEFINE([HAVE_SMBLDAP_SET_BIND_CALLBACK], [1], [struct smbldap_state is opaque])],
              [AC_MSG_WARN([libsmbldap is not opaque, not using smbldap_set_bind_callback])],
              [$SAMBA40EXTRA_LIBPATH])
+AC_CHECK_LIB([samba-security-private-samba],[dom_sid_string],
+             [SAMBA_SECURITY_LIBS=samba-security-private-samba],
+             [AC_CHECK_LIB([samba-security-samba4],[dom_sid_string],
+                           [SAMBA_SECURITY_LIBS=samba-security-samba4],
+                           [AC_MSG_ERROR([Cannot find private samba-security library])],
+                           [$SAMBA40EXTRA_LIBPATH])],
+             [$SAMBA40EXTRA_LIBPATH])
+AC_SUBST(SAMBA_SECURITY_LIBS)
 
 dnl ---------------------------------------------------------------------------
 dnl Check for libunistring


### PR DESCRIPTION
Samba 4.20 will change name extension of the private libraries from 'samba4' to 'private-samba'. Detect private extension through configure step and make sure to use the right library name in Makefile.