### PR TITLE
[ipa-4-9] ipd-kdb: Fix some mistakes in ipadb_check_for_bronze_bit_attack()

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.h
+++ b/daemons/ipa-kdb/ipa_kdb.h
@@ -382,7 +382,8 @@ krb5_error_code ipadb_is_princ_from_trusted_realm(krb5_context kcontext,
  *   status      If the call fails and the pointer is not NULL, set it with a
  *               message describing the cause of the failure. */
 krb5_error_code
-ipadb_check_for_bronze_bit_attack(krb5_context context, krb5_kdc_req *request,
+ipadb_check_for_bronze_bit_attack(krb5_context context,
+                                  const krb5_kdc_req *request,
                                   bool *supported, bool *detected,
                                   const char **status);
 #  endif

--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -190,7 +190,7 @@ ipa_kdcpolicy_check_tgs(krb5_context context, krb5_kdcpolicy_moddata moddata,
     krb5_error_code kerr;
     bool supported;
 
-    kerr = ipadb_check_for_bronze_bit_attack(context, request, supported, NULL,
+    kerr = ipadb_check_for_bronze_bit_attack(context, request, &supported, NULL,
                                              status);
     if (kerr)
         return KRB5KDC_ERR_POLICY;

--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -3308,13 +3308,14 @@ krb5_error_code ipadb_is_princ_from_trusted_realm(krb5_context kcontext,
 #if KRB5_KDB_DAL_MAJOR_VERSION <= 8
 #  ifdef HAVE_KRB5_PAC_FULL_SIGN_COMPAT
 krb5_error_code
-ipadb_check_for_bronze_bit_attack(krb5_context context, krb5_kdc_req *request,
+ipadb_check_for_bronze_bit_attack(krb5_context context,
+                                  const krb5_kdc_req *request,
                                   bool *supported, bool *detected,
                                   const char **status)
 {
     krb5_error_code kerr;
     const char *st = NULL;
-    size_t i, j;
+    size_t i, j = 0;
     bool in_supported = true, in_detected = false;
     struct ipadb_context *ipactx;
     krb5_ticket *evidence_tkt;


### PR DESCRIPTION
Primarily meant to fix this compilation error:

```
ipa_kdb_kdcpolicy.c:191:64: error: incompatible type for argument 3 of 'ipadb_check_for_bronze_bit_attack'
     kerr = ipadb_check_for_bronze_bit_attack(context, request, supported, NULL,
                                                                ^~~~~~~~~
In file included from ipa_kdb_kdcpolicy.c:12:
ipa_kdb.h:384:41: note: expected '_Bool *' but argument is of type '_Bool'
                                   bool *supported, bool *detected,
                                         ^
```

Also includes additional changes to silent some warnings.

Fixes: https://pagure.io/freeipa/issue/9521