### PR TITLE
[Backport][ipa-4-9] ipatests: fix tasks.wait_for_replication method

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1510,7 +1510,7 @@ def wait_for_replication(ldap, timeout=30,
         statuses = [entry.single_value[status_attr] for entry in entries]
         wrong_statuses = [s for s in statuses
                           if not re.match(target_status_re, s)]
-        if any(e.single_value[progress_attr] == 'TRUE' for e in entries):
+        if any(e.single_value[progress_attr] for e in entries):
             msg = 'Replication not finished'
             logger.debug(msg)
         elif wrong_statuses:


### PR DESCRIPTION
This PR was opened automatically because PR #7228 was pushed to master and backport to ipa-4-9 is required.