### PR TITLE
ipatests: check_subca should be more robust wrt key nickname 

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,41 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_replica_promotion_TestSubCAkeyReplication:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *master_1repl
+
+  pki-fedora/build:
+    requires: []
+    priority: 100
+    job:
+      class: Build
+      args:
+        copr: '@pki/master'
+        git_repo: '{git_repo}'
+        git_refspec: '{git_refspec}'
+        template: *ci-master-latest
+        timeout: 1800
+        topology: *build
+
+  pki-fedora/test_replica_promotion_TestSubCAkeyReplication:
+    requires: [pki-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{pki-fedora/build_url}'
+        update_packages: True
+        copr: '@pki/master'
+        test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -636,15 +636,9 @@ class TestSubCAkeyReplication(IntegrationTest):
         # ipa ca-show returns 0 even if the cert cannot be found locally.
         if "ipa: ERROR:" in result.stderr_text:
             return False
-        tasks.run_certutil(
-            host, ['-L', '-n', cert_nick], paths.PKI_TOMCAT_ALIAS_DIR
-        )
-        host.run_command([
-            paths.CERTUTIL, '-d', paths.PKI_TOMCAT_ALIAS_DIR,
-            '-f', paths.PKI_TOMCAT_ALIAS_PWDFILE_TXT,
-            '-K', '-n', cert_nick
-        ])
-        return True
+
+        certs, keys = self.get_certinfo(host)
+        return cert_nick in certs and cert_nick in keys
 
     def get_certinfo(self, host):
         result = tasks.run_certutil(


### PR DESCRIPTION
The test check_subca is using certutil -L -n nickname
or certutil -K -n nickname to find a cert or a key in a database
using its nickname.
Sometimes the key nickname contains the token (for instance
the cert nickname is "caSigningCert cert-pki-ca" but the key
nickname is "NSS Certificate DB:caSigningCert cert-pki-ca"),
and this make check_subca fail.

Rewrite the check_subca method so that it is more robust and
able to handle nicknames with token:nickname.

Fixes: https://pagure.io/freeipa/issue/9534