### PR TITLE
[Backport][ipa-4-10] ipa-kdb: Rework ipadb_reinit_mspac()

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -448,6 +448,7 @@ int ipadb_get_connection(struct ipadb_context *ipactx)
     struct timeval tv = { 5, 0 };
     LDAPMessage *res = NULL;
     LDAPMessage *first;
+    const char *stmsg;
     int ret;
     int v3;
 
@@ -527,16 +528,9 @@ int ipadb_get_connection(struct ipadb_context *ipactx)
     }
 
     /* get adtrust options using default refresh interval */
-    ret = ipadb_reinit_mspac(ipactx, false);
-    if (ret && ret != ENOENT) {
-        /* TODO: log that there is an issue with adtrust settings */
-        if (ipactx->lcontext == NULL) {
-            /* for some reason ldap connection was reset in ipadb_reinit_mspac
-             * and is no longer established => failure of ipadb_get_connection
-             */
-            goto done;
-        }
-    }
+    ret = ipadb_reinit_mspac(ipactx, false, &stmsg);
+    if (ret && stmsg)
+        krb5_klog_syslog(LOG_WARNING, "MS-PAC generator: %s", stmsg);
 
     ret = 0;
 

--- a/daemons/ipa-kdb/ipa_kdb.h
+++ b/daemons/ipa-kdb/ipa_kdb.h
@@ -369,7 +369,9 @@ krb5_error_code ipadb_v9_issue_pac(krb5_context context, unsigned int flags,
                                    krb5_data ***auth_indicators);
 #endif
 
-krb5_error_code ipadb_reinit_mspac(struct ipadb_context *ipactx, bool force_reinit);
+krb5_error_code ipadb_reinit_mspac(struct ipadb_context *ipactx,
+                                   bool force_reinit,
+                                   const char **stmsg);
 
 void ipadb_mspac_struct_free(struct ipadb_mspac **mspac);
 krb5_error_code ipadb_check_transited_realms(krb5_context kcontext,

--- a/daemons/ipa-kdb/ipa_kdb_mspac_private.h
+++ b/daemons/ipa-kdb/ipa_kdb_mspac_private.h
@@ -31,7 +31,7 @@ struct ipadb_mspac {
     char *fallback_group;
     uint32_t fallback_rid;
 
-    int num_trusts;
+    size_t num_trusts;
     struct ipadb_adtrusts *trusts;
     time_t last_update;
 };

--- a/daemons/ipa-kdb/ipa_kdb_mspac_v6.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac_v6.c
@@ -233,6 +233,7 @@ krb5_error_code ipadb_sign_authdata(krb5_context context,
     krb5_db_entry *client_entry = NULL;
     krb5_boolean is_equal;
     bool force_reinit_mspac = false;
+    const char *stmsg = NULL;
 
 
     is_as_req = ((flags & KRB5_KDB_FLAG_CLIENT_REFERRALS_ONLY) != 0);
@@ -309,7 +310,9 @@ krb5_error_code ipadb_sign_authdata(krb5_context context,
             force_reinit_mspac = true;
         }
 
-        (void)ipadb_reinit_mspac(ipactx, force_reinit_mspac);
+        kerr = ipadb_reinit_mspac(ipactx, force_reinit_mspac, &stmsg);
+        if (kerr && stmsg)
+            krb5_klog_syslog(LOG_WARNING, "MS-PAC generator: %s", stmsg);
 
         kerr = ipadb_get_pac(context, flags, client, server, NULL, authtime, &pac);
         if (kerr != 0 && kerr != ENOENT) {

--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -1567,6 +1567,7 @@ static krb5_error_code dbget_alias(krb5_context kcontext,
         -1,
     };
     size_t i = 0;
+    const char *stmsg = NULL;
 
     /* For TGS-REQ server principal lookup, KDC asks with KRB5_KDB_FLAG_REFERRAL_OK
      * and client usually asks for an KRB5_NT_PRINCIPAL type principal. */
@@ -1654,8 +1655,11 @@ static krb5_error_code dbget_alias(krb5_context kcontext,
     if (kerr == KRB5_KDB_NOENTRY) {
         /* If no trusted realm found, refresh trusted domain data and try again
          * because it might be a freshly added trust to AD */
-        kerr = ipadb_reinit_mspac(ipactx, false);
+        kerr = ipadb_reinit_mspac(ipactx, false, &stmsg);
         if (kerr != 0) {
+            if (stmsg)
+                krb5_klog_syslog(LOG_WARNING, "MS-PAC generator: %s",
+                                 stmsg);
             kerr = KRB5_KDB_NOENTRY;
             goto done;
         }


### PR DESCRIPTION
This PR was opened automatically because PR #7233 was pushed to master and backport to ipa-4-10 is required.