### PR TITLE
[Backport][ipa-4-11] ipa-kdb: Fix double free in ipadb_reinit_mspac()

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -3087,6 +3087,7 @@ ipadb_reinit_mspac(struct ipadb_context *ipactx, bool force_reinit,
     }
 
     free(resstr);
+    resstr = NULL;
 
     flat_server_name = get_server_netbios_name(ipactx);
     if (!flat_server_name) {


### PR DESCRIPTION
This PR was opened automatically because PR #7240 was pushed to master and backport to ipa-4-11 is required.