### PR TITLE
rpcserver: validate Kerberos principal name before running kinit

### DIFF
--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -1135,10 +1135,6 @@ class login_password(Backend, KerberosSession):
                 canonicalize=True,
                 lifetime=self.api.env.kinit_lifetime)
 
-            if armor_path:
-                logger.debug('Cleanup the armor ccache')
-                ipautil.run([paths.KDESTROY, '-A', '-c', armor_path],
-                            env={'KRB5CCNAME': armor_path}, raiseonerr=False)
         except RuntimeError as e:
             if ('kinit: Cannot read password while '
                     'getting initial credentials') in str(e):
@@ -1156,6 +1152,11 @@ class login_password(Backend, KerberosSession):
                 raise KrbPrincipalWrongFAST(principal=principal)
             raise InvalidSessionPassword(principal=principal,
                                          message=unicode(e))
+        finally:
+            if armor_path:
+                logger.debug('Cleanup the armor ccache')
+                ipautil.run([paths.KDESTROY, '-A', '-c', armor_path],
+                            env={'KRB5CCNAME': armor_path}, raiseonerr=False)
 
 
 class change_password(Backend, HTTP_Status):

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -310,3 +310,15 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
+
+  fedora-latest/test_ipalib_install:
+    requires: [fedora-latest/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-master-latest
+        timeout: 600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1897,3 +1897,15 @@ jobs:
         template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
+
+  fedora-latest/test_ipalib_install:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-master-latest
+        timeout: 600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -2048,3 +2048,16 @@ jobs:
         template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
+
+  fedora-latest/test_ipalib_install:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-master-latest
+        timeout: 600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -2200,3 +2200,17 @@ jobs:
         template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
+
+  testing-fedora/test_ipalib_install:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-master-latest
+        timeout: 600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2351,3 +2351,18 @@ jobs:
         template: *ci-master-latest
         timeout: 10800
         topology: *master_1repl
+
+  testing-fedora/test_ipalib_install:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-master-latest
+        timeout: 600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1897,3 +1897,15 @@ jobs:
         template: *ci-master-previous
         timeout: 10800
         topology: *master_1repl
+
+  fedora-previous/test_ipalib_install:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-master-previous
+        timeout: 600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -2048,3 +2048,16 @@ jobs:
         template: *ci-master-frawhide
         timeout: 10800
         topology: *master_1repl
+
+  fedora-rawhide/test_ipalib_install:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-master-frawhide
+        timeout: 600
+        topology: *master_1repl

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':
             "ipatests.test_integration",
             "ipatests.test_ipaclient",
             "ipatests.test_ipalib",
+            "ipatests.test_ipalib_install",
             "ipatests.test_ipaplatform",
             "ipatests.test_ipapython",
             "ipatests.test_ipaserver",

--- a/ipatests/test_ipalib_install/test_kinit.py
+++ b/ipatests/test_ipalib_install/test_kinit.py
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+"""Tests for ipalib.install.kinit module
+"""
+
+import pytest
+
+from ipalib.install.kinit import validate_principal
+
+
+# None means no exception is expected
+@pytest.mark.parametrize('principal, exception', [
+    ('testuser', None),
+    ('testuser@EXAMPLE.TEST', None),
+    ('test/ipa.example.test', None),
+    ('test/ipa.example.test@EXAMPLE.TEST', None),
+    ('test/ipa@EXAMPLE.TEST', RuntimeError),
+    ('test/-ipa.example.test@EXAMPLE.TEST', RuntimeError),
+    ('test/ipa.1example.test@EXAMPLE.TEST', RuntimeError),
+    ('test /ipa.example,test', RuntimeError),
+    ('testuser@OTHER.TEST', RuntimeError),
+    ('test/ipa.example.test@OTHER.TEST', RuntimeError),
+])
+def test_validate_principal(principal, exception):
+    try:
+        validate_principal(principal)
+    except Exception as e:
+        assert e.__class__ == exception

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps=
     ipatests
 commands=
     {envbindir}/ipa --help
-    {envbindir}/ipa-run-tests --junitxml={envdir}/junit-{envname}.xml {posargs:--ipaclient-unittests}
+    {envbindir}/ipa-run-tests --junitxml={envdir}/junit-{envname}.xml {posargs:--ipaclient-unittests} --ignore test_ipalib_install
 
 [testenv:pylint3]
 basepython=python3


### PR DESCRIPTION
Do minimal validation of the Kerberos principal name when passing it to kinit command line tool. Also pass it as the final argument to prevent option injection.

Accepted Kerberos principals are:
 - user names, using the following regexp (username with optional @realm, no spaces or slashes in the name): "(?!^[0-9]+$)^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*[a-zA-Z0-9_.$-]?@?[a-zA-Z0-9.-]*$"

 - service names (with slash in the name but no spaces). Validation of the hostname is done. There is no validation of the service name.

The regular expression above also covers cases where a principal name starts with '-'. This prevents option injection as well.

This fixes CVE-2024-1481

Fixes: https://pagure.io/freeipa/issue/9541