### PR TITLE
[Backport][ipa-4-10]rpcserver: validate Kerberos principal name before running kinit

### DIFF
--- a/ipalib/install/kinit.py
+++ b/ipalib/install/kinit.py
@@ -15,7 +15,6 @@ from ipaplatform.paths import paths
 from ipapython.ipautil import run
 from ipalib.constants import PATTERN_GROUPUSER_NAME
 from ipalib.util import validate_hostname
-from ipalib import api
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +38,9 @@ def validate_principal(principal):
     if ('/' in principal) and (' ' in principal):
         raise RuntimeError('Invalid principal: bad spacing')
     else:
-        realm = None
+        # For a user match in the regex
+        # username = match[1]
+        # realm = match[2]
         match = user_pattern.match(principal)
         if match is None:
             match = service_pattern.match(principal)
@@ -48,16 +49,11 @@ def validate_principal(principal):
             else:
                 # service = match[1]
                 hostname = match[2]
-                realm = match[3]
+                # realm = match[3]
                 try:
                     validate_hostname(hostname)
                 except ValueError as e:
                     raise RuntimeError(str(e))
-        else:  # user match, validate realm
-            # username = match[1]
-            realm = match[2]
-        if realm and 'realm' in api.env and realm != api.env.realm:
-            raise RuntimeError('Invalid principal: realm mismatch')
 
 
 def kinit_keytab(principal, keytab, ccache_name, config=None, attempts=1):

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -1135,10 +1135,6 @@ class login_password(Backend, KerberosSession):
                 canonicalize=True,
                 lifetime=self.api.env.kinit_lifetime)
 
-            if armor_path:
-                logger.debug('Cleanup the armor ccache')
-                ipautil.run([paths.KDESTROY, '-A', '-c', armor_path],
-                            env={'KRB5CCNAME': armor_path}, raiseonerr=False)
         except RuntimeError as e:
             if ('kinit: Cannot read password while '
                     'getting initial credentials') in str(e):
@@ -1156,6 +1152,11 @@ class login_password(Backend, KerberosSession):
                 raise KrbPrincipalWrongFAST(principal=principal)
             raise InvalidSessionPassword(principal=principal,
                                          message=unicode(e))
+        finally:
+            if armor_path:
+                logger.debug('Cleanup the armor ccache')
+                ipautil.run([paths.KDESTROY, '-A', '-c', armor_path],
+                            env={'KRB5CCNAME': armor_path}, raiseonerr=False)
 
 
 class change_password(Backend, HTTP_Status):

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -310,3 +310,15 @@ jobs:
         template: *ci-ipa-4-10-latest
         timeout: 3600
         topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-10/test_ipalib_install:
+    requires: [fedora-latest-ipa-4-10/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-10/build_url}'
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-ipa-4-10-latest
+        timeout: 600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
@@ -1897,3 +1897,15 @@ jobs:
         template: *ci-ipa-4-10-latest
         timeout: 10800
         topology: *master_1repl
+
+  fedora-latest-ipa-4-10/test_ipalib_install:
+    requires: [fedora-latest-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-10/build_url}'
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-ipa-4-10-latest
+        timeout: 600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
@@ -2048,3 +2048,16 @@ jobs:
         template: *ci-ipa-4-10-latest
         timeout: 10800
         topology: *master_1repl
+
+  fedora-latest-ipa-4-10/test_ipalib_install:
+    requires: [fedora-latest-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-10/build_url}'
+        selinux_enforcing: True
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-ipa-4-10-latest
+        timeout: 600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_previous.yaml
@@ -1897,3 +1897,16 @@ jobs:
         template: *ci-ipa-4-10-previous
         timeout: 10800
         topology: *master_1repl
+
+  fedora-previous-ipa-4-10/test_ipalib_install:
+    requires: [fedora-previous-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous-ipa-4-10/build_url}'
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-ipa-4-10-previous
+        timeout: 600
+        topology: *master_1repl
+

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':
             "ipatests.test_integration",
             "ipatests.test_ipaclient",
             "ipatests.test_ipalib",
+            "ipatests.test_ipalib_install",
             "ipatests.test_ipaplatform",
             "ipatests.test_ipapython",
             "ipatests.test_ipaserver",

--- a/ipatests/test_ipalib_install/test_kinit.py
+++ b/ipatests/test_ipalib_install/test_kinit.py
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+"""Tests for ipalib.install.kinit module
+"""
+
+import pytest
+
+from ipalib.install.kinit import validate_principal
+
+
+# None means no exception is expected
+@pytest.mark.parametrize('principal, exception', [
+    ('testuser', None),
+    ('testuser@EXAMPLE.TEST', None),
+    ('test/ipa.example.test', None),
+    ('test/ipa.example.test@EXAMPLE.TEST', None),
+    ('test/ipa@EXAMPLE.TEST', RuntimeError),
+    ('test/-ipa.example.test@EXAMPLE.TEST', RuntimeError),
+    ('test/ipa.1example.test@EXAMPLE.TEST', RuntimeError),
+    ('test /ipa.example,test', RuntimeError),
+    ('testuser@OTHER.TEST', RuntimeError),
+    ('test/ipa.example.test@OTHER.TEST', RuntimeError),
+])
+def test_validate_principal(principal, exception):
+    try:
+        validate_principal(principal)
+    except Exception as e:
+        assert e.__class__ == exception

--- a/ipatests/test_ipalib_install/test_kinit.py
+++ b/ipatests/test_ipalib_install/test_kinit.py
@@ -17,13 +17,16 @@ from ipalib.install.kinit import validate_principal
     ('test/ipa.example.test@EXAMPLE.TEST', None),
     ('test/ipa@EXAMPLE.TEST', RuntimeError),
     ('test/-ipa.example.test@EXAMPLE.TEST', RuntimeError),
-    ('test/ipa.1example.test@EXAMPLE.TEST', RuntimeError),
+    ('test/ipa.1example.test@EXAMPLE.TEST', None),
     ('test /ipa.example,test', RuntimeError),
-    ('testuser@OTHER.TEST', RuntimeError),
-    ('test/ipa.example.test@OTHER.TEST', RuntimeError),
+    ('testuser@OTHER.TEST', None),
+    ('test/ipa.example.test@OTHER.TEST', None)
 ])
 def test_validate_principal(principal, exception):
     try:
         validate_principal(principal)
     except Exception as e:
         assert e.__class__ == exception
+    else:
+        if exception is not None:
+            raise RuntimeError('Test should have failed')

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps=
     ipatests
 commands=
     {envbindir}/ipa --help
-    {envbindir}/ipa-run-tests --junitxml={envdir}/junit-{envname}.xml {posargs:--ipaclient-unittests}
+    {envbindir}/ipa-run-tests --junitxml={envdir}/junit-{envname}.xml {posargs:--ipaclient-unittests} --ignore test_ipalib_install
 
 [testenv:pylint3]
 basepython=python3


### PR DESCRIPTION
This PR was opened manually because PR #7244 was pushed to master and backport to ipa-4-10 is required.