### PR TITLE
[Backport][ipa-4-6]rpcserver: validate Kerberos principal name before running kinit

### DIFF
--- a/ipalib/install/kinit.py
+++ b/ipalib/install/kinit.py
@@ -15,7 +15,6 @@ from ipaplatform.paths import paths
 from ipapython.ipautil import run
 from ipalib.constants import PATTERN_GROUPUSER_NAME
 from ipalib.util import validate_hostname
-from ipalib import api
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +38,9 @@ def validate_principal(principal):
     if ('/' in principal) and (' ' in principal):
         raise RuntimeError('Invalid principal: bad spacing')
     else:
-        realm = None
+        # For a user match in the regex
+        # username = match[1]
+        # realm = match[2]
         match = user_pattern.match(principal)
         if match is None:
             match = service_pattern.match(principal)
@@ -48,16 +49,11 @@ def validate_principal(principal):
             else:
                 # service = match[1]
                 hostname = match[2]
-                realm = match[3]
+                # realm = match[3]
                 try:
                     validate_hostname(hostname)
                 except ValueError as e:
                     raise RuntimeError(str(e))
-        else:  # user match, validate realm
-            # username = match[1]
-            realm = match[2]
-        if realm and 'realm' in api.env and realm != api.env.realm:
-            raise RuntimeError('Invalid principal: realm mismatch')
 
 
 def kinit_keytab(principal, keytab, ccache_name, config=None, attempts=1):

--- a/ipalib/install/kinit.py
+++ b/ipalib/install/kinit.py
@@ -6,12 +6,16 @@ from __future__ import absolute_import
 
 import logging
 import os
+import re
 import time
 
 import gssapi
 
 from ipaplatform.paths import paths
 from ipapython.ipautil import run
+from ipalib.constants import PATTERN_GROUPUSER_NAME
+from ipalib.util import validate_hostname
+from ipalib import api
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +25,40 @@ KRB5_KDC_UNREACH = 2529639068
 # A service is not available that s required to process the request
 KRB5KDC_ERR_SVC_UNAVAILABLE = 2529638941
 
+PATTERN_REALM = '@?([a-zA-Z0-9.-]*)$'
+PATTERN_PRINCIPAL = '(' + PATTERN_GROUPUSER_NAME[:-1] + ')' + PATTERN_REALM
+PATTERN_SERVICE = '([a-zA-Z0-9.-]+)/([a-zA-Z0-9.-]+)' + PATTERN_REALM
+
+user_pattern = re.compile(PATTERN_PRINCIPAL)
+service_pattern = re.compile(PATTERN_SERVICE)
+
+
+def validate_principal(principal):
+    if not isinstance(principal, str):
+        raise RuntimeError('Invalid principal: not a string')
+    if ('/' in principal) and (' ' in principal):
+        raise RuntimeError('Invalid principal: bad spacing')
+    else:
+        realm = None
+        match = user_pattern.match(principal)
+        if match is None:
+            match = service_pattern.match(principal)
+            if match is None:
+                raise RuntimeError('Invalid principal: cannot parse')
+            else:
+                # service = match[1]
+                hostname = match[2]
+                realm = match[3]
+                try:
+                    validate_hostname(hostname)
+                except ValueError as e:
+                    raise RuntimeError(str(e))
+        else:  # user match, validate realm
+            # username = match[1]
+            realm = match[2]
+        if realm and 'realm' in api.env and realm != api.env.realm:
+            raise RuntimeError('Invalid principal: realm mismatch')
+
 
 def kinit_keytab(principal, keytab, ccache_name, config=None, attempts=1):
     """
@@ -29,6 +67,7 @@ def kinit_keytab(principal, keytab, ccache_name, config=None, attempts=1):
     The optional parameter 'attempts' specifies how many times the credential
     initialization should be attempted in case of non-responsive KDC.
     """
+    validate_principal(principal)
     errors_to_retry = {KRB5KDC_ERR_SVC_UNAVAILABLE,
                        KRB5_KDC_UNREACH}
     logger.debug("Initializing principal %s using keytab %s",
@@ -63,6 +102,9 @@ def kinit_keytab(principal, keytab, ccache_name, config=None, attempts=1):
             else:
                 os.environ.pop('KRB5_CONFIG', None)
 
+        return None
+
+
 def kinit_password(principal, password, ccache_name, config=None,
                    armor_ccache_name=None, canonicalize=False,
                    enterprise=False, lifetime=None):
@@ -71,8 +113,9 @@ def kinit_password(principal, password, ccache_name, config=None,
     web-based authentication, use armor_ccache_path to specify http service
     ccache.
     """
+    validate_principal(principal)
     logger.debug("Initializing principal %s using password", principal)
-    args = [paths.KINIT, principal, '-c', ccache_name]
+    args = [paths.KINIT, '-c', ccache_name]
     if armor_ccache_name is not None:
         logger.debug("Using armor ccache %s for FAST webauth",
                      armor_ccache_name)
@@ -89,6 +132,7 @@ def kinit_password(principal, password, ccache_name, config=None,
         logger.debug("Using enterprise principal")
         args.append('-E')
 
+    args.extend(['--', principal])
     env = {'LC_ALL': 'C'}
     if config is not None:
         env['KRB5_CONFIG'] = config

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -1045,10 +1045,6 @@ class login_password(Backend, KerberosSession):
                 canonicalize=True,
                 lifetime=self.api.env.kinit_lifetime)
 
-            if armor_path:
-                logger.debug('Cleanup the armor ccache')
-                ipautil.run([paths.KDESTROY, '-A', '-c', armor_path],
-                            env={'KRB5CCNAME': armor_path}, raiseonerr=False)
         except RuntimeError as e:
             if ('kinit: Cannot read password while '
                     'getting initial credentials') in str(e):
@@ -1063,6 +1059,11 @@ class login_password(Backend, KerberosSession):
                                  message=unicode(e))
             raise InvalidSessionPassword(principal=principal,
                                          message=unicode(e))
+        finally:
+            if armor_path:
+                logger.debug('Cleanup the armor ccache')
+                ipautil.run([paths.KDESTROY, '-A', '-c', armor_path],
+                            env={'KRB5CCNAME': armor_path}, raiseonerr=False)
 
 
 class change_password(Backend, HTTP_Status):

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -110,3 +110,15 @@ jobs:
         template: *ci-master-f27
         timeout: 3600
         topology: *master_1repl_1client
+
+  fedora-27/test_ipalib_install:
+    requires: [fedora-27/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-master-f27
+        timeout: 600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-6.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-6.yaml
@@ -1278,3 +1278,15 @@ jobs:
         template: *ci-master-f27
         timeout: 3600
         topology: *master_1repl
+
+  fedora-27/test_ipalib_install:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_ipalib_install/test_kinit.py
+        template: *ci-master-f27
+        timeout: 600
+        topology: *master_1repl

--- a/ipatests/setup.py
+++ b/ipatests/setup.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':
             "ipatests.test_integration",
             "ipatests.test_ipaclient",
             "ipatests.test_ipalib",
+            "ipatests.test_ipalib_install",
             "ipatests.test_ipaplatform",
             "ipatests.test_ipapython",
             "ipatests.test_ipaserver",

--- a/ipatests/test_ipalib_install/test_kinit.py
+++ b/ipatests/test_ipalib_install/test_kinit.py
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+"""Tests for ipalib.install.kinit module
+"""
+
+import pytest
+
+from ipalib.install.kinit import validate_principal
+
+
+# None means no exception is expected
+@pytest.mark.parametrize('principal, exception', [
+    ('testuser', None),
+    ('testuser@EXAMPLE.TEST', None),
+    ('test/ipa.example.test', None),
+    ('test/ipa.example.test@EXAMPLE.TEST', None),
+    ('test/ipa@EXAMPLE.TEST', RuntimeError),
+    ('test/-ipa.example.test@EXAMPLE.TEST', RuntimeError),
+    ('test/ipa.1example.test@EXAMPLE.TEST', RuntimeError),
+    ('test /ipa.example,test', RuntimeError),
+    ('testuser@OTHER.TEST', RuntimeError),
+    ('test/ipa.example.test@OTHER.TEST', RuntimeError),
+])
+def test_validate_principal(principal, exception):
+    try:
+        validate_principal(principal)
+    except Exception as e:
+        assert e.__class__ == exception

--- a/ipatests/test_ipalib_install/test_kinit.py
+++ b/ipatests/test_ipalib_install/test_kinit.py
@@ -17,13 +17,16 @@ from ipalib.install.kinit import validate_principal
     ('test/ipa.example.test@EXAMPLE.TEST', None),
     ('test/ipa@EXAMPLE.TEST', RuntimeError),
     ('test/-ipa.example.test@EXAMPLE.TEST', RuntimeError),
-    ('test/ipa.1example.test@EXAMPLE.TEST', RuntimeError),
+    ('test/ipa.1example.test@EXAMPLE.TEST', None),
     ('test /ipa.example,test', RuntimeError),
-    ('testuser@OTHER.TEST', RuntimeError),
-    ('test/ipa.example.test@OTHER.TEST', RuntimeError),
+    ('testuser@OTHER.TEST', None),
+    ('test/ipa.example.test@OTHER.TEST', None)
 ])
 def test_validate_principal(principal, exception):
     try:
         validate_principal(principal)
     except Exception as e:
         assert e.__class__ == exception
+    else:
+        if exception is not None:
+            raise RuntimeError('Test should have failed')

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps=
     ipatests
 commands=
     {envbindir}/ipa --help
-    {envpython} -bb {envbindir}/ipa-run-tests --ipaclient-unittests
+    {envpython} -bb {envbindir}/ipa-run-tests --ipaclient-unittests --ignore test_ipalib_install
 
 [testenv:py36]
 deps=


### PR DESCRIPTION
This PR was opened manually because PR #7244 was pushed to master and backport to ipa-4-6 is required.
