### PR TITLE
Trust-fetch-domain: realm should not be validated

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/install/oddjob/com.redhat.idm.trust-fetch-domains.in
+++ b/install/oddjob/com.redhat.idm.trust-fetch-domains.in
@@ -222,6 +222,7 @@ with ipautil.private_krb5_config(trusted_domain, options.server) as cfg_file:
                     oneway_principal,
                     oneway_keytab_name,
                     oneway_ccache_name,
+                    validate_realm=False,
                 )
                 if cred.lifetime > 0:
                     have_ccache = True
@@ -234,6 +235,7 @@ with ipautil.private_krb5_config(trusted_domain, options.server) as cfg_file:
                     oneway_principal,
                     oneway_keytab_name,
                     oneway_ccache_name,
+                    validate_realm=False,
                 )
         except (gssapi.exceptions.GSSError, gssapi.raw.misc.GSSError):
             # If there was failure on using keytab, assume it is stale and retrieve again
@@ -244,6 +246,7 @@ with ipautil.private_krb5_config(trusted_domain, options.server) as cfg_file:
                 oneway_principal,
                 oneway_keytab_name,
                 oneway_ccache_name,
+                validate_realm=False,
             )
     else:
         cred = kinit_password(
@@ -252,6 +255,7 @@ with ipautil.private_krb5_config(trusted_domain, options.server) as cfg_file:
             oneway_ccache_name,
             canonicalize=True,
             enterprise=True,
+            validate_realm=False,
         )
 
     if cred and cred.lifetime > 0:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,86 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_http_kdc_proxy:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_http_kdc_proxy.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *ad_master_2client
+
+  fedora-latest/test_idviews:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_idviews.py
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *ad_master_2client
+
+  fedora-latest/test_ipahealthcheck_adtrust:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithADtrust
+        template: *ci-master-latest
+        timeout: 4800
+        topology: *adroot_adchild_adtree_master_1client
+
+  fedora-latest/test_sssd:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_sssd.py
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client
+
+  fedora-latest/test_trust:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_trust.py::TestTrust
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client
+
+  fedora-latest/test_trust_autoprivate:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_trust.py::TestNonPosixAutoPrivateGroup test_integration/test_trust.py::TestPosixAutoPrivateGroup
+        template: *ci-master-latest
+        timeout: 6000
+        topology: *adroot_adchild_adtree_master_1client
+
+  fedora-latest/test_winsyncmigrate:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_winsyncmigrate.py
+        template: *ci-master-latest
+        timeout: 4800
+        topology: *ad_master


### PR DESCRIPTION
The oddjob com.redhat.idm.trust-fetch-domains is using a
principal from the AD realm to retrieve the trust information.
The principal should be validated but the check for the
realm must be relaxed (the AD realm is different from IPA realm).

Related: https://pagure.io/freeipa/issue/9541