### PR TITLE
ipatests: some tests are date-sensitive and fail Feb 29

### DIFF
--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1575,6 +1575,17 @@ class TestIPACommand(IntegrationTest):
         # upload script and run with Python executable
         script = "/tmp/example_cli.py"
         host.put_file_contents(script, contents)
+        # Important: this test is date-sensitive and may fail if executed
+        # around Feb 28 or Feb 29 on a leap year.
+        # The previous tests are playing with the date by jumping in the
+        # future and back to the (expected) current date but calling
+        # date -s +15Years and then date -s -15Years doesn't
+        # bring the date back to the original value if called around Feb 29.
+        # As a consequence, client and server are not synchronized any more
+        # and client API authentication may fail with the following error:
+        # ipalib.errors.KerberosError:
+        # No valid Negotiate header in server response
+        # If you see this failure, just ignore and relaunch on March 1.
         result = host.run_command([sys.executable, script])
 
         # script prints admin account

--- a/ipatests/test_integration/test_ipa_cert_fix.py
+++ b/ipatests/test_integration/test_ipa_cert_fix.py
@@ -391,6 +391,17 @@ class TestCertFixReplica(IntegrationTest):
         tasks.install_master(
             mh.master, setup_dns=False, extra_args=['--no-ntp']
         )
+        # Important: this test is date-sensitive and may fail if executed
+        # around Feb 28 or Feb 29 on a leap year.
+        # The previous tests are playing with the date by jumping in the
+        # future and back to the (expected) current date but calling
+        # date -s +3Years+1day and then date -s -3Years-1day doesn't
+        # bring the date back to the original value if called around Feb 29.
+        # As a consequence, client and server are not synchronized any more
+        # and client installation may fail with the following error:
+        # Joining realm failed: JSON-RPC call failed:
+        # SSL peer certificate or SSH remote key was not OK
+        # If you see this failure, just ignore and relaunch on March 1.
         tasks.install_replica(
             mh.master, mh.replicas[0],
             setup_dns=False, extra_args=['--no-ntp']


### PR DESCRIPTION
A few tests are changing the date back and forth using for instance date -s +3Years+1day and date -s -3Years-1day. This method does not bring the system back to the current date if executed around Feb 28 or 29 on a leap year, and may result in de-synchronized server and client.

Add a note in the test to warn about potential future failures.

Related: https://pagure.io/freeipa/issue/9548