### PR TITLE
Vault: add additional fallback to RSA-OAEP wrapping algo

### DIFF
--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -755,8 +755,12 @@ class ModVaultData(Local):
         Calls the internal counterpart of the command.
         """
         # try call with cached transport certificate
-        result = self._do_internal(algo, transport_cert, False,
-                                   False, *args, **options)
+        try:
+            result = self._do_internal(algo, transport_cert, False,
+                                       False, *args, **options)
+        except errors.EncodingError:
+            result = self._do_internal(algo, transport_cert, False,
+                                       True, *args, **options)
         if result is not None:
             return result
 


### PR DESCRIPTION
There is a fallback when creating the wrapping key but one was missing when trying to use the cached transport_cert.

This allows, along with forcing keyWrap.useOAEP=true, vault creation on an nCipher HSM.

This can be seen in HSMs where the device doesn't support the PKCS#1 v1.5 mechanism. It will error out with either "invalid algorithm" or CKR_FUNCTION_FAILED.

Related: https://pagure.io/freeipa/issue/9191