### PR TITLE
[Backport][ipa-4-9] Vault: add additional fallback to RSA-OAEP wrapping algo

### DIFF
--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -757,8 +757,12 @@ class ModVaultData(Local):
         Calls the internal counterpart of the command.
         """
         # try call with cached transport certificate
-        result = self._do_internal(algo, transport_cert, False,
-                                   False, *args, **options)
+        try:
+            result = self._do_internal(algo, transport_cert, False,
+                                       False, *args, **options)
+        except errors.EncodingError:
+            result = self._do_internal(algo, transport_cert, False,
+                                       True, *args, **options)
         if result is not None:
             return result
 


### PR DESCRIPTION
This PR was opened automatically because PR #7259 was pushed to master and backport to ipa-4-9 is required.