### PR TITLE
dcerpc: invalidate forest trust info cache when filtering out realm d…

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -1103,6 +1103,7 @@ class TrustDomainInstance:
 
         info.count = len(ftinfo_records)
         info.entries = ftinfo_records
+        another_domain.ftinfo_data = info
         return info
 
     def clear_ftinfo_conflict(self, another_domain, cinfo):
@@ -1778,6 +1779,7 @@ class TrustDomainJoins:
             return
 
         self.local_domain.ftinfo_records = []
+        self.local_domain.ftinfo_data = None
 
         realm_domains = self.api.Command.realmdomains_show()['result']
         # Use realmdomains' modification timestamp


### PR DESCRIPTION
…omains

When get_realmdomains() method is called, it will filter out subdomains of the IPA primary domain. This is required because Active Directory domain controllers are assuming subdomains already covered by the main domain namespace.

[MS-LSAD] 3.1.4.7.16.1, 'Forest Trust Collision Generation' defines the method of validating the forest trust information. They are the same as rules in [MS-ADTS] section 6.1.6. Specifically,

  - A top-level name must not be superior to an enabled top-level name for another trusted domain object, unless the current trusted domain object has a corresponding exclusion record.

In practice, we filtered those subdomains already but the code wasn't invalidating a previously retrieved forest trust information.

Fixes: https://pagure.io/freeipa/issue/9551