### PR TITLE
ipa-pwd-extop: declare operation notes support from 389-ds locally

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -1414,6 +1414,11 @@ done:
 }
 
 
+#ifdef USE_OP_NOTE_MFA_AUTH
+/* defined in ldap/servers/slapd/pblock.c in 389-ds but not exposed via slapi-plugin.h */
+extern void slapi_pblock_set_flag_operation_notes(Slapi_PBlock *pb, uint32_t opflag);
+#endif
+
 /* PRE BIND Operation
  *
  * Used for:


### PR DESCRIPTION
The function slapi_pblock_set_flag_operation_notes(); is defined in ldap/servers/slapd/pblock.c in 389-ds but is only available through slapi-private.h header, not through slapi-plugin.h public API.

It was introduced in ~1.4.1.7 (~2019) via https://pagure.io/389-ds-base/issue/50349.

Since we only use it with an MFA note, all versions of the 389-ds that will support MFA note will have this function.

Fixes: https://pagure.io/freeipa/issue/9554