### PR TITLE
[Backport][ipa-4-10] ipa-pwd-extop: declare operation notes support from 389-ds locally

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -1414,6 +1414,11 @@ done:
 }
 
 
+#ifdef USE_OP_NOTE_MFA_AUTH
+/* defined in ldap/servers/slapd/pblock.c in 389-ds but not exposed via slapi-plugin.h */
+extern void slapi_pblock_set_flag_operation_notes(Slapi_PBlock *pb, uint32_t opflag);
+#endif
+
 /* PRE BIND Operation
  *
  * Used for:


### PR DESCRIPTION
This PR was opened automatically because PR #7268 was pushed to master and backport to ipa-4-10 is required.