### PR TITLE
[Backport][ipa-4-11] dcerpc: invalidate forest trust info cache when filtering out realm d…

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -1103,6 +1103,7 @@ class TrustDomainInstance:
 
         info.count = len(ftinfo_records)
         info.entries = ftinfo_records
+        another_domain.ftinfo_data = info
         return info
 
     def clear_ftinfo_conflict(self, another_domain, cinfo):
@@ -1778,6 +1779,7 @@ class TrustDomainJoins:
             return
 
         self.local_domain.ftinfo_records = []
+        self.local_domain.ftinfo_data = None
 
         realm_domains = self.api.Command.realmdomains_show()['result']
         # Use realmdomains' modification timestamp


### PR DESCRIPTION
This PR was opened automatically because PR #7265 was pushed to master and backport to ipa-4-11 is required.