### PR TITLE
[Backport][ipa-4-9] idrange-add: add a warning because 389ds restart is required

### DIFF
--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -549,6 +549,12 @@ class idrange_add(LDAPCreate):
         self.obj.handle_ipabaserid(entry_attrs, options)
         self.obj.handle_iparangetype(entry_attrs, options,
                                      keep_objectclass=True)
+        self.add_message(
+            messages.ServiceRestartRequired(
+                service=services.knownservices.dirsrv.service_instance(""),
+                server=_('<all IPA servers>')
+            )
+        )
         return dn
 
 

--- a/ipatests/test_xmlrpc/test_range_plugin.py
+++ b/ipatests/test_xmlrpc/test_range_plugin.py
@@ -372,6 +372,8 @@ IPA_LOCAL_RANGE_MOD_ERR = (
     "domain. Run `ipa help idrange` for more information"
 )
 
+dirsrv_instance = services.knownservices.dirsrv.service_instance("")
+
 
 @pytest.mark.tier1
 class test_range(Declarative):
@@ -464,6 +466,11 @@ class test_range(Declarative):
                 ),
                 value=testrange1,
                 summary=u'Added ID range "%s"' % (testrange1),
+                messages=(
+                    messages.ServiceRestartRequired(
+                        service=dirsrv_instance,
+                        server='<all IPA servers>').to_dict(),
+                ),
             ),
         ),
 
@@ -633,6 +640,11 @@ class test_range(Declarative):
                 ),
                 value=testrange2,
                 summary=u'Added ID range "%s"' % (testrange2),
+                messages=(
+                    messages.ServiceRestartRequired(
+                        service=dirsrv_instance,
+                        server='<all IPA servers>').to_dict(),
+                ),
             ),
         ),
 
@@ -792,6 +804,11 @@ class test_range(Declarative):
                 ),
                 value=unicode(domain7range1),
                 summary=u'Added ID range "%s"' % (domain7range1),
+                messages=(
+                    messages.ServiceRestartRequired(
+                        service=dirsrv_instance,
+                        server='<all IPA servers>').to_dict(),
+                ),
             ),
         ),
 
@@ -1079,6 +1096,11 @@ class test_range(Declarative):
                 ),
                 value=testrange9,
                 summary=u'Added ID range "%s"' % (testrange9),
+                messages=(
+                    messages.ServiceRestartRequired(
+                        service=dirsrv_instance,
+                        server='<all IPA servers>').to_dict(),
+                ),
             ),
         ),
 


### PR DESCRIPTION
This PR was opened automatically because PR #7274 was pushed to master and backport to ipa-4-9 is required.