### PR TITLE
idrange plugin: warn about required restart for local range only

### DIFF
--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -552,12 +552,13 @@ class idrange_add(LDAPCreate):
         self.obj.handle_ipabaserid(entry_attrs, options)
         self.obj.handle_iparangetype(entry_attrs, options,
                                      keep_objectclass=True)
-        self.add_message(
-            messages.ServiceRestartRequired(
-                service=services.knownservices.dirsrv.service_instance(""),
-                server=_('<all IPA servers>')
+        if entry_attrs['iparangetyperaw'][0] == 'ipa-local':
+            self.add_message(
+                messages.ServiceRestartRequired(
+                    service=services.knownservices.dirsrv.service_instance(""),
+                    server=_('<all IPA servers>')
+                )
             )
-        )
         return dn
 
 

--- a/ipatests/test_xmlrpc/test_range_plugin.py
+++ b/ipatests/test_xmlrpc/test_range_plugin.py
@@ -804,11 +804,6 @@ class test_range(Declarative):
                 ),
                 value=unicode(domain7range1),
                 summary=u'Added ID range "%s"' % (domain7range1),
-                messages=(
-                    messages.ServiceRestartRequired(
-                        service=dirsrv_instance,
-                        server='<all IPA servers>').to_dict(),
-                ),
             ),
         ),
 


### PR DESCRIPTION
The previous commit adds a warning to ipa idrange-add but the warning is needed only if the range is a local one.

Fixes: ipatests/test_xmlrpc/test_range_plugin.py