### PR TITLE
rpc: do kinit if principal and password are present

### DIFF
--- a/ipalib/krb_utils.py
+++ b/ipalib/krb_utils.py
@@ -184,6 +184,17 @@ def get_principal(ccache_name=None):
     except gssapi.exceptions.GSSError as e:
         raise errors.CCacheError(message=str(e))
 
+def kinit(principal, password, ccache_name=None):
+    name = gssapi.Name(principal, gssapi.NameType.kerberos_principal)
+    acquire_credentials = gssapi.raw.acquire_cred_with_password(name, password.encode('utf-8'))
+    credentials = acquire_credentials.creds
+    # Store credentials in the cache
+    if not ccache_name:
+        gssapi.raw.store_cred(credentials, usage='initiate', overwrite=True, set_default=True)
+    else:
+        store = {'ccache': ccache_name}
+        gssapi.raw.store_cred_into(store, credentials, usage='initiate', overwrite=True)
+
 def get_credentials_if_valid(name=None, ccache_name=None):
     '''
     Obtains GSSAPI credentials with principal name from ccache. When no

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -65,7 +65,7 @@ from ipalib.text import _
 from ipalib.util import create_https_connection
 from ipalib.krb_utils import KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN, KRB5KRB_AP_ERR_TKT_EXPIRED, \
                              KRB5_FCC_PERM, KRB5_FCC_NOFILE, KRB5_CC_FORMAT, \
-                             KRB5_REALM_CANT_RESOLVE, KRB5_CC_NOTFOUND, get_principal
+                             KRB5_REALM_CANT_RESOLVE, KRB5_CC_NOTFOUND, get_principal, kinit
 from ipapython.dn import DN
 from ipapython.kerberos import Principal
 from ipalib.capabilities import VERSION_WITHOUT_CAPABILITIES
@@ -1014,6 +1014,8 @@ class RPCClient(Connectible):
 
         rpc_uri = self.env[self.env_rpc_uri_key]
         try:
+            if 'principal' in self.api.env and 'password' in self.api.env:
+                kinit(self.api.env.principal, self.api.env.password)
             principal = get_principal(ccache_name=ccache)
             stored_principal = getattr(context, 'principal', None)
             if principal != stored_principal:


### PR DESCRIPTION
This adds a `kinit` function `krb_utils` and calls it if a principal and password are supplied.

Motivation: I'd like to interact with the FreeIPA API through ipalib without having to set up a keytab or credentials cache before, e.g.

```
from ipalib import api

api.bootstrap(
    domain='example.com',
    principal=f'{username}@EXAMPLE.COM',
    password=password,
)
api.finalize()
api.Backend.rpcclient.connect()

result = api.Command...
```
This is quite useful in containerised, virtual, or generally ephemeral environments that are not IPA enrolled.

This could also be done similar to how [python-freeipa](https://github.com/waldur/python-freeipa) achieves this (i.e. use [password authentication](https://freeipa.readthedocs.io/en/latest/api/jsonrpc_usage.html#password-authentication) and save the provided cookie).

Pointers and feedback very welcome.