### PR TITLE
Ask interactively for user name and password if Kerberos credentials missing

### DIFF
--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -1466,10 +1466,47 @@ cli_plugins = (
 )
 
 
+def acquire_cred_interactively(*, api, principal, ccache, interactive, **kw):
+    # If it is not an interactive run, re-raise the original exception
+    # because we have no way to acquire credentials.
+    if not interactive:
+        raise kw['exc']()
+
+    from gssapi import Name, NameType
+    from gssapi.raw import (acquire_cred_from,
+                            store_cred, store_cred_into)
+
+    if principal is None or api.env.prompt_all:
+        default = str(principal) if principal is not None else os.getlogin()
+        principal = api.Backend.textui.prompt('Username',
+                                              default=default)
+        if not principal:
+            principal = default
+
+    password = api.Backend.textui.prompt_password('Password', False)
+    name = Name(principal, NameType.kerberos_principal)
+    store = {'password': password.encode('utf-8')}
+    acquire_credentials = acquire_cred_from(store, name, usage='initiate')
+    credentials = acquire_credentials.creds
+    # Store credentials in the cache
+    if not ccache:
+        store_cred(credentials, usage='initiate',
+                   overwrite=True, set_default=True)
+    else:
+        store = {'ccache': ccache}
+        store_cred_into(store, credentials,
+                        usage='initiate', overwrite=True)
+
+
 def run(api):
     error = None
     try:
-        (_options, argv) = api.bootstrap_with_global_options(context='cli')
+        acquire_cred_override = {
+            'acquire_cred': acquire_cred_interactively
+        }
+        (_options, argv) = api.bootstrap_with_global_options(
+            context='cli',
+            additional_overrides=acquire_cred_override)
 
         try:
             check_client_configuration(env=api.env)

--- a/ipalib/config.py
+++ b/ipalib/config.py
@@ -268,7 +268,8 @@ class Env:
                 value = int(value)
             elif key == 'basedn':
                 value = DN(value)
-        if type(value) not in (unicode, int, float, bool, type(None), DN):
+        if not callable(value) and type(
+                value) not in (unicode, int, float, bool, type(None), DN):
             raise TypeError(key, value)
         object.__setattr__(self, key, value)
         # pylint: disable=no-member

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -292,6 +292,8 @@ DEFAULT_CONFIG = (
     ('logdir', object),  # Directory containing log files
     ('log', object),  # Path to context specific log file
 
+    # API-specific callbacks
+    ('acquire_cred', None),  # callback object
 )
 
 LDAP_GENERALIZED_TIME_FORMAT = "%Y%m%d%H%M%SZ"

--- a/ipalib/plugable.py
+++ b/ipalib/plugable.py
@@ -586,10 +586,11 @@ class API(ReadOnly):
 
         return parser
 
-    def bootstrap_with_global_options(self, parser=None, context=None):
+    def bootstrap_with_global_options(self, parser=None, context=None,
+                                      additional_overrides=None):
         parser = self.build_global_parser(parser, context)
         (options, args) = parser.parse_args()
-        overrides = {}
+        overrides = additional_overrides or {}
         if options.env is not None:
             assert type(options.env) is list
             for item in options.env:

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -49,6 +49,7 @@ from cryptography import x509 as crypto_x509
 import gssapi
 from dns.exception import DNSException
 import six
+import sys
 
 from ipalib.backend import Connectible
 from ipalib.constants import LDAP_GENERALIZED_TIME_FORMAT
@@ -362,6 +363,7 @@ class MultiProtocolTransport(Transport):
     def __init__(self, *args, **kwargs):
         Transport.__init__(self)
         self.protocol = kwargs.get('protocol', None)
+        self.api = kwargs.get('api', None)
 
     def getparser(self):
         if self.protocol == 'json':
@@ -447,6 +449,27 @@ class KerbTransport(SSLTransport):
         self.service = kwargs.pop("service", "HTTP")
         self.ccache = kwargs.pop("ccache", None)
 
+    def _try_acquire_cred(self, service, exc):
+        if callable(self.api.env.acquire_cred):
+            interactive = (self.api.env.interactive
+                           and sys.stdin.isatty()) or self.api.env.prompt_all
+            principal = getattr(context, 'principal', None)
+            if service is None and self._connection is not None:
+                # We've been through make_connection() already
+                _service = self.get_service()
+            else:
+                _service = service
+            self.api.env.acquire_cred(
+                api=self.api,
+                context=context,
+                transport=self,
+                principal=principal,
+                ccache=self.ccache,
+                service=_service,
+                interactive=interactive,
+                exc=exc)
+            raise errors.NonFatalError(reason='credentials acquired')
+
     def _handle_exception(self, e, service=None):
         minor = e.min_code
         if minor == KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN:
@@ -454,6 +477,7 @@ class KerbTransport(SSLTransport):
         elif minor == KRB5_FCC_NOFILE:
             raise errors.NoCCacheError()
         elif minor == KRB5KRB_AP_ERR_TKT_EXPIRED:
+            self._try_acquire_cred(service, errors.TicketExpired)
             raise errors.TicketExpired()
         elif minor == KRB5_FCC_PERM:
             raise errors.BadCCachePerms()
@@ -462,6 +486,7 @@ class KerbTransport(SSLTransport):
         elif minor == KRB5_REALM_CANT_RESOLVE:
             raise errors.CannotResolveKDC()
         elif minor == KRB5_CC_NOTFOUND:
+            self._try_acquire_cred(service, errors.CCacheError)
             raise errors.CCacheError()
         else:
             raise errors.KerberosError(message=unicode(e))
@@ -505,7 +530,11 @@ class KerbTransport(SSLTransport):
                                                        flags=self.flags)
             response = self._sec_context.step()
         except gssapi.exceptions.GSSError as e:
-            self._handle_exception(e, service=service)
+            try:
+                self._handle_exception(e, service=service)
+            except errors.NonFatalError:
+                self.get_auth_info(use_cookie=use_cookie)
+                return
 
         self._set_auth_header(response)
 
@@ -923,7 +952,8 @@ class RPCClient(Connectible):
                 else:
                     transport_class = LanguageAwareTransport
                 proxy_kw['transport'] = transport_class(
-                    protocol=self.protocol, service='HTTP', ccache=ccache)
+                    protocol=self.protocol, service='HTTP', ccache=ccache,
+                    api=self.api)
                 logger.debug('trying %s', url)
                 setattr(context, 'request_url', url)
                 serverproxy = self.server_proxy_class(url, **proxy_kw)

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -491,8 +491,8 @@ class KerbTransport(SSLTransport):
         else:
             raise errors.KerberosError(message=unicode(e))
 
-    def _get_host(self):
-        return self._connection[0]
+    def _get_service(self):
+        return self.service + "@" + self._connection[0].split(':')[0]
 
     def _remove_extra_header(self, name):
         for (h, v) in self._extra_headers:
@@ -517,8 +517,7 @@ class KerbTransport(SSLTransport):
                 return
 
         # Set the remote host principal
-        host = self._get_host()
-        service = self.service + "@" + host.split(':')[0]
+        service = self._get_service()
 
         try:
             creds = None

--- a/ipapython/kerberos.py
+++ b/ipapython/kerberos.py
@@ -418,3 +418,242 @@ krb5_unparse_name.errcheck = krb5_errcheck
 krb5_free_unparsed_name = LIBKRB5.krb5_free_unparsed_name
 krb5_free_unparsed_name.argtypes = (krb5_context, ctypes.c_char_p, )
 krb5_free_unparsed_name.restype = None
+
+krb5_deltat = krb5_int32
+krb5_preauthtype = krb5_int32
+
+
+class _krb5_get_init_creds_opt(ctypes.Structure):  # noqa
+    """krb5/krb5.h struct krb5_get_init_creds_opt"""
+    _fields_ = [
+        ("flags", krb5_flags),
+        ("tkt_life", krb5_deltat),
+        ("renew_life", krb5_deltat),
+        ("forwardable", ctypes.c_uint),
+        ("proxiable", ctypes.c_uint),
+        ("etype_list", ctypes.POINTER(krb5_enctype)),
+        ("etype_list_length", ctypes.c_uint),
+        ("address_list", ctypes.POINTER(krb5_address_p)),
+        ("preauth_list", ctypes.POINTER(krb5_preauthtype)),
+        ("preauth_list_length", ctypes.c_uint),
+        ("salt", ctypes.POINTER(krb5_data))]
+
+
+krb5_get_init_creds_opt_p = ctypes.POINTER(_krb5_get_init_creds_opt)
+
+krb5_get_init_creds_opt_alloc = LIBKRB5.krb5_get_init_creds_opt_alloc
+krb5_get_init_creds_opt_alloc.argtypes = (krb5_context,
+                                          ctypes.POINTER(
+                                              krb5_get_init_creds_opt_p))
+krb5_get_init_creds_opt_alloc.restype = krb5_error_code
+
+krb5_get_init_creds_opt_free = LIBKRB5.krb5_get_init_creds_opt_free
+krb5_get_init_creds_opt_free.argtypes = (krb5_context,
+                                         krb5_get_init_creds_opt_p)
+krb5_get_init_creds_opt_free.restype = krb5_error_code
+
+krb5_get_init_creds_opt_set_tkt_life = (
+    LIBKRB5.krb5_get_init_creds_opt_set_tkt_life)
+krb5_get_init_creds_opt_set_tkt_life.argtypes = (krb5_get_init_creds_opt_p,
+                                                 krb5_deltat)
+krb5_get_init_creds_opt_set_tkt_life.restype = None
+
+krb5_get_init_creds_opt_set_renew_life = (
+    LIBKRB5.krb5_get_init_creds_opt_set_renew_life)
+krb5_get_init_creds_opt_set_renew_life.argtypes = (krb5_get_init_creds_opt_p,
+                                                   krb5_deltat)
+krb5_get_init_creds_opt_set_renew_life.restype = None
+
+krb5_get_init_creds_opt_set_forwardable = (
+    LIBKRB5.krb5_get_init_creds_opt_set_forwardable)
+krb5_get_init_creds_opt_set_forwardable.argtypes = (krb5_get_init_creds_opt_p,
+                                                    ctypes.c_int)
+krb5_get_init_creds_opt_set_forwardable.restype = None
+
+krb5_get_init_creds_opt_set_proxiable = (
+    LIBKRB5.krb5_get_init_creds_opt_set_proxiable)
+krb5_get_init_creds_opt_set_proxiable.argtypes = (krb5_get_init_creds_opt_p,
+                                                  ctypes.c_int)
+krb5_get_init_creds_opt_set_proxiable.restype = None
+
+krb5_get_init_creds_opt_set_anonymous = (
+    LIBKRB5.krb5_get_init_creds_opt_set_anonymous)
+krb5_get_init_creds_opt_set_anonymous.argtypes = (krb5_get_init_creds_opt_p,
+                                                  ctypes.c_int)
+krb5_get_init_creds_opt_set_anonymous.restype = None
+
+krb5_get_init_creds_opt_set_canonicalize = (
+    LIBKRB5.krb5_get_init_creds_opt_set_anonymous)
+krb5_get_init_creds_opt_set_canonicalize.argtypes = (krb5_get_init_creds_opt_p,
+                                                     ctypes.c_int)
+krb5_get_init_creds_opt_set_canonicalize.restype = None
+
+krb5_get_init_creds_opt_set_etype_list = (
+    LIBKRB5.krb5_get_init_creds_opt_set_etype_list)
+krb5_get_init_creds_opt_set_etype_list.argtypes = (
+    krb5_get_init_creds_opt_p,
+    ctypes.POINTER(krb5_enctype),
+    ctypes.c_uint)
+krb5_get_init_creds_opt_set_etype_list.restype = None
+
+krb5_get_init_creds_opt_set_address_list = (
+    LIBKRB5.krb5_get_init_creds_opt_set_address_list)
+krb5_get_init_creds_opt_set_address_list.argtypes = (
+    krb5_get_init_creds_opt_p,
+    ctypes.POINTER(krb5_address_p))
+krb5_get_init_creds_opt_set_address_list.restype = None
+
+krb5_get_init_creds_opt_set_fast_ccache_name = (
+    LIBKRB5.krb5_get_init_creds_opt_set_fast_ccache_name)
+krb5_get_init_creds_opt_set_fast_ccache_name.argtypes = (
+    krb5_context, krb5_get_init_creds_opt_p, ctypes.c_char_p)
+krb5_get_init_creds_opt_set_fast_ccache_name.restype = None
+
+krb5_get_init_creds_opt_set_out_ccache = (
+    LIBKRB5.krb5_get_init_creds_opt_set_out_ccache)
+krb5_get_init_creds_opt_set_out_ccache.argtypes = (
+    krb5_context, krb5_get_init_creds_opt_p, krb5_ccache)
+krb5_get_init_creds_opt_set_out_ccache.restype = None
+
+
+class _krb5_data_prompt(ctypes.Structure):  # noqa
+    """krb5/krb5.h struct _krb5_data"""
+    _fields_ = [
+        ("magic", krb5_magic),
+        ("length", ctypes.c_uint),
+        ("data", ctypes.c_void_p),
+    ]
+
+
+class krb5_prompt(ctypes.Structure):
+    _fields_ = [
+        ("prompt", ctypes.c_char_p),
+        ("hidden", krb5_boolean),
+        ("reply", ctypes.POINTER(_krb5_data_prompt))]
+
+
+krb5_prompt_p = ctypes.POINTER(krb5_prompt)
+
+krb5_prompter_fct = ctypes.CFUNCTYPE(
+    krb5_error_code,
+    krb5_context,
+    krb5_pointer,
+    ctypes.c_char_p,
+    ctypes.c_char_p,
+    ctypes.c_int,
+    krb5_prompt_p,
+)
+
+krb5_get_init_creds_password = (
+    LIBKRB5.krb5_get_init_creds_password)
+krb5_get_init_creds_password.argtypes = (
+    krb5_context, ctypes.POINTER(krb5_creds),
+    krb5_principal, ctypes.c_char_p,
+    krb5_prompter_fct, krb5_pointer,
+    krb5_deltat, ctypes.c_char_p,
+    krb5_get_init_creds_opt_p)
+krb5_get_init_creds_password.restype = krb5_error_code
+
+
+def _kinit_get_init_options(context, **flags):
+    koptions = krb5_get_init_creds_opt_p()
+    krb5_get_init_creds_opt_alloc(context, ctypes.byref(koptions))
+    if 'lifetime' in flags:
+        krb5_get_init_creds_opt_set_tkt_life(
+            koptions, krb5_deltat(flags["lifetime"]))
+
+    if 'renew_life' in flags:
+        krb5_get_init_creds_opt_set_renew_life(
+            koptions, krb5_deltat(flags["renew_life"]))
+
+    if 'forwardable' in flags:
+        krb5_get_init_creds_opt_set_forwardable(koptions, 1)
+
+    if 'not_forwardable' in flags:
+        krb5_get_init_creds_opt_set_forwardable(koptions, 0)
+
+    if 'proxiable' in flags:
+        krb5_get_init_creds_opt_set_proxiable(koptions, 1)
+
+    if 'not_proxiable' in flags:
+        krb5_get_init_creds_opt_set_proxiable(koptions, 0)
+
+    if 'canonicalize' in flags:
+        krb5_get_init_creds_opt_set_canonicalize(koptions, 1)
+
+    if 'anonymous' in flags:
+        krb5_get_init_creds_opt_set_anonymous(koptions, 1)
+
+    if 'addresses' in flags:
+        address_list = krb5_address_p * (flags['addresses'])
+        idx = 0
+        for ad in flags['addresses']:
+            address_list[idx] = ad
+            idx = idx + 1
+        krb5_get_init_creds_opt_set_address_list(
+            koptions, ctypes.byref(address_list)
+        )
+
+    if 'armor_ccache' in flags:
+        armor_ccache = flags['armor_ccache']
+        if not isinstance(armor_ccache, bytes):
+            armor_ccache = armor_ccache.encode('utf-8')
+        krb5_get_init_creds_opt_set_fast_ccache_name(
+            context, koptions, ctypes.c_char_p(armor_ccache))
+    return koptions
+
+
+def kinit_with_cb(princ_name, cb, **flags):
+    if not isinstance(princ_name, bytes):
+        princ_name = princ_name.encode('utf-8')
+
+    context = krb5_context()
+    principal = krb5_principal()
+    ccache = krb5_ccache()
+    pname_princ = krb5_principal()
+    pname = ctypes.c_char_p()
+    mycreds = krb5_creds()
+
+    try:
+        krb5_init_context(ctypes.byref(context))
+        koptions = _kinit_get_init_options(context, **flags)
+
+        krb5_cc_default(context, ctypes.byref(ccache))
+        try:
+            krb5_cc_get_principal(context, ccache, ctypes.byref(principal))
+        except KRB5Error as e:
+            print(f'Error: {e}')
+
+        # We need to parse and then unparse the name in case the pric_name
+        # passed in comes w/o a realm attached
+        krb5_parse_name(context, ctypes.c_char_p(princ_name),
+                        ctypes.byref(pname_princ))
+        krb5_unparse_name(context, pname_princ, ctypes.byref(pname))
+
+        krb5_get_init_creds_opt_set_out_ccache(context, koptions, ccache)
+
+        krb5_get_init_creds_password(
+            context,
+            ctypes.byref(mycreds),
+            pname_princ,
+            None,
+            cb,
+            None,
+            0,
+            None,
+            koptions,
+        )
+
+    finally:
+        if principal:
+            krb5_free_principal(context, principal)
+        if pname_princ:
+            krb5_free_principal(context, pname_princ)
+        if pname:
+            krb5_free_unparsed_name(context, pname)
+        if koptions:
+            krb5_get_init_creds_opt_free(context, koptions)
+        if ccache:
+            krb5_cc_close(context, ccache)
+        if context:
+            krb5_free_context(context)

--- a/ipapython/kerberos.py
+++ b/ipapython/kerberos.py
@@ -1,12 +1,15 @@
 #
-# Copyright (C) 2016 FreeIPA Contributors see COPYING for license
+# Copyright (C) 2016-2024 FreeIPA Contributors see COPYING for license
 #
 
 """
-classes/utils for Kerberos principal name validation/manipulation
+classes/utils for Kerberos operations using MIT Kerberos libraries
 """
+
+import ctypes
 import re
 import six
+import sys
 
 from ipapython.ipautil import escape_seq, unescape_seq
 
@@ -202,3 +205,216 @@ class Principal:
     def __repr__(self):
         return "{0.__module__}.{0.__name__}('{1}')".format(
             self.__class__, self)
+
+
+KRB5_CC_NOSUPP = -1765328137
+
+if sys.platform == 'darwin':
+    LIBKRB5_FILENAME = 'libkrb5.dylib'
+else:
+    LIBKRB5_FILENAME = 'libkrb5.so.3'
+
+try:
+    LIBKRB5 = ctypes.CDLL(LIBKRB5_FILENAME)
+except OSError as e:  # pragma: no cover
+    raise ImportError(str(e))
+
+krb5_int32 = ctypes.c_int32
+krb5_error_code = krb5_int32
+krb5_magic = krb5_error_code
+krb5_enctype = krb5_int32
+krb5_octet = ctypes.c_uint8
+krb5_timestamp = krb5_int32
+
+
+class _krb5_context(ctypes.Structure):  # noqa
+    """krb5/krb5.h struct _krb5_context"""
+    _fields_ = []
+
+
+class _krb5_ccache(ctypes.Structure):  # noqa
+    """krb5/krb5.h struct _krb5_ccache"""
+    _fields_ = []
+
+
+class _krb5_data(ctypes.Structure):  # noqa
+    """krb5/krb5.h struct _krb5_data"""
+    _fields_ = [
+        ("magic", krb5_magic),
+        ("length", ctypes.c_uint),
+        ("data", ctypes.c_char_p),
+    ]
+
+
+class krb5_principal_data(ctypes.Structure):  # noqa
+    """krb5/krb5.h struct krb5_principal_data"""
+    _fields_ = []
+
+
+class _krb5_keyblock(ctypes.Structure):  # noqa
+    """krb5/krb5.h struct _krb5_keyblock"""
+    _fields_ = [
+        ("magic", krb5_magic),
+        ("enctype", krb5_enctype),
+        ("length", ctypes.c_uint),
+        ("contents", ctypes.POINTER(krb5_octet))
+    ]
+
+
+class _krb5_ticket_times(ctypes.Structure):  # noqa
+    """krb5/krb5.h struct _krb5_ticket_times"""
+    _fields_ = [
+        ("authtime", krb5_timestamp),
+        ("starttime", krb5_timestamp),
+        ("endtime", krb5_timestamp),
+        ("renew_till", krb5_timestamp),
+    ]
+
+
+class _krb5_address(ctypes.Structure):  # noqa
+    """krb5/krb5.h struct _krb5_address"""
+    _fields_ = []
+
+
+class _krb5_authdata(ctypes.Structure):  # noqa
+    """krb5/krb5.h struct _krb5_authdata"""
+    _fields_ = []
+
+
+krb5_principal = ctypes.POINTER(krb5_principal_data)
+krb5_keyblock = _krb5_keyblock
+krb5_ticket_times = _krb5_ticket_times
+krb5_boolean = ctypes.c_uint
+krb5_flags = krb5_int32
+krb5_data = _krb5_data
+krb5_address_p = ctypes.POINTER(_krb5_address)
+krb5_authdata_p = ctypes.POINTER(_krb5_authdata)
+
+
+class _krb5_creds(ctypes.Structure):  # noqa
+    """krb5/krb5.h struct _krb5_creds"""
+    _fields_ = [
+        ("magic", krb5_magic),
+        ("client", krb5_principal),
+        ("server", krb5_principal),
+        ("keyblock", krb5_keyblock),
+        ("times", krb5_ticket_times),
+        ("is_skey", krb5_boolean),
+        ("ticket_flags", krb5_flags),
+        ("addresses", ctypes.POINTER(krb5_address_p)),
+        ("ticket", krb5_data),
+        ("second_ticket", krb5_data),
+        ("authdata", ctypes.POINTER(krb5_authdata_p))
+    ]
+
+
+class KRB5Error(Exception):
+    pass
+
+
+def krb5_errcheck(result, func, arguments):
+    """Error checker for krb5_error_code return value"""
+    if result != 0:
+        raise KRB5Error(result, func.__name__, arguments)
+
+
+krb5_context = ctypes.POINTER(_krb5_context)
+krb5_ccache = ctypes.POINTER(_krb5_ccache)
+krb5_data_p = ctypes.POINTER(_krb5_data)
+krb5_creds = _krb5_creds
+krb5_pointer = ctypes.c_void_p
+krb5_cc_cursor = krb5_pointer
+
+krb5_init_context = LIBKRB5.krb5_init_context
+krb5_init_context.argtypes = (ctypes.POINTER(krb5_context), )
+krb5_init_context.restype = krb5_error_code
+krb5_init_context.errcheck = krb5_errcheck
+
+krb5_free_context = LIBKRB5.krb5_free_context
+krb5_free_context.argtypes = (krb5_context, )
+krb5_free_context.restype = None
+
+krb5_free_principal = LIBKRB5.krb5_free_principal
+krb5_free_principal.argtypes = (krb5_context, krb5_principal)
+krb5_free_principal.restype = None
+
+krb5_free_data_contents = LIBKRB5.krb5_free_data_contents
+krb5_free_data_contents.argtypes = (krb5_context, krb5_data_p)
+krb5_free_data_contents.restype = None
+
+krb5_cc_default = LIBKRB5.krb5_cc_default
+krb5_cc_default.argtypes = (krb5_context, ctypes.POINTER(krb5_ccache), )
+krb5_cc_default.restype = krb5_error_code
+krb5_cc_default.errcheck = krb5_errcheck
+
+krb5_cc_close = LIBKRB5.krb5_cc_close
+krb5_cc_close.argtypes = (krb5_context, krb5_ccache, )
+krb5_cc_close.restype = krb5_error_code
+krb5_cc_close.errcheck = krb5_errcheck
+
+krb5_parse_name = LIBKRB5.krb5_parse_name
+krb5_parse_name.argtypes = (krb5_context, ctypes.c_char_p,
+                            ctypes.POINTER(krb5_principal), )
+krb5_parse_name.restype = krb5_error_code
+krb5_parse_name.errcheck = krb5_errcheck
+
+krb5_cc_set_config = LIBKRB5.krb5_cc_set_config
+krb5_cc_set_config.argtypes = (krb5_context, krb5_ccache, krb5_principal,
+                               ctypes.c_char_p, krb5_data_p, )
+krb5_cc_set_config.restype = krb5_error_code
+krb5_cc_set_config.errcheck = krb5_errcheck
+
+krb5_cc_get_principal = LIBKRB5.krb5_cc_get_principal
+krb5_cc_get_principal.argtypes = (krb5_context, krb5_ccache,
+                                  ctypes.POINTER(krb5_principal), )
+krb5_cc_get_principal.restype = krb5_error_code
+krb5_cc_get_principal.errcheck = krb5_errcheck
+
+# krb5_build_principal is a variadic function but that can't be expressed
+# in a ctypes argtypes definition, so I explicitly listed the number of
+# arguments we actually use through the code for type checking purposes
+krb5_build_principal = LIBKRB5.krb5_build_principal
+krb5_build_principal.argtypes = (krb5_context, ctypes.POINTER(krb5_principal),
+                                 ctypes.c_uint, ctypes.c_char_p,
+                                 ctypes.c_char_p, ctypes.c_char_p,
+                                 ctypes.c_char_p, ctypes.c_char_p, )
+krb5_build_principal.restype = krb5_error_code
+krb5_build_principal.errcheck = krb5_errcheck
+
+krb5_cc_start_seq_get = LIBKRB5.krb5_cc_start_seq_get
+krb5_cc_start_seq_get.argtypes = (krb5_context, krb5_ccache,
+                                  ctypes.POINTER(krb5_cc_cursor), )
+krb5_cc_start_seq_get.restype = krb5_error_code
+krb5_cc_start_seq_get.errcheck = krb5_errcheck
+
+krb5_cc_next_cred = LIBKRB5.krb5_cc_next_cred
+krb5_cc_next_cred.argtypes = (krb5_context, krb5_ccache,
+                              ctypes.POINTER(krb5_cc_cursor),
+                              ctypes.POINTER(krb5_creds), )
+krb5_cc_next_cred.restype = krb5_error_code
+krb5_cc_next_cred.errcheck = krb5_errcheck
+
+krb5_cc_end_seq_get = LIBKRB5.krb5_cc_end_seq_get
+krb5_cc_end_seq_get.argtypes = (krb5_context, krb5_ccache,
+                                ctypes.POINTER(krb5_cc_cursor), )
+krb5_cc_end_seq_get.restype = krb5_error_code
+krb5_cc_end_seq_get.errcheck = krb5_errcheck
+
+krb5_free_cred_contents = LIBKRB5.krb5_free_cred_contents
+krb5_free_cred_contents.argtypes = (krb5_context, ctypes.POINTER(krb5_creds))
+krb5_free_cred_contents.restype = None
+
+krb5_principal_compare = LIBKRB5.krb5_principal_compare
+krb5_principal_compare.argtypes = (krb5_context, krb5_principal,
+                                   krb5_principal, )
+krb5_principal_compare.restype = krb5_boolean
+
+krb5_unparse_name = LIBKRB5.krb5_unparse_name
+krb5_unparse_name.argtypes = (krb5_context, krb5_principal,
+                              ctypes.POINTER(ctypes.c_char_p), )
+krb5_unparse_name.restype = krb5_error_code
+krb5_unparse_name.errcheck = krb5_errcheck
+
+krb5_free_unparsed_name = LIBKRB5.krb5_free_unparsed_name
+krb5_free_unparsed_name.argtypes = (krb5_context, ctypes.c_char_p, )
+krb5_free_unparsed_name.restype = None

--- a/ipapython/session_storage.py
+++ b/ipapython/session_storage.py
@@ -2,221 +2,8 @@
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 #
 
+import ipapython.kerberos as krb5
 import ctypes
-import sys
-
-
-KRB5_CC_NOSUPP = -1765328137
-
-if sys.platform == 'darwin':
-    LIBKRB5_FILENAME = 'libkrb5.dylib'
-else:
-    LIBKRB5_FILENAME = 'libkrb5.so.3'
-
-try:
-    LIBKRB5 = ctypes.CDLL(LIBKRB5_FILENAME)
-except OSError as e:  # pragma: no cover
-    raise ImportError(str(e))
-
-krb5_int32 = ctypes.c_int32
-krb5_error_code = krb5_int32
-krb5_magic = krb5_error_code
-krb5_enctype = krb5_int32
-krb5_octet = ctypes.c_uint8
-krb5_timestamp = krb5_int32
-
-
-class _krb5_context(ctypes.Structure):  # noqa
-    """krb5/krb5.h struct _krb5_context"""
-    _fields_ = []
-
-
-class _krb5_ccache(ctypes.Structure):  # noqa
-    """krb5/krb5.h struct _krb5_ccache"""
-    _fields_ = []
-
-
-class _krb5_data(ctypes.Structure):  # noqa
-    """krb5/krb5.h struct _krb5_data"""
-    _fields_ = [
-        ("magic", krb5_magic),
-        ("length", ctypes.c_uint),
-        ("data", ctypes.c_char_p),
-    ]
-
-
-class krb5_principal_data(ctypes.Structure):  # noqa
-    """krb5/krb5.h struct krb5_principal_data"""
-    _fields_ = []
-
-
-class _krb5_keyblock(ctypes.Structure):  # noqa
-    """krb5/krb5.h struct _krb5_keyblock"""
-    _fields_ = [
-        ("magic", krb5_magic),
-        ("enctype", krb5_enctype),
-        ("length", ctypes.c_uint),
-        ("contents", ctypes.POINTER(krb5_octet))
-    ]
-
-
-class _krb5_ticket_times(ctypes.Structure):  # noqa
-    """krb5/krb5.h struct _krb5_ticket_times"""
-    _fields_ = [
-        ("authtime", krb5_timestamp),
-        ("starttime", krb5_timestamp),
-        ("endtime", krb5_timestamp),
-        ("renew_till", krb5_timestamp),
-    ]
-
-
-class _krb5_address(ctypes.Structure):  # noqa
-    """krb5/krb5.h struct _krb5_address"""
-    _fields_ = []
-
-
-class _krb5_authdata(ctypes.Structure):  # noqa
-    """krb5/krb5.h struct _krb5_authdata"""
-    _fields_ = []
-
-
-krb5_principal = ctypes.POINTER(krb5_principal_data)
-krb5_keyblock = _krb5_keyblock
-krb5_ticket_times = _krb5_ticket_times
-krb5_boolean = ctypes.c_uint
-krb5_flags = krb5_int32
-krb5_data = _krb5_data
-krb5_address_p = ctypes.POINTER(_krb5_address)
-krb5_authdata_p = ctypes.POINTER(_krb5_authdata)
-
-
-class _krb5_creds(ctypes.Structure):  # noqa
-    """krb5/krb5.h struct _krb5_creds"""
-    _fields_ = [
-        ("magic", krb5_magic),
-        ("client", krb5_principal),
-        ("server", krb5_principal),
-        ("keyblock", krb5_keyblock),
-        ("times", krb5_ticket_times),
-        ("is_skey", krb5_boolean),
-        ("ticket_flags", krb5_flags),
-        ("addresses", ctypes.POINTER(krb5_address_p)),
-        ("ticket", krb5_data),
-        ("second_ticket", krb5_data),
-        ("authdata", ctypes.POINTER(krb5_authdata_p))
-    ]
-
-
-class KRB5Error(Exception):
-    pass
-
-
-def krb5_errcheck(result, func, arguments):
-    """Error checker for krb5_error_code return value"""
-    if result != 0:
-        raise KRB5Error(result, func.__name__, arguments)
-
-
-krb5_context = ctypes.POINTER(_krb5_context)
-krb5_ccache = ctypes.POINTER(_krb5_ccache)
-krb5_data_p = ctypes.POINTER(_krb5_data)
-krb5_creds = _krb5_creds
-krb5_pointer = ctypes.c_void_p
-krb5_cc_cursor = krb5_pointer
-
-krb5_init_context = LIBKRB5.krb5_init_context
-krb5_init_context.argtypes = (ctypes.POINTER(krb5_context), )
-krb5_init_context.restype = krb5_error_code
-krb5_init_context.errcheck = krb5_errcheck
-
-krb5_free_context = LIBKRB5.krb5_free_context
-krb5_free_context.argtypes = (krb5_context, )
-krb5_free_context.restype = None
-
-krb5_free_principal = LIBKRB5.krb5_free_principal
-krb5_free_principal.argtypes = (krb5_context, krb5_principal)
-krb5_free_principal.restype = None
-
-krb5_free_data_contents = LIBKRB5.krb5_free_data_contents
-krb5_free_data_contents.argtypes = (krb5_context, krb5_data_p)
-krb5_free_data_contents.restype = None
-
-krb5_cc_default = LIBKRB5.krb5_cc_default
-krb5_cc_default.argtypes = (krb5_context, ctypes.POINTER(krb5_ccache), )
-krb5_cc_default.restype = krb5_error_code
-krb5_cc_default.errcheck = krb5_errcheck
-
-krb5_cc_close = LIBKRB5.krb5_cc_close
-krb5_cc_close.argtypes = (krb5_context, krb5_ccache, )
-krb5_cc_close.restype = krb5_error_code
-krb5_cc_close.errcheck = krb5_errcheck
-
-krb5_parse_name = LIBKRB5.krb5_parse_name
-krb5_parse_name.argtypes = (krb5_context, ctypes.c_char_p,
-                            ctypes.POINTER(krb5_principal), )
-krb5_parse_name.restype = krb5_error_code
-krb5_parse_name.errcheck = krb5_errcheck
-
-krb5_cc_set_config = LIBKRB5.krb5_cc_set_config
-krb5_cc_set_config.argtypes = (krb5_context, krb5_ccache, krb5_principal,
-                               ctypes.c_char_p, krb5_data_p, )
-krb5_cc_set_config.restype = krb5_error_code
-krb5_cc_set_config.errcheck = krb5_errcheck
-
-krb5_cc_get_principal = LIBKRB5.krb5_cc_get_principal
-krb5_cc_get_principal.argtypes = (krb5_context, krb5_ccache,
-                                  ctypes.POINTER(krb5_principal), )
-krb5_cc_get_principal.restype = krb5_error_code
-krb5_cc_get_principal.errcheck = krb5_errcheck
-
-# krb5_build_principal is a variadic function but that can't be expressed
-# in a ctypes argtypes definition, so I explicitly listed the number of
-# arguments we actually use through the code for type checking purposes
-krb5_build_principal = LIBKRB5.krb5_build_principal
-krb5_build_principal.argtypes = (krb5_context, ctypes.POINTER(krb5_principal),
-                                 ctypes.c_uint, ctypes.c_char_p,
-                                 ctypes.c_char_p, ctypes.c_char_p,
-                                 ctypes.c_char_p, ctypes.c_char_p, )
-krb5_build_principal.restype = krb5_error_code
-krb5_build_principal.errcheck = krb5_errcheck
-
-krb5_cc_start_seq_get = LIBKRB5.krb5_cc_start_seq_get
-krb5_cc_start_seq_get.argtypes = (krb5_context, krb5_ccache,
-                                  ctypes.POINTER(krb5_cc_cursor), )
-krb5_cc_start_seq_get.restype = krb5_error_code
-krb5_cc_start_seq_get.errcheck = krb5_errcheck
-
-krb5_cc_next_cred = LIBKRB5.krb5_cc_next_cred
-krb5_cc_next_cred.argtypes = (krb5_context, krb5_ccache,
-                              ctypes.POINTER(krb5_cc_cursor),
-                              ctypes.POINTER(krb5_creds), )
-krb5_cc_next_cred.restype = krb5_error_code
-krb5_cc_next_cred.errcheck = krb5_errcheck
-
-krb5_cc_end_seq_get = LIBKRB5.krb5_cc_end_seq_get
-krb5_cc_end_seq_get.argtypes = (krb5_context, krb5_ccache,
-                                ctypes.POINTER(krb5_cc_cursor), )
-krb5_cc_end_seq_get.restype = krb5_error_code
-krb5_cc_end_seq_get.errcheck = krb5_errcheck
-
-krb5_free_cred_contents = LIBKRB5.krb5_free_cred_contents
-krb5_free_cred_contents.argtypes = (krb5_context, ctypes.POINTER(krb5_creds))
-krb5_free_cred_contents.restype = None
-
-krb5_principal_compare = LIBKRB5.krb5_principal_compare
-krb5_principal_compare.argtypes = (krb5_context, krb5_principal,
-                                   krb5_principal, )
-krb5_principal_compare.restype = krb5_boolean
-
-krb5_unparse_name = LIBKRB5.krb5_unparse_name
-krb5_unparse_name.argtypes = (krb5_context, krb5_principal,
-                              ctypes.POINTER(ctypes.c_char_p), )
-krb5_unparse_name.restype = krb5_error_code
-krb5_unparse_name.errcheck = krb5_errcheck
-
-krb5_free_unparsed_name = LIBKRB5.krb5_free_unparsed_name
-krb5_free_unparsed_name.argtypes = (krb5_context, ctypes.c_char_p, )
-krb5_free_unparsed_name.restype = None
 
 CONF_REALM = b"X-CACHECONF:"
 CONF_NAME = b"krb5_ccache_conf_data"
@@ -239,32 +26,32 @@ def store_data(princ_name, key, value):
     if oldvalue == value:
         return
 
-    context = krb5_context()
-    principal = krb5_principal()
-    ccache = krb5_ccache()
+    context = krb5.krb5_context()
+    principal = krb5.krb5_principal()
+    ccache = krb5.krb5_ccache()
 
     try:
-        krb5_init_context(ctypes.byref(context))
+        krb5.krb5_init_context(ctypes.byref(context))
 
-        krb5_parse_name(context, ctypes.c_char_p(princ_name),
-                        ctypes.byref(principal))
+        krb5.krb5_parse_name(context, ctypes.c_char_p(princ_name),
+                             ctypes.byref(principal))
 
-        krb5_cc_default(context, ctypes.byref(ccache))
+        krb5.krb5_cc_default(context, ctypes.byref(ccache))
 
         buf = ctypes.create_string_buffer(value)
-        data = _krb5_data()
+        data = krb5._krb5_data()
         data.data = buf.value
         data.length = len(buf)
-        krb5_cc_set_config(context, ccache, principal, key,
-                           ctypes.byref(data))
+        krb5.krb5_cc_set_config(context, ccache, principal, key,
+                                ctypes.byref(data))
 
     finally:
         if principal:
-            krb5_free_principal(context, principal)
+            krb5.krb5_free_principal(context, principal)
         if ccache:
-            krb5_cc_close(context, ccache)
+            krb5.krb5_cc_close(context, ccache)
         if context:
-            krb5_free_context(context)
+            krb5.krb5_free_context(context)
 
 
 def get_data(princ_name, key):
@@ -276,84 +63,87 @@ def get_data(princ_name, key):
     if not isinstance(key, bytes):
         key = key.encode('utf-8')
 
-    context = krb5_context()
-    principal = krb5_principal()
-    srv_princ = krb5_principal()
-    ccache = krb5_ccache()
-    pname_princ = krb5_principal()
+    context = krb5.krb5_context()
+    principal = krb5.krb5_principal()
+    srv_princ = krb5.krb5_principal()
+    ccache = krb5.krb5_ccache()
+    pname_princ = krb5.krb5_principal()
     pname = ctypes.c_char_p()
 
     try:
-        krb5_init_context(ctypes.byref(context))
+        krb5.krb5_init_context(ctypes.byref(context))
 
-        krb5_cc_default(context, ctypes.byref(ccache))
-        krb5_cc_get_principal(context, ccache, ctypes.byref(principal))
+        krb5.krb5_cc_default(context, ctypes.byref(ccache))
+        krb5.krb5_cc_get_principal(context, ccache, ctypes.byref(principal))
 
         # We need to parse and then unparse the name in case the pric_name
         # passed in comes w/o a realm attached
-        krb5_parse_name(context, ctypes.c_char_p(princ_name),
-                        ctypes.byref(pname_princ))
-        krb5_unparse_name(context, pname_princ, ctypes.byref(pname))
+        krb5.krb5_parse_name(context, ctypes.c_char_p(princ_name),
+                             ctypes.byref(pname_princ))
+        krb5.krb5_unparse_name(context, pname_princ, ctypes.byref(pname))
 
-        krb5_build_principal(context, ctypes.byref(srv_princ),
-                             len(CONF_REALM), ctypes.c_char_p(CONF_REALM),
-                             ctypes.c_char_p(CONF_NAME), ctypes.c_char_p(key),
-                             pname, ctypes.c_char_p(None))
+        krb5.krb5_build_principal(context, ctypes.byref(srv_princ),
+                                  len(CONF_REALM), ctypes.c_char_p(CONF_REALM),
+                                  ctypes.c_char_p(CONF_NAME),
+                                  ctypes.c_char_p(key),
+                                  pname, ctypes.c_char_p(None))
 
         # Unfortunately we can't just use krb5_cc_get_config()
         # because of bugs in some ccache handling code in krb5
         # libraries that would always return the first entry
         # stored and not the last one, which is the one we want.
-        cursor = krb5_cc_cursor()
-        creds = krb5_creds()
+        cursor = krb5.krb5_cc_cursor()
+        creds = krb5.krb5_creds()
         got_creds = False
-        krb5_cc_start_seq_get(context, ccache, ctypes.byref(cursor))
+        krb5.krb5_cc_start_seq_get(context, ccache, ctypes.byref(cursor))
         try:
             while True:
-                checkcreds = krb5_creds()
+                checkcreds = krb5.krb5_creds()
                 # the next function will throw an error and break out of the
                 # while loop when we try to access past the last cred
                 try:
-                    krb5_cc_next_cred(context, ccache, ctypes.byref(cursor),
-                                      ctypes.byref(checkcreds))
-                except KRB5Error:
+                    krb5.krb5_cc_next_cred(context, ccache,
+                                           ctypes.byref(cursor),
+                                           ctypes.byref(checkcreds))
+                except krb5.KRB5Error:
                     break
 
-                if (krb5_principal_compare(context, principal,
-                                           checkcreds.client) == 1 and
-                    krb5_principal_compare(context, srv_princ,
-                                           checkcreds.server) == 1):
+                if (krb5.krb5_principal_compare(context, principal,
+                                                checkcreds.client) == 1
+                    and krb5.krb5_principal_compare(context, srv_princ,
+                                                    checkcreds.server) == 1):
                     if got_creds:
-                        krb5_free_cred_contents(context, ctypes.byref(creds))
+                        krb5.krb5_free_cred_contents(context,
+                                                     ctypes.byref(creds))
                     creds = checkcreds
                     got_creds = True
                     # We do not stop here, as we want the LAST entry
                     # in the ccache for those ccaches that cannot delete
                     # but only always append, like FILE
                 else:
-                    krb5_free_cred_contents(context,
-                                            ctypes.byref(checkcreds))
+                    krb5.krb5_free_cred_contents(context,
+                                                 ctypes.byref(checkcreds))
         finally:
-            krb5_cc_end_seq_get(context, ccache, ctypes.byref(cursor))
+            krb5.krb5_cc_end_seq_get(context, ccache, ctypes.byref(cursor))
 
         if got_creds:
             data = creds.ticket.data
-            krb5_free_cred_contents(context, ctypes.byref(creds))
+            krb5.krb5_free_cred_contents(context, ctypes.byref(creds))
             return data
 
     finally:
         if principal:
-            krb5_free_principal(context, principal)
+            krb5.krb5_free_principal(context, principal)
         if srv_princ:
-            krb5_free_principal(context, srv_princ)
+            krb5.krb5_free_principal(context, srv_princ)
         if pname_princ:
-            krb5_free_principal(context, pname_princ)
+            krb5.krb5_free_principal(context, pname_princ)
         if pname:
-            krb5_free_unparsed_name(context, pname)
+            krb5.krb5_free_unparsed_name(context, pname)
         if ccache:
-            krb5_cc_close(context, ccache)
+            krb5.krb5_cc_close(context, ccache)
         if context:
-            krb5_free_context(context)
+            krb5.krb5_free_context(context)
     return None
 
 
@@ -366,29 +156,29 @@ def remove_data(princ_name, key):
     if not isinstance(key, bytes):
         key = key.encode('utf-8')
 
-    context = krb5_context()
-    principal = krb5_principal()
-    ccache = krb5_ccache()
+    context = krb5.krb5_context()
+    principal = krb5.krb5_principal()
+    ccache = krb5.krb5_ccache()
 
     try:
-        krb5_init_context(ctypes.byref(context))
+        krb5.krb5_init_context(ctypes.byref(context))
 
-        krb5_parse_name(context, ctypes.c_char_p(princ_name),
-                        ctypes.byref(principal))
+        krb5.krb5_parse_name(context, ctypes.c_char_p(princ_name),
+                             ctypes.byref(principal))
 
-        krb5_cc_default(context, ctypes.byref(ccache))
+        krb5.krb5_cc_default(context, ctypes.byref(ccache))
 
         try:
-            krb5_cc_set_config(context, ccache, principal, key, None)
-        except KRB5Error as e:
-            if e.args[0] == KRB5_CC_NOSUPP:
+            krb5.krb5_cc_set_config(context, ccache, principal, key, None)
+        except krb5.KRB5Error as e:
+            if e.args[0] == krb5.KRB5_CC_NOSUPP:
                 # removal not supported with this CC type, just pass
                 pass
 
     finally:
         if principal:
-            krb5_free_principal(context, principal)
+            krb5.krb5_free_principal(context, principal)
         if ccache:
-            krb5_cc_close(context, ccache)
+            krb5.krb5_cc_close(context, ccache)
         if context:
-            krb5_free_context(context)
+            krb5.krb5_free_context(context)

--- a/ipapython/session_storage.py
+++ b/ipapython/session_storage.py
@@ -25,6 +25,7 @@ krb5_enctype = krb5_int32
 krb5_octet = ctypes.c_uint8
 krb5_timestamp = krb5_int32
 
+
 class _krb5_context(ctypes.Structure):  # noqa
     """krb5/krb5.h struct _krb5_context"""
     _fields_ = []
@@ -319,7 +320,7 @@ def get_data(princ_name, key):
                     break
 
                 if (krb5_principal_compare(context, principal,
-                                          checkcreds.client) == 1 and
+                                           checkcreds.client) == 1 and
                     krb5_principal_compare(context, srv_princ,
                                            checkcreds.server) == 1):
                     if got_creds:
@@ -388,6 +389,6 @@ def remove_data(princ_name, key):
         if principal:
             krb5_free_principal(context, principal)
         if ccache:
-          krb5_cc_close(context, ccache)
+            krb5_cc_close(context, ccache)
         if context:
             krb5_free_context(context)

--- a/ipatests/test_ipapython/test_session_storage.py
+++ b/ipatests/test_ipapython/test_session_storage.py
@@ -8,7 +8,7 @@ Test the `session_storage.py` module.
 import pytest
 
 from ipapython import session_storage
-
+from ipapython.kerberos import KRB5Error
 
 @pytest.mark.skip_ipaclient_unittest
 @pytest.mark.needs_ipaapi
@@ -37,5 +37,5 @@ class test_session_storage:
         session_storage.remove_data(self.principal, self.key)
         try:
             session_storage.get_data(self.principal, self.key)
-        except session_storage.KRB5Error:
+        except KRB5Error:
             pass

--- a/makeapi.in
+++ b/makeapi.in
@@ -32,6 +32,7 @@ import os
 import re
 import inspect
 import operator
+import textwrap
 
 from ipalib import api
 from ipalib.parameters import Param
@@ -39,7 +40,7 @@ from ipalib.output import Output
 from ipalib.text import Gettext, NGettext, ConcatenatedLazyText
 from ipalib.capabilities import capabilities
 
-API_FILE='API.txt'
+API_FILE = 'API.txt'
 
 API_FILE_DIFFERENCE = 1
 API_NEW_COMMAND = 2
@@ -83,18 +84,21 @@ OUTPUT_IGNORED_ATTRIBUTES = (
     'flags',
 )
 
+
 def parse_options():
     from optparse import OptionParser  # pylint: disable=deprecated-module
 
     parser = OptionParser()
     parser.add_option("--validate", dest="validate", action="store_true",
-        default=False, help="Validate the API vs the stored API")
+                      default=False, help="Validate the API vs the stored API")
 
-    parser.add_option("--no-validate-doc", dest="validate_doc", action="store_false",
-        default=True, help="Do not validate documentation")
+    parser.add_option("--no-validate-doc", dest="validate_doc",
+                      action="store_false", default=True,
+                      help="Do not validate documentation")
 
     options, args = parser.parse_args()
     return options, args
+
 
 def param_repr(p):
     """
@@ -218,26 +222,29 @@ def validate_doc():
             src_file = inspect.getsourcefile(cmd_class)
             line_num = inspect.getsourcelines(cmd_class)[1]
             n_missing_cmd_doc += 1
-            print("%s:%d command \"%s\" has no doc" % (src_file, line_num, cmd.name))
+            print("%s:%d command \"%s\" has no doc" % (
+                  src_file, line_num, cmd.name))
         # Yes the command has doc, but is it internationalized?
         elif not is_i18n(cmd.doc):
             src_file = inspect.getsourcefile(cmd_class)
             line_num = inspect.getsourcelines(cmd_class)[1]
             n_missing_cmd_i18n += 1
-            print("%s:%d command \"%s\" doc is not internationalized" % (src_file, line_num, cmd.name))
+            print("%s:%d command \"%s\" doc is not internationalized" % (
+                  src_file, line_num, cmd.name))
 
     # If any errors, emit summary information and adjust return value
     if n_missing_cmd_doc > 0 or n_missing_cmd_i18n > 0:
         rval = API_DOC_ERROR
-        print("%d commands without doc, %d commands whose doc is not i18n" % \
+        print("%d commands without doc, %d commands whose doc is not i18n" %
               (n_missing_cmd_doc, n_missing_cmd_i18n))
 
     if n_missing_mod_doc > 0 or n_missing_mod_i18n > 0:
         rval = API_DOC_ERROR
-        print("%d modules without doc, %d modules whose doc is not i18n" % \
+        print("%d modules without doc, %d modules whose doc is not i18n" %
               (n_missing_mod_doc, n_missing_mod_i18n))
 
     return rval
+
 
 def make_api():
     """
@@ -246,7 +253,8 @@ def make_api():
     fd = open(API_FILE, 'w')
     for cmd in api.Command():
         fd.write('command: %s\n' % cmd.full_name)
-        fd.write('args: %d,%d,%d\n' % (len(cmd.args), len(cmd.options), len(cmd.output)))
+        fd.write('args: %d,%d,%d\n' % (len(cmd.args),
+                                       len(cmd.options), len(cmd.output)))
         for a in cmd.args():
             fd.write('arg: %s\n' % param_repr(a))
         for o in sorted(cmd.options(), key=operator.attrgetter('name')):
@@ -356,7 +364,8 @@ def make_api_reference(validate_only=False):
     api_contents["doc/api/parameters.rst"] = "\n".join(param_lines)
 
     def generate_param_type_text(obj):
-        # If class is part of IPA Params, return text with ref, if not just return its name
+        # If class is part of IPA Params, return text with ref,
+        # if not just return its name
         if type(obj) in ipa_classes:
             return ":ref:`{n}<{n}>`".format(n=type(obj).__name__)
         else:
@@ -367,15 +376,16 @@ def make_api_reference(validate_only=False):
         lines = []
         lines.append("# %s" % cmd.name)
 
-        doc_stripped =  '\n'.join([s.strip() for s in str(cmd.doc).splitlines()])
+        doc_stripped = '\n'.join([s.strip() for s in str(cmd.doc).splitlines()])
         lines.append(doc_stripped)
 
         lines.append("\n### Arguments")
         try:
-            next(cmd.args()) # if empty, StopIteration is thrown
+            next(cmd.args())  # if empty, StopIteration is thrown
             table_rows = [["Name", "Type", "Required"]]
             for a in cmd.args():
-                table_rows.append([a.name, generate_param_type_text(a), str(a.required)])
+                table_rows.append(
+                    [a.name, generate_param_type_text(a), str(a.required)])
             lines.extend(make_md_table(table_rows))
         except StopIteration:
             lines.append("No arguments.")
@@ -383,9 +393,12 @@ def make_api_reference(validate_only=False):
         lines.append("\n### Options")
         try:
             next(cmd.options())
-            for o in sorted(cmd.options(), key=operator.attrgetter('required'), reverse=True):
+            for o in sorted(cmd.options(), key=operator.attrgetter('required'),
+                            reverse=True):
                 req_str = " **(Required)**" if o.required else ""
-                lines.append("* {} : {}{}".format(o.name, generate_param_type_text(o), req_str))
+                lines.append("* {} : {}{}".format(o.name,
+                                                  generate_param_type_text(o),
+                                                  req_str))
                 if hasattr(o, "default") and o.default is not None:
                     lines.append(" * Default: {}".format(o.default))
                 if hasattr(o, "values"):
@@ -410,7 +423,7 @@ def make_api_reference(validate_only=False):
                 # Read notes written to template
                 notes = f.read().split("//end)")[1].strip()
         except FileNotFoundError:
-                notes = notes_template
+            notes = notes_template
 
         out = class_template.format(
             automated_marker_start=automated_marker_start,
@@ -440,7 +453,7 @@ def find_name(line):
     could just eval() the line but we wouldn't have defined any validators
     or normalizers it may be using.
     """
-    m = re.match('^[a-zA-Z0-9]+\(\'([a-z][_a-z0-9?\*\+]*)\'.*', line)
+    m = re.match(r'^[a-zA-Z0-9]+\(\'([a-z][_a-z0-9?\*\+]*)\'.*', line)
     if m:
         name = m.group(1)
     else:
@@ -448,9 +461,10 @@ def find_name(line):
         name = ''
     return name
 
+
 def _finalize_command_validation(cmd, found_args, expected_args,
-                                      found_options, expected_options,
-                                      found_output, expected_output):
+                                 found_options, expected_options,
+                                 found_output, expected_output):
     passed = True
     # Check the args of the previous command.
     if len(found_args) != expected_args:
@@ -469,8 +483,9 @@ def _finalize_command_validation(cmd, found_args, expected_args,
     # Check if there is not a new arg/opt/output in previous command
     for a in cmd.args():
         if a.param_spec not in found_args:
-            print('Argument %s of command %s in ipalib, not in API file:\n%s' % (
-                a.param_spec, cmd.name, param_repr(a)))
+            print('Argument %s of command %s in ipalib, '
+                  'not in API file:\n%s' % (
+                      a.param_spec, cmd.name, param_repr(a)))
             passed = False
     for o in cmd.options():
         if o.param_spec not in found_options:
@@ -514,9 +529,12 @@ def validate_api():
         line = line.strip()
         if line.startswith('command:'):
             if cmd:
-                if not _finalize_command_validation(cmd, found_args, expected_args,
-                                      found_options, expected_options,
-                                      found_output, expected_output):
+                if not _finalize_command_validation(cmd, found_args,
+                                                    expected_args,
+                                                    found_options,
+                                                    expected_options,
+                                                    found_output,
+                                                    expected_output):
                     rval |= API_FILE_DIFFERENCE
 
             (arg, name) = line.split(': ', 1)
@@ -546,14 +564,16 @@ def validate_api():
                 else:
                     if a.name == arg:
                         found = True
-                        print('Arg in %s doesn\'t match.\nGot      %s\nExpected %s' % (
-                            name, param_repr(a), line))
+                        print('Arg in %s doesn\'t match.\n'
+                              'Got %s\nExpected %s' % (
+                                  name, param_repr(a), line))
                         rval |= API_FILE_DIFFERENCE
             if found:
                 found_args.append(arg)
             else:
                 arg = find_name(line)
-                print("Argument '%s' in command '%s' in API file not found" % (arg, name))
+                print("Argument '%s' in command '%s' "
+                      "in API file not found" % (arg, name))
                 rval |= API_FILE_DIFFERENCE
         if line.startswith('option:') and cmd:
             line = line.replace('option: ', '')
@@ -565,13 +585,15 @@ def validate_api():
                 else:
                     if o.name == option:
                         found = True
-                        print('Option in %s doesn\'t match. Got %s Expected %s' % (name, o, line))
+                        print('Option in %s doesn\'t match. '
+                              'Got %s Expected %s' % (name, o, line))
                         rval |= API_FILE_DIFFERENCE
             if found:
                 found_options.append(option)
             else:
                 option = find_name(line)
-                print("Option '%s' in command '%s' in API file not found" % (option, name))
+                print("Option '%s' in command '%s' "
+                      "in API file not found" % (option, name))
                 rval |= API_FILE_DIFFERENCE
         if line.startswith('output:') and cmd:
             line = line.replace('output: ', '')
@@ -583,13 +605,15 @@ def validate_api():
                 else:
                     if o.name == output:
                         found = True
-                        print('Output in %s doesn\'t match. Got %s Expected %s' % (name, o, line))
+                        print('Output in %s doesn\'t match. '
+                              'Got %s Expected %s' % (name, o, line))
                         rval |= API_FILE_DIFFERENCE
             if found:
                 found_output.append(output)
             else:
                 output = find_name(line)
-                print("Option '%s' in command '%s' in API file not found" % (output, name))
+                print("Option '%s' in command '%s' "
+                      "in API file not found" % (output, name))
                 rval |= API_FILE_DIFFERENCE
         if line.startswith('default:'):
             default = line.replace('default: ', '')
@@ -635,8 +659,8 @@ def validate_api():
 
     if cmd:
         if not _finalize_command_validation(cmd, found_args, expected_args,
-                              found_options, expected_options,
-                              found_output, expected_output):
+                                            found_options, expected_options,
+                                            found_output, expected_output):
             rval |= API_FILE_DIFFERENCE
 
     # Now look for new commands not in the current API
@@ -680,6 +704,7 @@ def validate_api_reference():
 
     return rval
 
+
 def main():
     rval = 0
     options, _args = parse_options()
@@ -718,18 +743,24 @@ def main():
 
     if rval & API_FILE_DIFFERENCE:
         print('')
-        print("There are one or more changes to the API.\n"
-              "Either undo the API changes or update API.txt, "
-              "API Reference, and increment the major version in VERSION.")
+        print(textwrap.dedent(
+              """There are one or more changes to the API.
+                 Either undo the API changes or update API.txt, "
+                 API Reference, and increment the major version in VERSION."""))
 
     if rval & API_NEW_COMMAND:
         print('')
-        print('There are one or more new commands defined.\nUpdate API.txt and increment the minor version in VERSION.')
+        print(textwrap.dedent(
+              '''There are one or more new commands defined.
+                 Update API.txt and increment the minor version in VERSION.'''))
 
     if rval & API_DOC_ERROR:
         print('')
-        print('There are one or more documentation problems.\nYou must fix these before preceeding')
+        print(textwrap.dedent(
+              '''There are one or more documentation problems.
+                 You must fix these before preceeding'''))
 
     return rval
+
 
 sys.exit(main())


### PR DESCRIPTION
## cli: add acquire_cred callback support to the Kerberos transport

This allows applications to specify their own acquire_cred callback. The callback should be put into the environment under '`acquire_cred`' name as a tuple of a `(callable, pass-in object)`.

The callable should accept `(pass-in object, principal, ccache, service)` and ideally should acquire a Kerberos credential into the `ccache`. Both `principal` and the `ccache` name might be None, signifying that a default name and a default credentials cache would need to be used.

Example usage:
```
import os
from ipalib import api
from ipalib.install.kinit import kinit_password

username = 'admin'
password = '<some-value>'

def acquire_cred(api, principal, ccache, service):
    if ccache is None:
        ccache = os.environ.get('KRB5CCNAME', 'KCM:')
    if principal is None:
        principal = username

    kinit_password(principal, password, ccache)

api.bootstrap(acquire_cred=(acquire_cred, api))
api.finalize()
api.Backend.rpcclient.connect()
print(api.Command.ping())
```

## cli: Ask for user name and password if Kerberos credentials missing

Ask interactively for credentials in case they are missing in the default credentials cache in the environment:
```
	$ ipa ping
	Username: testuser
	Password: <some-password>
	--------------------------------------------
	IPA server version 4.11.1. API version 2.253
	--------------------------------------------
```
Initial implementation only supports password-based credential.