### PR TITLE
[Backport][ipa-4-11] ipatests: Fixes for test_ipahealthcheck_ipansschainvalidation testcases

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -2766,17 +2766,18 @@ class TestIpaHealthCheckWithExternalCA(IntegrationTest):
         Fixture to remove Server cert and revert the change.
         """
         instance = realm_to_serverid(self.master.domain.realm)
+        instance_dir = paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % instance
         self.master.run_command(
             [
                 "certutil",
                 "-L",
                 "-d",
-                paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % instance,
+                instance_dir,
                 "-n",
                 "Server-Cert",
                 "-a",
                 "-o",
-                paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % instance
+                instance_dir
                 + "/Server-Cert.pem",
             ]
         )
@@ -2795,15 +2796,15 @@ class TestIpaHealthCheckWithExternalCA(IntegrationTest):
             [
                 "certutil",
                 "-d",
-                paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % instance,
+                instance_dir,
                 "-A",
                 "-i",
-                paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % instance
+                instance_dir
                 + "/Server-Cert.pem",
                 "-t",
                 "u,u,u",
                 "-f",
-                paths.IPA_NSSDB_PWDFILE_TXT,
+                "%s/pwdfile.txt" % instance_dir,
                 "-n",
                 "Server-Cert",
             ]


### PR DESCRIPTION
This PR was opened automatically because PR #7278 was pushed to master and backport to ipa-4-11 is required.