### PR TITLE
Check for file permissions after the ca/cert-show is complete

### DIFF
--- a/ipaclient/plugins/ca.py
+++ b/ipaclient/plugins/ca.py
@@ -26,15 +26,16 @@ class WithCertOutArgs(MethodOverride):
         filename = None
         if 'certificate_out' in options:
             filename = options.pop('certificate_out')
+
+        result = super(WithCertOutArgs, self).forward(*keys, **options)
+
+        if filename:
             try:
                 util.check_writable_file(filename)
             except errors.FileError as e:
                 raise errors.ValidationError(name='certificate-out',
                                              error=str(e))
 
-        result = super(WithCertOutArgs, self).forward(*keys, **options)
-
-        if filename:
             # if result certificate / certificate_chain not present in result,
             # it means Dogtag did not provide it (probably due to LWCA key
             # replication lag or failure.  The server transmits a warning

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -689,7 +689,7 @@ class ra(rabase.rabase, RestClient):
         :param err_msg:   diagnostic error message, if not supplied it will be
                           'Unable to communicate with CMS'
         :param detail:    extra information that will be appended to err_msg
-                          inside a parenthesis
+                          inside a parenthesis. This may be an HTTP status msg
 
         Raise a CertificateOperationError and log the error message.
         """
@@ -701,6 +701,8 @@ class ra(rabase.rabase, RestClient):
             err_msg = u'%s (%s)' % (err_msg, detail)
 
         logger.error('%s.%s(): %s', type(self).__name__, func_name, err_msg)
+        if detail == 404:
+            raise errors.NotFound(reason=err_msg)
         raise errors.CertificateOperationError(error=err_msg)
 
     def _request(self, url, port, **kw):

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -748,6 +748,27 @@ class TestIPACommand(IntegrationTest):
 
             self.master.run_command(['rm', '-f', filename])
 
+        # Ensure that ca/cert-show doesn't leave an empty file when
+        # the requested ca/cert does not exist.
+        commands = [
+            ['ipa', 'cert-show', '0xdeadbeef', '--certificate-out'],
+            ['ipa', 'ca-show', 'notfound', '--certificate-out'],
+        ]
+
+        for command in commands:
+            cmd = self.master.run_command(['mktemp', '--dry-run'])
+            filename = cmd.stdout_text.strip()
+
+            result = self.master.run_command(command + [filename],
+                                             raiseonerr=False)
+            assert result.returncode == 2
+
+            result = self.master.run_command(
+                ['stat', filename],
+                raiseonerr=False
+            )
+            assert result.returncode == 1
+
     def test_sssd_ifp_access_ipaapi(self):
         # check that ipaapi is allowed to access sssd-ifp for smartcard auth
         # https://pagure.io/freeipa/issue/7751

--- a/ipatests/test_xmlrpc/test_cert_plugin.py
+++ b/ipatests/test_xmlrpc/test_cert_plugin.py
@@ -558,6 +558,6 @@ class test_cert_remove_hold(BaseCert):
 
     def test_remove_hold_nonexistent_cert(self):
         # remove hold must print 'Certificate ID xx not found'
-        with pytest.raises(errors.CertificateOperationError,
+        with pytest.raises(errors.NotFound,
                            match=r'Certificate ID 0x.* not found'):
             api.Command['cert_remove_hold'](9999)


### PR DESCRIPTION
If it is done beforehand and the requested ca/cert does not exist then we'll leave an empty file.

Convert cert-show to be more like the simpler ca-show.

I considered cleaning up afterward but IMHO we shouldn't touch the file until we're ready to write. This costs an API roundtrip but its a small price to pay for potentially protecting existing data.

https://pagure.io/freeipa/issue/9562

I'm not inclined to backport this to older branches.