### PR TITLE
Allow access to new PKI APIs v2

### DIFF
--- a/install/share/ipa-pki-proxy.conf.template
+++ b/install/share/ipa-pki-proxy.conf.template
@@ -27,7 +27,7 @@ ProxyRequests Off
 </LocationMatch>
 
 # matches for REST API of CA, KRA, and PKI
-<LocationMatch "^/(ca|kra|pki)/rest/">
+<LocationMatch "^/(ca|kra|pki)/rest/|^/(ca|kra|pki)/v2/">
     SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
     SSLVerifyClient optional
     ProxyPassMatch ajp://localhost:$DOGTAG_PORT $DOGTAG_AJP_SECRET


### PR DESCRIPTION
PKI has a plan to re-implement REST APIs using different libraries and supporting only JSON format. The new APIs have a different path, `/v2`, and when ready the current implementation will be deprecated.

These APIs will not be back-ported to  other branches and for the moment the APIs will not be for external use but the CLI will be progressively migrated to the new API endpoints so these have to be accessible.

For reference: https://github.com/dogtagpki/pki/wiki/CA-REST-API-v2