### PR TITLE
[Backport][ipa-4-10] Only apply warning to the local ID range

### DIFF
--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -550,12 +550,15 @@ class idrange_add(LDAPCreate):
         self.obj.handle_ipabaserid(entry_attrs, options)
         self.obj.handle_iparangetype(entry_attrs, options,
                                      keep_objectclass=True)
-        self.add_message(
-            messages.ServiceRestartRequired(
-                service=services.knownservices.dirsrv.service_instance(""),
-                server=_('<all IPA servers>')
+
+        if entry_attrs.single_value.get('iparangetype') in (
+                'ipa-local', self.obj.range_types.get('ipa-local', None)):
+            self.add_message(
+                messages.ServiceRestartRequired(
+                    service=services.knownservices.dirsrv.service_instance(""),
+                    server=_('<all IPA servers>')
+                )
             )
-        )
         return dn
 
 
@@ -569,7 +572,8 @@ class idrange_del(LDAPDelete):
         try:
             old_attrs = ldap.get_entry(dn, ['ipabaseid',
                                             'ipaidrangesize',
-                                            'ipanttrusteddomainsid'])
+                                            'ipanttrusteddomainsid',
+                                            'iparangetype'])
         except errors.NotFound:
             raise self.obj.handle_not_found(*keys)
 
@@ -603,6 +607,20 @@ class idrange_del(LDAPDelete):
                     key=keys[0],
                     dependent=trust_domains[0].dn[0].value)
 
+        self.add_message(
+            messages.ServiceRestartRequired(
+                service=services.knownservices['sssd'].systemd_name,
+                server=_('<all IPA servers>')
+            )
+        )
+
+        if old_attrs.single_value.get('iparangetype') == 'ipa-local':
+            self.add_message(
+                messages.ServiceRestartRequired(
+                    service=services.knownservices.dirsrv.service_instance(""),
+                    server=_('<all IPA servers>')
+                )
+            )
 
         return dn
 
@@ -807,10 +825,20 @@ class idrange_mod(LDAPUpdate):
         assert isinstance(dn, DN)
         self.obj.handle_ipabaserid(entry_attrs, options)
         self.obj.handle_iparangetype(entry_attrs, options)
+
+        if entry_attrs.single_value.get('iparangetype') in (
+                'ipa-local', self.obj.range_types.get('ipa-local', None)):
+            self.add_message(
+                messages.ServiceRestartRequired(
+                    service=services.knownservices.dirsrv.service_instance(""),
+                    server=_('<all IPA servers>')
+                )
+            )
+
         self.add_message(
             messages.ServiceRestartRequired(
                 service=services.knownservices['sssd'].systemd_name,
-                server=keys[0]
+                server=_('<all IPA servers>')
             )
         )
         return dn

--- a/ipatests/test_xmlrpc/test_range_plugin.py
+++ b/ipatests/test_xmlrpc/test_range_plugin.py
@@ -613,8 +613,8 @@ class test_range(Declarative):
             desc='Delete ID range %r' % testrange1,
             command=('idrange_del', [testrange1], {}),
             expected=dict(
-                result=dict(failed=[],
-                            messages=fuzzy_restart_messages),
+                result=dict(failed=[]),
+                messages=fuzzy_restart_messages,
                 value=[testrange1],
                 summary=u'Deleted ID range "%s"' % testrange1,
             ),
@@ -718,8 +718,8 @@ class test_range(Declarative):
             desc='Delete ID range %r' % testrange2,
             command=('idrange_del', [testrange2], {}),
             expected=dict(
-                result=dict(failed=[],
-                            messages=fuzzy_restart_messages),
+                result=dict(failed=[]),
+                messages=fuzzy_restart_messages,
                 value=[testrange2],
                 summary=u'Deleted ID range "%s"' % testrange2,
             ),
@@ -809,11 +809,6 @@ class test_range(Declarative):
                 ),
                 value=unicode(domain7range1),
                 summary=u'Added ID range "%s"' % (domain7range1),
-                messages=(
-                    messages.ServiceRestartRequired(
-                        service=dirsrv_instance,
-                        server='<all IPA servers>').to_dict(),
-                ),
             ),
         ),
 
@@ -836,6 +831,7 @@ class test_range(Declarative):
                 result=dict(failed=[]),
                 value=[domain1range1],
                 summary=u'Deleted ID range "%s"' % domain1range1,
+                messages=fuzzy_restart_messages,
             ),
         ),
 
@@ -862,12 +858,7 @@ class test_range(Declarative):
             command=('idrange_mod', [domain3range2],
                      dict(ipabaseid=domain3range1_base_id)),
             expected=dict(
-                messages=(
-                    messages.ServiceRestartRequired(
-                        service=services.knownservices['sssd'].systemd_name,
-                        server=domain3range2
-                    ).to_dict(),
-                ),
+                messages=fuzzy_restart_messages,
                 result=dict(
                     cn=[domain3range2],
                     ipabaseid=[unicode(domain3range1_base_id)],
@@ -933,12 +924,7 @@ class test_range(Declarative):
             command=('idrange_mod', [domain2range1],
                      dict(ipabaserid=domain5range1_base_rid)),
             expected=dict(
-                messages=(
-                    messages.ServiceRestartRequired(
-                        service=services.knownservices['sssd'].systemd_name,
-                        server=domain2range1
-                    ).to_dict(),
-                ),
+                messages=fuzzy_restart_messages,
                 result=dict(
                     cn=[domain2range1],
                     ipabaseid=[unicode(domain2range1_base_id)],
@@ -973,12 +959,7 @@ class test_range(Declarative):
             command=('idrange_mod', [domain2range1],
                      dict(ipaautoprivategroups='true')),
             expected=dict(
-                messages=(
-                    messages.ServiceRestartRequired(
-                        service=services.knownservices['sssd'].systemd_name,
-                        server=domain2range1
-                    ).to_dict(),
-                ),
+                messages=fuzzy_restart_messages,
                 result=dict(
                     cn=[domain2range1],
                     ipabaseid=[unicode(domain2range1_base_id)],
@@ -1000,12 +981,7 @@ class test_range(Declarative):
             command=('idrange_mod', [domain2range1],
                      dict(ipaautoprivategroups='false')),
             expected=dict(
-                messages=(
-                    messages.ServiceRestartRequired(
-                        service=services.knownservices['sssd'].systemd_name,
-                        server=domain2range1
-                    ).to_dict(),
-                ),
+                messages=fuzzy_restart_messages,
                 result=dict(
                     cn=[domain2range1],
                     ipabaseid=[unicode(domain2range1_base_id)],
@@ -1027,12 +1003,7 @@ class test_range(Declarative):
             command=('idrange_mod', [domain2range1],
                      dict(ipaautoprivategroups='hybrid')),
             expected=dict(
-                messages=(
-                    messages.ServiceRestartRequired(
-                        service=services.knownservices['sssd'].systemd_name,
-                        server=domain2range1
-                    ).to_dict(),
-                ),
+                messages=fuzzy_restart_messages,
                 result=dict(
                     cn=[domain2range1],
                     ipabaseid=[unicode(domain2range1_base_id)],
@@ -1054,12 +1025,7 @@ class test_range(Declarative):
             command=('idrange_mod', [domain2range1],
                      dict(ipaautoprivategroups='')),
             expected=dict(
-                messages=(
-                    messages.ServiceRestartRequired(
-                        service=services.knownservices['sssd'].systemd_name,
-                        server=domain2range1
-                    ).to_dict(),
-                ),
+                messages=fuzzy_restart_messages,
                 result=dict(
                     cn=[domain2range1],
                     ipabaseid=[unicode(domain2range1_base_id)],
@@ -1116,6 +1082,7 @@ class test_range(Declarative):
                 result=dict(failed=[]),
                 value=[testrange9],
                 summary=u'Deleted ID range "%s"' % testrange9,
+                messages=fuzzy_restart_messages,
             ),
         ),
 

--- a/ipatests/test_xmlrpc/test_range_plugin.py
+++ b/ipatests/test_xmlrpc/test_range_plugin.py
@@ -26,7 +26,8 @@ import six
 from ipalib import api, errors, messages
 from ipalib import constants
 from ipaplatform import services
-from ipatests.test_xmlrpc.xmlrpc_test import Declarative, fuzzy_uuid
+from ipatests.test_xmlrpc.xmlrpc_test import (
+    Declarative, fuzzy_uuid, Fuzzy, fuzzy_sequence_of)
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.util import MockLDAP
 from ipapython.dn import DN
@@ -374,6 +375,8 @@ IPA_LOCAL_RANGE_MOD_ERR = (
 
 dirsrv_instance = services.knownservices.dirsrv.service_instance("")
 
+fuzzy_restart_messages = fuzzy_sequence_of(Fuzzy(type=dict))
+
 
 @pytest.mark.tier1
 class test_range(Declarative):
@@ -610,7 +613,8 @@ class test_range(Declarative):
             desc='Delete ID range %r' % testrange1,
             command=('idrange_del', [testrange1], {}),
             expected=dict(
-                result=dict(failed=[]),
+                result=dict(failed=[],
+                            messages=fuzzy_restart_messages),
                 value=[testrange1],
                 summary=u'Deleted ID range "%s"' % testrange1,
             ),
@@ -714,7 +718,8 @@ class test_range(Declarative):
             desc='Delete ID range %r' % testrange2,
             command=('idrange_del', [testrange2], {}),
             expected=dict(
-                result=dict(failed=[]),
+                result=dict(failed=[],
+                            messages=fuzzy_restart_messages),
                 value=[testrange2],
                 summary=u'Deleted ID range "%s"' % testrange2,
             ),


### PR DESCRIPTION
This PR was opened automatically because PR #7283 was pushed to master and backport to ipa-4-10 is required.