### PR TITLE
Use raw strings for Python 3 compatibility in old API client code

### DIFF
--- a/ipaclient/remote_plugins/2_164/automember.py
+++ b/ipaclient/remote_plugins/2_164/automember.py
@@ -16,7 +16,7 @@ from ipapython.dnsutil import DNSName
 if six.PY3:
     unicode = str
 
-__doc__ = _("""
+__doc__ = _(r"""
 Auto Membership Rule.
 
 Bring clarity to the membership of hosts and users by configuring inclusive

--- a/ipaclient/remote_plugins/2_164/group.py
+++ b/ipaclient/remote_plugins/2_164/group.py
@@ -16,7 +16,7 @@ from ipapython.dnsutil import DNSName
 if six.PY3:
     unicode = str
 
-__doc__ = _("""
+__doc__ = _(r"""
 Groups of users
 
 Manage groups of users. By default, new groups are POSIX groups. You

--- a/ipaclient/remote_plugins/2_164/hbactest.py
+++ b/ipaclient/remote_plugins/2_164/hbactest.py
@@ -16,7 +16,7 @@ from ipapython.dnsutil import DNSName
 if six.PY3:
     unicode = str
 
-__doc__ = _("""
+__doc__ = _(r"""
 Simulate use of Host-based access controls
 
 HBAC rules control who can access what services on what hosts.

--- a/ipaclient/remote_plugins/2_164/trust.py
+++ b/ipaclient/remote_plugins/2_164/trust.py
@@ -16,7 +16,7 @@ from ipapython.dnsutil import DNSName
 if six.PY3:
     unicode = str
 
-__doc__ = _("""
+__doc__ = _(r"""
 Cross-realm trusts
 
 Manage trust relationship between IPA and Active Directory domains.

--- a/ipaclient/remote_plugins/2_49/automember.py
+++ b/ipaclient/remote_plugins/2_49/automember.py
@@ -16,7 +16,7 @@ from ipapython.dnsutil import DNSName
 if six.PY3:
     unicode = str
 
-__doc__ = _("""
+__doc__ = _(r"""
 Auto Membership Rule.
 
 Bring clarity to the membership of hosts and users by configuring inclusive

--- a/ipaclient/remote_plugins/2_49/group.py
+++ b/ipaclient/remote_plugins/2_49/group.py
@@ -16,7 +16,7 @@ from ipapython.dnsutil import DNSName
 if six.PY3:
     unicode = str
 
-__doc__ = _("""
+__doc__ = _(r"""
 Groups of users
 
 Manage groups of users. By default, new groups are POSIX groups. You

--- a/ipaclient/remote_plugins/2_49/trust.py
+++ b/ipaclient/remote_plugins/2_49/trust.py
@@ -16,7 +16,7 @@ from ipapython.dnsutil import DNSName
 if six.PY3:
     unicode = str
 
-__doc__ = _("""
+__doc__ = _(r"""
 Cross-realm trusts
 
 Manage trust relationship between IPA and Active Directory domains.


### PR DESCRIPTION
Python 3 enforces checks on \ sequences in strings. Instead of copying over the new mix of normal and raw strings from the server side, turn those strings in the remote plugins to raw mode.

Fixes: https://pagure.io/freeipa/issue/9565