### PR TITLE
ipatests: Ignore spacing in OpenSSL validation error message

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -2750,12 +2750,14 @@ class TestIpaHealthCheckWithExternalCA(IntegrationTest):
         for check in data:
             assert check["result"] == "ERROR"
             if parse_version(version) >= parse_version("0.6"):
-                if check["kw"]["key"] == paths.HTTPD_CERT_FILE:
+                if check["kw"]["key"] in (
+                    paths.HTTPD_CERT_FILE,
+                    paths.RA_AGENT_PEM,
+                ):
                     assert error_msg in check["kw"]["msg"]
-                    assert error_reason in check["kw"]["reason"]
-                elif check["kw"]["key"] == paths.RA_AGENT_PEM:
-                    assert error_msg in check["kw"]["msg"]
-                    assert error_reason in check["kw"]["reason"]
+                    assert error_reason.replace(" ", "") in check["kw"][
+                        "reason"
+                    ].replace(" ", "")
             else:
                 assert error_reason in check["kw"]["reason"]
                 assert error_reason in check["kw"]["msg"]


### PR DESCRIPTION
The error message format changed between releases of OpenSSL.
The updated version has dropped spaces around equal signs
between RDN elements in the subject.

e.g. In 3.1.1 it reports O = EXAMPLE.TEST, CN = IPA RA
and in 3.2.1 reports O=EXAMPLE.TEST, CN=IPA RA

So ignore all spacing in the error message so it works on all
versions.

I saw this in openssl-3.1.1-4.fc39.x86_64 vs
openssl-3.2.1-3.fc41.x86_64

Fixes: https://pagure.io/freeipa/issue/9567