### PR TITLE
[Backport][ipa-4-9] ap: Migrate to docker compose V2

### DIFF
--- a/ipatests/azure/scripts/azure-run-tests.sh
+++ b/ipatests/azure/scripts/azure-run-tests.sh
@@ -41,7 +41,7 @@ IPA_TESTS_CLIENTS="${!IPA_TESTS_CLIENTS_VARNAME:-0}"
 IPA_TESTS_REPLICAS_VARNAME="IPA_TESTS_REPLICAS_${PROJECT_ID}"
 IPA_TESTS_REPLICAS="${!IPA_TESTS_REPLICAS_VARNAME:-0}"
 
-IPA_TESTS_CONTROLLER="${PROJECT_ID}_master_1"
+IPA_TESTS_CONTROLLER="${PROJECT_ID}-master-1"
 IPA_TESTS_LOGSDIR="${IPA_TESTS_REPO_PATH}/ipa_envs/${IPA_TESTS_ENV_NAME}/${CI_RUNNER_LOGS_DIR}"
 
 # path to azure scripts inside container
@@ -97,14 +97,14 @@ IPA_INSTALLED_PKGS_DIR="${project_dir}/installed_packages"
 BASH_CMD="/bin/bash --noprofile --norc"
 
 function containers() {
-    local _containers="${PROJECT_ID}_master_1"
+    local _containers="${PROJECT_ID}-master-1"
     # build list of replicas
     for i in $(seq 1 1 "$IPA_TESTS_REPLICAS"); do
-        _containers+=" ${PROJECT_ID}_replica_${i}"
+        _containers+=" ${PROJECT_ID}-replica-${i}"
     done
     # build list of clients
     for i in $(seq 1 1 "$IPA_TESTS_CLIENTS"); do
-        _containers+=" ${PROJECT_ID}_client_${i}"
+        _containers+=" ${PROJECT_ID}-client-${i}"
     done
     printf "$_containers"
 }
@@ -144,7 +144,7 @@ IPA_TESTS_CLIENT_MEM_LIMIT="$IPA_TESTS_CLIENT_MEM_LIMIT" \
 IPA_TESTS_SERVER_MEMSWAP_LIMIT="$IPA_TESTS_SERVER_MEMSWAP_LIMIT" \
 IPA_TESTS_REPLICA_MEMSWAP_LIMIT="$IPA_TESTS_REPLICA_MEMSWAP_LIMIT" \
 IPA_TESTS_CLIENT_MEMSWAP_LIMIT="$IPA_TESTS_CLIENT_MEMSWAP_LIMIT" \
-docker-compose -p "$PROJECT_ID" up \
+docker compose -p "$PROJECT_ID" up \
     --scale replica="$IPA_TESTS_REPLICAS" \
     --scale client="$IPA_TESTS_CLIENTS" \
     --force-recreate --remove-orphans -d
@@ -257,7 +257,7 @@ IPA_TESTS_CLIENT_MEM_LIMIT="$IPA_TESTS_CLIENT_MEM_LIMIT" \
 IPA_TESTS_SERVER_MEMSWAP_LIMIT="$IPA_TESTS_SERVER_MEMSWAP_LIMIT" \
 IPA_TESTS_REPLICA_MEMSWAP_LIMIT="$IPA_TESTS_REPLICA_MEMSWAP_LIMIT" \
 IPA_TESTS_CLIENT_MEMSWAP_LIMIT="$IPA_TESTS_CLIENT_MEMSWAP_LIMIT" \
-docker-compose -p "$PROJECT_ID" down
+docker compose -p "$PROJECT_ID" down
 popd
 
 exit $tests_result

--- a/ipatests/azure/scripts/setup_containers.py
+++ b/ipatests/azure/scripts/setup_containers.py
@@ -125,7 +125,7 @@ class ContainersGroup:
         # initialize containers
         self.containers = [
             Container(
-                name=f"{self.prefix}_{self.role}_{c}",
+                name=f"{self.prefix}-{self.role}-{c}",
                 hostname=f"{self.role}{c}.{self.domain}",
                 network=f"{IPA_TESTS_ENV_ID}_{IPA_NETWORK}",
             )


### PR DESCRIPTION
This PR was opened automatically because PR #7298 was pushed to master and backport to ipa-4-9 is required.