### PR TITLE
[Backport][ipa-4-10] Allow the admin user to be disabled

### DIFF
--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -144,8 +144,7 @@ PROTECTED_USERS = ('admin',)
 def check_protected_member(user, protected_group_name=u'admins'):
     '''
     Ensure admin and the last enabled member of a protected group cannot
-    be deleted or disabled by raising ProtectedEntryError or
-    LastMemberError as appropriate.
+    be deleted.
     '''
 
     if user in PROTECTED_USERS:
@@ -155,6 +154,12 @@ def check_protected_member(user, protected_group_name=u'admins'):
             reason=_("privileged user"),
         )
 
+
+def check_last_member(user, protected_group_name=u'admins'):
+    '''
+    Ensure the last enabled member of a protected group cannot
+    be disabled.
+    '''
     # Get all users in the protected group
     result = api.Command.user_find(in_group=protected_group_name)
 
@@ -796,6 +801,7 @@ class user_del(baseuser_del):
         # If the target entry is a Delete entry, skip the orphaning/removal
         # of OTP tokens.
         check_protected_member(keys[-1])
+        check_last_member(keys[-1])
 
         preserve = options.get('preserve', False)
 
@@ -1128,7 +1134,7 @@ class user_disable(LDAPQuery):
     def execute(self, *keys, **options):
         ldap = self.obj.backend
 
-        check_protected_member(keys[-1])
+        check_last_member(keys[-1])
 
         dn, _oc = self.obj.get_either_dn(*keys, **options)
         ldap.deactivate_entry(dn)

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1476,29 +1476,6 @@ class TestIPACommand(IntegrationTest):
             assert 'This account is currently not available' in \
                 result.stdout_text
 
-    def test_ipa_cacert_manage_prune(self):
-        """Test for ipa-cacert-manage prune"""
-
-        certfile = os.path.join(self.master.config.test_dir, 'cert.pem')
-        self.master.put_file_contents(certfile, isrgrootx1)
-        result = self.master.run_command(
-            [paths.IPA_CACERT_MANAGE, 'install', certfile])
-
-        certs_before_prune = self.master.run_command(
-            [paths.IPA_CACERT_MANAGE, 'list'], raiseonerr=False
-        ).stdout_text
-
-        assert isrgrootx1_nick in certs_before_prune
-
-        # Jump in time to make sure the cert is expired
-        self.master.run_command(['date', '-s', '+15Years'])
-        result = self.master.run_command(
-            [paths.IPA_CACERT_MANAGE, 'prune'], raiseonerr=False
-        ).stdout_text
-        self.master.run_command(['date', '-s', '-15Years'])
-
-        assert isrgrootx1_nick in result
-
     def test_ipa_getkeytab_server(self):
         """
         Exercise the ipa-getkeytab server options
@@ -1556,6 +1533,54 @@ class TestIPACommand(IntegrationTest):
             ], raiseonerr=False).stderr_text
 
         assert 'Discovered server %s' % self.master.hostname in result
+
+    def test_delete_last_enabled_admin(self):
+        """
+        The admin user may be disabled. Don't allow all other
+        members of admins to be removed if the admin user is
+        disabled which would leave the install with no
+        usable admins users
+        """
+        user = 'adminuser2'
+        passwd = 'Secret123'
+        tasks.create_active_user(self.master, user, passwd)
+        tasks.kinit_admin(self.master)
+        self.master.run_command(['ipa', 'group-add-member', 'admins',
+                                '--users', user])
+        tasks.kinit_user(self.master, user, passwd)
+        self.master.run_command(['ipa', 'user-disable', 'admin'])
+        result = self.master.run_command(
+            ['ipa', 'user-del', user],
+            raiseonerr=False
+        )
+        self.master.run_command(['ipa', 'user-enable', 'admin'])
+        tasks.kdestroy_all(self.master)
+
+        assert result.returncode == 1
+        assert 'cannot be deleted or disabled' in result.stderr_text
+
+    def test_ipa_cacert_manage_prune(self):
+        """Test for ipa-cacert-manage prune"""
+
+        certfile = os.path.join(self.master.config.test_dir, 'cert.pem')
+        self.master.put_file_contents(certfile, isrgrootx1)
+        result = self.master.run_command(
+            [paths.IPA_CACERT_MANAGE, 'install', certfile])
+
+        certs_before_prune = self.master.run_command(
+            [paths.IPA_CACERT_MANAGE, 'list'], raiseonerr=False
+        ).stdout_text
+
+        assert isrgrootx1_nick in certs_before_prune
+
+        # Jump in time to make sure the cert is expired
+        self.master.run_command(['date', '-s', '+15Years'])
+        result = self.master.run_command(
+            [paths.IPA_CACERT_MANAGE, 'prune'], raiseonerr=False
+        ).stdout_text
+        self.master.run_command(['date', '-s', '-15Years'])
+
+        assert isrgrootx1_nick in result
 
 
 class TestIPACommandWithoutReplica(IntegrationTest):

--- a/ipatests/test_xmlrpc/test_user_plugin.py
+++ b/ipatests/test_xmlrpc/test_user_plugin.py
@@ -1045,8 +1045,8 @@ class TestAdmins(XMLRPC_test):
         tracker = Tracker()
         command = tracker.make_command('user_disable', admin1)
 
-        with raises_exact(errors.ProtectedEntryError(label=u'user',
-                          key=admin1, reason='privileged user')):
+        with raises_exact(errors.LastMemberError(label=u'group',
+                          key=admin1, container=admin_group)):
             command()
 
     def test_create_admin2(self, admin2):
@@ -1064,8 +1064,8 @@ class TestAdmins(XMLRPC_test):
         admin2.disable()
         tracker = Tracker()
 
-        with raises_exact(errors.ProtectedEntryError(label=u'user',
-                          key=admin1, reason='privileged user')):
+        with raises_exact(errors.LastMemberError(label=u'group',
+                          key=admin1, container=admin_group)):
             tracker.run_command('user_disable', admin1)
         admin2.delete()
 


### PR DESCRIPTION
This PR was opened manually because PR https://github.com/freeipa/freeipa/pull/7311 was pushed to master and backport to ipa-4-10 is required.

The patch applied cleanly with slight fuzz hence adding ack.