### PR TITLE
[Backport][ipa-4-9] Allow the admin user to be disabled

### DIFF
--- a/ipaserver/plugins/user.py
+++ b/ipaserver/plugins/user.py
@@ -144,8 +144,7 @@ PROTECTED_USERS = ('admin',)
 def check_protected_member(user, protected_group_name=u'admins'):
     '''
     Ensure admin and the last enabled member of a protected group cannot
-    be deleted or disabled by raising ProtectedEntryError or
-    LastMemberError as appropriate.
+    be deleted.
     '''
 
     if user in PROTECTED_USERS:
@@ -155,6 +154,12 @@ def check_protected_member(user, protected_group_name=u'admins'):
             reason=_("privileged user"),
         )
 
+
+def check_last_member(user, protected_group_name=u'admins'):
+    '''
+    Ensure the last enabled member of a protected group cannot
+    be disabled.
+    '''
     # Get all users in the protected group
     result = api.Command.user_find(in_group=protected_group_name)
 
@@ -796,6 +801,7 @@ class user_del(baseuser_del):
         # If the target entry is a Delete entry, skip the orphaning/removal
         # of OTP tokens.
         check_protected_member(keys[-1])
+        check_last_member(keys[-1])
 
         preserve = options.get('preserve', False)
 
@@ -1128,7 +1134,7 @@ class user_disable(LDAPQuery):
     def execute(self, *keys, **options):
         ldap = self.obj.backend
 
-        check_protected_member(keys[-1])
+        check_last_member(keys[-1])
 
         dn, _oc = self.obj.get_either_dn(*keys, **options)
         ldap.deactivate_entry(dn)

--- a/ipatests/test_xmlrpc/test_user_plugin.py
+++ b/ipatests/test_xmlrpc/test_user_plugin.py
@@ -1045,8 +1045,8 @@ class TestAdmins(XMLRPC_test):
         tracker = Tracker()
         command = tracker.make_command('user_disable', admin1)
 
-        with raises_exact(errors.ProtectedEntryError(label=u'user',
-                          key=admin1, reason='privileged user')):
+        with raises_exact(errors.LastMemberError(label=u'group',
+                          key=admin1, container=admin_group)):
             command()
 
     def test_create_admin2(self, admin2):
@@ -1064,8 +1064,8 @@ class TestAdmins(XMLRPC_test):
         admin2.disable()
         tracker = Tracker()
 
-        with raises_exact(errors.ProtectedEntryError(label=u'user',
-                          key=admin1, reason='privileged user')):
+        with raises_exact(errors.LastMemberError(label=u'group',
+                          key=admin1, container=admin_group)):
             tracker.run_command('user_disable', admin1)
         admin2.delete()
 


### PR DESCRIPTION
This PR was opened manually because PR https://github.com/freeipa/freeipa/pull/7311 was pushed to master and backport to ipa-4-9 is required.

The automatic merge failed because the pruning test does not exist in ipa-4-9. The patch otherwise merged cleanly with minimal fuzz. Adding ack.