### PR TITLE
Replace netifaces with ifaddr

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -120,7 +120,7 @@ extraction:
         - lxml
         - gssapi
         - netaddr
-        - netifaces
+        - ifaddr
         - polib
         - requests
         - python-augeas

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,6 +11,7 @@ m2r2
 ## ipa dependencies
 dnspython
 jwcrypto
+ifaddr
 netaddr
 qrcode
 six

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -403,7 +403,7 @@ BuildRequires:  python3-libipa_hbac
 BuildRequires:  python3-libsss_nss_idmap
 BuildRequires:  python3-lxml
 BuildRequires:  python3-netaddr >= %{python_netaddr_version}
-BuildRequires:  python3-netifaces
+BuildRequires:  python3-ifaddr
 BuildRequires:  python3-pki >= %{pki_version}
 BuildRequires:  python3-polib
 BuildRequires:  python3-pyasn1
@@ -885,7 +885,7 @@ Requires: python3-gssapi >= 1.2.0
 Requires: python3-jwcrypto >= 0.4.2
 Requires: python3-libipa_hbac
 Requires: python3-netaddr >= %{python_netaddr_version}
-Requires: python3-netifaces >= 0.10.4
+Requires: python3-ifaddr
 Requires: python3-pyasn1 >= 0.3.2-2
 Requires: python3-pyasn1-modules >= 0.3.2-2
 Requires: python3-pyusb

--- a/ipapython/setup.py
+++ b/ipapython/setup.py
@@ -48,6 +48,6 @@ if __name__ == '__main__':
         extras_require={
             "ldap": ["python-ldap"],  # ipapython.ipaldap
             # CheckedIPAddress.get_matching_interface
-            "netifaces": ["netifaces"],
+            "ifaddr": ["ifaddr"],
         },
     )

--- a/ipasetup.py.in
+++ b/ipasetup.py.in
@@ -75,7 +75,7 @@ PACKAGE_VERSION = {
     'ipaserver': 'ipaserver == {}'.format(VERSION),
     'jwcrypto': 'jwcrypto >= 0.4.2',
     'kdcproxy': 'kdcproxy >= 0.3',
-    'netifaces': 'netifaces >= 0.10.4',
+    'ifaddr': 'ifaddr >= 0.1.7',
     'python-ldap': 'python-ldap >= 3.0.0',
     'python-yubico': 'python-yubico >= 1.2.3',
     'qrcode': 'qrcode >= 5.0',

--- a/pylintrc
+++ b/pylintrc
@@ -13,7 +13,6 @@ extension-pkg-allow-list=
     _ldap,
     cryptography,
     gssapi,
-    netifaces,
     lxml.etree,
     pysss_murmur,
 


### PR DESCRIPTION
Python netifaces has been unmaintained and its main repository has been archived since June, 2021.

Python ifaddr is an alternative to netifaces, is currently maintained, and provides an API which requires little change for FreeIPA current usage.

This patch modifies FreeIPA to rely on ifaddr instead of neitfaces, due to its current maintainance status.

Fixes: https://pagure.io/freeipa/issue/9555