### PR TITLE
Spec file: depend on nfs-utils or nfsv4-client-utils

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -716,7 +716,7 @@ Requires: oddjob-mkhomedir
 Requires: libsss_autofs
 Requires: autofs
 Requires: libnfsidmap
-Requires: nfs-utils
+Requires: (nfs-utils or nfsv4-client-utils)
 Requires: sssd-tools >= %{sssd_version}
 Requires(post): policycoreutils
 


### PR DESCRIPTION
The freeipa-client package currently requires nfs-utils. The requirement can be relaxed and modified into nfs-utils or nfsv4-client-utils.

Fixes: https://pagure.io/freeipa/issue/9586