### PR TITLE
[Backport][ipa-4-11] ipaserver: fix incorrect double negative in exception message

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -382,7 +382,7 @@ class DomainValidator:
             # Our domain is configured but no trusted domains are configured
             raise errors.ValidationError(name=_('Trust setup'),
                                          error=_('No trusted domain is '
-                                                 'not configured'))
+                                                 'configured'))
 
         entries = None
         if domain is not None:


### PR DESCRIPTION
This PR was opened automatically because PR #7337 was pushed to master and backport to ipa-4-11 is required.