### PR TITLE
[Backport][ipa-4-11] Spec file: depend on nfs-utils or nfsv4-client-utils

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -715,7 +715,7 @@ Requires: oddjob-mkhomedir
 Requires: libsss_autofs
 Requires: autofs
 Requires: libnfsidmap
-Requires: nfs-utils
+Requires: (nfs-utils or nfsv4-client-utils)
 Requires: sssd-tools >= %{sssd_version}
 Requires(post): policycoreutils
 


### PR DESCRIPTION
This PR was opened automatically because PR #7338 was pushed to master and backport to ipa-4-11 is required.