### PR TITLE
Removed 'config_file_version' option from 'sssd.conf'

### DIFF
--- a/install/share/advise/legacy/sssd.conf.template
+++ b/install/share/advise/legacy/sssd.conf.template
@@ -1,6 +1,5 @@
 [sssd]
 services = nss, pam
-config_file_version = 2
 domains = default
 re_expression = (?P<name>.+)
 


### PR DESCRIPTION
This option is obsolete / doesn't have meaning quite some time already. It wasn't required as well.
Starting sssd-2.10 it's removed altogether.