### PR TITLE
Allow to configure other valids referrers for HTTPS

### DIFF
--- a/client/man/default.conf.5
+++ b/client/man/default.conf.5
@@ -96,7 +96,12 @@ Specifies whether the CA is acting as an RA agent, such as when dogtag is being 
 Specifies whether an IPA client should attempt to fall back and try other services if the first connection fails.
 .TP
 .B host <hostname>
-Specifies the local system hostname.
+Specifies the local system hostname. This is the primary accepted Referer, others hostnames can be configured below.
+.TP
+.B allowed_referers <hostname>[,<hostname>][,<hostname>:<exotic_port>][,<hostname>:<exotic_port>[/path]][...]
+Specifies allowed hostnames present in Referer HTTPS header. This setting allows to access the application from multiple leg (behind reverse-proxy or multiple fqdn).
+.IP
+  allowed_referers = ipa.demo1.freeipa.org:443,ipa.demo1.local,ipa.demo1.freeipa.org:443/sub_folder
 .TP
 .B http_timeout <seconds>
 Timeout for HTTP blocking requests (e.g. connection). The default value is 30 seconds.

--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -160,8 +160,11 @@ class HTTP_Status(plugable.Plugin):
         if "HTTP_REFERER" not in environ:
             logger.error("Rejecting request with missing Referer")
             return False
+        allowed_referers = self.api.env.allowed_referers.split(',')
         if (not environ["HTTP_REFERER"].startswith(
                 "https://%s/ipa" % self.api.env.host)
+                and all(not environ["HTTP_REFERER"].startswith(
+                    "https://%s/ipa" % host) for host in allowed_referers)
                 and not self.env.in_tree):
             logger.error("Rejecting request with bad Referer %s",
                          environ["HTTP_REFERER"])
@@ -388,7 +391,12 @@ class WSGIExecutioner(Executioner):
         e = None
         if 'HTTP_REFERER' not in environ:
             return self.marshal(result, RefererError(referer='missing'), _id)
-        if not environ['HTTP_REFERER'].startswith('https://%s/ipa' % self.api.env.host) and not self.env.in_tree:
+        allowed_referers = self.api.env.allowed_referers.split(',')
+        if (not environ["HTTP_REFERER"].startswith(
+                "https://%s/ipa" % self.api.env.host)
+                and all(not environ["HTTP_REFERER"].startswith(
+                    "https://%s/ipa" % host) for host in allowed_referers)
+                and not self.env.in_tree):
             return self.marshal(result, RefererError(referer=environ['HTTP_REFERER']), _id)
         if self.api.env.debug:
             time_start = time.perf_counter_ns()


### PR DESCRIPTION
This check was added to protect [against possible CRSF](https://github.com/freeipa/freeipa/commit/2d6eeb205e196cc6556f832555e74968619c0f1e#diff-21d951ac2d07631c0818b056e289cd02d980b05545f9eabb18b407178da0af0c)

However it doesn't works well behind a proxy like [we saw here](https://github.com/haproxy/haproxy/issues/2555#issuecomment-2113978844). This change allow to define multiple valid referers (that would solve the issue) but also related issued https://lists.fedorahosted.org/archives/list/freeipa-users@lists.fedorahosted.org/thread/VN3RXS36GFK4JMZCCSHPJ3DKLSBEXDE4/ in the precedent message the user have to comment this check to have a working freeipa. Better to accept multiple referers so it works.

I remember comment about kerberos might not work for the added domains. Since we don't use kerberos we are not affected. It seems still possible to [configure it](https://freeipa-users.redhat.narkive.com/hClHC8Ny/ipa-server-ui-behind-proxy).

User with kerberos won't see change because they will keep using the classical name.