### PR TITLE
[Backport][ipa-4-11] ipa-client-install: add support for sss_ssh_knownhosts

### DIFF
--- a/client/share/ssh_ipa.conf.template
+++ b/client/share/ssh_ipa.conf.template
@@ -4,7 +4,13 @@ PubkeyAuthentication yes
 ${ENABLEPROXY}GlobalKnownHostsFile $KNOWNHOSTS
 ${VERIFYHOSTKEYDNS}VerifyHostKeyDNS yes
 
+# use sss_ssh_knownhosts if available
 # assumes that if a user does not have shell (/sbin/nologin),
 # this will return nonzero exit code and proxy command will be ignored
-${ENABLEPROXY}Match exec true   
+${ENABLEKNOWNHOSTS}Match exec true
+${ENABLEKNOWNHOSTS}	KnownHostsCommand $KNOWNHOSTSCOMMAND %H
+
+# assumes that if a user does not have shell (/sbin/nologin),
+# this will return nonzero exit code and proxy command will be ignored
+${ENABLEPROXY}Match exec true
 ${ENABLEPROXY}	ProxyCommand $KNOWNHOSTSPROXY -p %p %h

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1279,13 +1279,21 @@ if [ $1 -gt 1 ] ; then
             cp /etc/ipa/ca.crt /var/lib/ipa-client/pki/kdc-ca-bundle.pem
             cp /etc/ipa/ca.crt /var/lib/ipa-client/pki/ca-bundle.pem
         fi
-
         %{__python3} -c 'from ipaclient.install.client import configure_krb5_snippet; configure_krb5_snippet()' >>/var/log/ipaupgrade.log 2>&1
         %{__python3} -c 'from ipaclient.install.client import update_ipa_nssdb; update_ipa_nssdb()' >>/var/log/ipaupgrade.log 2>&1
         chmod 0600 /var/log/ipaupgrade.log
         SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config"
         if [ -f "$SSH_CLIENT_SYSTEM_CONF" ]; then
             sed -E --in-place=.orig 's/^(HostKeyAlgorithms ssh-rsa,ssh-dss)$/# disabled by ipa-client update\n# \1/' "$SSH_CLIENT_SYSTEM_CONF"
+            # https://pagure.io/freeipa/issue/9536
+            # replace sss_ssh_knownhostsproxy with sss_ssh_knownhosts
+            if [ -f '/usr/bin/sss_ssh_knownhosts' ]; then
+                if grep -E -q 'Include' $SSH_CLIENT_SYSTEM_CONF  2>/dev/null ; then
+                    SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config.d/04-ipa.conf"
+                fi
+                sed -E --in-place=.orig 's/^(GlobalKnownHostsFile \/var\/lib\/sss\/pubconf\/known_hosts)$/# disabled by ipa-client update\n# \1/' $SSH_CLIENT_SYSTEM_CONF
+                sed -E --in-place=.orig 's/(ProxyCommand \/usr\/bin\/sss_ssh_knownhostsproxy -p \%p \%h)/# replaced by ipa-client update\n    KnownHostsCommand \/usr\/bin\/sss_ssh_knownhosts \%H/' $SSH_CLIENT_SYSTEM_CONF
+            fi
         fi
     fi
 fi
@@ -1312,6 +1320,49 @@ fi
 # with_selinux
 %endif
 
+%triggerin client -- sssd-common < 2.10
+# Has the client been configured?
+restore=0
+test -f '/var/lib/ipa-client/sysrestore/sysrestore.index' && restore=$(wc -l '/var/lib/ipa-client/sysrestore/sysrestore.index' | awk '{print $1}')
+
+if [ -f '/etc/ssh/sshd_config' -a $restore -ge 2 ]; then
+    SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config"
+    if [ -f "$SSH_CLIENT_SYSTEM_CONF" ]; then
+        # https://pagure.io/freeipa/issue/9536
+        # downgrade sss_ssh_knownhosts with sss_ssh_knownhostsproxy
+        if [ -f '/usr/bin/sss_ssh_knownhosts' ]; then
+            if grep -E -q 'Include' $SSH_CLIENT_SYSTEM_CONF  2>/dev/null ; then
+                SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config.d/04-ipa.conf"
+            fi
+            GLOBALKNOWNHOSTFILE="GlobalKnownHostsFile /var/lib/sss/pubconf/known_hosts/"
+            grep -qF '$GLOBALKNOWNHOSTFILE' $SSH_CLIENT_SYSTEM_CONF
+            if [ $? -ne 0 ]; then
+                sed -E --in-place=.orig '/(# IPA-related configuration changes to ssh_config)/a # added by ipa-client update\n'"$GLOBALKNOWNHOSTFILE"'' $SSH_CLIENT_SYSTEM_CONF
+            fi
+            sed -E --in-place=.orig 's/(KnownHostsCommand \/usr\/bin\/sss_ssh_knownhosts \%H)/ProxyCommand \/usr\/bin\/sss_ssh_knownhostsproxy -p \%p \%h/' $SSH_CLIENT_SYSTEM_CONF
+        fi
+    fi
+fi
+
+%triggerin client -- sssd-common >= 2.10
+# Has the client been configured?
+restore=0
+test -f '/var/lib/ipa-client/sysrestore/sysrestore.index' && restore=$(wc -l '/var/lib/ipa-client/sysrestore/sysrestore.index' | awk '{print $1}')
+
+if [ -f '/etc/ssh/sshd_config' -a $restore -ge 2 ]; then
+    SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config"
+    if [ -f "$SSH_CLIENT_SYSTEM_CONF" ]; then
+        # https://pagure.io/freeipa/issue/9536
+        # upgrade sss_ssh_knownhostsproxy with sss_ssh_knownhosts
+        if [ -f '/usr/bin/sss_ssh_knownhosts' ]; then
+            if grep -E -q 'Include' $SSH_CLIENT_SYSTEM_CONF  2>/dev/null ; then
+                SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config.d/04-ipa.conf"
+            fi
+            sed -E --in-place=.orig 's/^(GlobalKnownHostsFile \/var\/lib\/sss\/pubconf\/known_hosts)$/# disabled by ipa-client update\n# \1/' $SSH_CLIENT_SYSTEM_CONF
+            sed -E --in-place=.orig 's/(ProxyCommand \/usr\/bin\/sss_ssh_knownhostsproxy -p \%p \%h)/# replaced by ipa-client update\n    KnownHostsCommand \/usr\/bin\/sss_ssh_knownhosts \%H/' $SSH_CLIENT_SYSTEM_CONF
+        fi
+    fi
+fi
 
 %triggerin client -- openssh-server < 8.2
 # Has the client been configured?

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1144,7 +1144,21 @@ def configure_ssh_config(fstore, options):
 def modify_ssh_config(options):
     changes = {'PubkeyAuthentication': 'yes'}
 
-    if options.sssd and os.path.isfile(paths.SSS_SSH_KNOWNHOSTSPROXY):
+    # sss_ssh_knownhostsproxy is deprecated in favor of sss_ssh_knownhosts
+    # use sss_ssh_knownhosts when possible
+    enableknownhosts = bool(
+        options.sssd and os.path.isfile(paths.SSS_SSH_KNOWNHOSTS)
+    )
+
+    enableproxy = bool(
+        options.sssd and os.path.isfile(paths.SSS_SSH_KNOWNHOSTSPROXY)
+        and not enableknownhosts
+    )
+
+    if options.sssd and enableknownhosts:
+        changes[
+            'KnownHostsCommand'] = '%s %%H' % paths.SSS_SSH_KNOWNHOSTS
+    if options.sssd and enableproxy:
         changes[
             'ProxyCommand'] = '%s -p %%p %%h' % paths.SSS_SSH_KNOWNHOSTSPROXY
         changes['GlobalKnownHostsFile'] = paths.SSSD_PUBCONF_KNOWN_HOSTS
@@ -1156,14 +1170,23 @@ def modify_ssh_config(options):
 
 def create_ssh_ipa_config(options):
     """Add the IPA snippet for ssh"""
+    # sss_ssh_knownhostsproxy is deprecated in favor of sss_ssh_knownhosts
+    # use sss_ssh_knownhosts when possible
+    enableknownhosts = bool(
+        options.sssd and os.path.isfile(paths.SSS_SSH_KNOWNHOSTS)
+    )
+
     enableproxy = bool(
         options.sssd and os.path.isfile(paths.SSS_SSH_KNOWNHOSTSPROXY)
+        and not enableknownhosts
     )
 
     ipautil.copy_template_file(
         os.path.join(paths.SSH_IPA_CONFIG_TEMPLATE),
         paths.SSH_IPA_CONFIG,
         dict(
+            ENABLEKNOWNHOSTS='' if enableknownhosts else '#',
+            KNOWNHOSTSCOMMAND=paths.SSS_SSH_KNOWNHOSTS,
             ENABLEPROXY='' if enableproxy else '#',
             KNOWNHOSTSPROXY=paths.SSS_SSH_KNOWNHOSTSPROXY,
             KNOWNHOSTS=paths.SSSD_PUBCONF_KNOWN_HOSTS,

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -229,6 +229,7 @@ class BasePathNamespace:
     SOFTHSM2_UTIL = "/usr/bin/softhsm2-util"
     SSLGET = "/usr/bin/sslget"
     SSS_SSH_AUTHORIZEDKEYS = "/usr/bin/sss_ssh_authorizedkeys"
+    SSS_SSH_KNOWNHOSTS = "/usr/bin/sss_ssh_knownhosts"
     SSS_SSH_KNOWNHOSTSPROXY = "/usr/bin/sss_ssh_knownhostsproxy"
     BIN_TIMEOUT = "/usr/bin/timeout"
     UPDATE_CA_TRUST = "/usr/bin/update-ca-trust"


### PR DESCRIPTION
This PR was opened automatically because PR #7254 was pushed to master and backport to ipa-4-11 is required.