### PR TITLE
Don't try to validate the HSM arguments on a non-HSM installation

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -181,6 +181,18 @@ def hsm_version():
 
 
 def hsm_validator(token_name, token_library, token_password):
+    """Do some basic validation of the HSM information provided.
+
+       - The local PKI server supports IPA HSM
+       - The token library exists
+       - The token name doesn't have a colon or semi-colon in it
+       - The token name exists after loading the library
+       - The token password works
+       - Super-simple test to see if the SELinux module is loaded
+    """
+    if not token_name:
+        logger.debug("No token name, assuming not an HSM install")
+        return
     val, pki_version = hsm_version()
     if val is False:
         raise ValueError(


### PR DESCRIPTION
If there is no token name it is safe to assume that an HSM
installation is not requested. The validator assumes that if
there is a token name then the library and password are also
provided.

Fixes: https://pagure.io/freeipa/issue/9593