### PR TITLE
[Backport][ipa-4-10] idviews: Use ipaAnchorUUID without DCERPC bindings for SID anchors

### DIFF
--- a/ipaserver/plugins/idviews.py
+++ b/ipaserver/plugins/idviews.py
@@ -692,6 +692,20 @@ def resolve_anchor_to_object_name(ldap, obj_type, anchor):
 
                 if type_correct:
                     return name
+        else:
+            # Without the DCERPC bindings the sid is not resolvable, return
+            # ipaAnchorUUID
+            _dn = DN(("cn", api.packages[0].idviews.DEFAULT_TRUST_VIEW_NAME),
+                     api.env.container_views + api.env.basedn)
+            try:
+                entry = ldap.find_entry_by_attr(attr="ipaanchoruuid",
+                                                value=anchor,
+                                                object_class="ipaUserOverride",
+                                                attrs_list=["ipaoriginaluid"],
+                                                base_dn=_dn)
+                return entry.single_value("ipaoriginaluid")
+            except (errors.EmptyResult, errors.NotFound):
+                pass
 
     # No acceptable object was found
     raise errors.NotFound(


### PR DESCRIPTION
This PR was opened automatically because PR #7253 was pushed to master and backport to ipa-4-10 is required.