### PR TITLE
custodia: do not use deprecated jwcrypto wrappers

### DIFF
--- a/install/tools/ipa-custodia-check.in
+++ b/install/tools/ipa-custodia-check.in
@@ -192,10 +192,10 @@ class IPACustodiaTester:
                 usage, IPA_CUSTODIA_KEYFILE
             ))
 
-        if pkey.key_id != self.host_spn:
+        if pkey.get('kid') != self.host_spn:
             raise self.error(  # pylint: disable=raising-bad-type, #4772
                 "KID '{}' != host service principal name '{}' "
-                "(usage: {})".format(pkey.key_id, self.host_spn, usage),
+                "(usage: {})".format(pkey.get('kid'), self.host_spn, usage),
                 fatal=True
             )
         else:


### PR DESCRIPTION
jwcrypto has turned JWK object into a dict-like structure in 2020 and marked data wrappers as deprecated. The only exception for direct foo['bar'] access is a key ID -- some keys might have no 'kid' property, thus it is best to use jwk.get('kid') instead for those.

Fixes: https://pagure.io/freeipa/issue/9597