### PR TITLE
Allow to enable or disable SELinux policy checking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -747,4 +747,11 @@ AM_COND_IF([WITH_IPA_JOIN_XML], [
     echo "\
         ipa-join RPC mode:        JSON-RPC"
 ])
+AM_COND_IF([BUILD_SELINUX_POLICY], [
+    echo "\
+        build SELinux policy:     yes"
+], [
+    echo "\
+        build SELinux policy:     no"
+])
 

--- a/configure.ac
+++ b/configure.ac
@@ -477,9 +477,9 @@ dnl ---------------------------------------------------------------------------
 selinux_makefile=/usr/share/selinux/devel/Makefile
 AC_SUBST([selinux_makefile])
 
-AC_CHECK_FILE([$selinux_makefile],
-              [build_selinux=yes],
-              [build_selinux=no])
+AS_IF([test -f "$selinux_makefile"],
+      [build_selinux=yes],
+      [build_selinux=no])
 
 AM_CONDITIONAL(BUILD_SELINUX_POLICY, test x$build_selinux = xyes)
 

--- a/configure.ac
+++ b/configure.ac
@@ -474,14 +474,25 @@ dnl ---------------------------------------------------------------------------
 dnl - Check for SELinux policy devel
 dnl ---------------------------------------------------------------------------
 
-selinux_makefile=/usr/share/selinux/devel/Makefile
-AC_SUBST([selinux_makefile])
+AC_ARG_ENABLE([selinux],
+    [AC_HELP_STRING([--enable-selinux], [Disable SELinux support])],
+    [case "${enableval}" in
+         yes) enable_selinux=yes ;;
+          no) enable_selinux=no ;;
+           *) AC_MSG_ERROR([bad value ${enableval} for --enable-selinux]) ;;
+     esac],
+    [enable_selinux=])
 
-AS_IF([test -f "$selinux_makefile"],
-      [build_selinux=yes],
-      [build_selinux=no])
+if test "x$enable_selinux" = "x" ; then
+        selinux_makefile=/usr/share/selinux/devel/Makefile
+        AC_SUBST([selinux_makefile])
 
-AM_CONDITIONAL(BUILD_SELINUX_POLICY, test x$build_selinux = xyes)
+        AS_IF([test -f "$selinux_makefile"],
+              [enable_selinux=yes],
+              [enable_selinux=no])
+fi
+
+AM_CONDITIONAL([BUILD_SELINUX_POLICY], [test "x$enable_selinux" = xyes])
 
 dnl ---------------------------------------------------------------------------
 dnl Finish


### PR DESCRIPTION
Dear Maintainers,

I am trying to cross-compile (the client) and the `./configure` fails because the host machine does not have the file `/usr/share/selinux/devel/Makefile` installed.

Note: It fails because the macro [AC_CHECK_FILE][1] dies if the file is not found and if cross-compiling. The `./configure` does not fail if doing native-compiling.

The first patch replaces the use of [AC_CHECK_FILE][1] by [AS_IF][2], as in that [change][patch] in that [PR][sssd].

The second patch outputs for if the SELinux policy is used or not.

Regards,
Gaël

Fixes:

```
checking for /usr/share/selinux/devel/Makefile... configure: error: cannot check for file existence when cross compiling
```

[1]: https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/html_node/Files.html
[2]: https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/html_node/Common-Shell-Constructs.html#index-AS_005fIF-1
[patch]: https://git.yoctoproject.org/meta-security/tree/recipes-security/sssd/files/0001-build-Don-t-use-AC_CHECK_FILE-when-building-manpages.patch?h=hardknott
[sssd]: https://github.com/SSSD/sssd/pull/5289