### PR TITLE
console: for public errors only print a final one

### DIFF
--- a/ipalib/cli.py
+++ b/ipalib/cli.py
@@ -957,6 +957,17 @@ class IPACompleter(rlcompleter.Completer):
         return super()._callable_postfix(val, word)
 
 
+class InteractiveConsole(code.InteractiveConsole):
+    def showtraceback(self):
+        ei = sys.exc_info()
+        e = ei[1]
+        if isinstance(e, PublicError):
+            self.write('IPA public error exception: %s: %s\n' %
+                       (e.__class__.__name__, str(e)))
+        else:
+            super().showtraceback()
+
+
 class console(frontend.Command):
     """Start the IPA interactive Python console, or run a script.
 
@@ -1018,13 +1029,14 @@ class console(frontend.Command):
         else:
             if readline is not None:
                 self._setup_tab_completion(local)
-            code.interact(
+            cons = InteractiveConsole(local)
+            cons.interact(
                 "\n".join((
                     "(Custom IPA interactive Python console)",
                     "    api: IPA API object",
                     "    pp: pretty printer",
                 )),
-                local=local
+                exitmsg=None
             )
 
 


### PR DESCRIPTION
By default, interactive console prints full traceback in case of an error. This looks weird in the console when LDAP errors pop up. Instead, process PublicError exceptions as if they are final ones and only print their message.

As a result, calls like api.Command.user_show('unknown') would result in a concise message:

  >>> api.Command.user_show('unknown')
  IPA public error exception: NotFound: unknown: user not found
  >>>

rather than a two-screen long traceback.

Fixes: https://pagure.io/freeipa/issue/9590