### PR TITLE
ipa-replica-manage list-ruvs: display FQDN in the output

### DIFF
--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -408,7 +408,7 @@ def get_ruv(realm, host, dirman_passwd, nolookup=False, ca=False,
             # Attempt to extract ldap url from ruv (it's not always present)
             netloc = "unknown host"
             host_data = re.match(
-                r'(\{\w+\s+\d+\s+)ldap://(\w+)',
+                r'(\{\w+\s+\d+\s+)ldap://(.+:\d+)',
                 ruv
             )
             if host_data:


### PR DESCRIPTION
The behavior of ipa-replica-manage list-ruv was modified with
the commit 544652a and now displays host short names instead
of FQDN:port.
Fix the regular expression in order to return the FQDN:port again.

Fixes: https://pagure.io/freeipa/issue/9598
