### PR TITLE
[Backport][ipa-4-10] ipa-replica-manage list-ruvs: display FQDN in the output

### DIFF
--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -408,7 +408,7 @@ def get_ruv(realm, host, dirman_passwd, nolookup=False, ca=False,
             # Attempt to extract ldap url from ruv (it's not always present)
             netloc = "unknown host"
             host_data = re.match(
-                r'(\{\w+\s+\d+\s+)ldap://(\w+)',
+                r'(\{\w+\s+\d+\s+)ldap://(.+:\d+)',
                 ruv
             )
             if host_data:


### PR DESCRIPTION
This PR was opened automatically because PR #7370 was pushed to master and backport to ipa-4-10 is required.