### PR TITLE
Gating and nightly tests: move to f39/f40

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -30,7 +30,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f39
+          name: freeipa/ci-master-f40
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f39
+          name: freeipa/ci-master-f40
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -35,7 +35,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f39
+          name: freeipa/ci-master-f40
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -39,7 +39,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f39
+          name: freeipa/ci-master-f40
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f39
+          name: freeipa/ci-master-f40
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -39,7 +39,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f39
+          name: freeipa/ci-master-f40
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -51,7 +51,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f39
+          name: freeipa/ci-master-f40
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -51,7 +51,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f39
+          name: freeipa/ci-master-f40
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -50,7 +50,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-previous
-          name: freeipa/ci-master-f38
+          name: freeipa/ci-master-f39
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -56,7 +56,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f39
+          name: freeipa/ci-master-f40
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/test_integration/test_cert.py
+++ b/ipatests/test_integration/test_cert.py
@@ -25,6 +25,7 @@ from pkg_resources import parse_version
 
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.base import IntegrationTest
+from ipatests.util import xfail_context
 
 DEFAULT_RA_AGENT_SUBMITTED_VAL = '19700101000000'
 
@@ -555,7 +556,11 @@ class TestCAShowErrorHandling(IntegrationTest):
         )
         error_msg = 'ipa: ERROR: The certificate for ' \
                     '{} is not available on this server.'.format(lwca)
-        assert error_msg in result.stderr_text
+        bad_version = (tasks.get_pki_version(self.master)
+                       >= tasks.parse_version('11.5.0'))
+        with xfail_context(bad_version,
+                           reason="https://pagure.io/freeipa/issue/9606"):
+            assert error_msg in result.stderr_text
 
     def test_certmonger_empty_cert_not_segfault(self):
         """Test empty cert request doesn't force certmonger to segfault

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -639,6 +639,11 @@ class TestIPACommand(IntegrationTest):
         # change private key permission to comply with SS rules
         os.chmod(first_priv_key_path, 0o600)
 
+        # Make sure that / has rwxr-xr-x permissions on the master
+        # otherwise sshd will deny login using private key
+        # https://access.redhat.com/solutions/6798261
+        self.master.run_command(['chmod', '755', '/'])
+
         # start to look at logs a bit before "now"
         # https://pagure.io/freeipa/issue/8432
         since = time.strftime(


### PR DESCRIPTION
Now that fedora 40 is available and fedora 38 is EOL, adjust the test pipelines:
- fedora-previous now refers to f39
- fedora-latest now refers to f40

Gating tests will now run on fedora 40.