### PR TITLE
Re-organize HSM validation to be more consistent with less duplication

### DIFF
--- a/install/tools/man/ipa-kra-install.1
+++ b/install/tools/man/ipa-kra-install.1
@@ -54,6 +54,15 @@ Log to the given file
 .TP
 \fB\-\-pki\-config\-override\fR=\fIFILE\fR
 File containing overrides for KRA installation.
+.SS "HSM OPTIONS"
+The token name and library path are retrieved from the existing
+installation.
+.TP 
+\fB\-\-token\-password\fR=\fITOKEN_PASSWORD\fR
+The PKCS#11 token password for the HSM.
+.TP 
+\fB\-\-token\-password\-file\fR=\fITOKEN_PASSWORD_FILE\fR
+The full path to a file containing the PKCS#11 token password.
 .SH "EXIT STATUS"
 0 if the command was successful
 

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -663,6 +663,8 @@ def install_check(installer):
             options.token_name is not None
         )
     ):
+        if options.unattended:
+            raise ScriptError("HSM token password required")
         token_password = read_password(
             f"HSM token '{options.token_name}'" , confirm=False)
         if token_password is None:


### PR DESCRIPTION
hsm_validator() was more or less bolted in place late in the
development cycle in in order to catch some of the more common
problems: bad token name, bad password, etc.

There was a fair bit of duplication and had the side-effect of not
reading in the token password from the --token-password-file option
in some cases.

This patch also re-adds a lost feature where an exception is raised if
both the --token-password and --token-password-file options are passed
in.

Fixes: https://pagure.io/freeipa/issue/9603
