### PR TITLE
ipa-otptoken-import: open the key file in binary mode

### DIFF
--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -539,7 +539,7 @@ class OTPTokenImport(admintool.AdminTool):
 
             # Load the keyfile.
             keyfile = self.safe_options.keyfile
-            with open(keyfile) as f:
+            with open(keyfile, "rb") as f:
                 self.doc.setKey(f.read())
 
     def run(self):


### PR DESCRIPTION
ipa-otptoken-import provides an option (-k KEYFILE) to import an encrypted PSKC file but this option does not work with python3 in RHEL8 and above, because the key should be passed in binary format to the cryptography functions instead of string format.

Open the keyfile in binary mode to pass the expected format.

Fixes: https://pagure.io/freeipa/issue/9609