### PR TITLE
[Backport][ipa-4-9] ipa-otptoken-import: open the key file in binary mode

### DIFF
--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -539,7 +539,7 @@ class OTPTokenImport(admintool.AdminTool):
 
             # Load the keyfile.
             keyfile = self.safe_options.keyfile
-            with open(keyfile) as f:
+            with open(keyfile, "rb") as f:
                 self.doc.setKey(f.read())
 
     def run(self):


### PR DESCRIPTION
This PR was opened automatically because PR #7390 was pushed to master and backport to ipa-4-9 is required.