### PR TITLE
ca.install_step_0: Use remote api for hsm conf lookup in standalone

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -566,7 +566,7 @@ def install_step_0(standalone, replica_config, options, custodia):
         promote = False
     else:
         _api = api if standalone else options._remote_api
-        (token_name, _token_library_path) = lookup_hsm_configuration(api)
+        (token_name, _token_library_path) = lookup_hsm_configuration(_api)
         if not token_name:
             cafile = os.path.join(replica_config.dir, 'cacert.p12')
             if replica_config.setup_ca:


### PR DESCRIPTION
_api was set for the lookup_hsm_configuration call, but then api was used instead. This could break server affinity.

Fixes: https://pagure.io/freeipa/issue/9608