### PR TITLE
[Backport][ipa-4-12] spec file: do not create /etc/ssh/ssh_config.orig if unchanged

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1320,7 +1320,9 @@ if [ $1 -gt 1 ] ; then
         chmod 0600 /var/log/ipaupgrade.log
         SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config"
         if [ -f "$SSH_CLIENT_SYSTEM_CONF" ]; then
-            sed -E --in-place=.orig 's/^(HostKeyAlgorithms ssh-rsa,ssh-dss)$/# disabled by ipa-client update\n# \1/' "$SSH_CLIENT_SYSTEM_CONF"
+            if grep -E -q '^HostKeyAlgorithms ssh-rsa,ssh-dss' $SSH_CLIENT_SYSTEM_CONF 2>/dev/null; then
+                sed -E --in-place=.orig 's/^(HostKeyAlgorithms ssh-rsa,ssh-dss)$/# disabled by ipa-client update\n# \1/' "$SSH_CLIENT_SYSTEM_CONF"
+            fi
             # https://pagure.io/freeipa/issue/9536
             # replace sss_ssh_knownhostsproxy with sss_ssh_knownhosts
             if [ -f '/usr/bin/sss_ssh_knownhosts' ]; then

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2550,6 +2550,21 @@ def install_packages(host, pkgs):
     host.run_command(install_cmd + pkgs)
 
 
+def reinstall_packages(host, pkgs):
+    """Install packages on a remote host.
+    :param host: the host where the installation takes place
+    :param pkgs: packages to install, provided as a list of strings
+    """
+    platform = get_platform(host)
+    if platform in {'rhel', 'fedora'}:
+        install_cmd = ['/usr/bin/dnf', 'reinstall', '-y']
+    elif platform in {'debian', 'ubuntu'}:
+        install_cmd = ['apt-get', '--reinstall', 'install', '-y']
+    else:
+        raise ValueError('install_packages: unknown platform %s' % platform)
+    host.run_command(install_cmd + pkgs)
+
+
 def download_packages(host, pkgs):
     """Download packages on a remote host.
     :param host: the host where the download takes place

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -477,3 +477,17 @@ class TestUpgrade(IntegrationTest):
         self.master.run_command(['ipa-server-upgrade'])
         assert self.master.transport.file_exists(
             paths.SYSTEMD_PKI_TOMCAT_IPA_CONF)
+
+    def test_ssh_config(self):
+        """Test that pkg upgrade does not create /etc/ssh/ssh_config.orig
+
+        Test for ticket 9610
+        The upgrade of ipa-client package should not create a backup file
+        /etc/ssh/ssh_config.orig if no change is applied.
+        """
+        # Ensure there is no backup file before the test
+        self.master.run_command(["rm", "-f", paths.SSH_CONFIG + ".orig"])
+        # Force client package reinstallation to trigger %post scriptlet
+        tasks.reinstall_packages(self.master, ['*ipa-client'])
+        assert not self.master.transport.file_exists(
+            paths.SSH_CONFIG + ".orig")


### PR DESCRIPTION
This PR was opened automatically because PR #7397 was pushed to master and backport to ipa-4-12 is required.