### PR TITLE
ipatests: Install replica using AD admin.

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -39,6 +39,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  ad_master_1replica_1client: &ad_master_1replica_1client
+    name: ad_master_1replica_1client
+    cpu: 6
+    memory: 12096
 
 jobs:
   fedora-latest/build:

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -39,8 +39,8 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
-  ad_master_1replica_1client: &ad_master_1replica_1client
-    name: ad_master_1replica_1client
+  ad_master_1repl_1client: &ad_master_1repl_1client
+    name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
 
@@ -983,6 +983,18 @@ jobs:
         template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
+
+  fedora-latest/test_replica_promotion_TestReplicaConn:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaConn
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *ad_master_1repl_1client
 
   fedora-latest/test_upgrade:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -23,8 +23,8 @@ topologies:
     name: master_3repl_1client
     cpu: 6
     memory: 13500
-  ad_master_1replica_1client: &ad_master_1replica_1client
-    name: ad_master_1replica_1client
+  ad_master_1repl_1client: &ad_master_1repl_1client
+    name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
 

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -23,6 +23,10 @@ topologies:
     name: master_3repl_1client
     cpu: 6
     memory: 13500
+  ad_master_1replica_1client: &ad_master_1replica_1client
+    name: ad_master_1replica_1client
+    cpu: 6
+    memory: 12096
 
 jobs:
   389ds-fedora/build:

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -27,6 +27,10 @@ topologies:
     name: ad_master
     cpu: 4
     memory: 8096
+  ad_master_1replica_1client: &ad_master_1replica_1client
+    name: ad_master_1replica_1client
+    cpu: 6
+    memory: 12096
 
 jobs:
   pki-fedora/build:

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -27,8 +27,8 @@ topologies:
     name: ad_master
     cpu: 4
     memory: 8096
-  ad_master_1replica_1client: &ad_master_1replica_1client
-    name: ad_master_1replica_1client
+  ad_master_1repl_1client: &ad_master_1repl_1client
+    name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
 

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -39,6 +39,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  ad_master_1replica_1client: &ad_master_1replica_1client
+    name: ad_master_1replica_1client
+    cpu: 6
+    memory: 12096
 
 jobs:
   fedora-latest/build:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -39,8 +39,8 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
-  ad_master_1replica_1client: &ad_master_1replica_1client
-    name: ad_master_1replica_1client
+  ad_master_1repl_1client: &ad_master_1repl_1client
+    name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
 
@@ -1060,6 +1060,19 @@ jobs:
         template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
+
+  fedora-latest/test_replica_promotion_TestReplicaConn:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaConn
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *ad_master_1repl_1client
 
   fedora-latest/test_upgrade:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -27,6 +27,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  ad_master_1replica_1client: &ad_master_1replica_1client
+    name: ad_master_1replica_1client
+    cpu: 6
+    memory: 12096
 
 jobs:
   sssd-fedora/build:

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -27,8 +27,8 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
-  ad_master_1replica_1client: &ad_master_1replica_1client
-    name: ad_master_1replica_1client
+  ad_master_1repl_1client: &ad_master_1repl_1client
+    name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
 

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -39,6 +39,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  ad_master_1replica_1client: &ad_master_1replica_1client
+    name: ad_master_1replica_1client
+    cpu: 6
+    memory: 12096
 
 jobs:
   testing-fedora/build:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -39,8 +39,8 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
-  ad_master_1replica_1client: &ad_master_1replica_1client
-    name: ad_master_1replica_1client
+  ad_master_1repl_1client: &ad_master_1repl_1client
+    name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
 
@@ -1138,6 +1138,20 @@ jobs:
         template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
+
+  testing-fedora/test_replica_promotion_TestReplicaConn:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaConn
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *ad_master_1repl_1client
 
   testing-fedora/test_upgrade:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -39,6 +39,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  ad_master_1replica_1client: &ad_master_1replica_1client
+    name: ad_master_1replica_1client
+    cpu: 6
+    memory: 12096
 
 jobs:
   testing-fedora/build:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -39,8 +39,8 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
-  ad_master_1replica_1client: &ad_master_1replica_1client
-    name: ad_master_1replica_1client
+  ad_master_1repl_1client: &ad_master_1repl_1client
+    name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
 
@@ -1215,6 +1215,21 @@ jobs:
         template: *ci-master-latest
         timeout: 7200
         topology: *master_2repl_1client
+
+  testing-fedora/test_replica_promotion_TestReplicaConn:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaConn
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *ad_master_1repl_1client
 
   testing-fedora/test_upgrade:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -39,6 +39,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  ad_master_1replica_1client: &ad_master_1replica_1client
+    name: ad_master_1replica_1client
+    cpu: 6
+    memory: 12096
 
 jobs:
   fedora-previous/build:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -39,8 +39,8 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
-  ad_master_1replica_1client: &ad_master_1replica_1client
-    name: ad_master_1replica_1client
+  ad_master_1repl_1client: &ad_master_1repl_1client
+    name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
 
@@ -983,6 +983,18 @@ jobs:
         template: *ci-master-previous
         timeout: 7200
         topology: *master_2repl_1client
+
+  fedora-previous/test_replica_promotion_TestReplicaConn:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaConn
+        template: *ci-master-previous
+        timeout: 7200
+        topology: *ad_master_1repl_1client
 
   fedora-previous/test_upgrade:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -39,8 +39,8 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
-  ad_master_1replica_1client: &ad_master_1replica_1client
-    name: ad_master_1replica_1client
+  ad_master_1repl_1client: &ad_master_1repl_1client
+    name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
 
@@ -1060,6 +1060,19 @@ jobs:
         template: *ci-master-frawhide
         timeout: 7200
         topology: *master_2repl_1client
+
+  fedora-rawhide/test_replica_promotion_TestReplicaConn:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaConn
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *ad_master_1repl_1client
 
   fedora-rawhide/test_upgrade:
     requires: [fedora-rawhide/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -39,6 +39,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  ad_master_1replica_1client: &ad_master_1replica_1client
+    name: ad_master_1replica_1client
+    cpu: 6
+    memory: 12096
 
 jobs:
   fedora-rawhide/build:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -45,6 +45,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  ad_master_1repl_1client: &ad_master_1repl_1client
+    name: ad_master_1repl_1client
+    cpu: 6
+    memory: 12096
 
 jobs:
   fedora-latest/build:

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -1300,3 +1300,49 @@ class TestHiddenReplicaKRA(IntegrationTest):
             self.replicas[0].hostname, '--state=hidden'
         ])
         assert result.returncode == 0
+
+
+class TestReplicaConn(IntegrationTest):
+    num_replicas = 1
+    num_ad_domains = 1
+
+    @classmethod
+    def install(cls, mh):
+        cls.replica = cls.replicas[0]
+        cls.ad = cls.ads[0]
+        ad_domain = cls.ad.domain.name
+        cls.ad_admin = 'Administrator@{}'.format(ad_domain.upper())
+        cls.adview = 'Default Trust View'
+        tasks.install_master(cls.master, setup_adtrust=True)
+        tasks.configure_dns_for_trust(cls.master, cls.ad)
+        tasks.establish_trust_with_ad(cls.master, cls.ad.domain.name)
+        tasks.install_client(cls.master, cls.replica)
+
+    def test_replica_conncheck_ad_admin(self):
+        """
+        Test to verify that replica installation is not failing for
+        replica connection check when AD administrator
+        Administrator@AD.EXAMPLE.COM is used for the deployment
+        or promotion of a replica.
+
+        Related : https://pagure.io/freeipa/issue/9542
+        """
+        self.master.run_command(
+            ['ipa', 'idoverrideuser-add', self.adview, self.ad_admin]
+        )
+        self.master.run_command(
+            ["ipa", "group-add-member", "admins", "--idoverrideusers",
+             self.ad_admin]
+        )
+        tasks.clear_sssd_cache(self.master)
+
+        self.replica.run_command(
+            ["ipa-replica-install", "--setup-ca", "-U", "--ip-address",
+             self.replica.ip, "--realm", self.replica.domain.realm,
+             "--domain", self.replica.domain.name,
+             "--principal={0}".format(self.ad_admin),
+             "--password", self.master.config.ad_admin_password]
+        )
+        logs = self.replica.get_file_contents(paths.IPAREPLICA_CONNCHECK_LOG)
+        error = "not allowed to perform server connection check"
+        assert error.encode() not in logs


### PR DESCRIPTION
ipatests: Test replica installation using AD admin.
    
Test to verify that replica connection check is not failing when
the AD administrator Administrator@AD.EXAMPLE.COM is
used for the deployment or promotion of a replica
    
Related: https://pagure.io/freeipa/issue/9542
