### PR TITLE
[Backport][ipa-4-9] PKINIT certificate: fix renewal on hidden replica

### DIFF
--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -55,7 +55,7 @@ from ipapython.dn import DN
 from ipapython.ipautil import datetime_from_utctimestamp
 from ipaserver.plugins.service import normalize_principal, validate_realm
 from ipaserver.masters import (
-    ENABLED_SERVICE, CONFIGURED_SERVICE, is_service_enabled
+    ENABLED_SERVICE, CONFIGURED_SERVICE, HIDDEN_SERVICE, is_service_enabled
 )
 
 try:
@@ -300,7 +300,7 @@ def caacl_check(principal, ca, profile_id):
 def ca_kdc_check(api_instance, hostname):
     master_dn = api_instance.Object.server.get_dn(unicode(hostname))
     kdc_dn = DN(('cn', 'KDC'), master_dn)
-    wanted = {ENABLED_SERVICE, CONFIGURED_SERVICE}
+    wanted = {ENABLED_SERVICE, CONFIGURED_SERVICE, HIDDEN_SERVICE}
     try:
         kdc_entry = api_instance.Backend.ldap2.get_entry(
             kdc_dn, ['ipaConfigString'])


### PR DESCRIPTION
This PR was opened automatically because PR #7398 was pushed to master and backport to ipa-4-9 is required.