### PR TITLE
ipatests: fix / permissions for test_nested_group_members

### DIFF
--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -672,6 +672,10 @@ class TestNestedMembers(IntegrationTest):
 
         clear_sssd_cache(client)
 
+        # Workaround for https://pagure.io/freeipa/issue/9615
+        # Make sure that / on the client has expected permissions
+        client.run_command(['chmod', '755', '/'])
+
         cmd = ['ssh', '-i', '/tmp/user_ssh_priv_key',
                '-q', '{}@{}'.format(self.username, client.hostname),
                'groups']


### PR DESCRIPTION
The test test_nested_group_members is performing a ssh login
with a private key and this command may fail if the root directory
does not have the right permissions on the ssh server
(see https://access.redhat.com/solutions/6798261)

Ensure that / has 755 before launching the test.

Fixes: https://pagure.io/freeipa/issue/9615
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>
