### PR TITLE
ipa-ods-enforcer: stop must also stop the socket

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3601,6 +3601,12 @@ def uninstall(options):
 
         remove_file(paths.SSSD_LDB)
         remove_file(paths.SSSD_CONFIG_LDB)
+        # Stop sssd-kcm.service before removing the KCM ccaches database
+        # it is socket-activated and will be restarted whenever needed
+        try:
+            services.service('sssd-kcm', api).stop()
+        except Exception as e:
+            logger.warning("Failed to stop sssd-kcm: %s", e)
         remove_file(paths.SSSD_SECRETS)
 
         sssd_timestamps = "timestamps_" + ipa_domain + ".ldb"

--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -290,6 +290,10 @@ class SystemdService(PlatformService):
         # https://bugzilla.redhat.com/show_bug.cgi?id=973331#c11
         if instance == "ipa-otpd.socket":
             args.append("--ignore-dependencies")
+        # ipa-ods-exporter is socket-activated, both the service and the
+        # socket have to be stopped
+        if instance == "ipa-ods-exporter.service":
+            args.append("ipa-ods-exporter.socket")
 
         ipautil.run(args, skip_output=not capture_output)
 

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -903,6 +903,7 @@ class TestReplicaInstallAfterRestore(IntegrationTest):
         master.run_command(['ipa-restore', backup_path],
                            stdin_text=dirman_password + '\nyes')
 
+        tasks.kinit_admin(master)
         # re-initialize topology after restore.
         for topo_suffix in 'domain', 'ca':
             topo_name = find_segment(master, replica1, topo_suffix)


### PR DESCRIPTION
ipa-ods-enforcer is a socket-activated service. In order to fully stop
the service, IPA needs to call
systemctl stop ipa-ods-enforcer.service ipa-ods-enforcer.socket
otherwise the socket remains active (listening) and can restart the
service.

A consequence of the issue is the backup / uninstall / restore
scenario that is failing to sign the zones. The uninstaller removes
the socket /run/opendnssec/engine.sock but leaves the ipa-ods-enforcer.socket
active. A subsequent restore or install will not re-create the socket.

Fixes: https://pagure.io/freeipa/issue/9613

### Uninstall: stop sssd-kcm before removing KCM ccaches database

The service is socket-activated and will be restarted whenever
needed. It must be stopped before the database is removed
otherwise it fails to recreate the file.

Fixes: https://pagure.io/freeipa/issue/9616

### test_replica_install_after_restore: kinit after restore

After uninstall and restore, kinit is required before
launching any ipa command.

Related: https://pagure.io/freeipa/issue/9613
