### PR TITLE
Removed the "-d"" option from the ipa-advise man page

### DIFF
--- a/install/tools/man/ipa-advise.1
+++ b/install/tools/man/ipa-advise.1
@@ -30,9 +30,6 @@ For the list of possible ADVICEs available, run the ipa\-advise with no argument
 \fB\-\-v\fR, \fB\-\-verbose\fR
 Print debugging information
 .TP
-\fB\-d\fR, \fB\-\-debug\fR
-Alias for \-\-verbose
-.TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Output only errors
 .TP

--- a/install/tools/man/ipa-advise.1
+++ b/install/tools/man/ipa-advise.1
@@ -30,6 +30,9 @@ For the list of possible ADVICEs available, run the ipa\-advise with no argument
 \fB\-\-v\fR, \fB\-\-verbose\fR
 Print debugging information
 .TP
+\fB\-d\fR, \fB\-\-debug\fR
+Alias for \-\-verbose
+.TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Output only errors
 .TP


### PR DESCRIPTION
Removed the "-d"" option from the ipa-advise man page

Removed the "-d" option from the ipa-advise man page because it is not able to be used.