### PR TITLE
[Backport][ipa-4-12] ipatests: fix / permissions for test_nested_group_members

### DIFF
--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -672,6 +672,10 @@ class TestNestedMembers(IntegrationTest):
 
         clear_sssd_cache(client)
 
+        # Workaround for https://pagure.io/freeipa/issue/9615
+        # Make sure that / on the client has expected permissions
+        client.run_command(['chmod', '755', '/'])
+
         cmd = ['ssh', '-i', '/tmp/user_ssh_priv_key',
                '-q', '{}@{}'.format(self.username, client.hostname),
                'groups']


### PR DESCRIPTION
This PR was opened automatically because PR #7408 was pushed to master and backport to ipa-4-12 is required.