### PR TITLE
[Backport][ipa-4-12] ipa-advise ipa-backup ipa-restore: Fix --v option of the manual.

### DIFF
--- a/install/tools/man/ipa-advise.1
+++ b/install/tools/man/ipa-advise.1
@@ -27,7 +27,7 @@ Provides customized advice for various IPA configuration issues.
 For the list of possible ADVICEs available, run the ipa\-advise with no arguments.
 .SH "OPTIONS"
 .TP
-\fB\-\-v\fR, \fB\-\-verbose\fR
+\fB\-v\fR, \fB\-\-verbose\fR
 Print debugging information
 .TP
 \fB\-d\fR, \fB\-\-debug\fR

--- a/install/tools/man/ipa-backup.1
+++ b/install/tools/man/ipa-backup.1
@@ -54,7 +54,7 @@ Perform the backup on\-line. Requires the \-\-data option.
 \fB\-\-disable\-role\-check\fR
 Perform the backup even if this host does not have all the roles in use in the cluster. This is not recommended.
 .TP
-\fB\-\-v\fR, \fB\-\-verbose\fR
+\fB\-v\fR, \fB\-\-verbose\fR
 Print debugging information
 .TP
 \fB\-d\fR, \fB\-\-debug\fR

--- a/install/tools/man/ipa-restore.1
+++ b/install/tools/man/ipa-restore.1
@@ -73,7 +73,7 @@ Restore only the databases in this 389\-ds instance. The default is to restore a
 \fB\-\-backend\fR=\fIBACKEND\fR
 The backend to restore within an instance or instances. Requires data\-only backup or the \-\-data option.
 .TP
-\fB\-\-v\fR, \fB\-\-verbose\fR
+\fB\-v\fR, \fB\-\-verbose\fR
 Print debugging information
 .TP
 \fB\-d\fR, \fB\-\-debug\fR


### PR DESCRIPTION
This PR was opened automatically because PR #7414 was pushed to master and backport to ipa-4-12 is required.