### PR TITLE
ipatests: Added new testsuite(ipa_ipa_migration) in prci definitions

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -2093,3 +2093,15 @@ jobs:
         template: *ci-master-latest
         timeout: 12000
         topology: *master_1repl_1client
+
+  fedora-latest/test_IPAMigrate:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_ipa_ipa_migration.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl_1client

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -2260,3 +2260,16 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
+
+  fedora-latest/test_IPAMigrate:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_ipa_ipa_migration.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl_1client

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -2428,3 +2428,17 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
+
+  testing-fedora/test_IPAMigrate:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_ipa_ipa_migration.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl_1client

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2595,3 +2595,18 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
+
+  testing-fedora/test_IPAMigrate:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_ipa_ipa_migration.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl_1client

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -2093,3 +2093,15 @@ jobs:
         template: *ci-master-previous
         timeout: 12000
         topology: *master_1repl_1client
+
+  fedora-previous/test_IPAMigrate:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_ipa_ipa_migration.py
+        template: *ci-master-previous
+        timeout: 3600
+        topology: *master_1repl_1client

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -2260,3 +2260,16 @@ jobs:
         template: *ci-master-frawhide
         timeout: 3600
         topology: *master_1repl_1client
+
+  fedora-rawhide/test_IPAMigrate:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_ipa_ipa_migration.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl_1client


### PR DESCRIPTION
test_ipa_ipa_migration.py was added to the below prci definitions

nightly_latest.yaml
nightly_latest_selinux.yaml
nightly_latest_testing.yaml
nightly_latest_testing_selinux.yaml
nightly_previous.yaml
nightly_rawhide.yaml