### PR TITLE
[Backport][ipa-4-11] ipa-ods-enforcer: stop must also stop the socket

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -3595,6 +3595,12 @@ def uninstall(options):
 
         remove_file(paths.SSSD_LDB)
         remove_file(paths.SSSD_CONFIG_LDB)
+        # Stop sssd-kcm.service before removing the KCM ccaches database
+        # it is socket-activated and will be restarted whenever needed
+        try:
+            services.service('sssd-kcm', api).stop()
+        except Exception as e:
+            logger.warning("Failed to stop sssd-kcm: %s", e)
         remove_file(paths.SSSD_SECRETS)
 
         sssd_timestamps = "timestamps_" + ipa_domain + ".ldb"

--- a/ipaplatform/base/services.py
+++ b/ipaplatform/base/services.py
@@ -290,6 +290,10 @@ class SystemdService(PlatformService):
         # https://bugzilla.redhat.com/show_bug.cgi?id=973331#c11
         if instance == "ipa-otpd.socket":
             args.append("--ignore-dependencies")
+        # ipa-ods-exporter is socket-activated, both the service and the
+        # socket have to be stopped
+        if instance == "ipa-ods-exporter.service":
+            args.append("ipa-ods-exporter.socket")
 
         ipautil.run(args, skip_output=not capture_output)
 

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -903,6 +903,7 @@ class TestReplicaInstallAfterRestore(IntegrationTest):
         master.run_command(['ipa-restore', backup_path],
                            stdin_text=dirman_password + '\nyes')
 
+        tasks.kinit_admin(master)
         # re-initialize topology after restore.
         for topo_suffix in 'domain', 'ca':
             topo_name = find_segment(master, replica1, topo_suffix)


### PR DESCRIPTION
This PR was opened automatically because PR #7411 was pushed to master and backport to ipa-4-11 is required.