### PR TITLE
Issue 9619 - ipa-migrate - starttls does not work

### DIFF
--- a/install/tools/man/ipa-migrate.1
+++ b/install/tools/man/ipa-migrate.1
@@ -25,7 +25,7 @@ network interruptions)
 In this mode everything will be migrated including the current user SIDs and
 DNA ranges
 .TP
-\fBstage\-mod\fR
+\fBstage\-mode\fR
 In this mode, SIDs & DNA ranges are not migrated, and DNA attributes are reset
 
 .SH "COMMANDS"

--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -27,7 +27,6 @@ from ipalib.x509 import IPACertificate
 from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipapython.ipaldap import LDAPClient, LDAPEntry, realm_to_ldapi_uri
-from ipapython.ipautil import write_tmp_file
 from ipapython.ipa_log_manager import standard_logging_setup
 from ipaserver.install.ipa_migrate_constants import (
     DS_CONFIG, DB_OBJECTS, DS_INDEXES, BIND_DN, LOG_FILE_NAME,
@@ -761,13 +760,19 @@ class IPAMigrate():
         insecure_bind = False
 
         if self.args.cacertfile is not None:
-            # Store CA cert into file
-            tmp_ca_cert_f = write_tmp_file(self.args.cacertfile)
-            cacert = tmp_ca_cert_f.name
-
             # Start TLS connection (START_TLS)
-            ds_conn = LDAPClient(ldapuri, cacert=cacert, start_tls=True)
-            tmp_ca_cert_f.close()
+            try:
+                ds_conn = LDAPClient(ldapuri, cacert=self.args.cacertfile,
+                                     start_tls=True)
+            except (
+                ldap.LDAPError,
+                errors.NetworkError,
+                errors.DatabaseError,
+                IOError
+            ) as e:
+                self.handle_error(
+                    f"Failed to connect to remote server: {str(e)}"
+                )
         else:
             # LDAP (insecure)
             ds_conn = LDAPClient(ldapuri)
@@ -776,7 +781,11 @@ class IPAMigrate():
         try:
             ds_conn.simple_bind(DN(self.args.bind_dn), self.bindpw,
                                 insecure_bind=insecure_bind)
-        except (errors.NetworkError, errors.ACIError) as e:
+        except (
+            errors.NetworkError,
+            errors.ACIError,
+            errors.DatabaseError
+        ) as e:
             self.handle_error(f"Failed to bind to remote server: {str(e)}")
 
         # All set, stash the remote connection


### PR DESCRIPTION
We were previousily taking the provided ca cert and creating a temporary file from it. This was incorrect and caused the secure connection to fail.  Instead just use the file path provided.

Fixes: https://pagure.io/freeipa/issue/9619