### PR TITLE
Add missing fi to the selinux-luna %postun script

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1367,6 +1367,7 @@ fi
 %postun selinux-luna
 if [ $1 -eq 0 ]; then
     %selinux_modules_uninstall -s %{selinuxtype} %{modulename}-luna
+fi
 
 %posttrans selinux
 %selinux_relabel_post -s %{selinuxtype}


### PR DESCRIPTION
This bad syntax was preventing cleanup of the
{free}ipa-selinux-luna SELinux module:

Running scriptlet: freeipa-selinux-luna-4.12.0.dev202402211727+git0ee   34/44
/var/tmp/rpm-tmp.qoCDFi: line 16: syntax error: unexpected end of file
warning: %postun(freeipa-selinux-luna-4.12.0.dev202402211727+git0eeecdcec-0.fc37.noarch) scriptlet failed, exit status