### PR TITLE
The -d option of the ipa-advise command was able to used.

### DIFF
--- a/ipaserver/advise/base.py
+++ b/ipaserver/advise/base.py
@@ -451,7 +451,7 @@ class IpaAdvise(admintool.AdminTool):
 
     @classmethod
     def add_options(cls, parser):
-        super(IpaAdvise, cls).add_options(parser)
+        super(IpaAdvise, cls).add_options(parser, debug_option=True)
 
     def validate_options(self):
         super(IpaAdvise, self).validate_options(needs_root=False)


### PR DESCRIPTION
The -d option of the ipa-advise command was unavailable, 
so the default value was changed to True to enable its use.

Fixes: https://pagure.io/freeipa/issue/9625