### PR TITLE
[Backport][ipa-4-12] The -d option of the ipa-advise command was able to used.

### DIFF
--- a/ipaserver/advise/base.py
+++ b/ipaserver/advise/base.py
@@ -451,7 +451,7 @@ class IpaAdvise(admintool.AdminTool):
 
     @classmethod
     def add_options(cls, parser):
-        super(IpaAdvise, cls).add_options(parser)
+        super(IpaAdvise, cls).add_options(parser, debug_option=True)
 
     def validate_options(self):
         super(IpaAdvise, self).validate_options(needs_root=False)


### PR DESCRIPTION
This PR was opened automatically because PR #7430 was pushed to master and backport to ipa-4-12 is required.