### PR TITLE
[Backport][ipa-4-12] Issue 9620 - ipa-migrate remove -V option

### DIFF
--- a/install/tools/man/ipa-migrate.1
+++ b/install/tools/man/ipa-migrate.1
@@ -67,9 +67,6 @@ Reset the ID range for migrated users/groups. In "stage-mode" this is done autom
 \fB\-F\fR, \fB\-\-force\fR
 Ignore any errors and continue to proceed with migration effort.
 .TP
-\fB\-V\fR, \fB\-\-version\fR
-Display the version of the migration tool.
-.TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Only log errors during the migration process.
 .TP

--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -389,9 +389,6 @@ class IPAMigrate():
         parser.add_argument('-F', '--force',
                             help='Ignore errors and continue with migration',
                             action='store_true', default=False)
-        parser.add_argument('-V', '--version',
-                            help='Display verison of the migration tool',
-                            action='store_true', default=False)
         parser.add_argument('-q', '--quiet',
                             help='Only display errors during the migration',
                             action='store_true', default=False)


### PR DESCRIPTION
This PR was opened automatically because PR #7427 was pushed to master and backport to ipa-4-12 is required.