### PR TITLE
Force a logout in KerberosSession if a login is needed

### DIFF
--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -664,6 +664,10 @@ class KerberosSession(HTTP_Status):
         headers = []
         response = b''
 
+        logout_cookie = getattr(context, 'logout_cookie', None)
+        if logout_cookie is not None:
+            headers.append(('IPASESSION', logout_cookie))
+
         logger.debug('%s need login', status)
 
         start_response(status, headers)
@@ -689,6 +693,7 @@ class KerberosSession(HTTP_Status):
         creds = get_credentials_if_valid(name=gss_name,
                                          ccache_name=ccache_name)
         if not creds:
+            setattr(context, 'logout_cookie', 'MagBearerToken=')
             logger.debug(
                 'ccache expired or invalid, deleting session, need login')
             return None


### PR DESCRIPTION
Remove the client side cookie if a user possesses an IPA session cookie and the associated credentials can't be found on the server.

This handles the case where the ccaches are removed for some reason (maybe cleanup, maybe a container was restarted) and allows for a successful SSO if the user's Kerberos ticket is still valid.

Without this change the user is always dropped into a the username/password dialog. The only workaround is to remove the cookie on the client side.

Fixes: https://pagure.io/freeipa/issue/9624