### PR TITLE
[Backport][ipa-4-12] Add missing fi to the selinux-luna %postun script

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1367,6 +1367,7 @@ fi
 %postun selinux-luna
 if [ $1 -eq 0 ]; then
     %selinux_modules_uninstall -s %{selinuxtype} %{modulename}-luna
+fi
 
 %posttrans selinux
 %selinux_relabel_post -s %{selinuxtype}


### PR DESCRIPTION
This PR was opened automatically because PR #7429 was pushed to master and backport to ipa-4-12 is required.