### PR TITLE
[Backport][ipa-4-12] Issue 9619 - ipa-migrate - starttls does not work

### DIFF
--- a/install/tools/man/ipa-migrate.1
+++ b/install/tools/man/ipa-migrate.1
@@ -25,7 +25,7 @@ network interruptions)
 In this mode everything will be migrated including the current user SIDs and
 DNA ranges
 .TP
-\fBstage\-mod\fR
+\fBstage\-mode\fR
 In this mode, SIDs & DNA ranges are not migrated, and DNA attributes are reset
 
 .SH "COMMANDS"


### PR DESCRIPTION
This PR was opened automatically because PR #7426 was pushed to master and backport to ipa-4-12 is required.