### PR TITLE
ipatests: Removed option to setup dns for remote IPA server

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -72,7 +72,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_ipa_ipa_migration.py
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_ipa_ipa_migration.py
+++ b/ipatests/test_integration/test_ipa_ipa_migration.py
@@ -308,7 +308,7 @@ class TestIPAMigrateScenario1(IntegrationTest):
         This test installs IPA server instead of replica on
         system under test with the same realm and domain name.
         """
-        tasks.install_master(self.replicas[0], setup_dns=True, setup_kra=True)
+        tasks.install_master(self.replicas[0], setup_dns=False, setup_kra=True)
 
     def test_ipa_migrate_without_kinit_as_admin(self):
         """


### PR DESCRIPTION
E subprocess.CalledProcessError: Command '['ipa-server-install', '-n', 'testrealm.test', '-r', 'TESTREALM.TEST', '-p', 'Secret.123', '-a', 'Secret.123', '--domain-level=1', '--dirsrv-config-file', '/root/ipatests/ipatests_dse.ldif', '-U', '--setup-dns', '--forwarder', '10.11.5.19', '--auto-reverse', '--setup-kra']' returned non-zero exit status 1.

ipa: ERROR: stderr: Checking DNS domain testrealm.test., please wait ... DNS zone testrealm.test. already exists in DNS and is handled by server(s): remote.testrealm.test. The ipa-server-install command failed. See /var/log/ipaserver-install.log for more information