### PR TITLE
[Backport][ipa-4-11] Always add MS-PAC to global config and remove old encryption types from the default list

### DIFF
--- a/install/updates/50-krbenctypes.update
+++ b/install/updates/50-krbenctypes.update
@@ -7,3 +7,5 @@ add: krbSupportedEncSaltTypes: aes128-sha2:normal
 add: krbSupportedEncSaltTypes: aes128-sha2:special
 add: krbSupportedEncSaltTypes: aes256-sha2:normal
 add: krbSupportedEncSaltTypes: aes256-sha2:special
+remove: krbDefaultEncSaltTypes: des3-hmac-sha1:special
+remove: krbDefaultEncSaltTypes: arcfour-hmac:special

--- a/install/updates/60-trusts.update
+++ b/install/updates/60-trusts.update
@@ -54,4 +54,4 @@ add:aci: (target="ldap:///krbprincipalname=cifs/($$dn),cn=services,cn=accounts,$
 
 # Add the default PAC type to configuration
 dn: cn=ipaConfig,cn=etc,$SUFFIX
-addifnew: ipaKrbAuthzData: MS-PAC
+add: ipaKrbAuthzData: MS-PAC


### PR DESCRIPTION
This PR was opened automatically because PR #7448 was pushed to master and backport to ipa-4-11 is required.