### PR TITLE
Fix a copy/paste issue when detecting the HSM SELinux subpackage

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -265,7 +265,7 @@ def hsm_validator(token_name, token_library, token_password):
         if 'nfast' in token_library:
             module = 'ipa-selinux-nfast'
         elif 'luna' in token_library:
-            module = 'ipa-selinux-nfast'
+            module = 'ipa-selinux-luna'
         else:
             module = None
         if module:


### PR DESCRIPTION
I made a mistake when trying to detect which HSM is being used to ensure that the appropriate SELinux subpackage is installed.

Fixes: https://pagure.io/freeipa/issue/9636