### PR TITLE
[Backport][ipa-4-12] Fix a copy/paste issue when detecting the HSM SELinux subpackage

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -265,7 +265,7 @@ def hsm_validator(token_name, token_library, token_password):
         if 'nfast' in token_library:
             module = 'ipa-selinux-nfast'
         elif 'luna' in token_library:
-            module = 'ipa-selinux-nfast'
+            module = 'ipa-selinux-luna'
         else:
             module = None
         if module:


### PR DESCRIPTION
This PR was opened automatically because PR #7456 was pushed to master and backport to ipa-4-12 is required.