### PR TITLE
ipa-migrate - properly handle invalid certificates

### DIFF
--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -761,6 +761,12 @@ class IPAMigrate():
             try:
                 ds_conn = LDAPClient(ldapuri, cacert=self.args.cacertfile,
                                      start_tls=True)
+            except ValueError:
+                # Most likely invalid certificate
+                self.handle_error(
+                    "Failed to connect to remote server: "
+                    "CA certificate is invalid"
+                )
             except (
                 ldap.LDAPError,
                 errors.NetworkError,


### PR DESCRIPTION
A ValueError is raised when an invalid certificate is used, so the tool should handle this properly and not produce a stack trace.

Fixes: https://pagure.io/freeipa/issue/9642