### PR TITLE
spec file: do not use nodejs-22 on f39 and f40

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -308,9 +308,12 @@ BuildRequires:  libpwquality-devel
 BuildRequires:  libsss_idmap-devel
 BuildRequires:  libsss_certmap-devel
 BuildRequires:  libsss_nss_idmap-devel >= %{sssd_version}
-%if 0%{?fedora} >= 39 || 0%{?rhel} >= 10
+%if 0%{?fedora} >= 41
+# Do not use nodejs22 on fedora < 41, https://pagure.io/freeipa/issue/9643
+BuildRequires: nodejs(abi)
+%elif 0%{?fedora} >= 39 || 0%{?rhel} >= 10
 # Do not use nodejs20 on fedora < 39, https://pagure.io/freeipa/issue/9374
-BuildRequires:  nodejs(abi)
+BuildRequires:  nodejs(abi) < 127
 %else
 BuildRequires:  nodejs(abi) < 111
 %endif


### PR DESCRIPTION
Nodejs22 has been released on f39 and f40 and freeipa fails to build with this version. Nodejs22 will be the default version in f41+ and adds a symlink from /usr/bin/node-22 to /usr/bin/node but on older fedora versions, the symlink is not created. As our build is using /usr/bin/node command, it fails with command not found.

Stick to Nodejs 20 on these older versions.

Fixes: https://pagure.io/freeipa/issue/9643