### PR TITLE
[Backport][ipa-4-12] spec file: do not use nodejs-22 on f39 and f40

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -308,9 +308,12 @@ BuildRequires:  libpwquality-devel
 BuildRequires:  libsss_idmap-devel
 BuildRequires:  libsss_certmap-devel
 BuildRequires:  libsss_nss_idmap-devel >= %{sssd_version}
-%if 0%{?fedora} >= 39 || 0%{?rhel} >= 10
+%if 0%{?fedora} >= 41
+# Do not use nodejs22 on fedora < 41, https://pagure.io/freeipa/issue/9643
+BuildRequires: nodejs(abi)
+%elif 0%{?fedora} >= 39 || 0%{?rhel} >= 10
 # Do not use nodejs20 on fedora < 39, https://pagure.io/freeipa/issue/9374
-BuildRequires:  nodejs(abi)
+BuildRequires:  nodejs(abi) < 127
 %else
 BuildRequires:  nodejs(abi) < 111
 %endif


### PR DESCRIPTION
This PR was opened automatically because PR #7466 was pushed to master and backport to ipa-4-12 is required.