### PR TITLE
[Backport][ipa-4-12] ipa-migrate - properly handle invalid certificates

### DIFF
--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -761,6 +761,12 @@ class IPAMigrate():
             try:
                 ds_conn = LDAPClient(ldapuri, cacert=self.args.cacertfile,
                                      start_tls=True)
+            except ValueError:
+                # Most likely invalid certificate
+                self.handle_error(
+                    "Failed to connect to remote server: "
+                    "CA certificate is invalid"
+                )
             except (
                 ldap.LDAPError,
                 errors.NetworkError,


### PR DESCRIPTION
This PR was opened automatically because PR #7465 was pushed to master and backport to ipa-4-12 is required.