### PR TITLE
[Backport][ipa-4-12] Replica CA installation: ignore time skew during initial replication

### DIFF
--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -38,7 +38,6 @@ dist_app_DATA =				\
 	default-trust-view.ldif		\
 	delegation.ldif			\
 	replica-acis.ldif		\
-	replica-prevent-time-skew.ldif  \
 	ds-nfiles.ldif			\
 	ds-ipa-env.conf.template	\
 	dns.ldif			\

--- a/install/share/replica-prevent-time-skew.ldif
+++ b/install/share/replica-prevent-time-skew.ldif
@@ -1,4 +1,0 @@
-dn: cn=config
-changetype: modify
-replace: nsslapd-ignore-time-skew
-nsslapd-ignore-time-skew: $SKEWVALUE

--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -1262,12 +1262,12 @@ def force_sync(realm, thishost, fromhost, dirman_passwd, nolookup=False):
         repl.force_sync(repl.conn, fromhost)
     else:
         ds = dsinstance.DsInstance(realm_name=realm)
-        ds.replica_manage_time_skew(prevent=False)
+        ds.replica_ignore_initial_time_skew()
         repl = replication.ReplicationManager(realm, fromhost, dirman_passwd)
         repl.force_sync(repl.conn, thishost)
         agreement = repl.get_replication_agreement(thishost)
         repl.wait_for_repl_update(repl.conn, agreement.dn)
-        ds.replica_manage_time_skew(prevent=True)
+        ds.replica_revert_time_skew()
 
 def show_DNA_ranges(hostname, master, realm, dirman_passwd, nextrange=False,
                     nolookup=False):

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -416,7 +416,11 @@ class CAInstance(DogtagInstance):
             if promote:
                 # Setup Database
                 self.step("creating certificate server db", self.__create_ds_db)
+                self.step("ignore time skew for initial replication",
+                          self.replica_ignore_initial_time_skew)
                 self.step("setting up initial replication", self.__setup_replication)
+                self.step("revert time skew after initial replication",
+                          self.replica_revert_time_skew)
                 self.step("creating ACIs for admin", self.add_ipaca_aci)
                 self.step("creating installation admin user", self.setup_admin)
             self.step("configuring certificate server instance",

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -387,11 +387,11 @@ class DsInstance(service.Service):
         # This helps with initial replication or force-sync because
         # the receiving side has no valuable changes itself yet.
         self.step("ignore time skew for initial replication",
-                  self.__replica_ignore_initial_time_skew)
+                  self.replica_ignore_initial_time_skew)
 
         self.step("setting up initial replication", self.__setup_replica)
         self.step("prevent time skew after initial replication",
-                  self.replica_manage_time_skew)
+                  self.replica_revert_time_skew)
         self.step("adding sasl mappings to the directory", self.__configure_sasl_mappings)
         self.step("updating schema", self.__update_schema)
         # See LDIFs for automember configuration during replica install
@@ -996,16 +996,6 @@ class DsInstance(service.Service):
 
     def __add_replication_acis(self):
         self._ldap_mod("replica-acis.ldif", self.sub_dict)
-
-    def __replica_ignore_initial_time_skew(self):
-        self.replica_manage_time_skew(prevent=False)
-
-    def replica_manage_time_skew(self, prevent=True):
-        if prevent:
-            self.sub_dict['SKEWVALUE'] = 'off'
-        else:
-            self.sub_dict['SKEWVALUE'] = 'on'
-        self._ldap_mod("replica-prevent-time-skew.ldif", self.sub_dict)
 
     def __setup_s4u2proxy(self):
 


### PR DESCRIPTION
This PR was opened automatically because PR #7450 was pushed to master and backport to ipa-4-12 is required.