### PR TITLE
ipatests: Tests for ipa-migrate tool

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -2125,10 +2125,22 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_ipa_ipa_migration.py
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 9000
         topology: *master_1repl_1client
+
+  fedora-latest/test_IPAMigrateADTrust:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrationWithADtrust
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *ad_master_1repl_1client
 
   fedora-latest/test_cockpit:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -2295,10 +2295,23 @@ jobs:
       args:
         build_url: '{fedora-latest/build_url}'
         selinux_enforcing: True
-        test_suite: test_integration/test_ipa_ipa_migration.py
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 9000
         topology: *master_1repl_1client
+
+  fedora-latest/test_IPAMigrateADTrust:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrationWithADtrust
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *ad_master_1repl_1client
 
   fedora-latest/test_cockpit:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -2466,10 +2466,24 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         enable_testing_repo: True
-        test_suite: test_integration/test_ipa_ipa_migration.py
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 9000
         topology: *master_1repl_1client
+
+  testing-fedora/test_IPAMigrateADTrust:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrationWithADtrust
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *ad_master_1repl_1client
 
   testing-fedora/test_cockpit:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2636,10 +2636,25 @@ jobs:
         update_packages: True
         selinux_enforcing: True
         enable_testing_repo: True
-        test_suite: test_integration/test_ipa_ipa_migration.py
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 9000
         topology: *master_1repl_1client
+
+  testing-fedora/test_IPAMigrateADTrust:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrationWithADtrust
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *ad_master_1repl_1client
 
   testing-fedora/test_cockpit:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -2125,9 +2125,21 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-previous/build_url}'
-        test_suite: test_integration/test_ipa_ipa_migration.py
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode
         template: *ci-master-previous
-        timeout: 3600
+        timeout: 9000
+        topology: *master_1repl_1client
+
+  fedora-previous/test_IPAMigrateADTrust:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrationWithADtrust
+        template: *ci-master-previous
+        timeout: 7200
         topology: *master_1repl_1client
 
   fedora-previous/test_cockpit:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -2295,10 +2295,23 @@ jobs:
       args:
         build_url: '{fedora-rawhide/build_url}'
         update_packages: True
-        test_suite: test_integration/test_ipa_ipa_migration.py
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode
         template: *ci-master-frawhide
-        timeout: 3600
+        timeout: 9000
         topology: *master_1repl_1client
+
+  fedora-rawhide/test_IPAMigrateADTrust:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrationWithADtrust
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *ad_master_1repl_1client
 
   fedora-rawhide/test_cockpit:
     requires: [fedora-rawhide/build]

--- a/ipatests/pytest_ipa/integration/__init__.py
+++ b/ipatests/pytest_ipa/integration/__init__.py
@@ -88,6 +88,8 @@ CLASS_LOGFILES = [
     paths.VAR_LOG_AUDIT,
     # sssd
     paths.VAR_LOG_SSSD_DIR,
+    # ipa-ipa-migration logs
+    paths.IPA_MIGRATE_LOG,
     # system
     paths.RESOLV_CONF,
     paths.HOSTS,

--- a/ipatests/test_integration/test_ipa_ipa_migration.py
+++ b/ipatests/test_integration/test_ipa_ipa_migration.py
@@ -12,6 +12,7 @@ from ipaplatform.paths import paths
 from collections import Counter
 
 import pytest
+import re
 import textwrap
 
 
@@ -65,29 +66,7 @@ def prepare_ipa_server(master):
             "--secondary-rid-base=400000",
         ]
     )
-
-    # Add Automount locations and maps
-    master.run_command(["ipa", "automountlocation-add", "baltimore"])
-    master.run_command(["ipa", "automountmap-add", "baltimore", "auto.share"])
-    master.run_command(
-        [
-            "ipa",
-            "automountmap-add-indirect",
-            "baltimore",
-            "--parentmap=auto.share",
-            "--mount=sub auto.man",
-        ]
-    )
-    master.run_command(
-        [
-            "ipa",
-            "automountkey-add",
-            "baltimore",
-            "auto.master",
-            "--key=/share",
-            "--info=auto.share",
-        ]
-    )
+    master.run_command(["ipactl", "restart"])
 
     # Run ipa-adtrust-install
     master.run_command(["dnf", "install", "-y", "ipa-server-trust-ad"])
@@ -235,6 +214,17 @@ def prepare_ipa_server(master):
         ["ipa", "hbacrule-add-service", "--hbacsvcs=sshd", "testuser_sshd"]
     )
 
+    # Add DNSForwardzone
+    master.run_command(
+        [
+            "ipa",
+            "dnsforwardzone-add",
+            "forwardzone.test",
+            "--forwarder",
+            "10.11.12.13",
+        ]
+    )
+
     # Vault addition
     master.run_command(
         [
@@ -244,6 +234,7 @@ def prepare_ipa_server(master):
             "vault1234",
             "--type",
             "symmetric",
+            "testvault",
         ]
     )
 
@@ -260,7 +251,46 @@ def prepare_ipa_server(master):
 
     # Modify passkeyconfig
     master.run_command(
-        ["ipa", "passkeyconfig-mod", "--require-user-verification=FALSE"]
+        [
+            "ipa", "passkeyconfig-mod",
+            "--require-user-verification=FALSE"
+        ]
+    )
+
+    # Adding automountlocation, maps, keys
+    master.run_command(
+        [
+            "ipa", "automountlocation-add",
+            "baltimore"
+        ]
+    )
+
+    master.run_command(
+        [
+            "ipa", "automountmap-add",
+            "baltimore",
+            "auto.share"
+        ]
+    )
+
+    master.run_command(
+        [
+            "ipa", "automountmap-add-indirect",
+            "baltimore",
+            "--parentmap=auto.share",
+            "--mount=sub",
+            "auto.man",
+        ]
+    )
+
+    master.run_command(
+        [
+            "ipa", "automountkey-add",
+            "baltimore",
+            "auto.master",
+            "--key=/share",
+            "--info=auto.share",
+        ]
     )
 
 
@@ -288,12 +318,24 @@ def run_migrate(
     return result
 
 
-class TestIPAMigrateScenario1(IntegrationTest):
+@pytest.fixture()
+def empty_log_file(request):
     """
-    Tier-1 tests for ipa-migrate tool with DNS enabled on
-    local and remote server
+    This fixture empties the log file before ipa-migrate tool
+    is run since the log is appended everytime the tool is run.
     """
+    request.cls.replicas[0].run_command(
+        ["truncate", "-s", "0", paths.IPA_MIGRATE_LOG]
+    )
+    yield
 
+
+class MigrationTest(IntegrationTest):
+    """
+    This class will help setup remote IPA server(cls.master)
+    and local IPA server(cls.replicas[0]) and it will
+    also prepare the remote IPA before migration actually begins.
+    """
     num_replicas = 1
     num_clients = 1
     topology = "line"
@@ -303,14 +345,14 @@ class TestIPAMigrateScenario1(IntegrationTest):
         tasks.install_master(cls.master, setup_dns=True, setup_kra=True)
         prepare_ipa_server(cls.master)
         tasks.install_client(cls.master, cls.clients[0], nameservers=None)
+        tasks.install_master(cls.replicas[0], setup_dns=True, setup_kra=True)
 
-    def test_remote_server(self):
-        """
-        This test installs IPA server instead of replica on
-        system under test with the same realm and domain name.
-        """
-        tasks.install_master(self.replicas[0], setup_dns=True, setup_kra=True)
 
+class TestIPAMigrateCLIOptions(MigrationTest):
+    """
+    Tests to check CLI options for ipa-migrate tool with
+    DNS enabled on local and remote server.
+    """
     def test_ipa_migrate_without_kinit_as_admin(self):
         """
         This test checks that ipa-migrate tool displays
@@ -417,7 +459,7 @@ class TestIPAMigrateScenario1(IntegrationTest):
         """
         ldif_file = "/tmp/test.ldif"
         param = ['-x', '-o', ldif_file]
-        run_migrate(
+        result = run_migrate(
             self.replicas[0],
             "stage-mode",
             self.master.hostname,
@@ -426,45 +468,21 @@ class TestIPAMigrateScenario1(IntegrationTest):
             extra_args=param,
         )
         assert self.replicas[0].transport.file_exists("/tmp/test.ldif")
+        assert result.returncode == 0
 
-    @pytest.fixture()
-    def empty_log_file(self):
-        """
-        This fixture empties the log file before ipa-migrate tool
-        is run since the log is appended everytime the tool is run.
-        """
-        self.replicas[0].run_command(
-            ["truncate", "-s", "0", paths.IPA_MIGRATE_LOG]
-        )
-        yield
-
-    def test_ipa_sigden_plugin_fail_error(self, empty_log_file):
-        """
-        This testcase checks that sidgen plugin fail error is
-        not seen during migrate prod-mode
-        """
-        SIDGEN_ERR_MSG = "SIDGEN task failed: \n"
-        run_migrate(
-            self.replicas[0],
-            "stage-mode",
-            self.master.hostname,
-            "cn=Directory Manager",
-            self.master.config.admin_password,
-            extra_args=['-x'],
-        )
-        error_msg = self.replicas[0].get_file_contents(
-            paths.IPA_MIGRATE_LOG, encoding="utf-8"
-        )
-        assert SIDGEN_ERR_MSG not in error_msg
-
-    def test_ipa_migrate_stage_mode_dry_run(self, empty_log_file):
+    def test_ipa_migrate_stage_mode_dry_run(self):
         """
         Test ipa-migrate stage mode with dry-run option
+        This test also checks SIDGEN task failure is
+        not seen in ipa migrate log.
         """
         tasks.kinit_admin(self.master)
         tasks.kinit_admin(self.replicas[0])
+        SIDGEN_ERR_MSG = "SIDGEN task failed: \n"
         IPA_MIGRATE_STAGE_DRY_RUN_LOG = "--dryrun=True\n"
-        IPA_SERVER_UPRGADE_LOG = "Skipping ipa-server-upgrade in dryrun mode.\n"
+        IPA_SERVER_UPRGADE_LOG = (
+            "Skipping ipa-server-upgrade in dryrun mode.\n"
+        )
         IPA_SKIP_SIDGEN_LOG = "Skipping SIDGEN task in dryrun mode."
         result = run_migrate(
             self.replicas[0],
@@ -481,6 +499,7 @@ class TestIPAMigrateScenario1(IntegrationTest):
         assert IPA_MIGRATE_STAGE_DRY_RUN_LOG in install_msg
         assert IPA_SERVER_UPRGADE_LOG in install_msg
         assert IPA_SKIP_SIDGEN_LOG in install_msg
+        assert SIDGEN_ERR_MSG not in install_msg
 
     def test_ipa_migrate_prod_mode_dry_run(self, empty_log_file):
         """
@@ -509,7 +528,7 @@ class TestIPAMigrateScenario1(IntegrationTest):
         assert IPA_SERVER_UPRGADE_LOG in install_msg
         assert IPA_SIDGEN_LOG in install_msg
 
-    def test_ipa_migrate_with_skip_schema_option_dry_run(self, empty_log_file):
+    def test_ipa_migrate_skip_schema_dry_run(self, empty_log_file):
         """
         This test checks that ipa-migrate tool works
         with -S(schema) options in stage mode
@@ -532,7 +551,7 @@ class TestIPAMigrateScenario1(IntegrationTest):
         )
         assert SKIP_SCHEMA_MSG_LOG in install_msg
 
-    def test_ipa_migrate_with_skip_config_option_dry_run(self, empty_log_file):
+    def test_ipa_migrate_skip_config_dry_run(self, empty_log_file):
         """
         This test checks that ipa-migrate tool works
         with -C(config) options in stage mode
@@ -579,7 +598,7 @@ class TestIPAMigrateScenario1(IntegrationTest):
         )
         assert RESET_RANGE_LOG in install_msg
 
-    def test_ipa_migrate_stage_mode_dry_override_schema(self, empty_log_file):
+    def test_ipa_migrate_stage_mode_override_schema(self, empty_log_file):
         """
         This test checks that -O option (override schema) works
         in dry mode
@@ -600,70 +619,6 @@ class TestIPAMigrateScenario1(IntegrationTest):
             paths.IPA_MIGRATE_LOG, encoding="utf-8"
         )
         assert SCHEMA_OVERRIDE_LOG in install_msg
-
-    def test_ipa_migrate_stage_mode(self, empty_log_file):
-        """
-        This test checks that ipa-migrate is successful
-        in dry run mode
-        """
-        tasks.kinit_admin(self.master)
-        tasks.kinit_admin(self.replicas[0])
-        MIGRATION_SCHEMA_LOG_MSG = "Migrating schema ...\n"
-        MIGRATION_CONFIG_LOG_MSG = "Migrating configuration ...\n"
-        IPA_UPGRADE_LOG_MSG = (
-            "Running ipa-server-upgrade ... (this may take a while)\n"
-        )
-        SIDGEN_TASK_LOG_MSG = "Running SIDGEN task ...\n"
-        MIGRATION_COMPLETE_LOG_MSG = "Migration complete!\n"
-        result = run_migrate(
-            self.replicas[0],
-            "stage-mode",
-            self.master.hostname,
-            "cn=Directory Manager",
-            self.master.config.admin_password,
-            extra_args=['-n'],
-        )
-        install_msg = self.replicas[0].get_file_contents(
-            paths.IPA_MIGRATE_LOG, encoding="utf-8"
-        )
-        assert result.returncode == 0
-        assert MIGRATION_SCHEMA_LOG_MSG in install_msg
-        assert MIGRATION_CONFIG_LOG_MSG in install_msg
-        assert IPA_UPGRADE_LOG_MSG in install_msg
-        assert SIDGEN_TASK_LOG_MSG in install_msg
-        assert MIGRATION_COMPLETE_LOG_MSG in install_msg
-
-    def test_ipa_migrate_prod_mode(self, empty_log_file):
-        """
-        This test checks that ipa-migrate is successful
-        in prod run mode
-        """
-        tasks.kinit_admin(self.master)
-        tasks.kinit_admin(self.replicas[0])
-        MIGRATION_SCHEMA_LOG_MSG = "Migrating schema ...\n"
-        MIGRATION_DATABASE_LOG_MSG = (
-            "Migrating database ... (this may take a while)\n"
-        )
-        IPA_UPGRADE_LOG_MSG = (
-            "Running ipa-server-upgrade ... (this may take a while)\n"
-        )
-        SIDGEN_TASK_LOG_MSG = "Running SIDGEN task ...\n"
-        result = run_migrate(
-            self.replicas[0],
-            "prod-mode",
-            self.master.hostname,
-            "cn=Directory Manager",
-            self.master.config.admin_password,
-            extra_args=['-n'],
-        )
-        install_msg = self.replicas[0].get_file_contents(
-            paths.IPA_MIGRATE_LOG, encoding="utf-8"
-        )
-        assert result.returncode == 0
-        assert MIGRATION_SCHEMA_LOG_MSG in install_msg
-        assert MIGRATION_DATABASE_LOG_MSG in install_msg
-        assert IPA_UPGRADE_LOG_MSG in install_msg
-        assert SIDGEN_TASK_LOG_MSG in install_msg
 
     def test_ipa_migrate_with_bind_pwd_file_option(self, empty_log_file):
         """
@@ -801,6 +756,9 @@ class TestIPAMigrateScenario1(IntegrationTest):
 
     @pytest.fixture()
     def modify_dns_zone(self):
+        """
+        This fixture adds dnszone and then removes the zone.
+        """
         zone_name = 'ipatest.test'
         self.master.run_command(
             ["ipa", "dnszone-add", zone_name, "--force"]
@@ -843,6 +801,20 @@ class TestIPAMigrateScenario1(IntegrationTest):
         assert DNS_LOG1 in install_msg
         assert DNS_LOG2 in install_msg
         assert DNS_LOG3 in install_msg
+
+    def test_ipa_migrate_dns_forwardzone(self):
+        """
+        This testcase checks that DNS forwardzone is
+        also migrated in prod-mode
+        """
+        zone_name = "forwardzone.test"
+        result = self.replicas[0].run_command(
+            ["ipa", "dnsforwardzone-show", zone_name]
+        )
+        assert 'Zone name: {}'.format(zone_name) in result.stdout_text
+        assert 'Active zone: True' in result.stdout_text
+        assert 'Zone forwarders: 10.11.12.13' in result.stdout_text
+        assert 'Forward policy: first' in result.stdout_text
 
     def test_ipa_migrate_version_option(self):
         """
@@ -922,20 +894,179 @@ class TestIPAMigrateScenario1(IntegrationTest):
         assert result.returncode == 1
         assert ERR_MSG in result.stderr_text
 
+
+class TestIPAMigrationStageMode(MigrationTest):
+    """
+    Tests for ipa-migrate tool in stage mode
+    """
+    def test_ipa_migrate_stage_mode(self, empty_log_file):
+        """
+        This test checks that ipa-migrate is successful
+        in dry run mode
+        """
+        tasks.kinit_admin(self.master)
+        tasks.kinit_admin(self.replicas[0])
+        MIGRATION_SCHEMA_LOG_MSG = "Migrating schema ...\n"
+        MIGRATION_CONFIG_LOG_MSG = "Migrating configuration ...\n"
+        IPA_UPGRADE_LOG_MSG = (
+            "Running ipa-server-upgrade ... (this may take a while)\n"
+        )
+        SIDGEN_TASK_LOG_MSG = "Running SIDGEN task ...\n"
+        MIGRATION_COMPLETE_LOG_MSG = "Migration complete!\n"
+        run_migrate(
+            self.replicas[0],
+            "stage-mode",
+            self.master.hostname,
+            "cn=Directory Manager",
+            self.master.config.admin_password,
+            extra_args=['-n'],
+        )
+        install_msg = self.replicas[0].get_file_contents(
+            paths.IPA_MIGRATE_LOG, encoding="utf-8"
+        )
+        assert MIGRATION_SCHEMA_LOG_MSG in install_msg
+        assert MIGRATION_CONFIG_LOG_MSG in install_msg
+        assert IPA_UPGRADE_LOG_MSG in install_msg
+        assert SIDGEN_TASK_LOG_MSG in install_msg
+        assert MIGRATION_COMPLETE_LOG_MSG in install_msg
+
+    def test_ipa_migrate_stage_mode_new_user(self):
+        """
+        This testcase checks that when a new user is added and
+        ipa-migrate is run in stage-mode, uid/gid of the
+        migrated user is not preserved i.e we have different
+        uid/gid for user on remote and local IPA server.
+        """
+        username = 'testuser4'
+        base_dn = str(self.master.domain.basedn)
+        LOG_MSG1 = (
+            "DEBUG Resetting the DNA range for new entry: "
+            "uid={},cn=users,cn=accounts,{}\n"
+        ).format(username, base_dn)
+        install_msg = self.replicas[0].get_file_contents(
+            paths.IPA_MIGRATE_LOG, encoding="utf-8"
+        )
+        assert LOG_MSG1 not in install_msg
+        tasks.clear_sssd_cache(self.master)
+        self.master.run_command(['ipa', 'user-show', username])
+        cmd1 = self.master.run_command(['id', username])
+        tasks.clear_sssd_cache(self.replicas[0])
+        self.replicas[0].run_command(['ipa', 'user-show', username])
+        cmd2 = self.replicas[0].run_command(['id', username])
+        assert cmd1.stdout_text != cmd2.stdout_text
+
+
+class TestIPAMigrationProdMode(MigrationTest):
+    """
+    Tests for ipa-migrate tool in prod mode
+    """
+    def test_ipa_migrate_prod_mode(self, empty_log_file):
+        """
+        This test checks that ipa-migrate is successful
+        in prod run mode
+        """
+        tasks.kinit_admin(self.master)
+        tasks.kinit_admin(self.replicas[0])
+        MIGRATION_SCHEMA_LOG_MSG = "Migrating schema ...\n"
+        MIGRATION_DATABASE_LOG_MSG = (
+            "Migrating database ... (this may take a while)\n"
+        )
+        IPA_UPGRADE_LOG_MSG = (
+            "Running ipa-server-upgrade ... (this may take a while)\n"
+        )
+        SIDGEN_TASK_LOG_MSG = "Running SIDGEN task ...\n"
+        result = run_migrate(
+            self.replicas[0],
+            "prod-mode",
+            self.master.hostname,
+            "cn=Directory Manager",
+            self.master.config.admin_password,
+            extra_args=['-n'],
+        )
+        install_msg = self.replicas[0].get_file_contents(
+            paths.IPA_MIGRATE_LOG, encoding="utf-8"
+        )
+        assert result.returncode == 0
+        assert MIGRATION_SCHEMA_LOG_MSG in install_msg
+        assert MIGRATION_DATABASE_LOG_MSG in install_msg
+        assert IPA_UPGRADE_LOG_MSG in install_msg
+        assert SIDGEN_TASK_LOG_MSG in install_msg
+
+    def test_ipa_migrate_prod_mode_hbac_rule(self):
+        """
+        This testcase checks that hbac rule is migrated from
+        remote server to local server in prod mode.
+        """
+        hbac_rule_name1 = 'test1'
+        hbac_rule_name2 = 'testuser_sshd'
+        tasks.kinit_admin(self.replicas[0])
+        cmd1 = self.replicas[0].run_command(
+            ["ipa", "hbacrule-find", hbac_rule_name1])
+        cmd2 = self.replicas[0].run_command(
+            ["ipa", "hbacrule-find", hbac_rule_name2])
+        assert hbac_rule_name1 in cmd1.stdout_text
+        assert hbac_rule_name2 in cmd2.stdout_text
+
+    def test_ipa_migrate_prod_mode_sudo_rule(self):
+        """
+        This testcase checks that sudo cmd and rules are
+        migrated from remote server to local server in prod mode.
+        """
+        sudorule = 'readfiles'
+        sudocmd = '/usr/bin/less'
+        tasks.kinit_admin(self.replicas[0])
+        cmd1 = self.replicas[0].run_command(
+            ["ipa", "sudorule-find", sudorule])
+        cmd2 = self.replicas[0].run_command(
+            ["ipa", "sudocmd-find", sudocmd])
+        assert 'Rule name: readfiles\n' in cmd1.stdout_text
+        assert 'Sudo Command: /usr/bin/less\n' in cmd2.stdout_text
+
+    def test_ipa_migrate_prod_mode_new_user_sid(self):
+        """
+        This testcase checks that in prod-mode uid/gid of the
+        migrated user is preserved i.e we have same
+        uid/gid for user on remote and local IPA server.
+        """
+        username = 'testuser4'
+        tasks.clear_sssd_cache(self.master)
+        result1 = self.master.run_command(['id', username])
+        tasks.clear_sssd_cache(self.replicas[0])
+        result2 = self.replicas[0].run_command(['id', username])
+        assert result1.stdout_text == result2.stdout_text
+
+    def test_check_vault_is_not_migrated(self):
+        """
+        This testcase checks that vault is
+        not migrated
+        """
+        vault_name = "testvault"
+        CMD_OUTPUT = "Number of entries returned 0"
+        cmd = self.replicas[0].run_command(
+            ["ipa", "vault-find", vault_name], raiseonerr=False)
+        assert cmd.returncode != 0
+        assert CMD_OUTPUT in cmd.stdout_text
+
+    def test_ipa_migrate_subids(self):
+        """
+        This testcase checks that subids for users are migrated
+        to the local server from the remote server
+        """
+        user_name = 'admin'
+        CMD_MSG = "1 subordinate id matched"
+        cmd = self.replicas[0].run_command(
+            ['ipa', 'subid-find',
+             '--owner', user_name]
+        )
+        assert cmd.returncode == 0
+        assert CMD_MSG in cmd.stdout_text
+
     def test_ipa_hbac_rule_duplication(self):
         """
         This testcase checks that default hbac rules
         are not duplicated on the local server when
         ipa-migrate command is run.
         """
-        run_migrate(
-            self.replicas[0],
-            "prod-mode",
-            self.master.hostname,
-            "cn=Directory Manager",
-            self.master.config.admin_password,
-            extra_args=['-n']
-        )
         result = self.replicas[0].run_command(
             ['ipa', 'hbacrule-find']
         )
@@ -946,3 +1077,192 @@ class TestIPAMigrateScenario1(IntegrationTest):
         count = Counter(line)
         assert count.get('Rule name: allow_all') < 2
         assert count.get('Rule name: allow_systemd-user') < 2
+
+    def test_ipa_migrate_otptoken(self):
+        """
+        This testcase checks that the otptoken
+        is migrated for the user.
+        """
+        owner = "testuser1"
+        CMD_OUTPUT = "1 OTP token matched"
+        result = self.replicas[0].run_command([
+            "ipa", "otptoken-find"
+        ])
+        assert CMD_OUTPUT in result.stdout_text
+        assert 'Type: TOTP' in result.stdout_text
+        assert 'Owner: {}'.format(owner) in result.stdout_text
+
+    def test_ipa_migrate_check_passkey_config(self):
+        """
+        This testcase checks that passkey config
+        is migrated
+        """
+        CMD_OUTPUT = "Require user verification: False"
+        result = self.replicas[0].run_command([
+            "ipa", "passkeyconfig-show"
+        ])
+        assert CMD_OUTPUT in result.stdout_text
+
+    def test_ipa_migrate_check_service_status(self):
+        """
+        This testcase checks that ipactl and sssd
+        services are running post ipa-migrate tool
+        successful runs completed
+        """
+        cmd1 = self.replicas[0].run_command([
+            "ipactl", "status"
+        ])
+        assert cmd1.returncode == 0
+        cmd2 = self.replicas[0].run_command([
+            "systemctl", "status", "sssd"
+        ])
+        assert cmd2.returncode == 0
+
+    def test_custom_idrange_is_migrated(self):
+        """
+        This testcase checks that custom idrange is migrated
+        from remote server to local server in production
+        mode.
+        """
+        range_name = "testrange"
+        CMD_OUTPUT = (
+            "---------------\n"
+            "1 range matched\n"
+            "---------------\n"
+            "  Range name: testrange\n"
+            "  First Posix ID of the range: 10000\n"
+            "  Number of IDs in the range: 10000\n"
+            "  First RID of the corresponding RID range: 300000\n"
+            "  First RID of the secondary RID range: 400000\n"
+            "  Range type: local domain range\n"
+            "----------------------------\n"
+            "Number of entries returned 1\n"
+            "----------------------------\n"
+        )
+        cmd = self.replicas[0].run_command(
+            ["ipa", "idrange-find", range_name])
+        assert CMD_OUTPUT in cmd.stdout_text
+
+    def test_automountlocation_is_migrated(self):
+        """
+        This testcase checks that automount location/maps
+        and keys are migrated.
+        """
+        base_dn = str(self.master.domain.basedn)
+        automount_cn = "automount"
+        loc_name = "baltimore"
+        auto_map_name = "auto.share"
+        DEBUG_LOG = (
+            "Added entry: cn={},cn={},{}\n"
+        ).format(loc_name, automount_cn, base_dn)
+        CMD1_OUTPUT = (
+            "  Location: baltimore\n"
+        )
+        CMD2_OUTPUT = (
+            "  Map: auto.share\n"
+        )
+        CMD3_OUTPUT = (
+            "-----------------------\n"
+            "1 automount key matched\n"
+            "-----------------------\n"
+            "  Key: sub\n"
+            "  Mount information: -fstype=autofs ldap:auto.man\n"
+        )
+        cmd1 = self.replicas[0].run_command(
+            ["ipa", "automountlocation-show", loc_name])
+        cmd2 = self.replicas[0].run_command(
+            ["ipa", "automountmap-find", loc_name])
+        cmd3 = self.replicas[0].run_command(
+            ["ipa", "automountkey-find", loc_name, auto_map_name]
+        )
+        install_msg = self.replicas[0].get_file_contents(
+            paths.IPA_MIGRATE_LOG, encoding="utf-8"
+        )
+        assert CMD1_OUTPUT in cmd1.stdout_text
+        assert CMD2_OUTPUT in cmd2.stdout_text
+        assert CMD3_OUTPUT in cmd3.stdout_text
+        assert DEBUG_LOG in install_msg
+
+
+class TestIPAMigrationWithADtrust(IntegrationTest):
+    """
+    Test for ipa-migrate tool with IPA Master having trust setup
+    with Windows AD.
+    """
+    topology = "line"
+    num_ad_domains = 1
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(
+            cls.master, setup_dns=True, extra_args=['--no-dnssec-validation']
+        )
+        cls.ad = cls.ads[0]
+        cls.ad_domain = cls.ad.domain.name
+        tasks.install_adtrust(cls.master)
+        tasks.configure_dns_for_trust(cls.master, cls.ad)
+        tasks.establish_trust_with_ad(cls.master, cls.ad.domain.name)
+
+    def test_install_local_server(self):
+        """
+        This test installs local IPA Server() i.e new IPA server with
+        the same realm and domain name that will receive the migration data.
+        """
+        tasks.install_master(
+            self.replicas[0], setup_dns=True,
+            extra_args=['--no-dnssec-validation']
+        )
+        tasks.install_adtrust(self.replicas[0])
+
+    def test_check_ad_attributes_migrate_prod_mode(self):
+        """
+        This test checks that IPA-AD trust related attributes
+        are migrated to local server.
+        """
+        result = run_migrate(
+            self.replicas[0],
+            "prod-mode",
+            self.master.hostname,
+            "cn=Directory Manager",
+            self.master.config.admin_password,
+            extra_args=['-n']
+        )
+        assert result.returncode == 0
+        trust1 = self.master.run_command(
+            ['ipa', 'trust-show', self.ad_domain]
+        ).stdout_text
+        trust2 = self.replicas[0].run_command(
+            ['ipa', 'trust-show', self.ad_domain]).stdout_text
+        assert trust1 == trust2
+
+    def test_check_domain_sid_is_migrated(self):
+        """
+        This testcase checks that domain sid is
+        migrated from a remote server having trust with AD
+        to local server and is displayed in the
+        ipa trustconfig-show command
+        """
+        regexp = (r'Security Identifier: (.*)$')
+        cmd1 = self.master.run_command(["ipa", "trustconfig-show"])
+        sid1 = re.findall(regexp, cmd1.stdout_text, re.MULTILINE)
+        cmd2 = self.replicas[0].run_command(
+            ["ipa", "trustconfig-show"]
+        )
+        sid2 = re.findall(regexp, cmd2.stdout_text, re.MULTILINE)
+        assert sid1 == sid2
+
+    def test_check_ad_idrange_is_migrated(self):
+        """
+        This testcase checks AD idrange is migrated
+        from remote IPA server having trust with AD
+        to local IPA server
+        """
+        ad_domain_name = self.ad.domain.name.upper()
+        cmd1 = self.master.run_command(
+            ["ipa", "idrange-show", ad_domain_name + "_id_range"]
+        )
+        cmd2 = self.replicas[0].run_command(
+            ["ipa", "idrange-show", ad_domain_name + "_id_range"]
+        )
+        assert cmd1.stdout_text == cmd2.stdout_text


### PR DESCRIPTION
  This patch includes test to covers below scenarios
  1. HBAC/SUDO rules are migrated in prod-mode to local server from remote server
  2. UID/Subids for user in stage/prod mode.
