### PR TITLE
Correct usage of public_key_algorithm_oid in ipalib/x509

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -25,6 +25,14 @@ All constants centralised in one file.
 import os
 import string
 import uuid
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    "TripleDES has been moved to "
+    "cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and "
+    "will be removed from this module in 48.0.0",
+    category=UserWarning)
 
 from ipaplatform.constants import constants as _constants
 from ipapython.dn import DN

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -298,7 +298,7 @@ class IPACertificate(crypto_x509.Certificate):
             """
             Returns the ObjectIdentifier of the public key.
             """
-            return self._cert.public_key_algorithm_oid()
+            return self._cert.public_key_algorithm_oid
 
     @property
     def tbs_certificate_bytes(self):


### PR DESCRIPTION
public_key_algorithm_oid is property of underlying Certificate object
that is not supposed to be callable. I missed that it contained
() at the end.

Fixes: https://pagure.io/freeipa/issue/9641

Also include a patch to suppress the TripleDES warning.