### PR TITLE
ipatests: increase the timeout for test_hsm.py::TestHSMInstall

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1935,7 +1935,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_hsm.py::TestHSMInstall
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6300
         topology: *master_3repl_1client
 
   fedora-latest/test_hsm_TestHSMInstallADTrustBase:

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -1116,7 +1116,7 @@ jobs:
         copr: '@pki/master'
         test_suite: test_integration/test_hsm.py::TestHSMInstall
         template: *ci-master-latest
-        timeout: 10800
+        timeout: 6300
         topology: *master_3repl_1client
 
   pki-fedora/test_hsm_TestHSMInstallADTrustBase:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -2089,7 +2089,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_hsm.py::TestHSMInstall
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6300
         topology: *master_3repl_1client
 
   fedora-latest/test_hsm_TestHSMInstallADTrustBase:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -2244,7 +2244,7 @@ jobs:
         enable_testing_repo: True
         test_suite: test_integration/test_hsm.py::TestHSMInstall
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6300
         topology: *master_3repl_1client
 
   testing-fedora/test_hsm_TestHSMInstallADTrustBase:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2398,7 +2398,7 @@ jobs:
         enable_testing_repo: True
         test_suite: test_integration/test_hsm.py::TestHSMInstall
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6300
         topology: *master_3repl_1client
 
   testing-fedora/test_hsm_TestHSMInstallADTrustBase:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1935,7 +1935,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_hsm.py::TestHSMInstall
         template: *ci-master-previous
-        timeout: 5400
+        timeout: 6300
         topology: *master_3repl_1client
 
   fedora-previous/test_hsm_TestHSMInstallADTrustBase:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -2089,7 +2089,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_hsm.py::TestHSMInstall
         template: *ci-master-frawhide
-        timeout: 5400
+        timeout: 6300
         topology: *master_3repl_1client
 
   fedora-rawhide/test_hsm_TestHSMInstallADTrustBase:


### PR DESCRIPTION
The test is often failing on timeout. Add 15min to the test definitions.