### PR TITLE
[Backport][ipa-4-12] ipatests: increase the timeout for test_hsm.py::TestHSMInstall

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
@@ -1935,7 +1935,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-12/build_url}'
         test_suite: test_integration/test_hsm.py::TestHSMInstall
         template: *ci-ipa-4-12-latest
-        timeout: 5400
+        timeout: 6300
         topology: *master_3repl_1client
 
   fedora-latest-ipa-4-12/test_hsm_TestHSMInstallADTrustBase:

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
@@ -2089,7 +2089,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_hsm.py::TestHSMInstall
         template: *ci-ipa-4-12-latest
-        timeout: 5400
+        timeout: 6300
         topology: *master_3repl_1client
 
   fedora-latest-ipa-4-12/test_hsm_TestHSMInstallADTrustBase:


### PR DESCRIPTION
The test is often failing on timeout. Add 15min to the test definitions.