### PR TITLE
ipatests: skip HSM test if pki < 11.5.9

### DIFF
--- a/ipatests/test_integration/test_hsm.py
+++ b/ipatests/test_integration/test_hsm.py
@@ -835,6 +835,7 @@ class TestHSMNegative(IntegrationTest):
 
     @classmethod
     def uninstall(cls, mh):
+        check_version(cls.master)
         cls.master.run_command(
             ['softhsm2-util', '--delete-token', '--token', cls.token_name],
             raiseonerr=False


### PR DESCRIPTION
The test TestHSMNegative should be skipped if PKI is too old,
but its uninstall method does not check the PKI version.

Add a call to check_version in the class uninstall method.

Fixes: https://pagure.io/freeipa/issue/9648
