### PR TITLE
[Backport][ipa-4-12] ipatests: skip HSM test if pki < 11.5.9

### DIFF
--- a/ipatests/test_integration/test_hsm.py
+++ b/ipatests/test_integration/test_hsm.py
@@ -835,6 +835,7 @@ class TestHSMNegative(IntegrationTest):
 
     @classmethod
     def uninstall(cls, mh):
+        check_version(cls.master)
         cls.master.run_command(
             ['softhsm2-util', '--delete-token', '--token', cls.token_name],
             raiseonerr=False


### PR DESCRIPTION
This PR was opened automatically because PR #7486 was pushed to master and backport to ipa-4-12 is required.