### PR TITLE
ipatests: Replace 'usermod -r' command with 'gpasswd -d' in test_hsm.py

### DIFF
--- a/ipatests/test_integration/test_hsm.py
+++ b/ipatests/test_integration/test_hsm.py
@@ -898,7 +898,7 @@ class TestHSMNegative(IntegrationTest):
              '--label', token_name]
         )
         self.master.run_command(
-            ['usermod', 'pkiuser', '-r', '-G', 'ods']
+            ['gpasswd', '-d', 'pkiuser', 'ods']
         )
         result = tasks.install_master(
             self.master, raiseonerr=False,


### PR DESCRIPTION
Test 'test_hsm_negative_bad_token_dir_permissions' was failing in RHEL because of the below error.
"ipa: ERROR: stderr: usermod: invalid option -- 'r'" 

Hence replaced the usermod with gpasswd command which does the same and works on both RHEL and Fedora.
    

