### PR TITLE
HSM: fix the module name

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -277,9 +277,9 @@ def hsm_validator(token_name, token_library, token_password):
         # validate that the appropriate SELinux module is installed
         # Only warn in case the expected paths don't match.
         if 'nfast' in token_library:
-            module = 'ipa-selinux-nfast'
+            module = 'ipa-nfast'
         elif 'luna' in token_library:
-            module = 'ipa-selinux-luna'
+            module = 'ipa-luna'
         else:
             module = None
         if module:


### PR DESCRIPTION
During the server installation, the installer checks if the SElinux policy module for the specific hardware is detected. The current code mixed up SElinux policy module name and RPM package name and resulted in a false warning that the module was missing.

The module name is ipa-nfast or ipa-luna, not ipa-selinux-nfast or ipa-selinux-luna.
The name is defined in the spec file as %{module}-nfast and module=ipa.

Fixes: https://pagure.io/freeipa/issue/9636