### PR TITLE
[Backport][ipa-4-10] trust-add: handle unavailable domain

### DIFF
--- a/ipaserver/plugins/trust.py
+++ b/ipaserver/plugins/trust.py
@@ -40,6 +40,7 @@ from .baseldap import (
     LDAPObject,
     LDAPQuery)
 from .dns import dns_container_exists
+from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipapython.ipautil import realm_to_suffix
 from ipalib import api, Str, StrEnum, Password, Bool, _, ngettext, Int, Flag
@@ -969,7 +970,12 @@ ipa idrange-del before retrying the command with the desired range type.
             self.realm_admin,
             self.realm_passwd
         )
-        dom_sid = self.trustinstance.remote_domain.info['sid']
+
+        dom_sid = self.trustinstance.remote_domain.info.get('sid', None)
+        if dom_sid is None:
+            raise errors.RemoteRetrieveError(
+                reason=_('Unable to read domain information, check {}'
+                         ).format(paths.VAR_LOG_HTTPD_ERROR))
 
         if old_range:
             old_dom_sid = old_range['result']['ipanttrusteddomainsid'][0]

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -1067,8 +1067,13 @@ class TestTrust(BaseTestTrust):
                 raiseonerr=False,
                 stdin_text=self.master.config.ad_admin_password)
             assert result.returncode == 1
+            assert 'Unable to read domain information' in result.stderr_text
+            httpd_error_log = self.master.get_file_contents(
+                paths.VAR_LOG_HTTPD_ERROR,
+                encoding='utf-8'
+            )
             assert 'CIFS server communication error: code "3221225653", ' \
-                   'message "{Device Timeout}' in result.stderr_text
+                   'message "{Device Timeout}' in httpd_error_log
 
             # Check that trust is successfully established with --server option
             tasks.establish_trust_with_ad(


### PR DESCRIPTION
This PR was opened automatically because PR #7487 was pushed to master and backport to ipa-4-10 is required.