### PR TITLE
[Backport][ipa-4-12] HSM: fix the module name

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -277,9 +277,9 @@ def hsm_validator(token_name, token_library, token_password):
         # validate that the appropriate SELinux module is installed
         # Only warn in case the expected paths don't match.
         if 'nfast' in token_library:
-            module = 'ipa-selinux-nfast'
+            module = 'ipa-nfast'
         elif 'luna' in token_library:
-            module = 'ipa-selinux-luna'
+            module = 'ipa-luna'
         else:
             module = None
         if module:


### PR DESCRIPTION
This PR was opened automatically because PR #7491 was pushed to master and backport to ipa-4-12 is required.