### PR TITLE
[Backport][ipa-4-12] ipatests: Replace 'usermod -r' command with 'gpasswd -d' in test_hsm.py

### DIFF
--- a/ipatests/test_integration/test_hsm.py
+++ b/ipatests/test_integration/test_hsm.py
@@ -898,7 +898,7 @@ class TestHSMNegative(IntegrationTest):
              '--label', token_name]
         )
         self.master.run_command(
-            ['usermod', 'pkiuser', '-r', '-G', 'ods']
+            ['gpasswd', '-d', 'pkiuser', 'ods']
         )
         result = tasks.install_master(
             self.master, raiseonerr=False,


### PR DESCRIPTION
This PR was opened automatically because PR #7490 was pushed to master and backport to ipa-4-12 is required.