### PR TITLE
ipatests: refactor password file handling in TestHSMInstall

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1950,6 +1950,18 @@ jobs:
         timeout: 6300
         topology: *master_3repl_1client
 
+  fedora-latest/test_hsm_TestHSMInstallPasswordFile:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_hsm.py::TestHSMInstallPasswordFile
+        template: *ci-master-latest
+        timeout: 6300
+        topology: *master_1repl
+
   fedora-latest/test_hsm_TestHSMInstallADTrustBase:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -1119,6 +1119,20 @@ jobs:
         timeout: 6300
         topology: *master_3repl_1client
 
+  pki-fedora/test_hsm_TestHSMInstallPasswordFile:
+    requires: [pki-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{pki-fedora/build_url}'
+        update_packages: True
+        copr: '@pki/master'
+        test_suite: test_integration/test_hsm.py::TestHSMInstallPasswordFile
+        template: *ci-master-latest
+        timeout: 6300
+        topology: *master_1repl
+
   pki-fedora/test_hsm_TestHSMInstallADTrustBase:
     requires: [pki-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -2105,6 +2105,19 @@ jobs:
         timeout: 6300
         topology: *master_3repl_1client
 
+  fedora-latest/test_hsm_TestHSMInstallPasswordFile:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_hsm.py::TestHSMInstallPasswordFile
+        template: *ci-master-latest
+        timeout: 6300
+        topology: *master_1repl
+
   fedora-latest/test_hsm_TestHSMInstallADTrustBase:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -2261,6 +2261,20 @@ jobs:
         timeout: 6300
         topology: *master_3repl_1client
 
+  testing-fedora/test_hsm_TestHSMInstallPasswordFile:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_hsm.py::TestHSMInstallPasswordFile
+        template: *ci-master-latest
+        timeout: 6300
+        topology: *master_1repl
+
   testing-fedora/test_hsm_TestHSMInstallADTrustBase:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2416,6 +2416,21 @@ jobs:
         timeout: 6300
         topology: *master_3repl_1client
 
+  testing-fedora/test_hsm_TestHSMInstallPasswordFile:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_hsm.py::TestHSMInstallPasswordFile
+        template: *ci-master-latest
+        timeout: 6300
+        topology: *master_1repl
+
   testing-fedora/test_hsm_TestHSMInstallADTrustBase:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1950,6 +1950,18 @@ jobs:
         timeout: 6300
         topology: *master_3repl_1client
 
+  fedora-previous/test_hsm_TestHSMInstallPasswordFile:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_hsm.py::TestHSMInstallPasswordFile
+        template: *ci-master-previous
+        timeout: 6300
+        topology: *master_1repl
+
   fedora-previous/test_hsm_TestHSMInstallADTrustBase:
     requires: [fedora-previous/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -2105,6 +2105,19 @@ jobs:
         timeout: 6300
         topology: *master_3repl_1client
 
+  fedora-rawhide/test_hsm_TestHSMInstallPasswordFile:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_hsm.py::TestHSMInstallPasswordFile
+        template: *ci-master-frawhide
+        timeout: 6300
+        topology: *master_1repl
+
   fedora-rawhide/test_hsm_TestHSMInstallADTrustBase:
     requires: [fedora-rawhide/build]
     priority: 50


### PR DESCRIPTION
 When token and associated certs are not being cleaned
up properly, the subsequent installation fails. Hence
Password file related scenarios moved out to new test class
so that it have fresh installation.
    
Signed-off-by: Mohammad Rizwan <myusuf@redhat.com>