### PR TITLE
[Backport][ipa-4-12] ipatests: Check Default PAC type is added to config

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1190,6 +1190,21 @@ class TestInstallMaster(IntegrationTest):
                 expected_stdout=f'href="https://{self.master.hostname}/'
             )
 
+    def test_pac_configuration_enabled(self):
+        """
+        This testcase checks that the default PAC type
+        is added to configuration.
+        """
+        base_dn = str(self.master.domain.basedn)
+        dn = DN(
+            ("cn", "ipaConfig"),
+            ("cn", "etc"),
+            base_dn
+        )
+        result = tasks.ldapsearch_dm(self.master, str(dn),
+                                     ["ipaKrbAuthzData"])
+        assert 'ipaKrbAuthzData: MS-PAC' in result.stdout_text
+
     def test_hostname_parameter(self, server_cleanup):
         """
         Test that --hostname parameter is respected in interactive mode.


### PR DESCRIPTION
This PR was opened automatically because PR #7502 was pushed to master and backport to ipa-4-12 is required.