### PR TITLE
ipatests: Update ipa-adtrust-install test with wait for SSSD to be online

### DIFF
--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -853,6 +853,8 @@ class TestIpaAdTrustInstall(IntegrationTest):
              self.master.config.admin_password,
              "-U"]
         )
+        # Wait for SSSD to become online before doing any other check
+        tasks.wait_for_sssd_domain_status_online(self.master)
         self.master.run_command(["mkdir", "/freeipa4234"])
         self.master.run_command(
             ["chcon", "-t", "samba_share_t",


### PR DESCRIPTION
update test_user_connects_smb_share_if_locked_specific_group with wait for SSSD to be online after ipa-adtrust-install command

after `ipa-adtrust-install` command some time is needed for everything to settle down, before SSSD is back online
this issue was causing failures in test_adtrust_install.py testsuite, missing some ipausers and groups in test

Related: https://pagure.io/freeipa/issue/9655 