### PR TITLE
[Backport][ipa-4-12] ipatests: Add missing comma in test_idrange_no_rid_bases_reversed

### DIFF
--- a/ipatests/test_integration/test_ipa_idrange_fix.py
+++ b/ipatests/test_integration/test_ipa_idrange_fix.py
@@ -72,7 +72,7 @@ class TestIpaIdrangeFix(IntegrationTest):
             "idrange_reversed",
             "--base-id", '50000',
             "--range-size", '20000',
-            "--rid-base", '100300000'
+            "--rid-base", '100300000',
             "--secondary-rid-base", '301000'
         ])
 


### PR DESCRIPTION
The test is calling ipa idrange-add but is missing a comma in the arguments list.
The resulting call is using "--rid-base 100300000--secondary-rid-base". Add the missing comma to build the command with
"--rid-base 100300000 --secondary-rid-base"

Fixes: https://pagure.io/freeipa/issue/9656