### PR TITLE
[Backport][ipa-4-11] ipatests: Update ipa-adtrust-install test with wait for SSSD to be online

### DIFF
--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -853,6 +853,8 @@ class TestIpaAdTrustInstall(IntegrationTest):
              self.master.config.admin_password,
              "-U"]
         )
+        # Wait for SSSD to become online before doing any other check
+        tasks.wait_for_sssd_domain_status_online(self.master)
         self.master.run_command(["mkdir", "/freeipa4234"])
         self.master.run_command(
             ["chcon", "-t", "samba_share_t",


### PR DESCRIPTION
This PR was opened automatically because PR #7511 was pushed to master and backport to ipa-4-11 is required.