### PR TITLE
[ipa-4-9] Fix lint

### DIFF
--- a/.wheelconstraints.in
+++ b/.wheelconstraints.in
@@ -14,5 +14,6 @@ ipatests == @VERSION@
 # https://pagure.io/freeipa/issue/8818 added pylint 2.8 support
 pylint ~= 2.12.2
 netaddr == 0.8.0
+setuptools == 70.2.0
 # f37 and f38 have python-cryptography 37.0.2
 cryptography == 37.0.2


### PR DESCRIPTION
pylint: use setuptools 70.2.0 on ipa-4-9 branch

pylint started detecting issues with more recent version of setuptools.
Pin the version to 70.2.0 to avoid false positives.

Fixes: https://pagure.io/freeipa/issue/9659