### PR TITLE
ipa-migrate - fix alternate entry search filter

### DIFF
--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -1486,13 +1486,13 @@ class IPAMigrate():
         # For entries with alternate identifying needs we need to rebuild the
         # local dn. Typically this is for entries that use ipaUniqueId as the
         # RDN attr
-        if 'alt_id' in DB_OBJECTS[entry_type]:
+        if entry_type != "custom" and 'alt_id' in DB_OBJECTS[entry_type]:
             attr = DB_OBJECTS[entry_type]['alt_id']['attr']
             base = DB_OBJECTS[entry_type]['alt_id']['base']
-            srch_filter = f'{attr}={entry_attrs[attr][0]}'
+            srch_filter = f'({attr}={entry_attrs[attr][0]})'
             if DB_OBJECTS[entry_type]['alt_id']['isDN'] is True:
                 # Convert the filter to match the local suffix
-                srch_filter = self.replace_suffix(srch_filter)
+                srch_filter = self.replace_suffix_value(srch_filter)
             srch_base = base + str(self.local_suffix)
 
             try:
@@ -1539,14 +1539,20 @@ class IPAMigrate():
 
             if self.dryrun:
                 self.write_update_to_ldif(local_entry)
-                DB_OBJECTS[entry_type]['count'] += 1
+                if entry_type == "custom":
+                    stats['custom'] += 1
+                else:
+                    DB_OBJECTS[entry_type]['count'] += 1
                 stats['total_db_migrated'] += 1
                 return
 
             # Update the local entry
             try:
                 self.local_conn.update_entry(local_entry)
-                DB_OBJECTS[entry_type]['count'] += 1
+                if entry_type == "custom":
+                    stats['custom'] += 1
+                else:
+                    DB_OBJECTS[entry_type]['count'] += 1
             except errors.ExecutionError as e:
                 self.log_error(f'Failed to update "{local_dn}" error: '
                                f'{str(e)}')

--- a/ipatests/test_integration/test_ipa_ipa_migration.py
+++ b/ipatests/test_integration/test_ipa_ipa_migration.py
@@ -610,7 +610,7 @@ class TestIPAMigrateScenario1(IntegrationTest):
         MIGRATION_SCHEMA_LOG_MSG = "Migrating schema ...\n"
         MIGRATION_CONFIG_LOG_MSG = "Migrating configuration ...\n"
         IPA_UPGRADE_LOG_MSG = (
-            "Running ipa-server-upgrade ... (this make take a while)\n"
+            "Running ipa-server-upgrade ... (this may take a while)\n"
         )
         SIDGEN_TASK_LOG_MSG = "Running SIDGEN task ...\n"
         MIGRATION_COMPLETE_LOG_MSG = "Migration complete!\n"
@@ -641,10 +641,10 @@ class TestIPAMigrateScenario1(IntegrationTest):
         tasks.kinit_admin(self.replicas[0])
         MIGRATION_SCHEMA_LOG_MSG = "Migrating schema ...\n"
         MIGRATION_DATABASE_LOG_MSG = (
-            "Migrating database ... (this make take a while)\n"
+            "Migrating database ... (this may take a while)\n"
         )
         IPA_UPGRADE_LOG_MSG = (
-            "Running ipa-server-upgrade ... (this make take a while)\n"
+            "Running ipa-server-upgrade ... (this may take a while)\n"
         )
         SIDGEN_TASK_LOG_MSG = "Running SIDGEN task ...\n"
         result = run_migrate(


### PR DESCRIPTION
Processing a filter like a DN can cause normalization issues that result in an invalid filter. Make sure the filter is encapsulated with parenthesis and we call replace_suffix_value() instead of replace_suffix()

Fixes: https://pagure.io/freeipa/issue/9658