### PR TITLE
[Backport][ipa-4-11] Installer: activate ssh service in sssd.conf

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -973,6 +973,8 @@ def configure_sssd_conf(
 
     sssd_enable_service(sssdconfig, 'nss')
     sssd_enable_service(sssdconfig, 'pam')
+    if options.conf_ssh:
+        sssd_enable_service(sssdconfig, 'ssh')
 
     domain.set_option('ipa_domain', cli_domain)
     domain.set_option('ipa_hostname', client_hostname)


### PR DESCRIPTION
This PR was opened automatically because PR #7492 was pushed to master and backport to ipa-4-11 is required.