### PR TITLE
ipatests: Update ipatests to test topology with multiple domain.

### DIFF
--- a/ipatests/pytest_ipa/integration/config.py
+++ b/ipatests/pytest_ipa/integration/config.py
@@ -88,13 +88,19 @@ class Config(pytest_multihost.config.Config):
     def ad_domains(self):
         return [d for d in self.domains if d.is_ad_type]
 
+    @property
+    def trusted_domains(self):
+        return [d for d in self.domains if d.is_trusted_ipa_type]
+
     def get_all_hosts(self):
         for domain in self.domains:
             for host in domain.hosts:
                 yield host
 
     def get_all_ipa_hosts(self):
-        for ipa_domain in (d for d in self.domains if d.is_ipa_type):
+        for ipa_domain in (d for d in self.domains
+                           if d.is_ipa_type or d.is_trusted_ipa_type
+                           ):
             for ipa_host in ipa_domain.hosts:
                 yield ipa_host
 
@@ -135,13 +141,17 @@ class Domain(pytest_multihost.config.Domain):
         self.name = str(name)
         self.hosts = []
 
-        assert self.is_ipa_type or self.is_ad_type
+        assert self.is_ipa_type or self.is_ad_type or self.is_trusted_ipa_type
         self.realm = self.name.upper()
         self.basedn = DN(*(('dc', p) for p in name.split('.')))
 
     @property
     def is_ipa_type(self):
         return self.type == 'IPA'
+
+    @property
+    def is_trusted_ipa_type(self):
+        return self.type == 'TRUSTED_IPA'
 
     @property
     def is_ad_type(self):
@@ -158,6 +168,8 @@ class Domain(pytest_multihost.config.Domain):
             return ('ad_subdomain',)
         elif self.type == 'AD_TREEDOMAIN':
             return ('ad_treedomain',)
+        elif self.type == 'TRUSTED_IPA':
+            return ('trusted_master', 'trusted_replica', 'trusted_client')
         else:
             raise LookupError(self.type)
 
@@ -168,12 +180,18 @@ class Domain(pytest_multihost.config.Domain):
             return Host
         elif self.is_ad_type:
             return WinHost
+        elif self.is_trusted_ipa_type:
+            return Host
         else:
             raise LookupError(self.type)
 
     @property
     def master(self):
         return self.host_by_role('master')
+
+    @property
+    def trusted_master(self):
+        return self.host_by_role('trusted_master')
 
     @property
     def masters(self):
@@ -184,7 +202,15 @@ class Domain(pytest_multihost.config.Domain):
         return self.hosts_by_role('replica')
 
     @property
+    def trusted_replicas(self):
+        return self.hosts_by_role('replica')
+
+    @property
     def clients(self):
+        return self.hosts_by_role('client')
+
+    @property
+    def trusted_clients(self):
         return self.hosts_by_role('client')
 
     @property

--- a/ipatests/test_integration/test_multidomain_ipa.py
+++ b/ipatests/test_integration/test_multidomain_ipa.py
@@ -1,0 +1,54 @@
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import MultiDomainIntegrationTest
+
+
+class TestMultidomain(MultiDomainIntegrationTest):
+    num_clients = 1
+    num_replicas = 1
+    num_trusted_clients = 1
+    num_trusted_replicas = 1
+    topology = 'line'
+
+    def test_multidomain_trust(self):
+        """
+        Test services on multidomain topology.
+        """
+
+        for host in (self.master, self.replicas[0],
+                     self.trusted_master, self.trusted_replicas[0]
+                     ):
+            tasks.start_ipa_server(host)
+
+        for host in (self.master, self.trusted_master):
+            tasks.disable_dnssec_validation(host)
+            tasks.restart_named(host)
+
+        for host in (self.master, self.replicas[0],
+                     self.trusted_master, self.trusted_replicas[0],
+                     self.clients[0], self.trusted_clients[0]
+                     ):
+            tasks.kinit_admin(host)
+
+        # Add DNS forwarder to trusted domain on ipa domain
+        self.master.run_command([
+            "ipa", "dnsforwardzone-add", self.trusted_master.domain.name,
+            "--forwarder", self.trusted_master.ip,
+            "--forward-policy=only"
+        ])
+        self.trusted_master.run_command([
+            "ipa", "dnsforwardzone-add", self.master.domain.name,
+            "--forwarder", self.master.ip,
+            "--forward-policy=only"
+        ])
+
+        tasks.install_adtrust(self.master)
+        tasks.install_adtrust(self.trusted_master)
+
+        #  Establish trust
+        # self.master.run_command([
+        #     "ipa", "trust-add", "--type=ipa",
+        #     "--admin", "admin@{}".format(self.trusted_master.domain.realm),
+        #     "--range-type=ipa-ad-trust-posix",
+        #     "--password", "--two-way=true",
+        #     self.trusted_master.domain.name
+        # ], stdin_text=self.trusted_master.config.admin_password)

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -566,6 +566,7 @@ AstroidBuilder(MANAGER).string_build(
     textwrap.dedent(
         """\
     from ipatests.test_integration.base import IntegrationTest
+    from ipatests.test_integration.base import MultiDomainIntegrationTest
     from ipatests.pytest_ipa.integration.host import Host, WinHost
     from ipatests.pytest_ipa.integration.config import Config, Domain
 
@@ -584,6 +585,9 @@ AstroidBuilder(MANAGER).string_build(
         def __getitem__(self, key):
             return Domain()
 
+    class PylintTrustedDomains:
+        def __getitem__(self, key):
+            return Domain()
 
     Host.config = Config()
     Host.domain = Domain()
@@ -596,6 +600,14 @@ AstroidBuilder(MANAGER).string_build(
     IntegrationTest.ad_treedomains = PylintWinHosts()
     IntegrationTest.ad_subdomains = PylintWinHosts()
     IntegrationTest.ad_domains = PylintADDomains()
+    MultiDomainIntegrationTest.domain = Domain()
+    MultiDomainIntegrationTest.master = Host()
+    MultiDomainIntegrationTest.replicas = PylintIPAHosts()
+    MultiDomainIntegrationTest.clients = PylintIPAHosts()
+    MultiDomainIntegrationTest.trusted_master = Host()
+    MultiDomainIntegrationTest.trusted_replicas = PylintIPAHosts()
+    MultiDomainIntegrationTest.trusted_clients = PylintIPAHosts()
+    MultiDomainIntegrationTest.trusted_domains = PylintTrustedDomains()
     """
     )
 )


### PR DESCRIPTION
Added changes in ipatests so that ipa server-replica-client can be installed with two domain - ipa.test and trustedipa.test

Related: https://pagure.io/freeipa/issue/9657