### PR TITLE
[Backport][ipa-4-12] ipa-migrate - fix alternate entry search filter

### DIFF
--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -1490,10 +1490,10 @@ class IPAMigrate():
         if entry_type != "custom" and 'alt_id' in DB_OBJECTS[entry_type]:
             attr = DB_OBJECTS[entry_type]['alt_id']['attr']
             base = DB_OBJECTS[entry_type]['alt_id']['base']
-            srch_filter = f'{attr}={entry_attrs[attr][0]}'
+            srch_filter = f'({attr}={entry_attrs[attr][0]})'
             if DB_OBJECTS[entry_type]['alt_id']['isDN'] is True:
                 # Convert the filter to match the local suffix
-                srch_filter = self.replace_suffix(srch_filter)
+                srch_filter = self.replace_suffix_value(srch_filter)
             srch_base = base + str(self.local_suffix)
 
             try:

--- a/ipatests/test_integration/test_ipa_ipa_migration.py
+++ b/ipatests/test_integration/test_ipa_ipa_migration.py
@@ -610,7 +610,7 @@ class TestIPAMigrateScenario1(IntegrationTest):
         MIGRATION_SCHEMA_LOG_MSG = "Migrating schema ...\n"
         MIGRATION_CONFIG_LOG_MSG = "Migrating configuration ...\n"
         IPA_UPGRADE_LOG_MSG = (
-            "Running ipa-server-upgrade ... (this make take a while)\n"
+            "Running ipa-server-upgrade ... (this may take a while)\n"
         )
         SIDGEN_TASK_LOG_MSG = "Running SIDGEN task ...\n"
         MIGRATION_COMPLETE_LOG_MSG = "Migration complete!\n"
@@ -641,10 +641,10 @@ class TestIPAMigrateScenario1(IntegrationTest):
         tasks.kinit_admin(self.replicas[0])
         MIGRATION_SCHEMA_LOG_MSG = "Migrating schema ...\n"
         MIGRATION_DATABASE_LOG_MSG = (
-            "Migrating database ... (this make take a while)\n"
+            "Migrating database ... (this may take a while)\n"
         )
         IPA_UPGRADE_LOG_MSG = (
-            "Running ipa-server-upgrade ... (this make take a while)\n"
+            "Running ipa-server-upgrade ... (this may take a while)\n"
         )
         SIDGEN_TASK_LOG_MSG = "Running SIDGEN task ...\n"
         result = run_migrate(


### PR DESCRIPTION
This PR was opened automatically because PR #7525 was pushed to master and backport to ipa-4-12 is required.