### PR TITLE
Change default to RSN when 389-ds uses the mdb backend

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -127,6 +127,10 @@
 # version supporting LMDB and lib389.cli_ctl.dblib.run_dbscan utility
 %if 0%{?fedora} < 34
 %global ds_version 1.4.4.16-1
+%elif 0%{?fedora} == 40
+%global ds_version 3.0.4-3
+%elif 0%{?fedora} >= 41
+%global ds_version 3.1.1-3
 %else
 %global ds_version 2.1.0
 %endif

--- a/install/tools/ipa-ca-install.in
+++ b/install/tools/ipa-ca-install.in
@@ -301,7 +301,11 @@ def install(safe_options, options):
             install_master(safe_options, options)
         else:
             if options.random_serial_numbers:
-                if ca.lookup_random_serial_number_version(api) == 0:
+                ldap_backend = cainstance.lookup_ldap_backend(api)
+                if (
+                    ca.lookup_random_serial_number_version(api) == 0
+                    and ldap_backend == "bdb"
+                ):
                     sys.exit(
                         "\nRandom serial numbers cannot be enabled in an "
                         "existing CA installation.\n")

--- a/install/tools/man/ipa-ca-install.1
+++ b/install/tools/man/ipa-ca-install.1
@@ -83,7 +83,7 @@ Signing algorithm of the IPA CA certificate. Possible values are SHA1withRSA, SH
 Do not use DNS for hostname lookup during installation
 .TP
 \fB\-\-random\-serial\-numbers\fR
-Enable Random Serial Numbers. Random serial numbers cannot be used in a mixed environment. Either all CA's have it enabled or none do.
+Enable Random Serial Numbers (RSN) and certificate pruning. This option is enabled by default if the system is installed with a 389-ds version that supports LMDB or if another CA in the topology is configured with Random Serial Numbers. This option remains present to avoid issues with automation. In mixed environments where existing CA servers are configured with sequential numbers, it is recommended to replace the sequential servers as soon as reasonably possible.
 .TP
 \fB\-\-token\-name\fR=\fITOKEN_NAME\fR
 The PKCS#11 token name if using an HSM to store and generate private keys.

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -126,7 +126,7 @@ If no template is specified, the template name "SubCA" is used.
 File containing the IPA CA certificate and the external CA certificate chain. The file is accepted in PEM and DER certificate and PKCS#7 certificate chain formats. This option may be used multiple times.
 .TP
 \fB\-\-random\-serial\-numbers\fR
-Enable Random Serial Numbers. Random serial numbers cannot be used in a mixed environment. Either all CA's have it enabled or none do.
+Enable Random Serial Numbers (RSN) and certificate pruning. This option is enabled by default if the system is installed with a 389-ds version that supports LMDB or if another CA in the topology is configured with Random Serial Numbers. This option remains present to avoid issues with automation. In mixed environments where existing CA servers are configured with sequential numbers, it is recommended to replace the sequential servers as soon as reasonably possible.
 .TP
 \fB\-\-no\-pkinit\fR
 Disables pkinit setup steps.

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -471,6 +471,8 @@ class CAInstance(DogtagInstance):
             self.step(
                 "Ensuring backward compatibility",
                 self.__dogtag10_migration)
+            if self.random_serial_numbers:
+                self.step("enable certificate pruning", self.enable_pruning)
             if promote:
                 self.step("destroying installation admin user",
                           self.teardown_admin)
@@ -789,6 +791,17 @@ class CAInstance(DogtagInstance):
         directivesetter.set_directive(paths.SYSCONFIG_PKI_TOMCAT,
                                    'NSS_ENABLE_PKIX_VERIFY', '1',
                                    quotes=False, separator='=')
+
+    def enable_pruning(self):
+        directivesetter.set_directive(paths.CA_CS_CFG_PATH,
+                                      'jobsScheduler.enabled', 'true',
+                                      quotes=False, separator='=')
+        directivesetter.set_directive(paths.CA_CS_CFG_PATH,
+                                      'jobsScheduler.job.pruning.enabled',
+                                      'true', quotes=False, separator='=')
+        directivesetter.set_directive(paths.CA_CS_CFG_PATH,
+                                      'jobsScheduler.job.pruning.owner',
+                                      'ipara', quotes=False, separator='=')
 
     def __import_ra_cert(self):
         """

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1897,9 +1897,11 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+        test_suite: >-
+            test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+            test_integration/test_random_serial_numbers.py::TestInstall_RSN_MDB
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   fedora-latest/test_random_serial_numbers_TestRSNPKIConfig:

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -1072,9 +1072,11 @@ jobs:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
         copr: '@pki/master'
-        test_suite: test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+        test_suite: >-
+            test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+            test_integration/test_random_serial_numbers.py::TestInstall_RSN_MDB
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   pki-fedora/test_random_serial_numbers_TestRSNPKIConfig:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -2048,9 +2048,11 @@ jobs:
       args:
         build_url: '{fedora-latest/build_url}'
         selinux_enforcing: True
-        test_suite: test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+        test_suite: >-
+            test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+            test_integration/test_random_serial_numbers.py::TestInstall_RSN_MDB
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   fedora-latest/test_random_serial_numbers_TestRSNPKIConfig:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -2200,9 +2200,11 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         enable_testing_repo: True
-        test_suite: test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+        test_suite: >-
+            test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+            test_integration/test_random_serial_numbers.py::TestInstall_RSN_MDB
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   testing-fedora/test_random_serial_numbers_TestRSNPKIConfig:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2351,9 +2351,11 @@ jobs:
         update_packages: True
         selinux_enforcing: True
         enable_testing_repo: True
-        test_suite: test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+        test_suite: >-
+            test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+            test_integration/test_random_serial_numbers.py::TestInstall_RSN_MDB
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   testing-fedora/test_random_serial_numbers_TestRSNPKIConfig:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1897,9 +1897,11 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-previous/build_url}'
-        test_suite: test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+        test_suite: >-
+            test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+            test_integration/test_random_serial_numbers.py::TestInstall_RSN_MDB
         template: *ci-master-previous
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   fedora-previous/test_random_serial_numbers_TestRSNPKIConfig:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -2048,9 +2048,11 @@ jobs:
       args:
         build_url: '{fedora-rawhide/build_url}'
         update_packages: True
-        test_suite: test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+        test_suite: >-
+            test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
+            test_integration/test_random_serial_numbers.py::TestInstall_RSN_MDB
         template: *ci-master-frawhide
-        timeout: 5400
+        timeout: 7200
         topology: *master_1repl
 
   fedora-rawhide/test_random_serial_numbers_TestRSNPKIConfig:

--- a/ipatests/test_integration/test_random_serial_numbers.py
+++ b/ipatests/test_integration/test_random_serial_numbers.py
@@ -3,10 +3,12 @@
 #
 
 import pytest
+import textwrap
 
 from ipaplatform.paths import paths
 
 from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
 from ipatests.test_integration.test_installation import (
     TestInstallWithCA_DNS1,
     TestInstallWithCA_KRA1,
@@ -119,3 +121,72 @@ class TestRSNVault(TestInstallKRA):
         if not pki_supports_RSNv3(mh.master):
             raise pytest.skip("RSNv3 not supported")
         super(TestRSNVault, cls).install(mh)
+
+
+class TestInstall_RSN_MDB(IntegrationTest):
+    """
+    Test installation when the 389-ds mdb backend is used. This has
+    poor performance for VLV compared to the older bdb backend so
+    RSN will be required.
+    """
+    num_replicas = 1
+
+    def disable_rsn(self):
+        """Mark RSN as disabled in the topology by setting
+           ipaCaRandomSerialNumberVersion to 0.
+        """
+        entry_ldif = textwrap.dedent("""
+            dn: cn=ipa,cn=cas,cn=ca,{base_dn}
+            changetype: modify
+            replace: ipaCaRandomSerialNumberVersion
+            ipaCaRandomSerialNumberVersion: 0
+        """).format(base_dn=str(self.master.domain.basedn))
+        tasks.ldapmodify_dm(self.master, entry_ldif)
+
+    def check_rsn_status(self, host):
+        """Verify that RSN is enabled on a host"""
+        base_dn = str(host.domain.basedn)
+        result = tasks.ldapsearch_dm(
+            host,
+            'cn=ipa,cn=cas,cn=ca,{base_dn}'.format(
+                base_dn=base_dn),
+            ['ipacarandomserialnumberversion',],
+            scope='base'
+        )
+        output = result.stdout_text.lower()
+        assert 'ipacarandomserialnumberversion: 3' in output
+
+        cs_cfg = host.get_file_contents(paths.CA_CS_CFG_PATH)
+        assert "dbs.cert.id.generator=random".encode() in cs_cfg
+
+    @classmethod
+    def install(cls, mh):
+        if not pki_supports_RSNv3(mh.master):
+            raise pytest.skip("RNSv3 not supported")
+        result = cls.replicas[0].run_command(
+            "python -c 'from lib389.utils import get_default_db_lib; "
+            "print(get_default_db_lib())'"
+        )
+        if 'mdb' not in result.stdout_text:
+            raise pytest.skip("MDB not supported")
+        tasks.install_master(cls.master, setup_dns=True)
+
+    def test_replica_install(self):
+        self.disable_rsn()
+        tasks.install_replica(
+            self.master, self.replicas[0], setup_ca=True)
+        self.check_rsn_status(self.replicas[0])
+        tasks.run_server_del(
+            self.master, self.replicas[0].hostname, force=True,
+            ignore_topology_disconnect=True, ignore_last_of_role=True)
+        tasks.uninstall_replica(
+            master=self.master,
+            replica=self.replicas[0]
+        )
+
+    def test_replica_install_noca(self):
+        self.disable_rsn()
+        tasks.install_replica(
+            self.master, self.replicas[0], setup_ca=False)
+        tasks.install_ca(self.replicas[0])
+        self.check_rsn_status(self.replicas[0])

--- a/ipatests/test_xmlrpc/tracker/ca_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/ca_plugin.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 import six
+from lib389.utils import get_default_db_lib
 
 from ipapython.dn import DN
 from ipatests.test_xmlrpc.tracker.base import Tracker, EnableTracker
@@ -83,7 +84,10 @@ class CATracker(Tracker, EnableTracker):
             objectclass=objectclasses.ca
         )
         if self.description == 'IPA CA':
-            self.attrs['ipacarandomserialnumberversion'] = ('0',)
+            if get_default_db_lib() == 'bdb':
+                self.attrs['ipacarandomserialnumberversion'] = ('0',)
+            else:
+                self.attrs['ipacarandomserialnumberversion'] = ('3',)
         self.exists = True
 
     def make_disable_command(self):


### PR DESCRIPTION
The lmdb performance for VLV indexes is not great so the PKI team recommended we switch from sequential serial numbers to Random Serial Numbers (RSN).

The first time a non-bdb backend (future-proofing) is installed then the replication RSN configuration value is stored. All future replica installs will use RSN.

We have no way of enforcing ONLY to have RSN so it will be up to administrators to retire sequential CAs.

Fixes: https://pagure.io/freeipa/issue/9661