### PR TITLE
azure tests: move to fedora 40

### DIFF
--- a/ipapython/ipautil.py
+++ b/ipapython/ipautil.py
@@ -119,7 +119,7 @@ class UnsafeIPAddress(netaddr.IPAddress):
                 if addr.version != 6:
                     raise
         except ValueError:
-            self._net = netaddr.IPNetwork(addr, flags=self.netaddr_ip_flags)
+            self._net = netaddr.IPNetwork(addr, flags=0)
             addr = self._net.ip
         super(UnsafeIPAddress, self).__init__(addr,
                                               flags=self.netaddr_ip_flags)

--- a/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
+++ b/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-toolbox:39
+FROM registry.fedoraproject.org/fedora-toolbox:40
 MAINTAINER [FreeIPA Developers freeipa-devel@lists.fedorahosted.org]
 ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 

--- a/ipatests/azure/templates/setup-test-environment.yml
+++ b/ipatests/azure/templates/setup-test-environment.yml
@@ -17,13 +17,13 @@ steps:
     sudo modprobe {nfs,nfsd}
   displayName: Configure NFS to allow NFS server/client within containers
 
-- task: DownloadPipelineArtifact@0
+- task: DownloadPipelineArtifact@2
   displayName: Download prebuilt packages '$(IPA_PACKAGES_ARTIFACT)'
   inputs:
     artifactName: $(IPA_PACKAGES_ARTIFACT)
     targetPath: $(Build.Repository.LocalPath)/dist
 
-- task: DownloadPipelineArtifact@0
+- task: DownloadPipelineArtifact@2
   displayName: Download pre-built container '$(IPA_IMAGE_ARTIFACT)'
   inputs:
     artifactName: $(IPA_IMAGE_ARTIFACT)

--- a/ipatests/azure/templates/variables-fedora.yml
+++ b/ipatests/azure/templates/variables-fedora.yml
@@ -1,7 +1,7 @@
 variables:
   IPA_PLATFORM: fedora
   # the Docker public image to build IPA packages (rpms)
-  DOCKER_BUILD_IMAGE: 'registry.fedoraproject.org/fedora-toolbox:39'
+  DOCKER_BUILD_IMAGE: 'registry.fedoraproject.org/fedora-toolbox:40'
 
   # the Dockerfile to build Docker image for running IPA tests
   DOCKER_DOCKERFILE: ${{ format('Dockerfile.build.{0}', variables.IPA_PLATFORM) }}


### PR DESCRIPTION
Fedora 39 is approaching its EOL (2024-11-12),
move azure tests to fedora 40