### PR TITLE
[Backport][ipa-4-12] man: fix a couple of instances of the "no-break control character" being used inadvertently

### DIFF
--- a/client/man/ipa-client-install.1
+++ b/client/man/ipa-client-install.1
@@ -240,8 +240,8 @@ for more information. The option is mutually exclusive with
 \fB\-\-pkinit\-anchor\fR=\fIFILEDIR\fR
 Trust anchors (root and intermediate CA certs) for PKINIT. \fIFILEDIR\fR is
 either the absolute path to a PEM bundle (for example
-'FILE:/etc/pki/tls/cert.pem') or to an OpenSSL hash directory (for example
-'DIR:/etc/ssl/certs/'). The option can be used multiple times. PKINIT
+\fIFILE:/etc/pki/tls/cert.pem\fR) or to an OpenSSL hash directory (for example
+\fIDIR:/etc/ssl/certs/\fR). The option can be used multiple times. PKINIT
 requires the full trust chain of the Kerberos KDC server as well as the full
 trust chain of the identity certificate.
 

--- a/client/man/ipa.1
+++ b/client/man/ipa.1
@@ -176,11 +176,11 @@ journal as journald records execution context. See systemd.journal\-fields(7)
 for details.
 
 The details of the individual logged messages can be explained with the help of
-'\fBjournalctl -x\fR' command, while full set of logged properties can be
-retrieved with '\fBjournalctl -o json-pretty\fR'. See journalctl(1) for details
+\fBjournalctl -x\fR command, while full set of logged properties can be
+retrieved with \fBjournalctl -o json-pretty\fR. See journalctl(1) for details
 on the systemd journal viewer.
 
-For the sample message above, an explanation could be requested with '\fBjournalctl -x -g ldap2_140328582446688\fR' where LDAP backend connection instance identifier can be used to uniquely fetch that individual message.
+For the sample message above, an explanation could be requested with \fBjournalctl -x -g ldap2_140328582446688\fR where LDAP backend connection instance identifier can be used to uniquely fetch that individual message.
 
 .SH "EXAMPLES"
 .TP


### PR DESCRIPTION
This PR was opened automatically because PR #7539 was pushed to master and backport to ipa-4-12 is required.