### PR TITLE
test_ipahealthcheck: skip connectivity_and_data check

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1219,6 +1219,9 @@ class TestIpaHealthCheck(IntegrationTest):
         This testcase checks that when ClonesConnectivyAndDataCheck
         is run it doesn't display source not found error
         """
+        if (tasks.get_pki_version(
+                self.master) >= tasks.parse_version('11.5.5')):
+            raise pytest.skip("PKI dropped ClonesConnectivyAndDataCheck")
         error_msg = (
             "Source 'pki.server.healthcheck.clones.connectivity_and_data' "
             "not found"


### PR DESCRIPTION
PKI removed the clones.check connectivity_and_data check in
11.5 and master branches. Skip the test depending on PKI version.
The most recent version on 11.5 is 11.5.4 and still contains the check,
hence skipping if version >= 11.5.5.

Fixes: https://pagure.io/freeipa/issue/9668