### PR TITLE
Remove overidden functions in ipaplatform/suse

### DIFF
--- a/ipaplatform/suse/tasks.py
+++ b/ipaplatform/suse/tasks.py
@@ -18,12 +18,6 @@ logger = logging.getLogger(__name__)
 
 
 class SuseTaskNamespace(RedHatTaskNamespace):
-    def restore_context(self, filepath, force=False):
-        pass  # FIXME: Implement after libexec move
-
-    def check_selinux_status(self, restorecon=paths.RESTORECON):
-        pass  # FIXME: Implement after libexec move
-
     def set_nisdomain(self, nisdomain):
         nis_variable = "NETCONFIG_NIS_STATIC_DOMAIN"
         try:
@@ -40,9 +34,6 @@ class SuseTaskNamespace(RedHatTaskNamespace):
 
         with open(paths.SYSCONF_NETWORK, "w") as f:
             f.writelines(content)
-
-    def set_selinux_booleans(self, required_settings, backup_func=None):
-        return False  # FIXME: Implement after libexec move
 
     def modify_nsswitch_pam_stack(self, sssd, mkhomedir, statestore,
                                   sudo=True, subid=False):


### PR DESCRIPTION
Running the freeipa ansible module against openSUSE MicroOS returns the following error:

`argument 'selinux_works' is of type <class 'str'> and we were unable to convert to bool: The value '' is not a valid boolean.  Valid booleans include: '1', 1, 0, 'false', 'yes', 'true', 'off', 'n', 'y', 't', '0', 'no', 'on', 'f'"`

Issue arises from functions in SuseTaskNamespace overriding the following functions from RedHatTaskNamespace
- restore_context
- check_selinux_status
- set_selinux_booleans

Each function was simply a 'pass' resulting in an empty string being returned to 'selinux_works'

SELinux on openSUSE is configured similarly enough to Red Hat distros that these empty overrides are not needed.

Tested on MicroOS