### PR TITLE
ipatests: Fixes for ipa-idrange-fix testsuite

### DIFF
--- a/ipatests/test_integration/test_ipa_idrange_fix.py
+++ b/ipatests/test_integration/test_ipa_idrange_fix.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 
 class TestIpaIdrangeFix(IntegrationTest):
+
+    topology = 'line'
+
     @classmethod
     def install(cls, mh):
         super(TestIpaIdrangeFix, cls).install(mh)


### PR DESCRIPTION
This patch adds the line tasks.install_master(cls.master).  The kinit admin command fails with the below error as the
IPA is not configured on the test system.
'ipa: ERROR: stderr: kinit: Configuration file does not specify default  realm when parsing name admin'
