### PR TITLE
selinux: allow Cockpit to use HTTP keytab on IPA servers

### DIFF
--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1124,6 +1124,7 @@ def update_http_keytab(http):
                 paths.OLD_IPA_KEYTAB, e
             )
     http.keytab_user.chown(http.keytab)
+    tasks.restore_context(http.keytab)
 
 
 def ds_enable_sidgen_extdom_plugins(ds):

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -2117,3 +2117,15 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
+
+  fedora-latest/test_cockpit:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_cockpit.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -2286,3 +2286,16 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
+
+  fedora-latest/test_cockpit:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_cockpit.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -2456,3 +2456,17 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
+
+  testing-fedora/test_cockpit:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_cockpit.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2625,3 +2625,18 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client
+
+  testing-fedora/test_cockpit:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_cockpit.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -2117,3 +2117,15 @@ jobs:
         template: *ci-master-previous
         timeout: 3600
         topology: *master_1repl_1client
+
+  fedora-previous/test_cockpit:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_cockpit.py
+        template: *ci-master-previous
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -2286,3 +2286,16 @@ jobs:
         template: *ci-master-frawhide
         timeout: 3600
         topology: *master_1repl_1client
+
+  fedora-rawhide/test_cockpit:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_cockpit.py
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/test_integration/test_cockpit.py
+++ b/ipatests/test_integration/test_cockpit.py
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+from __future__ import absolute_import
+
+import time
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+from ipaplatform.paths import paths
+
+
+class TestCockpitIntegration(IntegrationTest):
+    topology = "line"
+    reqcert = '/etc/cockpit/ws-certs.d/99-cockpit.cert'
+    reqkey = '/etc/cockpit/ws-certs.d/99-cockpit.key'
+    symlink = '/etc/cockpit/krb5.keytab'
+
+    @classmethod
+    def uninstall(cls, mh):
+        cls.master.run_command(['ipa-getcert', 'stop-tracking', '-f',
+                                cls.reqcert], raiseonerr=False)
+        cls.master.run_command(['rm', '-f', cls.symlink], raiseonerr=False)
+        cls.master.run_command(['systemctl', 'disable', '--now',
+                                'cockpit.socket'])
+        super(TestCockpitIntegration, cls).uninstall(mh)
+
+    @classmethod
+    def install(cls, mh):
+        master = cls.master
+
+        # Install Cockpit and configure it to use IPA certificate and keytab
+        master.run_command(['dnf', 'install', '-y', 'cockpit', 'curl'],
+                           raiseonerr=False)
+
+        super(TestCockpitIntegration, cls).install(mh)
+
+        master.run_command(['ipa-getcert', 'request', '-f', cls.reqcert, '-k',
+                            cls.reqkey, '-D', cls.master.hostname, '-K',
+                            'host/' + cls.master.hostname, '-m', '0640', '-o',
+                            'root:cockpit-ws', '-O', 'root:root', '-M',
+                            '0644'], raiseonerr=False)
+
+        master.run_command(['ln', '-s', paths.HTTP_KEYTAB, cls.symlink],
+                           raiseonerr=False)
+
+        time.sleep(5)
+        master.run_command(['systemctl', 'enable', '--now', 'cockpit.socket'])
+
+    def test_login_with_kerberos(self):
+        """
+        Login to Cockpit using GSSAPI authentication
+        """
+        master = self.master
+        tasks.kinit_admin(master)
+
+        cockpit_login = f'https://{master.hostname}:9090/cockpit/login'
+        result = master.run_command([paths.BIN_CURL, '-u:', '--negotiate',
+                                     '--cacert', paths.IPA_CA_CRT,
+                                     cockpit_login])
+        assert ("csrf-token" in result.stdout_text)

--- a/selinux/ipa.fc
+++ b/selinux/ipa.fc
@@ -22,6 +22,8 @@
 
 /var/lib/ipa(/.*)?              gen_context(system_u:object_r:ipa_var_lib_t,s0)
 
+/var/lib/ipa/gssproxy/http.keytab -- gen_context(system_u:object_r:ipa_http_keytab_t,s0)
+
 /var/log/ipa(/.*)?              gen_context(system_u:object_r:ipa_log_t,s0)
 
 /var/log/ipabackup.log	--	gen_context(system_u:object_r:ipa_log_t,s0)

--- a/selinux/ipa.if
+++ b/selinux/ipa.if
@@ -155,6 +155,7 @@ interface(`ipa_manage_log',`
 ########################################
 ## <summary>
 ##	Allow domain to manage ipa lib files/dirs.
+##      This includes reading ipa_http_keytab_t files.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -164,10 +165,33 @@ interface(`ipa_manage_log',`
 #
 interface(`ipa_read_lib',`
 	gen_require(`
+		type ipa_http_keytab_t;
 		type ipa_var_lib_t;
 	')
 
     read_files_pattern($1, ipa_var_lib_t, ipa_var_lib_t)
+    read_files_pattern($1, ipa_http_keytab_t, ipa_http_keytab_t)
+    list_dirs_pattern($1, ipa_var_lib_t, ipa_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Allow domain to manage ipa HTTP keytab file.
+##      This includes reading ipa_var_lib_t directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ipa_read_http_keytab',`
+	gen_require(`
+		type ipa_http_keytab_t;
+		type ipa_var_lib_t;
+	')
+
+    read_files_pattern($1, ipa_http_keytab_t, ipa_http_keytab_t)
     list_dirs_pattern($1, ipa_var_lib_t, ipa_var_lib_t)
 ')
 

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -43,6 +43,9 @@ logging_log_file(ipa_log_t)
 type ipa_var_lib_t;
 files_type(ipa_var_lib_t)
 
+type ipa_http_keytab_t;
+files_type(ipa_http_keytab_t)
+
 type ipa_var_run_t;
 files_pid_file(ipa_var_run_t)
 
@@ -515,4 +518,20 @@ optional_policy(`
         class file read;
     ')
     allow certmonger_t pki_tomcat_etc_rw_t:file { getattr ioctl open read };
+')
+
+# gssproxy needs to read http keytab
+optional_policy(`
+    gen_require(`
+        type gssproxy_t;
+    ')
+    ipa_read_http_keytab(gssproxy_t)
+')
+
+# Allow Cockpit to use HTTP keytab on IPA servers for GSSAPI authentication
+optional_policy(`
+    gen_require(`
+        type cockpit_session_t;
+    ')
+    ipa_read_http_keytab(cockpit_session_t)
 ')


### PR DESCRIPTION
Cockpit can use GSSAPI authentication and has pretty good definition of how to enable it: https://cockpit-project.org/guide/latest/sso.html. These instructions work on IPA clients but they cannot be used on IPA servers because IPA framework already owns HTTP/.. Kerberos service and its keytab.

Luckily, there are two changes that need to be done to enable Cockpit single sign-on with GSSAPI on IPA servers:

  - create a symlink /etc/cockpit/krb5.keytab to /var/lib/ipa/gssproxy/http.keytab

  - add SELinux policy to allow cockpit_session_t to operate on ipa_var_lib_t files

No additional changes are needed. Note that Cockpit instructions above also talk about Kerberos service modifications to enable delegation. These modifications should not be done for IPA servers' HTTP services, as these services are already enabled to handle delegation.

Fixes: https://pagure.io/freeipa/issue/9675