### PR TITLE
[Backport][ipa-4-12] Don't rely on removing the CA to uninstall the ACME depoyment

### DIFF
--- a/ipaserver/install/acmeinstance.py
+++ b/ipaserver/install/acmeinstance.py
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+import logging
+
+from ipaserver.install.dogtaginstance import DogtagInstance
+
+logger = logging.getLogger(__name__)
+
+
+class ACMEInstance(DogtagInstance):
+    """
+    ACME is deployed automatically with a CA subsystem but it is the
+    responsibility of IPA to uninstall the service.
+
+    This is mostly a placeholder for the uninstaller. We can
+    eventually move the ACME installation routines into this class
+    if we want but it might result in an extra PKI restart which
+    would be slow.
+    """
+    def __init__(self, realm=None, host_name=None):
+        super(ACMEInstance, self).__init__(
+            realm=realm,
+            subsystem="ACME",
+            service_desc="ACME server",
+            host_name=host_name
+        )
+
+    def uninstall(self):
+        DogtagInstance.uninstall(self)

--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -22,7 +22,7 @@ from ipaplatform.constants import constants
 from ipaserver.install import sysupgrade
 from ipapython.install import typing
 from ipapython.install.core import group, knob, extend_knob
-from ipaserver.install import cainstance, bindinstance, dsinstance
+from ipaserver.install import acmeinstance, cainstance, bindinstance, dsinstance
 from ipapython import ipautil, certdb
 from ipapython import ipaldap
 from ipapython.admintool import ScriptError
@@ -715,6 +715,9 @@ def install_step_1(standalone, replica_config, options, custodia):
 
 
 def uninstall():
+    acme = acmeinstance.ACMEInstance(api.env.realm)
+    acme.uninstall()
+
     ca_instance = cainstance.CAInstance(api.env.realm)
     ca_instance.stop_tracking_certificates()
     ipautil.remove_file(paths.RA_AGENT_PEM)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1118,6 +1118,7 @@ class CAInstance(DogtagInstance):
 
         ipautil.remove_file(paths.DOGTAG_ADMIN_P12)
         ipautil.remove_file(paths.CACERT_P12)
+        ipautil.remove_file(paths.ADMIN_CERT_PATH)
 
     def unconfigure_certmonger_renewal_guard(self):
         if not self.is_configured():

--- a/ipatests/test_integration/test_uninstallation.py
+++ b/ipatests/test_integration/test_uninstallation.py
@@ -197,6 +197,7 @@ class TestUninstallCleanup(IntegrationTest):
             '/var/lib/sss/pubconf/krb5.include.d/localauth_plugin',
             '/var/named/dynamic/managed-keys.bind',
             '/var/named/dynamic/managed-keys.bind.jnl',
+            '/var/lib/systemd/coredump/',
         ]
 
         leftovers = []
@@ -217,3 +218,23 @@ class TestUninstallCleanup(IntegrationTest):
                 leftovers.append(line)
 
         assert len(leftovers) == 0
+
+
+class TestUninstallReinstall(IntegrationTest):
+    """Test install, uninstall, re-install.
+
+       Reinstall with PKI 11.6.0 was failing
+       https://pagure.io/freeipa/issue/9673
+    """
+
+    num_replicas = 0
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(cls.master, setup_dns=False)
+
+    def test_uninstall_server(self):
+        tasks.uninstall_master(self.master)
+
+    def test_reinstall_server(self):
+        tasks.install_master(self.master, setup_dns=False)


### PR DESCRIPTION
This PR was opened automatically because PR #7549 was pushed to master and backport to ipa-4-12 is required.