### PR TITLE
Do not let user with an expired OTP token to log in if only OTP is allowed

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -1528,7 +1528,8 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
     if (!syncreq && (otpreq == OTP_IS_NOT_REQUIRED)) {
         ret = ipapwd_gen_checks(pb, &errMesg, &krbcfg, IPAPWD_CHECK_ONLY_CONFIG);
         if (ret != 0) {
-            LOG_FATAL("ipapwd_gen_checks failed!?\n");
+            LOG_FATAL("ipapwd_gen_checks failed for '%s': %s\n",
+                      slapi_sdn_get_dn(sdn), errMesg);
             slapi_entry_free(entry);
             slapi_sdn_free(&sdn);
             return 0;


### PR DESCRIPTION
If only OTP authentication is allowed, and a user tries to login with an expired token, do not let them log in with their password. Forcing the admin to intervene. If the user does not have an OTP token then allow them to log in with a password until an OTP token is configured

Fixes: https://pagure.io/freeipa/issue/9387