### PR TITLE
9450 - Replace instances of del os.environ with os.environ.pop

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit.in
@@ -475,7 +475,7 @@ def renew_ca_cert(reuse_existing, force_self_signed, **kwargs):
         if profile is not None:
             os.environ['CERTMONGER_CA_PROFILE'] = profile
         else:
-            del os.environ['CERTMONGER_CA_PROFILE']
+            os.environ.pop('CERTMONGER_CA_PROFILE', None)
 
     if result[0] == WAIT:
         return (result[0], '%s:%s' % (state, result[1]))

--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -70,7 +70,7 @@ class CertUpdate(admintool.AdminTool):
             raise
         finally:
             if old_krb5ccname is None:
-                del os.environ['KRB5CCNAME']
+                os.environ.pop('KRB5CCNAME', None)
             else:
                 os.environ['KRB5CCNAME'] = old_krb5ccname
 

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -2060,7 +2060,7 @@ def empty_ccache():
         if old_path:
             os.environ['KRB5CCNAME'] = old_path
         else:
-            del os.environ['KRB5CCNAME']
+            os.environ.pop('KRB5CCNAME', None)
         shutil.rmtree(kpath_dir)
 
 

--- a/ipatests/test_ipalib/test_x509.py
+++ b/ipatests/test_ipalib/test_x509.py
@@ -275,7 +275,7 @@ class test_x509:
         if tz:
             os.environ['TZ'] = tz
         else:
-            del os.environ['TZ']
+            os.environ.pop('TZ', None)
         # ensure the timezone doesn't mess with not_before and not_after
         assert cert.not_valid_before == not_before
         assert cert.not_valid_after == not_after

--- a/ipatests/test_ipaserver/test_ipap11helper.py
+++ b/ipatests/test_ipaserver/test_ipap11helper.py
@@ -84,7 +84,7 @@ def p11(request, token_path):
                 [SOFTHSM2_UTIL, '--delete-token', '--label', 'test'],
                 cwd=token_path
             )
-            del os.environ['SOFTHSM2_CONF']
+            os.environ.pop('SOFTHSM2_CONF', None)
 
     request.addfinalizer(fin)
 


### PR DESCRIPTION
Explanation:
Five instances of `del os.environ` found and changed to use pop.

Fixes: https://pagure.io/freeipa/issue/9450