### PR TITLE
Nightly test definition: use master_1repl topology for idrange_fix

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1804,7 +1804,7 @@ jobs:
         test_suite: test_integration/test_ipa_idrange_fix.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-latest/test_subids:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1947,7 +1947,7 @@ jobs:
         test_suite: test_integration/test_ipa_idrange_fix.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-latest/test_subids:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -2091,7 +2091,7 @@ jobs:
         test_suite: test_integration/test_ipa_idrange_fix.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   testing-fedora/test_subids:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2234,7 +2234,7 @@ jobs:
         test_suite: test_integration/test_ipa_idrange_fix.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   testing-fedora/test_subids:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1804,7 +1804,7 @@ jobs:
         test_suite: test_integration/test_ipa_idrange_fix.py
         template: *ci-master-previous
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-previous/test_subids:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1947,7 +1947,7 @@ jobs:
         test_suite: test_integration/test_ipa_idrange_fix.py
         template: *ci-master-frawhide
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-rawhide/test_subids:
     requires: [fedora-rawhide/build]


### PR DESCRIPTION
The test test_ipa_idrange_fix is installing IPA server as it sets
topology=line. Its test definition should not use a template
that pre-installs the IPA server (ipaserver preinstalls IPA server
but master_1repl does not).