### PR TITLE
[Backport][ipa-4-12] spec: Use nodejs22 on RHEL 10 and ELN

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -308,10 +308,10 @@ BuildRequires:  libpwquality-devel
 BuildRequires:  libsss_idmap-devel
 BuildRequires:  libsss_certmap-devel
 BuildRequires:  libsss_nss_idmap-devel >= %{sssd_version}
-%if 0%{?fedora} >= 41
+%if 0%{?fedora} >= 41 || 0%{?rhel} >= 10
 # Do not use nodejs22 on fedora < 41, https://pagure.io/freeipa/issue/9643
 BuildRequires: nodejs(abi)
-%elif 0%{?fedora} >= 39 || 0%{?rhel} >= 10
+%elif 0%{?fedora} >= 39
 # Do not use nodejs20 on fedora < 39, https://pagure.io/freeipa/issue/9374
 BuildRequires:  nodejs(abi) < 127
 %else


### PR DESCRIPTION
This PR was opened automatically because PR #7557 was pushed to master and backport to ipa-4-12 is required.