### PR TITLE
[Backport][ipa-4-12] Do not let user with an expired OTP token to log in if only OTP is allowed

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
+++ b/daemons/ipa-slapi-plugins/ipa-pwd-extop/prepost.c
@@ -1528,7 +1528,8 @@ static int ipapwd_pre_bind(Slapi_PBlock *pb)
     if (!syncreq && (otpreq == OTP_IS_NOT_REQUIRED)) {
         ret = ipapwd_gen_checks(pb, &errMesg, &krbcfg, IPAPWD_CHECK_ONLY_CONFIG);
         if (ret != 0) {
-            LOG_FATAL("ipapwd_gen_checks failed!?\n");
+            LOG_FATAL("ipapwd_gen_checks failed for '%s': %s\n",
+                      slapi_sdn_get_dn(sdn), errMesg);
             slapi_entry_free(entry);
             slapi_sdn_free(&sdn);
             return 0;


### PR DESCRIPTION
This PR was opened automatically because PR #7554 was pushed to master and backport to ipa-4-12 is required.