### PR TITLE
ipa-migrate - dryrun write updates feature crashes when removing values

### DIFF
--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -622,7 +622,7 @@ class IPAMigrate():
                 else:
                     action = "replace"
                 ldif_entry += f"{action}: {attr}\n"
-                for val in vals:
+                for val in list(vals or []):
                     ldif_entry += get_ldif_attr_val(attr, val)
                 ldif_entry += "-\n"
             ldif_entry += "\n"


### PR DESCRIPTION
When removing values the mod value list is None and that leads to a crash when trying to iterate it. Instead check that the vals are not None before looping.

Fixes: https://pagure.io/freeipa/issue/9682