### PR TITLE
web ui: Add explicit white border for QR code widget

### DIFF
--- a/install/ui/less/plugins/otp.less
+++ b/install/ui/less/plugins/otp.less
@@ -6,4 +6,5 @@
 .qrcode-widget img {
 	margin: 0 auto;
 	max-width: 100%;
+	border: 20px solid rgb(255, 255, 255) !important;
 }


### PR DESCRIPTION
There was discussion in the ticket 9202 how to do that and the simplest way is to force a border via CSS. We have a CSS specifically for QR code widget, so use it.

A default view is white, so the border will not be visible (white on white) but for dark backgrounds the border will be there clearly visible.

Fixes: https://pagure.io/freeipa/issue/9202