### PR TITLE
ipa-migrate should migrate dns forward zones

### DIFF
--- a/ipaserver/install/ipa_migrate_constants.py
+++ b/ipaserver/install/ipa_migrate_constants.py
@@ -969,7 +969,7 @@ DB_OBJECTS = {
         'count': 0,
     },
     'dns_records': {
-        'oc': ['idnsrecord', 'idnszone'],
+        'oc': ['idnsrecord', 'idnszone', 'idnsforwardzone'],
         'subtree': ',cn=dns,$SUFFIX',
         'label': 'DNS Records',
         'mode': 'all',


### PR DESCRIPTION
Fixes: https://pagure.io/freeipa/issue/9686