### PR TITLE
[Backport][ipa-4-12] ipa-migrate - dryrun write updates feature crashes when removing values

### DIFF
--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -622,7 +622,7 @@ class IPAMigrate():
                 else:
                     action = "replace"
                 ldif_entry += f"{action}: {attr}\n"
-                for val in vals:
+                for val in list(vals or []):
                     ldif_entry += get_ldif_attr_val(attr, val)
                 ldif_entry += "-\n"
             ldif_entry += "\n"


### PR DESCRIPTION
This PR was opened automatically because PR #7572 was pushed to master and backport to ipa-4-12 is required.