### PR TITLE
[Backport][ipa-4-12] ipa-migrate should migrate dns forward zones

### DIFF
--- a/ipaserver/install/ipa_migrate_constants.py
+++ b/ipaserver/install/ipa_migrate_constants.py
@@ -993,7 +993,7 @@ DB_OBJECTS = {
         'count': 0,
     },
     'dns_records': {
-        'oc': ['idnsrecord', 'idnszone'],
+        'oc': ['idnsrecord', 'idnszone', 'idnsforwardzone'],
         'subtree': ',cn=dns,$SUFFIX',
         'label': 'DNS Records',
         'mode': 'all',


### PR DESCRIPTION
This PR was opened automatically because PR #7574 was pushed to master and backport to ipa-4-12 is required.