### PR TITLE
[Backport][ipa-4-12] Small fixup to determine which ACME uninstaller to use

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -311,7 +311,7 @@ class DogtagInstance(service.Service):
                 return
             elif (
                 pki.util.Version("11.0.0") <= pki_version
-                <= pki.util.Version("11.5.0")
+                < pki.util.Version("11.6.0")
             ):
                 args = ['pki-server', 'acme-remove']
             else:


### PR DESCRIPTION
This PR was opened automatically because PR #7579 was pushed to master and backport to ipa-4-12 is required.