### PR TITLE
Fix: 'Organization' field in Okta not required

### DIFF
--- a/install/ui/src/freeipa/idp.js
+++ b/install/ui/src/freeipa/idp.js
@@ -41,7 +41,7 @@ idp.templates = [
       fields: ['ipaidporg']},
     { value: 'okta',
       label: text.get('@i18n:objects.idp.template_okta'),
-      fields: ['ipaidporg', 'ipaidpbaseurl']}
+      fields: ['ipaidpbaseurl']}
 ];
 
 


### PR DESCRIPTION
Although the 'Organization' field is not required when using the Okta template, the WebUI requires it in order to create a new IDP. If this is not provided, an error is shown.

Fixes: https://pagure.io/freeipa/issue/9687