### PR TITLE
Store and enforce that FIPS state doesn't change in an installation

### DIFF
--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -865,6 +865,8 @@ def install(installer):
     # Be clear that the installation process is beginning but not done
     sstore.backup_state('installation', 'complete', False)
 
+    sstore.backup_state('installation', 'fips', tasks.is_fips_enabled())
+
     if installer.interactive:
         print("")
         print("The following operations may take some minutes to complete.")

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -1320,6 +1320,8 @@ def install(installer):
     # Be clear that the installation process is beginning but not done
     sstore.backup_state('installation', 'complete', False)
 
+    sstore.backup_state('installation', 'fips', tasks.is_fips_enabled())
+
     if tasks.configure_pkcs11_modules(fstore):
         print("Disabled p11-kit-proxy")
 


### PR DESCRIPTION
The first patch adds a new state variable, fips, to retain the state of FIPS enablement on the server when IPA, or a replica, is installed. If on upgrade this state is not present then it will attempt to deduce what the initial state was based on the token name stored in certmonger. If the value is not clear then it is skipped.

The second patch will enforce that the FIPS state has not changed from the initial value when ipactl start or restart is called. If the state value is not present then it allows the command to proceed. There is no skip option.

This is easily fooled in any number of ways including:

- changing the key_token value in the certmonger request files
- directly modifying sysrestore.state

If someone did these then, to me, it demonstrates that they don't really care  about or understand what the system state is and actually being FIPS-compliant. I don't think there is a lot we can do about that. But this will enforce on the system if they try to change the FIPS state post installation, which is unsupported.

https://pagure.io/freeipa/issue/7423