### PR TITLE
[ipa-4-12] ipatests: move tests to fedora 41

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -30,7 +30,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
-          name: freeipa/ci-ipa-4-12-f40
+          name: freeipa/ci-ipa-4-12-f41
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
@@ -54,7 +54,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
-          name: freeipa/ci-ipa-4-12-f40
+          name: freeipa/ci-ipa-4-12-f41
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
@@ -54,7 +54,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
-          name: freeipa/ci-ipa-4-12-f40
+          name: freeipa/ci-ipa-4-12-f41
           version: 0.0.1
         timeout: 1800
         topology: *build


### PR DESCRIPTION
Now that fedora 41 is available, move the tests on ipa-4-12 branch
onto fedora 41 instead of fedora 40.