### PR TITLE
Add support for the PKI v2 REST API + fall back

### DIFF
--- a/install/share/ipa-pki-proxy.conf.template
+++ b/install/share/ipa-pki-proxy.conf.template
@@ -27,7 +27,7 @@ ProxyRequests Off
 </LocationMatch>
 
 # matches for REST API of CA, KRA, and PKI
-<LocationMatch "^/(ca|kra|pki)/rest/">
+<LocationMatch "^/(ca|kra|pki)/rest/|^/(ca|kra|pki)/v2/">
     SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
     SSLVerifyClient optional
     ProxyPassMatch ajp://localhost:$DOGTAG_PORT $DOGTAG_AJP_SECRET

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -225,6 +225,7 @@ DEFAULT_CONFIG = (
     # For the following ports, None means a default specific to the installed
     # Dogtag version.
     ('ca_install_port', None),
+    ('ca_url_base', '/ca/v2,/ca/rest'),
 
     # Topology plugin
     ('recommended_max_agmts', 4),  # Recommended maximum number of replication

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1119,6 +1119,7 @@ class CAInstance(DogtagInstance):
         ipautil.remove_file(paths.DOGTAG_ADMIN_P12)
         ipautil.remove_file(paths.CACERT_P12)
         ipautil.remove_file(paths.ADMIN_CERT_PATH)
+        ipautil.remove_file('/root/.dogtag/pki-tomcat/ca')
 
     def unconfigure_certmonger_renewal_guard(self):
         if not self.is_configured():

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -961,7 +961,6 @@ class cert_request(Create, BaseCertMethod, VirtualCommand):
                         reason=e,
                     )
                 )
-            result['request_id'] = result['request_id']
             result['cacn'] = ca_obj['cn'][0]
 
         # Success? Then add it to the principal's entry


### PR DESCRIPTION
This PR is mostly for verifying that fallover works when trying to contact a PKI API. It will use the v1/rest endpoints because v2 isn't available in Fedora yet. I will test with a temp commit at some point using the dogtag nightlies.

For now this is looking for regressions.

I haven't touch the KRA at all yet.