### PR TITLE
Nightly test def: fix topology for test_IPAMigrateADTrust

### DIFF
--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -2140,7 +2140,7 @@ jobs:
         test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrationWithADtrust
         template: *ci-master-previous
         timeout: 7200
-        topology: *master_1repl_1client
+        topology: *ad_master_1repl_1client
 
   fedora-previous/test_cockpit:
     requires: [fedora-previous/build]


### PR DESCRIPTION
The test needs topology: *ad_master_1repl_1client
instead of topology: *master_1repl_1client
because it requires an AD server.