### PR TITLE
[Backport][ipa-4-12] Fix: 'Organization' field in Okta not required

### DIFF
--- a/install/ui/src/freeipa/idp.js
+++ b/install/ui/src/freeipa/idp.js
@@ -41,7 +41,7 @@ idp.templates = [
       fields: ['ipaidporg']},
     { value: 'okta',
       label: text.get('@i18n:objects.idp.template_okta'),
-      fields: ['ipaidporg', 'ipaidpbaseurl']}
+      fields: ['ipaidpbaseurl']}
 ];
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #7581 was pushed to master and backport to ipa-4-12 is required.