### PR TITLE
ipaserver/dcerpc: support Samba 4.21

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -55,9 +55,13 @@ from samba import ntstatus
 import samba
 
 try:
-    from samba.trust_utils import CreateTrustedDomainRelax
+    from samba.lsa_utils import CreateTrustedDomainRelax
 except ImportError:
-    CreateTrustedDomainRelax = None
+    try:
+        from samba.trust_utils import CreateTrustedDomainRelax
+    except ImportError:
+        CreateTrustedDomainRelax = None
+
 try:
     from samba import arcfour_encrypt
 except ImportError:


### PR DESCRIPTION
Samba 4.21 moved samba.trust_utils module to samba.lsa_utils.

Fixes: https://pagure.io/freeipa/issue/9702