### PR TITLE
ipatests: Fix hostname for otp test suite.

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -72,7 +72,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_otp.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl

--- a/ipatests/test_integration/test_otp.py
+++ b/ipatests/test_integration/test_otp.py
@@ -402,7 +402,7 @@ class TestOTPToken(IntegrationTest):
             otpvalue = totp.generate(int(time.time())).decode('ascii')
             password = '{0}{1}'.format(PASSWORD, otpvalue)
             tasks.run_ssh_cmd(
-                to_host=self.master.external_hostname, username=USER1,
+                to_host=self.master.hostname, username=USER1,
                 auth_method="password", password=password
             )
             # check if user listed in output
@@ -504,7 +504,7 @@ class TestOTPToken(IntegrationTest):
             )
             with xfail_context(rhel_fail or fedora_fail, reason=github_ticket):
                 result = ssh_2fa_with_cmd(master,
-                                          self.master.external_hostname,
+                                          self.master.hostname,
                                           USER3, PASSWORD, otpvalue=otpvalue,
                                           command="klist")
                 print(result.stdout_text)
@@ -552,7 +552,7 @@ class TestOTPToken(IntegrationTest):
             otpvalue = totp.generate(int(time.time())).decode('ascii')
             tasks.clear_sssd_cache(self.master)
             result = ssh_2fa_with_cmd(master,
-                                      self.master.external_hostname,
+                                      self.master.hostname,
                                       USER4, PASSWORD, otpvalue=otpvalue,
                                       command="klist")
             print(result.stdout_text)


### PR DESCRIPTION
In downstream IDMCI test_2fa_only_with_password and test_2fa_with_otp_password are failing with error "sss_ssh_knownhostsproxy: Could not resolve hostname"
Added fix by replacing external_hostname to hostname.
Related : https://pagure.io/freeipa/issue/9703
