### PR TITLE
[Backport][ipa-4-12] ipaserver/dcerpc: support Samba 4.21

### DIFF
--- a/ipaserver/dcerpc.py
+++ b/ipaserver/dcerpc.py
@@ -55,9 +55,13 @@ from samba import ntstatus
 import samba
 
 try:
-    from samba.trust_utils import CreateTrustedDomainRelax
+    from samba.lsa_utils import CreateTrustedDomainRelax
 except ImportError:
-    CreateTrustedDomainRelax = None
+    try:
+        from samba.trust_utils import CreateTrustedDomainRelax
+    except ImportError:
+        CreateTrustedDomainRelax = None
+
 try:
     from samba import arcfour_encrypt
 except ImportError:


### PR DESCRIPTION
This PR was opened automatically because PR #7597 was pushed to master and backport to ipa-4-12 is required.