### PR TITLE
[Backport][ipa-4-10] ipatests: Fixes for ipa-idrange-fix testsuite

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest.yaml
@@ -1925,3 +1925,15 @@ jobs:
         template: *ci-ipa-4-10-latest
         timeout: 600
         topology: *master_1repl
+
+  fedora-latest-ipa-4-10/test_idrange_fix:
+    requires: [fedora-latest-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-10/build_url}'
+        test_suite: test_integration/test_ipa_idrange_fix.py
+        template: *ci-ipa-4-10-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-10_latest_selinux.yaml
@@ -2078,3 +2078,16 @@ jobs:
         template: *ci-ipa-4-10-latest
         timeout: 600
         topology: *master_1repl
+
+  fedora-latest-ipa-4-10/test_idrange_fix:
+    requires: [fedora-latest-ipa-4-10/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-10/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_ipa_idrange_fix.py
+        template: *ci-ipa-4-10-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -72,7 +72,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest-ipa-4-10/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_ipa_idrange_fix.py
         template: *ci-ipa-4-10-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_ipa_idrange_fix.py
+++ b/ipatests/test_integration/test_ipa_idrange_fix.py
@@ -1,0 +1,192 @@
+#
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Module provides tests for ipa-idrange-fix CLI.
+"""
+
+import logging
+import re
+
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+
+logger = logging.getLogger(__name__)
+
+
+class TestIpaIdrangeFix(IntegrationTest):
+
+    topology = 'line'
+
+    @classmethod
+    def install(cls, mh):
+        super(TestIpaIdrangeFix, cls).install(mh)
+        tasks.kinit_admin(cls.master)
+
+    def test_no_issues(self):
+        """Test ipa-idrange-fix command with no issues."""
+        result = self.master.run_command(["ipa-idrange-fix", "--unattended"])
+
+        expected_under1000 = "No IDs under 1000 found"
+        expected_nochanges = "No changes proposed for existing ranges"
+        expected_newrange = "No new ranges proposed"
+        expected_noissues = "No changes proposed, nothing to do."
+        assert expected_under1000 in result.stderr_text
+        assert expected_nochanges in result.stderr_text
+        assert expected_newrange in result.stderr_text
+        assert expected_noissues in result.stderr_text
+
+    def test_idrange_no_rid_bases(self):
+        """Test ipa-idrange-fix command with IDrange with no RID bases."""
+        self.master.run_command([
+            "ipa",
+            "idrange-add",
+            "idrange_no_rid_bases",
+            "--base-id", '10000',
+            "--range-size", '20000',
+        ])
+
+        result = self.master.run_command(["ipa-idrange-fix", "--unattended"])
+        expected_text = "RID bases updated for range 'idrange_no_rid_bases'"
+
+        # Remove IDrange with no rid bases
+        self.master.run_command(["ipa", "idrange-del", "idrange_no_rid_bases"])
+
+        assert expected_text in result.stderr_text
+
+    def test_idrange_no_rid_bases_reversed(self):
+        """
+        Test ipa-idrange-fix command with IDrange with no RID bases, but we
+        previously had a range with RID bases reversed - secondary lower than
+        primary. It is a valid configuration, so we should fix no-RID range.
+        """
+        self.master.run_command([
+            "ipa",
+            "idrange-add",
+            "idrange_no_rid_bases",
+            "--base-id", '10000',
+            "--range-size", '20000',
+        ])
+        self.master.run_command([
+            "ipa",
+            "idrange-add",
+            "idrange_reversed",
+            "--base-id", '50000',
+            "--range-size", '20000',
+            "--rid-base", '100300000',
+            "--secondary-rid-base", '301000'
+        ])
+
+        result = self.master.run_command(["ipa-idrange-fix", "--unattended"])
+        expected_text = "RID bases updated for range 'idrange_no_rid_bases'"
+
+        # Remove test IDranges
+        self.master.run_command(["ipa", "idrange-del", "idrange_no_rid_bases"])
+        self.master.run_command(["ipa", "idrange-del", "idrange_reversed"])
+
+        assert expected_text in result.stderr_text
+
+    def test_users_outofrange(self):
+        """Test ipa-idrange-fix command with users out of range."""
+        for i in range(1, 20):
+            self.master.run_command([
+                "ipa",
+                "user-add",
+                "testuser{}".format(i),
+                "--first", "Test",
+                "--last", "User {}".format(i),
+                "--uid", str(100000 + i * 10),
+            ])
+
+        result = self.master.run_command(["ipa-idrange-fix", "--unattended"])
+        expected_text = r"Range '[\w\.]+_id_range_\d{3}' created successfully"
+        match = re.search(expected_text, result.stderr_text)
+
+        # Remove users out of range and created IDrange
+        for i in range(1, 20):
+            self.master.run_command([
+                "ipa",
+                "user-del",
+                "testuser{}".format(i)
+            ])
+        if match is not None:
+            self.master.run_command([
+                "ipa",
+                "idrange-del",
+                match.group(0).split(" ")[1].replace("'", "")
+            ])
+
+        assert match is not None
+
+    def test_user_outlier(self):
+        """Test ipa-idrange-fix command with outlier user."""
+        self.master.run_command([
+            "ipa",
+            "user-add",
+            "testuser_outlier",
+            "--first", "Outlier",
+            "--last", "User",
+            "--uid", '500000',
+        ])
+
+        result = self.master.run_command(["ipa-idrange-fix", "--unattended"])
+        expected_text = "Identities that don't fit the criteria to get a new \
+range found!"
+        expected_user = "user 'Outlier User', uid=500000"
+
+        # Remove outlier user
+        self.master.run_command(["ipa", "user-del", "testuser_outlier"])
+
+        assert expected_text in result.stderr_text
+        assert expected_user in result.stderr_text
+
+    def test_user_under1000(self):
+        """Test ipa-idrange-fix command with user under 1000."""
+        self.master.run_command([
+            "ipa",
+            "user-add",
+            "testuser_under1000",
+            "--first", "Under",
+            "--last", "1000",
+            "--uid", '999',
+        ])
+
+        result = self.master.run_command(["ipa-idrange-fix", "--unattended"])
+        expected_text = "IDs under 1000:"
+        expected_user = "user 'Under 1000', uid=999"
+
+        # Remove user under 1000
+        self.master.run_command(["ipa", "user-del", "testuser_under1000"])
+
+        assert expected_text in result.stderr_text
+        assert expected_user in result.stderr_text
+
+    def test_user_preserved(self):
+        """Test ipa-idrange-fix command with preserved user."""
+        self.master.run_command([
+            "ipa",
+            "user-add",
+            "testuser_preserved",
+            "--first", "Preserved",
+            "--last", "User",
+            "--uid", '9999',
+        ])
+        self.master.run_command([
+            "ipa",
+            "user-del",
+            "testuser_preserved",
+            "--preserve"
+        ])
+
+        result = self.master.run_command(["ipa-idrange-fix", "--unattended"])
+        expected_text = "Identities that don't fit the criteria to get a new \
+range found!"
+        expected_user = "user 'Preserved User', uid=9999"
+
+        # Remove preserved user
+        self.master.run_command(["ipa", "user-del", "testuser_preserved"])
+
+        assert expected_text in result.stderr_text
+        assert expected_user in result.stderr_text


### PR DESCRIPTION
This PR was opened automatically because PR https://github.com/freeipa/freeipa/pull/7548 was pushed to master and backport to ipa-4-10 is required. 