### PR TITLE
[Backport][ipa-4-11] ipatests: Fixes for ipa-idrange-fix testsuite

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-11_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-11_latest.yaml
@@ -1804,7 +1804,7 @@ jobs:
         test_suite: test_integration/test_ipa_idrange_fix.py
         template: *ci-ipa-4-11-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-latest-ipa-4-11/test_subids:
     requires: [fedora-latest-ipa-4-11/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-11_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-11_latest_selinux.yaml
@@ -1947,7 +1947,7 @@ jobs:
         test_suite: test_integration/test_ipa_idrange_fix.py
         template: *ci-ipa-4-11-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-latest-ipa-4-11/test_subids:
     requires: [fedora-latest-ipa-4-11/build]

--- a/ipatests/test_integration/test_ipa_idrange_fix.py
+++ b/ipatests/test_integration/test_ipa_idrange_fix.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 
 class TestIpaIdrangeFix(IntegrationTest):
+
+    topology = 'line'
+
     @classmethod
     def install(cls, mh):
         super(TestIpaIdrangeFix, cls).install(mh)


### PR DESCRIPTION
This PR was opened automatically because PR https://github.com/freeipa/freeipa/pull/7548 was pushed to master and backport to ipa-4-11 is required.