### PR TITLE
[Backport][ipa-4-9] ipatests: Fixes for ipa-idrange-fix testsuite

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest.yaml
@@ -1776,7 +1776,7 @@ jobs:
         test_suite: test_integration/test_ipa_idrange_fix.py
         template: *ci-ipa-4-9-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-latest-ipa-4-9/test_subids:
     requires: [fedora-latest-ipa-4-9/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_latest_selinux.yaml
@@ -1917,7 +1917,7 @@ jobs:
         test_suite: test_integration/test_ipa_idrange_fix.py
         template: *ci-ipa-4-9-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-latest-ipa-4-9/test_subids:
     requires: [fedora-latest-ipa-4-9/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-9_previous.yaml
@@ -1776,7 +1776,7 @@ jobs:
         test_suite: test_integration/test_ipa_idrange_fix.py
         template: *ci-ipa-4-9-previous
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl
 
   fedora-previous-ipa-4-9/test_subids:
     requires: [fedora-previous-ipa-4-9/build]

--- a/ipatests/test_integration/test_ipa_idrange_fix.py
+++ b/ipatests/test_integration/test_ipa_idrange_fix.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 
 class TestIpaIdrangeFix(IntegrationTest):
+
+    topology = 'line'
+
     @classmethod
     def install(cls, mh):
         super(TestIpaIdrangeFix, cls).install(mh)


### PR DESCRIPTION
This PR was opened automatically because PR https://github.com/freeipa/freeipa/pull/7548 was pushed to master and backport to ipa-4-9 is required.