### PR TITLE
readthedocs: install crypto 43.0.0

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -21,7 +21,7 @@ requests
 
 ## C libraries with binary wheels
 cffi
-cryptography
+cryptography < 44.0.0
 lxml
 
 ## C libraries without binaries wheels


### PR DESCRIPTION
If crypto 44.0.0 is installed, readthedocs build fails with:
TypeError: type 'cryptography.hazmat.bindings._rust.x509.Certificate' is not an acceptable base type

Force installation of cryptography < 44.0.0