### PR TITLE
[Backport][ipa-4-12] readthedocs: install crypto 43.0.0

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -21,7 +21,7 @@ requests
 
 ## C libraries with binary wheels
 cffi
-cryptography
+cryptography < 44.0.0
 lxml
 
 ## C libraries without binaries wheels


### PR DESCRIPTION
This PR was opened automatically because PR #7609 was pushed to master and backport to ipa-4-12 is required.