### PR TITLE
Pass all pkiuser groups as suplementary when validating an HSM

### DIFF
--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -86,7 +86,10 @@ class Group(_Entity):
             try:
                 self._entity = entity = grp.getgrnam(self)
             except KeyError:
-                raise ValueError(f"group '{self!s}' not found") from None
+                try:
+                    self._entity = entity = grp.getgrgid(int(self))
+                except (TypeError, ValueError):
+                    raise ValueError(f"group '{self!s}' not found") from None
         return entity
 
     @property

--- a/ipatests/test_ipaplatform/test_constants.py
+++ b/ipatests/test_ipaplatform/test_constants.py
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2020  FreeIPA Contributors see COPYING for license
 #
+import grp
 import pytest
 
 from ipaplatform.base.constants import User, Group
@@ -38,6 +39,16 @@ def test_group():
 
     assert Group(group) is group
     assert Group(str(group)) is not group
+
+
+def test_numeric_group():
+    g = grp.getgrnam('apache')
+    group = Group(g.gr_gid)
+    assert group.gid == g.gr_gid
+    assert type(str(group)) is str
+    assert repr(group) == '<Group "%d">' % g.gr_gid
+    assert group.gid == g.gr_gid
+    assert group.entity.gr_gid == g.gr_gid
 
 
 def test_group_invalid():


### PR DESCRIPTION
We were doing a "best effort" when validating the HSM token is
visible with a valid PIN when it came to groups. A specific
workaround was added for softhsm2 but this didn't carry over
to other HSMs that may have group-specific read/write access.

Use the new capability in ipaplatform.constants.py::Group to be
able to use generate a valid entry from a group GID. Pair this
with os.getgrouplist() and all groups will be passed correctly
via ipautil.run().

Fixes: https://pagure.io/freeipa/issue/9709
