### PR TITLE
Cert renewal: update the trust flags for audit cert

### DIFF
--- a/install/restart_scripts/renew_ca_cert.in
+++ b/install/restart_scripts/renew_ca_cert.in
@@ -33,6 +33,7 @@ from ipalib import api, errors
 from ipalib import x509
 from ipalib.install.kinit import kinit_keytab
 from ipaserver.install import certs, cainstance
+from ipaserver.install.dogtaginstance import INTERNAL_TOKEN
 from ipaserver.plugins.ldap2 import ldap2
 from ipaplatform import services
 from ipaplatform.paths import paths
@@ -68,15 +69,24 @@ def _main():
             syslog.syslog(
                 syslog.LOG_NOTICE, "Stopped %s" % dogtag_service.service_name)
 
-    # Fetch the new certificate
-    db = certs.CertDB(api.env.realm, nssdir=paths.PKI_TOMCAT_ALIAS_DIR)
-    cert = db.get_cert_from_db(nickname)
-    if not cert:
-        syslog.syslog(syslog.LOG_ERR, 'No certificate %s found.' % nickname)
-        sys.exit(1)
-
     tmpdir = tempfile.mkdtemp(prefix="tmp-")
     try:
+        # If we are using HSM, create a pwd file with the password for
+        # the internal token + HSM
+        token_name = ca.get_token_name(nickname)
+        if token_name != INTERNAL_TOKEN:
+            pwd_file = ca.get_token_pwd_file(tmpdir)
+        else:
+            # Use the default pwd file
+            pwd_file = None
+        # Fetch the new certificate
+        db = certs.CertDB(api.env.realm, nssdir=paths.PKI_TOMCAT_ALIAS_DIR,
+                          pwd_file=pwd_file)
+        cert = db.get_cert_from_db(nickname)
+        if not cert:
+            syslog.syslog(syslog.LOG_ERR, 'No certificate %s found.' % nickname)
+            sys.exit(1)
+
         principal = str('host/%s@%s' % (api.env.host, api.env.realm))
         ccache_filename = os.path.join(tmpdir, 'ccache')
         kinit_keytab(principal, paths.KRB5_KEYTAB, ccache_filename)
@@ -95,9 +105,12 @@ def _main():
         ):
             # Fix trust on the audit cert
             try:
-                db.run_certutil(['-M',
-                                 '-n', nickname,
-                                 '-t', 'u,u,Pu'])
+                cmd_args = ['-M', '-t', 'u,u,Pu']
+                if token_name != INTERNAL_TOKEN:
+                    cmd_args.extend(['-n', token_name + ":" + nickname])
+                else:
+                    cmd_args.extend(['-n', token_name])
+                db.run_certutil(cmd_args)
                 syslog.syslog(
                     syslog.LOG_NOTICE,
                     "Updated trust on certificate %s in %s" %

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -60,7 +60,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f40
+          name: freeipa/ci-master-f41
           version: 0.0.1
         timeout: 1800
         topology: *build


### PR DESCRIPTION
When certmonger renews the auditSigningCert for the CA
or the KRA, it has to add the P trust flag to the NSS
database in /etc/pki/pki-tomcat/alias.

If IPA is installed in FIPS mode with an HSM, the
certutil commands must be provided a password file
containing both the internal token password and the
HSM password, and the cert name must be prefixed
with the tokenname (otherwise certutil -M succeeds
but does not update the trust flags).

Fixes: https://pagure.io/freeipa/issue/9705