### PR TITLE
[Backport][ipa-4-12] ipalib/x509: workaround PyCA 44.0

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -21,7 +21,7 @@ requests
 
 ## C libraries with binary wheels
 cffi
-cryptography < 44.0.0
+cryptography
 lxml
 
 ## C libraries without binaries wheels

--- a/ipaclient/plugins/vault.py
+++ b/ipaclient/plugins/vault.py
@@ -34,6 +34,12 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+try:
+    # cryptography>=43.0.0
+    from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
+except ImportError:
+    # will be removed from this module in cryptography 48.0.0
+    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
 from cryptography.hazmat.primitives.padding import PKCS7
 from cryptography.hazmat.primitives.serialization import (
     load_pem_public_key, load_pem_private_key)
@@ -661,7 +667,7 @@ class ModVaultData(Local):
         if name == constants.VAULT_WRAPPING_AES128_CBC:
             return algorithms.AES(os.urandom(128 // 8))
         elif name == constants.VAULT_WRAPPING_3DES:
-            return algorithms.TripleDES(os.urandom(196 // 8))
+            return TripleDES(os.urandom(196 // 8))
         else:
             # unreachable
             raise ValueError(name)

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -25,20 +25,19 @@ All constants centralised in one file.
 import os
 import string
 import uuid
-import warnings
-
-warnings.filterwarnings(
-    "ignore",
-    "TripleDES has been moved to "
-    "cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and "
-    "will be removed from this module in 48.0.0",
-    category=UserWarning)
 
 from ipaplatform.constants import constants as _constants
 from ipapython.dn import DN
 from ipapython.fqdn import gethostfqdn
 from ipapython.version import VERSION, API_VERSION
-from cryptography.hazmat.primitives.ciphers import algorithms, modes
+from cryptography.hazmat.primitives.ciphers import modes
+try:
+    # cryptography>=43.0.0
+    from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
+except ImportError:
+    # will be removed from this module in cryptography 48.0.0
+    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
+
 from cryptography.hazmat.backends.openssl.backend import backend
 
 
@@ -389,7 +388,6 @@ VAULT_WRAPPING_SUPPORTED_ALGOS = (
 VAULT_WRAPPING_DEFAULT_ALGO = VAULT_WRAPPING_AES128_CBC
 
 # Add 3DES for backwards compatibility if supported
-if getattr(algorithms, 'TripleDES', None):
-    if backend.cipher_supported(algorithms.TripleDES(
-                                b"\x00" * 8), modes.CBC(b"\x00" * 8)):
-        VAULT_WRAPPING_SUPPORTED_ALGOS += (VAULT_WRAPPING_3DES,)
+if backend.cipher_supported(TripleDES(
+                            b"\x00" * 8), modes.CBC(b"\x00" * 8)):
+    VAULT_WRAPPING_SUPPORTED_ALGOS += (VAULT_WRAPPING_3DES,)

--- a/ipalib/ipajson.py
+++ b/ipalib/ipajson.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 import json
 import six
 from ipalib.constants import LDAP_GENERALIZED_TIME_FORMAT
-from ipalib import capabilities
+from ipalib import capabilities, x509
 from ipalib.x509 import Encoding as x509_Encoding
 from ipapython.dn import DN
 from ipapython.dnsutil import DNSName
@@ -72,7 +72,7 @@ class _JSONPrimer(dict):
             list: self._enc_list,
             tuple: self._enc_list,
             dict: self._enc_dict,
-            crypto_x509.Certificate: self._enc_certificate,
+            x509.IPACertificate: self._enc_certificate,
             crypto_x509.CertificateSigningRequest: self._enc_certificate,
         })
 

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -88,7 +88,7 @@ SAN_UPN = '1.3.6.1.4.1.311.20.2.3'
 SAN_KRB5PRINCIPALNAME = '1.3.6.1.5.2.2'
 
 
-class IPACertificate(crypto_x509.Certificate):
+class IPACertificate:
     """
     A proxy class wrapping a python-cryptography certificate representation for
     IPA purposes
@@ -204,6 +204,10 @@ class IPACertificate(crypto_x509.Certificate):
         Counts fingerprint of the wrapped cryptography.Certificate
         """
         return self._cert.fingerprint(algorithm)
+
+    @property
+    def cert(self):
+        return self._cert
 
     @property
     def serial_number(self):
@@ -457,6 +461,8 @@ def load_pem_x509_certificate(data):
     :returns: a ``IPACertificate`` object.
     :raises: ``ValueError`` if unable to load the certificate.
     """
+    if isinstance(data, IPACertificate):
+        return data
     return IPACertificate(
         crypto_x509.load_pem_x509_certificate(data, backend=default_backend())
     )
@@ -469,6 +475,8 @@ def load_der_x509_certificate(data):
     :returns: a ``IPACertificate`` object.
     :raises: ``ValueError`` if unable to load the certificate.
     """
+    if isinstance(data, IPACertificate):
+        return data
     return IPACertificate(
         crypto_x509.load_der_x509_certificate(data, backend=default_backend())
     )

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -33,7 +33,6 @@ import warnings
 
 from collections import OrderedDict
 
-from cryptography import x509 as crypto_x509
 from cryptography.hazmat.primitives import serialization
 
 import ldap
@@ -748,10 +747,10 @@ class LDAPClient:
         'dnszoneidnsname': DNSName,
         'krbcanonicalname': Principal,
         'krbprincipalname': Principal,
-        'usercertificate': crypto_x509.Certificate,
-        'usercertificate;binary': crypto_x509.Certificate,
-        'cACertificate': crypto_x509.Certificate,
-        'cACertificate;binary': crypto_x509.Certificate,
+        'usercertificate': x509.IPACertificate,
+        'usercertificate;binary': x509.IPACertificate,
+        'cACertificate': x509.IPACertificate,
+        'cACertificate;binary': x509.IPACertificate,
         'nsds5replicalastupdatestart': unicode,
         'nsds5replicalastupdateend': unicode,
         'nsds5replicalastinitstart': unicode,
@@ -1000,7 +999,7 @@ class LDAPClient:
             return dct
         elif isinstance(val, datetime):
             return val.strftime(LDAP_GENERALIZED_TIME_FORMAT).encode('utf-8')
-        elif isinstance(val, crypto_x509.Certificate):
+        elif isinstance(val, x509.IPACertificate):
             return val.public_bytes(x509.Encoding.DER)
         elif val is None:
             return None
@@ -1027,7 +1026,7 @@ class LDAPClient:
                     return DNSName.from_text(val.decode('utf-8'))
                 elif target_type in (DN, Principal):
                     return target_type(val.decode('utf-8'))
-                elif target_type is crypto_x509.Certificate:
+                elif target_type is x509.IPACertificate:
                     return x509.load_der_x509_certificate(val)
                 else:
                     return target_type(val)
@@ -1381,7 +1380,7 @@ class LDAPClient:
             ]
             return cls.combine_filters(flts, rules)
         elif value is not None:
-            if isinstance(value, crypto_x509.Certificate):
+            if isinstance(value, x509.IPACertificate):
                 value = value.public_bytes(serialization.Encoding.DER)
             if isinstance(value, bytes):
                 value = binascii.hexlify(value).decode('ascii')

--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -37,6 +37,12 @@ from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.primitives.padding import PKCS7
 from cryptography.hazmat.primitives.kdf import pbkdf2
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+try:
+    # cryptography>=43.0.0
+    from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
+except ImportError:
+    # will be removed from this module in cryptography 48.0.0
+    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
 from cryptography.hazmat.backends import default_backend
 
 from ipaplatform.paths import paths
@@ -169,7 +175,7 @@ def convertAlgorithm(value):
     # in the list of the vault wrapping algorithms, we cannot use 3DES anywhere
     if VAULT_WRAPPING_3DES in VAULT_WRAPPING_SUPPORTED_ALGOS:
         supported_algs["http://www.w3.org/2001/04/xmlenc#tripledes-cbc"] = (
-            algorithms.TripleDES, modes.CBC, 64)
+            TripleDES, modes.CBC, 64)
 
     return supported_algs.get(value.lower(), (None, None, None))
 

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1581,7 +1581,8 @@ class kra(Backend):
 
         crypto = cryptoutil.CryptographyCryptoProvider(
             transport_cert_nick="ra_agent",
-            transport_cert=x509.load_certificate_from_file(paths.RA_AGENT_PEM)
+            transport_cert=x509.load_certificate_from_file(
+                paths.RA_AGENT_PEM).cert
         )
 
         # TODO: obtain KRA host & port from IPA service list or point to KRA load balancer


### PR DESCRIPTION
This PR was opened automatically because PR #7614 was pushed to master and backport to ipa-4-12 is required.