### PR TITLE
adtrust: add missing ipaAllowedOperations objectclass

### DIFF
--- a/ipaserver/install/plugins/adtrust.py
+++ b/ipaserver/install/plugins/adtrust.py
@@ -705,7 +705,8 @@ class update_tdo_to_new_layout(Updater):
                 self.set_krb_principal([tgt_principal, nbt_principal],
                                        passwd_incoming,
                                        t_dn,
-                                       flags=self.KRB_PRINC_CREATE_DEFAULT)
+                                       flags=self.KRB_PRINC_CREATE_DEFAULT
+                                       | self.KRB_PRINC_CREATE_AGENT_PERMISSION)
 
             # 3. INBOUND: krbtgt/<OUR REALM>@<REMOTE REALM> must exist
             trust_principal = self.tgt_principal_template.format(


### PR DESCRIPTION
Per @abbra explanation:
> When expected Kerberos principal names for this object were flipped to
  follow requirements for cross-realm krbtgt objects expected by Active
  Directory, trusted object changed its canonical Kerberos principal name.
  The keytab for this Kerberos principal name is fetched by SSSD and it
  needs to be permitted to read the key. We added the virtual permission
  to allow the keytab retrieval but didn't add the objectclass that
  actually allows adding an LDAP attribute to express the permission. When
  an attribute is added to an LDAP object, objectclasses of the object
  must allow presence of that attribute.

This is the followup to #9471 and fixes the upgrade.

Thanks @abbra!

Related: https://pagure.io/freeipa/issue/9471
Fixes: https://pagure.io/freeipa/issue/9712