### PR TITLE
Fix copr build

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,9 +1,10 @@
 srpm:
 	# Setup development environment
 	echo "Installing base development environment"
-	dnf install -y dnf-plugins-core
+	dnf install -y dnf5-plugins
 	echo "Installing FreeIPA development dependencies"
-	dnf builddep -y --skip-broken --spec freeipa.spec.in --best --allowerasing --setopt=install_weak_deps=False
+	cp freeipa.spec.in freeipa.spec
+	dnf builddep -y --best --allowerasing --setopt=install_weak_deps=False freeipa.spec > ${outdir}/builddep.log 2>&1
 
 	# Run autoconf
 	autoreconf -i

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1044,7 +1044,14 @@ for i in *.po ; do
 done
 popd
 
-%autopatch -p1
+%if 0%{?fedora}>=41
+    %global autopatch_options -q -p1
+%else
+    %global autopatch_options -p1
+%endif
+%autopatch %{autopatch_options}
+
+
 
 %build
 # PATH is workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1005235


### PR DESCRIPTION
With fedora41 and rpm 4.20, the copr build does not work anymore.

- rpm 4.20 introduces a change in %autopatch. The command now issues a warning if there is no patch to apply. This makes "dnf builddep" crash. The warning can be silenced with the "-q" option.

- dnf builddep produces non-utf8 characters (for instance when installing logrotate, the output of the scriptlet is printed in color). rpm-coprbuild fails to decode the output and exits on error.
To avoid this failure, redirect the output to a file.

- dnf5 does not recognize the options --skip-broken and --spec.