### PR TITLE
[Backport][ipa-4-12] adtrust: add missing ipaAllowedOperations objectclass

### DIFF
--- a/ipaserver/install/plugins/adtrust.py
+++ b/ipaserver/install/plugins/adtrust.py
@@ -705,7 +705,8 @@ class update_tdo_to_new_layout(Updater):
                 self.set_krb_principal([tgt_principal, nbt_principal],
                                        passwd_incoming,
                                        t_dn,
-                                       flags=self.KRB_PRINC_CREATE_DEFAULT)
+                                       flags=self.KRB_PRINC_CREATE_DEFAULT
+                                       | self.KRB_PRINC_CREATE_AGENT_PERMISSION)
 
             # 3. INBOUND: krbtgt/<OUR REALM>@<REMOTE REALM> must exist
             trust_principal = self.tgt_principal_template.format(


### PR DESCRIPTION
This PR was opened automatically because PR #7621 was pushed to master and backport to ipa-4-12 is required.