### PR TITLE
Fix the typo in ipa_migrate_constants.

### DIFF
--- a/ipaserver/install/ipa_migrate_constants.py
+++ b/ipaserver/install/ipa_migrate_constants.py
@@ -862,7 +862,7 @@ DB_OBJECTS = {
     'pbac_priv': {
         'oc': ['groupofnames'],
         'subtree': ',cn=privileges,cn=pbac,$SUFFIX',
-        'label': 'Privledges',
+        'label': 'Privileges',
         'mode': 'all',
         'count': 0,
     },


### PR DESCRIPTION
ipa-migrate.log displays Privileges migrated as Privledges due to typo in labelling i.e 'label': 'Privledges' Hence changed that to 'label': 'Privileges'

---- LOG FILE ----
INFO  - Privledges: 3
------------------