### PR TITLE
[Backport][ipa-4-12] Fix the typo in ipa_migrate_constants.

### DIFF
--- a/ipaserver/install/ipa_migrate_constants.py
+++ b/ipaserver/install/ipa_migrate_constants.py
@@ -886,7 +886,7 @@ DB_OBJECTS = {
     'pbac_priv': {
         'oc': ['groupofnames'],
         'subtree': ',cn=privileges,cn=pbac,$SUFFIX',
-        'label': 'Privledges',
+        'label': 'Privileges',
         'mode': 'all',
         'count': 0,
     },


### PR DESCRIPTION
This PR was opened automatically because PR #7629 was pushed to master and backport to ipa-4-12 is required.