### PR TITLE
ipatests: Fixes for ipa-ipa-migration tool

### DIFF
--- a/ipatests/test_integration/test_ipa_ipa_migration.py
+++ b/ipatests/test_integration/test_ipa_ipa_migration.py
@@ -437,10 +437,8 @@ class TestIPAMigrateCLIOptions(MigrationTest):
         """
         hostname = "server.invalid.host"
         ERR_MSG = (
-            "IPA to IPA migration starting ...\n"
             "Failed to bind to remote server: cannot connect to "
-            "'ldap://"
-            "{}': \n".format(hostname)
+            "'ldap://{}':".format(hostname)
         )
         result = run_migrate(
             self.replicas[0],


### PR DESCRIPTION
The test test_ipa_migrate_with_invalid_host has been failing in downstream run due to mismatch in the expected test output, hence the assert statement has been modified.