### PR TITLE
[Backport][ipa-4-11] ipalib/x509: support PyCA 44.0

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -20,7 +20,7 @@ requests
 
 ## C libraries with binary wheels
 cffi
-cryptography < 44.0.0
+cryptography
 lxml
 
 ## C libraries without binaries wheels

--- a/ipalib/ipajson.py
+++ b/ipalib/ipajson.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 import json
 import six
 from ipalib.constants import LDAP_GENERALIZED_TIME_FORMAT
-from ipalib import capabilities
+from ipalib import capabilities, x509
 from ipalib.x509 import Encoding as x509_Encoding
 from ipapython.dn import DN
 from ipapython.dnsutil import DNSName
@@ -72,7 +72,7 @@ class _JSONPrimer(dict):
             list: self._enc_list,
             tuple: self._enc_list,
             dict: self._enc_dict,
-            crypto_x509.Certificate: self._enc_certificate,
+            x509.IPACertificate: self._enc_certificate,
             crypto_x509.CertificateSigningRequest: self._enc_certificate,
         })
 

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -91,7 +91,7 @@ SAN_UPN = '1.3.6.1.4.1.311.20.2.3'
 SAN_KRB5PRINCIPALNAME = '1.3.6.1.5.2.2'
 
 
-class IPACertificate(crypto_x509.Certificate):
+class IPACertificate:
     """
     A proxy class wrapping a python-cryptography certificate representation for
     IPA purposes
@@ -207,6 +207,10 @@ class IPACertificate(crypto_x509.Certificate):
         Counts fingerprint of the wrapped cryptography.Certificate
         """
         return self._cert.fingerprint(algorithm)
+
+    @property
+    def cert(self):
+        return self._cert
 
     @property
     def serial_number(self):
@@ -450,6 +454,8 @@ def load_pem_x509_certificate(data):
     :returns: a ``IPACertificate`` object.
     :raises: ``ValueError`` if unable to load the certificate.
     """
+    if isinstance(data, IPACertificate):
+        return data
     return IPACertificate(
         crypto_x509.load_pem_x509_certificate(data, backend=default_backend())
     )
@@ -462,6 +468,8 @@ def load_der_x509_certificate(data):
     :returns: a ``IPACertificate`` object.
     :raises: ``ValueError`` if unable to load the certificate.
     """
+    if isinstance(data, IPACertificate):
+        return data
     return IPACertificate(
         crypto_x509.load_der_x509_certificate(data, backend=default_backend())
     )

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -33,7 +33,6 @@ import warnings
 
 from collections import OrderedDict
 
-from cryptography import x509 as crypto_x509
 from cryptography.hazmat.primitives import serialization
 
 import ldap
@@ -748,10 +747,10 @@ class LDAPClient:
         'dnszoneidnsname': DNSName,
         'krbcanonicalname': Principal,
         'krbprincipalname': Principal,
-        'usercertificate': crypto_x509.Certificate,
-        'usercertificate;binary': crypto_x509.Certificate,
-        'cACertificate': crypto_x509.Certificate,
-        'cACertificate;binary': crypto_x509.Certificate,
+        'usercertificate': x509.IPACertificate,
+        'usercertificate;binary': x509.IPACertificate,
+        'cACertificate': x509.IPACertificate,
+        'cACertificate;binary': x509.IPACertificate,
         'nsds5replicalastupdatestart': unicode,
         'nsds5replicalastupdateend': unicode,
         'nsds5replicalastinitstart': unicode,
@@ -1000,7 +999,7 @@ class LDAPClient:
             return dct
         elif isinstance(val, datetime):
             return val.strftime(LDAP_GENERALIZED_TIME_FORMAT).encode('utf-8')
-        elif isinstance(val, crypto_x509.Certificate):
+        elif isinstance(val, x509.IPACertificate):
             return val.public_bytes(x509.Encoding.DER)
         elif val is None:
             return None
@@ -1027,7 +1026,7 @@ class LDAPClient:
                     return DNSName.from_text(val.decode('utf-8'))
                 elif target_type in (DN, Principal):
                     return target_type(val.decode('utf-8'))
-                elif target_type is crypto_x509.Certificate:
+                elif target_type is x509.IPACertificate:
                     return x509.load_der_x509_certificate(val)
                 else:
                     return target_type(val)
@@ -1381,7 +1380,7 @@ class LDAPClient:
             ]
             return cls.combine_filters(flts, rules)
         elif value is not None:
-            if isinstance(value, crypto_x509.Certificate):
+            if isinstance(value, x509.IPACertificate):
                 value = value.public_bytes(serialization.Encoding.DER)
             if isinstance(value, bytes):
                 value = binascii.hexlify(value).decode('ascii')

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1581,7 +1581,8 @@ class kra(Backend):
 
         crypto = cryptoutil.CryptographyCryptoProvider(
             transport_cert_nick="ra_agent",
-            transport_cert=x509.load_certificate_from_file(paths.RA_AGENT_PEM)
+            transport_cert=x509.load_certificate_from_file(
+                paths.RA_AGENT_PEM).cert
         )
 
         # TODO: obtain KRA host & port from IPA service list or point to KRA load balancer


### PR DESCRIPTION
This PR was opened automatically because PR https://github.com/freeipa/freeipa/pull/7614 was pushed to master and backport to ipa-4-11 is required.

PR was ACKed automatically because this is backport of PR https://github.com/freeipa/freeipa/pull/7614. Wait for CI to finish before pushing. In case of questions or problems contact @abbra who is author of the original PR.