### PR TITLE
KRA cert renewal: update ca.connector.KRA.transportCert

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1262,11 +1262,14 @@ class CAInstance(DogtagInstance):
         """
 
         # The cert directive to update per nickname
-        directives = {'auditSigningCert cert-pki-ca': 'ca.audit_signing.cert',
-                      'ocspSigningCert cert-pki-ca': 'ca.ocsp_signing.cert',
-                      'caSigningCert cert-pki-ca': 'ca.signing.cert',
-                      'subsystemCert cert-pki-ca': 'ca.subsystem.cert',
-                      'Server-Cert cert-pki-ca': 'ca.sslserver.cert'}
+        directives = {
+            'auditSigningCert cert-pki-ca': 'ca.audit_signing.cert',
+            'ocspSigningCert cert-pki-ca': 'ca.ocsp_signing.cert',
+            'caSigningCert cert-pki-ca': 'ca.signing.cert',
+            'subsystemCert cert-pki-ca': 'ca.subsystem.cert',
+            'Server-Cert cert-pki-ca': 'ca.sslserver.cert',
+            'transportCert cert-pki-kra': 'ca.connector.KRA.transportCert'
+        }
 
         try:
             self.backup_config()

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1322,7 +1322,7 @@ class TestInstallMaster(IntegrationTest):
 
 class TestInstallMasterKRA(IntegrationTest):
 
-    num_replicas = 0
+    num_replicas = 1
 
     @classmethod
     def install(cls, mh):
@@ -1378,6 +1378,14 @@ class TestInstallMasterKRA(IntegrationTest):
                 nickname
             )
             assert starting_serial != int(cert.serial_number)
+
+    def test_install_replica_after_kracert_renewal(self):
+        """
+        Test replica installation with CA after the KRA certs renewal
+        """
+        tasks.install_replica(self.master, self.replicas[0],
+                              setup_ca=True)
+        tasks.install_kra(self.replicas[0])
 
 
 class TestInstallMasterDNS(IntegrationTest):


### PR DESCRIPTION
After the KRA transport cert has been renewed, the value
of ca.connector.KRA.transportCert must also be updated in
/etc/pki/pki-tomcat/ca/CS.cfg.
Otherwise replica installation with KRA fails.

Fixes: https://pagure.io/freeipa/issue/9692
