### PR TITLE
[ipa-4-11] KRA cert renewal: update the certs in kra/CS.cfg

### DIFF
--- a/install/restart_scripts/renew_ca_cert.in
+++ b/install/restart_scripts/renew_ca_cert.in
@@ -32,7 +32,7 @@ from ipapython import ipautil
 from ipalib import api, errors
 from ipalib import x509
 from ipalib.install.kinit import kinit_keytab
-from ipaserver.install import certs, cainstance
+from ipaserver.install import certs, cainstance, krainstance
 from ipaserver.plugins.ldap2 import ldap2
 from ipaplatform import services
 from ipaplatform.paths import paths
@@ -83,7 +83,9 @@ def _main():
         api.Backend.ldap2.connect()
 
         ca = cainstance.CAInstance(host_name=api.env.host)
+        kra = krainstance.KRAInstance(api.env.realm)
         ca.update_cert_config(nickname, cert)
+        kra.update_cert_config(nickname, cert)
         if ca.is_renewal_master():
             cainstance.update_people_entry(cert)
             cainstance.update_authority_entry(cert)

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -500,6 +500,13 @@ optional_policy(`
 
 optional_policy(`
     gen_require(` #selint-disable:S-001
+        type certmonger_t;
+    ')
+	  pki_manage_tomcat_etc_rw(certmonger_t)
+')
+
+optional_policy(`
+    gen_require(` #selint-disable:S-001
         type oddjob_t;
     ')
 	ipa_helper_noatsecure(oddjob_t)


### PR DESCRIPTION
After the KRA certificates have been renewed, they also
need to be updated in /etc/pki/pki-tomcat/kra/CS.cfg.
Otherwise replica installation with KRA fails.

Fixes: https://pagure.io/freeipa/issue/9692
