### PR TITLE
[Backport][ipa-4-12] ipatests: certbot removed the --manual-public-ip-logging-ok parameter

### DIFF
--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -311,7 +311,6 @@ class TestACME(CALessBase):
             '--domain', self.clients[0].hostname,
             '--preferred-challenges', 'dns',
             '--manual',
-            '--manual-public-ip-logging-ok',
             '--manual-auth-hook', CERTBOT_DNS_IPA_SCRIPT,
             '--manual-cleanup-hook', CERTBOT_DNS_IPA_SCRIPT,
             '--key-type', 'rsa',


### PR DESCRIPTION
This PR was opened automatically because PR #7641 was pushed to master and backport to ipa-4-12 is required.