### PR TITLE
ipatests: skip test_ipahealthcheck_ds_configcheck for recent versions

### DIFF
--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -605,6 +605,20 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  389ds-fedora/test_ipahealthcheck:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
+        template: *ci-master-latest
+        timeout: 6300
+        topology: *master_1repl_1client
+
   389ds-fedora/automember:
     requires: [389ds-fedora/build]
     priority: 50
@@ -660,3 +674,4 @@ jobs:
         template: *ci-master-latest
         timeout: 5000
         topology: *master_2repl_1client
+

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1634,6 +1634,11 @@ class TestIpaHealthCheck(IntegrationTest):
             grace_date = datetime.strftime(grace_date, "%Y-%m-%d 00:00:01 Z")
             self.master.run_command(['date', '-s', grace_date])
 
+            # Restart dirsrv as it doesn't like time jumps
+            instance = realm_to_serverid(self.master.domain.realm)
+            cmd = ["systemctl", "restart", "dirsrv@{}".format(instance)]
+            self.master.run_command(cmd)
+
             for check in ("IPACertmongerExpirationCheck",
                           "IPACertfileExpirationCheck",):
                 execute_expiring_check(check)


### PR DESCRIPTION
### ipatests: skip test_ipahealthcheck_ds_configcheck for recent versions
    
389-ds removed the parameter nsslapd-logging-hr-timestamps-enabled
in 2.5.3 and above. Skip the test that exercises the corresponding
healthcheck.

Fixes: https://pagure.io/freeipa/issue/9730

### Nightly tests: add test_ipahelthcheck to 389ds pipeline

Add the test to the list of nightlies run against 389ds.
