### PR TITLE
[Backport][ipa-4-12] ipatests: force the version for uninstall/reinstall

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2749,6 +2749,28 @@ def get_package_version(host, pkgname):
     return get_package_version
 
 
+def get_package_version_and_release(host, pkgname):
+    """
+    Get package version-release on remote host
+    """
+    platform = get_platform(host)
+    if platform in ("rhel", "fedora"):
+        cmd = host.run_command(
+            ["rpm", "-qa", "--qf", "%{VERSION}-%{RELEASE}", pkgname]
+        )
+        get_package_version = cmd.stdout_text
+        if not get_package_version:
+            raise ValueError(
+                "get_package_version: "
+                "pkgname package is not installed"
+            )
+    else:
+        raise ValueError(
+            "get_package_version: unknown platform %s" % platform
+        )
+    return get_package_version
+
+
 def get_openldap_client_version(host):
     """Get openldap-clients version on remote host"""
     return get_package_version(host, 'openldap-clients')

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -332,6 +332,8 @@ class BaseBackupAndRestoreWithDNS(IntegrationTest):
                                      '--uninstall',
                                      '-U'])
 
+            version = tasks.get_package_version_and_release(
+                self.master, '*ipa-server-dns')
             tasks.uninstall_packages(self.master, ['*ipa-server-dns'])
 
             dirman_password = self.master.config.dirman_password
@@ -341,7 +343,7 @@ class BaseBackupAndRestoreWithDNS(IntegrationTest):
                 raiseonerr=False)
             assert 'Please install the package' in result.stderr_text
 
-            tasks.install_packages(self.master, ['*ipa-server-dns'])
+            tasks.install_packages(self.master, ['*ipa-server-dns-' + version])
             if reinstall:
                 tasks.install_master(self.master, setup_dns=True)
             self.master.run_command(['ipa-restore', backup_path],
@@ -945,6 +947,8 @@ class TestBackupAndRestoreTrust(IntegrationTest):
                                      '--uninstall',
                                      '-U'])
 
+            version = tasks.get_package_version_and_release(
+                self.master, '*ipa-server-trust-ad')
             tasks.uninstall_packages(self.master, ['*ipa-server-trust-ad'])
 
             dirman_password = self.master.config.dirman_password
@@ -954,7 +958,8 @@ class TestBackupAndRestoreTrust(IntegrationTest):
                 raiseonerr=False)
             assert 'Please install the package' in result.stderr_text
 
-            tasks.install_packages(self.master, ['*ipa-server-trust-ad'])
+            tasks.install_packages(
+                self.master, ['*ipa-server-trust-ad-' + version])
             self.master.run_command(['ipa-restore', backup_path],
                                     stdin_text=dirman_password + '\nyes')
 


### PR DESCRIPTION
This PR was opened automatically because PR #7648 was pushed to master and backport to ipa-4-12 is required.