### PR TITLE
[Backport][ipa-4-12]  ipatests: skip test_ipahealthcheck_ds_configcheck for recent versions

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1634,6 +1634,11 @@ class TestIpaHealthCheck(IntegrationTest):
             grace_date = datetime.strftime(grace_date, "%Y-%m-%d 00:00:01 Z")
             self.master.run_command(['date', '-s', grace_date])
 
+            # Restart dirsrv as it doesn't like time jumps
+            instance = realm_to_serverid(self.master.domain.realm)
+            cmd = ["systemctl", "restart", "dirsrv@{}".format(instance)]
+            self.master.run_command(cmd)
+
             for check in ("IPACertmongerExpirationCheck",
                           "IPACertfileExpirationCheck",):
                 execute_expiring_check(check)


### PR DESCRIPTION
This is a manual backport of PR #7649 to the ipa-4-12 branch.

The backport cleanly cherry-picked 2 commits out of 3:
- https://github.com/freeipa/freeipa/commit/1d93e48644960231d72b2c75f7f847a31a62f84f ipatests: skip test_ipahealthcheck_ds_configcheck for recent versions
- https://github.com/freeipa/freeipa/commit/6f475294e0868b0b7bf6143260c9b30e00e25efd ipatests: restart dirsrv after time jumps

but the third one is not needed (there is no 389ds nightly pipeline for this branch):
- https://github.com/freeipa/freeipa/commit/3863043fd1a0cccd964daedc3d12928c236d8b4b Nightly tests: add test_ipahelthcheck to 389ds pipeline

Auto-Ack as this is a simple backport. In case of questions or problems contact @flo-renaud who is author of the original PR.