### PR TITLE
Apply certmonger_timeout to start_tracking and request_cert

### DIFF
--- a/client/man/default.conf.5
+++ b/client/man/default.conf.5
@@ -20,7 +20,7 @@
 .SH "NAME"
 default.conf \- IPA configuration file
 .SH "SYNOPSIS"
-/etc/ipa/default.conf, ~/.ipa/default.conf, /etc/ipa/server.conf, /etc/ipa/cli.conf
+/etc/ipa/default.conf, ~/.ipa/default.conf, /etc/ipa/server.conf, /etc/ipa/cli.conf, /etc/ipa/installer.conf, /etc/ipa/cli_installer.conf
 .SH "DESCRIPTION"
 The \fIdefault.conf \fRconfiguration file is used to set system\-wide defaults to be applied when running IPA clients and servers.
 
@@ -75,7 +75,7 @@ Specifies the hostname of the dogtag CA server. The default is the hostname of t
 Specifies the insecure CA end user port. The default is 8080.
 .TP
 .B certmonger_wait_timeout <seconds>
-The time to wait for a certmonger request to complete during installation. The default value is 300 seconds.
+The time to wait for a certmonger request to complete during installation. The default value is 300 seconds. To tune create/add to /etc/ipa/installer.conf.
 .TP
 .B context <context>
 Specifies the context that IPA is being executed in. IPA may operate differently depending on the context. The current defined contexts are cli, server and dns. Additionally this value is used to load /etc/ipa/\fBcontext\fR.conf to provide context\-specific configuration. For example, if you want to always perform client requests in verbose mode but do not want to have verbose enabled on the server, add the verbose option to \fI/etc/ipa/cli.conf\fR.
@@ -263,6 +263,12 @@ system\-wide IPA client configuration file
 .TP
 .I /etc/ipa/server.conf
 system\-wide IPA server configuration file
+.TP
+.I /etc/ipa/installer.conf
+IPA configuration used while installing an IPA server or replica
+.TP
+.I /etc/ipa/cli_installer.conf
+IPA configuration used while installing an IPA client
 .SH "EXAMPLES"
 .TP
 An example of a context-specific configuration file is \fB/etc/ipa/dns.conf\fR to be used to increase debug output of the IPA DNSSEC daemons.

--- a/ipalib/install/certmonger.py
+++ b/ipalib/install/certmonger.py
@@ -477,7 +477,8 @@ def request_cert(
         request_parameters['cert-perms'] = perms[0]
         request_parameters['key-perms'] = perms[1]
 
-    result = cm.obj_if.add_request(request_parameters, timeout=30)
+    result = cm.obj_if.add_request(request_parameters,
+                                   timeout=api.env.certmonger_wait_timeout)
     try:
         if result[0]:
             request = _cm_dbus_object(cm.bus, cm, result[1], DBUS_CM_REQUEST_IF,
@@ -581,7 +582,9 @@ def start_tracking(
     if nss_user:
         params['nss-user'] = nss_user
 
-    result = cm.obj_if.add_request(params, timeout=30)
+    logger.debug("start tracking %s", params)
+    result = cm.obj_if.add_request(params,
+                                   timeout=api.env.certmonger_wait_timeout)
     try:
         if result[0]:
             request = _cm_dbus_object(cm.bus, cm, result[1], DBUS_CM_REQUEST_IF,

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -539,7 +539,10 @@ class CAInstance(DogtagInstance):
         if ra_only:
             runtime = None
         else:
-            runtime = 180
+            if self.tokenname:
+                runtime = "HSM dependent"
+            else:
+                runtime = 180
 
         try:
             self.start_creation(runtime=runtime)

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -575,6 +575,24 @@ class DogtagInstance(service.Service):
             except RuntimeError as e:
                 logger.error(
                     "certmonger failed to start tracking certificate: %s", e)
+            except dbus.exceptions.DBusException as e:
+                if e._dbus_error_name == "org.freedesktop.DBus.Error.NoReply":
+                    logger.error(
+                        "Timeout encountered starting tracking of '%s'."
+                        "This timeout can be tuned using "
+                        "certmonger_wait_timeout in /etc/ipa/installer.conf.",
+                        nickname
+                    )
+                if self.hsm_enabled:
+                    logger.error(
+                        "On an initial install failure this may leave "
+                        "certificates and keys on the HSM token. These "
+                        "need to be manually cleaned per your HSM-specific "
+                        "documentation before installing IPA again. On a "
+                        "replica install no clean-up should be done (it will "
+                        "destroy your installation."
+                    )
+                raise
 
     def stop_tracking_certificates(self):
         """

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -59,6 +59,8 @@ def print_msg(message, output_fd=sys.stdout):
 
 def format_seconds(seconds):
     """Format a number of seconds as an English minutes+seconds message"""
+    if type(seconds) is not int:
+        return seconds
     parts = []
     minutes, seconds = divmod(seconds, 60)
     if minutes:
@@ -660,7 +662,7 @@ class Service:
                 else:
                     end_message = "Done configuring %s." % self.service_desc
 
-        if runtime is not None and runtime > 0:
+        if runtime is not None or (type(runtime) is int and runtime > 0):
             self.print_msg('%s. Estimated time: %s' % (start_message,
                                                       format_seconds(runtime)))
         else:


### PR DESCRIPTION
We've seen that with some slow HSMs the default DBus timeout the HSM doesn't respond quickly enough to certmonger start tracking requests which fails the entire installation.

A first attempt was made to bump up the default to 30 seconds which turned out to not be long enough.

There is already a certmonger timeout defined in the API but it is 300 seconds so I was hesitant to use it. It could delay the actual failure of a blown install by 5 minutes. But it also gives the end user the flexibility to be able to control success over an installation so we'll go ahead and use it.

Fixes: https://pagure.io/freeipa/issue/9725

ab was right, I should have made this user-configurable from the beginning :-(

To do that they need to pre-create /etc/ipa/installer.conf with the certmonger_timeout value defined.