### PR TITLE
test_idp: Use flatpak firefox binary if available

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -72,7 +72,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_idp.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_2repl_1client

--- a/ipatests/pytest_ipa/integration/create_keycloak.py
+++ b/ipatests/pytest_ipa/integration/create_keycloak.py
@@ -9,9 +9,14 @@ from ipatests.pytest_ipa.integration import tasks
 def setup_keycloakserver(host, version='26.1.0'):
     dir = "/opt/keycloak"
     password = host.config.admin_password
-    tasks.install_packages(host, ["unzip", "java-21-openjdk-headless",
-                                  "openssl", "maven", "wget",
-                                  "firefox", "xorg-x11-server-Xvfb"])
+    if (tasks.get_platform(host) == "rhel"
+       and tasks.get_platform_version(host)[0] == 10):
+        tasks.install_packages(host, ["unzip", "java-21-openjdk-headless",
+                                      "openssl", "maven", "wget"])
+    else:
+        tasks.install_packages(host, ["unzip", "java-11-openjdk-headless",
+                                      "openssl", "maven", "wget",
+                                      "firefox", "xorg-x11-server-Xvfb"])
     #  add keycloak system user/group and folder
     url = "https://github.com/keycloak/keycloak/releases/download/{0}/keycloak-{0}.zip".format(version)  # noqa: E501
     host.run_command(["wget", url, "-O", "{0}-{1}.zip".format(dir, version)])

--- a/ipatests/test_integration/test_idp.py
+++ b/ipatests/test_integration/test_idp.py
@@ -12,12 +12,20 @@ from ipatests.pytest_ipa.integration import tasks, create_keycloak
 user_code_script = textwrap.dedent("""
 from selenium import webdriver
 from datetime import datetime
+from os import path
 from pkg_resources import parse_version
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 options = Options()
+if path.exists(
+  "/var/lib/flatpak/app/org.mozilla.firefox/current/active/files/bin/firefox"):
+    options.binary_location = ("/var/lib/flatpak/app/org.mozilla.firefox/"
+                              "current/active/files/bin/firefox")
+else:
+    options.binary_location = "/usr/bin/firefox"
+
 if  parse_version(webdriver.__version__) < parse_version('4.10.0'):
     options.headless = True
     driver = webdriver.Firefox(executable_path="/opt/geckodriver",


### PR DESCRIPTION
In case the Firefox package is installed via flatpak, prefer that version instead of dnf-provided one.

Fixes: FREEIPA-11122