### PR TITLE
Suppress spurious failure messages when uninstalling ACME

### DIFF
--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -336,6 +336,8 @@ class DogtagInstance(service.Service):
         if self.subsystem == "ACME":
             if pki_version < pki.util.Version("11.0.0"):
                 return
+            elif not os.path.exists(os.path.join(paths.PKI_TOMCAT, 'acme')):
+                return
             elif (
                 pki.util.Version("11.0.0") <= pki_version
                 < pki.util.Version("11.6.0")
@@ -365,7 +367,6 @@ class DogtagInstance(service.Service):
 
         try:
             ipautil.run(args)
-
         except ipautil.CalledProcessError as e:
             logger.critical("failed to uninstall %s instance %s",
                             self.subsystem, e)


### PR DESCRIPTION
We fork out to pki-server to uninstall the ACME service and the results are very coarse, currently just a pass/fail. This can lead to displaying very long tracebacks as an error message.

It is also possible that the acme path doesn't exist in the pki-tomcat instance.

Ignore both of them.

Fixes: https://pagure.io/freeipa/issue/9740