### PR TITLE
Add a message where the ipa service restarted at end of install

### DIFF
--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1072,7 +1072,12 @@ def install(installer):
     # Everything installed properly, activate ipa service.
     sstore.delete_state('installation', 'complete')
     sstore.backup_state('installation', 'complete', True)
+
+    service.print_msg("Enabling and restarting the IPA service")
+    start = time.time()
     services.knownservices.ipa.enable()
+    dur = time.time() - start
+    logger.debug("Service enablement duration: %0.3f", dur)
 
     print("======================================="
           "=======================================")


### PR DESCRIPTION
There is a noticeable near the end of an IPA server installation after the client installation is complete and before the "Setup complete" message is displayed.

A few minor things are done here but the big time sink is enabling ipa.service and restarting it because the CA takes so long to start. In my testing it was between 40 and 60 seconds.

So add a little message so folks don't think the client installer hung up at the end.

Fixes: https://pagure.io/freeipa/issue/9741