### PR TITLE
[Backport][ipa-4-12] Add a message where the ipa service restarted at end of install

### DIFF
--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1072,7 +1072,12 @@ def install(installer):
     # Everything installed properly, activate ipa service.
     sstore.delete_state('installation', 'complete')
     sstore.backup_state('installation', 'complete', True)
+
+    service.print_msg("Enabling and restarting the IPA service")
+    start = time.time()
     services.knownservices.ipa.enable()
+    dur = time.time() - start
+    logger.debug("Service enablement duration: %0.3f", dur)
 
     print("======================================="
           "=======================================")


### PR DESCRIPTION
This PR was opened automatically because PR #7677 was pushed to master and backport to ipa-4-12 is required.