### PR TITLE
Log failed auth attempts over LDAP when a user is locked

### DIFF
--- a/daemons/ipa-slapi-plugins/common/util.h
+++ b/daemons/ipa-slapi-plugins/common/util.h
@@ -67,6 +67,9 @@
                     "[file %s, line %d]: " fmt, \
                     __FILE__, __LINE__, ##__VA_ARGS__)
 
+#define LOG_ALERT(fmt, ...) \
+    slapi_log_error(SLAPI_LOG_ALERT, log_func, fmt, ##__VA_ARGS__)
+
 #define LOG_PWDPOLICY(fmt, ...) \
     slapi_log_error(SLAPI_LOG_PWDPOLICY, log_func, fmt, ##__VA_ARGS__)
 

--- a/daemons/ipa-slapi-plugins/ipa-lockout/ipa_lockout.c
+++ b/daemons/ipa-slapi-plugins/ipa-lockout/ipa_lockout.c
@@ -552,6 +552,7 @@ static int ipalockout_postop(Slapi_PBlock *pb)
                 if ((lockout_duration == 0) ||
                     (time_now < timegm(&tm) + lockout_duration)) {
                     /* Within lockout duration */
+                    LOG_ALERT("User %s is locked out. Too many failed authentication attempts.\n", dn);
                     goto done;
                 }
             }


### PR DESCRIPTION
The KDC logs when a user who is locked out with
Client's credentials have been revoked

The LDAP server did not. This adds a message so administrators
can tell when a user is locked out.

ALERT - ipalockout_postop - User uid=tuser,cn=users,cn=accounts,dc=example,dc=test is locked out. Too many failed authentication attempts.

Fixes: https://pagure.io/freeipa/issue/9742
