### PR TITLE
[ipa-4-11] cert renewal: call kra renewal helper only if KRA is installed

### DIFF
--- a/install/restart_scripts/renew_ca_cert.in
+++ b/install/restart_scripts/renew_ca_cert.in
@@ -85,7 +85,8 @@ def _main():
         ca = cainstance.CAInstance(host_name=api.env.host)
         kra = krainstance.KRAInstance(api.env.realm)
         ca.update_cert_config(nickname, cert)
-        kra.update_cert_config(nickname, cert)
+        if kra.is_installed():
+            kra.update_cert_config(nickname, cert)
         if ca.is_renewal_master():
             cainstance.update_people_entry(cert)
             cainstance.update_authority_entry(cert)


### PR DESCRIPTION
In a previous patch, a call to kra.update_cert_config was added
to the helper in order to update the directives in
/etc/pki/pki-tomcat/kra/CS.cfg
This file exists only when a KRA instance is configured on the system.

The call must be done only in this case, otherwise it can be skipped.

Fixes: https://pagure.io/freeipa/issue/9692