### PR TITLE
[Backport][ipa-4-12] Configure the pki-tomcatd service systemd timeout

### DIFF
--- a/client/man/default.conf.5
+++ b/client/man/default.conf.5
@@ -191,7 +191,7 @@ Specifies the IPA Server hostname.
 Skip client vs. server API version checking. Can lead to errors/strange behavior when newer clients talk to older servers. Use with caution.
 .TP
 .B startup_timeout <time in seconds>
-Controls the amount of time waited when starting a service. The default value is 120 seconds.
+Controls the amount of time waited when starting a service. The default value is 90 seconds, the same as the default systemd startup timeout. If configuring a CA the startup_timeout value will be added as an override for TimeoutStartSec in systemd. If installation times out when starting the CA create /etc/ipa/installer.conf with this value set.
 .TP
 .B startup_traceback <boolean>
 If the IPA server fails to start and this value is True the server will attempt to generate a python traceback to make identifying the underlying problem easier.

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -189,8 +189,9 @@ DEFAULT_CONFIG = (
 
     # Time to wait for a service to start, in seconds.
     # Note that systemd has a DefaultTimeoutStartSec of 90 seconds. Higher
-    # values are not effective unless systemd is reconfigured, too.
-    ('startup_timeout', 120),
+    # values are not effective unless systemd is reconfigured, too. Or you
+    # can update the systemd service file with its own TimeoutStartSec.
+    ('startup_timeout', 90),
     # How long http connection should wait for reply [seconds].
     ('http_timeout', 30),
     # How long to wait for an entry to appear on a replica

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -453,6 +453,7 @@ class CAInstance(DogtagInstance):
             if promote:
                 self.step("destroying installation admin user",
                           self.teardown_admin)
+            self.step("updating IPA configuration", update_ipa_conf)
             # Materialize config changes and new ACLs
             self.step("starting certificate server instance",
                       self.start_instance)
@@ -480,7 +481,6 @@ class CAInstance(DogtagInstance):
                 self.step("configure certificate renewals", self.configure_renewal)
                 self.step("Configure HTTP to proxy connections",
                           self.http_proxy)
-                self.step("updating IPA configuration", update_ipa_conf)
                 self.step("enabling CA instance", self.__enable_instance)
                 if not promote:
                     if self.clone:
@@ -2453,6 +2453,7 @@ def update_ipa_conf(ca_host=None):
     parser.set('global', 'enable_ra', 'True')
     parser.set('global', 'ra_plugin', 'dogtag')
     parser.set('global', 'dogtag_version', '10')
+    parser.set('global', 'startup_timeout', api.env.startup_timeout)
     if ca_host is None:
         parser.remove_option('global', 'ca_host')
     else:

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -713,7 +713,12 @@ class CAInstance(DogtagInstance):
             f.write('[Service]\n')
             f.write('Environment=LC_ALL=C.UTF-8\n')
             f.write('ExecStartPost={}\n'.format(paths.IPA_PKI_WAIT_RUNNING))
+            f.write('TimeoutStartSec=%d\n' % api.env.startup_timeout)
         tasks.systemd_daemon_reload()
+        logger.info(
+            "Set start up timeout of pki-tomcatd service to %d seconds",
+            api.env.startup_timeout
+        )
 
     def safe_backup_config(self):
         """


### PR DESCRIPTION
This PR was opened automatically because PR #7686 was pushed to master and backport to ipa-4-12 is required.