### PR TITLE
[Backport][ipa-4-12] ipa-migrate - do not migrate tombstone entries, ignore MidairCollisions,

### DIFF
--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -1462,6 +1462,10 @@ class IPAMigrate():
             if DN(exclude_dn) in DN(entry_dn):
                 return
 
+        # Skip tombstones
+        if 'nsTombstone' in entry_attrs['objectClass']:
+            return
+
         # Determine entry type: user, group, hbac, etc
         entry_type = self.get_entry_type(entry_dn, entry_attrs)
         if entry_type is None:
@@ -1568,6 +1572,10 @@ class IPAMigrate():
                     stats['custom'] += 1
                 else:
                     DB_OBJECTS[entry_type]['count'] += 1
+            except errors.MidairCollision as e:
+                # Typically means no such attribute, ok to ignore
+                self.log_debug(f'Failed to update "{local_dn}" error: '
+                               f'{str(e)} - ok to ignore')
             except errors.ExecutionError as e:
                 self.log_error(f'Failed to update "{local_dn}" error: '
                                f'{str(e)}')

--- a/ipaserver/install/ipa_migrate_constants.py
+++ b/ipaserver/install/ipa_migrate_constants.py
@@ -71,6 +71,7 @@ IGNORE_ATTRS = [
     'serverhostname',
     'krbpasswordexpiration',
     'krblastadminunlock',
+    'krbpwdpolicyreference',  # COS attribute
 ]
 
 # For production mode, bring everything over


### PR DESCRIPTION
This PR was opened automatically because PR #7670 was pushed to master and backport to ipa-4-12 is required.