### PR TITLE
Validate the default e-mail domain in the config plugin

### DIFF
--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -36,6 +36,7 @@ from .selinuxusermap import validate_selinuxuser
 from ipalib import _
 from ipapython.admintool import ScriptError
 from ipapython.dn import DN
+from ipapython.ipavalidate import Email
 from ipaserver.plugins.privilege import principal_has_privilege
 from ipaserver.install.adtrust import set_and_check_netbios_name
 
@@ -116,6 +117,17 @@ def validate_search_records_limit(ugettext, value):
         return _('must be at least 10')
     return None
 
+
+def validate_emaildomain(ugettext, value):
+    """Do some basic e-mail domain validation.
+
+       Test using a sample user@domain.
+    """
+    test = "test@{}".format(value)
+    if not Email(test):
+        return _('Invalid e-mail domain')
+    return None
+
 @register()
 class config(LDAPObject):
     """
@@ -188,6 +200,7 @@ class config(LDAPObject):
             doc=_('Default group for new users'),
         ),
         Str('ipadefaultemaildomain?',
+            validate_emaildomain,
             cli_name='emaildomain',
             label=_('Default e-mail domain'),
             doc=_('Default e-mail domain'),

--- a/ipatests/test_xmlrpc/test_config_plugin.py
+++ b/ipatests/test_xmlrpc/test_config_plugin.py
@@ -340,4 +340,61 @@ class test_config(Declarative):
             ),
             expected=errors.EmptyModlist(),
         ),
+
+        dict(
+            desc='Set invalid default e-mail domain, no TLD',
+            command=(
+                'config_mod', [], {'ipadefaultemaildomain': 'foo'},
+            ),
+            expected=errors.ValidationError(
+                name='emaildomain',
+                error='Invalid e-mail domain'),
+        ),
+
+        dict(
+            desc='Set invalid default e-mail domain, trailing dots',
+            command=(
+                'config_mod', [], {'ipadefaultemaildomain': 'foo.com...'},
+            ),
+            expected=errors.ValidationError(
+                name='emaildomain',
+                error='Invalid e-mail domain'),
+        ),
+
+        dict(
+            desc='Set invalid default e-mail domain, with an @',
+            command=(
+                'config_mod', [], {'ipadefaultemaildomain': '@foo.com'},
+            ),
+            expected=errors.ValidationError(
+                name='emaildomain',
+                error='Invalid e-mail domain'),
+        ),
+
+
+        dict(
+            desc='Set valid default e-mail domain',
+            command=(
+                'config_mod', [], {'ipadefaultemaildomain': 'foo.com'},
+            ),
+            expected={
+                'result': lambda d: d['ipadefaultemaildomain'] == ('foo.com',),
+                'summary': None,
+                'value': None,
+            },
+        ),
+
+        dict(
+            desc='Reset default e-mail domain',
+            command=(
+                'config_mod', [], {'ipadefaultemaildomain': api.env.domain},
+            ),
+            expected={
+                'result': lambda d: (
+                    d['ipadefaultemaildomain'] == (api.env.domain,),
+                ),
+                'summary': None,
+                'value': None,
+            },
+        ),
     ]


### PR DESCRIPTION
There was zero validation at all. Re-use the Email validator since that will be used to validate the eventual e-mail address set in a user.

Fixes: https://pagure.io/freeipa/issue/9680