### PR TITLE
ipatests: use "sos report" instead of "sosreport" command

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1405,7 +1405,7 @@ class TestIpaHealthCheck(IntegrationTest):
         msg = "[plugin:ipa] collecting path '{}'".format(HEALTHCHECK_LOG)
         cmd = self.master.run_command(
             [
-                "sosreport",
+                "sos", "report",
                 "-o",
                 "ipa",
                 "--case-id",
@@ -1508,7 +1508,7 @@ class TestIpaHealthCheck(IntegrationTest):
         caseid = "123456"
         self.master.run_command(
             [
-                "sosreport",
+                "sos", "report",
                 "-o",
                 "ipa",
                 "--case-id",


### PR DESCRIPTION
ipatests: use "sos report" instead of "sosreport" command

The "soscommand" has been deprecated and "sos report" should be
used instead. The redirector was removed in sos 4.9.

Fixes: https://pagure.io/freeipa/issue/9752