### PR TITLE
[Backport][ipa-4-12] ipatests: use "sos report" instead of "sosreport" command

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1405,7 +1405,7 @@ class TestIpaHealthCheck(IntegrationTest):
         msg = "[plugin:ipa] collecting path '{}'".format(HEALTHCHECK_LOG)
         cmd = self.master.run_command(
             [
-                "sosreport",
+                "sos", "report",
                 "-o",
                 "ipa",
                 "--case-id",
@@ -1508,7 +1508,7 @@ class TestIpaHealthCheck(IntegrationTest):
         caseid = "123456"
         self.master.run_command(
             [
-                "sosreport",
+                "sos", "report",
                 "-o",
                 "ipa",
                 "--case-id",


### PR DESCRIPTION
This PR was opened automatically because PR #7702 was pushed to master and backport to ipa-4-12 is required.