### PR TITLE
[Backport][ipa-4-12] Make name of nobody group configurable and use nogroup on Debian

### DIFF
--- a/ipaplatform/base/constants.py
+++ b/ipaplatform/base/constants.py
@@ -124,6 +124,7 @@ class BaseConstantsNamespace:
     NAMED_OPTIONS_VAR = "OPTIONS"
     NAMED_OPENSSL_ENGINE = None
     NAMED_ZONE_COMMENT = ""
+    NOBODY_GROUP = Group("nobody")
     PKI_USER = User("pkiuser")
     PKI_GROUP = Group("pkiuser")
     # ntpd init variable used for daemon options

--- a/ipaplatform/debian/constants.py
+++ b/ipaplatform/debian/constants.py
@@ -29,5 +29,6 @@ class DebianConstantsNamespace(BaseConstantsNamespace):
     ODS_USER = User("opendnssec")
     ODS_GROUP = Group("opendnssec")
     SECURE_NFS_VAR = "NEED_GSSD"
+    NOBODY_GROUP = Group("nogroup")
 
 constants = DebianConstantsNamespace()

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -123,9 +123,11 @@ def make_netbios_name(s):
 def map_Guests_to_nobody():
     env = {'LC_ALL': 'C'}
     args = [paths.NET, '-s', '/dev/null', 'groupmap', 'add',
-            'sid=S-1-5-32-546', 'unixgroup=nobody', 'type=builtin']
+            'sid=S-1-5-32-546',
+            'unixgroup="' + constants.NOBODY_GROUP + '"', 'type=builtin']
 
-    logger.debug("Map BUILTIN\\Guests to a group 'nobody'")
+    logger.debug("Map BUILTIN\\Guests to a group '%s'",
+                 constants.NOBODY_GROUP)
     ipautil.run(args, env=env, raiseonerr=False, capture_error=True)
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #7703 was pushed to master and backport to ipa-4-12 is required.