### PR TITLE
Allow update of Kerberos master key

### DIFF
--- a/install/share/kerberos.ldif
+++ b/install/share/kerberos.ldif
@@ -14,25 +14,9 @@ objectClass: krbrealmcontainer
 objectClass: krbticketpolicyaux
 krbSubTrees: $SUFFIX
 krbSearchScope: 2
-krbSupportedEncSaltTypes: aes256-cts:normal
-krbSupportedEncSaltTypes: aes256-cts:special
-krbSupportedEncSaltTypes: aes128-cts:normal
-krbSupportedEncSaltTypes: aes128-cts:special
-krbSupportedEncSaltTypes: aes128-sha2:normal
-krbSupportedEncSaltTypes: aes128-sha2:special
-krbSupportedEncSaltTypes: aes256-sha2:normal
-krbSupportedEncSaltTypes: aes256-sha2:special
-${FIPS}krbSupportedEncSaltTypes: camellia128-cts-cmac:normal
-${FIPS}krbSupportedEncSaltTypes: camellia128-cts-cmac:special
-${FIPS}krbSupportedEncSaltTypes: camellia256-cts-cmac:normal
-${FIPS}krbSupportedEncSaltTypes: camellia256-cts-cmac:special
 krbMaxTicketLife: 86400
 krbMaxRenewableAge: 604800
-krbDefaultEncSaltTypes: aes256-sha2:special
-krbDefaultEncSaltTypes: aes128-sha2:special
-krbDefaultEncSaltTypes: aes256-cts:special
-krbDefaultEncSaltTypes: aes128-cts:special
-
+${LDIF_SUPPORTED_ENCTYPES}${LDIF_DEFAULT_ENCTYPES}
 # Default password Policy
 dn: cn=global_policy,cn=$REALM,cn=kerberos,$SUFFIX
 changetype: add

--- a/install/updates/50-krbenctypes.update
+++ b/install/updates/50-krbenctypes.update
@@ -1,11 +1,2 @@
 dn: cn=$REALM,cn=kerberos,$SUFFIX
-${FIPS}add: krbSupportedEncSaltTypes: camellia128-cts-cmac:normal
-${FIPS}add: krbSupportedEncSaltTypes: camellia128-cts-cmac:special
-${FIPS}add: krbSupportedEncSaltTypes: camellia256-cts-cmac:normal
-${FIPS}add: krbSupportedEncSaltTypes: camellia256-cts-cmac:special
-add: krbSupportedEncSaltTypes: aes128-sha2:normal
-add: krbSupportedEncSaltTypes: aes128-sha2:special
-add: krbSupportedEncSaltTypes: aes256-sha2:normal
-add: krbSupportedEncSaltTypes: aes256-sha2:special
-remove: krbDefaultEncSaltTypes: des3-hmac-sha1:special
-remove: krbDefaultEncSaltTypes: arcfour-hmac:special
+${ADD_SUPPORTED_ENCTYPES}${ADD_DEFAULT_ENCTYPES}${REMOVE_SUPPORTED_ENCTYPES}${REMOVE_DEFAULT_ENCTYPES}

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -540,4 +540,29 @@ class BaseTaskNamespace:
                 'ipa-client-automount-nsswitch', 'previous-automount'
             )
 
+    def get_masterkey_enctype(self):
+        return 'aes256-sha2'
+
+    # Encryption types allowed for Kerberos keys
+    def get_supported_enctypes(self):
+        return ('aes256-sha2:special', 'aes128-sha2:special',
+                'aes256-sha2:normal', 'aes128-sha2:normal',
+                'aes256-cts:special', 'aes128-cts:special',
+                'aes256-cts:normal', 'aes128-cts:normal',
+                'camellia256-cts:special', 'camellia128-cts:special',
+                'camellia256-cts:normal', 'camellia128-cts:normal')
+
+    # Encryption types used in the past, not supported anymore
+    def get_removed_supported_enctypes(self):
+        return ('des3-hmac-sha1:special')
+
+    # Encryption types used by default when generating Kerberos keys
+    def get_default_enctypes(self):
+        return ('aes256-sha2:special', 'aes128-sha2:special',
+                'aes256-cts:special', 'aes128-cts:special')
+
+    # Encryption types no longer used by default when generating keys
+    def get_removed_default_enctypes(self):
+        return ('des3-hmac-sha1:special', 'arcfour-hmac:special')
+
 tasks = BaseTaskNamespace()

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -751,5 +751,13 @@ class RedHatTaskNamespace(BaseTaskNamespace):
             logger.info("It may happen if the configuration was done "
                         "using authconfig instead of authselect")
 
+    def get_supported_enctypes(self):
+        enctypes = super().get_supported_enctypes()
+
+        if not self.is_fips_enabled():
+            return enctypes
+
+        return tuple(e for e in enctypes if not e.startswith('camellia'))
+
 
 tasks = RedHatTaskNamespace()

--- a/ipaplatform/setup.py
+++ b/ipaplatform/setup.py
@@ -42,6 +42,7 @@ if __name__ == '__main__':
             "ipaplatform.rhel",
             "ipaplatform.rhel_container",
             "ipaplatform.suse",
+            "ipaplatform.test_fedora_legacy",
             "ipaplatform.opencloudos",
             "ipaplatform.tencentos"
         ],

--- a/ipaplatform/test_fedora_legacy/__init__.py
+++ b/ipaplatform/test_fedora_legacy/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (C) 2025  FreeIPA Contributors see COPYING for license
+#
+"""
+This module contains Fedora AES HMAC-SHA1 master key specific platform files.
+"""
+NAME = 'test_fedora_legacy'

--- a/ipaplatform/test_fedora_legacy/constants.py
+++ b/ipaplatform/test_fedora_legacy/constants.py
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2025  FreeIPA Contributors see COPYING for license
+#
+"""Fedora AES HMAC-SHA1 master key constants
+"""
+from ipaplatform.fedora.constants import FedoraConstantsNamespace, User, Group
+
+
+__all__ = ("constants", "User", "Group")
+
+
+class TestFedoraLegacyConstantsNamespace(FedoraConstantsNamespace):
+    pass
+
+
+constants = TestFedoraLegacyConstantsNamespace()

--- a/ipaplatform/test_fedora_legacy/paths.py
+++ b/ipaplatform/test_fedora_legacy/paths.py
@@ -1,0 +1,13 @@
+#
+# Copyright (C) 2025  FreeIPA Contributors see COPYING for license
+#
+"""Fedora AES HMAC-SHA1 master key paths
+"""
+from ipaplatform.fedora.paths import FedoraPathNamespace
+
+
+class TestFedoraLegacyPathNamespace(FedoraPathNamespace):
+    pass
+
+
+paths = TestFedoraLegacyPathNamespace()

--- a/ipaplatform/test_fedora_legacy/services.py
+++ b/ipaplatform/test_fedora_legacy/services.py
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2025  FreeIPA Contributors see COPYING for license
+#
+"""Fedora AES HMAC-SHA1 master key services
+"""
+from ipaplatform.fedora import services as fedora_services
+
+
+test_fedora_legacy_system_units = fedora_services.fedora_system_units.copy()
+
+
+class TestFedoraLegacyService(fedora_services.FedoraService):
+    system_units = test_fedora_legacy_system_units
+
+
+def test_fedora_legacy_service_class_factory(name, api=None):
+    return fedora_services.fedora_service_class_factory(name, api)
+
+
+class TestFedoraLegacyServices(fedora_services.FedoraServices):
+    def service_class_factory(self, name, api=None):
+        return test_fedora_legacy_service_class_factory(name, api)
+
+
+timedate_services = fedora_services.timedate_services
+service = test_fedora_legacy_service_class_factory
+knownservices = TestFedoraLegacyServices()

--- a/ipaplatform/test_fedora_legacy/tasks.py
+++ b/ipaplatform/test_fedora_legacy/tasks.py
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2025  FreeIPA Contributors see COPYING for license
+#
+"""Fedora AES HMAC-SHA1 master key tasks
+"""
+from ipaplatform.fedora.tasks import FedoraTaskNamespace
+
+from re import compile
+
+
+def add_aes_sha1(enctypes):
+    return tuple({*enctypes,
+                  'aes256-cts:special', 'aes128-cts:special',
+                  'aes256-cts:normal', 'aes128-cts:normal'})
+
+
+class TestFedoraLegacyTaskNamespace(FedoraTaskNamespace):
+
+    def get_masterkey_enctype(self):
+        return 'aes256-cts'
+
+    def get_supported_enctypes(self):
+        aes_sha2_pattern = compile('^aes[0-9]+-sha2:')
+
+        return tuple(e for e in super().get_supported_enctypes()
+                     if not aes_sha2_pattern.match(e))
+
+    def get_removed_supported_enctypes(self):
+        return add_aes_sha1(super().get_removed_supported_enctypes())
+
+    def get_removed_default_enctypes(self):
+        return add_aes_sha1(super().get_removed_default_enctypes())
+
+
+tasks = TestFedoraLegacyTaskNamespace()

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -55,14 +55,6 @@ from ipaplatform.paths import paths
 
 logger = logging.getLogger(__name__)
 
-MASTER_KEY_TYPE = 'aes256-sha2'
-SUPPORTED_ENCTYPES = ('aes256-sha2:special', 'aes128-sha2:special',
-                      'aes256-sha2:normal', 'aes128-sha2:normal',
-                      'aes256-cts:special', 'aes128-cts:special',
-                      'aes256-cts:normal', 'aes128-cts:normal',
-                      'camellia256-cts:special', 'camellia128-cts:special',
-                      'camellia256-cts:normal', 'camellia128-cts:normal')
-
 
 def get_pkinit_request_ca():
     """
@@ -299,15 +291,18 @@ class KrbInstance(service.Service):
                              INCLUDES=includes,
                              FIPS='#' if fips_enabled else '')
 
-        if fips_enabled:
-            supported_enctypes = list(
-                filter(lambda e: not e.startswith('camellia'),
-                       SUPPORTED_ENCTYPES))
-        else:
-            supported_enctypes = SUPPORTED_ENCTYPES
-        self.sub_dict['SUPPORTED_ENCTYPES'] = ' '.join(supported_enctypes)
+        supported_enctypes = tasks.get_supported_enctypes()
+        str_supported_enctypes = ' '.join(supported_enctypes)
+        ldif_supported_enctypes = ''.join(f'krbSupportedEncSaltTypes: {e}\n'
+                                          for e in supported_enctypes)
+        ldif_default_enctypes = ''.join(f'krbDefaultEncSaltTypes: {e}\n'
+                                        for e in tasks.get_default_enctypes())
 
-        self.sub_dict['MASTER_KEY_TYPE'] = MASTER_KEY_TYPE
+        self.sub_dict['SUPPORTED_ENCTYPES'] = str_supported_enctypes
+        self.sub_dict['LDIF_SUPPORTED_ENCTYPES'] = ldif_supported_enctypes
+        self.sub_dict['LDIF_DEFAULT_ENCTYPES'] = ldif_default_enctypes
+
+        self.sub_dict['MASTER_KEY_TYPE'] = tasks.get_masterkey_enctype()
 
         # IPA server/KDC is not a subdomain of default domain
         # Proper domain-realm mapping needs to be specified

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -54,6 +54,9 @@ UPDATES_DIR=paths.UPDATES_DIR
 UPDATE_SEARCH_TIME_LIMIT = 30  # seconds
 
 
+def ldif_mod(op, attr, values):
+    return ''.join(f'{op}: {attr}: {v}\n' for v in values)
+
 def get_sub_dict(realm, domain, suffix, fqdn, idstart=None, idmax=None):
     """LDAP template substitution dict for installer and updater
     """
@@ -73,6 +76,15 @@ def get_sub_dict(realm, domain, suffix, fqdn, idstart=None, idmax=None):
         named_uid = None
         named_gid = None
 
+    add_supported_enctypes = ldif_mod('add', 'krbSupportedEncSaltTypes',
+                                      tasks.get_supported_enctypes())
+    add_default_enctypes = ldif_mod('add', 'krbDefaultEncSaltTypes',
+                                    tasks.get_default_enctypes())
+    rm_supported_enctypes = ldif_mod('remove', 'krbSupportedEncSaltTypes',
+                                     tasks.get_removed_supported_enctypes())
+    rm_default_enctypes = ldif_mod('remove', 'krbDefaultEncSaltTypes',
+                                   tasks.get_removed_default_enctypes())
+
     return dict(
         REALM=realm,
         DOMAIN=domain,
@@ -82,7 +94,10 @@ def get_sub_dict(realm, domain, suffix, fqdn, idstart=None, idmax=None):
         HOST=fqdn,
         LIBARCH=paths.LIBARCH,
         TIME=int(time.time()),
-        FIPS="#" if tasks.is_fips_enabled() else "",
+        ADD_SUPPORTED_ENCTYPES=add_supported_enctypes,
+        ADD_DEFAULT_ENCTYPES=add_default_enctypes,
+        REMOVE_SUPPORTED_ENCTYPES=rm_supported_enctypes,
+        REMOVE_DEFAULT_ENCTYPES=rm_default_enctypes,
         # idstart, idmax, and idrange_size may be None
         IDSTART=idstart,
         IDMAX=idmax,

--- a/ipatests/pytest_ipa/integration/firewall.py
+++ b/ipatests/pytest_ipa/integration/firewall.py
@@ -239,6 +239,7 @@ class Firewall(FirewallBase):
         firewalls = {
             'rhel': FirewallD,
             'fedora': FirewallD,
+            'test_fedora_legacy': FirewallD,
             'debian': FirewallD,
             'ubuntu': FirewallD,
             'altlinux': NoOpFirewall,

--- a/ipatests/test_integration/test_mkey_upgrade.py
+++ b/ipatests/test_integration/test_mkey_upgrade.py
@@ -1,0 +1,135 @@
+#
+# Copyright (C) 2015  FreeIPA Contributors see COPYING for license
+#
+
+import re
+import textwrap
+
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestMkeyUpgrade(IntegrationTest):
+
+    num_replicas = 1
+    topology = 'line'
+
+    @classmethod
+    def install(cls, mh):
+        cls.master.put_file_contents(
+            '/etc/profile.d/ipaplatform.sh',
+            'export IPAPLATFORM_OVERRIDE=test_fedora_legacy')
+        cls.master.run_command(['mkdir', '/etc/systemd/system/ipa.service.d'])
+        cls.master.put_file_contents(
+            '/etc/systemd/system/ipa.service.d/platform.conf',
+            '[Service]\n'
+            'Environment="IPAPLATFORM_OVERRIDE=test_fedora_legacy"')
+        cls.master.run_command(['systemctl', 'daemon-reload'])
+        tasks.install_master(cls.master, setup_dns=False)
+        tasks.install_replica(cls.master, cls.replicas[0], setup_dns=False)
+
+    def test_old_active_mkey(self):
+        p = re.compile('^KVNO: 1, Enctype: aes256-cts-hmac-sha1-96, .+ \\*$',
+                       flags=re.MULTILINE)
+
+        result = self.master.run_command(['kdb5_util', 'list_mkeys'])
+        assert p.search(result.stdout_text)
+        result = self.replicas[0].run_command(['kdb5_util', 'list_mkeys'])
+        assert p.search(result.stdout_text)
+
+    def test_enable_new_entypes(self):
+        base_dn = "dc=%s" % (",dc=".join(self.master.domain.name.split(".")))
+        realm = self.master.domain.name.upper()
+
+        entry_ldif = textwrap.dedent("""
+            dn: cn={realm},cn=kerberos,{base_dn}
+            changetype: modify
+            replace: krbSupportedEncSaltTypes
+            krbSupportedEncSaltTypes: aes128-sha2:normal
+            krbSupportedEncSaltTypes: aes128-sha2:special
+            krbSupportedEncSaltTypes: aes256-sha2:normal
+            krbSupportedEncSaltTypes: aes256-sha2:special
+            krbSupportedEncSaltTypes: aes256-cts:normal
+            krbSupportedEncSaltTypes: aes256-cts:special
+            krbSupportedEncSaltTypes: aes128-cts:normal
+            krbSupportedEncSaltTypes: aes128-cts:special
+            krbSupportedEncSaltTypes: camellia128-cts-cmac:normal
+            krbSupportedEncSaltTypes: camellia128-cts-cmac:special
+            krbSupportedEncSaltTypes: camellia256-cts-cmac:normal
+            krbSupportedEncSaltTypes: camellia256-cts-cmac:special
+            -
+            replace: krbDefaultEncSaltTypes
+            krbDefaultEncSaltTypes: aes256-sha2:special
+            krbDefaultEncSaltTypes: aes128-sha2:special
+            krbDefaultEncSaltTypes: aes256-cts:special
+            krbDefaultEncSaltTypes: aes128-cts:special""").format(
+            base_dn=base_dn, realm=realm)
+        tasks.ldapmodify_dm(self.master, entry_ldif)
+
+    def test_add_new_mkey(self):
+        self.master.run_command('kdb5_util add_mkey -e aes256-sha2 -s',
+                                stdin_text='Secret123\nSecret123')
+
+    def test_new_inactive_mkey(self):
+        p = re.compile('^KVNO: 2, Enctype: aes256-cts-hmac-sha384-192, ',
+                       flags=re.MULTILINE)
+
+        result = self.master.run_command(['kdb5_util', 'list_mkeys'])
+        assert p.search(result.stdout_text)
+        result = self.replicas[0].run_command(['kdb5_util', 'list_mkeys'])
+        assert p.search(result.stdout_text)
+
+    def test_switch_mkey(self):
+        self.master.run_command(['kdb5_util', 'use_mkey', '2'])
+
+    def test_new_active_mkey(self):
+        p = re.compile('^KVNO: 2, Enctype: aes256-cts-hmac-sha384-192, .+ \\*$',
+                       flags=re.MULTILINE)
+
+        result = self.master.run_command(['kdb5_util', 'list_mkeys'])
+        assert p.search(result.stdout_text)
+        result = self.replicas[0].run_command(['kdb5_util', 'list_mkeys'])
+        assert p.search(result.stdout_text)
+
+    def test_used_old_mkey(self):
+        p = re.compile('^MKey: vno 1$', flags=re.MULTILINE)
+
+        result = self.master.run_command(['kadmin.local', 'getprinc',
+                                          f'ldap/{self.master.hostname}'])
+        assert p.search(result.stdout_text)
+        result = self.replicas[0].run_command(['kadmin.local', 'getprinc',
+                                               f'ldap/{self.master.hostname}'])
+        assert p.search(result.stdout_text)
+
+    def test_reencrypt_with_new_mkey(self):
+        self.master.run_command(['kdb5_util', '-x', 'unlockiter',
+                                 'update_princ_encryption', '-vf'])
+
+    def test_used_new_mkey(self):
+        p = re.compile('^MKey: vno 2$', flags=re.MULTILINE)
+
+        result = self.master.run_command(['kadmin.local', 'getprinc',
+                                          f'ldap/{self.master.hostname}'])
+        assert p.search(result.stdout_text)
+        result = self.replicas[0].run_command(['kadmin.local', 'getprinc',
+                                               f'ldap/{self.master.hostname}'])
+        assert p.search(result.stdout_text)
+
+    def test_purge_old_mkey(self):
+        self.master.run_command(['kdb5_util', 'purge_mkeys', '-vf'])
+
+    def test_only_new_mkey(self):
+        p = re.compile('^KVNO: 1,', flags=re.MULTILINE)
+
+        result = self.master.run_command(['kdb5_util', 'list_mkeys'])
+        assert not p.search(result.stdout_text)
+        result = self.replicas[0].run_command(['kdb5_util', 'list_mkeys'])
+        assert not p.search(result.stdout_text)
+
+    @classmethod
+    def uninstall(cls, mh):
+        cls.master.run_command([
+            'rm', '/etc/profile.d/ipaplatform.sh',
+            '/etc/systemd/system/ipa.service.d/platform.conf'])
+        cls.master.run_command(['rmdir', '/etc/systemd/system/ipa.service.d'])
+        super().uninstall(mh)

--- a/util/ipa_krb5.c
+++ b/util/ipa_krb5.c
@@ -394,6 +394,13 @@ int ber_encode_krb5_key_data(krb5_key_data *data,
 
     for (i = 0; i < numk; i++) {
 
+        /* All keys must have the same KVNO, because there is only one attribute
+         * for all of them. */
+        if (data[i].key_data_kvno != data[0].key_data_kvno) {
+            ret = EINVAL;
+            goto done;
+        }
+
         ret = ber_printf(be, "{");
         if (ret == -1) {
             ret = EFAULT;


### PR DESCRIPTION
Until today it was not possible to modify the master key of a FreeIPA domain. This is a major issue in environments where security constraints are strengthened, and require to upgrade encryption types from AES HMAC-SHA1 to AES HMAC-SHA2 for example. There was two reasons for this limitation:
* FreeIPA did not support storing keys with different KVNOs, which is needed to store both the old and the new master key during the update period.
* There was a bug in MIT krb5 `kdb5_util` which was not setting the modification mask properly on updated principal entries, leading to the active master key attribute not being updated.

The `kdb5_util` problem was fixed in krb5/krb5#1364 ([4ed7da37](https://github.com/krb5/krb5/commit/4ed7da378940198cf4415f86d4eb013de6ac6455)).

The present pull request fixes the other problem:

All MIT krb5 keys are encoded with an encryption type identifier and a KVNO (key version number). The KVNO is referring to the original credentials string (and its associated salt) which was used to generate the key using the derivation function of the associated encryption type.

So far, when a set of Kerberos keys was provided to ipa-kdb, only the newest KVNO ones were saved in a single `krbPrincipalKey` LDAP attribute. All the older ones were deleted in the process. This pull request allows to keep older keys by splitting them in multiple `krbPrincipalKey` attribute based on their KVNO.

Testing this kind of master key upgrade scenario was not possible, because it was not possible to initialize a FreeIPA domain not using `aes256-cts-hmac-sha384-192` as encryption type. Thus the PR adds a `fedora_aes_sha1` ipaplatform which initializes the FreeIPA domain with an `aes256-cts-hmac-sha1-96` master key and removes AES HMAC-SHA2 from the supported and default encryption type lists (for coherence, but not needed per se, only the master key encryption type is required for the test).

Fixes: https://pagure.io/freeipa/issue/9370

## Summary by Sourcery

Enable updating of Kerberos master key in FreeIPA by supporting multiple key version numbers (KVNOs) and improving key storage and management

New Features:
- Add support for storing multiple Kerberos key version numbers (KVNOs) in LDAP
- Implement ability to update and manage Kerberos master keys across FreeIPA domains

Bug Fixes:
- Fix limitation preventing modification of Kerberos master key
- Resolve issues with key version number (KVNO) storage and management

Enhancements:
- Modify key data handling to support multiple key versions
- Improve key encoding and storage mechanisms
- Add platform-specific encryption type management

Tests:
- Add integration test for master key upgrade scenario
- Create test cases for key version number management