### PR TITLE
[Backport][ipa-4-9] Replica CA installation: ignore time skew during initial replication

### DIFF
--- a/install/share/Makefile.am
+++ b/install/share/Makefile.am
@@ -38,7 +38,6 @@ dist_app_DATA =				\
 	default-trust-view.ldif		\
 	delegation.ldif			\
 	replica-acis.ldif		\
-	replica-prevent-time-skew.ldif  \
 	ds-nfiles.ldif			\
 	ds-ipa-env.conf.template	\
 	dns.ldif			\

--- a/install/share/replica-prevent-time-skew.ldif
+++ b/install/share/replica-prevent-time-skew.ldif
@@ -1,4 +1,0 @@
-dn: cn=config
-changetype: modify
-replace: nsslapd-ignore-time-skew
-nsslapd-ignore-time-skew: $SKEWVALUE

--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -1269,12 +1269,12 @@ def force_sync(realm, thishost, fromhost, dirman_passwd, nolookup=False):
         repl.force_sync(repl.conn, fromhost)
     else:
         ds = dsinstance.DsInstance(realm_name=realm)
-        ds.replica_manage_time_skew(prevent=False)
+        ds.replica_ignore_initial_time_skew()
         repl = replication.ReplicationManager(realm, fromhost, dirman_passwd)
         repl.force_sync(repl.conn, thishost)
         agreement = repl.get_replication_agreement(thishost)
         repl.wait_for_repl_update(repl.conn, agreement.dn)
-        ds.replica_manage_time_skew(prevent=True)
+        ds.replica_revert_time_skew()
 
 
 def show_DNA_ranges(hostname, master, realm, dirman_passwd, nextrange=False,

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -409,7 +409,11 @@ class CAInstance(DogtagInstance):
             if promote:
                 # Setup Database
                 self.step("creating certificate server db", self.__create_ds_db)
+                self.step("ignore time skew for initial replication",
+                          self.replica_ignore_initial_time_skew)
                 self.step("setting up initial replication", self.__setup_replication)
+                self.step("revert time skew after initial replication",
+                          self.replica_revert_time_skew)
                 self.step("creating ACIs for admin", self.add_ipaca_aci)
                 self.step("creating installation admin user", self.setup_admin)
             self.step("configuring certificate server instance",

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -385,11 +385,11 @@ class DsInstance(service.Service):
         # This helps with initial replication or force-sync because
         # the receiving side has no valuable changes itself yet.
         self.step("ignore time skew for initial replication",
-                  self.__replica_ignore_initial_time_skew)
+                  self.replica_ignore_initial_time_skew)
 
         self.step("setting up initial replication", self.__setup_replica)
         self.step("prevent time skew after initial replication",
-                  self.replica_manage_time_skew)
+                  self.replica_revert_time_skew)
         self.step("adding sasl mappings to the directory", self.__configure_sasl_mappings)
         self.step("updating schema", self.__update_schema)
         # See LDIFs for automember configuration during replica install
@@ -994,16 +994,6 @@ class DsInstance(service.Service):
 
     def __add_replication_acis(self):
         self._ldap_mod("replica-acis.ldif", self.sub_dict)
-
-    def __replica_ignore_initial_time_skew(self):
-        self.replica_manage_time_skew(prevent=False)
-
-    def replica_manage_time_skew(self, prevent=True):
-        if prevent:
-            self.sub_dict['SKEWVALUE'] = 'off'
-        else:
-            self.sub_dict['SKEWVALUE'] = 'on'
-        self._ldap_mod("replica-prevent-time-skew.ldif", self.sub_dict)
 
     def __setup_s4u2proxy(self):
 

--- a/ipaserver/install/service.py
+++ b/ipaserver/install/service.py
@@ -811,6 +811,31 @@ class Service:
         self.run_getkeytab(self.api.env.ldap_uri, self.keytab, self.principal)
         self.set_keytab_owner()
 
+    def replica_ignore_initial_time_skew(self):
+        """
+        Set nsslapd-ignore-time-skew = on if not already set
+        and store the initial value in order to restore it later.
+
+        The on value allows replica initialization even if there
+        are excessive time skews.
+        """
+        dn = DN(('cn', 'config'))
+        entry_attrs = api.Backend.ldap2.get_entry(dn)
+        self.original_time_skew = entry_attrs['nsslapd-ignore-time-skew'][0]
+        if self.original_time_skew != 'on':
+            entry_attrs['nsslapd-ignore-time-skew'] = 'on'
+            api.Backend.ldap2.update_entry(entry_attrs)
+
+    def replica_revert_time_skew(self):
+        """
+        Revert nsslapd-ignore-time-skew to its previous value.
+        """
+        dn = DN(('cn', 'config'))
+        entry_attrs = api.Backend.ldap2.get_entry(dn)
+        if self.original_time_skew != 'on':
+            entry_attrs['nsslapd-ignore-time-skew'] = self.original_time_skew
+            api.Backend.ldap2.update_entry(entry_attrs)
+
 
 class SimpleServiceInstance(Service):
     def create_instance(self, gensvc_name=None, fqdn=None, ldap_suffix=None,

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -2132,3 +2132,69 @@ class TestHostnameValidator(IntegrationTest):
         assert result.returncode == 1
         assert 'hostname cannot be the same as the domain name' \
             in result.stderr_text
+
+
+class TestNsslapdIgnoreTimeSkew(IntegrationTest):
+    """
+    Test to check nsslapd-ignore-time-skew is not disabled.
+    """
+    num_replicas = 1
+    topology = 'line'
+
+    @pytest.fixture
+    def update_time_skew(self):
+        """
+        Fixture enables nsslapd-ignore-time-skew
+        parameter and reverts it back
+        """
+        ldap = self.replicas[0].ldap_connect()
+        dn = DN(
+            ("cn", "config"),
+        )
+        entry = ldap.get_entry(dn)
+        entry.single_value["nsslapd-ignore-time-skew"] = 'on'
+        ldap.update_entry(entry)
+
+        yield
+
+        entry = ldap.get_entry(dn)
+        entry.single_value["nsslapd-ignore-time-skew"] = 'off'
+        ldap.update_entry(entry)
+
+    def test_check_nsslapd_ignore_time_skew(self):
+        """
+        This testcase checks that the ignore time skew parameter
+        is set to on during the directory server replica
+        installation (replication of the suffix) and during
+        the CA replica (replication of o=ipaca).
+        It also checks that the time skew is reverted during
+        pki_tomcat setup stage.
+        """
+        DIRSRV_LOG = (
+            "ignore time skew for initial replication"
+        )
+        PKI_TOMCAT_LOG = (
+            "revert time skew after initial replication"
+        )
+        install_msg = self.replicas[0].get_file_contents(
+            paths.IPAREPLICA_INSTALL_LOG, encoding="utf-8"
+        )
+        dirsrv_msg = re.findall(DIRSRV_LOG, install_msg)
+        assert len(dirsrv_msg) == 2
+        assert PKI_TOMCAT_LOG in install_msg
+
+    def test_forcesync_does_not_overwrite_ignore_time_skew(
+            self, update_time_skew):
+        """
+        This testcase checks that calling ipa-replica-manage
+        force-sync does not overwrite the value of ignore
+        time skew
+        """
+        result = self.replicas[0].run_command(
+            ["ipa-replica-manage", "force-sync",
+             "--from", self.master.hostname,
+             "--no-lookup", "-v"])
+        assert result.returncode == 0
+        conn = self.replicas[0].ldap_connect()
+        ldap_entry = conn.get_entry(DN("cn=config"))
+        assert ldap_entry.single_value['nsslapd-ignore-time-skew'] == "on"


### PR DESCRIPTION
### Replica CA installation: ignore time skew during initial replication

During a replica CA installation, the initial replication step may fail
if there is too much time skew between the server and replica.
    
The replica installer already takes care of this for the replication of
the domain suffix but the replica CA installer does not set
nssldapd-ignore-time-skew to on for o=ipaca suffix.

During a replica CA installation, read the initial value of
nssldapd-ignore-time-skew, force it to on, start replication and
revert to the initial value.

Apply the same logic to dsinstance and ipa-replica-manage force-sync.

Fixes: https://pagure.io/freeipa/issue/9635

### ipatests: Test to check that the configured value for "nsslapd-ignore-time-skew" remains on even after a "force-sync" is done

Related: https://pagure.io/freeipa/issue/9635