### PR TITLE
Drop some no-longer-needed py2 compat code

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -13,8 +13,6 @@ import logging
 import os.path
 import pki.util
 
-import six
-
 from ipalib.constants import IPA_CA_CN
 from ipalib.install import certstore
 from ipalib.install.service import enroll_only, master_install_only, replica_install_only
@@ -35,8 +33,6 @@ from ipapython.dn import DN
 
 from . import conncheck, dogtag, cainstance
 
-if six.PY3:
-    unicode = str
 
 VALID_SUBJECT_BASE_ATTRS = {
     'st', 'o', 'ou', 'dnqualifier', 'c', 'serialnumber', 'l', 'title', 'sn',
@@ -54,8 +50,8 @@ external_ca_file = None
 
 
 def subject_validator(valid_attrs, value):
-    if not isinstance(value, unicode):
-        v = unicode(value, 'utf-8')
+    if not isinstance(value, str):
+        v = str(value, 'utf-8')
     else:
         v = value
     if any(ord(c) < 0x20 for c in v):

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -34,8 +34,6 @@ import fcntl
 import time
 import datetime
 
-import six
-
 from ipalib.install import certmonger, sysrestore
 from ipapython import dogtag
 from ipapython import ipautil
@@ -791,10 +789,7 @@ class _CrossProcessLock:
 
     def _read(self, fileobj):
         p = configparser.RawConfigParser()
-        if six.PY2:
-            p.readfp(fileobj)  # pylint: disable=no-member
-        else:
-            p.read_file(fileobj)
+        p.read_file(fileobj)
 
         try:
             self._locked = p.getboolean('lock', 'locked')

--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -42,7 +42,6 @@ from configparser import NoOptionError
 from dns import rrset, rdatatype, rdataclass
 from dns.exception import DNSException
 import ldap
-import six
 
 from ipalib import facts
 from ipalib.install.kinit import kinit_password
@@ -61,8 +60,6 @@ from ipaplatform import services
 from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks
 
-if six.PY3:
-    unicode = str
 
 logger = logging.getLogger(__name__)
 
@@ -155,7 +152,7 @@ def verify_fqdn(host_name, no_host_dns=False, local_hostname=True):
         # make sure that the host name meets the requirements in ipalib
         validate_hostname(host_name, maxlen=MAXHOSTNAMELEN)
     except ValueError as e:
-        raise BadHostError("Invalid hostname '%s', %s" % (host_name, unicode(e)))
+        raise BadHostError("Invalid hostname '%s', %s" % (host_name, e))
 
     if local_hostname:
         try:
@@ -496,7 +493,7 @@ def resolve_rrsets_nss(fqdn):
             ipautil.CheckedIPAddress(ip_address)
         except ValueError as e:
             logger.warning("Invalid IP address %s for %s: %s",
-                           ip_address, fqdn, unicode(e))
+                           ip_address, fqdn, e)
             continue
         if ip_address.version == 4:
             ipv4.append(str(ip_address))
@@ -540,7 +537,7 @@ def get_server_ip_address(host_name, unattended, setup_dns, ip_addresses):
                 ips.append(ipautil.CheckedIPAddress(ha))
             except ValueError as e:
                 logger.warning("Invalid IP address %s for %s: %s",
-                               ha, host_name, unicode(e))
+                               ha, host_name, e)
 
     if not ips and not ip_addresses:
         if not unattended:


### PR DESCRIPTION
A set of minor refactors/cleanups severed from #7688 (due to @rcritten), to be
tested/reviewed/delivered separately.

```
7886e45a6 (Rob Crittenden, 2 weeks ago)
   Drop python 2 support in ipaserver/install/ca.py

   Lint issues with unicode

   Signed-off-by: Rob Crittenden <rcritten@redhat.com>

3ef56f793 (Rob Crittenden, 2 weeks ago)
   Drop python 2 support in installutils.py

   Compatibility in python 3.12 is limited and is triggering lint failures.

d4871bae1 (Rob Crittenden, 5 weeks ago)
   Drop python v2 in ipaserver/install/certs.py for lint errors

   ipaserver/install/certs.py:908: [W4902(deprecated-method),
   _CrossProcessLock._read] Using deprecated method readfp()) 
   ipaserver/install/certs.py:908: [I0021(useless-suppression), ] Useless
   suppression of 'no-member')

   Related: https://pagure.io/freeipa/issue/9738

   Signed-off-by: Rob Crittenden <rcritten@redhat.com>
```