### PR TITLE
WebUI: fix the tooltip for Search Size limit

### DIFF
--- a/install/ui/src/freeipa/serverconfig.js
+++ b/install/ui/src/freeipa/serverconfig.js
@@ -47,7 +47,7 @@ return {
                     fields: [
                         {
                             name: 'ipasearchrecordslimit',
-                            tooltip: '@mc-opt:config_mod:ipasearchtimelimit:doc'
+                            tooltip: '@mc-opt:config_mod:ipasearchrecordslimit:doc'
                         },
                         {
                             name: 'ipasearchtimelimit',


### PR DESCRIPTION
The tooltip for IPA Server > Configuration > Search size limit is using the doc from ipasearchtimelimit instead of ipasearchrecordslimit.

Use the right tooltip to properly display:
Maximum number of records to search (-1 or 0 is unlimited)

Fixes: https://pagure.io/freeipa/issue/9758