### PR TITLE
[Backport][ipa-4-12] WebUI: fix the tooltip for Search Size limit

### DIFF
--- a/install/ui/src/freeipa/serverconfig.js
+++ b/install/ui/src/freeipa/serverconfig.js
@@ -47,7 +47,7 @@ return {
                     fields: [
                         {
                             name: 'ipasearchrecordslimit',
-                            tooltip: '@mc-opt:config_mod:ipasearchtimelimit:doc'
+                            tooltip: '@mc-opt:config_mod:ipasearchrecordslimit:doc'
                         },
                         {
                             name: 'ipasearchtimelimit',


### PR DESCRIPTION
This PR was opened automatically because PR #7720 was pushed to master and backport to ipa-4-12 is required.