### PR TITLE
[Backport][ipa-4-12] man: fix typo and groff syntax in man pages 

### DIFF
--- a/client/man/default.conf.5
+++ b/client/man/default.conf.5
@@ -47,7 +47,7 @@ Valid lines consist of an option name, an equals sign and a value. Spaces surrou
 
 Values should not be quoted, the quotes will not be stripped.
 
-.RS L
+.RS 4
     # Wrong \- don't include quotes
     verbose = "True"
 
@@ -273,7 +273,7 @@ IPA configuration used while installing an IPA client
 .TP
 An example of a context-specific configuration file is \fB/etc/ipa/dns.conf\fR to be used to increase debug output of the IPA DNSSEC daemons.
 .TP
-.RS L
+.RS 4
 [global]
 debug = True
 .RE

--- a/client/man/epn.conf.5
+++ b/client/man/epn.conf.5
@@ -34,7 +34,7 @@ Valid lines consist of an option name, an equals sign and a value. Spaces surrou
 
 Values should not be quoted, the quotes will not be stripped.
 
-.RS L
+.RS 4
     # Wrong \- don't include quotes
     verbose = "True"
 

--- a/client/man/ipa-client-install.1
+++ b/client/man/ipa-client-install.1
@@ -234,9 +234,9 @@ uninstall.
 
 .SS "PKINIT OPTIONS"
 .TP
-\fB\-\-pkinit\-identity=\fIDENTITY\fR
+\fB\-\-pkinit\-identity=\fIIDENTITY\fR
 Identity string for PKINIT authentication to use to join the IPA realm,
-for example 'FILE:/path/to/cert.pem,/path/to/key.pem'. See krb5.conf(5)
+for example \fIFILE:/path/to/cert.pem,/path/to/key.pem\fR. See krb5.conf(5)
 for more information. The option is mutually exclusive with
 \fB\-\-password\fR and \fB\-\-keytab\fR.
 .TP

--- a/client/man/ipa.1
+++ b/client/man/ipa.1
@@ -146,7 +146,7 @@ May 21 11:31:33 master1.ipa1.test /usr/bin/ipa[247422]: [IPA.API] [autobind]: us
 executable name and PID (`/mod_wsgi` for HTTP end-point)
 .TP
 \fB[IPA.API]\fR
-marker to allow searches with \fBjournalctl -g IPA.API\R
+marker to allow searches with \fBjournalctl -g IPA.API\fR
 .TP
 \fBusername@REALM\fR
 authenticated Kerberos principal or \fB[autobind]\fR marker for LDAP-based operations done as root


### PR DESCRIPTION
This PR was opened automatically because PR #7656 was pushed to master and backport to ipa-4-12 is required.