### PR TITLE
[Backport][ipa-4-12] Make path of Samba lock directory configurable and use /run/samba on Debian

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -350,6 +350,7 @@ class BasePathNamespace:
     KRA_CS_CFG_PATH = "/var/lib/pki/pki-tomcat/conf/kra/CS.cfg"
     KRACERT_P12 = "/root/kracert.p12"
     SAMBA_DIR = "/var/lib/samba"
+    SAMBA_LOCKDIR = "/var/lib/samba/lock"
     SSSD_DB = "/var/lib/sss/db"
     SSSD_MC_GROUP = "/var/lib/sss/mc/group"
     SSSD_MC_PASSWD = "/var/lib/sss/mc/passwd"

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -44,6 +44,7 @@ class DebianPathNamespace(BasePathNamespace):
     OPENSSL_DIR = "/usr/lib/ssl"
     OPENSSL_CERTS_DIR = "/usr/lib/ssl/certs"
     OPENSSL_PRIVATE_DIR = "/usr/lib/ssl/private"
+    SAMBA_LOCKDIR = "/run/samba"
     ETC_DEBIAN_VERSION = "/etc/debian_version"
     # Old versions of freeipa wrote all trusted certificates to a single
     # file, which is not supported by ca-certificates.

--- a/ipaserver/install/adtrustinstance.py
+++ b/ipaserver/install/adtrustinstance.py
@@ -962,7 +962,7 @@ class ADTRUSTInstance(service.Service):
         # in /var/lib/samba and /var/lib/samba/private
         for smbpath in (paths.SAMBA_DIR,
                         os.path.join(paths.SAMBA_DIR, "private"),
-                        os.path.join(paths.SAMBA_DIR, "lock")):
+                        paths.SAMBA_LOCKDIR):
             if os.path.isdir(smbpath):
                 tdb_files = [
                     os.path.join(smbpath, tdb_file)


### PR DESCRIPTION
This PR was opened automatically because PR #7710 was pushed to master and backport to ipa-4-12 is required.