### PR TITLE
Leapp upgrade: skip systemctl calls

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1245,8 +1245,11 @@ if [ $1 = 0 ]; then
 # NOTE: systemd specific section
     /bin/systemctl --quiet stop ipa.service || :
     /bin/systemctl --quiet disable ipa.service || :
-    /bin/systemctl reload-or-try-restart dbus
-    /bin/systemctl reload-or-try-restart oddjobd
+    # Skip systemctl calls when leapp upgrade is in progress
+    if [ -z "$LEAPP_IPU_IN_PROGRESS" ] ; then
+        /bin/systemctl reload-or-try-restart dbus
+        /bin/systemctl reload-or-try-restart oddjobd
+    fi
 # END
 fi
 
@@ -1310,8 +1313,11 @@ fi
 %preun server-trust-ad
 if [ $1 -eq 0 ]; then
     %{_sbindir}/update-alternatives --remove winbind_krb5_locator.so /dev/null
-    /bin/systemctl reload-or-try-restart dbus
-    /bin/systemctl reload-or-try-restart oddjobd
+    # Skip systemctl calls when leapp upgrade is in progress
+    if [ -z "$LEAPP_IPU_IN_PROGRESS" ] ; then
+        /bin/systemctl reload-or-try-restart dbus
+        /bin/systemctl reload-or-try-restart oddjobd
+    fi
 fi
 
 # ONLY_CLIENT


### PR DESCRIPTION
During LEAPP upgrade, the system is booted in a special mode without systemd. As a consequence, any scriptlet calling systemctl fails and may break the upgrade.

Skip the call to systemctl if a LEAPP upgrade is in progress (this is easily checked using the env variable $LEAPP_IPU_IN_PROGRESS that is set for instance to LEAPP_IPU_IN_PROGRESS=8to9).

Fixes: RHEL-82089