### PR TITLE
ipatest: make test_cert more robust to replication delays

### DIFF
--- a/ipatests/test_integration/test_cert.py
+++ b/ipatests/test_integration/test_cert.py
@@ -548,6 +548,8 @@ class TestCAShowErrorHandling(IntegrationTest):
             'ipa', 'ca-add', lwca, '--subject', 'CN=LWCA 1'
         ])
         assert 'Created CA "{}"'.format(lwca) in result.stdout_text
+        # wait for replication to propagate the change
+        tasks.wait_for_replication(self.replicas[0].ldap_connect())
         result = self.master.run_command(['ipa', 'ca-find'])
         assert 'Name: {}'.format(lwca) in result.stdout_text
         result = self.master.run_command(


### PR DESCRIPTION
The test TestCAShowErrorHandling::test_ca_show_error_handling is adding a subca on the replica, then checks the entry is present on the master.
If the replication is a bit slow, the call on the master may fail to return the newly created subca.
The test should wait for replication to complete before calling ipa ca-find.

Fixes: https://pagure.io/freeipa/issue/9762