### PR TITLE
idrange: use minvalue=0 for baserid and secondarybaserid

### DIFF
--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -235,13 +235,13 @@ class idrange(LDAPObject):
         Int('ipabaserid?',
             cli_name='rid_base',
             label=_('First RID of the corresponding RID range'),
-            minvalue=1,
+            minvalue=0,
             maxvalue=Int.MAX_UINT32
         ),
         Int('ipasecondarybaserid?',
             cli_name='secondary_rid_base',
             label=_('First RID of the secondary RID range'),
-            minvalue=1,
+            minvalue=0,
             maxvalue=Int.MAX_UINT32
         ),
         Str('ipanttrusteddomainsid?',

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -19,6 +19,10 @@ topologies:
     name: ad_master_2client
     cpu: 4
     memory: 10596
+  adroot_adchild_adtree_master_1client: &adroot_adchild_adtree_master_1client
+    name: adroot_adchild_adtree_master_1client
+    cpu: 8
+    memory: 14466
   ipaserver: &ipaserver
     name: ipaserver
     cpu: 2
@@ -350,3 +354,15 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_2repl_1client
+
+  fedora-latest/test_ipahealthcheck_adtrust:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithADtrust
+        template: *ci-master-latest
+        timeout: 4800
+        topology: *adroot_adchild_adtree_master_1client


### PR DESCRIPTION
With the support of 32 bit idrange, the minvalue was set to 1
but this introduces a regression in the command ipa trust-add
as the range for AD trust is added with baserid=0

Lower the minvalue to 0

Fixes: https://pagure.io/freeipa/issue/9765