### PR TITLE
[ipa-4-12] ipatests: use newer fedora 41 box

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -35,7 +35,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
           name: freeipa/ci-ipa-4-12-f41
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
@@ -55,7 +55,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
           name: freeipa/ci-ipa-4-12-f41
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
@@ -55,7 +55,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
           name: freeipa/ci-ipa-4-12-f41
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -60,8 +60,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
-          name: freeipa/ci-ipa-4-12-f40
-          version: 0.0.1
+          name: freeipa/ci-ipa-4-12-f41
+          version: 0.0.2
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Regenerated March 19 with latest pkgs