### PR TITLE
[Backport][ipa-4-12] Disallow removal of dogtag and ipa-dnskeysyncd services on IPA servers 

### DIFF
--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -323,7 +323,7 @@ def check_required_principal(ldap, principal):
     try:
         host_is_master(ldap, principal.hostname)
     except errors.ValidationError:
-        service_types = {'http', 'ldap', 'dns', 'dogtagldap'}
+        service_types = {'http', 'ldap', 'dns', 'dogtag', 'ipa-dnskeysyncd'}
         if principal.service_name.lower() in service_types:
             raise errors.ValidationError(
                 name='principal',

--- a/ipatests/test_xmlrpc/test_service_plugin.py
+++ b/ipatests/test_xmlrpc/test_service_plugin.py
@@ -864,6 +864,32 @@ class test_service(Declarative):
             ),
         ),
 
+        dict(
+            desc=('Delete the current host (master?) %s dogtag service,'
+                  ' should be caught' % api.env.host),
+            command=('service_del', ['dogtag/%s' % api.env.host], {}),
+            expected=errors.ValidationError(
+                name='principal',
+                error='dogtag/%s@%s is required by the IPA master' % (
+                    api.env.host,
+                    api.env.realm
+                )
+            ),
+        ),
+
+        dict(
+            desc=('Delete the current host (master?) %s ipa-dnskeysyncd'
+                  ' service, should be caught' % api.env.host),
+            command=('service_del', ['ipa-dnskeysyncd/%s' % api.env.host], {}),
+            expected=errors.ValidationError(
+                name='principal',
+                error='ipa-dnskeysyncd/%s@%s is required by the IPA master' % (
+                    api.env.host,
+                    api.env.realm
+                )
+            ),
+        ),
+
 
         dict(
             desc='Disable the current host (master?) %s HTTP service, should be caught' % api.env.host,


### PR DESCRIPTION
This PR was opened automatically because PR #7733 was pushed to master and backport to ipa-4-12 is required.