### PR TITLE
[Backport][ipa-4-12] add sourcery.ai github action

### DIFF
--- a/.github/workflows/sourcery-check.yml
+++ b/.github/workflows/sourcery-check.yml
@@ -1,0 +1,20 @@
+name: Check PR using Sourcery
+
+on: pull_request
+
+jobs:
+  review-with-sourcery:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+
+      - uses: sourcery-ai/action@438ce67e9f15fbeacb72257da23e2fffb1b6d354
+        with:
+          token: ${{ secrets.SOURCERY_TOKEN }}
+          diff_ref: ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
This PR was opened automatically because PR #7747 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

CI:
- Adds a new CI workflow to run Sourcery on pull requests.