### PR TITLE
PRCI: switch testing from f40 and f41 to f41 and f42

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -38,8 +38,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f41
-          version: 0.0.2
+          name: freeipa/ci-master-f42
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -54,8 +54,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f41
-          version: 0.0.2
+          name: freeipa/ci-master-f42
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -39,8 +39,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f41
-          version: 0.0.2
+          name: freeipa/ci-master-f42
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -43,8 +43,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f41
-          version: 0.0.2
+          name: freeipa/ci-master-f42
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -54,8 +54,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f41
-          version: 0.0.2
+          name: freeipa/ci-master-f42
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -43,8 +43,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f41
-          version: 0.0.2
+          name: freeipa/ci-master-f42
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -55,8 +55,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f41
-          version: 0.0.2
+          name: freeipa/ci-master-f42
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -55,8 +55,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f41
-          version: 0.0.2
+          name: freeipa/ci-master-f42
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -54,8 +54,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-previous
-          name: freeipa/ci-master-f40
-          version: 0.0.1
+          name: freeipa/ci-master-f41
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -60,8 +60,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f41
-          version: 0.0.2
+          name: freeipa/ci-master-f42
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/test_integration/test_idp.py
+++ b/ipatests/test_integration/test_idp.py
@@ -217,7 +217,7 @@ class TestIDPKeycloak(IntegrationTest):
             assert "User keycloakuser may run the following commands" in test
             assert "/usr/bin/yum" in test
             kinit_idp(self.client, 'keycloakuser', self.client)
-            test_sudo = 'su -c "sudo yum list yum" keycloakuser'
+            test_sudo = 'su -c "sudo yum list sssd-client" keycloakuser'
             self.client.run_command(test_sudo)
             list_fail = self.master.run_command(cmd).stdout_text
             assert "User keycloakuser is not allowed to run sudo" in list_fail


### PR DESCRIPTION
Fedora 42 will be available soon and Fedora 40 will be EOL May 13 2025. Start testing on fedora 41 and fedora 42.

## Summary by Sourcery

CI:
- Update PRCI (Pull Request Continuous Integration) configuration files to switch testing environments from Fedora 40 and 41 to Fedora 41 and 42