### PR TITLE
WIP: test pki copr build with VLV disabled against IPA CI

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -35,6 +35,7 @@ jobs:
     job:
       class: Build
       args:
+        copr: 'edewata/pki'
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
@@ -50,6 +51,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_installation.py::TestInstallMaster
         template: *ci-master-latest
         timeout: 7200
@@ -62,6 +65,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_simple_replication.py
         template: *ci-master-latest
         timeout: 3600
@@ -74,6 +79,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
         template: *ci-master-latest
         timeout: 3600
@@ -86,6 +93,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCA test_integration/test_external_ca.py::TestExternalCAConstraints
         template: *ci-master-latest
         timeout: 4800
@@ -98,6 +107,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
         template: *ci-master-latest
         timeout: 3600
@@ -110,6 +121,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
         template: *ci-master-latest
         timeout: 3600
@@ -122,6 +135,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_topologies.py
         template: *ci-master-latest
         timeout: 3600
@@ -134,6 +149,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_sudo.py
         template: *ci-master-latest
         timeout: 4800
@@ -146,6 +163,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
         timeout: 5400
@@ -158,6 +177,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_idm_api.py
         template: *ci-master-latest
         timeout: 3600
@@ -170,6 +191,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_kerberos_flags.py
         template: *ci-master-latest
         timeout: 3600
@@ -182,6 +205,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_forced_client_reenrollment.py
         template: *ci-master-latest
         timeout: 4800
@@ -194,6 +219,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_advise.py
         template: *ci-master-latest
         timeout: 3600
@@ -206,6 +233,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_testconfig.py
         template: *ci-master-latest
         timeout: 3600
@@ -218,6 +247,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_service_permissions.py
         template: *ci-master-latest
         timeout: 3600
@@ -230,6 +261,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_netgroup.py
         template: *ci-master-latest
         timeout: 3600
@@ -242,6 +275,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_authselect.py
         template: *ci-master-latest
         timeout: 4800
@@ -254,6 +289,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
         template: *ci-master-latest
         timeout: 3600
@@ -266,6 +303,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
         template: *ci-master-latest
         timeout: 3600
@@ -278,6 +317,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_membermanager.py
         template: *ci-master-latest
         timeout: 1800
@@ -290,6 +331,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_adtrust_install.py
         template: *ci-master-latest
         timeout: 3600
@@ -302,6 +345,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_cert.py
         template: *ci-master-latest
         timeout: 5400
@@ -314,6 +359,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_upgrade.py
         template: *ci-master-latest
         timeout: 3600
@@ -326,6 +373,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_subids.py
         template: *ci-master-latest
         timeout: 3600
@@ -338,6 +387,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_ipalib_install/test_kinit.py
         template: *ci-master-latest
         timeout: 600
@@ -350,6 +401,8 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_idp.py
         template: *ci-master-latest
         timeout: 3600
@@ -362,6 +415,8 @@ jobs:
       class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
+        copr: 'edewata/pki'
+        update_packages: True
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithADtrust
         template: *ci-master-latest
         timeout: 4800

--- a/ipatests/prci_definitions/prci_checker.py
+++ b/ipatests/prci_definitions/prci_checker.py
@@ -430,4 +430,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    print("CHECKS FINISHED SUCCESSFULLY")


### PR DESCRIPTION
## Summary by Sourcery

Update IPA integration test configuration to use PKI Copr repository and enable package updates for all test jobs

CI:
- Add 'edewata/pki' Copr repository to all test jobs
- Enable package updates for all test jobs to use the latest PKI packages