### PR TITLE
PRCI definitions: update vagrant box version for rawhide

### DIFF
--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -55,7 +55,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-frawhide
           name: freeipa/ci-master-frawhide
-          version: 0.8.3
+          version: 0.9.1
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Use version 0.9.1 based on fedora 43 - March 26, 2025

## Summary by Sourcery

Chores:
- Update the CI template version from 0.8.3 to 0.9.1 for Fedora Rawhide testing environment