### PR TITLE
[ipa-4-11] KRA cert renewal: allow certmonger_t to read "ca" dir

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -65,14 +65,15 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest-ipa-4-11/temp_commit:
+  fedora-latest-ipa-4-11/test_installation_TestInstallMasterKRA:
     requires: [fedora-latest-ipa-4-11/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest-ipa-4-11/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        selinux_enforcing: True
+        test_suite: test_integration/test_installation.py::TestInstallMasterKRA
         template: *ci-ipa-4-11-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 10800
+        topology: *master_1repl

--- a/selinux/ipa.te
+++ b/selinux/ipa.te
@@ -501,8 +501,10 @@ optional_policy(`
 optional_policy(`
     gen_require(` #selint-disable:S-001
         type certmonger_t;
+        type pki_tomcat_var_lib_t;
     ')
-	  pki_manage_tomcat_etc_rw(certmonger_t)
+	  pki_manage_tomcat_etc_rw(certmonger_t);
+    allow certmonger_t pki_tomcat_var_lib_t:dir read;
 ')
 
 optional_policy(`


### PR DESCRIPTION
During cert renewal, the helper checks if the KRA is installed by calling
krainstance.is_installed(). This call internally executes the command
pki-server subsystem-show kra
which needs read access to the ca dir with pki_tomcat_var_lib_t context.

Add required selinux permission.

Fixes: https://pagure.io/freeipa/issue/9770

## Summary by Sourcery

Add SELinux permissions to allow certmonger to read the CA directory during KRA certificate renewal

Bug Fixes:
- Fix SELinux access restrictions that prevent KRA certificate renewal by adding necessary read permissions for the certmonger domain

CI:
- Update CI configuration to run a specific KRA installation test with SELinux enforcing mode