### PR TITLE
WIP azure pipeline: replace ubuntu-20.04 with 22.04

### DIFF
--- a/ipatests/azure/templates/variables-common.yml
+++ b/ipatests/azure/templates/variables-common.yml
@@ -6,7 +6,7 @@ variables:
   # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1604-REA    DME.md
   # Ubuntu-18.04 - 3.6.9
   # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-REA    DME.md
-  VM_IMAGE: 'ubuntu-20.04'
+  VM_IMAGE: 'ubuntu-24.04'
   MAX_CONTAINER_ENVS: 5
   IPA_TESTS_ENV_WORKING_DIR: $(Build.Repository.LocalPath)/ipa_envs
   IPA_TESTS_SCRIPTS: 'ipatests/azure/scripts'


### PR DESCRIPTION
Azure is deprecating the Ubuntu-20.04 Apr 15th, see announcement https://devblogs.microsoft.com/devops/upcoming-updates-for-azure-pipelines-agents-images/#ubuntu

Replace the 20.04 image with 22.04.
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>

## Summary by Sourcery

CI:
- Update the default VM image in Azure Pipelines configuration to use the latest Ubuntu 24.04 image