### PR TITLE
Address deprecation warning in ipa-replica-manage

### DIFF
--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -30,7 +30,7 @@ from xmlrpc.client import MAXINT
 
 import ldap
 
-from ipaclient.install import ipadiscovery
+import ipaclient.discovery as ipadiscovery
 from ipapython import ipautil
 from ipaserver.install import replication, dsinstance, installutils
 from ipaserver.install import bindinstance, cainstance


### PR DESCRIPTION
Running ipa-replica-manage results in a deprecation warning:

/usr/lib/python3.12/site-packages/ipaclient/install/ipadiscovery.py:20: DeprecationWarning: ipaclient.install.ipadiscovery is deprecated, use ipacli ent.discovery

Switch to the new usage.

Fixes: https://pagure.io/freeipa/issue/9771

## Summary by Sourcery

Bug Fixes:
- Resolve deprecation warning in ipa-replica-manage related to the ipadiscovery module import