### PR TITLE
[ipa-4-11] Revert "Temp commit"

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/temp_commit.yaml
+ipatests/prci_definitions/gating.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -65,15 +65,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest-ipa-4-11/test_installation_TestInstallMasterKRA:
+  fedora-latest-ipa-4-11/temp_commit:
     requires: [fedora-latest-ipa-4-11/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest-ipa-4-11/build_url}'
-        selinux_enforcing: True
-        test_suite: test_integration/test_installation.py::TestInstallMasterKRA
+        test_suite: test_integration/test_REPLACEME.py
         template: *ci-ipa-4-11-latest
-        timeout: 10800
-        topology: *master_1repl
+        timeout: 3600
+        topology: *master_1repl_1client


### PR DESCRIPTION
This reverts commit 2310977a13ecbaaa44ac527e4d59f6f366d33f64.

## Summary by Sourcery

Revert a temporary commit by removing a specific test configuration from the CI pipeline

CI:
- Reverted changes to the test configuration in the PRCI (Pull Request Continuous Integration) definition files

Chores:
- Removed a temporary test configuration from the CI workflow definition