### PR TITLE
[Backport][ipa-4-12] Address deprecation warning in ipa-replica-manage

### DIFF
--- a/install/tools/ipa-replica-manage.in
+++ b/install/tools/ipa-replica-manage.in
@@ -30,7 +30,7 @@ from xmlrpc.client import MAXINT
 
 import ldap
 
-from ipaclient.install import ipadiscovery
+import ipaclient.discovery as ipadiscovery
 from ipapython import ipautil
 from ipaserver.install import replication, dsinstance, installutils
 from ipaserver.install import bindinstance, cainstance


### PR DESCRIPTION
This PR was opened automatically because PR #7754 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Bug Fixes:
- Address a deprecation warning in the ipa-replica-manage tool