### PR TITLE
ipa-getkeytab: fix enctype selection with pre-4.0 server

### DIFF
--- a/client/ipa-getkeytab.c
+++ b/client/ipa-getkeytab.c
@@ -570,23 +570,17 @@ static int ldap_set_keytab(krb5_context krbctx,
 	}
 
 	for (i = 0; i < keys->nkeys; i++) {
-		ret = ber_scanf(sctrl, "{i}", &encs[i]);
+		ber_int_t enctype = 0;
+		ret = ber_scanf(sctrl, "{i}", &enctype);
 		if (ret == LBER_ERROR) {
-			char enc[79]; /* fit std terminal or truncate */
-			krb5_error_code krberr;
-			krberr = krb5_enctype_to_string(
-				keys->ksdata[i].enctype, enc, 79);
-			if (krberr) {
-				fprintf(stderr, _("Failed to retrieve "
-					"encryption type type #%d\n"),
-					keys->ksdata[i].enctype);
-			} else {
-				fprintf(stderr, _("Failed to retrieve "
-					"encryption type %1$s (#%2$d)\n"),
-					enc, keys->ksdata[i].enctype);
+			break;
+		}
+		for (int j = 0; j < keys->nkeys; j++) {
+			if (enctype == keys->ksdata[j].enctype) {
+				encs[j] = enctype;
+				successful_keys++;
+				break;
 			}
-                } else {
-			successful_keys++;
 		}
 	}
 


### PR DESCRIPTION
When the server responds with the list of accepted enctypes, we were not processing the result correctly. filter_keys() expects that server supplied types in 'encs' are at the same offsets as the corresponding entries in the 'ksdata' (the values are not considered). However, the response parsing just copies the returned values sequentially.

Because of this, key selection is incorrectly done based on the number of enctypes returned. For example if a client sends (a, b, c, d) as supported keys and the server responds (c, d), the client will select the first two (a, b), which will lead to a failure to join. This issue is hidden if the number of overlapping types is large enough.

In practice, this means joining to very old servers requires permitting many obsolete enctypes, when only a minimal overlap should be necessary.

Resolve the issue by storing the received values at the expected offsets.