### PR TITLE
ipa-sidgen: fix memory leak in ipa_sidgen_add_post_op()

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-sidgen/ipa_sidgen.c
+++ b/daemons/ipa-slapi-plugins/ipa-sidgen/ipa_sidgen.c
@@ -81,7 +81,6 @@ static int ipa_sidgen_add_post_op(Slapi_PBlock *pb)
     const char *dn_str;
     Slapi_DN *dn = NULL;
     struct ipa_sidgen_ctx *ctx;
-    Slapi_PBlock *search_pb = NULL;
     char *errmsg = NULL;
 
     ret = slapi_pblock_get(pb, SLAPI_IS_REPLICATED_OPERATION, &is_repl_op);
@@ -152,9 +151,8 @@ static int ipa_sidgen_add_post_op(Slapi_PBlock *pb)
 
     ret = 0;
 done:
-    slapi_free_search_results_internal(search_pb);
-    slapi_pblock_destroy(search_pb);
     slapi_sdn_free(&dn);
+    slapi_entry_free(entry);
 
     if (ret != 0) {
         if (errmsg == NULL) {


### PR DESCRIPTION
Fixes: https://pagure.io/freeipa/issue/9772

## Summary by Sourcery

Bug Fixes:
- Resolve a memory leak in the ipa_sidgen_add_post_op() function by properly freeing the entry object