### PR TITLE
azure pipeline: replace ubuntu-20.04 with 22.04

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/azure/Dockerfiles/docker-compose.yml
+++ b/ipatests/azure/Dockerfiles/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     mem_limit: "${IPA_TESTS_SERVER_MEM_LIMIT}"
     memswap_limit: "${IPA_TESTS_SERVER_MEMSWAP_LIMIT}"
     volumes:
-    - /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd
+    - /sys/fs/cgroup/freeipa.scope:/sys/fs/cgroup:rw
     - ./ipa-test-config.yaml:/root/.ipa/ipa-test-config.yaml:ro
     - ${BUILD_REPOSITORY_LOCALPATH}:${IPA_TESTS_REPO_PATH}
 
@@ -29,7 +29,7 @@ services:
     mem_limit: "${IPA_TESTS_REPLICA_MEM_LIMIT}"
     memswap_limit: "${IPA_TESTS_REPLICA_MEMSWAP_LIMIT}"
     volumes:
-    - /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd
+    - /sys/fs/cgroup/freeipa.scope:/sys/fs/cgroup:rw
     - ${BUILD_REPOSITORY_LOCALPATH}:${IPA_TESTS_REPO_PATH}:ro
     networks:
     - ${IPA_NETWORK}
@@ -45,7 +45,7 @@ services:
     mem_limit: "${IPA_TESTS_CLIENT_MEM_LIMIT}"
     memswap_limit: "${IPA_TESTS_CLIENT_MEMSWAP_LIMIT}"
     volumes:
-    - /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd
+    - /sys/fs/cgroup/freeipa.scope:/sys/fs/cgroup:rw
     - ${BUILD_REPOSITORY_LOCALPATH}:${IPA_TESTS_REPO_PATH}:ro
     # nfs server
     - ./exports:/exports

--- a/ipatests/azure/scripts/azure-run-tests.sh
+++ b/ipatests/azure/scripts/azure-run-tests.sh
@@ -131,6 +131,13 @@ ln -sfr \
 # will be generated later in setup_containers.py
 touch "${project_dir}"/ipa-test-config.yaml
 
+# workaround for cgroupv2
+# Ubuntu 22.04 uses cgroupv2
+# launch any container with --groupns=host and without volume bindings
+# allow to mount group2 without the nsdelegate mount option
+docker run --rm --cgroupns host \
+    registry.fedoraproject.org/fedora-toolbox:40 echo done
+
 pushd "$project_dir"
 
 BUILD_REPOSITORY_LOCALPATH="$BUILD_REPOSITORY_LOCALPATH" \

--- a/ipatests/azure/templates/variables-common.yml
+++ b/ipatests/azure/templates/variables-common.yml
@@ -6,7 +6,7 @@ variables:
   # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1604-REA    DME.md
   # Ubuntu-18.04 - 3.6.9
   # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-REA    DME.md
-  VM_IMAGE: 'ubuntu-20.04'
+  VM_IMAGE: 'ubuntu-22.04'
   MAX_CONTAINER_ENVS: 5
   IPA_TESTS_ENV_WORKING_DIR: $(Build.Repository.LocalPath)/ipa_envs
   IPA_TESTS_SCRIPTS: 'ipatests/azure/scripts'

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -65,14 +65,15 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/simple_replication:
     requires: [fedora-latest/build]
-    priority: 50
+    priority: 100
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_simple_replication.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl
+


### PR DESCRIPTION
Azure is deprecating the Ubuntu-20.04 Apr 15th, see announcement
https://devblogs.microsoft.com/devops/upcoming-updates-for-azure-pipelines-agents-images/#ubuntu

## Summary by Sourcery

Update Azure pipeline configuration to use Ubuntu 22.04 and address compatibility changes for cgroupv2

Enhancements:
- Modify Docker compose and test scripts to support cgroupv2 system configuration
- Update test configuration to use newer Ubuntu image

CI:
- Update Azure pipeline VM image from Ubuntu 20.04 to Ubuntu 22.04 to address Azure's deprecation of the older image

Chores:
- Adjust cgroup volume mounting to use new path for systemd
- Update test configuration references