### PR TITLE
ipatests: Fix for ipa-healthcheck test in FIPS mode 

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -374,10 +374,10 @@ class TestIpaHealthCheck(IntegrationTest):
         if (
             parse_version(healthcheck_version) < parse_version("0.17")
             and osinfo.id == 'rhel'
-            and osinfo.version_number == (10,0)
+            and osinfo.version_number >= (10,0)
         ):
             # Patch: https://github.com/freeipa/freeipa-healthcheck/pull/349
-            pytest.xfail("Patch is unavailable for RHEL 10.0 and "
+            pytest.xfail("Patch is unavailable for RHEL 10.0 and above"
                          "freeipa-healtheck version 0.16 or less")
 
         returncode, check = run_healthcheck(self.master,


### PR DESCRIPTION
Fix https://github.com/freeipa/freeipa-healthcheck/pull/349
was added for RHEL10 only causing the tests to
fail in RHEL10.1.
Hence the if condition has been changed in the testcode.

## Summary by Sourcery

Modify the test condition for ipa-healthcheck to correctly handle RHEL 10.1 version compatibility

Bug Fixes:
- Fixed the version condition in the ipa-healthcheck test to correctly handle RHEL 10.1, addressing test failures in the newer RHEL version

Tests:
- Updated the test suite configuration to specifically target the ipa-healthcheck FIPS-enabled test