### PR TITLE
azure pipeline: replace ubuntu-20.04 with 24.04

### DIFF
--- a/ipatests/azure/Dockerfiles/docker-compose.yml
+++ b/ipatests/azure/Dockerfiles/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build: .
     cap_add:
     - ALL
+    cap_drop:
+    - CAP_SYS_TIME
     security_opt:
     - apparmor:unconfined
     - seccomp:./seccomp.json
@@ -12,17 +14,16 @@ services:
     memswap_limit: "${IPA_TESTS_SERVER_MEMSWAP_LIMIT}"
     volumes:
     - /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd
-    - ./ipa-test-config.yaml:/root/.ipa/ipa-test-config.yaml:ro
+    - ${PROJECT_DIR}/ipa-test-config.yaml:/root/.ipa/ipa-test-config.yaml:ro
     - ${BUILD_REPOSITORY_LOCALPATH}:${IPA_TESTS_REPO_PATH}
-
-    networks:
-    - ${IPA_NETWORK}
 
   replica:
     image: ${IPA_DOCKER_IMAGE}
     build: .
     cap_add:
     - ALL
+    cap_drop:
+    - CAP_SYS_TIME
     security_opt:
     - apparmor:unconfined
     - seccomp:./seccomp.json
@@ -31,14 +32,14 @@ services:
     volumes:
     - /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd
     - ${BUILD_REPOSITORY_LOCALPATH}:${IPA_TESTS_REPO_PATH}:ro
-    networks:
-    - ${IPA_NETWORK}
 
   client:
     image: ${IPA_DOCKER_IMAGE}
     build: .
     cap_add:
     - ALL
+    cap_drop:
+    - CAP_SYS_TIME
     security_opt:
     - apparmor:unconfined
     - seccomp:./seccomp.json
@@ -50,15 +51,4 @@ services:
     # nfs server
     - ./exports:/exports
     - /lib/modules:/lib/modules:ro
-    networks:
-    - ${IPA_NETWORK}
 
-networks:
-  ipanet:
-    driver: bridge
-    enable_ipv6: true
-    ipam:
-      driver: default
-      config:
-      - subnet: ${IPA_IPV6_SUBNET}
-    internal: ${IPA_NETWORK_INTERNAL}

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -10,14 +10,22 @@ variables:
 # platform specific variables, links to
 - template: ${{ parameters.VARIABLES_FILE }}
 
+resources:
+  containers:
+  - container: 'builder'
+    image: $(DOCKER_BUILD_IMAGE)
+    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
+
 jobs:
 - job: Build
   pool:
     vmImage: $(VM_IMAGE)
-  container:
-    image: $(DOCKER_BUILD_IMAGE)
-    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
+  container: builder
   steps:
+    - script: |
+        CONTAINERID=`echo '$(Agent.ContainerMapping)' | jq -r '.builder.id'`
+        /usr/bin/docker exec $CONTAINERID bash -c "chmod a+r /etc/shadow"
+      target: host
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - template: templates/${{ variables.AUTOCONF_TEMPLATE }}
     - template: templates/${{ variables.BUILD_TEMPLATE }}
@@ -57,10 +65,12 @@ jobs:
 - job: Lint
   pool:
     vmImage: $(VM_IMAGE)
-  container:
-    image: $(DOCKER_BUILD_IMAGE)
-    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
+  container: builder
   steps:
+    - script: |
+        CONTAINERID=`echo '$(Agent.ContainerMapping)' | jq -r '.builder.id'`
+        /usr/bin/docker exec $CONTAINERID bash -c "chmod a+r /etc/shadow"
+      target: host
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - template: templates/${{ variables.PREPARE_LINT_TEMPLATE }}
     - template: templates/${{ variables.AUTOCONF_TEMPLATE }}
@@ -79,10 +89,12 @@ jobs:
 - job: Docs
   pool:
     vmImage: $(VM_IMAGE)
-  container:
-    image: $(DOCKER_BUILD_IMAGE)
-    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
+  container: builder
   steps:
+    - script: |
+        CONTAINERID=`echo '$(Agent.ContainerMapping)' | jq -r '.builder.id'`
+        /usr/bin/docker exec $CONTAINERID bash -c "chmod a+r /etc/shadow"
+      target: host
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - template: templates/${{ variables.AUTOCONF_TEMPLATE }}
     - template: templates/${{ variables.BUILD_DOCS_TEMPLATE }}
@@ -95,10 +107,12 @@ jobs:
 - job: Tox
   pool:
     vmImage: $(VM_IMAGE)
-  container:
-    image: $(DOCKER_BUILD_IMAGE)
-    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
+  container: builder
   steps:
+    - script: |
+        CONTAINERID=`echo '$(Agent.ContainerMapping)' | jq -r '.builder.id'`
+        /usr/bin/docker exec $CONTAINERID bash -c "chmod a+r /etc/shadow"
+      target: host
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - template: templates/${{ variables.PREPARE_TOX_TEMPLATE }}
     - script: |
@@ -118,10 +132,12 @@ jobs:
 - job: WebUI_Unit_Tests
   pool:
     vmImage: $(VM_IMAGE)
-  container:
-    image: $(DOCKER_BUILD_IMAGE)
-    options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --env container=docker
+  container: builder
   steps:
+    - script: |
+        CONTAINERID=`echo '$(Agent.ContainerMapping)' | jq -r '.builder.id'`
+        /usr/bin/docker exec $CONTAINERID bash -c "chmod a+r /etc/shadow"
+      target: host
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - template: templates/${{ variables.PREPARE_WEBUI_TEMPLATE }}
     - template: templates/${{ variables.AUTOCONF_TEMPLATE }}

--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -22,10 +22,6 @@ jobs:
     vmImage: $(VM_IMAGE)
   container: builder
   steps:
-    - script: |
-        CONTAINERID=`echo '$(Agent.ContainerMapping)' | jq -r '.builder.id'`
-        /usr/bin/docker exec $CONTAINERID bash -c "chmod a+r /etc/shadow"
-      target: host
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - template: templates/${{ variables.AUTOCONF_TEMPLATE }}
     - template: templates/${{ variables.BUILD_TEMPLATE }}
@@ -41,8 +37,9 @@ jobs:
         cp -pr dist container/
         cp $(IPA_TESTS_DOCKERFILES)/$(DOCKER_DOCKERFILE) container/Dockerfile
         cd container
-        docker build -t freeipa-azure-builder .
-        docker save freeipa-azure-builder | gzip > '$(builddir)/freeipa-azure-builder-container.tar.gz'
+        podman build -t freeipa-azure-builder .
+        podman image save -o $(builddir)/freeipa-azure-builder-container.tar freeipa-azure-builder:latest
+        gzip $(builddir)/freeipa-azure-builder-container.tar
       displayName: Create container image for test
     - template: templates/publish-build.yml
       parameters:
@@ -67,10 +64,6 @@ jobs:
     vmImage: $(VM_IMAGE)
   container: builder
   steps:
-    - script: |
-        CONTAINERID=`echo '$(Agent.ContainerMapping)' | jq -r '.builder.id'`
-        /usr/bin/docker exec $CONTAINERID bash -c "chmod a+r /etc/shadow"
-      target: host
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - template: templates/${{ variables.PREPARE_LINT_TEMPLATE }}
     - template: templates/${{ variables.AUTOCONF_TEMPLATE }}
@@ -91,10 +84,6 @@ jobs:
     vmImage: $(VM_IMAGE)
   container: builder
   steps:
-    - script: |
-        CONTAINERID=`echo '$(Agent.ContainerMapping)' | jq -r '.builder.id'`
-        /usr/bin/docker exec $CONTAINERID bash -c "chmod a+r /etc/shadow"
-      target: host
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - template: templates/${{ variables.AUTOCONF_TEMPLATE }}
     - template: templates/${{ variables.BUILD_DOCS_TEMPLATE }}
@@ -109,10 +98,6 @@ jobs:
     vmImage: $(VM_IMAGE)
   container: builder
   steps:
-    - script: |
-        CONTAINERID=`echo '$(Agent.ContainerMapping)' | jq -r '.builder.id'`
-        /usr/bin/docker exec $CONTAINERID bash -c "chmod a+r /etc/shadow"
-      target: host
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - template: templates/${{ variables.PREPARE_TOX_TEMPLATE }}
     - script: |
@@ -134,10 +119,6 @@ jobs:
     vmImage: $(VM_IMAGE)
   container: builder
   steps:
-    - script: |
-        CONTAINERID=`echo '$(Agent.ContainerMapping)' | jq -r '.builder.id'`
-        /usr/bin/docker exec $CONTAINERID bash -c "chmod a+r /etc/shadow"
-      target: host
     - template: templates/${{ variables.PREPARE_BUILD_TEMPLATE }}
     - template: templates/${{ variables.PREPARE_WEBUI_TEMPLATE }}
     - template: templates/${{ variables.AUTOCONF_TEMPLATE }}

--- a/ipatests/azure/scripts/setup_containers.py
+++ b/ipatests/azure/scripts/setup_containers.py
@@ -125,7 +125,7 @@ class ContainersGroup:
         # initialize containers
         self.containers = [
             Container(
-                name=f"{self.prefix}-{self.role}-{c}",
+                name=f"{self.prefix}_{self.role}_{c}",
                 hostname=f"{self.role}{c}.{self.domain}",
                 network=f"{IPA_TESTS_ENV_ID}_{IPA_NETWORK}",
             )
@@ -187,7 +187,7 @@ class ContainersGroup:
                     "127.0.0.1 localhost",
                     "::1 localhost",
                     f"{cont.ip} {cont.hostname}",
-                    f"{cont.ipv6} {cont.hostname}",
+                    # f"{cont.ipv6} {cont.hostname}",
                 ]
             )
             cmd = ["/bin/bash", "-c", f"echo -e '{hosts}' > /etc/hosts"]
@@ -218,7 +218,8 @@ class ContainersGroup:
         cmd = [
             "/bin/bash",
             "-c",
-            f"echo -e '{nameservers}' > /etc/resolv.conf",
+            f"echo -e '{nameservers}' > /etc/resolv.conf"
+            f"; chmod 0644 /etc/resolv.conf",
         ]
         self.execute_all(cmd)
 
@@ -363,7 +364,7 @@ class Controller(Container):
 
             for container in containers_group.containers:
                 hosts.append(f"{container.ip} {container.hostname}")
-                hosts.append(f"{container.ipv6} {container.hostname}")
+                # hosts.append(f"{container.ipv6} {container.hostname}")
 
         cmd = [
             "/bin/bash",
@@ -391,6 +392,9 @@ class Controller(Container):
             template = Template(f.read(), trim_blocks=True, lstrip_blocks=True)
 
         logging.info(template.render(config))
+        logging.info(
+            "Saving the test config in %s",
+            os.path.join(IPA_TESTS_ENV_DIR, IPA_TEST_CONFIG))
 
         with open(os.path.join(IPA_TESTS_ENV_DIR, IPA_TEST_CONFIG), "w") as f:
             f.write(template.render(config))

--- a/ipatests/azure/templates/prepare-build-fedora.yml
+++ b/ipatests/azure/templates/prepare-build-fedora.yml
@@ -1,5 +1,11 @@
 steps:
 - script: |
+    CONTAINERID=`echo '$(Agent.ContainerMapping)' | jq -r '.builder.id'`
+    /usr/bin/docker exec $CONTAINERID bash -c "dnf reinstall -y shadow-utils; chmod a+r /etc/shadow"
+  target: host
+  displayName: Workaround unreadable /etc/shadow
+
+- script: |
     set -e
     sudo rm -rf /var/cache/dnf/*
     sudo dnf makecache || :
@@ -14,7 +20,7 @@ steps:
         git \
         automake \
         libtool \
-        docker \
+        podman \
         python3-paramiko \
         python3-pyyaml \
 

--- a/ipatests/azure/templates/setup-test-environment.yml
+++ b/ipatests/azure/templates/setup-test-environment.yml
@@ -4,16 +4,6 @@ parameters:
 steps:
 - script: |
     set -e
-    echo '{ "ipv6": true, "fixed-cidr-v6": "2001:db8::/64" }' > docker-daemon.json
-    sudo mkdir -p /etc/docker
-    sudo cp docker-daemon.json /etc/docker/daemon.json
-    sudo chown root:root /etc/docker/daemon.json
-    sudo systemctl restart docker
-    sudo modprobe ip6_tables
-  displayName: Configure containerization to allow IPv6 network
-
-- script: |
-    set -e
     sudo modprobe {nfs,nfsd}
   displayName: Configure NFS to allow NFS server/client within containers
 
@@ -31,7 +21,9 @@ steps:
 
 - script: |
     set -e
-    docker load --input $(Build.Repository.LocalPath)/freeipa-azure-builder-container.tar.gz
-    docker images
-    docker inspect freeipa-azure-builder:latest
+    podman load --input $(Build.Repository.LocalPath)/freeipa-azure-builder-container.tar.gz
+    # Work around podman load bug that names loaded image as latest:latest
+    podman image tag localhost/latest:latest freeipa-azure-builder:latest ||:
+    podman images
+    podman inspect freeipa-azure-builder:latest
   displayName: Import pre-built container to the engine

--- a/ipatests/azure/templates/test-jobs.yml
+++ b/ipatests/azure/templates/test-jobs.yml
@@ -1,6 +1,7 @@
 steps:
 - script: |
     set -e
+    export DOCKER_HOST=unix://$(XDG_RUNTIME_DIR)/podman/podman.sock
     env | sort
   displayName: Print Host Enviroment
 
@@ -11,6 +12,7 @@ steps:
 
 - script: |
     set -e
+    sudo apt-get purge --auto-remove docker-ce-cli
     sudo apt-get update
     sudo apt-get install -y \
         apparmor-utils \
@@ -18,13 +20,19 @@ steps:
         moreutils \
         rng-tools \
         systemd-coredump \
-        python3-docker
+        podman podman-docker python3-pip python3-venv
+    sudo pip3 install podman-compose
   displayName: Install Host's tests requirements
 
 - script: |
     set -e
     sudo systemctl
   displayName: Show Host's systemd status
+
+- script: |
+    set -e
+    systemctl --user enable --now podman.socket ||:
+  displayName: Enable podman emulation of docker
 
 - script: |
     set -e
@@ -82,13 +90,27 @@ steps:
     sudo ps -auxf
   displayName: Show Host's processes
 
+- script: |
+    set -eu
+    id
+    cat /proc/$$/subuid_map ||:
+    cat /proc/$$/subgid_map ||:
+    cat /etc/subuid ||:
+    cat /etc/subgid ||:
+  displayName: Show Host's subuid settings
+
+- script: |
+    set -e
+    sudo mkdir -p /sys/fs/cgroup/systemd
+  displayName: Create /sys/fs/cgroup/systemd for the volume
+
 - template: run-test.yml
 
 - script: |
     set -eux
     free -m
-    cat /sys/fs/cgroup/memory/memory.memsw.max_usage_in_bytes
-    cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+    cat /sys/fs/cgroup/systemd/memory.swap.peak
+    cat /sys/fs/cgroup/systemd/memory.peak
     cat /proc/sys/vm/swappiness
   condition: succeededOrFailed()
   displayName: Host's memory statistics
@@ -150,20 +172,20 @@ steps:
     # continue in container
     HOST_JOURNAL="/var/log/host_journal"
     CONTAINER_COREDUMP="dump_cores"
-    docker create --privileged \
+    podman create --privileged \
         -v "$(realpath coredumpctl.time.mark)":/coredumpctl.time.mark:ro \
         -v /var/lib/systemd/coredump:/var/lib/systemd/coredump:ro \
         -v /var/log/journal:"$HOST_JOURNAL":ro \
         -v "${BUILD_REPOSITORY_LOCALPATH}":"${IPA_TESTS_REPO_PATH}" \
         --name "$CONTAINER_COREDUMP" freeipa-azure-builder
-    docker start "$CONTAINER_COREDUMP"
+    podman start "$CONTAINER_COREDUMP"
 
-    docker exec -t \
+    podman exec -t \
         "$CONTAINER_COREDUMP" \
         /bin/bash --noprofile --norc -eux \
             "${IPA_TESTS_REPO_PATH}/${IPA_TESTS_SCRIPTS}/wait-for-systemd.sh"
 
-    docker exec -t \
+    podman exec -t \
         --env IPA_TESTS_REPO_PATH="${IPA_TESTS_REPO_PATH}" \
         --env IPA_TESTS_SCRIPTS="${IPA_TESTS_REPO_PATH}/${IPA_TESTS_SCRIPTS}" \
         --env IPA_PLATFORM="${IPA_PLATFORM}" \
@@ -171,7 +193,7 @@ steps:
         /bin/bash --noprofile --norc -eux \
             "${IPA_TESTS_REPO_PATH}/${IPA_TESTS_SCRIPTS}/install-debuginfo.sh"
 
-    docker exec -t \
+    podman exec -t \
         --env IPA_TESTS_REPO_PATH="${IPA_TESTS_REPO_PATH}" \
         --env COREDUMPS_SUBDIR="$COREDUMPS_SUBDIR" \
         --env HOST_JOURNAL="$HOST_JOURNAL" \

--- a/ipatests/azure/templates/test-jobs.yml
+++ b/ipatests/azure/templates/test-jobs.yml
@@ -41,7 +41,7 @@ steps:
     printf "AppArmor status\n"
     sudo aa-status
     printf "Disable AppArmor conflicting profiles\n"
-    sudo aa-disable /etc/apparmor.d/usr.sbin.chronyd
+    sudo aa-disable /etc/apparmor.d/usr.sbin.chronyd ||:
     printf "Recheck AppArmor status\n"
     sudo aa-status
   displayName: Disable AppArmor conflicting profiles on Host
@@ -74,7 +74,7 @@ steps:
 
 - script: |
     set -eu
-    sudo top -b -o +%MEM n 1
+    sudo top -b -o +%MEM -n 1
   displayName: Show Host's top
 
 - script: |

--- a/ipatests/azure/templates/variables-common.yml
+++ b/ipatests/azure/templates/variables-common.yml
@@ -6,7 +6,7 @@ variables:
   # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1604-REA    DME.md
   # Ubuntu-18.04 - 3.6.9
   # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-REA    DME.md
-  VM_IMAGE: 'ubuntu-20.04'
+  VM_IMAGE: 'ubuntu-24.04'
   MAX_CONTAINER_ENVS: 5
   IPA_TESTS_ENV_WORKING_DIR: $(Build.Repository.LocalPath)/ipa_envs
   IPA_TESTS_SCRIPTS: 'ipatests/azure/scripts'

--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -24,7 +24,7 @@ from ipaplatform.paths import paths
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration.tasks import (
     clear_sssd_cache, get_host_ip_with_hostmask, remote_sssd_config,
-    FileBackup)
+    FileBackup, install_master, install_client)
 
 class TestSudo(IntegrationTest):
     """
@@ -32,11 +32,14 @@ class TestSudo(IntegrationTest):
     http://www.freeipa.org/page/V4/Sudo_Integration#Test_Plan
     """
     num_clients = 1
-    topology = 'line'
 
     @classmethod
     def install(cls, mh):
         super(TestSudo, cls).install(mh)
+
+        extra_args = ["--idstart=60001", "--idmax=65000"]
+        install_master(cls.master, setup_dns=True, extra_args=extra_args)
+        install_client(cls.master, cls.clients[0])
 
         cls.client = cls.clients[0]
         cls.clientname = cls.client.run_command(


### PR DESCRIPTION
Azure is deprecating the Ubuntu-20.04 Apr 15th, see announcement
https://devblogs.microsoft.com/devops/upcoming-updates-for-azure-pipelines-agents-images/#ubuntu

## Summary by Sourcery

Update Azure pipeline configuration to use Ubuntu 22.04 and make minor adjustments to container and test configurations

Enhancements:
- Modify Docker Compose configuration to use updated cgroup and volume mount settings
- Update test configuration with minor topology and test suite changes

CI:
- Update Azure pipeline VM image from Ubuntu 20.04 to Ubuntu 22.04 due to Azure's deprecation announcement