### PR TITLE
fix sidgen for overflowing IDs

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/daemons/ipa-slapi-plugins/ipa-sidgen/ipa_sidgen_common.c
+++ b/daemons/ipa-slapi-plugins/ipa-sidgen/ipa_sidgen_common.c
@@ -449,8 +449,8 @@ int find_sid_for_ldap_entry(struct slapi_entry *entry,
 {
     int ret;
     const char *dn_str;
-    uint32_t uid_number;
-    uint32_t gid_number;
+    uint64_t uid_number;
+    uint64_t gid_number;
     uint32_t id;
     char *sid = NULL;
     char **objectclasses = NULL;
@@ -471,8 +471,8 @@ int find_sid_for_ldap_entry(struct slapi_entry *entry,
     }
     LOG("Trying to add SID for [%s].\n", dn_str);
 
-    uid_number = slapi_entry_attr_get_ulong(entry, UID_NUMBER);
-    gid_number = slapi_entry_attr_get_ulong(entry, GID_NUMBER);
+    uid_number = slapi_entry_attr_get_ulonglong(entry, UID_NUMBER);
+    gid_number = slapi_entry_attr_get_ulonglong(entry, GID_NUMBER);
 
     if (uid_number == 0 && gid_number == 0) {
         LOG("[%s] does not have Posix IDs, nothing to do.\n", dn_str);

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -72,7 +72,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_commands.py
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -1963,6 +1963,7 @@ class TestIPACommandWithoutReplica(IntegrationTest):
             - add a user with no uid (it will be auto-assigned inside
               the range)
             - add a user with uid 2000
+            - add a user with uid 4,294,967,306 (uint32 overflow)
             - add a user with no uid (it will be auto-assigned inside
               the range)
             - edit the first and 3rd users, remove the objectclass
@@ -1977,9 +1978,11 @@ class TestIPACommandWithoutReplica(IntegrationTest):
         test_user1 = 'test_user1'
         test_user2 = 'test_user2'
         test_user2000 = 'test_user2000'
+        test_useroverflow = 'test_useroverflow'
         base_dn = str(self.master.domain.basedn)
         old_err_msg = 'Cannot add SID to existing entry'
         new_err_msg = r'Finished with [0-9]+ failures, please check the log'
+        overflow_err_msg = 'ID value too large on entry'
 
         tasks.kinit_admin(self.master)
         tasks.user_add(self.master, test_user1)
@@ -1989,8 +1992,9 @@ class TestIPACommandWithoutReplica(IntegrationTest):
              '--uid', '2000']
         )
         tasks.user_add(self.master, test_user2)
+        tasks.user_add(self.master, test_useroverflow)
 
-        for user in (test_user1, test_user2):
+        for user in (test_user1, test_user2, test_useroverflow):
             entry_ldif = textwrap.dedent("""
                 dn: uid={user},cn=users,cn=accounts,{base_dn}
                 changetype: modify
@@ -2002,6 +2006,17 @@ class TestIPACommandWithoutReplica(IntegrationTest):
                 user=user,
                 base_dn=base_dn)
             tasks.ldapmodify_dm(self.master, entry_ldif)
+
+        # set uidNumber to 4,294,967,306 (uint32 overflow)
+        entry_ldif = textwrap.dedent("""
+            dn: uid={user},cn=users,cn=accounts,{base_dn}
+            changetype: modify
+            replace: uidNumber
+            uidNumber: 4294967306
+        """).format(
+            user=test_useroverflow,
+            base_dn=base_dn)
+        tasks.ldapmodify_dm(self.master, entry_ldif)
 
         # run sidgen task
         self.master.run_command(
@@ -2024,6 +2039,7 @@ class TestIPACommandWithoutReplica(IntegrationTest):
             encoding='utf-8'
         )
         assert old_err_msg not in dirsrv_error_log
+        assert overflow_err_msg in dirsrv_error_log
         assert re.search(new_err_msg, dirsrv_error_log)
 
     def test_ipa_cacert_manage_prune(self):


### PR DESCRIPTION
Fix sidgen behavior for IDs over int32
    
We should read IDs as uint64 and check against uint32_max, otherwise the value will overflow, possibly assigning wrong SID
    
Fixes: https://pagure.io/freeipa/issue/9773
    
Signed-off-by: Aleksandr Sharov <asharov@redhat.com>
