### PR TITLE
webui: Increase wait time for webui tests

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -72,7 +72,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_webui/test_loginscreen.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -90,6 +90,7 @@ ENV_MAP = {
 }
 
 DEFAULT_BROWSER = 'firefox'
+IMPLICIT_WAIT_TIME = 1
 DEFAULT_PORT = 4444
 DEFAULT_TYPE = 'local'
 
@@ -287,6 +288,8 @@ class UI_driver:
                     'Error while establishing webdriver: %s' % e
                 )
 
+        # default 0, wait N seconds for an element to appear
+        driver.implicitly_wait(IMPLICIT_WAIT_TIME)
         return driver
 
     @dismiss_unexpected_alert


### PR DESCRIPTION
Implicitly wait 1 second for any element before failing the search for
it.
This change should resolve instability of the tests and their dependency
on runner's performance.
    
Signed-off-by: Michal Polovka <mpolovka@redhat.com>
