### PR TITLE
Stop using deprecated pkg_resources

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -912,6 +912,7 @@ Requires: python3-jwcrypto >= 0.4.2
 Requires: python3-libipa_hbac
 Requires: python3-netaddr >= %{python_netaddr_version}
 Requires: python3-ifaddr
+Requires: python3-packaging
 Requires: python3-pyasn1 >= 0.3.2-2
 Requires: python3-pyasn1-modules >= 0.3.2-2
 Requires: python3-pyusb
@@ -920,11 +921,6 @@ Requires: python3-requests
 Requires: python3-six
 Requires: python3-sss-murmur
 Requires: python3-yubico >= 1.3.2-7
-%if 0%{?rhel} && 0%{?rhel} == 8
-Requires: platform-python-setuptools
-%else
-Requires: python3-setuptools
-%endif
 %if 0%{?rhel}
 Requires: python3-urllib3 >= 1.24.2-3
 %else

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -274,7 +274,9 @@ class BaseTaskNamespace:
         :param version: textual version
         :return: object implementing proper __cmp__ method for version compare
         """
-        return parse_version(version)
+        version_object = parse_version(version)
+        version_object.version = version_object.base_version
+        return version_object
 
     def set_hostname(self, hostname):
         """

--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -28,7 +28,7 @@ import os
 import logging
 import textwrap
 
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from ipaplatform.paths import paths
 from ipapython import ipautil

--- a/ipapython/version.py.in
+++ b/ipapython/version.py.in
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 # The full version including strings
 VERSION = "@VERSION@"

--- a/ipaserver/custodia/server/__init__.py
+++ b/ipaserver/custodia/server/__init__.py
@@ -2,9 +2,8 @@
 from __future__ import absolute_import
 
 import importlib
+import importlib.metadata
 import os
-
-import pkg_resources
 
 import six
 
@@ -37,17 +36,13 @@ def _load_plugin_class(menu, name):
     Entry points are preferred over dotted import path.
     """
     group = 'custodia.{}'.format(menu)
-    eps = list(pkg_resources.iter_entry_points(group, name))
+    eps = importlib.metadata.entry_points(group=group, name=name)
     if len(eps) > 1:
         raise ValueError(
             "Multiple entry points for {} {}: {}".format(menu, name, eps))
     elif len(eps) == 1:
-        # backwards compatibility with old setuptools
-        ep = eps[0]
-        if hasattr(ep, 'resolve'):
-            return ep.resolve()
-        else:
-            return ep.load(require=False)
+        ep, *_ = eps
+        return ep.load(require=False)
     elif '.' in name:
         # fall back to old style dotted name
         module, classname = name.rsplit('.', 1)

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -35,7 +35,7 @@ import syslog
 import time
 import tempfile
 from configparser import RawConfigParser
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from ipalib import api
 from ipalib import x509

--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -26,7 +26,7 @@ import socket
 import dbus
 
 import dns.name
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from ipalib import x509
 from ipalib.install import certstore

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -18,7 +18,7 @@ import tempfile
 import textwrap
 import traceback
 
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 import six
 
 from ipaclient.install.client import check_ldap_conf, sssd_enable_ifp

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -17,7 +17,7 @@ import sys
 import tempfile
 from contextlib import contextmanager
 from augeas import Augeas
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from ipalib import api, x509
 from ipalib.constants import RENEWAL_CA_NAME, RA_AGENT_PROFILE, IPA_CA_RECORD

--- a/ipaserver/plugins/trust.py
+++ b/ipaserver/plugins/trust.py
@@ -242,7 +242,6 @@ def verify_samba_component_presence(ldap, api):
         )
 
     # We're ok in this case, bail out
-    # pylint: disable-next=used-before-assignment
     if adtrust_present and _bindings_installed:
         return
 

--- a/ipatests/pytest_ipa/integration/create_caless_pki.py
+++ b/ipatests/pytest_ipa/integration/create_caless_pki.py
@@ -26,7 +26,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 from pyasn1.type import univ, char, namedtype, tag
 from pyasn1.codec.der import encoder as der_encoder
 from pyasn1.codec.native import decoder as native_decoder

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -36,7 +36,7 @@ import time
 from shlex import quote
 import configparser
 from contextlib import contextmanager
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 import uuid
 
 import dns

--- a/ipatests/test_custodia/test_plugins.py
+++ b/ipatests/test_custodia/test_plugins.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
-import pkg_resources
+import importlib.metadata
+
 import pytest
 
 from ipaserver.custodia.plugin import (
@@ -12,8 +13,8 @@ class TestCustodiaPlugins:
 
     def get_entry_points(self, group):
         eps = []
-        for e in pkg_resources.iter_entry_points(group):
-            if e.dist.project_name != self.project_name:
+        for e in importlib.metadata.entry_points(group=group):
+            if e.dist.name != self.project_name:
                 # only interested in our own entry points
                 continue
             eps.append(e)
@@ -21,11 +22,7 @@ class TestCustodiaPlugins:
 
     def assert_ep(self, ep, basecls):
         try:
-            # backwards compatibility with old setuptools
-            if hasattr(ep, "resolve"):
-                cls = ep.resolve()
-            else:
-                cls = ep.load(require=False)
+            cls = ep.load(require=False)
         except Exception as e:  # pylint: disable=broad-except
             pytest.fail("Failed to load %r: %r" % (ep, e))
         if not issubclass(cls, basecls):

--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -13,7 +13,7 @@ from ipaplatform.paths import paths
 from ipapython.dn import DN
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.base import IntegrationTest
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 import pytest
 

--- a/ipatests/test_integration/test_cert.py
+++ b/ipatests/test_integration/test_cert.py
@@ -21,7 +21,7 @@ from ipapython.dn import DN
 from cryptography import x509
 from cryptography.x509.oid import ExtensionOID
 from cryptography.hazmat.backends import default_backend
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.base import IntegrationTest

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -41,7 +41,7 @@ from ipatests.test_ipalib.test_x509 import good_pkcs7, badcert
 from ipapython.ipautil import realm_to_suffix, ipa_generate_password
 from ipatests.test_integration.test_topology import find_segment
 from ipaserver.install.installutils import realm_to_serverid
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 logger = logging.getLogger(__name__)
 

--- a/ipatests/test_integration/test_idp.py
+++ b/ipatests/test_integration/test_idp.py
@@ -12,7 +12,7 @@ from ipatests.pytest_ipa.integration import tasks, create_keycloak
 user_code_script = textwrap.dedent("""
 from selenium import webdriver
 from datetime import datetime
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -27,7 +27,7 @@ from ipaplatform.paths import paths
 from ipaplatform.osinfo import osinfo
 from ipaserver.install.installutils import resolve_ip_addresses_nss
 from ipatests.test_integration.base import IntegrationTest
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 from ipatests.test_integration.test_cert import get_certmonger_fs_id
 from ipatests.test_integration.test_external_ca import (
     install_server_external_ca_step1,

--- a/ipatests/test_ipaplatform/test_tasks.py
+++ b/ipatests/test_ipaplatform/test_tasks.py
@@ -25,7 +25,7 @@ def test_ipa_version():
     if hasattr(v4, '_rpmvercmp'):
         assert v4._rpmvercmp_func is not None
 
-    # pylint: disable=comparison-with-itself
+    # pylint: disable=comparison-with-itself,unnecessary-negation
     assert v3 < v4
     assert v3 <= v4
     assert v3 <= v3

--- a/ipatests/test_webui/ui_driver.py
+++ b/ipatests/test_webui/ui_driver.py
@@ -29,7 +29,7 @@ import re
 import time
 from datetime import datetime
 from functools import wraps
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 from urllib.error import URLError
 
 import pytest

--- a/ipatests/test_xmlrpc/test_automember_plugin.py
+++ b/ipatests/test_xmlrpc/test_automember_plugin.py
@@ -36,7 +36,7 @@ from ipaserver.plugins.automember import REBUILD_TASK_CONTAINER
 import time
 import pytest
 import re
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 try:
     from ipaserver.plugins.ldap2 import ldap2

--- a/pypi/test_placeholder.py
+++ b/pypi/test_placeholder.py
@@ -1,8 +1,7 @@
 # Copyright (C) 2017  FreeIPA Contributors see COPYING for license
 
 import importlib
-
-import pkg_resources
+import importlib.metadata
 
 import pytest
 
@@ -45,4 +44,4 @@ def test_import(modname):
     'ipatests',
 ])
 def test_package_installed(pkgname):
-    pkg_resources.require(pkgname)
+    importlib.metadata.distribution(pkgname)


### PR DESCRIPTION
Use packaging.version and importlib.metadata instead.

Note that packaging.version only parses versions compatible with Python packaging (originally defined in PEP 440).
https://packaging.python.org/en/latest/specifications/version-specifiers/

Fixes https://pagure.io/freeipa/issue/9676