### PR TITLE
[Backport][ipa-4-12] ipatests: Fix for ipa-healthcheck test in FIPS mode 

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -374,10 +374,10 @@ class TestIpaHealthCheck(IntegrationTest):
         if (
             parse_version(healthcheck_version) < parse_version("0.17")
             and osinfo.id == 'rhel'
-            and osinfo.version_number == (10,0)
+            and osinfo.version_number >= (10,0)
         ):
             # Patch: https://github.com/freeipa/freeipa-healthcheck/pull/349
-            pytest.xfail("Patch is unavailable for RHEL 10.0 and "
+            pytest.xfail("Patch is unavailable for RHEL 10.0 and above"
                          "freeipa-healtheck version 0.16 or less")
 
         returncode, check = run_healthcheck(self.master,


### PR DESCRIPTION
This PR was opened automatically because PR #7761 was pushed to master and backport to ipa-4-12 is required.