### PR TITLE
[ipa-4-12] Remove ipa-nis-manage on fedora 42+

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -63,6 +63,11 @@
     %global modulename ipa
 %endif
 
+# Remove NIS support for f42+
+%if 0%{?fedora} <= 41
+    %global with_nis 1
+%endif
+
 %if 0%{?rhel}
 %global package_name ipa
 %global alt_name freeipa
@@ -1191,6 +1196,15 @@ mkdir -p %{buildroot}%{_sysconfdir}/cron.d
 # ONLY_CLIENT
 %endif
 
+%if ! %{with nis}
+rm %{buildroot}/%{_sbindir}/ipa-nis-manage
+rm %{buildroot}/%{_mandir}/man1/ipa-nis-manage.1*
+rm %{buildroot}%{python3_sitelib}/ipaserver/install/plugins/update_nis.py
+rm %{buildroot}%{_usr}/share/ipa/nis.uldif
+rm %{buildroot}%{_usr}/share/ipa/nis-update.uldif
+rm %{buildroot}%{_usr}/share/ipa/updates/50-nis.update
+%endif
+
 %if ! %{ONLY_CLIENT}
 
 %post server
@@ -1540,7 +1554,9 @@ fi
 %{_sbindir}/ipa-ldap-updater
 %{_sbindir}/ipa-otptoken-import
 %{_sbindir}/ipa-compat-manage
+%if %{with nis}
 %{_sbindir}/ipa-nis-manage
+%endif
 %{_sbindir}/ipa-managed-entries
 %{_sbindir}/ipactl
 %{_sbindir}/ipa-advise
@@ -1616,7 +1632,9 @@ fi
 %{_mandir}/man1/ipa-ca-install.1*
 %{_mandir}/man1/ipa-kra-install.1*
 %{_mandir}/man1/ipa-compat-manage.1*
+%if %{with nis}
 %{_mandir}/man1/ipa-nis-manage.1*
+%endif
 %{_mandir}/man1/ipa-managed-entries.1*
 %{_mandir}/man1/ipa-ldap-updater.1*
 %{_mandir}/man8/ipactl.8*

--- a/install/tools/ipa-compat-manage.in
+++ b/install/tools/ipa-compat-manage.in
@@ -25,6 +25,7 @@ import sys
 from ipaplatform.paths import paths
 try:
     from ipapython import ipautil, config
+    from ipapython.ipaldap import realm_to_serverid
     from ipaserver.install import installutils
     from ipaserver.install.ldapupdate import LDAPUpdate
     from ipalib import api, errors
@@ -152,9 +153,19 @@ def main():
         try:
             entry = get_entry(nis_config_dn)
             # We can't disable schema compat if the NIS plugin is enabled
-            if entry is not None and entry.get('nsslapd-pluginenabled', [''])[0].lower() == 'on':
-                print("The NIS plugin is configured, cannot disable compatibility.", file=sys.stderr)
-                print("Run 'ipa-nis-manage disable' first.", file=sys.stderr)
+            if (
+                entry is not None
+                and entry.get('nsslapd-pluginenabled', [''])[0].lower() == 'on'
+            ):
+                instance = realm_to_serverid(api.env.realm)
+                print(
+                    "The NIS plugin is configured, cannot "
+                    "disable compatibility.", file=sys.stderr,
+                )
+                print(
+                    f"Run \"dsconf {instance} plugin set --enabled off "
+                    "'NIS Server'\" first.", file=sys.stderr,
+                )
                 retval = 2
         except errors.ExecutionError as lde:
             print("An error occurred while talking to the server.")

--- a/install/updates/10-enable-betxn.update
+++ b/install/updates/10-enable-betxn.update
@@ -46,4 +46,4 @@ dn: cn=Schema Compatibility, cn=plugins, cn=config
 onlyifexist: nsslapd-pluginbetxn: on
 
 dn: cn=NIS Server, cn=plugins, cn=config
-onlyifexist: nsslapd-pluginbetxn: on
+${NIS}onlyifexist: nsslapd-pluginbetxn: on

--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -1975,26 +1975,29 @@ class IPAMigrate():
                     stats['config_processed'] += 1
 
             # Slapi NIS Plugin
-            if DN(NIS_PLUGIN['dn']) == DN(entry['dn']):
-                # Parent plugin entry
-                self.process_config_entry(
-                    entry['dn'], entry['attrs'], NIS_PLUGIN,
-                    add_missing=True)
-                stats['config_processed'] += 1
-            elif DN(NIS_PLUGIN['dn']) in DN(entry['dn']):
-                # Child NIS plugin entry
-                nis_dn = entry['dn']
-                lc_remote_realm = self.remote_realm.lower()
-                lc_realm = self.realm.lower()
-                nis_dn = nis_dn.replace(lc_remote_realm, lc_realm)
-                if 'nis-domain' in entry['attrs']:
-                    value = entry['attrs']['nis-domain'][0]
-                    value = value.replace(lc_remote_realm, lc_realm)
-                    entry['attrs']['nis-domain'][0] = value
-                # Process the entry
-                self.process_config_entry(nis_dn, entry['attrs'], NIS_PLUGIN,
-                                          add_missing=True)
-                stats['config_processed'] += 1
+            # If the file nis-update.uldif does not exist, no support for NIS
+            if os.path.exists(paths.NIS_ULDIF):
+                if DN(NIS_PLUGIN['dn']) == DN(entry['dn']):
+                    # Parent plugin entry
+                    self.process_config_entry(
+                        entry['dn'], entry['attrs'], NIS_PLUGIN,
+                        add_missing=True)
+                    stats['config_processed'] += 1
+                elif DN(NIS_PLUGIN['dn']) in DN(entry['dn']):
+                    # Child NIS plugin entry
+                    nis_dn = entry['dn']
+                    lc_remote_realm = self.remote_realm.lower()
+                    lc_realm = self.realm.lower()
+                    nis_dn = nis_dn.replace(lc_remote_realm, lc_realm)
+                    if 'nis-domain' in entry['attrs']:
+                        value = entry['attrs']['nis-domain'][0]
+                        value = value.replace(lc_remote_realm, lc_realm)
+                        entry['attrs']['nis-domain'][0] = value
+                    # Process the entry
+                    self.process_config_entry(nis_dn, entry['attrs'],
+                                              NIS_PLUGIN,
+                                              add_missing=True)
+                    stats['config_processed'] += 1
 
     #
     # Migration

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -110,6 +110,7 @@ def get_sub_dict(realm, domain, suffix, fqdn, idstart=None, idmax=None):
         SELINUX_USERMAP_ORDER=platformconstants.SELINUX_USERMAP_ORDER,
         NAMED_UID=named_uid,
         NAMED_GID=named_gid,
+        NIS='' if os.path.exists(paths.NIS_ULDIF) else '#',
     )
 
 

--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -385,7 +385,6 @@ IPA_CLIENT_NOT_CONFIGURED = b'IPA client is not configured on this system'
           '/usr/share/ipa/updates/05-pre_upgrade_plugins.update'],
          2, None, IPA_NOT_CONFIGURED),
         (['ipa-managed-entries'], 2, None, IPA_NOT_CONFIGURED),
-        (['ipa-nis-manage'], 2, None, IPA_NOT_CONFIGURED),
         (['ipa-pkinit-manage'], 2, None, IPA_NOT_CONFIGURED),
         (['ipa-replica-manage', 'list'], 1, IPA_NOT_CONFIGURED, None),
         (['ipa-server-certinstall'], 2, None, IPA_NOT_CONFIGURED),

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -26,6 +26,7 @@ from datetime import datetime, timedelta
 from ipalib.constants import IPAAPI_USER
 from ipalib.errors import DatabaseError
 
+from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 
 from ipapython.dn import DN
@@ -1353,6 +1354,9 @@ class TestIPACommand(IntegrationTest):
         serverid = realm_to_serverid(self.master.domain.realm)
         return ("dirsrv@%s.service" % serverid)
 
+    @pytest.mark.skipif((osinfo.id == 'fedora'
+                        and osinfo.version_number > (41,)),
+                        reason="NIS server support removed")
     def test_ipa_nis_manage_enable(self):
         """
         This testcase checks if ipa-nis-manage enable
@@ -1389,6 +1393,9 @@ class TestIPACommand(IntegrationTest):
         )
         assert status_msg in result.stdout_text
 
+    @pytest.mark.skipif((osinfo.id == 'fedora'
+                        and osinfo.version_number > (41,)),
+                        reason="NIS server support removed")
     def test_ipa_nis_manage_disable(self):
         """
         This testcase checks if ipa-nis-manage disable
@@ -1424,6 +1431,9 @@ class TestIPACommand(IntegrationTest):
         assert result.returncode == 4
         assert status_msg in result.stdout_text
 
+    @pytest.mark.skipif((osinfo.id == 'fedora'
+                        and osinfo.version_number > (41,)),
+                        reason="NIS server support removed")
     def test_ipa_nis_manage_enable_incorrect_password(self):
         """
         This testcase checks if ipa-nis-manage enable


### PR DESCRIPTION
Remove NIS server integration from the migration and
management tools on fedora 42+

The patch is slightly different from the version on master branch because it needs to be compatible with fedora 41 where NIS server integration is still supported and fedora 42+ where support is removed.

Fixes: https://pagure.io/freeipa/issue/9363