### PR TITLE
[Backport][ipa-4-9] Check if CA is close to expiry before running

### DIFF
--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -69,6 +69,7 @@ logger = logging.getLogger(__name__)
 
 
 cert_nicknames = {
+    'ca_issuing': 'caSigningCert cert-pki-ca',
     'sslserver': 'Server-Cert cert-pki-ca',
     'subsystem': 'subsystemCert cert-pki-ca',
     'ca_ocsp_signing': 'ocspSigningCert cert-pki-ca',
@@ -134,6 +135,16 @@ class IPACertFix(AdminTool):
         if not certs and not extra_certs:
             print("Nothing to do.")
             return 0
+
+        if any(key == 'ca_issuing' for key, _ in certs):
+            logger.debug("CA signing cert is expired, exiting!")
+            print(
+                "The CA signing certificate is expired or will expire within "
+                "the next two weeks.\n\nipa-cert-fix cannot proceed, please "
+                "refer to the ipa-cacert-manage tool to renew the CA "
+                "certificate before proceeding."
+            )
+            return 1
 
         print(msg)
 

--- a/ipatests/test_integration/test_ipa_cert_fix.py
+++ b/ipatests/test_integration/test_ipa_cert_fix.py
@@ -302,13 +302,18 @@ class TestIpaCertFix(IntegrationTest):
         valid. If CA cert expired, ipa-cert-fix won't work.
 
         related: https://pagure.io/freeipa/issue/8721
+
+        If CA cert is close to expiry, there's no reason to issue new certs
+        with short validity period. So, ipa-cert-fix should fail in this case.
+
+        related: https://pagure.io/freeipa/issue/9760
         """
         result = self.master.run_command(['ipa-cert-fix', '-v'],
                                          stdin_text='yes\n',
                                          raiseonerr=False)
         # check that pki-server cert-fix command fails
-        err_msg = ("ERROR: CalledProcessError(Command "
-                   "['pki-server', 'cert-fix'")
+        err_msg = ("CA signing cert is expired, exiting!")
+        assert result.returncode == 1
         assert err_msg in result.stderr_text
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #7723 was pushed to master and backport to ipa-4-9 is required.