### PR TITLE
ipa-migrate - remove replication state information

### DIFF
--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -202,6 +202,14 @@ def decode_attr_vals(entry_attrs):
     decoded_attrs = {}
     for attr in entry_attrs:
         vals = ensure_list_str(entry_attrs[attr])
+        # Remove replication state data, but don't remove ";binary"
+        # e.g.  userCertififccate;binary;adcsn=<CSN>
+        parts = attr.split(";")
+        if len(parts) > 1 and not attr.endswith(";binary"):
+            if parts[1] == "binary":
+                attr = parts[0] + ";binary"
+            else:
+                attr = parts[0]
         decoded_attrs[attr] = vals
     return decoded_attrs
 
@@ -269,19 +277,19 @@ class LDIFParser(ldif.LDIFParser):
         if self.mc is None:
             return
 
+        entry_attrs = decode_attr_vals(entry)
         if self.get_realm:
             # Get the realm from krb container
             if DN(("cn", "kerberos"), self.mc.remote_suffix) in DN(dn):
                 # check objectclass krbrealmcontainer
                 oc_attr = 'objectClass'
-                if 'objectclass' in entry:
+                if 'objectclass' in entry_attrs:
                     oc_attr = 'objectclass'
-                if 'krbrealmcontainer' in ensure_list_str(entry[oc_attr]):
-                    self.mc.remote_realm = ensure_str(entry['cn'][0])
+                if 'krbrealmcontainer' in entry_attrs[oc_attr]:
+                    self.mc.remote_realm = ensure_str(entry_attrs['cn'][0])
                     self.mc.log_debug("Found remote realm from ldif: "
                                       f"{self.mc.remote_realm}")
         else:
-            entry_attrs = decode_attr_vals(entry)
             self.mc.process_db_entry(entry_dn=dn, entry_attrs=entry_attrs)
 
 
@@ -1075,11 +1083,9 @@ class IPAMigrate():
         if isinstance(val, bytes) or isinstance(val, DN):
             return val
 
-        # Replace base DN
-        val = self.replace_suffix_value(val)
-
         # For DNS DN we only replace suffix
         if dns:
+            val = self.replace_suffix_value(val)
             return val
 
         # Replace host
@@ -1092,6 +1098,9 @@ class IPAMigrate():
 
         # Replace realm
         val = val.replace(self.remote_realm, self.realm)
+
+        # Finally replace base DN
+        val = self.replace_suffix_value(val)
 
         return val
 

--- a/ipaserver/install/ipa_migrate_constants.py
+++ b/ipaserver/install/ipa_migrate_constants.py
@@ -846,7 +846,7 @@ DB_OBJECTS = {
         'oc': ['ipantdomainattrs'],
         'subtree': ',cn=ad,cn=etc,$SUFFIX',
         'label': 'AD',
-        'mode': 'all',
+        'mode': 'production',
         'count': 0,
     },
 


### PR DESCRIPTION
Also, do not process AD entries in staging mode becuase AD entries require ipantsecurityidentifier and other "NT" attributes and objectclass.

Additionally fixed an issue with how DN values are incorrectly normalized.

Fixes: https://pagure.io/freeipa/issue/9776

## Summary by Sourcery

Fix several issues in the `ipa-migrate` tool.

Bug Fixes:
- Exclude replication state information from attribute names during migration.
- Skip processing Active Directory entries in staging mode.
- Correct the normalization order for Distinguished Name (DN) values.