### PR TITLE
PRCI tests: update vagrant image with latest bind package

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -39,7 +39,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f42
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -55,7 +55,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f42
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -40,7 +40,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f42
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -44,7 +44,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f42
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -55,7 +55,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f42
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -44,7 +44,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f42
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -56,7 +56,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f42
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -56,7 +56,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f42
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,7 +61,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f42
-          version: 0.0.3
+          version: 0.0.4
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Fedora 42 is now officially available. Update the bind and bind-dyndb-ldap packages to the latest versions
(bind-9.18.35-2.fc42, bind-dyndb-ldap-11.11-3.fc42) by updating the vragrant image to 0.0.4

## Summary by Sourcery

CI:
- Update the `freeipa/ci-master-f42` template version from 0.0.3 to 0.0.4 across various PRCI job definitions.