### PR TITLE
[ipa-4-12] PRCI tests: update vagrant image with latest bind package

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -39,7 +39,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
           name: freeipa/ci-ipa-4-12-f42
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
@@ -55,7 +55,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
           name: freeipa/ci-ipa-4-12-f42
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
@@ -55,7 +55,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
           name: freeipa/ci-ipa-4-12-f42
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,7 +61,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
           name: freeipa/ci-ipa-4-12-f42
-          version: 0.0.1
+          version: 0.0.2
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Fedora 42 is now officially available. Update the bind and bind-dyndb-ldap packages to the latest versions
(bind-9.18.35-2.fc42, bind-dyndb-ldap-11.11-3.fc42) by updating the vragrant image to 0.0.2

## Summary by Sourcery

CI:
- Update the `freeipa/ci-ipa-4-12-f42` template version from `0.0.1` to `0.0.2` in gating, nightly, and temporary commit job definitions.