### PR TITLE
ipa-migrate - do not process AD entries in staging mode

### DIFF
--- a/ipaserver/install/ipa_migrate_constants.py
+++ b/ipaserver/install/ipa_migrate_constants.py
@@ -846,7 +846,7 @@ DB_OBJECTS = {
         'oc': ['ipantdomainattrs'],
         'subtree': ',cn=ad,cn=etc,$SUFFIX',
         'label': 'AD',
-        'mode': 'all',
+        'mode': 'production',
         'count': 0,
     },
 


### PR DESCRIPTION
Only migrate AD entries in production mode due to schema conflicts created when removing certain AD attributes (e.g.
ipantsecurityidentifier)

relates: https://pagure.io/freeipa/issue/9776

## Summary by Sourcery

Bug Fixes:
- Prevent processing of AD entries in staging mode to resolve potential schema conflicts