### PR TITLE
ipa-migrate - improve suffix replacement

### DIFF
--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -1075,11 +1075,9 @@ class IPAMigrate():
         if isinstance(val, bytes) or isinstance(val, DN):
             return val
 
-        # Replace base DN
-        val = self.replace_suffix_value(val)
-
         # For DNS DN we only replace suffix
         if dns:
+            val = self.replace_suffix_value(val)
             return val
 
         # Replace host
@@ -1092,6 +1090,9 @@ class IPAMigrate():
 
         # Replace realm
         val = val.replace(self.remote_realm, self.realm)
+
+        # Lastly, replace base DN
+        val = self.replace_suffix_value(val)
 
         return val
 


### PR DESCRIPTION
When values are "normalized/converted" to a new domain the order in which the host/release/suffix are converted matters. Replacing the suffix first can lead to incorrect results, so convert the host/realm before converting the suffix


relates: https://pagure.io/freeipa/issue/9776

## Summary by Sourcery

Modify the order of domain conversion in IPA migration to ensure correct value normalization by changing the sequence of suffix, host, and realm replacements

Bug Fixes:
- Fixed potential incorrect domain conversion when replacing suffixes before host and realm

Enhancements:
- Reordered domain conversion steps to prevent incorrect value normalization during migration