### PR TITLE
[Backport][ipa-4-12] ipa-migrate - do not process AD entries in staging mode

### DIFF
--- a/ipaserver/install/ipa_migrate_constants.py
+++ b/ipaserver/install/ipa_migrate_constants.py
@@ -870,7 +870,7 @@ DB_OBJECTS = {
         'oc': ['ipantdomainattrs'],
         'subtree': ',cn=ad,cn=etc,$SUFFIX',
         'label': 'AD',
-        'mode': 'all',
+        'mode': 'production',
         'count': 0,
     },
 


### PR DESCRIPTION
This PR was opened automatically because PR #7788 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Bug Fixes:
- Do not process AD entries during migration in staging mode.