### PR TITLE
[Backport][ipa-4-12] ipa-migrate - improve suffix replacement

### DIFF
--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -1076,11 +1076,9 @@ class IPAMigrate():
         if isinstance(val, bytes) or isinstance(val, DN):
             return val
 
-        # Replace base DN
-        val = self.replace_suffix_value(val)
-
         # For DNS DN we only replace suffix
         if dns:
+            val = self.replace_suffix_value(val)
             return val
 
         # Replace host
@@ -1093,6 +1091,9 @@ class IPAMigrate():
 
         # Replace realm
         val = val.replace(self.remote_realm, self.realm)
+
+        # Lastly, replace base DN
+        val = self.replace_suffix_value(val)
 
         return val
 


### PR DESCRIPTION
This PR was opened automatically because PR #7789 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Enhancements:
- Modify the order of suffix replacement in the convert_value method to handle different types of values more accurately