### PR TITLE
ipatests: Tests for krbLastSuccessfulAuth warning [ipa-4-12]

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -72,7 +72,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest-ipa-4-12/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-ipa-4-12-latest
-        timeout: 3600
+        timeout: 6300
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -1527,6 +1527,40 @@ class TestIpaHealthCheck(IntegrationTest):
         )
 
     @pytest.fixture
+    def change_pwd_plugin_default(self):
+        """
+        Fixture to change the password plugin feature
+        to AllowNThash and change it to default
+        """
+        self.master.run_command(
+            ["ipa", "config-mod", "--ipaconfigstring=AllowNThash"]
+        )
+        yield
+        self.master.run_command(
+            ["ipa", "config-mod",
+             "--ipaconfigstring={AllowNThash, 'KDC:Disable Last Success'}"]
+        )
+
+    def test_krbLastSuccessfulAuth_warning(self, change_pwd_plugin_default):
+        """
+        This test checks that warning message is displayed
+        when password plugin feature is modified to
+        AllowNThash
+        """
+        err_msg = (
+            "Last Successful Auth is enabled. "
+            "It may cause performance problems."
+        )
+        returncode, data = run_healthcheck(
+            self.master, "ipahealthcheck.ipa.config",
+            "IPAkrbLastSuccessfulAuth",
+        )
+        assert returncode == 1
+        for check in data:
+            assert check["result"] == "WARNING"
+            assert check["kw"]["msg"] == err_msg
+
+    @pytest.fixture
     def expire_cert_critical(self):
         """
         Fixture to expire the cert by moving the system date using
@@ -1552,7 +1586,6 @@ class TestIpaHealthCheck(IntegrationTest):
             assert check["kw"]["key"] == "DSCERTLE0002"
             assert "Expired Certificate" in check["kw"]["items"]
             assert check["kw"]["msg"] == msg
-
 
     def test_ipa_healthcheck_expiring(self, restart_service):
         """


### PR DESCRIPTION
This testcase checks that ipa-healthcheck issues warning when ipaconfigstring=AllowNThash

## Summary by Sourcery

Add a test case to verify the ipa-healthcheck warning for krbLastSuccessfulAuth when AllowNThash is configured

New Features:
- Implemented a test fixture to modify and revert password plugin configuration

CI:
- Updated CI configuration to run the new ipahealthcheck test

Tests:
- Added a new test to check warning message when password plugin feature is set to AllowNThash