### PR TITLE
Don't arbitrarily fail BaseTaskNamespace.parse_ipa_version(), do it explicitly

### DIFF
--- a/ipaplatform/base/tasks.py
+++ b/ipaplatform/base/tasks.py
@@ -29,8 +29,6 @@ import os
 import logging
 import textwrap
 
-from packaging.version import parse as parse_version
-
 from ipaplatform.paths import paths
 from ipapython import ipautil
 from ipapython.ipachangeconf import IPAChangeConf
@@ -301,9 +299,9 @@ class BaseTaskNamespace:
     def parse_ipa_version(version):
         """
         :param version: textual version
-        :return: object implementing proper __cmp__ method for version compare
+        :return: object implementing the IPAAbstractVersion interface
         """
-        return IPAAbstractVersion(parse_version(version))
+        raise NotImplementedError()
 
     def set_hostname(self, hostname):
         """


### PR DESCRIPTION
Classes inheriting from BaseTaskNamespace
always need to implement their own parse_ipa_version method, because otherwise they would get instances of IPAAbstractVersion which is not comparable.

Even if that was not the problem,
passing packaging.version.Version objects to IPAAbstractVersion leads to AttributeError in __init__ when trying to call .encode() on them.

## Summary by Sourcery

Modify BaseTaskNamespace to require explicit implementation of parse_ipa_version method

Bug Fixes:
- Prevent potential AttributeError when parsing versions
- Remove default implementation that could lead to incorrect version comparisons

Enhancements:
- Enforce explicit implementation of parse_ipa_version in subclasses