### PR TITLE
Add --domain option to ipa-client-automount for DNS discovery

### DIFF
--- a/client/man/ipa-client-automount.1
+++ b/client/man/ipa-client-automount.1
@@ -49,6 +49,9 @@ NFSv4 is also configured. The rpc.gssd and rpc.idmapd are started on clients to 
 \fB\-\-server\fR=\fISERVER\fR
 Set the FQDN of the IPA server to connect to.
 .TP
+\fB\-\-domain\fR=\fIDOMAIN\fR
+Primary DNS domain of the IPA deployment to be used for server discovery.
+.TP
 \fB\-\-location\fR=\fILOCATION\fR
 Automount location.
 .TP

--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -62,6 +62,12 @@ def parse_options():
     parser = IPAOptionParser(usage=usage)
     parser.add_option("--server", dest="server", help="FQDN of IPA server")
     parser.add_option(
+        "--domain",
+        dest="domain",
+        default="",
+        help="Primary DNS domain of the IPA deployment"
+    )
+    parser.add_option(
         "--location",
         dest="location",
         default="default",
@@ -387,7 +393,7 @@ def configure_automount():
     ds = discovery.IPADiscovery()
     if not options.server:
         print("Searching for IPA server...")
-        ret = ds.search(ca_cert_path=ca_cert_path)
+        ret = ds.search(domain=options.domain, ca_cert_path=ca_cert_path)
         logger.debug('Executing DNS discovery')
         if ret == discovery.NO_LDAP_SERVER:
             logger.debug('Autodiscovery did not find LDAP server')

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -355,3 +355,27 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
 
     def test_nsswitch_backup_restore_sssd(self):
         self.nsswitch_backup_restore()
+
+
+class TestIpaClientAutomountDiscovery(IntegrationTest):
+
+    num_clients = 1
+    topology = 'line'
+
+    def test_automount_invalid_domain(self):
+        """Validate that the --domain option is passed into
+           Discovery. This is expected to fail discovery.
+        """
+        testdomain = "client.test"
+        msg1 = f"Search for LDAP SRV record in {testdomain}"
+        msg2 = f"Search DNS for SRV record of _ldap._tcp.{testdomain}"
+        msg3 = "Autodiscovery did not find LDAP server"
+
+        client = self.clients[0]
+        result = client.run_command([
+            'ipa-client-automount', '--domain', 'client.test',
+            '--debug'
+        ], stdin_text="n", raiseonerr=False)
+        assert msg1 in result.stderr_text
+        assert msg2 in result.stderr_text
+        assert msg3 in result.stderr_text


### PR DESCRIPTION
If the client machine is not in the IPA DNS domain then discovery will not find a server. Add a --domain option so that the set of servers can be discovered.

Note that --domain is initialized to "" rather than None to match the behavior in ipa-client-install.

Fixes: https://pagure.io/freeipa/issue/9780

## Summary by Sourcery

Add a --domain option to ipa-client-automount to enable DNS discovery for servers in non-default domains

New Features:
- Added --domain option to ipa-client-automount for specifying DNS domain during server discovery

Bug Fixes:
- Fixed issue with server discovery when client is not in the IPA DNS domain

Enhancements:
- Extended DNS discovery to support searching for servers in a specified domain

Documentation:
- Updated man page to document the new --domain option

Tests:
- Added integration test to validate --domain option behavior during server discovery