### PR TITLE
Warn when UID is out of local ID ranges

### DIFF
--- a/ipalib/messages.py
+++ b/ipalib/messages.py
@@ -519,6 +519,18 @@ class ServerUpgradeRequired(PublicMessage):
     )
 
 
+class UidNumberOutOfLocalIDRange(PublicMessage):
+    """
+    **13034** UID Number is out of all local ID Ranges
+    """
+    errno = 13034
+    type = "warning"
+    format = _(
+        "User '%(user)s', with UID Number '%(uidnumber)d' is out of all ID "
+        "Ranges, 'SID' will not be correctly generated."
+    )
+
+
 def iter_messages(variables, base):
     """Return a tuple with all subclasses
     """

--- a/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
@@ -3,6 +3,7 @@
 #
 
 import six
+import copy
 
 from ipalib import api, errors
 from ipaplatform.constants import constants as platformconstants
@@ -181,6 +182,27 @@ class StageUserTracker(PasskeyMixin, KerberosAliasMixin, Tracker):
     def check_create(self, result, extra_keys=()):
         """ Check 'stageuser-add' command result """
         expected = self.filter_attrs(self.create_keys | set(extra_keys))
+        assert_deepequal(dict(
+            value=self.uid,
+            summary=u'Added stage user "%s"' % self.uid,
+            result=self.filter_attrs(expected),
+        ), result)
+
+    def check_create_with_warning(self, result,
+                                  warning_codes=(), extra_keys=()):
+        """ Check 'stageuser-add' command result """
+        expected = self.filter_attrs(self.create_keys | set(extra_keys))
+
+        result = copy.deepcopy(result)
+        assert 'messages' in result
+        assert len(result['messages']) == len(warning_codes)
+        codes = [message['code'] for message in result['messages']]
+        for code in warning_codes:
+            assert code in codes
+            codes.pop(codes.index(code))
+
+        del result['messages']
+
         assert_deepequal(dict(
             value=self.uid,
             summary=u'Added stage user "%s"' % self.uid,


### PR DESCRIPTION
Provides simple warning when creating new user with uid out of all local ranges, as this is the main culprit of breaking Kerberos, by not generating ipantsecurityidentifier. We don't have to check for user-mod, because modification never changes ipantsecurityidentifier. We do not have to check groups, as groups are ignored for ipa without AD trust. It's reasonable to revisit this in the future for group creation and warn against groups out of ranges as well as warn for users with groups without SID, in case AD trust is enabled.

Fixes: https://pagure.io/freeipa/issue/9781

## Summary by Sourcery

Add a warning mechanism for user creation when the UID number is outside of local ID ranges, which can prevent proper Kerberos security identifier generation

New Features:
- Implement a check to warn when a user's UID is outside local ID ranges

Bug Fixes:
- Prevent potential Kerberos security identifier generation issues by providing early warning

Tests:
- Add test case to verify warning is thrown when UID is out of range