### PR TITLE
[Backport][ipa-4-12] Add --domain option to ipa-client-automount for DNS discovery

### DIFF
--- a/client/man/ipa-client-automount.1
+++ b/client/man/ipa-client-automount.1
@@ -49,6 +49,9 @@ NFSv4 is also configured. The rpc.gssd and rpc.idmapd are started on clients to 
 \fB\-\-server\fR=\fISERVER\fR
 Set the FQDN of the IPA server to connect to.
 .TP
+\fB\-\-domain\fR=\fIDOMAIN\fR
+Primary DNS domain of the IPA deployment to be used for server discovery.
+.TP
 \fB\-\-location\fR=\fILOCATION\fR
 Automount location.
 .TP

--- a/ipaclient/install/ipa_client_automount.py
+++ b/ipaclient/install/ipa_client_automount.py
@@ -62,6 +62,12 @@ def parse_options():
     parser = IPAOptionParser(usage=usage)
     parser.add_option("--server", dest="server", help="FQDN of IPA server")
     parser.add_option(
+        "--domain",
+        dest="domain",
+        default="",
+        help="Primary DNS domain of the IPA deployment"
+    )
+    parser.add_option(
         "--location",
         dest="location",
         default="default",
@@ -387,7 +393,7 @@ def configure_automount():
     ds = discovery.IPADiscovery()
     if not options.server:
         print("Searching for IPA server...")
-        ret = ds.search(ca_cert_path=ca_cert_path)
+        ret = ds.search(domain=options.domain, ca_cert_path=ca_cert_path)
         logger.debug('Executing DNS discovery')
         if ret == discovery.NO_LDAP_SERVER:
             logger.debug('Autodiscovery did not find LDAP server')

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -355,3 +355,27 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
 
     def test_nsswitch_backup_restore_sssd(self):
         self.nsswitch_backup_restore()
+
+
+class TestIpaClientAutomountDiscovery(IntegrationTest):
+
+    num_clients = 1
+    topology = 'line'
+
+    def test_automount_invalid_domain(self):
+        """Validate that the --domain option is passed into
+           Discovery. This is expected to fail discovery.
+        """
+        testdomain = "client.test"
+        msg1 = f"Search for LDAP SRV record in {testdomain}"
+        msg2 = f"Search DNS for SRV record of _ldap._tcp.{testdomain}"
+        msg3 = "Autodiscovery did not find LDAP server"
+
+        client = self.clients[0]
+        result = client.run_command([
+            'ipa-client-automount', '--domain', 'client.test',
+            '--debug'
+        ], stdin_text="n", raiseonerr=False)
+        assert msg1 in result.stderr_text
+        assert msg2 in result.stderr_text
+        assert msg3 in result.stderr_text


### PR DESCRIPTION
This PR was opened automatically because PR #7798 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Add support for a --domain flag in ipa-client-automount to control DNS-based IPA server discovery, including CLI parsing updates, discovery invocation changes, documentation, and tests.

New Features:
- Add --domain option to ipa-client-automount for specifying the DNS domain during server discovery

Enhancements:
- Pass the provided domain value into the IPA discovery search routine

Documentation:
- Document the new --domain option in the ipa-client-automount man page

Tests:
- Add integration test to verify discovery fails with an invalid domain argument