### PR TITLE
ipatests: in caless mode generate server cert with AKI

### DIFF
--- a/ipatests/pytest_ipa/integration/create_caless_pki.py
+++ b/ipatests/pytest_ipa/integration/create_caless_pki.py
@@ -199,6 +199,20 @@ def profile_server(builder, ca_nick, ca,
             critical=False,
         )
 
+    if ca:
+        try:
+            ski_ext = ca.cert.extensions.get_extension_for_class(
+                x509.SubjectKeyIdentifier)
+            builder = builder.add_extension(
+                x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(
+                    ski_ext.value
+                ),
+                critical=False,
+            )
+        except x509.ExtensionNotFound:
+            # if the CA doesn't have a SKI, just ignore
+            pass
+
     if badusage:
         builder = builder.add_extension(
             x509.KeyUsage(


### PR DESCRIPTION
Generate server cert with an Authority Key Identifier extension
using the CA's subject key identifier.

Without this extension, replica installation fails with
    certificate verify failed: Missing Authority Key Identifier
in the step fetching the DM password from the server.

Fixes: https://pagure.io/freeipa/issue/9787

## Summary by Sourcery

Include Authority Key Identifier extension in server certificates generated in CA-less mode to prevent replica installation failures and migrate CI pipeline to Fedora Rawhide with expanded CALess and HSM test coverage.

Bug Fixes:
- Include Authority Key Identifier extension in server certificates generated in CA-less mode to fix missing AKI errors during replica installation.

CI:
- Switch CI build and test jobs from Fedora latest to Fedora Rawhide with updated template version.
- Add new pytest jobs for CA-less integration (TestPKINIT, replica install and CA-full transitions) and HSM scenarios with appropriate timeouts and topologies.
- Update .freeipa-pr-ci.yaml to reference the correct gating configuration.