### PR TITLE
azure pipelines: use timezone in the date format for core files

### DIFF
--- a/ipatests/azure/templates/test-jobs.yml
+++ b/ipatests/azure/templates/test-jobs.yml
@@ -64,7 +64,7 @@ steps:
 
 - script: |
     set -eu
-    date +'%Y-%m-%d %H:%M:%S' > coredumpctl.time.mark
+    date +'%Y-%m-%d %H:%M:%S %Z' > coredumpctl.time.mark
     systemd_conf="/etc/systemd/system.conf"
     sudo sed -i 's/^DumpCore=.*/#&/g' "$systemd_conf"
     sudo sed -i 's/^DefaultLimitCORE=.*/#&/g' "$systemd_conf"


### PR DESCRIPTION
The azure pipeline note the start time using a '%Y-%m-%d %H:%M:%S' format, then check for coredumps after this time.

If the host and the container have a different timezone this can result in a failure to find the core files.
Use a time format including the timezone.