### PR TITLE
ipatests: Fix test_clean_uninstall

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -65,14 +65,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_client_uninstallation:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_uninstallation.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_uninstallation.py
+++ b/ipatests/test_integration/test_uninstallation.py
@@ -186,8 +186,6 @@ class TestUninstallCleanup(IntegrationTest):
             '/root/.cache',
             '/root/.dogtag',
             '/root/.local',
-            '/run/dirsrv',
-            '/run/lock/dirsrv',
             '/var/lib/authselect/backups',
             '/var/lib/gssproxy/rcache/krb5_0.rcache2',
             '/var/lib/ipa/ipa-kasp.db.backup',


### PR DESCRIPTION
Update allow list

Fixes: https://pagure.io/freeipa/issue/9788

## Summary by Sourcery

Tests:
- Remove /run/dirsrv and /run/lock/dirsrv from the allowed cleanup paths in test_clean_uninstall