### PR TITLE
ipatests: test_manual_renewal_master_transfer must wait for replication

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -417,6 +417,9 @@ class TestRenewalMaster(IntegrationTest):
         replica = self.replicas[0]
         replica.run_command(['ipa', 'config-mod',
                              '--ca-renewal-master-server', replica.hostname])
+        # wait for replication to complete before checking on the master
+        tasks.wait_for_replication(replica.ldap_connect())
+
         result = self.master.run_command(["ipa", "config-show"]).stdout_text
         assert("IPA CA renewal master: %s" % replica.hostname in result), (
             "Replica hostname not found among CA renewal masters"


### PR DESCRIPTION
The test is transferring the CA renewal role from master to replica. It calls ipa config-mod on the replica then checks with ipa config-show on the master.
Wait for replication to complete between the 2 steps.

Fixes: https://pagure.io/freeipa/issue/9790

## Summary by Sourcery

Tests:
- Add wait_for_replication call in test_manual_renewal_master_transfer to prevent race condition before verifying CA renewal master transfer