### PR TITLE
[WIP][debug] azure pipelines: use timezone in the date format for core files

### DIFF
--- a/ipatests/azure/scripts/dump_cores.sh
+++ b/ipatests/azure/scripts/dump_cores.sh
@@ -22,7 +22,10 @@ chmod +x "$debugger"
 # make sure coredumpctl installed
 which coredumpctl
 coredumpctl \
-    --no-pager --directory="$HOST_JOURNAL" --since="$since_time" list ||:
+    --no-pager --directory="$HOST_JOURNAL" list ||:
+ls -l /var/lib/systemd/coredump/
+ls -l /var/log/host_journal
+journalctl -D /var/log/host_journal/ -t systemd-coredump
 
 rm -rvf "$COREDUMPS_DIR" ||:
 mkdir "$COREDUMPS_DIR"

--- a/ipatests/azure/templates/test-jobs.yml
+++ b/ipatests/azure/templates/test-jobs.yml
@@ -64,7 +64,8 @@ steps:
 
 - script: |
     set -eu
-    date +'%Y-%m-%d %H:%M:%S' > coredumpctl.time.mark
+    date +'%Y-%m-%d %H:%M:%S %Z' > coredumpctl.time.mark
+    cat coredumpctl.time.mark
     systemd_conf="/etc/systemd/system.conf"
     sudo sed -i 's/^DumpCore=.*/#&/g' "$systemd_conf"
     sudo sed -i 's/^DefaultLimitCORE=.*/#&/g' "$systemd_conf"


### PR DESCRIPTION
The azure pipeline note the start time using a '%Y-%m-%d %H:%M:%S' format, then check for coredumps after this time.

If the host and the container have a different timezone this can result in a failure to find the core files.
Use a time format including the timezone.

## Summary by Sourcery

Make core dump detection in Azure pipelines timezone-aware and improve core dump collection logging

Enhancements:
- Include the timezone in the date format used for coredumpctl timestamp markers
- Log the generated timestamp marker to the build output
- Remove the --since filter and list the /var/lib/systemd/coredump directory in dump_cores.sh for better visibility of core files