### PR TITLE
[Backport][ipa-4-12] azure pipeline: disable InstallDNSSECFirst

### DIFF
--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -45,16 +45,16 @@ vms:
     - test_integration/test_external_ca.py::TestExternalCAInstall
 
 - vm_jobs:
-  - container_job: InstallDNSSECFirst
-    containers:
-      replicas: 1
-      resources:
-        replica:
-          mem_limit: "2400m"
-          memswap_limit: "3500m"
-    tests:
-    - test_integration/test_dnssec.py::TestInstallDNSSECFirst
-
+#  - container_job: InstallDNSSECFirst
+#    containers:
+#      replicas: 1
+#      resources:
+#        replica:
+#          mem_limit: "2400m"
+#          memswap_limit: "3500m"
+#    tests:
+#    - test_integration/test_dnssec.py::TestInstallDNSSECFirst
+#
   - container_job: simple_replication
     containers:
       replicas: 1


### PR DESCRIPTION
This PR was opened automatically because PR #7818 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

CI:
- Comment out the InstallDNSSECFirst job configuration in gating-fedora.yml to skip DNSSEC first tests