### PR TITLE
ipatests: fix xfail annotation for test_ipa_healthcheck_fips_enabled

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -375,11 +375,11 @@ class TestIpaHealthCheck(IntegrationTest):
         if (
             parse_version(healthcheck_version) < parse_version("0.17")
             and osinfo.id == 'rhel'
-            and osinfo.version_number >= (10,0)
+            and osinfo.version_number == (10,0)
         ):
             # Patch: https://github.com/freeipa/freeipa-healthcheck/pull/349
-            pytest.xfail("Patch is unavailable for RHEL 10.0 and above"
-                         "freeipa-healtheck version 0.16 or less")
+            pytest.skip("Patch is unavailable for RHEL 10.0 "
+                        "freeipa-healthcheck version 0.16 or less")
 
         returncode, check = run_healthcheck(self.master,
                                             source="ipahealthcheck.meta.core",


### PR DESCRIPTION
The test is expected to fail
- on rhel 10.0 with ipa-healthcheck < 0.17
- on fedora 42+ with ipa-healthcheck < 0.18

Fixes: https://pagure.io/freeipa/issue/9791

## Summary by Sourcery

Refine FIPS-enabled healthcheck test annotations and expand Fedora CI job matrix for PRCI

Bug Fixes:
- Correct xfail triggers in test_ipa_healthcheck_fips_enabled for RHEL 10.0 when ipa-healthcheck <0.17 and add a new xfail for Fedora 42+ with ipa-healthcheck <0.18

CI:
- Rename fedora-latest test job to fedora-latest/test_ipahealthcheck with updated suite path and extended timeout
- Introduce testing-fedora and fedora-previous build and test jobs with appropriate repo flags, templates, and timeouts

Chores:
- Remove deprecated gating reference from .freeipa-pr-ci.yaml