### PR TITLE
ipatests: ipahealthcheck warns for user provided certificates about to expire

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1442,6 +1442,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-latest/test_ipahealthcheck_caless:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIPAHealthcheckWithCALess
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-latest/test_ipahealthcheck_adtrust:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -1529,6 +1529,19 @@ jobs:
         timeout: 6300
         topology: *master_1repl_1client
 
+  fedora-latest/test_ipahealthcheck_caless:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_ipahealthcheck.py::TestIPAHealthcheckWithCALess
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-latest/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-latest/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1641,6 +1641,20 @@ jobs:
         topology: *master_1repl_1client
         timeout: 6300
 
+  testing-fedora/test_ipahealthcheck_caless:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_ipahealthcheck.py::TestIPAHealthcheckWithCALess
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   testing-fedora/test_ipahealthcheck_nodns_extca_file:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -1752,6 +1752,21 @@ jobs:
         topology: *master_1repl_1client
         timeout: 6300
 
+  testing-fedora/test_ipahealthcheck_caless:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_ipahealthcheck.py::TestIPAHealthcheckWithCALess
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
   testing-fedora/test_ipahealthcheck_nodns_extca_file:
     requires: [testing-fedora/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1418,6 +1418,18 @@ jobs:
         timeout: 6300
         topology: *master_1repl_1client
 
+  fedora-previous/test_ipahealthcheck_caless:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIPAHealthcheckWithCALess
+        template: *ci-master-previous
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-previous/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-previous/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1529,6 +1529,19 @@ jobs:
         timeout: 6300
         topology: *master_1repl_1client
 
+  fedora-rawhide/test_ipahealthcheck_caless:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_ipahealthcheck.py::TestIPAHealthcheckWithCALess
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-rawhide/test_ipahealthcheck_nodns_extca_file:
     requires: [fedora-rawhide/build]
     priority: 50


### PR DESCRIPTION
This patch tests that ipa-healthcheck tools warns when IPA server is installed CALess and user provided certificates are
about to expire.

## Summary by Sourcery

Add integration test for CALess IPA servers that verifies ipa-healthcheck warns about user-provided certificates nearing expiration and update CI to run the new test

CI:
- Update prci temp_commit.yaml to run the new TestIPAHealthcheckWithCALess test suite and adjust topology
- Simplify .freeipa-pr-ci.yaml to reference the gating configuration

Tests:
- Add TestIPAHealthcheckWithCALess class with expire_cert_warn fixture to simulate certificate expiration
- Add test_ipahealthcheck_warns_on_expired_user_certs verifying WARNING for expiring user-provided certificates