### PR TITLE
[Backport][ipa-4-12] ipatests: test_manual_renewal_master_transfer must wait for replication

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -417,6 +417,9 @@ class TestRenewalMaster(IntegrationTest):
         replica = self.replicas[0]
         replica.run_command(['ipa', 'config-mod',
                              '--ca-renewal-master-server', replica.hostname])
+        # wait for replication to complete before checking on the master
+        tasks.wait_for_replication(replica.ldap_connect())
+
         result = self.master.run_command(["ipa", "config-show"]).stdout_text
         assert("IPA CA renewal master: %s" % replica.hostname in result), (
             "Replica hostname not found among CA renewal masters"


### PR DESCRIPTION
This PR was opened automatically because PR #7815 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Tests:
- Add a replication wait in test_manual_renewal_master_transfer before checking the master to avoid race conditions