### PR TITLE
Atmt domain

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -49,6 +49,10 @@ topologies:
     name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
+  ipa_ipa_trust: &ipa_ipa_trust
+    name: ipa_ipa_trust
+    cpu: 7
+    memory: 14750
 
 jobs:
   fedora-latest/build:
@@ -65,14 +69,15 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/ipa_ipa_trust:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountDiscovery
+        trusted_domain: True
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *ipa_ipa_trust


### PR DESCRIPTION
## Summary by Sourcery

Add support for testing automount discovery in a multidomain setup and wire it into the CI pipeline

New Features:
- Introduce a TestMultidomain class to perform automount discovery across primary and trusted domains
- Add a test_multidomain_automount to verify kinit and automount in a multidomain environment

Enhancements:
- Refactor test_automount_invalid_domain to iterate against both primary and trusted clients using explicit server and domain flags

Build:
- Define a new 'ipa_ipa_trust' topology in PRCI definitions

CI:
- Add a 'fedora-latest/ipa_ipa_trust' CI job to run the multidomain test suite with trusted_domain enabled

Tests:
- Update test suite to install and initialize both primary and trusted clients before running tests

Chores:
- Remove the default gating CI configuration in .freeipa-pr-ci.yaml