### PR TITLE
[Backport][ipa-4-12] Require baserid and secondarybaserid

### DIFF
--- a/ipaclient/plugins/idrange.py
+++ b/ipaclient/plugins/idrange.py
@@ -19,7 +19,6 @@
 
 from ipaclient.frontend import MethodOverride
 from ipalib.plugable import Registry
-from ipalib import api
 
 register = Registry()
 
@@ -33,8 +32,7 @@ class idrange_add(MethodOverride):
         Also ensure that secondary-rid-base is prompted for when rid-base is
         specified and vice versa, in case that dom-sid was not specified.
 
-        Also ensure that rid-base and secondary-rid-base is prompted for
-        if ipa-adtrust-install has been run on the system.
+        Also ensure that rid-base and secondary-rid-base is prompted for.
         """
 
         # dom-sid can be specified using dom-sid or dom-name options
@@ -63,27 +61,10 @@ class idrange_add(MethodOverride):
 
         else:
             # This is a local range
-            # Find out whether ipa-adtrust-install has been ran
-            adtrust_is_enabled = api.Command['adtrust_is_enabled']()['result']
 
-            if adtrust_is_enabled:
-                # If ipa-adtrust-install has been ran, all local ranges
-                # require both RID base and secondary RID base
+            # All local ranges require both RID base and secondary RID base
+            if rid_base is None:
+                set_from_prompt('ipabaserid')
 
-                if rid_base is None:
-                    set_from_prompt('ipabaserid')
-
-                if secondary_rid_base is None:
-                    set_from_prompt('ipasecondarybaserid')
-
-            else:
-                # This is a local range on a server with no adtrust support
-
-                # Prompt for secondary RID base only if RID base was given
-                if rid_base is not None and secondary_rid_base is None:
-                    set_from_prompt('ipasecondarybaserid')
-
-                # Symetrically, prompt for RID base if secondary RID base was
-                # given
-                if rid_base is None and secondary_rid_base is not None:
-                    set_from_prompt('ipabaserid')
+            if secondary_rid_base is None:
+                set_from_prompt('ipasecondarybaserid')

--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -276,25 +276,12 @@ class TestCLIParsing:
                 ipasecondarybaserid=u'500000',
             )
 
-        def test_without_options():
-            self.check_command(
-                'idrange_add range1 --base-id=1 --range-size=1',
-                'idrange_add',
-                cn=u'range1',
-                ipabaseid=u'1',
-                ipaidrangesize=u'1',
-            )
-
         adtrust_dn = 'cn=ADTRUST,cn=%s,cn=masters,cn=ipa,cn=etc,%s' % \
                      (api.env.host, api.env.basedn)
         adtrust_is_enabled = api.Command['adtrust_is_enabled']()['result']
         mockldap = None
 
         if not adtrust_is_enabled:
-            # ipa-adtrust-install not run - no need to pass rid-base
-            # and secondary-rid-base
-            test_without_options()
-
             # Create a mock service object to test against
             adtrust_add = dict(
                 ipaconfigstring=b'enabledService',

--- a/ipatests/test_xmlrpc/test_range_plugin.py
+++ b/ipatests/test_xmlrpc/test_range_plugin.py
@@ -1086,4 +1086,50 @@ class test_range(Declarative):
             ),
         ),
 
+        # Fail without baserid and secondarybaserid
+
+        dict(
+            desc='Try creating ID range %r without both rid' % (testrange9),
+            command=('idrange_add', [testrange9],
+                     dict(ipabaseid=testrange9_base_id,
+                          ipaidrangesize=testrange9_size)),
+            expected=errors.ValidationError(
+                name='ID Range setup',
+                error=(
+                    'You must specify both rid-base and '
+                    'secondary-rid-base options.'
+                )
+            )
+        ),
+
+        dict(
+            desc='Try creating ID range %r without'
+            'secondarybaserid' % (testrange9),
+            command=('idrange_add', [testrange9],
+                     dict(ipabaseid=testrange9_base_id,
+                          ipaidrangesize=testrange9_size,
+                          ipabaserid=testrange9_base_rid)),
+            expected=errors.ValidationError(
+                name='ID Range setup',
+                error=(
+                    'You must specify both rid-base and '
+                    'secondary-rid-base options.'
+                )
+            )
+        ),
+
+        dict(
+            desc='Try creating ID range %r without baserid' % (testrange9),
+            command=('idrange_add', [testrange9],
+                     dict(ipabaseid=testrange9_base_id,
+                          ipaidrangesize=testrange9_size,
+                          ipasecondarybaserid=testrange9_secondary_base_rid)),
+            expected=errors.ValidationError(
+                name='ID Range setup',
+                error=(
+                    'You must specify both rid-base and '
+                    'secondary-rid-base options.'
+                )
+            )
+        ),
     ]


### PR DESCRIPTION
This PR was opened automatically because PR #7794 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Require both rid-base and secondary-rid-base options for local ID ranges across server and client plugins; simplify prompt logic, update documentation, and extend tests to enforce this validation.

Bug Fixes:
- Enforce validation error in server idrange_add when either rid-base or secondary-rid-base is missing
- Remove legacy adtrust-specific exceptions to rid-base requirements

Enhancements:
- Simplify client prompt to always request both rid-base and secondary-rid-base for local ranges
- Add recommendation to use ipa-idrange-fix for existing ranges missing rid options

Documentation:
- Update plugin documentation to specify that rid-base and secondary-rid-base are mandatory and reference ipa-idrange-fix

Tests:
- Add XMLRPC tests to verify idrange_add fails without both rid options
- Remove obsolete CLI test that allowed idrange_add without rid-base and secondary-rid-base