### PR TITLE
[Backport][ipa-4-12] ipatests: Ignore /run/log/journal in test_uninstallation.py

### DIFF
--- a/ipatests/test_integration/test_uninstallation.py
+++ b/ipatests/test_integration/test_uninstallation.py
@@ -178,6 +178,7 @@ class TestUninstallCleanup(IntegrationTest):
             '/var/log',
             '/var/tmp/systemd-private',
             '/run/systemd',
+            '/run/log/journal',
             '/var/lib/authselect/backups/pre_ipaclient',
             '/var/named/data/named.run',
             paths.DNSSEC_SOFTHSM_PIN_SO,  # See commit eb54814741


### PR DESCRIPTION
This PR was opened automatically because PR #7826 was pushed to master and backport to ipa-4-12 is required.