### PR TITLE
[Backport][ipa-4-12] ipa config-mod: fix internalerror when setting an empty ipaconfigstring

### DIFF
--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -524,7 +524,7 @@ class config(LDAPObject):
     def is_config_option_present(self, option):
         dn = DN(('cn', 'ipaconfig'), ('cn', 'etc'), self.api.env.basedn)
         configentry = self.api.Backend.ldap2.get_entry(dn, ['ipaconfigstring'])
-        configstring = configentry['ipaconfigstring']
+        configstring = configentry.get('ipaconfigstring') or []
         return (option.lower() in map(str.lower, configstring))
 
 
@@ -702,7 +702,7 @@ class config_mod(LDAPUpdate):
                     error=_('SELinux user map default user not in order list'))
 
         if 'ipaconfigstring' in entry_attrs:
-            configstring = entry_attrs['ipaconfigstring']
+            configstring = entry_attrs['ipaconfigstring'] or []
             if 'SubID:Disable'.lower() in map(str.lower, configstring):
                 # Check if SubIDs already allocated
                 try:


### PR DESCRIPTION
This PR was opened automatically because PR #7827 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Backport a fix for handling empty ipaconfigstring values in the config plugin and add tests to verify setting an empty ipaconfigstring does not cause errors

Bug Fixes:
- Treat missing or empty ipaconfigstring as an empty list to prevent internal errors in config plugin methods

Tests:
- Add fixture to backup and restore ipaconfigstring around tests
- Add integration test to verify ipa config-mod with an empty ipaconfigstring and subsequent ipa subid-stats succeed