### PR TITLE
Add token options to immutables for pki override

### DIFF
--- a/doc/designs/hsm.md
+++ b/doc/designs/hsm.md
@@ -32,7 +32,8 @@ Only RSA keys will be supported.
 
 Using an HSM should be largely invisible to users and administrators beyond passing additional options during installation. The options required and any pre-installion work are HSM-specific.
 
-It will not be possible to mix and match by default. PKI supports specifying the token values so a user can override these using --pki-config-override but it is, and will be, untested.
+It will not be possible to mix and match by default. IPA allows overriding some, but not all, of the PKI options. The following HSM-specific options are added to the not allowed list: pki_hsm_enable, pki_hsm_libfile, pki_hsm_modulename, pki_token_name, pki_token_password. IPA requires that its HSM command-line options are used.
+
 
 There are a few basic rules:
 

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -1042,6 +1042,12 @@ class PKIIniLoader:
         'pki_clone_replication_clone_port',
         'pki_clone_replicate_schema',
         'pki_clone_uri',
+        # hsm
+        'pki_hsm_enable',
+        'pki_hsm_libfile',
+        'pki_hsm_modulename',
+        'pki_token_name',
+        'pki_token_password',
         # cainstance
         'pki_ds_secure_connection',
         'pki_server_database_password',

--- a/ipatests/test_integration/test_pki_config_override.py
+++ b/ipatests/test_integration/test_pki_config_override.py
@@ -20,6 +20,25 @@ ipa_ca_key_algorithm=SHA512withRSA
 ipa_ca_signing_algorithm=SHA512withRSA
 """
 
+HSM_OVERRIDE = """
+[CA]
+pki_hsm_enable = True
+pki_hsm_libfile = /usr/lib64/pkcs11/libsofthsm2.so
+pki_hsm_modulename = libsofthsm2
+pki_token_name = ipa_token
+pki_token_password = Secret123
+"""
+
+
+def server_install_teardown(func):
+    def wrapped(*args):
+        master = args[0].master
+        try:
+            func(*args)
+        finally:
+            tasks.uninstall_master(master)
+    return wrapped
+
 
 class TestPKIConfigOverride(IntegrationTest):
     @classmethod
@@ -40,3 +59,29 @@ class TestPKIConfigOverride(IntegrationTest):
         cert = load_pem_x509_certificate(ca_pem)
         assert cert.public_key().key_size == 4096
         assert cert.signature_hash_algorithm.name == hashes.SHA512.name
+
+
+class TestPKIHSMConfigOverride(IntegrationTest):
+    num_replicas = 0
+
+    @classmethod
+    def install(cls, mh):
+        pass
+
+    @server_install_teardown
+    def test_immutable_options(self):
+        """Providing the immunible HSM options should fail"""
+        pki_ini = tasks.upload_temp_contents(self.master, HSM_OVERRIDE)
+        extra_args = [
+            '--pki-config-override', pki_ini,
+        ]
+        result = tasks.install_master(
+            self.master, setup_dns=False, extra_args=extra_args,
+            raiseonerr=False
+        )
+        self.master.run_command(['rm', '-f', pki_ini])
+        tasks.assert_error(
+            result,
+            'immutable options: pki_hsm_enable, pki_hsm_libfile, '
+            'pki_hsm_modulename, pki_token_name, pki_token_password'
+        )


### PR DESCRIPTION
Setting the HSM options in a pki-override-file will result in a successful installation but it affects the storage of the token library path. It is stored as None.

We could also instead save the provided value from the override but an override isn't necessary in this case since IPA provides command-line options to enable it.

## Summary by Sourcery

Enforce immutability of HSM-related PKI options by adding them to the immutable list, prevent overrides via pki-config-override, and add integration tests and CI updates to verify this behavior.

Enhancements:
- Add HSM and token-related parameters to PKIIniLoader's immutable options list
- Fail installation when HSM options are provided via pki-config override

CI:
- Configure PR CI to execute the new HSM override integration test with updated topology

Tests:
- Introduce TestPKIHSMConfigOverride with a teardown decorator to validate override errors against immutable HSM settings

Chores:
- Remove legacy gating configuration reference in .freeipa-pr-ci.yaml