### PR TITLE
[Backport][ipa-4-12] ipatests: ipahealthcheck warns for user provided certificates about to expire

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
@@ -1442,6 +1442,18 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-latest-ipa-4-12/test_ipahealthcheck_caless:
+    requires: [fedora-latest-ipa-4-12/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-12/build_url}'
+        test_suite: test_integration/test_ipahealthcheck.py::TestIPAHealthcheckWithCALess
+        template: *ci-ipa-4-12-latest
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-latest-ipa-4-12/test_ipahealthcheck_adtrust:
     requires: [fedora-latest-ipa-4-12/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
@@ -1555,6 +1555,19 @@ jobs:
         timeout: 3600
         topology: *master_1repl
 
+  fedora-latest-ipa-4-12/test_ipahealthcheck_caless:
+    requires: [fedora-latest-ipa-4-12/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-12/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_ipahealthcheck.py::TestIPAHealthcheckWithCALess
+        template: *ci-ipa-4-12-latest
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-latest-ipa-4-12/test_ipahealthcheck_adtrust:
     requires: [fedora-latest-ipa-4-12/build]
     priority: 50


### PR DESCRIPTION
This PR was opened manually because PR https://github.com/freeipa/freeipa/pull/7822 was pushed to master and backport to ipa-4-12 is required.

The automatic backport failed because of the nightly tests definitions that must be adapted to ipa-4-12 branch.

## Summary by Sourcery

Backport the IPA healthcheck expiration warning test for user-provided certificates to the ipa-4-12 branch and integrate it into the nightly CI pipelines.

New Features:
- Add TestIPAHealthcheckWithCALess integration test to verify ipa-healthcheck warns on expiring user-provided certificates in a CA-less setup.

CI:
- Add nightly ipa-4-12 CI jobs for running the new CA-less healthcheck test in both selinux and non-selinux pipelines.