### PR TITLE
ipatests: skip encrypted dns tests on fedora 41

### DIFF
--- a/ipatests/test_integration/test_edns.py
+++ b/ipatests/test_integration/test_edns.py
@@ -4,15 +4,20 @@
 """This covers tests for DNS over TLS related feature"""
 
 from __future__ import absolute_import
+import pytest
 import textwrap
 
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.test_integration.test_dns import TestDNS
 from ipatests.pytest_ipa.integration.firewall import Firewall
+from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 
 
+@pytest.mark.skipif(
+    osinfo.id == 'fedora' and osinfo.version_number == (41,),
+    reason='Encrypted DNS not supported in fedora 41')
 class TestDNSOverTLS(IntegrationTest):
     """Tests for DNS over TLS feature."""
 
@@ -246,6 +251,9 @@ class TestDNSOverTLS(IntegrationTest):
         assert '''--dns-over-tls      Configure DNS over TLS''' in cmdout.stdout_text  # noqa: E501
 
 
+@pytest.mark.skipif(
+    osinfo.id == 'fedora' and osinfo.version_number == (41,),
+    reason='Encrypted DNS not supported in fedora 41')
 class TestDNS_DoT(TestDNS):
 
     @classmethod


### PR DESCRIPTION
The package ipa-server-encrypted-dns is not available on fedora 41
as it requires a more recent bind version.
Skip the tests that require this package in f41.

Fixes: https://pagure.io/freeipa/issue/9799

## Summary by Sourcery

Skip encrypted DNS tests on Fedora 41 and update CI definitions to run dedicated edns test jobs for both the latest and Fedora 41 builds while removing an outdated CI override.

Enhancements:
- Add pytest skip markers to exclude encrypted DNS tests on Fedora 41.

CI:
- Rename and configure the fedora-latest edns test job with updated test suite path, timeout, topology, and priority.
- Introduce fedora-previous (Fedora 41) build and edns test jobs using the ci-master-f41 template.

Chores:
- Remove obsolete .freeipa-pr-ci.yaml gating override.