### PR TITLE
[Backport][ipa-4-12] ipatests: fix xfail annotation for test_ipa_healthcheck_fips_enabled

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -375,11 +375,11 @@ class TestIpaHealthCheck(IntegrationTest):
         if (
             parse_version(healthcheck_version) < parse_version("0.17")
             and osinfo.id == 'rhel'
-            and osinfo.version_number >= (10,0)
+            and osinfo.version_number == (10,0)
         ):
             # Patch: https://github.com/freeipa/freeipa-healthcheck/pull/349
-            pytest.xfail("Patch is unavailable for RHEL 10.0 and above"
-                         "freeipa-healtheck version 0.16 or less")
+            pytest.skip("Patch is unavailable for RHEL 10.0 "
+                        "freeipa-healthcheck version 0.16 or less")
 
         returncode, check = run_healthcheck(self.master,
                                             source="ipahealthcheck.meta.core",


### PR DESCRIPTION
This PR was opened automatically because PR #7821 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Backport the test fix for test_ipa_healthcheck_fips_enabled to ipa-4-12 by tightening the RHEL 10.0 version check and replacing xfail with skip for unsupported freeipa-healthcheck versions.

Bug Fixes:
- Restrict the RHEL version check to exactly 10.0 instead of 10.0 and above in test_ipa_healthcheck_fips_enabled.
- Change pytest.xfail to pytest.skip for the patch unavailability scenario in the healthcheck test.