### PR TITLE
[Backport][ipa-4-12] Fix inconsistency in manpage for DoT forwarder option

### DIFF
--- a/install/tools/man/ipa-dns-install.1
+++ b/install/tools/man/ipa-dns-install.1
@@ -74,7 +74,7 @@ An unattended installation that will never prompt for user input
 Configure DNS over TLS.
 .TP
 \fB\-\-dot\-forwarder\fR=\fIIP_ADDRESS#HOSTNAME\fR
-Add a DNS-over-TLS-enabled forwarder in the format of ip#hostname, e.g.: dns.example.com#1.2.3.4. This option can be used multiple times.
+Add a DNS-over-TLS-enabled forwarder in the format of ip#hostname, e.g.: 1.2.3.4#dns.example.com. This option can be used multiple times.
 .TP
 \fB\-\-dns\-over\-tls\-cert\fR=\fIFILE\fR
 Certificate to use for DNS over TLS. If empty, a new certificate will be requested from IPA CA.

--- a/install/tools/man/ipa-replica-install.1
+++ b/install/tools/man/ipa-replica-install.1
@@ -228,7 +228,7 @@ Disable DNSSEC validation on this server.
 Configure DNS over TLS.
 .TP
 \fB\-\-dot\-forwarder\fR=\fIIP_ADDRESS#HOSTNAME\fR
-Add a DNS-over-TLS-enabled forwarder in the format of ip#hostname, e.g.: dns.example.com#1.2.3.4. This option can be used multiple times.
+Add a DNS-over-TLS-enabled forwarder in the format of ip#hostname, e.g.: 1.2.3.4#dns.example.com. This option can be used multiple times.
 .TP
 \fB\-\-dns\-over\-tls\-cert\fR=\fIFILE\fR
 Certificate to use for DNS over TLS. If empty, a new certificate will be requested from IPA CA.

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -257,7 +257,7 @@ Allow creation of (reverse) zone even if the zone is already resolvable. Using t
 Configure DNS over TLS.
 .TP
 \fB\-\-dot\-forwarder\fR=\fIIP_ADDRESS#HOSTNAME\fR
-Add a DNS-over-TLS-enabled forwarder in the format of ip#hostname, e.g.: dns.example.com#1.2.3.4. This option can be used multiple times.
+Add a DNS-over-TLS-enabled forwarder in the format of ip#hostname, e.g.: 1.2.3.4#dns.example.com. This option can be used multiple times.
 .TP
 \fB\-\-dns\-over\-tls\-cert\fR=\fIFILE\fR
 Certificate to use for DNS over TLS. If empty, a new certificate will be requested from IPA CA.


### PR DESCRIPTION
This PR was opened automatically because PR #7840 was pushed to master and backport to ipa-4-12 is required.