### PR TITLE
ipa-client-install: Fix nsupdate issues when dns_over_tls is enabled

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1540,7 +1540,7 @@ def update_dns(server, hostname, options):
 
     update_txt = "debug\n"
     if options.dns_over_tls:
-        update_txt += "server %s 853" % server
+        update_txt += "server %s 853\n" % server
     update_txt += ipautil.template_str(DELETE_TEMPLATE_A,
                                        dict(HOSTNAME=hostname))
     update_txt += ipautil.template_str(DELETE_TEMPLATE_AAAA,
@@ -1788,7 +1788,7 @@ def update_ssh_keys(hostname, ssh_dir, options, server):
 
         update_txt = 'debug\n'
         if options.dns_over_tls:
-            update_txt += "server %s 853" % server
+            update_txt += "server %s 853\n" % server
         update_txt += 'update delete %s. IN SSHFP\nshow\nsend\n' % hostname
         for pubkey in pubkeys:
             sshfp = pubkey.fingerprint_dns_sha1()


### PR DESCRIPTION
The server commands for nsupdate.txt to define the server with the port 853 have been added for dns_over_tls. These commands do not have a leading newline. This results in a syntax error as the next line is added to the command.

Fixes: https://pagure.io/freeipa/issue/9806

## Summary by Sourcery

Bug Fixes:
- Append a newline to the "server <host> 853" command in both update_dns and update_ssh_keys when dns_over_tls is enabled to fix syntax errors.