### PR TITLE
ipa-client-install: Add creation of reverse records

### DIFF
--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -732,6 +732,12 @@ def get_reverse_zone_default(ip_address):
     return normalize_zone('.'.join(items))
 
 
+def get_reverse_record_default(ip_address):
+    ip = netaddr.IPAddress(str(ip_address))
+
+    return normalize_zone(ip.reverse_dns)
+
+
 def validate_rdn_param(ugettext, value):
     try:
         RDN(value)


### PR DESCRIPTION
This enables the update or generation of the reverse records so that ipa-replica-install could run with internal IPA DNS without the need to either turn off the host DNS check or to add the reverse records manually before promoting a client to become a replica.

Fixes: https://pagure.io/freeipa/issue/9807

## Summary by Sourcery

Implement automatic creation and deletion of reverse DNS PTR records during ipa-client-install to enable replica installation against internal IPA DNS without manual reverse entries.

New Features:
- Automatically delete and add reverse PTR records for each client IP during DNS updates.

Enhancements:
- Introduce get_reverse_record_default utility to compute the reverse record zone for an IP address.