### PR TITLE
Replica: Request cert for DoT before setting up bind

### DIFF
--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -114,7 +114,7 @@ def _disable_dnssec():
             conn.update_entry(entry)
 
 
-def _setup_dns_over_tls(options):
+def _request_cert_for_dns_over_tls(options):
     if os.path.isfile(paths.IPA_CA_CRT) and not options.dns_over_tls_cert:
         # request certificate for DNS over TLS, using IPA CA
         cert = paths.BIND_DNS_OVER_TLS_CRT
@@ -128,6 +128,8 @@ def _setup_dns_over_tls(options):
         constants.NAMED_USER.chown(cert, gid=constants.NAMED_GROUP.gid)
         constants.NAMED_USER.chown(key, gid=constants.NAMED_GROUP.gid)
 
+
+def _setup_dns_over_tls(options):
     # setup and enable Unbound as resolver
     forward_addrs = ["# forward-addr: specify here forwarders"]
     if options.dot_forwarders:
@@ -430,6 +432,10 @@ def install(standalone, replica, options, api=api):
             "Certificate for DNS over TLS not specified "
             "and IPA CA is not present."
         )
+
+    if options.dns_over_tls:
+        print("Request certificate for DNS over TLS, using IPA CA")
+        _request_cert_for_dns_over_tls(options)
 
     bind = bindinstance.BindInstance(fstore, api=api)
     bind.setup(api.env.host, ip_addresses, api.env.realm, api.env.domain,


### PR DESCRIPTION
Deploying a replica with DNS support using an IPA server DNS with DoT fails while setting up DNS over TLS. The request for the certificate for DoT using IPA CA is done after the DNS server for the replica is configured.

The nameserver in /etc/resolv.conf has been changed to 127.0.0.1, but unbound was not yet configured as a forwarder.

The solution is to move the cert request before the DNS server configuration. The unbound config from the client deployment is still working at that moment.

Fixes: https://pagure.io/freeipa/issue/9808

## Summary by Sourcery

Request the DNS over TLS certificate before setting up the DNS server during replica installation.

Bug Fixes:
- Request DNS over TLS certificate before configuring Unbound to prevent resolution failures when /etc/resolv.conf points to localhost.

Enhancements:
- Extract certificate request into a dedicated _request_cert_for_dns_over_tls function and rename the original setup function accordingly.