### PR TITLE
[Backport][ipa-4-12] ipa-client-install: Fix nsupdate issues when dns_over_tls is enabled

### DIFF
--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1540,7 +1540,7 @@ def update_dns(server, hostname, options):
 
     update_txt = "debug\n"
     if options.dns_over_tls:
-        update_txt += "server %s 853" % server
+        update_txt += "server %s 853\n" % server
     update_txt += ipautil.template_str(DELETE_TEMPLATE_A,
                                        dict(HOSTNAME=hostname))
     update_txt += ipautil.template_str(DELETE_TEMPLATE_AAAA,
@@ -1788,7 +1788,7 @@ def update_ssh_keys(hostname, ssh_dir, options, server):
 
         update_txt = 'debug\n'
         if options.dns_over_tls:
-            update_txt += "server %s 853" % server
+            update_txt += "server %s 853\n" % server
         update_txt += 'update delete %s. IN SSHFP\nshow\nsend\n' % hostname
         for pubkey in pubkeys:
             sshfp = pubkey.fingerprint_dns_sha1()


### PR DESCRIPTION
This PR was opened automatically because PR #7846 was pushed to master and backport to ipa-4-12 is required.