### PR TITLE
ipatests: test_fips: Remove obsolete patch

### DIFF
--- a/ipatests/test_integration/test_fips.py
+++ b/ipatests/test_integration/test_fips.py
@@ -39,18 +39,6 @@ class TestInstallFIPS(IntegrationTest):
         for host in cls.get_all_hosts():
             assert host.is_fips_mode
             assert fips.is_fips_enabled(host)
-        # patch named-pkcs11 crypto policy
-        # see RHBZ#1772111
-        for host in [cls.master] + cls.replicas:
-            host.run_command(
-                [
-                    "sed",
-                    "-i",
-                    "-E",
-                    "s/RSAMD5;//g",
-                    "/etc/crypto-policies/back-ends/bind.config",
-                ]
-            )
         # master with CA, KRA, DNS+DNSSEC
         tasks.install_master(cls.master, setup_dns=True, setup_kra=True)
         # replica with CA, KRA, DNS


### PR DESCRIPTION
Remove no-longer-required patch for crypto policy from the test_fips.py suite which causes failures in the test runs.

Resolves: https://pagure.io/freeipa/issue/9810