### PR TITLE
[Backport][ipa-4-12] ipa-idrange-fix: check that IPA server is installed

### DIFF
--- a/ipaserver/install/ipa_idrange_fix.py
+++ b/ipaserver/install/ipa_idrange_fix.py
@@ -10,6 +10,7 @@ from ipalib import api, errors
 from ipapython.admintool import AdminTool
 from ipapython.dn import DN
 from ipapython import ipautil
+from ipaserver.install.installutils import check_server_configuration
 from typing import List, Tuple
 
 logger = logging.getLogger(__name__)
@@ -169,6 +170,8 @@ for confirmation",
         super().validate_options(needs_root)
 
     def run(self):
+        check_server_configuration()
+
         api.bootstrap(in_server=True)
         api.finalize()
 

--- a/ipatests/test_integration/test_cli_ipa_not_configured.py
+++ b/ipatests/test_integration/test_cli_ipa_not_configured.py
@@ -22,3 +22,13 @@ class TestIPANotConfigured(IntegrationTest):
         assert (exp_str in cmd.stderr_text and
                 cmd.returncode == SERVER_NOT_CONFIGURED and
                 unexp_str not in cmd.stderr_text)
+
+    def test_ipa_idrange_fix(self):
+        """
+        Test for https://pagure.io/freeipa/issue/9809
+        Launch ipa-idrange-fix command when the server is not configured.
+        """
+        exp_str = "IPA is not configured"
+        cmd = self.master.run_command(["ipa-idrange-fix"], raiseonerr=False)
+        assert (exp_str in cmd.stderr_text
+                and cmd.returncode == SERVER_NOT_CONFIGURED)


### PR DESCRIPTION
This PR was opened automatically because PR #7850 was pushed to master and backport to ipa-4-12 is required.