### PR TITLE
[Backport][ipa-4-12] ipa-migrate - only remove repl state attribute options

### DIFF
--- a/ipaserver/install/ipa_migrate_constants.py
+++ b/ipaserver/install/ipa_migrate_constants.py
@@ -117,6 +117,8 @@ AD_TRUST_ATTRS = [  # ipaNTTrustedDomain objectclass
     'ipantadditionalsuffixes',
 ]
 
+STATE_OPTIONS = ('adcsn-', 'mdcsn-', 'vucsn-', 'vdcsn-')
+
 DNA_REGEN_VAL = "-1"
 
 DNA_REGEN_ATTRS = [


### PR DESCRIPTION
This PR was opened manually because PR https://github.com/freeipa/freeipa/pull/7852 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Refine attribute value decoding to strip only replication state suffixes while preserving other options

Enhancements:
- Introduce STATE_OPTIONS constant listing replication state attribute prefixes
- Update decode_attr_vals to filter out only replication state options using STATE_OPTIONS instead of removing all non-binary suffixes