### PR TITLE
dns: disable all previous Unbound configuration before deploying ours

### DIFF
--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -102,6 +102,7 @@ class BasePathNamespace:
     NAMED_MANAGED_KEYS_DIR = "/var/named/dynamic"
     NAMED_CRYPTO_POLICY_FILE = None
     UNBOUND_CONF_SRC = '/usr/share/ipa/client/unbound.conf.template'
+    UNBOUND_CONFIG_DIR = "/etc/unbound/conf.d/"
     UNBOUND_CONF = "/etc/unbound/conf.d/zzz-ipa.conf"
     NSLCD_CONF = "/etc/nslcd.conf"
     NSS_LDAP_CONF = "/etc/nss_ldap.conf"

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -138,6 +138,16 @@ def _setup_dns_over_tls(options):
     # module_config_iterator is commented out if DNSSEC validation is
     # not disabled.
     module_config_iterator = '' if options.no_dnssec_validation else '# '
+
+    # backup and remove all previous Unbound configuration
+    fstore = sysrestore.FileStore(paths.SYSRESTORE)
+    for filename in os.listdir(paths.UNBOUND_CONFIG_DIR):
+        filepath = os.path.join(paths.UNBOUND_CONFIG_DIR, filename)
+        if filepath == paths.UNBOUND_CONF:
+            continue
+        fstore.backup_file(filepath)
+        ipautil.remove_file(filepath)
+
     ipautil.copy_template_file(
         paths.UNBOUND_CONF_SRC,
         paths.UNBOUND_CONF,
@@ -179,7 +189,6 @@ def _setup_dns_over_tls(options):
     ]
     nameservers = get_ipa_resolver().nameservers
     if not nameservers or nameservers[0] != "127.0.0.1":
-        fstore = sysrestore.FileStore(paths.SYSRESTORE)
         fstore.backup_file(paths.RESOLV_CONF)
         with open(paths.RESOLV_CONF, 'w') as f:
             f.write('\n'.join(cfg))


### PR DESCRIPTION
Previous configuration from another packages might break our Unbound
setup. Rename the config files to disable them before deploying our
configuration.

Fixes: https://pagure.io/freeipa/issue/9814
Signed-off-by: Antonio Torres <antorres@redhat.com>

## Summary by Sourcery

Disable previous Unbound configurations before deploying IPA’s new unbound.conf in both server and client installs, and update CI pipelines for EDNS testing and YAML consistency.

Bug Fixes:
- Prevent legacy Unbound configuration files from interfering by renaming them with a .disabled suffix before deploying the new template.

Enhancements:
- Add UNBOUND_CONFIG_DIR constant to centralize the Unbound configuration directory path.

CI:
- Standardize YAML quoting, switch the CI test suite to test_integration/test_edns.py, extend the timeout to 14400 seconds, adjust the topology to master+2 replicas, and update the gating include file path.