### PR TITLE
[Backport][ipa-4-12] ipatests: Tests for 32BitIdranges in IPA-AD trust enviornment #7845

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
@@ -2177,3 +2177,15 @@ jobs:
         template: *ci-ipa-4-12-latest
         timeout: 14400
         topology: *master_2repl_1client
+
+  fedora-latest-ipa-4-12/test_32BitIdranges:
+    requires: [fedora-latest-ipa-4-12/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest-ipa-4-12/build_url}'
+        test_suite: test_integration/test_32bit_idranges.py
+        template: *ci-ipa-4-12-latest
+        timeout: 7200
+        topology: *ad_master

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
@@ -2351,3 +2351,16 @@ jobs:
         template: *ci-ipa-4-12-latest
         timeout: 14400
         topology: *master_2repl_1client
+
+  fedora-latest-ipa-4-12/test_32BitIdranges:
+    requires: [fedora-latest-ipa-4-12/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest-ipa-4-12/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_32bit_idranges.py
+        template: *ci-ipa-4-12-latest
+        timeout: 7200
+        topology: *ad_master

--- a/ipatests/test_integration/test_32bit_idranges.py
+++ b/ipatests/test_integration/test_32bit_idranges.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.base import IntegrationTest
+from ipatests.test_integration.test_trust import BaseTestTrust
 
 
 class Test32BitIdRanges(IntegrationTest):
@@ -102,3 +103,24 @@ class Test32BitIdRanges(IntegrationTest):
         )
         assert result.returncode == 0
         assert str(uid) in result.stdout_text
+
+
+class Test32BitIdrangeInTrustEnv(Test32BitIdRanges, BaseTestTrust):
+    """
+    Tests to check 32BitIdrange functionality
+    in IPA-AD trust enviornment
+    """
+    topology = 'line'
+    num_ad_domains = 1
+    num_ad_subdomains = 0
+    num_ad_treedomains = 0
+    num_clients = 0
+
+    @classmethod
+    def install(cls, mh):
+        super(BaseTestTrust, cls).install(mh)
+        cls.ad = cls.ads[0]
+        cls.ad_domain = cls.ad.domain.name
+        tasks.configure_dns_for_trust(cls.master, cls.ad)
+        tasks.install_adtrust(cls.master)
+        tasks.establish_trust_with_ad(cls.master, cls.ad.domain.name)


### PR DESCRIPTION
## Summary by Sourcery

Introduce a dedicated integration test for 32-bit ID range behavior in an IPA-AD trust topology and integrate it into the IPA-4-12 nightly CI pipelines.

New Features:
- Add Test32BitIdrangeInTrustEnv integration test for 32-bit ID range functionality in IPA-AD trust environments

CI:
- Introduce nightly Fedora IPA-4-12 CI jobs (SELinux-enforcing and default) to run the 32-bit ID range AD trust tests