### PR TITLE
ipa-migrate - ignore deleted replication state attribute options

### DIFF
--- a/ipaserver/install/ipa_migrate_constants.py
+++ b/ipaserver/install/ipa_migrate_constants.py
@@ -117,7 +117,7 @@ AD_TRUST_ATTRS = [  # ipaNTTrustedDomain objectclass
     'ipantadditionalsuffixes',
 ]
 
-STATE_OPTIONS = ('adcsn-', 'mdcsn-', 'vucsn-', 'vdcsn-')
+STATE_OPTIONS = ('adcsn-', 'mdcsn-', 'vucsn-', 'vdcsn-', 'deleted')
 
 DNA_REGEN_VAL = "-1"
 


### PR DESCRIPTION
We need to ignore attribute options that start with "deleted"

Relates: https://pagure.io/freeipa/issue/9776

## Summary by Sourcery

Enhancements:
- Add "deleted" to STATE_OPTIONS to exclude deleted replication state attribute options