### PR TITLE
[Backport][ipa-4-12]  ipa-client-install: New --no-dnssec-validation option 

### DIFF
--- a/client/man/ipa-client-install.1
+++ b/client/man/ipa-client-install.1
@@ -204,6 +204,9 @@ Create DNS A/AAAA record for each IP address on this host.
 .TP
 \fB\-\-dns\-over\-tls\fR
 Configure DNS over TLS.
+.TP
+\fB\-\-no\-dnssec\-validation\fR
+Disable DNSSEC validation for DNS over TLS.
 
 .SS "SSSD OPTIONS"
 .TP

--- a/client/share/unbound.conf.template
+++ b/client/share/unbound.conf.template
@@ -3,6 +3,7 @@ server:
     tls-upstream: yes
     interface: 127.0.0.55
     log-servfail: yes
+    ${MODULE_CONFIG_ITERATOR}module-config: "iterator"
 forward-zone:
     name: "."
     forward-tls-upstream: yes

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -133,13 +133,17 @@ def _setup_dns_over_tls(options):
     if options.dot_forwarders:
         forward_addrs = ["forward-addr: %s" % fw
                          for fw in options.dot_forwarders]
+    # module_config_iterator is commented out if DNSSEC validation is
+    # not disabled.
+    module_config_iterator = '' if options.no_dnssec_validation else '# '
     ipautil.copy_template_file(
         paths.UNBOUND_CONF_SRC,
         paths.UNBOUND_CONF,
         dict(
             TLS_CERT_BUNDLE_PATH=os.path.join(
                 paths.OPENSSL_CERTS_DIR, "ca-bundle.crt"),
-            FORWARD_ADDRS="\n".join(forward_addrs)
+            FORWARD_ADDRS="\n".join(forward_addrs),
+            MODULE_CONFIG_ITERATOR=module_config_iterator
         )
     )
 


### PR DESCRIPTION
This PR was opened automatically because PR #7844 was pushed to master and backport to ipa-4-12 is required.