### PR TITLE
[Backport][ipa-4-12] Replica: Request cert for DoT before setting up bind

### DIFF
--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -114,7 +114,7 @@ def _disable_dnssec():
             conn.update_entry(entry)
 
 
-def _setup_dns_over_tls(options):
+def _request_cert_for_dns_over_tls(options):
     if os.path.isfile(paths.IPA_CA_CRT) and not options.dns_over_tls_cert:
         # request certificate for DNS over TLS, using IPA CA
         cert = paths.BIND_DNS_OVER_TLS_CRT
@@ -128,6 +128,8 @@ def _setup_dns_over_tls(options):
         constants.NAMED_USER.chown(cert, gid=constants.NAMED_GROUP.gid)
         constants.NAMED_USER.chown(key, gid=constants.NAMED_GROUP.gid)
 
+
+def _setup_dns_over_tls(options):
     # setup and enable Unbound as resolver
     forward_addrs = ["# forward-addr: specify here forwarders"]
     if options.dot_forwarders:
@@ -430,6 +432,10 @@ def install(standalone, replica, options, api=api):
             "Certificate for DNS over TLS not specified "
             "and IPA CA is not present."
         )
+
+    if options.dns_over_tls:
+        print("Request certificate for DNS over TLS, using IPA CA")
+        _request_cert_for_dns_over_tls(options)
 
     bind = bindinstance.BindInstance(fstore, api=api)
     bind.setup(api.env.host, ip_addresses, api.env.realm, api.env.domain,


### PR DESCRIPTION
This PR was opened automatically because PR #7848 was pushed to master and backport to ipa-4-12 is required.