### PR TITLE
ipatests: Add comprehensive tests for ipa-client-automount --domain option

### DIFF
--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -43,6 +43,10 @@ topologies:
     name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
+  ipa_ipa_trust: &ipa_ipa_trust
+    name: ipa_ipa_trust
+    cpu: 7
+    memory: 14750
 
 jobs:
   fedora-latest/build:
@@ -1549,6 +1553,19 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_3client
+
+  fedora-latest/nfs_automountdiscovery:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountDiscovery
+        trusted_domain: True
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *ipa_ipa_trust
 
   fedora-latest/mask:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -43,6 +43,10 @@ topologies:
     name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
+  ipa_ipa_trust: &ipa_ipa_trust
+    name: ipa_ipa_trust
+    cpu: 7
+    memory: 14750
 
 jobs:
   fedora-latest/build:
@@ -1671,6 +1675,20 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_3client
+
+  fedora-latest/nfs_automountdiscovery:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountDiscovery
+        trusted_domain: True
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *ipa_ipa_trust
 
   fedora-latest/mask:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -31,6 +31,10 @@ topologies:
     name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
+  ipa_ipa_trust: &ipa_ipa_trust
+    name: ipa_ipa_trust
+    cpu: 7
+    memory: 14750
 
 jobs:
   sssd-fedora/build:
@@ -117,6 +121,21 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_3client
+
+  sssd-fedora/nfs_automountdiscovery:
+    requires: [sssd-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{sssd-fedora/build_url}'
+        update_packages: True
+        copr: '@sssd/nightly'
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountDiscovery
+        trusted_domain: True
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *ipa_ipa_trust
 
   sssd-fedora/test_otp:
     requires: [sssd-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -43,6 +43,10 @@ topologies:
     name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
+  ipa_ipa_trust: &ipa_ipa_trust
+    name: ipa_ipa_trust
+    cpu: 7
+    memory: 14750
 
 jobs:
   testing-fedora/build:
@@ -1794,6 +1798,21 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_3client
+
+  testing-fedora/nfs_automountdiscovery:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountDiscovery
+        trusted_domain: True
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *ipa_ipa_trust
 
   testing-fedora/mask:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -43,6 +43,10 @@ topologies:
     name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
+  ipa_ipa_trust: &ipa_ipa_trust
+    name: ipa_ipa_trust
+    cpu: 7
+    memory: 14750
 
 jobs:
   testing-fedora/build:
@@ -1916,6 +1920,22 @@ jobs:
         template: *ci-master-latest
         timeout: 3600
         topology: *master_3client
+
+  testing-fedora/nfs_automountdiscovery:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountDiscovery
+        trusted_domain: True
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *ipa_ipa_trust
 
   testing-fedora/mask:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -43,6 +43,10 @@ topologies:
     name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
+  ipa_ipa_trust: &ipa_ipa_trust
+    name: ipa_ipa_trust
+    cpu: 7
+    memory: 14750
 
 jobs:
   fedora-previous/build:
@@ -1549,6 +1553,19 @@ jobs:
         template: *ci-master-previous
         timeout: 3600
         topology: *master_3client
+
+  fedora-previous/nfs_automountdiscovery:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountDiscovery
+        trusted_domain: True
+        template: *ci-master-previous
+        timeout: 3600
+        topology: *ipa_ipa_trust
 
   fedora-previous/mask:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -43,7 +43,10 @@ topologies:
     name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
-
+  ipa_ipa_trust: &ipa_ipa_trust
+    name: ipa_ipa_trust
+    cpu: 7
+    memory: 14750
 jobs:
   fedora-rawhide/build:
     requires: []
@@ -1697,6 +1700,20 @@ jobs:
         template: *ci-master-frawhide
         timeout: 9000
         topology: *master_3client
+
+  fedora-rawhide/nfs_automountdiscovery:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountDiscovery
+        trusted_domain: True
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *ipa_ipa_trust
 
   fedora-rawhide/automember:
     requires: [fedora-rawhide/build]

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -49,6 +49,10 @@ topologies:
     name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
+  ipa_ipa_trust: &ipa_ipa_trust
+    name: ipa_ipa_trust
+    cpu: 7
+    memory: 14750
 
 jobs:
   fedora-latest/build:


### PR DESCRIPTION
- Add parametrized test for domain validation covering valid/invalid formats
- Add cross-domain discovery test showing --domain enables discovery when
client is in different domain than IPA domain
- Validate configuration in sssd.conf after successful automount setup
    
The new tests ensure --domain option works correctly and provides proper
hints for DNS discovery in cross-domain scenarios, reducing user friction
compared to requiring --server specification.
    
Related: https://pagure.io/freeipa/issue/9780

## Summary by Sourcery

Add comprehensive integration tests for ipa-client-automount’s --domain option covering input validation, explicit override behavior, cross-domain DNS discovery, and configuration verification, and include them in CI pipelines

CI:
- Add nfs_automountdiscovery job to multiple nightly and rawhide pipeline definitions

Tests:
- Add parametrized tests for --domain option validation of ipa-client-automount
- Add test to ensure explicit --domain option overrides automatic discovery
- Add cross-domain discovery test enabling DNS hint and validating sssd.conf
- Add test for valid domain installation and log verification