### PR TITLE
freeipa.spec.in: protect scriptlets in environment where dbus or syst…

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1316,8 +1316,8 @@ fi
 %post server-trust-ad
 %{_sbindir}/update-alternatives --install %{_libdir}/krb5/plugins/libkrb5/winbind_krb5_locator.so \
         winbind_krb5_locator.so /dev/null 90
-/bin/systemctl reload-or-try-restart dbus
-/bin/systemctl reload-or-try-restart oddjobd
+/bin/systemctl reload-or-try-restart dbus >/dev/null 2>&1 || :
+/bin/systemctl reload-or-try-restart oddjobd >/dev/null 2>&1 || :
 
 
 %posttrans server-trust-ad
@@ -1334,8 +1334,8 @@ if [ $1 -eq 0 ]; then
     %{_sbindir}/update-alternatives --remove winbind_krb5_locator.so /dev/null
     # Skip systemctl calls when leapp upgrade is in progress
     if [ -z "$LEAPP_IPU_IN_PROGRESS" ] ; then
-        /bin/systemctl reload-or-try-restart dbus
-        /bin/systemctl reload-or-try-restart oddjobd
+        /bin/systemctl reload-or-try-restart dbus >/dev/null 2>&1 || :
+        /bin/systemctl reload-or-try-restart oddjobd >/dev/null 2>&1 || :
     fi
 fi
 


### PR DESCRIPTION
…emd do not run

For quite some time, even as early as with Fedora 37, we had

  Running scriptlet: freeipa-server-trust-ad-4.10.1-1.fc37.x86_64
                                            338/343
System has not been booted with systemd as init system (PID 1). Can't operate. Failed to connect to bus: Host is down
System has not been booted with systemd as init system (PID 1). Can't operate. Failed to connect to bus: Host is down
warning: %post(freeipa-server-trust-ad-4.10.1-1.fc37.x86_64) scriptlet failed, exit status 1

Error in POSTIN scriptlet in rpm package freeipa-server-trust-ad

when installing freeipa-server-trust-ad, but the whole rpm transaction passed and the dnf command returned with exit 0. So we did not care about that failure because, well, it did not get reported in any way it could be caught.

This has changed with recent registry.fedoraproject.org/fedora:rawhide image which seem so have rpm-5.99.91-1.fc43.x86_64. Now instead of exiting with 0 as with previous registry.fedoraproject.org/fedora:rawhide images, the dnf exits with 1, even if the version freeipa-server-trust-ad-4.12.2-14.fc43.x86_64 is the same in both cases.

Fixes: https://pagure.io/freeipa/issue/9826

## Summary by Sourcery

Prevent RPM scriptlets from failing in environments without a running systemd or dbus by adding guard conditions around systemd-dependent commands in the spec file

Bug Fixes:
- Guard post-install and other scriptlets against failures on systems not booted with systemd or lacking a dbus session

Build:
- Update freeipa.spec.in to wrap systemctl and dbus calls in conditional checks