### PR TITLE
kdb: prevent double crash in RBCD ACL free

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -2160,7 +2160,8 @@ void ipadb_free_principal(krb5_context kcontext, krb5_db_entry *entry)
                 for (i = 0; (acl_list != NULL) && (acl_list[i] != NULL); i++) {
                     free(acl_list[i]);
                 }
-                free(acl_list);
+                /* prev->tl_data_contents will be removed below */
+                acl_list = NULL;
             }
             free(prev->tl_data_contents);
             free(prev);


### PR DESCRIPTION
acl_list was set to prev->tl_data_contents and its value is freed but then is is freed again outside of the if(). Just reset acl_list pointer as prev->tl_data_contents is removed unconditionally outside of the RBCD ACL removal.

Related: https://pagure.io/freeipa/issue/9367