### PR TITLE
Fix terminal height for Rawhide

### DIFF
--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -35,10 +35,7 @@ import dns
 import encodings
 import sys
 import ssl
-import termios
-import fcntl
 import shutil
-import struct
 import subprocess
 
 import netaddr
@@ -1335,7 +1332,7 @@ def no_matching_interface_for_ip_address_warning(addr_list):
             )
 
 
-def get_terminal_height(fd=1):
+def get_terminal_height():
     """
     Get current terminal height
 
@@ -1345,11 +1342,7 @@ def get_terminal_height(fd=1):
     Returns:
         int: Terminal height
     """
-    try:
-        return struct.unpack(
-            'hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, b'1234'))[0]
-    except (IOError, OSError, struct.error):
-        return os.environ.get("LINES", 25)
+    return shutil.get_terminal_size().lines
 
 
 def get_pager():


### PR DESCRIPTION
Replaces old ioctl function with shutil.get_terminal_size.
This should be more universal.

Fixes: https://pagure.io/freeipa/issue/9824

## Summary by Sourcery

Replace ioctl-based terminal height detection with shutil.get_terminal_size to improve universality and fix Rawhide compatibility

Bug Fixes:
- Correct terminal height retrieval on Rawhide by replacing ioctl with shutil.get_terminal_size

Enhancements:
- Remove unused file descriptor parameter from get_terminal_height