### PR TITLE
Change the path to identify the tomcat version for Tomcat 10

### DIFF
--- a/ipaplatform/fedora/paths.py
+++ b/ipaplatform/fedora/paths.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import
 
 from ipaplatform.redhat.paths import RedHatPathNamespace
 from ipaplatform.fedora.constants import HAS_NFS_CONF
+from ipaplatform.osinfo import osinfo
 
 
 class FedoraPathNamespace(RedHatPathNamespace):
@@ -36,6 +37,8 @@ class FedoraPathNamespace(RedHatPathNamespace):
     NAMED_CRYPTO_POLICY_FILE = "/etc/crypto-policies/back-ends/bind.config"
     if HAS_NFS_CONF:
         SYSCONFIG_NFS = '/etc/nfs.conf'
+    if osinfo.version_number >= (45,):
+        BIN_TOMCAT = "/usr/share/tomcat/bin/version.sh"
 
 
 paths = FedoraPathNamespace()

--- a/ipaplatform/rhel/paths.py
+++ b/ipaplatform/rhel/paths.py
@@ -27,12 +27,15 @@ from __future__ import absolute_import
 
 from ipaplatform.redhat.paths import RedHatPathNamespace
 from ipaplatform.rhel.constants import HAS_NFS_CONF
+from ipaplatform.osinfo import osinfo
 
 
 class RHELPathNamespace(RedHatPathNamespace):
     NAMED_CRYPTO_POLICY_FILE = "/etc/crypto-policies/back-ends/bind.config"
     if HAS_NFS_CONF:
         SYSCONFIG_NFS = '/etc/nfs.conf'
+    if osinfo.version_number >= (11,0):
+        BIN_TOMCAT = "/usr/share/tomcat/bin/version.sh"
 
 
 paths = RHELPathNamespace()


### PR DESCRIPTION
PKI is changing from tomcat 9 to 10. Tomcat 10 introduces a number of changes, one of which is there is no /usr/sbin/tomcat.

Instead the scripts are split between /usr/libexec and /usr/share/tomcat/bin.

We call tomcat to get the version number for backwards compatibility. We can use the script version.sh instead of calling tomcat/catalina.sh directly.

Fixes: https://pagure.io/freeipa/issue/9832

NOTE: this patch is primarily intended for Fedora rawhide. This will not work with other releases using the ipa-4-12 branch. Decisions will need to be made whether this bumps the release or not.

## Summary by Sourcery

Enhancements:
- Update BIN_TOMCAT path from /usr/sbin/tomcat to /usr/share/tomcat/bin/version.sh for Tomcat 10 compatibility