### PR TITLE
[Backport][ipa-4-12] kdb: prevent double crash in RBCD ACL free

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -2160,7 +2160,8 @@ void ipadb_free_principal(krb5_context kcontext, krb5_db_entry *entry)
                 for (i = 0; (acl_list != NULL) && (acl_list[i] != NULL); i++) {
                     free(acl_list[i]);
                 }
-                free(acl_list);
+                /* prev->tl_data_contents will be removed below */
+                acl_list = NULL;
             }
             free(prev->tl_data_contents);
             free(prev);


### PR DESCRIPTION
This PR was opened automatically because PR #7878 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Bug Fixes:
- Prevent double free of RBCD ACL list by clearing acl_list instead of freeing it twice