### PR TITLE
ap: restore ability to generate coredumps inside podman container

### DIFF
--- a/ipatests/azure/azure-pipelines.yml
+++ b/ipatests/azure/azure-pipelines.yml
@@ -33,7 +33,13 @@ jobs:
 
     - script: |
         set -e
+        gcc main.c -g -o main
+      displayName: Build crashing binary
+
+    - script: |
+        set -e
         mkdir container
+        cp main dist/
         cp -pr dist container/
         cp $(IPA_TESTS_DOCKERFILES)/$(DOCKER_DOCKERFILE) container/Dockerfile
         cd container

--- a/ipatests/azure/scripts/azure-run-integration-tests.sh
+++ b/ipatests/azure/scripts/azure-run-integration-tests.sh
@@ -9,6 +9,8 @@ rm -rf "$IPA_TESTS_LOGSDIR"
 mkdir "$IPA_TESTS_LOGSDIR"
 pushd "$IPA_TESTS_LOGSDIR"
 
+/root/main
+
 tests_result=1
 { IPATEST_YAML_CONFIG=~/.ipa/ipa-test-config.yaml \
     ipa-run-tests \

--- a/ipatests/azure/templates/test-jobs.yml
+++ b/ipatests/azure/templates/test-jobs.yml
@@ -169,23 +169,30 @@ steps:
     # nothing to dump
     [ -z "$pids" ] && exit 0
 
+    # run podman as privileged user to have access to system journal and cores
+    # podman uses per user storage
+    echo 'Importing pre-built image for generating stacktraces and coredumps...'
+    sudo podman load --input $(Build.Repository.LocalPath)/freeipa-azure-builder-container.tar.gz
+    sudo podman images
+
     # continue in container
     HOST_JOURNAL="/var/log/host_journal"
     CONTAINER_COREDUMP="dump_cores"
-    podman create --privileged \
+    sudo podman create --privileged \
         -v "$(realpath coredumpctl.time.mark)":/coredumpctl.time.mark:ro \
         -v /var/lib/systemd/coredump:/var/lib/systemd/coredump:ro \
         -v /var/log/journal:"$HOST_JOURNAL":ro \
         -v "${BUILD_REPOSITORY_LOCALPATH}":"${IPA_TESTS_REPO_PATH}" \
         --name "$CONTAINER_COREDUMP" freeipa-azure-builder
-    podman start "$CONTAINER_COREDUMP"
+    sudo podman start "$CONTAINER_COREDUMP"
 
-    podman exec -t \
+
+    sudo podman exec -t \
         "$CONTAINER_COREDUMP" \
         /bin/bash --noprofile --norc -eux \
             "${IPA_TESTS_REPO_PATH}/${IPA_TESTS_SCRIPTS}/wait-for-systemd.sh"
 
-    podman exec -t \
+    sudo podman exec -t \
         --env IPA_TESTS_REPO_PATH="${IPA_TESTS_REPO_PATH}" \
         --env IPA_TESTS_SCRIPTS="${IPA_TESTS_REPO_PATH}/${IPA_TESTS_SCRIPTS}" \
         --env IPA_PLATFORM="${IPA_PLATFORM}" \
@@ -193,7 +200,7 @@ steps:
         /bin/bash --noprofile --norc -eux \
             "${IPA_TESTS_REPO_PATH}/${IPA_TESTS_SCRIPTS}/install-debuginfo.sh"
 
-    podman exec -t \
+    sudo podman exec -t \
         --env IPA_TESTS_REPO_PATH="${IPA_TESTS_REPO_PATH}" \
         --env COREDUMPS_SUBDIR="$COREDUMPS_SUBDIR" \
         --env HOST_JOURNAL="$HOST_JOURNAL" \
@@ -201,6 +208,7 @@ steps:
         /bin/bash --noprofile --norc -eux \
             "${IPA_TESTS_REPO_PATH}/${IPA_TESTS_SCRIPTS}/dump_cores.sh"
     # there should be no crashes
+    echo 'Stacktraces and coredumps of crashed processes can be found in build artifacts'
     exit 1
   condition: succeededOrFailed()
   displayName: Check for coredumps

--- a/main.c
+++ b/main.c
@@ -1,0 +1,9 @@
+int main(int argc, char **argv)
+{
+   char *r;
+   do
+   {
+       r = *argv;
+   } while (++argv);
+   return 0;
+}


### PR DESCRIPTION
Rootless podman (run as unprivileged host user) can't access mounted host journal for retrieving info about coredumps from inside the container:
    
```console
$ ls -la /var/log/host_journal
drwxr-sr-x+ 3 nobody nobody .
drwxr-xr-x  1 root   root   ..
drwxr-sr-x+ 2 nobody nobody 475350142b5f402a85aede7cb15a5a14

$ getfacl -R /var/log/host_journal
file: var/log/host_journal
owner: nobody
group: nobody
flags: -s-
user::rwx
group::r-x
group:4294967295:r-x
mask::r-x
other::r-x
default:user::rwx
default:group::r-x
default:group:4294967295:r-x
default:mask::r-x
default:other::r-x
    
file: var/log/host_journal/475350142b5f402a85aede7cb15a5a14
owner: nobody
group: nobody
flags: -s-
user::rwx
group::r-x
group:4294967295:r-x
mask::r-x
other::r-x
default:user::rwx
default:group::r-x
default:group:4294967295:r-x
default:mask::r-x
default:other::r-x

file: var/log/host_journal/475350142b5f402a85aede7cb15a5a14/system.journal
owner: nobody
group: nobody
user::rw-
group::r-x                      #effective:r--
group:4294967295:r-x            #effective:r--
mask::r--
other::---
```
    
And coredumpctl can't find any coredumps:
```console
$ coredumpctl --no-pager --directory=/var/log/host_journal list
No coredumps found.
```
    
Thereby to be able to have access to system journal and cores:
- run podman as privileged user
- import podman prebuilt image for root too as it uses per user storage
    
About podman rootless containers:
https://www.redhat.com/en/blog/rootless-containers-podman