### PR TITLE
[Backport][ipa-4-11]  ipatests: Remove xfail from test_installation::test_number_of_zones 

### DIFF
--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -587,12 +587,15 @@ class TestInstallWithCA_DNS3(CALessBase):
     ticket 7239
     """
 
-    @pytest.mark.xfail(
-        osinfo.id == 'fedora' and osinfo.version_number >= (36,),
-        reason='freeipa ticket 9135', strict=True)
     @server_install_setup
     def test_number_of_zones(self):
         """There should be two zones: one forward, one reverse"""
+
+        # Removed xfail for test_number_of_zones
+        # This test is xpass when executed in IdM-CI
+        # but still failing in PRCI. There is a different configuration
+        # in the 2 CIs and with this we will get a green test
+        # in IdM-CI nightly tests.
 
         self.create_pkcs12('ca1/server')
         self.prepare_cacert('ca1')


### PR DESCRIPTION
This PR was opened automatically because PR #7885 was pushed to master and backport to ipa-4-11 is required.