### PR TITLE
Spec file: use nodejs22 on fedora 41+

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -327,8 +327,9 @@ BuildRequires:  libsss_idmap-devel
 BuildRequires:  libsss_certmap-devel
 BuildRequires:  libsss_nss_idmap-devel >= %{sssd_version}
 %if 0%{?fedora} >= 41 || 0%{?rhel} >= 10
+# on fedora 41+, stick to nodejs22
 # Do not use nodejs22 on fedora < 41, https://pagure.io/freeipa/issue/9643
-BuildRequires: nodejs(abi)
+BuildRequires: nodejs(abi) == 127
 %elif 0%{?fedora} >= 39
 # Do not use nodejs20 on fedora < 39, https://pagure.io/freeipa/issue/9374
 BuildRequires:  nodejs(abi) < 127


### PR DESCRIPTION
Do not use the newest nodesjs24 as it does not provide the /usr/bin/node command, only /usr/bin/node-24.
Force the use of nodejs22.

Fixes: https://pagure.io/freeipa/issue/9836

## Summary by Sourcery

Enforce use of nodejs22 on Fedora 41+ in the RPM spec to ensure the /usr/bin/node symlink is present

Bug Fixes:
- Force nodejs22 instead of nodejs24 on Fedora 41 and newer to restore the /usr/bin/node command

Build:
- Update freeipa.spec to require nodejs22 on Fedora 41+