### PR TITLE
[Backport][ipa-4-12] Spec file: use nodejs22 on fedora 41+

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -328,8 +328,9 @@ BuildRequires:  libsss_idmap-devel
 BuildRequires:  libsss_certmap-devel
 BuildRequires:  libsss_nss_idmap-devel >= %{sssd_version}
 %if 0%{?fedora} >= 41 || 0%{?rhel} >= 10
+# on fedora 41+, stick to nodejs22
 # Do not use nodejs22 on fedora < 41, https://pagure.io/freeipa/issue/9643
-BuildRequires: nodejs(abi)
+BuildRequires: nodejs(abi) == 127
 %elif 0%{?fedora} >= 39
 # Do not use nodejs20 on fedora < 39, https://pagure.io/freeipa/issue/9374
 BuildRequires:  nodejs(abi) < 127


### PR DESCRIPTION
This PR was opened automatically because PR #7895 was pushed to master and backport to ipa-4-12 is required.