### PR TITLE
Fix ipa-client-install failure when a trusted CA's distinguished name contains slash characters

### DIFF
--- a/ipaplatform/debian/tasks.py
+++ b/ipaplatform/debian/tasks.py
@@ -146,9 +146,15 @@ used by ca-certificates and is provided for information only.\
             # CAs who used the same serial number?)
             filename = f'{subject.ldap_text()} {cert.serial_number}.crt'
 
-            # pylint: disable=old-division
-            cert_path = path / filename
-            # pylint: enable=old-division
+            # Some CAs have DNs with a / or NUL character, which are not legal
+            # in paths. Also escape some other annoying characters for good
+            # measure.
+            bad_chars = {'\0', '/', ':'}
+            safe_filename = ''.join(
+                ('-' if c in bad_chars else c for c in filename)
+            )
+
+            cert_path = os.path.join(path, safe_filename)
             try:
                 f = open(cert_path, 'w')
             except Exception:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Sanitize CA certificate filenames by replacing slash and null characters with hyphens to ensure valid file paths