### PR TITLE
Don't let lack of subca in PKI prevent LDAP deletion

### DIFF
--- a/ipaserver/plugins/ca.py
+++ b/ipaserver/plugins/ca.py
@@ -353,7 +353,10 @@ class ca_del(LDAPDelete):
                 key=keys[0],
                 reason=_("IPA CA cannot be deleted"))
 
-        ca_id = self.api.Command.ca_show(keys[0])['result']['ipacaid'][0]
+        try:
+            ca_id = self.api.Command.ca_show(keys[0])['result']['ipacaid'][0]
+        except errors.NotFound:
+            return dn
         with self.api.Backend.ra_lightweight_ca as ca_api:
             data = ca_api.read_ca(ca_id)
             if data['enabled']:


### PR DESCRIPTION
If a subCA only exists in LDAP then it couldn't be removed.

Allow the process to continue. It will fail in the same way if it doesn't exist on both Dogtag and IPA.

Related: https://pagure.io/freeipa/issue/9738

(note, @rcritten wrote the patch but I am prosecuting the merge)