### PR TITLE
Allow ipa-certupdate to force specific server

### DIFF
--- a/client/man/ipa-certupdate.1
+++ b/client/man/ipa-certupdate.1
@@ -16,7 +16,7 @@
 .\"
 .\" Author: Jan Cholasta <jcholast@redhat.com>
 .\"
-.TH "ipa-certupdate" "1" "Jul 2 2014" "IPA" "IPA Manual Pages"
+.TH "ipa-certupdate" "1" "Dec 27 2025" "IPA" "IPA Manual Pages"
 .SH "NAME"
 ipa\-certupdate \- Update local IPA certificate databases with certificates from the server
 .SH "SYNOPSIS"
@@ -24,6 +24,9 @@ ipa\-certupdate \- Update local IPA certificate databases with certificates from
 .SH "DESCRIPTION"
 \fBipa\-certupdate\fR can be used to update local IPA certificate databases with certificates from the server.
 .SH "OPTIONS"
+.TP
+\fB\-\-force\-server\fR=\fIipa.server.fqdn\fR
+Force the use of the specified server for the update. Use only fully-qualified domain name of the server, and verify that target server has a correct set of CA certificates, local certificates will be overwritten.
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR
 Print debugging information.


### PR DESCRIPTION
Adding option to specify a server to ipa-certupdate tool.
    
    Fixes: https://pagure.io/freeipa/issue/9839
    Signed-off-by: Aleksandr Sharov (asharov@redhat.com)

## Summary by Sourcery

Add a new --force-server option to ipa-certupdate to target a specific IPA server for certificate updates, update code to respect the forced server, and include documentation and tests to verify the new behavior.

New Features:
- Add --force-server option to specify server for certificate update in ipa-certupdate

Enhancements:
- Support variadic certificate tuple unpacking in update_db

CI:
- Update PRCI configuration to run test_commands suite and increase timeout

Documentation:
- Update ipa-certupdate man page with --force-server option and revise manual date

Tests:
- Add integration test to verify certupdate works with --force-server