### PR TITLE
[Manual Backport][ipa-4-12] ipatests: Add comprehensive tests for ipa-client-automount --domain o…

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
@@ -43,6 +43,10 @@ topologies:
     name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
+  ipa_ipa_trust: &ipa_ipa_trust
+    name: ipa_ipa_trust
+    cpu: 7
+    memory: 14750
 
 jobs:
   fedora-latest-ipa-4-12/build:
@@ -58,6 +62,19 @@ jobs:
           version: 0.0.2
         timeout: 1800
         topology: *build
+
+  fedora-latest-ipa-4-12/nfs_automountdiscovery:
+    requires: [fedora-latest-ipa-4-12/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-12/build_url}'
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountDiscovery
+        trusted_domain: True
+        template: *ci-ipa-4-12-latest
+        timeout: 3600
+        topology: *ipa_ipa_trust
 
   fedora-latest-ipa-4-12/simple_replication:
     requires: [fedora-latest-ipa-4-12/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
@@ -43,6 +43,10 @@ topologies:
     name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
+  ipa_ipa_trust: &ipa_ipa_trust
+    name: ipa_ipa_trust
+    cpu: 7
+    memory: 14750
 
 jobs:
   fedora-latest-ipa-4-12/build:
@@ -58,6 +62,20 @@ jobs:
           version: 0.0.2
         timeout: 1800
         topology: *build
+
+  fedora-latest-ipa-4-12/nfs_automountdiscovery:
+    requires: [fedora-latest-ipa-4-12/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-12/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountDiscovery
+        trusted_domain: True
+        template: *ci-ipa-4-12-latest
+        timeout: 3600
+        topology: *ipa_ipa_trust
 
   fedora-latest-ipa-4-12/simple_replication:
     requires: [fedora-latest-ipa-4-12/build]

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -49,6 +49,10 @@ topologies:
     name: ad_master_1repl_1client
     cpu: 6
     memory: 12096
+  ipa_ipa_trust: &ipa_ipa_trust
+    name: ipa_ipa_trust
+    cpu: 7
+    memory: 14750
 
 jobs:
   fedora-latest-ipa-4-12/build:


### PR DESCRIPTION
…ption

- Add parametrized test for domain validation covering valid/invalid formats
- Add cross-domain discovery test showing --domain enables discovery when client is in different domain than IPA domain
- Validate configuration in sssd.conf after successful automount setup

The new tests ensure --domain option works correctly and provides proper hints for DNS discovery in cross-domain scenarios, reducing user friction compared to requiring --server specification.

Related: https://pagure.io/freeipa/issue/9780


Reviewed-By: Rob Crittenden <rcritten@redhat.com>

## Summary by Sourcery

Add comprehensive tests for ipa-client-automount --domain functionality and domain name validation, and update PRCI definitions to schedule the new integration suite

CI:
- Add nfs_automountdiscovery job in ipa-4-12 nightly PRCI definitions to run TestIpaClientAutomountDiscovery under selinux and standard topologies

Tests:
- Add integration tests for ipa-client-automount --domain option covering valid/invalid domain formats, explicit override of discovery, cross-domain discovery hints, and sssd.conf validation
- Add unit tests for ipalib.util.validate_domain_name to ensure invalid domain formats are rejected

Chores:
- Normalize whitespace in test_get_pager assertion