### PR TITLE
ipatests: remove xfail for PKI 11.7

### DIFF
--- a/ipatests/test_integration/test_cert.py
+++ b/ipatests/test_integration/test_cert.py
@@ -558,8 +558,10 @@ class TestCAShowErrorHandling(IntegrationTest):
         )
         error_msg = 'ipa: ERROR: The certificate for ' \
                     '{} is not available on this server.'.format(lwca)
-        bad_version = (tasks.get_pki_version(self.master)
-                       >= tasks.parse_version('11.5.0'))
+        pki_version = tasks.get_pki_version(self.master)
+        # The regression was introduced in 11.5 and fixed in 11.7
+        bad_version = (tasks.parse_version('11.5.0') <= pki_version
+                       < tasks.parse_version('11.7.0'))
         with xfail_context(bad_version,
                            reason="https://pagure.io/freeipa/issue/9606"):
             assert error_msg in result.stderr_text


### PR DESCRIPTION
The test test_ca_show_error_handling is green with PKI 11.7
because the PKI regression has been fixed.
Update the xfail condition to 11.5 <= version < 11.7.

Fixes: https://pagure.io/freeipa/issue/9606

## Summary by Sourcery

Refine PKI version xfail handling in test_ca_show_error_handling and update CI job definitions to consolidate test_cert suite on Fedora branches and remove obsolete gating config.

CI:
- Rename and reconfigure fedora-latest job to run test_cert suite with increased priority, extended timeout, and master topology
- Add fedora-rawhide build and test_cert jobs with package updates and master topology
- Remove reference to gating configuration in .freeipa-pr-ci.yaml

Tests:
- Update test_ca_show_error_handling to xfail only for PKI versions >= 11.5.0 and < 11.7.0