### PR TITLE
[Backport][ipa-4-12] DNS over TLS: use system trust store

### DIFF
--- a/client/share/unbound.conf.template
+++ b/client/share/unbound.conf.template
@@ -1,5 +1,5 @@
 server:
-    tls-cert-bundle: $TLS_CERT_BUNDLE_PATH
+    tls-system-cert: yes
     tls-upstream: yes
     interface: 127.0.0.55
     log-servfail: yes

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1413,6 +1413,17 @@ if [ $1 -gt 1 ] ; then
             fi
         fi
     fi
+
+    UNBOUND_CFG=/etc/unbound/conf.d/zzz-ipa.conf
+    if [ -f "$UNBOUND_CFG" -a $restore -ge 2 ]; then
+        # The client has been configured for Dot
+        # replace the line tls-cert-bundle: /etc/pki/tls/certs/ca-bundle.crt
+        # with tls-system-cert: yes
+        # See https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile
+        if grep -E -q 'tls-cert-bundle: \/etc\/pki\/tls\/certs\/ca-bundle.crt'  $UNBOUND_CFG 2>/dev/null; then
+            sed -E --in-place=.orig 's/tls-cert-bundle: \/etc\/pki\/tls\/certs\/ca-bundle.crt/tls-system-cert: yes/' $UNBOUND_CFG
+        fi
+    fi
 fi
 
 

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1692,8 +1692,6 @@ def client_dns(server, hostname, options, statestore):
             paths.UNBOUND_CONF_SRC,
             paths.UNBOUND_CONF,
             dict(
-                TLS_CERT_BUNDLE_PATH=os.path.join(
-                    paths.OPENSSL_CERTS_DIR, "ca-bundle.crt"),
                 FORWARD_ADDRS=forward_addr,
                 MODULE_CONFIG_ITERATOR=module_config_iterator
             )

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -152,8 +152,6 @@ def _setup_dns_over_tls(options):
         paths.UNBOUND_CONF_SRC,
         paths.UNBOUND_CONF,
         dict(
-            TLS_CERT_BUNDLE_PATH=os.path.join(
-                paths.OPENSSL_CERTS_DIR, "ca-bundle.crt"),
             FORWARD_ADDRS="\n".join(forward_addrs),
             MODULE_CONFIG_ITERATOR=module_config_iterator
         )


### PR DESCRIPTION
This PR was opened automatically because PR #7914 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Backport DNS over TLS trust store configuration to ipa-4-12 by dropping custom certificate bundle paths in client and server installations and updating related templates and spec file.

Enhancements:
- Use the system default trust store for DNS over TLS by removing explicit TLS_CERT_BUNDLE_PATH from unbound configuration on both client and server sides

Build:
- Update freeipa.spec.in to remove hardcoded ca-bundle.crt reference