### PR TITLE
ipatests: fix test_certmonger_ipa_responder_jsonrpc

### DIFF
--- a/ipatests/test_integration/test_cert.py
+++ b/ipatests/test_integration/test_cert.py
@@ -13,7 +13,6 @@ import pytest
 import random
 import re
 import string
-import time
 import textwrap
 
 from ipaplatform.paths import paths
@@ -70,9 +69,10 @@ class TestInstallMasterClient(IntegrationTest):
     def install(cls, mh):
         super().install(mh)
 
-        # time to look into journal logs in
+        # store the start time to look into journal logs in
         # test_certmonger_ipa_responder_jsonrpc
-        cls.since = time.strftime('%Y-%m-%d %H:%M:%S')
+        result = cls.clients[0].run_command(['date', '+%Y-%m-%d %H:%M:%S'])
+        cls.since = result.stdout_text.strip()
 
     def test_cacert_file_appear_with_option_F(self):
         """Test if getcert creates cacert file with -F option


### PR DESCRIPTION
Test scenario:
- install IPA server and client
- store the start date
- request a certificate on the client using ipa-getcert
- check in the journal after start date that the request was done using the https://.../ipa/json URI

The test obtains the start date on the runner. As a consequence, if the runner is late compared to the client, it may miss the message in the journal. The date should rather be obtained on the client.

Fixes: https://pagure.io/freeipa/issue/9848

## Summary by Sourcery

Bug Fixes:
- Obtain the start timestamp on the client instead of the test runner to avoid missing journal entries due to time skew