### PR TITLE
ipatests: fix test_otp

### DIFF
--- a/ipatests/test_integration/test_otp.py
+++ b/ipatests/test_integration/test_otp.py
@@ -504,7 +504,7 @@ class TestOTPToken(IntegrationTest):
             )
             with xfail_context(rhel_fail or fedora_fail, reason=github_ticket):
                 result = ssh_2fa_with_cmd(master,
-                                          self.master.external_hostname,
+                                          self.master.hostname,
                                           USER3, PASSWORD, otpvalue=otpvalue,
                                           command="klist")
                 print(result.stdout_text)
@@ -552,7 +552,7 @@ class TestOTPToken(IntegrationTest):
             otpvalue = totp.generate(int(time.time())).decode('ascii')
             tasks.clear_sssd_cache(self.master)
             result = ssh_2fa_with_cmd(master,
-                                      self.master.external_hostname,
+                                      self.master.hostname,
                                       USER4, PASSWORD, otpvalue=otpvalue,
                                       command="klist")
             print(result.stdout_text)


### PR DESCRIPTION
The test is performing ssh from the runner to the master but is using the external_hostname and randomly fails.

Make sure to use the configured hostname instead.

Fixes: https://pagure.io/freeipa/issue/9849

## Summary by Sourcery

Tests:
- Use master.hostname instead of master.external_hostname in test_otp SSH invocations