### PR TITLE
[Backport][ipa-4-12] ipatests: fix test_otp

### DIFF
--- a/ipatests/test_integration/test_otp.py
+++ b/ipatests/test_integration/test_otp.py
@@ -504,7 +504,7 @@ class TestOTPToken(IntegrationTest):
             )
             with xfail_context(rhel_fail or fedora_fail, reason=github_ticket):
                 result = ssh_2fa_with_cmd(master,
-                                          self.master.external_hostname,
+                                          self.master.hostname,
                                           USER3, PASSWORD, otpvalue=otpvalue,
                                           command="klist")
                 print(result.stdout_text)
@@ -552,7 +552,7 @@ class TestOTPToken(IntegrationTest):
             otpvalue = totp.generate(int(time.time())).decode('ascii')
             tasks.clear_sssd_cache(self.master)
             result = ssh_2fa_with_cmd(master,
-                                      self.master.external_hostname,
+                                      self.master.hostname,
                                       USER4, PASSWORD, otpvalue=otpvalue,
                                       command="klist")
             print(result.stdout_text)


### PR DESCRIPTION
This PR was opened automatically because PR #7922 was pushed to master and backport to ipa-4-12 is required.