### PR TITLE
azure webui tests: force chromium version

### DIFF
--- a/ipatests/azure/templates/prepare-webui-fedora.yml
+++ b/ipatests/azure/templates/prepare-webui-fedora.yml
@@ -1,5 +1,6 @@
 steps:
 - script: |
     set -e
-    sudo dnf -y install npm fontconfig gtk3 atk at-spi2-atk chromium
+    sudo dnf install -y chromium-134.0.6998.165-1.fc42
+    sudo dnf -y install npm fontconfig gtk3 atk at-spi2-atk
   displayName: Install WebUI Unit tests prerequisites


### PR DESCRIPTION
azure webui tests are failing with chromium-140.0.7339.80-1.fc42 Force to install an older version

## Summary by Sourcery

Pin chromium to an older version in the Fedora WebUI test setup to avoid failures with chromium 140 in Azure pipelines.

Bug Fixes:
- Force installation of chromium-134.0.6998.165-1.fc42 in Fedora test prerequisites to work around failures with chromium 140

CI:
- Update prepare-webui-fedora.yml to install a specific chromium package before other dependencies