### PR TITLE
[Backport][ipa-4-12] azure webui tests: force chromium version

### DIFF
--- a/ipatests/azure/templates/prepare-webui-fedora.yml
+++ b/ipatests/azure/templates/prepare-webui-fedora.yml
@@ -1,5 +1,6 @@
 steps:
 - script: |
     set -e
-    sudo dnf -y install npm fontconfig gtk3 atk at-spi2-atk chromium
+    sudo dnf install -y chromium-134.0.6998.165-1.fc42
+    sudo dnf -y install npm fontconfig gtk3 atk at-spi2-atk
   displayName: Install WebUI Unit tests prerequisites


### PR DESCRIPTION
This PR was opened automatically because PR #7927 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Enhancements:
- Force install chromium-134.0.6998.165-1.fc42 before other prerequisites in prepare-webui-fedora.yml to ensure consistent test behavior.