### PR TITLE
Add POSIX ID uniqueness enforcement

### DIFF
--- a/install/updates/10-uniqueness.update
+++ b/install/updates/10-uniqueness.update
@@ -115,3 +115,47 @@ default:nsslapd-pluginVendor: Fedora Project
 # A unique ipaCertSubject is no longer required
 dn: cn=certificate store subject uniqueness,cn=plugins,cn=config
 deleteentry: cn=certificate store subject uniqueness,cn=plugins,cn=config
+
+dn: cn=POSIX GID uniqueness,cn=plugins,cn=config
+default:objectClass: top
+default:objectClass: nsSlapdPlugin
+default:objectClass: extensibleObject
+default:cn: POSIX GID uniqueness
+default:nsslapd-pluginPath: libattr-unique-plugin
+default:nsslapd-pluginInitfunc: NSUniqueAttr_Init
+default:nsslapd-pluginType: preoperation
+default:nsslapd-pluginEnabled: on
+default:nsslapd-plugin-depends-on-type: database
+default:nsslapd-pluginId: NSUniqueAttr
+default:nsslapd-pluginVersion: 1.1.0
+default:nsslapd-pluginVendor: Fedora Project
+default:nsslapd-pluginDescription: Enforce unique attribute values
+default:uniqueness-attribute-name: gidNumber
+default:uniqueness-subtrees: $SUFFIX
+default:uniqueness-exclude-subtrees: cn=compat,$SUFFIX
+default:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
+default:uniqueness-exclude-subtrees: cn=trusts,$SUFFIX
+default:uniqueness-across-all-subtrees: on
+default:uniqueness-subtree-entries-oc: posixAccount
+
+dn: cn=POSIX UID uniqueness,cn=plugins,cn=config
+default:objectClass: top
+default:objectClass: nsSlapdPlugin
+default:objectClass: extensibleObject
+default:cn: POSIX UID uniqueness
+default:nsslapd-pluginPath: libattr-unique-plugin
+default:nsslapd-pluginInitfunc: NSUniqueAttr_Init
+default:nsslapd-pluginType: preoperation
+default:nsslapd-pluginEnabled: on
+default:nsslapd-plugin-depends-on-type: database
+default:nsslapd-pluginId: NSUniqueAttr
+default:nsslapd-pluginVersion: 1.1.0
+default:nsslapd-pluginVendor: Fedora Project
+default:nsslapd-pluginDescription: Enforce unique attribute values
+default:uniqueness-attribute-name: uidNumber
+default:uniqueness-subtrees: $SUFFIX
+default:uniqueness-exclude-subtrees: cn=compat,$SUFFIX
+default:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
+default:uniqueness-exclude-subtrees: cn=trusts,$SUFFIX
+default:uniqueness-across-all-subtrees: on
+default:uniqueness-subtree-entries-oc: posixAccount


### PR DESCRIPTION
We expect POSIX IDs to be consistently applied: the same UID value maps uniquely to the user name and vice-versa, the same GID value to the same group name and vice-versa.

Apply uniqueness enforcement so that admins cannot create duplicate UID values or duplicate GID values across uidNumber and gidNumber values. The configuration is not enfocing cross-matches as there are valid use cases to have the same uidNumber and gidNumber, called 'user-private groups'.

Fixes: https://pagure.io/freeipa/issue/9853

## Summary by Sourcery

Enforce unique mapping between uidNumber and users, and between gidNumber and groups to prevent duplicate POSIX IDs while supporting user-private groups.

New Features:
- Enforce uniqueness of uidNumber across users
- Enforce uniqueness of gidNumber across groups

Enhancements:
- Add update script to migrate existing entries and apply uniqueness constraints
- Allow user-private groups by not enforcing cross-uniqueness between UIDs and GIDs

Tests:
- Add tests to verify POSIX ID uniqueness enforcement