### PR TITLE
ipatests: exclude TomcatFileCheck when RSN are enabled

### DIFF
--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -2521,6 +2521,12 @@ class TestIpaHealthCLI(IntegrationTest):
         )
         tasks.install_packages(cls.master, HEALTHCHECK_PKG)
         set_excludes(cls.master, "key", "DSCLE0004")
+        # Because of issue PKI#4906, skip the check ipahealthcheck.ipa.files
+        # TomcatFileCheck if random serial numbers are enabled
+        cs_cfg = cls.master.get_file_contents(paths.CA_CS_CFG_PATH,
+                                              encoding='utf-8')
+        if "dbs.cert.id.generator=random" in cs_cfg:
+            set_excludes(cls.master, "check", "TomcatFileCheck")
 
     def test_indent(self):
         """


### PR DESCRIPTION
Because of PKI issue https://github.com/freeipa/freeipa/pull/4906, the permissions of
/var/lib/pki/pki-tomcat/conf/ca/CS.cfg
are too permissive when RSN is enabled and the check TomcatFileCheck
from ipahealthcheck.ipa.files fails.

Exclude this check when RSN are enabled.

Related: https://github.com/dogtagpki/pki/issues/4906

## Summary by Sourcery

Exclude the TomcatFileCheck health check when random serial numbers are enabled and update CI job definitions accordingly

Enhancements:
- Rename the Fedora test job to test_ipahealthcheck_cli_fsspace and update its test suite path and topology

CI:
- Adjust temp_commit.yaml to reference the new test job and remove the outdated gating config from .freeipa-pr-ci.yaml

Tests:
- Skip the ipahealthcheck.ipa.files TomcatFileCheck when random serial numbers are enabled in CS.cfg