### PR TITLE
[Backport][ipa-4-12] Don't let lack of subca in PKI prevent LDAP deletion

### DIFF
--- a/ipaserver/plugins/ca.py
+++ b/ipaserver/plugins/ca.py
@@ -353,7 +353,10 @@ class ca_del(LDAPDelete):
                 key=keys[0],
                 reason=_("IPA CA cannot be deleted"))
 
-        ca_id = self.api.Command.ca_show(keys[0])['result']['ipacaid'][0]
+        try:
+            ca_id = self.api.Command.ca_show(keys[0])['result']['ipacaid'][0]
+        except errors.NotFound:
+            return dn
         with self.api.Backend.ra_lightweight_ca as ca_api:
             data = ca_api.read_ca(ca_id)
             if data['enabled']:

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -667,6 +667,8 @@ class RestClient(Backend):
         )
         if status < 200 or status >= 300:
             explanation = self._parse_dogtag_error(resp_body) or ''
+            if status == 404:
+                raise errors.NotFound(reason=explanation)
             raise errors.HTTPRequestError(
                 status=status,
                 reason=_('Non-2xx response from CA REST API: %(status)d. %(explanation)s')


### PR DESCRIPTION
This PR was opened automatically because PR #7902 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Allow IPA CA deletion in LDAP to proceed even if the corresponding sub-CA is absent in PKI by catching NotFound errors and updating Dogtag HTTP 404 handling

Bug Fixes:
- Catch NotFound error in ca_show to bypass PKI checks and allow LDAP deletion of a CA if its Dogtag copy is missing
- Map HTTP 404 responses from the Dogtag REST API to errors.NotFound for proper error handling

Tests:
- Add test_remove_missing_lwca integration test to verify CA removal from LDAP when the PKI CA is missing