### PR TITLE
[Backport][ipa-4-12] Catch decoding errors in CertificateSigningRequest parameters

### DIFF
--- a/ipalib/parameters.py
+++ b/ipalib/parameters.py
@@ -102,6 +102,7 @@ a more detailed description for clarity.
 import re
 import decimal
 import base64
+import binascii
 import datetime
 import inspect
 import typing
@@ -1523,7 +1524,11 @@ class CertificateSigningRequest(Param):
             return value
 
         value = strip_csr_header(value)
-        return base64.b64decode(value)
+        try:
+            return base64.b64decode(value)
+        except binascii.Error as e:
+            raise CertificateOperationError(
+                error=_('not a valid CSR: %s') % e)
 
     def _convert_scalar(self, value, index=None):
         """
@@ -1537,7 +1542,7 @@ class CertificateSigningRequest(Param):
             try:
                 value = value.encode('ascii')
             except UnicodeDecodeError:
-                raise CertificateOperationError('not a valid CSR')
+                raise CertificateOperationError(error=_('not a valid CSR'))
 
         if isinstance(value, bytes):
             # try to extract DER from whatever we got

--- a/ipatests/test_ipalib/test_parameters.py
+++ b/ipatests/test_ipalib/test_parameters.py
@@ -1720,9 +1720,14 @@ class test_CertificateSigningRequest(ClassChecker):
         b'\xed\r\x96\xfb\x1b\x8dN\xac\x89gz9\x98\xd9\xd6\x9e\x7fW}\xf4\x97;'
         b'\xad\xfe\xad\xc276\x80qmE\xc7|\x0b\xb1^R],'
     )
-    malformed_csr = (
+    malformed_csr = (  # value not a CSR
         b'-----BEGIN CERTIFICATE REQUEST-----\n'
         b'VGhpcyBpcyBhbiBpbnZhbGlkIENTUg==\n'
+        b'-----END CERTIFICATE REQUEST-----\n'
+    )
+    malformed_csr_2 = (  # invalid input
+        b'-----BEGIN CERTIFICATE REQUEST-----\n'
+        b'123\n'
         b'-----END CERTIFICATE REQUEST-----\n'
     )
 
@@ -1752,14 +1757,18 @@ class test_CertificateSigningRequest(ClassChecker):
                     self.sample_csr)
 
         # test that we fail the same with malformed CSR as bytes or str
-        for prep_input in (
-            lambda x: x,
-            lambda x: x.decode('utf-8'),
+        for input in (
+            self.malformed_csr,
+            self.malformed_csr_2
         ):
-            # test that malformed CSRs won't be accepted
-            raises(errors.CertificateOperationError,
-                   o.convert,
-                   prep_input(self.malformed_csr))
+            for prep_input in (
+                lambda x: x,
+                lambda x: x.decode('utf-8'),
+            ):
+                # test that malformed CSRs won't be accepted
+                raises(errors.CertificateOperationError,
+                       o.convert,
+                       prep_input(input))
 
         # test DER as an input to the convert method
         csr_object = o.convert(self.sample_der_csr)


### PR DESCRIPTION
This PR was opened automatically because PR #7901 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Backport improved error handling for malformed certificate signing requests by catching decoding errors and ensuring proper exceptions are raised, along with corresponding test coverage

Bug Fixes:
- Catch base64 decoding errors in CertificateSigningRequest parameters and raise CertificateOperationError with a localized message
- Use localized error message for Unicode decode failures in CSR conversion

Tests:
- Add a second malformed CSR test case and expand the conversion tests to ensure invalid CSR inputs (bytes and str) raise CertificateOperationError