### PR TITLE
[do not merge] test PR for dogtagpki/pki#5184

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,6 +61,7 @@ jobs:
     job:
       class: Build
       args:
+        copr: 'ftweedal/pki-lwca'
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
@@ -69,14 +70,16 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_replica_promotion_TestSubCAkeyReplication:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
+        copr: 'ftweedal/pki-lwca'
+        update_packages: False
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl


### PR DESCRIPTION
Temporary commit for testing a change to LWCA key replication, via a pki COPR.

## Summary by Sourcery

Configure the CI pipeline to test LWCA key replication via a COPR package and refine the temporary test job to run the TestSubCAkeyReplication suite.

Enhancements:
- Include COPR repository for pki-lwca in CI build and pytest jobs
- Enable package updates in the RunPytest job for the test environment
- Rename the temp test job and target the specific TestSubCAkeyReplication suite with updated topology

CI:
- Remove the gating configuration reference from .freeipa-pr-ci.yaml