### PR TITLE
ipatests: fix TestIPAMigratewithBackupRestore setup

### DIFF
--- a/ipatests/test_integration/test_ipa_ipa_migration.py
+++ b/ipatests/test_integration/test_ipa_ipa_migration.py
@@ -1283,7 +1283,8 @@ class TestIPAMigratewithBackupRestore(IntegrationTest):
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=True, setup_kra=True)
         prepare_ipa_server(cls.master)
-        tasks.install_master(cls.replicas[0], setup_dns=True, setup_kra=True)
+        tasks.install_master(cls.replicas[0], setup_dns=True, setup_kra=True,
+                             extra_args=['--allow-zone-overlap'])
         tasks.install_replica(cls.master, cls.replicas[1],
                               setup_dns=True, setup_kra=True)
 


### PR DESCRIPTION
The test is installing a first master with DNS enabled, then a second master (same domain name, with DNS enabled) in order to perform migration.
Add --allow-zone-overlap to the 2nd master installation.

Fixes: https://pagure.io/freeipa/issue/9858