### PR TITLE
[Backport][ipa-4-12] ipatests: fix TestIPAMigratewithBackupRestore setup

### DIFF
--- a/ipatests/test_integration/test_ipa_ipa_migration.py
+++ b/ipatests/test_integration/test_ipa_ipa_migration.py
@@ -1283,7 +1283,8 @@ class TestIPAMigratewithBackupRestore(IntegrationTest):
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=True, setup_kra=True)
         prepare_ipa_server(cls.master)
-        tasks.install_master(cls.replicas[0], setup_dns=True, setup_kra=True)
+        tasks.install_master(cls.replicas[0], setup_dns=True, setup_kra=True,
+                             extra_args=['--allow-zone-overlap'])
         tasks.install_replica(cls.master, cls.replicas[1],
                               setup_dns=True, setup_kra=True)
 


### PR DESCRIPTION
This PR was opened automatically because PR #7952 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Bug Fixes:
- Add '--allow-zone-overlap' to tasks.install_master in TestIPAMigratewithBackupRestore setup to allow overlapping DNS zones