### PR TITLE
PRCI tests: update vagrant image with latest PKI package

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -39,7 +39,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
           name: freeipa/ci-ipa-4-12-f42
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
@@ -59,7 +59,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
           name: freeipa/ci-ipa-4-12-f42
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
@@ -59,7 +59,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
           name: freeipa/ci-ipa-4-12-f42
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -65,7 +65,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-12-latest
           name: freeipa/ci-ipa-4-12-f42
-          version: 0.0.2
+          version: 0.0.3
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Fedora 42 now ships PKI 11.7. Update the vagrant image to 0.0.3 in order to pull the new PKI version.