### PR TITLE
Treat PKI 500 "No such object" exceptions as NotFound

### DIFF
--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -1707,13 +1707,13 @@ class ra_lightweight_ca(RestClient):
     def read_ca_cert(self, ca_id):
         _status, _resp_headers, resp_body = self._ssldo(
             'GET', '{}/cert'.format(ca_id),
-            headers={'Accept': 'application/pkix-cert'})
+            headers={'Accept': 'application/pkix-cert, application/json'})
         return resp_body
 
     def read_ca_chain(self, ca_id):
         _status, _resp_headers, resp_body = self._ssldo(
             'GET', '{}/chain'.format(ca_id),
-            headers={'Accept': 'application/pkcs7-mime'})
+            headers={'Accept': 'application/pkcs7-mime, application/json'})
         return resp_body
 
     def disable_ca(self, ca_id):


### PR DESCRIPTION
In order to get JSON error messages back we need to specify application/json as part of the Accept message. Otherwise PKI will default to XML messages.

Fixes: https://pagure.io/freeipa/issue/9860

## Summary by Sourcery

Enhancements:
- Include application/json in Accept headers for CA cert and chain API calls to receive JSON-formatted error messages