### PR TITLE
Spec file: bump version for 389-ds

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -73,15 +73,14 @@
 %global samba_version 4.17.4-101
 %global slapi_nis_version 0.56.4
 %global python_ldap_version 3.1.0-1
-%if 0%{?rhel} < 9
-# Bug 1929067 - PKI instance creation failed with new 389-ds-base build
-%global ds_version 1.4.3.16-12
-%global selinux_policy_version 3.14.3-107
+# version supporting Allow Uniqueness plugin to search uniqueness attributes
+# using custom matching rules - 389-ds-base 6857
+%if 0%{?rhel} == 9
+%global ds_version 2.7.0-7
 %else
-# version supporting LMDB and lib389.cli_ctl.dblib.run_dbscan utility
-%global ds_version 2.1.0
-%global selinux_policy_version 38.1.1-1
+%global ds_version 3.1.3-5
 %endif
+%global selinux_policy_version 38.1.1-1
 
 # Fix for TLS 1.3 PHA, RHBZ#1775158
 %global httpd_version 2.4.37-21
@@ -138,17 +137,11 @@
 # fix for segfault in python3-ldap, https://pagure.io/freeipa/issue/7324
 %global python_ldap_version 3.1.0-1
 
-# Make sure to use 389-ds-base versions that fix https://github.com/389ds/389-ds-base/issues/4700
-# and has DNA interval enabled
-# version supporting LMDB and lib389.cli_ctl.dblib.run_dbscan utility
-%if 0%{?fedora} < 34
-%global ds_version 1.4.4.16-1
-%elif 0%{?fedora} == 40
-%global ds_version 3.0.4-3
-%elif 0%{?fedora} >= 41
-%global ds_version 3.1.1-3
+# Make sure to use 389-ds-base versions that fix https://github.com/389ds/389-ds-base/issues/6857
+%if 0%{?fedora} <= 42
+%global ds_version 3.1.3-2
 %else
-%global ds_version 2.1.0
+%global ds_version 3.1.3-7
 %endif
 
 # Fix for TLS 1.3 PHA, RHBZ#1775146


### PR DESCRIPTION
IPA relies on the patch for https://github.com/389ds/389-ds-base/issues/6857 Allow Uniqueness plugin to search uniqueness attributes using custom matching rules

Provided in 389-ds 3.1.3-2 on fedora 41, 42
                   3.1.3-7 on fedora 43+
                   2.7.0-7 on RHEL 9.7
                   3.1.3-5 on RHEL 10.1

## Summary by Sourcery

Enhancements:
- Update required 389-ds versions on Fedora 41/42 to 3.1.3-2, Fedora 43+ to 3.1.3-7, RHEL 9.7 to 2.7.0-7, and RHEL 10.1 to 3.1.3-5