### PR TITLE
[WIP] Reproducer for sssd#8292

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -55,12 +55,13 @@ topologies:
     memory: 14750
 
 jobs:
-  fedora-latest/build:
+  sssd-fedora/build:
     requires: []
     priority: 100
     job:
       class: Build
       args:
+        copr: '@sssd/nightly'
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
@@ -69,14 +70,16 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
-    requires: [fedora-latest/build]
+  sssd-fedora/test_otp:
+    requires: [sssd-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        build_url: '{sssd-fedora/build_url}'
+        update_packages: True
+        copr: '@sssd/nightly'
+        test_suite: test_integration/test_otp.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -852,10 +852,10 @@ def setup_sssd_conf(host):
             pass
 
         for sssd_service_name in sssd_config.list_services():
-            sssd_config.edit_service(sssd_service_name, "debug_level", 7)
+            sssd_config.edit_service(sssd_service_name, "debug_level", 9)
 
         for sssd_domain_name in sssd_config.list_domains():
-            sssd_config.edit_domain(sssd_domain_name, "debug_level", 7)
+            sssd_config.edit_domain(sssd_domain_name, "debug_level", 9)
 
     # Clear the cache and restart SSSD
     clear_sssd_cache(host)


### PR DESCRIPTION
set debug_level=9 in /etc/sssd/sssd.conf
run test_otp

## Summary by Sourcery

Configure CI to build FreeIPA against the SSSD nightly COPR and run the OTP integration tests with increased SSSD logging.

New Features:
- Add a CI job that builds FreeIPA using the sssd-fedora COPR nightly repository and runs the test_integration/test_otp.py suite.

Enhancements:
- Raise SSSD service and domain debug_level from 7 to 9 in the test SSSD configuration helper to capture more detailed logs during integration tests.