### PR TITLE
Fix CA sizelimit and allow users, hosts, services

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1853,7 +1853,9 @@ Search for existing certificates.
 
             result[issuer, serial_number] = obj
 
-        return result, False, len(ca_objs) >= len(result)
+        # We return complete=False, to not be
+        # breaking with the old functionality
+        return result, False, False
 
     def _ldap_search(self, all, pkey_only, no_members, current_result,
                      **options):
@@ -1985,9 +1987,7 @@ Search for existing certificates.
                    'validnotbefore_from', 'validnotbefore_to',
                    'issuedon_from', 'issuedon_to',
                    'revokedon_from', 'revokedon_to',
-                   'status', 'users', 'no_users',
-                   'hosts', 'no_hosts',
-                   'services', 'no_services']):
+                   'status']):
             searches.append(self._ldap_search)
 
         for sub_search in searches:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,28 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_webui_users:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: >-
+          test_webui/test_group.py
+          test_webui/test_user.py
+        template: *ci-master-latest
+        timeout: 4800
+        topology: *ipaserver
+
+  fedora-latest/test_webui_host:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_webui/test_host.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *ipaserver


### PR DESCRIPTION
_ca_search incorrectly checks whether we are finished with the search,
result should be checked against sizelimit.

users, no_users and their hosts and services equavalent are dropped, as
they should never occur, they get automatically converted to their
singular form.

Fixes: https://pagure.io/freeipa/issue/9928