### PR TITLE
ipatests: Tests SELinux user mapping for AD users in trust environment

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -27,6 +27,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  adroot_adchild_master_2client: &adroot_adchild_master_2client
+    name: adroot_adchild_master_2client
+    cpu: 8
+    memory: 12644
   ipaserver: &ipaserver
     name: ipaserver
     cpu: 2

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -39,6 +39,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  adroot_adchild_master_2client: &adroot_adchild_master_2client
+    name: adroot_adchild_master_2client
+    cpu: 8
+    memory: 12644
   ad_master_1repl_1client: &ad_master_1repl_1client
     name: ad_master_1repl_1client
     cpu: 6
@@ -2243,7 +2247,7 @@ jobs:
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-latest
         timeout: 7200
-        topology: *adroot_adchild_adtree_master_1client
+        topology: *adroot_adchild_master_2client
 
   fedora-latest/test_hbac_functional:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -39,6 +39,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  adroot_adchild_master_2client: &adroot_adchild_master_2client
+    name: adroot_adchild_master_2client
+    cpu: 8
+    memory: 12644
   ad_master_1repl_1client: &ad_master_1repl_1client
     name: ad_master_1repl_1client
     cpu: 6
@@ -2423,7 +2427,7 @@ jobs:
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-latest
         timeout: 7200
-        topology: *adroot_adchild_adtree_master_1client
+        topology: *adroot_adchild_master_2client
 
   fedora-latest/test_hbac_functional:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -27,6 +27,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  adroot_adchild_master_2client: &adroot_adchild_master_2client
+    name: adroot_adchild_master_2client
+    cpu: 8
+    memory: 12644
   ad_master_1repl_1client: &ad_master_1repl_1client
     name: ad_master_1repl_1client
     cpu: 6
@@ -303,7 +307,7 @@ jobs:
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-latest
         timeout: 7200
-        topology: *adroot_adchild_adtree_master_1client
+        topology: *adroot_adchild_master_2client
 
   sssd-fedora/test_hbac_functional:
     requires: [sssd-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -39,6 +39,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  adroot_adchild_master_2client: &adroot_adchild_master_2client
+    name: adroot_adchild_master_2client
+    cpu: 8
+    memory: 12644
   ad_master_1repl_1client: &ad_master_1repl_1client
     name: ad_master_1repl_1client
     cpu: 6
@@ -2602,7 +2606,7 @@ jobs:
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-latest
         timeout: 7200
-        topology: *adroot_adchild_adtree_master_1client
+        topology: *adroot_adchild_master_2client
 
   testing-fedora/test_hbac_functional:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -39,6 +39,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  adroot_adchild_master_2client: &adroot_adchild_master_2client
+    name: adroot_adchild_master_2client
+    cpu: 8
+    memory: 12644
   ad_master_1repl_1client: &ad_master_1repl_1client
     name: ad_master_1repl_1client
     cpu: 6
@@ -2781,7 +2785,7 @@ jobs:
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-latest
         timeout: 7200
-        topology: *adroot_adchild_adtree_master_1client
+        topology: *adroot_adchild_master_2client
 
   testing-fedora/test_hbac_functional:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -39,6 +39,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  adroot_adchild_master_2client: &adroot_adchild_master_2client
+    name: adroot_adchild_master_2client
+    cpu: 8
+    memory: 12644
   ad_master_1repl_1client: &ad_master_1repl_1client
     name: ad_master_1repl_1client
     cpu: 6
@@ -2243,7 +2247,7 @@ jobs:
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-previous
         timeout: 7200
-        topology: *adroot_adchild_adtree_master_1client
+        topology: *adroot_adchild_master_2client
 
   fedora-previous/test_hbac_functional:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -39,6 +39,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  adroot_adchild_master_2client: &adroot_adchild_master_2client
+    name: adroot_adchild_master_2client
+    cpu: 8
+    memory: 12644
   ad_master_1repl_1client: &ad_master_1repl_1client
     name: ad_master_1repl_1client
     cpu: 6
@@ -2421,7 +2425,7 @@ jobs:
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-frawhide
         timeout: 7200
-        topology: *adroot_adchild_adtree_master_1client
+        topology: *adroot_adchild_master_2client
 
   fedora-rawhide/test_hbac_functional:
     requires: [fedora-rawhide/build]

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -45,6 +45,10 @@ topologies:
     name: adroot_adchild_adtree_master_1client
     cpu: 8
     memory: 14466
+  adroot_adchild_master_2client: &adroot_adchild_master_2client
+    name: adroot_adchild_master_2client
+    cpu: 8
+    memory: 12644
   ad_master_1repl_1client: &ad_master_1repl_1client
     name: ad_master_1repl_1client
     cpu: 6

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,17 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_trust_functional:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        update_packages: True
+        copr: '@sssd/nightly'
+        selinux_enforcing: True
+        test_suite: test_integration/test_trust_functional.py::TestTrustFunctionalSelinuxUsermap
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *adroot_adchild_master_2client

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -2402,12 +2402,13 @@ def hbacrule_remove_service(host, rulename, services=None,
     return host.run_command(cmd, raiseonerr=raiseonerr)
 
 
-def hbacrule_del(host, rulename, extra_args=()):
+def hbacrule_del(host, rulename, extra_args=(),
+                 raiseonerr=True):
     cmd = [
         "ipa", "hbacrule-del", rulename
     ]
     cmd.extend(extra_args)
-    return host.run_command(cmd)
+    return host.run_command(cmd, raiseonerr=raiseonerr)
 
 
 def hbacrule_enable(host, rulename, raiseonerr=True):
@@ -2417,6 +2418,186 @@ def hbacrule_enable(host, rulename, raiseonerr=True):
 
 def hbacrule_disable(host, rulename, raiseonerr=True):
     cmd = ["ipa", "hbacrule-disable", rulename]
+    return host.run_command(cmd, raiseonerr=raiseonerr)
+
+
+def selinuxusermap_add(host, mapname, extra_args=()):
+    """Create an SELinux User Map rule via ``ipa selinuxusermap-add``.
+
+    :param host: Host on which to run the command (usually the IPA master).
+    :param mapname: Rule name (``cn``) of the new map.
+    :param extra_args: Extra CLI arguments, for example ``--selinuxuser``,
+        ``--hbacrule``, ``--usercat=all``, or ``--hostcat=all``.  Note that
+        an HBAC rule reference cannot be combined with user or host category
+        ``all``; see the server plugin for mutual exclusion rules.
+    :return: ``run_command`` result object.
+    """
+    cmd = ["ipa", "selinuxusermap-add", mapname]
+    cmd.extend(extra_args)
+    return host.run_command(cmd)
+
+
+def selinuxusermap_del(host, mapname, extra_args=(), raiseonerr=True):
+    """Remove an SELinux User Map rule via ``ipa selinuxusermap-del``.
+
+    :param host: Host on which to run the command (usually the IPA master).
+    :param mapname: Rule name to delete.
+    :param extra_args: Extra CLI arguments passed to ``ipa selinuxusermap-del``.
+    :param raiseonerr: Forwarded to ``run_command``.
+    :return: ``run_command`` result object.
+    """
+    cmd = ["ipa", "selinuxusermap-del", mapname]
+    cmd.extend(extra_args)
+    return host.run_command(cmd, raiseonerr=raiseonerr)
+
+
+def selinuxusermap_show(host, mapname, extra_args=()):
+    """Show an SELinux User Map rule via ``ipa selinuxusermap-show``.
+
+    :param host: Host on which to run the command (usually the IPA master).
+    :param mapname: Rule name to display.
+    :param extra_args: Extra CLI arguments (e.g. ``--all``, ``--raw``).
+    :return: ``run_command`` result object.
+    """
+    cmd = ["ipa", "selinuxusermap-show", mapname]
+    cmd.extend(extra_args)
+    return host.run_command(cmd)
+
+
+def selinuxusermap_add_user(host, mapname, users=None, groups=None,
+                            raiseonerr=True, extra_args=()):
+    """Add users or groups to a map via ``ipa selinuxusermap-add-user``.
+
+    :param host: Host on which to run the command (usually the IPA master).
+    :param mapname: Target SELinux User Map rule name.
+    :param users: User login to add (single string passed as ``--users=``).
+    :param groups: Group name to add (single string passed as ``--groups=``).
+    :param raiseonerr: Forwarded to ``run_command``.
+    :param extra_args: Additional CLI arguments.
+    :return: ``run_command`` result object.
+    """
+    cmd = ["ipa", "selinuxusermap-add-user", mapname]
+    if users:
+        cmd.append(f"--users={users}")
+    if groups:
+        cmd.append(f"--groups={groups}")
+    cmd.extend(extra_args)
+    return host.run_command(cmd, raiseonerr=raiseonerr)
+
+
+def selinuxusermap_add_host(host, mapname, hosts=None,
+                            raiseonerr=True, extra_args=()):
+    """Add hosts or hostgroups to a map via ``ipa selinuxusermap-add-host``.
+
+    :param host: Host on which to run the command (usually the IPA master).
+    :param mapname: Target SELinux User Map rule name.
+    :param hosts: Hostname to add (single string passed as ``--hosts``).
+    :param raiseonerr: Forwarded to ``run_command``.
+    :param extra_args: Additional CLI arguments (e.g. ``--hostgroups=``).
+    :return: ``run_command`` result object.
+    """
+    cmd = ["ipa", "selinuxusermap-add-host", mapname]
+    if hosts:
+        cmd.append("--hosts")
+        cmd.append(hosts)
+    cmd.extend(extra_args)
+    return host.run_command(cmd, raiseonerr=raiseonerr)
+
+
+def selinuxusermap_enable(host, mapname, extra_args=()):
+    """Enable an SELinux User Map rule via ``ipa selinuxusermap-enable``.
+
+    :param host: Host on which to run the command (usually the IPA master).
+    :param mapname: Rule name to enable.
+    :param extra_args: Extra CLI arguments.
+    :return: ``run_command`` result object.
+    """
+    cmd = ["ipa", "selinuxusermap-enable", mapname]
+    cmd.extend(extra_args)
+    return host.run_command(cmd)
+
+
+def selinuxusermap_disable(host, mapname, extra_args=()):
+    """Disable an SELinux User Map rule via ``ipa selinuxusermap-disable``.
+
+    :param host: Host on which to run the command (usually the IPA master).
+    :param mapname: Rule name to disable.
+    :param extra_args: Extra CLI arguments.
+    :return: ``run_command`` result object.
+    """
+    cmd = ["ipa", "selinuxusermap-disable", mapname]
+    cmd.extend(extra_args)
+    return host.run_command(cmd)
+
+
+def selinuxusermap_mod(host, mapname, extra_args=()):
+    """Modify an SELinux User Map rule via ``ipa selinuxusermap-mod``.
+
+    :param host: Host on which to run the command (usually the IPA master).
+    :param mapname: Rule name to modify.
+    :param extra_args: CLI options such as ``--selinuxuser=``,
+    ``--description=``, or ``--hbacrule=``.
+    :return: ``run_command`` result object.
+    """
+    cmd = ["ipa", "selinuxusermap-mod", mapname]
+    cmd.extend(extra_args)
+    return host.run_command(cmd)
+
+
+def selinuxusermap_find(host, criteria=None, extra_args=()):
+    """Search SELinux User Map rules via ``ipa selinuxusermap-find``.
+
+    :param host: Host on which to run the command (usually the IPA master).
+    :param criteria: Optional search string passed as the CLI positional
+        argument (rule name fragment or empty for all).
+    :param extra_args: Additional filters or display options (e.g.
+        ``--hbacrule=NAME``, ``--all``).
+    :return: ``run_command`` result object.
+    """
+    cmd = ["ipa", "selinuxusermap-find"]
+    if criteria is not None:
+        cmd.append(criteria)
+    cmd.extend(extra_args)
+    return host.run_command(cmd)
+
+
+def selinuxusermap_remove_user(host, mapname, users=None, groups=None,
+                               raiseonerr=True, extra_args=()):
+    """Remove users or groups from a map via ``ipa selinuxusermap-remove-user``.
+
+    :param host: Host on which to run the command (usually the IPA master).
+    :param mapname: Target SELinux User Map rule name.
+    :param users: User login to remove (single string passed as ``--users=``).
+    :param groups: Group name to remove (single string passed as ``--groups=``).
+    :param raiseonerr: Forwarded to ``run_command``.
+    :param extra_args: Additional CLI arguments.
+    :return: ``run_command`` result object.
+    """
+    cmd = ["ipa", "selinuxusermap-remove-user", mapname]
+    if users:
+        cmd.append(f"--users={users}")
+    if groups:
+        cmd.append(f"--groups={groups}")
+    cmd.extend(extra_args)
+    return host.run_command(cmd, raiseonerr=raiseonerr)
+
+
+def selinuxusermap_remove_host(host, mapname, hosts=None,
+                               raiseonerr=True, extra_args=()):
+    """Remove hosts from a map via ``ipa selinuxusermap-remove-host``.
+
+    :param host: Host on which to run the command (usually the IPA master).
+    :param mapname: Target SELinux User Map rule name.
+    :param hosts: Hostname to remove (single string passed as ``--hosts``).
+    :param raiseonerr: Forwarded to ``run_command``.
+    :param extra_args: Additional CLI arguments (e.g. ``--hostgroups=``).
+    :return: ``run_command`` result object.
+    """
+    cmd = ["ipa", "selinuxusermap-remove-host", mapname]
+    if hosts:
+        cmd.append("--hosts")
+        cmd.append(hosts)
+    cmd.extend(extra_args)
     return host.run_command(cmd, raiseonerr=raiseonerr)
 
 
@@ -2879,6 +3060,13 @@ def remote_ini_file(host, filename):
 
 
 def is_selinux_enabled(host):
+    """Return whether SELinux is enabled on ``host`` (enforcing/permissive).
+
+    Uses ``selinuxenabled`` exit codes: 0 if enabled, 1 if disabled.
+
+    :param host: Remote host to query.
+    :return: ``True`` if SELinux is enabled, ``False`` otherwise.
+    """
     res = host.run_command('selinuxenabled', ok_returncode=(0, 1))
     return res.returncode == 0
 

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -69,6 +69,10 @@ class BaseTestTrust(IntegrationTest):
             cls.subaduser = f"subdomaintestuser@{cls.ad_subdomain}"
             cls.subaduser2 = f"subdomaindisabledadu@{cls.ad_subdomain}"
             cls.ad_sub_group = f"subdomaintestgroup@{cls.ad_subdomain}"
+            cls.subdomaintestuser2 = f"subdomaintestuser2@{cls.ad_subdomain}"
+            cls.subnonposixuser1 = f"subnonposixuser1@{cls.ad_subdomain}"
+            cls.subnonposixuser2 = f"subnonposixuser2@{cls.ad_subdomain}"
+            cls.subexpiredaduser = f"subexpiredaduser@{cls.ad_subdomain}"
 
         if cls.num_ad_treedomains > 0:
             cls.tree_ad = cls.ad_treedomains[0]
@@ -80,6 +84,14 @@ class BaseTestTrust(IntegrationTest):
         cls.srv_gc_record_value = '0 100 389 {}.'.format(cls.master.hostname)
         cls.aduser = f"nonposixuser@{cls.ad_domain}"
         cls.aduser2 = f"nonposixuser1@{cls.ad_domain}"
+        cls.testuser = f"testuser@{cls.ad_domain}"
+        cls.testuser1 = f"testuser1@{cls.ad_domain}"
+        cls.testuser2 = f"testuser2@{cls.ad_domain}"
+        cls.upnuser = f"upnuser@{cls.ad_domain}"
+        cls.upnuser_password = "Secret123456"
+        cls.mytestuser = f"mytestuser@{cls.ad_domain}"
+        cls.disabledaduser = f"disabledaduser@{cls.ad_domain}"
+        cls.expiredaduser = f"expiredaduser@{cls.ad_domain}"
         cls.ad_group = f"testgroup@{cls.ad_domain}"
 
     @classmethod

--- a/ipatests/test_integration/test_trust_functional.py
+++ b/ipatests/test_integration/test_trust_functional.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 import re
 import time
 import textwrap
+from contextlib import contextmanager
+import pytest
 from ipaplatform.paths import paths
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_trust import BaseTestTrust
@@ -865,3 +867,1023 @@ class TestTrustFunctionalHttp(BaseTestTrust):
         tasks.kdestroy_all(self.clients[0])
 
         self._assert_curl_GSSAPI_access_denied()
+
+
+class TestTrustFunctionalSelinuxUsermap(BaseTestTrust):
+    """Trusted AD users, IPA SELinux user maps, and HBAC (Beaker).
+
+    Beaker suite: ``ipa-trust-functional``.
+
+    Forest scenarios match ``t.ipa_trust_func_selinuxusermap.sh``; each
+    numbered test also runs the subdomain variant from
+    ``t.ipa_trust_func_selinuxusermap_sub.sh``.
+    Every ``test_ipa_trust_func_selinuxusermap_*`` docstring states **what**
+    is verified (SSH success, ``id -Z`` context strings, or expected denial).
+    """
+
+    topology = 'line'
+    num_clients = 2
+    num_ad_treedomains = 0
+
+    ADPASS = 'Secret123'
+    SELINUX_STAFF = 'staff_u:s0-s0:c0.c1023'
+    SELINUX_USER_U = 'user_u:s0'
+    SELINUX_XGUEST = 'xguest_u:s0'
+    SELINUX_GUEST = 'guest_u:s0'
+    SELINUX_UNCONFINED_DEFAULT = 'unconfined_u:s0-s0:c0.c1023'
+    G1_EXT = 'ad_testgrp1_ext'
+    G1 = 'ad_testgrp1'
+    G2_EXT = 'ad_testgrp2_ext'
+    G2 = 'ad_testgrp2'
+    SG1_EXT = 'ad_subtestgrp1_ext'
+    SG1 = 'ad_subtestgrp1'
+    SG2_EXT = 'ad_subtestgrp2_ext'
+    SG2 = 'ad_subtestgrp2'
+
+    @classmethod
+    def install(cls, mh):
+        """Prepare trust, AD groups, and SSSD for SELinux user map tests.
+
+        Configures DNS and establishes a one-way trust to AD, creates four
+        external+posix group pairs (forest ``G1``/``G2`` and subdomain
+        ``SG1``/``SG2``) with the usual test AD principals as external
+        members, then clears SSSD
+        caches on the master and both clients so group membership is visible
+        before any test runs.
+        """
+        super().install(mh)
+        tasks.configure_dns_for_trust(cls.master, cls.ad)
+        tasks.establish_trust_with_ad(
+            cls.master, cls.ad_domain,
+            extra_args=['--range-type', 'ipa-ad-trust'])
+        tasks.kinit_admin(cls.master)
+        cls._add_pair(cls.G1_EXT, cls.G1, cls.testuser1)
+        cls._add_pair(cls.G2_EXT, cls.G2, cls.testuser2)
+        cls._add_pair(cls.SG1_EXT, cls.SG1, cls.subaduser)
+        cls._add_pair(cls.SG2_EXT, cls.SG2, cls.subdomaintestuser2)
+        for host in (cls.master, *cls.clients):
+            tasks.clear_sssd_cache(host)
+            tasks.wait_for_sssd_domain_status_online(host)
+
+    def _require_selinux_clients(self):
+        """Skip the class unless every client has SELinux enforcing.
+
+        The suite relies on ``id -Z`` over SSH; without SELinux on clients the
+        checks are meaningless, so we abort early with ``pytest.skip``.
+        """
+        for client_host in self.clients:
+            if not tasks.is_selinux_enabled(client_host):
+                pytest.skip(
+                    'SELinux must be enabled on all clients for id -Z tests'
+                )
+
+    def _sssd_clear_all(self):
+        """Invalidate SSSD caches on master and all clients; wait until online.
+
+        Call after IPA objects that affect identity or SELinux mapping change
+        so ``id -Z`` reflects the current server state.
+        """
+        for host in (self.master, *self.clients):
+            tasks.clear_sssd_cache(host)
+            tasks.wait_for_sssd_domain_status_online(host)
+
+    def _sssd_prime_trusted_users(self, users, hosts):
+        """Warm SSSD after a cache clear (``id`` on each *user* / *host* pair).
+
+        Matches the pattern in ``test_hbac_functional`` before password SSH
+        when ``allow_all`` is off: cold caches can yield sshpass exit 5 even
+        when HBAC allows access.
+        """
+        for host in hosts:
+            for user in users:
+                host.run_command(['id', user], raiseonerr=False)
+
+    def _ssh_id_z(self, runner, user, target, password=ADPASS):
+        """Run ``id -Z`` on *target* by SSH from *runner*, as trusted *user*.
+
+        Uses ``sshpass`` with *password* (default ``ADPASS``).  *runner* is a
+        multihost host that executes the SSH client; *target* may be a host
+        object (``hostname`` used) or a bare hostname string.  Does not raise
+        on SSH failure—inspect the returned exit code.
+
+        :param runner: Host running ``ssh`` (typically a client).
+        :param user: Remote login (trusted AD user principal).
+        :param target: Destination host or hostname.
+        :param password: Password for ``sshpass``.
+        :return: ``(combined_stdout_stderr, exit_code)``.
+        """
+        run_result = runner.run_command(
+            [
+                'sshpass', '-p', password,
+                'ssh',
+                '-o', 'StrictHostKeyChecking=no',
+                '-o', 'PasswordAuthentication=yes',
+                '-o', 'PubkeyAuthentication=no',
+                '-o', 'GSSAPIAuthentication=no',
+                '-l', user, target.hostname, 'id', '-Z',
+            ],
+            raiseonerr=False,
+        )
+        combined_output = (
+            f'{run_result.stdout_text}{run_result.stderr_text}')
+        return combined_output, run_result.returncode
+
+    @classmethod
+    def _unconfined_ctx(cls, output):
+        """True if *output* looks like the default unconfined ``id -Z`` line.
+
+        ``ipa config-mod --ipaselinuxusermapdefault`` uses the short MLS user
+        string (``SELINUX_UNCONFINED_DEFAULT``), but ``id -Z`` on recent
+        Fedora/RHEL prints the full context with role and type in between.
+        Accept either form.
+        """
+        if re.search(
+                re.escape(cls.SELINUX_UNCONFINED_DEFAULT),
+                output,
+                re.DOTALL,
+        ):
+            return True
+        return re.search(
+            r'unconfined_u:unconfined_r:unconfined_t:s0-s0:c0\.c1023',
+            output,
+        ) is not None
+
+    def _ssh_id_z_assert(self, runner, user, target, role, password=ADPASS):
+        """SSH ``id -Z`` and assert exit code 0 and SELinux role *role*.
+
+        Combines ``_ssh_id_z`` with role checks.  Use when login and ``id -Z``
+        must succeed (contrast ``_ssh_id_z_assert_denied``).
+        """
+        output, code = self._ssh_id_z(runner, user, target, password=password)
+        assert code == 0, output
+        has_staff = 'staff_u' in output and 's0-s0:c0.c1023' in output
+        # Full contexts look like user_u:user_r:user_t:s0 (not ``user_u:s0``).
+        has_user_u = (
+            re.search(r'user_u:user_r:user_t:s0', output) is not None
+        )
+        has_guest = (
+            re.search(r'guest_u:guest_r:guest_t:s0', output) is not None
+        )
+        # Match xguest full context; do not use bare ``:s0`` (staff has
+        # ``s0-s0``).
+        has_xguest = (
+            re.search(r'xguest_u:xguest_r:xguest_t:s0', output) is not None
+        )
+
+        if role == 'staff':
+            assert has_staff, output
+        elif role == 'unconfined':
+            assert self._unconfined_ctx(output), output
+        elif role == 'not_staff_unconfined':
+            assert (not has_staff and self._unconfined_ctx(output)), output
+        elif role == 'user_u':
+            assert has_user_u, output
+        elif role == 'user_u_not_staff':
+            assert has_user_u and not has_staff, output
+        elif role == 'guest':
+            assert has_guest, output
+        elif role == 'not_guest_unconfined':
+            assert (not has_guest and self._unconfined_ctx(output)), output
+        elif role == 'xguest':
+            assert has_xguest, output
+        elif role == 'not_staff':
+            assert not has_staff, output
+        else:
+            raise ValueError(f'unknown id -Z role: {role!r}')
+        return output, code
+
+    def _ssh_id_z_assert_denied(self, runner, user, target, password=ADPASS):
+        """SSH ``id -Z`` and assert the session fails (non-zero exit code).
+
+        Used when HBAC or SSH must reject access; output is not interpreted as
+        a successful SELinux context.
+        """
+        output, code = self._ssh_id_z(runner, user, target, password=password)
+        assert code != 0, output
+        return output, code
+
+    @classmethod
+    def _add_pair(cls, external_group_name, posix_group_name,
+                  trusted_member_account):
+        """Create an external IPA group, a posix group, and link them with AD.
+
+        Adds *trusted_member_account* to *external_group_name*, then nests the
+        external group inside *posix_group_name* so trusted users resolve
+        through the posix group for SELinux user map and HBAC tests.
+        """
+        tasks.group_add(
+            cls.master, groupname=external_group_name,
+            extra_args=['--external'])
+        tasks.group_add(cls.master, groupname=posix_group_name)
+        cls.master.run_command([
+            'ipa', '-n', 'group-add-member', '--external',
+            trusted_member_account, external_group_name,
+        ])
+        tasks.group_add_member(
+            cls.master, groupname=posix_group_name,
+            extra_args=[f'--groups={external_group_name}'],
+        )
+
+    @contextmanager
+    def _staff_selinux_user_map_context(
+            self, map_name, posix_group, map_host_hostname):
+        """Context: staff SELinux user map for one host and one posix group.
+
+        On entry: ``kinit`` admin, ``ipa selinuxusermap-add`` with
+        ``SELINUX_STAFF``, attach *posix_group* and *map_host_hostname*,
+        refresh SSSD.  On exit: ``kinit`` admin, remove the map, refresh SSSD.
+
+        Used by tests 001–002 to share setup/teardown without duplicated
+        ``try``/``finally`` blocks.
+
+        :param map_name: IPA selinuxusermap name (unique per scenario).
+        :param posix_group: IPA posix group whose members get the map.
+        :param map_host_hostname: Host where the map applies (FQDN string).
+        """
+        tasks.kinit_admin(self.master)
+        try:
+            tasks.selinuxusermap_add(
+                self.master, map_name,
+                extra_args=[f'--selinuxuser={self.SELINUX_STAFF}'])
+            tasks.selinuxusermap_add_user(
+                self.master, map_name, groups=posix_group)
+            tasks.selinuxusermap_add_host(
+                self.master, map_name, hosts=map_host_hostname)
+            self._sssd_clear_all()
+            yield
+        finally:
+            tasks.kinit_admin(self.master)
+            tasks.selinuxusermap_del(
+                self.master, map_name, raiseonerr=False)
+            self._sssd_clear_all()
+
+    @contextmanager
+    def _hbac_staff_selinux_map_context(
+            self, hbac_rule_name, staff_map_name, posix_group,
+            hbac_host_hostname):
+        """Context: HBAC (sshd) on one host plus staff SELinux map tied to it.
+
+        Creates an HBAC rule allowing *posix_group* to *hbac_host_hostname*
+        for ``sshd``, then a selinuxusermap with ``SELINUX_STAFF`` referencing
+        that HBAC rule.  On exit: remove the map, delete the HBAC rule,
+        refresh SSSD.
+
+        :param hbac_rule_name: IPA hbacrule name.
+        :param staff_map_name: IPA selinuxusermap name.
+        :param posix_group: Group allowed by HBAC and used on the map.
+        :param hbac_host_hostname: Client FQDN attached to the HBAC rule.
+        """
+        tasks.kinit_admin(self.master)
+        try:
+            tasks.hbacrule_add(self.master, hbac_rule_name)
+            tasks.hbacrule_add_user(
+                self.master, hbac_rule_name, groups=posix_group)
+            tasks.hbacrule_add_host(
+                self.master, hbac_rule_name, hosts=hbac_host_hostname)
+            tasks.hbacrule_add_service(
+                self.master, hbac_rule_name, services='sshd')
+            tasks.selinuxusermap_add(
+                self.master, staff_map_name,
+                extra_args=[
+                    f'--selinuxuser={self.SELINUX_STAFF}',
+                    f'--hbacrule={hbac_rule_name}',
+                ])
+            self._sssd_clear_all()
+            yield
+        finally:
+            tasks.kinit_admin(self.master)
+            tasks.selinuxusermap_del(
+                self.master, staff_map_name, raiseonerr=False)
+            self.master.run_command(
+                ['ipa', 'hbacrule-del', hbac_rule_name], raiseonerr=False)
+            self._sssd_clear_all()
+
+    def _run_id_z_case_rows(self, case_rows):
+        """Execute a table of SSH ``id -Z`` checks.
+
+        *case_rows* is an iterable of ``(ssh_runner_host, login_user,
+        target_host, role)`` tuples passed to ``_ssh_id_z_assert`` in order.
+        """
+        for ssh_client, user, target, role in case_rows:
+            self._ssh_id_z_assert(ssh_client, user, target, role)
+
+    def test_ipa_trust_func_selinuxusermap_001(self):
+        """SELinux user map restricted to one client host (001 / sub_001).
+
+        **Verifies (forest, map on client 0 for ``G1`` + ``SELINUX_STAFF``):**
+
+        - From client 0 or 1, ``aduser`` SSH to client 0 → ``id -Z`` shows
+          staff MLS (``staff_u`` + ``s0-s0:c0.c1023``); SSH succeeds.
+        - ``aduser2`` from client 0 to client 0 → not staff, default
+          unconfined.
+        - ``aduser`` from client 0 to client 1 → unconfined (no staff map on
+          client 1).
+        - ``aduser`` from client 1 to client 1 → not staff and unconfined
+          (self-login on unmapped host).
+
+        **Verifies (subdomain, ``SG1`` / ``subaduser`` / ``subaduser2``):**
+
+        - ``subaduser`` → client 0: staff; → client 1: unconfined only.
+        - ``subaduser2`` → client 0: not staff + unconfined.
+        - From client 1, ``subaduser`` → client 0: staff; → client 1: not
+          staff + unconfined.
+
+        Password SSH; exit code 0 wherever a context is read.
+        """
+        self._require_selinux_clients()
+        first_client, second_client = self.clients[0], self.clients[1]
+        with self._staff_selinux_user_map_context(
+                'selinux_umap_001_ad', self.G1, first_client.hostname):
+            for ssh_client in first_client, second_client:
+                self._ssh_id_z_assert(
+                    ssh_client, self.testuser1, first_client, 'staff')
+            self._ssh_id_z_assert(
+                first_client, self.testuser2, first_client,
+                'not_staff_unconfined')
+            self._ssh_id_z_assert(
+                second_client, self.testuser1, second_client,
+                'not_staff_unconfined')
+            self._ssh_id_z_assert(
+                first_client, self.testuser1, second_client, 'unconfined')
+
+        with self._staff_selinux_user_map_context(
+                'selinux_umap_001_sub', self.SG1, first_client.hostname):
+            self._run_id_z_case_rows([
+                (first_client, self.subaduser, first_client, 'staff'),
+                (first_client, self.subaduser, second_client, 'unconfined'),
+                (first_client, self.subdomaintestuser2, first_client,
+                 'not_staff_unconfined'),
+                (second_client, self.subaduser, first_client, 'staff'),
+                (second_client, self.subaduser, second_client,
+                 'not_staff_unconfined'),
+            ])
+
+    def test_ipa_trust_func_selinuxusermap_002(self):
+        """SELinux user map on the IPA master host only (002 / sub_002).
+
+        **Verifies (forest, map host = master, group ``G1``):**
+
+        - From client 0, ``aduser`` SSH to master → ``id -Z`` is staff.
+        - From client 0, ``aduser`` SSH to client 0 → not staff, unconfined
+          (map does not apply to the client).
+        - From client 0, ``aduser2`` SSH to master → not staff, unconfined
+          (not in mapped group).
+
+        **Verifies (subdomain, map host = master, group ``SG1``):**
+
+        - Same three cases for ``subaduser`` / ``subaduser2`` on master vs
+          client 0.
+
+        The map **host** limits where staff applies, not where SSH starts.
+        """
+        self._require_selinux_clients()
+        first_client = self.clients[0]
+        with self._staff_selinux_user_map_context(
+                'selinux_umap_002_ad', self.G1, self.master.hostname):
+            self._run_id_z_case_rows([
+                (first_client, self.testuser1, self.master, 'staff'),
+                (first_client, self.testuser1, first_client,
+                 'not_staff_unconfined'),
+                (first_client, self.testuser2, self.master,
+                 'not_staff_unconfined'),
+            ])
+
+        with self._staff_selinux_user_map_context(
+                'selinux_umap_002_sub', self.SG1, self.master.hostname):
+            self._run_id_z_case_rows([
+                (first_client, self.subaduser, self.master, 'staff'),
+                (first_client, self.subaduser, first_client,
+                 'not_staff_unconfined'),
+                (first_client, self.subdomaintestuser2, self.master,
+                 'not_staff_unconfined'),
+            ])
+
+    def test_ipa_trust_func_selinuxusermap_003(self):
+        """Staff SELinux user map conditioned on an HBAC rule (003 / sub_003).
+
+        HBAC rule allows ``sshd`` to one client for members of the posix
+        group; selinuxusermap uses ``--hbacrule=`` so staff applies only when
+        that HBAC allows access.
+
+        **Verifies (forest, ``hbacrule3_1_ad``, map on client 0, ``G1``):**
+
+        - From client 0, ``aduser`` SSH to client 0 → ``id -Z`` is staff.
+        - From client 0, ``aduser2`` SSH to client 0 → not staff, unconfined.
+
+        **Verifies (subdomain, ``hbacrule3_1_sub``, group ``SG1``):**
+
+        - Same for ``subaduser`` / ``subaduser2`` on the first client.
+
+        So membership in the HBAC rule and the map’s user list must align for
+        staff; others keep the default unconfined mapping.
+        """
+        self._require_selinux_clients()
+        first_client = self.clients[0]
+        with self._hbac_staff_selinux_map_context(
+                'hbacrule3_1_ad', 'selinux_umap3_1_ad', self.G1,
+                first_client.hostname):
+            self._run_id_z_case_rows([
+                (first_client, self.testuser1, first_client, 'staff'),
+                (first_client, self.testuser2, first_client,
+                 'not_staff_unconfined'),
+            ])
+
+        with self._hbac_staff_selinux_map_context(
+                'hbacrule3_1_sub', 'selinux_umap3_1_sub', self.SG1,
+                first_client.hostname):
+            self._run_id_z_case_rows([
+                (first_client, self.subaduser, first_client, 'staff'),
+                (first_client, self.subdomaintestuser2, first_client,
+                 'not_staff_unconfined'),
+            ])
+
+    def _chain_004_cleanup(self, suffix):
+        """Remove HBAC/selinux objects from :meth:`_chain_004` (best-effort).
+
+        Called from test ``finally`` so a failed chain does not leave
+        ``allow_all`` disabled, stale maps, or HBAC rules that break later
+        tests (e.g. SSH exit failures or wrong ``id -Z`` in 008/009).
+        """
+        admin_allow_all_rule = f'admin_allow_all_{suffix}'
+        hbac_user_u_rule = f'hbacrule4_1_{suffix}'
+        hbac_staff_ssh_rule = f'hbacrule4_2_{suffix}'
+        selinux_map_xguest_allow_all = f'selinux_umap4_0_{suffix}'
+        selinux_map_user_u = f'selinux_umap4_1_{suffix}'
+        selinux_map_staff = f'selinux_umap4_2_{suffix}'
+        tasks.kinit_admin(self.master)
+        for map_name in (
+                selinux_map_staff,
+                selinux_map_user_u,
+                selinux_map_xguest_allow_all):
+            tasks.selinuxusermap_del(
+                self.master, map_name, raiseonerr=False)
+        tasks.hbacrule_del(
+            self.master, hbac_staff_ssh_rule, raiseonerr=False)
+        tasks.hbacrule_del(self.master, hbac_user_u_rule, raiseonerr=False)
+        tasks.hbacrule_enable(self.master, 'allow_all')
+        tasks.hbacrule_del(
+            self.master, admin_allow_all_rule, raiseonerr=False)
+        tasks.hbacrule_enable(self.master, 'allow_all')
+
+    def _chain_004(self, suffix, mapped_posix_group,
+                   trusted_user_primary, trusted_user_secondary):
+        """Long sequence: allow_all off, layered maps, then restore.
+
+        Steps: admin ``allow_all``-style HBAC; disable global ``allow_all``;
+        xguest map tied to ``allow_all``; per-user_u HBAC + map; staff map on
+        first client with sshd HBAC.  Asserts staff vs user_u on different
+        targets, removes maps/rules in order, re-enables ``allow_all``, checks
+        xguest then unconfined for both trusted users, deletes admin rule.
+
+        *suffix* disambiguates object names (``ad`` vs ``sub``).
+        *mapped_posix_group* is ``G1`` or ``SG1``; *trusted_user_primary* /
+        *trusted_user_secondary* are used for xguest/unconfined checks.
+        """
+        first_client, second_client = self.clients[0], self.clients[1]
+        admin_allow_all_rule = f'admin_allow_all_{suffix}'
+        hbac_user_u_rule = f'hbacrule4_1_{suffix}'
+        hbac_staff_ssh_rule = f'hbacrule4_2_{suffix}'
+        selinux_map_xguest_allow_all = f'selinux_umap4_0_{suffix}'
+        selinux_map_user_u = f'selinux_umap4_1_{suffix}'
+        selinux_map_staff = f'selinux_umap4_2_{suffix}'
+        tasks.kinit_admin(self.master)
+        self.master.run_command([
+            'ipa', 'hbacrule-add', admin_allow_all_rule,
+            '--hostcat=all', '--servicecat=all'])
+        tasks.hbacrule_add_user(
+            self.master, admin_allow_all_rule, groups='admins')
+        tasks.hbacrule_disable(self.master, 'allow_all')
+        tasks.selinuxusermap_add(
+            self.master, selinux_map_xguest_allow_all,
+            extra_args=[f'--selinuxuser={self.SELINUX_XGUEST}'])
+        tasks.selinuxusermap_mod(
+            self.master, selinux_map_xguest_allow_all,
+            extra_args=['--hbacrule=allow_all'])
+        # Explicit ``sshd`` + enrolled hosts (cf. test_hbac_functional): broad
+        # ``--hostcat=all --servicecat=all`` can leave trusted users denied
+        # when ``allow_all`` is off, which shows up as sshpass exit 5.
+        tasks.hbacrule_add(self.master, hbac_user_u_rule)
+        tasks.hbacrule_add_user(
+            self.master, hbac_user_u_rule, groups=mapped_posix_group)
+        for hb_host in (first_client, second_client, self.master):
+            tasks.hbacrule_add_host(
+                self.master, hbac_user_u_rule, hosts=hb_host.hostname)
+        tasks.hbacrule_add_service(
+            self.master, hbac_user_u_rule, services='sshd')
+        tasks.selinuxusermap_add(
+            self.master, selinux_map_user_u,
+            extra_args=[f'--selinuxuser={self.SELINUX_USER_U}'])
+        tasks.selinuxusermap_mod(
+            self.master, selinux_map_user_u,
+            extra_args=[f'--hbacrule={hbac_user_u_rule}'])
+        tasks.hbacrule_add(self.master, hbac_staff_ssh_rule)
+        tasks.hbacrule_add_user(
+            self.master, hbac_staff_ssh_rule, groups=mapped_posix_group)
+        tasks.hbacrule_add_host(
+            self.master, hbac_staff_ssh_rule, hosts=first_client.hostname)
+        tasks.hbacrule_add_service(
+            self.master, hbac_staff_ssh_rule, services='sshd')
+        tasks.selinuxusermap_add(
+            self.master, selinux_map_staff,
+            extra_args=[
+                f'--selinuxuser={self.SELINUX_STAFF}',
+                f'--hbacrule={hbac_staff_ssh_rule}',
+            ])
+        self._sssd_clear_all()
+        self._sssd_prime_trusted_users(
+            (trusted_user_primary, trusted_user_secondary),
+            (self.master, first_client, second_client),
+        )
+        for target, role in (
+                (first_client, 'staff'),
+                (self.master, 'user_u_not_staff'),
+                (second_client, 'user_u_not_staff')):
+            self._ssh_id_z_assert(
+                first_client, trusted_user_primary, target, role)
+        tasks.selinuxusermap_del(self.master, selinux_map_staff)
+        tasks.hbacrule_del(self.master, hbac_staff_ssh_rule)
+        self._sssd_clear_all()
+
+        self._ssh_id_z_assert(
+            first_client, trusted_user_primary, first_client,
+            'user_u_not_staff')
+
+        tasks.selinuxusermap_del(self.master, selinux_map_user_u)
+        tasks.hbacrule_del(self.master, hbac_user_u_rule)
+        tasks.hbacrule_enable(self.master, 'allow_all')
+        self._sssd_clear_all()
+
+        self._ssh_id_z_assert(
+            first_client, trusted_user_primary, first_client, 'xguest')
+        self._ssh_id_z_assert(
+            first_client, trusted_user_secondary, first_client, 'xguest')
+
+        tasks.selinuxusermap_del(self.master, selinux_map_xguest_allow_all)
+        self._sssd_clear_all()
+
+        self._ssh_id_z_assert(
+            first_client, trusted_user_primary, first_client, 'unconfined')
+        self._ssh_id_z_assert(
+            first_client, trusted_user_secondary, first_client, 'unconfined')
+
+        tasks.hbacrule_del(self.master, admin_allow_all_rule)
+        tasks.hbacrule_enable(self.master, 'allow_all')
+
+    def test_ipa_trust_func_selinuxusermap_004(self):
+        """Layered HBAC + selinuxusermap; ``allow_all`` toggled (004* / sub).
+
+        Runs :meth:`_chain_004` twice (``suffix`` ``ad`` then ``sub``).  See
+        that method for object names.  **End-to-end checks:**
+
+        **While staff map + user_u HBAC + disabled global ``allow_all``:**
+
+        - Primary user, SSH client 0 → client 0 → staff.
+        - Same user to master or client 1 → ``user_u``, not staff.
+
+        **After removing staff + user_u maps and re-enabling ``allow_all``:**
+
+        - Primary on client 0 → xguest (map tied to ``allow_all``).
+        - Secondary on client 0 → xguest.
+
+        **After removing the xguest / ``allow_all`` map:**
+
+        - Both users on client 0 → default unconfined.
+
+        **Cleanup:** admin allow-all HBAC rule removed; ``allow_all`` on.
+
+        Each run uses ``G1``/``aduser``/``aduser2`` or ``SG1``/subdomain;
+        ``finally`` re-kinit admin and clears SSSD so a failed chain does not
+        poison the next suffix.
+        """
+        self._require_selinux_clients()
+        for suffix, mapped_group, user_primary, user_secondary in (
+                ('ad', self.G1, self.testuser1, self.testuser2),
+                ('sub', self.SG1, self.subaduser, self.subdomaintestuser2)):
+            try:
+                self._chain_004(
+                    suffix, mapped_group, user_primary, user_secondary)
+            finally:
+                self._chain_004_cleanup(suffix)
+                tasks.kinit_admin(self.master)
+                self._sssd_clear_all()
+
+    def _chain_005(self, suffix, mapped_posix_group,
+                   trusted_user_primary, trusted_user_secondary):
+        """Guest map on hostgroup containing only the second client (005*).
+
+        Members of *mapped_posix_group* (``G2`` or ``SG2``) get ``guest_u``
+        when SSHing to the second client via a map that references a hostgroup.
+        Removing users from the map or deleting the hostgroup drops guest
+        context back to unconfined for the secondary trusted user.
+        """
+        first_client, second_client = self.clients[0], self.clients[1]
+        second_client_hostgroup = f'hostgrp_selinux_005_{suffix}'
+        selinux_map_name = f'test_user_specific_hostgroup_{suffix}'
+        tasks.kinit_admin(self.master)
+        try:
+            tasks.hostgroup_add(self.master, second_client_hostgroup)
+            tasks.hostgroup_add_member(
+                self.master, second_client_hostgroup,
+                hosts=second_client.hostname)
+            tasks.selinuxusermap_add(
+                self.master, selinux_map_name,
+                extra_args=[f'--selinuxuser={self.SELINUX_GUEST}'])
+            tasks.selinuxusermap_add_host(
+                self.master, selinux_map_name,
+                extra_args=[f'--hostgroups={second_client_hostgroup}'])
+            tasks.selinuxusermap_add_user(
+                self.master, selinux_map_name, groups=mapped_posix_group)
+            self._sssd_clear_all()
+
+            self._ssh_id_z_assert(
+                first_client, trusted_user_secondary, second_client, 'guest')
+            self._ssh_id_z_assert(
+                first_client, trusted_user_primary, second_client,
+                'not_guest_unconfined')
+
+            tasks.selinuxusermap_remove_user(
+                self.master, selinux_map_name, groups=mapped_posix_group)
+            self._sssd_clear_all()
+
+            self._ssh_id_z_assert(
+                first_client, trusted_user_secondary, second_client,
+                'not_guest_unconfined')
+        finally:
+            tasks.kinit_admin(self.master)
+            tasks.selinuxusermap_del(
+                self.master, selinux_map_name, raiseonerr=False)
+            tasks.hostgroup_del(
+                self.master, second_client_hostgroup, raiseonerr=False)
+
+    def test_ipa_trust_func_selinuxusermap_005(self):
+        """Hostgroup map (client 1 only) with guest SELinux user (005*).
+
+        **Verifies (forest ``G2`` / subdomain ``SG2``, :meth:`_chain_005`):**
+
+        - Map uses ``SELINUX_GUEST`` and ``--hostgroups`` (hostgroup is only
+          client 1).  User **not** on map: from client 0,
+          ``trusted_user_primary`` → client 1 → not guest, unconfined.
+        - ``trusted_user_secondary`` (in mapped posix group) → client 1 →
+          ``guest_u``.
+        - After ``selinuxusermap-remove-user`` drops the group from the map,
+          ``trusted_user_secondary`` → client 1 → not guest, unconfined.
+
+        Hostgroup targeting and map membership drive guest vs unconfined.
+        """
+        self._require_selinux_clients()
+        for suffix, mapped_group, user_primary, user_secondary in (
+                ('ad', self.G2, self.testuser1, self.testuser2),
+                ('sub', self.SG2, self.subaduser, self.subdomaintestuser2)):
+            try:
+                self._chain_005(
+                    suffix, mapped_group, user_primary, user_secondary)
+            finally:
+                tasks.kinit_admin(self.master)
+                tasks.hbacrule_enable(self.master, 'allow_all')
+                self._sssd_clear_all()
+
+    def _chain_006(self, suffix, mapped_posix_group,
+                   trusted_user_primary, trusted_user_secondary):
+        """HBAC (sshd) to client 1 via hostgroup; staff map linked (006*).
+
+        With ``allow_all`` disabled, only users in *mapped_posix_group* may SSH
+        to the second client; staff SELinux map is tied to that HBAC rule.
+        After removing users from the HBAC rule, both trusted users lose access
+        (assert SSH denial).  Cleans up hostgroup, map, rule, re-enables
+        ``allow_all``.
+        """
+        first_client = self.clients[0]
+        second_client = self.clients[1]
+        hostgroup_second_client = f'hostgrp_selinux_006_{suffix}'
+        selinux_map_name = f'test_u_hostgroup_hbac_{suffix}'
+        hbac_rule_name = f'rule6_{suffix}'
+        tasks.kinit_admin(self.master)
+        try:
+            tasks.hbacrule_disable(self.master, 'allow_all')
+            tasks.hostgroup_add(self.master, hostgroup_second_client)
+            tasks.hostgroup_add_member(
+                self.master, hostgroup_second_client,
+                hosts=second_client.hostname)
+            tasks.hbacrule_add(self.master, hbac_rule_name)
+            tasks.hbacrule_add_service(
+                self.master, hbac_rule_name, services='sshd')
+            tasks.hbacrule_add_user(
+                self.master, hbac_rule_name, groups=mapped_posix_group)
+            self.master.run_command([
+                'ipa', 'hbacrule-add-host', hbac_rule_name,
+                f'--hostgroups={hostgroup_second_client}',
+            ])
+            tasks.selinuxusermap_add(
+                self.master, selinux_map_name,
+                extra_args=[
+                    f'--selinuxuser={self.SELINUX_STAFF}',
+                    f'--hbacrule={hbac_rule_name}',
+                ])
+            self._sssd_clear_all()
+            self._sssd_prime_trusted_users(
+                (trusted_user_primary, trusted_user_secondary),
+                (first_client, second_client),
+            )
+
+            self._ssh_id_z_assert(
+                first_client, trusted_user_secondary, second_client, 'staff')
+            self._ssh_id_z_assert_denied(
+                first_client, trusted_user_primary, second_client)
+            tasks.hbacrule_remove_user(
+                self.master, hbac_rule_name, groups=mapped_posix_group)
+            self._sssd_clear_all()
+
+            self._ssh_id_z_assert_denied(
+                first_client, trusted_user_secondary, second_client)
+        finally:
+            tasks.kinit_admin(self.master)
+            tasks.hostgroup_del(
+                self.master, hostgroup_second_client, raiseonerr=False)
+            tasks.selinuxusermap_del(
+                self.master, selinux_map_name, raiseonerr=False)
+            tasks.hbacrule_del(self.master, hbac_rule_name, raiseonerr=False)
+            tasks.hbacrule_enable(self.master, 'allow_all')
+
+    def test_ipa_trust_func_selinuxusermap_006(self):
+        """HBAC hostgroup + sshd to client 1; staff map on that rule (006*).
+
+        **Verifies (``G2`` / ``SG2``, :meth:`_chain_006`):**
+
+        With ``allow_all`` **disabled**, HBAC allows only members of the mapped
+        posix group to reach client 1 via ``sshd`` (hostgroup contains client
+        1).  Staff selinuxusermap references that HBAC rule.
+
+        - ``trusted_user_secondary`` (in group) client 0 → client 1: SSH OK,
+          ``id -Z`` staff.
+        - ``trusted_user_primary`` (not in group) same path: SSH **fails**
+          (non-zero exit).
+
+        After ``hbacrule-remove-user`` removes the group from the rule:
+
+        - ``trusted_user_secondary`` → client 1: SSH **fails**.
+
+        **Finally:** hostgroup, map, and HBAC rule removed; ``allow_all`` on.
+        The test ``finally`` kinit admin, ``hbacrule-enable allow_all``, SSSD
+        clear so HBAC is not left disabled.
+        """
+        self._require_selinux_clients()
+        for suffix, mapped_group, user_primary, user_secondary in (
+                ('ad', self.G2, self.testuser1, self.testuser2),
+                ('sub', self.SG2, self.subaduser, self.subdomaintestuser2)):
+            try:
+                self._chain_006(
+                    suffix, mapped_group, user_primary, user_secondary)
+            finally:
+                tasks.kinit_admin(self.master)
+                tasks.hbacrule_enable(self.master, 'allow_all')
+                self._sssd_clear_all()
+
+    def _chain_007(self, suffix, mapped_posix_group,
+                   trusted_user_primary, trusted_user_secondary):
+        """One HBAC rule, two hostgroups (one per client); staff map (007*).
+
+        ``allow_all`` is off.  HBAC permits *mapped_posix_group* for ``sshd``
+        on hosts in both hostgroups.  Primary trusted user gets staff on each
+        client; secondary user is not in the group (not staff).  After
+        removing the group from HBAC, primary user can no longer SSH to the
+        first client.
+        """
+        first_client, second_client = self.clients[0], self.clients[1]
+        hostgroup_first_client = f'hostgrp7_1_{suffix}'
+        hostgroup_second_client = f'hostgrp7_2_{suffix}'
+        hbac_rule_name = f'rule7_{suffix}'
+        hbac_ssh_secondary_rule = f'rule7_sshonly_{suffix}'
+        selinux_map_name = f'test_umap_from_hg_{suffix}'
+        secondary_hbac_group = self.G2 if suffix == 'ad' else self.SG2
+        tasks.kinit_admin(self.master)
+        try:
+            self._sssd_clear_all()
+            self._sssd_prime_trusted_users(
+                (trusted_user_primary, trusted_user_secondary),
+                (self.master, first_client, second_client),
+            )
+            tasks.hbacrule_disable(self.master, 'allow_all')
+            for hostgroup_name, client_host in (
+                    (hostgroup_first_client, first_client),
+                    (hostgroup_second_client, second_client)):
+                tasks.hostgroup_add(self.master, hostgroup_name)
+                tasks.hostgroup_add_member(
+                    self.master, hostgroup_name, hosts=client_host.hostname)
+            tasks.hbacrule_add(self.master, hbac_rule_name)
+            tasks.hbacrule_add_service(
+                self.master, hbac_rule_name, services='sshd')
+            tasks.hbacrule_add_user(
+                self.master, hbac_rule_name, groups=mapped_posix_group)
+            self.master.run_command([
+                'ipa', 'hbacrule-add-host', hbac_rule_name,
+                f'--hostgroups={hostgroup_first_client}',
+                f'--hostgroups={hostgroup_second_client}',
+            ])
+            tasks.selinuxusermap_add(
+                self.master, selinux_map_name,
+                extra_args=[
+                    f'--selinuxuser={self.SELINUX_STAFF}',
+                    f'--hbacrule={hbac_rule_name}',
+                ])
+            # Secondary trusted user is not in *mapped_posix_group*; with
+            # ``allow_all`` off they still need sshd HBAC.  No selinux map on
+            # this rule so they stay unconfined (not staff).
+            # ``ipa hbacrule-add-user --users=`` only accepts IPA user entries,
+            # not ``user@ad.test`` principals (no such entry).  Use the
+            # secondary user's posix group (``G2`` / ``SG2``) instead.
+            tasks.hbacrule_add(self.master, hbac_ssh_secondary_rule)
+            tasks.hbacrule_add_service(
+                self.master, hbac_ssh_secondary_rule, services='sshd')
+            tasks.hbacrule_add_user(
+                self.master, hbac_ssh_secondary_rule,
+                groups=secondary_hbac_group)
+            self.master.run_command([
+                'ipa', 'hbacrule-add-host', hbac_ssh_secondary_rule,
+                f'--hostgroups={hostgroup_first_client}',
+                f'--hostgroups={hostgroup_second_client}',
+            ])
+            self._sssd_clear_all()
+            self._sssd_prime_trusted_users(
+                (trusted_user_primary, trusted_user_secondary),
+                (first_client, second_client),
+            )
+
+            for ssh_target_host in (first_client, second_client):
+                self._ssh_id_z_assert(
+                    first_client, trusted_user_primary, ssh_target_host,
+                    'staff')
+            self._ssh_id_z_assert(
+                first_client, trusted_user_secondary, first_client,
+                'not_staff')
+
+            tasks.hbacrule_remove_user(
+                self.master, hbac_rule_name, groups=mapped_posix_group)
+            self._sssd_clear_all()
+
+            self._ssh_id_z_assert_denied(
+                first_client, trusted_user_primary, first_client)
+        finally:
+            tasks.kinit_admin(self.master)
+            tasks.selinuxusermap_del(
+                self.master, selinux_map_name, raiseonerr=False)
+            tasks.hostgroup_del(
+                self.master, hostgroup_first_client, raiseonerr=False)
+            tasks.hostgroup_del(
+                self.master, hostgroup_second_client, raiseonerr=False)
+            tasks.hbacrule_del(
+                self.master, hbac_ssh_secondary_rule, raiseonerr=False)
+            tasks.hbacrule_del(self.master, hbac_rule_name, raiseonerr=False)
+            tasks.hbacrule_enable(self.master, 'allow_all')
+
+    def test_ipa_trust_func_selinuxusermap_007(self):
+        """One HBAC rule, two hostgroups (clients 0 and 1); staff map (007*).
+
+        **Verifies (``G1`` / ``SG1``, :meth:`_chain_007`):**
+
+        With ``allow_all`` disabled, one HBAC rule grants ``sshd`` to both
+        hostgroups for members of the posix group; staff map references that
+        rule.
+
+        - ``trusted_user_primary`` client 0 → client 0 and → client 1:
+          staff.
+        - ``trusted_user_secondary`` client 0 → client 0: SSH OK, ``id -Z``
+          **not** staff (user outside mapped group).
+
+        After removing the posix group from the HBAC rule:
+
+        - ``trusted_user_primary`` client 0 → client 0: SSH **denied**.
+
+        Cleanup: hostgroups, map, rule; ``allow_all`` on.  Test ``finally``:
+        ``allow_all`` + SSSD after each suffix.
+        """
+        self._require_selinux_clients()
+        for suffix, mapped_group, user_primary, user_secondary in (
+                ('ad', self.G1, self.testuser1, self.testuser2),
+                ('sub', self.SG1, self.subaduser, self.subdomaintestuser2)):
+            try:
+                self._chain_007(
+                    suffix, mapped_group, user_primary, user_secondary)
+            finally:
+                tasks.kinit_admin(self.master)
+                tasks.hbacrule_enable(self.master, 'allow_all')
+                self._sssd_clear_all()
+
+    def test_ipa_trust_func_selinuxusermap_008(self):
+        """Empty ``ipaselinuxusermapdefault`` → unconfined for trusted users.
+
+        **Verifies:**
+
+        - After ``ipa config-mod --ipaselinuxusermapdefault=`` (empty) and
+          SSSD refresh, from client 0 each of ``aduser``, ``aduser2``,
+          ``subaduser``, ``subaduser2`` SSH to client 0; ``id -Z`` shows
+          ``SELINUX_UNCONFINED_DEFAULT``.
+
+        **``finally``:** config key restored to ``SELINUX_UNCONFINED_DEFAULT``.
+
+        Beaker 008 (empty default selinux user).
+        """
+        self._require_selinux_clients()
+        first_client = self.clients[0]
+        tasks.kinit_admin(self.master)
+        try:
+            self.master.run_command(
+                ['ipa', 'config-mod', '--ipaselinuxusermapdefault='])
+            self._sssd_clear_all()
+
+            trusted_users = (
+                self.testuser1,
+                self.testuser2,
+                self.subaduser,
+                self.subdomaintestuser2,
+            )
+            for trusted_user in trusted_users:
+                self._ssh_id_z_assert(
+                    first_client, trusted_user, first_client, 'unconfined')
+        finally:
+            tasks.kinit_admin(self.master)
+            default = self.SELINUX_UNCONFINED_DEFAULT
+            self.master.run_command([
+                'ipa', 'config-mod',
+                '--ipaselinuxusermapdefault=' + default,
+            ])
+            self._sssd_clear_all()
+
+    def _chain_009(self, suffix, mapped_posix_group,
+                   trusted_user_primary, _trusted_user_secondary):
+        """Three overlapping maps on one host; ``user_u`` wins first (009*).
+
+        Adds xguest, user_u, and guest maps for the same *mapped_posix_group*
+        on the first client.  Expects ``user_u`` to win on that host; on the
+        second client no map applies (unconfined).  Disables the user_u map and
+        expects xguest to take over on the first client.  Deletes all three
+        maps.  *trusted_user_secondary* is unused but kept for a uniform call
+        signature with other chains.
+        """
+        first_client, second_client = self.clients[0], self.clients[1]
+        selinux_map_xguest = f'selinux_umap9a_{suffix}'
+        selinux_map_user_u = f'selinux_umap9b_{suffix}'
+        selinux_map_guest = f'selinux_umap9c_{suffix}'
+        tasks.kinit_admin(self.master)
+        try:
+            for map_name, selinux_user in (
+                    (selinux_map_xguest, self.SELINUX_XGUEST),
+                    (selinux_map_user_u, self.SELINUX_USER_U),
+                    (selinux_map_guest, self.SELINUX_GUEST)):
+                tasks.selinuxusermap_add(
+                    self.master, map_name,
+                    extra_args=[f'--selinuxuser={selinux_user}'])
+                tasks.selinuxusermap_add_user(
+                    self.master, map_name, groups=mapped_posix_group)
+                tasks.selinuxusermap_add_host(
+                    self.master, map_name, hosts=first_client.hostname)
+            self._sssd_clear_all()
+
+            self._ssh_id_z_assert(
+                first_client, trusted_user_primary, first_client, 'user_u')
+            self._ssh_id_z_assert(
+                first_client, trusted_user_primary, second_client,
+                'unconfined')
+
+            tasks.selinuxusermap_disable(self.master, selinux_map_user_u)
+            self._sssd_clear_all()
+
+            self._ssh_id_z_assert(
+                first_client, trusted_user_primary, first_client, 'xguest')
+        finally:
+            tasks.kinit_admin(self.master)
+            for map_name in (
+                    selinux_map_xguest,
+                    selinux_map_user_u,
+                    selinux_map_guest):
+                tasks.selinuxusermap_del(
+                    self.master, map_name, raiseonerr=False)
+
+    def test_ipa_trust_func_selinuxusermap_009(self):
+        """Overlapping selinuxusermaps on one host; precedence (009 / sub).
+
+        **Verifies (``G1`` / ``SG1``, :meth:`_chain_009`):**
+
+        Three maps on client 0 for the same posix group: xguest, user_u,
+        guest (different IPA map names).
+
+        - ``trusted_user_primary`` client 0 → client 0: ``id -Z`` is
+          **user_u** (wins over xguest/guest).
+        - Same user → client 1: **unconfined** (no map there).
+
+        After ``selinuxusermap-disable`` on the user_u map:
+
+        - Same user → client 0: **xguest**.
+
+        All three maps deleted.  Test ``finally``: kinit admin, SSSD clear
+        after each forest/subdomain iteration.
+        """
+        self._require_selinux_clients()
+        for suffix, mapped_group, user_primary, user_secondary in (
+                ('ad', self.G1, self.testuser1, self.testuser2),
+                ('sub', self.SG1, self.subaduser, self.subdomaintestuser2)):
+            try:
+                self._chain_009(
+                    suffix, mapped_group, user_primary, user_secondary)
+            finally:
+                tasks.kinit_admin(self.master)
+                self._sssd_clear_all()


### PR DESCRIPTION
What each test verifies:    
    - Mapping applies only when target host matches (CLIENT1 vs CLIENT2 vs Master)
    - Mapping applies only when target host is Master
    - HBAC rule and selinuxusermap together control access and SELinux context
    - Host-specific selinuxusermap overrides general one when both match
    - Fallback to general map when host-specific map is removed
    - Fallback to default map when general map is removed
    - Fallback to IPA default when default map is removed
    - Hostgroup restricts mapping to hosts in that hostgroup
    - Users get default when removed from selinuxusermap
    - HBAC + selinuxusermap + hostgroup work together
    - Access denied when user group removed from HBAC rule
    - Mapping applies across multiple hostgroups in one HBAC rule
    - Access denied when user group removed from multi-hostgroup HBAC rule
    - AD users get system default when IPA selinuxusermap default is empty
    - Precedence when multiple selinuxusermaps match same user/host
    - Next map applies when leading map is disabled
    
Related : https://pagure.io/freeipa/issue/9845
Assisted-by: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)

## Summary by Sourcery

Add comprehensive integration coverage for SELinux user mapping of AD users in a trust environment and wire it into PR CI on an AD topology.

New Features:
- Introduce SELinux user mapping integration scenarios for AD-trusted users, covering host-specific mappings, HBAC integration, hostgroups, precedence, and fallback behaviors.

CI:
- Add a dedicated AD-based pytest job running the new TestTrustFunctionalSelinuxusermap suite with an extended timeout and AD master + two-client topology.

Tests:
- Add TestTrustFunctionalSelinuxusermap integration test suite validating SELinux context assignment for AD users across masters, clients, hostgroups, HBAC rules, precedence, and default/fallback paths.