### PR TITLE
ipa-migrate: treat objectlass values as case-insensitive

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipaserver/install/ipa_migrate.py
+++ b/ipaserver/install/ipa_migrate.py
@@ -34,6 +34,7 @@ from ipaserver.install.ipa_migrate_constants import (
     STRIP_OP_ATTRS, STRIP_ATTRS, STRIP_OC, PROD_ATTRS,
     DNA_REGEN_VAL, DNA_REGEN_ATTRS, IGNORE_ATTRS,
     DB_EXCLUDE_TREES, POLICY_OP_ATTRS, STATE_OPTIONS, REDACTED_ATTRS,
+    CASE_INSENSITIVE_MATCHING_RULES,
 )
 
 """
@@ -318,6 +319,8 @@ class IPAMigrate():
     local_suffix = None
     log_file_name = LOG_FILE_NAME
     log_file_mode = "a"  # or "w" TBD
+    _case_insensitive_attrs = set()
+    _case_sensitive_attrs = set()
     local_conn = None
     remote_conn = None
     log = logger
@@ -558,6 +561,49 @@ class IPAMigrate():
         if attr_obj is not None:
             if attr_obj.usage == 1:
                 return True
+        return False
+
+    def attr_is_case_insensitive(self, attr):
+        """
+        Check the schema to determine if an attribute uses case-insensitive
+        equality matching. Results are cached in two sets for O(1) lookup
+        on subsequent calls.
+        """
+        attr_lower = attr.lower()
+
+        if attr_lower in self._case_insensitive_attrs:
+            return True
+        if attr_lower in self._case_sensitive_attrs:
+            return False
+
+        result = self._resolve_case_sensitivity(attr)
+        if result:
+            self._case_insensitive_attrs.add(attr_lower)
+        else:
+            self._case_sensitive_attrs.add(attr_lower)
+        return result
+
+    def _resolve_case_sensitivity(self, attr):
+        """
+        Look up the schema to determine if an attribute uses case-insensitive
+        equality matching. Walks the superior attribute type chain if the
+        equality rule is not set directly on the attribute.
+        """
+        schema = self.local_conn.schema
+        if schema is None:
+            return False
+
+        visited = set()
+        attr_name = attr
+        while attr_name and attr_name not in visited:
+            visited.add(attr_name)
+            attr_obj = schema.get_obj(ldap.schema.AttributeType, attr_name)
+            if attr_obj is None:
+                return False
+            if attr_obj.equality:
+                return attr_obj.equality in CASE_INSENSITIVE_MATCHING_RULES
+            # No equality rule set, walk up to the superior type
+            attr_name = attr_obj.sup[0] if attr_obj.sup else None
         return False
 
     def replace_suffix(self, entry_dn):
@@ -1413,7 +1459,13 @@ class IPAMigrate():
                 for val in remote_attrs[attr]:
                     local_attr_vals = self.get_ldapentry_attr_vals(local_entry,
                                                                    attr)
-                    if val not in local_attr_vals:
+                    if self.attr_is_case_insensitive(attr):
+                        val_exists = any(val.lower() == local_val.lower()
+                                         for local_val in local_attr_vals)
+                    else:
+                        val_exists = val in local_attr_vals
+
+                    if not val_exists:
                         # Check if we should reset the DNA range for this entry
                         if (
                             self.args.reset_range

--- a/ipaserver/install/ipa_migrate_constants.py
+++ b/ipaserver/install/ipa_migrate_constants.py
@@ -10,6 +10,16 @@ LOG_FILE_NAME = "/var/log/ipa-migrate.log"
 LDIF_FILE_NAME = "/var/log/ipa-migrate.ldif"
 CONFLICT_FILE_NAME = "/var/log/ipa-migrate-conflict.ldif"
 
+# Matching rules that use case-insensitive comparison
+# We use both names and corresponding OIDs (located on same lines) in one set,
+# since we may get numeric OID in the answer.
+CASE_INSENSITIVE_MATCHING_RULES = {
+    'caseIgnoreMatch', '2.5.13.2',
+    'caseIgnoreIA5Match', '1.3.6.1.4.1.1466.109.114.2',
+    'caseIgnoreListMatch', '2.5.13.11',
+    'objectIdentifierMatch', '2.5.13.0',
+}
+
 # Operational attributes to strip from the remote server
 STRIP_OP_ATTRS = [
     'modifiersname',

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -76,7 +76,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_ipa_ipa_migration.py
+++ b/ipatests/test_integration/test_ipa_ipa_migration.py
@@ -1439,9 +1439,14 @@ class TestIPAMigrationProdMode(MigrationTest):
         assert "test@example.test" in result.stdout_text
         assert "ssh-ed25519" in result.stdout_text
 
-    def test_ipa_migrate_skip_replication_conflicts(self):
-        """
-        Test that ipa-migrate skips replication conflict entries
+    def _migrate_with_modified_ldif(self, ldif_modifier):
+        """Helper method to run migration with a modified LDIF file.
+
+        :param ldif_modifier: A callable that takes ldif_content and returns
+            modified ldif_content
+        :type ldif_modifier: callable
+        :return: Tuple of (result, install_msg)
+        :rtype: tuple
         """
         tasks.kinit_admin(self.master)
         tasks.kinit_admin(self.replicas[0])
@@ -1461,36 +1466,19 @@ class TestIPAMigrationProdMode(MigrationTest):
         # Start IPA back on master
         self.master.run_command(['ipactl', 'start'])
 
-        # Copy LDIF to replica
+        # Get LDIF content
         ldif_content = self.master.get_file_contents(
             ldif_file, encoding="utf-8"
         )
-        replica_ldif = "/tmp/userroot_with_conflict.ldif"
 
-        # Add mocked replication conflict entry to the LDIF
-        users_dn = "cn=users,cn=accounts," + str(self.master.domain.basedn)
-        conflict_entry = textwrap.dedent(
-            """
-            # entry-id: 12345678
-            dn: nsuniqueid=12345678-1234+uid=conflictuser,{users_dn}
-            uid: conflictuser
-            cn: Conflict User
-            uidNumber: 1234
-            gidNumber: 1234
-            sn: User
-            objectClass: top
-            objectClass: person
-            objectClass: inetorgperson
-            objectClass: nsds5replconflict
-            nsds5ReplConflict: namingConflict uid=conflictuser,{users_dn}
+        # Apply modifications
+        modified_ldif = ldif_modifier(ldif_content)
 
-            """
-        ).format(users_dn=users_dn)
-
-        # Append conflict entry to LDIF
-        modified_ldif = ldif_content + conflict_entry
+        # Write modified LDIF to replica
+        replica_ldif = "/tmp/userroot_modified.ldif"
         self.replicas[0].put_file_contents(replica_ldif, modified_ldif)
 
+        # Run migration
         result = run_migrate(
             self.replicas[0],
             "prod-mode",
@@ -1504,8 +1492,127 @@ class TestIPAMigrationProdMode(MigrationTest):
             paths.IPA_MIGRATE_LOG, encoding="utf-8"
         )
 
+        return result, install_msg
+
+    def test_ipa_migrate_skip_replication_conflicts(self):
+        """
+        Test that ipa-migrate skips replication conflict entries
+        """
+        def add_conflict_entry(ldif_content):
+            # Add mocked replication conflict entry to the LDIF
+            users_dn = "cn=users,cn=accounts," + str(self.master.domain.basedn)
+            conflict_entry = textwrap.dedent(
+                """
+                # entry-id: 12345678
+                dn: nsuniqueid=12345678-1234+uid=conflictuser,{users_dn}
+                uid: conflictuser
+                cn: Conflict User
+                uidNumber: 1234
+                gidNumber: 1234
+                sn: User
+                objectClass: top
+                objectClass: person
+                objectClass: inetorgperson
+                objectClass: nsds5replconflict
+                nsds5ReplConflict: namingConflict uid=conflictuser,{users_dn}
+
+                """
+            ).format(users_dn=users_dn)
+            return ldif_content + conflict_entry
+
+        result, install_msg = self._migrate_with_modified_ldif(
+            add_conflict_entry
+        )
+
         assert result.returncode == 0
         assert "Skipping replication conflict entry" in install_msg
+
+    def test_ipa_migrate_case_insensitive_objectclass(self):
+        """
+        Test that ipa-migrate handles case-insensitive objectClass values
+        correctly. LDAP treats objectClass values as case-insensitive
+        (objectIdentifierMatch), so 'ipapwdpolicy' and 'ipaPwdPolicy'
+        should be recognized as the same value and not cause
+        "Type or value exists" errors.
+        """
+        def lowercase_objectclass(ldif_content):
+            # Replace objectClass: ipaPwdPolicy with lowercase version
+            # This simulates a scenario where LDIF has different case
+            # for objectClass values.
+            return ldif_content.replace(
+                'objectClass: ipaPwdPolicy',
+                'objectClass: ipapwdpolicy'
+            )
+
+        result, install_msg = self._migrate_with_modified_ldif(
+            lowercase_objectclass
+        )
+
+        assert result.returncode == 0
+        # Verify no "Type or value exists" error from attempting to add
+        # duplicate objectClass values with different case
+        assert "Type or value exists" not in install_msg
+        assert "Failed to update" not in install_msg
+
+    def test_ipa_migrate_case_insensitive_objectclass_user_entries(self):
+        """
+        Test that case-insensitive objectClass handling works across
+        different entry types, not just password policies. Modifies
+        objectClass values on user entries (inetOrgPerson, posixAccount)
+        to verify schema-based matching rule lookup handles
+        objectIdentifierMatch correctly for any entry type.
+        """
+        def lowercase_user_objectclasses(ldif_content):
+            content = ldif_content.replace(
+                'objectClass: inetOrgPerson',
+                'objectClass: inetorgperson'
+            )
+            content = content.replace(
+                'objectClass: posixAccount',
+                'objectClass: posixaccount'
+            )
+            return content
+
+        result, install_msg = self._migrate_with_modified_ldif(
+            lowercase_user_objectclasses
+        )
+
+        assert result.returncode == 0
+        assert "Type or value exists" not in install_msg
+        assert "Failed to update" not in install_msg
+
+    def test_ipa_migrate_case_insensitive_sn_attribute(self):
+        """
+        Test that ipa-migrate uses schema-based case-insensitive comparison
+        for attributes with caseIgnoreMatch equality rule. The 'sn' attribute
+        inherits caseIgnoreMatch from 'name' via SUP, so the tool should
+        walk the SUP chain, determine it is case-insensitive, and not
+        produce unnecessary updates when only the case differs.
+        """
+        def uppercase_sn(ldif_content):
+            # Change sn values to uppercase for testuser entries.
+            # prepare_ipa_server creates users with --last "User1" etc.,
+            # so the LDIF contains "sn: User1", "sn: User2", etc.
+            for i in range(1, 6):
+                ldif_content = ldif_content.replace(
+                    f'sn: User{i}',
+                    f'sn: USER{i}'
+                )
+            return ldif_content
+
+        result, install_msg = self._migrate_with_modified_ldif(
+            uppercase_sn
+        )
+
+        assert result.returncode == 0
+        # Since sn uses caseIgnoreMatch (via SUP 'name'), 'USER1' and
+        # 'User1' should be recognized as the same value. The tool
+        # should NOT log unnecessary updates for sn attributes.
+        for i in range(1, 6):
+            assert (
+                f"attribute 'sn' replaced with val 'USER{i}'"
+                not in install_msg
+            )
 
 
 class TestIPAMigrationDNSRecords(MigrationTest):


### PR DESCRIPTION
ipa-migrate should treat objectlass values as case-insensitive to update
attribute properly and avoid LDAP errors like 'Type or value exists'

- Behavior fixed
- Added test coverage
- Added helper method to work with modified LDIF for ipa-migrate tests

Fixes: https://pagure.io/freeipa/issue/9961

Signed-off-by: Aleksandr Sharov <asharov@redhat.com>

## Summary by Sourcery

Handle case-insensitive objectClass values during ipa-migrate and add targeted integration coverage for migration edge cases.

Bug Fixes:
- Prevent ipa-migrate from attempting to add duplicate objectClass values that differ only by case, avoiding LDAP 'Type or value exists' errors.

Enhancements:
- Refactor ipa-ipa migration integration tests to use a reusable helper for running migrations with modified LDIF content.

CI:
- Update temporary PR CI configuration to execute the ipa-ipa migration prod-mode test suite with a longer timeout.

Tests:
- Extend ipa-ipa migration integration tests to cover replication conflict skipping via the new helper and to verify correct handling of case-insensitive objectClass values.
- Adjust PR CI temporary definition to run the ipa-ipa migration prod-mode integration tests with an increased timeout.