### PR TITLE
dnssec: fix ipa-ods-exporter crash on empty CKA_ID in SoftHSM

### DIFF
--- a/ipaserver/dnssec/localhsm.py
+++ b/ipaserver/dnssec/localhsm.py
@@ -5,6 +5,7 @@
 from __future__ import print_function, absolute_import
 
 from collections.abc import MutableMapping
+import logging
 import os
 from pprint import pprint
 
@@ -15,6 +16,8 @@ from ipaserver.dnssec.abshsm import (attrs_name2id, attrs_id2name, AbstractHSM,
                                      keytype_id2name, keytype_name2id,
                                      ldap2p11helper_api_params)
 from ipaserver.dnssec.ldapkeydb import str_hexlify
+
+logger = logging.getLogger(__name__)
 
 
 private_key_api_params = set(["label", "id", "data", "unwrapping_key",
@@ -35,17 +38,21 @@ class Key(MutableMapping):
         # sanity check CKA_ID and CKA_LABEL
         try:
             cka_id = self.p11.get_attribute(handle, _ipap11helper.CKA_ID)
-            assert len(cka_id) != 0, 'ipk11id length should not be 0'
         except _ipap11helper.NotFound:
-            raise _ipap11helper.NotFound('key without ipk11id: handle %s' % handle)
+            raise _ipap11helper.NotFound(
+                'key without ipk11id: handle %s' % handle)
+        if len(cka_id) == 0:
+            raise _ipap11helper.NotFound(
+                'key with empty ipk11id: handle %s' % handle)
 
         try:
             cka_label = self.p11.get_attribute(handle, _ipap11helper.CKA_LABEL)
-            assert len(cka_label) != 0, 'ipk11label length should not be 0'
-
         except _ipap11helper.NotFound:
             raise _ipap11helper.NotFound(
                 'key without ipk11label: id 0x%s' % str_hexlify(cka_id))
+        if len(cka_label) == 0:
+            raise _ipap11helper.NotFound(
+                'key with empty ipk11label: id 0x%s' % str_hexlify(cka_id))
 
     def __getitem__(self, key):
         key = key.lower()
@@ -96,7 +103,8 @@ class LocalHSM(AbstractHSM):
         self.p11 = _ipap11helper.P11_Helper(label, pin, library)
 
     def __del__(self):
-        self.p11.finalize()
+        if hasattr(self, 'p11'):
+            self.p11.finalize()
 
     def find_keys(self, **kwargs):
         """Return dict with Key objects matching given criteria.
@@ -111,7 +119,11 @@ class LocalHSM(AbstractHSM):
         handles = self.p11.find_keys(**kwargs)
         keys = {}
         for h in handles:
-            key = Key(self.p11, h)
+            try:
+                key = Key(self.p11, h)
+            except _ipap11helper.NotFound as e:
+                logger.warning('Skipping PKCS#11 object: %s', e)
+                continue
             o_id = key['ipk11id']
             assert o_id not in keys, 'duplicate ipk11Id = 0x%s; keys = %s' % (
                     str_hexlify(o_id), keys)


### PR DESCRIPTION
## Summary

`ipa-ods-exporter` enters an infinite crash loop after enabling DNSSEC
via `ipa-dns-install --dnssec-master`. The crash is caused by a bare
`assert` in `localhsm.py:Key.__init__()` that fires when SoftHSM
contains PKCS#11 objects with zero-length CKA_ID (ipk11id).

FreeIPA's DNSSEC setup creates `ipaSecretKeyObject` LDAP entries
(wrapped master key copies) without setting `ipk11Id`. When
`ipa-dnskeysyncd` syncs these to SoftHSM, the objects get empty
CKA_ID attributes. The `AssertionError` is uncatchable by
`find_keys()`, so one malformed key crashes the entire key
enumeration, making all valid keys in the token inaccessible.

Reproduced on FreeIPA 4.12.2-24.el10 (AlmaLinux 10) on a fresh
3-replica topology. Cleaning SoftHSM tokens and re-running
`--dnssec-master` reproduces the same crash — the bug is in the
setup code path, not stale data.

An identical crash was reported on the freeipa-users mailing list
in April 2024 (FreeIPA 4.10.2 / AlmaLinux 9.3) and went unanswered.
The assertion is unchanged on upstream `master`.

## Changes

- Replace bare `assert` in `Key.__init__()` with
  `_ipap11helper.NotFound` exception for empty CKA_ID and CKA_LABEL,
  matching the existing pattern for missing attributes
- Add try/except in `find_keys()` to log a warning and skip malformed
  PKCS#11 objects instead of crashing the enumeration
- Guard `LocalHSM.__del__()` against `AttributeError` when
  `__init__()` fails before `self.p11` is assigned
- Add `logging` import (consistent with `abshsm.py` and other modules
  in the package)

The LDAP counterpart `ldapkeydb.py:_get_key_dict()` already handles
missing `ipk11Id` gracefully with `raise ValueError`; this aligns the
SoftHSM side with that existing pattern.

## Traceback

```
File "/usr/libexec/ipa/ipa-ods-exporter", line 720
  master2ldap_zone_keys_sync(ldapkeydb, localhsm)
File "/usr/libexec/ipa/ipa-ods-exporter", line 425
  pubkeys_local = localhsm.zone_pubkeys
File "ipaserver/dnssec/localhsm.py", line 114, in find_keys
  key = Key(self.p11, h)
File "ipaserver/dnssec/localhsm.py", line 38, in __init__
  assert len(cka_id) != 0, 'ipk11id length should not be 0'
AssertionError: ipk11id length should not be 0
```

## Note on root cause

This patch is defensive — it prevents the crash regardless of how
malformed keys end up in SoftHSM. The deeper root cause (why
`ipa-dns-install --dnssec-master` creates LDAP entries without
`ipk11Id`) is a separate issue tracked in the Pagure ticket.

Fixes: https://pagure.io/freeipa/issue/9969

## Summary by Sourcery

Handle malformed PKCS#11 objects in DNSSEC local HSM key enumeration to prevent ipa-ods-exporter crashes when encountering empty CKA_ID or CKA_LABEL in SoftHSM.

Bug Fixes:
- Treat empty CKA_ID and CKA_LABEL attributes like missing values and raise a NotFound error instead of asserting, avoiding uncatchable AssertionError crashes.
- Skip malformed PKCS#11 objects during key enumeration while logging a warning, so valid keys remain accessible and ipa-ods-exporter no longer enters a crash loop.
- Guard LocalHSM cleanup against AttributeError when initialization fails before the PKCS#11 helper is created.

Enhancements:
- Add a module-level logger for localhsm to emit warnings about malformed PKCS#11 objects.