### PR TITLE
[Backport][ipa-4-13] ipatests: fix migration test

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-13_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-13_latest.yaml
@@ -2168,9 +2168,21 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest-ipa-4-13/build_url}'
-        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationDNSRecords
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode
         template: *ci-ipa-4-13-latest
         timeout: 9000
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-13/test_IPAMigrate_dns:
+    requires: [fedora-latest-ipa-4-13/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-13/build_url}'
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrationDNSRecords
+        template: *ci-ipa-4-13-latest
+        timeout: 3600
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-13/test_IPAMigrateADTrust:

--- a/ipatests/prci_definitions/nightly_ipa-4-13_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-13_latest_selinux.yaml
@@ -2341,9 +2341,22 @@ jobs:
       args:
         build_url: '{fedora-latest-ipa-4-13/build_url}'
         selinux_enforcing: True
-        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationDNSRecords
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode
         template: *ci-ipa-4-13-latest
         timeout: 9000
+        topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-13/test_IPAMigrate_dns:
+    requires: [fedora-latest-ipa-4-13/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-13/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrationDNSRecords
+        template: *ci-ipa-4-13-latest
+        timeout: 3600
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-13/test_IPAMigrateADTrust:

--- a/ipatests/test_integration/test_ipa_ipa_migration.py
+++ b/ipatests/test_integration/test_ipa_ipa_migration.py
@@ -26,6 +26,7 @@ TEST_SSHKEY = (
 # Expected SSH key fingerprint for TEST_SSHKEY
 TEST_SSHKEY_FP = "SHA256:PSDEIT8MJGMMLpyjFS1oFNcnPNB1cWf10LeJGyI2h7M"
 
+TEST_ZONE_FORWARDER = "10.11.12.13"
 
 def prepare_ipa_server(master):
     """
@@ -265,7 +266,7 @@ def prepare_ipa_server(master):
             "dnsforwardzone-add",
             "forwardzone.test",
             "--forwarder",
-            "192.168.124.10",
+            TEST_ZONE_FORWARDER,
         ]
     )
 
@@ -885,7 +886,7 @@ class TestIPAMigrateCLIOptions(MigrationTest):
         )
         assert 'Zone name: {}'.format(zone_name) in result.stdout_text
         assert 'Active zone: True' in result.stdout_text
-        assert 'Zone forwarders: 10.11.12.13' in result.stdout_text
+        assert f'Zone forwarders: {TEST_ZONE_FORWARDER}' in result.stdout_text
         assert 'Forward policy: first' in result.stdout_text
 
     def test_ipa_migrate_version_option(self):


### PR DESCRIPTION
This is a manual backport of PR #8290 to ipa-4-13 branch.

The pr ci definitions had to be manually adapted.

## Summary by Sourcery

Adjust IPA migration integration tests and their CI jobs for the ipa-4-13 branch.

Tests:
- Split the IPA migration DNS records test into a dedicated CI job with its own timeout and configuration in nightly ipa-4-13 pipelines.
- Update the DNS forward zone migration test to use a shared test forwarder constant for configuring and asserting the zone forwarder.