### PR TITLE
[Backport][ipa-4-12] ipatests: fix migration test

### DIFF
--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest.yaml
@@ -2166,9 +2166,22 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest-ipa-4-12/build_url}'
-        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationDNSRecords
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode
         template: *ci-ipa-4-12-latest
         timeout: 9000
+        topology: *master_1repl_1client
+
+
+  fedora-latest-ipa-4-12/test_IPAMigrate_dns:
+    requires: [fedora-latest-ipa-4-12/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-12/build_url}'
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrationDNSRecords
+        template: *ci-ipa-4-12-latest
+        timeout: 3600
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-12/test_IPAMigrate_mixedmode:

--- a/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-12_latest_selinux.yaml
@@ -2339,9 +2339,23 @@ jobs:
       args:
         build_url: '{fedora-latest-ipa-4-12/build_url}'
         selinux_enforcing: True
-        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationDNSRecords
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrateCLIOptions test_integration/test_ipa_ipa_migration.py::TestIPAMigrationStageMode test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode
         template: *ci-ipa-4-12-latest
         timeout: 9000
+        topology: *master_1repl_1client
+
+
+  fedora-latest-ipa-4-12/test_IPAMigrate_dns:
+    requires: [fedora-latest-ipa-4-12/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-12/build_url}'
+        selinux_enforcing: True
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigrationDNSRecords
+        template: *ci-ipa-4-12-latest
+        timeout: 3600
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-12/test_IPAMigrate_mixedmode:

--- a/ipatests/test_integration/test_ipa_ipa_migration.py
+++ b/ipatests/test_integration/test_ipa_ipa_migration.py
@@ -26,6 +26,7 @@ TEST_SSHKEY = (
 # Expected SSH key fingerprint for TEST_SSHKEY
 TEST_SSHKEY_FP = "SHA256:PSDEIT8MJGMMLpyjFS1oFNcnPNB1cWf10LeJGyI2h7M"
 
+TEST_ZONE_FORWARDER = "10.11.12.13"
 
 # Extdom extop plugin cn=config (TestIPAMigrationPluginsMigrated)
 EXTDOM_EXTOP_PLUGIN_DN = "cn=ipa_extdom_extop,cn=plugins,cn=config"
@@ -272,7 +273,7 @@ def prepare_ipa_server(master):
             "dnsforwardzone-add",
             "forwardzone.test",
             "--forwarder",
-            "192.168.124.10",
+            TEST_ZONE_FORWARDER,
         ]
     )
 
@@ -893,7 +894,7 @@ class TestIPAMigrateCLIOptions(MigrationTest):
         )
         assert 'Zone name: {}'.format(zone_name) in result.stdout_text
         assert 'Active zone: True' in result.stdout_text
-        assert 'Zone forwarders: 10.11.12.13' in result.stdout_text
+        assert f'Zone forwarders: {TEST_ZONE_FORWARDER}' in result.stdout_text
         assert 'Forward policy: first' in result.stdout_text
 
     def test_ipa_migrate_version_option(self):


### PR DESCRIPTION
This is a manual backport of PR https://github.com/freeipa/freeipa/pull/8290 to ipa-4-12 branch.

The pr ci definitions had to be manually adapted.

## Summary by Sourcery

Adjust IPA migration DNS forwarder test configuration and CI jobs for the ipa-4-12 branch.

CI:
- Modify nightly ipa-4-12 SELinux and non-SELinux PR CI definitions to run the DNS migration test in an isolated job.

Tests:
- Split the IPA migration DNS records test into a separate CI job with its own timeout in nightly ipa-4-12 workflows.
- Update the IPA DNS forwardzone migration test to use a shared forwarder constant for configuration and assertions.