### PR TITLE
Add CSP headers to webui

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -684,6 +684,7 @@ AC_CONFIG_FILES([
     install/ui/Makefile
     install/ui/css/Makefile
     install/ui/src/Makefile
+    install/ui/src/inline/Makefile
     install/ui/src/libs/Makefile
     install/ui/images/Makefile
     install/ui/build/Makefile

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1751,6 +1751,8 @@ fi
 %dir %{_usr}/share/ipa/ui/css
 %{_usr}/share/ipa/ui/css/*.css
 %dir %{_usr}/share/ipa/ui/js
+%dir %{_usr}/share/ipa/ui/js/inline
+%{_usr}/share/ipa/ui/js/inline/*.js
 %dir %{_usr}/share/ipa/ui/js/dojo
 %{_usr}/share/ipa/ui/js/dojo/dojo.js
 %dir %{_usr}/share/ipa/ui/js/libs

--- a/install/html/ssbrowser.html
+++ b/install/html/ssbrowser.html
@@ -4,65 +4,7 @@
 <meta charset="utf-8">
     <title>Identity Management</title>
     <script type="text/javascript" src="../ui/js/libs/loader.js"></script>
-    <script type="text/javascript">
-        var dojoConfig = {
-            baseUrl: "../ui/js",
-            has: {
-                'dojo-firebug': false,
-                'dojo-debug-messages': true
-            },
-            parseOnLoad: false,
-            async: true,
-            packages: [
-                {
-                    name:'dojo',
-                    location:'dojo'
-                },
-                {
-                    name: 'freeipa',
-                    location: 'freeipa'
-                }
-            ]
-        };
-        (function() {
-            var icons = [
-                '../ui/favicon.ico'
-            ];
-            var styles = [
-                '../ui/css/patternfly.css',
-                '../ui/css/ipa.css'
-            ];
-            var scripts = [
-                '../ui/js/libs/jquery.js',
-                '../ui/js/libs/jquery.ordered-map.js',
-                '../ui/js/dojo/dojo.js'
-            ];
-            ipa_loader.scripts(scripts, function() {
-                require([
-                    'dojo/dom',
-                    'freeipa/core',
-                    'dojo/domReady!'
-                    ],
-                    function(dom) {
-                        var text = require('freeipa/text');
-                        var msg = "".concat(
-                            text.get('@i18n:ssbrowser-page.header'),
-                            text.get('@i18n:ssbrowser-page.firefox-header'),
-                            text.get('@i18n:ssbrowser-page.firefox-actions'),
-                            text.get('@i18n:ssbrowser-page.chrome-header'),
-                            text.get('@i18n:ssbrowser-page.chrome-certificate'),
-                            text.get('@i18n:ssbrowser-page.chrome-spnego'),
-                            text.get('@i18n:ssbrowser-page.ie-header'),
-                            text.get('@i18n:ssbrowser-page.ie-actions')
-                        );
-                        dom.byId('ssbrowser-msg').innerHTML=msg;
-                    });
-            });
-            ipa_loader.styles(styles);
-            ipa_loader.icons(icons);
-        })();
-    </script>
-
+    <script type="text/javascript" src="../ui/js/inline/ssbrowser_inline.js"></script>
 </head>
 
 <body class="info-page">

--- a/install/html/unauthorized.html
+++ b/install/html/unauthorized.html
@@ -4,58 +4,7 @@
     <meta charset="utf-8">
     <title>Identity Management</title>
     <script type="text/javascript" src="../ui/js/libs/loader.js"></script>
-    <script type="text/javascript">
-        var dojoConfig = {
-            baseUrl: "../ui/js",
-            has: {
-                'dojo-firebug': false,
-                'dojo-debug-messages': true
-            },
-            parseOnLoad: false,
-            async: true,
-            packages: [
-                {
-                    name:'dojo',
-                    location:'dojo'
-                },
-                {
-                    name: 'freeipa',
-                    location: 'freeipa'
-                }
-            ]
-        };
-        (function() {
-            var icons = [
-                '../ui/favicon.ico'
-            ];
-            var styles = [
-                '../ui/css/patternfly.css',
-                '../ui/css/ipa.css'
-            ];
-            var scripts = [
-                '../ui/js/libs/jquery.js',
-                '../ui/js/libs/jquery.ordered-map.js',
-                '../ui/js/dojo/dojo.js'
-            ];
-
-            ipa_loader.scripts(scripts, function() {
-                require([
-                    'dojo/dom',
-                    'freeipa/core',
-                    'dojo/domReady!'
-                    ],
-                    function(dom) {
-                        var text = require('freeipa/text');
-                        var msg = text.get('@i18n:unauthorized-page');
-                        if (msg) {
-                            dom.byId('unauthorized-msg').innerHTML=msg;
-                        }
-                    });
-            });
-            ipa_loader.styles(styles);
-            ipa_loader.icons(icons);
-        })();
-    </script>
+    <script type="text/javascript" src="../ui/js/inline/unauthorized_inline.js"></script>
 </head>
 
 <body class="info-page">

--- a/install/html/unauthorized.html
+++ b/install/html/unauthorized.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="utf-8">
     <title>Identity Management</title>
-    <script type="text/javascript" src="../ui/js/libs/loader.js"></script>
-    <script type="text/javascript" src="../ui/js/inline/unauthorized_inline.js"></script>
+    <script type="text/javascript" src="./ui/js/libs/loader.js"></script>
+    <script type="text/javascript" src="./ui/js/inline/unauthorized_inline.js"></script>
 </head>
 
 <body class="info-page">
 
     <nav class="navbar navbar-default navbar-pf" role="navigation">
     <div class="navbar-header">
-        <a class="brand" href="../ui/index.html"><img src="../ui/images/header-logo.png" alt="Identity Management"></a>
+        <a class="brand" href="./ui/index.html"><img src="./ui/images/header-logo.png" alt="Identity Management"></a>
     </div>
     </nav>
 
@@ -30,7 +30,7 @@
 
         <div id="first-time">
             <p>
-                If this is your first time, please <a href="ssbrowser.html">configure your browser</a>.
+                If this is your first time, please <a href="./config/ssbrowser.html">configure your browser</a>.
             </p>
         </div>
     </noscript>

--- a/install/migration/index.html
+++ b/install/migration/index.html
@@ -11,55 +11,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <base href="../ui/" target="_blank">
     <script type="text/javascript" src="../ui/js/libs/loader.js"></script>
-    <script type="text/javascript">
-        var dojoConfig = {
-            baseUrl: "js",
-            has: {
-                'dojo-firebug': false,
-                'dojo-debug-messages': true
-            },
-            parseOnLoad: false,
-            async: true,
-            packages: [
-                {
-                    name:'dojo',
-                    location:'dojo'
-                },
-                {
-                    name: 'freeipa',
-                    location: 'freeipa'
-                }
-            ],
-            cacheBust: ipa_loader.num_version || ""
-        };
-
-        (function() {
-            var ie = !!document.getElementById('ie-detector');
-            var styles = [
-		    'css/patternfly.css',
-		    'css/ipa.css',
-		    'ipa.css'
-	    ];
-            if (ie) styles.push('ie.css');
-            var icons = ['favicon.ico'];
-            var scripts = [
-                'js/libs/jquery.js',
-                'js/libs/jquery.ordered-map.js',
-                'js/dojo/dojo.js'
-            ];
-            ipa_loader.scripts(scripts, function() {
-                require([
-                    'freeipa/core',
-                    'dojo/domReady!'
-                    ], function(app) {
-                        app.run_simple('migrate');
-                    });
-            });
-            ipa_loader.styles(styles);
-            ipa_loader.icons(icons);
-
-	})();
-    </script>
+    <script type="text/javascript" src="../ui/js/inline/migration_inline.js"></script>
 </head>
 
 <body>

--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 37 - DO NOT REMOVE THIS LINE
+# VERSION 38 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -85,8 +85,8 @@ ServerTokens Prod
   Require valid-user
   ErrorDocument 401 /ipa/errors/unauthorized.html
   Header always append X-Frame-Options DENY
-  Header always append Content-Security-Policy "frame-ancestors 'none'"
   Header always set X-Content-Type-Options "nosniff"
+  Header setifempty Content-Security-Policy "upgrade-insecure-requests; frame-ancestors 'none'; default-src 'none'; img-src 'self' data:; font-src 'self'; connect-src 'self'; form-action 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'"
 
   # mod_session always sets two copies of the cookie, and this confuses our
   # legacy clients, the unset here works because it ends up unsetting only one
@@ -223,6 +223,7 @@ Alias /ipa/modern-ui "/usr/share/ipa/modern-ui"
   RewriteRule ^(.*)/assets/(.*)$$ assets/$$2 [L]
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteRule ^ index.html [QSA,L]
+  Header set Content-Security-Policy "upgrade-insecure-requests; frame-ancestors 'none'; default-src 'none'; img-src 'self' data:; font-src 'self'; connect-src 'self'; form-action 'self'; style-src 'self'; script-src 'self'"
 </Directory>
 
 #  Simple wsgi scripts required by ui

--- a/install/ui/index.html
+++ b/install/ui/index.html
@@ -10,62 +10,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script type="text/javascript" src="js/libs/loader.js"></script>
-    <script type="text/javascript">
-
-        var dojoConfig = {
-            baseUrl: "js",
-            has: {
-                'dojo-firebug': false,
-                'dojo-debug-messages': true
-            },
-            parseOnLoad: false,
-            async: true,
-            packages: [
-                {
-                    name: 'libs',
-                    location: 'libs'
-                },
-                {
-                    name:'dojo',
-                    location:'dojo'
-                },
-                {
-                    name: 'freeipa',
-                    location: 'freeipa'
-                }
-            ],
-            cacheBust: ipa_loader.num_version || ""
-        };
-
-        (function() {
-            var ie = !!document.getElementById('ie-detector');
-            var styles = [
-                'css/patternfly.css',
-                'css/bootstrap-datepicker3.min.css',
-                'css/ipa.css',
-                'ipa.css'
-            ];
-            if (ie) styles.push('ie.css');
-            var icons = ['favicon.ico'];
-            var scripts = [
-                'js/libs/json2.js',
-                'js/libs/jquery.js',
-                'js/libs/bootstrap.js',
-                'js/libs/bootstrap-datepicker.js',
-                'js/libs/patternfly.js',
-                'js/libs/jquery.ordered-map.js',
-                'js/libs/browser.js',
-                'js/dojo/dojo.js',
-                'js/libs/qrcode.js'
-            ];
-            ipa_loader.scripts(scripts, function() {
-                require(['freeipa/app'], function(app){ app.run(); });
-            });
-            ipa_loader.styles(styles);
-            ipa_loader.icons(icons);
-
-        })();
-    </script>
+    <script type="text/javascript" src="js/inline/ipa_inline.js"></script>
 </head>
 
 <body>

--- a/install/ui/js/inline
+++ b/install/ui/js/inline
@@ -1,0 +1,1 @@
+../src/inline/

--- a/install/ui/reset_password.html
+++ b/install/ui/reset_password.html
@@ -10,58 +10,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script type="text/javascript" src="js/libs/loader.js"></script>
-    <script type="text/javascript">
-
-        var dojoConfig = {
-            baseUrl: "js",
-            has: {
-                'dojo-firebug': false,
-                'dojo-debug-messages': true
-            },
-            parseOnLoad: false,
-            async: true,
-            packages: [
-                {
-                    name:'dojo',
-                    location:'dojo'
-                },
-                {
-                    name: 'freeipa',
-                    location: 'freeipa'
-                }
-            ],
-            cacheBust: ipa_loader.num_version || ""
-        };
-
-        (function() {
-            var ie = !!document.getElementById('ie-detector');
-            var styles = [
-                'css/patternfly.css',
-                'css/ipa.css',
-                'ipa.css'
-            ];
-            if (ie) styles.push('ie.css');
-            var icons = ['favicon.ico'];
-            var scripts = [
-                'js/libs/json2.js',
-                'js/libs/jquery.js',
-                'js/libs/bootstrap.js',
-                'js/libs/jquery.ordered-map.js',
-                'js/libs/browser.js',
-                'js/dojo/dojo.js'
-            ];
-            ipa_loader.scripts(scripts, function() {
-                require(['freeipa/core', 'dojo/domReady!'], function(app) {
-                    var reset_pass = require('freeipa/plugins/login');
-                    reset_pass.facet_spec.widgets[1].view = "reset";
-                    app.run_simple('login');
-                });
-            });
-            ipa_loader.styles(styles);
-            ipa_loader.icons(icons);
-
-        })();
-    </script>
+    <script type="text/javascript" src="js/inline/reset_password_inline.js"></script>
 </head>
 
 <body>

--- a/install/ui/src/Makefile.am
+++ b/install/ui/src/Makefile.am
@@ -3,6 +3,7 @@ AUTOMAKE_OPTIONS = 1.7
 NULL =
 
 SUBDIRS =  				\
+	inline				\
 	libs				\
 	$(NULL)
 

--- a/install/ui/src/inline/Makefile.am
+++ b/install/ui/src/inline/Makefile.am
@@ -1,0 +1,15 @@
+NULL =
+
+appdir = $(IPA_DATA_DIR)/ui/js/inline
+app_DATA =				\
+	ipa_inline.js			\
+	migration_inline.js		\
+	reset_password_inline.js	\
+	ssbrowser_inline.js		\
+	sync_otp_inline.js		\
+	unauthorized_inline.js		\
+	$(NULL)
+
+EXTRA_DIST =				\
+	$(app_DATA)			\
+	$(NULL)

--- a/install/ui/src/inline/ipa_inline.js
+++ b/install/ui/src/inline/ipa_inline.js
@@ -1,0 +1,52 @@
+var dojoConfig = {
+    baseUrl: "js",
+    has: {
+        'dojo-firebug': false,
+        'dojo-debug-messages': true
+    },
+    parseOnLoad: false,
+    async: true,
+    packages: [
+        {
+            name: 'libs',
+            location: 'libs'
+        },
+        {
+            name:'dojo',
+            location:'dojo'
+        },
+        {
+            name: 'freeipa',
+            location: 'freeipa'
+        }
+    ],
+    cacheBust: ipa_loader.num_version || ""
+};
+
+(function() {
+    var ie = !!document.getElementById('ie-detector');
+    var styles = [
+        'css/patternfly.css',
+        'css/bootstrap-datepicker3.min.css',
+        'css/ipa.css',
+        'ipa.css'
+    ];
+    if (ie) styles.push('ie.css');
+    var icons = ['favicon.ico'];
+    var scripts = [
+        'js/libs/json2.js',
+        'js/libs/jquery.js',
+        'js/libs/bootstrap.js',
+        'js/libs/bootstrap-datepicker.js',
+        'js/libs/patternfly.js',
+        'js/libs/jquery.ordered-map.js',
+        'js/libs/browser.js',
+        'js/dojo/dojo.js',
+        'js/libs/qrcode.js'
+    ];
+    ipa_loader.scripts(scripts, function() {
+        require(['freeipa/app'], function(app){ app.run(); });
+    });
+    ipa_loader.styles(styles);
+    ipa_loader.icons(icons);
+})();

--- a/install/ui/src/inline/migration_inline.js
+++ b/install/ui/src/inline/migration_inline.js
@@ -1,0 +1,47 @@
+var dojoConfig = {
+    baseUrl: "js",
+    has: {
+        'dojo-firebug': false,
+        'dojo-debug-messages': true
+    },
+    parseOnLoad: false,
+    async: true,
+    packages: [
+        {
+            name:'dojo',
+            location:'dojo'
+        },
+        {
+            name: 'freeipa',
+            location: 'freeipa'
+        }
+    ],
+    cacheBust: ipa_loader.num_version || ""
+};
+
+(function() {
+    var ie = !!document.getElementById('ie-detector');
+    var styles = [
+        'css/patternfly.css',
+        'css/ipa.css',
+        'ipa.css'
+    ];
+    if (ie) styles.push('ie.css');
+    var icons = ['favicon.ico'];
+    var scripts = [
+        'js/libs/jquery.js',
+        'js/libs/jquery.ordered-map.js',
+        'js/dojo/dojo.js'
+    ];
+    ipa_loader.scripts(scripts, function() {
+        require([
+            'freeipa/core',
+            'dojo/domReady!'
+            ], function(app) {
+                app.run_simple('migrate');
+            });
+    });
+    ipa_loader.styles(styles);
+    ipa_loader.icons(icons);
+
+})();

--- a/install/ui/src/inline/reset_password_inline.js
+++ b/install/ui/src/inline/reset_password_inline.js
@@ -1,0 +1,48 @@
+var dojoConfig = {
+    baseUrl: "js",
+    has: {
+        'dojo-firebug': false,
+        'dojo-debug-messages': true
+    },
+    parseOnLoad: false,
+    async: true,
+    packages: [
+        {
+            name:'dojo',
+            location:'dojo'
+        },
+        {
+            name: 'freeipa',
+            location: 'freeipa'
+        }
+    ],
+    cacheBust: ipa_loader.num_version || ""
+};
+
+(function() {
+    var ie = !!document.getElementById('ie-detector');
+    var styles = [
+        'css/patternfly.css',
+        'css/ipa.css',
+        'ipa.css'
+    ];
+    if (ie) styles.push('ie.css');
+    var icons = ['favicon.ico'];
+    var scripts = [
+        'js/libs/json2.js',
+        'js/libs/jquery.js',
+        'js/libs/bootstrap.js',
+        'js/libs/jquery.ordered-map.js',
+        'js/libs/browser.js',
+        'js/dojo/dojo.js'
+    ];
+    ipa_loader.scripts(scripts, function() {
+        require(['freeipa/core', 'dojo/domReady!'], function(app) {
+            var reset_pass = require('freeipa/plugins/login');
+            reset_pass.facet_spec.widgets[1].view = "reset";
+            app.run_simple('login');
+        });
+    });
+    ipa_loader.styles(styles);
+    ipa_loader.icons(icons);
+})();

--- a/install/ui/src/inline/ssbrowser_inline.js
+++ b/install/ui/src/inline/ssbrowser_inline.js
@@ -1,0 +1,56 @@
+var dojoConfig = {
+    baseUrl: "../ui/js",
+    has: {
+        'dojo-firebug': false,
+        'dojo-debug-messages': true
+    },
+    parseOnLoad: false,
+    async: true,
+    packages: [
+        {
+            name:'dojo',
+            location:'dojo'
+        },
+        {
+            name: 'freeipa',
+            location: 'freeipa'
+        }
+    ]
+};
+(function() {
+    var icons = [
+        '../ui/favicon.ico'
+    ];
+    var styles = [
+        '../ui/css/patternfly.css',
+        '../ui/css/ipa.css'
+    ];
+    var scripts = [
+        '../ui/js/libs/jquery.js',
+        '../ui/js/libs/jquery.ordered-map.js',
+        '../ui/js/dojo/dojo.js'
+    ];
+    ipa_loader.scripts(scripts, function() {
+        require([
+            'dojo/dom',
+            'freeipa/core',
+            'dojo/domReady!'
+            ],
+            function(dom) {
+                var text = require('freeipa/text');
+                var msg = "".concat(
+                    text.get('@i18n:ssbrowser-page.header'),
+                    text.get('@i18n:ssbrowser-page.firefox-header'),
+                    text.get('@i18n:ssbrowser-page.firefox-actions'),
+                    text.get('@i18n:ssbrowser-page.chrome-header'),
+                    text.get('@i18n:ssbrowser-page.chrome-certificate'),
+                    text.get('@i18n:ssbrowser-page.chrome-spnego'),
+                    text.get('@i18n:ssbrowser-page.ie-header'),
+                    text.get('@i18n:ssbrowser-page.ie-actions')
+                );
+                dom.byId('ssbrowser-msg').innerHTML=msg;
+            });
+    });
+    ipa_loader.styles(styles);
+    ipa_loader.icons(icons);
+})();

--- a/install/ui/src/inline/sync_otp_inline.js
+++ b/install/ui/src/inline/sync_otp_inline.js
@@ -1,0 +1,44 @@
+var dojoConfig = {
+    baseUrl: "js",
+    has: {
+        'dojo-firebug': false,
+        'dojo-debug-messages': true
+    },
+    parseOnLoad: false,
+    async: true,
+    packages: [
+        {
+            name:'dojo',
+            location:'dojo'
+        },
+        {
+            name: 'freeipa',
+            location: 'freeipa'
+        }
+    ],
+    cacheBust: ipa_loader.num_version || ""
+};
+
+(function() {
+    var ie = !!document.getElementById('ie-detector');
+    var styles = ['css/patternfly.css', 'css/ipa.css', 'ipa.css'];
+    if (ie) styles.push('ie.css');
+    var icons = ['favicon.ico'];
+    var scripts = [
+        'js/libs/json2.js',
+        'js/libs/jquery.js',
+        'js/libs/bootstrap.js',
+        'js/libs/jquery.ordered-map.js',
+        'js/libs/browser.js',
+        'js/dojo/dojo.js'
+    ];
+    ipa_loader.scripts(scripts, function() {
+        require(['freeipa/core', 'dojo/domReady!'], function(app) {
+            var sync = require('freeipa/plugins/sync_otp');
+            sync.facet_spec.widgets[1].allow_cancel = false;
+            app.run_simple('sync-otp');
+        });
+    });
+    ipa_loader.styles(styles);
+    ipa_loader.icons(icons);
+})();

--- a/install/ui/src/inline/unauthorized_inline.js
+++ b/install/ui/src/inline/unauthorized_inline.js
@@ -1,0 +1,50 @@
+var dojoConfig = {
+    baseUrl: "../ui/js",
+    has: {
+        'dojo-firebug': false,
+        'dojo-debug-messages': true
+    },
+    parseOnLoad: false,
+    async: true,
+    packages: [
+        {
+            name:'dojo',
+            location:'dojo'
+        },
+        {
+            name: 'freeipa',
+            location: 'freeipa'
+        }
+    ]
+};
+(function() {
+    var icons = [
+        '../ui/favicon.ico'
+    ];
+    var styles = [
+        '../ui/css/patternfly.css',
+        '../ui/css/ipa.css'
+    ];
+    var scripts = [
+        '../ui/js/libs/jquery.js',
+        '../ui/js/libs/jquery.ordered-map.js',
+        '../ui/js/dojo/dojo.js'
+    ];
+
+    ipa_loader.scripts(scripts, function() {
+        require([
+            'dojo/dom',
+            'freeipa/core',
+            'dojo/domReady!'
+            ],
+            function(dom) {
+                var text = require('freeipa/text');
+                var msg = text.get('@i18n:unauthorized-page');
+                if (msg) {
+                    dom.byId('unauthorized-msg').innerHTML=msg;
+                }
+            });
+    });
+    ipa_loader.styles(styles);
+    ipa_loader.icons(icons);
+})();

--- a/install/ui/src/inline/unauthorized_inline.js
+++ b/install/ui/src/inline/unauthorized_inline.js
@@ -1,5 +1,5 @@
 var dojoConfig = {
-    baseUrl: "../ui/js",
+    baseUrl: "./ui/js",
     has: {
         'dojo-firebug': false,
         'dojo-debug-messages': true
@@ -19,16 +19,16 @@ var dojoConfig = {
 };
 (function() {
     var icons = [
-        '../ui/favicon.ico'
+        './ui/favicon.ico'
     ];
     var styles = [
-        '../ui/css/patternfly.css',
-        '../ui/css/ipa.css'
+        './ui/css/patternfly.css',
+        './ui/css/ipa.css'
     ];
     var scripts = [
-        '../ui/js/libs/jquery.js',
-        '../ui/js/libs/jquery.ordered-map.js',
-        '../ui/js/dojo/dojo.js'
+        './ui/js/libs/jquery.js',
+        './ui/js/libs/jquery.ordered-map.js',
+        './ui/js/dojo/dojo.js'
     ];
 
     ipa_loader.scripts(scripts, function() {
@@ -41,6 +41,8 @@ var dojoConfig = {
                 var text = require('freeipa/text');
                 var msg = text.get('@i18n:unauthorized-page');
                 if (msg) {
+                    // Unauthorized is rendered through /ipa/whatever, but most pages expect /ipa/ui/whatever
+                    msg = msg.replace('<a href="ssbrowser.html">', '<a href="config/ssbrowser.html">');
                     dom.byId('unauthorized-msg').innerHTML=msg;
                 }
             });

--- a/install/ui/sync_otp.html
+++ b/install/ui/sync_otp.html
@@ -10,54 +10,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script type="text/javascript" src="js/libs/loader.js"></script>
-    <script type="text/javascript">
-
-        var dojoConfig = {
-            baseUrl: "js",
-            has: {
-                'dojo-firebug': false,
-                'dojo-debug-messages': true
-            },
-            parseOnLoad: false,
-            async: true,
-            packages: [
-                {
-                    name:'dojo',
-                    location:'dojo'
-                },
-                {
-                    name: 'freeipa',
-                    location: 'freeipa'
-                }
-            ],
-            cacheBust: ipa_loader.num_version || ""
-        };
-
-        (function() {
-            var ie = !!document.getElementById('ie-detector');
-            var styles = ['css/patternfly.css', 'css/ipa.css', 'ipa.css'];
-            if (ie) styles.push('ie.css');
-            var icons = ['favicon.ico'];
-            var scripts = [
-                'js/libs/json2.js',
-                'js/libs/jquery.js',
-                'js/libs/bootstrap.js',
-                'js/libs/jquery.ordered-map.js',
-                'js/libs/browser.js',
-                'js/dojo/dojo.js'
-            ];
-            ipa_loader.scripts(scripts, function() {
-                require(['freeipa/core', 'dojo/domReady!'], function(app) {
-                    var sync = require('freeipa/plugins/sync_otp');
-                    sync.facet_spec.widgets[1].allow_cancel = false;
-                    app.run_simple('sync-otp');
-                });
-            });
-            ipa_loader.styles(styles);
-            ipa_loader.icons(icons);
-
-        })();
-    </script>
+    <script type="text/javascript" src="js/inline/sync_otp_inline.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Add Content-Security-Policy headers for legacy and modern web UI.

Legacy UI: Extract inline scripts from index.html, reset_password.html, and sync_otp.html into external JS files to eliminate the need for script hash in the CSP policy.

Fixes: https://pagure.io/freeipa/issue/9900
Fixes: https://pagure.io/freeipa/issue/9901

## Summary by Sourcery

Add Content-Security-Policy headers to legacy web UI pages and externalize their inline bootstrapping scripts into separate JavaScript assets.

Enhancements:
- Introduce restrictive Content-Security-Policy meta headers for index, reset password, and OTP sync legacy UI pages.
- Extract inline JavaScript bootstrapping logic from legacy HTML pages into dedicated JS files served from a new inline asset directory.
- Wire the new inline JS directory into the build system so the scripts are packaged and installed with the web UI.

## Summary by Sourcery

Externalize legacy web UI inline bootstrapping scripts into dedicated JavaScript assets and wire them into the build so they are installed as part of the web UI.

Enhancements:
- Introduce a new js/inline asset directory and install rules for legacy web UI bootstrapping scripts.
- Refactor legacy HTML pages (index, reset password, sync OTP, migration, ssbrowser, unauthorized) to load their initialization logic from external inline JavaScript files instead of inline script blocks.
- Adjust unauthorized and browser configuration pages to use consistent relative paths for UI assets and links.