### PR TITLE
ipatests: fix the method add_a_record

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_replica_promotion_TestReplicaPromotionRandomPassword:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionRandomPassword
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *master_1repl

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1620,7 +1620,7 @@ def add_a_record(master, host):
                              raiseonerr=False)
 
     # If not, add it
-    if cmd.returncode != 0:
+    if cmd.returncode != 0 or 'A record' not in cmd.stdout_text:
         master.run_command(['ipa',
                             'dnsrecord-add',
                             master.domain.name,


### PR DESCRIPTION
The method add_a_record first checks if a DNS record exists.
If it finds one, it assumes there is already a DNS A record for
the host but this assumption is wrong. The dnsrecord-show command
may return another type of DNS record (for instance an SSHFP record).

Create the A record if dnsrecord-show fails or if it doesn't return
any A record.

Fixes: https://pagure.io/freeipa/issue/9972

## Summary by Sourcery

Ensure A DNS records are created when missing and align temporary CI configuration with the specific replica promotion test.

Bug Fixes:
- Correct add_a_record logic to create an A DNS record when dnsrecord-show fails or returns no A record for the host.

CI:
- Retarget the temporary Fedora CI job to run the TestReplicaPromotionRandomPassword test with updated topology and timeout.