### PR TITLE
Revert "Temp commit"

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/temp_commit.yaml
+ipatests/prci_definitions/gating.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/test_replica_promotion_TestReplicaPromotionRandomPassword:
+  fedora-latest/temp_commit:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionRandomPassword
+        test_suite: test_integration/test_REPLACEME.py
         template: *ci-master-latest
-        timeout: 7200
-        topology: *master_1repl
+        timeout: 3600
+        topology: *master_1repl_1client


### PR DESCRIPTION
This reverts commit 1b4c20c464a8a6c8dc6b929822f9ebe6ee150b61.

## Summary by Sourcery

Revert temporary PR CI job configuration used for ad-hoc testing and restore standard settings for this temp_commit definition.

CI:
- Adjust the temporary Fedora latest CI job to use a generic test suite, shorter timeout, and an updated topology.
- Remove the reference to the temp_commit PR CI definition from the main .freeipa-pr-ci.yaml configuration.