### PR TITLE
[Backport][ipa-4-12] ipatests: fix the method add_a_record

### DIFF
--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1620,7 +1620,7 @@ def add_a_record(master, host):
                              raiseonerr=False)
 
     # If not, add it
-    if cmd.returncode != 0:
+    if cmd.returncode != 0 or 'A record' not in cmd.stdout_text:
         master.run_command(['ipa',
                             'dnsrecord-add',
                             master.domain.name,


### PR DESCRIPTION
The method add_a_record first checks if a DNS record exists. If it finds one, it assumes there is already a DNS A record for the host but this assumption is wrong. The dnsrecord-show command may return another type of DNS record (for instance an SSHFP record).

Create the A record if dnsrecord-show fails or if it doesn't return any A record.

Fixes: https://pagure.io/freeipa/issue/9972

Reviewed-By: Anuja More <amore@redhat.com>

## Summary by Sourcery

Bug Fixes:
- Fix add_a_record helper to create an A record when dnsrecord-show succeeds but returns no A record for the host.