### PR TITLE
Fix ipa ca-show ipa --all not listing RSN version

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1688,7 +1688,7 @@ class CAInstance(DogtagInstance):
                 api.env.basedn)
         entry_attrs = api.Backend.ldap2.get_entry(dn)
         version = entry_attrs.single_value.get(
-            "ipaCaRandomSerialNumberVersion", "0"
+            "ipaCaRandomSerialNumberVersion", "-"
         )
         if str(version) == str(value):
             return


### PR DESCRIPTION
Fixes: https://pagure.io/freeipa/issue/9974

## Summary by Sourcery

Bug Fixes:
- Ensure ipa ca-show --all correctly reports the random serial number (RSN) version when it is unset versus explicitly set to 0.