### PR TITLE
Test ssh 11

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -2242,7 +2242,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-latest
-        timeout: 7200
+        timeout: 10800
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest/test_hbac_functional:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -2422,7 +2422,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-latest
-        timeout: 7200
+        timeout: 10800
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-latest/test_hbac_functional:

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -302,7 +302,7 @@ jobs:
         copr: '@sssd/nightly'
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-latest
-        timeout: 7200
+        timeout: 10800
         topology: *adroot_adchild_adtree_master_1client
 
   sssd-fedora/test_hbac_functional:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -2601,7 +2601,7 @@ jobs:
         enable_testing_repo: True
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-latest
-        timeout: 7200
+        timeout: 10800
         topology: *adroot_adchild_adtree_master_1client
 
   testing-fedora/test_hbac_functional:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -2780,7 +2780,7 @@ jobs:
         enable_testing_repo: True
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-latest
-        timeout: 7200
+        timeout: 10800
         topology: *adroot_adchild_adtree_master_1client
 
   testing-fedora/test_hbac_functional:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -2242,7 +2242,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-previous
-        timeout: 7200
+        timeout: 10800
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-previous/test_hbac_functional:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -2420,7 +2420,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_trust_functional.py
         template: *ci-master-frawhide
-        timeout: 7200
+        timeout: 10800
         topology: *adroot_adchild_adtree_master_1client
 
   fedora-rawhide/test_hbac_functional:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,28 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_trust_functional:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_trust_functional.py::TestTrustFunctionalHbac
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 10800
+        topology: *adroot_adchild_adtree_master_1client
+
+  sssd-latest/test_trust_functional:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        update_packages: True
+        copr: '@sssd/nightly'
+        test_suite: test_integration/test_trust_functional.py::TestTrustFunctionalHbac
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -69,6 +69,13 @@ class BaseTestTrust(IntegrationTest):
             cls.subaduser = f"subdomaintestuser@{cls.ad_subdomain}"
             cls.subaduser2 = f"subdomaindisabledadu@{cls.ad_subdomain}"
             cls.ad_sub_group = f"subdomaintestgroup@{cls.ad_subdomain}"
+            cls.subdomaintestuser2 = f"subdomaintestuser2@{cls.ad_subdomain}"
+            cls.subnonposixuser1 = f"subnonposixuser1@{cls.ad_subdomain}"
+            cls.subnonposixuser2 = f"subnonposixuser2@{cls.ad_subdomain}"
+            cls.subexpiredaduser = f"subexpiredaduser@{cls.ad_subdomain}"
+            cls.subdisableduser = f"subdomaindisabledaduser@{cls.ad_subdomain}"
+            cls.subcantchgpwduser = f"subcantchgpwduser@{cls.ad_subdomain}"
+            cls.submustchgpwduser = f"submustchgpwduser@{cls.ad_subdomain}"
 
         if cls.num_ad_treedomains > 0:
             cls.tree_ad = cls.ad_treedomains[0]
@@ -80,7 +87,102 @@ class BaseTestTrust(IntegrationTest):
         cls.srv_gc_record_value = '0 100 389 {}.'.format(cls.master.hostname)
         cls.aduser = f"nonposixuser@{cls.ad_domain}"
         cls.aduser2 = f"nonposixuser1@{cls.ad_domain}"
+        cls.testuser = f"testuser@{cls.ad_domain}"
+        cls.testuser1 = f"testuser1@{cls.ad_domain}"
+        cls.testuser2 = f"testuser2@{cls.ad_domain}"
+        cls.upnuser = f"upnuser@{cls.ad_domain}"
+        cls.upnuser_password = "Secret123456"
+        cls.mytestuser = f"mytestuser@{cls.ad_domain}"
+        cls.disabledaduser = f"disabledaduser@{cls.ad_domain}"
+        cls.expiredaduser = f"expiredaduser@{cls.ad_domain}"
         cls.ad_group = f"testgroup@{cls.ad_domain}"
+        cls.cannotchangepwduser = f"cannotchangepwduser@{cls.ad_domain}"
+        cls.changepwdatlogonuser = f"changepwdatlogonuser@{cls.ad_domain}"
+
+    def _ad_user_base(self, principal):
+        """Return username part of principal (before @)."""
+        return principal.split('@', 1)[0]
+
+    def _ad_domain_netbios(self, domain):
+        """Return NetBIOS name (first label) of AD domain."""
+        return domain.split('.', 1)[0]
+
+    def _ad_principal(self, username, domain, realm=False):
+        """Build AD principal: user@DOMAIN (realm) or user@domain (dns)."""
+        suffix = domain.upper() if realm else domain.lower()
+        return f"{username}@{suffix}"
+
+    def _ad_basedn(self, domain):
+        """Build LDAP base DN from domain."""
+        return ','.join(f'DC={part}' for part in domain.split('.'))
+
+    def _ad_user_dn(self, username, domain):
+        """Build AD user DN: CN=username,CN=Users,{basedn}."""
+        return f"CN={username},CN=Users,{self._ad_basedn(domain)}"
+
+    def _kinit_as_ad_admin(self, host, domain, admin_name, admin_password):
+        """Kinit as AD admin for the given domain.
+
+        Caller must call tasks.kdestroy_all(host) and tasks.kinit_admin(host)
+        when done with AD operations.
+        """
+        admin_principal = self._ad_principal(admin_name, domain, realm=True)
+        tasks.kdestroy_all(host)
+        tasks.kinit_as_user(host, admin_principal, admin_password)
+
+    def _ad_user_add(self, username, password, ad_host=None, domain=None):
+        """Create a user account on the given AD DC and enable it."""
+        ad_host = ad_host or self.ad
+        domain = domain or self.ad_domain
+        admin = self.master.config.ad_admin_name
+        admin_password = self.master.config.ad_admin_password
+        ad_realm = domain.upper()
+
+        self._kinit_as_ad_admin(self.master, domain, admin, admin_password)
+        self.master.run_command(['kvno', f'kadmin/changepw@{ad_realm}'])
+        self.master.run_command(
+            ['kvno', f'ldap/{ad_host.hostname}@{ad_realm}'])
+
+        self.master.run_command([
+            'net', '--debuglevel=10', 'ads', 'user', 'add',
+            username, password, '-k', '-S', ad_host.hostname
+        ])
+
+        # net ads user add leaves the account disabled; set
+        # userAccountControl 512 (NORMAL_ACCOUNT) to enable it
+        basedn = self._ad_basedn(domain)
+        ldif = (
+            f"dn: CN={username},CN=Users,{basedn}\n"
+            f"changetype: modify\n"
+            f"replace: userAccountControl\n"
+            f"userAccountControl: 512\n"
+        )
+        ad_dirman = self._ad_user_dn(admin, domain)
+        self.master.run_command(
+            ['ldapmodify', '-Y', 'GSS-SPNEGO',
+             '-H', f'ldap://{ad_host.hostname}',
+             '-D', ad_dirman,
+             '-w', admin_password],
+            stdin_text=ldif
+        )
+
+        tasks.kdestroy_all(self.master)
+        tasks.kinit_admin(self.master)
+
+    def _ad_user_del(self, username, ad_host=None, domain=None):
+        """Delete a user account from the given AD DC."""
+        ad_host = ad_host or self.ad
+        domain = domain or self.ad_domain
+        admin = self.master.config.ad_admin_name
+        admin_password = self.master.config.ad_admin_password
+
+        self._kinit_as_ad_admin(self.master, domain, admin, admin_password)
+        self.master.run_command([
+            'net', 'ads', 'user', 'delete', username,
+            '-k', '-S', ad_host.hostname
+        ], raiseonerr=False)
+        tasks.kdestroy_all(self.master)
+        tasks.kinit_admin(self.master)
 
     @classmethod
     def check_sid_generation(cls):

--- a/ipatests/test_integration/test_trust_functional.py
+++ b/ipatests/test_integration/test_trust_functional.py
@@ -5,9 +5,125 @@ from __future__ import absolute_import
 import re
 import time
 import textwrap
+from datetime import datetime, timedelta
+
+import pytest
+
 from ipaplatform.paths import paths
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_trust import BaseTestTrust
+
+PLUGIN_CONF = "/var/lib/sss/pubconf/krb5.include.d/localauth_plugin"
+
+
+def ssh_with_password(host, login, target_host, password, expect_success=True):
+    """Run SSH with password authentication.
+
+    :param host: Host on which to run the SSH command.
+    :param login: SSH login name (``-l`` argument).
+    :param target_host: Hostname to connect to.
+    :param password: Password for authentication.
+    :param expect_success: If ``True``, raise on failure; if ``False``, return
+        the result object even when the command fails.
+    :returns: Object returned by ``host.run_command()``.
+    """
+    if not tasks.is_package_installed(host, 'sshpass'):
+        pytest.skip(f"sshpass not available on {host.hostname}")
+    result = host.run_command(
+        [
+            'sshpass', '-p', password,
+            'ssh', '-o', 'StrictHostKeyChecking=no',
+            "-o", "PubkeyAuthentication=no",
+            "-o", "GSSAPIAuthentication=no",
+            '-l', login, target_host, 'id'
+        ],
+        raiseonerr=expect_success,
+    )
+    return result
+
+
+def ssh_with_gssapi(host, kinit_principal, login, target_host, password,
+                    expect_success=True):
+    """Run SSH with GSSAPI authentication after kinit.
+
+    :param host: Host on which to run ``kinit`` and SSH.
+    :param kinit_principal: Kerberos principal for ``kinit``.
+    :param login: SSH login name (``-l`` argument).
+    :param target_host: Hostname to connect to.
+    :param password: Password for ``kinit``.
+    :param expect_success: If ``True``, raise on failure; if ``False``, return
+        the result object even when the command fails.
+    :returns: Object returned by ``host.run_command()``.
+    """
+    tasks.kdestroy_all(host)
+    tasks.kinit_as_user(host, kinit_principal, password)
+    result = host.run_command(
+        [
+            'ssh', '-o', 'StrictHostKeyChecking=no', '-K',
+            '-o', 'PubkeyAuthentication=no',
+            '-o', 'GSSAPIAuthentication=yes',
+            '-l', login, target_host, 'id'
+        ],
+        raiseonerr=expect_success,
+    )
+    return result
+
+
+def spawn_ssh_interactive(host, login, target_host, extra_ssh_options=None,
+                          remote_cmd=None):
+    """Return a ``spawn_expect`` context for an interactive SSH session.
+
+    :param host: Host on which to run SSH.
+    :param login: SSH login name (``-l`` argument).
+    :param target_host: Hostname to connect to.
+    :param extra_ssh_options: Extra SSH options (e.g. ``['-tt']`` for a PTY),
+        or ``None``.
+    :param remote_cmd: Optional remote command string, or ``None`` for an
+        interactive shell.
+    :returns: Context manager from ``host.spawn_expect()``.
+    """
+    cmd = [
+        'ssh', '-o', 'StrictHostKeyChecking=no',
+        '-l', login, target_host,
+    ]
+    if remote_cmd is not None:
+        cmd.append(remote_cmd)
+    return host.spawn_expect(cmd, extra_ssh_options=extra_ssh_options)
+
+
+def expect_password_change_prompts(test, current_password, new_password):
+    """Drive the current->new->confirm password-change prompt sequence.
+
+    Handles the three-step interactive password-change dialogue that
+    both SSH forced-change and ``passwd`` in-session flows share.
+
+    :param test: Active ``spawn_expect`` context.
+    :param current_password: User's current password.
+    :param new_password: New password to set.
+    """
+    # (?i) ignores case, enabling flag this way is atypical.
+    test.expect(r'(?i)current password:')
+    test.sendline(current_password)
+    test.expect(r'(?i).*password.*:')
+    test.sendline(new_password)
+    test.expect(r'(?i).*password.*:')
+    test.sendline(new_password)
+
+
+def get_localauth_module_from_plugin(host):
+    """Extract module path from SSSD localauth plugin config on the given host.
+
+    :param host: Host from which to read the plugin config at path
+        ``PLUGIN_CONF``.
+    :returns: Module path from the ``module:`` line in the config file.
+    :rtype: str
+    :raises ValueError: If no ``module`` line is found in the plugin config.
+    """
+    plugin_content = host.get_file_contents(PLUGIN_CONF, encoding='utf-8')
+    for line in plugin_content.splitlines():
+        if line.strip().startswith('module'):
+            return line.split(':', 1)[-1].strip()
+    raise ValueError("No 'module' line found in localauth plugin config")
 
 
 class TestTrustFunctionalHbac(BaseTestTrust):
@@ -39,22 +155,6 @@ class TestTrustFunctionalHbac(BaseTestTrust):
         self.master.run_command(["ipa", "hbacrule-enable", "allow_all"])
         tasks.wait_for_sssd_domain_status_online(self.master)
         tasks.wait_for_sssd_domain_status_online(self.clients[0])
-
-    def _ssh_with_password(
-        self,
-        login,
-        host,
-        password,
-        success_expected=False
-    ):
-        result = self.clients[0].run_command(
-            ['sshpass', '-p', password,
-             'ssh', '-v', '-o', 'StrictHostKeyChecking=no',
-             '-l', login, host, "id"],
-            raiseonerr=success_expected
-        )
-        output = f"{result.stdout_text}{result.stderr_text}"
-        return output
 
     def _get_log_tail(self, host, log_path, start_offset):
         return host.get_file_contents(log_path)[start_offset:]
@@ -138,11 +238,12 @@ class TestTrustFunctionalHbac(BaseTestTrust):
                 logsize = tasks.get_logsize(
                     self.clients[0], log_file
                 )
-                self._ssh_with_password(
+                ssh_with_password(
+                    self.clients[0],
                     user,
                     self.clients[0].hostname,
                     'Secret123',
-                    success_expected=False,
+                    expect_success=False,
                 )
                 sssd_logs = self._get_log_tail(
                     self.clients[0], log_file, logsize
@@ -182,21 +283,24 @@ class TestTrustFunctionalHbac(BaseTestTrust):
                      ]
                 )
                 tasks.kdestroy_all(self.clients[0])
-                output = self._ssh_with_password(
+                output = ssh_with_password(
+                    self.clients[0],
                     user,
                     self.clients[0].hostname,
                     'Secret123',
-                    success_expected=True,
+                    expect_success=True,
                 )
-                assert "domain users" in output
+                assert "domain users" in output.stdout_text
 
-            for user2 in [self.aduser2, self.subaduser2]:
-                self._ssh_with_password(
+            for user2 in [self.testuser, self.subaduser2]:
+                output2 = ssh_with_password(
+                    self.clients[0],
                     user2,
                     self.clients[0].hostname,
                     'Secret123',
-                    success_expected=False,
+                    expect_success=False,
                 )
+                assert "domain users" not in output2.stdout_text
         finally:
             self._cleanup_hrule_allow_all_and_wait(hrule)
 
@@ -306,6 +410,8 @@ class TestTrustFunctionalHbac(BaseTestTrust):
                     raiseonerr=False
                 )
                 assert result.returncode != 0
+                output = f"{result.stdout_text}{result.stderr_text}"
+                assert 'uid=0(root)' not in output
         finally:
             self._cleanup_hrule_allow_all_and_wait(hrule)
             self.master.run_command(["ipa", "sudorule-del", srule])
@@ -865,3 +971,689 @@ class TestTrustFunctionalHttp(BaseTestTrust):
         tasks.kdestroy_all(self.clients[0])
 
         self._assert_curl_GSSAPI_access_denied()
+
+
+class TestTrustFunctionalSSH(BaseTestTrust):
+    topology = 'line'
+    num_ad_treedomains = 0
+
+    ad_user_password = 'Secret123'
+    ad_user_first_password = 'Passw0rd1'
+
+    @classmethod
+    def install(cls, mh):
+        super().install(mh)
+        tasks.kinit_admin(cls.clients[0])
+        # mkhomedir + oddjobd for AD user home dir creation on first login
+        for host in [cls.master, cls.clients[0]]:
+            host.run_command(
+                ["authselect", "enable-feature", "with-mkhomedir"]
+            )
+            host.run_command(
+                ["systemctl", "enable", "--now", "oddjobd"]
+            )
+        tasks.configure_dns_for_trust(cls.master, cls.ad)
+        tasks.establish_trust_with_ad(
+            cls.master, cls.ad_domain,
+            extra_args=['--range-type', 'ipa-ad-trust'])
+        tasks.kinit_admin(cls.master)
+
+    def _ad_hosts(self):
+        """Return (ad_host, domain) pairs for primary AD and the subdomain.
+
+        Each entry is a tuple of (AD host object, domain name string) so
+        that callers can drive user-lifecycle operations (add/mod/del) against
+        both the root AD DC and the child-domain DC in a single loop.
+        """
+        return [
+            (self.ad, self.ad_domain),
+            (self.child_ad, self.ad_subdomain),
+        ]
+
+    def _sssd_cache_reset_all(self):
+        tasks.clear_sssd_cache(self.master)
+        tasks.clear_sssd_cache(self.clients[0])
+
+    def _ad_user_domain_pairs(self):
+        """Return (user_principal, domain) pairs for both AD and subdomain.
+
+        Each entry is a tuple of (fully-qualified user principal, AD domain
+        name) so that callers can build login names and UPNs for both the
+        primary AD domain and its subdomain in a single loop.
+        """
+        return [
+            (self.aduser, self.ad_domain),
+            (self.subaduser, self.ad_subdomain),
+        ]
+
+    def test_ssh_password_unqualified_login_fails(self):
+        """AD user SSH with password using short (unqualified) username fails.
+
+        Verifies that password authentication is rejected when the AD user
+        logs in with only their sAMAccountName (no domain suffix), because
+        the IPA client cannot map an unqualified name to an AD identity.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        for user, domain in self._ad_user_domain_pairs():
+            testuser = self._ad_user_base(user)
+            result = ssh_with_password(
+                self.clients[0], testuser, self.clients[0].hostname,
+                self.ad_user_password, expect_success=False)
+            assert result.returncode != 0, (
+                f"Expected unqualified login for '{testuser}' "
+                f"(domain: {domain}) to fail"
+            )
+
+    def test_ssh_gssapi_unqualified_login_fails(self):
+        """AD user SSH with GSSAPI using short (unqualified) username fails.
+
+        Verifies that GSSAPI authentication is rejected when the AD user's
+        login name contains no domain suffix, even though a valid Kerberos
+        ticket is obtained with the full UPN.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        for user, domain in self._ad_user_domain_pairs():
+            testuser = self._ad_user_base(user)
+            ad_upn = self._ad_principal(testuser, domain, realm=True)
+            result = ssh_with_gssapi(
+                self.clients[0], ad_upn, testuser, self.clients[0].hostname,
+                self.ad_user_password, expect_success=False)
+            assert result.returncode != 0, (
+                f"Expected unqualified GSSAPI login for '{testuser}' "
+                f"(domain: {domain}) to fail"
+            )
+
+    def test_ssh_password_fqdn_login(self):
+        """AD user SSH with password using fully-qualified user@domain login.
+
+        Verifies that password authentication succeeds when the AD user
+        logs in as user@domain.lower.  Also checks that no sssd_be crash
+        or core dump appears in journalctl after the login.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        since = time.strftime(
+            '%Y-%m-%d %H:%M:%S',
+            (datetime.now() - timedelta(seconds=10)).timetuple()
+        )
+        for user, domain in self._ad_user_domain_pairs():
+            base = self._ad_user_base(user)
+            testuser = self._ad_principal(base, domain, realm=False)
+            ssh_with_password(
+                self.clients[0], testuser, self.clients[0].hostname,
+                self.ad_user_password)
+        result = self.clients[0].run_command([
+            'journalctl', f'--since={since}', '--no-pager'
+        ], raiseonerr=False)
+        log_output = result.stdout_text
+        assert "core dump" not in log_output
+        assert "sssd_be" not in log_output
+
+    def test_ssh_gssapi_localauth_plugin(self):
+        """SSSD localauth plugin is present and AD user GSSAPI login works.
+
+        Verifies that the SSSD localauth plugin configuration file and its
+        module binary exist on the client, that krb5.conf does not contain
+        a legacy auth_to_local rule, and that the AD user can log in via
+        GSSAPI using the lowercase domain principal.
+        """
+        assert self.clients[0].transport.file_exists(PLUGIN_CONF)
+        localauth_module = get_localauth_module_from_plugin(self.clients[0])
+        assert self.clients[0].transport.file_exists(localauth_module)
+        krb5_conf = self.clients[0].get_file_contents(
+            paths.KRB5_CONF, encoding='utf-8'
+        )
+        assert "auth_to_local" not in krb5_conf
+        for user, domain in self._ad_user_domain_pairs():
+            base = self._ad_user_base(user)
+            testuser = self._ad_principal(base, domain, realm=False)
+            ad_upn = self._ad_principal(base, domain, realm=True)
+            ssh_with_gssapi(
+                self.clients[0], ad_upn, testuser, self.clients[0].hostname,
+                self.ad_user_password)
+
+    def test_ssh_password_upn_login(self):
+        """AD user SSH with password using UPN (user@REALM) login succeeds.
+
+        Verifies that password authentication works when the AD user's
+        login name is in UPN format with the uppercase Kerberos realm
+        (user@AD.DOMAIN.COM).
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        for user, domain in self._ad_user_domain_pairs():
+            base = self._ad_user_base(user)
+            testuser = self._ad_principal(base, domain, realm=True)
+            ssh_with_password(
+                self.clients[0], testuser, self.clients[0].hostname,
+                self.ad_user_password)
+
+    def test_ssh_gssapi_upn_login(self):
+        """AD user SSH with GSSAPI using UPN for both kinit and login.
+
+        Verifies that GSSAPI authentication succeeds when the same UPN
+        (user@REALM) is used as the kinit principal and as the SSH login
+        name.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        for user, domain in self._ad_user_domain_pairs():
+            base = self._ad_user_base(user)
+            ad_upn = self._ad_principal(base, domain, realm=True)
+            ssh_with_gssapi(
+                self.clients[0], ad_upn, ad_upn, self.clients[0].hostname,
+                self.ad_user_password)
+
+    def test_ssh_password_netbios_lower_login(self):
+        """AD user SSH with password using lowercase NetBIOS prefix login.
+
+        Verifies that password authentication succeeds when the AD user
+        logs in with the Windows-style netbios\\user notation using a
+        lowercase NetBIOS domain prefix.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        for user, domain in self._ad_user_domain_pairs():
+            testuser = "{0}\\{1}".format(
+                self._ad_domain_netbios(domain).lower(),
+                self._ad_user_base(user),
+            )
+            ssh_with_password(
+                self.clients[0], testuser, self.clients[0].hostname,
+                self.ad_user_password)
+
+    def test_ssh_gssapi_netbios_lower_login(self):
+        """AD user SSH with GSSAPI using lowercase NetBIOS prefix login.
+
+        Verifies that GSSAPI authentication succeeds when the SSH login
+        name uses the lowercase netbios\\user notation while kinit is
+        performed with the full UPN.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        for user, domain in self._ad_user_domain_pairs():
+            testuser = "{0}\\{1}".format(
+                self._ad_domain_netbios(domain).lower(),
+                self._ad_user_base(user),
+            )
+            base = self._ad_user_base(user)
+            ad_upn = self._ad_principal(base, domain, realm=True)
+            ssh_with_gssapi(
+                self.clients[0], ad_upn, testuser, self.clients[0].hostname,
+                self.ad_user_password)
+
+    def test_ssh_password_netbios_upper_login(self):
+        """AD user SSH with password using uppercase NetBIOS prefix login.
+
+        Verifies that password authentication succeeds when the AD user
+        logs in with the Windows-style NETBIOS\\user notation using an
+        uppercase NetBIOS domain prefix.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        for user, domain in self._ad_user_domain_pairs():
+            testuser = "{0}\\{1}".format(
+                self._ad_domain_netbios(domain).upper(),
+                self._ad_user_base(user),
+            )
+            ssh_with_password(
+                self.clients[0], testuser, self.clients[0].hostname,
+                self.ad_user_password)
+
+    def test_ssh_gssapi_netbios_upper_login(self):
+        """AD user SSH with GSSAPI using uppercase NetBIOS prefix login.
+
+        Verifies that GSSAPI authentication succeeds when the SSH login
+        name uses the uppercase NETBIOS\\user notation while kinit is
+        performed with the full UPN.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        for user, domain in self._ad_user_domain_pairs():
+            testuser = "{0}\\{1}".format(
+                self._ad_domain_netbios(domain).upper(),
+                self._ad_user_base(user),
+            )
+            base = self._ad_user_base(user)
+            ad_upn = self._ad_principal(base, domain, realm=True)
+            ssh_with_gssapi(
+                self.clients[0], ad_upn, testuser, self.clients[0].hostname,
+                self.ad_user_password)
+
+    def test_ssh_gssapi_credential_forwarding(self):
+        """AD user kinit and SSH as a second AD user via credential forwarding.
+
+        Verifies that one AD user can obtain a Kerberos ticket and then
+        forward GSSAPI credentials to SSH into the client as a different
+        AD user, confirming cross-user credential delegation within an AD
+        trust environment.
+        Repeated for the root AD domain (testuser1 -> testuser2) and
+        for subdomaintestuser -> subdomaintestuser2.
+        """
+        pairs = [(self.testuser1, self.testuser2),
+                 (self.subaduser, self.subdomaintestuser2)
+                 ]
+        client = self.clients[0]
+        for first_user, second_user in pairs:
+            tasks.kdestroy_all(client)
+            tasks.kinit_as_user(client, first_user, self.ad_user_password)
+            result = client.run_command([
+                'ssh', '-o', 'StrictHostKeyChecking=no', '-K',
+                '-l', first_user, client.hostname,
+                '--',
+                'sshpass', '-p', self.ad_user_password,
+                'ssh', '-o', 'StrictHostKeyChecking=no',
+                '-o', 'GSSAPIAuthentication=no',
+                '-o', 'PubkeyAuthentication=no',
+                '-o', 'PasswordAuthentication=yes',
+                '-l', second_user, client.hostname, 'id',
+            ])
+            assert second_user in result.stdout_text
+
+    def test_ssh_gssapi_new_user_no_cache_flush(self):
+        """Newly created AD user can SSH with GSSAPI without cache flush.
+
+        Verifies that an AD user added during the test can immediately
+        authenticate via GSSAPI over SSH, confirming that SSSD resolves
+        brand-new AD accounts without requiring a manual cache reset.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        username = 'adnew1'
+        for ad_host, domain in self._ad_hosts():
+            testuser = self._ad_principal(username, domain)
+            ad_upn = self._ad_principal(username, domain, realm=True)
+            try:
+                self._ad_user_add(
+                    username, self.ad_user_password,
+                    ad_host=ad_host, domain=domain)
+                ssh_with_gssapi(
+                    self.clients[0], ad_upn, testuser,
+                    self.clients[0].hostname, self.ad_user_password)
+            finally:
+                self._ad_user_del(username, ad_host=ad_host, domain=domain)
+
+    def test_ssh_deleted_user_evicted_from_cache(self):
+        """Deleted AD user is evicted from SSSD cache and kinit fails.
+
+        Creates an AD user, resolves it via getent (populating the SSSD
+        cache), deletes the user, flushes the SSSD cache, and then verifies
+        that getent returns no entry and kinit reports the principal is not
+        found in the Kerberos database.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        username = 'adnew2'
+        for ad_host, domain in self._ad_hosts():
+            testuser = self._ad_principal(username, domain)
+            ad_upn = self._ad_principal(username, domain, realm=True)
+            try:
+                self._ad_user_add(
+                    username, self.ad_user_password,
+                    ad_host=ad_host, domain=domain)
+                self.master.run_command(['getent', 'passwd', testuser])
+                ssh_with_gssapi(
+                    self.clients[0], ad_upn, testuser,
+                    self.clients[0].hostname, self.ad_user_password)
+                self._ad_user_del(username, ad_host=ad_host, domain=domain)
+                self._sssd_cache_reset_all()
+                result = self.clients[0].run_command(
+                    ['getent', '-s', 'sss', 'passwd', testuser],
+                    raiseonerr=False,
+                )
+                assert result.returncode != 0
+                result = self.clients[0].run_command(
+                    ['kinit', testuser],
+                    stdin_text=self.ad_user_password,
+                    raiseonerr=False,
+                )
+                output = f"{result.stdout_text}{result.stderr_text}"
+                assert "not found in Kerberos database" in output
+            finally:
+                self._ad_user_del(username, ad_host=ad_host, domain=domain)
+
+    def test_ssh_recreated_user_login_after_cache_clear(self):
+        """Re-created AD user can SSH after SSSD cache is cleared.
+
+        Verifies that an AD user which was deleted and then re-added with
+        the same name can still authenticate via GSSAPI and password SSH
+        once the SSSD cache is flushed, ensuring stale cache entries do
+        not block the re-created account.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        username = 'adnew3'
+        for ad_host, domain in self._ad_hosts():
+            testuser = self._ad_principal(username, domain)
+            ad_upn = self._ad_principal(username, domain, realm=True)
+            try:
+                self._ad_user_add(
+                    username, self.ad_user_password,
+                    ad_host=ad_host, domain=domain)
+                self.master.run_command(['getent', 'passwd', testuser])
+                self._ad_user_del(username, ad_host=ad_host, domain=domain)
+                self._sssd_cache_reset_all()
+                self.master.run_command(['getent', 'passwd', testuser],
+                                        raiseonerr=False)
+                self._ad_user_add(
+                    username, self.ad_user_password,
+                    ad_host=ad_host, domain=domain)
+                self._sssd_cache_reset_all()
+                tasks.kdestroy_all(self.clients[0])
+                tasks.clear_sssd_cache(self.clients[0])
+                self.clients[0].run_command(['getent', 'passwd', testuser])
+                ssh_with_gssapi(
+                    self.clients[0], ad_upn, testuser,
+                    self.clients[0].hostname, self.ad_user_password)
+                ssh_with_password(
+                    self.clients[0], testuser, self.clients[0].hostname,
+                    self.ad_user_password)
+            finally:
+                self._ad_user_del(username, ad_host=ad_host, domain=domain)
+
+    def test_ssh_su_second_ad_user_in_session(self):
+        """AD user can switch to a second AD user via su within SSH session.
+
+        Verifies that after logging in via GSSAPI as one AD user, it is
+        possible to switch to a different AD user using su inside the same
+        SSH session, confirming correct PAM/SSSD identity handling for
+        cross-user switches under an AD trust.
+        Repeated for the root AD domain (testuser1 -> testuser2) and
+        subdomaintestuser -> subdomaintestuser2.
+        """
+        pairs = [(self.testuser1, self.testuser2),
+                 (self.subaduser, self.subdomaintestuser2)
+                 ]
+        client = self.clients[0]
+        for first_user, second_user in pairs:
+            tasks.kdestroy_all(client)
+            tasks.kinit_as_user(client, first_user, self.ad_user_password)
+            with client.spawn_expect([
+                'ssh', '-t', '-o', 'StrictHostKeyChecking=no', '-K',
+                '-l', first_user, client.hostname,
+                '--', 'su', '-', second_user, '-c', 'id',
+            ], extra_ssh_options=['-t']) as test:
+                # (?i) ignores case, enabling flag this way is atypical.
+                test.expect(r'(?i)password')
+                test.sendline(self.ad_user_password)
+                test.expect_exit(ignore_remaining_output=True, timeout=60)
+                output = test.get_last_output()
+            assert second_user in output
+
+    def test_ssh_password_to_master(self):
+        """AD user SSH with password to the IPA master (server mode).
+
+        Verifies that password authentication succeeds when the AD user
+        connects to the IPA master rather than to a regular IPA client,
+        exercising the server-mode SSSD code path.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        for user, domain in self._ad_user_domain_pairs():
+            base = self._ad_user_base(user)
+            testuser = self._ad_principal(base, domain, realm=False)
+            ssh_with_password(
+                self.clients[0], testuser, self.master.hostname,
+                self.ad_user_password)
+
+    def test_ssh_gssapi_to_master(self):
+        """AD user SSH with GSSAPI to the IPA master (server mode).
+
+        Verifies that GSSAPI authentication succeeds when the AD user
+        connects to the IPA master, exercising the server-mode SSSD and
+        Kerberos PAC processing code paths.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        for user, domain in self._ad_user_domain_pairs():
+            base = self._ad_user_base(user)
+            testuser = self._ad_principal(base, domain, realm=False)
+            ad_upn = self._ad_principal(base, domain, realm=True)
+            ssh_with_gssapi(
+                self.clients[0], ad_upn, testuser, self.master.hostname,
+                self.ad_user_password)
+
+    def test_ssh_gssapi_ad_user_ipa_cmd_denied(self):
+        """AD user cannot run privileged IPA commands over GSSAPI SSH.
+
+        Verifies that an AD user authenticated via GSSAPI is denied when
+        attempting to execute `ipa trust-del` on the master over SSH,
+        receiving an "insufficient access" or "cannot connect" error.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        for user, domain in self._ad_user_domain_pairs():
+            base = self._ad_user_base(user)
+            testuser = self._ad_principal(base, domain, realm=False)
+            ad_upn = self._ad_principal(base, domain, realm=True)
+            tasks.kdestroy_all(self.master)
+            tasks.kinit_as_user(self.master, ad_upn, self.ad_user_password)
+            result = self.master.run_command(
+                [
+                    'ssh', '-o', 'StrictHostKeyChecking=no', '-K',
+                    '-l', testuser, self.master.hostname,
+                    'ipa', 'trust-del', self.ad_domain
+                ],
+                raiseonerr=False,
+            )
+            output = f"{result.stdout_text}{result.stderr_text}"
+            assert ("insufficient access" in output.lower()), (
+                f"Expected trust-del to be denied for '{testuser}' "
+                f"(domain: {domain}), got: {output}"
+            )
+
+    def test_ssh_gssapi_ad_admin_trust_del_denied(self):
+        """AD domain admin cannot delete the IPA-AD trust over GSSAPI SSH.
+
+        Verifies that even the AD domain administrator is denied when
+        trying to execute `ipa trust-del` on the master over SSH using
+        GSSAPI credentials, ensuring the trust cannot be removed by an
+        AD-side account.
+        """
+        admin = self.master.config.ad_admin_name
+        admin_principal = self._ad_principal(admin, self.ad_domain, realm=True)
+        admin_login = self._ad_principal(admin, self.ad_domain, realm=False)
+        tasks.kdestroy_all(self.master)
+        tasks.kinit_as_user(self.master, admin_principal,
+                            self.master.config.ad_admin_password)
+        result = self.master.run_command(
+            [
+                'ssh', '-o', 'StrictHostKeyChecking=no', '-K',
+                '-l', admin_login, self.master.hostname,
+                'ipa', 'trust-del', self.ad_domain
+            ],
+            raiseonerr=False,
+        )
+        output = f"{result.stdout_text}{result.stderr_text}"
+        assert ("insufficient access" in output.lower())
+
+    def test_ssh_password_change_forced_at_login(self):
+        """AD user forced to change password on first SSH login can do so.
+
+        Verifies the SSH session prompts for the current and a new
+        password, accepts the change, and subsequently allows a successful
+        login with the new credentials.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        ad_user_new_password = 'Password01'
+        for user in [self.changepwdatlogonuser, self.submustchgpwduser]:
+            tasks.clear_sssd_cache(self.clients[0])
+            with spawn_ssh_interactive(
+                self.clients[0], user, self.clients[0].hostname,
+                extra_ssh_options=['-tt']
+            ) as test:
+                # (?i) ignores case, enabling flag this way is atypical.
+                test.expect(r'(?i).*password.*:')
+                test.sendline('Secret123')
+                expect_password_change_prompts(
+                    test, 'Secret123', ad_user_new_password
+                )
+                test.expect(r'.*[$#] ')
+                test.sendline('whoami')
+                test.expect(user)
+                test.sendline('exit')
+                test.expect_exit(
+                    ignore_remaining_output=True, raiseonerr=False
+                )
+
+    def test_ssh_passwd_change_denied_canchpwd_no(self):
+        """Aduser with 'cannot change password' is denied password change SSH
+
+        ADuser with "cannot change password" flag, logs in over
+        SSH, attempts a password change via passwd, and verifies that the
+        change is rejected with a "password change failed" message.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        ad_user_new_password = 'Password01'
+        for user in [self.cannotchangepwduser, self.subcantchgpwduser]:
+            with spawn_ssh_interactive(
+                self.clients[0], user, self.clients[0].hostname,
+                extra_ssh_options=['-tt']
+            ) as test:
+                # (?i) ignores case, enabling flag this way is atypical.
+                test.expect(r'(?i).*password.*:')
+                test.sendline('Secret123')
+                test.expect(r'.*[$#] ')
+                test.sendline('passwd')
+                expect_password_change_prompts(
+                    test, 'Secret123', ad_user_new_password
+                )
+                test.sendline('exit')
+                test.expect_exit(
+                    ignore_remaining_output=True, raiseonerr=False
+                )
+                assert 'password change failed' in test.before.lower()
+
+    def test_ssh_password_disabled_account_rejected(self):
+        """Disabled AD account is rejected during SSH password authentication.
+
+        Disables an AD user account, attempts SSH password authentication,
+        and verifies the login is denied.  Also checks that the failure is
+        recorded as an authentication failure in journalctl (sshd).
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        for user in [self.disabledaduser, self.subdisableduser]:
+            tasks.clear_sssd_cache(self.clients[0])
+            tasks.wait_for_sssd_domain_status_online(self.clients[0])
+
+            since = time.strftime(
+                '%Y-%m-%d %H:%M:%S',
+                (datetime.now() - timedelta(seconds=5)).timetuple()
+            )
+
+            with spawn_ssh_interactive(
+                self.clients[0], user, self.clients[0].hostname,
+                extra_ssh_options=['-tt']
+            ) as test:
+                # (?i) ignores case, enabling flag this way is atypical.
+                test.expect(r'(?i).*password.*:')
+                test.sendline(self.ad_user_first_password)
+                test.expect(r'(?i).*password.*:')
+                test.sendcontrol('c')
+                test.expect_exit(
+                    ignore_remaining_output=True, raiseonerr=False
+                )
+
+            result = self.clients[0].run_command([
+                'journalctl', '-u', 'sshd', f'--since={since}',
+                '--no-pager'
+            ], raiseonerr=False)
+            log_data = result.stdout_text
+            assert (
+                "authentication failure" in log_data.lower()
+            ), f"No auth failure in log for disabled user {user}"
+
+    def test_ipa_trust_func_sssd_error(self):
+        """
+        Test sssd logs do not throw error when AD user tries to login via
+        ipa client.
+
+        Bug: [BZ954342] In IPA AD trust setup, the sssd logs throws
+        'sysdb_search_user_by_name failed' error when AD user tries to
+        login via ipa client.
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        sssd_log = '{0}/sssd_{1}.log'.format(
+            paths.VAR_LOG_SSSD_DIR, self.master.domain.name)
+
+        for user, domain in self._ad_user_domain_pairs():
+            base = self._ad_user_base(user)
+            testuser = self._ad_principal(base, domain, realm=False)
+            ad_upn = self._ad_principal(base, domain, realm=True)
+
+            tasks.kdestroy_all(self.master)
+            tasks.kinit_as_user(
+                self.master, ad_upn, self.master.config.ad_admin_password)
+
+            # Capture current sssd log offset so we only inspect new entries
+            sssd_log_offset = len(self.master.get_file_contents(sssd_log))
+
+            # SSH with GSSAPI
+            self.master.run_command([
+                'ssh', '-K', '-l', testuser, self.master.hostname,
+                'echo login successful $(whoami)'
+            ])
+
+            # Check only the log content generated during this test step
+            if self.master.transport.file_exists(sssd_log):
+                log_content = self.master.get_file_contents(sssd_log)
+                new_log_content = log_content[sssd_log_offset:]
+                assert b'sysdb_search_user_by_name failed' not in (
+                    new_log_content
+                ), f"sysdb_search_user_by_name failed for {testuser}"
+
+        tasks.kdestroy_all(self.master)
+        tasks.kinit_admin(self.master)
+
+    def test_ipa_trust_func_pac_responder(self):
+        """
+        Test expanding home directory works when the request comes from
+        the PAC responder.
+
+        Bug: [BZ1097286] Expanding home directory fails when the request
+        comes from the PAC responder
+        """
+        testuser = f"Administrator@{self.ad_domain}"
+        testuserupn = f"Administrator@{self.ad_domain.upper()}"
+
+        # Test on master (server mode)
+        self._sssd_cache_reset_all()
+        tasks.wait_for_sssd_domain_status_online(self.master)
+
+        # Verify server mode
+        sssd_conf = self.master.get_file_contents(
+            paths.SSSD_CONF, encoding='utf-8')
+        assert 'ipa_server_mode = True' in sssd_conf
+
+        tasks.kdestroy_all(self.master)
+        ssh_with_gssapi(
+            self.master, testuserupn, testuser, self.master.hostname,
+            self.master.config.ad_admin_password)
+
+        # Test on client
+        sssd_conf = self.clients[0].get_file_contents(
+            paths.SSSD_CONF, encoding='utf-8')
+        assert f'ipa_server = _srv_, {self.master.hostname}' in sssd_conf
+
+        tasks.kdestroy_all(self.clients[0])
+        ssh_with_gssapi(
+            self.clients[0], testuserupn, testuser,
+            self.clients[0].hostname,
+            self.clients[0].config.ad_admin_password)
+
+    def test_ipa_trust_func_sssd_crash_check(self):
+        """
+        Test sssd_be must not crash on passwordless login.
+
+        Bug: [BZ1123432] sssdbe must not crash on passwordless login
+        Repeated for both the primary AD domain and the AD subdomain.
+        """
+        # Capture timestamp to scope log check to this test (journalctl)
+        since = time.strftime(
+            '%Y-%m-%d %H:%M:%S',
+            (datetime.now() - timedelta(seconds=10)).timetuple()
+        )
+
+        for user, domain in self._ad_user_domain_pairs():
+            base = self._ad_user_base(user)
+            testuser = self._ad_principal(base, domain, realm=False)
+            ad_upn = self._ad_principal(base, domain, realm=True)
+            ssh_with_gssapi(
+                self.clients[0], ad_upn, testuser, self.clients[0].hostname,
+                self.ad_user_password)
+
+        # Check logs via journalctl (equivalent to /var/log/messages)
+        result = self.clients[0].run_command([
+            'journalctl', f'--since={since}', '--no-pager'
+        ], raiseonerr=False)
+        log_output = result.stdout_text
+        assert 'Internal credentials cache error' not in log_output
+        assert 'core_backtrace' not in log_output
+        assert 'segfault' not in log_output

--- a/ipatests/test_integration/test_trust_functional.py
+++ b/ipatests/test_integration/test_trust_functional.py
@@ -10,10 +10,22 @@ from datetime import datetime, timedelta
 import pytest
 
 from ipaplatform.paths import paths
+from ipaplatform.tasks import tasks as platform_tasks
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_trust import BaseTestTrust
 
 PLUGIN_CONF = "/var/lib/sss/pubconf/krb5.include.d/localauth_plugin"
+
+
+def xfail_if_sssd_lt_212_trust_client(host):
+    cmd = host.run_command(['sssd', '--version'])
+    sssd_version = platform_tasks.parse_ipa_version(
+        cmd.stdout_text.strip())
+    if (tasks.get_platform(host) == "fedora"
+            and sssd_version < platform_tasks.parse_ipa_version('2.12.0')):
+        pytest.xfail(
+            reason='Requires sssd-client 2.12+'
+        )
 
 
 def ssh_with_password(host, login, target_host, password, expect_success=True):
@@ -372,6 +384,7 @@ class TestTrustFunctionalHbac(BaseTestTrust):
         It verifies that AD users who are members of the external group can
         successfully use sudo and gain root privileges.
         """
+        xfail_if_sssd_lt_212_trust_client(self.clients[0])
         hrule = "ipa_trust_func_hbac_0011"
         srule = "ipa_trust_func_hbac_0011"
         tasks.clear_sssd_cache(self.master)
@@ -512,6 +525,7 @@ class TestTrustFunctionalSudo(BaseTestTrust):
         root. It verifies that AD users who are members of the external group
         can successfully use sudo to gain root privileges.
         """
+        xfail_if_sssd_lt_212_trust_client(self.clients[0])
         srule = "sudorule_01"
         cmd = ["ipa", "sudorule-add", srule, "--hostcat=all", "--cmdcat=all"]
         try:
@@ -539,6 +553,7 @@ class TestTrustFunctionalSudo(BaseTestTrust):
         successfully use sudo to switch to other AD user accounts when they
         have the appropriate sudo permissions.
         """
+        xfail_if_sssd_lt_212_trust_client(self.clients[0])
         srule = "sudorule_02"
         cmd = ["ipa", "sudorule-add", srule, "--hostcat=all", "--cmdcat=all"]
         try:
@@ -620,6 +635,7 @@ class TestTrustFunctionalSudo(BaseTestTrust):
         2. AD users are denied sudo access when the rule is disabled
         3. AD users can sudo as root again when the rule is re-enabled
         """
+        xfail_if_sssd_lt_212_trust_client(self.clients[0])
         srule = "sudorule_05"
         cmd = ["ipa", "sudorule-add", srule, "--hostcat=all", "--cmdcat=all"]
         try:
@@ -666,6 +682,7 @@ class TestTrustFunctionalSudo(BaseTestTrust):
         The test uses /usr/bin/id as a denied command and /usr/bin/whoami as an
         allowed command to demonstrate the allow/deny functionality.
         """
+        xfail_if_sssd_lt_212_trust_client(self.clients[0])
         srule = "sudorule_07"
         try:
             tasks.kinit_admin(self.master)

--- a/ipatests/test_integration/test_trust_functional.py
+++ b/ipatests/test_integration/test_trust_functional.py
@@ -8,24 +8,29 @@ import textwrap
 from datetime import datetime, timedelta
 
 import pytest
+from packaging.version import parse as parse_version
 
+from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
-from ipaplatform.tasks import tasks as platform_tasks
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_trust import BaseTestTrust
+from ipatests.util import xfail_context
 
 PLUGIN_CONF = "/var/lib/sss/pubconf/krb5.include.d/localauth_plugin"
 
 
-def xfail_if_sssd_lt_212_trust_client(host):
-    cmd = host.run_command(['sssd', '--version'])
-    sssd_version = platform_tasks.parse_ipa_version(
-        cmd.stdout_text.strip())
-    if (tasks.get_platform(host) == "fedora"
-            and sssd_version < platform_tasks.parse_ipa_version('2.12.0')):
-        pytest.xfail(
-            reason='Requires sssd-client 2.12+'
-        )
+def xfail_fedora_sssd_before_2_12(host):
+    """Return ``xfail_context`` for Fedora when SSSD is older than 2.12.0.
+
+    Several trust sudo/HBAC checks are known to fail on Fedora until SSSD
+    2.12.0+; callers wrap the affected assertions in this context manager.
+    """
+    sssd_version = tasks.get_sssd_version(host)
+    condition = (
+            osinfo.id == 'fedora'
+            and sssd_version < parse_version('2.12.0')
+    )
+    return xfail_context(condition, reason="Fix available on 2.12.0+")
 
 
 def ssh_with_password(host, login, target_host, password, expect_success=True):
@@ -367,8 +372,8 @@ class TestTrustFunctionalHbac(BaseTestTrust):
                 )
                 output = f"{result.stdout_text}{result.stderr_text}"
                 assert (
-                    "sudo: PAM account management error: Permission denied"
-                    in output
+                        "sudo: PAM account management error: Permission denied"
+                        in output
                 )
         finally:
             self._cleanup_hrule_allow_all_and_wait(hrule)
@@ -384,7 +389,6 @@ class TestTrustFunctionalHbac(BaseTestTrust):
         It verifies that AD users who are members of the external group can
         successfully use sudo and gain root privileges.
         """
-        xfail_if_sssd_lt_212_trust_client(self.clients[0])
         hrule = "ipa_trust_func_hbac_0011"
         srule = "ipa_trust_func_hbac_0011"
         tasks.clear_sssd_cache(self.master)
@@ -406,25 +410,28 @@ class TestTrustFunctionalHbac(BaseTestTrust):
             tasks.clear_sssd_cache(self.clients[0])
             tasks.wait_for_sssd_domain_status_online(self.master)
             test_sudo = "su {user} -c 'sudo -S id'"
-            for user in [self.aduser, self.subaduser]:
-                with self.clients[0].spawn_expect(
-                        test_sudo.format(user=user)) as e:
-                    e.sendline('Secret123')
-                    e.sendline('exit')
-                    e.expect_exit(
-                        ignore_remaining_output=True, raiseonerr=False)
-                    output = e.get_last_output()
-                    assert 'uid=0(root)' in output
-            for user in [self.aduser2, self.subaduser2]:
-                test_sudo = "su {0} -c 'sudo -S id'".format(user)
-                result = self.clients[0].run_command(
-                    test_sudo,
-                    stdin_text='Secret123',
-                    raiseonerr=False
-                )
-                assert result.returncode != 0
-                output = f"{result.stdout_text}{result.stderr_text}"
-                assert 'uid=0(root)' not in output
+            with xfail_fedora_sssd_before_2_12(self.clients[0]):
+                for user in [self.aduser, self.subaduser]:
+                    with self.clients[0].spawn_expect(
+                            test_sudo.format(user=user)) as e:
+                        e.sendline('Secret123')
+                        e.sendline('exit')
+                        e.expect_exit(
+                            ignore_remaining_output=True, raiseonerr=False)
+                        output = e.get_last_output()
+                        assert 'uid=0(root)' in output
+                for user in [self.testuser, self.subnonposixuser1]:
+                    test_sudo = "su {0} -c 'sudo -S id'".format(user)
+                    result = self.clients[0].run_command(
+                        test_sudo,
+                        stdin_text='Secret123',
+                        raiseonerr=False
+                    )
+                    output = f"{result.stdout_text}{result.stderr_text}"
+                    assert (
+                            "PAM account management error: Permission denied"
+                            in output
+                    )
         finally:
             self._cleanup_hrule_allow_all_and_wait(hrule)
             self.master.run_command(["ipa", "sudorule-del", srule])
@@ -525,7 +532,6 @@ class TestTrustFunctionalSudo(BaseTestTrust):
         root. It verifies that AD users who are members of the external group
         can successfully use sudo to gain root privileges.
         """
-        xfail_if_sssd_lt_212_trust_client(self.clients[0])
         srule = "sudorule_01"
         cmd = ["ipa", "sudorule-add", srule, "--hostcat=all", "--cmdcat=all"]
         try:
@@ -535,12 +541,13 @@ class TestTrustFunctionalSudo(BaseTestTrust):
                 ["ipa", "sudorule-add-user", srule, "--groups=sudogroup1"]
             )
             self.cache_reset()
-            for user in [self.aduser, self.subaduser]:
-                test_sudo = f"su {user} -c 'sudo -S id'"
-                self._run_sudo_command(
-                    self.clients[0], test_sudo, user,
-                    expected_output='uid=0(root)'
-                )
+            with xfail_fedora_sssd_before_2_12(self.clients[0]):
+                for user in [self.aduser, self.subaduser]:
+                    test_sudo = f"su {user} -c 'sudo -S id'"
+                    self._run_sudo_command(
+                        self.clients[0], test_sudo, user,
+                        expected_output='uid=0(root)'
+                    )
         finally:
             self._cleanup_srule(srule)
 
@@ -553,7 +560,6 @@ class TestTrustFunctionalSudo(BaseTestTrust):
         successfully use sudo to switch to other AD user accounts when they
         have the appropriate sudo permissions.
         """
-        xfail_if_sssd_lt_212_trust_client(self.clients[0])
         srule = "sudorule_02"
         cmd = ["ipa", "sudorule-add", srule, "--hostcat=all", "--cmdcat=all"]
         try:
@@ -566,19 +572,21 @@ class TestTrustFunctionalSudo(BaseTestTrust):
                 ["ipa", "sudorule-add-runasuser", srule, "--groups=sudogroup2"]
             )
             self.cache_reset()
-            test_sudo = "su {0} -c 'sudo -S -u {1} id'".format(
-                self.aduser, self.aduser2
-            )
-            self._run_sudo_command(self.clients[0], test_sudo, self.aduser,
-                                   expected_output=self.aduser2
-                                   )
+            with xfail_fedora_sssd_before_2_12(self.clients[0]):
+                test_sudo = "su {0} -c 'sudo -S -u {1} id'".format(
+                    self.aduser, self.aduser2
+                )
+                self._run_sudo_command(self.clients[0], test_sudo, self.aduser,
+                                       expected_output=self.aduser2
+                                       )
 
-            test_sudo = "su {0} -c 'sudo -S -u {1} id'".format(
-                self.subaduser, self.subaduser2
-            )
-            self._run_sudo_command(self.clients[0], test_sudo, self.subaduser,
-                                   expected_output=self.subaduser2
-                                   )
+                test_sudo = "su {0} -c 'sudo -S -u {1} id'".format(
+                    self.subaduser, self.subaduser2
+                )
+                self._run_sudo_command(
+                    self.clients[0], test_sudo, self.subaduser,
+                    expected_output=self.subaduser2
+                )
         finally:
             self._cleanup_srule(srule)
 
@@ -635,7 +643,6 @@ class TestTrustFunctionalSudo(BaseTestTrust):
         2. AD users are denied sudo access when the rule is disabled
         3. AD users can sudo as root again when the rule is re-enabled
         """
-        xfail_if_sssd_lt_212_trust_client(self.clients[0])
         srule = "sudorule_05"
         cmd = ["ipa", "sudorule-add", srule, "--hostcat=all", "--cmdcat=all"]
         try:
@@ -654,19 +661,19 @@ class TestTrustFunctionalSudo(BaseTestTrust):
                 # disable sudorule
                 self.master.run_command(["ipa", "sudorule-disable", srule])
                 self.cache_reset()
+                with xfail_fedora_sssd_before_2_12(self.clients[0]):
+                    # now make sure user cannot sudo as root
+                    sudo_cmd = f"su - {aduser} -c 'sudo -S id'"
+                    self._run_sudo_command(self.clients[0], sudo_cmd, aduser,
+                                           expected_output="is not allowed to",
+                                           raiseonerr=False)
 
-                # now make sure user cannot sudo as root
-                sudo_cmd = f"su - {aduser} -c 'sudo -S id'"
-                self._run_sudo_command(self.clients[0], sudo_cmd, aduser,
-                                       expected_output="is not allowed to",
-                                       raiseonerr=False)
-
-                # now reenable rule
-                self.master.run_command(["ipa", "sudorule-enable", srule])
-                self.cache_reset()
-                sudo_cmd = f"su - {aduser} -c 'sudo -S id'"
-                self._run_sudo_command(self.clients[0], sudo_cmd, aduser,
-                                       expected_output='uid=0(root)')
+                    # now reenable rule
+                    self.master.run_command(["ipa", "sudorule-enable", srule])
+                    self.cache_reset()
+                    sudo_cmd = f"su - {aduser} -c 'sudo -S id'"
+                    self._run_sudo_command(self.clients[0], sudo_cmd, aduser,
+                                           expected_output='uid=0(root)')
         finally:
             self._cleanup_srule(srule)
 
@@ -682,7 +689,6 @@ class TestTrustFunctionalSudo(BaseTestTrust):
         The test uses /usr/bin/id as a denied command and /usr/bin/whoami as an
         allowed command to demonstrate the allow/deny functionality.
         """
-        xfail_if_sssd_lt_212_trust_client(self.clients[0])
         srule = "sudorule_07"
         try:
             tasks.kinit_admin(self.master)
@@ -701,15 +707,16 @@ class TestTrustFunctionalSudo(BaseTestTrust):
                  '--sudocmds', '/usr/bin/whoami']
             )
             self.cache_reset()
-            for aduser in [self.aduser, self.subaduser]:
-                sudo_cmd = f"su - {aduser} -c 'sudo -S id'"
-                self._run_sudo_command(self.clients[0], sudo_cmd, aduser,
-                                       expected_output="is not allowed to",
-                                       raiseonerr=False)
-            for aduser in [self.aduser, self.subaduser]:
-                sudo_cmd = f"su - {aduser} -c 'sudo -S whoami'"
-                self._run_sudo_command(self.clients[0], sudo_cmd, aduser,
-                                       expected_output='root')
+            with xfail_fedora_sssd_before_2_12(self.clients[0]):
+                for aduser in [self.aduser, self.subaduser]:
+                    sudo_cmd = f"su - {aduser} -c 'sudo -S id'"
+                    self._run_sudo_command(self.clients[0], sudo_cmd, aduser,
+                                           expected_output="is not allowed to",
+                                           raiseonerr=False)
+                for aduser in [self.aduser, self.subaduser]:
+                    sudo_cmd = f"su - {aduser} -c 'sudo -S whoami'"
+                    self._run_sudo_command(self.clients[0], sudo_cmd, aduser,
+                                           expected_output='root')
         finally:
             self._cleanup_srule(srule)
             self.master.run_command(['ipa', 'sudocmd-del', '/usr/bin/id'])
@@ -842,7 +849,7 @@ class TestTrustFunctionalHttp(BaseTestTrust):
             paths.BIN_CURL, '-v', '--negotiate', '-u:', url
         ])
         assert "TEST_MY_WEB_APP" in result.stdout_text, (
-            msg or f"Expected webapp content at {url}"
+                msg or f"Expected webapp content at {url}"
         )
 
     def _assert_curl_GSSAPI_access_denied(self, msg=None):
@@ -855,7 +862,7 @@ class TestTrustFunctionalHttp(BaseTestTrust):
         assert ("401" in output
                 or "Unauthorized" in output
                 or "Authorization Required" in output), (
-            msg or f"Expected 401/Unauthorized at {url}, got: {output[:200]}"
+                msg or f"Expected 401/Unauthorized at {url}, got: {output[:200]}"
         )
 
     @classmethod
@@ -1483,8 +1490,8 @@ class TestTrustFunctionalSSH(BaseTestTrust):
         for user in [self.changepwdatlogonuser, self.submustchgpwduser]:
             tasks.clear_sssd_cache(self.clients[0])
             with spawn_ssh_interactive(
-                self.clients[0], user, self.clients[0].hostname,
-                extra_ssh_options=['-tt']
+                    self.clients[0], user, self.clients[0].hostname,
+                    extra_ssh_options=['-tt']
             ) as test:
                 # (?i) ignores case, enabling flag this way is atypical.
                 test.expect(r'(?i).*password.*:')
@@ -1511,8 +1518,8 @@ class TestTrustFunctionalSSH(BaseTestTrust):
         ad_user_new_password = 'Password01'
         for user in [self.cannotchangepwduser, self.subcantchgpwduser]:
             with spawn_ssh_interactive(
-                self.clients[0], user, self.clients[0].hostname,
-                extra_ssh_options=['-tt']
+                    self.clients[0], user, self.clients[0].hostname,
+                    extra_ssh_options=['-tt']
             ) as test:
                 # (?i) ignores case, enabling flag this way is atypical.
                 test.expect(r'(?i).*password.*:')
@@ -1546,8 +1553,8 @@ class TestTrustFunctionalSSH(BaseTestTrust):
             )
 
             with spawn_ssh_interactive(
-                self.clients[0], user, self.clients[0].hostname,
-                extra_ssh_options=['-tt']
+                    self.clients[0], user, self.clients[0].hostname,
+                    extra_ssh_options=['-tt']
             ) as test:
                 # (?i) ignores case, enabling flag this way is atypical.
                 test.expect(r'(?i).*password.*:')
@@ -1564,7 +1571,7 @@ class TestTrustFunctionalSSH(BaseTestTrust):
             ], raiseonerr=False)
             log_data = result.stdout_text
             assert (
-                "authentication failure" in log_data.lower()
+                    "authentication failure" in log_data.lower()
             ), f"No auth failure in log for disabled user {user}"
 
     def test_ipa_trust_func_sssd_error(self):


### PR DESCRIPTION
## Summary by Sourcery

Extend AD trust functional testing to cover SSH scenarios, enhance AD user management helpers, and adjust CI jobs for the expanded test suite.

New Features:
- Add a dedicated TestTrustFunctionalSSH suite exercising AD user SSH authentication, password changes, account states, and PAC/SSSD behaviour across multiple AD domains.
- Introduce reusable SSH and password-change helper utilities for password-based and GSSAPI logins, interactive sessions, and SSSD localauth plugin inspection.
- Provide AD user and domain helper methods to create, delete, and address users consistently across root and child AD domains.

Enhancements:
- Update existing HBAC and sudo trust functional tests to use shared SSH helpers, refine user selections, and add stricter assertions on access denials and log contents.
- Increase timeouts for trust functional test jobs to accommodate the larger SSH-focused test coverage in complex AD topologies.

CI:
- Add targeted temp_commit jobs to run the trust functional HBAC tests on Fedora latest and SSSD nightly builds with AD trust topology, and bump timeouts for all nightly trust functional jobs.

Tests:
- Add comprehensive integration tests verifying SSH behaviour for AD users under various naming forms, credential-forwarding, cache and lifecycle handling, disabled/expired accounts, and first-login password changes in IPA-AD trust setups.