### PR TITLE
[Backport][ipa-4-13] Fix ipa ca-show ipa --all not listing RSN version

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1681,7 +1681,7 @@ class CAInstance(DogtagInstance):
                 api.env.basedn)
         entry_attrs = api.Backend.ldap2.get_entry(dn)
         version = entry_attrs.single_value.get(
-            "ipaCaRandomSerialNumberVersion", "0"
+            "ipaCaRandomSerialNumberVersion", "-"
         )
         if str(version) == str(value):
             return


### PR DESCRIPTION
This PR was opened automatically because PR #8327 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Bug Fixes:
- Ensure ipa ca-show --all correctly reports the random serial number (RSN) version when the attribute is missing by using a dash as the default value instead of zero.