### PR TITLE
ipa-cert-fix: Add design document for multi-scenario certificate recovery

### DIFF
--- a/.claude/check-line-length.sh
+++ b/.claude/check-line-length.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+f=$(jq -r '.tool_input.file_path // .tool_response.filePath')
+if echo "$f" | grep -q '\.py$'; then
+    awk 'length > 79 {found=1; printf "LINE TOO LONG L%d (%d chars): %s\n", NR, length, $0} END {if(found) exit 1}' "$f"
+fi

--- a/doc/designs/index.rst
+++ b/doc/designs/index.rst
@@ -37,3 +37,4 @@ FreeIPA design documentation
    audit-ipa-api.md
    sysaccounts.md
    namespace.md
+   ipa-cert-fix-expansion.md

--- a/doc/designs/ipa-cert-fix-expansion.md
+++ b/doc/designs/ipa-cert-fix-expansion.md
@@ -1,0 +1,749 @@
+# ipa-cert-fix Expansion: Multi-Scenario Certificate Recovery
+
+## Overview
+
+The `ipa-cert-fix` tool was originally designed to handle only one scenario: recovering a CA renewal master when expired certificates prevent normal operation.  It runs `pki-server cert-fix` to regenerate Dogtag subsystem certificates and installs renewed IPA service certificates.
+
+This design is insufficient for real-world deployments where:
+
+- Non-renewal-master CA replicas have expired certificates but the renewal master is healthy and reachable.
+- CA-less replicas have only IPA service certificates (HTTP, LDAP, KDC, RA) and no local PKI.
+- Some service certificates are signed by an external CA rather than the internal IPA CA.
+- The renewal master is permanently unavailable and another CA replica must take over.
+
+Running the original `ipa-cert-fix` on a non-renewal-master replica was potentially destructive: while it did not change the IPA renewal master configuration, it effectively acted as a renewal master by using `pki-server cert-fix` to regenerate all shared PKI certificates (subsystem, OCSP, audit signing, etc.) locally instead of fetching them from the actual renewal master.  These locally-regenerated certs would then conflict with the ones managed by the real renewal master, potentially disrupting certificate replication across the topology.
+
+This expansion extends `ipa-cert-fix` to auto-detect the deployment type and choose the least-invasive fix path.  It adds non-destructive recovery for replicas by fetching certificates from a working master, and handles external certificates by generating CSRs or offering transition to the internal CA.
+
+## Use Cases
+
+1. **Renewal master with expired certs** -- existing use case.  The CA signing certificate must still be valid (at least one month remaining); other Dogtag and IPA service certificates are renewed via `pki-server cert-fix`.
+
+2. **CA-full replica with working master** -- the replica fetches the CA chain, RA and shared certificates from the master's LDAP, then uses certmonger to renew expired service certificates through the master's CA.  No `pki-server cert-fix` is needed, and the renewal master role is preserved.
+
+3. **CA-full replica, renewal master unrecoverable** -- the administrator explicitly promotes this replica to renewal master, then certificates are renewed using `pki-server cert-fix`.  CRL generation must be enabled manually afterwards.
+
+4. **CA-less replica with CA servers in topology** -- similar to use case 2 but without Dogtag certificates. RA certificate is fetched, then HTTP, LDAP, and KDC certificates are renewed through a remote CA server.
+
+5. **Externally-signed certificates** -- certificates signed by a CA other than the IPA CA cannot be renewed automatically.  The tool offers per-cert transition to the internal CA (if available) or generates CSR files and prints instructions for manual renewal.
+
+## Design
+
+### Deployment Detection
+
+On startup, `ipa-cert-fix` classifies the local replica into one of four deployment types:
+
+| Deployment Type | Condition |
+|---|---|
+| `CA_SELF_SIGNED` | CA installed locally, caSigningCert is self-signed |
+| `CA_EXTERNALLY_SIGNED` | CA installed locally, caSigningCert issued by external CA |
+| `CA_LESS` | No local CA, but CA servers exist in the topology |
+| `CA_LESS_EXTERNAL` | No local CA, no CA servers in the topology |
+
+When some service certs (HTTP, LDAP, KDC) are signed by an external CA while the CA itself is internal, the deployment is still classified as `CA_SELF_SIGNED` or `CA_EXTERNALLY_SIGNED`.  The externally-signed service certs are captured in `CertFixContext.external_certs` and handled separately by each scenario handler (offered for transition to internal CA or CSR generation).
+
+Detection uses:
+- `cainstance.is_ca_installed_locally()` to check for local PKI
+- `find_providing_servers('CA', ...)` to discover CA servers in the topology
+- Comparison of `caSigningCert` issuer and subject DNs for self-signed detection
+- `is_ipa_issued_cert(api, cert)` on each service certificate for external detection
+
+### Fix Scenarios
+
+Based on the deployment type, renewal master status, and CLI options, one of five fix scenarios is selected:
+
+| Scenario | Entry Condition | Actions |
+|---|---|---|
+| `RENEWAL_MASTER` | CA-full + is renewal master (or `--renewal-master`) | `pki-server cert-fix`, install certs, become RM, restart |
+| `CA_FULL_WITH_MASTER` | CA-full + not RM + working master found | Fetch CA chain + RA + shared certs from master, renew server-specific via certmonger, restart, resubmit |
+| `CA_FULL_PROMOTE` | CA-full + not RM + no working master | Promote to RM, then renew certs via `pki-server cert-fix` |
+| `CA_LESS_WITH_MASTER` | CA-less + CA servers in topology | Fetch CA chain + RA from master, renew HTTP/LDAP/KDC via certmonger, restart |
+| `EXTERNAL_CERTS` | CA-less + no CA servers, or only external certs | Generate CSRs and print manual renewal instructions (transition offered only if CA servers exist in topology) |
+
+### CLI Options
+
+| Option | Description |
+|---|---|
+| `--force-server=FQDN` | Use this server as the master to fetch certificates from |
+| `--renewal-master` | Force this server to become the renewal master |
+| `--dry-run` | Print intended actions without executing |
+| `-U, --unattended` | Non-interactive mode, never prompt the user |
+
+Existing options (`--verbose`, `--quiet`, `--log-file`, `--help`, `--version`) are preserved from the base `AdminTool` class.
+
+Option validation:
+- `--renewal-master` and `--force-server` are mutually exclusive (caught in `validate_options`).
+- `--renewal-master` on a CA-less replica is rejected in `determine_scenario` (no local CA to become renewal master of).  The `RuntimeError` is caught by `_detect_and_dispatch` and printed as a clean error with exit code 1.
+
+### Master Server Selection
+
+When the tool needs a master server (replica and CA-less paths), it determines one as follows:
+
+1. If `--force-server=FQDN` is given, use it (after reachability check).
+2. Otherwise, look up the current renewal master from LDAP.  If found and it is not this server, use it as the default.
+3. If no renewal master is found, discover CA servers in the topology and use the first one as the default.
+4. In interactive mode, prompt the user with the default pre-filled.  The user can accept it (press Enter) or type a different FQDN.  Leaving the prompt empty (only possible when no default exists) returns `None` -- the caller routes to `CA_FULL_PROMOTE` (CA-full) or `EXTERNAL_CERTS` (CA-less).
+5. In unattended mode (`-U`), the default is used automatically.  If no default exists, returns `None`.  For CA-full, `CA_FULL_PROMOTE` requires explicit `--renewal-master` in unattended mode (refuses silent promotion).
+
+### Certificate Classification
+
+Expired certificates are classified into three categories:
+
+- **Dogtag certificates** -- PKI subsystem certs in the Tomcat NSS database (caSigningCert, Server-Cert, subsystemCert, ocspSigningCert, auditSigningCert, KRA certs).  Only present on CA-full replicas.
+- **IPA certificates** -- service certs issued by the internal IPA CA (HTTP, LDAP, KDC, RA).
+- **External certificates** -- service certs whose issuer does not match the IPA CA.  Detected by `is_ipa_issued_cert()` returning `False`.
+
+The two-week lookahead threshold is preserved from the original implementation: certificates expiring within two weeks are treated as expired.
+
+### RA and Subsystem LDAP Consistency
+
+On CA-full replicas, the RA certificate on disk (`ra-agent.pem`) and the subsystem certificate in the PKI NSSDB must match their corresponding `ou=People,o=ipaca` LDAP entries (`uid=ipara` and `uid=pkidbuser`).  Both the `userCertificate` blob and the `description` field (which contains the serial number in `2;<serial>;<issuer>;<subject>` format) must be consistent.  Mismatches cause Dogtag authentication failures even when the certificates themselves are valid.
+
+This is a common failure mode — for example, a prior `ipa-cert-fix` crash or interrupted replication can leave the LDAP entry with a stale serial or missing cert blob.
+
+The consistency check compares all cert copies (local filesystem/NSSDB and LDAP blobs) and picks the **newest** one (by `notAfter`) as authoritative.  If the local cert is older than the LDAP blob, the local file/NSSDB is updated to match LDAP — not the other way around.  This prevents a stale local cert from overwriting a correctly-replicated LDAP entry and disrupting other servers in the topology.  Only the LDAP `description` field (serial number) is updated to match the newest cert, and only if the newest cert blob is already present in LDAP.
+
+`_detect_ra_subsystem_mismatches` runs on CA-full deployments at two points, but never both in the same invocation:
+
+1. **When no certs are expired** ("Nothing to do" scenario) — catches mismatches that cause authentication failures even with valid certs.  Prints what would be fixed and asks for confirmation (interactive mode), fixes automatically (unattended), or prints dry-run info.
+
+2. **After a fix scenario completes** — verifies that certs fetched or renewed during the fix landed in LDAP correctly.  This is the only check when certs are expired, because fixing LDAP before the scenario runs would be pointless — the scenario fetches new certs that supersede the current ones.
+
+### Certmonger Integration
+
+For non-renewal-master scenarios, only **server-specific** certificates (sslserver, HTTP, LDAP, KDC) are renewed through certmonger.  **Shared** certificates (subsystem, OCSP, audit signing, KRA certs) are fetched directly from the master's LDAP `cn=ca_renewal` entries and installed into the local NSSDB — see [Shared vs Server-Specific Certificate Handling](#shared-vs-server-specific-certificate-handling) for details.
+
+For the server-specific certs, the tool temporarily modifies the IPA CA helper in certmonger to point renewal requests at the master server.  This is done by appending `-J https://<master>/ipa/json` to the IPA CA helper command, which overrides the JSON-RPC endpoint that `ipa-submit` uses.
+
+The flow for each server-specific expired certificate:
+
+1. Look up the certmonger tracking request by certificate location criteria.
+2. For Dogtag certs (sslserver): temporarily switch the CA from `dogtag-ipa-ca-renew-agent` to `IPA`, add a host principal, and override the profile to `caIPAserviceCert`.
+3. Resubmit the request through the modified IPA CA helper.
+4. Wait for certmonger to reach `MONITORING` state (timeout: 300 seconds).
+5. Wait for certmonger to become D-Bus responsive again (post-save commands like `renew_ca_cert` may restart PKI, blocking certmonger temporarily).
+6. Verify the renewed certificate has a different serial number.
+
+All modifications are restored in a `finally` block: the original CA helper, CA assignment, profile, and temporary principals are reverted regardless of success or failure.
+
+### External Certificate Handling
+
+When externally-signed certificates are detected:
+
+1. If an internal CA exists in the topology, the user is offered a per-cert choice to transition to the internal CA.  Externally-signed certificates typically have no certmonger tracking request (tracking is stopped when a cert is installed externally).  Transition is performed by:
+   - Stopping any existing tracking for the certificate.
+   - Creating a new certmonger tracking request with the correct IPA parameters (CA name, profile, post-save command), mirroring what `httpinstance.py`, `dsinstance.py`, and `krbinstance.py` use during server installation.
+   - If a master server is available (replica scenarios), the IPA CA helper is temporarily overridden to point at the master so that certmonger can obtain the new certificate immediately.
+   - Waiting for certmonger to reach `MONITORING` state.
+
+2. For certificates not transitioned (or when no internal CA exists), the tool generates a CSR and writes it to `/run/ipa/cert-fix/<type>.csr`.  CSR generation tries three sources in order:
+   - Extract existing CSR from certmonger tracking request (if tracking is still active).
+   - Generate a new CSR from the existing private key and the expired certificate's subject/SANs.  For file-based keys (HTTP, KDC), uses the `cryptography` library.  For NSSDB keys (LDAP), uses `certutil -R`.
+   - If neither works, prints manual instructions.
+
+   Along with the CSR files, the tool prints the corresponding `ipa-server-certinstall` commands for each certificate type.
+
+On `CA_LESS_EXTERNAL` deployments (no internal CA anywhere in the topology), transitions are not possible -- the tool skips the CA server lookup entirely and proceeds directly to CSR generation.  Installing an internal CA via `ipa-ca-install` is outside the scope of this tool and requires valid HTTP/LDAP certificates first.
+
+In unattended mode, no transitions are offered -- only CSR generation.
+
+### HSM Support
+
+When PKI is configured with an HSM (Hardware Security Module), the private keys for Dogtag subsystem certificates (caSigningCert, subsystemCert, ocspSigningCert, auditSigningCert) reside on the HSM token rather than in the software NSSDB.  Service certificates (HTTP, LDAP, KDC) are always in software and are not affected.
+
+On startup, `ipa-cert-fix` detects HSM configuration via `CAInstance().hsm_enabled` and stores the token name in `CertFixContext.hsm_token_name`.  This affects:
+
+- **Renewal master path**: `pki-server cert-fix` handles HSM internally (reads token config from CS.cfg).  No changes needed.
+- **Replica path**: certmonger tracking requests for Dogtag certs already include the HSM token (configured during installation).  The resubmit path reuses the existing tracking configuration.
+- **CSR generation**: `certutil -K` and `certutil -R` receive `-h <token>` to access keys on the HSM token.
+- **Cert transition**: `certmonger.start_tracking` receives `token_name` for any new tracking requests.
+
+The Server-Cert (`sslserver`) always uses the internal token, even on HSM deployments.
+
+### Error Handling and Safeguards
+
+- **LDAP via LDAPI**: All local LDAP operations use the UNIX socket, which does not require TLS and works even with expired certificates.
+- **Kerberos from host keytab**: Remote operations use `KRB5_CLIENT_KTNAME` with the host keytab and an in-memory ccache.
+- **certmonger responsiveness**: A wait loop with configurable timeout checks that certmonger is responsive on D-Bus before modifying helpers.  Certmonger is NOT automatically restarted (restarting triggers renewal attempts on all tracked certs, interfering with the controlled renewal flow).
+- **LDAP reconnection**: `_ensure_ldap_connected()` unconditionally disconnects and reconnects the `ldap2` backend.  Called after every operation that may restart Directory Server: `ipa-certupdate`, `pki-server cert-fix`, `ipactl restart`, and before `set_renewal_master()`.
+- **ipa-certupdate skip**: Before running `ipa-certupdate`, `update_ca_cert_from_master` checks two conditions: (1) the local CA chain (`/etc/ipa/ca.crt`) is present and valid (no expired certs in the trust path), and (2) a TLS handshake to the master's port 443 succeeds using the local CA trust store.  If both pass, `ipa-certupdate` is skipped entirely, avoiding unnecessary service restarts and certmonger D-Bus disruption.  If the chain is valid but TLS fails (e.g. the master's CA cert was renewed and the local trust store is stale), `ipa-certupdate` runs to update the trust store.
+- **ipa-certupdate tolerance**: When `ipa-certupdate` does run, a non-zero exit code is tolerated if the CA chain is present and contains no expired certificates.  The exit code is often non-zero due to service restart failures or certmonger D-Bus timeouts, which are expected with expired certs.  If the CA chain is missing or contains expired certs, the tool fails with instructions to fix the master first or manually copy `ca.crt`.
+- **Duplicate-subject CA certs**: After CA renewal, `ca.crt` may contain both old (expired) and new (valid) CA certificates with the same subject DN.  The chain validator builds the subject-to-cert map by preferring the cert with the latest `notAfter`, so a valid chain is not rejected because the expired copy happens to appear later in the file.
+- **pki-server cert-fix tolerance**: `CalledProcessError` is tolerated if the DS cert was expired (PKI restart fails) but renewed cert files exist on disk.
+- **Post-renewal CA verification**: After `pki-server cert-fix` renews the CA signing cert, it is re-checked for validity.  If still expired (partial failure), the tool exits with instructions to use `ipa-cacert-manage`.
+- **Externally-signed CA protection**: On `CA_EXTERNALLY_SIGNED` deployments, the `ca_issuing` cert is filtered out of the `pki-server cert-fix` arguments.  This prevents `pki-server cert-fix` from regenerating the CA cert as self-signed, which would silently overwrite the external CA chain.
+- **IPA restart tolerance**: `ipactl restart` uses `--ignore-service-failures` in all scenarios because certmonger post-save commands may have already restarted individual services.
+- **Resubmit safety**: `resubmit_expired_certs()` uses explicit skip/error state sets to avoid interfering with certs that certmonger is already processing (SUBMITTING, CA_WORKING, etc.).  Only certs in error states (CA_UNREACHABLE, CA_REJECTED, etc.) are resubmitted.
+- **Fetched cert validation**: Every certificate fetched from the master (RA and all shared dogtag certs) is checked for expiry before installation.  If the master's cert is also expired, the tool fails with a clear message directing the administrator to fix the master first.
+- **Certmonger timeout after restart**: After the final `ipactl restart`, certmonger unresponsiveness is non-fatal (certs are already installed, services restarted).  The tool prints a warning and skips `resubmit_expired_certs`.  Mid-renewal timeouts (inside `_resubmit_cert_via_master` or `_transition_cert`) remain fatal since certmonger must be responsive to proceed.
+- **Renewal master detection resilience**: `check_is_renewal_master` guards against `None` CA instance (CA-less deployments) and catches LDAP errors broadly so that unexpected LDAP failures on broken systems fall through to the non-RM path rather than crashing the tool.
+- **renew_certs_from_master returns only successful IDs**: `resubmit_expired_certs` receives only the IDs of successfully renewed certs, so failed certs get a second chance during the resubmit pass.
+- **Always-restore**: The IPA CA helper, certmonger request parameters, Kerberos environment, and LDAP connections are always restored in `finally` blocks.
+- **CA signing cert check**: On renewal master, the CA signing certificate must have at least one month of remaining validity.  This check runs inside `run_renewal_master_fix`, not as a pre-flight gate in `run()`, so it does not block replica or CA-less scenarios where the local CA cert being expired is expected.  If the CA cert is expired:
+  - For **self-signed CA**: the user is directed to `ipa-cacert-manage renew`.
+  - For **externally-signed CA**: the existing CSR is extracted from certmonger and written to `/var/lib/ipa/ca.csr`.  Instructions are printed to submit the CSR to the external CA and install the renewed certificate with `ipa-cacert-manage renew --external-cert-file=...` before retrying `ipa-cert-fix`.
+
+## Implementation
+
+### Key Types
+
+```python
+@dataclass(frozen=True)
+class CertIdentity:
+    """Identity and metadata for a Dogtag certificate."""
+    id: str                          # e.g., 'sslserver'
+    nickname: str                    # e.g., 'Server-Cert cert-pki-ca'
+    is_shared: bool                  # managed by RM, replicated via LDAP
+    cfg_path: Optional[str]          # CS.cfg path for this cert
+    cs_cfg_directive: Optional[str]  # cert blob directive (e.g., 'ca.subsystem.cert')
+    certreq_directive: Optional[str] # CSR directive (e.g., 'ca.subsystem.certreq')
+    display_name: str                # property: returns nickname
+    is_dogtag: bool                  # property: always True
+
+class DeploymentType(Enum):
+    CA_SELF_SIGNED = "CA-full, self-signed"
+    CA_EXTERNALLY_SIGNED = "CA-full, externally-signed"
+    CA_LESS = "CA-less (internal CA on other replicas)"
+    CA_LESS_EXTERNAL = "CA-less (fully external)"
+
+class FixScenario(Enum):
+    RENEWAL_MASTER = "renewal_master"
+    CA_FULL_WITH_MASTER = "ca_full_with_master"
+    CA_FULL_PROMOTE = "ca_full_promote"
+    CA_LESS_WITH_MASTER = "ca_less_with_master"
+    EXTERNAL_CERTS = "external_certs"
+
+@dataclass
+class CertFixContext:
+    deployment_type: DeploymentType
+    scenario: FixScenario
+    subject_base: DN
+    ca_subject_dn: DN
+    dogtag_certs: list       # [(certid, cert), ...]
+    ipa_certs: list           # [(IPACertType, cert), ...]
+    external_certs: list      # [(IPACertType, cert), ...]
+    master_server: Optional[str]
+    serverid: str             # DS instance id
+    ds_dbdir: str             # DS NSS database directory
+    ds_nickname: str          # DS server cert nickname
+    hsm_enabled: bool
+    hsm_token_name: Optional[str]
+```
+
+The `DOGTAG_CERTS` registry is a module-level dict mapping cert IDs to `CertIdentity` instances.  It is the single source of truth for Dogtag certificate metadata — nicknames, shared/server-specific classification, CS.cfg directives, and CSR directives are all derived from it.
+
+### Architecture
+
+The code is organized into five classes and a set of module-level utility functions:
+
+```
+IPACertFix (AdminTool)          -- CLI orchestrator (16 methods)
+├── DeploymentDetector          -- detection, classification, scenario routing
+├── ExternalCertHandler         -- external cert transition and CSR generation
+├── CertRenewalFromMaster       -- certmonger-based renewal via master server
+└── CertmongerClient            -- adapter for certmonger D-Bus/module operations
+```
+
+`CertmongerClient` is an adapter that wraps the `ipalib.install.certmonger` module.  It provides a mockable boundary for unit tests and centralizes D-Bus retry logic.  Key methods: `get_ca_helper` (reads current helper with retry), `set_ca_override`/`restore_ca_override` (manages the `-J` JSON-RPC override), `is_responsive` (polls certmonger D-Bus via `getcert list-cas`), `is_cert_valid` (checks whether a tracked cert is still valid).
+
+`DeploymentDetector` handles deployment type detection (`detect_deployment_type`), certificate classification (`_classify_certs`), scenario routing (`determine_scenario`), CA signing cert validation (`_check_ca_signing_cert`), CA chain verification (`_verify_ca_chain_valid`), RA/subsystem LDAP consistency checking (`_detect_ra_subsystem_mismatches`), and master server selection (`get_master_server`).  Constructed with a `CertmongerClient`, CA instance, and CLI options.
+
+`ExternalCertHandler` handles externally-signed certificates.  `handle(ctx)` dispatches to `offer_transition` (interactive per-cert transition to internal IPA CA) or `generate_csrs` (CSR generation for manual external renewal).  Transitions create new certmonger tracking requests mirroring the parameters used during IPA server installation (`httpinstance.py`, `dsinstance.py`, `krbinstance.py`).  CSR generation tries three sources in order: extract from certmonger tracking, generate from existing private key, or fall back to manual instructions.  CSR files are written to `/run/ipa/cert-fix/` with 0o600 permissions.
+
+`CertRenewalFromMaster` manages the certmonger-based renewal flow for non-renewal-master replicas.  `renew(certs, ipa_certs, ctx)` builds a tracking list, temporarily overrides the IPA CA helper to point at the master (`-J` flag), resubmits each tracking request, and restores all certmonger state in a `finally` block.  Dogtag certs are temporarily switched from `dogtag-ipa-ca-renew-agent` to the `IPA` CA with a host principal and `caIPAserviceCert` profile.  All per-request state (original CA name, profile, principals) is tracked and restored regardless of success or failure.
+
+`IPACertFix` is the CLI entry point (`AdminTool` subclass) and orchestrator.  It has 16 methods:
+
+- **CLI**: `add_options`, `validate_options`
+- **Bootstrap & dispatch**: `run`, `_classify_and_dispatch`
+- **Scenario handlers**: `run_renewal_master_fix`, `_run_non_rm_replica_fix`, `run_ca_full_promote`, `run_external_certs`
+- **Master cert operations**: `_promote_to_renewal_master`, `_fetch_certs_from_master`, `_fetch_shared_dogtag_certs`, `update_ca_cert_from_master`
+- **CA-less RA staleness**: `_check_ra_cert_staleness`, `_fetch_ra_from_ca_server`
+- **Shared**: `_confirm_execution`, `resubmit_expired_certs`
+
+### Dispatch Architecture
+
+`run()` performs bootstrap, LDAP connect, and cleanup in a `try/finally` block.  `_classify_and_dispatch()` creates the `DeploymentDetector` and `ExternalCertHandler`, performs detection and classification, then dispatches to a scenario handler via a dictionary lookup:
+
+```python
+dispatch = {
+    FixScenario.RENEWAL_MASTER: self.run_renewal_master_fix,
+    FixScenario.CA_FULL_WITH_MASTER: lambda ctx: self._run_non_rm_replica_fix(ctx, is_ca_full=True),
+    FixScenario.CA_FULL_PROMOTE: self.run_ca_full_promote,
+    FixScenario.CA_LESS_WITH_MASTER: lambda ctx: self._run_non_rm_replica_fix(ctx, is_ca_full=False),
+    FixScenario.EXTERNAL_CERTS: self.run_external_certs,
+}
+```
+
+Error handling convention:
+- Scenario handlers return exit codes (0/1) to `_classify_and_dispatch`.
+- `determine_scenario` raises `RuntimeError` for invalid option combos; `_classify_and_dispatch` catches it and returns exit code 1 with a clean message.
+- Internal helpers raise `RuntimeError` for fatal errors (e.g., expired cert fetched from master, certmonger unresponsive mid-renewal); these propagate to the dispatch-level catch for a clean error message.
+
+`_run_non_rm_replica_fix(ctx, is_ca_full)` is the shared handler for both CA-full and CA-less replica scenarios.  It sets up Kerberos credentials, updates the CA chain from the master, fetches RA and shared certs, creates a `CertRenewalFromMaster` to renew server-specific certs via certmonger, handles any external certs, restarts IPA, and resubmits remaining tracking requests.
+
+### Shared vs Server-Specific Certificate Handling
+
+On non-renewal-master replicas, Dogtag certificates fall into two categories:
+
+- **Server-specific** (`sslserver`): unique per server, renewed via certmonger with the IPA CA helper pointed at the master (`-J` override).
+
+- **Shared/replicated** (`subsystem`, `ocspSigningCert`, `auditSigningCert`, and KRA certs): identical across all replicas, managed by the renewal master and replicated via LDAP `cn=ca_renewal,cn=ipa,cn=etc`.
+
+The distinction is encoded in `CertIdentity.is_shared` within the `DOGTAG_CERTS` registry.  `CertRenewalFromMaster._build_tracking_list` skips any cert where `is_shared` is `True` (not resubmitted via certmonger; instead fetched directly from the master's LDAP).  Only `sslserver` (the sole non-shared Dogtag cert) goes through certmonger resubmit with the `-J` override.
+
+Because shared certs are installed directly into the NSSDB (bypassing certmonger's `renew_ca_cert` post-save command), the base64 certificate blobs in the Dogtag CS.cfg configuration files must be updated manually.  The `_update_cs_cfg` module-level function writes the new blob to the appropriate directive (looked up from `CertIdentity.cs_cfg_directive`).  The KRA transport certificate additionally requires updating `ca.connector.KRA.transportCert` in the CA config.
+
+### Files Modified
+
+- `ipaserver/install/ipa_cert_fix.py` -- orchestrator (`IPACertFix`), classification functions, cert operations, and re-exports from the two modules below
+- `ipaserver/install/ipa_cert_fix_types.py` -- data definitions: `CertIdentity`, `DOGTAG_CERTS`, enums, `CertFixContext`, constants, string templates
+- `ipaserver/install/ipa_cert_fix_services.py` -- extracted classes (`CertmongerClient`, `DeploymentDetector`, `ExternalCertHandler`, `CertRenewalFromMaster`) and helper functions they use
+- `ipatests/test_integration/test_ipa_cert_fix.py` -- integration tests (15 classes, require IPA VMs)
+- `ipatests/test_integration/test_ipa_cert_fix_unit.py` -- unit tests (61 classes, mock-only, run in seconds)
+- `install/tools/man/ipa-cert-fix.1` -- man page
+
+All public names remain importable from `ipaserver.install.ipa_cert_fix` via re-exports.
+
+### Module-Level Functions
+
+The following module-level functions support the classes above:
+
+- **Certificate operations**: `expired_dogtag_certs()`, `expired_ipa_certs()` (with `_check_ipa_cert` helper), `print_intentions()`, `print_cert_info()`, `get_csr_from_certmonger()`, `fix_certreq_directives()`, `run_cert_fix()`, `replicate_dogtag_certs()`, `check_renewed_ipa_certs()`, `install_ipa_certs()`, `replicate_cert()`, `_get_newest_cert()`, `_fetch_and_update_cert()`
+- **Infrastructure**: `_ensure_ldap_connected()`, `_check_tcp_reachable()`, `_check_tls_handshake()`, `_setup_kerberos()`, `_restore_kerberos()`, `_kill_stuck_helpers()`, `_replace_cert_in_nssdb()`, `_update_cs_cfg()`, `_find_current_renewal_master()`, `_get_pki_nssdb()`
+
+## Upgrade
+
+No impact on upgrades.  The new CLI options are additive and backward-compatible.  Existing invocations of `ipa-cert-fix` without options will auto-detect the deployment type and behave identically to the original tool on renewal masters.
+
+## Future Work
+
+### Further file split
+
+The current three-file layout (`ipa_cert_fix_types.py`, `ipa_cert_fix_services.py`, `ipa_cert_fix.py`) keeps the orchestrator at ~1600 lines and the services file at ~2200 lines.  A follow-up refactor could promote these into an `ipaserver/install/certfix/` package with one file per class:
+
+- `ipa_cert_fix.py` -- re-export shim (~20 lines)
+- `certfix/__init__.py` -- public API re-exports
+- `certfix/_constants.py` -- CertIdentity, DOGTAG_CERTS, timeouts
+- `certfix/_types.py` -- enums, CertFixContext
+- `certfix/_helpers.py` -- stateless utility functions
+- `certfix/_certmonger.py` -- CertmongerClient
+- `certfix/_classification.py` -- expired_dogtag_certs, expired_ipa_certs
+- `certfix/_detection.py` -- DeploymentDetector
+- `certfix/_external.py` -- ExternalCertHandler
+- `certfix/_renewal.py` -- CertRenewalFromMaster
+- `certfix/_certops.py` -- pki-server helpers, LDAP replication
+- `certfix/_cli.py` -- IPACertFix AdminTool
+
+This would bring the largest file to ~450 lines and enable per-class unit test files.  Deferred because the current layout works, follows existing IPA conventions, and the package split is mechanical once the three-file structure is stable.
+
+### HSM integration tests
+
+The HSM code path (`-h <token>` for `certutil`, HSM detection via `CAInstance().hsm_enabled`) is exercised in production but has no dedicated test coverage.  The unit tests always set `hsm_enabled=False`.  Integration tests require a SoftHSM or hardware token, which is not available in standard CI.  A future test class (e.g. `TestHSMRenewalMaster`) should:
+
+- Install IPA with SoftHSM (`ipa-server-install --token-name=...`)
+- Expire Dogtag certs and run `ipa-cert-fix`
+- Verify that `certutil -K -h <token>` is used for CSR generation
+- Verify that renewed certs are stored on the HSM token
+
+### Missing unit test coverage
+
+Several code paths lack dedicated unit tests:
+
+- `_fetch_certs_from_master`: TLS error branch (certificate vs non-certificate exceptions)
+- `_fetch_ra_from_ca_server`: expiry validation of fetched cert
+- `_check_ra_cert_staleness`: serial mismatch detection
+- `update_ca_cert_from_master`: ipa-certupdate partial failure (non-zero exit but valid chain)
+- `run_renewal_master_fix`: externally-signed CA deployment (`ca_issuing` skip logic)
+- `ExternalCertHandler._generate_csr_nssdb`: HSM token pass-through
+
+### Automatic CRL generation after promotion
+
+When `ipa-cert-fix` promotes a replica to renewal master (`CA_FULL_PROMOTE` scenario), CRL generation must be enabled manually afterward (`ipa-crlgen-manage enable` on the new RM, `disable` on others).  The tool prints instructions but does not act because CRL configuration is a topology-wide concern -- the administrator must also disable CRL on the old master (if it comes back) and verify CRL distribution points.  A future enhancement could automate the local `ipa-crlgen-manage enable` and optionally disable CRL on other reachable CA servers.
+
+### Trust-on-first-use for stale CA trust store
+
+The stale CA trust store problem (Known Limitations below) currently requires manual `ca.crt` copy.  A `--trust-on-first-use` option could fetch the CA chain over an unverified TLS connection, display the certificate fingerprint, and ask the administrator to confirm it matches out-of-band.  This would eliminate the manual file copy while preserving explicit trust verification.  The option should never be available in unattended mode.
+
+## Known Limitations
+
+### No concurrent execution on multiple replicas
+
+Running `ipa-cert-fix` simultaneously on two replicas that both target the same master (e.g., both using `--force-server=master`) is not supported.  The tool temporarily modifies the certmonger IPA CA helper (a global, per-host setting) to point at the master.  If two instances run at the same time on the same host, or if a second instance starts before the first has restored the helper, the restore logic may clobber the other instance's override.
+
+**Workaround**: Run `ipa-cert-fix` on one replica at a time.  Wait for completion before starting on the next replica.
+
+### Stale CA trust store requires manual ca.crt copy
+
+When the CA certificate on the master has been renewed (via `ipa-cacert-manage renew`), replicas still have the old CA certificate in their trust store (`/etc/ipa/ca.crt`).  If a replica's certificates expire in this state, `ipa-cert-fix` cannot automatically update the trust store because all remote operations (HTTPS, LDAPS) require verifying the master's TLS certificate — which is signed by the new CA that the replica doesn't trust yet.
+
+Automatically fetching the updated CA chain over an unverified connection would risk a man-in-the-middle attack on degraded infrastructure, so `ipa-cert-fix` refuses and prints instructions for manual intervention.
+
+**Workaround**: Before running `ipa-cert-fix` on the replica, copy `/etc/ipa/ca.crt` from the master to the replica using a trusted channel (e.g. `scp` with host key verification, or physical media).  Verify the file's authenticity by comparing checksums out-of-band.  Then re-run `ipa-cert-fix`.
+
+### External CA certificates require manual renewal
+
+The CA signing certificate on externally-signed CA deployments cannot be renewed by `ipa-cert-fix`.  If the CA signing certificate is expired:
+
+- For **self-signed CA**: the tool directs the administrator to use `ipa-cacert-manage renew`.
+- For **externally-signed CA**: the tool extracts the existing CSR (or directs the administrator to `ipa-cacert-manage renew --external-ca`) and prints instructions to submit it to the external CA and install the renewed certificate with `ipa-cacert-manage renew --external-cert-file`.
+
+Only after the CA signing certificate is renewed can `ipa-cert-fix` proceed to fix the remaining service and shared certificates.
+
+### External service certificates require manual installation
+
+Service certificates (HTTP, LDAP, KDC) signed by an external CA cannot be renewed automatically.  The tool offers two options:
+
+1. **Transition to internal IPA CA** (interactive only) -- creates a new certmonger tracking request with the IPA CA, obtaining a new internally-signed certificate.  This changes the trust model for that service.
+2. **CSR generation** -- generates a CSR from the existing private key (file-based certs) or a new key pair (NSSDB-based certs) and writes it to `/run/ipa/cert-fix/` (root-owned tmpfs, avoids TOCTOU races inherent to `/tmp/`).  The administrator must submit the CSR to the external CA and install the renewed certificate using `ipa-server-certinstall`.
+
+In unattended mode (`-U`), only CSR generation is performed -- no transitions are offered.
+
+### CA-less replicas cannot become renewal masters
+
+`--renewal-master` is rejected on CA-less replicas.  There is no local CA to become the renewal master of.  Installing a CA on a CA-less replica requires `ipa-ca-install`, which needs valid HTTP and LDAP certificates first -- so `ipa-cert-fix` must run successfully before `ipa-ca-install` can be attempted.
+
+### pki-server cert-fix availability
+
+The renewal master scenario requires the `pki-server cert-fix` command from the `pki-server` package.  If this command is not available (e.g., PKI is not installed or is too old), the renewal master scenario fails.  The non-destructive replica and CA-less scenarios do not require it.
+
+### NSSDB-based CSR generation
+
+When generating CSRs for externally-signed LDAP certificates (stored in an NSS database), the tool extracts the hex key ID via `certutil -K` and passes it to `certutil -R -k <key-id>` to reuse the existing private key.  If the key ID cannot be determined, CSR generation for that certificate is skipped and manual instructions are printed instead.  Private keys never leave the NSS database.
+
+### GSSAPI authentication requires a working KDC
+
+Remote LDAP operations (fetching RA and shared certs from the master) use GSSAPI authentication with the host keytab.  The Kerberos client uses the KDC(s) configured in `/etc/krb5.conf` or discovered via DNS SRV records.  If the local KDC is down (e.g., expired KDC cert) and `krb5.conf` points to it, the GSSAPI bind to the master will fail even though the master's KDC may be operational.
+
+**Workaround**: Before running `ipa-cert-fix`, ensure at least one KDC in the topology is reachable.  If the local KDC is down, edit `/etc/krb5.conf` temporarily to point `kdc` at the master, or run `ipa-cert-fix` on the master first so its KDC is operational before fixing replicas.
+
+## User Stories
+
+As an IPA administrator, I want to recover a renewal master with expired Dogtag and IPA service certificates by running a single command so that I can restore IPA operations without manual certificate manipulation.
+
+As an IPA administrator, I want to fix expired certificates on a CA-full replica by fetching them from a healthy renewal master so that I don't have to promote the replica or disrupt the topology.
+
+As an IPA administrator, I want to promote a CA-full replica to renewal master when the original master is permanently lost so that I can recover the deployment without rebuilding from scratch.
+
+As an IPA administrator, I want to fix expired HTTP, LDAP, and KDC certificates on a CA-less replica by renewing them through a remote CA server so that CA-less replicas are not a dead end when certs expire.
+
+As an IPA administrator, I want ipa-cert-fix to extract the CA signing certificate CSR and print renewal instructions when my externally-signed CA certificate expires so that I know exactly what to submit to the external CA and how to install the result.
+
+As an IPA administrator, I want to choose per-certificate whether to transition an externally-signed service certificate to the internal IPA CA or generate a CSR for manual renewal so that I retain control over my PKI trust model.
+
+As an IPA administrator, I want a dry-run mode that shows what ipa-cert-fix would do without making changes so that I can review the plan before committing to it.
+
+As an automation engineer, I want to run ipa-cert-fix in unattended mode with a specific server so that I can include certificate recovery in Ansible playbooks and CI pipelines without interactive prompts.
+
+As an IPA developer, I want a dedicated test suite for ipa-cert-fix that covers each deployment type and fix scenario so that regressions are caught in upstream CI before they reach production deployments.
+
+## Troubleshooting and debugging
+
+### Common failure modes
+
+**"certmonger did not become responsive"** -- certmonger is overwhelmed processing tracked requests after a restart.  The tool waits up to 120 seconds for certmonger to respond on D-Bus.  If still unresponsive, check `journalctl -u certmonger` for errors and consider restarting the certmonger service manually.
+
+**"ipa-certupdate failed and the CA certificate chain was not updated"** -- the master server is unreachable or its certificates are also expired.  Manually copy `/etc/ipa/ca.crt` from a working server and retry.
+
+**"Failed to set renewal master"** -- LDAP is not running or the LDAPI connection is broken.  Check Directory Server logs.
+
+**"Certmonger request ... timed out"** -- the CA did not respond within 300 seconds.  Check CA server logs (`/var/log/pki/pki-tomcat/ca/debug`) and network connectivity.
+
+**"Cannot connect to <server>: TLS certificate error ... Run ipa-cert-fix on <server> first"** -- the remote server's HTTPS/LDAPS certificate is expired.  The local server cannot establish a TLS connection to fetch certificates.  Run `ipa-cert-fix` on the remote server first, then retry on this server.
+
+### Debug logging
+
+Run with `-v` or `--verbose` to enable debug logging.  Use `--log-file` to capture output to a file.  Key information logged:
+
+- Deployment type detection results
+- Fix scenario selection
+- Each certificate's serial, expiry, and issuer
+- Certmonger request IDs and state transitions
+- IPA CA helper modification and restoration
+- LDAP operations and reconnections
+
+### Post-fix verification
+
+After `ipa-cert-fix` completes, run `ipa-healthcheck` to verify that no certificate issues remain:
+
+    ipa-healthcheck --source ipahealthcheck.ipa.certs
+
+This checks certificate expiry, certmonger tracking status, and CA chain validity.  Any remaining warnings indicate certificates that `ipa-cert-fix` could not renew (e.g. external certs awaiting manual CSR submission) or services that need a manual restart.
+
+## Test plan
+
+Tests marked with [x] are implemented in `ipatests/test_integration/test_ipa_cert_fix.py` (integration) or `ipatests/test_integration/test_ipa_cert_fix_unit.py` (unit).  Tests marked with [ ] are planned but not yet implemented.
+
+### Test tiers
+
+Each test is marked with a tier that determines where it runs:
+
+- **Unit** -- no IPA deployment needed.  Tests pure logic (classification, routing, serialization) with mocks or fakes.  Runs in seconds in any CI environment.
+- **Integration** -- single IPA server.  Tests a complete scenario end-to-end but does not require multi-host topology.
+- **System** -- multi-host topology (2-3 replicas).  Tests cross-server interactions, replication, and degraded-topology recovery.  Requires VM provisioning; runs in PRCI nightly jobs.
+
+### Cross-cutting postconditions
+
+Every test that exercises a scenario handler (positive or negative) MUST assert these invariants after `ipa-cert-fix` returns, regardless of success or failure:
+
+- **P1**: The certmonger IPA CA helper (`external-helper` property) is in its original state (no leftover `-J` override).
+- **P2**: No certmonger tracking request has orphaned `template-principal` entries.
+- **P3**: `KRB5CCNAME` is restored to its pre-invocation value (or unset if it was unset before).
+- **P4**: The `ldap2` backend is either connected or cleanly disconnected -- no half-open sockets.
+- **P5**: No certmonger tracking requests have been switched to a different CA name (`ca-name`) or profile (`template-profile`) without being restored.
+- **P6**: HTTPS serves valid TLS — `openssl s_client` to port 443 with IPA CA trust verifies successfully.
+- **P7**: PKI subsystem operational — `ipa cert-find --sizelimit=1` returns certificates (works on any enrolled host, not just CA hosts, as long as the deployment has a CA).
+
+These postconditions are not listed in each test below to avoid repetition, but they apply to every test from T-RM-1 onward.
+
+### 1. Renewal Master
+
+#### Positive
+
+[x] **T-RM-1. All certs expired, self-signed CA** [integration] -- Expire all Dogtag and IPA certs (+3 years).  Run `ipa-cert-fix`, enter "yes".  Verify: all certs renewed, certmonger returns to MONITORING, IPA operational.  Re-run: "Nothing to do".
+
+[x] **T-RM-2. All certs expired with KRA installed** [integration] -- Same as T-RM-1 but with KRA.  Verify: KRA certs (transport, storage, audit) are also renewed (12 certs total in MONITORING).
+
+[x] **T-RM-3. Dry-run shows plan without changes** [integration] -- Run `ipa-cert-fix --dry-run` with expired certs.  Verify: `[DRY RUN]` on all output, no certs modified, no services restarted, exit code 0.
+
+[x] **T-RM-4. Only some certs expired** [integration] -- Expire only the HTTP and KDC certs (leave Dogtag certs valid).  Run `ipa-cert-fix`.  Verify: only the expired certs are renewed, valid certs untouched.
+
+#### Negative
+
+[x] **T-RM-5. CA signing cert near expiry blocks renewal** [integration] -- Set clock so caSigningCert has 15 days left.  Run `ipa-cert-fix`.  Verify: "CA signing certificate is expired or will expire within the next month", exit code 1, no certs renewed.
+
+[ ] **T-RM-6. CA signing cert expired, self-signed** [integration] -- Expire the caSigningCert entirely (+20 years).  Verify: tool refuses, directs admin to `ipa-cacert-manage renew`.
+
+[ ] **T-RM-7. CA signing cert expired, externally-signed** [integration] -- Deploy with external CA, expire caSigningCert.  Verify: CSR extracted and written to `/var/lib/ipa/ca.csr`, instructions printed for `ipa-cacert-manage renew --external-cert-file`, exit code 1.
+
+[ ] **T-RM-8. CSR not found in certmonger for CA signing cert** [integration] -- Remove the CSR from the caSigningCert tracking request before running `ipa-cert-fix` on an externally-signed deployment.  Verify: "Could not extract the existing CSR", directs admin to `ipa-cacert-manage renew --external-ca`.
+
+[x] **T-RM-9. pki-server cert-fix unavailable** [integration] -- Rename `pki-server` binary.  Verify: "'pki-server cert-fix' command is not available", exit code 1.
+
+[x] **T-RM-10. CSR directive missing from CS.cfg** [integration] -- Remove `ca.sslserver.certreq` from `CS.cfg`, resubmit via `getcert` to recreate CSR in certmonger.  Run `ipa-cert-fix`.  Verify: directive restored from certmonger before `pki-server cert-fix` runs, no "sslserver.crt not found" error.  (Regression: issue #8618.)
+
+[x] **T-RM-11. selftests startup directive missing** [integration] -- Remove `selftests.container.order.startup` from `CS.cfg`.  Run `ipa-cert-fix`.  Verify: on PKI < 10.11.0, error about missing directive; on PKI >= 10.11.0, warning and proceed.  (Regression: issue #8721/#8890.)
+
+[x] **T-RM-12. User declines confirmation** [integration] -- Enter "no" at the confirmation prompt.  Verify: "Not proceeding", exit code 0, no certs modified.
+
+### 2. CA-Full Replica (Non-Destructive)
+
+#### Positive
+
+[x] **T-REP-1. Replica fixed from healthy master** [system] -- 2-replica topology.  Expire certs on non-RM replica only.  Run `ipa-cert-fix`.  Verify: certs fetched from master and renewed, RM role unchanged.  Create user on master, verify on replica (replication works).
+
+[x] **T-REP-2. Unattended with --force-server** [system] -- Run `ipa-cert-fix -U --force-server=master` on replica.  Verify: no prompts, completes autonomously, exit code 0.
+
+[x] **T-REP-3. Dry-run on replica** [system] -- Run `ipa-cert-fix --dry-run` on replica.  Verify: shows which server would be used, no certs modified.
+
+#### Negative
+
+[x] **T-REP-4. --force-server points to self** [integration] -- Run `ipa-cert-fix --force-server=$(hostname)`.  Verify: error "must point to a different server".
+
+[x] **T-REP-5. --force-server points to unreachable host** [system] -- Run `ipa-cert-fix --force-server=nonexistent.example.com`.  Verify: fails during `ipa-certupdate` or GSSAPI bind, actionable error.
+
+[ ] **T-REP-6. --force-server points to CA-less server** [system] -- Point `--force-server` at a CA-less replica.  Verify: fails when fetching RA cert from a server without `o=ipaca`.
+
+[ ] **T-REP-7. Master LDAP unreachable during cert fetch** [system] -- After `ipa-certupdate` succeeds, block LDAPS to master (iptables). Verify: GSSAPI bind fails, Kerberos env restored.
+
+[ ] **T-REP-8. ipa-certupdate fails, ca.crt not updated** [system] -- Block all network to master.  Verify: "ipa-certupdate failed and the CA certificate chain was not updated", instructions to manually copy `ca.crt`.
+
+[ ] **T-REP-9. DS stops after ipa-certupdate** [system] -- Arrange for DS to fail to restart after `ipa-certupdate`.  Verify: "LDAP server is no longer running after ipa-certupdate", exit code 1.
+
+[ ] **T-REP-10. certmonger renewal times out** [system] -- Firewall master's port 443 after helper modification.  Verify: "Certmonger request ... timed out", IPA CA helper restored.
+
+[ ] **T-REP-11. certmonger reaches wrong state** [system] -- Simulate CA rejection (e.g., revoke the RA cert on master).  Verify: error includes `ca-error` message, helper and profiles restored.
+
+[ ] **T-REP-12. Tracking request missing for one cert** [system] -- Remove HTTP cert tracking from certmonger.  Run `ipa-cert-fix`. Verify: warning logged, other certs still renewed.
+
+[x] **T-REP-13. User declines confirmation** [system] -- Enter "no" at replica fix prompt.  Verify: "Not proceeding", no changes, RM role unchanged.
+
+### 3. CA-Full Replica -- Promote to Renewal Master
+
+#### Positive
+
+[x] **T-PROMO-1. Promotion when master is permanently down** [system] -- 2-replica topology.  Shut down master permanently.  Run `ipa-cert-fix` on replica.  Verify: promotion warning shown, user confirms, replica becomes RM, CRL warning printed, certs renewed.
+
+#### Negative
+
+[x] **T-PROMO-2. Unattended refuses silent promotion** [system] -- Run `ipa-cert-fix -U` with no reachable master and no `--force-server`.  Verify: refuses silent promotion, prints message directing to `--renewal-master` or `--force-server`, RM role unchanged, no certs renewed, exit code 1.
+
+[ ] **T-PROMO-4. Promotion fails (LDAP error)** [system] -- Arrange for `set_renewal_master()` to fail (e.g., make the LDAP entry read-only).  Verify: "Failed to set renewal master", no certs renewed.
+
+### 4. CA-Less Replica
+
+#### Positive
+
+[x] **T-CALESS-1. HTTP/LDAP/KDC renewed from CA server** [system] -- 3-host topology (2 CA-full + 1 CA-less).  Expire service certs on CA-less replica.  Run `ipa-cert-fix --force-server=<ca-server>`. Verify: only IPA service certs renewed, no Dogtag certs touched, RA cert fetched.
+
+[x] **T-CALESS-2. Dry-run on CA-less replica** [system] -- Run `--dry-run`.  Verify: shows empty Dogtag list, lists IPA certs that would be renewed.
+
+#### Negative
+
+[ ] **T-CALESS-3. All CA servers unreachable** [system] -- Shut down all CA servers.  Run `ipa-cert-fix` on CA-less replica. Verify: falls back to CSR generation, does not hang.
+
+[x] **T-CALESS-4. User declines confirmation** [system] -- Enter "no".  Verify: "Not proceeding", no changes.
+
+### 5. External and Mixed Certificates
+
+#### Positive
+
+[x] **T-EXT-1. Mixed deployment, transition to internal CA** [integration] -- Replace HTTP cert with externally-signed cert, expire it.  Run `ipa-cert-fix`.  Accept transition.  Verify: HTTP cert re-issued by IPA CA, service operational.
+
+[x] **T-EXT-2. Mixed deployment, decline transition** [integration] -- Same setup.  Decline transition.  Verify: CSR generated from existing private key and written to `/run/ipa/cert-fix/apache-https.csr`, `ipa-server-certinstall` instructions printed.
+
+[x] **T-EXT-3. Unattended skips transition, generates CSR** [integration] -- Run with `-U`.  Verify: no transition offered, CSR generated from existing keys, written to `/run/ipa/cert-fix/`.
+
+#### Negative
+
+[ ] **T-EXT-4. No CSR in certmonger, fallback to key-based CSR**
+[integration] -- Stop certmonger tracking for HTTP cert (simulating external cert install).  Run `ipa-cert-fix`, decline transition. Verify: CSR generated from `/var/lib/ipa/private/httpd.key` and the expired cert's subject/SANs, written to `/run/ipa/cert-fix/`.
+
+[ ] **T-EXT-5. Cannot write CSR to /run/ipa/cert-fix** [integration] -- Make `/run/ipa` read-only (remount).  Verify: IOError caught, logged, no crash.
+
+[ ] **T-EXT-6. Transition resubmit fails** [integration] -- Offer transition but certmonger resubmit fails (e.g., CA ACL denies the profile).  Verify: error printed for that cert, remaining certs still offered, certmonger state clean.
+
+[x] **T-EXT-7. Fully external (CA_LESS_EXTERNAL), no tracking**
+[unit] -- Verify: no CA server lookup attempted, no transition offered, CSRs generated from existing keys, `ipa-server-certinstall` instructions printed.
+
+### 6. Topology-Wide Expiry (Degraded Master)
+
+[x] **T-TOPO-1. Fix master first, then replica** [system] -- 2-replica topology, expire certs on both hosts.  Fix master first with `ipa-cert-fix`.  Then fix replica with `--force-server=master`. Verify: replica fetches certs from the freshly-repaired master and renews.  This is the most common real-world scenario.
+
+[x] **T-TOPO-2. Replica attempt before master is fixed** [system] -- Expire certs on both hosts.  Do NOT fix master first.  Run `ipa-cert-fix --force-server=master` on replica.  Verify: fails because master's HTTPS cert is expired (TLS handshake rejected), actionable error telling admin to fix master first.
+
+[ ] **T-TOPO-3. Master CA chain changed, replica stale** [system] -- Renew the CA cert on master (`ipa-cacert-manage renew`).  Replica still has old `ca.crt`.  Run `ipa-cert-fix --force-server=master` on replica.  Verify: `ipa-certupdate` updates local CA chain before cert renewal, GSSAPI bind succeeds, certs renewed.
+
+[ ] **T-TOPO-4. Replica fixed before replication catches up** [system] -- Fix master, immediately run `ipa-cert-fix` on replica before shared certs replicate.  Verify: tool fetches directly from master's LDAP, not from local LDAP.  Replication lag does not block recovery.
+
+[ ] **T-TOPO-5. Multiple replicas down, only master available** [system] -- 3-replica topology, shut down replicas 2 and 3.  Expire certs on replica 1.  Verify: tool discovers master from LDAP, cert fetch works despite other replicas being offline.
+
+### 7. Cross-Cutting Concerns
+
+#### Pre-flight checks
+
+[x] **T-PRE-1. IPA not configured** [unit] -- Call `run()` on a system where `is_ipa_configured()` returns False. Verify: "IPA is not configured", exit code 2.
+
+[x] **T-PRE-2. Not running as root** [unit] -- Call `validate_options()` as unprivileged user.  Verify: permission denied, exit code 1.
+
+[x] **T-PRE-3. Directory Server down** [integration] -- Stop `dirsrv` before running `ipa-cert-fix`.  Verify: "The LDAP server is not running; cannot proceed", exit code 1.
+
+[x] **T-PRE-4. No expired certs** [integration] -- Run `ipa-cert-fix` when all certs are valid.  Verify: "Nothing to do", exit code 0.
+
+#### Idempotency
+
+[x] **T-IDEM-1. Second run immediately after fix** [integration] -- After a successful fix, re-run immediately.  Verify: "Nothing to do", no double-renewal.
+
+[ ] **T-IDEM-2. Re-run while certmonger still processing** [integration] -- Run `ipa-cert-fix` while certmonger is still re-submitting certs from the previous run.  Verify: second run sees MONITORING/SUBMITTING states, says "Nothing to do", does not interfere.
+
+[x] **T-IDEM-3. Re-run after interrupted fix** [unit variant] -- KeyboardInterrupt during pki-server cert-fix.  Verify: certmonger state not corrupted (no resubmit called).  Full integration variant (SIGINT + re-run) deferred.
+
+#### State restoration under failure
+
+These tests verify the cross-cutting postconditions (P1-P7) hold after mid-flight failures.  Each test causes a failure at a specific point and checks that cleanup ran correctly.
+
+[x] **T-RESTORE-1. IPA CA helper restored after renewal timeout**
+[system] -- Cause a timeout during `renew_certs_from_master` (first cert succeeds, second times out via firewall).  Verify postcondition P1: certmonger `external-helper` matches original value.
+
+[x] **T-RESTORE-2. Dogtag CA name and profile restored after failure**
+[system] -- Cause a failure after a Dogtag cert's CA is switched to IPA.  Verify postconditions P2 and P5: `ca-name` restored to `dogtag-ipa-ca-renew-agent`, `template-profile` restored, `template-principal` cleared.
+
+[ ] **T-RESTORE-3. Kerberos env restored after failure** [integration] -- Set `KRB5CCNAME` to a custom value, cause a failure after `_setup_kerberos()`.  Verify postcondition P3: `KRB5CCNAME` restored.
+
+[ ] **T-RESTORE-4. LDAP reconnected after ipa-certupdate** [system] -- Run `ipa-cert-fix` where `ipa-certupdate` restarts DS.  Verify postcondition P4: `ldap2` reconnected unconditionally (not relying on `isconnected()` which may report True on a broken pipe).
+
+#### Deployment detection edge cases
+
+[x] **T-DETECT-1. NSS database unreadable** [integration] -- Corrupt or permission-deny the PKI Tomcat NSS database.  Verify: "Cannot read caSigningCert from NSS database", actionable error.
+
+[ ] **T-DETECT-2. LDAP topology query fails during detection**
+[integration] -- Arrange for `find_providing_servers` to raise. Verify: warning logged, detection falls back gracefully.
+
+[x] **T-DETECT-3. One service cert file missing** [integration] -- Delete `paths.KDC_CERT`.  Verify: deployment detection and cert classification still work, missing cert skipped with debug log.
+
+[ ] **T-DETECT-4. All service cert files missing** [integration] -- Delete HTTP, LDAP, and KDC cert files.  Verify: tool exits with actionable error, does not claim "Nothing to do".
+
+[x] **T-DETECT-5. Custom DS cert nickname** [integration] -- Install a third-party LDAP certificate with a non-default nickname via `ipa-server-certinstall -d`.  Run `ipa-cert-fix -v`.  Verify: correct nickname used (visible in verbose output), no "certificate not found" error.  (Regression: existing test_third_party_certs.)
+
+#### RA/Subsystem LDAP consistency
+
+[x] **T-CONSIST-1. RA cert serial mismatch in LDAP** [integration] -- Modify the `description` field in `uid=ipara,ou=People,o=ipaca` to contain a wrong serial number.  Run `ipa-cert-fix`.  Verify: mismatch detected, user prompted, LDAP updated with correct serial after "yes".
+
+[ ] **T-CONSIST-2. Subsystem cert blob missing in LDAP** [integration] -- Remove the `userCertificate` value from `uid=pkidbuser,ou=People,o=ipaca`.  Run `ipa-cert-fix`.  Verify: mismatch detected, cert blob added to LDAP after confirmation.
+
+[x] **T-CONSIST-3. Dry-run shows mismatches without fixing** [integration] -- Same setup as T-CONSIST-1.  Run `ipa-cert-fix --dry-run`.  Verify: mismatch printed, no LDAP modification.
+
+[x] **T-CONSIST-4. No mismatches, no prompt** [integration] -- Run `ipa-cert-fix` on a healthy server.  Verify: no consistency prompt shown, just "Nothing to do".
+
+[ ] **T-CONSIST-5. Post-fix verification catches stale entry** [system] -- On a replica, expire certs and fix from master.  Artificially break `uid=ipara` description between fetch and post-fix check.  Verify: post-fix verification detects and offers to fix.
+
+### 8. Unit Tests (no IPA deployment)
+
+These tests exercise pure logic with mocks.  They run in seconds and should be part of every PR gate.
+
+[x] **T-UNIT-1. KDC cert classified as KDC, not HTTPS** [unit] -- Call `expired_ipa_certs()` with a non-IPA-issued KDC cert.  Verify: it appears in `non_renewed` as `IPACertType.KDC`. (Regression: pre-existing bug fixed in this expansion.)
+
+[x] **T-UNIT-2. D-Bus empty list uses typed Array** [unit] -- Verify that the cleanup code constructs `dbus.Array([], signature='s')` not a bare `[]` when clearing `template-principal`. (Regression: D-Bus serialization error.)
+
+[x] **T-UNIT-3. Scenario routing for each deployment type** [unit] -- For each `DeploymentType` x `is_renewal_master` x `master_available` combination, call `determine_scenario()` with mocks.  Verify: correct `FixScenario` returned.  Matrix:
+
+| DeploymentType | is_RM | master | Expected scenario |
+|---|---|---|---|
+| CA_SELF_SIGNED | yes | -- | RENEWAL_MASTER |
+| CA_SELF_SIGNED | no | yes | CA_FULL_WITH_MASTER |
+| CA_SELF_SIGNED | no | no | CA_FULL_PROMOTE |
+| CA_EXTERNALLY_SIGNED | yes | -- | RENEWAL_MASTER |
+| CA_EXTERNALLY_SIGNED | no | yes | CA_FULL_WITH_MASTER |
+| CA_LESS | -- | yes | CA_LESS_WITH_MASTER |
+| CA_LESS | -- | no | EXTERNAL_CERTS |
+| CA_LESS_EXTERNAL | -- | -- | EXTERNAL_CERTS |
+
+[x] **T-UNIT-4. Cert classification splits external from IPA-issued**
+[unit] -- Call `_classify_certs()` with mocked `expired_ipa_certs()` returning certs in `non_renewed`.  Verify: they appear in `external_certs`, not `non_renewed`.
+
+[x] **T-UNIT-5. --force-server=self rejected** [unit] -- Call `get_master_server()` with `options.force_server` set to the local hostname.  Verify: `RuntimeError` raised.
+
+[x] **T-UNIT-6. Dry-run returns 0 for each scenario** [unit] -- Call each scenario handler with `options.dry_run=True` and a mocked context.  Verify: returns 0, no side-effecting methods called.
+
+Additionally implemented but not in the original plan:
+
+[x] **T-UNIT-7. --renewal-master + --force-server rejected** [unit] -- Verify `validate_options` rejects mutual exclusion.
+
+[x] **T-UNIT-8. --renewal-master on CA-less rejected** [unit] -- Verify `determine_scenario` raises `RuntimeError` for CA-less + `--renewal-master`.  Also tests `CA_LESS_EXTERNAL`.
+
+[x] **T-UNIT-9. CA cert still expired after pki-server cert-fix**
+[unit] -- Verify `run_renewal_master_fix` returns 1 when post-renewal `_check_ca_signing_cert` fails.
+
+[x] **T-UNIT-10. CA_LESS_EXTERNAL skips CA server lookup** [unit] -- Verify `_handle_external_certs` does not call `find_providing_servers` for fully-external deployments.
+
+[x] **T-UNIT-11. No tracking generates CSR from key** [unit] -- Verify `_generate_external_csrs` calls `_generate_csr_from_key` when certmonger has no tracking request.
+
+[x] **T-UNIT-12. Duplicate-subject CA certs prefer valid** [unit] -- `ca.crt` contains both expired and valid CA certs with same subject DN (normal after CA renewal).  Verify `_verify_ca_chain_valid` picks the valid cert regardless of file ordering.
+
+### 9. End-to-End Story Tests
+
+These tests walk through a complete multi-host recovery sequence. They validate that `ipa-cert-fix` works as a coherent workflow across an entire topology, not just in isolation.
+
+[x] **T-E2E-1. Full topology recovery: master, CA replica, CA-less**
+[system] -- 3-host topology: CA renewal master, CA-full replica, CA-less replica.  Expire all certs on all hosts (+3 years).  Recovery sequence:
+
+1. Fix master with `ipa-cert-fix`.
+2. Fix CA-full replica with `ipa-cert-fix --force-server=master`.
+3. Fix CA-less replica with `ipa-cert-fix --force-server=master`.
+4. Verify all hosts operational: `ipa user-add` on master replicates to both replicas, `kinit` works on all hosts, `getcert list` shows MONITORING on all hosts.
+
+This is the single most important test.  If it passes, the tool works for the most common real-world disaster recovery scenario.
+
+[ ] **T-E2E-2. Recovery with externally-signed CA** [system] -- 2-host topology with externally-signed CA.  Expire caSigningCert and service certs.  Recovery sequence:
+
+1. Run `ipa-cert-fix` on master -- tool extracts CSR, prints instructions, exits with code 1.
+2. Simulate external CA renewal: sign the CSR, install with `ipa-cacert-manage renew --external-cert-file`.
+3. Re-run `ipa-cert-fix` -- now proceeds to renew remaining certs.
+4. Fix replica.
+5. Verify topology healthy.
+
+[ ] **T-E2E-3. Recovery with promotion** [system] -- 2-host topology.  Shut down master (permanent failure).  Recovery:
+
+1. Run `ipa-cert-fix` on replica -- promoted to RM, certs renewed.
+2. Run `ipa-crlgen-manage enable` on replica.
+3. Verify: replica is sole operational server, `ipa` commands work, CRL generation active.

--- a/install/tools/man/ipa-cert-fix.1
+++ b/install/tools/man/ipa-cert-fix.1
@@ -1,7 +1,7 @@
 .\"
 .\" Copyright (C) 2019  FreeIPA Contributors see COPYING for license
 .\"
-.TH "ipa-cert-fix" "1" "Mar 25 2019" "IPA" "IPA Manual Pages"
+.TH "ipa-cert-fix" "1" "Apr 06 2026" "IPA" "IPA Manual Pages"
 .SH "NAME"
 ipa\-cert\-fix \- Renew expired certificates
 .SH "SYNOPSIS"
@@ -18,35 +18,103 @@ normal operation and renewal procedures.
 
 To renew the IPA CA certificate, use \fIipa-cacert-manage(1)\fR.
 
-This tool cannot renew certificates signed by external CAs.  To
-install new, externally-signed HTTP, LDAP or KDC certificates, use
-\fIipa-server-certinstall(1)\fR.
+\fIipa-cert-fix\fR automatically detects the deployment type of the
+local server and chooses the appropriate recovery path.  It handles
+CA\-full servers (both renewal masters and non\-renewal\-master
+replicas), CA\-less replicas, and servers with a mix of internally
+and externally signed certificates.
 
-\fIipa-cert-fix\fR will examine IPA and Certificate System
-certificates and renew certificates that are expired, or close to
-expiry (less than two weeks).  If any "shared" certificates are
-renewed, \fIipa-cert-fix\fR will set the current server to be the CA
-renewal master, and add the new shared certificate(s) to LDAP for
-replication to other CA servers.  Shared certificates include all
-Dogtag system certificates except the HTTPS certificate, and the IPA
-RA certificate.
+On a CA renewal master, \fIipa-cert-fix\fR uses \fBpki-server cert-fix\fR
+to regenerate expired Dogtag and IPA service certificates.  If any
+"shared" certificates are renewed (all Dogtag system certificates except
+the HTTPS certificate, and the IPA RA certificate), the server is set
+as the renewal master and the new certificates are added to LDAP for
+replication.
 
-To repair certificates across multiple CA servers, first ensure that
-LDAP replication is working across the topology.  Then run
-\fIipa-cert-fix\fR on one CA server.  Before running
-\fIipa-cert-fix\fR on another CA server, trigger Certmonger renewals
-for shared certificates via \fIgetcert-resubmit(1)\fR (on the other
-CA server).  This is to avoid unnecessary renewal of shared
-certificates.
+On a non\-renewal\-master CA replica, \fIipa-cert-fix\fR fetches the CA
+chain, RA and shared certificates from a working master server,
+then uses certmonger to renew expired certificates through the
+master's CA.  This is a non\-destructive approach that does not
+change the renewal master assignment.
+
+On a CA\-less replica, \fIipa-cert-fix\fR fetches the CA chain and RA
+certificate from a CA server in the topology, then renews HTTP, LDAP
+and KDC certificates through that server via certmonger.
+
+Certificates signed by an external CA cannot be automatically renewed.
+When externally\-signed certificates are detected, \fIipa-cert-fix\fR
+offers to transition them to the internal IPA CA (if available) or
+generates CSR files in \fB/run/ipa/cert\-fix/\fR and prints instructions for manual
+renewal using \fIipa-server-certinstall(1)\fR.
+
+The CA signing certificate must have at least one month of remaining
+validity for the renewal master fix path to proceed.  If it is
+expired or near expiry and the CA is self\-signed, the user is
+directed to \fIipa-cacert-manage(1)\fR.  If the CA is externally
+signed, \fIipa-cert-fix\fR automatically extracts the existing CSR
+from certmonger and writes it to \fB/var/lib/ipa/ca.csr\fR, then
+prints instructions for submitting it to the external CA and
+installing the renewed certificate with
+\fIipa-cacert-manage renew \-\-external\-cert\-file\fR.
 
 Important note: the \fIcertmonger\fR daemon does not immediately notice
 the updated certificates and may trigger a renewal after \fIipa-cert-fix\fR
-completes. As a consequence, \fIgetcert list\fR output may display
+completes.  As a consequence, \fIgetcert list\fR output may display
 that a renewal is in progress even if \fIipa-cert-fix\fR just
-finished. It is recommended to monitor the certmonger-initiated
+finished.  It is recommended to monitor the certmonger\-initiated
 renewal and wait for its completion before any other administrative task.
 
+.SH "SCENARIOS"
+.TP
+\fBRenewal master\fR
+Detected automatically when the server holds the renewal master role,
+or forced with \fB\-\-renewal\-master\fR.  Runs \fBpki-server cert-fix\fR
+to renew Dogtag certificates and installs renewed IPA service
+certificates.  The server becomes (or remains) the renewal master.
+.TP
+\fBCA\-full replica with working master\fR
+Detected when the server has a local CA but is not the renewal master.
+Fetches certificates from a master server and renews via certmonger.
+Does not change the renewal master assignment.
+.TP
+\fBCA\-full replica, promote to renewal master\fR
+Selected when no working master is available.  The user is asked to
+confirm promotion.  After promotion, the renewal master fix path is
+used.  CRL generation must be enabled manually with
+\fIipa-crlgen-manage(1)\fR afterward.
+.TP
+\fBCA\-less replica\fR
+Detected when no CA is installed locally but CA servers exist in the
+topology.  Fetches the CA chain and RA certificate, then renews
+HTTP, LDAP, and KDC certificates via certmonger.
+.TP
+\fBExternal certificates\fR
+Detected when certificates are signed by an external CA.  Offers
+per\-certificate transition to the internal IPA CA or generates CSR
+files for manual renewal.
+
 .SH "OPTIONS"
+.TP
+\fB\-\-force\-server\fR=\fIFQDN\fR
+Use the specified server to fetch certificates from, instead of
+auto\-discovering a master from the topology.  Cannot specify the
+current server.
+.TP
+\fB\-\-renewal\-master\fR
+Force this server to become the renewal master and use the renewal
+master fix path.  Use with caution.  Verify CRL generation and IPA
+configuration after the topology is stable.  Cannot be combined
+with \fB\-\-force\-server\fR.  Not valid on CA\-less replicas.
+.TP
+\fB\-\-dry\-run\fR
+Print the intended actions without executing them.  Useful for
+reviewing what \fIipa-cert-fix\fR would do before committing.
+.TP
+\fB\-U\fR, \fB\-\-unattended\fR
+Non\-interactive mode.  Never prompt the user for input.  Uses
+auto\-discovered defaults where possible.  If no working master
+can be found in unattended mode, falls back to the renewal master
+approach.
 .TP
 \fB\-\-version\fR
 Show the program's version and exit.
@@ -67,7 +135,24 @@ Log to the given file.
 
 1 if an error occurred
 
+2 if IPA is not configured
+
+.SH "EXAMPLES"
+.TP
+Dry\-run to see what would happen:
+.B ipa\-cert\-fix \-\-dry\-run
+.TP
+Fix a CA replica using a specific master:
+.B ipa\-cert\-fix \-\-force\-server=master.example.com
+.TP
+Unattended fix (e.g., in a script):
+.B ipa\-cert\-fix \-U
+.TP
+Force promotion to renewal master:
+.B ipa\-cert\-fix \-\-renewal\-master
+
 .SH "SEE ALSO"
-.BR ipa-cacert-manage(1)
-.BR ipa-server-certinstall(1)
-.BR getcert-resubmit(1)
+.BR ipa-cacert-manage (1),
+.BR ipa-server-certinstall (1),
+.BR ipa-crlgen-manage (1),
+.BR getcert-resubmit (1)

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -37,17 +37,22 @@ from ipapython.certdb import NSSDatabase, EMPTY_TRUST_FLAGS
 from ipapython.dn import DN
 from ipapython.ipaldap import realm_to_serverid
 from ipaserver.install import ca, cainstance, dsinstance
-from ipaserver.install.certs import is_ipa_issued_cert
-# Re-export public names from the helper module so that all symbols are
+# Re-export public names from the helper modules so that all symbols are
 # importable from ``ipaserver.install.ipa_cert_fix``.
 from ipaserver.install.ipa_cert_fix_services import (  # noqa: F401
     CertmongerClient,
+    DeploymentDetector,
+    expired_dogtag_certs,
+    expired_ipa_certs,
     get_csr_from_certmonger,
     print_cert_info,
 )
-from ipaserver.install.ipa_cert_fix_types import (
+from ipaserver.install.ipa_cert_fix_types import (  # noqa: F401
     CERT_EXPIRY_LOOKAHEAD,
+    CertFixContext,
     DOGTAG_CERTS,
+    DeploymentType,
+    FixScenario,
     IPACertType,
     RENEWAL_NOTE,
     RENEWED_CERT_PATH_TEMPLATE,
@@ -65,37 +70,37 @@ class IPACertFix(AdminTool):
     usage = "%prog"
     description = "Renew expired certificates."
 
+    _cm = None  # CertmongerClient; set in run()
+    _detector = None  # DeploymentDetector; set in _classify_and_dispatch
+
     def validate_options(self):
         super(IPACertFix, self).validate_options(needs_root=True)
 
     def run(self):
+        """Top-level entry point for ipa-cert-fix.
+
+        Detects the deployment type, classifies expired certificates,
+        determines the appropriate fix scenario, and dispatches to the
+        corresponding handler.
+
+        :returns: exit code (0 success, 1 error, 2 not configured)
+        """
         if not is_ipa_configured():
             print("IPA is not configured.")
             return 2
 
-        if not cainstance.is_ca_installed_locally():
-            print("CA is not installed on this server.")
-            return 1
-
-        try:
-            ipautil.run(['pki-server', 'cert-fix', '--help'], raiseonerr=True)
-        except ipautil.CalledProcessError:
-            print(
-                "The 'pki-server cert-fix' command is not available; "
-                "cannot proceed."
-            )
-            return 1
-
         api.bootstrap(in_server=True, confdir=paths.ETC_IPA)
         api.finalize()
 
+        if self._cm is None:
+            self._cm = CertmongerClient()
+
         if not dsinstance.is_ds_running(realm_to_serverid(api.env.realm)):
-            print(
-                "The LDAP server is not running; cannot proceed."
-            )
+            print("The LDAP server is not running; cannot proceed.\n"
+                  "Try starting IPA first with: ipactl start -f")
             return 1
 
-        api.Backend.ldap2.connect()  # ensure DS is up
+        api.Backend.ldap2.connect()
 
         try:
             return self._classify_and_dispatch()
@@ -106,24 +111,43 @@ class IPACertFix(AdminTool):
     def _classify_and_dispatch(self):
         """Classify expired certificates and dispatch to a fix scenario.
 
-        Currently only the renewal-master scenario is implemented.  Future
-        commits will add deployment-type detection and route to additional
-        scenarios (CA-full replica, CA-less replica, external certificates).
+        Detects deployment type, classifies expired certs, picks a scenario
+        via :class:`DeploymentDetector`, builds a :class:`CertFixContext`,
+        and dispatches to the appropriate handler.  Currently only the
+        renewal-master scenario is implemented; other scenarios raise a
+        clear "not implemented yet" error and will be filled in by
+        subsequent commits.
         """
-        subject_base = dsinstance.DsInstance().find_subject_base()
+        serverid = realm_to_serverid(api.env.realm)
+        ds = dsinstance.DsInstance(realm_name=api.env.realm)
+        subject_base = ds.find_subject_base()
         if not subject_base:
             raise RuntimeError("Cannot determine certificate subject base.")
+        ds_dbdir = dsinstance.config_dirname(serverid).rstrip('/')
+        ds_nickname = ds.get_server_cert_nickname(serverid)
 
-        ca_subject_dn = ca.lookup_ca_subject(api, subject_base)
+        # CA-specific setup (skip on CA-less deployments)
+        ca_subject_dn = None
+        has_ca = cainstance.is_ca_installed_locally()
+        ca_inst = cainstance.CAInstance() if has_ca else None
+
+        self._detector = DeploymentDetector(
+            self._cm, ca_inst, self.options)
+
+        deployment_type = self._detector.detect_deployment_type()
+        logger.info("Deployment type: %s", deployment_type.value)
+        if has_ca:
+            ca_subject_dn = ca.lookup_ca_subject(api, subject_base)
 
         now = _utcnow() + CERT_EXPIRY_LOOKAHEAD
-        certs, extra_certs, non_renewed = expired_certs(now)
+        dogtag_certs, ipa_certs, external_certs = \
+            self._detector._classify_certs(now, ds_dbdir, ds_nickname)
 
-        if not certs and not extra_certs:
+        if not dogtag_certs and not ipa_certs and not external_certs:
             print("Nothing to do.")
             return 0
 
-        if any(key == 'ca_issuing' for key, _ in certs):
+        if any(key == 'ca_issuing' for key, _ in dogtag_certs):
             logger.debug("CA signing cert is expired, exiting!")
             print(
                 "The CA signing certificate is expired or will expire within "
@@ -133,53 +157,97 @@ class IPACertFix(AdminTool):
             )
             return 1
 
-        return self.run_renewal_master_fix(
-            subject_base, ca_subject_dn, certs, extra_certs, non_renewed)
+        try:
+            scenario, master = self._detector.determine_scenario(
+                deployment_type)
+        except RuntimeError as e:
+            print(str(e))
+            return 1
+        logger.info("Fix scenario: %s, master: %s", scenario.value, master)
 
-    def run_renewal_master_fix(
-        self, subject_base, ca_subject_dn, certs, extra_certs, non_renewed
-    ):
+        ctx = CertFixContext(
+            deployment_type=deployment_type,
+            scenario=scenario,
+            subject_base=subject_base,
+            ca_subject_dn=ca_subject_dn,
+            dogtag_certs=dogtag_certs,
+            ipa_certs=ipa_certs,
+            external_certs=external_certs,
+            master_server=master,
+            serverid=serverid,
+            ds_dbdir=ds_dbdir,
+            ds_nickname=ds_nickname,
+        )
+
+        dispatch = {
+            FixScenario.RENEWAL_MASTER: self.run_renewal_master_fix,
+        }
+        handler = dispatch.get(scenario)
+        if handler is None:
+            print(
+                "Scenario %s is not yet implemented." % scenario.value)
+            return 1
+
+        try:
+            return handler(ctx)
+        except RuntimeError as e:
+            print("ERROR: %s" % e)
+            return 1
+
+    def run_renewal_master_fix(self, ctx):
         """Fix certificates on the renewal master via ``pki-server cert-fix``.
 
         Regenerates expired Dogtag system certificates and installs renewed
         IPA service certificates.  If any "shared" certificate is renewed,
         promotes this server to the renewal master.
         """
+        certs = ctx.dogtag_certs
+        ipa_certs = ctx.ipa_certs
+        external_certs = ctx.external_certs
+
+        try:
+            ipautil.run(['pki-server', 'cert-fix', '--help'], raiseonerr=True)
+        except (ipautil.CalledProcessError, FileNotFoundError):
+            print(
+                "The 'pki-server cert-fix' command is not available; "
+                "cannot proceed.")
+            return 1
+
         print(WARNING_BANNER)
 
-        print_intentions(certs, extra_certs, non_renewed)
+        print_intentions(certs, ipa_certs, external_certs)
 
         if not self._confirm_execution():
             return 0
 
         try:
             fix_certreq_directives(certs)
-            run_cert_fix(certs, extra_certs)
+            run_cert_fix(certs, ipa_certs)
         except ipautil.CalledProcessError:
             if any(
                 x[0] is IPACertType.LDAPS
-                for x in extra_certs + non_renewed
+                for x in ipa_certs + external_certs
             ):
                 # The DS cert was expired.  This will cause 'pki-server
                 # cert-fix' to fail at the final restart, and return nonzero.
                 # So this exception *might* be OK to ignore.
                 #
                 # If 'pki-server cert-fix' has written new certificates
-                # corresponding to all the extra_certs, then ignore the
-                # CalledProcessError and proceed to installing the IPA-specific
-                # certs.  Otherwise re-raise.
-                if check_renewed_ipa_certs(extra_certs):
+                # corresponding to all the ipa_certs, then ignore the
+                # CalledProcessError and proceed to installing the
+                # IPA-specific certs.  Otherwise re-raise.
+                if check_renewed_ipa_certs(ipa_certs):
                     pass
                 else:
                     raise
             else:
-                raise  # otherwise re-raise
+                raise
 
-        replicate_dogtag_certs(subject_base, ca_subject_dn, certs)
-        install_ipa_certs(subject_base, ca_subject_dn, extra_certs)
+        replicate_dogtag_certs(ctx.subject_base, ctx.ca_subject_dn, certs)
+        install_ipa_certs(ctx.subject_base, ctx.ca_subject_dn, ipa_certs)
 
         if any(x[0] != 'sslserver' for x in certs) \
-                or any(x[0] is IPACertType.IPARA for x in extra_certs):
+                or any(x[0] is IPACertType.IPARA for x in ipa_certs):
             # we renewed a "shared" certificate, therefore we must
             # become the renewal master
             print("Becoming renewal master.")
@@ -199,80 +267,6 @@ class IPACertFix(AdminTool):
             return False
         print("Proceeding.")
         return True
-
-
-def expired_certs(now):
-    expired_ipa, non_renew_ipa = expired_ipa_certs(now)
-    return expired_dogtag_certs(now), expired_ipa, non_renew_ipa
-
-
-def expired_dogtag_certs(now):
-    """
-    Determine which Dogtag certs are expired, or close to expiry.
-
-    Return a list of (cert_id, cert) pairs.
-
-    """
-    certs = []
-    db = NSSDatabase(nssdir=paths.PKI_TOMCAT_ALIAS_DIR)
-
-    for certid, ci in DOGTAG_CERTS.items():
-        try:
-            cert = db.get_cert(ci.nickname)
-        except RuntimeError:
-            pass  # unfortunately certdb doesn't give us a better exception
-        else:
-            if cert.not_valid_after_utc <= now:
-                certs.append((certid, cert))
-
-    return certs
-
-
-def expired_ipa_certs(now):
-    """
-    Determine which IPA certs are expired, or close to expiry.
-
-    Return a list of (IPACertType, cert) pairs.
-
-    """
-    certs = []
-    non_renewed = []
-
-    # IPA RA
-    cert = x509.load_certificate_from_file(paths.RA_AGENT_PEM)
-    if cert.not_valid_after_utc <= now:
-        certs.append((IPACertType.IPARA, cert))
-
-    # Apache HTTPD
-    cert = x509.load_certificate_from_file(paths.HTTPD_CERT_FILE)
-    if cert.not_valid_after_utc <= now:
-        if not is_ipa_issued_cert(api, cert):
-            non_renewed.append((IPACertType.HTTPS, cert))
-        else:
-            certs.append((IPACertType.HTTPS, cert))
-
-    # LDAPS
-    serverid = realm_to_serverid(api.env.realm)
-    ds = dsinstance.DsInstance(realm_name=api.env.realm)
-    ds_dbdir = dsinstance.config_dirname(serverid)
-    ds_nickname = ds.get_server_cert_nickname(serverid)
-    db = NSSDatabase(nssdir=ds_dbdir)
-    cert = db.get_cert(ds_nickname)
-    if cert.not_valid_after_utc <= now:
-        if not is_ipa_issued_cert(api, cert):
-            non_renewed.append((IPACertType.LDAPS, cert))
-        else:
-            certs.append((IPACertType.LDAPS, cert))
-
-    # KDC
-    cert = x509.load_certificate_from_file(paths.KDC_CERT)
-    if cert.not_valid_after_utc <= now:
-        if not is_ipa_issued_cert(api, cert):
-            non_renewed.append((IPACertType.HTTPS, cert))
-        else:
-            certs.append((IPACertType.KDC, cert))
-
-    return certs, non_renewed
 
 
 def print_intentions(dogtag_certs, ipa_certs, non_renewed):

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -25,16 +25,12 @@
 
 from __future__ import print_function, absolute_import
 
-import base64
-from cryptography import x509 as crypto_x509
-from cryptography.hazmat.backends import default_backend
 import logging
 import shutil
 
 from ipalib import api
 from ipalib import x509
 from ipalib.facts import is_ipa_configured
-from ipalib.install import certmonger
 from ipaplatform.paths import paths
 from ipapython.admintool import AdminTool
 from ipapython.certdb import NSSDatabase, EMPTY_TRUST_FLAGS
@@ -42,6 +38,13 @@ from ipapython.dn import DN
 from ipapython.ipaldap import realm_to_serverid
 from ipaserver.install import ca, cainstance, dsinstance
 from ipaserver.install.certs import is_ipa_issued_cert
+# Re-export public names from the helper module so that all symbols are
+# importable from ``ipaserver.install.ipa_cert_fix``.
+from ipaserver.install.ipa_cert_fix_services import (  # noqa: F401
+    CertmongerClient,
+    get_csr_from_certmonger,
+    print_cert_info,
+)
 from ipaserver.install.ipa_cert_fix_types import (
     CERT_EXPIRY_LOOKAHEAD,
     DOGTAG_CERTS,
@@ -291,42 +294,6 @@ def print_intentions(dogtag_certs, ipa_certs, non_renewed):
 
         for certtype, cert in non_renewed:
             print_cert_info("IPA", certtype.value, cert)
-
-
-def print_cert_info(context, desc, cert):
-    print("{} {} certificate:".format(context, desc))
-    print("  Subject: {}".format(DN(cert.subject)))
-    print("  Serial:  {}".format(cert.serial_number))
-    print("  Expires: {}".format(cert.not_valid_after_utc))
-    print()
-
-
-def get_csr_from_certmonger(nickname):
-    """
-    Get the csr for the provided nickname by asking certmonger.
-
-    Returns the csr in ASCII format without the header/footer in a single line
-    or None if not found.
-    """
-    criteria = {
-        'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
-        'cert-nickname': nickname,
-    }
-
-    id = certmonger.get_request_id(criteria)
-    if id:
-        csr = certmonger.get_request_value(id, "csr")
-        if csr:
-            try:
-                # Make sure the value can be parsed as valid CSR
-                csr_obj = crypto_x509.load_pem_x509_csr(
-                    csr.encode('ascii'), default_backend())
-                val = base64.b64encode(csr_obj.public_bytes(x509.Encoding.DER))
-                return val.decode('ascii')
-            except Exception as e:
-                # Fallthrough and return None
-                logger.debug("Unable to get CSR from certmonger: %s", e)
-    return None
 
 
 def fix_certreq_directives(certs):

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -1,29 +1,33 @@
 #
-# Copyright (C) 2019  FreeIPA Contributors see COPYING for license
+# Copyright (C) 2019, 2026  FreeIPA Contributors see COPYING for license
 #
 
-# ipa-cert-fix performs the following steps:
+# ipa-cert-fix: Multi-scenario certificate recovery tool.
 #
-# 1. Confirm running as root (AdminTool.validate_options does this)
+# Auto-detects the deployment type and chooses the least-invasive fix path:
 #
-# 2. Confirm that DS is up.
+#   DeploymentType        -> FixScenario
+#   CA_SELF_SIGNED + RM   -> RENEWAL_MASTER
+#   CA_SELF_SIGNED + !RM  -> CA_FULL_WITH_MASTER or CA_FULL_PROMOTE
+#   CA_EXTERNALLY_SIGNED  -> (same as above)
+#   CA_LESS               -> CA_LESS_WITH_MASTER or EXTERNAL_CERTS
+#   CA_LESS_EXTERNAL      -> EXTERNAL_CERTS
 #
-# 3. Determine which of following certs (if any) need renewing
-#     - IPA RA
-#     - Apache HTTPS
-#     - 389 LDAPS
-#     - Kerberos KDC (PKINIT)
+# RENEWAL_MASTER: pki-server cert-fix, install certs, become RM, restart,
+#   resubmit.
 #
-# 4. Execute `pki-server cert-fix` with relevant options,
-#    including `--extra-cert SERIAL` for each cert from #3.
+# CA_FULL_WITH_MASTER: ipa-certupdate, fetch RA/subsystem from master LDAP,
+#   renew via certmonger pointed at master (-J), restart, resubmit.
 #
-# 5. Print details of renewed certificates.
+# CA_FULL_PROMOTE: verify pki-server cert-fix available, promote to RM,
+#   then run renewal master path.
+#   Requires --renewal-master in unattended mode.
 #
-# 6. Install renewed certs from #3 in relevant places
+# CA_LESS_WITH_MASTER: ipa-certupdate, fetch RA from master,
+#   renew HTTP/LDAP/KDC via certmonger, restart, resubmit.
 #
-# 7. ipactl restart
-
-from __future__ import print_function, absolute_import
+# EXTERNAL_CERTS: offer per-cert transition to IPA CA (interactive) or
+#   generate CSRs for external renewal.
 
 from dataclasses import replace
 import logging
@@ -31,7 +35,7 @@ import os
 import shutil
 import socket
 
-from ipalib import api
+from ipalib import api, errors
 from ipalib import x509
 from ipalib.facts import is_ipa_configured
 from ipaplatform.paths import paths
@@ -42,38 +46,30 @@ from ipapython import ipaldap
 from ipapython.ipaldap import realm_to_serverid
 from ipaserver.install import ca, cainstance, dsinstance
 from ipaserver.masters import find_providing_servers
-# Re-export public names from the helper modules so that all symbols are
-# importable from ``ipaserver.install.ipa_cert_fix``.
-from ipaserver.install.ipa_cert_fix_services import (  # noqa: F401
-    CertRenewalFromMaster,
-    CertmongerClient,
-    DeploymentDetector,
-    ExternalCertHandler,
-    _ensure_ldap_connected,
-    _find_current_renewal_master,
-    _get_pki_nssdb,
-    _replace_cert_in_nssdb,
-    _update_cs_cfg,
-    expired_dogtag_certs,
-    expired_ipa_certs,
-    get_csr_from_certmonger,
-    print_cert_info,
-)
-from ipaserver.install.ipa_cert_fix_types import (  # noqa: F401
-    CERT_EXPIRY_LOOKAHEAD,
-    CertFixContext,
-    DOGTAG_CERTS,
-    DeploymentType,
-    FixScenario,
-    IPACertType,
-    PROMOTE_WARNING,
-    RENEWAL_NOTE,
-    RENEWED_CERT_PATH_TEMPLATE,
-    WARNING_BANNER,
-    _utcnow,
-)
 from ipapython import directivesetter
 from ipapython import ipautil
+
+# Re-export public names from helper modules so that all symbols are importable
+# from ``ipaserver.install.ipa_cert_fix``.
+# pylint: disable=unused-import
+from ipaserver.install.ipa_cert_fix_types import (
+    CertIdentity, DOGTAG_CERTS, _CS_CFG_CERT_DIRECTIVES,
+    IPACertType, DeploymentType, FixScenario, CertFixContext,
+    CERT_EXPIRY_LOOKAHEAD, CERTMONGER_WAIT_TIMEOUT,
+    DBUS_RETRY_TIMEOUT, DBUS_RETRY_DELAY, HELPER_KILL_SETTLE,
+    IPA_SERVICE_PROFILE, DOGTAG_CERT_PATH_TEMPLATE,
+    RENEWED_CERT_PATH_TEMPLATE,
+    WARNING_BANNER, RENEWAL_NOTE, PROMOTE_WARNING, _utcnow,)
+from ipaserver.install.ipa_cert_fix_services import (
+    CertmongerClient, ExternalCertHandler,
+    CertRenewalFromMaster, DeploymentDetector,
+    _get_pki_nssdb, _replace_cert_in_nssdb,
+    _update_cs_cfg, _kill_stuck_helpers, print_cert_info,
+    _check_tcp_reachable, _find_current_renewal_master,
+    _ensure_ldap_connected, expired_dogtag_certs,
+    _check_ipa_cert, expired_ipa_certs,
+    get_csr_from_certmonger,)
+# pylint: enable=unused-import
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +79,10 @@ def _check_tls_handshake(server, timeout=10):
 
     Uses the system CA trust store (which includes ``/etc/ipa/ca.crt``) to
     verify that local trust chain is sufficient to connect to the master.
+
+    :param server: FQDN to connect to
+    :param timeout: connection timeout in seconds
+    :raises Exception: if TLS handshake fails
     """
     import ssl
     ctx = ssl.create_default_context()
@@ -101,6 +101,10 @@ def _setup_kerberos():
     Kerberos, but remote LDAP connections and ``ipa-certupdate`` require
     a ticket.
 
+    Note: the Kerberos client uses the KDC(s) from ``/etc/krb5.conf`` or
+    DNS SRV records.  If the local KDC is down (expired KDC cert), GSSAPI
+    to the master may fail.  See Known Limitations in the design doc.
+
     :returns: tuple of previous ``(KRB5CCNAME, KRB5_CLIENT_KTNAME)``
         values for restoration
     """
@@ -113,7 +117,10 @@ def _setup_kerberos():
 
 
 def _restore_kerberos(old_krb_env):
-    """Restore Kerberos environment after remote operations."""
+    """Restore Kerberos environment after remote operations.
+
+    :param old_krb_env: tuple returned by :func:`_setup_kerberos`
+    """
     old_ccname, old_ktname = old_krb_env
     if old_ccname is None:
         os.environ.pop('KRB5CCNAME', None)
@@ -130,11 +137,22 @@ class IPACertFix(AdminTool):
     usage = "%prog [options]"
     description = "Renew expired certificates."
 
+    # Error handling convention:
+    # - Scenario handlers (run_*) return exit codes (0/1).
+    # - determine_scenario raises RuntimeError for invalid option combos;
+    #   _classify_and_dispatch catches it for a clean exit.
+    # - Internal helpers raise exceptions (caught by handlers).
+
+    # Instance variables -- declared here so they exist regardless of which
+    # code path runs. Set in _classify_and_dispatch().
+    _ca_instance = None
     _cm = None  # CertmongerClient; set in run()
-    _ca_instance = None  # cainstance.CAInstance; set in _classify_and_dispatch
-    _detector = None  # DeploymentDetector; set in _classify_and_dispatch
-    _external_handler = None  # ExternalCertHandler; set in dispatch
     _scenario_made_changes = False  # set by _confirm_execution
+    _external_handler = None  # set in _classify_and_dispatch
+
+    # =========================================================
+    #  CLI & Entry Point
+    # =========================================================
 
     @classmethod
     def add_options(cls, parser):
@@ -149,8 +167,8 @@ class IPACertFix(AdminTool):
             action="store_true",
             default=False,
             help="Force this replica to become the renewal master. Use with "
-                 "caution, and verify CRL generation and IPA config after "
-                 "the topology is stable again!")
+                 "caution, and verify CRL generation and IPA config after the "
+                 "topology is stable again!")
         parser.add_option(
             "--dry-run",
             dest="dry_run",
@@ -171,12 +189,14 @@ class IPACertFix(AdminTool):
             self.option_parser.error(
                 "--renewal-master and --force-server are mutually exclusive")
 
+    _detector = None  # DeploymentDetector; set in _classify_and_dispatch
+
     def run(self):
         """Top-level entry point for ipa-cert-fix.
 
         Detects the deployment type, classifies expired certificates,
-        determines the appropriate fix scenario, and dispatches to the
-        corresponding handler.
+        determines the appropriate fix scenario,
+        and dispatches to the corresponding handler.
 
         :returns: exit code (0 success, 1 error, 2 not configured)
         """
@@ -211,14 +231,12 @@ class IPACertFix(AdminTool):
                 api.Backend.ldap2.disconnect()
 
     def _classify_and_dispatch(self):
-        """Classify expired certificates and dispatch to a fix scenario.
+        """Inner dispatch logic for :meth:`run`.
 
-        Detects deployment type, classifies expired certs, picks a scenario
-        via :class:`DeploymentDetector`, builds a :class:`CertFixContext`,
-        and dispatches to the appropriate handler.  Currently only the
-        renewal-master scenario is implemented; other scenarios raise a
-        clear "not implemented yet" error and will be filled in by
-        subsequent commits.
+        Separated so that ``run()`` can guarantee LDAP cleanup in
+        a finally block.
+
+        :returns: exit code
         """
         serverid = realm_to_serverid(api.env.realm)
         ds = dsinstance.DsInstance(realm_name=api.env.realm)
@@ -229,25 +247,53 @@ class IPACertFix(AdminTool):
         ds_nickname = ds.get_server_cert_nickname(serverid)
 
         # CA-specific setup (skip on CA-less deployments)
+        hsm_enabled = False
+        hsm_token_name = None
         ca_subject_dn = None
         has_ca = cainstance.is_ca_installed_locally()
         self._ca_instance = cainstance.CAInstance() if has_ca else None
 
+        # Create the detector before deployment detection
         self._detector = DeploymentDetector(
             self._cm, self._ca_instance, self.options)
 
+        # Detect deployment type
         deployment_type = self._detector.detect_deployment_type()
         logger.info("Deployment type: %s", deployment_type.value)
         if has_ca:
+            cai = self._ca_instance
+            if hasattr(cai, 'hsm_enabled') and cai.hsm_enabled:
+                hsm_enabled = True
+                hsm_token_name = cai.token_name
+                logger.info("HSM enabled, token: %s", hsm_token_name)
             ca_subject_dn = ca.lookup_ca_subject(api, subject_base)
 
+        # Classify expired certificates
         now = _utcnow() + CERT_EXPIRY_LOOKAHEAD
         dogtag_certs, ipa_certs, external_certs = \
             self._detector._classify_certs(now, ds_dbdir, ds_nickname)
 
+        logger.debug(
+            "Expired certs: dogtag=%d, ipa=%d, external=%d",
+            len(dogtag_certs), len(ipa_certs), len(external_certs),)
+        for certid, cert in dogtag_certs:
+            logger.debug(
+                "  Dogtag: %s serial=%s expires=%s",
+                certid, cert.serial_number, cert.not_valid_after_utc,)
+        for certtype, cert in ipa_certs:
+            logger.debug(
+                "  IPA: %s serial=%s expires=%s",
+                certtype.value, cert.serial_number, cert.not_valid_after_utc,
+            )
+        for certtype, cert in external_certs:
+            logger.debug(
+                "  External: %s serial=%s expires=%s",
+                certtype.value, cert.serial_number, cert.not_valid_after_utc,
+            )
+
         # On CA-full, detect RA/subsystem LDAP mismatches for certs we're NOT
-        # going to fetch from master (those will be fixed by the fetch itself
-        # plus a post-fix check).
+        # going to fetch from master (those will be fixed by the fetch itself +
+        # post-fix check).
         ldap_mismatches = []
         if has_ca:
             ra_will_be_fetched = any(
@@ -260,13 +306,12 @@ class IPACertFix(AdminTool):
                     skip_ra=ra_will_be_fetched,
                     skip_subsystem=sub_will_be_fetched)
             except Exception as e:
-                logger.warning(
-                    "RA/subsystem consistency check failed: %s", e)
+                logger.warning("RA/subsystem consistency check failed: %s", e)
 
-        # On CA-less replicas, the RA cert may be valid but stale (renewed
-        # on the CA server, not yet updated here).  A stale RA cert causes
-        # ipa commands to fail with auth errors even though no cert is
-        # technically expired.
+        # On CA-less replicas, the RA cert may be valid but stale (renewed on
+        # the CA server, not yet updated here). A stale RA cert causes ipa
+        # commands to fail with auth errors even though no cert is technically
+        # expired.
         ra_stale = False
         if (not has_ca
                 and deployment_type == DeploymentType.CA_LESS
@@ -280,22 +325,27 @@ class IPACertFix(AdminTool):
             print("Nothing to do.")
             return 0
 
+        print(WARNING_BANNER)
+
+        # Show unified list of intentions
+        print_intentions(dogtag_certs, ipa_certs, external_certs)
         if ldap_mismatches:
             DeploymentDetector._print_ra_subsystem_mismatches(ldap_mismatches)
 
         # Only LDAP mismatches and/or stale RA, no expired certs
         if not dogtag_certs and not ipa_certs and not external_certs:
-            extras = []
-            if ldap_mismatches:
-                extras.append("Would fix RA/Subsystem LDAP entries above")
-            if ra_stale:
-                extras.append("Would fetch updated RA cert from a CA server")
-            if not self._confirm_execution(
-                "RA/subsystem reconciliation",
-                "fix the entries above",
-                dry_extra_lines=extras,
-            ):
+            if self.options.dry_run:
+                if ldap_mismatches:
+                    print("[DRY RUN] Would fix LDAP entries above.")
+                if ra_stale:
+                    print("[DRY RUN] Would fetch updated RA cert "
+                          "from a CA server.")
                 return 0
+            if not self.options.unattended:
+                response = ipautil.user_input('Enter "yes" to proceed')
+                if response.lower() != 'yes':
+                    print("Not proceeding.")
+                    return 0
             if ldap_mismatches:
                 DeploymentDetector._fix_ra_subsystem_mismatches(
                     ldap_mismatches)
@@ -303,6 +353,7 @@ class IPACertFix(AdminTool):
                 self._fetch_ra_from_ca_server()
             return 0
 
+        # Determine fix scenario (may prompt for server)
         try:
             scenario, master = self._detector.determine_scenario(
                 deployment_type)
@@ -323,74 +374,73 @@ class IPACertFix(AdminTool):
             serverid=serverid,
             ds_dbdir=ds_dbdir,
             ds_nickname=ds_nickname,
-        )
+            hsm_enabled=hsm_enabled,
+            hsm_token_name=hsm_token_name,)
 
         self._external_handler = ExternalCertHandler(
-            self._cm,
-            unattended=getattr(self.options, 'unattended', False))
+            self._cm, unattended=self.options.unattended)
 
         dispatch = {
-            FixScenario.RENEWAL_MASTER: self.run_renewal_master_fix,
+            FixScenario.RENEWAL_MASTER:
+                self.run_renewal_master_fix,
             FixScenario.CA_FULL_WITH_MASTER:
-                lambda c: self._run_non_rm_replica_fix(c, is_ca_full=True),
-            FixScenario.CA_FULL_PROMOTE: self.run_ca_full_promote,
+                lambda ctx: self._run_non_rm_replica_fix(ctx, is_ca_full=True),
+            FixScenario.CA_FULL_PROMOTE:
+                self.run_ca_full_promote,
             FixScenario.CA_LESS_WITH_MASTER:
-                lambda c: self._run_non_rm_replica_fix(c, is_ca_full=False),
-            FixScenario.EXTERNAL_CERTS: self.run_external_certs,
+                lambda ctx: self._run_non_rm_replica_fix(
+                    ctx, is_ca_full=False),
+            FixScenario.EXTERNAL_CERTS:
+                self.run_external_certs,
         }
-        handler = dispatch.get(scenario)
-        if handler is None:
-            print(
-                "Scenario %s is not yet implemented." % scenario.value)
-            return 1
 
+        handler = dispatch[scenario]
         try:
             result = handler(ctx)
         except RuntimeError as e:
             print("ERROR: %s" % e)
             return 1
 
-        # Post-fix: detect and fix any RA/subsystem LDAP mismatches that
-        # arose during the fix (e.g. fetched RA cert needing a description
-        # update).  Skip when the user declined the confirmation prompt
-        # (no changes were actually made).
+        # Post-fix: detect and fix all RA/subsystem LDAP mismatches. This
+        # catches both pre-existing mismatches (shown in intentions above) and
+        # any new ones from fetched certs. Use a flag to know whether the
+        # handler actually did work vs the user declining at the confirmation
+        # prompt (both return 0).
         if has_ca and result == 0 and self._scenario_made_changes:
-            try:
-                det = self._detector
-                post_mismatches = det._detect_ra_subsystem_mismatches()
-                if post_mismatches:
-                    det._fix_ra_subsystem_mismatches(post_mismatches)
-            except Exception as e:
-                logger.warning("Post-fix consistency check failed: %s", e)
+            det = self._detector
+            post_mismatches = det._detect_ra_subsystem_mismatches()
+            if post_mismatches:
+                det._fix_ra_subsystem_mismatches(post_mismatches)
 
         return result
 
-    def run_renewal_master_fix(self, ctx):
-        """Fix certificates on the renewal master via ``pki-server cert-fix``.
+    # =========================================================
+    #  Scenario Handlers
+    # =========================================================
 
-        Regenerates expired Dogtag system certificates and installs renewed
-        IPA service certificates.  If any "shared" certificate is renewed,
-        promotes this server to the renewal master.
+    def run_renewal_master_fix(self, ctx):
+        """Fix certificates on the renewal master.
+
+        Uses ``pki-server cert-fix`` to regenerate expired Dogtag certificates
+        and installs renewed IPA service certificates. If shared certificates
+        are renewed, sets this server as the renewal master.
+
+        :param ctx: :class:`CertFixContext` with certificate details
+        :returns: exit code (0 for success)
         """
         certs = ctx.dogtag_certs
         ipa_certs = ctx.ipa_certs
-        external_certs = ctx.external_certs
 
-        try:
-            ipautil.run(['pki-server', 'cert-fix', '--help'], raiseonerr=True)
-        except (ipautil.CalledProcessError, FileNotFoundError):
-            print(
-                "The 'pki-server cert-fix' command is not available; "
-                "cannot proceed.")
-            return 1
-
-        if not self._detector._check_ca_signing_cert():
-            return self._detector._handle_expired_ca_signing_cert(
-                ctx.deployment_type)
-
-        print(WARNING_BANNER)
-
-        print_intentions(certs, ipa_certs, external_certs)
+        # On externally-signed CA deployments, the CA signing cert is managed
+        # by the external CA (renewed via ipa-cacert-manage).  Do not pass it
+        # to pki-server cert-fix -- that would regenerate it as self-signed,
+        # silently overwriting the external chain.
+        if ctx.deployment_type == DeploymentType.CA_EXTERNALLY_SIGNED:
+            if any(cid == 'ca_issuing' for cid, _ in certs):
+                logger.info(
+                    "Externally-signed CA: skipping ca_issuing cert "
+                    "(managed by external CA)")
+                certs = [(cid, c) for cid, c in certs if cid != 'ca_issuing']
 
         dry_extra = []
         if certs:
@@ -405,9 +455,8 @@ class IPACertFix(AdminTool):
             dry_extra.append(
                 "External certs (handled separately): "
                 + ", ".join(ct.value for ct, _ in ctx.external_certs))
-        has_shared = (
-            any(DOGTAG_CERTS[cid].is_shared for cid, _ in certs)
-            or any(ct is IPACertType.IPARA for ct, _ in ipa_certs))
+        has_shared = (any(DOGTAG_CERTS[cid].is_shared for cid, _ in certs)
+                      or any(ct is IPACertType.IPARA for ct, _ in ipa_certs))
         if has_shared:
             if self._detector.check_is_renewal_master():
                 dry_extra.append("Would remain renewal master")
@@ -421,22 +470,34 @@ class IPACertFix(AdminTool):
         ):
             return 0
 
+        # Pre-flight checks run after dry-run so that --dry-run always shows
+        # the plan even when pki-server or the CA cert is unavailable.
+        try:
+            ipautil.run(['pki-server', 'cert-fix', '--help'], raiseonerr=True)
+        except (ipautil.CalledProcessError, FileNotFoundError):
+            print(
+                "The 'pki-server cert-fix' command is not available; "
+                "cannot proceed.")
+            self._scenario_made_changes = False
+            return 1
+
+        if not self._detector._check_ca_signing_cert():
+            self._scenario_made_changes = False
+            return self._detector._handle_expired_ca_signing_cert(
+                ctx.deployment_type)
+
+        print("Proceeding with renewal master approach.")
+        print("Running pki-server cert-fix (this may take several minutes)...")
+
         try:
             fix_certreq_directives(certs)
             run_cert_fix(certs, ipa_certs)
         except ipautil.CalledProcessError:
             if any(
-                x[0] is IPACertType.LDAPS
-                for x in ipa_certs + external_certs
+                x[0] is IPACertType.LDAPS for x in ipa_certs
             ):
-                # The DS cert was expired.  This will cause 'pki-server
-                # cert-fix' to fail at the final restart, and return nonzero.
-                # So this exception *might* be OK to ignore.
-                #
-                # If 'pki-server cert-fix' has written new certificates
-                # corresponding to all the ipa_certs, then ignore the
-                # CalledProcessError and proceed to installing the
-                # IPA-specific certs.  Otherwise re-raise.
+                # DS cert was expired. pki-server cert-fix may fail at final
+                # restart. If renewed cert files exist on disk, we can proceed.
                 if check_renewed_ipa_certs(ipa_certs):
                     pass
                 else:
@@ -444,9 +505,10 @@ class IPACertFix(AdminTool):
             else:
                 raise
 
-        # If the CA signing cert was renewed, verify it is now valid.
-        # A partially-failed pki-server cert-fix could leave us with a
-        # still-expired CA cert.
+        # If the CA signing cert was renewed, verify it is now valid. A
+        # partially-failed pki-server cert-fix could leave us with a
+        # still-expired CA cert, which would cause all subsequent cert issuance
+        # to fail.
         if any(cid == 'ca_issuing' for cid, _ in certs):
             if not self._detector._check_ca_signing_cert():
                 print(
@@ -455,20 +517,34 @@ class IPACertFix(AdminTool):
                     "Please renew it manually using ipa-cacert-manage.")
                 return 1
 
+        # pki-server cert-fix may have restarted DS (if the LDAP cert was
+        # renewed), breaking our connection.
+        _ensure_ldap_connected()
+
         replicate_dogtag_certs(ctx.subject_base, ctx.ca_subject_dn, certs)
         install_ipa_certs(ctx.subject_base, ctx.ca_subject_dn, ipa_certs)
 
-        if any(x[0] != 'sslserver' for x in certs) \
-                or any(x[0] is IPACertType.IPARA for x in ipa_certs):
-            # we renewed a "shared" certificate, therefore we must
-            # become the renewal master
-            print("Becoming renewal master.")
-            cainstance.CAInstance().set_renewal_master()
+        # Shared certs are Dogtag certs other than sslserver (which is
+        # host-specific) and the RA cert. Renewing any shared cert requires
+        # effectively becoming RM.
+        has_shared_dogtag = any(
+            DOGTAG_CERTS[cid].is_shared for cid, _ in certs)
+        has_shared_ipa = any(ct is IPACertType.IPARA for ct, _ in ipa_certs)
+        became_rm = False
+        if has_shared_dogtag or has_shared_ipa:
+            if self._detector.check_is_renewal_master():
+                print("Remaining renewal master.")
+            else:
+                print("Becoming renewal master.")
+                became_rm = True
+                self._ca_instance.set_renewal_master()
 
         # External certs are handled inline (not via a separate scenario
-        # dispatch) because the RM/replica path must complete first --
-        # certmonger state needs to be restored before transitioning or
-        # generating CSRs.
+        # dispatch) because the RM/replica path must complete first -- the IPA
+        # CA helper and certmonger state need to be restored before
+        # transitioning or generating CSRs. run_external_certs is only reached
+        # for the EXTERNAL_CERTS scenario (fully external, no internal CA at
+        # all).
         if ctx.external_certs:
             self._external_handler.handle(ctx)
 
@@ -487,14 +563,21 @@ class IPACertFix(AdminTool):
                 "verify tracking status.")
 
         print(RENEWAL_NOTE)
+        if became_rm:
+            print(
+                "IMPORTANT: This server is now the renewal master.\n"
+                "Enable CRL generation on this server:\n"
+                "  ipa-crlgen-manage enable\n"
+                "Disable CRL generation on all other CA servers:\n"
+                "  ipa-crlgen-manage disable\n")
         return 0
 
     def _run_non_rm_replica_fix(self, ctx, is_ca_full):
         """Shared logic for CA-full and CA-less replica fix.
 
         Fetches the CA chain from the master, fetches RA (and subsystem certs
-        for CA-full), renews expired certs via certmonger pointed at the
-        master, then restarts IPA.
+        for CA-full), renews expired certs via certmonger pointed at
+        the master, restarts IPA, and resubmits remaining requests.
 
         :param ctx: :class:`CertFixContext` with master_server
         :param is_ca_full: ``True`` for CA-full replica, ``False`` for CA-less
@@ -505,10 +588,10 @@ class IPACertFix(AdminTool):
         master_server = ctx.master_server
         label = ("CA-full replica" if is_ca_full else "CA-less replica")
 
-        print(WARNING_BANNER)
-        print_intentions(dogtag, ipa_certs, ctx.external_certs)
-
-        dry_extra = ["Would fetch certificates from %s" % master_server]
+        dry_extra = [
+            "Would fetch certificates from %s"
+            % master_server,
+        ]
         if dogtag:
             dry_extra.append(
                 "Dogtag certs to renew: "
@@ -531,6 +614,7 @@ class IPACertFix(AdminTool):
             return 0
 
         old_krb_env = _setup_kerberos()
+
         try:
             self.update_ca_cert_from_master(master_server)
 
@@ -541,9 +625,13 @@ class IPACertFix(AdminTool):
             renewal = CertRenewalFromMaster(self._cm, master_server)
             renewed_ids = renewal.renew(dogtag, ipa_certs, ctx)
 
+            # See comment in run_renewal_master_fix for why external certs are
+            # handled inline.
             if ctx.external_certs:
                 self._external_handler.handle(ctx)
 
+            # Certmonger post-save commands may have already restarted
+            # individual services.
             print("Restarting IPA")
             ipautil.run(['ipactl', 'restart', '--ignore-service-failures'])
             _ensure_ldap_connected()
@@ -553,62 +641,32 @@ class IPACertFix(AdminTool):
             else:
                 print(
                     "WARNING: certmonger is not responding. "
-                    "Certificate renewal completed successfully, but "
-                    "certmonger tracking requests were not resubmitted.\n"
-                    "Run 'getcert list' once certmonger recovers to "
-                    "verify tracking status.")
+                    "Certificate renewal completed successfully, "
+                    "but certmonger tracking requests were not resubmitted.\n"
+                    "Run 'getcert list' once certmonger recovers "
+                    "to verify tracking status.")
         finally:
             _restore_kerberos(old_krb_env)
 
         # Advisory: warn if any CA cert in the local chain is near expiry.
+        # The replica path doesn't need it for signing, but services will break
+        # again if it isn't renewed in time.
         self._detector._warn_ca_chain_near_expiry()
 
         print(RENEWAL_NOTE)
         return 0
 
-    def run_external_certs(self, ctx):
-        """Handle expired externally-signed certificates.
-
-        Delegates to :class:`ExternalCertHandler` for transition offers and
-        CSR generation.
-
-        :param ctx: :class:`CertFixContext` with external_certs
-        :returns: exit code
-        """
-        if not ctx.external_certs:
-            print("Nothing to do.")
-            return 0
-
-        if self.options.dry_run:
-            print("[DRY RUN] Would handle external certificates:")
-            for certtype, _cert in ctx.external_certs:
-                print("[DRY RUN]   %s: CSR to %s/%s.csr"
-                      % (certtype.value,
-                         ExternalCertHandler.DEFAULT_CSR_DIR,
-                         certtype.value.lower().replace(' ', '-')))
-            if ctx.deployment_type != DeploymentType.CA_LESS_EXTERNAL:
-                print("[DRY RUN]   Transition to IPA CA would be offered "
-                      "(interactive only)")
-            return 0
-
-        if self._external_handler.handle(ctx):
-            return 0
-        return 1
-
     def run_ca_full_promote(self, ctx):
         """Promote this replica to renewal master and fix certs.
 
-        Used when the current renewal master is unrecoverable.  Sets this
-        server as the renewal master, then delegates to
-        :meth:`run_renewal_master_fix`.  If the cert fix fails after
-        promotion, attempts a best-effort rollback of the renewal master
-        role.
+        Used when the current renewal master is unrecoverable. Sets this server
+        as renewal master, then delegates to :meth:`run_renewal_master_fix`.
 
         :param ctx: :class:`CertFixContext`
         :returns: exit code
         """
-        # Verify pki-server cert-fix is available BEFORE promoting --
-        # promotion is a topology-wide change that is hard to undo.
+        # Verify pki-server cert-fix is available BEFORE promoting -- promotion
+        # is a topology-wide change that is hard to undo.
         try:
             ipautil.run(
                 ['pki-server', 'cert-fix', '--help'],
@@ -625,11 +683,13 @@ class IPACertFix(AdminTool):
 
         if self.options.dry_run:
             print("[DRY RUN] Would promote this server to renewal master")
+            # Delegate to RM handler's dry-run for cert detail
             return self.run_renewal_master_fix(
-                replace(ctx, scenario=FixScenario.RENEWAL_MASTER))
+                replace(ctx,
+                        scenario=FixScenario.RENEWAL_MASTER))
 
-        # In unattended mode, refuse to silently promote.  Promotion is the
-        # most destructive path -- it must be explicitly requested via
+        # In unattended mode, refuse to silently promote. Promotion is the most
+        # destructive path -- it must be explicitly requested via
         # --renewal-master (which routes to RENEWAL_MASTER, not here).
         if self.options.unattended:
             print(
@@ -646,15 +706,15 @@ class IPACertFix(AdminTool):
             print("Not proceeding.")
             return 0
 
-        # Record the current RM (if any) so we can attempt rollback if the
-        # cert fix fails after promotion.
+        # Record the current RM (if any) so we can attempt rollback if the cert
+        # fix fails after promotion.
         old_rm = _find_current_renewal_master()
 
         self._promote_to_renewal_master()
 
         rm_ctx = replace(ctx, scenario=FixScenario.RENEWAL_MASTER)
-        # User already confirmed promotion -- suppress the second
-        # confirmation inside run_renewal_master_fix.
+        # User already confirmed promotion -- suppress the second confirmation
+        # inside run_renewal_master_fix.
         saved_unattended = self.options.unattended
         self.options.unattended = True
         try:
@@ -663,8 +723,7 @@ class IPACertFix(AdminTool):
                 # RM-fix returned a guarded failure (pre-flight check, partial
                 # cert-fix, post-fix CA still expired). The promotion is a
                 # topology-wide change -- attempt to roll it back so we don't
-                # leave the cluster with this host as RM holding expired
-                # certs.
+                # leave the cluster with this host as RM holding expired certs.
                 self._rollback_promotion(old_rm)
                 return result
             print(
@@ -685,8 +744,8 @@ class IPACertFix(AdminTool):
 
         Called when ``run_renewal_master_fix`` either raises or returns a
         non-zero exit code after this host was promoted.  Failure is logged
-        and printed -- never re-raised -- because the caller is already on
-        an error path.
+        and printed -- never re-raised -- because the caller is already on an
+        error path.
 
         :param old_rm: previous renewal master FQDN (may be ``None``)
         """
@@ -708,30 +767,54 @@ class IPACertFix(AdminTool):
                 "expired certs.\nManual intervention required."
                 % (old_rm, api.env.host))
 
-    def _promote_to_renewal_master(self):
-        """Promote the current replica to renewal master.
+    # =========================================================
+    #  External Cert Handling (delegates to ExternalCertHandler)
+    # =========================================================
 
-        Sets this server as the renewal master in LDAP.
+    def run_external_certs(self, ctx):
+        """Handle expired externally-signed certificates.
 
-        :raises RuntimeError: if promotion fails
+        Delegates to :class:`ExternalCertHandler` for transition offers and
+        CSR generation.
+
+        :param ctx: :class:`CertFixContext` with external_certs
+        :returns: exit code
         """
-        _ensure_ldap_connected()
-        print("Setting this server as the renewal master.")
-        try:
-            self._ca_instance.set_renewal_master(api.env.host)
-        except Exception as e:
-            raise RuntimeError("Failed to set renewal master: %s" % e)
-        logger.info("Successfully set %s as renewal master", api.env.host)
+        if not ctx.external_certs:
+            print("Nothing to do.")
+            return 0
+
+        if self.options.dry_run:
+            print("[DRY RUN] Would handle external certificates:")
+            for certtype, _cert in ctx.external_certs:
+                print("[DRY RUN]   %s: CSR to %s/%s.csr"
+                      % (certtype.value,
+                         ExternalCertHandler.DEFAULT_CSR_DIR,
+                         certtype.value.lower().replace(' ', '-')))
+            if (ctx.deployment_type
+                    != DeploymentType.CA_LESS_EXTERNAL):
+                print("[DRY RUN]   Transition to IPA CA would be offered "
+                      "(interactive only)")
+            return 0
+
+        # Cert details already printed by _classify_and_dispatch.
+        if self._external_handler.handle(ctx):
+            return 0
+        return 1
+
+    # =========================================================
+    #  Master Cert Operations
+    # =========================================================
 
     def _check_ra_cert_staleness(self):
         """Check if the local RA cert is stale on a CA-less replica.
 
-        Compares the local RA cert serial against the CA server's LDAP
-        entry.  Returns True if the serials differ (local cert is
-        outdated), False if they match or the check fails.
+        Compares the local RA cert serial against the CA server's
+        LDAP entry.  Returns True if the serials differ (local cert
+        is outdated), False if they match or the check fails.
 
-        Only meaningful on CA-less replicas where the RA cert is not
-        managed by local certmonger renewal.
+        Only meaningful on CA-less replicas where the RA cert is
+        not managed by local certmonger renewal.
         """
         try:
             local_ra = x509.load_certificate_from_file(paths.RA_AGENT_PEM)
@@ -739,6 +822,7 @@ class IPACertFix(AdminTool):
             logger.debug("Cannot load local RA cert, skipping staleness check")
             return False
 
+        ca_servers = []
         try:
             ca_servers = find_providing_servers(
                 'CA', conn=api.Backend.ldap2, api=api)
@@ -782,8 +866,8 @@ class IPACertFix(AdminTool):
     def _fetch_ra_from_ca_server(self):
         """Fetch the current RA cert from a CA server.
 
-        Used when the local RA cert is valid but stale (different serial
-        than the CA server's copy).
+        Used when the local RA cert is valid but stale (different
+        serial than the CA server's copy).
         """
         ca_servers = find_providing_servers(
             'CA', conn=api.Backend.ldap2, api=api)
@@ -820,6 +904,21 @@ class IPACertFix(AdminTool):
                 conn.unbind()
             _restore_kerberos(old_krb)
 
+    def _promote_to_renewal_master(self):
+        """Promote the current replica to renewal master.
+
+        Sets this server as the renewal master in LDAP.
+
+        :raises RuntimeError: if promotion fails
+        """
+        _ensure_ldap_connected()
+        print("Setting this server as the renewal master.")
+        try:
+            self._ca_instance.set_renewal_master(api.env.host)
+        except Exception as e:
+            raise RuntimeError("Failed to set renewal master: %s" % e)
+        logger.info("Successfully set %s as renewal master", api.env.host)
+
     def _fetch_certs_from_master(
         self, master_server, ctx, fetch_subsystem=True,
     ):
@@ -833,10 +932,10 @@ class IPACertFix(AdminTool):
 
         :param master_server: FQDN of the master server
         :param ctx: :class:`CertFixContext`
-        :param fetch_subsystem: if ``True``, also fetch shared dogtag certs
-            (CA-full only)
-        :raises RuntimeError: if a fetched cert is expired (master needs
-            fixing first)
+        :param fetch_subsystem: if ``True``, also fetch shared dogtag
+            certs (CA-full only)
+        :raises RuntimeError: if a fetched cert is expired (master
+            needs fixing first)
         """
         now = _utcnow()
 
@@ -874,6 +973,7 @@ class IPACertFix(AdminTool):
         logger.debug("Successfully connected to master LDAP")
 
         try:
+            # RA certificate -- only fetch if expired
             ra_expired = any(
                 ct is IPACertType.IPARA for ct, _ in ctx.ipa_certs)
             if ra_expired:
@@ -902,16 +1002,15 @@ class IPACertFix(AdminTool):
             else:
                 logger.debug("RA cert is valid, skipping fetch")
 
+            # Subsystem certificate -- only fetch if expired
             if fetch_subsystem:
                 db = _get_pki_nssdb()
                 sub_expired = any(
                     cid == 'subsystem' for cid, _ in ctx.dogtag_certs)
                 if sub_expired:
-                    sub_dn = DN(
-                        ('uid', 'pkidbuser'),
-                        ('ou', 'people'),
-                        ('o', 'ipaca'),
-                    )
+                    sub_dn = DN(('uid', 'pkidbuser'),
+                                ('ou', 'people'),
+                                ('o', 'ipaca'),)
                     sub_cert = _fetch_and_update_cert(
                         conn, sub_dn,
                         "Subsystem", "CA Subsystem")
@@ -933,8 +1032,8 @@ class IPACertFix(AdminTool):
         finally:
             conn.unbind()
 
-    # Subset fetched from cn=ca_renewal by _fetch_shared_dogtag_certs.
-    # Excludes ca_issuing (ipa-certupdate) and subsystem (direct fetch).
+    # Subset fetched from cn=ca_renewal by _fetch_shared_dogtag_certs. Excludes
+    # ca_issuing (ipa-certupdate) and subsystem (direct fetch).
     _SHARED_DOGTAG_CERTS = {
         ci.id: ci.nickname for ci in DOGTAG_CERTS.values()
         if ci.is_shared and ci.id not in ('ca_issuing', 'subsystem')
@@ -943,8 +1042,14 @@ class IPACertFix(AdminTool):
     def _fetch_shared_dogtag_certs(self, conn, db, ctx, master_server, now):
         """Fetch shared dogtag certs from cn=ca_renewal on the master.
 
-        Installs each cert into the local NSSDB, sets audit cert trust
-        flags, and updates the CS.cfg blob.
+        Installs each cert into the local NSSDB, sets audit cert trust flags,
+        and updates the CS.cfg blob.
+
+        :param conn: LDAP connection to the master
+        :param db: local PKI :class:`NSSDatabase`
+        :param ctx: :class:`CertFixContext`
+        :param master_server: master FQDN (for error messages)
+        :param now: current UTC datetime (for expiry check)
         """
         # Only fetch certs that are actually expired. KRA certs are only in
         # expired_ids if KRA is installed locally (expired_dogtag_certs skips
@@ -954,13 +1059,11 @@ class IPACertFix(AdminTool):
             if certid not in expired_ids:
                 continue
             try:
-                renewal_dn = DN(
-                    ('cn', nickname),
-                    ('cn', 'ca_renewal'),
-                    ('cn', 'ipa'),
-                    ('cn', 'etc'),
-                    api.env.basedn,
-                )
+                renewal_dn = DN(('cn', nickname),
+                                ('cn', 'ca_renewal'),
+                                ('cn', 'ipa'),
+                                ('cn', 'etc'),
+                                api.env.basedn)
                 entry = conn.get_entry(renewal_dn, ['usercertificate'])
                 new_cert = entry.single_value['usercertificate']
                 print_cert_info("Fetched", nickname, new_cert)
@@ -987,43 +1090,59 @@ class IPACertFix(AdminTool):
                     "Failed to fetch shared cert %s: %s", nickname, e)
 
     def update_ca_cert_from_master(self, master_server):
-        """Update the CA certificate chain from the master server.
+        """
+        Update the CA certificate chain from the master server.
 
-        If the local CA chain (``/etc/ipa/ca.crt``) is already present and
-        valid (no expired certs in the trust path) and TLS to the master
-        works, skips the expensive ``ipa-certupdate`` call.  Otherwise runs
+        If the local CA chain (``/etc/ipa/ca.crt``) is already present
+        and valid (no expired certs in the trust path), skips the
+        expensive ``ipa-certupdate`` call.  Otherwise runs
         ``ipa-certupdate --force-server <master_server>``.
 
-        ipa-certupdate may exit non-zero if some service restarts fail (e.g.
-        httpd, krb5kdc with expired certs), but the CA cert chain update
-        itself happens before any restarts.  We re-verify the chain after
-        the call to determine success.
+        ipa-certupdate may exit non-zero if some service restarts fail
+        (e.g. httpd, krb5kdc with expired certs), but the CA cert chain
+        update itself happens before any restarts. We check whether the
+        chain file was actually modified to determine success.
         """
+        # Check if local CA chain is already valid and we can reach the master
+        # over TLS. If both are fine, ipa-certupdate is unnecessary -- skip it
+        # to avoid service restarts and certmonger D-Bus disruption.
         try:
             DeploymentDetector._verify_ca_chain_valid(master_server)
         except RuntimeError:
             logger.debug("Local CA chain is missing or invalid, "
                          "running ipa-certupdate")
         else:
+            # Chain is valid -- can we TLS handshake to the master?
             try:
                 _check_tls_handshake(master_server)
                 print("Local CA chain is valid and TLS to %s works, "
                       "skipping ipa-certupdate." % master_server)
                 return
             except Exception as e:
-                # Local chain is valid but TLS to master fails.  The
-                # master's CA cert was likely renewed and our trust store
-                # is stale.  ipa-certupdate would also fail here.
+                # Local chain is valid but TLS to master fails. The master's CA
+                # cert was likely renewed and our trust store is stale.
+                # ipa-certupdate will also fail (it needs HTTPS to the master).
+                # The only safe fix is to manually copy the updated ca.crt.
                 raise RuntimeError(
                     "Cannot verify TLS to %s: %s\n\n"
-                    "The local CA chain (%s) is valid but does not match "
-                    "the master's current certificate.  Copy the updated "
-                    "%s from %s to this host (verify authenticity "
-                    "out-of-band first), then re-run ipa-cert-fix."
+                    "The local CA chain (%s) is valid but does not match the "
+                    "master's current certificate. This typically means the "
+                    "CA certificate on %s was renewed.\n\n"
+                    "ipa-cert-fix cannot update the trust store automatically "
+                    "because it cannot verify the master's identity without "
+                    "the updated CA chain (MITM risk).\n\n"
+                    "To fix this:\n"
+                    "  1. On %s, copy %s to this server\n"
+                    "  2. Place it at %s\n"
+                    "  3. Re-run ipa-cert-fix\n\n"
+                    "Verify the file authenticity before copying "
+                    "(e.g. compare checksums out-of-band)."
                     % (master_server, e, paths.IPA_CA_CRT,
-                       paths.IPA_CA_CRT, master_server))
+                       master_server, master_server,
+                       paths.IPA_CA_CRT, paths.IPA_CA_CRT))
 
         print("Updating CA certificate chain from %s" % master_server)
+
         logger.debug("Running: ipa-certupdate --force-server %s",
                      master_server)
         result = ipautil.run(
@@ -1031,21 +1150,23 @@ class IPACertFix(AdminTool):
             raiseonerr=False)
         logger.debug("ipa-certupdate returncode=%s", result.returncode)
 
-        # Regardless of ipa-certupdate exit code, check whether the CA
-        # chain is present and valid.  ipa-certupdate may exit non-zero
-        # due to service restart failures (expected with expired certs),
-        # but the CA chain itself may be fine.
-        DeploymentDetector._verify_ca_chain_valid(master_server)
-
         if result.returncode != 0:
             logger.warning("ipa-certupdate exited with code %s",
                            result.returncode)
-            print(
-                "WARNING: ipa-certupdate exited with an error, but the CA "
-                "chain is valid.\nThis is expected if some services "
-                "failed to restart due to expired certificates. "
-                "Continuing.")
 
+        # Regardless of ipa-certupdate exit code, check whether the CA chain is
+        # present and valid.  ipa-certupdate may exit non-zero due to service
+        # restart failures (expected with expired certs) or certmonger D-Bus
+        # timeouts, but the CA chain itself may be fine.
+        DeploymentDetector._verify_ca_chain_valid(master_server)
+
+        if result.returncode != 0:
+            print("WARNING: ipa-certupdate exited with an error, but "
+                  "the CA chain is valid.\n"
+                  "This is expected if some services failed to restart "
+                  "due to expired certificates. Continuing.")
+
+        # LDAP must still be running for subsequent steps
         if not dsinstance.is_ds_running(realm_to_serverid(api.env.realm)):
             raise RuntimeError(
                 "LDAP server is no longer running after ipa-certupdate. "
@@ -1056,146 +1177,274 @@ class IPACertFix(AdminTool):
         # connection.
         _ensure_ldap_connected()
 
+    # =========================================================
+    #  Infrastructure Helpers
+    # =========================================================
+
     def _confirm_execution(self, dry_label, prompt, dry_extra_lines=None):
-        """Handle dry-run, unattended, or interactive confirmation.
+        """Handle dry-run or ask for user confirmation.
 
-        :param dry_label: short label printed in [DRY RUN] output
-        :param prompt: action description for the confirmation prompt
-        :param dry_extra_lines: extra lines printed when --dry-run is set
-        :returns: ``True`` if the caller should proceed, ``False`` to exit
-            without making changes (dry-run, declined, or unattended skip)
+        The expired cert summary is already printed before scenario
+        dispatch.  This method only handles the dry-run label/extras
+        or the yes/no confirmation.
+
+        :param dry_label: label for ``[DRY RUN]`` output
+        :param prompt: text after ``Enter "yes" to``
+        :param dry_extra_lines: extra ``[DRY RUN]`` lines
+        :returns: ``True`` to proceed, ``False`` to bail
         """
-        if getattr(self.options, 'dry_run', False):
-            label = dry_label or "this action"
-            print("[DRY RUN] Would perform: %s" % label)
+        if self.options.dry_run:
+            print("[DRY RUN] Would execute %s" % dry_label)
             for line in (dry_extra_lines or []):
-                print("[DRY RUN]   %s" % line)
+                print("[DRY RUN] %s" % line)
+            logger.info("Dry run completed, no changes made")
             return False
 
-        if getattr(self.options, 'unattended', False):
-            self._scenario_made_changes = True
-            return True
+        # Print the plan in all modes so the user (or log) sees what will
+        # happen before the tool proceeds.
+        for line in (dry_extra_lines or []):
+            print("  %s" % line)
 
-        text = 'Enter "yes" to %s' % (prompt or "proceed")
-        response = ipautil.user_input(text)
-        if response.lower() != 'yes':
-            print("Not proceeding.")
-            return False
-        print("Proceeding.")
+        if not self.options.unattended:
+            response = ipautil.user_input('Enter "yes" to %s' % prompt)
+            if response.lower() != 'yes':
+                print("Not proceeding.")
+                logger.info("User declined, no changes made")
+                return False
+
         self._scenario_made_changes = True
         return True
 
     def resubmit_expired_certs(self, renewed_ids=None):
-        """Resubmit lingering certmonger requests after a fix.
+        """Resubmit remaining expired certificate requests.
 
-        Walks the certmonger requests for the local PKI and IPA service
-        cert directories, skipping those already renewed in this run, and
-        resubmits any that are still tracking an expired or
-        about-to-expire certificate.
+        After IPA restart, certmonger may already be processing some requests
+        (triggered by the restart or by post-save commands from earlier
+        renewals).  This method:
+
+        - Skips requests already renewed by :class:`CertRenewalFromMaster`
+        - Skips requests that certmonger is actively processing
+          (``SUBMITTING``, ``CA_WORKING``, etc.)
+        - Skips requests whose cert is already valid (renewed by certmonger
+          autonomously)
+        - Only resubmits requests stuck in error states
+          (``CA_UNREACHABLE``, ``CA_REJECTED``, etc.)
+
+        :param renewed_ids: set of request IDs already renewed
+            from master (skipped to avoid double-submission)
         """
         if renewed_ids is None:
             renewed_ids = set()
-        ipa_request_dirs = [
-            paths.PKI_TOMCAT_ALIAS_DIR,
-            os.path.dirname(paths.HTTPD_CERT_FILE),
-            dsinstance.config_dirname(
-                realm_to_serverid(api.env.realm)).rstrip('/'),
-            os.path.dirname(paths.KDC_CERT),
-        ]
-        seen = set()
-        for d in ipa_request_dirs:
-            try:
-                ids = self._cm.get_requests_for_dir(d) or []
-            except Exception as e:
-                logger.debug("Cannot list certmonger requests in %s: %s",
-                             d, e)
+        print("Checking remaining certificate requests...")
+
+        request_ids = []
+
+        # Dogtag NSS database (empty on CA-less)
+        pki_ids = self._cm.get_requests_for_dir(paths.PKI_TOMCAT_ALIAS_DIR)
+        logger.debug(
+            "Tracking requests in %s: %s",
+            paths.PKI_TOMCAT_ALIAS_DIR, pki_ids)
+        request_ids.extend(pki_ids)
+
+        # DS NSS database
+        serverid = realm_to_serverid(api.env.realm)
+        ds_dbdir = dsinstance.config_dirname(serverid).rstrip('/')
+        ds_ids = self._cm.get_requests_for_dir(ds_dbdir)
+        logger.debug("Tracking requests in %s: %s", ds_dbdir, ds_ids)
+        request_ids.extend(ds_ids)
+
+        # File-based certs (HTTPD, KDC, RA)
+        for certfile in (paths.HTTPD_CERT_FILE,
+                         paths.KDC_CERT,
+                         paths.RA_AGENT_PEM):
+            request_id = self._cm.get_request_id({'cert-file': certfile})
+            if request_id is not None:
+                logger.debug(
+                    "Tracking request for %s: %s", certfile, request_id)
+                request_ids.append(request_id)
+
+        logger.debug("Total tracking requests to check: %s", request_ids)
+
+        # States where certmonger is actively processing the request or the
+        # cert is already good. Resubmitting in these states would interfere
+        # with certmonger's own renewal attempt.
+        skip_states = {
+            'MONITORING',
+            'SUBMITTING', 'CA_WORKING',
+            'READING_CERT', 'POST_SAVED_CERT', 'SAVING_CERT',
+            'NEWLY_ADDED_NEED_KEYINFO_READ_PIN',
+            'NEED_KEY_PAIR', 'GENERATING_KEY_PAIR',
+            'NEED_CSR', 'GENERATING_CSR',
+        }
+
+        # Error states where a resubmit is warranted.
+        error_states = {
+            'CA_UNREACHABLE', 'CA_REJECTED',
+            'CA_UNCONFIGURED', 'NEED_GUIDANCE',
+            'NEED_CA',
+        }
+
+        resubmitted = 0
+        for request_id in request_ids:
+            if request_id in renewed_ids:
+                logger.debug(
+                    "Request %s already renewed from master, skipping",
+                    request_id)
                 continue
-            for rid in ids:
-                if rid in seen or rid in renewed_ids:
-                    continue
-                seen.add(rid)
-                try:
-                    state = self._cm.get_request_value(rid, 'status')
-                except Exception:
-                    state = None
-                if state == 'MONITORING':
-                    if self._cm.is_cert_valid(rid):
-                        continue
-                if state in (None, 'CA_UNREACHABLE',
-                             'NEED_KEYINFO', 'NEED_GUIDANCE',
-                             'CA_REJECTED', 'CA_UNCONFIGURED'):
-                    logger.debug(
-                        "Resubmitting certmonger request %s (state=%s)",
-                        rid, state)
-                    try:
-                        self._cm.resubmit_request(rid)
-                    except Exception as e:
-                        logger.warning(
-                            "Failed to resubmit %s: %s", rid, e)
-                else:
-                    logger.debug(
-                        "Skipping certmonger request %s in state %s",
-                        rid, state)
+
+            try:
+                status = self._cm.get_request_value(request_id, 'status')
+            except Exception as e:
+                logger.warning(
+                    "Cannot read status for request %s: %s",
+                    request_id, e)
+                print("  Request %s: cannot read status, skipping"
+                      % request_id)
+                continue
+
+            if status in skip_states:
+                logger.debug(
+                    "Request %s in state %s, skipping",
+                    request_id, status)
+                continue
+
+            if status not in error_states:
+                # Unknown state -- log it but don't blindly resubmit.
+                logger.info(
+                    "Request %s in unexpected state %s, not resubmitting",
+                    request_id, status)
+                continue
+
+            # Check if the cert is already valid (e.g. we just installed it
+            # via LDAP fetch but certmonger doesn't know yet).  Resubmitting
+            # a valid cert causes certmonger to request a new one from CA,
+            # which is wasteful and can get stuck in CA_WORKING state.
+            if self._cm.is_cert_valid(request_id):
+                logger.debug("Request %s cert is already valid, "
+                             "skipping resubmit", request_id)
+                print("  Request %s cert is already valid, skipping."
+                      % request_id)
+                continue
+
+            print(
+                "  Resubmitting request %s (status: %s)" % (request_id, status)
+            )
+            try:
+                self._cm.resubmit_request(request_id)
+            except Exception as e:
+                logger.warning(
+                    "Failed to resubmit request %s: %s", request_id, e)
+                print("  WARNING: Failed to resubmit request %s "
+                      "(certmonger may be busy)" % request_id)
+                continue
+            resubmitted += 1
+            try:
+                state = self._cm.wait_for_request(request_id, timeout=60)
+            except RuntimeError:
+                logger.debug("Timeout waiting for request %s", request_id)
+                state = self._cm.get_request_value(request_id, 'status')
+
+            if state == 'MONITORING':
+                print("  Request %s completed." % request_id)
+            elif state in ('CA_WORKING', 'SUBMITTING',
+                           'POST_SAVED_CERT', 'READING_CERT'):
+                print("  Request %s still being processed, "
+                      "will complete in background." % request_id)
+            else:
+                logger.warning("Request %s is in state %s", request_id, state)
+                print("  WARNING: Request %s is in state: %s"
+                      % (request_id, state))
+
+        if resubmitted == 0:
+            print("  All requests are already being processed or completed.")
+
+
+# =============================================================
+#  Module-level cert operations (renewal master path)
+# =============================================================
 
 
 def _get_newest_cert(certs):
-    """Return the certificate with the latest notAfter from a list."""
+    """
+    Given a list of certificates, return the one with the latest
+    notAfter date.
+    """
+    if not certs:
+        raise RuntimeError("No certificates found in LDAP entry")
     return max(certs, key=lambda c: c.not_valid_after_utc)
 
 
 def _fetch_and_update_cert(remote_conn, dn, context, desc):
-    """Fetch the newest cert at *dn* from a remote master and update LDAP.
-
-    Reads ``userCertificate`` from the remote entry, picks the cert with the
-    latest ``notAfter``, and writes it back into the local LDAP entry along
-    with the matching ``description`` value (the format Dogtag expects).
-
-    :param remote_conn: LDAP connection to the master
-    :param dn: target DN (RA or subsystem)
-    :param context: short label used in print/log
-    :param desc: descriptive label for ``print_cert_info``
-    :returns: the cert chosen as newest
     """
+    Fetch the newest certificate from a remote LDAP entry and update
+    the corresponding local LDAP entry.
+
+    Picks the cert with the latest notAfter from the remote entry's
+    userCertificate attribute. Then updates the local entry: adds the cert
+    if not already present, and updates the description with the current
+    serial number.
+
+    :param remote_conn: LDAP connection to the master server
+    :param dn: DN of the entry (same on remote and local)
+    :param context: label for log/print (e.g. "RA", "Subsystem")
+    :param desc: certificate description for print_cert_info
+    :returns: the newest certificate from the remote entry
+    """
+    logger.debug("Fetching %s cert from remote DN: %s", context, dn)
     remote_entry = remote_conn.get_entry(dn, ['userCertificate'])
-    new_cert = _get_newest_cert(remote_entry['userCertificate'])
-    print_cert_info("Fetched", desc, new_cert)
+    remote_certs = remote_entry['userCertificate']
+    logger.debug(
+        "Remote entry %s has %d userCertificate value(s)",
+        dn, len(remote_certs))
+    cert = _get_newest_cert(remote_certs)
+    logger.debug(
+        "Selected newest %s cert: serial=%s, subject=%s, "
+        "notBefore=%s, notAfter=%s",
+        context, cert.serial_number, DN(cert.subject),
+        cert.not_valid_before_utc, cert.not_valid_after_utc)
+    print_cert_info("Fetched", desc, cert)
 
-    expected_desc = '2;%d;%s;%s' % (
-        new_cert.serial_number,
-        DN(new_cert.issuer), DN(new_cert.subject))
+    # Update local LDAP entry
+    local_conn = api.Backend.ldap2
+    local_entry = local_conn.get_entry(dn, ['userCertificate', 'description'])
+    local_certs = local_entry.get('userCertificate', [])
+    logger.debug(
+        "Local entry %s has %d userCertificate value(s)",
+        dn, len(local_certs))
 
-    conn = api.Backend.ldap2
+    # Add the cert if not already present
+    cert_der = cert.public_bytes(x509.Encoding.DER)
+    already_present = any(
+        c.public_bytes(x509.Encoding.DER) == cert_der
+        for c in local_certs)
+    if already_present:
+        logger.debug(
+            "Cert serial=%s already present in local entry, "
+            "not adding duplicate", cert.serial_number)
+    else:
+        logger.debug(
+            "Adding cert serial=%s to local entry", cert.serial_number)
+        local_certs.append(cert)
+        local_entry['userCertificate'] = local_certs
+
+    # Update description with current serial: 2;SERIAL;issuer;subject
+    new_desc = '2;%d;%s;%s' % (
+        cert.serial_number, DN(cert.issuer), DN(cert.subject))
     try:
-        local_entry = conn.get_entry(dn, ['userCertificate', 'description'])
-    except Exception as e:
-        logger.warning("Cannot read local LDAP entry %s: %s", dn, e)
-        return new_cert
-
-    new_der = new_cert.public_bytes(x509.Encoding.DER)
-    have_cert = any(
-        c.public_bytes(x509.Encoding.DER) == new_der
-        for c in local_entry.get('userCertificate', []))
-    changed = False
-    if not have_cert:
-        local_entry.setdefault('userCertificate', []).append(new_cert)
-        changed = True
-
-    try:
-        current_desc = local_entry.single_value.get('description', '')
+        old_desc = local_entry.single_value.get('description', '')
     except ValueError:
-        current_desc = None
-    if current_desc != expected_desc:
-        local_entry['description'] = expected_desc
-        changed = True
+        old_desc = None
+    logger.debug("Updating description: old='%s', new='%s'",
+                 old_desc, new_desc)
+    local_entry['description'] = new_desc
 
-    if changed:
-        try:
-            conn.update_entry(local_entry)
-            logger.debug("Updated local %s LDAP entry %s", context, dn)
-        except Exception as e:
-            logger.warning("Failed to update local LDAP entry %s: %s", dn, e)
+    try:
+        local_conn.update_entry(local_entry)
+        logger.debug("Local entry %s updated successfully", dn)
+    except errors.EmptyModlist:
+        logger.debug("Local entry %s already up to date", dn)
 
-    return new_cert
+    return cert
 
 
 def print_intentions(dogtag_certs, ipa_certs, external_certs=None):
@@ -1221,16 +1470,14 @@ def fix_certreq_directives(certs):
     in PKI config file, or try to get the CSR from certmonger.
     """
     # pki-server cert-fix needs to find the CSR in the subsystem config file
-    # otherwise it will fail.  Walk each cert to renew, check whether the CSR
-    # directive is present, and fall back to certmonger.
+    # otherwise it will fail. For each cert to be fixed, check that the CSR is
+    # present or get it from certmonger.
     for (certid, _cert) in certs:
-        ci = DOGTAG_CERTS[certid]
-        if ci.certreq_directive is None or ci.cfg_path is None:
+        ci = DOGTAG_CERTS.get(certid)
+        if ci is None or ci.certreq_directive is None:
             continue
         if directivesetter.get_directive(
-            ci.cfg_path, ci.certreq_directive, '='
-        ) is None:
-            # The CSR is missing, try to get it from certmonger
+                ci.cfg_path, ci.certreq_directive, '=') is None:
             csr = get_csr_from_certmonger(ci.nickname)
             if csr:
                 directivesetter.set_directive(
@@ -1241,8 +1488,7 @@ def fix_certreq_directives(certs):
 def run_cert_fix(certs, ipa_certs):
     ldapi_path = (
         paths.SLAPD_INSTANCE_SOCKET_TEMPLATE
-        % '-'.join(api.env.realm.split('.'))
-    )
+        % realm_to_serverid(api.env.realm))
     cmd = [
         'pki-server',
         'cert-fix',
@@ -1258,10 +1504,24 @@ def run_cert_fix(certs, ipa_certs):
 
 def replicate_dogtag_certs(subject_base, ca_subject_dn, certs):
     for certid, _oldcert in certs:
-        cert_path = "/etc/pki/pki-tomcat/certs/{}.crt".format(certid)
+        cert_path = DOGTAG_CERT_PATH_TEMPLATE.format(certid)
         cert = x509.load_certificate_from_file(cert_path)
         print_cert_info("Renewed Dogtag", certid, cert)
         replicate_cert(subject_base, ca_subject_dn, cert)
+        # Update ou=People,o=ipaca entry (userCertificate blob + description
+        # with serial) and the lightweight authority entry (authoritySerial).
+        # This mirrors what renew_ca_cert post-save does on the renewal master.
+        try:
+            cainstance.update_people_entry(cert)
+        except Exception as e:
+            logger.warning(
+                "Failed to update people entry for %s: %s", certid, e)
+        try:
+            cainstance.update_authority_entry(cert)
+        except Exception as e:
+            logger.debug(
+                "No authority entry for %s (expected for most certs): %s",
+                certid, e)
 
 
 def check_renewed_ipa_certs(certs):

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -48,6 +48,7 @@ from ipaserver.install.ipa_cert_fix_services import (  # noqa: F401
     CertRenewalFromMaster,
     CertmongerClient,
     DeploymentDetector,
+    ExternalCertHandler,
     _ensure_ldap_connected,
     _find_current_renewal_master,
     _get_pki_nssdb,
@@ -132,6 +133,7 @@ class IPACertFix(AdminTool):
     _cm = None  # CertmongerClient; set in run()
     _ca_instance = None  # cainstance.CAInstance; set in _classify_and_dispatch
     _detector = None  # DeploymentDetector; set in _classify_and_dispatch
+    _external_handler = None  # ExternalCertHandler; set in dispatch
 
     @classmethod
     def add_options(cls, parser):
@@ -284,6 +286,10 @@ class IPACertFix(AdminTool):
             ds_nickname=ds_nickname,
         )
 
+        self._external_handler = ExternalCertHandler(
+            self._cm,
+            unattended=getattr(self.options, 'unattended', False))
+
         dispatch = {
             FixScenario.RENEWAL_MASTER: self.run_renewal_master_fix,
             FixScenario.CA_FULL_WITH_MASTER:
@@ -291,6 +297,7 @@ class IPACertFix(AdminTool):
             FixScenario.CA_FULL_PROMOTE: self.run_ca_full_promote,
             FixScenario.CA_LESS_WITH_MASTER:
                 lambda c: self._run_non_rm_replica_fix(c, is_ca_full=False),
+            FixScenario.EXTERNAL_CERTS: self.run_external_certs,
         }
         handler = dispatch.get(scenario)
         if handler is None:
@@ -363,6 +370,13 @@ class IPACertFix(AdminTool):
             print("Becoming renewal master.")
             cainstance.CAInstance().set_renewal_master()
 
+        # External certs are handled inline (not via a separate scenario
+        # dispatch) because the RM/replica path must complete first --
+        # certmonger state needs to be restored before transitioning or
+        # generating CSRs.
+        if ctx.external_certs:
+            self._external_handler.handle(ctx)
+
         print("Restarting IPA")
         ipautil.run(['ipactl', 'restart'], raiseonerr=True)
 
@@ -405,6 +419,9 @@ class IPACertFix(AdminTool):
             renewal = CertRenewalFromMaster(self._cm, master_server)
             renewal.renew(dogtag, ipa_certs, ctx)
 
+            if ctx.external_certs:
+                self._external_handler.handle(ctx)
+
             print("Restarting IPA")
             ipautil.run(['ipactl', 'restart', '--ignore-service-failures'])
             _ensure_ldap_connected()
@@ -413,6 +430,23 @@ class IPACertFix(AdminTool):
 
         print(RENEWAL_NOTE)
         return 0
+
+    def run_external_certs(self, ctx):
+        """Handle expired externally-signed certificates.
+
+        Delegates to :class:`ExternalCertHandler` for transition offers and
+        CSR generation.
+
+        :param ctx: :class:`CertFixContext` with external_certs
+        :returns: exit code
+        """
+        if not ctx.external_certs:
+            print("Nothing to do.")
+            return 0
+
+        if self._external_handler.handle(ctx):
+            return 0
+        return 1
 
     def run_ca_full_promote(self, ctx):
         """Promote this replica to renewal master and fix certs.
@@ -900,25 +934,21 @@ def _fetch_and_update_cert(remote_conn, dn, context, desc):
     return new_cert
 
 
-def print_intentions(dogtag_certs, ipa_certs, non_renewed):
-    print("The following certificates will be renewed:")
-    print()
-
-    for certid, cert in dogtag_certs:
-        print_cert_info("Dogtag", certid, cert)
-
-    for certtype, cert in ipa_certs:
-        print_cert_info("IPA", certtype.value, cert)
-
-    if non_renewed:
-        print(
-            "The following certificates will NOT be renewed because "
-            "they were not issued by the IPA CA:"
-        )
+def print_intentions(dogtag_certs, ipa_certs, external_certs=None):
+    if dogtag_certs or ipa_certs:
+        print("The following certificates will be renewed:")
         print()
-
-        for certtype, cert in non_renewed:
+        for certid, cert in dogtag_certs:
+            print_cert_info("Dogtag", certid, cert)
+        for certtype, cert in ipa_certs:
             print_cert_info("IPA", certtype.value, cert)
+    if external_certs:
+        print("The following externally-signed certificates require "
+              "separate handling")
+        print("(transition to IPA CA or CSR generation for external renewal):")
+        print()
+        for certtype, cert in external_certs:
+            print_cert_info("External", certtype.value, cert)
 
 
 def fix_certreq_directives(certs):

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -25,6 +25,7 @@
 
 from __future__ import print_function, absolute_import
 
+from dataclasses import replace
 import logging
 import os
 import shutil
@@ -47,6 +48,7 @@ from ipaserver.install.ipa_cert_fix_services import (  # noqa: F401
     CertmongerClient,
     DeploymentDetector,
     _ensure_ldap_connected,
+    _find_current_renewal_master,
     _get_pki_nssdb,
     _replace_cert_in_nssdb,
     _update_cs_cfg,
@@ -62,6 +64,7 @@ from ipaserver.install.ipa_cert_fix_types import (  # noqa: F401
     DeploymentType,
     FixScenario,
     IPACertType,
+    PROMOTE_WARNING,
     RENEWAL_NOTE,
     RENEWED_CERT_PATH_TEMPLATE,
     WARNING_BANNER,
@@ -126,11 +129,16 @@ class IPACertFix(AdminTool):
     description = "Renew expired certificates."
 
     _cm = None  # CertmongerClient; set in run()
+    _ca_instance = None  # cainstance.CAInstance; set in _classify_and_dispatch
     _detector = None  # DeploymentDetector; set in _classify_and_dispatch
 
     @classmethod
     def add_options(cls, parser):
         super(IPACertFix, cls).add_options(parser)
+        parser.add_option(
+            "--force-server",
+            dest="force_server",
+            help="FQDN of the master server to fetch certificates from")
         parser.add_option(
             "--renewal-master",
             dest="renewal_master",
@@ -142,6 +150,10 @@ class IPACertFix(AdminTool):
 
     def validate_options(self):
         super(IPACertFix, self).validate_options(needs_root=True)
+
+        if self.options.renewal_master and self.options.force_server:
+            self.option_parser.error(
+                "--renewal-master and --force-server are mutually exclusive")
 
     def run(self):
         """Top-level entry point for ipa-cert-fix.
@@ -161,6 +173,13 @@ class IPACertFix(AdminTool):
 
         if self._cm is None:
             self._cm = CertmongerClient()
+
+        if (self.options.force_server
+                and self.options.force_server == api.env.host):
+            print(
+                "--force-server must point to a different server, "
+                "not this one (%s)" % api.env.host)
+            return 1
 
         if not dsinstance.is_ds_running(realm_to_serverid(api.env.realm)):
             print("The LDAP server is not running; cannot proceed.\n"
@@ -196,10 +215,10 @@ class IPACertFix(AdminTool):
         # CA-specific setup (skip on CA-less deployments)
         ca_subject_dn = None
         has_ca = cainstance.is_ca_installed_locally()
-        ca_inst = cainstance.CAInstance() if has_ca else None
+        self._ca_instance = cainstance.CAInstance() if has_ca else None
 
         self._detector = DeploymentDetector(
-            self._cm, ca_inst, self.options)
+            self._cm, self._ca_instance, self.options)
 
         deployment_type = self._detector.detect_deployment_type()
         logger.info("Deployment type: %s", deployment_type.value)
@@ -250,6 +269,7 @@ class IPACertFix(AdminTool):
             FixScenario.RENEWAL_MASTER: self.run_renewal_master_fix,
             FixScenario.CA_FULL_WITH_MASTER:
                 lambda c: self._run_non_rm_replica_fix(c, is_ca_full=True),
+            FixScenario.CA_FULL_PROMOTE: self.run_ca_full_promote,
         }
         handler = dispatch.get(scenario)
         if handler is None:
@@ -372,6 +392,123 @@ class IPACertFix(AdminTool):
 
         print(RENEWAL_NOTE)
         return 0
+
+    def run_ca_full_promote(self, ctx):
+        """Promote this replica to renewal master and fix certs.
+
+        Used when the current renewal master is unrecoverable.  Sets this
+        server as the renewal master, then delegates to
+        :meth:`run_renewal_master_fix`.  If the cert fix fails after
+        promotion, attempts a best-effort rollback of the renewal master
+        role.
+
+        :param ctx: :class:`CertFixContext`
+        :returns: exit code
+        """
+        # Verify pki-server cert-fix is available BEFORE promoting --
+        # promotion is a topology-wide change that is hard to undo.
+        try:
+            ipautil.run(
+                ['pki-server', 'cert-fix', '--help'],
+                raiseonerr=True, capture_output=True)
+        except (ipautil.CalledProcessError, FileNotFoundError):
+            print(
+                "No working master server was found and "
+                "'pki-server cert-fix' is not available.\n"
+                "Cannot proceed with promotion or renewal.\n"
+                "Either point to a working master with\n"
+                "--force-server=<FQDN>, or install/update "
+                "pki-server on this host.")
+            return 1
+
+        # In unattended mode, refuse to silently promote.  Promotion is the
+        # most destructive path -- it must be explicitly requested via
+        # --renewal-master (which routes to RENEWAL_MASTER, not here).
+        if getattr(self.options, 'unattended', False):
+            print(
+                "No working CA server was found. In unattended mode,\n"
+                "promotion to renewal master requires the explicit "
+                "--renewal-master flag.\n"
+                "Alternatively, use --force-server=<FQDN> to point to "
+                "a working master.")
+            return 1
+
+        print(PROMOTE_WARNING)
+        response = ipautil.user_input('Enter "yes" to promote and proceed')
+        if response.lower() != 'yes':
+            print("Not proceeding.")
+            return 0
+
+        # Record the current RM (if any) so we can attempt rollback if the
+        # cert fix fails after promotion.
+        old_rm = _find_current_renewal_master()
+
+        self._promote_to_renewal_master()
+
+        rm_ctx = replace(ctx, scenario=FixScenario.RENEWAL_MASTER)
+        try:
+            result = self.run_renewal_master_fix(rm_ctx)
+            if result != 0:
+                # RM-fix returned a guarded failure (pre-flight check, partial
+                # cert-fix, post-fix CA still expired). The promotion is a
+                # topology-wide change -- attempt to roll it back so we don't
+                # leave the cluster with this host as RM holding expired
+                # certs.
+                self._rollback_promotion(old_rm)
+                return result
+            print(
+                "IMPORTANT: This server is now the renewal master.\n"
+                "Enable CRL generation on this server:\n"
+                "  ipa-crlgen-manage enable\n"
+                "Disable CRL generation on all other CA servers:\n"
+                "  ipa-crlgen-manage disable\n")
+            return 0
+        except Exception:
+            self._rollback_promotion(old_rm)
+            raise
+
+    def _rollback_promotion(self, old_rm):
+        """Best-effort rollback of an RM promotion.
+
+        Called when ``run_renewal_master_fix`` either raises or returns a
+        non-zero exit code after this host was promoted.  Failure is logged
+        and printed -- never re-raised -- because the caller is already on
+        an error path.
+
+        :param old_rm: previous renewal master FQDN (may be ``None``)
+        """
+        if not old_rm or old_rm == api.env.host:
+            return
+        logger.warning(
+            "Certificate fix failed after promotion. "
+            "Attempting to restore renewal master to %s", old_rm)
+        try:
+            self._ca_instance.set_renewal_master(old_rm)
+            print("Restored renewal master to %s" % old_rm)
+        except Exception as rollback_err:
+            logger.error(
+                "Failed to restore renewal master to %s: %s",
+                old_rm, rollback_err,)
+            print(
+                "WARNING: Could not restore renewal master to %s.\n"
+                "This server (%s) is now the renewal master with "
+                "expired certs.\nManual intervention required."
+                % (old_rm, api.env.host))
+
+    def _promote_to_renewal_master(self):
+        """Promote the current replica to renewal master.
+
+        Sets this server as the renewal master in LDAP.
+
+        :raises RuntimeError: if promotion fails
+        """
+        _ensure_ldap_connected()
+        print("Setting this server as the renewal master.")
+        try:
+            self._ca_instance.set_renewal_master(api.env.host)
+        except Exception as e:
+            raise RuntimeError("Failed to set renewal master: %s" % e)
+        logger.info("Successfully set %s as renewal master", api.env.host)
 
     def _fetch_certs_from_master(
         self, master_server, ctx, fetch_subsystem=True,

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -134,6 +134,7 @@ class IPACertFix(AdminTool):
     _ca_instance = None  # cainstance.CAInstance; set in _classify_and_dispatch
     _detector = None  # DeploymentDetector; set in _classify_and_dispatch
     _external_handler = None  # ExternalCertHandler; set in dispatch
+    _scenario_made_changes = False  # set by _confirm_execution
 
     @classmethod
     def add_options(cls, parser):
@@ -150,6 +151,18 @@ class IPACertFix(AdminTool):
             help="Force this replica to become the renewal master. Use with "
                  "caution, and verify CRL generation and IPA config after "
                  "the topology is stable again!")
+        parser.add_option(
+            "--dry-run",
+            dest="dry_run",
+            action="store_true",
+            default=False,
+            help="Print intended actions without executing them")
+        parser.add_option(
+            "-U", "--unattended",
+            dest="unattended",
+            action="store_true",
+            default=False,
+            help="Unattended mode, never prompts the user")
 
     def validate_options(self):
         super(IPACertFix, self).validate_options(needs_root=True)
@@ -272,7 +285,16 @@ class IPACertFix(AdminTool):
 
         # Only LDAP mismatches and/or stale RA, no expired certs
         if not dogtag_certs and not ipa_certs and not external_certs:
-            if not self._confirm_execution():
+            extras = []
+            if ldap_mismatches:
+                extras.append("Would fix RA/Subsystem LDAP entries above")
+            if ra_stale:
+                extras.append("Would fetch updated RA cert from a CA server")
+            if not self._confirm_execution(
+                "RA/subsystem reconciliation",
+                "fix the entries above",
+                dry_extra_lines=extras,
+            ):
                 return 0
             if ldap_mismatches:
                 DeploymentDetector._fix_ra_subsystem_mismatches(
@@ -330,8 +352,9 @@ class IPACertFix(AdminTool):
 
         # Post-fix: detect and fix any RA/subsystem LDAP mismatches that
         # arose during the fix (e.g. fetched RA cert needing a description
-        # update).
-        if has_ca and result == 0:
+        # update).  Skip when the user declined the confirmation prompt
+        # (no changes were actually made).
+        if has_ca and result == 0 and self._scenario_made_changes:
             try:
                 det = self._detector
                 post_mismatches = det._detect_ra_subsystem_mismatches()
@@ -369,7 +392,33 @@ class IPACertFix(AdminTool):
 
         print_intentions(certs, ipa_certs, external_certs)
 
-        if not self._confirm_execution():
+        dry_extra = []
+        if certs:
+            dry_extra.append(
+                "Dogtag certs for pki-server cert-fix: "
+                + ", ".join(cid for cid, _ in certs))
+        if ipa_certs:
+            dry_extra.append(
+                "IPA service certs (extra-cert): "
+                + ", ".join(ct.value for ct, _ in ipa_certs))
+        if ctx.external_certs:
+            dry_extra.append(
+                "External certs (handled separately): "
+                + ", ".join(ct.value for ct, _ in ctx.external_certs))
+        has_shared = (
+            any(DOGTAG_CERTS[cid].is_shared for cid, _ in certs)
+            or any(ct is IPACertType.IPARA for ct, _ in ipa_certs))
+        if has_shared:
+            if self._detector.check_is_renewal_master():
+                dry_extra.append("Would remain renewal master")
+            else:
+                dry_extra.append("Would become renewal master")
+        dry_extra.append("Would restart IPA services")
+        if not self._confirm_execution(
+            "renewal master certificate fix",
+            "proceed",
+            dry_extra_lines=dry_extra,
+        ):
             return 0
 
         try:
@@ -424,7 +473,18 @@ class IPACertFix(AdminTool):
             self._external_handler.handle(ctx)
 
         print("Restarting IPA")
-        ipautil.run(['ipactl', 'restart'], raiseonerr=True)
+        ipautil.run(['ipactl', 'restart', '--ignore-service-failures'])
+        _ensure_ldap_connected()
+
+        if self._cm.is_responsive():
+            self.resubmit_expired_certs()
+        else:
+            print(
+                "WARNING: certmonger is not responding. "
+                "Certificate renewal completed successfully, but "
+                "certmonger tracking requests were not resubmitted.\n"
+                "Run 'getcert list' once certmonger recovers to "
+                "verify tracking status.")
 
         print(RENEWAL_NOTE)
         return 0
@@ -447,12 +507,28 @@ class IPACertFix(AdminTool):
 
         print(WARNING_BANNER)
         print_intentions(dogtag, ipa_certs, ctx.external_certs)
-        print("This will fetch certificates from %s." % master_server)
-        if not self._confirm_execution():
-            return 0
 
-        print("Proceeding with %s fix using server %s."
-              % (label, master_server))
+        dry_extra = ["Would fetch certificates from %s" % master_server]
+        if dogtag:
+            dry_extra.append(
+                "Dogtag certs to renew: "
+                + ", ".join(cid for cid, _ in dogtag))
+        if ipa_certs:
+            dry_extra.append(
+                "IPA service certs to renew: "
+                + ", ".join(ct.value for ct, _ in ipa_certs))
+        if ctx.external_certs:
+            dry_extra.append(
+                "External certs (handled separately): "
+                + ", ".join(ct.value for ct, _ in ctx.external_certs))
+        if is_ca_full:
+            dry_extra.append("Would NOT become renewal master")
+        if not self._confirm_execution(
+            "%s certificate fix" % label,
+            "proceed with %s fix using server %s" % (label, master_server),
+            dry_extra_lines=dry_extra,
+        ):
+            return 0
 
         old_krb_env = _setup_kerberos()
         try:
@@ -463,7 +539,7 @@ class IPACertFix(AdminTool):
                 fetch_subsystem=is_ca_full,)
 
             renewal = CertRenewalFromMaster(self._cm, master_server)
-            renewal.renew(dogtag, ipa_certs, ctx)
+            renewed_ids = renewal.renew(dogtag, ipa_certs, ctx)
 
             if ctx.external_certs:
                 self._external_handler.handle(ctx)
@@ -471,6 +547,16 @@ class IPACertFix(AdminTool):
             print("Restarting IPA")
             ipautil.run(['ipactl', 'restart', '--ignore-service-failures'])
             _ensure_ldap_connected()
+
+            if self._cm.is_responsive():
+                self.resubmit_expired_certs(renewed_ids)
+            else:
+                print(
+                    "WARNING: certmonger is not responding. "
+                    "Certificate renewal completed successfully, but "
+                    "certmonger tracking requests were not resubmitted.\n"
+                    "Run 'getcert list' once certmonger recovers to "
+                    "verify tracking status.")
         finally:
             _restore_kerberos(old_krb_env)
 
@@ -491,6 +577,18 @@ class IPACertFix(AdminTool):
         """
         if not ctx.external_certs:
             print("Nothing to do.")
+            return 0
+
+        if self.options.dry_run:
+            print("[DRY RUN] Would handle external certificates:")
+            for certtype, _cert in ctx.external_certs:
+                print("[DRY RUN]   %s: CSR to %s/%s.csr"
+                      % (certtype.value,
+                         ExternalCertHandler.DEFAULT_CSR_DIR,
+                         certtype.value.lower().replace(' ', '-')))
+            if ctx.deployment_type != DeploymentType.CA_LESS_EXTERNAL:
+                print("[DRY RUN]   Transition to IPA CA would be offered "
+                      "(interactive only)")
             return 0
 
         if self._external_handler.handle(ctx):
@@ -525,10 +623,15 @@ class IPACertFix(AdminTool):
                 "pki-server on this host.")
             return 1
 
+        if self.options.dry_run:
+            print("[DRY RUN] Would promote this server to renewal master")
+            return self.run_renewal_master_fix(
+                replace(ctx, scenario=FixScenario.RENEWAL_MASTER))
+
         # In unattended mode, refuse to silently promote.  Promotion is the
         # most destructive path -- it must be explicitly requested via
         # --renewal-master (which routes to RENEWAL_MASTER, not here).
-        if getattr(self.options, 'unattended', False):
+        if self.options.unattended:
             print(
                 "No working CA server was found. In unattended mode,\n"
                 "promotion to renewal master requires the explicit "
@@ -550,6 +653,10 @@ class IPACertFix(AdminTool):
         self._promote_to_renewal_master()
 
         rm_ctx = replace(ctx, scenario=FixScenario.RENEWAL_MASTER)
+        # User already confirmed promotion -- suppress the second
+        # confirmation inside run_renewal_master_fix.
+        saved_unattended = self.options.unattended
+        self.options.unattended = True
         try:
             result = self.run_renewal_master_fix(rm_ctx)
             if result != 0:
@@ -570,6 +677,8 @@ class IPACertFix(AdminTool):
         except Exception:
             self._rollback_promotion(old_rm)
             raise
+        finally:
+            self.options.unattended = saved_unattended
 
     def _rollback_promotion(self, old_rm):
         """Best-effort rollback of an RM promotion.
@@ -947,14 +1056,86 @@ class IPACertFix(AdminTool):
         # connection.
         _ensure_ldap_connected()
 
-    def _confirm_execution(self):
-        """Interactively confirm before performing destructive actions."""
-        response = ipautil.user_input('Enter "yes" to proceed')
+    def _confirm_execution(self, dry_label, prompt, dry_extra_lines=None):
+        """Handle dry-run, unattended, or interactive confirmation.
+
+        :param dry_label: short label printed in [DRY RUN] output
+        :param prompt: action description for the confirmation prompt
+        :param dry_extra_lines: extra lines printed when --dry-run is set
+        :returns: ``True`` if the caller should proceed, ``False`` to exit
+            without making changes (dry-run, declined, or unattended skip)
+        """
+        if getattr(self.options, 'dry_run', False):
+            label = dry_label or "this action"
+            print("[DRY RUN] Would perform: %s" % label)
+            for line in (dry_extra_lines or []):
+                print("[DRY RUN]   %s" % line)
+            return False
+
+        if getattr(self.options, 'unattended', False):
+            self._scenario_made_changes = True
+            return True
+
+        text = 'Enter "yes" to %s' % (prompt or "proceed")
+        response = ipautil.user_input(text)
         if response.lower() != 'yes':
             print("Not proceeding.")
             return False
         print("Proceeding.")
+        self._scenario_made_changes = True
         return True
+
+    def resubmit_expired_certs(self, renewed_ids=None):
+        """Resubmit lingering certmonger requests after a fix.
+
+        Walks the certmonger requests for the local PKI and IPA service
+        cert directories, skipping those already renewed in this run, and
+        resubmits any that are still tracking an expired or
+        about-to-expire certificate.
+        """
+        if renewed_ids is None:
+            renewed_ids = set()
+        ipa_request_dirs = [
+            paths.PKI_TOMCAT_ALIAS_DIR,
+            os.path.dirname(paths.HTTPD_CERT_FILE),
+            dsinstance.config_dirname(
+                realm_to_serverid(api.env.realm)).rstrip('/'),
+            os.path.dirname(paths.KDC_CERT),
+        ]
+        seen = set()
+        for d in ipa_request_dirs:
+            try:
+                ids = self._cm.get_requests_for_dir(d) or []
+            except Exception as e:
+                logger.debug("Cannot list certmonger requests in %s: %s",
+                             d, e)
+                continue
+            for rid in ids:
+                if rid in seen or rid in renewed_ids:
+                    continue
+                seen.add(rid)
+                try:
+                    state = self._cm.get_request_value(rid, 'status')
+                except Exception:
+                    state = None
+                if state == 'MONITORING':
+                    if self._cm.is_cert_valid(rid):
+                        continue
+                if state in (None, 'CA_UNREACHABLE',
+                             'NEED_KEYINFO', 'NEED_GUIDANCE',
+                             'CA_REJECTED', 'CA_UNCONFIGURED'):
+                    logger.debug(
+                        "Resubmitting certmonger request %s (state=%s)",
+                        rid, state)
+                    try:
+                        self._cm.resubmit_request(rid)
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to resubmit %s: %s", rid, e)
+                else:
+                    logger.debug(
+                        "Skipping certmonger request %s in state %s",
+                        rid, state)
 
 
 def _get_newest_cert(certs):

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -41,6 +41,7 @@ from ipapython.dn import DN
 from ipapython import ipaldap
 from ipapython.ipaldap import realm_to_serverid
 from ipaserver.install import ca, cainstance, dsinstance
+from ipaserver.masters import find_providing_servers
 # Re-export public names from the helper modules so that all symbols are
 # importable from ``ipaserver.install.ipa_cert_fix``.
 from ipaserver.install.ipa_cert_fix_services import (  # noqa: F401
@@ -229,8 +230,26 @@ class IPACertFix(AdminTool):
         dogtag_certs, ipa_certs, external_certs = \
             self._detector._classify_certs(now, ds_dbdir, ds_nickname)
 
-        if not dogtag_certs and not ipa_certs and not external_certs:
+        # On CA-less replicas, the RA cert may be valid but stale (renewed
+        # on the CA server, not yet updated here).  A stale RA cert causes
+        # ipa commands to fail with auth errors even though no cert is
+        # technically expired.
+        ra_stale = False
+        if (not has_ca
+                and deployment_type == DeploymentType.CA_LESS
+                and not any(ct is IPACertType.IPARA
+                            for ct, _ in ipa_certs)):
+            ra_stale = self._check_ra_cert_staleness()
+
+        if (not dogtag_certs and not ipa_certs
+                and not external_certs and not ra_stale):
             print("Nothing to do.")
+            return 0
+
+        if ra_stale and not (dogtag_certs or ipa_certs or external_certs):
+            if not self._confirm_execution():
+                return 0
+            self._fetch_ra_from_ca_server()
             return 0
 
         if any(key == 'ca_issuing' for key, _ in dogtag_certs):
@@ -270,6 +289,8 @@ class IPACertFix(AdminTool):
             FixScenario.CA_FULL_WITH_MASTER:
                 lambda c: self._run_non_rm_replica_fix(c, is_ca_full=True),
             FixScenario.CA_FULL_PROMOTE: self.run_ca_full_promote,
+            FixScenario.CA_LESS_WITH_MASTER:
+                lambda c: self._run_non_rm_replica_fix(c, is_ca_full=False),
         }
         handler = dispatch.get(scenario)
         if handler is None:
@@ -509,6 +530,103 @@ class IPACertFix(AdminTool):
         except Exception as e:
             raise RuntimeError("Failed to set renewal master: %s" % e)
         logger.info("Successfully set %s as renewal master", api.env.host)
+
+    def _check_ra_cert_staleness(self):
+        """Check if the local RA cert is stale on a CA-less replica.
+
+        Compares the local RA cert serial against the CA server's LDAP
+        entry.  Returns True if the serials differ (local cert is
+        outdated), False if they match or the check fails.
+
+        Only meaningful on CA-less replicas where the RA cert is not
+        managed by local certmonger renewal.
+        """
+        try:
+            local_ra = x509.load_certificate_from_file(paths.RA_AGENT_PEM)
+        except Exception:
+            logger.debug("Cannot load local RA cert, skipping staleness check")
+            return False
+
+        try:
+            ca_servers = find_providing_servers(
+                'CA', conn=api.Backend.ldap2, api=api)
+        except Exception as e:
+            logger.debug("Cannot discover CA servers: %s", e)
+            return False
+
+        if not ca_servers:
+            return False
+
+        server = ca_servers[0]
+        old_krb = _setup_kerberos()
+        try:
+            conn = ipaldap.LDAPClient.from_hostname_secure(server)
+            conn.gssapi_bind()
+            ra_dn = DN(('uid', 'ipara'), ('ou', 'people'), ('o', 'ipaca'))
+            entry = conn.get_entry(ra_dn, ['userCertificate'])
+            remote_ra = _get_newest_cert(entry['userCertificate'])
+            conn.unbind()
+        except Exception as e:
+            logger.debug("Cannot check RA cert on %s: %s", server, e)
+            return False
+        finally:
+            _restore_kerberos(old_krb)
+
+        if local_ra.serial_number != remote_ra.serial_number:
+            logger.info(
+                "Local RA cert (serial %s) differs from %s (serial %s)",
+                local_ra.serial_number, server, remote_ra.serial_number)
+            print(
+                "The local RA certificate (serial %s) is outdated.\n"
+                "The CA server %s has serial %s."
+                % (local_ra.serial_number, server,
+                   remote_ra.serial_number))
+            return True
+
+        logger.debug("Local RA cert matches CA server %s (serial %s)",
+                     server, local_ra.serial_number)
+        return False
+
+    def _fetch_ra_from_ca_server(self):
+        """Fetch the current RA cert from a CA server.
+
+        Used when the local RA cert is valid but stale (different serial
+        than the CA server's copy).
+        """
+        ca_servers = find_providing_servers(
+            'CA', conn=api.Backend.ldap2, api=api)
+        if not ca_servers:
+            print("ERROR: No CA servers found.")
+            return
+
+        server = ca_servers[0]
+        print("Fetching updated RA certificate from %s" % server)
+        old_krb = _setup_kerberos()
+        conn = None
+        try:
+            conn = ipaldap.LDAPClient.from_hostname_secure(server)
+            conn.gssapi_bind()
+            ra_dn = DN(('uid', 'ipara'), ('ou', 'people'), ('o', 'ipaca'))
+            entry = conn.get_entry(ra_dn, ['userCertificate'])
+            ra_cert = _get_newest_cert(entry['userCertificate'])
+
+            print_cert_info("Fetched", "IPA RA", ra_cert)
+            if ra_cert.not_valid_after_utc <= _utcnow():
+                print("ERROR: RA cert fetched from %s is expired "
+                      "(notAfter=%s). The CA server's RA cert "
+                      "must be renewed first."
+                      % (server, ra_cert.not_valid_after_utc))
+                return
+            x509.write_certificate(ra_cert, paths.RA_AGENT_PEM)
+            cainstance.CAInstance._set_ra_cert_perms()
+            print("RA certificate updated.")
+        except Exception as e:
+            print("ERROR: Failed to fetch RA cert from %s: %s"
+                  % (server, e))
+        finally:
+            if conn is not None:
+                conn.unbind()
+            _restore_kerberos(old_krb)
 
     def _fetch_certs_from_master(
         self, master_server, ctx, fetch_subsystem=True,

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -28,8 +28,6 @@ from __future__ import print_function, absolute_import
 import base64
 from cryptography import x509 as crypto_x509
 from cryptography.hazmat.backends import default_backend
-import datetime
-from enum import Enum
 import logging
 import shutil
 
@@ -44,46 +42,19 @@ from ipapython.dn import DN
 from ipapython.ipaldap import realm_to_serverid
 from ipaserver.install import ca, cainstance, dsinstance
 from ipaserver.install.certs import is_ipa_issued_cert
+from ipaserver.install.ipa_cert_fix_types import (
+    CERT_EXPIRY_LOOKAHEAD,
+    DOGTAG_CERTS,
+    IPACertType,
+    RENEWAL_NOTE,
+    RENEWED_CERT_PATH_TEMPLATE,
+    WARNING_BANNER,
+    _utcnow,
+)
 from ipapython import directivesetter
 from ipapython import ipautil
 
-msg = """
-                          WARNING
-
-ipa-cert-fix is intended for recovery when expired certificates
-prevent the normal operation of IPA.  It should ONLY be used
-in such scenarios, and backup of the system, especially certificates
-and keys, is STRONGLY RECOMMENDED.
-
-"""
-
-renewal_note = """
-Note: Monitor the certmonger-initiated renewal of
-certificates after ipa-cert-fix and wait for its completion before
-any other administrative task.
-"""
-
-RENEWED_CERT_PATH_TEMPLATE = "/etc/pki/pki-tomcat/certs/{}-renewed.crt"
-
 logger = logging.getLogger(__name__)
-
-
-cert_nicknames = {
-    'ca_issuing': 'caSigningCert cert-pki-ca',
-    'sslserver': 'Server-Cert cert-pki-ca',
-    'subsystem': 'subsystemCert cert-pki-ca',
-    'ca_ocsp_signing': 'ocspSigningCert cert-pki-ca',
-    'ca_audit_signing': 'auditSigningCert cert-pki-ca',
-    'kra_transport': 'transportCert cert-pki-kra',
-    'kra_storage': 'storageCert cert-pki-kra',
-    'kra_audit_signing': 'auditSigningCert cert-pki-kra',
-}
-
-class IPACertType(Enum):
-    IPARA = "IPA RA"
-    HTTPS = "Apache HTTPS"
-    LDAPS = "LDAP"
-    KDC = "KDC"
 
 
 class IPACertFix(AdminTool):
@@ -142,9 +113,7 @@ class IPACertFix(AdminTool):
 
         ca_subject_dn = ca.lookup_ca_subject(api, subject_base)
 
-        now = (
-            datetime.datetime.now(tz=datetime.timezone.utc)
-            + datetime.timedelta(weeks=2))
+        now = _utcnow() + CERT_EXPIRY_LOOKAHEAD
         certs, extra_certs, non_renewed = expired_certs(now)
 
         if not certs and not extra_certs:
@@ -173,7 +142,7 @@ class IPACertFix(AdminTool):
         IPA service certificates.  If any "shared" certificate is renewed,
         promotes this server to the renewal master.
         """
-        print(msg)
+        print(WARNING_BANNER)
 
         print_intentions(certs, extra_certs, non_renewed)
 
@@ -216,7 +185,7 @@ class IPACertFix(AdminTool):
         print("Restarting IPA")
         ipautil.run(['ipactl', 'restart'], raiseonerr=True)
 
-        print(renewal_note)
+        print(RENEWAL_NOTE)
         return 0
 
     def _confirm_execution(self):
@@ -244,9 +213,9 @@ def expired_dogtag_certs(now):
     certs = []
     db = NSSDatabase(nssdir=paths.PKI_TOMCAT_ALIAS_DIR)
 
-    for certid, nickname in cert_nicknames.items():
+    for certid, ci in DOGTAG_CERTS.items():
         try:
-            cert = db.get_cert(nickname)
+            cert = db.get_cert(ci.nickname)
         except RuntimeError:
             pass  # unfortunately certdb doesn't give us a better exception
         else:
@@ -365,41 +334,25 @@ def fix_certreq_directives(certs):
     For all the certs to be fixed, ensure that the corresponding CSR is found
     in PKI config file, or try to get the CSR from certmonger.
     """
-    directives = {
-        'auditSigningCert cert-pki-ca': ('ca.audit_signing.certreq',
-                                         paths.CA_CS_CFG_PATH),
-        'ocspSigningCert cert-pki-ca': ('ca.ocsp_signing.certreq',
-                                        paths.CA_CS_CFG_PATH),
-        'subsystemCert cert-pki-ca': ('ca.subsystem.certreq',
-                                      paths.CA_CS_CFG_PATH),
-        'Server-Cert cert-pki-ca': ('ca.sslserver.certreq',
-                                    paths.CA_CS_CFG_PATH),
-        'auditSigningCert cert-pki-kra': ('kra.audit_signing.certreq',
-                                          paths.KRA_CS_CFG_PATH),
-        'storageCert cert-pki-kra': ('kra.storage.certreq',
-                                     paths.KRA_CS_CFG_PATH),
-        'transportCert cert-pki-kra': ('kra.transport.certreq',
-                                       paths.KRA_CS_CFG_PATH),
-    }
-
     # pki-server cert-fix needs to find the CSR in the subsystem config file
-    # otherwise it will fail
-    # For each cert to be fixed, check that the CSR is present or
-    # get it from certmonger
+    # otherwise it will fail.  Walk each cert to renew, check whether the CSR
+    # directive is present, and fall back to certmonger.
     for (certid, _cert) in certs:
-        # Check if the directive is set in the config file
-        nickname = cert_nicknames[certid]
-        (directive, cfg_path) = directives[nickname]
-        if directivesetter.get_directive(cfg_path, directive, '=') is None:
+        ci = DOGTAG_CERTS[certid]
+        if ci.certreq_directive is None or ci.cfg_path is None:
+            continue
+        if directivesetter.get_directive(
+            ci.cfg_path, ci.certreq_directive, '='
+        ) is None:
             # The CSR is missing, try to get it from certmonger
-            csr = get_csr_from_certmonger(nickname)
+            csr = get_csr_from_certmonger(ci.nickname)
             if csr:
-                # Update the directive
-                directivesetter.set_directive(cfg_path, directive, csr,
-                                              quotes=False, separator='=')
+                directivesetter.set_directive(
+                    ci.cfg_path, ci.certreq_directive, csr,
+                    quotes=False, separator='=')
 
 
-def run_cert_fix(certs, extra_certs):
+def run_cert_fix(certs, ipa_certs):
     ldapi_path = (
         paths.SLAPD_INSTANCE_SOCKET_TEMPLATE
         % '-'.join(api.env.realm.split('.'))
@@ -412,7 +365,7 @@ def run_cert_fix(certs, extra_certs):
     ]
     for certid, _cert in certs:
         cmd.extend(['--cert', certid])
-    for _certtype, cert in extra_certs:
+    for _certtype, cert in ipa_certs:
         cmd.extend(['--extra-cert', str(cert.serial_number)])
     ipautil.run(cmd, raiseonerr=True)
 
@@ -427,21 +380,32 @@ def replicate_dogtag_certs(subject_base, ca_subject_dn, certs):
 
 def check_renewed_ipa_certs(certs):
     """
-    Check whether all expected IPA-specific certs (extra_certs) were renewed
-    successfully.
+    Check whether all expected IPA-specific certs were renewed successfully by
+    ``pki-server cert-fix``.
 
-    For now this subroutine just checks that the files that we expect
-    ``pki-server cert-fix`` to have written do exist and contain an X.509
-    certificate.
+    Verifies that each renewed cert file:
+    - exists and contains valid X.509 data
+    - has a different serial number than the old cert
+    - is not expired (using the 2-week lookahead threshold)
 
-    Return ``True`` if everything seems to be as expected, otherwise ``False``.
-
+    Return ``True`` if everything looks good, otherwise ``False``.
     """
+    threshold = _utcnow() + CERT_EXPIRY_LOOKAHEAD
     for _certtype, oldcert in certs:
         cert_path = RENEWED_CERT_PATH_TEMPLATE.format(oldcert.serial_number)
         try:
-            x509.load_certificate_from_file(cert_path)
+            newcert = x509.load_certificate_from_file(cert_path)
         except (IOError, ValueError):
+            return False
+        if newcert.serial_number == oldcert.serial_number:
+            logger.warning(
+                "Renewed cert at %s has same serial as old (%s)",
+                cert_path, oldcert.serial_number)
+            return False
+        if newcert.not_valid_after_utc <= threshold:
+            logger.warning(
+                "Renewed cert at %s is expired or near expiry (notAfter=%s)",
+                cert_path, newcert.not_valid_after_utc)
             return False
 
     return True

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -232,6 +232,24 @@ class IPACertFix(AdminTool):
         dogtag_certs, ipa_certs, external_certs = \
             self._detector._classify_certs(now, ds_dbdir, ds_nickname)
 
+        # On CA-full, detect RA/subsystem LDAP mismatches for certs we're NOT
+        # going to fetch from master (those will be fixed by the fetch itself
+        # plus a post-fix check).
+        ldap_mismatches = []
+        if has_ca:
+            ra_will_be_fetched = any(
+                ct is IPACertType.IPARA for ct, _ in ipa_certs)
+            sub_will_be_fetched = any(
+                cid == 'subsystem' for cid, _ in dogtag_certs)
+            try:
+                det = self._detector
+                ldap_mismatches = det._detect_ra_subsystem_mismatches(
+                    skip_ra=ra_will_be_fetched,
+                    skip_subsystem=sub_will_be_fetched)
+            except Exception as e:
+                logger.warning(
+                    "RA/subsystem consistency check failed: %s", e)
+
         # On CA-less replicas, the RA cert may be valid but stale (renewed
         # on the CA server, not yet updated here).  A stale RA cert causes
         # ipa commands to fail with auth errors even though no cert is
@@ -244,25 +262,24 @@ class IPACertFix(AdminTool):
             ra_stale = self._check_ra_cert_staleness()
 
         if (not dogtag_certs and not ipa_certs
-                and not external_certs and not ra_stale):
+                and not external_certs and not ldap_mismatches
+                and not ra_stale):
             print("Nothing to do.")
             return 0
 
-        if ra_stale and not (dogtag_certs or ipa_certs or external_certs):
+        if ldap_mismatches:
+            DeploymentDetector._print_ra_subsystem_mismatches(ldap_mismatches)
+
+        # Only LDAP mismatches and/or stale RA, no expired certs
+        if not dogtag_certs and not ipa_certs and not external_certs:
             if not self._confirm_execution():
                 return 0
-            self._fetch_ra_from_ca_server()
+            if ldap_mismatches:
+                DeploymentDetector._fix_ra_subsystem_mismatches(
+                    ldap_mismatches)
+            if ra_stale:
+                self._fetch_ra_from_ca_server()
             return 0
-
-        if any(key == 'ca_issuing' for key, _ in dogtag_certs):
-            logger.debug("CA signing cert is expired, exiting!")
-            print(
-                "The CA signing certificate is expired or will expire within "
-                "the next two weeks.\n\nipa-cert-fix cannot proceed, please "
-                "refer to the ipa-cacert-manage tool to renew the CA "
-                "certificate before proceeding."
-            )
-            return 1
 
         try:
             scenario, master = self._detector.determine_scenario(
@@ -306,10 +323,24 @@ class IPACertFix(AdminTool):
             return 1
 
         try:
-            return handler(ctx)
+            result = handler(ctx)
         except RuntimeError as e:
             print("ERROR: %s" % e)
             return 1
+
+        # Post-fix: detect and fix any RA/subsystem LDAP mismatches that
+        # arose during the fix (e.g. fetched RA cert needing a description
+        # update).
+        if has_ca and result == 0:
+            try:
+                det = self._detector
+                post_mismatches = det._detect_ra_subsystem_mismatches()
+                if post_mismatches:
+                    det._fix_ra_subsystem_mismatches(post_mismatches)
+            except Exception as e:
+                logger.warning("Post-fix consistency check failed: %s", e)
+
+        return result
 
     def run_renewal_master_fix(self, ctx):
         """Fix certificates on the renewal master via ``pki-server cert-fix``.
@@ -329,6 +360,10 @@ class IPACertFix(AdminTool):
                 "The 'pki-server cert-fix' command is not available; "
                 "cannot proceed.")
             return 1
+
+        if not self._detector._check_ca_signing_cert():
+            return self._detector._handle_expired_ca_signing_cert(
+                ctx.deployment_type)
 
         print(WARNING_BANNER)
 
@@ -359,6 +394,17 @@ class IPACertFix(AdminTool):
                     raise
             else:
                 raise
+
+        # If the CA signing cert was renewed, verify it is now valid.
+        # A partially-failed pki-server cert-fix could leave us with a
+        # still-expired CA cert.
+        if any(cid == 'ca_issuing' for cid, _ in certs):
+            if not self._detector._check_ca_signing_cert():
+                print(
+                    "The CA signing certificate is still expired after "
+                    "pki-server cert-fix.\n"
+                    "Please renew it manually using ipa-cacert-manage.")
+                return 1
 
         replicate_dogtag_certs(ctx.subject_base, ctx.ca_subject_dn, certs)
         install_ipa_certs(ctx.subject_base, ctx.ca_subject_dn, ipa_certs)
@@ -427,6 +473,9 @@ class IPACertFix(AdminTool):
             _ensure_ldap_connected()
         finally:
             _restore_kerberos(old_krb_env)
+
+        # Advisory: warn if any CA cert in the local chain is near expiry.
+        self._detector._warn_ca_chain_near_expiry()
 
         print(RENEWAL_NOTE)
         return 0
@@ -831,14 +880,40 @@ class IPACertFix(AdminTool):
     def update_ca_cert_from_master(self, master_server):
         """Update the CA certificate chain from the master server.
 
-        Runs ``ipa-certupdate --force-server <master_server>`` to refresh
-        the local CA trust store from the master before any other remote
-        operation.
+        If the local CA chain (``/etc/ipa/ca.crt``) is already present and
+        valid (no expired certs in the trust path) and TLS to the master
+        works, skips the expensive ``ipa-certupdate`` call.  Otherwise runs
+        ``ipa-certupdate --force-server <master_server>``.
 
-        ipa-certupdate may exit non-zero if some service restarts fail
-        (e.g. httpd, krb5kdc with expired certs), but the CA cert chain
-        update itself happens before any restarts.
+        ipa-certupdate may exit non-zero if some service restarts fail (e.g.
+        httpd, krb5kdc with expired certs), but the CA cert chain update
+        itself happens before any restarts.  We re-verify the chain after
+        the call to determine success.
         """
+        try:
+            DeploymentDetector._verify_ca_chain_valid(master_server)
+        except RuntimeError:
+            logger.debug("Local CA chain is missing or invalid, "
+                         "running ipa-certupdate")
+        else:
+            try:
+                _check_tls_handshake(master_server)
+                print("Local CA chain is valid and TLS to %s works, "
+                      "skipping ipa-certupdate." % master_server)
+                return
+            except Exception as e:
+                # Local chain is valid but TLS to master fails.  The
+                # master's CA cert was likely renewed and our trust store
+                # is stale.  ipa-certupdate would also fail here.
+                raise RuntimeError(
+                    "Cannot verify TLS to %s: %s\n\n"
+                    "The local CA chain (%s) is valid but does not match "
+                    "the master's current certificate.  Copy the updated "
+                    "%s from %s to this host (verify authenticity "
+                    "out-of-band first), then re-run ipa-cert-fix."
+                    % (master_server, e, paths.IPA_CA_CRT,
+                       paths.IPA_CA_CRT, master_server))
+
         print("Updating CA certificate chain from %s" % master_server)
         logger.debug("Running: ipa-certupdate --force-server %s",
                      master_server)
@@ -846,13 +921,21 @@ class IPACertFix(AdminTool):
             ['ipa-certupdate', '--force-server', master_server],
             raiseonerr=False)
         logger.debug("ipa-certupdate returncode=%s", result.returncode)
+
+        # Regardless of ipa-certupdate exit code, check whether the CA
+        # chain is present and valid.  ipa-certupdate may exit non-zero
+        # due to service restart failures (expected with expired certs),
+        # but the CA chain itself may be fine.
+        DeploymentDetector._verify_ca_chain_valid(master_server)
+
         if result.returncode != 0:
             logger.warning("ipa-certupdate exited with code %s",
                            result.returncode)
             print(
-                "WARNING: ipa-certupdate exited with an error.\n"
-                "This is expected if some services failed to restart "
-                "due to expired certificates. Continuing.")
+                "WARNING: ipa-certupdate exited with an error, but the CA "
+                "chain is valid.\nThis is expected if some services "
+                "failed to restart due to expired certificates. "
+                "Continuing.")
 
         if not dsinstance.is_ds_running(realm_to_serverid(api.env.realm)):
             raise RuntimeError(

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -26,7 +26,9 @@
 from __future__ import print_function, absolute_import
 
 import logging
+import os
 import shutil
+import socket
 
 from ipalib import api
 from ipalib import x509
@@ -35,13 +37,19 @@ from ipaplatform.paths import paths
 from ipapython.admintool import AdminTool
 from ipapython.certdb import NSSDatabase, EMPTY_TRUST_FLAGS
 from ipapython.dn import DN
+from ipapython import ipaldap
 from ipapython.ipaldap import realm_to_serverid
 from ipaserver.install import ca, cainstance, dsinstance
 # Re-export public names from the helper modules so that all symbols are
 # importable from ``ipaserver.install.ipa_cert_fix``.
 from ipaserver.install.ipa_cert_fix_services import (  # noqa: F401
+    CertRenewalFromMaster,
     CertmongerClient,
     DeploymentDetector,
+    _ensure_ldap_connected,
+    _get_pki_nssdb,
+    _replace_cert_in_nssdb,
+    _update_cs_cfg,
     expired_dogtag_certs,
     expired_ipa_certs,
     get_csr_from_certmonger,
@@ -65,13 +73,72 @@ from ipapython import ipautil
 logger = logging.getLogger(__name__)
 
 
+def _check_tls_handshake(server, timeout=10):
+    """Verify TLS handshake to a server succeeds.
+
+    Uses the system CA trust store (which includes ``/etc/ipa/ca.crt``) to
+    verify that local trust chain is sufficient to connect to the master.
+    """
+    import ssl
+    ctx = ssl.create_default_context()
+    ctx.load_verify_locations(paths.IPA_CA_CRT)
+    with socket.create_connection(
+        (server, 443), timeout=timeout
+    ) as sock:
+        with ctx.wrap_socket(sock, server_hostname=server):
+            logger.debug("TLS handshake to %s:443 succeeded", server)
+
+
+def _setup_kerberos():
+    """Set up Kerberos credentials from the host keytab.
+
+    The local ldap2 connection uses LDAPI (unix socket) and does not need
+    Kerberos, but remote LDAP connections and ``ipa-certupdate`` require
+    a ticket.
+
+    :returns: tuple of previous ``(KRB5CCNAME, KRB5_CLIENT_KTNAME)``
+        values for restoration
+    """
+    old_ccname = os.environ.get('KRB5CCNAME')
+    old_ktname = os.environ.get('KRB5_CLIENT_KTNAME')
+    os.environ['KRB5_CLIENT_KTNAME'] = '/etc/krb5.keytab'
+    os.environ['KRB5CCNAME'] = "MEMORY:"
+    logger.debug("Set KRB5_CLIENT_KTNAME=/etc/krb5.keytab, KRB5CCNAME=MEMORY:")
+    return old_ccname, old_ktname
+
+
+def _restore_kerberos(old_krb_env):
+    """Restore Kerberos environment after remote operations."""
+    old_ccname, old_ktname = old_krb_env
+    if old_ccname is None:
+        os.environ.pop('KRB5CCNAME', None)
+    else:
+        os.environ['KRB5CCNAME'] = old_ccname
+    if old_ktname is None:
+        os.environ.pop('KRB5_CLIENT_KTNAME', None)
+    else:
+        os.environ['KRB5_CLIENT_KTNAME'] = old_ktname
+
+
 class IPACertFix(AdminTool):
     command_name = "ipa-cert-fix"
-    usage = "%prog"
+    usage = "%prog [options]"
     description = "Renew expired certificates."
 
     _cm = None  # CertmongerClient; set in run()
     _detector = None  # DeploymentDetector; set in _classify_and_dispatch
+
+    @classmethod
+    def add_options(cls, parser):
+        super(IPACertFix, cls).add_options(parser)
+        parser.add_option(
+            "--renewal-master",
+            dest="renewal_master",
+            action="store_true",
+            default=False,
+            help="Force this replica to become the renewal master. Use with "
+                 "caution, and verify CRL generation and IPA config after "
+                 "the topology is stable again!")
 
     def validate_options(self):
         super(IPACertFix, self).validate_options(needs_root=True)
@@ -181,6 +248,8 @@ class IPACertFix(AdminTool):
 
         dispatch = {
             FixScenario.RENEWAL_MASTER: self.run_renewal_master_fix,
+            FixScenario.CA_FULL_WITH_MASTER:
+                lambda c: self._run_non_rm_replica_fix(c, is_ca_full=True),
         }
         handler = dispatch.get(scenario)
         if handler is None:
@@ -259,6 +328,253 @@ class IPACertFix(AdminTool):
         print(RENEWAL_NOTE)
         return 0
 
+    def _run_non_rm_replica_fix(self, ctx, is_ca_full):
+        """Shared logic for CA-full and CA-less replica fix.
+
+        Fetches the CA chain from the master, fetches RA (and subsystem certs
+        for CA-full), renews expired certs via certmonger pointed at the
+        master, then restarts IPA.
+
+        :param ctx: :class:`CertFixContext` with master_server
+        :param is_ca_full: ``True`` for CA-full replica, ``False`` for CA-less
+        :returns: exit code (0 for success)
+        """
+        dogtag = ctx.dogtag_certs if is_ca_full else []
+        ipa_certs = ctx.ipa_certs
+        master_server = ctx.master_server
+        label = ("CA-full replica" if is_ca_full else "CA-less replica")
+
+        print(WARNING_BANNER)
+        print_intentions(dogtag, ipa_certs, ctx.external_certs)
+        print("This will fetch certificates from %s." % master_server)
+        if not self._confirm_execution():
+            return 0
+
+        print("Proceeding with %s fix using server %s."
+              % (label, master_server))
+
+        old_krb_env = _setup_kerberos()
+        try:
+            self.update_ca_cert_from_master(master_server)
+
+            self._fetch_certs_from_master(
+                master_server, ctx,
+                fetch_subsystem=is_ca_full,)
+
+            renewal = CertRenewalFromMaster(self._cm, master_server)
+            renewal.renew(dogtag, ipa_certs, ctx)
+
+            print("Restarting IPA")
+            ipautil.run(['ipactl', 'restart', '--ignore-service-failures'])
+            _ensure_ldap_connected()
+        finally:
+            _restore_kerberos(old_krb_env)
+
+        print(RENEWAL_NOTE)
+        return 0
+
+    def _fetch_certs_from_master(
+        self, master_server, ctx, fetch_subsystem=True,
+    ):
+        """Fetch RA and shared certs from master.
+
+        Connects to the master's LDAP via GSSAPI and retrieves the RA cert.
+        For CA-full replicas, also fetches the subsystem cert and any other
+        shared/replicated dogtag certs (OCSP, audit, KRA) from
+        ``cn=ca_renewal`` in LDAP, and installs them in the local PKI NSS
+        database.
+
+        :param master_server: FQDN of the master server
+        :param ctx: :class:`CertFixContext`
+        :param fetch_subsystem: if ``True``, also fetch shared dogtag certs
+            (CA-full only)
+        :raises RuntimeError: if a fetched cert is expired (master needs
+            fixing first)
+        """
+        now = _utcnow()
+
+        def _check_not_expired(cert, desc):
+            if cert.not_valid_after_utc <= now:
+                raise RuntimeError(
+                    "Certificate '%s' fetched from %s is expired "
+                    "(notAfter=%s). The master server's certificates "
+                    "must be renewed first."
+                    % (desc, master_server, cert.not_valid_after_utc))
+
+        label = ("RA and shared certs" if fetch_subsystem else "RA")
+        print("Fetching %s from %s" % (label, master_server))
+
+        logger.debug("Connecting to master LDAP: %s (GSSAPI)", master_server)
+        try:
+            conn = ipaldap.LDAPClient.from_hostname_secure(master_server)
+            conn.gssapi_bind()
+        except Exception as e:
+            err_str = str(e).lower()
+            if ('certificate' in err_str
+                    and ('expired' in err_str or 'verify' in err_str)):
+                raise RuntimeError(
+                    "Cannot connect to %s: TLS certificate error (%s).\n\n"
+                    "Possible causes:\n"
+                    "  - The server's certificates are expired."
+                    "  Run ipa-cert-fix on %s first.\n"
+                    "  - The CA certificate on %s was renewed "
+                    "and this server's trust store is stale.\n"
+                    "    Copy %s from %s to this server and retry."
+                    % (master_server, e, master_server,
+                       master_server, paths.IPA_CA_CRT,
+                       master_server))
+            raise
+        logger.debug("Successfully connected to master LDAP")
+
+        try:
+            ra_expired = any(
+                ct is IPACertType.IPARA for ct, _ in ctx.ipa_certs)
+            if ra_expired:
+                ra_dn = DN(('uid', 'ipara'), ('ou', 'people'), ('o', 'ipaca'))
+                try:
+                    old_ra = x509.load_certificate_from_file(
+                        paths.RA_AGENT_PEM)
+                    old_serial = old_ra.serial_number
+                except Exception:
+                    old_serial = None
+                if fetch_subsystem:
+                    ra_cert = _fetch_and_update_cert(
+                        conn, ra_dn, "RA", "IPA RA")
+                else:
+                    # CA-less: no local o=ipaca -- just fetch
+                    remote_entry = conn.get_entry(ra_dn, ['userCertificate'])
+                    ra_cert = _get_newest_cert(remote_entry['userCertificate'])
+                    print_cert_info("Fetched", "IPA RA", ra_cert)
+                _check_not_expired(ra_cert, "IPA RA")
+                logger.debug(
+                    "Writing RA cert to %s (old serial: %s, new serial: %s)",
+                    paths.RA_AGENT_PEM, old_serial,
+                    ra_cert.serial_number)
+                x509.write_certificate(ra_cert, paths.RA_AGENT_PEM)
+                cainstance.CAInstance._set_ra_cert_perms()
+            else:
+                logger.debug("RA cert is valid, skipping fetch")
+
+            if fetch_subsystem:
+                db = _get_pki_nssdb()
+                sub_expired = any(
+                    cid == 'subsystem' for cid, _ in ctx.dogtag_certs)
+                if sub_expired:
+                    sub_dn = DN(
+                        ('uid', 'pkidbuser'),
+                        ('ou', 'people'),
+                        ('o', 'ipaca'),
+                    )
+                    sub_cert = _fetch_and_update_cert(
+                        conn, sub_dn,
+                        "Subsystem", "CA Subsystem")
+                    _check_not_expired(sub_cert, "CA Subsystem")
+                    nickname = DOGTAG_CERTS['subsystem'].nickname
+                    logger.debug(
+                        "Updating subsystem cert in NSS database "
+                        "%s, nickname=%s, serial=%s",
+                        paths.PKI_TOMCAT_ALIAS_DIR,
+                        nickname,
+                        sub_cert.serial_number,)
+                    _replace_cert_in_nssdb(db, nickname, sub_cert)
+                    _update_cs_cfg(nickname, sub_cert)
+                else:
+                    logger.debug("Subsystem cert is valid, skipping fetch")
+
+                self._fetch_shared_dogtag_certs(
+                    conn, db, ctx, master_server, now)
+        finally:
+            conn.unbind()
+
+    # Subset fetched from cn=ca_renewal by _fetch_shared_dogtag_certs.
+    # Excludes ca_issuing (ipa-certupdate) and subsystem (direct fetch).
+    _SHARED_DOGTAG_CERTS = {
+        ci.id: ci.nickname for ci in DOGTAG_CERTS.values()
+        if ci.is_shared and ci.id not in ('ca_issuing', 'subsystem')
+    }
+
+    def _fetch_shared_dogtag_certs(self, conn, db, ctx, master_server, now):
+        """Fetch shared dogtag certs from cn=ca_renewal on the master.
+
+        Installs each cert into the local NSSDB, sets audit cert trust
+        flags, and updates the CS.cfg blob.
+        """
+        # Only fetch certs that are actually expired. KRA certs are only in
+        # expired_ids if KRA is installed locally (expired_dogtag_certs skips
+        # missing nicknames).
+        expired_ids = {cid for cid, _ in ctx.dogtag_certs}
+        for certid, nickname in self._SHARED_DOGTAG_CERTS.items():
+            if certid not in expired_ids:
+                continue
+            try:
+                renewal_dn = DN(
+                    ('cn', nickname),
+                    ('cn', 'ca_renewal'),
+                    ('cn', 'ipa'),
+                    ('cn', 'etc'),
+                    api.env.basedn,
+                )
+                entry = conn.get_entry(renewal_dn, ['usercertificate'])
+                new_cert = entry.single_value['usercertificate']
+                print_cert_info("Fetched", nickname, new_cert)
+                if new_cert.not_valid_after_utc <= now:
+                    raise RuntimeError(
+                        "Certificate '%s' fetched from %s is expired "
+                        "(notAfter=%s). The master server's certificates "
+                        "must be renewed first."
+                        % (nickname, master_server,
+                           new_cert.not_valid_after_utc))
+                _replace_cert_in_nssdb(db, nickname, new_cert)
+                # Audit signing certs need 'u,u,Pu' trust (same as
+                # renew_ca_cert post-save command)
+                if 'audit' in certid:
+                    db.run_certutil(['-M', '-t', 'u,u,Pu', '-n', nickname])
+                _update_cs_cfg(nickname, new_cert)
+                logger.debug(
+                    "Installed shared cert %s (serial %s) in NSSDB",
+                    nickname, new_cert.serial_number)
+            except RuntimeError:
+                raise  # expiry check -- must propagate
+            except Exception as e:
+                logger.warning(
+                    "Failed to fetch shared cert %s: %s", nickname, e)
+
+    def update_ca_cert_from_master(self, master_server):
+        """Update the CA certificate chain from the master server.
+
+        Runs ``ipa-certupdate --force-server <master_server>`` to refresh
+        the local CA trust store from the master before any other remote
+        operation.
+
+        ipa-certupdate may exit non-zero if some service restarts fail
+        (e.g. httpd, krb5kdc with expired certs), but the CA cert chain
+        update itself happens before any restarts.
+        """
+        print("Updating CA certificate chain from %s" % master_server)
+        logger.debug("Running: ipa-certupdate --force-server %s",
+                     master_server)
+        result = ipautil.run(
+            ['ipa-certupdate', '--force-server', master_server],
+            raiseonerr=False)
+        logger.debug("ipa-certupdate returncode=%s", result.returncode)
+        if result.returncode != 0:
+            logger.warning("ipa-certupdate exited with code %s",
+                           result.returncode)
+            print(
+                "WARNING: ipa-certupdate exited with an error.\n"
+                "This is expected if some services failed to restart "
+                "due to expired certificates. Continuing.")
+
+        if not dsinstance.is_ds_running(realm_to_serverid(api.env.realm)):
+            raise RuntimeError(
+                "LDAP server is no longer running after ipa-certupdate. "
+                "Please check the directory server logs and restart it "
+                "before retrying.")
+
+        # ipa-certupdate may have restarted dirsrv, which breaks our LDAPI
+        # connection.
+        _ensure_ldap_connected()
+
     def _confirm_execution(self):
         """Interactively confirm before performing destructive actions."""
         response = ipautil.user_input('Enter "yes" to proceed')
@@ -267,6 +583,66 @@ class IPACertFix(AdminTool):
             return False
         print("Proceeding.")
         return True
+
+
+def _get_newest_cert(certs):
+    """Return the certificate with the latest notAfter from a list."""
+    return max(certs, key=lambda c: c.not_valid_after_utc)
+
+
+def _fetch_and_update_cert(remote_conn, dn, context, desc):
+    """Fetch the newest cert at *dn* from a remote master and update LDAP.
+
+    Reads ``userCertificate`` from the remote entry, picks the cert with the
+    latest ``notAfter``, and writes it back into the local LDAP entry along
+    with the matching ``description`` value (the format Dogtag expects).
+
+    :param remote_conn: LDAP connection to the master
+    :param dn: target DN (RA or subsystem)
+    :param context: short label used in print/log
+    :param desc: descriptive label for ``print_cert_info``
+    :returns: the cert chosen as newest
+    """
+    remote_entry = remote_conn.get_entry(dn, ['userCertificate'])
+    new_cert = _get_newest_cert(remote_entry['userCertificate'])
+    print_cert_info("Fetched", desc, new_cert)
+
+    expected_desc = '2;%d;%s;%s' % (
+        new_cert.serial_number,
+        DN(new_cert.issuer), DN(new_cert.subject))
+
+    conn = api.Backend.ldap2
+    try:
+        local_entry = conn.get_entry(dn, ['userCertificate', 'description'])
+    except Exception as e:
+        logger.warning("Cannot read local LDAP entry %s: %s", dn, e)
+        return new_cert
+
+    new_der = new_cert.public_bytes(x509.Encoding.DER)
+    have_cert = any(
+        c.public_bytes(x509.Encoding.DER) == new_der
+        for c in local_entry.get('userCertificate', []))
+    changed = False
+    if not have_cert:
+        local_entry.setdefault('userCertificate', []).append(new_cert)
+        changed = True
+
+    try:
+        current_desc = local_entry.single_value.get('description', '')
+    except ValueError:
+        current_desc = None
+    if current_desc != expected_desc:
+        local_entry['description'] = expected_desc
+        changed = True
+
+    if changed:
+        try:
+            conn.update_entry(local_entry)
+            logger.debug("Updated local %s LDAP entry %s", context, dn)
+        except Exception as e:
+            logger.warning("Failed to update local LDAP entry %s: %s", dn, e)
+
+    return new_cert
 
 
 def print_intentions(dogtag_certs, ipa_certs, non_renewed):

--- a/ipaserver/install/ipa_cert_fix.py
+++ b/ipaserver/install/ipa_cert_fix.py
@@ -123,6 +123,19 @@ class IPACertFix(AdminTool):
 
         api.Backend.ldap2.connect()  # ensure DS is up
 
+        try:
+            return self._classify_and_dispatch()
+        finally:
+            if api.Backend.ldap2.isconnected():
+                api.Backend.ldap2.disconnect()
+
+    def _classify_and_dispatch(self):
+        """Classify expired certificates and dispatch to a fix scenario.
+
+        Currently only the renewal-master scenario is implemented.  Future
+        commits will add deployment-type detection and route to additional
+        scenarios (CA-full replica, CA-less replica, external certificates).
+        """
         subject_base = dsinstance.DsInstance().find_subject_base()
         if not subject_base:
             raise RuntimeError("Cannot determine certificate subject base.")
@@ -148,15 +161,24 @@ class IPACertFix(AdminTool):
             )
             return 1
 
+        return self.run_renewal_master_fix(
+            subject_base, ca_subject_dn, certs, extra_certs, non_renewed)
+
+    def run_renewal_master_fix(
+        self, subject_base, ca_subject_dn, certs, extra_certs, non_renewed
+    ):
+        """Fix certificates on the renewal master via ``pki-server cert-fix``.
+
+        Regenerates expired Dogtag system certificates and installs renewed
+        IPA service certificates.  If any "shared" certificate is renewed,
+        promotes this server to the renewal master.
+        """
         print(msg)
 
         print_intentions(certs, extra_certs, non_renewed)
 
-        response = ipautil.user_input('Enter "yes" to proceed')
-        if response.lower() != 'yes':
-            print("Not proceeding.")
+        if not self._confirm_execution():
             return 0
-        print("Proceeding.")
 
         try:
             fix_certreq_directives(certs)
@@ -196,6 +218,15 @@ class IPACertFix(AdminTool):
 
         print(renewal_note)
         return 0
+
+    def _confirm_execution(self):
+        """Interactively confirm before performing destructive actions."""
+        response = ipautil.user_input('Enter "yes" to proceed')
+        if response.lower() != 'yes':
+            print("Not proceeding.")
+            return False
+        print("Proceeding.")
+        return True
 
 
 def expired_certs(now):

--- a/ipaserver/install/ipa_cert_fix_services.py
+++ b/ipaserver/install/ipa_cert_fix_services.py
@@ -15,23 +15,38 @@ import base64
 from cryptography import x509 as crypto_x509
 from cryptography.hazmat.backends import default_backend
 import logging
+import socket
 import time
 
+from ipalib import api, errors
 from ipalib import x509
 from ipalib.install import certmonger
 from ipaplatform.paths import paths
 from ipapython.certdb import NSSDatabase
 from ipapython.dn import DN
+from ipapython.ipaldap import realm_to_serverid
 from ipapython import ipautil
+from ipaserver.install import cainstance, dsinstance
+from ipaserver.install.certs import is_ipa_issued_cert
+from ipaserver.masters import find_providing_servers
 
 from ipaserver.install.ipa_cert_fix_types import (
     CERT_EXPIRY_LOOKAHEAD,
     DBUS_RETRY_DELAY,
     DBUS_RETRY_TIMEOUT,
+    DOGTAG_CERTS,
+    DeploymentType,
+    FixScenario,
+    IPACertType,
     _utcnow,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _get_pki_nssdb():
+    """Lazy accessor for the PKI Tomcat NSS database."""
+    return NSSDatabase(nssdir=paths.PKI_TOMCAT_ALIAS_DIR)
 
 
 def print_cert_info(context, desc, cert):
@@ -236,3 +251,467 @@ class CertmongerClient:
             except Exception:
                 return False
         return False
+
+
+def _ensure_ldap_connected():
+    """Ensure the ldap2 backend is connected.
+
+    After operations that restart Directory Server (``ipa-certupdate``,
+    ``ipactl restart``, ``pki-server cert-fix``), the LDAPI socket is
+    recycled and our existing connection becomes a broken pipe.
+    ``isconnected()`` is unreliable in this case -- it may still
+    return ``True`` on the stale socket.
+
+    This function unconditionally disconnects and reconnects to guarantee
+    a live connection.
+    """
+    try:
+        if api.Backend.ldap2.isconnected():
+            api.Backend.ldap2.disconnect()
+    except Exception as e:
+        logger.debug("ldap2 disconnect error (ignored): %s", e)
+    api.Backend.ldap2.connect()
+    logger.debug("ldap2 reconnected")
+
+
+def _check_tcp_reachable(server):
+    """Verify a server is TCP-reachable before using it.
+
+    Performs DNS resolution and a TCP connect to port 443.  This is
+    intentionally TCP-only (no TLS): the local CA trust store may be stale at
+    this point.  TLS verification happens later in ``_check_tls_handshake``
+    after ``ipa-certupdate`` updates the trust store.
+
+    :param server: FQDN to check
+    :raises RuntimeError: if the server is unreachable
+    """
+    logger.debug("Checking reachability of %s", server)
+    try:
+        addrs = socket.getaddrinfo(
+            server, 443, socket.AF_UNSPEC,
+            socket.SOCK_STREAM,)
+    except socket.gaierror as e:
+        raise RuntimeError("Cannot resolve %s: %s" % (server, e))
+
+    for family, socktype, proto, _cn, addr in addrs:
+        s = socket.socket(family, socktype, proto)
+        try:
+            s.settimeout(10)
+            s.connect(addr)
+            logger.debug("TCP connect to %s:%d succeeded", server, 443)
+            return
+        except OSError:
+            continue
+        finally:
+            s.close()
+
+    raise RuntimeError(
+        "Cannot connect to %s on port 443. Verify the server is running "
+        "and network connectivity is available." % server)
+
+
+def _find_current_renewal_master():
+    """Find the current renewal master FQDN.
+
+    :returns: FQDN string, or ``None`` if not found
+    """
+    try:
+        base_dn = DN(api.env.container_masters, api.env.basedn)
+        ldap_filter = ('(&(cn=CA)(ipaConfigString=caRenewalMaster))')
+        entries = api.Backend.ldap2.get_entries(
+            base_dn=base_dn,
+            filter=ldap_filter,
+            attrs_list=[],)
+        if entries:
+            fqdn = entries[0].dn[1].value
+            logger.debug("Current renewal master: %s", fqdn)
+            return fqdn
+    except Exception as e:
+        logger.debug("Cannot determine current renewal master: %s", e)
+    return None
+
+
+def expired_dogtag_certs(now):
+    """Determine which Dogtag certs are expired or close to expiry.
+
+    Return a list of (cert_id, cert) pairs.
+    """
+    certs = []
+    db = _get_pki_nssdb()
+
+    for certid, ci in DOGTAG_CERTS.items():
+        try:
+            cert = db.get_cert(ci.nickname)
+        except RuntimeError:
+            logger.debug("Dogtag cert %s (%s): not found in NSSDB",
+                         certid, ci.nickname)
+        else:
+            if cert.not_valid_after_utc <= now:
+                logger.debug("Dogtag cert %s: EXPIRED (expires %s)",
+                             certid, cert.not_valid_after_utc)
+                certs.append((certid, cert))
+            else:
+                logger.debug("Dogtag cert %s: valid (expires %s)",
+                             certid, cert.not_valid_after_utc)
+
+    return certs
+
+
+def _check_ipa_cert(certtype, cert, now, certs, non_renewed):
+    """Classify an expired IPA cert as IPA-issued or external.
+
+    :param certtype: :class:`IPACertType`
+    :param cert: loaded certificate
+    :param now: expiry threshold
+    :param certs: list to append IPA-issued certs to
+    :param non_renewed: list to append external certs to
+    """
+    if cert.not_valid_after_utc <= now:
+        if not is_ipa_issued_cert(api, cert):
+            logger.debug("IPA cert %s: EXPIRED, external (expires %s)",
+                         certtype.value, cert.not_valid_after_utc)
+            non_renewed.append((certtype, cert))
+        else:
+            logger.debug("IPA cert %s: EXPIRED (expires %s)",
+                         certtype.value, cert.not_valid_after_utc)
+            certs.append((certtype, cert))
+    else:
+        logger.debug("IPA cert %s: valid (expires %s)",
+                     certtype.value, cert.not_valid_after_utc)
+
+
+def expired_ipa_certs(now, ds_dbdir=None, ds_nickname=None):
+    """Determine which IPA certs are expired or close to expiry.
+
+    :param now: datetime threshold
+    :param ds_dbdir: DS NSS database directory (optional, avoids creating a
+        DsInstance if provided)
+    :param ds_nickname: DS server cert nickname (optional)
+    :returns: tuple of ``(certs, non_renewed)``
+    """
+    certs = []
+    non_renewed = []
+
+    # IPA RA (always IPA-issued, no external check)
+    try:
+        cert = x509.load_certificate_from_file(paths.RA_AGENT_PEM)
+        if cert.not_valid_after_utc <= now:
+            logger.debug("IPA cert RA: EXPIRED (expires %s)",
+                         cert.not_valid_after_utc)
+            certs.append((IPACertType.IPARA, cert))
+        else:
+            logger.debug("IPA cert RA: valid (expires %s)",
+                         cert.not_valid_after_utc)
+    except FileNotFoundError:
+        logger.debug("IPA cert RA: not present at %s "
+                     "(expected on CA-less-external deployments)",
+                     paths.RA_AGENT_PEM)
+    except Exception as e:
+        logger.debug("Cannot load RA cert from %s: %s",
+                     paths.RA_AGENT_PEM, e)
+
+    # Apache HTTPD
+    try:
+        cert = x509.load_certificate_from_file(paths.HTTPD_CERT_FILE)
+        _check_ipa_cert(IPACertType.HTTPS, cert, now, certs, non_renewed)
+    except Exception as e:
+        logger.debug("Cannot load HTTP cert from %s: %s",
+                     paths.HTTPD_CERT_FILE, e)
+
+    # LDAPS
+    try:
+        if ds_dbdir is None or ds_nickname is None:
+            serverid = realm_to_serverid(api.env.realm)
+            ds = dsinstance.DsInstance(realm_name=api.env.realm)
+            ds_dbdir = dsinstance.config_dirname(serverid)
+            ds_nickname = ds.get_server_cert_nickname(serverid)
+        db = NSSDatabase(nssdir=ds_dbdir)
+        cert = db.get_cert(ds_nickname)
+        _check_ipa_cert(IPACertType.LDAPS, cert, now, certs, non_renewed)
+    except Exception as e:
+        logger.debug("Cannot load LDAP cert: %s", e)
+
+    # KDC (can be self-signed if PKINIT is disabled)
+    try:
+        cert = x509.load_certificate_from_file(paths.KDC_CERT)
+        _check_ipa_cert(IPACertType.KDC, cert, now, certs, non_renewed)
+    except Exception as e:
+        logger.debug("Cannot load KDC cert from %s: %s", paths.KDC_CERT, e)
+
+    return certs, non_renewed
+
+
+class DeploymentDetector:
+    """Detection, classification, and scenario routing.
+
+    Determines the deployment type, classifies expired certificates, and
+    routes to the appropriate fix scenario.  CA chain validation and
+    RA/subsystem LDAP consistency checks are added in a later commit.
+    """
+
+    def __init__(self, cm_client, ca_instance, options):
+        self._cm = cm_client
+        self._ca_instance = ca_instance
+        self.options = options
+
+    def detect_deployment_type(self):
+        """Detect the deployment type of this replica.
+
+        Checks whether a CA is installed locally and whether the CA signing
+        certificate is self-signed or externally signed.
+
+        :returns: :class:`DeploymentType` enum value
+        """
+        has_ca = cainstance.is_ca_installed_locally()
+
+        if not has_ca:
+            ca_servers = []
+            ldap_failed = False
+            try:
+                _ensure_ldap_connected()
+                ca_servers = find_providing_servers(
+                    'CA', conn=api.Backend.ldap2,
+                    api=api,)
+            except Exception as e:
+                logger.warning("Failed to discover CA servers: %s", e)
+                ldap_failed = True
+
+            if not ca_servers:
+                if ldap_failed:
+                    # LDAP query failed -- don't assume fully external. Warn
+                    # and default to CA_LESS so the user is prompted for a
+                    # server FQDN.
+                    print(
+                        "WARNING: Could not query topology for CA servers "
+                        "(LDAP error).\n"
+                        "Assuming CA servers exist. Use --force-server "
+                        "to specify one explicitly.")
+                    return DeploymentType.CA_LESS
+
+                logger.info(
+                    "No CA servers in topology, deployment is fully external."
+                )
+                return DeploymentType.CA_LESS_EXTERNAL
+            logger.info(
+                "CA-less replica, CA servers in topology: %s",
+                ca_servers)
+            return DeploymentType.CA_LESS
+
+        # CA is installed locally -- check if self-signed
+        db = _get_pki_nssdb()
+        try:
+            ca_cert = db.get_cert(DOGTAG_CERTS['ca_issuing'].nickname)
+        except RuntimeError:
+            logger.error(
+                "Cannot read caSigningCert from %s",
+                paths.PKI_TOMCAT_ALIAS_DIR)
+            raise RuntimeError(
+                "Cannot read caSigningCert from NSS database "
+                "at %s" % paths.PKI_TOMCAT_ALIAS_DIR)
+
+        is_self_signed = (DN(ca_cert.issuer) == DN(ca_cert.subject))
+        logger.debug(
+            "caSigningCert: issuer=%s, subject=%s, self_signed=%s",
+            DN(ca_cert.issuer), DN(ca_cert.subject), is_self_signed)
+
+        if is_self_signed:
+            return DeploymentType.CA_SELF_SIGNED
+        return DeploymentType.CA_EXTERNALLY_SIGNED
+
+    @staticmethod
+    def _classify_certs(now, ds_dbdir=None, ds_nickname=None):
+        """Classify expired certificates into categories.
+
+        Wraps :func:`expired_dogtag_certs` and :func:`expired_ipa_certs`,
+        then re-classifies certs that are not IPA-issued as external.
+
+        For CA-less deployments, Dogtag certs are skipped (the NSS database
+        does not exist).
+
+        :param now: datetime threshold for expiry check
+        :param ds_dbdir: DS NSS database directory
+        :param ds_nickname: DS server cert nickname
+        :returns: tuple of ``(dogtag_certs, ipa_certs, external_certs)``
+        """
+        has_ca = cainstance.is_ca_installed_locally()
+        if has_ca:
+            dogtag = expired_dogtag_certs(now)
+        else:
+            dogtag = []
+
+        ipa, non_renewed = expired_ipa_certs(now, ds_dbdir, ds_nickname)
+
+        # non_renewed from expired_ipa_certs() contains certs where
+        # is_ipa_issued_cert() returned False, i.e. they are externally signed.
+        external = non_renewed
+
+        return dogtag, ipa, external
+
+    def determine_scenario(self, deployment_type):
+        """Determine the fix scenario and master server.
+
+        Uses the deployment type, renewal master status, and CLI options to
+        choose the correct fix path.  May prompt the user interactively for
+        a master server FQDN.
+
+        :param deployment_type: :class:`DeploymentType` value
+        :returns: tuple of ``(FixScenario, master_server_or_None)``
+        """
+        opt_renewal_master = getattr(self.options, 'renewal_master', False)
+        opt_force_server = getattr(self.options, 'force_server', None)
+
+        # CA-less paths
+        if deployment_type in (
+            DeploymentType.CA_LESS,
+            DeploymentType.CA_LESS_EXTERNAL,
+        ):
+            if opt_renewal_master:
+                raise RuntimeError(
+                    "--renewal-master cannot be used on a CA-less replica "
+                    "(no local CA to become renewal master of).")
+            if deployment_type == DeploymentType.CA_LESS_EXTERNAL:
+                return FixScenario.EXTERNAL_CERTS, None
+            master = self.get_master_server()
+            if master is None:
+                raise RuntimeError(
+                    "No server was selected. Re-run with "
+                    "--force-server=<FQDN> to renew certificates "
+                    "from a working CA server.")
+            return FixScenario.CA_LESS_WITH_MASTER, master
+
+        # CA-full paths
+        is_rm = self.check_is_renewal_master()
+        if opt_renewal_master or is_rm:
+            if opt_force_server and is_rm:
+                print(
+                    "WARNING: --force-server ignored -- this server is the "
+                    "renewal master and will use the renewal master fix path.")
+            return FixScenario.RENEWAL_MASTER, None
+
+        master = self.get_master_server()
+        if master is not None:
+            return FixScenario.CA_FULL_WITH_MASTER, master
+
+        # No master available -- promotion is the only option. Prerequisites
+        # are validated in run_ca_full_promote() before any destructive action
+        # (promotion is a topology-wide change).
+        return FixScenario.CA_FULL_PROMOTE, None
+
+    def check_is_renewal_master(self):
+        """Check if the current server is the renewal master.
+
+        Uses LDAP via LDAPI (unix socket) which works even when TLS
+        certificates are expired.
+
+        :returns: ``True`` if this server is the renewal master,
+            ``False`` otherwise
+        :raises RuntimeError: if no CA instance is available (CA-less)
+        """
+        if self._ca_instance is None:
+            raise RuntimeError(
+                "check_is_renewal_master called without a CA instance "
+                "(CA-less deployment?)")
+        try:
+            result = self._ca_instance.is_renewal_master()
+            logger.debug("Renewal master check result: %s", result)
+            return result
+        except (errors.NetworkError, errors.DatabaseError) as e:
+            logger.warning("Failed to determine renewal master status: %s", e)
+            return False
+        except Exception as e:
+            logger.warning("Unexpected error checking renewal master: %s", e)
+            return False
+
+    def get_master_server(self):
+        """Determine the master server FQDN.
+
+        Resolution order:
+
+        1. ``--force-server`` CLI option
+        2. Interactive prompt (default from LDAP if any)
+        3. ``None`` if no server selected (caller decides whether to fall
+           back to promote or external path)
+
+        :returns: FQDN string, or ``None``
+        """
+        opt_force_server = getattr(self.options, 'force_server', None)
+        opt_unattended = getattr(self.options, 'unattended', False)
+
+        if opt_force_server:
+            server = opt_force_server
+            _check_tcp_reachable(server)
+            logger.info("Using server from --force-server: %s", server)
+            return server
+
+        # Find the current renewal master to use as default
+        default_server = None
+        ca_servers = []
+        renewal_master = _find_current_renewal_master()
+        if renewal_master and renewal_master != api.env.host:
+            default_server = renewal_master
+        elif renewal_master:
+            logger.debug("Renewal master is this server, not using as default")
+
+        # Find other CA servers in the topology (excluding ourselves)
+        if not default_server:
+            try:
+                ca_servers = find_providing_servers(
+                    'CA', conn=api.Backend.ldap2, api=api)
+                ca_servers = [s for s in ca_servers if s != api.env.host]
+                logger.debug("CA servers in topology: %s", ca_servers)
+            except Exception as e:
+                logger.warning("Failed to discover CA servers: %s", e)
+                ca_servers = []
+
+            if ca_servers:
+                print("The following CA servers were found in the topology:")
+                for s in ca_servers:
+                    print("  %s" % s)
+                print()
+
+        if not default_server and ca_servers:
+            default_server = ca_servers[0]
+
+        # In unattended mode, use the default server if found, otherwise fall
+        # back to the destructive path.
+        if opt_unattended:
+            if default_server:
+                logger.info("Unattended mode: using server %s", default_server)
+                return default_server
+            logger.warning("Unattended mode: no working server found")
+            return None
+
+        while True:
+            if default_server:
+                prompt = ("Enter FQDN of a working CA server with valid "
+                          "certificates\n(press Enter to use %s, or type "
+                          "a different FQDN)" % default_server)
+            else:
+                prompt = ("Enter FQDN of a working CA server with valid "
+                          "certificates\n(leave empty to skip; re-run with "
+                          "--renewal-master to promote this server)")
+            server = ipautil.user_input(prompt, default=default_server)
+
+            if server:
+                if server == api.env.host:
+                    print(
+                        "Cannot use the current server (%s) as the source."
+                        % server)
+                    print("Please enter a different server.")
+                    continue
+                try:
+                    _check_tcp_reachable(server)
+                except RuntimeError as e:
+                    print("  %s" % e)
+                    print("Please enter a different server.")
+                    continue
+                logger.debug("User selected master server: %s", server)
+                return server
+
+            # User chose empty -- fall back
+            break
+
+        # No server selected -- caller decides whether to fall back to the
+        # promote/external path.
+        logger.info("No master server selected")
+        return None

--- a/ipaserver/install/ipa_cert_fix_services.py
+++ b/ipaserver/install/ipa_cert_fix_services.py
@@ -15,6 +15,7 @@ import base64
 from contextlib import contextmanager
 from cryptography import x509 as crypto_x509
 from cryptography.hazmat.backends import default_backend
+import datetime
 import logging
 import os
 import re
@@ -1416,15 +1417,22 @@ class CertRenewalFromMaster:
 class DeploymentDetector:
     """Detection, classification, and scenario routing.
 
-    Determines the deployment type, classifies expired certificates, and
-    routes to the appropriate fix scenario.  CA chain validation and
-    RA/subsystem LDAP consistency checks are added in a later commit.
+    Determines the deployment type, classifies expired certificates,
+    validates the CA chain, detects RA/subsystem LDAP mismatches, and
+    routes to the appropriate fix scenario.
     """
+
+    CA_SIGNING_MIN_VALIDITY = datetime.timedelta(days=30)
 
     def __init__(self, cm_client, ca_instance, options):
         self._cm = cm_client
         self._ca_instance = ca_instance
         self.options = options
+
+    @staticmethod
+    def _ca_minimum_valid_until():
+        """Threshold for CA signing cert validity checks."""
+        return _utcnow() + DeploymentDetector.CA_SIGNING_MIN_VALIDITY
 
     def detect_deployment_type(self):
         """Detect the deployment type of this replica.
@@ -1518,6 +1526,367 @@ class DeploymentDetector:
         external = non_renewed
 
         return dogtag, ipa, external
+
+    def _check_ca_signing_cert(self):
+        """Verify the CA signing certificate has enough validity.
+
+        The caSigningCert must have at least one month of remaining validity
+        for ``pki-server cert-fix`` to succeed.  If it is expired or near
+        expiry, prints guidance to use ``ipa-cacert-manage`` and returns
+        ``False``.
+        """
+        db = _get_pki_nssdb()
+        try:
+            ca_cert = db.get_cert(DOGTAG_CERTS['ca_issuing'].nickname)
+        except RuntimeError:
+            print("Cannot read the CA signing certificate.")
+            return False
+
+        if ca_cert.not_valid_after_utc <= self._ca_minimum_valid_until():
+            print(
+                "The CA signing certificate is expired or will expire within "
+                "the next %d days.\n\n"
+                "ipa-cert-fix cannot proceed. Please use ipa-cacert-manage "
+                "to renew the CA certificate first."
+                % self.CA_SIGNING_MIN_VALIDITY.days)
+            return False
+
+        logger.debug(
+            "CA signing cert validity OK: expires %s",
+            ca_cert.not_valid_after_utc)
+        return True
+
+    @staticmethod
+    def _verify_ca_chain_valid(master_server):
+        """Verify the CA trust chain is valid after ipa-certupdate.
+
+        Reads ``/etc/ipa/ca.crt``, finds the IPA issuing CA cert, then
+        walks up the chain of trust to a self-signed root.  Every cert in
+        that path must not be expired.
+
+        :raises RuntimeError: if the chain file is missing/empty or the
+            trust path contains an expired certificate
+        """
+        try:
+            certs = x509.load_certificate_list_from_file(paths.IPA_CA_CRT)
+        except Exception as e:
+            print("CA chain file %s is missing or unreadable after "
+                  "ipa-certupdate.\n"
+                  "Please manually copy %s from %s to this server and retry."
+                  % (paths.IPA_CA_CRT, paths.IPA_CA_CRT, master_server))
+            raise RuntimeError("CA chain not available: %s" % e)
+
+        if not certs:
+            raise RuntimeError(
+                "CA chain file %s is empty after ipa-certupdate"
+                % paths.IPA_CA_CRT)
+
+        # Build a subject->cert map; prefer the latest notAfter when there
+        # are multiple certs with the same subject.
+        by_subject = {}
+        for cert in certs:
+            subj = DN(cert.subject)
+            existing = by_subject.get(subj)
+            if (existing is None
+                    or cert.not_valid_after_utc
+                    > existing.not_valid_after_utc):
+                by_subject[subj] = cert
+
+        # Find the IPA issuing CA.  On CA-full, its subject matches
+        # caSigningCert.  On CA-less, use the first cert in the file.
+        issuing_cert = None
+        try:
+            db = _get_pki_nssdb()
+            ca_cert = db.get_cert(DOGTAG_CERTS['ca_issuing'].nickname)
+            issuing_cert = by_subject.get(DN(ca_cert.subject))
+        except Exception:
+            pass  # CA-less or NSS unreadable
+        if issuing_cert is None:
+            issuing_cert = certs[0]
+
+        now = _utcnow()
+        visited = set()
+        current = issuing_cert
+        while current is not None:
+            subj = DN(current.subject)
+            if subj in visited:
+                break  # cycle protection
+            visited.add(subj)
+
+            if current.not_valid_after_utc <= now:
+                raise RuntimeError(
+                    "CA certificate (subject: %s) from %s is expired "
+                    "(expired: %s).\nFix the CA on %s first, then retry."
+                    % (subj, master_server,
+                       current.not_valid_after_utc, master_server))
+
+            issuer = DN(current.issuer)
+            if issuer == subj:
+                break
+
+            current = by_subject.get(issuer)
+            if current is None:
+                raise RuntimeError(
+                    "Incomplete CA chain: issuer %s for cert %s "
+                    "not found in %s.\n"
+                    "The full chain (including root CA) must be present in "
+                    "the chain file."
+                    % (issuer, subj, paths.IPA_CA_CRT))
+
+        logger.debug("CA trust chain from %s verified (%d certs checked)",
+                     master_server, len(visited))
+
+    def _warn_ca_chain_near_expiry(self):
+        """Advisory: warn if any CA cert in the local chain is near expiry."""
+        try:
+            chain = x509.load_certificate_list_from_file(paths.IPA_CA_CRT)
+        except Exception:
+            return
+
+        threshold = self._ca_minimum_valid_until()
+        for cert in chain:
+            if cert.not_valid_after_utc <= threshold:
+                print(
+                    "WARNING: CA certificate (subject: %s) expires %s.\n"
+                    "Certmonger should renew it automatically from "
+                    "the master.\n"
+                    "If it does not, run ipa-cacert-manage on the "
+                    "renewal master.\n"
+                    % (DN(cert.subject), cert.not_valid_after_utc))
+                return  # one warning is enough
+
+    def _handle_expired_ca_signing_cert(self, deployment_type):
+        """Handle an expired CA signing certificate.
+
+        For self-signed CA deployments, the user must use
+        ``ipa-cacert-manage renew`` (no CSR needed).
+
+        For externally-signed CA deployments, extracts the existing CSR from
+        certmonger and writes it to ``/var/lib/ipa/ca.csr``, then prints
+        instructions for submitting it to the external CA.
+        """
+        if deployment_type in (
+            DeploymentType.CA_LESS,
+            DeploymentType.CA_LESS_EXTERNAL,
+        ):
+            raise RuntimeError(
+                "_handle_expired_ca_signing_cert called for CA-less "
+                "deployment %s"
+                % deployment_type.value)
+
+        ca_nickname = DOGTAG_CERTS['ca_issuing'].nickname
+        days = self.CA_SIGNING_MIN_VALIDITY.days
+
+        if deployment_type == DeploymentType.CA_SELF_SIGNED:
+            print(
+                "The CA signing certificate is expired or will expire "
+                "within the next %d days.\n\nipa-cert-fix cannot proceed.\n"
+                "Please use\n  ipa-cacert-manage renew\n"
+                "to renew the CA certificate, then retry ipa-cert-fix." % days)
+            return 1
+
+        print(
+            "The CA signing certificate is expired or will expire within "
+            "the next %d days.\n\n"
+            "This CA certificate is externally signed. A CSR is needed to "
+            "request a renewed certificate from your external CA." % days)
+
+        csr_b64 = get_csr_from_certmonger(ca_nickname)
+        if csr_b64 is None:
+            logger.warning("No CSR found in certmonger for %s", ca_nickname)
+            print(
+                "\nCould not extract the existing CSR from certmonger.\n"
+                "Please generate a CSR manually using:\n"
+                "  ipa-cacert-manage renew --external-ca\n"
+                "and submit it to your external CA.")
+            return 1
+
+        # get_csr_from_certmonger returns base64-encoded DER as a single
+        # line.  Re-wrap to 64-char PEM body and add headers.
+        csr_path = paths.IPA_CA_CSR
+        try:
+            wrapped = '\n'.join(
+                csr_b64[i:i + 64]
+                for i in range(0, len(csr_b64), 64))
+            pem_data = ("-----BEGIN CERTIFICATE REQUEST-----\n%s\n"
+                        "-----END CERTIFICATE REQUEST-----\n" % wrapped)
+            fd = os.open(
+                csr_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600)
+            with os.fdopen(fd, 'w') as f:
+                f.write(pem_data)
+            logger.info("Wrote CA CSR to %s", csr_path)
+        except IOError as e:
+            logger.error("Failed to write CSR to %s: %s", csr_path, e)
+            print("\nFailed to write CSR to %s: %s" % (csr_path, e))
+            print("Please generate a CSR manually using:\n"
+                  "  ipa-cacert-manage renew --external-ca")
+            return 1
+
+        print(
+            "\nThe CA signing certificate CSR has been written to:\n  %s\n\n"
+            "Submit this CSR to your external CA to obtain a renewed "
+            "certificate.\nThen install it using:\n"
+            "  ipa-cacert-manage renew --external-cert-file=<renewed.crt> "
+            "--external-cert-file=<ca-chain.crt>\n\n"
+            "After the CA certificate is renewed, retry ipa-cert-fix to fix "
+            "the remaining certificates." % csr_path)
+        return 1
+
+    def _detect_ra_subsystem_mismatches(self, skip_ra=False,
+                                        skip_subsystem=False):
+        """Detect RA and subsystem cert vs LDAP mismatches.
+
+        For each cert, finds the **newest** cert among local (FS/NSSDB) and
+        LDAP blobs.  The newest is authoritative:
+            - If local is older, local needs updating.
+            - If LDAP is missing the newest cert or the description serial
+              is wrong, LDAP needs updating.
+        """
+        checks = []
+
+        if not skip_ra:
+            try:
+                ra_cert = x509.load_certificate_from_file(paths.RA_AGENT_PEM)
+                ra_dn = DN(('uid', 'ipara'), ('ou', 'people'), ('o', 'ipaca'))
+                checks.append((
+                    'IPA RA', ra_cert, ra_dn,
+                    ('file', paths.RA_AGENT_PEM)))
+            except Exception as e:
+                logger.debug(
+                    "Cannot load RA cert for consistency check: %s", e)
+
+        if not skip_subsystem:
+            try:
+                db = _get_pki_nssdb()
+                sub_cert = db.get_cert(DOGTAG_CERTS['subsystem'].nickname)
+                sub_dn = DN(('uid', 'pkidbuser'),
+                            ('ou', 'people'), ('o', 'ipaca'))
+                checks.append((
+                    'CA Subsystem', sub_cert, sub_dn,
+                    ('nssdb', paths.PKI_TOMCAT_ALIAS_DIR,
+                     DOGTAG_CERTS['subsystem'].nickname)))
+            except Exception as e:
+                logger.debug(
+                    "Cannot load subsystem cert for consistency check: %s", e)
+
+        conn = api.Backend.ldap2
+        mismatches = []
+        logger.debug("LDAP consistency check: %d entries to verify",
+                     len(checks))
+        for label, local_cert, dn, path_info in checks:
+            try:
+                entry = conn.get_entry(dn, ['userCertificate', 'description'])
+            except Exception as e:
+                logger.warning(
+                    "Cannot read LDAP entry %s for %s: %s",
+                    dn, label, e)
+                continue
+
+            ldap_certs = entry.get('userCertificate', [])
+
+            all_certs = list(ldap_certs) + [local_cert]
+            newest = max(all_certs, key=lambda c: c.not_valid_after_utc)
+
+            newest_der = newest.public_bytes(x509.Encoding.DER)
+            local_der = local_cert.public_bytes(x509.Encoding.DER)
+
+            update_local = (local_der != newest_der)
+            ldap_has_newest = any(
+                c.public_bytes(x509.Encoding.DER) == newest_der
+                for c in ldap_certs)
+            expected_desc = '2;%d;%s;%s' % (
+                newest.serial_number,
+                DN(newest.issuer), DN(newest.subject))
+            try:
+                current_desc = entry.single_value.get('description', '')
+            except ValueError:
+                current_desc = None
+            update_desc = (current_desc != expected_desc)
+
+            logger.debug(
+                "%s: local_serial=%s, newest_serial=%s, "
+                "local_is_newest=%s, ldap_has_newest=%s, "
+                "desc_matches=%s",
+                label, local_cert.serial_number,
+                newest.serial_number, not update_local,
+                ldap_has_newest, not update_desc)
+
+            if not update_local and ldap_has_newest and not update_desc:
+                logger.debug("%s LDAP entry %s is consistent", label, dn)
+                continue
+
+            mismatches.append({
+                'label': label,
+                'newest': newest,
+                'dn': dn,
+                'entry': entry,
+                'update_local': update_local,
+                'update_ldap_cert': not ldap_has_newest,
+                'update_desc': update_desc,
+                'path_info': path_info,
+                'expected_desc': expected_desc,
+            })
+
+        return mismatches
+
+    @staticmethod
+    def _print_ra_subsystem_mismatches(mismatches):
+        """Print mismatch descriptions for user display."""
+        print("The following RA/Subsystem entries need updating:")
+        for m in mismatches:
+            label, dn = m['label'], m['dn']
+            serial = m['newest'].serial_number
+            if m['update_local']:
+                print("  %s: local cert is older than LDAP "
+                      "(will update local to serial %s)"
+                      % (label, serial))
+            if m['update_ldap_cert']:
+                print("  %s: certificate blob missing in %s (serial %s)"
+                      % (label, dn, serial))
+            if m['update_desc']:
+                print("  %s: description serial mismatch in %s (should be %s)"
+                      % (label, dn, serial))
+
+    @staticmethod
+    def _fix_ra_subsystem_mismatches(mismatches):
+        """Apply fixes for detected mismatches."""
+        conn = api.Backend.ldap2
+        for m in mismatches:
+            label = m['label']
+            newest = m['newest']
+            dn = m['dn']
+            entry = m['entry']
+
+            if m['update_local']:
+                path_info = m['path_info']
+                if path_info[0] == 'file':
+                    x509.write_certificate(newest, path_info[1])
+                    if path_info[1] == paths.RA_AGENT_PEM:
+                        cainstance.CAInstance._set_ra_cert_perms()
+                    print("  Updated local %s file" % label)
+                elif path_info[0] == 'nssdb':
+                    db = NSSDatabase(nssdir=path_info[1])
+                    _replace_cert_in_nssdb(db, path_info[2], newest)
+                    print("  Updated local %s in NSSDB" % label)
+
+            ldap_changed = False
+            if m['update_ldap_cert']:
+                entry['userCertificate'].append(newest)
+                ldap_changed = True
+            if m['update_desc']:
+                entry['description'] = m['expected_desc']
+                ldap_changed = True
+
+            if ldap_changed:
+                try:
+                    conn.update_entry(entry)
+                    print("  Updated %s LDAP entry %s" % (label, dn))
+                except Exception as e:
+                    logger.warning(
+                        "Failed to update LDAP entry %s for %s: %s",
+                        dn, label, e)
 
     def determine_scenario(self, deployment_type):
         """Determine the fix scenario and master server.

--- a/ipaserver/install/ipa_cert_fix_services.py
+++ b/ipaserver/install/ipa_cert_fix_services.py
@@ -12,19 +12,23 @@ handling, deployment detection) are added in subsequent commits.
 """
 
 import base64
+from contextlib import contextmanager
 from cryptography import x509 as crypto_x509
 from cryptography.hazmat.backends import default_backend
 import logging
 import os
+import re
 import socket
 import time
 
 from ipalib import api, errors
+from ipalib.constants import IPA_CA_RECORD
 from ipalib import x509
 from ipalib.install import certmonger
 from ipaplatform.paths import paths
 from ipapython.certdb import NSSDatabase, EMPTY_TRUST_FLAGS
 from ipapython.dn import DN
+from ipapython.dogtag import KDC_PROFILE
 from ipapython.ipaldap import realm_to_serverid
 from ipapython import directivesetter
 from ipapython import ipautil
@@ -531,6 +535,512 @@ def expired_ipa_certs(now, ds_dbdir=None, ds_nickname=None):
         logger.debug("Cannot load KDC cert from %s: %s", paths.KDC_CERT, e)
 
     return certs, non_renewed
+
+
+class ExternalCertHandler:
+    """Handle expired externally-signed service certificates.
+
+    Offers per-cert transition to the internal IPA CA (interactive) or
+    generates CSRs for manual renewal with the external CA.
+
+    Extracted from IPACertFix so the logic can be tested and reused
+    independently of the AdminTool lifecycle.
+    """
+
+    DEFAULT_CSR_DIR = '/run/ipa/cert-fix'
+
+    def __init__(self, cm_client, unattended=False, csr_dir=None):
+        self._cm = cm_client
+        self._unattended = unattended
+        self._csr_dir = csr_dir or self.DEFAULT_CSR_DIR
+
+    def handle(self, ctx):
+        """Dispatch external cert handling.
+
+        If an internal CA exists in the topology, offers per-cert transition
+        to the IPA CA via :meth:`offer_transition`.  For remaining certs (or
+        if no CA exists), generates CSRs and prints manual installation
+        instructions via :meth:`generate_csrs`.
+
+        On ``CA_LESS_EXTERNAL`` deployments (no internal CA anywhere),
+        transitions are not possible -- only CSR generation is performed.
+
+        :param ctx: :class:`CertFixContext`
+        :returns: ``True`` if any certs were handled (transitioned or CSRs
+            generated), ``False`` if all failed
+        """
+        if not ctx.external_certs:
+            return True
+
+        remaining = list(ctx.external_certs)
+        handled = False
+
+        if ctx.deployment_type != DeploymentType.CA_LESS_EXTERNAL:
+            try:
+                ca_servers = find_providing_servers(
+                    'CA', conn=api.Backend.ldap2, api=api)
+            except Exception as e:
+                logger.warning("Failed to discover CA servers: %s", e)
+                ca_servers = []
+
+            # find_providing_servers returns all CA replicas including this
+            # host; filter so the helper override never points at self.
+            other_cas = [s for s in ca_servers if s != api.env.host]
+            master = ctx.master_server or (
+                other_cas[0] if other_cas else None)
+
+            if master is not None:
+                transitioned = (
+                    self.offer_transition(ctx.external_certs, master, ctx))
+                if transitioned:
+                    handled = True
+                remaining = [
+                    (t, c) for t, c in ctx.external_certs
+                    if t not in transitioned
+                ]
+
+        if remaining:
+            if self.generate_csrs(remaining, ctx):
+                handled = True
+
+        return handled
+
+    def offer_transition(self, external_certs, master, ctx):
+        """Offer to transition external certs to the internal CA.
+
+        Externally-signed certificates typically have no certmonger tracking
+        request (tracking is stopped when a cert is installed externally).
+        To transition, we stop any existing tracking, create a new tracking
+        request with the correct IPA parameters, optionally override the IPA
+        CA helper to point at *master*, and wait for renewal.
+
+        In unattended mode, no transitions are offered.
+        """
+        if self._unattended:
+            logger.info(
+                "Unattended mode: skipping external cert transition offers")
+            return set()
+
+        transitioned = set()
+
+        for certtype, cert in external_certs:
+            print(
+                "Certificate %s is signed by an external CA (issuer: %s)."
+                % (certtype.value, DN(cert.issuer)))
+            response = ipautil.user_input(
+                "Transition to internal IPA CA?",
+                default=False,)
+            if not response:
+                continue
+
+            try:
+                self._transition_cert(certtype, cert, master, ctx)
+                transitioned.add(certtype)
+            except Exception as e:
+                logger.error("Failed to transition %s: %s", certtype.value, e)
+                print("ERROR: Failed to transition %s: %s"
+                      % (certtype.value, e))
+
+        return transitioned
+
+    def _transition_cert(self, certtype, cert, master, ctx):
+        """Transition a single cert to the internal IPA CA."""
+        params = self._tracking_params(certtype, ctx)
+        if params is None:
+            raise RuntimeError(
+                "No tracking parameters for %s" % certtype.value)
+
+        criteria = self._cert_criteria(certtype, ctx)
+        if criteria:
+            old_id = self._cm.get_request_id(criteria)
+            if old_id is not None:
+                logger.debug(
+                    "Stopping existing tracking %s for %s",
+                    old_id, certtype.value,)
+                self._cm.stop_tracking(request_id=old_id)
+
+        print("  Creating IPA tracking request for %s..." % certtype.value)
+        logger.debug("Tracking params for %s: %s", certtype.value, params)
+
+        if master:
+            if not self._cm.is_responsive():
+                raise RuntimeError(
+                    "certmonger did not become responsive; "
+                    "cannot create tracking request for %s"
+                    % certtype.value)
+            with self._override_ca_helper(master):
+                request_id = self._create_tracking(certtype, params)
+                state = self._cm.wait_for_request(
+                    request_id,
+                    timeout=CERTMONGER_WAIT_TIMEOUT)
+        else:
+            request_id = self._create_tracking(certtype, params)
+            state = self._cm.wait_for_request(
+                request_id,
+                timeout=CERTMONGER_WAIT_TIMEOUT)
+
+        if state == 'MONITORING':
+            print("  %s transitioned successfully." % certtype.value)
+        else:
+            ca_error = self._cm.get_request_value(request_id, 'ca-error')
+            raise RuntimeError(
+                "%s transition failed: state=%s, error=%s"
+                % (certtype.value, state, ca_error))
+
+    def _create_tracking(self, certtype, params):
+        """Create a certmonger tracking request."""
+        request_id = self._cm.start_tracking(
+            certpath=params['certpath'],
+            ca=params['ca'],
+            storage=params['storage'],
+            profile=params['profile'],
+            post_command=params.get('post_command'),
+            pinfile=params.get('pinfile'),
+            nickname=params.get('nickname'),
+            dns=params.get('dns'),
+            perms=params.get('perms'),
+            token_name=params.get('token'),)
+        logger.debug(
+            "Created tracking request %s for %s",
+            request_id, certtype.value,)
+        if params.get('principal'):
+            self._cm.add_principal(request_id, params['principal'])
+        if params.get('subject'):
+            self._cm.add_subject(request_id, params['subject'])
+        return request_id
+
+    @staticmethod
+    def _tracking_params(certtype, ctx):
+        """Return certmonger tracking parameters for a cert.
+
+        These mirror the parameters used during IPA server installation.
+        """
+        subject = str(DN(('CN', api.env.host), ctx.subject_base))
+
+        if certtype is IPACertType.HTTPS:
+            passwd_file = (
+                paths.HTTPD_PASSWD_FILE_FMT.format(host=api.env.host))
+            return {
+                'certpath': (paths.HTTPD_CERT_FILE, paths.HTTPD_KEY_FILE),
+                'ca': 'IPA',
+                'storage': 'FILE',
+                'profile': IPA_SERVICE_PROFILE,
+                'post_command': 'restart_httpd',
+                'pinfile': passwd_file,
+                'dns': [
+                    api.env.host,
+                    '%s.%s' % (IPA_CA_RECORD,
+                               api.env.domain),
+                ],
+                'principal': 'HTTP/%s@%s' % (api.env.host, api.env.realm),
+                'subject': subject,
+            }
+
+        if certtype is IPACertType.LDAPS:
+            return {
+                'certpath': ctx.ds_dbdir,
+                'ca': 'IPA',
+                'storage': 'NSSDB',
+                'profile': IPA_SERVICE_PROFILE,
+                'post_command': ('restart_dirsrv %s'
+                                 % ctx.serverid),
+                'pinfile': os.path.join(ctx.ds_dbdir, 'pwdfile.txt'),
+                'nickname': ctx.ds_nickname,
+                'principal': 'ldap/%s@%s' % (api.env.host, api.env.realm),
+                'subject': subject,
+            }
+
+        if certtype is IPACertType.KDC:
+            return {
+                'certpath': (paths.KDC_CERT, paths.KDC_KEY),
+                'ca': 'IPA',
+                'storage': 'FILE',
+                'profile': KDC_PROFILE,
+                'post_command': 'renew_kdc_cert',
+                'dns': [api.env.host],
+                'perms': (0o644, 0o600),
+                'principal': 'krbtgt/%s@%s' % (api.env.realm, api.env.realm),
+                'subject': subject,
+            }
+
+        # IPARA is handled separately (fetched from master LDAP, not via
+        # certmonger tracking).
+        return None
+
+    def generate_csrs(self, external_certs, ctx):
+        """Generate CSR files for externally-signed certificates.
+
+        For each expired external cert, tries three sources for a CSR:
+
+        1. Extract existing CSR from certmonger tracking
+        2. Generate a new CSR from the existing private key and the expired
+           cert's subject/SANs
+        3. Fall back to manual instructions
+        """
+        csr_dir = self._csr_dir
+        os.makedirs(csr_dir, mode=0o700, exist_ok=True)
+
+        csr_paths = {}
+
+        for certtype, cert in external_certs:
+            csr_path = os.path.join(
+                csr_dir, '%s.csr'
+                % certtype.value.lower().replace(' ', '-'))
+
+            csr_pem = self._get_csr_from_tracking(certtype, ctx)
+
+            if csr_pem is None:
+                csr_pem = self._generate_csr_from_key(certtype, cert, ctx)
+
+            if csr_pem is None:
+                logger.warning("Cannot generate CSR for %s", certtype.value)
+                continue
+
+            try:
+                fd = os.open(
+                    csr_path,
+                    os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                    0o600)
+                with os.fdopen(fd, 'w') as f:
+                    f.write(csr_pem)
+                csr_paths[certtype] = csr_path
+                logger.debug(
+                    "Wrote CSR for %s to %s",
+                    certtype.value, csr_path,)
+            except IOError as e:
+                logger.error(
+                    "Failed to write CSR for %s: %s",
+                    certtype.value, e,)
+
+        install_cmds = {
+            IPACertType.HTTPS: (
+                "ipa-server-certinstall --http /path/to/renewed.crt"),
+            IPACertType.LDAPS: (
+                "ipa-server-certinstall --dirsrv /path/to/renewed.crt"),
+            IPACertType.KDC: (
+                "ipa-server-certinstall --kdc /path/to/renewed.crt"),
+        }
+
+        if csr_paths:
+            print()
+            print("CSR files have been generated for external renewal:")
+            print()
+            for certtype, path in csr_paths.items():
+                print("  %s:" % certtype.value)
+                print("    CSR: %s" % path)
+                cmd = install_cmds.get(certtype)
+                if cmd:
+                    print("    Install: %s" % cmd)
+            print()
+            print(
+                "Submit these CSRs to your external CA, "
+                "then install the renewed certificates "
+                "using the commands above.")
+            print()
+            return True
+        else:
+            print(
+                "Could not generate CSRs for the "
+                "externally-signed certificates.")
+            print(
+                "Generate CSRs manually from your existing "
+                "keys and submit them to your external CA, "
+                "then install using ipa-server-certinstall.")
+            print()
+            return False
+
+    def _get_csr_from_tracking(self, certtype, ctx):
+        """Try to extract a CSR from certmonger tracking."""
+        criteria = self._cert_criteria(certtype, ctx)
+        if criteria is None:
+            return None
+        request_id = self._cm.get_request_id(criteria)
+        if request_id is None:
+            logger.debug("No certmonger tracking for %s", certtype.value)
+            return None
+        csr = self._cm.get_request_value(request_id, 'csr')
+        if not csr:
+            logger.debug("No CSR in tracking for %s", certtype.value)
+            return None
+        logger.debug("Extracted CSR from certmonger for %s", certtype.value)
+        return csr
+
+    def _generate_csr_from_key(self, certtype, cert, ctx):
+        """Generate a CSR from the existing private key.
+
+        Uses the subject and SANs from the expired certificate to build a
+        new CSR signed with the existing private key.
+        """
+        from cryptography.exceptions import (UnsupportedAlgorithm)
+        from cryptography.hazmat.primitives import (hashes, serialization)
+
+        params = self._tracking_params(certtype, ctx)
+        if params is None:
+            return None
+
+        if params['storage'] == 'NSSDB':
+            return self._generate_csr_nssdb(certtype, cert, params)
+
+        certpath = params['certpath']
+        _cert_file, key_file = certpath
+
+        try:
+            with open(key_file, 'rb') as f:
+                key_pem = f.read()
+        except IOError as e:
+            logger.warning(
+                "Cannot read key for %s from %s: %s",
+                certtype.value, key_file, e,)
+            return None
+
+        try:
+            key = serialization.load_pem_private_key(key_pem, password=None)
+        except (ValueError, TypeError, UnsupportedAlgorithm):
+            pinfile = params.get('pinfile')
+            if pinfile:
+                try:
+                    with open(pinfile, 'rb') as f:
+                        pin = f.read().strip()
+                    key = serialization.load_pem_private_key(
+                        key_pem, password=pin,)
+                except Exception as e:
+                    logger.warning(
+                        "Cannot decrypt key for %s: %s",
+                        certtype.value, e,)
+                    return None
+            else:
+                logger.warning(
+                    "Key for %s is encrypted, no pin file available",
+                    certtype.value,)
+                return None
+
+        builder = crypto_x509.CertificateSigningRequestBuilder()
+        builder = builder.subject_name(cert.subject)
+
+        try:
+            san = cert.extensions.get_extension_for_class(
+                crypto_x509.SubjectAlternativeName)
+            builder = builder.add_extension(san.value, critical=san.critical)
+        except crypto_x509.ExtensionNotFound:
+            pass
+
+        csr = builder.sign(key, hashes.SHA256())
+        csr_pem = csr.public_bytes(serialization.Encoding.PEM).decode('ascii')
+
+        logger.info(
+            "Generated CSR for %s from key %s",
+            certtype.value, key_file,)
+        return csr_pem
+
+    @staticmethod
+    def _generate_csr_nssdb(certtype, cert, params):
+        """Generate a CSR from an NSSDB private key."""
+        dbdir = params['certpath']
+        nickname = params.get('nickname')
+        pinfile = params.get('pinfile')
+        token = params.get('token')
+        subject = str(DN(cert.subject))
+
+        key_id = None
+        if nickname:
+            key_id = ExternalCertHandler._get_nssdb_key_id(
+                dbdir, nickname, pinfile, token)
+
+        cmd = ['certutil', '-R', '-d', dbdir, '-s', subject, '-a']
+        if token:
+            cmd.extend(['-h', token])
+        if key_id:
+            cmd.extend(['-k', key_id])
+        else:
+            logger.warning(
+                "Cannot find key ID for %s in %s, cannot generate CSR",
+                nickname, dbdir,)
+            return None
+        if pinfile:
+            cmd.extend(['-f', pinfile])
+
+        try:
+            san = cert.extensions.get_extension_for_class(
+                crypto_x509.SubjectAlternativeName)
+            dns_names = san.value.get_values_for_type(crypto_x509.DNSName)
+            if dns_names:
+                cmd.extend(['-8', ','.join(dns_names)])
+        except crypto_x509.ExtensionNotFound:
+            pass
+
+        try:
+            result = ipautil.run(cmd, capture_output=True)
+            csr_pem = result.output
+            begin = csr_pem.find('-----BEGIN CERTIFICATE REQUEST')
+            if begin >= 0:
+                csr_pem = csr_pem[begin:]
+            logger.info(
+                "Generated CSR for %s via certutil (key=%s in %s)",
+                certtype.value, nickname or 'new', dbdir,)
+            return csr_pem
+        except Exception as e:
+            logger.warning(
+                "certutil CSR generation failed for %s: %s",
+                certtype.value, e)
+            return None
+
+    @staticmethod
+    def _get_nssdb_key_id(dbdir, nickname, pinfile=None, token=None):
+        """Extract the hex key ID for a cert from NSSDB."""
+        cmd = ['certutil', '-K', '-d', dbdir]
+        if token:
+            cmd.extend(['-h', token])
+        if pinfile:
+            cmd.extend(['-f', pinfile])
+
+        try:
+            result = ipautil.run(cmd, capture_output=True)
+        except Exception as e:
+            logger.debug("certutil -K failed for %s: %s", nickname, e)
+            return None
+
+        # Output format: < 0> rsa <hex-key-id> <token>:<nickname>
+        hex_re = re.compile(r'^[0-9a-fA-F]{16,}$')
+
+        for line in result.output.splitlines():
+            line = line.strip()
+            if not line.startswith('<'):
+                continue
+            if nickname not in line:
+                continue
+            parts = line.split()
+            for part in parts:
+                if hex_re.match(part):
+                    logger.debug("Found key ID %s for %s", part, nickname)
+                    return part
+
+        logger.debug("No key ID found for %s in %s", nickname, dbdir)
+        return None
+
+    @staticmethod
+    def _cert_criteria(certtype, ctx):
+        """Return certmonger search criteria for a cert type."""
+        if certtype is IPACertType.HTTPS:
+            return {'cert-file': paths.HTTPD_CERT_FILE}
+        elif certtype is IPACertType.KDC:
+            return {'cert-file': paths.KDC_CERT}
+        elif certtype is IPACertType.LDAPS:
+            return {
+                'cert-database': ctx.ds_dbdir,
+                'cert-nickname': ctx.ds_nickname,
+            }
+        elif certtype is IPACertType.IPARA:
+            return {'cert-file': paths.RA_AGENT_PEM}
+        return None
+
+    @contextmanager
+    def _override_ca_helper(self, master):
+        """Temporarily override IPA CA helper to point at master."""
+        base = self._cm.set_ca_override('IPA', master)
+        try:
+            yield
+        finally:
+            self._cm.restore_ca_override('IPA', base)
 
 
 class CertRenewalFromMaster:

--- a/ipaserver/install/ipa_cert_fix_services.py
+++ b/ipaserver/install/ipa_cert_fix_services.py
@@ -1,0 +1,238 @@
+#
+# Copyright (C) 2026  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Service classes and utility functions for ipa-cert-fix.
+
+Currently provides :class:`CertmongerClient` (the certmonger D-Bus adapter)
+and a couple of small helpers shared by the main module.  This module will
+grow as additional scenarios (CA-full replica recovery, external cert
+handling, deployment detection) are added in subsequent commits.
+"""
+
+import base64
+from cryptography import x509 as crypto_x509
+from cryptography.hazmat.backends import default_backend
+import logging
+import time
+
+from ipalib import x509
+from ipalib.install import certmonger
+from ipaplatform.paths import paths
+from ipapython.certdb import NSSDatabase
+from ipapython.dn import DN
+from ipapython import ipautil
+
+from ipaserver.install.ipa_cert_fix_types import (
+    CERT_EXPIRY_LOOKAHEAD,
+    DBUS_RETRY_DELAY,
+    DBUS_RETRY_TIMEOUT,
+    _utcnow,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def print_cert_info(context, desc, cert):
+    print("{} {} certificate:".format(context, desc))
+    print("  Subject: {}".format(DN(cert.subject)))
+    print("  Serial:  {}".format(cert.serial_number))
+    print("  Expires: {}".format(cert.not_valid_after_utc))
+    print()
+
+
+def get_csr_from_certmonger(nickname):
+    """
+    Get the csr for the provided nickname by asking certmonger.
+
+    :returns: base64-encoded DER as a single ASCII line (no PEM headers,
+        no internal newlines), suitable for writing into pkispawn-style
+        config directives.  Callers that want PEM must wrap it themselves.
+        ``None`` if no tracking request is found or the value cannot be
+        parsed as a CSR.
+    """
+    criteria = {
+        'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
+        'cert-nickname': nickname,
+    }
+
+    id = certmonger.get_request_id(criteria)
+    if id:
+        csr = certmonger.get_request_value(id, "csr")
+        if csr:
+            try:
+                # Make sure the value can be parsed as valid CSR
+                csr_obj = crypto_x509.load_pem_x509_csr(
+                    csr.encode('ascii'), default_backend())
+                val = base64.b64encode(csr_obj.public_bytes(x509.Encoding.DER))
+                return val.decode('ascii')
+            except Exception as e:
+                # Fallthrough and return None
+                logger.debug("Unable to get CSR from certmonger: %s", e)
+    return None
+
+
+class CertmongerClient:
+    """Adapter for certmonger operations.
+
+    Provides a mockable boundary for unit tests and centralizes D-Bus retry
+    logic for operations that may fail transiently when certmonger is busy
+    or restarting.
+    """
+
+    def __init__(self, dbus_timeout=DBUS_RETRY_TIMEOUT):
+        self._timeout = dbus_timeout
+
+    def get_request_id(self, criteria):
+        return certmonger.get_request_id(criteria)
+
+    def get_request_value(self, request_id, key):
+        return certmonger.get_request_value(request_id, key)
+
+    def resubmit_request(self, request_id, ca=None, profile=None):
+        certmonger.resubmit_request(request_id, ca=ca, profile=profile)
+
+    def wait_for_request(self, request_id, timeout):
+        return certmonger.wait_for_request(request_id, timeout=timeout)
+
+    def modify_ca_helper(self, ca_name, helper):
+        certmonger.modify_ca_helper(ca_name, helper)
+
+    def get_ca_helper(self, ca_name):
+        """Read the current CA helper via D-Bus with retry.
+
+        Certmonger's D-Bus may be unresponsive after restarts.
+        Retries until timeout.
+
+        :param ca_name: CA nickname (e.g. ``'IPA'``)
+        :returns: current external-helper string
+        """
+        import dbus
+        deadline = time.monotonic() + self._timeout
+        delay = DBUS_RETRY_DELAY
+        while True:
+            try:
+                bus = dbus.SystemBus()
+                obj = bus.get_object(
+                    'org.fedorahosted.certmonger',
+                    '/org/fedorahosted/certmonger',)
+                iface = dbus.Interface(obj, 'org.fedorahosted.certmonger')
+                ca_path = iface.find_ca_by_nickname(ca_name)
+                if not ca_path:
+                    raise RuntimeError(
+                        "%s CA is not configured in certmonger"
+                        % ca_name)
+                ca_obj = bus.get_object('org.fedorahosted.certmonger', ca_path)
+                ca_props = dbus.Interface(
+                    ca_obj,
+                    'org.freedesktop.DBus.Properties',)
+                return str(ca_props.Get(
+                    'org.fedorahosted.certmonger.ca',
+                    'external-helper',
+                ))
+            except dbus.exceptions.DBusException as e:
+                if time.monotonic() >= deadline:
+                    raise
+                logger.debug(
+                    "certmonger D-Bus not ready (%s), retrying in %ds",
+                    e, delay, )
+                time.sleep(delay)
+
+    def set_ca_override(self, ca_name, master_server):
+        """Override a CA helper to point at a specific server.
+
+        Reads the current helper, strips any prior ``-J`` override,
+        and appends ``-J https://<master>/ipa/json``.
+
+        :param ca_name: CA nickname (e.g. ``'IPA'``)
+        :param master_server: FQDN of the master
+        :returns: the base helper string (for restore)
+        """
+        old_helper = self.get_ca_helper(ca_name)
+        base = old_helper.split(' -J ', maxsplit=1)[0].strip()
+        url = 'https://%s/ipa/json' % master_server
+        self.modify_ca_helper(ca_name, '%s -J %s' % (base, url))
+        return base
+
+    def restore_ca_override(self, ca_name, base_helper):
+        """Restore a CA helper to its base value."""
+        self.modify_ca_helper(ca_name, base_helper)
+
+    def add_principal(self, request_id, principal):
+        certmonger.add_principal(request_id, principal)
+
+    def add_subject(self, request_id, subject):
+        certmonger.add_subject(request_id, subject)
+
+    def add_request_value(self, request_id, key, value):
+        certmonger.add_request_value(request_id, key, value)
+
+    def start_tracking(self, **params):
+        return certmonger.start_tracking(**params)
+
+    def stop_tracking(self, request_id):
+        certmonger.stop_tracking(request_id=request_id)
+
+    def modify(self, request_id, ca=None, profile=None):
+        certmonger.modify(request_id, ca=ca, profile=profile)
+
+    def get_requests_for_dir(self, directory):
+        return certmonger.get_requests_for_dir(directory)
+
+    def is_responsive(self, timeout=None):
+        """Check if certmonger responds on D-Bus.
+
+        Uses ``getcert list-cas`` as a lightweight probe.
+        Polls until responsive or timeout.
+
+        :param timeout: max seconds to wait (default: ``self._timeout``)
+        :returns: ``True`` if responsive, ``False`` on timeout
+        """
+        if timeout is None:
+            timeout = self._timeout
+        deadline = time.monotonic() + timeout
+        delay = DBUS_RETRY_DELAY
+        while True:
+            try:
+                ipautil.run(
+                    ['getcert', 'list-cas'],
+                    capture_output=True)
+                return True
+            except Exception as e:
+                if time.monotonic() >= deadline:
+                    logger.error(
+                        "certmonger not responsive after %ds: %s", timeout, e)
+                    return False
+                logger.debug(
+                    "certmonger not ready yet (%s), retrying in %ds", e, delay)
+                time.sleep(delay)
+
+    def is_cert_valid(self, request_id):
+        """Check if the cert tracked by a request is valid.
+
+        Reads the cert file or NSS database referenced by the certmonger
+        tracking request and checks expiry against the standard 2-week
+        lookahead.
+
+        :param request_id: certmonger request ID
+        :returns: ``True`` if valid, ``False`` if expired/unreadable
+        """
+        threshold = (_utcnow() + CERT_EXPIRY_LOOKAHEAD)
+        cert_file = self.get_request_value(request_id, 'cert-file')
+        if cert_file:
+            try:
+                cert = x509.load_certificate_from_file(cert_file)
+                return cert.not_valid_after_utc > threshold
+            except Exception:
+                return False
+        cert_db = self.get_request_value(request_id, 'cert-database')
+        cert_nick = self.get_request_value(request_id, 'cert-nickname')
+        if cert_db and cert_nick:
+            try:
+                db = NSSDatabase(nssdir=cert_db)
+                cert = db.get_cert(cert_nick)
+                return cert.not_valid_after_utc > threshold
+            except Exception:
+                return False
+        return False

--- a/ipaserver/install/ipa_cert_fix_services.py
+++ b/ipaserver/install/ipa_cert_fix_services.py
@@ -15,6 +15,7 @@ import base64
 from cryptography import x509 as crypto_x509
 from cryptography.hazmat.backends import default_backend
 import logging
+import os
 import socket
 import time
 
@@ -22,9 +23,10 @@ from ipalib import api, errors
 from ipalib import x509
 from ipalib.install import certmonger
 from ipaplatform.paths import paths
-from ipapython.certdb import NSSDatabase
+from ipapython.certdb import NSSDatabase, EMPTY_TRUST_FLAGS
 from ipapython.dn import DN
 from ipapython.ipaldap import realm_to_serverid
+from ipapython import directivesetter
 from ipapython import ipautil
 from ipaserver.install import cainstance, dsinstance
 from ipaserver.install.certs import is_ipa_issued_cert
@@ -32,12 +34,16 @@ from ipaserver.masters import find_providing_servers
 
 from ipaserver.install.ipa_cert_fix_types import (
     CERT_EXPIRY_LOOKAHEAD,
+    CERTMONGER_WAIT_TIMEOUT,
     DBUS_RETRY_DELAY,
     DBUS_RETRY_TIMEOUT,
     DOGTAG_CERTS,
     DeploymentType,
     FixScenario,
+    HELPER_KILL_SETTLE,
     IPACertType,
+    IPA_SERVICE_PROFILE,
+    _CS_CFG_CERT_DIRECTIVES,
     _utcnow,
 )
 
@@ -47,6 +53,92 @@ logger = logging.getLogger(__name__)
 def _get_pki_nssdb():
     """Lazy accessor for the PKI Tomcat NSS database."""
     return NSSDatabase(nssdir=paths.PKI_TOMCAT_ALIAS_DIR)
+
+
+def _replace_cert_in_nssdb(db, nickname, cert, trust_flags=EMPTY_TRUST_FLAGS):
+    """Replace a certificate in an NSS database.
+
+    Deletes the old cert (ignoring "not found") and adds the new
+    one.  This is the standard pattern for updating a cert in
+    NSSDB without losing the private key.
+
+    :param db: :class:`NSSDatabase` instance
+    :param nickname: certificate nickname
+    :param cert: new certificate to install
+    :param trust_flags: trust flags for the new cert
+    """
+    try:
+        db.delete_cert(nickname)
+    except ipautil.CalledProcessError:
+        logger.debug(
+            "Cert '%s' not found in NSS database, nothing to delete", nickname)
+    db.add_cert(cert, nickname, trust_flags)
+
+
+def _update_cs_cfg(nickname, cert):
+    """Update the certificate blob in the Dogtag CS.cfg file.
+
+    When a certificate is installed directly into the NSSDB (bypassing
+    certmonger's post-save commands), the base64 cert blob in CS.cfg
+    must be updated manually.  Otherwise Dogtag will have a stale
+    certificate in its configuration.
+
+    Also updates ``ca.connector.KRA.transportCert`` in the CA config
+    when the KRA transport cert is renewed (used by CA to encrypt
+    key archival requests to KRA).
+
+    :param nickname: NSSDB certificate nickname
+    :param cert: the new certificate (IPACertificate)
+    """
+    if nickname not in _CS_CFG_CERT_DIRECTIVES:
+        return
+
+    directive, cfg_path = _CS_CFG_CERT_DIRECTIVES[nickname]
+    if not os.path.exists(cfg_path):
+        logger.debug("CS.cfg not found at %s, skipping update", cfg_path)
+        return
+
+    cert_b64 = base64.b64encode(cert.public_bytes(x509.Encoding.DER))\
+        .decode('ascii')
+    logger.debug("Updating CS.cfg directive %s in %s", directive, cfg_path)
+    directivesetter.set_directive(
+        cfg_path, directive, cert_b64,
+        quotes=False, separator='=')
+
+    # KRA transport cert is also referenced in the CA config as
+    # ca.connector.KRA.transportCert
+    if nickname == 'transportCert cert-pki-kra':
+        if os.path.exists(paths.CA_CS_CFG_PATH):
+            logger.debug(
+                "Updating ca.connector.KRA.transportCert in %s",
+                paths.CA_CS_CFG_PATH)
+            directivesetter.set_directive(
+                paths.CA_CS_CFG_PATH,
+                'ca.connector.KRA.transportCert', cert_b64,
+                quotes=False, separator='=')
+
+
+def _kill_stuck_helpers():
+    """Kill running ipa-submit and ipa-server-guard processes.
+
+    Certmonger processes D-Bus requests serially.  If ``ipa-submit`` is
+    running (trying to contact httpd with expired certs), any D-Bus write
+    (like ``modify_ca_helper``) blocks until the helper times out --
+    which can take minutes.
+
+    Killing the helpers makes certmonger's D-Bus responsive immediately.
+    Certmonger will re-queue the requests and attempt them again later.
+    """
+    for proc_name in ('ipa-submit', 'ipa-server-guard'):
+        try:
+            result = ipautil.run(
+                ['pkill', '-f', proc_name],
+                raiseonerr=False, capture_output=True)
+            if result.returncode == 0:
+                logger.debug("Killed %s processes", proc_name)
+        except Exception as e:
+            logger.debug("pkill %s failed: %s", proc_name, e)
+    time.sleep(HELPER_KILL_SETTLE)
 
 
 def print_cert_info(context, desc, cert):
@@ -439,6 +531,376 @@ def expired_ipa_certs(now, ds_dbdir=None, ds_nickname=None):
         logger.debug("Cannot load KDC cert from %s: %s", paths.KDC_CERT, e)
 
     return certs, non_renewed
+
+
+class CertRenewalFromMaster:
+    """Renew expired certificates via certmonger pointed at a master.
+
+    Manages the IPA CA helper override, per-request CA/profile switching, and
+    cleanup.  Used by the CA-full and CA-less replica recovery scenarios.
+    """
+
+    def __init__(self, cm_client, master_server):
+        self._cm = cm_client
+        self._master = master_server
+        self._original_principals = {}
+        self._original_profiles = {}
+
+    def _set_helper(self):
+        """Point the IPA CA helper at the master server.
+
+        :returns: the base helper string (without ``-J``)
+        """
+        logger.debug("Setting IPA CA helper to master: %s", self._master)
+        base = self._cm.set_ca_override('IPA', self._master)
+        logger.debug("IPA CA helper base: '%s'", base)
+        return base
+
+    def _restore_helper(self, old_helper, timeout=DBUS_RETRY_TIMEOUT):
+        """Restore the IPA CA helper to its original value.
+
+        Retries for *timeout* seconds if certmonger's D-Bus is temporarily
+        unreachable (e.g., being restarted by a post-save command).
+
+        :param old_helper: value returned by :meth:`_set_helper`
+        :param timeout: max seconds to retry
+        """
+        logger.debug("Restoring IPA CA helper to: %s", old_helper)
+        deadline = time.monotonic() + timeout
+        delay = DBUS_RETRY_DELAY
+        while True:
+            try:
+                self._cm.restore_ca_override('IPA', old_helper)
+                return
+            except Exception as e:
+                if time.monotonic() >= deadline:
+                    logger.error(
+                        "Failed to restore IPA CA helper after %ds: %s",
+                        timeout, e,)
+                    print(
+                        "\nCRITICAL: Failed to restore the IPA CA certmonger "
+                        "helper.\n"
+                        "All future certificate renewals on this host may "
+                        "fail or contact the wrong server.\nRun manually:\n\n"
+                        "  getcert modify-ca -c IPA -e '%s'\n" % old_helper)
+                    return
+                logger.debug(
+                    "certmonger not ready for restore (%s), retrying in %ds",
+                    e, delay,)
+                time.sleep(delay)
+
+    def _resubmit(
+        self, desc, old_cert, request_id, original_ca, load_renewed,
+    ):
+        """Resubmit a single cert's tracking request via master.
+
+        Handles the Dogtag-vs-IPA distinction: Dogtag certs need their CA
+        switched to IPA, a host principal added, and the profile overridden
+        to ``caIPAserviceCert``.
+
+        Mutates ``self._original_principals`` and ``self._original_profiles``
+        for later cleanup by :meth:`_restore`.
+        """
+        desc_str = getattr(desc, 'display_name',
+                           getattr(desc, 'value', str(desc)))
+        print("\n  Renewing %s (request %s)..." % (desc_str, request_id))
+
+        _kill_stuck_helpers()
+
+        if self._cm.is_cert_valid(request_id):
+            print("  %s already has a valid cert, skipping." % desc_str)
+            return
+
+        print_cert_info("  Old", desc_str, old_cert)
+
+        is_dogtag = getattr(desc, 'is_dogtag', False)
+        override_profile = None
+
+        if is_dogtag:
+            host_principal = 'host/%s@%s' % (api.env.host, api.env.realm)
+            orig = self._cm.get_request_value(request_id, 'template-principal')
+            self._original_principals[request_id] = orig
+            logger.debug(
+                "Setting template-principal on request %s to %s "
+                "(original: %s)", request_id, host_principal, orig)
+            self._cm.add_principal(request_id, host_principal)
+
+            original_profile = self._cm.get_request_value(
+                request_id, 'template-profile')
+            if original_profile and original_profile != IPA_SERVICE_PROFILE:
+                override_profile = IPA_SERVICE_PROFILE
+                self._original_profiles[request_id] = (original_profile)
+                logger.debug(
+                    "Overriding profile on request %s: %s -> %s",
+                    request_id, original_profile, override_profile)
+
+        try:
+            current_ca = self._cm.get_request_value(request_id, 'ca-name')
+            logger.debug("Request %s current CA: %s", request_id, current_ca)
+            cas_output = ipautil.run(
+                ['getcert', 'list-cas', '-c', 'IPA'],
+                capture_output=True, raiseonerr=False)
+            logger.debug("IPA CA helper config:\n%s", cas_output.output)
+        except Exception as diag_err:
+            logger.debug("Pre-resubmit diagnostics failed: %s", diag_err)
+
+        logger.debug(
+            "Resubmitting request %s via %s CA (original CA: %s, "
+            "is_dogtag: %s, profile_override: %s)",
+            request_id,
+            'IPA' if is_dogtag else '%s (unchanged)' % original_ca,
+            original_ca, is_dogtag, override_profile)
+        self._cm.resubmit_request(
+            request_id,
+            ca='IPA' if is_dogtag else None,
+            profile=override_profile,)
+
+        try:
+            state = self._cm.wait_for_request(
+                request_id, timeout=CERTMONGER_WAIT_TIMEOUT)
+        except RuntimeError:
+            logger.error("Timeout waiting for request %s", request_id)
+            raise RuntimeError(
+                "Certmonger request %s for %s timed out"
+                % (request_id, desc_str))
+
+        if state != 'MONITORING':
+            ca_error = self._cm.get_request_value(request_id, 'ca-error')
+            raise RuntimeError(
+                "Certmonger request %s for %s failed: state=%s, ca-error=%s"
+                % (request_id, desc_str, state, ca_error))
+
+        if not self._cm.is_responsive():
+            raise RuntimeError(
+                "certmonger did not become responsive after renewing %s"
+                % desc_str)
+
+        try:
+            new_cert = load_renewed()
+            logger.debug(
+                "Renewed %s: serial=%s, issued=%s, expires=%s",
+                desc_str, new_cert.serial_number,
+                new_cert.not_valid_before_utc,
+                new_cert.not_valid_after_utc)
+            if new_cert.serial_number == old_cert.serial_number:
+                print("  WARNING: %s serial unchanged after renewal (%s) -- "
+                      "cert may not have been updated"
+                      % (desc_str, new_cert.serial_number))
+            else:
+                print("  %s renewed successfully." % desc_str)
+            print_cert_info("  New", desc_str, new_cert)
+        except Exception as e:
+            logger.warning("Could not read renewed cert for %s: %s",
+                           desc_str, e)
+            print("  %s submitted for renewal." % desc_str)
+
+    def _restore(self, request_id, original_ca):
+        """Restore a single certmonger request after renewal.
+
+        Restores the original CA name, profile, and removes any temporary
+        principal that was added for Dogtag cert renewal through the IPA CA.
+        """
+        try:
+            current_ca = self._cm.get_request_value(request_id, 'ca-name')
+            restore_profile = self._original_profiles.get(request_id)
+            if current_ca != original_ca or restore_profile:
+                logger.debug(
+                    "Restoring request %s: CA %s -> %s, profile -> %s",
+                    request_id, current_ca, original_ca, restore_profile)
+                self._cm.modify(
+                    request_id, ca=original_ca, profile=restore_profile,)
+        except Exception as e:
+            logger.warning(
+                "Failed to restore CA/profile for request %s: %s",
+                request_id, e)
+
+        if request_id in self._original_principals:
+            orig = self._original_principals[request_id]
+            if orig:
+                try:
+                    logger.debug(
+                        "Restoring template-principal on request %s to %s",
+                        request_id, orig)
+                    self._cm.add_request_value(
+                        request_id, 'template-principal', orig)
+                except Exception as e:
+                    logger.warning(
+                        "Failed to restore principal on request %s: %s",
+                        request_id, e)
+            else:
+                logger.debug(
+                    "Request %s had no original principals, "
+                    "skipping principal removal (harmless)",
+                    request_id)
+
+    def renew(self, certs, ipa_certs, ctx):
+        """Renew expired certificates from a master via certmonger.
+
+        Builds tracking criteria for each expired cert, temporarily overrides
+        the IPA CA helper to point at the master, resubmits each request, and
+        restores all certmonger state afterward.
+
+        :param certs: list of ``(certid, cert)`` for Dogtag certs
+        :param ipa_certs: list of ``(IPACertType, cert)`` for IPA service
+            certs
+        :param ctx: :class:`CertFixContext`
+        :returns: set of renewed request IDs
+        """
+        tracking = self._build_tracking_list(certs, ipa_certs, ctx)
+
+        if not tracking:
+            print("No certificates to renew from master.")
+            return set()
+
+        requests = self._resolve_tracking_requests(tracking)
+
+        if not requests:
+            print("No certmonger tracking requests found.")
+            return set()
+
+        _kill_stuck_helpers()
+
+        old_helper = self._set_helper()
+
+        failed = []
+        renewed_ids = set()
+        try:
+            print("Renewing certificates from %s" % self._master)
+            for (desc, old_cert, request_id,
+                 original_ca, load_renewed) in requests:
+                _kill_stuck_helpers()
+                try:
+                    self._resubmit(
+                        desc, old_cert, request_id,
+                        original_ca, load_renewed,)
+                    renewed_ids.add(request_id)
+                except Exception as e:
+                    desc_str = getattr(desc, 'display_name',
+                                       getattr(desc, 'value', str(desc)))
+                    logger.error("Failed to renew %s: %s", desc_str, e)
+                    print("  ERROR: %s failed: %s" % (desc_str, e))
+                    failed.append(desc_str)
+        finally:
+            for (_desc, _cert, request_id,
+                 original_ca, _load) in requests:
+                try:
+                    self._restore(request_id, original_ca)
+                except Exception as e:
+                    logger.error(
+                        "Failed to restore request %s: %s", request_id, e,)
+            self._restore_helper(old_helper)
+
+        if failed:
+            print(
+                "\nWARNING: %d certificate(s) failed to renew: %s\n"
+                "These may need manual intervention."
+                % (len(failed), ', '.join(failed)))
+
+        return renewed_ids
+
+    @staticmethod
+    def _make_cert_loader(storage, path, nickname=None):
+        """Create a callable that loads a renewed certificate.
+
+        :param storage: ``'NSSDB'`` or ``'FILE'``
+        :param path: NSS database dir or PEM file path
+        :param nickname: cert nickname (NSSDB only)
+        :returns: zero-arg callable returning the cert
+        """
+        if storage == 'NSSDB':
+            db = NSSDatabase(nssdir=path)
+
+            def _load(nn=nickname, _db=db):
+                return _db.get_cert(nn)
+            return _load
+
+        def _load(_p=path):
+            return x509.load_certificate_from_file(_p)
+        return _load
+
+    def _build_tracking_list(self, certs, ipa_certs, ctx):
+        """Build certmonger tracking criteria for expired certs.
+
+        Skips RA and subsystem certs (handled separately via
+        ``_fetch_certs_from_master``).
+        """
+        tracking = []
+
+        # Shared/replicated certs are fetched from master's LDAP
+        # (cn=ca_renewal), not renewed via certmonger. Only sslserver is
+        # server-specific and needs certmonger resubmit.
+        for certid, cert in certs:
+            if DOGTAG_CERTS[certid].is_shared:
+                logger.debug("Skipping shared cert %s (fetched from LDAP)",
+                             certid)
+                continue
+            ci = DOGTAG_CERTS[certid]
+            logger.debug(
+                "Adding dogtag cert to tracking: %s "
+                "(nickname=%s, serial=%s, expires=%s)",
+                certid, ci.nickname,
+                cert.serial_number, cert.not_valid_after_utc,)
+            tracking.append((
+                ci, cert,
+                {
+                    'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
+                    'cert-nickname': ci.nickname,
+                },
+                self._make_cert_loader(
+                    'NSSDB',
+                    paths.PKI_TOMCAT_ALIAS_DIR,
+                    ci.nickname,),
+            ))
+
+        cert_map = {
+            IPACertType.HTTPS: (
+                {'cert-file': paths.HTTPD_CERT_FILE},
+                self._make_cert_loader('FILE', paths.HTTPD_CERT_FILE),),
+            IPACertType.LDAPS: (
+                {
+                    'cert-database': ctx.ds_dbdir,
+                    'cert-nickname': ctx.ds_nickname,
+                },
+                self._make_cert_loader('NSSDB', ctx.ds_dbdir, ctx.ds_nickname),
+            ),
+            IPACertType.KDC: (
+                {'cert-file': paths.KDC_CERT},
+                self._make_cert_loader('FILE', paths.KDC_CERT),),
+        }
+
+        for certtype, cert in ipa_certs:
+            if certtype is IPACertType.IPARA:
+                logger.debug("Skipping RA cert (already fetched)")
+                continue
+            entry = cert_map.get(certtype)
+            if entry is None:
+                continue
+            criteria, loader = entry
+            logger.debug(
+                "Adding IPA cert to tracking: %s (serial=%s, expires=%s)",
+                certtype.value, cert.serial_number, cert.not_valid_after_utc,
+            )
+            tracking.append((certtype, cert, criteria, loader))
+
+        return tracking
+
+    def _resolve_tracking_requests(self, tracking):
+        """Look up certmonger request IDs for tracked certs."""
+        requests = []
+        for desc, old_cert, criteria, load_renewed in tracking:
+            request_id = self._cm.get_request_id(criteria)
+            if request_id is None:
+                logger.warning(
+                    "No certmonger tracking request found for %s "
+                    "(criteria: %s)", desc, criteria)
+                continue
+            original_ca = self._cm.get_request_value(request_id, 'ca-name')
+            requests.append(
+                (desc, old_cert, request_id, original_ca, load_renewed))
+            logger.debug(
+                "Found tracking request %s for %s (CA: %s)",
+                request_id, desc, original_ca)
+        return requests
 
 
 class DeploymentDetector:

--- a/ipaserver/install/ipa_cert_fix_services.py
+++ b/ipaserver/install/ipa_cert_fix_services.py
@@ -5,10 +5,9 @@
 """
 Service classes and utility functions for ipa-cert-fix.
 
-Currently provides :class:`CertmongerClient` (the certmonger D-Bus adapter)
-and a couple of small helpers shared by the main module.  This module will
-grow as additional scenarios (CA-full replica recovery, external cert
-handling, deployment detection) are added in subsequent commits.
+Contains CertmongerClient, ExternalCertHandler, CertRenewalFromMaster,
+DeploymentDetector, certificate classification functions, and shared
+helper functions.
 """
 
 import base64
@@ -27,30 +26,25 @@ from ipalib.constants import IPA_CA_RECORD
 from ipalib import x509
 from ipalib.install import certmonger
 from ipaplatform.paths import paths
+from ipapython.dogtag import KDC_PROFILE
 from ipapython.certdb import NSSDatabase, EMPTY_TRUST_FLAGS
 from ipapython.dn import DN
-from ipapython.dogtag import KDC_PROFILE
-from ipapython.ipaldap import realm_to_serverid
 from ipapython import directivesetter
 from ipapython import ipautil
-from ipaserver.install import cainstance, dsinstance
+from ipaserver.install import cainstance
 from ipaserver.install.certs import is_ipa_issued_cert
 from ipaserver.masters import find_providing_servers
 
+from ipapython.ipaldap import realm_to_serverid
+from ipaserver.install import dsinstance
+
 from ipaserver.install.ipa_cert_fix_types import (
-    CERT_EXPIRY_LOOKAHEAD,
-    CERTMONGER_WAIT_TIMEOUT,
-    DBUS_RETRY_DELAY,
-    DBUS_RETRY_TIMEOUT,
-    DOGTAG_CERTS,
-    DeploymentType,
-    FixScenario,
-    HELPER_KILL_SETTLE,
-    IPACertType,
+    DOGTAG_CERTS, _CS_CFG_CERT_DIRECTIVES,
+    IPACertType, DeploymentType, FixScenario,
+    CERT_EXPIRY_LOOKAHEAD, CERTMONGER_WAIT_TIMEOUT,
+    DBUS_RETRY_TIMEOUT, DBUS_RETRY_DELAY, HELPER_KILL_SETTLE,
     IPA_SERVICE_PROFILE,
-    _CS_CFG_CERT_DIRECTIVES,
-    _utcnow,
-)
+    _utcnow,)
 
 logger = logging.getLogger(__name__)
 
@@ -126,8 +120,8 @@ def _update_cs_cfg(nickname, cert):
 def _kill_stuck_helpers():
     """Kill running ipa-submit and ipa-server-guard processes.
 
-    Certmonger processes D-Bus requests serially.  If ``ipa-submit`` is
-    running (trying to contact httpd with expired certs), any D-Bus write
+    Certmonger processes D-Bus requests serially.  If ``ipa-submit`` is running
+    (trying to contact httpd with expired certs), any D-Bus write
     (like ``modify_ca_helper``) blocks until the helper times out --
     which can take minutes.
 
@@ -152,37 +146,6 @@ def print_cert_info(context, desc, cert):
     print("  Serial:  {}".format(cert.serial_number))
     print("  Expires: {}".format(cert.not_valid_after_utc))
     print()
-
-
-def get_csr_from_certmonger(nickname):
-    """
-    Get the csr for the provided nickname by asking certmonger.
-
-    :returns: base64-encoded DER as a single ASCII line (no PEM headers,
-        no internal newlines), suitable for writing into pkispawn-style
-        config directives.  Callers that want PEM must wrap it themselves.
-        ``None`` if no tracking request is found or the value cannot be
-        parsed as a CSR.
-    """
-    criteria = {
-        'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
-        'cert-nickname': nickname,
-    }
-
-    id = certmonger.get_request_id(criteria)
-    if id:
-        csr = certmonger.get_request_value(id, "csr")
-        if csr:
-            try:
-                # Make sure the value can be parsed as valid CSR
-                csr_obj = crypto_x509.load_pem_x509_csr(
-                    csr.encode('ascii'), default_backend())
-                val = base64.b64encode(csr_obj.public_bytes(x509.Encoding.DER))
-                return val.decode('ascii')
-            except Exception as e:
-                # Fallthrough and return None
-                logger.debug("Unable to get CSR from certmonger: %s", e)
-    return None
 
 
 class CertmongerClient:
@@ -350,199 +313,11 @@ class CertmongerClient:
         return False
 
 
-def _ensure_ldap_connected():
-    """Ensure the ldap2 backend is connected.
-
-    After operations that restart Directory Server (``ipa-certupdate``,
-    ``ipactl restart``, ``pki-server cert-fix``), the LDAPI socket is
-    recycled and our existing connection becomes a broken pipe.
-    ``isconnected()`` is unreliable in this case -- it may still
-    return ``True`` on the stale socket.
-
-    This function unconditionally disconnects and reconnects to guarantee
-    a live connection.
-    """
-    try:
-        if api.Backend.ldap2.isconnected():
-            api.Backend.ldap2.disconnect()
-    except Exception as e:
-        logger.debug("ldap2 disconnect error (ignored): %s", e)
-    api.Backend.ldap2.connect()
-    logger.debug("ldap2 reconnected")
-
-
-def _check_tcp_reachable(server):
-    """Verify a server is TCP-reachable before using it.
-
-    Performs DNS resolution and a TCP connect to port 443.  This is
-    intentionally TCP-only (no TLS): the local CA trust store may be stale at
-    this point.  TLS verification happens later in ``_check_tls_handshake``
-    after ``ipa-certupdate`` updates the trust store.
-
-    :param server: FQDN to check
-    :raises RuntimeError: if the server is unreachable
-    """
-    logger.debug("Checking reachability of %s", server)
-    try:
-        addrs = socket.getaddrinfo(
-            server, 443, socket.AF_UNSPEC,
-            socket.SOCK_STREAM,)
-    except socket.gaierror as e:
-        raise RuntimeError("Cannot resolve %s: %s" % (server, e))
-
-    for family, socktype, proto, _cn, addr in addrs:
-        s = socket.socket(family, socktype, proto)
-        try:
-            s.settimeout(10)
-            s.connect(addr)
-            logger.debug("TCP connect to %s:%d succeeded", server, 443)
-            return
-        except OSError:
-            continue
-        finally:
-            s.close()
-
-    raise RuntimeError(
-        "Cannot connect to %s on port 443. Verify the server is running "
-        "and network connectivity is available." % server)
-
-
-def _find_current_renewal_master():
-    """Find the current renewal master FQDN.
-
-    :returns: FQDN string, or ``None`` if not found
-    """
-    try:
-        base_dn = DN(api.env.container_masters, api.env.basedn)
-        ldap_filter = ('(&(cn=CA)(ipaConfigString=caRenewalMaster))')
-        entries = api.Backend.ldap2.get_entries(
-            base_dn=base_dn,
-            filter=ldap_filter,
-            attrs_list=[],)
-        if entries:
-            fqdn = entries[0].dn[1].value
-            logger.debug("Current renewal master: %s", fqdn)
-            return fqdn
-    except Exception as e:
-        logger.debug("Cannot determine current renewal master: %s", e)
-    return None
-
-
-def expired_dogtag_certs(now):
-    """Determine which Dogtag certs are expired or close to expiry.
-
-    Return a list of (cert_id, cert) pairs.
-    """
-    certs = []
-    db = _get_pki_nssdb()
-
-    for certid, ci in DOGTAG_CERTS.items():
-        try:
-            cert = db.get_cert(ci.nickname)
-        except RuntimeError:
-            logger.debug("Dogtag cert %s (%s): not found in NSSDB",
-                         certid, ci.nickname)
-        else:
-            if cert.not_valid_after_utc <= now:
-                logger.debug("Dogtag cert %s: EXPIRED (expires %s)",
-                             certid, cert.not_valid_after_utc)
-                certs.append((certid, cert))
-            else:
-                logger.debug("Dogtag cert %s: valid (expires %s)",
-                             certid, cert.not_valid_after_utc)
-
-    return certs
-
-
-def _check_ipa_cert(certtype, cert, now, certs, non_renewed):
-    """Classify an expired IPA cert as IPA-issued or external.
-
-    :param certtype: :class:`IPACertType`
-    :param cert: loaded certificate
-    :param now: expiry threshold
-    :param certs: list to append IPA-issued certs to
-    :param non_renewed: list to append external certs to
-    """
-    if cert.not_valid_after_utc <= now:
-        if not is_ipa_issued_cert(api, cert):
-            logger.debug("IPA cert %s: EXPIRED, external (expires %s)",
-                         certtype.value, cert.not_valid_after_utc)
-            non_renewed.append((certtype, cert))
-        else:
-            logger.debug("IPA cert %s: EXPIRED (expires %s)",
-                         certtype.value, cert.not_valid_after_utc)
-            certs.append((certtype, cert))
-    else:
-        logger.debug("IPA cert %s: valid (expires %s)",
-                     certtype.value, cert.not_valid_after_utc)
-
-
-def expired_ipa_certs(now, ds_dbdir=None, ds_nickname=None):
-    """Determine which IPA certs are expired or close to expiry.
-
-    :param now: datetime threshold
-    :param ds_dbdir: DS NSS database directory (optional, avoids creating a
-        DsInstance if provided)
-    :param ds_nickname: DS server cert nickname (optional)
-    :returns: tuple of ``(certs, non_renewed)``
-    """
-    certs = []
-    non_renewed = []
-
-    # IPA RA (always IPA-issued, no external check)
-    try:
-        cert = x509.load_certificate_from_file(paths.RA_AGENT_PEM)
-        if cert.not_valid_after_utc <= now:
-            logger.debug("IPA cert RA: EXPIRED (expires %s)",
-                         cert.not_valid_after_utc)
-            certs.append((IPACertType.IPARA, cert))
-        else:
-            logger.debug("IPA cert RA: valid (expires %s)",
-                         cert.not_valid_after_utc)
-    except FileNotFoundError:
-        logger.debug("IPA cert RA: not present at %s "
-                     "(expected on CA-less-external deployments)",
-                     paths.RA_AGENT_PEM)
-    except Exception as e:
-        logger.debug("Cannot load RA cert from %s: %s",
-                     paths.RA_AGENT_PEM, e)
-
-    # Apache HTTPD
-    try:
-        cert = x509.load_certificate_from_file(paths.HTTPD_CERT_FILE)
-        _check_ipa_cert(IPACertType.HTTPS, cert, now, certs, non_renewed)
-    except Exception as e:
-        logger.debug("Cannot load HTTP cert from %s: %s",
-                     paths.HTTPD_CERT_FILE, e)
-
-    # LDAPS
-    try:
-        if ds_dbdir is None or ds_nickname is None:
-            serverid = realm_to_serverid(api.env.realm)
-            ds = dsinstance.DsInstance(realm_name=api.env.realm)
-            ds_dbdir = dsinstance.config_dirname(serverid)
-            ds_nickname = ds.get_server_cert_nickname(serverid)
-        db = NSSDatabase(nssdir=ds_dbdir)
-        cert = db.get_cert(ds_nickname)
-        _check_ipa_cert(IPACertType.LDAPS, cert, now, certs, non_renewed)
-    except Exception as e:
-        logger.debug("Cannot load LDAP cert: %s", e)
-
-    # KDC (can be self-signed if PKINIT is disabled)
-    try:
-        cert = x509.load_certificate_from_file(paths.KDC_CERT)
-        _check_ipa_cert(IPACertType.KDC, cert, now, certs, non_renewed)
-    except Exception as e:
-        logger.debug("Cannot load KDC cert from %s: %s", paths.KDC_CERT, e)
-
-    return certs, non_renewed
-
-
 class ExternalCertHandler:
     """Handle expired externally-signed service certificates.
 
-    Offers per-cert transition to the internal IPA CA (interactive) or
-    generates CSRs for manual renewal with the external CA.
+    Offers per-cert transition to the internal IPA CA (interactive)
+    or generates CSRs for manual renewal with the external CA.
 
     Extracted from IPACertFix so the logic can be tested and reused
     independently of the AdminTool lifecycle.
@@ -558,17 +333,17 @@ class ExternalCertHandler:
     def handle(self, ctx):
         """Dispatch external cert handling.
 
-        If an internal CA exists in the topology, offers per-cert transition
-        to the IPA CA via :meth:`offer_transition`.  For remaining certs (or
-        if no CA exists), generates CSRs and prints manual installation
-        instructions via :meth:`generate_csrs`.
+        If an internal CA exists in the topology, offers per-cert transition to
+        the IPA CA via :meth:`offer_transition`. For remaining certs (or if no
+        CA exists), generates CSRs and prints manual installation instructions
+        via :meth:`generate_csrs`.
 
         On ``CA_LESS_EXTERNAL`` deployments (no internal CA anywhere),
         transitions are not possible -- only CSR generation is performed.
 
         :param ctx: :class:`CertFixContext`
-        :returns: ``True`` if any certs were handled (transitioned or CSRs
-            generated), ``False`` if all failed
+        :returns: ``True`` if any certs were handled (transitioned or
+            CSRs generated), ``False`` if all failed
         """
         if not ctx.external_certs:
             return True
@@ -576,6 +351,7 @@ class ExternalCertHandler:
         remaining = list(ctx.external_certs)
         handled = False
 
+        # Only look for CA servers if we might have one
         if ctx.deployment_type != DeploymentType.CA_LESS_EXTERNAL:
             try:
                 ca_servers = find_providing_servers(
@@ -607,15 +383,24 @@ class ExternalCertHandler:
         return handled
 
     def offer_transition(self, external_certs, master, ctx):
-        """Offer to transition external certs to the internal CA.
+        """Offer to transition external certs to internal CA.
 
         Externally-signed certificates typically have no certmonger tracking
         request (tracking is stopped when a cert is installed externally).
-        To transition, we stop any existing tracking, create a new tracking
-        request with the correct IPA parameters, optionally override the IPA
-        CA helper to point at *master*, and wait for renewal.
+
+        To transition, we:
+        1. Stop any existing tracking for the cert
+        2. Create a new tracking request with the correct IPA parameters
+            (CA, profile, post-save command)
+        3. If a master server is available, temporarily override the IPA CA
+            helper to point at it
+        4. Wait for certmonger to obtain the new cert
 
         In unattended mode, no transitions are offered.
+
+        :param external_certs: list of ``(IPACertType, cert)``
+        :param master: FQDN of a working CA server
+        :returns: set of :class:`IPACertType` values that were transitioned
         """
         if self._unattended:
             logger.info(
@@ -645,12 +430,24 @@ class ExternalCertHandler:
         return transitioned
 
     def _transition_cert(self, certtype, cert, master, ctx):
-        """Transition a single cert to the internal IPA CA."""
+        """Transition a single cert to the internal IPA CA.
+
+        Stops any existing tracking, creates a new tracking request with
+        correct IPA parameters, and waits for renewal. If *master* is set, the
+        IPA CA helper is temporarily overridden to reach the master.
+
+        :param certtype: :class:`IPACertType` value
+        :param cert: the expired certificate object
+        :param master: FQDN of a working CA server, or None
+        :param ctx: :class:`CertFixContext`
+        :raises RuntimeError: on failure
+        """
         params = self._tracking_params(certtype, ctx)
         if params is None:
             raise RuntimeError(
                 "No tracking parameters for %s" % certtype.value)
 
+        # Stop existing tracking (if any)
         criteria = self._cert_criteria(certtype, ctx)
         if criteria:
             old_id = self._cm.get_request_id(criteria)
@@ -663,6 +460,8 @@ class ExternalCertHandler:
         print("  Creating IPA tracking request for %s..." % certtype.value)
         logger.debug("Tracking params for %s: %s", certtype.value, params)
 
+        # Create tracking -- certmonger will immediately attempt renewal.
+        # If we have a master, override the IPA CA helper first.
         if master:
             if not self._cm.is_responsive():
                 raise RuntimeError(
@@ -689,7 +488,12 @@ class ExternalCertHandler:
                 % (certtype.value, state, ca_error))
 
     def _create_tracking(self, certtype, params):
-        """Create a certmonger tracking request."""
+        """Create a certmonger tracking request.
+
+        :param certtype: :class:`IPACertType` value
+        :param params: dict from :meth:`_tracking_params`
+        :returns: certmonger request ID (nickname)
+        """
         request_id = self._cm.start_tracking(
             certpath=params['certpath'],
             ca=params['ca'],
@@ -715,8 +519,16 @@ class ExternalCertHandler:
         """Return certmonger tracking parameters for a cert.
 
         These mirror the parameters used during IPA server installation.
+        See ``httpinstance.py``, ``dsinstance.py``, and ``krbinstance.py``.
+
+        :param certtype: :class:`IPACertType` value
+        :param ctx: :class:`CertFixContext` with DS info
+        :returns: dict of tracking parameters, or ``None``
         """
         subject = str(DN(('CN', api.env.host), ctx.subject_base))
+        # IPA service certs (HTTP, LDAP, KDC) always use the internal NSSDB
+        # token, even on HSM deployments. Only Dogtag subsystem certs use the
+        # HSM token, and those go through _build_tracking_list, not here.
 
         if certtype is IPACertType.HTTPS:
             passwd_file = (
@@ -771,12 +583,18 @@ class ExternalCertHandler:
     def generate_csrs(self, external_certs, ctx):
         """Generate CSR files for externally-signed certificates.
 
-        For each expired external cert, tries three sources for a CSR:
+        For each expired external cert, tries three sources for a
+        CSR:
 
         1. Extract existing CSR from certmonger tracking
-        2. Generate a new CSR from the existing private key and the expired
-           cert's subject/SANs
+        2. Generate a new CSR from the existing private key and the
+           expired cert's subject/SANs
         3. Fall back to manual instructions
+
+        CSRs are written to :attr:`_csr_dir` (under ``/run/ipa``, a
+        root-owned tmpfs).
+
+        :param external_certs: list of ``(IPACertType, cert)``
         """
         csr_dir = self._csr_dir
         os.makedirs(csr_dir, mode=0o700, exist_ok=True)
@@ -788,8 +606,10 @@ class ExternalCertHandler:
                 csr_dir, '%s.csr'
                 % certtype.value.lower().replace(' ', '-'))
 
+            # Try 1: extract from certmonger
             csr_pem = self._get_csr_from_tracking(certtype, ctx)
 
+            # Try 2: generate from existing key + cert
             if csr_pem is None:
                 csr_pem = self._generate_csr_from_key(certtype, cert, ctx)
 
@@ -851,7 +671,12 @@ class ExternalCertHandler:
             return False
 
     def _get_csr_from_tracking(self, certtype, ctx):
-        """Try to extract a CSR from certmonger tracking."""
+        """Try to extract a CSR from certmonger tracking.
+
+        :param certtype: :class:`IPACertType`
+        :param ctx: :class:`CertFixContext`
+        :returns: PEM-encoded CSR string, or ``None``
+        """
         criteria = self._cert_criteria(certtype, ctx)
         if criteria is None:
             return None
@@ -869,8 +694,17 @@ class ExternalCertHandler:
     def _generate_csr_from_key(self, certtype, cert, ctx):
         """Generate a CSR from the existing private key.
 
-        Uses the subject and SANs from the expired certificate to build a
-        new CSR signed with the existing private key.
+        Uses the subject and SANs from the expired certificate to
+        build a new CSR signed with the existing private key.
+
+        For NSSDB-based certs (LDAP), uses ``certutil -R``.
+        For file-based certs (HTTP, KDC), uses the ``cryptography``
+        library.
+
+        :param certtype: :class:`IPACertType`
+        :param cert: the expired certificate object
+        :param ctx: :class:`CertFixContext`
+        :returns: PEM-encoded CSR string, or ``None``
         """
         from cryptography.exceptions import (UnsupportedAlgorithm)
         from cryptography.hazmat.primitives import (hashes, serialization)
@@ -882,6 +716,7 @@ class ExternalCertHandler:
         if params['storage'] == 'NSSDB':
             return self._generate_csr_nssdb(certtype, cert, params)
 
+        # FILE-based: load private key and build CSR
         certpath = params['certpath']
         _cert_file, key_file = certpath
 
@@ -895,8 +730,10 @@ class ExternalCertHandler:
             return None
 
         try:
+            # Try unencrypted first
             key = serialization.load_pem_private_key(key_pem, password=None)
         except (ValueError, TypeError, UnsupportedAlgorithm):
+            # Try with pin file
             pinfile = params.get('pinfile')
             if pinfile:
                 try:
@@ -918,6 +755,7 @@ class ExternalCertHandler:
         builder = crypto_x509.CertificateSigningRequestBuilder()
         builder = builder.subject_name(cert.subject)
 
+        # Copy SANs from expired cert if present
         try:
             san = cert.extensions.get_extension_for_class(
                 crypto_x509.SubjectAlternativeName)
@@ -935,18 +773,34 @@ class ExternalCertHandler:
 
     @staticmethod
     def _generate_csr_nssdb(certtype, cert, params):
-        """Generate a CSR from an NSSDB private key."""
+        """Generate a CSR from an NSSDB private key.
+
+        Extracts the hex key ID via ``certutil -K`` and uses
+        ``certutil -R -k <key-id>`` to generate a CSR reusing the
+        existing private key.  Returns ``None`` if the key ID cannot
+        be determined.
+
+        Supports HSM tokens via the ``token`` key in *params*.
+
+        :param certtype: :class:`IPACertType`
+        :param cert: the expired certificate (for subject)
+        :param params: tracking params with db path/nickname
+        :returns: PEM-encoded CSR string, or ``None``
+        """
         dbdir = params['certpath']
         nickname = params.get('nickname')
         pinfile = params.get('pinfile')
         token = params.get('token')
         subject = str(DN(cert.subject))
 
+        # Try to find the existing key ID so we can reuse it. certutil -R -k
+        # accepts a hex key ID, not a cert nickname.
         key_id = None
         if nickname:
             key_id = ExternalCertHandler._get_nssdb_key_id(
                 dbdir, nickname, pinfile, token)
 
+        # ASCII/PEM output
         cmd = ['certutil', '-R', '-d', dbdir, '-s', subject, '-a']
         if token:
             cmd.extend(['-h', token])
@@ -960,6 +814,7 @@ class ExternalCertHandler:
         if pinfile:
             cmd.extend(['-f', pinfile])
 
+        # Add SANs if present in expired cert
         try:
             san = cert.extensions.get_extension_for_class(
                 crypto_x509.SubjectAlternativeName)
@@ -972,6 +827,8 @@ class ExternalCertHandler:
         try:
             result = ipautil.run(cmd, capture_output=True)
             csr_pem = result.output
+            # certutil may include extra output before the PEM block;
+            # extract just the CSR
             begin = csr_pem.find('-----BEGIN CERTIFICATE REQUEST')
             if begin >= 0:
                 csr_pem = csr_pem[begin:]
@@ -981,13 +838,23 @@ class ExternalCertHandler:
             return csr_pem
         except Exception as e:
             logger.warning(
-                "certutil CSR generation failed for %s: %s",
-                certtype.value, e)
+                "certutil CSR generation failed for %s: %s", certtype.value, e)
             return None
 
     @staticmethod
     def _get_nssdb_key_id(dbdir, nickname, pinfile=None, token=None):
-        """Extract the hex key ID for a cert from NSSDB."""
+        """Extract the hex key ID for a cert from NSSDB.
+
+        Uses ``certutil -K`` to list all keys and finds the one whose line
+        contains *nickname*.
+
+        :param dbdir: NSS database directory
+        :param nickname: cert nickname
+        :param pinfile: password file path
+        :param token: HSM token name, or ``None`` for
+            internal token
+        :returns: hex key ID string, or ``None``
+        """
         cmd = ['certutil', '-K', '-d', dbdir]
         if token:
             cmd.extend(['-h', token])
@@ -1000,7 +867,13 @@ class ExternalCertHandler:
             logger.debug("certutil -K failed for %s: %s", nickname, e)
             return None
 
-        # Output format: < 0> rsa <hex-key-id> <token>:<nickname>
+        # Output format (real example): < 0> rsa e025e8... NSS Certificate
+        # DB:Server-Cert
+        #
+        # Fields: < N> type hex-key-id token:nickname Split on whitespace
+        # gives:
+        #   ['<', '0>', 'rsa', 'e025e8...', 'NSS', ...]
+        # The hex key ID is a 40-char hex string.
         hex_re = re.compile(r'^[0-9a-fA-F]{16,}$')
 
         for line in result.output.splitlines():
@@ -1020,7 +893,12 @@ class ExternalCertHandler:
 
     @staticmethod
     def _cert_criteria(certtype, ctx):
-        """Return certmonger search criteria for a cert type."""
+        """Return certmonger search criteria for a cert type.
+
+        :param certtype: :class:`IPACertType` value
+        :param ctx: :class:`CertFixContext` with DS info
+        :returns: dict of certmonger search criteria, or ``None`` if unknown
+        """
         if certtype is IPACertType.HTTPS:
             return {'cert-file': paths.HTTPD_CERT_FILE}
         elif certtype is IPACertType.KDC:
@@ -1048,7 +926,8 @@ class CertRenewalFromMaster:
     """Renew expired certificates via certmonger pointed at a master.
 
     Manages the IPA CA helper override, per-request CA/profile switching, and
-    cleanup.  Used by the CA-full and CA-less replica recovery scenarios.
+    cleanup.  Temporal coupling eliminated: _original_principals and
+    _original_profiles are initialized in __init__, not lazily.
     """
 
     def __init__(self, cm_client, master_server):
@@ -1071,9 +950,11 @@ class CertRenewalFromMaster:
         """Restore the IPA CA helper to its original value.
 
         Retries for *timeout* seconds if certmonger's D-Bus is temporarily
-        unreachable (e.g., being restarted by a post-save command).
+        unreachable (e.g., being restarted by a post-save command). This is
+        postcondition P1 -- the invariant the tool must guarantee.
 
-        :param old_helper: value returned by :meth:`_set_helper`
+        :param old_helper: value returned by
+            :meth:`_set_helper`
         :param timeout: max seconds to retry
         """
         logger.debug("Restoring IPA CA helper to: %s", old_helper)
@@ -1101,34 +982,54 @@ class CertRenewalFromMaster:
                 time.sleep(delay)
 
     def _resubmit(
-        self, desc, old_cert, request_id, original_ca, load_renewed,
+        self, desc, old_cert, request_id, original_ca,
+        load_renewed,
     ):
         """Resubmit a single cert's tracking request via master.
 
         Handles the Dogtag-vs-IPA distinction: Dogtag certs need their CA
-        switched to IPA, a host principal added, and the profile overridden
-        to ``caIPAserviceCert``.
+        switched to IPA, a host principal added, and the profile overridden to
+        ``caIPAserviceCert``.
 
         Mutates ``self._original_principals`` and ``self._original_profiles``
         for later cleanup by :meth:`_restore`.
+
+        :param desc: cert descriptor (str or IPACertType)
+        :param old_cert: the expired certificate object
+        :param request_id: certmonger request ID
+        :param original_ca: original ``ca-name`` value
+        :param load_renewed: callable returning renewed cert
         """
         desc_str = getattr(desc, 'display_name',
                            getattr(desc, 'value', str(desc)))
         print("\n  Renewing %s (request %s)..." % (desc_str, request_id))
 
+        # Kill any stuck ipa-submit helpers from a previous cert's renewal.
+        # Certmonger can't process D-Bus calls while a helper is running.
         _kill_stuck_helpers()
 
+        # Skip if cert was already renewed (e.g. by certmonger autonomously
+        # after a service restart triggered by ipa-certupdate).
         if self._cm.is_cert_valid(request_id):
             print("  %s already has a valid cert, skipping." % desc_str)
             return
 
         print_cert_info("  Old", desc_str, old_cert)
 
+        # Dogtag certs (sslserver, audit, etc.) need:
+        # - CA switched from dogtag-ipa-ca-renew-agent to IPA
+        # - template-principal set (ipa-submit requires it)
+        # - profile overridden (host principal lacks CA ACL for dogtag profiles
+        #   like caServerCert)
         is_dogtag = getattr(desc, 'is_dogtag', False)
         override_profile = None
 
         if is_dogtag:
             host_principal = 'host/%s@%s' % (api.env.host, api.env.realm)
+            # Save original values BEFORE modifying. If the save fails (D-Bus
+            # timeout), the modify also won't run, so nothing needs restoring.
+            # If the modify fails after the save, _restore will find the saved
+            # value.
             orig = self._cm.get_request_value(request_id, 'template-principal')
             self._original_principals[request_id] = orig
             logger.debug(
@@ -1145,6 +1046,7 @@ class CertRenewalFromMaster:
                     "Overriding profile on request %s: %s -> %s",
                     request_id, original_profile, override_profile)
 
+        # Log current helper and request state for debugging
         try:
             current_ca = self._cm.get_request_value(request_id, 'ca-name')
             logger.debug("Request %s current CA: %s", request_id, current_ca)
@@ -1181,6 +1083,9 @@ class CertRenewalFromMaster:
                 "Certmonger request %s for %s failed: state=%s, ca-error=%s"
                 % (request_id, desc_str, state, ca_error))
 
+        # After MONITORING, certmonger runs post-save commands (e.g.
+        # renew_ca_cert which may restart PKI). Wait for certmonger to finish
+        # and become D-Bus responsive before proceeding to the next cert.
         if not self._cm.is_responsive():
             raise RuntimeError(
                 "certmonger did not become responsive after renewing %s"
@@ -1210,6 +1115,12 @@ class CertRenewalFromMaster:
 
         Restores the original CA name, profile, and removes any temporary
         principal that was added for Dogtag cert renewal through the IPA CA.
+
+        Uses ``self._original_principals`` and ``self._original_profiles``
+        populated by :meth:`_resubmit`.
+
+        :param request_id: certmonger request ID
+        :param original_ca: original ``ca-name`` to restore
         """
         try:
             current_ca = self._cm.get_request_value(request_id, 'ca-name')
@@ -1228,6 +1139,7 @@ class CertRenewalFromMaster:
         if request_id in self._original_principals:
             orig = self._original_principals[request_id]
             if orig:
+                # Restore the original principals
                 try:
                     logger.debug(
                         "Restoring template-principal on request %s to %s",
@@ -1239,6 +1151,10 @@ class CertRenewalFromMaster:
                         "Failed to restore principal on request %s: %s",
                         request_id, e)
             else:
+                # Original had no principals. Certmonger's modify() does not
+                # accept an empty array for template-principal, but the added
+                # principal is harmless -- certmonger ignores it once the cert
+                # is in MONITORING state.
                 logger.debug(
                     "Request %s had no original principals, "
                     "skipping principal removal (harmless)",
@@ -1247,13 +1163,12 @@ class CertRenewalFromMaster:
     def renew(self, certs, ipa_certs, ctx):
         """Renew expired certificates from a master via certmonger.
 
-        Builds tracking criteria for each expired cert, temporarily overrides
-        the IPA CA helper to point at the master, resubmits each request, and
-        restores all certmonger state afterward.
+        Builds tracking criteria for each expired cert, temporarily
+        overrides the IPA CA helper to point at the master, resubmits
+        each request, and restores all certmonger state afterward.
 
         :param certs: list of ``(certid, cert)`` for Dogtag certs
-        :param ipa_certs: list of ``(IPACertType, cert)`` for IPA service
-            certs
+        :param ipa_certs: list of ``(IPACertType, cert)`` for IPA service certs
         :param ctx: :class:`CertFixContext`
         :returns: set of renewed request IDs
         """
@@ -1269,8 +1184,14 @@ class CertRenewalFromMaster:
             print("No certmonger tracking requests found.")
             return set()
 
+        # Kill any running ipa-submit helpers before modifying the CA helper.
+        # Certmonger processes D-Bus requests serially -- if ipa-submit is
+        # running (trying to contact httpd with expired certs), D-Bus Set calls
+        # will block until it times out. Killing the helpers makes certmonger
+        # responsive immediately.
         _kill_stuck_helpers()
 
+        # _set_helper has its own D-Bus retry loop
         old_helper = self._set_helper()
 
         failed = []
@@ -1279,6 +1200,10 @@ class CertRenewalFromMaster:
             print("Renewing certificates from %s" % self._master)
             for (desc, old_cert, request_id,
                  original_ca, load_renewed) in requests:
+                # Kill any helpers certmonger may have respawned after we
+                # installed shared certs into the NSSDB. Without this,
+                # certmonger D-Bus is blocked by ipa-submit processes that it
+                # launched in response to the NSSDB changes.
                 _kill_stuck_helpers()
                 try:
                     self._resubmit(
@@ -1292,6 +1217,9 @@ class CertRenewalFromMaster:
                     print("  ERROR: %s failed: %s" % (desc_str, e))
                     failed.append(desc_str)
         finally:
+            # Restore per-request state (CA name, profile, principal), then the
+            # global helper. Each call is guarded so one failure doesn't skip
+            # the rest or prevent helper restoration (P1).
             for (_desc, _cert, request_id,
                  original_ca, _load) in requests:
                 try:
@@ -1333,7 +1261,13 @@ class CertRenewalFromMaster:
         """Build certmonger tracking criteria for expired certs.
 
         Skips RA and subsystem certs (handled separately via
-        ``_fetch_certs_from_master``).
+        :meth:`_fetch_certs_from_master`).
+
+        :param certs: Dogtag certs ``[(certid, cert), ...]``
+        :param ipa_certs: IPA certs
+            ``[(IPACertType, cert), ...]``
+        :param ctx: :class:`CertFixContext` with DS info
+        :returns: list of ``(desc, cert, criteria, load_fn)``
         """
         tracking = []
 
@@ -1396,7 +1330,12 @@ class CertRenewalFromMaster:
         return tracking
 
     def _resolve_tracking_requests(self, tracking):
-        """Look up certmonger request IDs for tracked certs."""
+        """Look up certmonger request IDs for tracked certs.
+
+        :param tracking: list from :meth:`_build_tracking_list`
+        :returns: list of ``(desc, cert, request_id,
+            original_ca, load_fn)``
+        """
         requests = []
         for desc, old_cert, criteria, load_renewed in tracking:
             request_id = self._cm.get_request_id(criteria)
@@ -1417,9 +1356,8 @@ class CertRenewalFromMaster:
 class DeploymentDetector:
     """Detection, classification, and scenario routing.
 
-    Determines the deployment type, classifies expired certificates,
-    validates the CA chain, detects RA/subsystem LDAP mismatches, and
-    routes to the appropriate fix scenario.
+    Determines the deployment type, classifies expired certificates, detects
+    RA/subsystem LDAP mismatches, and routes to the appropriate fix scenario.
     """
 
     CA_SIGNING_MIN_VALIDITY = datetime.timedelta(days=30)
@@ -1505,8 +1443,8 @@ class DeploymentDetector:
         Wraps :func:`expired_dogtag_certs` and :func:`expired_ipa_certs`,
         then re-classifies certs that are not IPA-issued as external.
 
-        For CA-less deployments, Dogtag certs are skipped (the NSS database
-        does not exist).
+        For CA-less deployments, Dogtag certs are skipped
+        (the NSS database does not exist).
 
         :param now: datetime threshold for expiry check
         :param ds_dbdir: DS NSS database directory
@@ -1531,9 +1469,11 @@ class DeploymentDetector:
         """Verify the CA signing certificate has enough validity.
 
         The caSigningCert must have at least one month of remaining validity
-        for ``pki-server cert-fix`` to succeed.  If it is expired or near
-        expiry, prints guidance to use ``ipa-cacert-manage`` and returns
+        for ``pki-server cert-fix`` to succeed. If it is expired or
+        near expiry, prints guidance to use ``ipa-cacert-manage`` and returns
         ``False``.
+
+        :returns: ``True`` if validity is sufficient, ``False`` otherwise
         """
         db = _get_pki_nssdb()
         try:
@@ -1560,12 +1500,15 @@ class DeploymentDetector:
     def _verify_ca_chain_valid(master_server):
         """Verify the CA trust chain is valid after ipa-certupdate.
 
-        Reads ``/etc/ipa/ca.crt``, finds the IPA issuing CA cert, then
-        walks up the chain of trust to a self-signed root.  Every cert in
-        that path must not be expired.
+        Reads ``/etc/ipa/ca.crt``, finds the IPA issuing CA cert (matching
+        caSigningCert from local PKI, or the first cert in the file for
+        CA-less), then walks up the chain of trust to a self-signed root.
+        Every cert in that path must not be expired.  Other certs in the file
+        (old cross-signed, renewed) are ignored.
 
-        :raises RuntimeError: if the chain file is missing/empty or the
-            trust path contains an expired certificate
+        :param master_server: FQDN (for error messages)
+        :raises RuntimeError: if the chain file is missing, empty,
+            or the trust path contains an expired certificate
         """
         try:
             certs = x509.load_certificate_list_from_file(paths.IPA_CA_CRT)
@@ -1577,12 +1520,14 @@ class DeploymentDetector:
             raise RuntimeError("CA chain not available: %s" % e)
 
         if not certs:
-            raise RuntimeError(
-                "CA chain file %s is empty after ipa-certupdate"
-                % paths.IPA_CA_CRT)
+            raise RuntimeError("CA chain file %s is empty after ipa-certupdate"
+                               % paths.IPA_CA_CRT)
 
-        # Build a subject->cert map; prefer the latest notAfter when there
-        # are multiple certs with the same subject.
+        # Build a subject->cert map for chain walking. ca.crt may contain both
+        # old and renewed CA certs with the same subject DN (normal after CA
+        # renewal). Prefer the one with the latest notAfter so we don't reject
+        # a valid chain because the expired copy happens to come last in the
+        # file.
         by_subject = {}
         for cert in certs:
             subj = DN(cert.subject)
@@ -1592,8 +1537,9 @@ class DeploymentDetector:
                     > existing.not_valid_after_utc):
                 by_subject[subj] = cert
 
-        # Find the IPA issuing CA.  On CA-full, its subject matches
-        # caSigningCert.  On CA-less, use the first cert in the file.
+        # Find the IPA issuing CA. On CA-full, its subject matches
+        # caSigningCert. On CA-less, use the first cert in the file
+        # (ipa-certupdate writes the issuing CA first).
         issuing_cert = None
         try:
             db = _get_pki_nssdb()
@@ -1604,6 +1550,7 @@ class DeploymentDetector:
         if issuing_cert is None:
             issuing_cert = certs[0]
 
+        # Walk up the trust chain from issuing CA to root
         now = _utcnow()
         visited = set()
         current = issuing_cert
@@ -1620,10 +1567,12 @@ class DeploymentDetector:
                     % (subj, master_server,
                        current.not_valid_after_utc, master_server))
 
+            # Self-signed root -- chain is complete
             issuer = DN(current.issuer)
             if issuer == subj:
                 break
 
+            # Walk to issuer
             current = by_subject.get(issuer)
             if current is None:
                 raise RuntimeError(
@@ -1637,7 +1586,11 @@ class DeploymentDetector:
                      master_server, len(visited))
 
     def _warn_ca_chain_near_expiry(self):
-        """Advisory: warn if any CA cert in the local chain is near expiry."""
+        """Advisory: warn if any CA cert in the local chain is near expiry.
+
+        Reads ``/etc/ipa/ca.crt`` and checks each cert against
+        :attr:`CA_SIGNING_MIN_VALIDITY`. Prints a warning but does not fail.
+        """
         try:
             chain = x509.load_certificate_list_from_file(paths.IPA_CA_CRT)
         except Exception:
@@ -1664,6 +1617,9 @@ class DeploymentDetector:
         For externally-signed CA deployments, extracts the existing CSR from
         certmonger and writes it to ``/var/lib/ipa/ca.csr``, then prints
         instructions for submitting it to the external CA.
+
+        :param deployment_type: :class:`DeploymentType` value
+        :returns: exit code (always 1 -- manual action required)
         """
         if deployment_type in (
             DeploymentType.CA_LESS,
@@ -1675,6 +1631,7 @@ class DeploymentDetector:
                 % deployment_type.value)
 
         ca_nickname = DOGTAG_CERTS['ca_issuing'].nickname
+
         days = self.CA_SIGNING_MIN_VALIDITY.days
 
         if deployment_type == DeploymentType.CA_SELF_SIGNED:
@@ -1685,6 +1642,7 @@ class DeploymentDetector:
                 "to renew the CA certificate, then retry ipa-cert-fix." % days)
             return 1
 
+        # Externally-signed CA: extract CSR and guide user
         print(
             "The CA signing certificate is expired or will expire within "
             "the next %d days.\n\n"
@@ -1701,8 +1659,8 @@ class DeploymentDetector:
                 "and submit it to your external CA.")
             return 1
 
-        # get_csr_from_certmonger returns base64-encoded DER as a single
-        # line.  Re-wrap to 64-char PEM body and add headers.
+        # get_csr_from_certmonger returns base64-encoded DER as a single line.
+        # Re-wrap to 64-char PEM body and add headers.
         csr_path = paths.IPA_CA_CSR
         try:
             wrapped = '\n'.join(
@@ -1741,9 +1699,15 @@ class DeploymentDetector:
         For each cert, finds the **newest** cert among local (FS/NSSDB) and
         LDAP blobs.  The newest is authoritative:
             - If local is older, local needs updating.
-            - If LDAP is missing the newest cert or the description serial
-              is wrong, LDAP needs updating.
+            - If LDAP is missing the newest cert or the description serial is
+        wrong, LDAP needs updating.
+
+        :param skip_ra: skip RA check (will be fetched from master)
+        :param skip_subsystem: skip subsystem check (will be fetched)
+        :returns: list of mismatch dicts, empty if consistent
         """
+        # Each check: (label, local_cert, dn, local_path_info) local_path_info:
+        # ('file', path) or ('nssdb', dbdir, nick)
         checks = []
 
         if not skip_ra:
@@ -1786,22 +1750,28 @@ class DeploymentDetector:
 
             ldap_certs = entry.get('userCertificate', [])
 
+            # Find the newest cert among local + LDAP
             all_certs = list(ldap_certs) + [local_cert]
             newest = max(all_certs, key=lambda c: c.not_valid_after_utc)
 
             newest_der = newest.public_bytes(x509.Encoding.DER)
             local_der = local_cert.public_bytes(x509.Encoding.DER)
 
+            # Is local cert the newest?
             update_local = (local_der != newest_der)
+            # Does LDAP have the newest cert?
             ldap_has_newest = any(
                 c.public_bytes(x509.Encoding.DER) == newest_der
                 for c in ldap_certs)
+            # Does description match newest cert?
             expected_desc = '2;%d;%s;%s' % (
                 newest.serial_number,
                 DN(newest.issuer), DN(newest.subject))
             try:
                 current_desc = entry.single_value.get('description', '')
             except ValueError:
+                # Multi-valued description (e.g. after interrupted pki-server
+                # cert-fix). Needs replacing.
                 current_desc = None
             update_desc = (current_desc != expected_desc)
 
@@ -1859,6 +1829,7 @@ class DeploymentDetector:
             dn = m['dn']
             entry = m['entry']
 
+            # Update local cert if LDAP has a newer one
             if m['update_local']:
                 path_info = m['path_info']
                 if path_info[0] == 'file':
@@ -1871,6 +1842,7 @@ class DeploymentDetector:
                     _replace_cert_in_nssdb(db, path_info[2], newest)
                     print("  Updated local %s in NSSDB" % label)
 
+            # Update LDAP entry
             ldap_changed = False
             if m['update_ldap_cert']:
                 entry['userCertificate'].append(newest)
@@ -1898,15 +1870,12 @@ class DeploymentDetector:
         :param deployment_type: :class:`DeploymentType` value
         :returns: tuple of ``(FixScenario, master_server_or_None)``
         """
-        opt_renewal_master = getattr(self.options, 'renewal_master', False)
-        opt_force_server = getattr(self.options, 'force_server', None)
-
         # CA-less paths
         if deployment_type in (
             DeploymentType.CA_LESS,
             DeploymentType.CA_LESS_EXTERNAL,
         ):
-            if opt_renewal_master:
+            if self.options.renewal_master:
                 raise RuntimeError(
                     "--renewal-master cannot be used on a CA-less replica "
                     "(no local CA to become renewal master of).")
@@ -1914,6 +1883,7 @@ class DeploymentDetector:
                 return FixScenario.EXTERNAL_CERTS, None
             master = self.get_master_server()
             if master is None:
+                # CA servers exist but user didn't select one.
                 raise RuntimeError(
                     "No server was selected. Re-run with "
                     "--force-server=<FQDN> to renew certificates "
@@ -1922,8 +1892,8 @@ class DeploymentDetector:
 
         # CA-full paths
         is_rm = self.check_is_renewal_master()
-        if opt_renewal_master or is_rm:
-            if opt_force_server and is_rm:
+        if self.options.renewal_master or is_rm:
+            if self.options.force_server and is_rm:
                 print(
                     "WARNING: --force-server ignored -- this server is the "
                     "renewal master and will use the renewal master fix path.")
@@ -1942,7 +1912,7 @@ class DeploymentDetector:
         """Check if the current server is the renewal master.
 
         Uses LDAP via LDAPI (unix socket) which works even when TLS
-        certificates are expired.
+            certificates are expired.
 
         :returns: ``True`` if this server is the renewal master,
             ``False`` otherwise
@@ -1970,16 +1940,14 @@ class DeploymentDetector:
 
         1. ``--force-server`` CLI option
         2. Interactive prompt (default from LDAP if any)
-        3. ``None`` if no server selected (caller decides whether to fall
-           back to promote or external path)
+        3. ``None`` if no server selected (caller decides
+           whether to fall back to promote or external path)
 
         :returns: FQDN string, or ``None``
         """
-        opt_force_server = getattr(self.options, 'force_server', None)
-        opt_unattended = getattr(self.options, 'unattended', False)
-
-        if opt_force_server:
-            server = opt_force_server
+        if self.options.force_server:
+            server = self.options.force_server
+            # Self-check already done in run() before reaching here.
             _check_tcp_reachable(server)
             logger.info("Using server from --force-server: %s", server)
             return server
@@ -2015,7 +1983,7 @@ class DeploymentDetector:
 
         # In unattended mode, use the default server if found, otherwise fall
         # back to the destructive path.
-        if opt_unattended:
+        if self.options.unattended:
             if default_server:
                 logger.info("Unattended mode: using server %s", default_server)
                 return default_server
@@ -2049,10 +2017,232 @@ class DeploymentDetector:
                 logger.debug("User selected master server: %s", server)
                 return server
 
-            # User chose empty -- fall back
+            # User chose empty — fall back
             break
 
-        # No server selected -- caller decides whether to fall back to the
+        # No server selected — caller decides whether to fall back to the
         # promote/external path.
         logger.info("No master server selected")
         return None
+
+
+def _ensure_ldap_connected():
+    """Ensure the ldap2 backend is connected.
+
+    After operations that restart Directory Server (``ipa-certupdate``,
+    ``ipactl restart``, ``pki-server cert-fix``), the LDAPI socket is
+    recycled and our existing connection becomes a broken pipe.
+    ``isconnected()`` is unreliable in this case -- it may still
+    return ``True`` on the stale socket.
+
+    This function unconditionally disconnects and reconnects to guarantee
+    a live connection.
+    """
+    try:
+        if api.Backend.ldap2.isconnected():
+            api.Backend.ldap2.disconnect()
+    except Exception as e:
+        logger.debug("ldap2 disconnect error (ignored): %s", e)
+    api.Backend.ldap2.connect()
+    logger.debug("ldap2 reconnected")
+
+
+def _check_tcp_reachable(server):
+    """Verify a server is TCP-reachable before using it.
+
+    Performs DNS resolution and a TCP connect to port 443.  This is
+    intentionally TCP-only (no TLS): the local CA trust store may be stale at
+    this point.  TLS verification happens later in ``_check_tls_handshake``
+    after ``ipa-certupdate`` updates the trust store.
+
+    :param server: FQDN to check
+    :raises RuntimeError: if the server is unreachable
+    """
+    logger.debug("Checking reachability of %s", server)
+    try:
+        addrs = socket.getaddrinfo(
+            server, 443, socket.AF_UNSPEC,
+            socket.SOCK_STREAM,)
+    except socket.gaierror as e:
+        raise RuntimeError("Cannot resolve %s: %s" % (server, e))
+
+    for family, socktype, proto, _cn, addr in addrs:
+        s = socket.socket(family, socktype, proto)
+        try:
+            s.settimeout(10)
+            s.connect(addr)
+            logger.debug("TCP connect to %s:%d succeeded", server, 443)
+            return
+        except OSError:
+            continue
+        finally:
+            s.close()
+
+    raise RuntimeError(
+        "Cannot connect to %s on port 443. Verify the server is running "
+        "and network connectivity is available." % server)
+
+
+def _find_current_renewal_master():
+    """Find the current renewal master FQDN.
+
+    :returns: FQDN string, or ``None`` if not found
+    """
+    try:
+        base_dn = DN(api.env.container_masters, api.env.basedn)
+        ldap_filter = ('(&(cn=CA)(ipaConfigString=caRenewalMaster))')
+        entries = api.Backend.ldap2.get_entries(
+            base_dn=base_dn,
+            filter=ldap_filter,
+            attrs_list=[],)
+        if entries:
+            fqdn = entries[0].dn[1].value
+            logger.debug("Current renewal master: %s", fqdn)
+            return fqdn
+    except Exception as e:
+        logger.debug("Cannot determine current renewal master: %s", e)
+    return None
+
+
+def expired_dogtag_certs(now):
+    """
+    Determine which Dogtag certs are expired, or close to expiry.
+
+    Return a list of (cert_id, cert) pairs.
+
+    """
+    certs = []
+    db = _get_pki_nssdb()
+
+    for certid, ci in DOGTAG_CERTS.items():
+        try:
+            cert = db.get_cert(ci.nickname)
+        except RuntimeError:
+            logger.debug("Dogtag cert %s (%s): not found in NSSDB",
+                         certid, ci.nickname)
+        else:
+            if cert.not_valid_after_utc <= now:
+                logger.debug("Dogtag cert %s: EXPIRED (expires %s)",
+                             certid, cert.not_valid_after_utc)
+                certs.append((certid, cert))
+            else:
+                logger.debug("Dogtag cert %s: valid (expires %s)",
+                             certid, cert.not_valid_after_utc)
+
+    return certs
+
+
+def _check_ipa_cert(certtype, cert, now, certs, non_renewed):
+    """Classify an expired IPA cert as IPA-issued or external.
+
+    :param certtype: :class:`IPACertType`
+    :param cert: loaded certificate
+    :param now: expiry threshold
+    :param certs: list to append IPA-issued certs to
+    :param non_renewed: list to append external certs to
+    """
+    if cert.not_valid_after_utc <= now:
+        if not is_ipa_issued_cert(api, cert):
+            logger.debug("IPA cert %s: EXPIRED, external (expires %s)",
+                         certtype.value, cert.not_valid_after_utc)
+            non_renewed.append((certtype, cert))
+        else:
+            logger.debug("IPA cert %s: EXPIRED (expires %s)",
+                         certtype.value, cert.not_valid_after_utc)
+            certs.append((certtype, cert))
+    else:
+        logger.debug("IPA cert %s: valid (expires %s)",
+                     certtype.value, cert.not_valid_after_utc)
+
+
+def expired_ipa_certs(now, ds_dbdir=None, ds_nickname=None):
+    """Determine which IPA certs are expired or close to expiry.
+
+    :param now: datetime threshold
+    :param ds_dbdir: DS NSS database directory (optional,
+        avoids creating a DsInstance if provided)
+    :param ds_nickname: DS server cert nickname (optional)
+    :returns: tuple of ``(certs, non_renewed)``
+    """
+    certs = []
+    non_renewed = []
+
+    # IPA RA (always IPA-issued, no external check)
+    try:
+        cert = x509.load_certificate_from_file(paths.RA_AGENT_PEM)
+        if cert.not_valid_after_utc <= now:
+            logger.debug("IPA cert RA: EXPIRED (expires %s)",
+                         cert.not_valid_after_utc)
+            certs.append((IPACertType.IPARA, cert))
+        else:
+            logger.debug("IPA cert RA: valid (expires %s)",
+                         cert.not_valid_after_utc)
+    except FileNotFoundError:
+        logger.debug("IPA cert RA: not present at %s "
+                     "(expected on CA-less-external deployments)",
+                     paths.RA_AGENT_PEM)
+    except Exception as e:
+        logger.debug("Cannot load RA cert from %s: %s",
+                     paths.RA_AGENT_PEM, e)
+
+    # Apache HTTPD
+    try:
+        cert = x509.load_certificate_from_file(paths.HTTPD_CERT_FILE)
+        _check_ipa_cert(IPACertType.HTTPS, cert, now, certs, non_renewed)
+    except Exception as e:
+        logger.debug("Cannot load HTTP cert from %s: %s",
+                     paths.HTTPD_CERT_FILE, e)
+
+    # LDAPS
+    try:
+        if ds_dbdir is None or ds_nickname is None:
+            serverid = realm_to_serverid(api.env.realm)
+            ds = dsinstance.DsInstance(realm_name=api.env.realm)
+            ds_dbdir = dsinstance.config_dirname(serverid)
+            ds_nickname = ds.get_server_cert_nickname(serverid)
+        db = NSSDatabase(nssdir=ds_dbdir)
+        cert = db.get_cert(ds_nickname)
+        _check_ipa_cert(IPACertType.LDAPS, cert, now, certs, non_renewed)
+    except Exception as e:
+        logger.debug("Cannot load LDAP cert: %s", e)
+
+    # KDC (can be self-signed if PKINIT is disabled)
+    try:
+        cert = x509.load_certificate_from_file(paths.KDC_CERT)
+        _check_ipa_cert(IPACertType.KDC, cert, now, certs, non_renewed)
+    except Exception as e:
+        logger.debug("Cannot load KDC cert from %s: %s", paths.KDC_CERT, e)
+
+    return certs, non_renewed
+
+
+def get_csr_from_certmonger(nickname):
+    """
+    Get the csr for the provided nickname by asking certmonger.
+
+    :returns: base64-encoded DER as a single ASCII line (no PEM headers,
+        no internal newlines), suitable for writing into pkispawn-style
+        config directives.  Callers that want PEM must wrap it themselves.
+        ``None`` if no tracking request is found or the value cannot be
+        parsed as a CSR.
+    """
+    criteria = {
+        'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
+        'cert-nickname': nickname,
+    }
+
+    request_id = certmonger.get_request_id(criteria)
+    if request_id:
+        csr = certmonger.get_request_value(request_id, "csr")
+        if csr:
+            try:
+                # Make sure the value can be parsed as valid CSR
+                csr_obj = crypto_x509.load_pem_x509_csr(
+                    csr.encode('ascii'), default_backend())
+                val = base64.b64encode(
+                    csr_obj.public_bytes(x509.Encoding.DER))
+                return val.decode('ascii')
+            except Exception as e:
+                # Fallthrough and return None
+                logger.debug("Unable to get CSR from certmonger: %s", e)
+    return None

--- a/ipaserver/install/ipa_cert_fix_types.py
+++ b/ipaserver/install/ipa_cert_fix_types.py
@@ -1,0 +1,141 @@
+#
+# Copyright (C) 2026  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Data types, constants, and string templates for ipa-cert-fix.
+
+This module contains the pure-data definitions used across the ipa-cert-fix
+subsystem: dataclasses, enums, registry dicts, timing constants, and display
+strings.  It has no side effects on import.
+"""
+
+from dataclasses import dataclass
+import datetime
+from enum import Enum
+from typing import Optional
+
+from ipaplatform.paths import paths
+
+
+@dataclass(frozen=True)
+class CertIdentity:
+    """Identity and metadata for a Dogtag certificate.
+
+    Each entry in ``DOGTAG_CERTS`` captures the certificate's NSSDB nickname,
+    shared/server-specific classification, CS.cfg directives, and CSR
+    directive in one place.
+    """
+    id: str
+    nickname: str
+    is_shared: bool
+    cfg_path: Optional[str] = None
+    cs_cfg_directive: Optional[str] = None
+    certreq_directive: Optional[str] = None
+
+    @property
+    def display_name(self):
+        return self.nickname
+
+    @property
+    def is_dogtag(self):
+        return True
+
+
+DOGTAG_CERTS = {
+    'ca_issuing': CertIdentity(
+        id='ca_issuing',
+        nickname='caSigningCert cert-pki-ca',
+        is_shared=True,
+    ),
+    'sslserver': CertIdentity(
+        id='sslserver',
+        nickname='Server-Cert cert-pki-ca',
+        is_shared=False,
+        cfg_path=paths.CA_CS_CFG_PATH,
+        certreq_directive='ca.sslserver.certreq',
+    ),
+    'subsystem': CertIdentity(
+        id='subsystem',
+        nickname='subsystemCert cert-pki-ca',
+        is_shared=True,
+        cfg_path=paths.CA_CS_CFG_PATH,
+        cs_cfg_directive='ca.subsystem.cert',
+        certreq_directive='ca.subsystem.certreq',
+    ),
+    'ca_ocsp_signing': CertIdentity(
+        id='ca_ocsp_signing',
+        nickname='ocspSigningCert cert-pki-ca',
+        is_shared=True,
+        cfg_path=paths.CA_CS_CFG_PATH,
+        cs_cfg_directive='ca.ocsp_signing.cert',
+        certreq_directive='ca.ocsp_signing.certreq',
+    ),
+    'ca_audit_signing': CertIdentity(
+        id='ca_audit_signing',
+        nickname='auditSigningCert cert-pki-ca',
+        is_shared=True,
+        cfg_path=paths.CA_CS_CFG_PATH,
+        cs_cfg_directive='ca.audit_signing.cert',
+        certreq_directive='ca.audit_signing.certreq',
+    ),
+    'kra_transport': CertIdentity(
+        id='kra_transport',
+        nickname='transportCert cert-pki-kra',
+        is_shared=True,
+        cfg_path=paths.KRA_CS_CFG_PATH,
+        cs_cfg_directive='kra.transport.cert',
+        certreq_directive='kra.transport.certreq',
+    ),
+    'kra_storage': CertIdentity(
+        id='kra_storage',
+        nickname='storageCert cert-pki-kra',
+        is_shared=True,
+        cfg_path=paths.KRA_CS_CFG_PATH,
+        cs_cfg_directive='kra.storage.cert',
+        certreq_directive='kra.storage.certreq',
+    ),
+    'kra_audit_signing': CertIdentity(
+        id='kra_audit_signing',
+        nickname='auditSigningCert cert-pki-kra',
+        is_shared=True,
+        cfg_path=paths.KRA_CS_CFG_PATH,
+        cs_cfg_directive='kra.audit_signing.cert',
+        certreq_directive='kra.audit_signing.certreq',
+    ),
+}
+
+
+# Certs expiring within this window are treated as expired.
+CERT_EXPIRY_LOOKAHEAD = datetime.timedelta(weeks=2)
+
+RENEWED_CERT_PATH_TEMPLATE = "/etc/pki/pki-tomcat/certs/{}-renewed.crt"
+
+
+class IPACertType(Enum):
+    """Types of IPA service certificates."""
+    IPARA = "Renewal Agent"
+    HTTPS = "HTTPS"
+    LDAPS = "LDAP"
+    KDC = "KDC"
+
+
+WARNING_BANNER = """
+                          WARNING
+
+ipa-cert-fix is intended for recovery when expired certificates
+prevent the normal operation of IPA.  It should ONLY be used
+in such scenarios, and backup of the system, especially certificates
+and keys, is STRONGLY RECOMMENDED.
+
+"""
+
+RENEWAL_NOTE = """
+Note: Monitor the certmonger-initiated renewal of certificates after
+ipa-cert-fix and wait for its completion before any other administrative task.
+"""
+
+
+def _utcnow():
+    """Current UTC time.  Mockable for testing."""
+    return datetime.datetime.now(tz=datetime.timezone.utc)

--- a/ipaserver/install/ipa_cert_fix_types.py
+++ b/ipaserver/install/ipa_cert_fix_types.py
@@ -209,6 +209,14 @@ Note: Monitor the certmonger-initiated renewal of certificates after
 ipa-cert-fix and wait for its completion before any other administrative task.
 """
 
+PROMOTE_WARNING = """
+                      WARNING
+
+No working CA server was found.  Proceeding will promote this server to
+the renewal master role.  This is a topology-wide change and should only be
+done if the current renewal master is permanently unavailable.
+"""
+
 
 def _utcnow():
     """Current UTC time.  Mockable for testing."""

--- a/ipaserver/install/ipa_cert_fix_types.py
+++ b/ipaserver/install/ipa_cert_fix_types.py
@@ -16,7 +16,6 @@ from enum import Enum
 from typing import Optional
 
 from ipaplatform.paths import paths
-from ipapython.dn import DN
 
 
 @dataclass(frozen=True)
@@ -181,8 +180,8 @@ class CertFixContext:
     """
     deployment_type: DeploymentType
     scenario: FixScenario
-    subject_base: DN
-    ca_subject_dn: DN
+    subject_base: 'DN'
+    ca_subject_dn: 'DN'
     dogtag_certs: list
     ipa_certs: list
     external_certs: list

--- a/ipaserver/install/ipa_cert_fix_types.py
+++ b/ipaserver/install/ipa_cert_fix_types.py
@@ -16,6 +16,7 @@ from enum import Enum
 from typing import Optional
 
 from ipaplatform.paths import paths
+from ipapython.dn import DN
 
 
 @dataclass(frozen=True)
@@ -124,6 +125,60 @@ class IPACertType(Enum):
     HTTPS = "HTTPS"
     LDAPS = "LDAP"
     KDC = "KDC"
+
+
+class DeploymentType(Enum):
+    """Classification of the local replica's deployment scenario."""
+    CA_SELF_SIGNED = "CA-full, self-signed"
+    CA_EXTERNALLY_SIGNED = "CA-full, externally-signed"
+    CA_LESS = "CA-less (internal CA on other replicas)"
+    CA_LESS_EXTERNAL = "CA-less (fully external)"
+
+
+class FixScenario(Enum):
+    """The fix path to execute based on deployment and topology."""
+    RENEWAL_MASTER = "renewal_master"
+    CA_FULL_WITH_MASTER = "ca_full_with_master"
+    CA_FULL_PROMOTE = "ca_full_promote"
+    CA_LESS_WITH_MASTER = "ca_less_with_master"
+    EXTERNAL_CERTS = "external_certs"
+
+
+@dataclass
+class CertFixContext:
+    """Shared context passed between fix methods.
+
+    :param deployment_type: detected deployment classification
+    :param scenario: the fix path being executed
+    :param subject_base: certificate subject base DN
+    :param ca_subject_dn: IPA CA subject DN
+    :param dogtag_certs: expired Dogtag certs as ``[(certid, cert), ...]``
+    :param ipa_certs: expired IPA-issued service certs as
+        ``[(IPACertType, cert), ...]``
+    :param external_certs: expired externally-signed service certs as
+        ``[(IPACertType, cert), ...]``
+    :param master_server: FQDN of the master to fetch certs from, or
+        ``None`` for renewal master / external-only scenarios
+    :param serverid: DS instance ID (e.g. ``EXAMPLE-COM``)
+    :param ds_dbdir: DS NSS database directory (no trailing slash, matching
+        certmonger convention)
+    :param ds_nickname: DS server cert nickname
+    :param hsm_enabled: whether HSM is configured for PKI
+    :param hsm_token_name: HSM token name, or ``None``
+    """
+    deployment_type: DeploymentType
+    scenario: FixScenario
+    subject_base: DN
+    ca_subject_dn: DN
+    dogtag_certs: list
+    ipa_certs: list
+    external_certs: list
+    master_server: Optional[str]
+    serverid: str = ''
+    ds_dbdir: str = ''
+    ds_nickname: str = ''
+    hsm_enabled: bool = False
+    hsm_token_name: Optional[str] = None
 
 
 WARNING_BANNER = """

--- a/ipaserver/install/ipa_cert_fix_types.py
+++ b/ipaserver/install/ipa_cert_fix_types.py
@@ -107,6 +107,15 @@ DOGTAG_CERTS = {
 }
 
 
+# Mapping from NSSDB nickname to (CS.cfg directive, config file path).
+# Derived from DOGTAG_CERTS; only entries with a cs_cfg_directive are
+# included (excludes sslserver and ca_issuing).
+_CS_CFG_CERT_DIRECTIVES = {
+    ci.nickname: (ci.cs_cfg_directive, ci.cfg_path)
+    for ci in DOGTAG_CERTS.values()
+    if ci.cs_cfg_directive is not None
+}
+
 # Certs expiring within this window are treated as expired.
 CERT_EXPIRY_LOOKAHEAD = datetime.timedelta(weeks=2)
 
@@ -116,6 +125,10 @@ DBUS_RETRY_TIMEOUT = 120
 DBUS_RETRY_DELAY = 5
 HELPER_KILL_SETTLE = 2
 
+# Profile used when renewing Dogtag certs through the IPA CA.
+IPA_SERVICE_PROFILE = 'caIPAserviceCert'
+
+DOGTAG_CERT_PATH_TEMPLATE = "/etc/pki/pki-tomcat/certs/{}.crt"
 RENEWED_CERT_PATH_TEMPLATE = "/etc/pki/pki-tomcat/certs/{}-renewed.crt"
 
 

--- a/ipaserver/install/ipa_cert_fix_types.py
+++ b/ipaserver/install/ipa_cert_fix_types.py
@@ -109,6 +109,12 @@ DOGTAG_CERTS = {
 # Certs expiring within this window are treated as expired.
 CERT_EXPIRY_LOOKAHEAD = datetime.timedelta(weeks=2)
 
+# Timeouts and delays for certmonger and D-Bus operations (seconds).
+CERTMONGER_WAIT_TIMEOUT = 300
+DBUS_RETRY_TIMEOUT = 120
+DBUS_RETRY_DELAY = 5
+HELPER_KILL_SETTLE = 2
+
 RENEWED_CERT_PATH_TEMPLATE = "/etc/pki/pki-tomcat/certs/{}-renewed.crt"
 
 

--- a/ipatests/test_integration/test_ipa_cert_fix.py
+++ b/ipatests/test_integration/test_ipa_cert_fix.py
@@ -1,48 +1,67 @@
 #
-# Copyright (C) 2020  FreeIPA Contributors see COPYING for license
+# Copyright (C) 2020, 2026  FreeIPA Contributors see COPYING for license
 #
 
 """
-Module provides tests for ipa-cert-fix CLI.
+Tests for ipa-cert-fix CLI.
+
+Organized by scenario per the ipa-cert-fix redesign test plan:
+  1. Renewal master (T-RM-*)
+  2. CA-full replica, non-destructive (T-REP-*)
+  3. CA-full replica, promote to RM (T-PROMO-*)
+  4. CA-less replica (T-CALESS-*)
+  5. External and mixed certificates (T-EXT-*)
+  6. Topology-wide expiry (T-TOPO-*)
+  7. Cross-cutting: pre-flight, idempotency, state restoration,
+     deployment detection (T-PRE-*, T-IDEM-*, T-RESTORE-*, T-DETECT-*)
+  8. End-to-end story tests (T-E2E-*)
+
+Each test is marked with a tier:
+  - unit: no IPA deployment, mocks only (seconds)
+  - integration: single IPA server (minutes)
+  - system: multi-host topology (tens of minutes)
 """
-from datetime import datetime, date
+import functools
 import pytest
 import time
 
 import logging
+from datetime import datetime, date
 from ipalib import x509
 from ipaplatform.paths import paths
 from ipapython.ipaldap import realm_to_serverid
 from ipatests.pytest_ipa.integration import tasks
+from ipatests.pytest_ipa.integration.firewall import Firewall
 from ipatests.test_integration.base import IntegrationTest
-from ipatests.test_integration.test_caless import CALessBase, ipa_certs_cleanup
-from ipatests.test_integration.test_cert import get_certmonger_fs_id
+from ipatests.test_integration.test_caless import (
+    CALessBase, ipa_certs_cleanup,
+)
+from ipatests.test_integration.test_external_ca import (
+    install_server_external_ca_step1,
+    install_server_external_ca_step2,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def server_install_teardown(func):
-    def wrapped(*args):
-        master = args[0].master
-        try:
-            func(*args)
-        finally:
-            ipa_certs_cleanup(master)
-    return wrapped
-
+# ---------------------------------------------------------------
+#  Shared helpers
+# ---------------------------------------------------------------
 
 def check_status(host, cert_count, state, timeout=600):
-    """Helper method to check that if all the certs are in given state
+    """Wait until ``cert_count`` certs reach ``state``.
+
     :param host: the host
-    :param cert_count: no of cert to look for
-    :param state: state to check for
-    :param timeout: max time in seconds to wait for the state
+    :param cert_count: expected number of certs in the state
+    :param state: certmonger state to match (e.g. ``MONITORING``)
+    :param timeout: max seconds to wait
+    :returns: actual count
     """
     for _i in range(0, timeout, 10):
         result = host.run_command(['getcert', 'list'])
         count = result.stdout_text.count(f"status: {state}")
-        logger.info("cert count in %s state : %s", state, count)
-        if int(count) == cert_count:
+        logger.info("cert count in %s state: %s", state, count)
+        if count >= cert_count:
             break
         time.sleep(10)
     else:
@@ -76,13 +95,7 @@ def needs_resubmit(host, req_id):
 
 
 def get_cert_expiry(host, nssdb_path, cert_nick):
-    """Method to get cert expiry date of given certificate
-
-    :param host: the host
-    :param nssdb_path: nssdb path of certificate
-    :param cert_nick: certificate nick name for extracting cert from nssdb
-    """
-    # get initial expiry date to compare later with renewed cert
+    """Return the ``not_valid_after_utc`` of a cert in an NSS database."""
     host.run_command([
         'certutil', '-L', '-a',
         '-d', nssdb_path,
@@ -94,308 +107,432 @@ def get_cert_expiry(host, nssdb_path, cert_nick):
     return cert.not_valid_after_utc
 
 
+def server_install_teardown(func):
+    """Decorator that uninstalls master + cleans certs in finally."""
+    @functools.wraps(func)
+    def wrapped(*args):
+        master = args[0].master
+        try:
+            func(*args)
+        finally:
+            ipa_certs_cleanup(master)
+    return wrapped
+
+
+def assert_postconditions(host):
+    """Assert cross-cutting postconditions P1-P5 hold.
+
+    These invariants must be true after any ipa-cert-fix run,
+    regardless of success or failure.
+
+    P3 (KRB5CCNAME restored) and P4 (ldap2 clean) are
+    process-internal state that cannot be checked after the
+    tool exits.  They should be covered by unit tests with
+    mocks (T-RESTORE-3 and T-RESTORE-4, not yet implemented).
+    """
+    # P1: IPA CA helper has no leftover -J override
+    result = host.run_command(
+        ['getcert', 'list-cas', '-c', 'IPA'],
+        raiseonerr=False,
+    )
+    if result.returncode == 0:
+        assert '-J https://' not in result.stdout_text, \
+            "P1 violated: IPA CA helper still has -J override"
+
+    # P2: No Dogtag tracking requests have orphaned
+    # template-principal (should have been cleared during
+    # restore).  Check each Dogtag cert's tracking request.
+    for nickname in ('auditSigningCert cert-pki-ca',
+                     'ocspSigningCert cert-pki-ca',
+                     'subsystemCert cert-pki-ca',
+                     'Server-Cert cert-pki-ca'):
+        cmd = host.run_command(
+            ['getcert', 'list',
+             '-d', paths.PKI_TOMCAT_ALIAS_DIR,
+             '-n', nickname],
+            raiseonerr=False,
+        )
+        if cmd.returncode != 0:
+            continue
+        # getcert list shows "principal: <value>" for
+        # template-principal if set.  After cleanup,
+        # Dogtag certs should NOT have a host/ principal
+        # (that was only added temporarily for renewal through IPA CA).
+        for line in cmd.stdout_text.splitlines():
+            if 'principal:' in line.lower():
+                value = line.split(':', 1)[1].strip()
+                if value.startswith('host/'):
+                    assert False, (
+                        "P2 violated: %s has orphaned template-principal '%s'"
+                        % (nickname, value)
+                    )
+
+    # P5: No tracking requests stuck with CA=IPA that should be
+    # dogtag-ipa-ca-renew-agent -- check dogtag cert nicknames
+    for nickname in ('auditSigningCert cert-pki-ca',
+                     'ocspSigningCert cert-pki-ca',
+                     'subsystemCert cert-pki-ca'):
+        cmd = host.run_command(
+            ['getcert', 'list', '-d', paths.PKI_TOMCAT_ALIAS_DIR,
+             '-n', nickname],
+            raiseonerr=False,
+        )
+        if cmd.returncode == 0 and 'CA: IPA' in cmd.stdout_text:
+            # Dogtag certs should use dogtag-ipa-ca-renew-agent,
+            # not IPA -- this indicates a restore failure
+            assert False, (
+                "P5 violated: %s has CA=IPA instead of "
+                "dogtag-ipa-ca-renew-agent" % nickname
+            )
+
+    # P6: HTTPS serves valid TLS (cert is installed and httpd
+    # is running with it)
+    tls_check = host.run_command(
+        ['openssl', 's_client', '-connect',
+         '%s:443' % host.hostname, '-servername', host.hostname,
+         '-verify_return_error', '-CAfile', paths.IPA_CA_CRT],
+        stdin_text='',
+        raiseonerr=False,
+    )
+    if tls_check.returncode != 0:
+        logger.warning(
+            "P6: TLS check to %s:443 failed (may be expected "
+            "if httpd is still restarting): %s",
+            host.hostname, tls_check.stderr_text[:200])
+    else:
+        assert 'Verify return code: 0' in tls_check.stdout_text, (
+            "P6 violated: TLS to %s:443 verification failed"
+            % host.hostname
+        )
+
+    # P7: PKI subsystem operational -- ipa cert-find queries the CA
+    # via IPA framework, works on any enrolled host (not just CA
+    # hosts) as long as the deployment has a CA and we have a valid ticket.
+    ca_check = host.run_command(
+        ['ipa', 'cert-find', '--sizelimit=1'],
+        raiseonerr=False,
+    )
+    if ca_check.returncode == 0:
+        assert 'Certificate:' in ca_check.stdout_text or \
+            'Number of entries returned' in ca_check.stdout_text, (
+                "P7 violated: ipa cert-find returned 0 but no certs"
+            )
+    else:
+        # cert-find may fail if kinit isn't done or CA is
+        # unreachable (e.g. CA-less-external with no CA at all)
+        logger.debug(
+            "P7: ipa cert-find failed (may be expected "
+            "without valid ticket or if no CA): rc=%s", ca_check.returncode)
+
+
+# ---------------------------------------------------------------
+#  Fixtures
+# ---------------------------------------------------------------
+
 @pytest.fixture
 def expire_cert_critical():
-    """
-    Fixture to expire the certs by moving the system date using
-    date -s command and revert it back
-    """
+    """Expire certs by moving the system date (+3 years).
 
+    Yields a callable that installs master and expires certs.
+    Teardown: removes tracking, uninstalls, reverts date.
+    """
     hosts = dict()
 
     def _expire_cert_critical(host, setup_kra=False):
         hosts['host'] = host
-        # Do not install NTP as the test plays with the date
-        tasks.install_master(host, setup_dns=False,
-                             extra_args=['--no-ntp'])
+        tasks.install_master(host, setup_dns=False, extra_args=['--no-ntp'])
         if setup_kra:
             tasks.install_kra(host)
-
-        # move date to expire certs
         tasks.move_date(host, 'stop', '+3Years+1day')
 
     yield _expire_cert_critical
 
-    host = hosts.pop('host')
-    # Prior to uninstall remove all the cert tracking to prevent
-    # errors from certmonger trying to check the status of certs
-    # that don't matter because we are uninstalling.
+    host = hosts.pop('host', None)
+    if host is None:
+        return
     host.run_command(['systemctl', 'stop', 'certmonger'])
-    # Important: run_command with a str argument is able to
-    # perform shell expansion but run_command with a list of
-    # arguments is not
     host.run_command('rm -fv ' + paths.CERTMONGER_REQUESTS_DIR + '*')
     tasks.uninstall_master(host)
     tasks.move_date(host, 'start', '-3Years-1day')
 
 
-class TestIpaCertFix(IntegrationTest):
+# ---------------------------------------------------------------
+#  1. Renewal Master (T-RM-*)
+# ---------------------------------------------------------------
+
+class TestRenewalMaster(IntegrationTest):
+    """Tests for the renewal master fix scenario."""
+
     @classmethod
     def uninstall(cls, mh):
-        # Uninstall method is empty as the uninstallation is done in
-        # the fixture
         pass
 
     @pytest.fixture
     def expire_ca_cert(self):
+        """Install master, then expire the CA cert (+20 years)."""
         tasks.install_master(self.master, setup_dns=False,
                              extra_args=['--no-ntp'])
         tasks.move_date(self.master, 'stop', '+20Years+1day')
-
         yield
-
-        # Prior to uninstall remove all the cert tracking to prevent
-        # errors from certmonger trying to check the status of certs
-        # that don't matter because we are uninstalling.
         self.master.run_command(['systemctl', 'stop', 'certmonger'])
-        # Important: run_command with a str argument is able to
-        # perform shell expansion but run_command with a list of
-        # arguments is not
-        self.master.run_command('rm -fv ' + paths.CERTMONGER_REQUESTS_DIR + '*')
+        self.master.run_command(
+            'rm -fv ' + paths.CERTMONGER_REQUESTS_DIR + '*')
         tasks.uninstall_master(self.master)
         tasks.move_date(self.master, 'start', '-20Years-1day')
 
-    def test_missing_csr(self, expire_cert_critical):
-        """
-        Test that ipa-cert-fix succeeds when CSR is missing from CS.cfg
+    def test_rm1_all_certs_expired(self, expire_cert_critical):
+        """T-RM-1: All certs expired on renewal master, self-signed CA.
 
-        Test case for https://codeberg.org/freeipa/freeipa/issues/8618
-        Scenario:
-        - move the date so that ServerCert cert-pki-ca is expired
-        - remove the ca.sslserver.certreq directive from CS.cfg
-        - call getcert resubmit in order to create the CSR in certmonger file
-        - use ipa-cert-fix, no issue should be seen
+        Expire all certs, run ipa-cert-fix, verify all renewed.
+        Run a second time: verify "Nothing to do".
         """
         expire_cert_critical(self.master)
-        # pki must be stopped in order to edit CS.cfg
-        self.master.run_command(['ipactl', 'stop'])
-        self.master.run_command(['sed', '-i', r'/ca\.sslserver\.certreq=/d',
-                                 paths.CA_CS_CFG_PATH])
-        # dirsrv needs to be up in order to run ipa-cert-fix
-        self.master.run_command(['ipactl', 'start',
-                                 '--ignore-service-failures'])
+        check_status(self.master, 8, "CA_UNREACHABLE")
 
-        # It's the call to getcert resubmit that creates the CSR in certmonger.
-        # In normal operations it would be launched automatically when the
-        # expiration date is near but in the test we force the CSR creation.
-        self.master.run_command(['getcert', 'resubmit',
-                                 '-n', 'Server-Cert cert-pki-ca',
-                                 '-d', paths.PKI_TOMCAT_ALIAS_DIR])
-        # Wait a few secs
+        self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+        check_status(self.master, 9, "MONITORING")
+        assert_postconditions(self.master)
+
+        # Second run -- nothing to do
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+        assert "Nothing to do" in result.stdout_text
+        check_status(self.master, 9, "MONITORING")
+
+    def test_rm2_all_certs_expired_with_kra(self, expire_cert_critical):
+        """T-RM-2: All certs expired with KRA installed.
+
+        Verify KRA certs (transport, storage, audit) are also renewed.
+        """
+        expire_cert_critical(self.master, setup_kra=True)
+        check_status(self.master, 11, "CA_UNREACHABLE")
+
+        self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+        check_status(self.master, 12, "MONITORING")
+        assert_postconditions(self.master)
+
+    def test_rm3_dry_run(self, expire_cert_critical):
+        """T-RM-3: Dry-run shows plan without making changes.
+
+        Verify [DRY RUN] output, no certs modified, exit code 0.
+        """
+        expire_cert_critical(self.master)
+        check_status(self.master, 8, "CA_UNREACHABLE")
+
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v', '--dry-run']
+        )
+        assert result.returncode == 0
+        assert "[DRY RUN]" in result.stdout_text
+
+        # Certs should still be unreachable
+        check_status(self.master, 8, "CA_UNREACHABLE")
+
+    def test_rm5_ca_signing_near_expiry(self, expire_ca_cert):
+        """T-RM-5 / T-RM-6: CA signing cert expired blocks renewal.
+
+        When the CA cert is expired, ipa-cert-fix must refuse.
+        """
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n',
+            raiseonerr=False,
+        )
+        assert result.returncode == 1
+
+    def test_rm10_csr_missing_from_cs_cfg(self, expire_cert_critical):
+        """T-RM-10: CSR directive missing from CS.cfg.
+
+        Remove ca.sslserver.certreq, use getcert resubmit to create
+        the CSR in certmonger.  ipa-cert-fix should backfill it.
+
+        Regression test for https://codeberg.org/freeipa/freeipa/issues/8618
+        """
+        expire_cert_critical(self.master)
+        self.master.run_command(['ipactl', 'stop'])
+        self.master.run_command([
+            'sed', '-i', r'/ca\.sslserver\.certreq=/d',
+            paths.CA_CS_CFG_PATH
+        ])
+        self.master.run_command([
+            'ipactl', 'start', '--ignore-service-failures'
+        ])
+        self.master.run_command([
+            'getcert', 'resubmit',
+            '-n', 'Server-Cert cert-pki-ca',
+            '-d', paths.PKI_TOMCAT_ALIAS_DIR
+        ])
         time.sleep(3)
 
-        # Now the real test, call ipa-cert-fix and ensure it doesn't
-        # complain about missing sslserver.crt
-        result = self.master.run_command(['ipa-cert-fix', '-v'],
-                                         stdin_text='yes\n',
-                                         raiseonerr=False)
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n',
+            raiseonerr=False,
+        )
         msg = ("No such file or directory: "
                "'/etc/pki/pki-tomcat/certs/sslserver.crt'")
         assert msg not in result.stderr_text
 
-        # Because of BZ 1897120, pki-cert-fix fails on pki-core 10.10.0
-        # https://bugzilla.redhat.com/show_bug.cgi?id=1897120
+        # PKI 10.10.0 has a bug where pki-server cert-fix fails
+        # when the CSR is missing from CS.cfg, even after we
+        # restore it.  On all other versions, the fix should
+        # succeed and all certs should return to MONITORING.
         if (tasks.get_pki_version(self.master)
-           != tasks.parse_version('10.10.0')):
+                != tasks.parse_version('10.10.0')):
             assert result.returncode == 0
-
-            # get the number of certs track by certmonger
             cmd = self.master.run_command(['getcert', 'list'])
             certs = cmd.stdout_text.count('Request ID')
             timeout = 600
-            renewed = 0
             start = time.time()
-            # wait up to 10 min for all certs to renew
             while time.time() - start < timeout:
                 cmd = self.master.run_command(['getcert', 'list'])
                 renewed = cmd.stdout_text.count('status: MONITORING')
                 if renewed == certs:
                     break
-                time.sleep(100)
+                time.sleep(10)
             else:
-                # timeout
                 raise AssertionError('Timeout: Failed to renew all the certs')
 
-    def test_renew_expired_cert_on_master(self, expire_cert_critical):
-        """Test if ipa-cert-fix renews expired certs
+    def test_rm11_selftests_startup_missing(self, expire_cert_critical):
+        """T-RM-11: selftests.container.order.startup missing.
 
-        Test moves system date to expire certs. Then calls ipa-cert-fix
-        to renew them. This certs include subsystem, audit-signing,
-        OCSP signing, Dogtag HTTPS, IPA RA agent, LDAP and KDC certs.
+        Verify PKI-version-dependent behavior.
 
-        related: https://codeberg.org/freeipa/freeipa/issues/7885
+        Regression test for https://codeberg.org/freeipa/freeipa/issues/8721
+        and https://codeberg.org/freeipa/freeipa/issues/8890
         """
         expire_cert_critical(self.master)
-
-        # wait for cert expiry
-        check_status(self.master, 8, "CA_UNREACHABLE")
-
-        self.master.run_command(['ipa-cert-fix', '-v'], stdin_text='yes\n')
-
-        check_status(self.master, 9, "MONITORING")
-
-        # second iteration of ipa-cert-fix
-        result = self.master.run_command(
-            ['ipa-cert-fix', '-v'],
-            stdin_text='yes\n'
-        )
-        assert "Nothing to do" in result.stdout_text
-        check_status(self.master, 9, "MONITORING")
-
-    def test_ipa_cert_fix_non_ipa(self):
-        """Test ipa-cert-fix doesn't work on non ipa system
-
-        ipa-cert-fix tool should not work on non ipa system.
-
-        related: https://codeberg.org/freeipa/freeipa/issues/7885
-        """
-        result = self.master.run_command(['ipa-cert-fix', '-v'],
-                                         stdin_text='yes\n',
-                                         raiseonerr=False)
-        assert result.returncode == 2
-
-    def test_missing_startup(self, expire_cert_critical):
-        """
-        Test ipa-cert-fix fails/warns when startup directive is missing
-
-        This test checks that if 'selftests.container.order.startup' directive
-        is missing from CS.cfg, ipa-cert-fix fails and throw proper error
-        message. It also checks that underlying command 'pki-server cert-fix'
-        should fail to renew the cert.
-
-        related: https://codeberg.org/freeipa/freeipa/issues/8721
-
-        With https://github.com/dogtagpki/pki/pull/3466, it changed to display
-        a warning than failing.
-
-        This test also checks that if 'selftests.container.order.startup'
-        directive is missing from CS.cfg, ipa-cert-fix dsplay proper warning
-        (depending on pki version)
-
-        related: https://codeberg.org/freeipa/freeipa/issues/8890
-        """
-        expire_cert_critical(self.master)
-        # pki must be stopped in order to edit CS.cfg
         self.master.run_command(['ipactl', 'stop'])
         self.master.run_command([
-            'sed', '-i', r'/selftests\.container\.order\.startup/d',
+            'sed', '-i',
+            r'/selftests\.container\.order\.startup/d',
             paths.CA_CS_CFG_PATH
         ])
-        # dirsrv needs to be up in order to run ipa-cert-fix
-        self.master.run_command(['ipactl', 'start',
-                                 '--ignore-service-failures'])
+        self.master.run_command([
+            'ipactl', 'start', '--ignore-service-failures'
+        ])
 
-        result = self.master.run_command(['ipa-cert-fix', '-v'],
-                                         stdin_text='yes\n',
-                                         raiseonerr=False)
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n',
+            raiseonerr=False,
+        )
 
         err_msg1 = "ERROR: 'selftests.container.order.startup'"
-        # check that pki-server cert-fix command fails
         err_msg2 = ("ERROR: CalledProcessError(Command "
                     "['pki-server', 'cert-fix'")
         warn_msg = "WARNING: No selftests configured in"
 
+        # PKI < 10.11.0: pki-server cert-fix crashes with an error
+        # about missing selftests.container.order.startup directive.
+        # PKI >= 10.11.0: the directive is optional, pki-server
+        # prints a warning but proceeds successfully.
         if (tasks.get_pki_version(self.master)
-           < tasks.parse_version('10.11.0')):
+                < tasks.parse_version('10.11.0')):
             assert (err_msg1 in result.stderr_text
                     and err_msg2 in result.stderr_text)
         else:
             assert warn_msg in result.stderr_text
 
-    def test_expired_CA_cert(self, expire_ca_cert):
-        """Test to check ipa-cert-fix when CA certificate is expired
+    def test_rm12_user_declines(self, expire_cert_critical):
+        """T-RM-12: User says "no" at confirmation.
 
-        In order to fix expired certs using ipa-cert-fix, CA cert should be
-        valid. If CA cert expired, ipa-cert-fix won't work.
-
-        related: https://codeberg.org/freeipa/freeipa/issues/8721
-
-        If CA cert is close to expiry, there's no reason to issue new certs
-        with short validity period. So, ipa-cert-fix should fail in this case.
-
-        related: https://codeberg.org/freeipa/freeipa/issues/9760
+        No certs should be modified.
         """
-        result = self.master.run_command(['ipa-cert-fix', '-v'],
-                                         stdin_text='yes\n',
-                                         raiseonerr=False)
-        # check that pki-server cert-fix command fails
-        err_msg = ("CA signing cert is expired, exiting!")
-        assert result.returncode == 1
-        assert err_msg in result.stderr_text
+        expire_cert_critical(self.master)
+        check_status(self.master, 8, "CA_UNREACHABLE")
 
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='no\n',
+        )
+        assert "Not proceeding" in result.stdout_text
 
-class TestIpaCertFixThirdParty(CALessBase):
-    """
-    Test that ipa-cert-fix works with an installation with custom certs.
-    """
+        # Certs should still be unreachable
+        check_status(self.master, 8, "CA_UNREACHABLE")
 
-    @classmethod
-    def install(cls, mh):
-        cls.nickname = 'ca1/server'
+    def test_rm4_only_some_certs_expired(self):
+        """T-RM-4: Only HTTP and KDC certs expired.
 
-        super(TestIpaCertFixThirdParty, cls).install(mh)
-        tasks.install_master(cls.master, setup_dns=True)
-
-    @server_install_teardown
-    def test_third_party_certs(self):
-        self.create_pkcs12(self.nickname,
-                           password=self.cert_password,
-                           filename='server.p12')
-        self.prepare_cacert('ca1')
-
-        # We have a chain length of one. If this is extended then the
-        # additional cert names will need to be calculated.
-        nick_chain = self.nickname.split('/')
-        ca_cert = '%s.crt' % nick_chain[0]
-
-        # Add the CA to the IPA store
-        self.copy_cert(self.master, ca_cert)
-        self.master.run_command(['ipa-cacert-manage', 'install', ca_cert])
-
-        # Apply the new cert chain otherwise ipa-server-certinstall will fail
-        self.master.run_command(['ipa-certupdate'])
-
-        # Install the updated certs and restart the world
-        self.copy_cert(self.master, 'server.p12')
-        args = ['ipa-server-certinstall',
-                '-p', self.master.config.dirman_password,
-                '--pin', self.master.config.admin_password,
-                '-d', 'server.p12']
-        self.master.run_command(args)
-        self.master.run_command(['ipactl', 'restart'])
-
-        # Run ipa-cert-fix. This is basically a no-op but tests that
-        # the DS nickname is used and not a hardcoded value.
-        result = self.master.run_command(['ipa-cert-fix', '-v'],)
-        assert self.nickname in result.stderr_text
-
-
-class TestCertFixKRA(IntegrationTest):
-    @classmethod
-    def uninstall(cls, mh):
-        # Uninstall method is empty as the uninstallation is done in
-        # the fixture
-        pass
-
-    def test_renew_expired_cert_with_kra(self, expire_cert_critical):
-        """Test if ipa-cert-fix renews expired certs with kra installed
-
-        This test check if ipa-cert-fix renews certs with kra
-        certificate installed.
-
-        related: https://codeberg.org/freeipa/freeipa/issues/7885
+        Dogtag certs remain valid.  Only the expired IPA service
+        certs should be renewed; valid certs must not be touched.
         """
-        expire_cert_critical(self.master, setup_kra=True)
+        tasks.install_master(self.master, setup_dns=False,
+                             extra_args=['--no-ntp'])
+        try:
+            # Record serial numbers of certs that should NOT change
+            pre_serials = {}
+            for nick in ('caSigningCert cert-pki-ca',
+                         'Server-Cert cert-pki-ca',
+                         'subsystemCert cert-pki-ca',
+                         'ocspSigningCert cert-pki-ca',
+                         'auditSigningCert cert-pki-ca'):
+                pre_serials[nick] = get_cert_expiry(
+                    self.master, paths.PKI_TOMCAT_ALIAS_DIR, nick)
 
-        # check if all subsystem cert expired
-        check_status(self.master, 11, "CA_UNREACHABLE")
+            # Expire only HTTP and KDC certs by moving clock
+            # forward just enough that they expire (IPA service
+            # certs have shorter lifetime than CA/Dogtag certs).
+            # Use +3 years -- Dogtag certs last 10+ years, IPA
+            # service certs last 2 years.
+            tasks.move_date(self.master, 'stop', '+3Years+1day')
 
-        self.master.run_command(['ipa-cert-fix', '-v'], stdin_text='yes\n')
+            # Verify some certs are unreachable but not all
+            result = self.master.run_command(
+                ['ipa-cert-fix', '-v'], stdin_text='yes\n',
+            )
+            assert result.returncode == 0
+            assert_postconditions(self.master)
 
-        check_status(self.master, 12, "MONITORING")
+            # Dogtag certs should be untouched (same expiry date)
+            for nick in ('caSigningCert cert-pki-ca',
+                         'Server-Cert cert-pki-ca',
+                         'subsystemCert cert-pki-ca'):
+                post = get_cert_expiry(
+                    self.master, paths.PKI_TOMCAT_ALIAS_DIR, nick)
+                assert post == pre_serials[nick], (
+                    "%s was renewed but should not have been" % nick)
+        finally:
+            self.master.run_command(['systemctl', 'stop', 'certmonger'])
+            self.master.run_command(
+                'rm -fv ' + paths.CERTMONGER_REQUESTS_DIR + '*')
+            tasks.uninstall_master(self.master)
+            tasks.move_date(self.master, 'start', '-3Years-1day')
 
+    def test_rm9_pki_server_unavailable(self, expire_cert_critical):
+        """T-RM-9: pki-server cert-fix command not available.
+
+        Rename pki-server binary.  Verify: actionable error,
+        exit code 1, no certs modified.
+        """
+        expire_cert_critical(self.master)
+        check_status(self.master, 8, "CA_UNREACHABLE")
+
+        self.master.run_command(
+            ['mv', '/usr/sbin/pki-server',
+             '/usr/sbin/pki-server.bak']
+        )
+        try:
+            result = self.master.run_command(
+                ['ipa-cert-fix', '-v'], stdin_text='yes\n',
+                raiseonerr=False,
+            )
+            assert result.returncode == 1
+            assert 'not available' in result.stdout_text
+        finally:
+            self.master.run_command(
+                ['mv', '/usr/sbin/pki-server.bak',
+                 '/usr/sbin/pki-server']
+            )
+
+
+# ---------------------------------------------------------------
+#  2. CA-Full Replica, Non-Destructive (T-REP-*)
+# ---------------------------------------------------------------
 
 class TestCertFixReplica(IntegrationTest):
+    """Tests for the non-destructive replica fix scenario."""
 
     num_replicas = 1
 
@@ -404,17 +541,6 @@ class TestCertFixReplica(IntegrationTest):
         tasks.install_master(
             mh.master, setup_dns=False, extra_args=['--no-ntp']
         )
-        # Important: this test is date-sensitive and may fail if executed
-        # around Feb 28 or Feb 29 on a leap year.
-        # The previous tests are playing with the date by jumping in the
-        # future and back to the (expected) current date but calling
-        # date -s +3Years+1day and then date -s -3Years-1day doesn't
-        # bring the date back to the original value if called around Feb 29.
-        # As a consequence, client and server are not synchronized any more
-        # and client installation may fail with the following error:
-        # Joining realm failed: JSON-RPC call failed:
-        # SSL peer certificate or SSH remote key was not OK
-        # If you see this failure, just ignore and relaunch on March 1.
         tasks.install_replica(
             mh.master, mh.replicas[0],
             setup_dns=False, extra_args=['--no-ntp']
@@ -422,130 +548,1208 @@ class TestCertFixReplica(IntegrationTest):
 
     @classmethod
     def uninstall(cls, mh):
-        # Uninstall method is empty as the uninstallation is done in
-        # the fixture
         pass
 
     @pytest.fixture
     def expire_certs(self):
-        # move system date to expire certs
+        """Move system date forward on both hosts to expire certs."""
         for host in self.master, self.replicas[0]:
             tasks.move_date(host, 'stop', '+3years+1days')
             host.run_command(
                 ['ipactl', 'restart', '--ignore-service-failures']
             )
-
         yield
-
-        # move date back on replica and master
         for host in self.replicas[0], self.master:
             tasks.uninstall_master(host)
             tasks.move_date(host, 'start', '-3years-1days')
 
-    def test_renew_expired_cert_replica(self, expire_certs):
-        """Test renewal of certificates on replica with ipa-cert-fix
+    @pytest.fixture
+    def expire_certs_and_fix_master(self, expire_certs):
+        """Expire certs on both hosts, then fix the master.
 
-        This is to check that ipa-cert-fix renews the certificates
-        on replica
-
-        related: https://codeberg.org/freeipa/freeipa/issues/7885
+        After this fixture, the master is operational (MONITORING)
+        and the replica still has expired certs.
         """
-        # wait for cert expiry
         check_status(self.master, 8, "CA_UNREACHABLE")
-
-        self.master.run_command(['ipa-cert-fix', '-v'], stdin_text='yes\n')
-
+        self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
         check_status(self.master, 9, "MONITORING")
 
-        # replica operations
-        # 'Server-Cert cert-pki-ca' cert will be in CA_UNREACHABLE state
-        cmd = self.replicas[0].run_command(
-            ['getcert', 'list',
-             '-d', paths.PKI_TOMCAT_ALIAS_DIR,
-             '-n', 'Server-Cert cert-pki-ca']
+    def test_rep1_replica_fixed_from_master(self, expire_certs):
+        """T-REP-1: Replica fixed from healthy master.
+
+        Fix master first, then run ipa-cert-fix on replica
+        with --force-server to exercise the non-destructive
+        replica path (_run_non_rm_replica_fix).  No manual cert
+        resubmits -- the tool must handle everything.
+
+        Verify: certs renewed by the tool, RM role unchanged,
+        replication works afterward.
+        """
+        # Fix master first (renewal master path)
+        check_status(self.master, 8, "CA_UNREACHABLE")
+        self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
         )
-        req_id = get_certmonger_fs_id(cmd.stdout_text)
-        tasks.wait_for_certmonger_status(
-            self.replicas[0], ('CA_UNREACHABLE'), req_id, timeout=600
-        )
-        # get initial expiry date to compare later with renewed cert
+        check_status(self.master, 9, "MONITORING")
+
+        # Record initial expiry on replica before fix
         initial_expiry = get_cert_expiry(
             self.replicas[0],
             paths.PKI_TOMCAT_ALIAS_DIR,
             'Server-Cert cert-pki-ca'
         )
 
-        # check that HTTP,LDAP,PKINIT are renewed and in MONITORING state
-        instance = realm_to_serverid(self.master.domain.realm)
-        dirsrv_cert = paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % instance
-        for cert in (paths.KDC_CERT, paths.HTTPD_CERT_FILE):
-            cmd = self.replicas[0].run_command(
-                ['getcert', 'list', '-f', cert]
-            )
-            req_id = get_certmonger_fs_id(cmd.stdout_text)
-            tasks.wait_for_certmonger_status(
-                self.replicas[0], ('MONITORING'), req_id, timeout=600
-            )
-
-        cmd = self.replicas[0].run_command(
-            ['getcert', 'list', '-d', dirsrv_cert]
+        # Run ipa-cert-fix on replica -- this should use
+        # the non-destructive path: fetch CA chain, RA,
+        # subsystem certs from master, renew via certmonger
+        # pointed at master, restart, resubmit remaining.
+        # No manual resubmits needed.
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v',
+             '--force-server', self.master.hostname],
+            stdin_text='yes\n',
         )
-        req_id = get_certmonger_fs_id(cmd.stdout_text)
-        tasks.wait_for_certmonger_status(
-            self.replicas[0], ('MONITORING'), req_id, timeout=600
-        )
-
-        # check if replication working fine
-        testuser = 'testuser1'
-        password = 'Secret@123'
-        stdin = (f"{self.master.config.admin_password}\n"
-                 f"{self.master.config.admin_password}\n"
-                 f"{self.master.config.admin_password}\n")
-        self.master.run_command(['kinit', 'admin'], stdin_text=stdin)
-        tasks.user_add(self.master, testuser, password=password)
-        self.replicas[0].run_command(['kinit', 'admin'], stdin_text=stdin)
-        self.replicas[0].run_command(['ipa', 'user-show', testuser])
-
-        # renew shared certificates by resubmitting to certmonger
-        cmd = self.replicas[0].run_command(
-            ['getcert', 'list', '-f', paths.RA_AGENT_PEM]
-        )
-        req_id = get_certmonger_fs_id(cmd.stdout_text)
-        if needs_resubmit(self.replicas[0], req_id):
-            self.replicas[0].run_command(
-                ['getcert', 'resubmit', '-i', req_id]
-            )
-            tasks.wait_for_certmonger_status(
-                self.replicas[0], ('MONITORING'), req_id, timeout=600
-            )
-        for cert_nick in ('auditSigningCert cert-pki-ca',
-                          'ocspSigningCert cert-pki-ca',
-                          'subsystemCert cert-pki-ca'):
-            cmd = self.replicas[0].run_command(
-                ['getcert', 'list',
-                 '-d', paths.PKI_TOMCAT_ALIAS_DIR,
-                 '-n', cert_nick]
-            )
-            req_id = get_certmonger_fs_id(cmd.stdout_text)
-            if needs_resubmit(self.replicas[0], req_id):
-                self.replicas[0].run_command(
-                    ['getcert', 'resubmit', '-i', req_id]
-                )
-                tasks.wait_for_certmonger_status(
-                    self.replicas[0], ('MONITORING'), req_id, timeout=600
-                )
-
-        self.replicas[0].run_command(
-            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
-        )
-
+        assert result.returncode == 0
         check_status(self.replicas[0], 9, "MONITORING")
+        assert_postconditions(self.replicas[0])
 
-        # Sometimes certmonger takes time to update the cert status
-        # So check in nssdb instead of relying on getcert command
+        # Verify cert was actually renewed by the tool
         renewed_expiry = get_cert_expiry(
             self.replicas[0],
             paths.PKI_TOMCAT_ALIAS_DIR,
             'Server-Cert cert-pki-ca'
         )
         assert renewed_expiry > initial_expiry
+
+        # Verify replication works after fix
+        stdin = (f"{self.master.config.admin_password}\n"
+                 f"{self.master.config.admin_password}\n"
+                 f"{self.master.config.admin_password}\n")
+        self.master.run_command(
+            ['kinit', 'admin'], stdin_text=stdin
+        )
+        tasks.user_add(
+            self.master, 'rep1testuser',
+            password='Secret@123',
+        )
+        time.sleep(5)
+        self.replicas[0].run_command(
+            ['kinit', 'admin'], stdin_text=stdin
+        )
+        self.replicas[0].run_command(
+            ['ipa', 'user-show', 'rep1testuser']
+        )
+
+    def test_rep2_unattended_force_server(
+        self, expire_certs_and_fix_master,
+    ):
+        """T-REP-2: Unattended with --force-server.
+
+        No prompts, completes autonomously, exit code 0.
+        """
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v', '-U',
+             '--force-server', self.master.hostname],
+        )
+        assert result.returncode == 0
+        check_status(self.replicas[0], 9, "MONITORING")
+        assert_postconditions(self.replicas[0])
+
+    def test_rep3_dry_run_on_replica(
+        self, expire_certs_and_fix_master,
+    ):
+        """T-REP-3: Dry-run on replica shows plan, no changes."""
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v', '--dry-run',
+             '--force-server', self.master.hostname],
+        )
+        assert result.returncode == 0
+        assert "[DRY RUN]" in result.stdout_text
+
+    def test_rep4_force_server_self(self):
+        """T-REP-4: --force-server pointing to self is rejected."""
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v',
+             '--force-server', self.replicas[0].hostname],
+            raiseonerr=False,
+        )
+        assert result.returncode != 0
+        assert "different server" in result.stdout_text
+
+    def test_rep5_force_server_unreachable(
+        self, expire_certs_and_fix_master,
+    ):
+        """T-REP-5: --force-server to unreachable host fails."""
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v',
+             '--force-server', 'nonexistent.example.com'],
+            stdin_text='yes\n',
+            raiseonerr=False,
+        )
+        assert result.returncode != 0
+
+    def test_rep13_user_declines(
+        self, expire_certs_and_fix_master,
+    ):
+        """T-REP-13: User says "no" at replica fix prompt."""
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='no\n',
+            raiseonerr=False,
+        )
+        assert "Not proceeding" in result.stdout_text
+
+
+# ---------------------------------------------------------------
+#  3. Third-party DS cert nickname (T-DETECT-5)
+# ---------------------------------------------------------------
+
+class TestCertFixThirdParty(CALessBase):
+    """Verify ipa-cert-fix handles custom DS cert nicknames.
+
+    T-DETECT-5: When LDAP uses a non-default certificate nickname
+    (from ipa-server-certinstall), the tool must use the actual
+    nickname, not a hardcoded value.
+    """
+
+    @classmethod
+    def install(cls, mh):
+        cls.nickname = 'ca1/server'
+        super(TestCertFixThirdParty, cls).install(mh)
+        tasks.install_master(cls.master, setup_dns=True)
+
+    @server_install_teardown
+    def test_detect5_custom_ds_nickname(self):
+        """T-DETECT-5: Custom (third-party) DS certificate nickname."""
+        self.create_pkcs12(self.nickname,
+                           password=self.cert_password,
+                           filename='server.p12')
+        self.prepare_cacert('ca1')
+
+        nick_chain = self.nickname.split('/')
+        ca_cert = '%s.crt' % nick_chain[0]
+
+        self.copy_cert(self.master, ca_cert)
+        self.master.run_command(
+            ['ipa-cacert-manage', 'install', ca_cert]
+        )
+        self.master.run_command(['ipa-certupdate'])
+
+        self.copy_cert(self.master, 'server.p12')
+        args = ['ipa-server-certinstall',
+                '-p', self.master.config.dirman_password,
+                '--pin', self.master.config.admin_password,
+                '-d', 'server.p12']
+        self.master.run_command(args)
+        self.master.run_command(['ipactl', 'restart'])
+
+        # ipa-cert-fix should use the custom nickname
+        result = self.master.run_command(['ipa-cert-fix', '-v'])
+        assert self.nickname in result.stderr_text
+
+
+# ---------------------------------------------------------------
+#  7. Cross-Cutting: Pre-flight (T-PRE-*)
+# ---------------------------------------------------------------
+
+class TestPreFlight(IntegrationTest):
+    """Pre-flight check tests -- no install needed for some."""
+
+    @classmethod
+    def uninstall(cls, mh):
+        pass
+
+    def test_pre1_ipa_not_configured(self):
+        """T-PRE-1: ipa-cert-fix on non-IPA system returns exit code 2."""
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n',
+            raiseonerr=False,
+        )
+        assert result.returncode == 2
+
+    def test_pre4_no_expired_certs(self):
+        """T-PRE-4: No expired certs -- "Nothing to do"."""
+        tasks.install_master(self.master, setup_dns=False,
+                             extra_args=['--no-ntp'])
+        try:
+            result = self.master.run_command(
+                ['ipa-cert-fix', '-v']
+            )
+            assert "Nothing to do" in result.stdout_text
+            assert result.returncode == 0
+        finally:
+            tasks.uninstall_master(self.master)
+
+
+# ---------------------------------------------------------------
+#  6. Topology-Wide Expiry (T-TOPO-*)
+#  9. End-to-End Story Tests (T-E2E-*)
+# ---------------------------------------------------------------
+
+class TestTopologyWideExpiry(IntegrationTest):
+    """Tests for topology-wide certificate expiry.
+
+    Covers T-TOPO-* and T-E2E-1: the realistic scenario where
+    all certs are expired on all hosts and recovery must proceed
+    in the correct order.
+    """
+
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(
+            mh.master, setup_dns=False,
+            extra_args=['--no-ntp']
+        )
+        tasks.install_replica(
+            mh.master, mh.replicas[0],
+            setup_dns=False, extra_args=['--no-ntp']
+        )
+
+    @classmethod
+    def uninstall(cls, mh):
+        pass
+
+    @pytest.fixture
+    def expire_all(self):
+        """Expire certs on both master and replica."""
+        for host in self.master, self.replicas[0]:
+            tasks.move_date(host, 'stop', '+3years+1days')
+            host.run_command(
+                ['ipactl', 'restart', '--ignore-service-failures']
+            )
+        yield
+        for host in self.replicas[0], self.master:
+            tasks.uninstall_master(host)
+            tasks.move_date(host, 'start', '-3years-1days')
+
+    def test_topo1_fix_master_then_replica(self, expire_all):
+        """T-TOPO-1 / T-E2E-1: Fix master first, then replica.
+
+        This is the most common real-world disaster recovery scenario.
+        Both hosts have expired certs.  Fix the master (renewal master
+        path), then fix the replica (non-destructive path).
+        """
+        # Step 1: Fix master
+        check_status(self.master, 8, "CA_UNREACHABLE")
+        self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+        check_status(self.master, 9, "MONITORING")
+        assert_postconditions(self.master)
+
+        # Step 2: Fix replica using master
+        self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v',
+             '--force-server', self.master.hostname],
+            stdin_text='yes\n',
+        )
+        check_status(self.replicas[0], 9, "MONITORING")
+        assert_postconditions(self.replicas[0])
+
+        # Step 3: Verify topology healthy
+        stdin = (f"{self.master.config.admin_password}\n"
+                 f"{self.master.config.admin_password}\n"
+                 f"{self.master.config.admin_password}\n")
+        self.master.run_command(
+            ['kinit', 'admin'], stdin_text=stdin
+        )
+        tasks.user_add(self.master, 'topo1testuser', password='Secret@123')
+
+        self.replicas[0].run_command(
+            ['kinit', 'admin'], stdin_text=stdin
+        )
+        # Wait a moment for replication
+        time.sleep(5)
+        self.replicas[0].run_command(
+            ['ipa', 'user-show', 'topo1testuser']
+        )
+
+    def test_topo2_replica_before_master_fixed(self, expire_all):
+        """T-TOPO-2: Replica attempt before master is fixed.
+
+        Master's HTTPS cert is expired.  TLS handshake from
+        replica to master must fail with an actionable error.
+        """
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v',
+             '--force-server', self.master.hostname],
+            stdin_text='yes\n',
+            raiseonerr=False,
+        )
+        # Should fail -- master's certs are also expired
+        assert result.returncode != 0
+
+
+# ---------------------------------------------------------------
+#  7. Cross-Cutting: Idempotency (T-IDEM-*)
+# ---------------------------------------------------------------
+
+class TestIdempotency(IntegrationTest):
+    """Verify ipa-cert-fix is safe to re-run."""
+
+    @classmethod
+    def uninstall(cls, mh):
+        pass
+
+    def test_idem1_second_run(self, expire_cert_critical):
+        """T-IDEM-1: Second run immediately after fix.
+
+        After a successful fix, re-run produces "Nothing to do".
+        """
+        expire_cert_critical(self.master)
+        check_status(self.master, 8, "CA_UNREACHABLE")
+
+        self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+        check_status(self.master, 9, "MONITORING")
+
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+        assert "Nothing to do" in result.stdout_text
+        assert_postconditions(self.master)
+
+
+# ---------------------------------------------------------------
+#  3. CA-Full Replica -- Promote to RM (T-PROMO-*)
+# ---------------------------------------------------------------
+
+class TestCertFixPromotion(IntegrationTest):
+    """Tests for the promote-to-renewal-master scenario.
+
+    Requires a topology where the renewal master is permanently
+    down so the replica must be promoted.
+    """
+
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(
+            mh.master, setup_dns=False, extra_args=['--no-ntp']
+        )
+        tasks.install_replica(
+            mh.master, mh.replicas[0],
+            setup_dns=False, extra_args=['--no-ntp']
+        )
+
+    @classmethod
+    def uninstall(cls, mh):
+        pass
+
+    @pytest.fixture
+    def expire_and_shutdown_master(self):
+        """Expire certs on replica, shut down master permanently."""
+        # Expire certs on both hosts
+        for host in self.master, self.replicas[0]:
+            tasks.move_date(host, 'stop', '+3years+1days')
+        # Shut down master entirely to simulate permanent failure
+        self.master.run_command(['ipactl', 'stop'])
+        self.replicas[0].run_command(
+            ['ipactl', 'restart', '--ignore-service-failures']
+        )
+        yield
+        for host in self.replicas[0], self.master:
+            tasks.uninstall_master(host)
+            tasks.move_date(host, 'start', '-3years-1days')
+
+    def test_promo1_promote_when_master_down(
+        self, expire_and_shutdown_master
+    ):
+        """T-PROMO-1: Promotion when master is permanently down.
+
+        Replica should detect no working master, offer promotion,
+        become RM, and renew certs.
+        """
+        check_status(self.replicas[0], 8, "CA_UNREACHABLE")
+
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v', '--renewal-master'],
+            stdin_text='yes\n',
+        )
+        assert result.returncode == 0
+        check_status(self.replicas[0], 9, "MONITORING")
+        assert_postconditions(self.replicas[0])
+
+        # Verify CRL warning is printed
+        assert "ipa-crlgen-manage" in result.stdout_text
+
+    def test_promo2_unattended_refuses_promotion(
+        self, expire_and_shutdown_master
+    ):
+        """T-PROMO-2/3: Unattended without --renewal-master refuses.
+
+        In unattended mode without --renewal-master, the tool
+        must refuse to silently promote.  RM role unchanged, no certs
+        renewed, exit code 1, message mentions --renewal-master.
+        """
+        check_status(self.replicas[0], 8, "CA_UNREACHABLE")
+
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v', '-U'],
+            raiseonerr=False,
+        )
+        assert result.returncode == 1
+        assert "--renewal-master" in result.stdout_text
+
+
+# ---------------------------------------------------------------
+#  4. CA-Less Replica (T-CALESS-*)
+# ---------------------------------------------------------------
+
+class TestCertFixCALess(IntegrationTest):
+    """Tests for the CA-less replica fix scenario.
+
+    Topology: CA-full master + CA-less replica.
+    """
+
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(
+            mh.master, setup_dns=True, extra_args=['--no-ntp']
+        )
+        tasks.install_replica(
+            mh.master, mh.replicas[0],
+            setup_ca=False, setup_dns=False,
+            extra_args=['--no-ntp'],
+        )
+
+    @classmethod
+    def uninstall(cls, mh):
+        pass
+
+    @pytest.fixture
+    def expire_caless_certs(self):
+        """Expire service certs on the CA-less replica."""
+        for host in self.master, self.replicas[0]:
+            tasks.move_date(host, 'stop', '+3years+1days')
+            host.run_command(
+                ['ipactl', 'restart', '--ignore-service-failures']
+            )
+        yield
+        for host in self.replicas[0], self.master:
+            tasks.uninstall_master(host)
+            tasks.move_date(host, 'start', '-3years-1days')
+
+    @pytest.fixture
+    def expire_caless_and_fix_master(self, expire_caless_certs):
+        """Expire certs on both hosts, then fix the master."""
+        check_status(self.master, 8, "CA_UNREACHABLE")
+        self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+        check_status(self.master, 9, "MONITORING")
+
+    def test_caless1_renewed_from_ca_server(
+        self, expire_caless_certs
+    ):
+        """T-CALESS-1: HTTP/LDAP/KDC renewed from CA server.
+
+        Fix master first (RM path), then fix CA-less replica
+        using --force-server=master.  Verify: only IPA service
+        certs renewed, no Dogtag certs touched.
+        """
+        # Fix master first
+        check_status(self.master, 8, "CA_UNREACHABLE")
+        self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+        check_status(self.master, 9, "MONITORING")
+
+        # Fix CA-less replica
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v',
+             '--force-server', self.master.hostname],
+            stdin_text='yes\n',
+        )
+        assert result.returncode == 0
+        assert_postconditions(self.replicas[0])
+
+        # Verify no dogtag certs on CA-less replica
+        cmd = self.replicas[0].run_command(
+            ['getcert', 'list',
+             '-d', paths.PKI_TOMCAT_ALIAS_DIR],
+            raiseonerr=False,
+        )
+        # CA-less replica should not have PKI tomcat certs
+        if cmd.returncode == 0:
+            assert 'caSigningCert' not in cmd.stdout_text
+
+    def test_caless2_dry_run(self, expire_caless_and_fix_master):
+        """T-CALESS-2: Dry-run on CA-less replica.
+
+        Shows empty Dogtag list, lists IPA certs to be renewed.
+        """
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v', '--dry-run',
+             '--force-server', self.master.hostname],
+        )
+        assert result.returncode == 0
+        assert "[DRY RUN]" in result.stdout_text
+
+    def test_caless4_user_declines(
+        self, expire_caless_and_fix_master,
+    ):
+        """T-CALESS-4: User declines confirmation on CA-less replica."""
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v',
+             '--force-server', self.master.hostname],
+            stdin_text='no\n',
+        )
+        assert "Not proceeding" in result.stdout_text
+
+
+# ---------------------------------------------------------------
+#  5. External CA (T-EXT-*)
+# ---------------------------------------------------------------
+
+class TestCertFixExternalCA(IntegrationTest):
+    """Tests for external CA deployment scenarios.
+
+    Uses 2-step external CA installation.
+    """
+
+    ROOT_CA = 'root_ca.crt'
+    IPA_CA = 'ipa_ca.crt'
+
+    @classmethod
+    def install(cls, mh):
+        pass
+
+    @classmethod
+    def uninstall(cls, mh):
+        pass
+
+    @pytest.fixture
+    def external_ca_server(self):
+        """Install IPA with external CA, then expire certs."""
+        # Step 1
+        install_server_external_ca_step1(self.master)
+
+        # Sign CSR and transport certs
+        root_ca_fname, ipa_ca_fname = tasks.sign_ca_and_transport(
+            self.master, paths.ROOT_IPA_CSR,
+            self.ROOT_CA, self.IPA_CA,
+        )
+
+        # Step 2
+        install_server_external_ca_step2(
+            self.master, ipa_ca_fname, root_ca_fname,
+        )
+
+        yield
+
+        self.master.run_command(
+            ['systemctl', 'stop', 'certmonger'],
+            raiseonerr=False,
+        )
+        self.master.run_command(
+            'rm -fv ' + paths.CERTMONGER_REQUESTS_DIR + '*',
+            raiseonerr=False,
+        )
+        tasks.uninstall_master(self.master)
+
+    def test_ext3_unattended_generates_csr(self, external_ca_server):
+        """T-EXT-3: Unattended with externally-signed CA.
+
+        With all certs expired on an externally-signed CA
+        deployment, the CA cert is expired too.  The tool
+        must refuse (CA cert renewal is manual), extract
+        the CSR, and return exit code 1.
+        """
+        # Move date to expire certs
+        tasks.move_date(self.master, 'stop', '+3years+1days')
+        self.master.run_command(
+            ['ipactl', 'restart', '--ignore-service-failures']
+        )
+
+        try:
+            result = self.master.run_command(
+                ['ipa-cert-fix', '-v', '-U'],
+                raiseonerr=False,
+            )
+            # CA cert is expired → tool prints guidance and exits with code 1
+            assert result.returncode == 1
+            assert (
+                'ipa-cacert-manage' in result.stdout_text
+                or 'ca.csr' in result.stdout_text
+            )
+        finally:
+            tasks.move_date(
+                self.master, 'start', '-3years-1days'
+            )
+
+
+class TestCertFixMixedExternal(IntegrationTest):
+    """T-EXT-1/2: Mixed deployment with externally-signed HTTP cert.
+
+    IPA CA is self-signed (normal), but HTTP cert is replaced with
+    an externally-signed one via ipa-server-certinstall.  Tests
+    transition to internal CA and CSR generation.
+    """
+
+    @classmethod
+    def install(cls, mh):
+        pass
+
+    @classmethod
+    def uninstall(cls, mh):
+        pass
+
+    @pytest.fixture
+    def mixed_expired(self):
+        """Install master, replace HTTP cert with external, expire."""
+        tasks.install_master(self.master, setup_dns=False,
+                             extra_args=['--no-ntp'])
+
+        # Generate a self-signed external cert for HTTP
+        self.master.run_command([
+            'openssl', 'req', '-x509', '-newkey', 'rsa:2048',
+            '-keyout', '/root/ext-http.key',
+            '-out', '/root/ext-http.crt',
+            '-days', '365', '-nodes',
+            '-subj', '/CN=%s' % self.master.hostname,
+        ])
+        # Create PKCS#12 for ipa-server-certinstall
+        self.master.run_command([
+            'openssl', 'pkcs12', '-export',
+            '-in', '/root/ext-http.crt',
+            '-inkey', '/root/ext-http.key',
+            '-out', '/root/ext-http.p12',
+            '-passout', 'pass:Secret123',
+            '-name', self.master.hostname,
+        ])
+        # Install external HTTP cert
+        self.master.run_command([
+            'ipa-server-certinstall', '--http',
+            '/root/ext-http.p12',
+            '--pin', 'Secret123',
+            '-p', self.master.config.dirman_password,
+        ])
+
+        # Expire certs
+        tasks.move_date(self.master, 'stop', '+3Years+1day')
+        yield
+        self.master.run_command(
+            ['systemctl', 'stop', 'certmonger'],
+            raiseonerr=False)
+        self.master.run_command(
+            'rm -fv ' + paths.CERTMONGER_REQUESTS_DIR + '*',
+            raiseonerr=False)
+        tasks.uninstall_master(self.master)
+        tasks.move_date(self.master, 'start', '-3Years-1day')
+
+    def test_ext1_transition_to_internal_ca(self, mixed_expired):
+        """T-EXT-1: Accept transition of external HTTP cert to IPA CA.
+
+        The tool should detect the externally-signed HTTP cert,
+        offer transition, and upon acceptance obtain a new
+        internally-signed cert via certmonger.
+        """
+        # Answer 'yes' to the warning, then 'True' to transition
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v'],
+            stdin_text='yes\nTrue\n',
+        )
+        assert result.returncode == 0
+        assert 'transitioned successfully' in result.stdout_text
+        assert_postconditions(self.master)
+
+    def test_ext2_decline_transition_generates_csr(self, mixed_expired):
+        """T-EXT-2: Decline transition -> CSR generated.
+
+        The tool should generate a CSR from the existing key and
+        print ipa-server-certinstall instructions.
+        """
+        # Answer 'yes' to the warning, then 'False' to decline
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v'],
+            stdin_text='yes\nFalse\n',
+        )
+        assert result.returncode == 0
+        output = result.stdout_text
+        assert 'CSR' in output or '.csr' in output
+        assert 'ipa-server-certinstall' in output
+
+
+# ---------------------------------------------------------------
+#  7. Cross-Cutting: Pre-flight additions (T-PRE-3)
+# ---------------------------------------------------------------
+
+class TestPreFlightDS(IntegrationTest):
+    """Pre-flight check: DS down."""
+
+    @classmethod
+    def uninstall(cls, mh):
+        pass
+
+    def test_pre3_ds_down(self, expire_cert_critical):
+        """T-PRE-3: Directory Server down blocks ipa-cert-fix.
+
+        Stop dirsrv, verify ipa-cert-fix refuses to proceed.
+        """
+        expire_cert_critical(self.master)
+        instance = realm_to_serverid(self.master.domain.realm)
+        self.master.run_command(
+            ['systemctl', 'stop',
+             'dirsrv@%s' % instance]
+        )
+        try:
+            result = self.master.run_command(
+                ['ipa-cert-fix', '-v'],
+                stdin_text='yes\n',
+                raiseonerr=False,
+            )
+            assert result.returncode == 1
+        finally:
+            self.master.run_command(
+                ['systemctl', 'start',
+                 'dirsrv@%s' % instance],
+                raiseonerr=False,
+            )
+
+
+# ---------------------------------------------------------------
+#  7. Cross-Cutting: State Restoration (T-RESTORE-*)
+# ---------------------------------------------------------------
+
+class TestStateRestoration(IntegrationTest):
+    """Verify state is properly restored after failures."""
+
+    num_replicas = 1
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(
+            mh.master, setup_dns=False, extra_args=['--no-ntp']
+        )
+        tasks.install_replica(
+            mh.master, mh.replicas[0],
+            setup_dns=False, extra_args=['--no-ntp']
+        )
+
+    @classmethod
+    def uninstall(cls, mh):
+        pass
+
+    @pytest.fixture
+    def expire_and_block(self):
+        """Expire certs on replica, fix master, then block master."""
+        for host in self.master, self.replicas[0]:
+            tasks.move_date(host, 'stop', '+3years+1days')
+            host.run_command(
+                ['ipactl', 'restart', '--ignore-service-failures']
+            )
+        # Fix master first
+        self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+        check_status(self.master, 9, "MONITORING")
+
+        # Block HTTPS on master to cause replica fix timeout
+        fw = Firewall(self.master)
+        fw.disable_service("https")
+        yield
+        fw.enable_service("https")
+        for host in self.replicas[0], self.master:
+            tasks.uninstall_master(host)
+            tasks.move_date(host, 'start', '-3years-1days')
+
+    def test_restore1_ca_helper_after_timeout(
+        self, expire_and_block
+    ):
+        """T-RESTORE-1: IPA CA helper restored after timeout.
+
+        Cause a timeout during cert renewal by blocking HTTPS.
+        Verify P1: certmonger external-helper has no -J override.
+        """
+        result = self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v',
+             '--force-server', self.master.hostname],
+            stdin_text='yes\n',
+            raiseonerr=False,
+        )
+        # Should fail due to blocked HTTPS
+        assert result.returncode != 0
+
+        # P1: IPA CA helper must be cleaned up
+        assert_postconditions(self.replicas[0])
+
+    @pytest.fixture
+    def expire_and_block_after_first(self):
+        """Expire certs on replica, fix master, let first cert
+        renew, then block master mid-flow."""
+        for host in self.master, self.replicas[0]:
+            tasks.move_date(host, 'stop', '+3years+1days')
+            host.run_command(
+                ['ipactl', 'restart', '--ignore-service-failures']
+            )
+        # Fix master first
+        self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+        check_status(self.master, 9, "MONITORING")
+        yield
+        # Ensure firewall is restored even if test fails
+        fw = Firewall(self.master)
+        fw.enable_service("https")
+        for host in self.replicas[0], self.master:
+            tasks.uninstall_master(host)
+            tasks.move_date(host, 'start', '-3years-1days')
+
+    def test_restore2_dogtag_ca_profile_restored(
+        self, expire_and_block_after_first,
+    ):
+        """T-RESTORE-2: Dogtag CA name and profile restored.
+
+        Start renewal on replica, block HTTPS after the first
+        cert succeeds so the second times out.  Verify P2/P5:
+        Dogtag certs have ca-name=dogtag-ipa-ca-renew-agent
+        (not IPA) and no orphaned host/ principal.
+        """
+        # Start ipa-cert-fix on replica; it will begin renewing
+        # certs from the master.  Block HTTPS partway through.
+        # The tool's finally block should restore all certmonger
+        # state regardless of which cert failed.
+        fw = Firewall(self.master)
+
+        # Give the tool time to start renewing the first cert,
+        # then block HTTPS so subsequent certs time out.
+        # We use a background ipa-cert-fix + sleep + firewall.
+        self.replicas[0].run_command(
+            ['bash', '-c',
+             'nohup ipa-cert-fix -v --force-server %s '
+             '< <(echo yes) &>/root/certfix.log &'
+             % self.master.hostname],)
+        time.sleep(30)
+        fw.disable_service("https")
+
+        # Wait for ipa-cert-fix to finish (it will time out)
+        for _i in range(60):
+            rc = self.replicas[0].run_command(
+                ['pgrep', '-f', 'ipa-cert-fix'],
+                raiseonerr=False,
+            )
+            if rc.returncode != 0:
+                break
+            time.sleep(10)
+
+        # P2 + P5: certmonger state must be clean
+        assert_postconditions(self.replicas[0])
+
+        # Explicit check: Dogtag certs must NOT have CA=IPA
+        for nickname in ('auditSigningCert cert-pki-ca',
+                         'ocspSigningCert cert-pki-ca',
+                         'subsystemCert cert-pki-ca'):
+            cmd = self.replicas[0].run_command(
+                ['getcert', 'list',
+                 '-d', paths.PKI_TOMCAT_ALIAS_DIR,
+                 '-n', nickname],
+                raiseonerr=False,
+            )
+            if cmd.returncode == 0:
+                assert 'CA: IPA' not in cmd.stdout_text, (
+                    "%s still has CA=IPA after failure"
+                    % nickname
+                )
+
+
+# ---------------------------------------------------------------
+#  7. Cross-Cutting: Detection Edge Cases (T-DETECT-*)
+# ---------------------------------------------------------------
+
+class TestDetectionEdgeCases(IntegrationTest):
+    """Deployment detection edge case tests."""
+
+    @classmethod
+    def uninstall(cls, mh):
+        pass
+
+    def test_detect1_nss_unreadable(self, expire_cert_critical):
+        """T-DETECT-1: NSS database unreadable.
+
+        Corrupt permissions on PKI NSS database. Verify:
+        actionable error, no crash.
+        """
+        expire_cert_critical(self.master)
+
+        # Make NSS db unreadable
+        self.master.run_command(
+            ['chmod', '000', paths.PKI_TOMCAT_ALIAS_DIR]
+        )
+        try:
+            result = self.master.run_command(
+                ['ipa-cert-fix', '-v'],
+                stdin_text='yes\n',
+                raiseonerr=False,
+            )
+            # Should fail with a meaningful error, not a traceback
+            assert result.returncode != 0
+        finally:
+            self.master.run_command(
+                ['chmod', '755', paths.PKI_TOMCAT_ALIAS_DIR]
+            )
+
+    def test_detect3_cert_file_missing(self, expire_cert_critical):
+        """T-DETECT-3: One service cert file missing.
+
+        Delete KDC cert. Verify: detection still works,
+        missing cert skipped with warning.
+        """
+        expire_cert_critical(self.master)
+
+        # Back up and remove KDC cert
+        self.master.run_command(
+            ['cp', paths.KDC_CERT, '/root/kdc_cert.bak']
+        )
+        self.master.run_command(['rm', '-f', paths.KDC_CERT])
+        try:
+            result = self.master.run_command(
+                ['ipa-cert-fix', '-v'],
+                stdin_text='yes\n',
+                raiseonerr=False,
+            )
+            # Missing KDC cert is skipped; other expired
+            # certs are still fixed.  Should succeed.
+            assert result.returncode == 0
+        finally:
+            self.master.run_command(
+                ['cp', '/root/kdc_cert.bak', paths.KDC_CERT],
+                raiseonerr=False,
+            )
+
+    def test_detect4_all_cert_files_missing(self, expire_cert_critical):
+        """T-DETECT-4: All service cert files missing.
+
+        Delete HTTP, LDAP, and KDC cert files.  Verify: tool does
+        not claim "Nothing to do" -- it should still detect expired
+        Dogtag certs and proceed (or report the missing files).
+        """
+        expire_cert_critical(self.master)
+
+        # Back up and remove all IPA service cert files
+        for certfile in (paths.HTTPD_CERT_FILE,
+                         paths.KDC_CERT):
+            self.master.run_command(
+                ['cp', certfile, certfile + '.bak'],
+                raiseonerr=False,
+            )
+            self.master.run_command(['rm', '-f', certfile])
+
+        try:
+            result = self.master.run_command(
+                ['ipa-cert-fix', '-v'], stdin_text='yes\n',
+                raiseonerr=False,
+            )
+            # Should NOT say "Nothing to do" -- Dogtag certs
+            # are still expired even if IPA cert files are gone.
+            assert "Nothing to do" not in result.stdout_text
+        finally:
+            for certfile in (paths.HTTPD_CERT_FILE,
+                             paths.KDC_CERT):
+                self.master.run_command(
+                    ['cp', certfile + '.bak', certfile],
+                    raiseonerr=False,
+                )
+
+
+# ---------------------------------------------------------------
+#  7. RA/Subsystem LDAP Consistency (T-CONSIST-*)
+# ---------------------------------------------------------------
+
+class TestConsistency(IntegrationTest):
+    """RA/Subsystem LDAP consistency check tests."""
+
+    @classmethod
+    def uninstall(cls, mh):
+        pass
+
+    @pytest.fixture
+    def installed_master(self):
+        """Install a master for consistency tests."""
+        tasks.install_master(self.master, setup_dns=False,
+                             extra_args=['--no-ntp'])
+        yield
+        tasks.uninstall_master(self.master)
+
+    def _break_ra_serial(self):
+        """Modify uid=ipara description to contain a wrong serial."""
+        self.master.run_command([
+            'ldapmodify', '-x', '-H',
+            'ldap://%s' % self.master.hostname,
+            '-D', 'cn=Directory Manager',
+            '-w', self.master.config.dirman_password,
+        ], stdin_text=(
+            "dn: uid=ipara,ou=People,o=ipaca\nchangetype: modify\n"
+            "replace: description\ndescription: 2;99999;CN=bad;CN=bad\n"
+        ))
+
+    def test_consist1_ra_serial_mismatch(self, installed_master):
+        """T-CONSIST-1: RA cert serial mismatch in LDAP.
+
+        Modify uid=ipara description to contain a wrong serial.
+        Run ipa-cert-fix.  Verify mismatch detected and fixed.
+        """
+        self._break_ra_serial()
+
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n',
+        )
+        assert result.returncode == 0
+        assert 'description serial mismatch' in result.stdout_text
+        assert 'Updated' in result.stdout_text
+
+        # Verify fixed: re-run should say "Nothing to do"
+        result2 = self.master.run_command(
+            ['ipa-cert-fix', '-v'],
+        )
+        assert "Nothing to do" in result2.stdout_text
+
+    def test_consist3_dry_run_no_fix(self, installed_master):
+        """T-CONSIST-3: Dry-run shows mismatches without fixing.
+
+        Same setup as T-CONSIST-1 but with --dry-run.  LDAP
+        must not be modified.
+        """
+        self._break_ra_serial()
+
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v', '--dry-run'],
+        )
+        assert result.returncode == 0
+        assert '[DRY RUN]' in result.stdout_text
+        assert 'description serial mismatch' in result.stdout_text
+
+        # Mismatch should still be present (not fixed)
+        result2 = self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n',
+        )
+        assert 'description serial mismatch' in result2.stdout_text
+
+    def test_consist4_no_mismatches_no_prompt(self, installed_master):
+        """T-CONSIST-4: No mismatches, no consistency prompt.
+
+        On a healthy server with no expired certs, the tool
+        should say "Nothing to do" without any mismatch output.
+        """
+        result = self.master.run_command(
+            ['ipa-cert-fix', '-v'],
+        )
+        assert "Nothing to do" in result.stdout_text
+        assert 'mismatch' not in result.stdout_text.lower()
+        assert 'Updated' not in result.stdout_text
+
+
+# ---------------------------------------------------------------
+#  9. End-to-End: Full Topology Recovery (T-E2E-1)
+# ---------------------------------------------------------------
+
+class TestE2EFullTopology(IntegrationTest):
+    """End-to-end: master + CA replica + CA-less replica.
+
+    T-E2E-1: The single most important test -- complete
+    topology recovery.
+    """
+
+    num_replicas = 2
+
+    @classmethod
+    def install(cls, mh):
+        tasks.install_master(
+            mh.master, setup_dns=True, extra_args=['--no-ntp']
+        )
+        # replica 0: CA-full
+        tasks.install_replica(
+            mh.master, mh.replicas[0],
+            setup_dns=False, extra_args=['--no-ntp'],
+        )
+        # replica 1: CA-less
+        tasks.install_replica(
+            mh.master, mh.replicas[1],
+            setup_ca=False, setup_dns=False,
+            extra_args=['--no-ntp'],
+        )
+
+    @classmethod
+    def uninstall(cls, mh):
+        pass
+
+    @pytest.fixture
+    def expire_topology(self):
+        """Expire certs on all three hosts."""
+        for host in (self.master, self.replicas[0], self.replicas[1]):
+            tasks.move_date(host, 'stop', '+3years+1days')
+            host.run_command(
+                ['ipactl', 'restart', '--ignore-service-failures']
+            )
+        yield
+        for host in (self.replicas[1], self.replicas[0], self.master):
+            tasks.uninstall_master(host)
+            tasks.move_date(host, 'start', '-3years-1days')
+
+    def test_e2e1_full_recovery(self, expire_topology):
+        """T-E2E-1: Full topology recovery sequence.
+
+        1. Fix master (renewal master path)
+        2. Fix CA-full replica (non-destructive)
+        3. Fix CA-less replica
+        4. Verify all hosts operational
+        """
+        # Step 1: Fix master
+        check_status(self.master, 8, "CA_UNREACHABLE")
+        self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+        check_status(self.master, 9, "MONITORING")
+        assert_postconditions(self.master)
+
+        # Step 2: Fix CA-full replica
+        self.replicas[0].run_command(
+            ['ipa-cert-fix', '-v',
+             '--force-server', self.master.hostname],
+            stdin_text='yes\n',
+        )
+        check_status(self.replicas[0], 9, "MONITORING")
+        assert_postconditions(self.replicas[0])
+
+        # Step 3: Fix CA-less replica
+        self.replicas[1].run_command(
+            ['ipa-cert-fix', '-v',
+             '--force-server', self.master.hostname],
+            stdin_text='yes\n',
+        )
+        assert_postconditions(self.replicas[1])
+
+        # Step 4: Verify topology is healthy
+        stdin = (f"{self.master.config.admin_password}\n"
+                 f"{self.master.config.admin_password}\n"
+                 f"{self.master.config.admin_password}\n")
+        self.master.run_command(
+            ['kinit', 'admin'], stdin_text=stdin
+        )
+        tasks.user_add(
+            self.master, 'e2e1testuser', password='Secret@123'
+        )
+
+        # Verify replication to CA-full replica
+        time.sleep(5)
+        self.replicas[0].run_command(
+            ['kinit', 'admin'], stdin_text=stdin
+        )
+        self.replicas[0].run_command(
+            ['ipa', 'user-show', 'e2e1testuser']
+        )
+
+        # Verify replication to CA-less replica
+        self.replicas[1].run_command(
+            ['kinit', 'admin'], stdin_text=stdin
+        )
+        self.replicas[1].run_command(
+            ['ipa', 'user-show', 'e2e1testuser']
+        )

--- a/ipatests/test_integration/test_ipa_cert_fix_unit.py
+++ b/ipatests/test_integration/test_ipa_cert_fix_unit.py
@@ -8,12 +8,18 @@ Unit tests for ipa-cert-fix.
 These tests use mocks and do not require an IPA deployment.  They exercise
 pure logic and should run in seconds.
 """
+from unittest import mock
 import pytest
 
+from ipaserver.install.ipa_cert_fix import (
+    CertmongerClient,
+)
 from ipaserver.install.ipa_cert_fix_types import (
     CertIdentity,
     DOGTAG_CERTS,
 )
+
+SMOD = 'ipaserver.install.ipa_cert_fix_services'
 
 
 class TestCertIdentityRegistry:
@@ -90,3 +96,78 @@ class TestCertIdentityRegistry:
         """All CertIdentity instances report is_dogtag=True."""
         for ci in DOGTAG_CERTS.values():
             assert ci.is_dogtag is True
+
+
+class TestCertmongerClient:
+    """CertmongerClient adapter delegation and retry logic."""
+
+    @mock.patch(SMOD + '.certmonger')
+    def test_get_request_id_delegates(self, mock_cm):
+        mock_cm.get_request_id.return_value = 'req-1'
+        client = CertmongerClient()
+        result = client.get_request_id({'cert-file': '/a'})
+        assert result == 'req-1'
+        mock_cm.get_request_id.assert_called_once_with({'cert-file': '/a'})
+
+    @mock.patch(SMOD + '.certmonger')
+    def test_get_request_value_delegates(self, mock_cm):
+        mock_cm.get_request_value.return_value = 'MONITORING'
+        client = CertmongerClient()
+        result = client.get_request_value('req-1', 'status')
+        assert result == 'MONITORING'
+
+    @mock.patch(SMOD + '.certmonger')
+    def test_resubmit_request_delegates(self, mock_cm):
+        client = CertmongerClient()
+        client.resubmit_request('req-1', ca='IPA')
+        mock_cm.resubmit_request.assert_called_once_with(
+            'req-1', ca='IPA', profile=None)
+
+    @mock.patch(SMOD + '.certmonger')
+    def test_modify_ca_helper_delegates(self, mock_cm):
+        client = CertmongerClient()
+        client.modify_ca_helper('IPA', '/usr/libexec/ipa-submit')
+        mock_cm.modify_ca_helper.assert_called_once_with(
+            'IPA', '/usr/libexec/ipa-submit')
+
+    @mock.patch(SMOD + '.time.sleep')
+    @mock.patch(SMOD + '.time.monotonic')
+    @mock.patch(SMOD + '.ipautil')
+    def test_is_responsive_returns_true(
+        self, mock_ipautil, mock_mono, mock_sleep,
+    ):
+        mock_ipautil.run.return_value = mock.MagicMock()
+        mock_mono.return_value = 0
+        client = CertmongerClient()
+        assert client.is_responsive(timeout=10) is True
+
+    @mock.patch(SMOD + '.time.sleep')
+    @mock.patch(SMOD + '.time.monotonic')
+    @mock.patch(SMOD + '.ipautil')
+    def test_is_responsive_timeout_returns_false(
+        self, mock_ipautil, mock_mono, mock_sleep,
+    ):
+        mock_ipautil.run.side_effect = Exception("D-Bus down")
+        mock_mono.side_effect = [0, 0, 200]
+        client = CertmongerClient()
+        assert client.is_responsive(timeout=1) is False
+
+    @mock.patch(SMOD + '.certmonger')
+    def test_start_tracking_delegates(self, mock_cm):
+        mock_cm.start_tracking.return_value = 'new-req'
+        client = CertmongerClient()
+        result = client.start_tracking(certpath='/cert', ca='IPA')
+        assert result == 'new-req'
+
+    @mock.patch(SMOD + '.certmonger')
+    def test_stop_tracking_delegates(self, mock_cm):
+        client = CertmongerClient()
+        client.stop_tracking('req-1')
+        mock_cm.stop_tracking.assert_called_once_with(request_id='req-1')
+
+    @mock.patch(SMOD + '.certmonger')
+    def test_get_requests_for_dir_delegates(self, mock_cm):
+        mock_cm.get_requests_for_dir.return_value = ['r1', 'r2']
+        client = CertmongerClient()
+        result = client.get_requests_for_dir('/etc/pki')
+        assert result == ['r1', 'r2']

--- a/ipatests/test_integration/test_ipa_cert_fix_unit.py
+++ b/ipatests/test_integration/test_ipa_cert_fix_unit.py
@@ -17,6 +17,7 @@ from ipaserver.install.ipa_cert_fix import (
     CertmongerClient,
     DeploymentDetector,
     DeploymentType,
+    ExternalCertHandler,
     FixScenario,
     IPACertType,
 )
@@ -650,3 +651,65 @@ class TestUnitPromoteRollback:
 
         obj._ca_instance.set_renewal_master.assert_called_with(
             'old-master.example.com')
+
+
+class TestUnitExternalCertsNoCA:
+    """ExternalCertHandler on fully-external deployments."""
+
+    @mock.patch(SMOD + '.os.makedirs')
+    @mock.patch(SMOD + '.find_providing_servers')
+    def test_caless_external_skips_ca_lookup(
+        self, mock_fps, mock_makedirs,
+    ):
+        """CA_LESS_EXTERNAL skips the CA server lookup entirely."""
+        cm = mock.MagicMock()
+        cm.get_request_id.return_value = None
+        handler = ExternalCertHandler(cm_client=cm, unattended=True)
+        handler._generate_csr_from_key = mock.MagicMock(return_value=None)
+
+        cert = mock.MagicMock()
+        ctx = _make_ctx(
+            deployment_type=DeploymentType.CA_LESS_EXTERNAL,
+            scenario=FixScenario.EXTERNAL_CERTS,
+            external_certs=[(IPACertType.HTTPS, cert)],
+            master_server=None,
+        )
+        handler.handle(ctx)
+
+        # find_providing_servers must NOT be called
+        mock_fps.assert_not_called()
+
+    def test_no_tracking_generates_csr_from_key(self, tmp_path):
+        """When no tracking exists, generate CSR from existing key."""
+        cm = mock.MagicMock()
+        cm.get_request_id.return_value = None
+        handler = ExternalCertHandler(
+            cm_client=cm, unattended=True, csr_dir=str(tmp_path))
+        fake_csr = (
+            "-----BEGIN CERTIFICATE REQUEST-----\nfake\n"
+            "-----END CERTIFICATE REQUEST-----\n"
+        )
+        handler._generate_csr_from_key = mock.MagicMock(return_value=fake_csr)
+
+        cert = mock.MagicMock()
+        ctx = _make_ctx(
+            deployment_type=DeploymentType.CA_LESS_EXTERNAL,
+            scenario=FixScenario.EXTERNAL_CERTS,
+            external_certs=[(IPACertType.HTTPS, cert)],
+            master_server=None,
+        )
+
+        import io
+        import sys
+        captured = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            handler.handle(ctx)
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        assert 'ipa-server-certinstall --http' in output
+        assert 'CSR:' in output
+        handler._generate_csr_from_key.assert_called_once()

--- a/ipatests/test_integration/test_ipa_cert_fix_unit.py
+++ b/ipatests/test_integration/test_ipa_cert_fix_unit.py
@@ -543,3 +543,110 @@ class TestUnitSetHelperTimeout:
         obj = CertRenewalFromMaster(cm, 'master.example.com')
         with pytest.raises(dbus.exceptions.DBusException):
             obj._set_helper()
+
+
+class TestUnitValidateOptions:
+    """Option validation."""
+
+    @mock.patch('ipapython.admintool.AdminTool.validate_options')
+    def test_renewal_master_and_force_server_exclusive(self, mock_super):
+        """--renewal-master + --force-server is rejected."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.renewal_master = True
+        obj.options.force_server = 'master.example.com'
+        obj.option_parser = mock.MagicMock()
+
+        obj.validate_options()
+
+        obj.option_parser.error.assert_called_once()
+        assert "mutually exclusive" in \
+            obj.option_parser.error.call_args[0][0]
+
+    def test_renewal_master_on_caless_rejected(self):
+        """--renewal-master on CA-less raises RuntimeError."""
+        options = mock.MagicMock()
+        options.renewal_master = True
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=options,
+        )
+
+        with pytest.raises(RuntimeError, match="CA-less"):
+            obj.determine_scenario(DeploymentType.CA_LESS)
+
+    def test_renewal_master_on_caless_external_rejected(self):
+        """--renewal-master on CA_LESS_EXTERNAL raises RuntimeError."""
+        options = mock.MagicMock()
+        options.renewal_master = True
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=options,
+        )
+
+        with pytest.raises(RuntimeError, match="CA-less"):
+            obj.determine_scenario(DeploymentType.CA_LESS_EXTERNAL)
+
+
+class TestUnitForceServerSelf:
+    """--force-server=self is rejected early in run()."""
+
+    @mock.patch(MODULE + '.is_ipa_configured', return_value=True)
+    @mock.patch(MODULE + '.api')
+    def test_force_server_self_rejected(self, mock_api, _mock_cfg):
+        """run() returns 1 when --force-server points to self."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        mock_api.env.host = 'replica.example.com'
+        mock_api.bootstrap = mock.MagicMock()
+        mock_api.finalize = mock.MagicMock()
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.force_server = 'replica.example.com'
+
+        result = obj.run()
+        assert result == 1
+
+
+class TestUnitPromoteRollback:
+    """run_ca_full_promote rollback on failure."""
+
+    @mock.patch(MODULE + '.ipautil')
+    @mock.patch(MODULE + '._find_current_renewal_master',
+                return_value='old-master.example.com')
+    @mock.patch(MODULE + '.api')
+    def test_rm_restored_on_failure(
+        self, mock_api, mock_find_rm, mock_ipautil,
+    ):
+        """Renewal master is rolled back if cert fix fails."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        mock_ipautil.run.return_value = mock.MagicMock(returncode=0)
+        mock_ipautil.CalledProcessError = Exception
+        mock_api.env.host = 'replica.example.com'
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.unattended = False
+
+        obj._promote_to_renewal_master = mock.MagicMock()
+        obj._ca_instance = mock.MagicMock()
+        obj.run_renewal_master_fix = mock.MagicMock(
+            side_effect=RuntimeError("cert-fix failed"))
+
+        ctx = _make_ctx(
+            scenario=FixScenario.CA_FULL_PROMOTE,
+            master_server=None,
+        )
+
+        with mock.patch(MODULE + '.ipautil.user_input', return_value='yes'):
+            with pytest.raises(RuntimeError, match="cert-fix failed"):
+                obj.run_ca_full_promote(ctx)
+
+        obj._ca_instance.set_renewal_master.assert_called_with(
+            'old-master.example.com')

--- a/ipatests/test_integration/test_ipa_cert_fix_unit.py
+++ b/ipatests/test_integration/test_ipa_cert_fix_unit.py
@@ -8,6 +8,7 @@ Unit tests for ipa-cert-fix.
 These tests use mocks and do not require an IPA deployment.  They exercise
 pure logic and should run in seconds.
 """
+import datetime
 from unittest import mock
 import pytest
 
@@ -713,3 +714,59 @@ class TestUnitExternalCertsNoCA:
         assert 'ipa-server-certinstall --http' in output
         assert 'CSR:' in output
         handler._generate_csr_from_key.assert_called_once()
+
+
+class TestUnitCheckCASigningCert:
+    """_check_ca_signing_cert validity threshold."""
+
+    def _make_detector(self):
+        return DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=mock.MagicMock(),
+        )
+
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    def test_valid_far_future_passes(self, mock_nssdb):
+        """CA cert valid for years -> True."""
+        import datetime as dt
+        cert = mock.MagicMock()
+        cert.not_valid_after_utc = dt.datetime(
+            2099, 1, 1, tzinfo=dt.timezone.utc)
+        mock_nssdb.return_value.get_cert.return_value = cert
+
+        det = self._make_detector()
+        assert det._check_ca_signing_cert() is True
+
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    def test_near_expiry_fails(self, mock_nssdb):
+        """CA cert near expiry -> False."""
+        cert = mock.MagicMock()
+        cert.not_valid_after_utc = (
+            DeploymentDetector._ca_minimum_valid_until()
+            - datetime.timedelta(days=1))
+        mock_nssdb.return_value.get_cert.return_value = cert
+
+        det = self._make_detector()
+        assert det._check_ca_signing_cert() is False
+
+
+class TestUnitVerifyCaChainValid:
+    """_verify_ca_chain_valid trust-path walking."""
+
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    @mock.patch(SMOD + '.x509')
+    def test_missing_chain_raises(self, mock_x509, mock_nssdb):
+        """Missing chain file -> RuntimeError."""
+        mock_x509.load_certificate_list_from_file.side_effect = (
+            FileNotFoundError())
+        with pytest.raises(RuntimeError, match="CA chain not available"):
+            DeploymentDetector._verify_ca_chain_valid('m.example.com')
+
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    @mock.patch(SMOD + '.x509')
+    def test_empty_chain_raises(self, mock_x509, mock_nssdb):
+        """Empty chain file -> RuntimeError."""
+        mock_x509.load_certificate_list_from_file.return_value = []
+        with pytest.raises(RuntimeError, match="empty"):
+            DeploymentDetector._verify_ca_chain_valid('m.example.com')

--- a/ipatests/test_integration/test_ipa_cert_fix_unit.py
+++ b/ipatests/test_integration/test_ipa_cert_fix_unit.py
@@ -12,6 +12,8 @@ from unittest import mock
 import pytest
 
 from ipaserver.install.ipa_cert_fix import (
+    CertFixContext,
+    CertRenewalFromMaster,
     CertmongerClient,
     DeploymentDetector,
     DeploymentType,
@@ -390,3 +392,154 @@ class TestUnitCertClassification:
 
         assert dogtag == []
         assert len(ipa) == 1
+
+
+def _make_ctx(**overrides):
+    """Build a minimal CertFixContext with optional field overrides."""
+    fields = dict(
+        deployment_type=DeploymentType.CA_SELF_SIGNED,
+        scenario=FixScenario.CA_FULL_WITH_MASTER,
+        subject_base='O=TEST',
+        ca_subject_dn='CN=CA',
+        dogtag_certs=[],
+        ipa_certs=[],
+        external_certs=[],
+        master_server='m.example.com',
+        serverid='TEST',
+        ds_dbdir='/etc/dirsrv/slapd-TEST',
+        ds_nickname='Server-Cert',
+    )
+    fields.update(overrides)
+    return CertFixContext(**fields)
+
+
+class TestUnitBuildTrackingList:
+    """_build_tracking_list filtering logic."""
+
+    def test_skips_subsystem_and_ra(self):
+        """subsystem and RA certs are skipped (fetched separately from
+        master's LDAP)."""
+        cert = mock.MagicMock()
+        ctx = _make_ctx()
+
+        dogtag = [('subsystem', cert), ('sslserver', cert)]
+        ipa = [(IPACertType.IPARA, cert), (IPACertType.HTTPS, cert)]
+
+        obj = CertRenewalFromMaster(mock.MagicMock(), 'm.example.com')
+        tracking = obj._build_tracking_list(dogtag, ipa, ctx)
+
+        descs = [d for d, _c, _cr, _l in tracking]
+        desc_ids = [getattr(d, 'id', d) for d in descs]
+        assert 'subsystem' not in desc_ids
+        assert IPACertType.IPARA not in descs
+        assert 'sslserver' in desc_ids
+        assert IPACertType.HTTPS in descs
+
+    def test_all_ipa_cert_types_mapped(self):
+        """HTTPS, LDAPS, KDC all produce tracking entries."""
+        cert = mock.MagicMock()
+        ctx = _make_ctx()
+
+        ipa = [
+            (IPACertType.HTTPS, cert),
+            (IPACertType.LDAPS, cert),
+            (IPACertType.KDC, cert),
+        ]
+
+        obj = CertRenewalFromMaster(mock.MagicMock(), 'm.example.com')
+        tracking = obj._build_tracking_list([], ipa, ctx)
+
+        descs = [d for d, _c, _cr, _l in tracking]
+        assert IPACertType.HTTPS in descs
+        assert IPACertType.LDAPS in descs
+        assert IPACertType.KDC in descs
+        assert len(tracking) == 3
+
+
+class TestUnitMakeCertLoader:
+    """_make_cert_loader factory."""
+
+    @mock.patch(SMOD + '.NSSDatabase')
+    def test_nssdb_loader(self, mock_nss):
+        """NSSDB loader calls db.get_cert(nickname)."""
+        db = mock.MagicMock()
+        mock_nss.return_value = db
+
+        loader = CertRenewalFromMaster._make_cert_loader(
+            'NSSDB', '/some/db', 'MyCert')
+        loader()
+        db.get_cert.assert_called_once_with('MyCert')
+
+    @mock.patch(SMOD + '.x509')
+    def test_file_loader(self, mock_x509):
+        """FILE loader calls load_certificate_from_file."""
+        loader = CertRenewalFromMaster._make_cert_loader(
+            'FILE', '/some/cert.pem')
+        loader()
+        mock_x509.load_certificate_from_file.assert_called_once_with(
+            '/some/cert.pem')
+
+
+class TestUnitSetIpaCaHelperStripping:
+    """_set_helper / set_ca_override strips leftover -J."""
+
+    @mock.patch(SMOD + '.certmonger')
+    def test_strips_stale_j_flag(self, mock_cm):
+        """If old helper already has -J from a crashed run, the stale
+        -J is stripped before appending the new one."""
+        stale = '/usr/libexec/ipa-submit -J https://old.example.com/ipa/json'
+        client = CertmongerClient()
+        client.get_ca_helper = mock.MagicMock(return_value=stale)
+
+        result = client.set_ca_override('IPA', 'new.example.com')
+
+        assert result == '/usr/libexec/ipa-submit'
+        new_helper = mock_cm.modify_ca_helper.call_args[0][1]
+        assert new_helper.count('-J') == 1
+        assert 'new.example.com' in new_helper
+
+
+class TestUnitPartialRenewalFailure:
+    """Partial failure in CertRenewalFromMaster.renew."""
+
+    def test_failed_cert_not_in_renewed_ids(self):
+        """Failed certs excluded from renewed_ids."""
+        obj = CertRenewalFromMaster(mock.MagicMock(), 'master.example.com')
+
+        obj._build_tracking_list = mock.MagicMock(return_value=[
+            ('sslserver', mock.MagicMock(), {}, mock.MagicMock()),
+            ('httpd', mock.MagicMock(), {}, mock.MagicMock()),
+        ])
+        obj._resolve_tracking_requests = mock.MagicMock(return_value=[
+            ('sslserver', mock.MagicMock(), 'req1', 'dogtag', None),
+            ('httpd', mock.MagicMock(), 'req2', 'IPA', None),
+        ])
+        obj._set_helper = mock.MagicMock(return_value='old')
+        obj._restore_helper = mock.MagicMock()
+        obj._restore = mock.MagicMock()
+
+        obj._resubmit = mock.MagicMock(
+            side_effect=[None, RuntimeError("timeout")])
+
+        ctx = mock.MagicMock()
+        ctx.dogtag_certs = []
+        ctx.ipa_certs = []
+        result = obj.renew([], [], ctx)
+
+        assert 'req1' in result
+        assert 'req2' not in result
+
+
+class TestUnitSetHelperTimeout:
+    """D-Bus timeout in _set_helper."""
+
+    def test_dbus_timeout_raises(self):
+        """_set_helper raises when set_ca_override fails."""
+        import dbus
+        cm = mock.MagicMock()
+        cm.set_ca_override.side_effect = \
+            dbus.exceptions.DBusException("timeout")
+
+        obj = CertRenewalFromMaster(cm, 'master.example.com')
+        with pytest.raises(dbus.exceptions.DBusException):
+            obj._set_helper()

--- a/ipatests/test_integration/test_ipa_cert_fix_unit.py
+++ b/ipatests/test_integration/test_ipa_cert_fix_unit.py
@@ -635,6 +635,7 @@ class TestUnitPromoteRollback:
         obj = object.__new__(IPACertFix)
         obj.options = mock.MagicMock()
         obj.options.unattended = False
+        obj.options.dry_run = False
 
         obj._promote_to_renewal_master = mock.MagicMock()
         obj._ca_instance = mock.MagicMock()
@@ -770,3 +771,34 @@ class TestUnitVerifyCaChainValid:
         mock_x509.load_certificate_list_from_file.return_value = []
         with pytest.raises(RuntimeError, match="empty"):
             DeploymentDetector._verify_ca_chain_valid('m.example.com')
+
+
+class TestUnitDryRunExitCode:
+    """--dry-run short-circuits _confirm_execution."""
+
+    def test_confirm_execution_returns_false_on_dry_run(self):
+        """In --dry-run mode, _confirm_execution returns False (no
+        prompt, no scenario_made_changes flag)."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.dry_run = True
+        obj.options.unattended = False
+
+        result = obj._confirm_execution(
+            "scenario", "do thing", dry_extra_lines=["a", "b"])
+        assert result is False
+        assert obj._scenario_made_changes is False
+
+    def test_confirm_execution_unattended_skips_prompt(self):
+        """-U returns True without prompting and sets the flag."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.dry_run = False
+        obj.options.unattended = True
+
+        assert obj._confirm_execution("scenario", "do thing") is True
+        assert obj._scenario_made_changes is True

--- a/ipatests/test_integration/test_ipa_cert_fix_unit.py
+++ b/ipatests/test_integration/test_ipa_cert_fix_unit.py
@@ -5,34 +5,1250 @@
 """
 Unit tests for ipa-cert-fix.
 
-These tests use mocks and do not require an IPA deployment.  They exercise
-pure logic and should run in seconds.
+These tests use mocks and do not require an IPA deployment.
+They exercise pure logic and should run in seconds.
 """
-import datetime
 from unittest import mock
 import pytest
 
 from ipaserver.install.ipa_cert_fix import (
-    CertFixContext,
-    CertRenewalFromMaster,
+    CertIdentity,
     CertmongerClient,
     DeploymentDetector,
     DeploymentType,
+    DOGTAG_CERTS,
     ExternalCertHandler,
     FixScenario,
     IPACertType,
-)
-from ipaserver.install.ipa_cert_fix_types import (
-    CertIdentity,
-    DOGTAG_CERTS,
+    _check_tcp_reachable,
 )
 
 MODULE = 'ipaserver.install.ipa_cert_fix'
 SMOD = 'ipaserver.install.ipa_cert_fix_services'
 
 
+class TestUnitKDCCertClassification:
+    """T-UNIT-1: KDC cert classified as KDC, not HTTPS."""
+
+    @mock.patch(SMOD + '.is_ipa_issued_cert', return_value=False)
+    @mock.patch(SMOD + '.x509.load_certificate_from_file')
+    @mock.patch(SMOD + '.NSSDatabase')
+    @mock.patch(SMOD + '.dsinstance')
+    @mock.patch(SMOD + '.realm_to_serverid',
+                return_value='EXAMPLE-COM')
+    @mock.patch(SMOD + '.api')
+    def test_kdc_not_tagged_as_https(
+        self, mock_api, mock_r2s, mock_ds, mock_nssdb,
+        mock_load_cert, mock_is_ipa,
+    ):
+        """Non-IPA-issued KDC cert must appear in non_renewed
+        as IPACertType.KDC, not IPACertType.HTTPS.
+
+        Regression test for a bug where the KDC entry in
+        expired_ipa_certs() was incorrectly tagged HTTPS.
+        """
+        from ipaserver.install.ipa_cert_fix import (
+            expired_ipa_certs,
+        )
+
+        import datetime as dt
+        now = dt.datetime(
+            2030, 1, 1, tzinfo=dt.timezone.utc
+        )
+        expired = dt.datetime(
+            2029, 6, 1, tzinfo=dt.timezone.utc
+        )
+
+        # All certs expired
+        cert_mock = mock.MagicMock()
+        cert_mock.not_valid_after_utc = expired
+        mock_load_cert.return_value = cert_mock
+
+        # LDAP cert via NSSDatabase
+        db_instance = mock.MagicMock()
+        db_instance.get_cert.return_value = cert_mock
+        mock_nssdb.return_value = db_instance
+
+        # dsinstance setup
+        ds_instance = mock.MagicMock()
+        ds_instance.get_server_cert_nickname.return_value = ('Server-Cert')
+        mock_ds.DsInstance.return_value = ds_instance
+        mock_ds.config_dirname.return_value = '/etc/dirsrv/slapd-X'
+        mock_api.env.realm = 'EXAMPLE.COM'
+
+        # is_ipa_issued_cert returns False for HTTPS, LDAP, KDC
+        # (RA is always added without the IPA-issued check)
+        certs, non_renewed = expired_ipa_certs(now)
+
+        # RA is always IPA-issued, so it goes to certs
+        assert any(
+            t == IPACertType.IPARA for t, _c in certs
+        )
+
+        # HTTPS, LDAPS, KDC are externally signed -> non_renewed
+        non_renewed_types = [t for t, _c in non_renewed]
+        assert IPACertType.HTTPS in non_renewed_types
+        assert IPACertType.LDAPS in non_renewed_types
+        assert IPACertType.KDC in non_renewed_types
+
+        # The bug: KDC was tagged as HTTPS.  Verify no duplicate HTTPS entries.
+        https_count = non_renewed_types.count(IPACertType.HTTPS)
+        assert https_count == 1, (
+            "KDC cert misclassified as HTTPS "
+            "(got %d HTTPS entries)" % https_count
+        )
+
+
+class TestUnitPrincipalRestore:
+    """T-UNIT-2: Principal save/restore behavior."""
+
+    def test_original_principals_restored(self):
+        """_restore restores saved principals."""
+        from ipaserver.install.ipa_cert_fix import CertRenewalFromMaster
+
+        obj = CertRenewalFromMaster(mock.MagicMock(), 'master')
+        obj._original_principals = {
+            '123': ['dogtag-ipa-ca-renew-agent'],
+        }
+        obj._original_profiles = {}
+
+        obj._cm.get_request_value.return_value = 'IPA'
+
+        obj._restore('123', 'dogtag-ipa-ca-renew-agent')
+
+        # Should restore the saved principal
+        obj._cm.add_request_value.assert_called_once_with(
+            '123', 'template-principal',
+            ['dogtag-ipa-ca-renew-agent'])
+
+    def test_empty_principals_skipped(self):
+        """No principal restore when original was empty."""
+        from ipaserver.install.ipa_cert_fix import CertRenewalFromMaster
+
+        obj = CertRenewalFromMaster(mock.MagicMock(), 'master')
+        obj._original_principals = {'123': None}
+        obj._original_profiles = {}
+
+        obj._cm.get_request_value.return_value = 'IPA'
+
+        obj._restore('123', 'dogtag-ipa-ca-renew-agent')
+
+        # Should NOT call add_request_value for principals
+        obj._cm.add_request_value.assert_not_called()
+
+
+class TestUnitScenarioRouting:
+    """T-UNIT-3: Scenario routing for each deployment type."""
+
+    def _make_detector(self, is_rm, master, force_rm=False):
+        """Create a mock DeploymentDetector with controlled state."""
+        options = mock.MagicMock()
+        options.renewal_master = force_rm
+        options.force_server = None
+        options.unattended = False
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=options,
+        )
+        obj.check_is_renewal_master = mock.MagicMock(
+            return_value=is_rm
+        )
+        obj.get_master_server = mock.MagicMock(
+            return_value=master
+        )
+        return obj
+
+    @pytest.mark.parametrize(
+        "dt,is_rm,master,expected_scenario", [
+            (DeploymentType.CA_SELF_SIGNED,
+             True, None,
+             FixScenario.RENEWAL_MASTER),
+            (DeploymentType.CA_SELF_SIGNED,
+             False, 'master.example.com',
+             FixScenario.CA_FULL_WITH_MASTER),
+            (DeploymentType.CA_SELF_SIGNED,
+             False, None,
+             FixScenario.CA_FULL_PROMOTE),
+            (DeploymentType.CA_EXTERNALLY_SIGNED,
+             True, None,
+             FixScenario.RENEWAL_MASTER),
+            (DeploymentType.CA_EXTERNALLY_SIGNED,
+             False, 'master.example.com',
+             FixScenario.CA_FULL_WITH_MASTER),
+            (DeploymentType.CA_LESS,
+             False, 'master.example.com',
+             FixScenario.CA_LESS_WITH_MASTER),
+            (DeploymentType.CA_LESS_EXTERNAL,
+             False, None,
+             FixScenario.EXTERNAL_CERTS),
+        ],
+    )
+    def test_scenario_matrix(
+        self, dt, is_rm, master, expected_scenario
+    ):
+        """Verify correct FixScenario for each combination."""
+        obj = self._make_detector(is_rm, master)
+        scenario, srv = obj.determine_scenario(dt)
+        assert scenario == expected_scenario
+        if expected_scenario in (
+            FixScenario.CA_FULL_WITH_MASTER,
+            FixScenario.CA_LESS_WITH_MASTER,
+        ):
+            assert srv == master
+        elif expected_scenario in (
+            FixScenario.RENEWAL_MASTER,
+            FixScenario.CA_FULL_PROMOTE,
+            FixScenario.EXTERNAL_CERTS,
+        ):
+            assert srv is None
+
+    def test_caless_no_server_raises(self):
+        """CA_LESS with no server selected raises RuntimeError."""
+        obj = self._make_detector(is_rm=False, master=None)
+        with pytest.raises(RuntimeError, match="No server"):
+            obj.determine_scenario(DeploymentType.CA_LESS)
+
+    def test_force_renewal_master_flag(self):
+        """--renewal-master forces RENEWAL_MASTER scenario."""
+        obj = self._make_detector(
+            is_rm=False, master='m.example.com',
+            force_rm=True,
+        )
+        scenario, srv = obj.determine_scenario(
+            DeploymentType.CA_SELF_SIGNED
+        )
+        assert scenario == FixScenario.RENEWAL_MASTER
+        assert srv is None
+
+
+class TestUnitCertClassification:
+    """T-UNIT-4: Cert classification splits external from IPA."""
+
+    @mock.patch(SMOD + '.cainstance')
+    @mock.patch(SMOD + '.expired_dogtag_certs')
+    @mock.patch(SMOD + '.expired_ipa_certs')
+    def test_external_certs_split(
+        self, mock_exp_ipa, mock_exp_dog, mock_ca,
+    ):
+        """Verify _classify_certs moves non_renewed to external."""
+        import datetime as dt
+        now = dt.datetime(
+            2030, 1, 1, tzinfo=dt.timezone.utc
+        )
+
+        mock_ca.is_ca_installed_locally.return_value = True
+
+        cert_mock = mock.MagicMock()
+        mock_exp_dog.return_value = [('ca_audit', cert_mock)]
+        mock_exp_ipa.return_value = (
+            [(IPACertType.IPARA, cert_mock)],
+            [(IPACertType.HTTPS, cert_mock)],  # non_renewed
+        )
+
+        dogtag, ipa, external = DeploymentDetector._classify_certs(now)
+
+        assert len(dogtag) == 1
+        assert len(ipa) == 1
+        assert len(external) == 1
+        assert external[0][0] == IPACertType.HTTPS
+
+    @mock.patch(SMOD + '.cainstance')
+    @mock.patch(SMOD + '.expired_ipa_certs')
+    def test_caless_skips_dogtag(
+        self, mock_exp_ipa, mock_ca,
+    ):
+        """On CA-less, dogtag certs list is empty."""
+        import datetime as dt
+        now = dt.datetime(
+            2030, 1, 1, tzinfo=dt.timezone.utc
+        )
+
+        mock_ca.is_ca_installed_locally.return_value = False
+
+        cert_mock = mock.MagicMock()
+        mock_exp_ipa.return_value = (
+            [(IPACertType.HTTPS, cert_mock)],
+            [],
+        )
+
+        dogtag, ipa, _external = DeploymentDetector._classify_certs(now)
+
+        assert dogtag == []
+        assert len(ipa) == 1
+
+
+class TestUnitForceServerSelf:
+    """T-UNIT-5: --force-server=self rejected early in run()."""
+
+    @mock.patch(MODULE + '.is_ipa_configured', return_value=True)
+    @mock.patch(MODULE + '.api')
+    def test_force_server_self_rejected(self, mock_api, _mock_cfg):
+        """run() returns 1 when --force-server points to self."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        mock_api.env.host = 'replica.example.com'
+        mock_api.bootstrap = mock.MagicMock()
+        mock_api.finalize = mock.MagicMock()
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.force_server = 'replica.example.com'
+
+        result = obj.run()
+        assert result == 1
+
+
+class TestUnitDryRunExitCode:
+    """T-UNIT-6: Dry-run returns 0 for each scenario."""
+
+    def _make_certfix_with_dry_run(self):
+        """Create a mock IPACertFix with dry_run=True."""
+        from ipaserver.install.ipa_cert_fix import (
+            IPACertFix, CertFixContext,
+        )
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.dry_run = True
+        obj.options.unattended = False
+        obj.options.verbose = False
+
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_SELF_SIGNED,
+            scenario=FixScenario.RENEWAL_MASTER,
+            subject_base=mock.MagicMock(),
+            ca_subject_dn=mock.MagicMock(),
+            dogtag_certs=[],
+            ipa_certs=[],
+
+            external_certs=[],
+            master_server=None,
+        )
+        return obj, ctx
+
+    def test_dry_run_renewal_master(self):
+        """Dry-run renewal master returns 0.
+
+        Pre-flight checks (pki-server, CA cert validity)
+        run after dry-run, so dry-run always succeeds.
+        """
+        obj, ctx = self._make_certfix_with_dry_run()
+        ctx.scenario = FixScenario.RENEWAL_MASTER
+        result = obj.run_renewal_master_fix(ctx)
+        assert result == 0
+
+    def test_dry_run_ca_full_with_master(self):
+        """Dry-run CA-full with master returns 0."""
+        obj, ctx = self._make_certfix_with_dry_run()
+        ctx.scenario = FixScenario.CA_FULL_WITH_MASTER
+        ctx.master_server = 'master.example.com'
+        result = obj._run_non_rm_replica_fix(ctx, is_ca_full=True)
+        assert result == 0
+
+    def test_dry_run_ca_less_with_master(self):
+        """Dry-run CA-less with master returns 0."""
+        obj, ctx = self._make_certfix_with_dry_run()
+        ctx.scenario = FixScenario.CA_LESS_WITH_MASTER
+        ctx.master_server = 'master.example.com'
+        result = obj._run_non_rm_replica_fix(ctx, is_ca_full=False)
+        assert result == 0
+
+
+class TestUnitValidateOptions:
+    """Unit tests for option validation."""
+
+    @mock.patch('ipapython.admintool.AdminTool.validate_options')
+    def test_renewal_master_and_force_server_exclusive(
+        self, mock_super,
+    ):
+        """--renewal-master + --force-server is rejected."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.renewal_master = True
+        obj.options.force_server = 'master.example.com'
+        obj.option_parser = mock.MagicMock()
+
+        obj.validate_options()
+
+        obj.option_parser.error.assert_called_once()
+        assert "mutually exclusive" in \
+            obj.option_parser.error.call_args[0][0]
+
+    def test_renewal_master_on_caless_rejected(self):
+        """--renewal-master on CA-less raises RuntimeError."""
+        options = mock.MagicMock()
+        options.renewal_master = True
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=options,
+        )
+
+        with pytest.raises(RuntimeError, match="CA-less"):
+            obj.determine_scenario(DeploymentType.CA_LESS)
+
+    def test_renewal_master_on_caless_external_rejected(self):
+        """--renewal-master on CA_LESS_EXTERNAL raises RuntimeError."""
+        options = mock.MagicMock()
+        options.renewal_master = True
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=options,
+        )
+
+        with pytest.raises(RuntimeError, match="CA-less"):
+            obj.determine_scenario(DeploymentType.CA_LESS_EXTERNAL)
+
+
+class TestUnitPostRenewalCACheck:
+    """Verify CA cert is checked after pki-server cert-fix."""
+
+    @mock.patch(MODULE + '.api')
+    @mock.patch(MODULE + '.ipautil')
+    @mock.patch(MODULE + '.run_cert_fix')
+    @mock.patch(MODULE + '.fix_certreq_directives')
+    def test_ca_still_expired_returns_1(
+        self, mock_fix, mock_rcf,
+        mock_ipautil, mock_api,
+    ):
+        """If CA cert is still expired after cert-fix, exit 1."""
+        from ipaserver.install.ipa_cert_fix import (
+            IPACertFix, CertFixContext,
+        )
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.dry_run = False
+        obj.options.unattended = True
+        # Pre-flight passes, post-renewal fails
+        obj._detector = mock.MagicMock()
+        obj._detector._check_ca_signing_cert = mock.MagicMock(
+            side_effect=[True, False]
+        )
+        obj._detector.check_is_renewal_master = mock.MagicMock(
+            return_value=True)
+
+        cert = mock.MagicMock()
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_SELF_SIGNED,
+            scenario=FixScenario.RENEWAL_MASTER,
+            subject_base=mock.MagicMock(),
+            ca_subject_dn=mock.MagicMock(),
+            dogtag_certs=[('ca_issuing', cert)],
+            ipa_certs=[],
+            external_certs=[],
+            master_server=None,
+        )
+        result = obj.run_renewal_master_fix(ctx)
+        assert result == 1
+        assert obj._detector._check_ca_signing_cert.call_count == 2
+
+
+class TestUnitExternalCertsNoCA:
+    """T-EXT-7: Fully external, no internal CA."""
+
+    @mock.patch(SMOD + '.os.makedirs')
+    @mock.patch(SMOD + '.find_providing_servers')
+    def test_caless_external_skips_ca_lookup(
+        self, mock_fps, mock_makedirs,
+    ):
+        """CA_LESS_EXTERNAL skips CA server lookup entirely.
+
+        No transition is offered; manual instructions printed.
+        """
+        from ipaserver.install.ipa_cert_fix import CertFixContext
+
+        cm = mock.MagicMock()
+        cm.get_request_id.return_value = None
+        handler = ExternalCertHandler(
+            cm_client=cm, unattended=True,
+        )
+        # Mock CSR generation to avoid hitting DN/api
+        handler._generate_csr_from_key = mock.MagicMock(
+            return_value=None,
+        )
+
+        cert = mock.MagicMock()
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_LESS_EXTERNAL,
+            scenario=FixScenario.EXTERNAL_CERTS,
+            subject_base=mock.MagicMock(),
+            ca_subject_dn=mock.MagicMock(),
+            dogtag_certs=[], ipa_certs=[],
+            external_certs=[
+                (IPACertType.HTTPS, cert),
+            ],
+            master_server=None,
+        )
+        handler.handle(ctx)
+
+        # find_providing_servers must NOT be called
+        mock_fps.assert_not_called()
+
+    def test_no_tracking_generates_csr_from_key(self, tmp_path):
+        """When no tracking exists, generate CSR from key.
+
+        Externally-signed certs typically have tracking stopped.
+        The tool should generate CSRs from the existing private
+        keys and print ipa-server-certinstall commands.
+        """
+        from ipaserver.install.ipa_cert_fix import CertFixContext
+
+        cm = mock.MagicMock()
+        cm.get_request_id.return_value = None
+        handler = ExternalCertHandler(
+            cm_client=cm, unattended=True,
+            csr_dir=str(tmp_path),
+        )
+        # Mock CSR generation to return a fake CSR
+        fake_csr = (
+            "-----BEGIN CERTIFICATE REQUEST-----\nfake\n"
+            "-----END CERTIFICATE REQUEST-----\n"
+        )
+        handler._generate_csr_from_key = mock.MagicMock(
+            return_value=fake_csr
+        )
+
+        cert = mock.MagicMock()
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_LESS_EXTERNAL,
+            scenario=FixScenario.EXTERNAL_CERTS,
+            subject_base=mock.MagicMock(),
+            ca_subject_dn=mock.MagicMock(),
+            dogtag_certs=[], ipa_certs=[],
+            external_certs=[
+                (IPACertType.HTTPS, cert),
+            ],
+            master_server=None,
+        )
+        import io
+        import sys
+        captured = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            handler.handle(ctx)
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        assert 'ipa-server-certinstall --http' in output
+        assert 'CSR:' in output
+        handler._generate_csr_from_key.assert_called_once()
+
+
+class TestUnitBuildTrackingList:
+    """Unit tests for _build_tracking_list filtering logic."""
+
+    @mock.patch(SMOD + '.NSSDatabase')
+    @mock.patch(SMOD + '.api')
+    @mock.patch(MODULE + '.dsinstance')
+    @mock.patch(MODULE + '.realm_to_serverid',
+                return_value='TEST')
+    def test_skips_subsystem_and_ra(
+        self, mock_r2s, mock_ds, mock_api, mock_nss,
+    ):
+        """subsystem and RA certs are skipped (fetched
+        separately from master's LDAP).
+        """
+        from ipaserver.install.ipa_cert_fix import (
+            CertRenewalFromMaster, CertFixContext,
+        )
+
+        cert = mock.MagicMock()
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_SELF_SIGNED,
+            scenario=FixScenario.CA_FULL_WITH_MASTER,
+            subject_base='O=TEST',
+            ca_subject_dn='CN=CA',
+            dogtag_certs=[], ipa_certs=[],
+            external_certs=[],
+            master_server='m.example.com',
+            serverid='TEST',
+            ds_dbdir='/etc/dirsrv/slapd-TEST',
+            ds_nickname='Server-Cert',
+        )
+
+        dogtag = [
+            ('subsystem', cert), ('sslserver', cert),
+        ]
+        ipa = [
+            (IPACertType.IPARA, cert), (IPACertType.HTTPS, cert),
+        ]
+
+        obj = CertRenewalFromMaster(mock.MagicMock(), 'm.example.com')
+        tracking = obj._build_tracking_list(dogtag, ipa, ctx)
+
+        descs = [d for d, _c, _cr, _l in tracking]
+        desc_ids = [getattr(d, 'id', d) for d in descs]
+        # subsystem and RA must be skipped
+        assert 'subsystem' not in desc_ids
+        assert IPACertType.IPARA not in descs
+        # sslserver and HTTPS must be present
+        assert 'sslserver' in desc_ids
+        assert IPACertType.HTTPS in descs
+
+    @mock.patch(SMOD + '.NSSDatabase')
+    @mock.patch(SMOD + '.api')
+    @mock.patch(MODULE + '.dsinstance')
+    @mock.patch(MODULE + '.realm_to_serverid',
+                return_value='TEST')
+    def test_all_ipa_cert_types_mapped(
+        self, mock_r2s, mock_ds, mock_api, mock_nss,
+    ):
+        """HTTPS, LDAPS, KDC all produce tracking entries."""
+        from ipaserver.install.ipa_cert_fix import (
+            CertRenewalFromMaster, CertFixContext,
+        )
+
+        cert = mock.MagicMock()
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_SELF_SIGNED,
+            scenario=FixScenario.CA_FULL_WITH_MASTER,
+            subject_base='O=TEST',
+            ca_subject_dn='CN=CA',
+            dogtag_certs=[], ipa_certs=[],
+            external_certs=[],
+            master_server='m.example.com',
+            serverid='TEST',
+            ds_dbdir='/etc/dirsrv/slapd-TEST',
+            ds_nickname='Server-Cert',
+        )
+
+        ipa = [
+            (IPACertType.HTTPS, cert), (IPACertType.LDAPS, cert),
+            (IPACertType.KDC, cert),
+        ]
+
+        obj = CertRenewalFromMaster(mock.MagicMock(), 'm.example.com')
+        tracking = obj._build_tracking_list([], ipa, ctx)
+
+        descs = [d for d, _c, _cr, _l in tracking]
+        assert IPACertType.HTTPS in descs
+        assert IPACertType.LDAPS in descs
+        assert IPACertType.KDC in descs
+        assert len(tracking) == 3
+
+
+class TestUnitMakeCertLoader:
+    """Unit tests for _make_cert_loader factory."""
+
+    @mock.patch(SMOD + '.NSSDatabase')
+    def test_nssdb_loader(self, mock_nss):
+        """NSSDB loader calls db.get_cert(nickname)."""
+        from ipaserver.install.ipa_cert_fix import CertRenewalFromMaster
+
+        db = mock.MagicMock()
+        mock_nss.return_value = db
+
+        loader = CertRenewalFromMaster._make_cert_loader(
+            'NSSDB', '/some/db', 'MyCert'
+        )
+        loader()
+        db.get_cert.assert_called_once_with('MyCert')
+
+    @mock.patch(SMOD + '.x509')
+    def test_file_loader(self, mock_x509):
+        """FILE loader calls load_certificate_from_file."""
+        from ipaserver.install.ipa_cert_fix import CertRenewalFromMaster
+
+        loader = CertRenewalFromMaster._make_cert_loader(
+            'FILE', '/some/cert.pem'
+        )
+        loader()
+        mock_x509.load_certificate_from_file \
+            .assert_called_once_with('/some/cert.pem')
+
+
+class TestUnitSetIpaCaHelperStripping:
+    """Verify _set_helper strips leftover -J."""
+
+    @mock.patch(SMOD + '.certmonger')
+    def test_strips_stale_j_flag(self, mock_cm):
+        """If old helper already has -J from a crashed run,
+        the stale -J is stripped before appending the new one.
+
+        Logic now lives in CertmongerClient.set_ca_override.
+        """
+        stale = ('/usr/libexec/ipa-submit -J https://old.example.com/ipa/json')
+        client = CertmongerClient()
+        client.get_ca_helper = mock.MagicMock(return_value=stale)
+
+        result = client.set_ca_override('IPA', 'new.example.com')
+
+        assert result == '/usr/libexec/ipa-submit'
+        call_args = mock_cm.modify_ca_helper.call_args
+        new_helper = call_args[0][1]
+        assert new_helper.count('-J') == 1
+        assert 'new.example.com' in new_helper
+
+
+class TestUnitGenerateCsrFromKey:
+    """Verify _generate_csr_from_key logic."""
+
+    @mock.patch(SMOD + '.api')
+    @mock.patch(SMOD + '.ipa_certs')
+    def test_returns_none_on_missing_key(
+        self, mock_certs, mock_api,
+    ):
+        """If key file doesn't exist, returns None."""
+        from ipaserver.install.ipa_cert_fix import CertFixContext
+
+        mock_api.env.host = 'h.example.com'
+        mock_api.env.realm = 'EXAMPLE.COM'
+        mock_api.env.domain = 'example.com'
+        mock_certs.get_default_profile.return_value = ('caIPAserviceCert')
+
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_SELF_SIGNED,
+            scenario=FixScenario.RENEWAL_MASTER,
+            subject_base='O=EXAMPLE.COM',
+            ca_subject_dn='CN=CA',
+            dogtag_certs=[], ipa_certs=[],
+            external_certs=[], master_server=None,
+            serverid='X',
+            ds_dbdir='/etc/dirsrv/slapd-X',
+            ds_nickname='Server-Cert',
+        )
+
+        handler = ExternalCertHandler(cm_client=mock.MagicMock())
+        cert = mock.MagicMock()
+        # Use a nonexistent key file
+        result = handler._generate_csr_from_key(
+            IPACertType.HTTPS, cert, ctx
+        )
+        # Should return None (key file missing)
+        assert result is None
+
+
+class TestUnitUpdateCaCertChainCheck:
+    """Verify update_ca_cert_from_master chain validation."""
+
+    @mock.patch(MODULE + '.x509')
+    @mock.patch(MODULE + '.ipautil')
+    @mock.patch(MODULE + '.dsinstance')
+    @mock.patch(MODULE + '.realm_to_serverid',
+                return_value='X')
+    def test_missing_chain_raises(
+        self, mock_r2s, mock_ds, mock_ipautil,
+        mock_x509,
+    ):
+        """If CA chain file is unreadable after
+        ipa-certupdate, RuntimeError is raised.
+        """
+        from ipaserver.install.ipa_cert_fix import (
+            IPACertFix,
+        )
+
+        mock_run = mock.MagicMock()
+        mock_run.returncode = 1
+        mock_ipautil.run.return_value = mock_run
+        mock_x509.load_certificate_list_from_file \
+            .side_effect = IOError("not found")
+
+        obj = object.__new__(IPACertFix)
+        with mock.patch(MODULE + '.paths') as mp:
+            mp.IPA_CA_CRT = '/nonexistent'
+            try:
+                obj.update_ca_cert_from_master('m')
+                assert False, 'Should have raised'
+            except RuntimeError as e:
+                assert 'not available' in str(e)
+
+
+class TestUnitVerifyCaChainValid:
+    """Unit tests for _verify_ca_chain_valid chain walking."""
+
+    def _make_cert(self, subject_dn, issuer_dn, expired=False):
+        """Create a mock cert with string DN subject/issuer."""
+        import datetime as dt
+        from cryptography.x509 import Name, NameAttribute
+        from cryptography.x509.oid import NameOID
+        cert = mock.MagicMock()
+        # Use real x509.Name objects so DN() works
+        cert.subject = Name([NameAttribute(NameOID.COMMON_NAME, subject_dn)])
+        cert.issuer = Name([NameAttribute(NameOID.COMMON_NAME, issuer_dn)])
+        if expired:
+            cert.not_valid_after_utc = dt.datetime(
+                2020, 1, 1, tzinfo=dt.timezone.utc)
+        else:
+            cert.not_valid_after_utc = dt.datetime(
+                2030, 1, 1, tzinfo=dt.timezone.utc)
+        return cert
+
+    @mock.patch(SMOD + '.NSSDatabase')
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.paths')
+    def test_valid_self_signed_chain(self, mock_paths, mock_x509, mock_nss):
+        """Self-signed CA: single cert, subject==issuer, valid."""
+        cert = self._make_cert('IPA CA', 'IPA CA')
+        mock_x509.load_certificate_list_from_file.return_value = [cert]
+        db = mock.MagicMock()
+        db.get_cert.return_value = cert
+        mock_nss.return_value = db
+        DeploymentDetector._verify_ca_chain_valid('master.example.com')
+
+    @mock.patch(SMOD + '.NSSDatabase')
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.paths')
+    def test_expired_issuing_cert_raises(
+        self, mock_paths, mock_x509, mock_nss,
+    ):
+        """Expired issuing CA cert raises RuntimeError."""
+        cert = self._make_cert('IPA CA', 'IPA CA', expired=True)
+        mock_x509.load_certificate_list_from_file.return_value = [cert]
+        db = mock.MagicMock()
+        db.get_cert.return_value = cert
+        mock_nss.return_value = db
+        with pytest.raises(RuntimeError, match="expired"):
+            DeploymentDetector._verify_ca_chain_valid('master.example.com')
+
+    @mock.patch(SMOD + '.NSSDatabase')
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.paths')
+    def test_expired_intermediate_raises(
+        self, mock_paths, mock_x509, mock_nss,
+    ):
+        """Expired intermediate in chain raises RuntimeError."""
+        root = self._make_cert('Root CA', 'Root CA')
+        inter = self._make_cert('IPA CA', 'Root CA', expired=True)
+        leaf = self._make_cert('Sub CA', 'IPA CA')
+        mock_x509.load_certificate_list_from_file.return_value = [
+            leaf, inter, root]
+        db = mock.MagicMock()
+        db.get_cert.return_value = leaf
+        mock_nss.return_value = db
+        with pytest.raises(RuntimeError, match="expired"):
+            DeploymentDetector._verify_ca_chain_valid('master.example.com')
+
+    @mock.patch(SMOD + '.NSSDatabase')
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.paths')
+    def test_incomplete_chain_raises(self, mock_paths, mock_x509, mock_nss):
+        """Missing issuer in chain raises RuntimeError."""
+        leaf = self._make_cert('IPA CA', 'Root CA')
+        mock_x509.load_certificate_list_from_file.return_value = [leaf]
+        db = mock.MagicMock()
+        db.get_cert.return_value = leaf
+        mock_nss.return_value = db
+        with pytest.raises(RuntimeError, match="Incomplete"):
+            DeploymentDetector._verify_ca_chain_valid('master.example.com')
+
+    @mock.patch(SMOD + '.NSSDatabase')
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.paths')
+    def test_caless_uses_first_cert(self, mock_paths, mock_x509, mock_nss):
+        """CA-less: NSS fails, uses first cert in file."""
+        cert = self._make_cert('IPA CA', 'IPA CA')
+        mock_x509.load_certificate_list_from_file.return_value = [cert]
+        mock_nss.side_effect = Exception("no NSSDB")
+        DeploymentDetector._verify_ca_chain_valid('master.example.com')
+
+    @mock.patch(SMOD + '.NSSDatabase')
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.paths')
+    def test_duplicate_subject_prefers_valid(
+        self, mock_paths, mock_x509, mock_nss,
+    ):
+        """Duplicate-subject certs: prefer valid over expired.
+
+        After CA renewal, ca.crt contains both old (expired) and new
+        (valid) CA certs with the same subject DN.  The chain walker
+        must pick the valid one regardless of file ordering.
+        """
+        old_ca = self._make_cert('IPA CA', 'IPA CA', expired=True)
+        new_ca = self._make_cert('IPA CA', 'IPA CA')
+        # expired cert comes LAST -- would overwrite in naive dict
+        mock_x509.load_certificate_list_from_file.return_value = [
+            new_ca, old_ca]
+        db = mock.MagicMock()
+        db.get_cert.return_value = new_ca
+        mock_nss.return_value = db
+        # Should not raise -- valid cert should be preferred
+        DeploymentDetector._verify_ca_chain_valid('master.example.com')
+
+
+class TestUnitResubmitSkipStates:
+    """Unit tests for resubmit_expired_certs skip/error logic."""
+
+    def test_monitoring_skipped(self):
+        """Certs in MONITORING are skipped."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        obj = object.__new__(IPACertFix)
+        obj._cm = mock.MagicMock()
+        obj._cm.get_requests_for_dir.return_value = ['req1']
+        obj._cm.get_request_id.return_value = None
+        obj._cm.get_request_value.return_value = 'MONITORING'
+        obj.options = mock.MagicMock()
+        obj._is_cert_valid = mock.MagicMock(return_value=True)
+
+        with mock.patch(MODULE + '.dsinstance') as md, \
+             mock.patch(MODULE + '.realm_to_serverid',
+                        return_value='TESTID'), \
+             mock.patch(MODULE + '.api') as mapi:
+            mapi.env.realm = 'TEST.REALM'
+            md.config_dirname.return_value = '/etc/dirsrv/slapd-TESTID/'
+            obj.resubmit_expired_certs(renewed_ids=set())
+
+        # Should NOT resubmit -- cert is valid
+        obj._cm.resubmit_request.assert_not_called()
+
+    def test_renewed_ids_skipped(self):
+        """Certs already renewed from master are skipped."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        obj = object.__new__(IPACertFix)
+        obj._cm = mock.MagicMock()
+        obj._cm.get_requests_for_dir.return_value = ['req1']
+        obj._cm.get_request_id.return_value = None
+        obj.options = mock.MagicMock()
+
+        with mock.patch(MODULE + '.dsinstance') as md, \
+             mock.patch(MODULE + '.realm_to_serverid',
+                        return_value='TESTID'), \
+             mock.patch(MODULE + '.api') as mapi:
+            mapi.env.realm = 'TEST.REALM'
+            md.config_dirname.return_value = '/etc/dirsrv/slapd-TESTID/'
+            obj.resubmit_expired_certs(renewed_ids={'req1'})
+
+        # Should NOT resubmit -- already renewed
+        obj._cm.resubmit_request.assert_not_called()
+
+
+class TestUnitCheckRenewedIpaCerts:
+    """Unit tests for check_renewed_ipa_certs validation."""
+
+    def _make_cert(self, serial, expired=False):
+        import datetime as dt
+        cert = mock.MagicMock()
+        cert.serial_number = serial
+        if expired:
+            cert.not_valid_after_utc = dt.datetime(
+                2020, 1, 1, tzinfo=dt.timezone.utc)
+        else:
+            cert.not_valid_after_utc = dt.datetime(
+                2030, 1, 1, tzinfo=dt.timezone.utc)
+        return cert
+
+    @mock.patch(MODULE + '.x509')
+    def test_same_serial_rejected(self, mock_x509):
+        """Renewed cert with same serial as old is rejected."""
+        from ipaserver.install.ipa_cert_fix import (
+            check_renewed_ipa_certs,
+        )
+
+        old = self._make_cert(42)
+        new = self._make_cert(42)  # same serial
+        mock_x509.load_certificate_from_file.return_value = new
+
+        result = check_renewed_ipa_certs([(IPACertType.HTTPS, old)])
+        assert result is False
+
+    @mock.patch(MODULE + '.x509')
+    def test_expired_renewed_cert_rejected(self, mock_x509):
+        """Renewed cert that is expired is rejected."""
+        from ipaserver.install.ipa_cert_fix import (
+            check_renewed_ipa_certs,
+        )
+
+        old = self._make_cert(42)
+        new = self._make_cert(99, expired=True)
+        mock_x509.load_certificate_from_file.return_value = new
+
+        result = check_renewed_ipa_certs([(IPACertType.HTTPS, old)])
+        assert result is False
+
+    @mock.patch(MODULE + '.x509')
+    def test_valid_renewal_accepted(self, mock_x509):
+        """Renewed cert with new serial and valid expiry passes."""
+        from ipaserver.install.ipa_cert_fix import (
+            check_renewed_ipa_certs,
+        )
+
+        old = self._make_cert(42)
+        new = self._make_cert(99)  # different serial, valid
+        mock_x509.load_certificate_from_file.return_value = new
+
+        result = check_renewed_ipa_certs([(IPACertType.HTTPS, old)])
+        assert result is True
+
+
+class TestUnitDetectMismatches:
+    """Unit tests for _detect_ra_subsystem_mismatches."""
+
+    def _make_cert(self, serial, subject='CN=Test'):
+        import datetime as dt
+        from cryptography.x509 import Name, NameAttribute
+        from cryptography.x509.oid import NameOID
+        cert = mock.MagicMock()
+        cert.serial_number = serial
+        cert.subject = Name([NameAttribute(NameOID.COMMON_NAME, subject)])
+        cert.issuer = Name([NameAttribute(NameOID.COMMON_NAME, 'CN=CA')])
+        cert.not_valid_after_utc = dt.datetime(
+            2030, 1, 1, tzinfo=dt.timezone.utc)
+        cert.public_bytes.return_value = (b'cert-%d' % serial)
+        return cert
+
+    @mock.patch(SMOD + '.api')
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.paths')
+    def test_ldap_newer_detected(
+        self, _paths, mock_x509, mock_nssdb, mock_api,
+    ):
+        """Detects when LDAP has a newer cert than local."""
+        local_cert = self._make_cert(10)
+        ldap_cert = self._make_cert(20)
+
+        mock_x509.load_certificate_from_file.return_value = local_cert
+        mock_x509.Encoding.DER = 'DER'
+
+        entry = mock.MagicMock()
+        entry.get.return_value = [ldap_cert]
+        entry.single_value.get.return_value = ''
+        mock_api.Backend.ldap2.get_entry.return_value = entry
+
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=mock.MagicMock(),
+        )
+        mismatches = obj._detect_ra_subsystem_mismatches(skip_subsystem=True)
+
+        assert len(mismatches) == 1
+        assert mismatches[0]['update_local'] is True
+
+    @mock.patch(SMOD + '.api')
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.paths')
+    def test_consistent_no_mismatch(
+        self, _paths, mock_x509, mock_nssdb, mock_api,
+    ):
+        """No mismatch when local and LDAP match."""
+        from ipapython.dn import DN
+
+        cert = self._make_cert(10)
+
+        mock_x509.load_certificate_from_file.return_value = cert
+        mock_x509.Encoding.DER = 'DER'
+
+        expected_desc = '2;%d;%s;%s' % (
+            cert.serial_number,
+            DN(cert.issuer), DN(cert.subject))
+        entry = mock.MagicMock()
+        entry.get.return_value = [cert]
+        entry.single_value.get.return_value = expected_desc
+        mock_api.Backend.ldap2.get_entry.return_value = entry
+
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=mock.MagicMock(),
+        )
+        mismatches = obj._detect_ra_subsystem_mismatches(skip_subsystem=True)
+
+        assert len(mismatches) == 0
+
+
+class TestUnitPartialRenewalFailure:
+    """Partial failure in CertRenewalFromMaster.renew."""
+
+    def test_failed_cert_not_in_renewed_ids(self):
+        """Failed certs excluded from renewed_ids."""
+        from ipaserver.install.ipa_cert_fix import CertRenewalFromMaster
+
+        obj = CertRenewalFromMaster(mock.MagicMock(), 'master.example.com')
+
+        # Mock two tracking requests
+        obj._build_tracking_list = mock.MagicMock(return_value=[
+            ('sslserver', mock.MagicMock(), {}, mock.MagicMock()),
+            ('httpd', mock.MagicMock(), {}, mock.MagicMock()),
+        ])
+        obj._resolve_tracking_requests = mock.MagicMock(
+            return_value=[
+                ('sslserver', mock.MagicMock(), 'req1', 'dogtag', None),
+                ('httpd', mock.MagicMock(), 'req2', 'IPA', None),
+            ])
+        obj._set_helper = mock.MagicMock(return_value='old')
+        obj._restore_helper = mock.MagicMock()
+        obj._restore = mock.MagicMock()
+
+        # First cert succeeds, second fails
+        obj._resubmit = mock.MagicMock(
+            side_effect=[None, RuntimeError("timeout")])
+
+        ctx = mock.MagicMock()
+        ctx.dogtag_certs = []
+        ctx.ipa_certs = []
+        result = obj.renew([], [], ctx)
+
+        # Only the successful cert should be in renewed_ids
+        assert 'req1' in result
+        assert 'req2' not in result
+
+
+class TestUnitResubmitUnexpectedState:
+    """resubmit_expired_certs with unexpected certmonger state."""
+
+    def test_unknown_state_logged(self):
+        """Certs in unknown states are not resubmitted."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        obj = object.__new__(IPACertFix)
+        obj._cm = mock.MagicMock()
+        obj._cm.get_requests_for_dir.return_value = ['req1']
+        obj._cm.get_request_id.return_value = None
+        obj._cm.get_request_value.return_value = 'WEIRD_STATE'
+        obj.options = mock.MagicMock()
+        obj._is_cert_valid = mock.MagicMock(return_value=False)
+
+        with mock.patch(MODULE + '.dsinstance') as md, \
+             mock.patch(MODULE + '.realm_to_serverid',
+                        return_value='TESTID'), \
+             mock.patch(MODULE + '.api') as mapi:
+            mapi.env.realm = 'TEST.REALM'
+            md.config_dirname.return_value = '/etc/dirsrv/slapd-TESTID/'
+            obj.resubmit_expired_certs(renewed_ids=set())
+
+        # Unknown state -- should not resubmit
+        obj._cm.resubmit_request.assert_not_called()
+
+
+class TestUnitSetHelperTimeout:
+    """D-Bus timeout in _set_helper."""
+
+    def test_dbus_timeout_raises(self):
+        """_set_helper raises when set_ca_override fails."""
+        import dbus
+        from ipaserver.install.ipa_cert_fix import CertRenewalFromMaster
+
+        cm = mock.MagicMock()
+        cm.set_ca_override.side_effect = \
+            dbus.exceptions.DBusException("timeout")
+
+        obj = CertRenewalFromMaster(cm, 'master.example.com')
+        with pytest.raises(dbus.exceptions.DBusException):
+            obj._set_helper()
+
+
+class TestUnitPromoteRollback:
+    """run_ca_full_promote rollback on failure."""
+
+    @mock.patch(MODULE + '.ipautil')
+    @mock.patch(MODULE + '._find_current_renewal_master',
+                return_value='old-master.example.com')
+    @mock.patch(MODULE + '.api')
+    def test_rm_restored_on_failure(self, mock_api, mock_find_rm,
+                                    mock_ipautil):
+        """Renewal master is rolled back if cert fix fails."""
+        from ipaserver.install.ipa_cert_fix import (
+            IPACertFix, CertFixContext,
+        )
+
+        mock_ipautil.run.return_value = mock.MagicMock(returncode=0)
+        mock_ipautil.CalledProcessError = Exception
+        mock_api.env.host = 'replica.example.com'
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.dry_run = False
+        obj.options.unattended = False
+        obj._scenario_made_changes = False
+
+        # Mock the promote/fix chain
+        obj._promote_to_renewal_master = mock.MagicMock()
+        obj._ca_instance = mock.MagicMock()
+        obj.run_renewal_master_fix = mock.MagicMock(
+            side_effect=RuntimeError("cert-fix failed"))
+
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_SELF_SIGNED,
+            scenario=FixScenario.CA_FULL_PROMOTE,
+            subject_base=mock.MagicMock(),
+            ca_subject_dn=mock.MagicMock(),
+            dogtag_certs=[], ipa_certs=[],
+            external_certs=[],
+            master_server=None,
+            serverid='TESTID',
+            ds_dbdir='/etc/dirsrv/slapd-TESTID',
+            ds_nickname='Server-Cert',
+            hsm_enabled=False,
+            hsm_token_name=None,
+        )
+
+        # Simulate user confirming promotion
+        with mock.patch(MODULE + '.ipautil.user_input', return_value='yes'):
+            with pytest.raises(RuntimeError, match="cert-fix failed"):
+                obj.run_ca_full_promote(ctx)
+
+        # Rollback should have been attempted
+        obj._ca_instance.set_renewal_master.assert_called_with(
+            'old-master.example.com')
+
+
+class TestUnitFetchSharedPartialFailure:
+    """_fetch_shared_dogtag_certs with some certs failing."""
+
+    @mock.patch(SMOD + '.api')
+    def test_one_fails_others_succeed(self, mock_api):
+        """Failed shared cert doesn't block other certs."""
+        import datetime as dt
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        mock_api.env.basedn = 'dc=example,dc=com'
+
+        now = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+        good_cert = mock.MagicMock()
+        good_cert.not_valid_after_utc = dt.datetime(
+            2030, 1, 1, tzinfo=dt.timezone.utc)
+        good_cert.serial_number = 99
+
+        conn = mock.MagicMock()
+        db = mock.MagicMock()
+
+        # First cert fetch fails, second succeeds
+        entry_ok = mock.MagicMock()
+        entry_ok.single_value.__getitem__ = mock.MagicMock(
+            return_value=good_cert)
+
+        call_count = [0]
+
+        def get_entry_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise Exception("LDAP error")
+            return entry_ok
+
+        conn.get_entry.side_effect = get_entry_side_effect
+
+        ctx = mock.MagicMock()
+        ctx.dogtag_certs = [
+            ('ca_ocsp_signing', mock.MagicMock()),
+            ('ca_audit_signing', mock.MagicMock()),
+        ]
+
+        obj = object.__new__(IPACertFix)
+        # Should not raise -- failed cert logged, loop continues
+        obj._fetch_shared_dogtag_certs(
+            conn, db, ctx, 'master.example.com', now)
+
+        # Second cert should have been installed despite first failing
+        assert db.add_cert.called or conn.get_entry.call_count == 2
+
+
+# =============================================================
+#  Phase 1: CertIdentity Tests
+# =============================================================
+
+
 class TestCertIdentityRegistry:
-    """CertIdentity dataclass and DOGTAG_CERTS registry invariants."""
+    """Phase 1.1: CertIdentity dataclass and DOGTAG_CERTS registry."""
 
     def test_sslserver_is_not_shared(self):
         """sslserver is server-specific, not shared/replicated."""
@@ -57,8 +1273,8 @@ class TestCertIdentityRegistry:
             assert ci.nickname, certid
 
     def test_all_shared_certs_have_cs_cfg_directive(self):
-        """Shared certs (except ca_issuing and sslserver) must have CS.cfg
-        directives so the cert blob can be updated in-place."""
+        """Shared certs (except ca_issuing and sslserver) must have
+        CS.cfg directives so _update_cs_cfg can update them."""
         for certid, ci in DOGTAG_CERTS.items():
             if ci.is_shared and certid not in ('ca_issuing',):
                 assert ci.cs_cfg_directive is not None, (
@@ -108,7 +1324,7 @@ class TestCertIdentityRegistry:
 
 
 class TestCertmongerClient:
-    """CertmongerClient adapter delegation and retry logic."""
+    """Phase 2: CertmongerClient adapter tests."""
 
     @mock.patch(SMOD + '.certmonger')
     def test_get_request_id_delegates(self, mock_cm):
@@ -182,8 +1398,16 @@ class TestCertmongerClient:
         assert result == ['r1', 'r2']
 
 
+# =============================================================
+#  Phase 0: Characterization Tests (Safety Net)
+#
+#  Pin current behavior before refactoring.  Each test documents
+#  what the code does today, not what it should do.
+# =============================================================
+
+
 class TestUnitDeploymentDetection:
-    """detect_deployment_type with all 4 return values."""
+    """Characterization: detect_deployment_type with all 4 return values."""
 
     def _make_detector(self):
         return DeploymentDetector(
@@ -196,7 +1420,9 @@ class TestUnitDeploymentDetection:
     @mock.patch(SMOD + '.api')
     @mock.patch(SMOD + '._get_pki_nssdb')
     @mock.patch(SMOD + '.cainstance')
-    def test_ca_self_signed(self, mock_ca, mock_nssdb, mock_api, mock_fps):
+    def test_ca_self_signed(
+        self, mock_ca, mock_nssdb, mock_api, mock_fps,
+    ):
         """CA installed, issuer == subject -> CA_SELF_SIGNED."""
         mock_ca.is_ca_installed_locally.return_value = True
         cert = mock.MagicMock()
@@ -245,7 +1471,9 @@ class TestUnitDeploymentDetection:
     @mock.patch(SMOD + '.find_providing_servers', return_value=[])
     @mock.patch(SMOD + '.api')
     @mock.patch(SMOD + '.cainstance')
-    def test_ca_less_external(self, mock_ca, mock_api, mock_fps, mock_elc):
+    def test_ca_less_external(
+        self, mock_ca, mock_api, mock_fps, mock_elc,
+    ):
         """No local CA, no CA servers -> CA_LESS_EXTERNAL."""
         mock_ca.is_ca_installed_locally.return_value = False
 
@@ -268,10 +1496,33 @@ class TestUnitDeploymentDetection:
         result = obj.detect_deployment_type()
         assert result == DeploymentType.CA_LESS
 
+    @mock.patch(SMOD + '._ensure_ldap_connected')
+    @mock.patch(SMOD + '.find_providing_servers',
+                side_effect=Exception("LDAP down"))
+    @mock.patch(SMOD + '.api')
+    @mock.patch(SMOD + '.cainstance')
+    def test_detect2_ldap_query_fails_warns(
+        self, mock_ca, mock_api, mock_fps, mock_elc, capsys,
+    ):
+        """T-DETECT-2: LDAP topology query fails during detection.
+
+        Verify: warning printed, detection defaults to CA_LESS.
+        """
+        mock_ca.is_ca_installed_locally.return_value = False
+
+        obj = self._make_detector()
+        result = obj.detect_deployment_type()
+        assert result == DeploymentType.CA_LESS
+        captured = capsys.readouterr()
+        assert 'WARNING' in captured.out
+        assert 'Could not query topology' in captured.out
+
     @mock.patch(SMOD + '.api')
     @mock.patch(SMOD + '._get_pki_nssdb')
     @mock.patch(SMOD + '.cainstance')
-    def test_nssdb_unreadable_raises(self, mock_ca, mock_nssdb, mock_api):
+    def test_nssdb_unreadable_raises(
+        self, mock_ca, mock_nssdb, mock_api,
+    ):
         """CA installed but NSSDB unreadable -> RuntimeError."""
         mock_ca.is_ca_installed_locally.return_value = True
         mock_nssdb.return_value.get_cert.side_effect = RuntimeError("db error")
@@ -281,444 +1532,409 @@ class TestUnitDeploymentDetection:
             obj.detect_deployment_type()
 
 
-class TestUnitScenarioRouting:
-    """Scenario routing for each deployment type."""
+class TestUnitDetectAndDispatchNothingToDo:
+    """Characterization: _classify_and_dispatch 'Nothing to do' path."""
 
-    def _make_detector(self, is_rm, master, force_rm=False):
-        options = mock.MagicMock()
-        options.renewal_master = force_rm
-        options.force_server = None
-        options.unattended = False
-        obj = DeploymentDetector(
-            cm_client=mock.MagicMock(),
-            ca_instance=mock.MagicMock(),
-            options=options,
-        )
-        obj.check_is_renewal_master = mock.MagicMock(return_value=is_rm)
-        obj.get_master_server = mock.MagicMock(return_value=master)
+    @mock.patch(MODULE + '.cainstance')
+    @mock.patch(MODULE + '.ca')
+    @mock.patch(MODULE + '.dsinstance')
+    @mock.patch(MODULE + '.realm_to_serverid', return_value='EXAMPLE-COM')
+    @mock.patch(MODULE + '.api')
+    def test_no_expired_certs_no_mismatches_returns_zero(
+        self, mock_api, mock_r2s, mock_ds, mock_ca_mod, mock_cai,
+    ):
+        """No expired certs + no LDAP mismatches -> exit 0."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        mock_cai.is_ca_installed_locally.return_value = False
+        mock_api.env.realm = 'EXAMPLE.COM'
+        ds_inst = mock.MagicMock()
+        ds_inst.find_subject_base.return_value = 'O=EXAMPLE.COM'
+        ds_inst.get_server_cert_nickname.return_value = 'Server-Cert'
+        mock_ds.DsInstance.return_value = ds_inst
+        mock_ds.config_dirname.return_value = '/etc/dirsrv/slapd-EXAMPLE-COM/'
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.dry_run = False
+        obj.options.unattended = True
+        obj._ca_instance = None
+        obj._scenario_made_changes = False
+        obj._cm = mock.MagicMock()
+
+        with mock.patch.object(
+            DeploymentDetector, 'detect_deployment_type',
+            return_value=DeploymentType.CA_LESS_EXTERNAL,
+        ), mock.patch.object(
+            DeploymentDetector, '_classify_certs',
+            return_value=([], [], []),
+        ):
+            result = obj._classify_and_dispatch()
+        assert result == 0
+
+
+class TestUnitDetectAndDispatchLdapMismatchOnly:
+    """Characterization: _classify_and_dispatch with only LDAP mismatches."""
+
+    def _setup(self):
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.dry_run = False
+        obj.options.unattended = False
+        obj._ca_instance = mock.MagicMock()
+        obj._scenario_made_changes = False
+        obj._cm = mock.MagicMock()
+
+        mismatch = {
+            'label': 'IPA RA', 'newest': mock.MagicMock(serial_number=42),
+            'dn': mock.MagicMock(),
+            'entry': mock.MagicMock(),
+            'update_local': False,
+            'update_ldap_cert': False,
+            'update_desc': True,
+            'path_info': ('file', '/etc/pki/ra-agent.pem'),
+            'expected_desc': '2;42;CN=CA;CN=RA',
+        }
+        obj._mock_mismatch = mismatch
         return obj
 
-    @pytest.mark.parametrize("dt,is_rm,master,expected_scenario", [
-        (DeploymentType.CA_SELF_SIGNED,
-         True, None, FixScenario.RENEWAL_MASTER),
-        (DeploymentType.CA_SELF_SIGNED,
-         False, 'master.example.com', FixScenario.CA_FULL_WITH_MASTER),
-        (DeploymentType.CA_SELF_SIGNED,
-         False, None, FixScenario.CA_FULL_PROMOTE),
-        (DeploymentType.CA_EXTERNALLY_SIGNED,
-         True, None, FixScenario.RENEWAL_MASTER),
-        (DeploymentType.CA_EXTERNALLY_SIGNED,
-         False, 'master.example.com', FixScenario.CA_FULL_WITH_MASTER),
-        (DeploymentType.CA_LESS,
-         False, 'master.example.com', FixScenario.CA_LESS_WITH_MASTER),
-        (DeploymentType.CA_LESS_EXTERNAL,
-         False, None, FixScenario.EXTERNAL_CERTS),
-    ])
-    def test_scenario_matrix(self, dt, is_rm, master, expected_scenario):
-        """Verify correct FixScenario for each combination."""
-        obj = self._make_detector(is_rm, master)
-        scenario, srv = obj.determine_scenario(dt)
-        assert scenario == expected_scenario
-        if expected_scenario in (
-            FixScenario.CA_FULL_WITH_MASTER,
-            FixScenario.CA_LESS_WITH_MASTER,
-        ):
-            assert srv == master
-        elif expected_scenario in (
-            FixScenario.RENEWAL_MASTER,
-            FixScenario.CA_FULL_PROMOTE,
-            FixScenario.EXTERNAL_CERTS,
-        ):
-            assert srv is None
-
-    def test_caless_no_server_raises(self):
-        """CA_LESS with no server selected raises RuntimeError."""
-        obj = self._make_detector(is_rm=False, master=None)
-        with pytest.raises(RuntimeError, match="No server"):
-            obj.determine_scenario(DeploymentType.CA_LESS)
-
-    def test_force_renewal_master_flag(self):
-        """--renewal-master forces RENEWAL_MASTER scenario."""
-        obj = self._make_detector(
-            is_rm=False, master='m.example.com', force_rm=True,
-        )
-        scenario, srv = obj.determine_scenario(
-            DeploymentType.CA_SELF_SIGNED)
-        assert scenario == FixScenario.RENEWAL_MASTER
-        assert srv is None
-
-
-class TestUnitCertClassification:
-    """Cert classification splits external from IPA."""
-
-    @mock.patch(SMOD + '.cainstance')
-    @mock.patch(SMOD + '.expired_dogtag_certs')
-    @mock.patch(SMOD + '.expired_ipa_certs')
-    def test_external_certs_split(
-        self, mock_exp_ipa, mock_exp_dog, mock_ca,
-    ):
-        """Verify _classify_certs moves non_renewed to external."""
-        import datetime as dt
-        now = dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc)
-        mock_ca.is_ca_installed_locally.return_value = True
-
-        cert_mock = mock.MagicMock()
-        mock_exp_dog.return_value = [('ca_audit', cert_mock)]
-        mock_exp_ipa.return_value = (
-            [(IPACertType.IPARA, cert_mock)],
-            [(IPACertType.HTTPS, cert_mock)],  # non_renewed -> external
-        )
-
-        dogtag, ipa, external = DeploymentDetector._classify_certs(now)
-
-        assert len(dogtag) == 1
-        assert len(ipa) == 1
-        assert len(external) == 1
-        assert external[0][0] == IPACertType.HTTPS
-
-    @mock.patch(SMOD + '.cainstance')
-    @mock.patch(SMOD + '.expired_ipa_certs')
-    def test_caless_skips_dogtag(self, mock_exp_ipa, mock_ca):
-        """On CA-less, dogtag certs list is empty."""
-        import datetime as dt
-        now = dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc)
-        mock_ca.is_ca_installed_locally.return_value = False
-
-        cert_mock = mock.MagicMock()
-        mock_exp_ipa.return_value = (
-            [(IPACertType.HTTPS, cert_mock)],
-            [],
-        )
-
-        dogtag, ipa, external = DeploymentDetector._classify_certs(now)
-
-        assert dogtag == []
-        assert len(ipa) == 1
-
-
-def _make_ctx(**overrides):
-    """Build a minimal CertFixContext with optional field overrides."""
-    fields = dict(
-        deployment_type=DeploymentType.CA_SELF_SIGNED,
-        scenario=FixScenario.CA_FULL_WITH_MASTER,
-        subject_base='O=TEST',
-        ca_subject_dn='CN=CA',
-        dogtag_certs=[],
-        ipa_certs=[],
-        external_certs=[],
-        master_server='m.example.com',
-        serverid='TEST',
-        ds_dbdir='/etc/dirsrv/slapd-TEST',
-        ds_nickname='Server-Cert',
-    )
-    fields.update(overrides)
-    return CertFixContext(**fields)
-
-
-class TestUnitBuildTrackingList:
-    """_build_tracking_list filtering logic."""
-
-    def test_skips_subsystem_and_ra(self):
-        """subsystem and RA certs are skipped (fetched separately from
-        master's LDAP)."""
-        cert = mock.MagicMock()
-        ctx = _make_ctx()
-
-        dogtag = [('subsystem', cert), ('sslserver', cert)]
-        ipa = [(IPACertType.IPARA, cert), (IPACertType.HTTPS, cert)]
-
-        obj = CertRenewalFromMaster(mock.MagicMock(), 'm.example.com')
-        tracking = obj._build_tracking_list(dogtag, ipa, ctx)
-
-        descs = [d for d, _c, _cr, _l in tracking]
-        desc_ids = [getattr(d, 'id', d) for d in descs]
-        assert 'subsystem' not in desc_ids
-        assert IPACertType.IPARA not in descs
-        assert 'sslserver' in desc_ids
-        assert IPACertType.HTTPS in descs
-
-    def test_all_ipa_cert_types_mapped(self):
-        """HTTPS, LDAPS, KDC all produce tracking entries."""
-        cert = mock.MagicMock()
-        ctx = _make_ctx()
-
-        ipa = [
-            (IPACertType.HTTPS, cert),
-            (IPACertType.LDAPS, cert),
-            (IPACertType.KDC, cert),
-        ]
-
-        obj = CertRenewalFromMaster(mock.MagicMock(), 'm.example.com')
-        tracking = obj._build_tracking_list([], ipa, ctx)
-
-        descs = [d for d, _c, _cr, _l in tracking]
-        assert IPACertType.HTTPS in descs
-        assert IPACertType.LDAPS in descs
-        assert IPACertType.KDC in descs
-        assert len(tracking) == 3
-
-
-class TestUnitMakeCertLoader:
-    """_make_cert_loader factory."""
-
-    @mock.patch(SMOD + '.NSSDatabase')
-    def test_nssdb_loader(self, mock_nss):
-        """NSSDB loader calls db.get_cert(nickname)."""
-        db = mock.MagicMock()
-        mock_nss.return_value = db
-
-        loader = CertRenewalFromMaster._make_cert_loader(
-            'NSSDB', '/some/db', 'MyCert')
-        loader()
-        db.get_cert.assert_called_once_with('MyCert')
-
-    @mock.patch(SMOD + '.x509')
-    def test_file_loader(self, mock_x509):
-        """FILE loader calls load_certificate_from_file."""
-        loader = CertRenewalFromMaster._make_cert_loader(
-            'FILE', '/some/cert.pem')
-        loader()
-        mock_x509.load_certificate_from_file.assert_called_once_with(
-            '/some/cert.pem')
-
-
-class TestUnitSetIpaCaHelperStripping:
-    """_set_helper / set_ca_override strips leftover -J."""
-
-    @mock.patch(SMOD + '.certmonger')
-    def test_strips_stale_j_flag(self, mock_cm):
-        """If old helper already has -J from a crashed run, the stale
-        -J is stripped before appending the new one."""
-        stale = '/usr/libexec/ipa-submit -J https://old.example.com/ipa/json'
-        client = CertmongerClient()
-        client.get_ca_helper = mock.MagicMock(return_value=stale)
-
-        result = client.set_ca_override('IPA', 'new.example.com')
-
-        assert result == '/usr/libexec/ipa-submit'
-        new_helper = mock_cm.modify_ca_helper.call_args[0][1]
-        assert new_helper.count('-J') == 1
-        assert 'new.example.com' in new_helper
-
-
-class TestUnitPartialRenewalFailure:
-    """Partial failure in CertRenewalFromMaster.renew."""
-
-    def test_failed_cert_not_in_renewed_ids(self):
-        """Failed certs excluded from renewed_ids."""
-        obj = CertRenewalFromMaster(mock.MagicMock(), 'master.example.com')
-
-        obj._build_tracking_list = mock.MagicMock(return_value=[
-            ('sslserver', mock.MagicMock(), {}, mock.MagicMock()),
-            ('httpd', mock.MagicMock(), {}, mock.MagicMock()),
-        ])
-        obj._resolve_tracking_requests = mock.MagicMock(return_value=[
-            ('sslserver', mock.MagicMock(), 'req1', 'dogtag', None),
-            ('httpd', mock.MagicMock(), 'req2', 'IPA', None),
-        ])
-        obj._set_helper = mock.MagicMock(return_value='old')
-        obj._restore_helper = mock.MagicMock()
-        obj._restore = mock.MagicMock()
-
-        obj._resubmit = mock.MagicMock(
-            side_effect=[None, RuntimeError("timeout")])
-
-        ctx = mock.MagicMock()
-        ctx.dogtag_certs = []
-        ctx.ipa_certs = []
-        result = obj.renew([], [], ctx)
-
-        assert 'req1' in result
-        assert 'req2' not in result
-
-
-class TestUnitSetHelperTimeout:
-    """D-Bus timeout in _set_helper."""
-
-    def test_dbus_timeout_raises(self):
-        """_set_helper raises when set_ca_override fails."""
-        import dbus
-        cm = mock.MagicMock()
-        cm.set_ca_override.side_effect = \
-            dbus.exceptions.DBusException("timeout")
-
-        obj = CertRenewalFromMaster(cm, 'master.example.com')
-        with pytest.raises(dbus.exceptions.DBusException):
-            obj._set_helper()
-
-
-class TestUnitValidateOptions:
-    """Option validation."""
-
-    @mock.patch('ipapython.admintool.AdminTool.validate_options')
-    def test_renewal_master_and_force_server_exclusive(self, mock_super):
-        """--renewal-master + --force-server is rejected."""
-        from ipaserver.install.ipa_cert_fix import IPACertFix
-
-        obj = object.__new__(IPACertFix)
-        obj.options = mock.MagicMock()
-        obj.options.renewal_master = True
-        obj.options.force_server = 'master.example.com'
-        obj.option_parser = mock.MagicMock()
-
-        obj.validate_options()
-
-        obj.option_parser.error.assert_called_once()
-        assert "mutually exclusive" in \
-            obj.option_parser.error.call_args[0][0]
-
-    def test_renewal_master_on_caless_rejected(self):
-        """--renewal-master on CA-less raises RuntimeError."""
-        options = mock.MagicMock()
-        options.renewal_master = True
-        obj = DeploymentDetector(
-            cm_client=mock.MagicMock(),
-            ca_instance=mock.MagicMock(),
-            options=options,
-        )
-
-        with pytest.raises(RuntimeError, match="CA-less"):
-            obj.determine_scenario(DeploymentType.CA_LESS)
-
-    def test_renewal_master_on_caless_external_rejected(self):
-        """--renewal-master on CA_LESS_EXTERNAL raises RuntimeError."""
-        options = mock.MagicMock()
-        options.renewal_master = True
-        obj = DeploymentDetector(
-            cm_client=mock.MagicMock(),
-            ca_instance=mock.MagicMock(),
-            options=options,
-        )
-
-        with pytest.raises(RuntimeError, match="CA-less"):
-            obj.determine_scenario(DeploymentType.CA_LESS_EXTERNAL)
-
-
-class TestUnitForceServerSelf:
-    """--force-server=self is rejected early in run()."""
-
-    @mock.patch(MODULE + '.is_ipa_configured', return_value=True)
+    @mock.patch(MODULE + '.print_intentions')
+    @mock.patch(MODULE + '.ca')
+    @mock.patch(MODULE + '.cainstance')
+    @mock.patch(MODULE + '.dsinstance')
+    @mock.patch(MODULE + '.realm_to_serverid', return_value='EXAMPLE-COM')
     @mock.patch(MODULE + '.api')
-    def test_force_server_self_rejected(self, mock_api, _mock_cfg):
-        """run() returns 1 when --force-server points to self."""
-        from ipaserver.install.ipa_cert_fix import IPACertFix
+    def test_dry_run_shows_mismatches_no_fix(
+        self, mock_api, mock_r2s, mock_ds, mock_cai,
+        mock_ca_mod, mock_pi,
+    ):
+        """Dry-run with LDAP mismatches only -> shows plan, no fix."""
+        mock_api.env.realm = 'EXAMPLE.COM'
+        mock_cai.is_ca_installed_locally.return_value = True
+        mock_cai.CAInstance.return_value = mock.MagicMock()
+        ds_inst = mock.MagicMock()
+        ds_inst.find_subject_base.return_value = 'O=EXAMPLE.COM'
+        ds_inst.get_server_cert_nickname.return_value = 'Server-Cert'
+        mock_ds.DsInstance.return_value = ds_inst
+        mock_ds.config_dirname.return_value = '/etc/dirsrv/slapd-EXAMPLE-COM/'
 
-        mock_api.env.host = 'replica.example.com'
-        mock_api.bootstrap = mock.MagicMock()
-        mock_api.finalize = mock.MagicMock()
+        obj = self._setup()
+        obj.options.dry_run = True
+
+        with mock.patch.object(
+            DeploymentDetector, 'detect_deployment_type',
+            return_value=DeploymentType.CA_SELF_SIGNED,
+        ), mock.patch.object(
+            DeploymentDetector, '_classify_certs',
+            return_value=([], [], []),
+        ), mock.patch.object(
+            DeploymentDetector, '_detect_ra_subsystem_mismatches',
+            return_value=[obj._mock_mismatch],
+        ), mock.patch.object(
+            DeploymentDetector, '_fix_ra_subsystem_mismatches',
+        ) as mock_fix:
+            result = obj._classify_and_dispatch()
+        assert result == 0
+        mock_fix.assert_not_called()
+
+    @mock.patch(MODULE + '.print_intentions')
+    @mock.patch(MODULE + '.ca')
+    @mock.patch(MODULE + '.cainstance')
+    @mock.patch(MODULE + '.dsinstance')
+    @mock.patch(MODULE + '.realm_to_serverid', return_value='EXAMPLE-COM')
+    @mock.patch(MODULE + '.api')
+    def test_unattended_fixes_mismatches(
+        self, mock_api, mock_r2s, mock_ds, mock_cai,
+        mock_ca_mod, mock_pi,
+    ):
+        """Unattended with LDAP mismatches only -> fixes applied, exit 0."""
+        mock_api.env.realm = 'EXAMPLE.COM'
+        mock_cai.is_ca_installed_locally.return_value = True
+        mock_cai.CAInstance.return_value = mock.MagicMock()
+        ds_inst = mock.MagicMock()
+        ds_inst.find_subject_base.return_value = 'O=EXAMPLE.COM'
+        ds_inst.get_server_cert_nickname.return_value = 'Server-Cert'
+        mock_ds.DsInstance.return_value = ds_inst
+        mock_ds.config_dirname.return_value = '/etc/dirsrv/slapd-EXAMPLE-COM/'
+
+        obj = self._setup()
+        obj.options.unattended = True
+
+        with mock.patch.object(
+            DeploymentDetector, 'detect_deployment_type',
+            return_value=DeploymentType.CA_SELF_SIGNED,
+        ), mock.patch.object(
+            DeploymentDetector, '_classify_certs',
+            return_value=([], [], []),
+        ), mock.patch.object(
+            DeploymentDetector, '_detect_ra_subsystem_mismatches',
+            return_value=[obj._mock_mismatch],
+        ), mock.patch.object(
+            DeploymentDetector, '_fix_ra_subsystem_mismatches',
+        ) as mock_fix:
+            result = obj._classify_and_dispatch()
+        assert result == 0
+        mock_fix.assert_called_once()
+
+
+class TestUnitRenewalMasterCalledProcessError:
+    """Characterization: run_renewal_master_fix CalledProcessError tolerance."""
+
+    def _make_obj(self):
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.dry_run = False
+        obj.options.unattended = True
+        obj._scenario_made_changes = False
+        obj._detector = mock.MagicMock()
+        obj._detector._check_ca_signing_cert = mock.MagicMock(
+            return_value=True)
+        obj._detector.check_is_renewal_master = mock.MagicMock(
+            return_value=True)
+        obj._ca_instance = mock.MagicMock()
+        obj._handle_external_certs = mock.MagicMock()
+        obj._cm = mock.MagicMock()
+        obj._cm.is_responsive.return_value = True
+        obj.resubmit_expired_certs = mock.MagicMock()
+        return obj
+
+    @mock.patch(MODULE + '._ensure_ldap_connected')
+    @mock.patch(MODULE + '.install_ipa_certs')
+    @mock.patch(MODULE + '.replicate_dogtag_certs')
+    @mock.patch(MODULE + '.check_renewed_ipa_certs', return_value=True)
+    @mock.patch(MODULE + '.run_cert_fix',
+                side_effect=Exception("pki-server failed"))
+    @mock.patch(MODULE + '.fix_certreq_directives')
+    @mock.patch(MODULE + '.ipautil')
+    @mock.patch(MODULE + '.api')
+    def test_ds_cert_expired_tolerates_pki_error(
+        self, mock_api, mock_ipautil, mock_fix_dir,
+        mock_run_cf, mock_check, mock_repl, mock_install,
+        mock_elc,
+    ):
+        """When DS cert is in the list and renewed files exist,
+        CalledProcessError from pki-server cert-fix is tolerated."""
+        from ipaserver.install.ipa_cert_fix import (
+            CertFixContext,
+        )
+        mock_ipautil.CalledProcessError = Exception
+        mock_ipautil.run.return_value = mock.MagicMock(returncode=0)
+
+        obj = self._make_obj()
+        cert = mock.MagicMock()
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_SELF_SIGNED,
+            scenario=FixScenario.RENEWAL_MASTER,
+            subject_base=mock.MagicMock(),
+            ca_subject_dn=mock.MagicMock(),
+            dogtag_certs=[('sslserver', cert)],
+            ipa_certs=[(IPACertType.LDAPS, cert)],
+            external_certs=[],
+            master_server=None,
+        )
+
+        result = obj.run_renewal_master_fix(ctx)
+        assert result == 0
+        mock_check.assert_called_once()
+
+    @mock.patch(MODULE + '.check_renewed_ipa_certs', return_value=False)
+    @mock.patch(MODULE + '.run_cert_fix',
+                side_effect=Exception("pki-server failed"))
+    @mock.patch(MODULE + '.fix_certreq_directives')
+    @mock.patch(MODULE + '.ipautil')
+    @mock.patch(MODULE + '.api')
+    def test_ds_cert_expired_no_renewed_files_raises(
+        self, mock_api, mock_ipautil, mock_fix_dir,
+        mock_run_cf, mock_check,
+    ):
+        """When DS cert is in list but renewed files DON'T exist, re-raises."""
+        from ipaserver.install.ipa_cert_fix import (
+            CertFixContext,
+        )
+        mock_ipautil.CalledProcessError = Exception
+
+        obj = self._make_obj()
+        cert = mock.MagicMock()
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_SELF_SIGNED,
+            scenario=FixScenario.RENEWAL_MASTER,
+            subject_base=mock.MagicMock(),
+            ca_subject_dn=mock.MagicMock(),
+            dogtag_certs=[],
+            ipa_certs=[(IPACertType.LDAPS, cert)],
+            external_certs=[],
+            master_server=None,
+        )
+
+        with pytest.raises(Exception, match="pki-server failed"):
+            obj.run_renewal_master_fix(ctx)
+
+    @mock.patch(MODULE + '.run_cert_fix',
+                side_effect=Exception("pki-server failed"))
+    @mock.patch(MODULE + '.fix_certreq_directives')
+    @mock.patch(MODULE + '.ipautil')
+    @mock.patch(MODULE + '.api')
+    def test_no_ds_cert_pki_error_raises(
+        self, mock_api, mock_ipautil, mock_fix_dir, mock_run_cf,
+    ):
+        """Without DS cert in list, CalledProcessError is NOT tolerated."""
+        from ipaserver.install.ipa_cert_fix import (
+            CertFixContext,
+        )
+        mock_ipautil.CalledProcessError = Exception
+
+        obj = self._make_obj()
+        cert = mock.MagicMock()
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_SELF_SIGNED,
+            scenario=FixScenario.RENEWAL_MASTER,
+            subject_base=mock.MagicMock(),
+            ca_subject_dn=mock.MagicMock(),
+            dogtag_certs=[('sslserver', cert)],
+            ipa_certs=[(IPACertType.HTTPS, cert)],
+            external_certs=[],
+            master_server=None,
+        )
+
+        with pytest.raises(Exception, match="pki-server failed"):
+            obj.run_renewal_master_fix(ctx)
+
+
+class TestUnitPromoteFullRollbackSequence:
+    """Characterization: run_ca_full_promote full rollback sequence."""
+
+    def _make_promote_obj(self):
+        from ipaserver.install.ipa_cert_fix import IPACertFix
 
         obj = object.__new__(IPACertFix)
         obj.options = mock.MagicMock()
-        obj.options.force_server = 'replica.example.com'
+        obj.options.dry_run = False
+        obj.options.unattended = False
+        obj._scenario_made_changes = False
+        obj._promote_to_renewal_master = mock.MagicMock()
+        obj._ca_instance = mock.MagicMock()
+        return obj
 
-        result = obj.run()
-        assert result == 1
+    def _make_ctx(self):
+        from ipaserver.install.ipa_cert_fix import CertFixContext
+        return CertFixContext(
+            deployment_type=DeploymentType.CA_SELF_SIGNED,
+            scenario=FixScenario.CA_FULL_PROMOTE,
+            subject_base=mock.MagicMock(),
+            ca_subject_dn=mock.MagicMock(),
+            dogtag_certs=[], ipa_certs=[],
+            external_certs=[],
+            master_server=None,
+        )
 
-
-class TestUnitPromoteRollback:
-    """run_ca_full_promote rollback on failure."""
-
-    @mock.patch(MODULE + '.ipautil')
     @mock.patch(MODULE + '._find_current_renewal_master',
                 return_value='old-master.example.com')
+    @mock.patch(MODULE + '.ipautil')
     @mock.patch(MODULE + '.api')
-    def test_rm_restored_on_failure(
-        self, mock_api, mock_find_rm, mock_ipautil,
+    def test_unattended_forced_during_rm_fix(
+        self, mock_api, mock_ipautil, mock_find_rm,
     ):
-        """Renewal master is rolled back if cert fix fails."""
-        from ipaserver.install.ipa_cert_fix import IPACertFix
-
+        """After user confirms, unattended is set True for RM fix,
+        then restored in finally."""
         mock_ipautil.run.return_value = mock.MagicMock(returncode=0)
         mock_ipautil.CalledProcessError = Exception
         mock_api.env.host = 'replica.example.com'
 
-        obj = object.__new__(IPACertFix)
-        obj.options = mock.MagicMock()
-        obj.options.unattended = False
-        obj.options.dry_run = False
+        obj = self._make_promote_obj()
+        obj.run_renewal_master_fix = mock.MagicMock(return_value=0)
 
-        obj._promote_to_renewal_master = mock.MagicMock()
-        obj._ca_instance = mock.MagicMock()
-        obj.run_renewal_master_fix = mock.MagicMock(
-            side_effect=RuntimeError("cert-fix failed"))
+        unattended_during_fix = []
 
-        ctx = _make_ctx(
-            scenario=FixScenario.CA_FULL_PROMOTE,
-            master_server=None,
-        )
+        def capture_unattended(ctx):
+            unattended_during_fix.append(obj.options.unattended)
+            return 0
+
+        obj.run_renewal_master_fix.side_effect = capture_unattended
 
         with mock.patch(MODULE + '.ipautil.user_input', return_value='yes'):
-            with pytest.raises(RuntimeError, match="cert-fix failed"):
-                obj.run_ca_full_promote(ctx)
+            obj.run_ca_full_promote(self._make_ctx())
 
-        obj._ca_instance.set_renewal_master.assert_called_with(
-            'old-master.example.com')
+        assert unattended_during_fix == [True]
+        assert obj.options.unattended is False
 
-
-class TestUnitExternalCertsNoCA:
-    """ExternalCertHandler on fully-external deployments."""
-
-    @mock.patch(SMOD + '.os.makedirs')
-    @mock.patch(SMOD + '.find_providing_servers')
-    def test_caless_external_skips_ca_lookup(
-        self, mock_fps, mock_makedirs,
+    @mock.patch(MODULE + '._find_current_renewal_master',
+                return_value='old-master.example.com')
+    @mock.patch(MODULE + '.ipautil')
+    @mock.patch(MODULE + '.api')
+    def test_rollback_failure_prints_warning(
+        self, mock_api, mock_ipautil, mock_find_rm, capsys,
     ):
-        """CA_LESS_EXTERNAL skips the CA server lookup entirely."""
-        cm = mock.MagicMock()
-        cm.get_request_id.return_value = None
-        handler = ExternalCertHandler(cm_client=cm, unattended=True)
-        handler._generate_csr_from_key = mock.MagicMock(return_value=None)
+        """When rollback itself fails, a warning is printed
+        (not a crash)."""
+        mock_ipautil.run.return_value = mock.MagicMock(returncode=0)
+        mock_ipautil.CalledProcessError = Exception
+        mock_api.env.host = 'replica.example.com'
 
-        cert = mock.MagicMock()
-        ctx = _make_ctx(
-            deployment_type=DeploymentType.CA_LESS_EXTERNAL,
-            scenario=FixScenario.EXTERNAL_CERTS,
-            external_certs=[(IPACertType.HTTPS, cert)],
-            master_server=None,
-        )
-        handler.handle(ctx)
+        obj = self._make_promote_obj()
+        obj.run_renewal_master_fix = mock.MagicMock(
+            side_effect=RuntimeError("cert-fix boom"))
+        # Rollback calls _ca_instance.set_renewal_master(old_rm) directly
+        # (_promote_to_renewal_master is a separate mock).
+        # Make the rollback call fail:
+        obj._ca_instance.set_renewal_master.side_effect = Exception(
+            "LDAP down")
 
-        # find_providing_servers must NOT be called
-        mock_fps.assert_not_called()
+        with mock.patch(MODULE + '.ipautil.user_input', return_value='yes'):
+            with pytest.raises(RuntimeError, match="cert-fix boom"):
+                obj.run_ca_full_promote(self._make_ctx())
 
-    def test_no_tracking_generates_csr_from_key(self, tmp_path):
-        """When no tracking exists, generate CSR from existing key."""
-        cm = mock.MagicMock()
-        cm.get_request_id.return_value = None
-        handler = ExternalCertHandler(
-            cm_client=cm, unattended=True, csr_dir=str(tmp_path))
-        fake_csr = (
-            "-----BEGIN CERTIFICATE REQUEST-----\nfake\n"
-            "-----END CERTIFICATE REQUEST-----\n"
-        )
-        handler._generate_csr_from_key = mock.MagicMock(return_value=fake_csr)
+        # Rollback was attempted via _ca_instance.set_renewal_master
+        obj._ca_instance.set_renewal_master.assert_called_once_with(
+            'old-master.example.com')
+        captured = capsys.readouterr()
+        assert 'Could not restore renewal master' in captured.out
 
-        cert = mock.MagicMock()
-        ctx = _make_ctx(
-            deployment_type=DeploymentType.CA_LESS_EXTERNAL,
-            scenario=FixScenario.EXTERNAL_CERTS,
-            external_certs=[(IPACertType.HTTPS, cert)],
-            master_server=None,
-        )
+    @mock.patch(MODULE + '._find_current_renewal_master',
+                return_value='old-master.example.com')
+    @mock.patch(MODULE + '.ipautil')
+    @mock.patch(MODULE + '.api')
+    def test_successful_promote_prints_crl_message(
+        self, mock_api, mock_ipautil, mock_find_rm, capsys,
+    ):
+        """Successful promotion prints CRL generation instructions."""
+        mock_ipautil.run.return_value = mock.MagicMock(returncode=0)
+        mock_ipautil.CalledProcessError = Exception
+        mock_api.env.host = 'replica.example.com'
 
-        import io
-        import sys
-        captured = io.StringIO()
-        old_stdout = sys.stdout
-        sys.stdout = captured
-        try:
-            handler.handle(ctx)
-        finally:
-            sys.stdout = old_stdout
+        obj = self._make_promote_obj()
+        obj.run_renewal_master_fix = mock.MagicMock(return_value=0)
 
-        output = captured.getvalue()
-        assert 'ipa-server-certinstall --http' in output
-        assert 'CSR:' in output
-        handler._generate_csr_from_key.assert_called_once()
+        with mock.patch(MODULE + '.ipautil.user_input', return_value='yes'):
+            result = obj.run_ca_full_promote(self._make_ctx())
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert 'ipa-crlgen-manage enable' in captured.out
+
+    @mock.patch(MODULE + '.ipautil')
+    @mock.patch(MODULE + '.api')
+    def test_unattended_no_rm_flag_refuses(
+        self, mock_api, mock_ipautil,
+    ):
+        """Unattended mode without --renewal-master refuses promotion."""
+        mock_ipautil.run.return_value = mock.MagicMock(returncode=0)
+        mock_ipautil.CalledProcessError = Exception
+        mock_api.env.host = 'replica.example.com'
+
+        obj = self._make_promote_obj()
+        obj.options.unattended = True
+        obj.options.renewal_master = False
+
+        result = obj.run_ca_full_promote(self._make_ctx())
+        assert result == 1
+        obj._promote_to_renewal_master.assert_not_called()
 
 
-class TestUnitCheckCASigningCert:
-    """_check_ca_signing_cert validity threshold."""
+class TestUnitHandleExpiredCaSigningCert:
+    """Characterization: _handle_expired_ca_signing_cert paths."""
 
     def _make_detector(self):
         return DeploymentDetector(
@@ -727,78 +1943,1620 @@ class TestUnitCheckCASigningCert:
             options=mock.MagicMock(),
         )
 
-    @mock.patch(SMOD + '._get_pki_nssdb')
-    def test_valid_far_future_passes(self, mock_nssdb):
-        """CA cert valid for years -> True."""
+    def test_self_signed_returns_1(self, capsys):
+        """Self-signed CA -> directs to ipa-cacert-manage, returns 1."""
+        obj = self._make_detector()
+        result = obj._handle_expired_ca_signing_cert(
+            DeploymentType.CA_SELF_SIGNED)
+        assert result == 1
+        captured = capsys.readouterr()
+        assert 'ipa-cacert-manage renew' in captured.out
+
+    @mock.patch(SMOD + '.get_csr_from_certmonger',
+                return_value='AQIDBA==')
+    def test_externally_signed_extracts_csr(
+        self, mock_get_csr, capsys, tmp_path,
+    ):
+        """Externally-signed CA -> extracts CSR, returns 1."""
+        obj = self._make_detector()
+
+        csr_path = str(tmp_path / 'ca.csr')
+        with mock.patch(SMOD + '.paths') as mock_paths:
+            mock_paths.IPA_CA_CSR = csr_path
+            result = obj._handle_expired_ca_signing_cert(
+                DeploymentType.CA_EXTERNALLY_SIGNED)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert 'external-cert-file' in captured.out
+        import os
+        assert os.path.exists(csr_path)
+
+    @mock.patch(SMOD + '.get_csr_from_certmonger',
+                return_value=None)
+    def test_externally_signed_no_csr_directs_manual(
+        self, mock_get_csr, capsys,
+    ):
+        """Externally-signed CA, no CSR in certmonger ->
+        manual instructions."""
+        obj = self._make_detector()
+        result = obj._handle_expired_ca_signing_cert(
+            DeploymentType.CA_EXTERNALLY_SIGNED)
+        assert result == 1
+        captured = capsys.readouterr()
+        assert 'ipa-cacert-manage renew --external-ca' in captured.out
+
+    def test_ca_less_raises(self):
+        """CA-less should never call this -> RuntimeError."""
+        obj = self._make_detector()
+        with pytest.raises(RuntimeError, match="CA-less"):
+            obj._handle_expired_ca_signing_cert(DeploymentType.CA_LESS)
+
+
+class TestUnitConfirmOrDryRun:
+    """Characterization: _confirm_execution behavior."""
+
+    def _make_obj(self, dry_run=False, unattended=False):
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.dry_run = dry_run
+        obj.options.unattended = unattended
+        obj._scenario_made_changes = False
+        return obj
+
+    def test_dry_run_returns_false(self, capsys):
+        """Dry-run prints plan and returns False."""
+        obj = self._make_obj(dry_run=True)
+        result = obj._confirm_execution(
+            "test label", "proceed",
+            dry_extra_lines=["Extra line 1"])
+        assert result is False
+        assert obj._scenario_made_changes is False
+        captured = capsys.readouterr()
+        assert '[DRY RUN]' in captured.out
+        assert 'Extra line 1' in captured.out
+
+    def test_unattended_returns_true(self):
+        """Unattended mode skips prompt, returns True."""
+        obj = self._make_obj(unattended=True)
+        result = obj._confirm_execution("test", "proceed")
+        assert result is True
+        assert obj._scenario_made_changes is True
+
+    @mock.patch(MODULE + '.ipautil.user_input', return_value='yes')
+    def test_interactive_yes_returns_true(self, mock_input):
+        """Interactive mode, user says 'yes' -> True."""
+        obj = self._make_obj()
+        result = obj._confirm_execution("test", "proceed")
+        assert result is True
+        assert obj._scenario_made_changes is True
+
+    @mock.patch(MODULE + '.ipautil.user_input', return_value='no')
+    def test_interactive_no_returns_false(self, mock_input):
+        """Interactive mode, user says 'no' -> False."""
+        obj = self._make_obj()
+        result = obj._confirm_execution("test", "proceed")
+        assert result is False
+        assert obj._scenario_made_changes is False
+
+
+class TestUnitKerberosSetupRestore:
+    """Characterization: _setup_kerberos / _restore_kerberos."""
+
+    def test_setup_sets_env_vars(self):
+        """_setup_kerberos sets KRB5 env vars and returns old values."""
+        from ipaserver.install.ipa_cert_fix import _setup_kerberos
+        import os
+
+        old_cc = os.environ.get('KRB5CCNAME')
+        old_kt = os.environ.get('KRB5_CLIENT_KTNAME')
+
+        try:
+            os.environ['KRB5CCNAME'] = 'FILE:/tmp/old'
+            os.environ['KRB5_CLIENT_KTNAME'] = '/old/keytab'
+
+            result = _setup_kerberos()
+            assert result == ('FILE:/tmp/old', '/old/keytab')
+            assert os.environ['KRB5CCNAME'] == 'MEMORY:'
+            assert os.environ['KRB5_CLIENT_KTNAME'] == '/etc/krb5.keytab'
+        finally:
+            if old_cc is None:
+                os.environ.pop('KRB5CCNAME', None)
+            else:
+                os.environ['KRB5CCNAME'] = old_cc
+            if old_kt is None:
+                os.environ.pop('KRB5_CLIENT_KTNAME', None)
+            else:
+                os.environ['KRB5_CLIENT_KTNAME'] = old_kt
+
+    def test_restore_clears_when_originally_unset(self):
+        """_restore_kerberos removes vars if they were originally unset."""
+        from ipaserver.install.ipa_cert_fix import _restore_kerberos
+        import os
+
+        old_cc = os.environ.get('KRB5CCNAME')
+        old_kt = os.environ.get('KRB5_CLIENT_KTNAME')
+
+        try:
+            os.environ['KRB5CCNAME'] = 'MEMORY:'
+            os.environ['KRB5_CLIENT_KTNAME'] = '/etc/krb5.keytab'
+
+            _restore_kerberos((None, None))
+            assert 'KRB5CCNAME' not in os.environ
+            assert 'KRB5_CLIENT_KTNAME' not in os.environ
+        finally:
+            if old_cc is not None:
+                os.environ['KRB5CCNAME'] = old_cc
+            if old_kt is not None:
+                os.environ['KRB5_CLIENT_KTNAME'] = old_kt
+
+    def test_restore_preserves_previous_values(self):
+        """_restore_kerberos puts back old values."""
+        from ipaserver.install.ipa_cert_fix import _restore_kerberos
+        import os
+
+        old_cc = os.environ.get('KRB5CCNAME')
+        old_kt = os.environ.get('KRB5_CLIENT_KTNAME')
+
+        try:
+            os.environ['KRB5CCNAME'] = 'MEMORY:'
+            os.environ['KRB5_CLIENT_KTNAME'] = '/etc/krb5.keytab'
+
+            _restore_kerberos(('FILE:/tmp/prev', '/prev/keytab'))
+            assert os.environ['KRB5CCNAME'] == 'FILE:/tmp/prev'
+            assert os.environ['KRB5_CLIENT_KTNAME'] == '/prev/keytab'
+        finally:
+            if old_cc is None:
+                os.environ.pop('KRB5CCNAME', None)
+            else:
+                os.environ['KRB5CCNAME'] = old_cc
+            if old_kt is None:
+                os.environ.pop('KRB5_CLIENT_KTNAME', None)
+            else:
+                os.environ['KRB5_CLIENT_KTNAME'] = old_kt
+
+
+class TestUnitCertCriteria:
+    """Characterization: _cert_criteria for all cert types."""
+
+    @mock.patch(SMOD + '.paths')
+    def test_https_criteria(self, mock_paths):
+        """HTTPS -> cert-file criteria."""
+        mock_paths.HTTPD_CERT_FILE = '/etc/pki/tls/certs/httpd.crt'
+        ctx = mock.MagicMock()
+        result = ExternalCertHandler._cert_criteria(IPACertType.HTTPS, ctx)
+        assert result == {'cert-file': '/etc/pki/tls/certs/httpd.crt'}
+
+    @mock.patch(SMOD + '.paths')
+    def test_kdc_criteria(self, mock_paths):
+        """KDC -> cert-file criteria."""
+        mock_paths.KDC_CERT = '/var/kerberos/krb5kdc/kdc.crt'
+        ctx = mock.MagicMock()
+        result = ExternalCertHandler._cert_criteria(IPACertType.KDC, ctx)
+        assert result == {'cert-file': '/var/kerberos/krb5kdc/kdc.crt'}
+
+    def test_ldaps_criteria(self):
+        """LDAPS -> cert-database + cert-nickname criteria."""
+        ctx = mock.MagicMock()
+        ctx.ds_dbdir = '/etc/dirsrv/slapd-EXAMPLE'
+        ctx.ds_nickname = 'Server-Cert'
+        result = ExternalCertHandler._cert_criteria(IPACertType.LDAPS, ctx)
+        assert result == {
+            'cert-database': '/etc/dirsrv/slapd-EXAMPLE',
+            'cert-nickname': 'Server-Cert',
+        }
+
+    @mock.patch(SMOD + '.paths')
+    def test_ipara_criteria(self, mock_paths):
+        """IPARA -> cert-file criteria."""
+        mock_paths.RA_AGENT_PEM = '/etc/pki/ra-agent.pem'
+        ctx = mock.MagicMock()
+        result = ExternalCertHandler._cert_criteria(IPACertType.IPARA, ctx)
+        assert result == {'cert-file': '/etc/pki/ra-agent.pem'}
+
+
+class TestUnitTrackingParams:
+    """Characterization: _tracking_params for each cert type."""
+
+    @mock.patch(SMOD + '.ipa_certs')
+    @mock.patch(SMOD + '.IPA_CA_RECORD', 'ipa-ca')
+    @mock.patch(SMOD + '.paths')
+    @mock.patch(SMOD + '.api')
+    def test_https_params(self, mock_api, mock_paths, mock_certs):
+        """HTTPS params include dns, principal, post_command."""
+        mock_api.env.host = 'server.example.com'
+        mock_api.env.realm = 'EXAMPLE.COM'
+        mock_api.env.domain = 'example.com'
+        mock_paths.HTTPD_CERT_FILE = '/etc/pki/tls/certs/httpd.crt'
+        mock_paths.HTTPD_KEY_FILE = '/etc/pki/tls/private/httpd.key'
+        mock_paths.HTTPD_PASSWD_FILE_FMT = '/var/lib/ipa/passwds/{host}'
+        mock_certs.get_default_profile.return_value = 'caIPAserviceCert'
+
+        ctx = mock.MagicMock()
+        ctx.subject_base = 'O=EXAMPLE.COM'
+        params = ExternalCertHandler._tracking_params(IPACertType.HTTPS, ctx)
+
+        assert params['ca'] == 'IPA'
+        assert params['storage'] == 'FILE'
+        assert params['post_command'] == 'restart_httpd'
+        assert 'server.example.com' in params['dns']
+        assert params['principal'] == 'HTTP/server.example.com@EXAMPLE.COM'
+
+    @mock.patch(SMOD + '.ipa_certs')
+    @mock.patch(SMOD + '.paths')
+    @mock.patch(SMOD + '.api')
+    def test_ldaps_params(self, mock_api, mock_paths, mock_certs):
+        """LDAPS params use NSSDB storage with ds_dbdir."""
+        mock_api.env.host = 'server.example.com'
+        mock_api.env.realm = 'EXAMPLE.COM'
+        mock_certs.get_default_profile.return_value = 'caIPAserviceCert'
+
+        ctx = mock.MagicMock()
+        ctx.subject_base = 'O=EXAMPLE.COM'
+        ctx.ds_dbdir = '/etc/dirsrv/slapd-EXAMPLE-COM'
+        ctx.ds_nickname = 'Server-Cert'
+        ctx.serverid = 'EXAMPLE-COM'
+        params = ExternalCertHandler._tracking_params(IPACertType.LDAPS, ctx)
+
+        assert params['storage'] == 'NSSDB'
+        assert params['certpath'] == '/etc/dirsrv/slapd-EXAMPLE-COM'
+        assert params['nickname'] == 'Server-Cert'
+
+    @mock.patch(SMOD + '.KDC_PROFILE', 'KDCs_PKINIT_Certs')
+    @mock.patch(SMOD + '.paths')
+    @mock.patch(SMOD + '.api')
+    def test_kdc_params(self, mock_api, mock_paths):
+        """KDC params use KDC_PROFILE and krbtgt principal."""
+        mock_api.env.host = 'server.example.com'
+        mock_api.env.realm = 'EXAMPLE.COM'
+        mock_paths.KDC_CERT = '/var/kerberos/krb5kdc/kdc.crt'
+        mock_paths.KDC_KEY = '/var/kerberos/krb5kdc/kdc.key'
+
+        ctx = mock.MagicMock()
+        ctx.subject_base = 'O=EXAMPLE.COM'
+        params = ExternalCertHandler._tracking_params(IPACertType.KDC, ctx)
+
+        assert params['profile'] == 'KDCs_PKINIT_Certs'
+        assert params['principal'] == 'krbtgt/EXAMPLE.COM@EXAMPLE.COM'
+        assert params['post_command'] == 'renew_kdc_cert'
+
+    @mock.patch(SMOD + '.api')
+    def test_ipara_returns_none(self, mock_api):
+        """IPARA has no tracking params (fetched from LDAP)."""
+        mock_api.env.host = 'server.example.com'
+        ctx = mock.MagicMock()
+        ctx.subject_base = 'O=EXAMPLE.COM'
+        result = ExternalCertHandler._tracking_params(IPACertType.IPARA, ctx)
+        assert result is None
+
+
+class TestUnitIsCertValid:
+    """Characterization: _is_cert_valid checks cert expiry."""
+
+    @mock.patch(SMOD + '.x509')
+    def test_valid_file_cert(self, mock_x509):
+        """File-based cert that is not near expiry -> True."""
         import datetime as dt
+
+        client = object.__new__(CertmongerClient)
+        client.get_request_value = mock.MagicMock(
+            side_effect=lambda rid, k: {
+                'cert-file': '/etc/pki/tls/certs/httpd.crt',
+                'cert-database': None,
+                'cert-nickname': None,
+            }.get(k))
+
         cert = mock.MagicMock()
         cert.not_valid_after_utc = dt.datetime(
-            2099, 1, 1, tzinfo=dt.timezone.utc)
-        mock_nssdb.return_value.get_cert.return_value = cert
+            2030, 1, 1, tzinfo=dt.timezone.utc)
+        mock_x509.load_certificate_from_file.return_value = cert
 
-        det = self._make_detector()
-        assert det._check_ca_signing_cert() is True
+        assert client.is_cert_valid('req1') is True
 
-    @mock.patch(SMOD + '._get_pki_nssdb')
-    def test_near_expiry_fails(self, mock_nssdb):
-        """CA cert near expiry -> False."""
+    @mock.patch(SMOD + '.x509')
+    def test_expired_file_cert(self, mock_x509):
+        """File-based cert that is expired -> False."""
+        import datetime as dt
+
+        client = object.__new__(CertmongerClient)
+        client.get_request_value = mock.MagicMock(
+            side_effect=lambda rid, k: {
+                'cert-file': '/etc/pki/tls/certs/httpd.crt',
+                'cert-database': None,
+                'cert-nickname': None,
+            }.get(k))
+
         cert = mock.MagicMock()
-        cert.not_valid_after_utc = (
-            DeploymentDetector._ca_minimum_valid_until()
-            - datetime.timedelta(days=1))
-        mock_nssdb.return_value.get_cert.return_value = cert
+        cert.not_valid_after_utc = dt.datetime(
+            2020, 1, 1, tzinfo=dt.timezone.utc)
+        mock_x509.load_certificate_from_file.return_value = cert
 
-        det = self._make_detector()
-        assert det._check_ca_signing_cert() is False
+        assert client.is_cert_valid('req1') is False
+
+    def test_no_cert_location_returns_false(self):
+        """No cert-file or cert-database -> False."""
+        client = object.__new__(CertmongerClient)
+        client.get_request_value = mock.MagicMock(return_value=None)
+        assert client.is_cert_valid('req1') is False
 
 
-class TestUnitVerifyCaChainValid:
-    """_verify_ca_chain_valid trust-path walking."""
+class TestUnitReplaceCertInNssdb:
+    """Characterization: _replace_cert_in_nssdb."""
 
-    @mock.patch(SMOD + '._get_pki_nssdb')
+    @mock.patch(SMOD + '.ipautil')
+    def test_replaces_existing_cert(self, mock_ipautil):
+        """Deletes old cert and adds new one."""
+        from ipaserver.install.ipa_cert_fix import _replace_cert_in_nssdb
+
+        db = mock.MagicMock()
+        cert = mock.MagicMock()
+
+        _replace_cert_in_nssdb(db, 'Server-Cert', cert)
+        db.delete_cert.assert_called_once_with('Server-Cert')
+        db.add_cert.assert_called_once()
+
+    @mock.patch(SMOD + '.ipautil')
+    def test_handles_missing_cert_on_delete(self, mock_ipautil):
+        """CalledProcessError on delete (cert not found) is ignored."""
+        from ipaserver.install.ipa_cert_fix import _replace_cert_in_nssdb
+
+        mock_ipautil.CalledProcessError = Exception
+        db = mock.MagicMock()
+        db.delete_cert.side_effect = Exception("not found")
+        cert = mock.MagicMock()
+
+        _replace_cert_in_nssdb(db, 'Server-Cert', cert)
+        db.add_cert.assert_called_once()
+
+
+class TestUnitUpdateCsCfg:
+    """Characterization: _update_cs_cfg updates Dogtag config."""
+
+    @mock.patch(SMOD + '.directivesetter')
+    @mock.patch(SMOD + '.os.path.exists', return_value=True)
     @mock.patch(SMOD + '.x509')
-    def test_missing_chain_raises(self, mock_x509, mock_nssdb):
-        """Missing chain file -> RuntimeError."""
-        mock_x509.load_certificate_list_from_file.side_effect = (
-            FileNotFoundError())
-        with pytest.raises(RuntimeError, match="CA chain not available"):
-            DeploymentDetector._verify_ca_chain_valid('m.example.com')
+    def test_updates_subsystem_directive(
+        self, mock_x509, mock_exists, mock_ds,
+    ):
+        """Subsystem cert updates ca.subsystem.cert in CA CS.cfg."""
+        from ipaserver.install.ipa_cert_fix import _update_cs_cfg
 
-    @mock.patch(SMOD + '._get_pki_nssdb')
+        cert = mock.MagicMock()
+        cert.public_bytes.return_value = b'\x01\x02\x03'
+        mock_x509.Encoding.DER = 'DER'
+
+        _update_cs_cfg('subsystemCert cert-pki-ca', cert)
+
+        mock_ds.set_directive.assert_called_once()
+        call_args = mock_ds.set_directive.call_args
+        assert call_args[0][1] == 'ca.subsystem.cert'
+
+    @mock.patch(SMOD + '.directivesetter')
+    @mock.patch(SMOD + '.os.path.exists', return_value=True)
     @mock.patch(SMOD + '.x509')
-    def test_empty_chain_raises(self, mock_x509, mock_nssdb):
-        """Empty chain file -> RuntimeError."""
-        mock_x509.load_certificate_list_from_file.return_value = []
-        with pytest.raises(RuntimeError, match="empty"):
-            DeploymentDetector._verify_ca_chain_valid('m.example.com')
+    def test_kra_transport_updates_connector(
+        self, mock_x509, mock_exists, mock_ds,
+    ):
+        """KRA transport cert also updates ca.connector.KRA.transportCert."""
+        from ipaserver.install.ipa_cert_fix import _update_cs_cfg
+
+        cert = mock.MagicMock()
+        cert.public_bytes.return_value = b'\x01\x02\x03'
+        mock_x509.Encoding.DER = 'DER'
+
+        _update_cs_cfg('transportCert cert-pki-kra', cert)
+
+        # Should be called twice: once for kra.transport.cert,
+        # once for ca.connector.KRA.transportCert
+        assert mock_ds.set_directive.call_count == 2
+
+    def test_unknown_nickname_is_noop(self):
+        """Nickname not in _CS_CFG_CERT_DIRECTIVES -> no-op."""
+        from ipaserver.install.ipa_cert_fix import _update_cs_cfg
+        cert = mock.MagicMock()
+        # Should not raise
+        _update_cs_cfg('Server-Cert cert-pki-ca', cert)
 
 
-class TestUnitDryRunExitCode:
-    """--dry-run short-circuits _confirm_execution."""
+class TestUnitEnsureLdapConnected:
+    """Characterization: _ensure_ldap_connected unconditional reconnect."""
 
-    def test_confirm_execution_returns_false_on_dry_run(self):
-        """In --dry-run mode, _confirm_execution returns False (no
-        prompt, no scenario_made_changes flag)."""
-        from ipaserver.install.ipa_cert_fix import IPACertFix
+    @mock.patch(SMOD + '.api')
+    def test_disconnects_and_reconnects(self, mock_api):
+        """Always disconnects then connects, regardless of state."""
+        from ipaserver.install.ipa_cert_fix import (
+            _ensure_ldap_connected,
+        )
+        mock_api.Backend.ldap2.isconnected.return_value = True
+
+        _ensure_ldap_connected()
+
+        mock_api.Backend.ldap2.disconnect.assert_called_once()
+        mock_api.Backend.ldap2.connect.assert_called_once()
+
+    @mock.patch(SMOD + '.api')
+    def test_handles_disconnect_error(self, mock_api):
+        """Disconnect error is swallowed, connect still called."""
+        from ipaserver.install.ipa_cert_fix import (
+            _ensure_ldap_connected,
+        )
+        mock_api.Backend.ldap2.isconnected.return_value = True
+        mock_api.Backend.ldap2.disconnect.side_effect = Exception("broken")
+
+        _ensure_ldap_connected()
+        mock_api.Backend.ldap2.connect.assert_called_once()
+
+    @mock.patch(SMOD + '.api')
+    def test_skips_disconnect_if_not_connected(self, mock_api):
+        """If not connected, skips disconnect."""
+        from ipaserver.install.ipa_cert_fix import (
+            _ensure_ldap_connected,
+        )
+        mock_api.Backend.ldap2.isconnected.return_value = False
+
+        _ensure_ldap_connected()
+        mock_api.Backend.ldap2.disconnect.assert_not_called()
+        mock_api.Backend.ldap2.connect.assert_called_once()
+
+
+class TestUnitRestoreHelper:
+    """Characterization: _restore_helper retries on failure."""
+
+    def test_successful_restore(self):
+        """Normal case: restores helper in one call."""
+        from ipaserver.install.ipa_cert_fix import CertRenewalFromMaster
+
+        obj = CertRenewalFromMaster(mock.MagicMock(), 'master')
+        obj._restore_helper('/usr/libexec/ipa/ipa-submit')
+        obj._cm.restore_ca_override.assert_called_once_with(
+            'IPA', '/usr/libexec/ipa/ipa-submit')
+
+    @mock.patch(SMOD + '.time.sleep')
+    @mock.patch(SMOD + '.time.monotonic')
+    def test_timeout_prints_critical(
+        self, mock_mono, mock_sleep, capsys,
+    ):
+        """After timeout, prints CRITICAL message."""
+        from ipaserver.install.ipa_cert_fix import CertRenewalFromMaster
+
+        obj = CertRenewalFromMaster(mock.MagicMock(), 'master')
+        obj._cm.restore_ca_override.side_effect = Exception("D-Bus down")
+        mock_mono.side_effect = [0, 0, 200]
+
+        obj._restore_helper('/usr/libexec/ipa/ipa-submit', timeout=1)
+
+        captured = capsys.readouterr()
+        assert 'CRITICAL' in captured.out
+        assert 'getcert modify-ca' in captured.out
+
+
+class TestUnitRunExternalCertsDryRun:
+    """Characterization: run_external_certs dry-run path."""
+
+    def test_dry_run_returns_zero(self, capsys):
+        """Dry-run lists CSR paths and exits 0."""
+        from ipaserver.install.ipa_cert_fix import (
+            IPACertFix, CertFixContext,
+        )
 
         obj = object.__new__(IPACertFix)
         obj.options = mock.MagicMock()
         obj.options.dry_run = True
-        obj.options.unattended = False
 
-        result = obj._confirm_execution(
-            "scenario", "do thing", dry_extra_lines=["a", "b"])
-        assert result is False
-        assert obj._scenario_made_changes is False
+        cert = mock.MagicMock()
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_LESS_EXTERNAL,
+            scenario=FixScenario.EXTERNAL_CERTS,
+            subject_base=mock.MagicMock(),
+            ca_subject_dn=mock.MagicMock(),
+            dogtag_certs=[],
+            ipa_certs=[],
+            external_certs=[(IPACertType.HTTPS, cert)],
+            master_server=None,
+        )
 
-    def test_confirm_execution_unattended_skips_prompt(self):
-        """-U returns True without prompting and sets the flag."""
-        from ipaserver.install.ipa_cert_fix import IPACertFix
+        result = obj.run_external_certs(ctx)
+        assert result == 0
+        captured = capsys.readouterr()
+        assert '[DRY RUN]' in captured.out
+        assert 'HTTPS' in captured.out
+
+    def test_no_external_certs_nothing_to_do(self, capsys):
+        """No external certs -> 'Nothing to do', exit 0."""
+        from ipaserver.install.ipa_cert_fix import (
+            IPACertFix, CertFixContext,
+        )
 
         obj = object.__new__(IPACertFix)
         obj.options = mock.MagicMock()
         obj.options.dry_run = False
-        obj.options.unattended = True
 
-        assert obj._confirm_execution("scenario", "do thing") is True
-        assert obj._scenario_made_changes is True
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_LESS_EXTERNAL,
+            scenario=FixScenario.EXTERNAL_CERTS,
+            subject_base=mock.MagicMock(),
+            ca_subject_dn=mock.MagicMock(),
+            dogtag_certs=[], ipa_certs=[],
+            external_certs=[],
+            master_server=None,
+        )
+
+        result = obj.run_external_certs(ctx)
+        assert result == 0
+
+
+class TestUnitCheckTcpReachable:
+    """Characterization: _check_tcp_reachable."""
+
+    @mock.patch(SMOD + '.socket')
+    def test_dns_failure_raises(self, mock_socket):
+        """DNS resolution failure -> RuntimeError."""
+        import socket as real_socket
+        mock_socket.gaierror = real_socket.gaierror
+        mock_socket.getaddrinfo.side_effect = real_socket.gaierror(
+            "Name or service not known")
+        mock_socket.AF_UNSPEC = real_socket.AF_UNSPEC
+        mock_socket.SOCK_STREAM = real_socket.SOCK_STREAM
+
+        with pytest.raises(RuntimeError, match="Cannot resolve"):
+            _check_tcp_reachable('nonexistent.example.com')
+
+    @mock.patch(SMOD + '.socket')
+    def test_all_addrs_unreachable_raises(self, mock_socket):
+        """All addresses fail -> RuntimeError."""
+        import socket as real_socket
+        mock_socket.AF_UNSPEC = real_socket.AF_UNSPEC
+        mock_socket.SOCK_STREAM = real_socket.SOCK_STREAM
+        mock_socket.getaddrinfo.return_value = [
+            (real_socket.AF_INET, real_socket.SOCK_STREAM, 0, '',
+             ('1.2.3.4', 443)),
+        ]
+        sock_inst = mock.MagicMock()
+        sock_inst.connect.side_effect = OSError("refused")
+        mock_socket.socket.return_value = sock_inst
+
+        with pytest.raises(RuntimeError, match="Cannot connect"):
+            _check_tcp_reachable('down.example.com')
+
+
+class TestUnitResolveTrackingRequests:
+    """Characterization: _resolve_tracking_requests."""
+
+    def test_missing_request_skipped(self):
+        """If certmonger has no tracking for a cert, it's skipped."""
+        from ipaserver.install.ipa_cert_fix import CertRenewalFromMaster
+
+        cm = mock.MagicMock()
+        cm.get_request_id.return_value = None
+        obj = CertRenewalFromMaster(cm, 'master')
+
+        tracking = [
+            ('sslserver', mock.MagicMock(),
+             {'cert-nickname': 'Server-Cert'}, lambda: None),
+        ]
+        result = obj._resolve_tracking_requests(tracking)
+        assert result == []
+
+    def test_found_request_included(self):
+        """Found tracking request is included with original CA."""
+        from ipaserver.install.ipa_cert_fix import CertRenewalFromMaster
+
+        cm = mock.MagicMock()
+        cm.get_request_id.return_value = 'req-42'
+        cm.get_request_value.return_value = ('dogtag-ipa-ca-renew-agent')
+        obj = CertRenewalFromMaster(cm, 'master')
+
+        cert = mock.MagicMock()
+
+        def loader():
+            return None
+        tracking = [
+            ('sslserver', cert, {'cert-nickname': 'Server-Cert'}, loader),
+        ]
+        result = obj._resolve_tracking_requests(tracking)
+        assert len(result) == 1
+        desc, _old_cert, req_id, orig_ca, _load_fn = result[0]
+        assert desc == 'sslserver'
+        assert req_id == 'req-42'
+        assert orig_ca == 'dogtag-ipa-ca-renew-agent'
+
+
+class TestUnitCheckIsRenewalMaster:
+    """Characterization: check_is_renewal_master error handling."""
+
+    def test_returns_true_when_rm(self):
+        ca_inst = mock.MagicMock()
+        ca_inst.is_renewal_master.return_value = True
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=ca_inst,
+            options=mock.MagicMock(),
+        )
+        assert obj.check_is_renewal_master() is True
+
+    def test_returns_false_when_not_rm(self):
+        ca_inst = mock.MagicMock()
+        ca_inst.is_renewal_master.return_value = False
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=ca_inst,
+            options=mock.MagicMock(),
+        )
+        assert obj.check_is_renewal_master() is False
+
+    def test_none_ca_instance_raises(self):
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=None,
+            options=mock.MagicMock(),
+        )
+        with pytest.raises(RuntimeError, match="CA instance"):
+            obj.check_is_renewal_master()
+
+    def test_network_error_returns_false(self):
+        from ipalib import errors
+        ca_inst = mock.MagicMock()
+        ca_inst.is_renewal_master.side_effect = (
+            errors.NetworkError(message="conn refused"))
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=ca_inst,
+            options=mock.MagicMock(),
+        )
+        assert obj.check_is_renewal_master() is False
+
+    def test_unexpected_error_returns_false(self):
+        ca_inst = mock.MagicMock()
+        ca_inst.is_renewal_master.side_effect = (ValueError("unexpected"))
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=ca_inst,
+            options=mock.MagicMock(),
+        )
+        assert obj.check_is_renewal_master() is False
+
+
+class TestUnitWarnCaChainNearExpiry:
+    """Characterization: _warn_ca_chain_near_expiry."""
+
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.paths')
+    def test_warns_near_expiry(self, mock_paths, mock_x509, capsys):
+        import datetime as dt
+
+        mock_paths.IPA_CA_CRT = '/etc/ipa/ca.crt'
+        near_cert = mock.MagicMock()
+        near_cert.not_valid_after_utc = dt.datetime(
+            2026, 4, 25, tzinfo=dt.timezone.utc)
+        near_cert.subject = 'CN=CA'
+        mock_x509.load_certificate_list_from_file.return_value = [near_cert]
+
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=mock.MagicMock(),
+        )
+        obj._warn_ca_chain_near_expiry()
+
+        captured = capsys.readouterr()
+        assert 'WARNING' in captured.out
+        assert 'ipa-cacert-manage' in captured.out
+
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.paths')
+    def test_no_warning_for_valid_chain(
+        self, mock_paths, mock_x509, capsys,
+    ):
+        import datetime as dt
+
+        mock_paths.IPA_CA_CRT = '/etc/ipa/ca.crt'
+        valid_cert = mock.MagicMock()
+        valid_cert.not_valid_after_utc = dt.datetime(
+            2030, 1, 1, tzinfo=dt.timezone.utc)
+        mock_x509.load_certificate_list_from_file.return_value = [valid_cert]
+
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=mock.MagicMock(),
+        )
+        obj._warn_ca_chain_near_expiry()
+
+        captured = capsys.readouterr()
+        assert 'WARNING' not in captured.out
+
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.paths')
+    def test_file_missing_no_crash(self, mock_paths, mock_x509):
+        mock_paths.IPA_CA_CRT = '/etc/ipa/ca.crt'
+        mock_x509.load_certificate_list_from_file.side_effect = Exception()
+
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=mock.MagicMock(),
+        )
+        obj._warn_ca_chain_near_expiry()  # should not raise
+
+
+class TestUnitKillStuckHelpers:
+    """Characterization: _kill_stuck_helpers."""
+
+    @mock.patch(SMOD + '.time.sleep')
+    @mock.patch(SMOD + '.ipautil')
+    def test_kills_both_processes(self, mock_ipautil, mock_sleep):
+        from ipaserver.install.ipa_cert_fix import _kill_stuck_helpers
+        mock_ipautil.run.return_value = mock.MagicMock(returncode=0)
+        _kill_stuck_helpers()
+        assert mock_ipautil.run.call_count == 2
+        calls = [c[0][0] for c in mock_ipautil.run.call_args_list]
+        assert any('ipa-submit' in str(c) for c in calls)
+        assert any('ipa-server-guard' in str(c) for c in calls)
+
+    @mock.patch(SMOD + '.time.sleep')
+    @mock.patch(SMOD + '.ipautil')
+    def test_pkill_failure_ignored(self, mock_ipautil, mock_sleep):
+        from ipaserver.install.ipa_cert_fix import _kill_stuck_helpers
+        mock_ipautil.run.side_effect = Exception("pkill not found")
+        _kill_stuck_helpers()  # should not raise
+
+
+class TestUnitDetectAndDispatchScenarioPath:
+    """Characterization: _classify_and_dispatch full scenario dispatch."""
+
+    @mock.patch(MODULE + '.print_intentions')
+    @mock.patch(MODULE + '.ca')
+    @mock.patch(MODULE + '.cainstance')
+    @mock.patch(MODULE + '.dsinstance')
+    @mock.patch(MODULE + '.realm_to_serverid', return_value='EXAMPLE-COM')
+    @mock.patch(MODULE + '.api')
+    def test_dispatches_to_scenario_handler(
+        self, mock_api, mock_r2s, mock_ds, mock_cai,
+        mock_ca_mod, mock_pi,
+    ):
+        """With expired certs, dispatches to the correct handler."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        mock_api.env.realm = 'EXAMPLE.COM'
+        mock_cai.is_ca_installed_locally.return_value = False
+        ds_inst = mock.MagicMock()
+        ds_inst.find_subject_base.return_value = 'O=EXAMPLE.COM'
+        ds_inst.get_server_cert_nickname.return_value = 'Server-Cert'
+        mock_ds.DsInstance.return_value = ds_inst
+        mock_ds.config_dirname.return_value = '/etc/dirsrv/slapd-X/'
+
+        cert = mock.MagicMock()
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.dry_run = False
+        obj.options.unattended = True
+        obj._ca_instance = None
+        obj._scenario_made_changes = False
+        obj._cm = mock.MagicMock()
+
+        handler = mock.MagicMock(return_value=0)
+        obj.run_external_certs = handler
+
+        with mock.patch.object(
+            DeploymentDetector, 'detect_deployment_type',
+            return_value=DeploymentType.CA_LESS_EXTERNAL,
+        ), mock.patch.object(
+            DeploymentDetector, '_classify_certs',
+            return_value=([], [], [(IPACertType.HTTPS, cert)]),
+        ), mock.patch.object(
+            DeploymentDetector, 'determine_scenario',
+            return_value=(FixScenario.EXTERNAL_CERTS, None),
+        ):
+            result = obj._classify_and_dispatch()
+        assert result == 0
+        handler.assert_called_once()
+
+    @mock.patch(MODULE + '.print_intentions')
+    @mock.patch(MODULE + '.ca')
+    @mock.patch(MODULE + '.cainstance')
+    @mock.patch(MODULE + '.dsinstance')
+    @mock.patch(MODULE + '.realm_to_serverid', return_value='EXAMPLE-COM')
+    @mock.patch(MODULE + '.api')
+    def test_scenario_runtime_error_returns_1(
+        self, mock_api, mock_r2s, mock_ds, mock_cai,
+        mock_ca_mod, mock_pi,
+    ):
+        """RuntimeError from determine_scenario -> exit 1."""
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        mock_api.env.realm = 'EXAMPLE.COM'
+        mock_cai.is_ca_installed_locally.return_value = False
+        ds_inst = mock.MagicMock()
+        ds_inst.find_subject_base.return_value = 'O=EXAMPLE.COM'
+        ds_inst.get_server_cert_nickname.return_value = 'Server-Cert'
+        mock_ds.DsInstance.return_value = ds_inst
+        mock_ds.config_dirname.return_value = '/etc/dirsrv/slapd-X/'
+
+        cert = mock.MagicMock()
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.dry_run = False
+        obj.options.unattended = True
+        obj._ca_instance = None
+        obj._scenario_made_changes = False
+        obj._cm = mock.MagicMock()
+
+        with mock.patch.object(
+            DeploymentDetector, 'detect_deployment_type',
+            return_value=DeploymentType.CA_LESS,
+        ), mock.patch.object(
+            DeploymentDetector, '_classify_certs',
+            return_value=([], [(IPACertType.HTTPS, cert)], []),
+        ), mock.patch.object(
+            DeploymentDetector, 'determine_scenario',
+            side_effect=RuntimeError("No server"),
+        ):
+            result = obj._classify_and_dispatch()
+        assert result == 1
+
+
+class TestUnitResubmitCertViaMaster:
+    """Characterization: _resubmit core flow."""
+
+    def _make_obj(self):
+        from ipaserver.install.ipa_cert_fix import CertRenewalFromMaster
+        cm = mock.MagicMock()
+        cm.is_cert_valid.return_value = False
+        cm.is_responsive.return_value = True
+        obj = CertRenewalFromMaster(cm, 'master.example.com')
+        return obj
+
+    @mock.patch(SMOD + '._kill_stuck_helpers')
+    @mock.patch(SMOD + '.print_cert_info')
+    @mock.patch(SMOD + '.ipautil')
+    @mock.patch(SMOD + '.api')
+    def test_ipa_cert_resubmit(
+        self, mock_api, mock_ipautil, mock_pci, mock_ksh,
+    ):
+        """IPA cert (IPACertType) resubmits without CA switch."""
+        import datetime as dt
+
+        mock_api.env.host = 'server.example.com'
+        mock_api.env.realm = 'EXAMPLE.COM'
+
+        obj = self._make_obj()
+        obj._cm.wait_for_request.return_value = 'MONITORING'
+        obj._cm.get_request_value.return_value = 'IPA'
+        mock_ipautil.run.return_value = mock.MagicMock()
+
+        old_cert = mock.MagicMock()
+        old_cert.serial_number = 100
+        new_cert = mock.MagicMock()
+        new_cert.serial_number = 200
+        new_cert.not_valid_before_utc = dt.datetime(
+            2026, 1, 1, tzinfo=dt.timezone.utc)
+        new_cert.not_valid_after_utc = dt.datetime(
+            2028, 1, 1, tzinfo=dt.timezone.utc)
+        loader = mock.MagicMock(return_value=new_cert)
+
+        obj._resubmit(IPACertType.HTTPS, old_cert, 'req-1', 'IPA', loader)
+
+        # Should NOT switch CA for IPA certs
+        obj._cm.resubmit_request.assert_called_once_with(
+            'req-1', ca=None, profile=None)
+
+    @mock.patch(SMOD + '._kill_stuck_helpers')
+    @mock.patch(SMOD + '.print_cert_info')
+    @mock.patch(SMOD + '.ipautil')
+    @mock.patch(SMOD + '.api')
+    def test_dogtag_cert_switches_ca_and_adds_principal(
+        self, mock_api, mock_ipautil, mock_pci, mock_ksh,
+    ):
+        """Dogtag cert (string) switches CA to IPA and adds principal."""
+        import datetime as dt
+
+        mock_api.env.host = 'server.example.com'
+        mock_api.env.realm = 'EXAMPLE.COM'
+
+        obj = self._make_obj()
+        obj._cm.wait_for_request.return_value = 'MONITORING'
+        obj._cm.get_request_value.side_effect = lambda rid, k: {
+            'template-principal': None,
+            'template-profile': 'caServerCert',
+            'ca-name': 'dogtag-ipa-ca-renew-agent',
+        }.get(k)
+        mock_ipautil.run.return_value = mock.MagicMock()
+
+        old_cert = mock.MagicMock()
+        old_cert.serial_number = 100
+        new_cert = mock.MagicMock()
+        new_cert.serial_number = 200
+        new_cert.not_valid_before_utc = dt.datetime(
+            2026, 1, 1, tzinfo=dt.timezone.utc)
+        new_cert.not_valid_after_utc = dt.datetime(
+            2028, 1, 1, tzinfo=dt.timezone.utc)
+        loader = mock.MagicMock(return_value=new_cert)
+
+        desc = DOGTAG_CERTS['sslserver']
+        obj._resubmit(
+            desc, old_cert, 'req-2',
+            'dogtag-ipa-ca-renew-agent', loader)
+
+        # Should switch CA to IPA for dogtag certs
+        obj._cm.resubmit_request.assert_called_once_with(
+            'req-2', ca='IPA', profile='caIPAserviceCert')
+        # Should add host principal
+        obj._cm.add_principal.assert_called_once_with(
+            'req-2', 'host/server.example.com@EXAMPLE.COM')
+        # Original principal saved for restore
+        assert 'req-2' in obj._original_principals
+
+    @mock.patch(SMOD + '._kill_stuck_helpers')
+    @mock.patch(SMOD + '.print_cert_info')
+    @mock.patch(SMOD + '.api')
+    def test_timeout_raises(self, mock_api, mock_pci, mock_ksh):
+        """Timeout waiting for MONITORING -> RuntimeError."""
+        mock_api.env.host = 'server.example.com'
+        mock_api.env.realm = 'EXAMPLE.COM'
+
+        obj = self._make_obj()
+        obj._cm.wait_for_request.side_effect = RuntimeError("timeout")
+        obj._cm.get_request_value.return_value = 'IPA'
+
+        old_cert = mock.MagicMock()
+        old_cert.serial_number = 100
+
+        with pytest.raises(RuntimeError, match="timed out"):
+            obj._resubmit(
+                IPACertType.HTTPS, old_cert, 'req-1', 'IPA',
+                lambda: None)
+
+    @mock.patch(SMOD + '._kill_stuck_helpers')
+    @mock.patch(SMOD + '.print_cert_info')
+    @mock.patch(SMOD + '.api')
+    def test_wrong_state_raises(self, mock_api, mock_pci, mock_ksh):
+        """Non-MONITORING state -> RuntimeError with ca-error."""
+        mock_api.env.host = 'server.example.com'
+        mock_api.env.realm = 'EXAMPLE.COM'
+
+        obj = self._make_obj()
+        obj._cm.wait_for_request.return_value = 'CA_REJECTED'
+        obj._cm.get_request_value.side_effect = lambda rid, k: {
+            'ca-error': 'ACL denied',
+            'ca-name': 'IPA',
+        }.get(k)
+
+        old_cert = mock.MagicMock()
+        old_cert.serial_number = 100
+
+        with pytest.raises(RuntimeError, match="CA_REJECTED"):
+            obj._resubmit(
+                IPACertType.HTTPS, old_cert, 'req-1', 'IPA',
+                lambda: None)
+
+    @mock.patch(SMOD + '._kill_stuck_helpers')
+    @mock.patch(SMOD + '.print_cert_info')
+    @mock.patch(SMOD + '.ipautil')
+    @mock.patch(SMOD + '.certmonger')
+    @mock.patch(SMOD + '.api')
+    def test_already_valid_skips(
+        self, mock_api, mock_cm, mock_ipautil, mock_pci,
+        mock_ksh, capsys,
+    ):
+        """Cert already valid -> skips resubmit."""
+        mock_api.env.host = 'server.example.com'
+        mock_api.env.realm = 'EXAMPLE.COM'
+
+        obj = self._make_obj()
+        obj._cm.is_cert_valid.return_value = True
+        old_cert = mock.MagicMock()
+        old_cert.serial_number = 100
+
+        obj._resubmit(IPACertType.HTTPS, old_cert, 'req-1', 'IPA', lambda: None)
+
+        mock_cm.resubmit_request.assert_not_called()
+        captured = capsys.readouterr()
+        assert 'already has a valid cert' in captured.out
+
+
+class TestUnitExpiredDogtagCerts:
+    """Characterization: expired_dogtag_certs module-level function."""
+
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    def test_returns_expired_certs(self, mock_nssdb):
+        import datetime as dt
+        from ipaserver.install.ipa_cert_fix import expired_dogtag_certs
+
+        now = dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc)
+        expired = dt.datetime(2029, 6, 1, tzinfo=dt.timezone.utc)
+        valid = dt.datetime(2031, 1, 1, tzinfo=dt.timezone.utc)
+
+        def get_cert(nickname):
+            cert = mock.MagicMock()
+            if 'caSigningCert' in nickname:
+                cert.not_valid_after_utc = expired
+            else:
+                cert.not_valid_after_utc = valid
+            return cert
+
+        mock_nssdb.return_value.get_cert.side_effect = get_cert
+
+        result = expired_dogtag_certs(now)
+        expired_ids = [cid for cid, _ in result]
+        assert 'ca_issuing' in expired_ids
+        # Valid certs should not be in the list
+        assert 'sslserver' not in expired_ids
+
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    def test_missing_cert_skipped(self, mock_nssdb):
+        import datetime as dt
+        from ipaserver.install.ipa_cert_fix import expired_dogtag_certs
+
+        now = dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc)
+        mock_nssdb.return_value.get_cert.side_effect = RuntimeError("not found")
+
+        result = expired_dogtag_certs(now)
+        assert result == []
+
+
+class TestUnitPrintIntentions:
+    """Characterization: print_intentions output."""
+
+    def test_prints_dogtag_and_ipa(self, capsys):
+        from ipaserver.install.ipa_cert_fix import print_intentions
+
+        cert = mock.MagicMock()
+        cert.subject = 'CN=CA'
+        cert.serial_number = 42
+        cert.not_valid_after_utc = '2026-01-01'
+
+        print_intentions(
+            [('sslserver', cert)],
+            [(IPACertType.HTTPS, cert)],
+        )
+        captured = capsys.readouterr()
+        assert 'will be renewed' in captured.out
+        assert 'sslserver' in captured.out
+        assert 'HTTPS' in captured.out
+
+    def test_prints_external_separately(self, capsys):
+        from ipaserver.install.ipa_cert_fix import print_intentions
+
+        cert = mock.MagicMock()
+        cert.subject = 'CN=ext'
+        cert.serial_number = 99
+        cert.not_valid_after_utc = '2026-01-01'
+
+        print_intentions([], [], [(IPACertType.KDC, cert)])
+        captured = capsys.readouterr()
+        assert 'externally-signed' in captured.out
+        assert 'KDC' in captured.out
+
+    def test_no_certs_no_output(self, capsys):
+        from ipaserver.install.ipa_cert_fix import print_intentions
+        print_intentions([], [])
+        captured = capsys.readouterr()
+        assert captured.out == ''
+
+
+class TestUnitGetCsrFromCertmonger:
+    """Characterization: get_csr_from_certmonger."""
+
+    @mock.patch(SMOD + '.certmonger')
+    def test_no_request_returns_none(self, mock_cm):
+        from ipaserver.install.ipa_cert_fix import get_csr_from_certmonger
+        mock_cm.get_request_id.return_value = None
+        assert get_csr_from_certmonger('Server-Cert') is None
+
+    @mock.patch(SMOD + '.certmonger')
+    def test_no_csr_returns_none(self, mock_cm):
+        from ipaserver.install.ipa_cert_fix import get_csr_from_certmonger
+        mock_cm.get_request_id.return_value = 'req-1'
+        mock_cm.get_request_value.return_value = None
+        assert get_csr_from_certmonger('Server-Cert') is None
+
+
+class TestUnitFindCurrentRenewalMaster:
+    """Characterization: _find_current_renewal_master."""
+
+    @mock.patch(SMOD + '.api')
+    def test_returns_fqdn(self, mock_api):
+        from ipaserver.install.ipa_cert_fix import (
+            _find_current_renewal_master,
+        )
+        from ipapython.dn import DN
+
+        mock_api.env.container_masters = 'cn=masters,cn=ipa,cn=etc'
+        mock_api.env.basedn = 'dc=example,dc=com'
+
+        entry = mock.MagicMock()
+        entry.dn = DN('cn=CA,cn=master.example.com,cn=masters,'
+                      'cn=ipa,cn=etc,dc=example,dc=com')
+        mock_api.Backend.ldap2.get_entries.return_value = [entry]
+
+        result = _find_current_renewal_master()
+        assert result == 'master.example.com'
+
+    @mock.patch(SMOD + '.api')
+    def test_ldap_error_returns_none(self, mock_api):
+        from ipaserver.install.ipa_cert_fix import (
+            _find_current_renewal_master,
+        )
+        mock_api.env.container_masters = 'cn=masters'
+        mock_api.env.basedn = 'dc=example'
+        mock_api.Backend.ldap2.get_entries.side_effect = Exception("fail")
+        assert _find_current_renewal_master() is None
+
+
+class TestUnitFixRaSubsystemMismatches:
+    """Characterization: _fix_ra_subsystem_mismatches."""
+
+    @mock.patch(SMOD + '.cainstance')
+    @mock.patch(SMOD + '.NSSDatabase')
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.api')
+    def test_updates_local_file_and_ldap(
+        self, mock_api, mock_x509, mock_nssdb, mock_cai, capsys,
+    ):
+        """Mismatch with update_desc -> updates LDAP description."""
+
+        newest = mock.MagicMock()
+        newest.serial_number = 42
+        entry = mock.MagicMock()
+        conn = mock.MagicMock()
+        mock_api.Backend.ldap2 = conn
+
+        mismatches = [{
+            'label': 'IPA RA',
+            'newest': newest,
+            'dn': 'uid=ipara,ou=people,o=ipaca',
+            'entry': entry,
+            'update_local': False,
+            'update_ldap_cert': False,
+            'update_desc': True,
+            'path_info': ('file', '/etc/pki/ra-agent.pem'),
+            'expected_desc': '2;42;CN=CA;CN=RA',
+        }]
+
+        DeploymentDetector._fix_ra_subsystem_mismatches(mismatches)
+
+        conn.update_entry.assert_called_once_with(entry)
+        entry.__setitem__.assert_called_with('description', '2;42;CN=CA;CN=RA')
+
+    @mock.patch(SMOD + '.cainstance')
+    @mock.patch(SMOD + '.x509')
+    @mock.patch(SMOD + '.api')
+    def test_updates_local_file(
+        self, mock_api, mock_x509, mock_cai, capsys,
+    ):
+        """Mismatch with update_local on file -> writes cert file."""
+
+        newest = mock.MagicMock()
+        newest.serial_number = 42
+        entry = mock.MagicMock()
+        conn = mock.MagicMock()
+        mock_api.Backend.ldap2 = conn
+
+        mismatches = [{
+            'label': 'IPA RA',
+            'newest': newest,
+            'dn': 'uid=ipara,ou=people,o=ipaca',
+            'entry': entry,
+            'update_local': True,
+            'update_ldap_cert': False,
+            'update_desc': False,
+            'path_info': ('file', '/etc/pki/ra-agent.pem'),
+            'expected_desc': '2;42;CN=CA;CN=RA',
+        }]
+
+        mock_x509.write_certificate = mock.MagicMock()
+        DeploymentDetector._fix_ra_subsystem_mismatches(mismatches)
+        mock_x509.write_certificate.assert_called_once_with(
+            newest, '/etc/pki/ra-agent.pem')
+
+
+class TestUnitPrintRaSubsystemMismatches:
+    """Characterization: _print_ra_subsystem_mismatches output."""
+
+    def test_prints_all_mismatch_types(self, capsys):
+
+        mismatches = [{
+            'label': 'IPA RA', 'newest': mock.MagicMock(serial_number=42),
+            'dn': 'uid=ipara,ou=people,o=ipaca',
+            'update_local': True,
+            'update_ldap_cert': True,
+            'update_desc': True,
+        }]
+        DeploymentDetector._print_ra_subsystem_mismatches(mismatches)
+        captured = capsys.readouterr()
+        assert 'local cert is older' in captured.out
+        assert 'certificate blob missing' in captured.out
+        assert 'description serial mismatch' in captured.out
+
+    def test_only_desc_mismatch(self, capsys):
+
+        mismatches = [{
+            'label': 'CA Subsystem',
+            'newest': mock.MagicMock(serial_number=99),
+            'dn': 'uid=pkidbuser,ou=people,o=ipaca',
+            'update_local': False,
+            'update_ldap_cert': False,
+            'update_desc': True,
+        }]
+        DeploymentDetector._print_ra_subsystem_mismatches(mismatches)
+        captured = capsys.readouterr()
+        assert 'description serial mismatch' in captured.out
+        assert 'local cert is older' not in captured.out
+
+
+class TestUnitRunMethod:
+    """Characterization: run() bootstrap and early exits."""
+
+    @mock.patch(MODULE + '.is_ipa_configured', return_value=False)
+    def test_not_configured_returns_2(self, _mock, capsys):
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        result = obj.run()
+        assert result == 2
+
+    @mock.patch(MODULE + '.dsinstance')
+    @mock.patch(MODULE + '.realm_to_serverid', return_value='EXAMPLE-COM')
+    @mock.patch(MODULE + '.api')
+    @mock.patch(MODULE + '.is_ipa_configured', return_value=True)
+    def test_ds_not_running_returns_1(
+        self, _cfg, mock_api, mock_r2s, mock_ds, capsys,
+    ):
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+        mock_api.env.host = 'local.example.com'
+        mock_api.env.realm = 'EXAMPLE.COM'
+        mock_ds.is_ds_running.return_value = False
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.force_server = None
+        result = obj.run()
+        assert result == 1
+        captured = capsys.readouterr()
+        assert 'LDAP server is not running' in captured.out
+
+    def test_not_root_raises(self):
+        """T-PRE-2: validate_options rejects non-root user."""
+        import os
+        from ipapython.admintool import ScriptError
+        from ipaserver.install.ipa_cert_fix import IPACertFix
+
+        if os.getegid() == 0:
+            pytest.skip("test must run as non-root")
+
+        obj = object.__new__(IPACertFix)
+        obj.options = mock.MagicMock()
+        obj.options.verbose = False
+        obj.options.quiet = False
+        obj.options.renewal_master = False
+        obj.options.force_server = None
+        obj.option_parser = mock.MagicMock()
+        with pytest.raises(ScriptError, match="Must be root"):
+            obj.validate_options()
+
+
+class TestUnitGetMasterServer:
+    """Characterization: get_master_server resolution paths."""
+
+    def _make_detector(self, force_server=None, unattended=False):
+        options = mock.MagicMock()
+        options.force_server = force_server
+        options.unattended = unattended
+        return DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=options,
+        )
+
+    @mock.patch(SMOD + '._check_tcp_reachable')
+    @mock.patch(SMOD + '.find_providing_servers', return_value=[])
+    @mock.patch(SMOD + '.api')
+    def test_force_server_returned(self, mock_api, mock_fps, mock_tcp):
+        """--force-server value is used directly."""
+        mock_api.env.host = 'local.example.com'
+        obj = self._make_detector(force_server='master.example.com')
+        result = obj.get_master_server()
+        assert result == 'master.example.com'
+        mock_tcp.assert_called_once_with('master.example.com')
+
+    @mock.patch(SMOD + '._find_current_renewal_master',
+                return_value='rm.example.com')
+    @mock.patch(SMOD + '.find_providing_servers', return_value=[])
+    @mock.patch(SMOD + '.api')
+    def test_unattended_uses_renewal_master(
+        self, mock_api, mock_fps, mock_frm,
+    ):
+        """Unattended uses renewal master from LDAP as default."""
+        mock_api.env.host = 'local.example.com'
+        obj = self._make_detector(unattended=True)
+        result = obj.get_master_server()
+        assert result == 'rm.example.com'
+
+    @mock.patch(SMOD + '._find_current_renewal_master',
+                return_value=None)
+    @mock.patch(SMOD + '.find_providing_servers', return_value=[])
+    @mock.patch(SMOD + '.api')
+    def test_unattended_no_default_returns_none(
+        self, mock_api, mock_fps, mock_frm,
+    ):
+        """Unattended with no renewal master and no CA servers -> None."""
+        mock_api.env.host = 'local.example.com'
+        obj = self._make_detector(unattended=True)
+        result = obj.get_master_server()
+        assert result is None
+
+    @mock.patch(SMOD + '._find_current_renewal_master',
+                return_value=None)
+    @mock.patch(SMOD + '.find_providing_servers',
+                return_value=['ca1.example.com'])
+    @mock.patch(SMOD + '.api')
+    def test_unattended_uses_first_ca_server(
+        self, mock_api, mock_fps, mock_frm,
+    ):
+        """Unattended, no RM, but CA servers -> uses first one."""
+        mock_api.env.host = 'local.example.com'
+        obj = self._make_detector(unattended=True)
+        result = obj.get_master_server()
+        assert result == 'ca1.example.com'
+
+    @mock.patch(SMOD + '._check_tcp_reachable')
+    @mock.patch(SMOD + '.ipautil.user_input',
+                return_value='chosen.example.com')
+    @mock.patch(SMOD + '._find_current_renewal_master',
+                return_value=None)
+    @mock.patch(SMOD + '.find_providing_servers', return_value=[])
+    @mock.patch(SMOD + '.api')
+    def test_interactive_user_input(
+        self, mock_api, mock_fps, mock_frm, mock_input, mock_tcp,
+    ):
+        """Interactive: user types a server FQDN."""
+        mock_api.env.host = 'local.example.com'
+        obj = self._make_detector()
+        result = obj.get_master_server()
+        assert result == 'chosen.example.com'
+
+
+class TestUnitGenerateCsrFromKeySuccess:
+    """Characterization: _generate_csr_from_key success path."""
+
+    @mock.patch(SMOD + '.api')
+    def test_file_based_csr_generated(self, mock_api, tmp_path):
+        """Generates CSR from file-based key and expired cert SANs."""
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.hazmat.primitives import serialization
+        from cryptography import x509 as crypto_x509
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.x509.oid import NameOID
+        import datetime as dt
+
+        mock_api.env.host = 'server.example.com'
+        mock_api.env.realm = 'EXAMPLE.COM'
+        mock_api.env.domain = 'example.com'
+
+        # Generate a real test key
+        key = rsa.generate_private_key(65537, 2048)
+        key_path = str(tmp_path / 'test.key')
+        with open(key_path, 'wb') as f:
+            f.write(key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption()))
+
+        # Build a minimal expired cert
+        subject = crypto_x509.Name([
+            crypto_x509.NameAttribute(NameOID.COMMON_NAME, 'server'), ])
+        cert = (
+            crypto_x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(key.public_key())
+            .serial_number(1)
+            .not_valid_before(dt.datetime(2020, 1, 1))
+            .not_valid_after(dt.datetime(2021, 1, 1))
+            .add_extension(
+                crypto_x509.SubjectAlternativeName([
+                    crypto_x509.DNSName('server.example.com'), ]),
+                critical=False,
+            )
+            .sign(key, hashes.SHA256())
+        )
+
+        handler = ExternalCertHandler(cm_client=mock.MagicMock())
+        ctx = mock.MagicMock()
+        ctx.subject_base = 'O=EXAMPLE.COM'
+
+        with mock.patch(SMOD + '.paths') as mock_paths:
+            mock_paths.HTTPD_CERT_FILE = '/cert.pem'
+            mock_paths.HTTPD_KEY_FILE = key_path
+            mock_paths.HTTPD_PASSWD_FILE_FMT = str(tmp_path / '{host}')
+            with mock.patch(SMOD + '.ipa_certs') as mock_ic:
+                mock_ic.get_default_profile.return_value = ('caIPAserviceCert')
+                with mock.patch(SMOD + '.IPA_CA_RECORD', 'ipa-ca'):
+                    result = handler._generate_csr_from_key(
+                        IPACertType.HTTPS, cert, ctx)
+
+        assert result is not None
+        assert '-----BEGIN CERTIFICATE REQUEST-----' in result
+
+
+class TestUnitFixCertreqDirectives:
+    """Characterization: fix_certreq_directives."""
+
+    @mock.patch(MODULE + '.get_csr_from_certmonger',
+                return_value='BASE64CSR==')
+    @mock.patch(MODULE + '.directivesetter')
+    @mock.patch(MODULE + '.paths')
+    def test_missing_directive_restored(
+        self, mock_paths, mock_ds, mock_get_csr,
+    ):
+        """Missing CSR directive is restored from certmonger."""
+        from ipaserver.install.ipa_cert_fix import fix_certreq_directives
+        mock_paths.CA_CS_CFG_PATH = '/var/lib/pki/pki-tomcat/ca/CS.cfg'
+        mock_paths.KRA_CS_CFG_PATH = '/var/lib/pki/pki-tomcat/kra/CS.cfg'
+        mock_ds.get_directive.return_value = None
+
+        cert = mock.MagicMock()
+        fix_certreq_directives([('sslserver', cert)])
+
+        mock_ds.set_directive.assert_called_once()
+        args = mock_ds.set_directive.call_args[0]
+        assert args[1] == 'ca.sslserver.certreq'
+        assert args[2] == 'BASE64CSR=='
+
+    @mock.patch(MODULE + '.directivesetter')
+    @mock.patch(MODULE + '.paths')
+    def test_existing_directive_not_touched(
+        self, mock_paths, mock_ds,
+    ):
+        """Existing CSR directive is left alone."""
+        from ipaserver.install.ipa_cert_fix import fix_certreq_directives
+        mock_paths.CA_CS_CFG_PATH = '/var/lib/pki/pki-tomcat/ca/CS.cfg'
+        mock_paths.KRA_CS_CFG_PATH = '/var/lib/pki/pki-tomcat/kra/CS.cfg'
+        mock_ds.get_directive.return_value = 'EXISTINGCSR'
+
+        cert = mock.MagicMock()
+        fix_certreq_directives([('sslserver', cert)])
+
+        mock_ds.set_directive.assert_not_called()
+
+
+class TestUnitRunCertFix:
+    """Characterization: run_cert_fix command construction."""
+
+    @mock.patch(MODULE + '.ipautil')
+    @mock.patch(MODULE + '.realm_to_serverid', return_value='EXAMPLE-COM')
+    @mock.patch(MODULE + '.paths')
+    @mock.patch(MODULE + '.api')
+    def test_builds_correct_command(
+        self, mock_api, mock_paths, mock_r2s, mock_ipautil,
+    ):
+        """Verify pki-server cert-fix command includes certs."""
+        from ipaserver.install.ipa_cert_fix import run_cert_fix
+
+        mock_api.env.realm = 'EXAMPLE.COM'
+        mock_paths.SLAPD_INSTANCE_SOCKET_TEMPLATE = (
+            '/var/run/slapd-%s.socket')
+
+        cert_dog = mock.MagicMock()
+        cert_ipa = mock.MagicMock()
+        cert_ipa.serial_number = 42
+
+        run_cert_fix(
+            [('sslserver', cert_dog)],
+            [(IPACertType.HTTPS, cert_ipa)])
+
+        mock_ipautil.run.assert_called_once()
+        cmd = mock_ipautil.run.call_args[0][0]
+        assert 'pki-server' in cmd
+        assert 'cert-fix' in cmd
+        assert '--cert' in cmd
+        assert 'sslserver' in cmd
+        assert '--extra-cert' in cmd
+        assert '42' in cmd
+
+
+class TestUnitCheckCaSigningCert:
+    """Characterization: _check_ca_signing_cert validity check."""
+
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    def test_valid_cert_returns_true(self, mock_nssdb):
+        import datetime as dt
+
+        cert = mock.MagicMock()
+        cert.not_valid_after_utc = dt.datetime(
+            2030, 1, 1, tzinfo=dt.timezone.utc)
+        mock_nssdb.return_value.get_cert.return_value = cert
+
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=mock.MagicMock(),
+        )
+        assert obj._check_ca_signing_cert() is True
+
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    def test_near_expiry_returns_false(self, mock_nssdb, capsys):
+        import datetime as dt
+
+        cert = mock.MagicMock()
+        cert.not_valid_after_utc = dt.datetime(
+            2026, 4, 25, tzinfo=dt.timezone.utc)
+        mock_nssdb.return_value.get_cert.return_value = cert
+
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=mock.MagicMock(),
+        )
+        assert obj._check_ca_signing_cert() is False
+        captured = capsys.readouterr()
+        assert 'ipa-cacert-manage' in captured.out
+
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    def test_unreadable_returns_false(self, mock_nssdb, capsys):
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=mock.MagicMock(),
+        )
+        mock_nssdb.return_value.get_cert.side_effect = RuntimeError("db error")
+        assert obj._check_ca_signing_cert() is False
+
+
+class TestUnitIdempotencyInterrupt:
+    """T-IDEM-3 unit variant: interrupted fix leaves clean state."""
+
+    @mock.patch(MODULE + '._kill_stuck_helpers')
+    @mock.patch(MODULE + '.install_ipa_certs')
+    @mock.patch(MODULE + '.replicate_dogtag_certs')
+    @mock.patch(MODULE + '.run_cert_fix',
+                side_effect=KeyboardInterrupt)
+    @mock.patch(MODULE + '.fix_certreq_directives')
+    @mock.patch(MODULE + '.ipautil')
+    @mock.patch(MODULE + '.api')
+    def test_keyboard_interrupt_during_cert_fix(
+        self, mock_api, mock_ipautil, mock_fix_dir,
+        mock_run_cf, mock_repl, mock_install, mock_ksh,
+    ):
+        """KeyboardInterrupt during pki-server cert-fix propagates
+        but LDAP is still disconnected cleanly by run()."""
+        from ipaserver.install.ipa_cert_fix import (
+            IPACertFix, CertFixContext,
+        )
+
+        mock_ipautil.CalledProcessError = Exception
+        mock_ipautil.run.return_value = mock.MagicMock(returncode=0)
+        mock_api.env.host = 'master.example.com'
+
+        obj = object.__new__(IPACertFix)
+        obj._cm = mock.MagicMock()
+        obj._cm.is_responsive.return_value = True
+        obj.options = mock.MagicMock()
+        obj.options.dry_run = False
+        obj.options.unattended = True
+        obj._scenario_made_changes = False
+        obj._ca_instance = mock.MagicMock()
+        obj._detector = mock.MagicMock()
+        obj._detector._check_ca_signing_cert.return_value = True
+        obj._detector.check_is_renewal_master.return_value = True
+        obj._external_handler = mock.MagicMock()
+
+        cert = mock.MagicMock()
+        ctx = CertFixContext(
+            deployment_type=DeploymentType.CA_SELF_SIGNED,
+            scenario=FixScenario.RENEWAL_MASTER,
+            subject_base=mock.MagicMock(),
+            ca_subject_dn=mock.MagicMock(),
+            dogtag_certs=[('sslserver', cert)],
+            ipa_certs=[],
+            external_certs=[],
+            master_server=None,
+        )
+
+        with pytest.raises(KeyboardInterrupt):
+            obj.run_renewal_master_fix(ctx)
+
+        # Postcondition P5: certmonger state not corrupted
+        # (run_cert_fix raised before any certmonger modification)
+        obj._cm.resubmit_request.assert_not_called()

--- a/ipatests/test_integration/test_ipa_cert_fix_unit.py
+++ b/ipatests/test_integration/test_ipa_cert_fix_unit.py
@@ -1,0 +1,92 @@
+#
+# Copyright (C) 2026  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Unit tests for ipa-cert-fix.
+
+These tests use mocks and do not require an IPA deployment.  They exercise
+pure logic and should run in seconds.
+"""
+import pytest
+
+from ipaserver.install.ipa_cert_fix_types import (
+    CertIdentity,
+    DOGTAG_CERTS,
+)
+
+
+class TestCertIdentityRegistry:
+    """CertIdentity dataclass and DOGTAG_CERTS registry invariants."""
+
+    def test_sslserver_is_not_shared(self):
+        """sslserver is server-specific, not shared/replicated."""
+        assert DOGTAG_CERTS['sslserver'].is_shared is False
+
+    def test_subsystem_is_shared(self):
+        assert DOGTAG_CERTS['subsystem'].is_shared is True
+
+    def test_ca_issuing_is_shared(self):
+        assert DOGTAG_CERTS['ca_issuing'].is_shared is True
+
+    def test_all_entries_are_cert_identity(self):
+        for certid, ci in DOGTAG_CERTS.items():
+            assert isinstance(ci, CertIdentity), certid
+
+    def test_all_ids_match_keys(self):
+        for certid, ci in DOGTAG_CERTS.items():
+            assert ci.id == certid
+
+    def test_all_have_nickname(self):
+        for certid, ci in DOGTAG_CERTS.items():
+            assert ci.nickname, certid
+
+    def test_all_shared_certs_have_cs_cfg_directive(self):
+        """Shared certs (except ca_issuing and sslserver) must have CS.cfg
+        directives so the cert blob can be updated in-place."""
+        for certid, ci in DOGTAG_CERTS.items():
+            if ci.is_shared and certid not in ('ca_issuing',):
+                assert ci.cs_cfg_directive is not None, (
+                    "%s is shared but has no cs_cfg_directive" % certid)
+                assert ci.cfg_path is not None, (
+                    "%s is shared but has no cfg_path" % certid)
+
+    def test_sslserver_has_no_cs_cfg_directive(self):
+        """sslserver CS.cfg is updated by certmonger post-save."""
+        assert DOGTAG_CERTS['sslserver'].cs_cfg_directive is None
+
+    def test_ca_issuing_has_no_cs_cfg_directive(self):
+        """ca_issuing is handled by ipa-certupdate."""
+        assert DOGTAG_CERTS['ca_issuing'].cs_cfg_directive is None
+
+    def test_registry_has_all_eight_certs(self):
+        expected = {
+            'ca_issuing', 'sslserver', 'subsystem',
+            'ca_ocsp_signing', 'ca_audit_signing',
+            'kra_transport', 'kra_storage', 'kra_audit_signing',
+        }
+        assert set(DOGTAG_CERTS.keys()) == expected
+
+    def test_certreq_directives_present(self):
+        """All non-ca_issuing certs have certreq directives for
+        fix_certreq_directives."""
+        for certid, ci in DOGTAG_CERTS.items():
+            if certid != 'ca_issuing':
+                assert ci.certreq_directive is not None, (
+                    "%s has no certreq_directive" % certid)
+
+    def test_frozen(self):
+        """CertIdentity is immutable."""
+        ci = DOGTAG_CERTS['sslserver']
+        with pytest.raises(AttributeError):
+            ci.id = 'changed'
+
+    def test_display_name(self):
+        """display_name returns the NSSDB nickname."""
+        ci = DOGTAG_CERTS['sslserver']
+        assert ci.display_name == 'Server-Cert cert-pki-ca'
+
+    def test_is_dogtag(self):
+        """All CertIdentity instances report is_dogtag=True."""
+        for ci in DOGTAG_CERTS.values():
+            assert ci.is_dogtag is True

--- a/ipatests/test_integration/test_ipa_cert_fix_unit.py
+++ b/ipatests/test_integration/test_ipa_cert_fix_unit.py
@@ -13,12 +13,17 @@ import pytest
 
 from ipaserver.install.ipa_cert_fix import (
     CertmongerClient,
+    DeploymentDetector,
+    DeploymentType,
+    FixScenario,
+    IPACertType,
 )
 from ipaserver.install.ipa_cert_fix_types import (
     CertIdentity,
     DOGTAG_CERTS,
 )
 
+MODULE = 'ipaserver.install.ipa_cert_fix'
 SMOD = 'ipaserver.install.ipa_cert_fix_services'
 
 
@@ -171,3 +176,217 @@ class TestCertmongerClient:
         client = CertmongerClient()
         result = client.get_requests_for_dir('/etc/pki')
         assert result == ['r1', 'r2']
+
+
+class TestUnitDeploymentDetection:
+    """detect_deployment_type with all 4 return values."""
+
+    def _make_detector(self):
+        return DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=None,
+            options=mock.MagicMock(),
+        )
+
+    @mock.patch(SMOD + '.find_providing_servers')
+    @mock.patch(SMOD + '.api')
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    @mock.patch(SMOD + '.cainstance')
+    def test_ca_self_signed(self, mock_ca, mock_nssdb, mock_api, mock_fps):
+        """CA installed, issuer == subject -> CA_SELF_SIGNED."""
+        mock_ca.is_ca_installed_locally.return_value = True
+        cert = mock.MagicMock()
+        cert.issuer = 'CN=Certificate Authority,O=EXAMPLE.COM'
+        cert.subject = 'CN=Certificate Authority,O=EXAMPLE.COM'
+        mock_nssdb.return_value.get_cert.return_value = cert
+
+        obj = self._make_detector()
+        result = obj.detect_deployment_type()
+        assert result == DeploymentType.CA_SELF_SIGNED
+
+    @mock.patch(SMOD + '.find_providing_servers')
+    @mock.patch(SMOD + '.api')
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    @mock.patch(SMOD + '.cainstance')
+    def test_ca_externally_signed(
+        self, mock_ca, mock_nssdb, mock_api, mock_fps,
+    ):
+        """CA installed, issuer != subject -> CA_EXTERNALLY_SIGNED."""
+        mock_ca.is_ca_installed_locally.return_value = True
+        cert = mock.MagicMock()
+        cert.issuer = 'CN=External Root CA,O=EXTCA'
+        cert.subject = 'CN=Certificate Authority,O=EXAMPLE.COM'
+        mock_nssdb.return_value.get_cert.return_value = cert
+
+        obj = self._make_detector()
+        result = obj.detect_deployment_type()
+        assert result == DeploymentType.CA_EXTERNALLY_SIGNED
+
+    @mock.patch(SMOD + '._ensure_ldap_connected')
+    @mock.patch(SMOD + '.find_providing_servers',
+                return_value=['ca1.example.com'])
+    @mock.patch(SMOD + '.api')
+    @mock.patch(SMOD + '.cainstance')
+    def test_ca_less_with_ca_servers(
+        self, mock_ca, mock_api, mock_fps, mock_elc,
+    ):
+        """No local CA, CA servers in topology -> CA_LESS."""
+        mock_ca.is_ca_installed_locally.return_value = False
+
+        obj = self._make_detector()
+        result = obj.detect_deployment_type()
+        assert result == DeploymentType.CA_LESS
+
+    @mock.patch(SMOD + '._ensure_ldap_connected')
+    @mock.patch(SMOD + '.find_providing_servers', return_value=[])
+    @mock.patch(SMOD + '.api')
+    @mock.patch(SMOD + '.cainstance')
+    def test_ca_less_external(self, mock_ca, mock_api, mock_fps, mock_elc):
+        """No local CA, no CA servers -> CA_LESS_EXTERNAL."""
+        mock_ca.is_ca_installed_locally.return_value = False
+
+        obj = self._make_detector()
+        result = obj.detect_deployment_type()
+        assert result == DeploymentType.CA_LESS_EXTERNAL
+
+    @mock.patch(SMOD + '._ensure_ldap_connected')
+    @mock.patch(SMOD + '.find_providing_servers',
+                side_effect=Exception("LDAP down"))
+    @mock.patch(SMOD + '.api')
+    @mock.patch(SMOD + '.cainstance')
+    def test_ca_less_ldap_fails_defaults_to_ca_less(
+        self, mock_ca, mock_api, mock_fps, mock_elc,
+    ):
+        """LDAP query failure on CA-less -> CA_LESS (not EXTERNAL)."""
+        mock_ca.is_ca_installed_locally.return_value = False
+
+        obj = self._make_detector()
+        result = obj.detect_deployment_type()
+        assert result == DeploymentType.CA_LESS
+
+    @mock.patch(SMOD + '.api')
+    @mock.patch(SMOD + '._get_pki_nssdb')
+    @mock.patch(SMOD + '.cainstance')
+    def test_nssdb_unreadable_raises(self, mock_ca, mock_nssdb, mock_api):
+        """CA installed but NSSDB unreadable -> RuntimeError."""
+        mock_ca.is_ca_installed_locally.return_value = True
+        mock_nssdb.return_value.get_cert.side_effect = RuntimeError("db error")
+
+        obj = self._make_detector()
+        with pytest.raises(RuntimeError, match="Cannot read caSigningCert"):
+            obj.detect_deployment_type()
+
+
+class TestUnitScenarioRouting:
+    """Scenario routing for each deployment type."""
+
+    def _make_detector(self, is_rm, master, force_rm=False):
+        options = mock.MagicMock()
+        options.renewal_master = force_rm
+        options.force_server = None
+        options.unattended = False
+        obj = DeploymentDetector(
+            cm_client=mock.MagicMock(),
+            ca_instance=mock.MagicMock(),
+            options=options,
+        )
+        obj.check_is_renewal_master = mock.MagicMock(return_value=is_rm)
+        obj.get_master_server = mock.MagicMock(return_value=master)
+        return obj
+
+    @pytest.mark.parametrize("dt,is_rm,master,expected_scenario", [
+        (DeploymentType.CA_SELF_SIGNED,
+         True, None, FixScenario.RENEWAL_MASTER),
+        (DeploymentType.CA_SELF_SIGNED,
+         False, 'master.example.com', FixScenario.CA_FULL_WITH_MASTER),
+        (DeploymentType.CA_SELF_SIGNED,
+         False, None, FixScenario.CA_FULL_PROMOTE),
+        (DeploymentType.CA_EXTERNALLY_SIGNED,
+         True, None, FixScenario.RENEWAL_MASTER),
+        (DeploymentType.CA_EXTERNALLY_SIGNED,
+         False, 'master.example.com', FixScenario.CA_FULL_WITH_MASTER),
+        (DeploymentType.CA_LESS,
+         False, 'master.example.com', FixScenario.CA_LESS_WITH_MASTER),
+        (DeploymentType.CA_LESS_EXTERNAL,
+         False, None, FixScenario.EXTERNAL_CERTS),
+    ])
+    def test_scenario_matrix(self, dt, is_rm, master, expected_scenario):
+        """Verify correct FixScenario for each combination."""
+        obj = self._make_detector(is_rm, master)
+        scenario, srv = obj.determine_scenario(dt)
+        assert scenario == expected_scenario
+        if expected_scenario in (
+            FixScenario.CA_FULL_WITH_MASTER,
+            FixScenario.CA_LESS_WITH_MASTER,
+        ):
+            assert srv == master
+        elif expected_scenario in (
+            FixScenario.RENEWAL_MASTER,
+            FixScenario.CA_FULL_PROMOTE,
+            FixScenario.EXTERNAL_CERTS,
+        ):
+            assert srv is None
+
+    def test_caless_no_server_raises(self):
+        """CA_LESS with no server selected raises RuntimeError."""
+        obj = self._make_detector(is_rm=False, master=None)
+        with pytest.raises(RuntimeError, match="No server"):
+            obj.determine_scenario(DeploymentType.CA_LESS)
+
+    def test_force_renewal_master_flag(self):
+        """--renewal-master forces RENEWAL_MASTER scenario."""
+        obj = self._make_detector(
+            is_rm=False, master='m.example.com', force_rm=True,
+        )
+        scenario, srv = obj.determine_scenario(
+            DeploymentType.CA_SELF_SIGNED)
+        assert scenario == FixScenario.RENEWAL_MASTER
+        assert srv is None
+
+
+class TestUnitCertClassification:
+    """Cert classification splits external from IPA."""
+
+    @mock.patch(SMOD + '.cainstance')
+    @mock.patch(SMOD + '.expired_dogtag_certs')
+    @mock.patch(SMOD + '.expired_ipa_certs')
+    def test_external_certs_split(
+        self, mock_exp_ipa, mock_exp_dog, mock_ca,
+    ):
+        """Verify _classify_certs moves non_renewed to external."""
+        import datetime as dt
+        now = dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc)
+        mock_ca.is_ca_installed_locally.return_value = True
+
+        cert_mock = mock.MagicMock()
+        mock_exp_dog.return_value = [('ca_audit', cert_mock)]
+        mock_exp_ipa.return_value = (
+            [(IPACertType.IPARA, cert_mock)],
+            [(IPACertType.HTTPS, cert_mock)],  # non_renewed -> external
+        )
+
+        dogtag, ipa, external = DeploymentDetector._classify_certs(now)
+
+        assert len(dogtag) == 1
+        assert len(ipa) == 1
+        assert len(external) == 1
+        assert external[0][0] == IPACertType.HTTPS
+
+    @mock.patch(SMOD + '.cainstance')
+    @mock.patch(SMOD + '.expired_ipa_certs')
+    def test_caless_skips_dogtag(self, mock_exp_ipa, mock_ca):
+        """On CA-less, dogtag certs list is empty."""
+        import datetime as dt
+        now = dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc)
+        mock_ca.is_ca_installed_locally.return_value = False
+
+        cert_mock = mock.MagicMock()
+        mock_exp_ipa.return_value = (
+            [(IPACertType.HTTPS, cert_mock)],
+            [],
+        )
+
+        dogtag, ipa, external = DeploymentDetector._classify_certs(now)
+
+        assert dogtag == []
+        assert len(ipa) == 1


### PR DESCRIPTION
Add comprehensive design document covering the expansion of ipa-cert-fix from a renewal-master-only tool to a multi-scenario certificate recovery tool.

The document describes:
- Five deployment types and fix scenarios (renewal master, CA-full replica with working master, CA-full promote, CA-less, external certs)
- Auto-detection of deployment type and scenario routing
- Non-destructive replica fix via certmonger pointed at a master server
- Shared vs server-specific certificate handling (LDAP fetch from cn=ca_renewal for shared certs, certmonger resubmit for sslserver)
- CS.cfg blob updates when bypassing certmonger post-save commands
- External certificate handling (transition to IPA CA or CSR generation)
- HSM support, error handling safeguards, and state restoration
- CLI options: --force-server, --renewal-master, --dry-run, -U
- Test plan with 70+ test cases across unit, integration, and system tiers

Fixes: https://pagure.io/freeipa/issue/9976

Claude code was used to refine language and create test plan.

## Summary by Sourcery

Documentation:
- Document multi-scenario certificate recovery behavior for ipa-cert-fix, including deployment detection, fix scenarios, CLI options, error handling, HSM support, and an extensive test plan.