### PR TITLE
dns: support BIND 9.20

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/install/share/bind.ipa-logging-ext.conf.template
+++ b/install/share/bind.ipa-logging-ext.conf.template
@@ -86,6 +86,5 @@ category database       { database; };
 category client         { default_syslog; named; };
 category network        { default_syslog; named; };
 category unmatched      { named; };
-category delegation-only { named; };
 category update         { default_syslog; update; };
 category update-security { default_syslog; update; };

--- a/install/share/bind.ipa-logging-ext.conf.template
+++ b/install/share/bind.ipa-logging-ext.conf.template
@@ -86,6 +86,6 @@ category database       { database; };
 category client         { default_syslog; named; };
 category network        { default_syslog; named; };
 category unmatched      { named; };
-category delegation-only { named; };
+${NAMED_DELEGATION_ONLY_CATEGORY}
 category update         { default_syslog; update; };
 category update-security { default_syslog; update; };

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -255,7 +255,6 @@ class BasePathNamespace:
     DOGTAG_IPA_RENEW_AGENT_SUBMIT = "/usr/libexec/certmonger/dogtag-ipa-renew-agent-submit"
     CERTMONGER_DOGTAG_SUBMIT = "/usr/libexec/certmonger/dogtag-submit"
     IPA_SERVER_GUARD = "/usr/libexec/certmonger/ipa-server-guard"
-    GENERATE_RNDC_KEY = "/usr/libexec/generate-rndc-key.sh"
     RNDC_KEY = "/etc/rndc.key"
     LIBEXEC_IPA_DIR = "/usr/libexec/ipa"
     IPA_DNSKEYSYNCD_REPLICA = "/usr/libexec/ipa/ipa-dnskeysync-replica"

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -90,7 +90,6 @@ class DebianPathNamespace(BasePathNamespace):
     DOGTAG_IPA_RENEW_AGENT_SUBMIT = "/usr/lib/certmonger/dogtag-ipa-renew-agent-submit"
     CERTMONGER_DOGTAG_SUBMIT = "/usr/lib/certmonger/dogtag-submit"
     IPA_SERVER_GUARD = "/usr/lib/certmonger/ipa-server-guard"
-    GENERATE_RNDC_KEY = "/bin/true"
     LIBEXEC_IPA_DIR = "/usr/lib/ipa"
     IPA_DNSKEYSYNCD_REPLICA = "/usr/lib/ipa/ipa-dnskeysync-replica"
     IPA_DNSKEYSYNCD = "/usr/lib/ipa/ipa-dnskeysyncd"

--- a/ipaplatform/suse/paths.py
+++ b/ipaplatform/suse/paths.py
@@ -62,7 +62,6 @@ class SusePathNamespace(BasePathNamespace):
     )
     CERTMONGER_DOGTAG_SUBMIT = "/usr/lib/certmonger/dogtag-submit"
     IPA_SERVER_GUARD = "/usr/lib/certmonger/ipa-server-guard"
-    GENERATE_RNDC_KEY = "/usr/lib/generate-rndc-key.sh"
     LIBEXEC_IPA_DIR = "/usr/lib/ipa"
     IPA_DNSKEYSYNCD_REPLICA = "/usr/lib/ipa/ipa-dnskeysync-replica"
     IPA_DNSKEYSYNCD = "/usr/lib/ipa/ipa-dnskeysyncd"

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -1216,7 +1216,9 @@ class BindInstance(service.Service):
 
     def __generate_rndc_key(self):
         installutils.check_entropy()
-        ipautil.run([paths.GENERATE_RNDC_KEY])
+        ipautil.run([
+            paths.SYSTEMCTL, "start", "named-setup-rndc.service"
+        ])
 
     def add_master_dns_records(self, fqdn, ip_addresses, realm_name, domain_name,
                                reverse_zones):

--- a/ipaserver/install/bindinstance.py
+++ b/ipaserver/install/bindinstance.py
@@ -897,6 +897,19 @@ class BindInstance(service.Service):
         else:
             crypto_policy = "// not available"
 
+        try:
+            result = ipautil.run(["named", "-v"], capture_output=True)
+            named_version = tasks.parse_ipa_version(
+                result.output.split()[1]
+            )
+        except Exception:
+            named_version = None
+
+        if named_version and named_version >= tasks.parse_ipa_version("9.20"):
+            delegation_only_category = ""
+        else:
+            delegation_only_category = "category delegation-only { named; };"
+
         if self.dns_over_tls:
             named_tls_conf = textwrap.dedent("""\
                 tls local-tls {{
@@ -931,6 +944,7 @@ class BindInstance(service.Service):
             NAMED_CUSTOM_CONF=paths.NAMED_CUSTOM_CONF,
             NAMED_CUSTOM_OPTIONS_CONF=paths.NAMED_CUSTOM_OPTIONS_CONF,
             NAMED_LOGGING_OPTIONS_CONF=paths.NAMED_LOGGING_OPTIONS_CONF,
+            NAMED_DELEGATION_ONLY_CATEGORY=delegation_only_category,
             NAMED_DATA_DIR=constants.NAMED_DATA_DIR,
             NAMED_ZONE_COMMENT=constants.NAMED_ZONE_COMMENT,
             NAMED_DNSSEC_VALIDATION=self._get_dnssec_validation(),

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_dnssec:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_dnssec.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 10800
+        topology: *master_2repl_1client

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_dnssec:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_dnssec.py::TestInstallDNSSECFirst
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 10800
+        topology: *master_2repl_1client

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -473,16 +473,18 @@ class TestInstallDNSSECFirst(IntegrationTest):
         """
         INITIAL_KEY_FMT = '%s initial-key %d %d %d "%s";'
 
-        # delv reports its version on stderr
-        delv_version = self.master.run_command(
-            ["delv", "-v"]
-        ).stderr_text.rstrip().replace("delv ", "")
-        assert delv_version
+        # delv reports its version on stderr when version < 9.20, and
+        # on stdout otherwise. Parse BIND version instead, as it should match.
+        # example output: BIND 9.18.48 (Extended Support Version) <id:>
+        named_version = self.master.run_command(
+            ["named", "-v"]
+        ).stdout_text.split()[1]
+        assert named_version
 
-        delv_version_parsed = platform_tasks.parse_ipa_version(delv_version)
-        if delv_version_parsed < platform_tasks.parse_ipa_version("9.16"):
+        named_version_parsed = platform_tasks.parse_ipa_version(named_version)
+        if named_version_parsed < platform_tasks.parse_ipa_version("9.16"):
             pytest.skip(
-                f"Requires delv >= 9.16(+yaml), installed: '{delv_version}'"
+                f"Requires delv >= 9.16(+yaml), installed: '{named_version}'"
             )
 
         # extract DSKEY from root zone
@@ -541,7 +543,6 @@ class TestInstallDNSSECFirst(IntegrationTest):
             "SOA",
         ]
 
-        # delv puts trace info on stderr
         for host in [self.master, self.replicas[0]]:
             result = host.run_command(args)
             yaml_data = yaml.safe_load(result.stdout_text)

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -510,16 +510,18 @@ class TestInstallDNSSECFirst(IntegrationTest):
         """
         INITIAL_KEY_FMT = '%s initial-key %d %d %d "%s";'
 
-        # delv reports its version on stderr
-        delv_version = self.master.run_command(
-            ["delv", "-v"]
-        ).stderr_text.rstrip().replace("delv ", "")
-        assert delv_version
+        # delv reports its version on stderr when version < 9.20, and
+        # on stdout otherwise. Parse BIND version instead, as it should match.
+        # example output: BIND 9.18.48 (Extended Support Version) <id:>
+        named_version = self.master.run_command(
+            ["named", "-v"]
+        ).stdout_text.split()[1]
+        assert named_version
 
-        delv_version_parsed = platform_tasks.parse_ipa_version(delv_version)
-        if delv_version_parsed < platform_tasks.parse_ipa_version("9.16"):
+        named_version_parsed = platform_tasks.parse_ipa_version(named_version)
+        if named_version_parsed < platform_tasks.parse_ipa_version("9.16"):
             pytest.skip(
-                f"Requires delv >= 9.16(+yaml), installed: '{delv_version}'"
+                f"Requires delv >= 9.16(+yaml), installed: '{named_version}'"
             )
 
         # extract DSKEY from root zone
@@ -580,7 +582,6 @@ class TestInstallDNSSECFirst(IntegrationTest):
             "SOA",
         ]
 
-        # delv puts trace info on stderr
         for host in [self.master, self.replicas[0]]:
             result = host.run_command(args)
             yaml_data = yaml.safe_load(result.stdout_text)


### PR DESCRIPTION
Following the adaptation of bind-dyndb-ldap to support BIND 9.20, some minor changes are required on FreeIPA side.

* dns: remove delegation-only from BIND logging options

> `delegation-only` has been removed in BIND 9.20 [1]. Remove its usage in order to properly support newer versions of BIND.

* ipatests: properly parse delv version in dnssec tests

> Prior to BIND 9.20, delv reported its version on stderr. It now does it in stdout. In order to properly parse it regardless of the version, use the BIND version output instead.

* dns: use BIND systemd service for generating rndc key
> Instead of calling the script directly, use the oneshot systemd service that
BIND provides that calls this script. This avoids compatibility issues
with newest versions of BIND, since this script has been moved to a
different location.

## Summary by Sourcery

Update DNS logging configuration and DNSSEC integration tests to support BIND 9.20 and adjust CI to run the updated DNSSEC test suite.

Bug Fixes:
- Ensure DNSSEC chain-of-trust tests correctly detect supported delv/BIND versions by parsing named version output instead of delv stderr/stdout.

Enhancements:
- Remove deprecated delegation-only option from the BIND logging configuration template to align with BIND 9.20 behavior.

CI:
- Update temporary PRCI definition to run the DNSSEC integration test suite against the ipa-4-12 Fedora build with extended timeout and topology.

Tests:
- Adjust DNSSEC integration tests to rely on named -v output for version checks and simplify handling of delv output.