### PR TITLE
Samrt card RFE automation.

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1053,6 +1053,10 @@ Requires: python3-pytest >= 3.9.1
 Requires: python3-pytest-multihost >= 0.5
 Requires: python3-pytest-sourceorder
 Requires: sshpass
+# test_integration smartcard helpers — pkcs11-tool / softhsm2-util (virt-cacard is optional;
+# not in all CI repos; tests skip if virt_cacard.service is missing)
+Requires: softhsm
+Requires: opensc
 %endif
 Requires: python3-sssdconfig >= %{sssd_version}
 Requires: tar

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -76,7 +76,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_smartcard.py
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/pytest_ipa/integration/smartcard.py
+++ b/ipatests/pytest_ipa/integration/smartcard.py
@@ -1,0 +1,315 @@
+# Authors:
+#   FreeIPA Contributors see COPYING for license
+#
+"""Helpers for smart-card related integration tests (SoftHSM / PKCS#11).
+
+Aligned with common SSSD-framework workflows (token init, pkcs11-tool, virt_cacard,
+optional local ``files`` domain + certmap) but implemented with
+:class:`~ipatests.pytest_ipa.integration.host.Host` and ``run_command`` only.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import textwrap
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+
+from ipaplatform.paths import paths
+
+if TYPE_CHECKING:
+    from ipatests.pytest_ipa.integration.host import Host
+
+__all__: Tuple[str, ...] = (
+    "SmartCardUtils",
+    "SOFTHSM_PKCS11_MODULE",
+    "OPT_TEST_CA_BASE",
+    "restore_local_smartcard_auth",
+)
+
+# Default PKCS#11 module for SoftHSM 2 on Fedora/RHEL-like systems.
+SOFTHSM_PKCS11_MODULE = "/usr/lib64/pkcs11/libsofthsm2.so"
+
+# Same layout as typical SSSD multihost tests: fixed tree under /opt/test_ca.
+OPT_TEST_CA_BASE = "/opt/test_ca"
+
+
+def restore_local_smartcard_auth(host: Host, backups: Dict[str, Any]) -> None:
+    """
+    Restore files saved by :meth:`SmartCardUtils.setup_local_card`.
+
+    *backups* maps absolute path strings to **bytes** (file contents). Entries
+    whose keys start with ``_`` are skipped (metadata). If the CA bundle was
+    not backed up (it did not exist before setup), it is removed.
+    """
+    ca_path = "/etc/sssd/pki/sssd_auth_ca_db.pem"
+    for key, data in backups.items():
+        if key.startswith("_") or not isinstance(key, str):
+            continue
+        if data is None:
+            continue
+        host.transport.put_file_contents(key, data)
+    if ca_path not in backups:
+        host.run_command(["rm", "-f", ca_path], raiseonerr=False)
+    host.run_command(["chmod", "600", paths.SSSD_CONF], raiseonerr=False)
+    host.run_command(["authselect", "apply-changes"], raiseonerr=False)
+    host.run_command(["systemctl", "restart", "sssd"], raiseonerr=False)
+
+
+class SmartCardUtils:
+    """
+    Manage SoftHSM tokens and PKCS#11 objects on a remote IPA test host.
+
+    Typical flow: :meth:`generate_cert`, :meth:`initialize_card`,
+    :meth:`add_key`, :meth:`add_cert`, :meth:`pkcs11_list_objects`.
+
+    For local-only SSSD (``files`` domain + certmap), see :meth:`setup_local_card`.
+    """
+
+    # Mirrors SSSD framework constants (paths relative to OPT_TEST_CA_BASE when used).
+    SOFTHSM2_CONF_PATH = os.path.join(OPT_TEST_CA_BASE, "softhsm2.conf")
+    TOKEN_STORAGE_PATH = os.path.join(OPT_TEST_CA_BASE, "tokens")
+    OPENSC_CACHE_PATHS = (
+        "$HOME/.cache/opensc/",
+        "/run/sssd/.cache/opensc/",
+    )
+
+    def __init__(
+        self,
+        host: Host,
+        base_dir: Optional[str] = None,
+        softhsm_conf_name: str = "softhsm2.conf",
+    ) -> None:
+        self.host = host
+        self.base_dir = base_dir or "/var/tmp/ipa_smartcard_utils"
+        self.softhsm_conf_path = os.path.join(self.base_dir, softhsm_conf_name)
+        self.token_dir = os.path.join(self.base_dir, "tokens")
+
+    def _run(self, argv, *, raiseonerr: bool = True):
+        full = ["env", "SOFTHSM2_CONF=" + self.softhsm_conf_path] + argv
+        return self.host.run_command(full, raiseonerr=raiseonerr)
+
+    def _write_softhsm_conf(self) -> None:
+        content = (
+            "directories.tokendir = {tokendir}\n"
+            "objectstore.backend = file\n"
+        ).format(tokendir=self.token_dir)
+        self.host.transport.put_file_contents(self.softhsm_conf_path, content.encode("utf-8"))
+
+    def clear_opensc_caches(self) -> None:
+        """Remove OpenSC cache dirs (same intent as SSSD ``OPENSC_CACHE_PATHS``)."""
+        for path in self.OPENSC_CACHE_PATHS:
+            self.host.run_command(
+                ["bash", "-c", "rm -rf {}".format(path)],
+                raiseonerr=False,
+            )
+
+    def initialize_card(
+        self,
+        label: str = "sc_test",
+        so_pin: str = "12345678",
+        user_pin: str = "123456",
+    ) -> None:
+        """Initialize a SoftHSM token (destroys previous token storage under ``base_dir``)."""
+        self.clear_opensc_caches()
+        self.host.run_command(["mkdir", "-p", os.path.dirname(self.base_dir) or self.base_dir])
+        self.host.run_command(["rm", "-rf", self.base_dir])
+        self.host.run_command(["mkdir", "-p", self.token_dir])
+        self._write_softhsm_conf()
+        self._run(
+            [
+                "softhsm2-util",
+                "--init-token",
+                "--free",
+                "--label",
+                label,
+                "--so-pin",
+                so_pin,
+                "--pin",
+                user_pin,
+            ]
+        )
+
+    def add_cert(
+        self,
+        cert_path: str,
+        cert_id: str = "01",
+        pin: str = "123456",
+        private: bool = False,
+    ) -> None:
+        """Import a PEM certificate or private key onto the token."""
+        obj_type = "privkey" if private else "cert"
+        self._run(
+            [
+                "pkcs11-tool",
+                "--module",
+                SOFTHSM_PKCS11_MODULE,
+                "--login",
+                "--pin",
+                pin,
+                "--write-object",
+                cert_path,
+                "--type",
+                obj_type,
+                "--id",
+                cert_id,
+            ]
+        )
+
+    def add_key(self, key_path: str, key_id: str = "01", pin: str = "123456") -> None:
+        """Import a PEM private key onto the token."""
+        self.add_cert(cert_path=key_path, cert_id=key_id, pin=pin, private=True)
+
+    def generate_cert(
+        self,
+        key_path: str = "/tmp/ipa_sc_selfsigned.key",
+        cert_path: str = "/tmp/ipa_sc_selfsigned.crt",
+        subj: str = "/CN=Test Cert",
+    ) -> Tuple[str, str]:
+        """Generate a self-signed certificate and private key (PEM) on the host."""
+        self.host.run_command(
+            [
+                "openssl",
+                "req",
+                "-x509",
+                "-nodes",
+                "-sha256",
+                "-days",
+                "365",
+                "-newkey",
+                "rsa:2048",
+                "-keyout",
+                key_path,
+                "-out",
+                cert_path,
+                "-subj",
+                subj,
+            ]
+        )
+        return key_path, cert_path
+
+    def insert_card(self) -> None:
+        """Start ``virt_cacard.service``."""
+        self.host.run_command(["systemctl", "start", "virt_cacard.service"])
+
+    def remove_card(self) -> None:
+        """Stop ``virt_cacard.service``."""
+        self.host.run_command(["systemctl", "stop", "virt_cacard.service"])
+
+    def append_sssd_auth_ca(self, cert_path: str) -> None:
+        """
+        Append PEM at *cert_path* to ``/etc/sssd/pki/sssd_auth_ca_db.pem``.
+
+        Modifies the live client trust store; pair with backups from
+        :meth:`setup_local_card` or restore manually.
+        """
+        ca_path = "/etc/sssd/pki/sssd_auth_ca_db.pem"
+        self.host.run_command(["mkdir", "-p", "/etc/sssd/pki"])
+        self.host.run_command(
+            [
+                "bash",
+                "-c",
+                "test -f {ca} && cat {cert} >> {ca} || cat {cert} > {ca}".format(
+                    ca=ca_path, cert=cert_path
+                ),
+            ]
+        )
+
+    def pkcs11_list_objects(self, pin: str = "123456") -> str:
+        """Return ``pkcs11-tool -O`` stdout for assertions."""
+        result = self._run(
+            [
+                "pkcs11-tool",
+                "--module",
+                SOFTHSM_PKCS11_MODULE,
+                "-O",
+                "--login",
+                "--pin",
+                pin,
+            ]
+        )
+        return result.stdout_text
+
+    def setup_local_card(
+        self,
+        username: str,
+        subj: str = "/CN=Test Cert",
+        user_pin: str = "123456",
+    ) -> Dict[str, Any]:
+        """
+        Configure **local** ``files`` SSSD domain + smart-card PAM + certmap.
+
+        Equivalent intent to SSSD framework ``setup_local_card``: token under
+        ``/opt/test_ca``, ``authselect`` with ``with-smartcard``, certmap rule
+        matching *subj*, ``pam_cert_auth``, CA PEM for the self-signed cert.
+
+        **Warning:** replaces ``sssd.conf`` with a minimal local configuration.
+        Call :func:`restore_local_smartcard_auth` with the returned dict when
+        done. Destructive on an enrolled IPA client; use only for dedicated
+        scenarios.
+
+        :return: Mapping of file paths to **bytes** for restore (plus metadata
+                 keys starting with ``_``).
+        """
+        host = self.host
+        backups: Dict[str, Any] = {}
+
+        for fpath in (
+            paths.SSSD_CONF,
+            "/etc/sssd/pki/sssd_auth_ca_db.pem",
+            "/etc/authselect/authselect.conf",
+        ):
+            if host.transport.file_exists(fpath):
+                backups[fpath] = host.get_file_contents(fpath)
+
+        tok = SmartCardUtils(host, base_dir=OPT_TEST_CA_BASE)
+        host.run_command(["rm", "-f", "/etc/sssd/pki/sssd_auth_ca_db.pem"], raiseonerr=False)
+
+        key_path = "/tmp/ipa_sc_local.key"
+        cert_path = "/tmp/ipa_sc_local.crt"
+        tok.generate_cert(key_path=key_path, cert_path=cert_path, subj=subj)
+        tok.initialize_card(label="sc_test", user_pin=user_pin)
+        tok.add_key(key_path, pin=user_pin)
+        tok.add_cert(cert_path, pin=user_pin)
+
+        host.run_command(
+            ["authselect", "select", "sssd", "with-smartcard", "--force"],
+            raiseonerr=False,
+        )
+        host.run_command(["systemctl", "restart", "virt_cacard.service"])
+
+        m = re.search(r"CN=([^/]+)", subj.replace(",", "/"))
+        cn = m.group(1).strip() if m else "Test Cert"
+        match = "<SUBJECT>.*CN=%s.*" % re.escape(cn)
+        sssd_conf = textwrap.dedent(
+            """
+            [sssd]
+            config_file_version = 2
+            services = nss, pam
+            domains = local
+
+            [nss]
+
+            [pam]
+            pam_cert_auth = True
+
+            [domain/local]
+            id_provider = files
+            local_auth_policy = only
+            debug_level = 2
+
+            [certmap/local/{user}]
+            matchrule = {rule}
+            debug_level = 2
+            """
+        ).format(user=username, rule=match)
+
+        host.transport.put_file_contents(paths.SSSD_CONF, sssd_conf.encode("utf-8"))
+        host.run_command(["chmod", "600", paths.SSSD_CONF])
+
+        cert_pem = host.get_file_contents(cert_path)
+        host.transport.put_file_contents("/etc/sssd/pki/sssd_auth_ca_db.pem", cert_pem)
+
+        host.run_command(["systemctl", "restart", "sssd"], raiseonerr=False)
+        backups["_username"] = username
+        return backups

--- a/ipatests/test_integration/test_smartcard.py
+++ b/ipatests/test_integration/test_smartcard.py
@@ -1,0 +1,159 @@
+#
+# Copyright (C) 2026  FreeIPA Contributors see COPYING for license
+#
+"""Smart-card (SoftHSM / PKCS#11) checks for the IPA multihost stack.
+
+Uses :class:`~ipatests.test_integration.base.IntegrationTest` (``topology`` +
+``clients[0]``) and :class:`~ipatests.pytest_ipa.integration.smartcard.SmartCardUtils`
+via ``host.run_command`` / ``transport`` — **not** ``pytest_mh`` / ``CLIBuilder``.
+
+Behavior matches the intent of ``sssd-test-framework`` smart-card tests (same
+underlying commands: ``softhsm2-util``, ``pkcs11-tool``, ``openssl``,
+``virt_cacard.service``). See module docstring of ``smartcard`` for RPM/binary
+requirements; ``python3-ipatests`` declares ``softhsm``, ``opensc``, and
+``virt-cacard`` on Fedora so clients that install tests get dependencies.
+
+Do **not** comment out :func:`_require_pkcs11_tools`—without ``pkcs11-tool``
+(from ``opensc``) you get exit status **127** (command not found).
+
+Token/list tests do not exercise full PAM login; :meth:`test_setup_local_card_sssd_files_domain`
+temporarily replaces ``sssd.conf`` and restores it from backup.
+"""
+
+from __future__ import absolute_import
+
+import pytest
+
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_ipa.integration.smartcard import (
+    SmartCardUtils,
+    restore_local_smartcard_auth,
+)
+from ipaplatform.paths import paths
+
+
+def _require_pkcs11_tools(host):
+    """Skip if SoftHSM/OpenSC/openssl CLIs are missing (same as SSSD framework needs)."""
+    for binary in ("softhsm2-util", "pkcs11-tool", "openssl"):
+        result = host.run_command(["which", binary], raiseonerr=False)
+        if result.returncode != 0:
+            pytest.skip("%s is not installed on %s" % (binary, host.hostname))
+
+
+class TestSmartCardUtils(IntegrationTest):
+    """Exercise SoftHSM helpers on an enrolled IPA client."""
+
+    topology = "line"
+    num_clients = 1
+
+    @property
+    def host(self):
+        """Single enrolled IPA client in this topology."""
+        return self.clients[0]
+
+    def smartcard(self, base_dir=None):
+        """Build :class:`SmartCardUtils` for :attr:`host` (optional *base_dir*)."""
+        if base_dir is not None:
+            return SmartCardUtils(self.host, base_dir=base_dir)
+        return SmartCardUtils(self.host)
+
+    def test_soft_token_contains_cert_after_import(self):
+        """Initialize a token, import key/cert, list objects via PKCS#11."""
+        _require_pkcs11_tools(self.host)
+
+        sc = self.smartcard()
+        key_path, cert_path = sc.generate_cert()
+        sc.initialize_card()
+        sc.add_key(key_path)
+        sc.add_cert(cert_path)
+
+        listing = sc.pkcs11_list_objects()
+        assert "Certificate" in listing or "cert" in listing.lower()
+
+    def test_generate_cert_creates_pem_files(self):
+        """Sanity check OpenSSL self-signed generation on the client."""
+        _require_pkcs11_tools(self.host)
+
+        sc = self.smartcard()
+        key_path, cert_path = sc.generate_cert(
+            key_path="/tmp/ipa_sc_gen.key",
+            cert_path="/tmp/ipa_sc_gen.crt",
+        )
+        self.host.run_command(["test", "-s", key_path])
+        self.host.run_command(["test", "-s", cert_path])
+        subj = self.host.run_command(
+            ["openssl", "x509", "-in", cert_path, "-noout", "-subject", "-nameopt", "RFC2253"]
+        ).stdout_text
+        assert "Test Cert" in subj
+
+    def test_virt_cacard_insert_soft_token_and_credentials(self):
+        """
+        One workflow: simulate card insert, create SoftHSM token, load credentials.
+
+        1. ``insert_card`` — ``systemctl start virt_cacard.service``.
+        2. ``generate_cert`` — PEM key + self-signed cert on the client.
+        3. ``initialize_card`` — new SoftHSM token.
+        4. ``add_key`` / ``add_cert`` — private key and cert on the token.
+        5. ``pkcs11_list_objects`` — token lists a certificate.
+        6. ``remove_card`` — ``systemctl stop virt_cacard.service`` in
+           ``finally``.
+
+        Note: SoftHSM uses ``libsofthsm2.so``; ``virt_cacard`` only toggles the
+        virtual reader service where installed. Both are exercised together for
+        CI workflows that start the simulator before programming a software token.
+        """
+        _require_pkcs11_tools(self.host)
+
+        sc = self.smartcard(base_dir="/var/tmp/ipa_smartcard_combo")
+        try:
+            sc.insert_card()
+
+            key_path = "/var/tmp/ipa_sc_combo.key"
+            cert_path = "/var/tmp/ipa_sc_combo.crt"
+            sc.generate_cert(
+                key_path=key_path,
+                cert_path=cert_path,
+                subj="/CN=IPA Smartcard Combo Test",
+            )
+            sc.initialize_card(
+                label="ipa_sc_combo",
+                so_pin="12345678",
+                user_pin="123456",
+            )
+            sc.add_key(key_path, key_id="01", pin="123456")
+            sc.add_cert(cert_path, cert_id="01", pin="123456")
+
+            listing = sc.pkcs11_list_objects(pin="123456")
+            assert (
+                "Certificate" in listing
+                or "certificate" in listing.lower()
+            )
+        finally:
+            sc.remove_card()
+
+    def test_setup_local_card_sssd_files_domain(self):
+        """
+        Local ``files`` SSSD + certmap (same intent as SSSD ``setup_local_card``).
+
+        Replaces ``sssd.conf`` temporarily; always restores from backup in
+        ``finally``.
+        """
+        _require_pkcs11_tools(self.host)
+
+        self.host.run_command(["useradd", "-m", "localscuser1"], raiseonerr=False)
+
+        sc = self.smartcard()
+        backups = None
+        try:
+            backups = sc.setup_local_card("localscuser1")
+            conf = self.host.get_file_contents(paths.SSSD_CONF, encoding="utf-8")
+            assert "[domain/local]" in conf
+            assert "pam_cert_auth = True" in conf
+            assert "[certmap/local/localscuser1]" in conf
+            ca_ok = self.host.transport.file_exists(
+                "/etc/sssd/pki/sssd_auth_ca_db.pem"
+            )
+            assert ca_ok
+        finally:
+            if backups is not None:
+                restore_local_smartcard_auth(self.host, backups)


### PR DESCRIPTION
## Summary by Sourcery

Add reusable smart-card (SoftHSM/PKCS#11) helper utilities for integration hosts and introduce integration tests validating token initialization, certificate/key loading, virt_cacard interaction, and local SSSD files-domain smart-card configuration.

New Features:
- Provide SmartCardUtils helper class to manage SoftHSM tokens, PKCS#11 objects, and related services on IPA integration hosts.
- Add restore_local_smartcard_auth utility to revert local SSSD smart-card configuration after tests.
- Introduce integration test suite exercising smart-card helpers, including token programming, PKCS#11 object listing, virt_cacard-based card insertion/removal, and local SSSD files-domain certmap setup.

Tests:
- Add integration tests that verify importing keys/certificates into a SoftHSM token and listing them via pkcs11-tool.
- Add tests that validate self-signed certificate generation on the client with OpenSSL.
- Add tests covering virt_cacard service interaction combined with SoftHSM token setup and credential loading.
- Add tests that configure a temporary local SSSD files domain with smart-card authentication and certmap, and ensure configuration and CA bundle are correctly applied and restorable.