### PR TITLE
[Backport][ipa-4-13] Add X-Content-Type-Options header in IdM WebUI

### DIFF
--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 34 - DO NOT REMOVE THIS LINE
+# VERSION 35 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -83,6 +83,7 @@ WSGIScriptReloading Off
   ErrorDocument 401 /ipa/errors/unauthorized.html
   Header always append X-Frame-Options DENY
   Header always append Content-Security-Policy "frame-ancestors 'none'"
+  Header always set X-Content-Type-Options "nosniff"
 
   # mod_session always sets two copies of the cookie, and this confuses our
   # legacy clients, the unset here works because it ends up unsetting only one


### PR DESCRIPTION
This PR was opened automatically because PR #8316 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Enhancements:
- Configure the IdM WebUI Apache template to send the X-Content-Type-Options response header to improve security.