### PR TITLE
[Backport][ipa-4-6] Add X-Content-Type-Options header in IdM WebUI

### DIFF
--- a/install/conf/ipa.conf
+++ b/install/conf/ipa.conf
@@ -1,5 +1,5 @@
 #
-# VERSION 27 - DO NOT REMOVE THIS LINE
+# VERSION 28 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -90,6 +90,7 @@ WSGIScriptReloading Off
   WSGIApplicationGroup ipa
   Header always append X-Frame-Options DENY
   Header always append Content-Security-Policy "frame-ancestors 'none'"
+  Header always set X-Content-Type-Options "nosniff"
 
   # mod_session always sets two copies of the cookie, and this confuses our
   # legacy clients, the unset here works because it ends up unsetting only one

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -23,7 +23,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f27
           name: freeipa/ci-ipa-4-6-f27
-          version: 1.0.3
+          version: 1.0.5
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Manual backport of: https://github.com/freeipa/freeipa/pull/8316

Fixes: https://pagure.io/freeipa/issue/9898

## Summary by Sourcery

Add security-related HTTP response header configuration to the IdM WebUI Apache setup.

Enhancements:
- Configure the IdM WebUI Apache virtual host to always send the X-Content-Type-Options=nosniff header.
- Bump the ipa.conf configuration version marker to reflect the updated HTTP header configuration.