### PR TITLE
[Backport][ipa-4-10] Add X-Content-Type-Options header in IdM WebUI

### DIFF
--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 33 - DO NOT REMOVE THIS LINE
+# VERSION 34 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -82,6 +82,7 @@ WSGIScriptReloading Off
   ErrorDocument 401 /ipa/errors/unauthorized.html
   Header always append X-Frame-Options DENY
   Header always append Content-Security-Policy "frame-ancestors 'none'"
+  Header always set X-Content-Type-Options "nosniff"
 
   # mod_session always sets two copies of the cookie, and this confuses our
   # legacy clients, the unset here works because it ends up unsetting only one


### PR DESCRIPTION
This PR was opened automatically because PR #8345 was pushed to ipa-4-12 and backport to ipa-4-10 is required.

## Summary by Sourcery

Enhancements:
- Configure the IdM WebUI Apache template to send the X-Content-Type-Options response header to improve browser security.