### PR TITLE
ipatests: add migrate-ds integration tests for bugs.

### DIFF
--- a/ipatests/test_integration/data/ds_migration/instance1.ldif
+++ b/ipatests/test_integration/data/ds_migration/instance1.ldif
@@ -81,6 +81,57 @@ cn: bosgrp
 gidNumber: 2001
 member: uid=bosusr,ou=BostonUsers,ou=Boston,dc=testrealm,dc=test
 
+dn: uid=mgr_user,ou=People,dc=testrealm,dc=test
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: posixAccount
+uid: mgr_user
+cn: Manager User
+sn: User
+givenName: Manager
+uidNumber: 3001
+gidNumber: 3001
+homeDirectory: /home/mgr_user
+userPassword: Secret123
+
+dn: uid=user_with_mgr,ou=People,dc=testrealm,dc=test
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: posixAccount
+uid: user_with_mgr
+cn: Subordinate User
+sn: User
+givenName: Subordinate
+uidNumber: 3002
+gidNumber: 3002
+homeDirectory: /home/user_with_mgr
+userPassword: Secret123
+manager: uid=mgr_user,ou=People,dc=testrealm,dc=test
+
+dn: uid=posixuser_no_privgrp,ou=People,dc=testrealm,dc=test
+objectClass: top
+objectClass: person
+objectClass: posixAccount
+uid: posixuser_no_privgrp
+cn: Posix User No PrivGrp
+sn: User
+uidNumber: 4001
+gidNumber: 1001
+homeDirectory: /home/posixuser_no_privgrp
+userPassword: Secret123
+
+dn: cn=dupgid_group,ou=Groups,dc=testrealm,dc=test
+objectClass: top
+objectClass: groupOfNames
+objectClass: posixGroup
+cn: dupgid_group
+gidNumber: 1001
+member: uid=ldapuser_0001,ou=People,dc=testrealm,dc=test
+
 dn: cn=HR Managers,ou=Groups,dc=testrealm,dc=test
 objectClass: top
 objectClass: groupOfNames

--- a/ipatests/test_integration/data/ds_migration/instance_hashedpwd.ldif
+++ b/ipatests/test_integration/data/ds_migration/instance_hashedpwd.ldif
@@ -1,12 +1,17 @@
 # Hashed-password test data for test_hashedpwd_migration.
-# Only leaf entries — the base suffix, ou=People and ou=Groups are
-# already present from instance1.ldif.
+# Brings its own ou=HashedPwdPeople so it does not touch ou=People used by
+# instance1.ldif / other migrate-ds tests.
 #
 # Users:
 #   puser1  — posixAccount, SSHA password for fo0m4nchU
 #   puser2  — posixAccount, SSHA password for Secret123
 
-dn: uid=puser1,ou=People,dc=testrealm,dc=test
+dn: ou=HashedPwdPeople,dc=testrealm,dc=test
+objectClass: top
+objectClass: organizationalUnit
+ou: HashedPwdPeople
+
+dn: uid=puser1,ou=HashedPwdPeople,dc=testrealm,dc=test
 objectClass: top
 objectClass: person
 objectClass: posixAccount
@@ -18,7 +23,7 @@ gidNumber: 2001
 homeDirectory: /home/puser1
 userPassword: {SSHA}OzA3jqAnLtOHUqFwAXGCj+XUNryWFN/VwvkhcA==
 
-dn: uid=puser2,ou=People,dc=testrealm,dc=test
+dn: uid=puser2,ou=HashedPwdPeople,dc=testrealm,dc=test
 objectClass: top
 objectClass: person
 objectClass: posixAccount

--- a/ipatests/test_integration/test_ds_migration.py
+++ b/ipatests/test_integration/test_ds_migration.py
@@ -86,6 +86,15 @@ class TestDSMigrationConfig(IntegrationTest):
     num_replicas = 0
     num_clients = 1
 
+    MIGRATED_USERS = [
+        "ldapuser_0001", "mgr_user", "user_with_mgr",
+        "posixuser_no_privgrp", "puser1", "puser2",
+    ]
+    MIGRATED_GROUPS = [
+        "ldapgroup_0001", "dupgid_group",
+        "HR Managers", "Directory Administrators",
+    ]
+
     @classmethod
     def install(cls, mh):
         # Install master and IPA client (full topology)
@@ -107,6 +116,17 @@ class TestDSMigrationConfig(IntegrationTest):
             stdin_text=cls.master.config.admin_password,
         )
         tasks.service_control_dirsrv(cls.master, "restart")
+
+    def cleanup_migrated_data(self):
+        """Remove all users and groups that migrate-ds may have created."""
+        for user in self.MIGRATED_USERS:
+            self.master.run_command(
+                ["ipa", "user-del", user], raiseonerr=False
+            )
+        for group in self.MIGRATED_GROUPS:
+            self.master.run_command(
+                ["ipa", "group-del", group], raiseonerr=False
+            )
 
     def test_attempt_migration_with_configuration_false(self):
         """
@@ -192,19 +212,7 @@ class TestDSMigrationConfig(IntegrationTest):
             ["ipa", "group-show", "ldapgroup_0001"]
         )
 
-        # Clean up migrated user and group
-        self.master.run_command(
-            ["ipa", "user-del", "ldapuser_0001"], raiseonerr=False
-        )
-        for group in [
-            "ldapgroup_0001",
-            "HR Managers",
-            "Directory Administrators",
-        ]:
-            self.master.run_command(
-                ["ipa", "group-del", group],
-                raiseonerr=False,
-            )
+        self.cleanup_migrated_data()
 
     def test_bz804807_invalid_user_and_group_container_rdn(self):
         """
@@ -340,18 +348,7 @@ class TestDSMigrationConfig(IntegrationTest):
                 raiseonerr=False,
             )
             tasks.service_control_dirsrv(self.master, "restart")
-            self.master.run_command(
-                ["ipa", "user-del", "ldapuser_0001"], raiseonerr=False
-            )
-            for group in [
-                "ldapgroup_0001",
-                "HR Managers",
-                "Directory Administrators",
-            ]:
-                self.master.run_command(
-                    ["ipa", "group-del", group],
-                    raiseonerr=False,
-                )
+            self.cleanup_migrated_data()
 
     def test_bz783270_02_migrate_ds_with_compat_enabled(self):
         """
@@ -407,19 +404,86 @@ class TestDSMigrationConfig(IntegrationTest):
                 raiseonerr=False,
             )
             tasks.service_control_dirsrv(self.master, "restart")
+            self.cleanup_migrated_data()
+
+    def test_bz804609_user_show_all_no_internal_error(self):
+        """
+        bz804609: ipa user-show --all on a migrated user with a manager
+        attribute must not return an internal error.
+        https://bugzilla.redhat.com/show_bug.cgi?id=804609
+        """
+        tasks.kinit_admin(self.master)
+        pwd = self.master.config.admin_password
+        try:
             self.master.run_command(
-                ["ipa", "user-del", "ldapuser_0001"],
+                [
+                    "ipa",
+                    "migrate-ds",
+                    "--user-container=ou=People",
+                    "--group-container=ou=nonexistent",
+                    "--continue",
+                    self.ldap_uri,
+                ],
+                stdin_text=pwd,
+            )
+            result = self.master.run_command(
+                ["ipa", "user-show", "--all", "user_with_mgr"],
+            )
+            out = result.stdout_text + result.stderr_text
+            assert "an internal error has occurred" not in out.lower(), out
+            assert "mgr_user" in result.stdout_text
+
+            base = self.master.domain.basedn
+            user_dn = f"uid=user_with_mgr,cn=users,cn=accounts,{base}"
+            ipa_mgr_dn = f"uid=mgr_user,cn=users,cn=accounts,{base}"
+            remote_mgr_dn = f"manager: uid=mgr_user,ou=People,{DS_BASEDN}"
+
+            ldap_res = tasks.ldapsearch_dm(
+                self.master,
+                user_dn,
+                ["(objectclass=*)", "manager"],
+                scope="base",
+            )
+            ldap_text = ldap_res.stdout_text
+            normalized = ldap_text.lower()
+            assert ipa_mgr_dn.lower() in normalized, ldap_text
+            assert remote_mgr_dn.lower() not in normalized, ldap_text
+        finally:
+            self.cleanup_migrated_data()
+
+    def test_bz753966_delete_migrated_group_with_spaces(self):
+        """
+        bz753966: Migrated groups with spaces in their names must be
+        deletable via ipa group-del.
+        https://bugzilla.redhat.com/show_bug.cgi?id=753966
+        """
+        tasks.kinit_admin(self.master)
+        pwd = self.master.config.admin_password
+
+        try:
+            self.master.run_command(
+                [
+                    "ipa",
+                    "migrate-ds",
+                    "--user-container=ou=People",
+                    "--group-container=ou=Groups",
+                    self.ldap_uri,
+                ],
+                stdin_text=pwd,
+            )
+            self.master.run_command(
+                ["ipa", "group-find", "HR Managers"]
+            )
+            self.master.run_command(
+                ["ipa", "group-del", "HR Managers"]
+            )
+            result = self.master.run_command(
+                ["ipa", "group-find", "HR Managers"],
                 raiseonerr=False,
             )
-            for group in [
-                "ldapgroup_0001",
-                "HR Managers",
-                "Directory Administrators",
-            ]:
-                self.master.run_command(
-                    ["ipa", "group-del", group],
-                    raiseonerr=False,
-                )
+            assert "0 groups matched" in result.stdout_text
+        finally:
+            self.cleanup_migrated_data()
 
     def kerberos_keys_available(self, uid):
         """Return True if Kerberos keys are available for *uid*."""
@@ -477,14 +541,14 @@ class TestDSMigrationConfig(IntegrationTest):
 
         tasks.kinit_admin(self.master)
         pwd_admin = self.master.config.admin_password
-        user_container = "ou=People,{}".format(DS_BASEDN)
-        group_container = "ou=groups,{}".format(DS_BASEDN)
-
+        user_container = "ou=HashedPwdPeople,{}".format(DS_BASEDN)
+        group_container = "ou=HashedPwdPeople,{}".format(DS_BASEDN)
         try:
             self.master.run_command(
                 [
                     "ipa",
                     "migrate-ds",
+                    "--continue",
                     "--user-container",
                     user_container,
                     "--group-container",
@@ -506,8 +570,71 @@ class TestDSMigrationConfig(IntegrationTest):
             tasks.kinit_as_user(self.master, user2, user2pwd)
         finally:
             tasks.kinit_admin(self.master)
-            for user in (user1, user2):
-                self.master.run_command(
-                    ["ipa", "user-del", user],
-                    raiseonerr=False,
-                )
+            self.cleanup_migrated_data()
+
+    def test_bz809560_no_private_group_for_migrated_posix_user(self):
+        """
+        bz809560: Private groups must not be created for migrated posix
+        users whose GID points to another group.
+        https://bugzilla.redhat.com/show_bug.cgi?id=809560
+        """
+        tasks.kinit_admin(self.master)
+        pwd = self.master.config.admin_password
+
+        try:
+            self.master.run_command(
+                [
+                    "ipa",
+                    "migrate-ds",
+                    "--user-container=ou=People",
+                    "--group-container=ou=Groups",
+                    self.ldap_uri,
+                ],
+                stdin_text=pwd,
+            )
+            self.master.run_command(
+                ["ipa", "user-show", "posixuser_no_privgrp"]
+            )
+            result = self.master.run_command(
+                ["ipa", "group-show", "posixuser_no_privgrp"],
+                raiseonerr=False,
+            )
+            assert result.returncode != 0, (
+                "Private group should not exist for migrated posix user"
+            )
+        finally:
+            self.cleanup_migrated_data()
+
+    def test_bz813389_duplicate_gid_warning(self):
+        """
+        bz813389: When two groups share the same GID, migrate-ds must
+        succeed and log a warning instead of failing with a cryptic error.
+        https://bugzilla.redhat.com/show_bug.cgi?id=813389
+        """
+        tasks.kinit_admin(self.master)
+        pwd = self.master.config.admin_password
+        logfile = "/var/log/httpd/error_log"
+
+        try:
+            logsize = tasks.get_logsize(self.master, logfile)
+            result = self.master.run_command(
+                [
+                    "ipa",
+                    "migrate-ds",
+                    "--user-container=ou=People",
+                    "--group-container=ou=Groups",
+                    self.ldap_uri,
+                ],
+                stdin_text=pwd,
+            )
+            out = result.stdout_text + result.stderr_text
+            assert "Expected 1" not in out, (
+                "Migration should not fail with cryptic error"
+            )
+            self.master.run_command(
+                ["ipa", "user-show", "ldapuser_0001"]
+            )
+            log_bytes = self.master.get_file_contents(logfile)[logsize:]
+            assert b"should match 1 group, but it matched 2 groups" in log_bytes
+        finally:
+            self.cleanup_migrated_data()


### PR DESCRIPTION
ipatests: add migrate-ds integration tests for bugs.
    
    - BZ 804609: ipa user-show --all on a migrated user with a manager
      attribute no longer causes an internal error
    - BZ 753966: migrated groups with spaces in their names can be
      deleted via ipa group-del
    - BZ 809560: private groups are not created for migrated posix users
      whose GID points to an existing group
    - BZ 813389: when two groups share the same GID, migrate-ds succeeds
      with a warning instead of failing with a cryptic error
    
Added corresponding LDIF test entries (mgr_user, user_with_mgr, posixuser_no_privgrp, dupgid_group) to instance1.ldif
Added a cleanup_migrated_data() helper that removes the users and groups migrated.
    
Ref: https://pagure.io/freeipa/issue/9965
    
Assisted-by: claude <no-reply@anthropic.com>
Signed-off-by: Sudhir Menon <sumenon@redhat.com>

## Summary by Sourcery

Add integration coverage for FreeIPA directory server migration edge cases and centralize cleanup of migrated test data.

CI:
- Update temporary CI definition to run the ds_migration integration test suite with an increased timeout.

Tests:
- Add migrate-ds integration tests covering manager attribute handling, group names with spaces, private group creation for migrated POSIX users, and duplicate GID behavior.
- Introduce a reusable helper to clean up users and groups created by migrate-ds across tests.