### PR TITLE
fix: COMPAT_DN common name changed for proper Schema Compat turn off

### DIFF
--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -39,7 +39,7 @@ from ipaserver.install import service
 logger = logging.getLogger(__name__)
 
 DSE = 'dse.ldif'
-COMPAT_DN = "cn=Schema Compatibility,cn=plugins,cn=config"
+COMPAT_DN = "cn=schema compatibility,cn=plugins,cn=config"
 REPL_PLUGIN_DN_TEMPLATE = "cn=Multi%s Replication Plugin,cn=plugins,cn=config"
 
 


### PR DESCRIPTION
Removes 'DN: cn=Schema Compatibility,cn=plugins,cn=config does not exists or haven't been updated' warn while schema compat disabling

## Summary by Sourcery

Bug Fixes:
- Fix incorrect Schema Compatibility plugin DN that caused spurious warnings about missing or not updated configuration when disabling schema compat.