### PR TITLE
[Backport][ipa-4-13] Disallow retrieving software versions

### DIFF
--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 35 - DO NOT REMOVE THIS LINE
+# VERSION 36 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -47,6 +47,9 @@ WSGIScriptAlias /ipa /usr/share/ipa/wsgi.py process-group=ipa \
   application-group=%{GLOBAL}
 WSGIScriptReloading Off
 
+# Disallow sniffing server software versions
+ServerSignature Off
+ServerTokens Prod
 
 # Turn off mod_msgi handler for errors, config, crl:
 <Location "/ipa/errors">


### PR DESCRIPTION
This PR was opened automatically because PR #8335 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Backport configuration changes in ipa.conf.template related to restricting or disallowing retrieval of software version information on the ipa-4-13 branch.