### PR TITLE
[Backport][ipa-4-12] Disallow retrieving software versions

### DIFF
--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 34 - DO NOT REMOVE THIS LINE
+# VERSION 35 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -47,6 +47,9 @@ WSGIScriptAlias /ipa /usr/share/ipa/wsgi.py process-group=ipa \
   application-group=%{GLOBAL}
 WSGIScriptReloading Off
 
+# Disallow sniffing server software versions
+ServerSignature Off
+ServerTokens Prod
 
 # Turn off mod_msgi handler for errors, config, crl:
 <Location "/ipa/errors">


### PR DESCRIPTION
Manual backport of: https://github.com/freeipa/freeipa/pull/8335

Fixes: https://pagure.io/freeipa/issue/9897

## Summary by Sourcery

Disallow retrieval of software version information via the IPA web server configuration to align with upstream changes and address issue #9897.