### PR TITLE
[Backport][ipa-4-8] Disallow retrieving software versions

### DIFF
--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 32 - DO NOT REMOVE THIS LINE
+# VERSION 33 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -48,6 +48,9 @@ WSGIImportScript /usr/share/ipa/wsgi.py process-group=ipa application-group=ipa
 WSGIScriptAlias /ipa /usr/share/ipa/wsgi.py
 WSGIScriptReloading Off
 
+# Disallow sniffing server software versions
+ServerSignature Off
+ServerTokens Prod
 
 # Turn off mod_msgi handler for errors, config, crl:
 <Location "/ipa/errors">


### PR DESCRIPTION
Manual backport of: https://github.com/freeipa/freeipa/pull/8335

Fixes: https://pagure.io/freeipa/issue/9897

## Summary by Sourcery

Disallow retrieval of software version information via the IPA web server configuration to avoid exposing version details.